### PR TITLE
Add sidebar row context menus

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -25,6 +25,7 @@
     "@pierre/diffs": "^1.0.11",
     "@pierre/trees": "^1.0.0-beta.3",
     "@radix-ui/react-compose-refs": "^1.1.2",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -1,9 +1,14 @@
 import { FolderPlus, MoreHorizontal, PencilLine, Trash2 } from "lucide-react";
 import { findLocalPathProjectSourceForHost } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
+import type { ReactNode } from "react";
 import { Button } from "@/components/ui";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@/components/ui";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -13,11 +18,103 @@ import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { cn } from "@/lib/utils";
 import { useProjectActions } from "./ProjectActionsProvider";
 
-interface ProjectActionsMenuProps {
+interface ProjectActionsMenuBaseProps {
   project: ProjectResponse;
+}
+
+interface ProjectActionsMenuProps extends ProjectActionsMenuBaseProps {
   triggerClassName?: string;
   align?: "start" | "center" | "end";
   onOpenChange?: (open: boolean) => void;
+}
+
+interface ProjectActionsContextMenuProps extends ProjectActionsMenuBaseProps {
+  children: ReactNode;
+  onOpenChange?: (open: boolean) => void;
+}
+
+type ProjectActionsMenuSurface = "context" | "dropdown";
+
+interface ProjectActionsMenuItemsProps extends ProjectActionsMenuBaseProps {
+  surface: ProjectActionsMenuSurface;
+}
+
+interface ProjectActionMenuItemProps {
+  children: ReactNode;
+  className?: string;
+  onSelect?: (event: Event) => void;
+  surface: ProjectActionsMenuSurface;
+}
+
+function ProjectActionMenuItem({
+  children,
+  className,
+  onSelect,
+  surface,
+}: ProjectActionMenuItemProps) {
+  if (surface === "context") {
+    return (
+      <ContextMenuItem className={className} onSelect={onSelect}>
+        {children}
+      </ContextMenuItem>
+    );
+  }
+
+  return (
+    <DropdownMenuItem className={className} onSelect={onSelect}>
+      {children}
+    </DropdownMenuItem>
+  );
+}
+
+function ProjectActionsMenuItems({
+  project,
+  surface,
+}: ProjectActionsMenuItemsProps) {
+  const { localHostId } = useHostDaemon();
+  const { requestRename, requestDelete, requestAddLocalPath } =
+    useProjectActions();
+  const showAddLocalPath =
+    localHostId != null &&
+    !findLocalPathProjectSourceForHost(project.sources, localHostId);
+
+  return (
+    <>
+      <ProjectActionMenuItem
+        surface={surface}
+        onSelect={(event) => {
+          event.preventDefault();
+          requestRename(project);
+        }}
+      >
+        <PencilLine className="size-4" />
+        Rename
+      </ProjectActionMenuItem>
+      {showAddLocalPath ? (
+        <ProjectActionMenuItem
+          surface={surface}
+          onSelect={(event) => {
+            event.preventDefault();
+            requestAddLocalPath(project);
+          }}
+        >
+          <FolderPlus className="size-4" />
+          Add local path
+        </ProjectActionMenuItem>
+      ) : null}
+      <ProjectActionMenuItem
+        surface={surface}
+        className="text-destructive focus:text-destructive"
+        onSelect={(event) => {
+          event.preventDefault();
+          requestDelete(project);
+        }}
+      >
+        <Trash2 className="size-4" />
+        Remove
+      </ProjectActionMenuItem>
+    </>
+  );
 }
 
 export function ProjectActionsMenu({
@@ -26,13 +123,6 @@ export function ProjectActionsMenu({
   align = "end",
   onOpenChange,
 }: ProjectActionsMenuProps) {
-  const { localHostId } = useHostDaemon();
-  const { requestRename, requestDelete, requestAddLocalPath } =
-    useProjectActions();
-  const showAddLocalPath =
-    localHostId != null &&
-    !findLocalPathProjectSourceForHost(project.sources, localHostId);
-
   return (
     <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
@@ -54,37 +144,26 @@ export function ProjectActionsMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align} className="w-44">
-        <DropdownMenuItem
-          onSelect={(event) => {
-            event.preventDefault();
-            requestRename(project);
-          }}
-        >
-          <PencilLine className="size-4" />
-          Rename
-        </DropdownMenuItem>
-        {showAddLocalPath ? (
-          <DropdownMenuItem
-            onSelect={(event) => {
-              event.preventDefault();
-              requestAddLocalPath(project);
-            }}
-          >
-            <FolderPlus className="size-4" />
-            Add local path
-          </DropdownMenuItem>
-        ) : null}
-        <DropdownMenuItem
-          className="text-destructive focus:text-destructive"
-          onSelect={(event) => {
-            event.preventDefault();
-            requestDelete(project);
-          }}
-        >
-          <Trash2 className="size-4" />
-          Remove
-        </DropdownMenuItem>
+        <ProjectActionsMenuItems project={project} surface="dropdown" />
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+export function ProjectActionsContextMenu({
+  children,
+  project,
+  onOpenChange,
+}: ProjectActionsContextMenuProps) {
+  return (
+    <ContextMenu onOpenChange={onOpenChange}>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent
+        aria-label={`${project.name} actions`}
+        className="w-44"
+      >
+        <ProjectActionsMenuItems project={project} surface="context" />
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -83,7 +83,9 @@ function ProjectActionsMenuItems({
       <ProjectActionMenuItem
         surface={surface}
         onSelect={(event) => {
-          event.preventDefault();
+          if (surface === "dropdown") {
+            event.preventDefault();
+          }
           requestRename(project);
         }}
       >
@@ -94,7 +96,9 @@ function ProjectActionsMenuItems({
         <ProjectActionMenuItem
           surface={surface}
           onSelect={(event) => {
-            event.preventDefault();
+            if (surface === "dropdown") {
+              event.preventDefault();
+            }
             requestAddLocalPath(project);
           }}
         >
@@ -106,7 +110,9 @@ function ProjectActionsMenuItems({
         surface={surface}
         className="text-destructive focus:text-destructive"
         onSelect={(event) => {
-          event.preventDefault();
+          if (surface === "dropdown") {
+            event.preventDefault();
+          }
           requestDelete(project);
         }}
       >

--- a/apps/app/src/components/sidebar/ProjectRow.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.test.tsx
@@ -374,6 +374,51 @@ describe("ProjectRow", () => {
     ).toBe("false");
   });
 
+  it("dismisses a right-click-opened project actions menu after selecting an action", async () => {
+    await renderProjectRow({
+      threadListState: {
+        status: "ready",
+        threads: [],
+      },
+    });
+
+    fireEvent.contextMenu(screen.getByText("Project Alpha"), {
+      clientX: 96,
+      clientY: 48,
+    });
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+    });
+  });
+
+  it("dismisses a right-click-opened project actions menu when clicking outside", async () => {
+    await renderProjectRow({
+      threadListState: {
+        status: "ready",
+        threads: [],
+      },
+    });
+
+    fireEvent.contextMenu(screen.getByText("Project Alpha"), {
+      clientX: 96,
+      clientY: 48,
+    });
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Rename" }),
+    ).not.toBeNull();
+
+    fireEvent.pointerDown(document.body, { button: 0 });
+    fireEvent.click(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+    });
+  });
+
   it("closes a right-click-opened project actions menu with Escape", async () => {
     await renderProjectRow({
       threadListState: {

--- a/apps/app/src/components/sidebar/ProjectRow.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.test.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 
 import { Suspense, type ReactNode } from "react";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Provider as JotaiProvider } from "jotai";
 import type { ThreadListEntry } from "@bb/domain";
@@ -15,8 +22,14 @@ import { installFetchRoutes, jsonResponse } from "@/test/http-test-utils";
 import { createAppQueryClient } from "@/lib/query-client";
 import { ProjectRow, type ProjectThreadListState } from "./ProjectRow";
 
+vi.mock("@/components/sidebar/sidebarCollapsedAtoms", async () => {
+  const { atom } = await import("jotai");
+  return { collapsedProjectIdsAtom: atom<string[]>([]) };
+});
+
 interface RenderProjectRowArgs {
   collapsedManagerIds?: Set<string>;
+  onProjectSelect?: () => void;
   threadListState: ProjectThreadListState;
 }
 
@@ -119,6 +132,7 @@ async function renderProjectRow(args: RenderProjectRowArgs): Promise<void> {
           collapsedManagerIds={args.collapsedManagerIds ?? new Set()}
           isLocalPathInvalid={false}
           localHostId={null}
+          onProjectSelect={args.onProjectSelect}
           onToggleProjectCollapsed={vi.fn()}
           onToggleManagerCollapsed={vi.fn()}
           promotedBranchName={null}
@@ -134,6 +148,16 @@ function getThreadOpenLabels(): string[] {
     const label = link.getAttribute("aria-label")?.replace(/^Open /u, "");
     return label === undefined ? [] : [label];
   });
+}
+
+function getProjectOpenLink(): HTMLAnchorElement {
+  const link = document.querySelector<HTMLAnchorElement>(
+    'a[href="/projects/proj_1"]',
+  );
+  if (link === null) {
+    throw new Error("Expected project open link to be rendered");
+  }
+  return link;
 }
 
 afterEach(() => {
@@ -284,5 +308,93 @@ describe("ProjectRow", () => {
       ]);
     });
     expect(screen.queryByLabelText("Open Managed child")).toBeNull();
+  });
+
+  it("preserves left-click project opening", async () => {
+    const onProjectSelect = vi.fn();
+
+    await renderProjectRow({
+      onProjectSelect,
+      threadListState: {
+        status: "ready",
+        threads: [],
+      },
+    });
+
+    fireEvent.click(getProjectOpenLink());
+
+    expect(onProjectSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+  });
+
+  it("opens the project actions menu from the ellipsis trigger", async () => {
+    await renderProjectRow({
+      threadListState: {
+        status: "ready",
+        threads: [],
+      },
+    });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Project Alpha actions" }),
+      {
+        button: 0,
+        ctrlKey: false,
+      },
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Rename" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Remove" })).not.toBeNull();
+  });
+
+  it("opens the project actions menu from the row context menu gesture", async () => {
+    await renderProjectRow({
+      threadListState: {
+        status: "ready",
+        threads: [],
+      },
+    });
+
+    const browserMenuAllowed = fireEvent.contextMenu(
+      screen.getByText("Project Alpha"),
+      { clientX: 96, clientY: 48 },
+    );
+
+    expect(browserMenuAllowed).toBe(false);
+    expect(
+      await screen.findByRole("menuitem", { name: "Rename" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Remove" })).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { hidden: true, name: "Project Alpha actions" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
+  it("closes a right-click-opened project actions menu with Escape", async () => {
+    await renderProjectRow({
+      threadListState: {
+        status: "ready",
+        threads: [],
+      },
+    });
+
+    fireEvent.contextMenu(screen.getByText("Project Alpha"), {
+      clientX: 96,
+      clientY: 48,
+    });
+
+    const menu = await screen.findByRole("menu", {
+      name: "Project Alpha actions",
+    });
+
+    fireEvent.keyDown(menu, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+    });
   });
 });

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -4,7 +4,10 @@ import type { ProjectResponse } from "@bb/server-contract";
 import { AlertTriangle, ChevronRight, Folder, FolderOpen } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import { EmptyState, SidebarStickyTier } from "@/components/ui";
-import { ProjectActionsMenu } from "@/components/project/ProjectActionsMenu";
+import {
+  ProjectActionsContextMenu,
+  ProjectActionsMenu,
+} from "@/components/project/ProjectActionsMenu";
 import { SidebarMenuItem, SidebarMenuSkeleton } from "@/components/ui";
 import {
   COARSE_POINTER_ICON_SIZE_CLASS,
@@ -75,96 +78,102 @@ export function ProjectRow({
 
   return (
     <SidebarMenuItem data-sidebar-sticky-project-item="">
-      <SidebarStickyTier
-        tier="project"
-        className={cn(
-          "group/project-row flex w-full items-center rounded-md text-sm transition-colors",
-          isActive
-            ? "bg-sidebar-border text-sidebar-foreground"
-            : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-        )}
-        title={project.name}
-      >
-        <NavLink
-          to={`/projects/${project.id}`}
-          onClick={onProjectSelect}
-          className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
-        />
-        <button
-          type="button"
-          aria-expanded={!isCollapsed}
-          aria-label={
-            isCollapsed ? `Expand ${project.name}` : `Collapse ${project.name}`
-          }
-          title={
-            isCollapsed ? "Expand project threads" : "Collapse project threads"
-          }
-          onClick={() => {
-            onToggleProjectCollapsed(project.id);
-          }}
+      <ProjectActionsContextMenu project={project}>
+        <SidebarStickyTier
+          tier="project"
           className={cn(
-            "relative z-10 flex shrink-0 items-center justify-center rounded-md text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-colors hover:text-sidebar-foreground focus-visible:ring-2",
-            COARSE_POINTER_PROJECT_ROW_ACTION_SIZE_CLASS,
+            "group/project-row flex w-full items-center rounded-md text-sm transition-colors",
+            isActive
+              ? "bg-sidebar-border text-sidebar-foreground"
+              : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
           )}
+          title={project.name}
         >
-          <span
+          <NavLink
+            to={`/projects/${project.id}`}
+            onClick={onProjectSelect}
+            className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
+          />
+          <button
+            type="button"
+            aria-expanded={!isCollapsed}
+            aria-label={
+              isCollapsed
+                ? `Expand ${project.name}`
+                : `Collapse ${project.name}`
+            }
+            title={
+              isCollapsed
+                ? "Expand project threads"
+                : "Collapse project threads"
+            }
+            onClick={() => {
+              onToggleProjectCollapsed(project.id);
+            }}
             className={cn(
-              "relative inline-flex items-center justify-center",
-              COARSE_POINTER_ICON_SIZE_CLASS,
+              "relative z-10 flex shrink-0 items-center justify-center rounded-md text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-colors hover:text-sidebar-foreground focus-visible:ring-2",
+              COARSE_POINTER_PROJECT_ROW_ACTION_SIZE_CLASS,
             )}
           >
-            <ChevronRight
+            <span
               className={cn(
-                "absolute opacity-0 transition-all duration-150 group-hover/project-row:opacity-100",
+                "relative inline-flex items-center justify-center",
                 COARSE_POINTER_ICON_SIZE_CLASS,
-                !isCollapsed && "rotate-90",
               )}
-            />
-            {isCollapsed ? (
-              <Folder
+            >
+              <ChevronRight
                 className={cn(
-                  "absolute opacity-100 transition-opacity duration-150 group-hover/project-row:opacity-0",
+                  "absolute opacity-0 transition-all duration-150 group-hover/project-row:opacity-100",
                   COARSE_POINTER_ICON_SIZE_CLASS,
+                  !isCollapsed && "rotate-90",
                 )}
               />
-            ) : (
-              <FolderOpen
-                className={cn(
-                  "absolute opacity-100 transition-opacity duration-150 group-hover/project-row:opacity-0",
-                  COARSE_POINTER_ICON_SIZE_CLASS,
-                )}
-              />
-            )}
+              {isCollapsed ? (
+                <Folder
+                  className={cn(
+                    "absolute opacity-100 transition-opacity duration-150 group-hover/project-row:opacity-0",
+                    COARSE_POINTER_ICON_SIZE_CLASS,
+                  )}
+                />
+              ) : (
+                <FolderOpen
+                  className={cn(
+                    "absolute opacity-100 transition-opacity duration-150 group-hover/project-row:opacity-0",
+                    COARSE_POINTER_ICON_SIZE_CLASS,
+                  )}
+                />
+              )}
+            </span>
+          </button>
+          <span className="pointer-events-none relative z-10 min-w-0 flex-1 truncate text-left">
+            {project.name}
           </span>
-        </button>
-        <span className="pointer-events-none relative z-10 min-w-0 flex-1 truncate text-left">
-          {project.name}
-        </span>
-        {isLocalPathInvalid ? (
-          <NavLink
-            to={`/projects/${project.id}/settings`}
-            onClick={(event) => {
-              event.stopPropagation();
-              onProjectSelect?.();
-            }}
-            title="Project folder not found. Open project settings to fix."
-            aria-label="Project folder not found"
-            className={cn(
-              "relative z-10 inline-flex shrink-0 items-center justify-center rounded-md text-destructive outline-none ring-sidebar-ring transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2",
+          {isLocalPathInvalid ? (
+            <NavLink
+              to={`/projects/${project.id}/settings`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onProjectSelect?.();
+              }}
+              title="Project folder not found. Open project settings to fix."
+              aria-label="Project folder not found"
+              className={cn(
+                "relative z-10 inline-flex shrink-0 items-center justify-center rounded-md text-destructive outline-none ring-sidebar-ring transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2",
+                COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+              )}
+            >
+              <AlertTriangle className={COARSE_POINTER_ICON_SIZE_CLASS} />
+            </NavLink>
+          ) : null}
+          <ProjectActionsMenu
+            project={project}
+            triggerClassName={cn(
+              "relative z-10 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
               COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
             )}
-          >
-            <AlertTriangle className={COARSE_POINTER_ICON_SIZE_CLASS} />
-          </NavLink>
-        ) : null}
-        <ProjectActionsMenu
-          project={project}
-          triggerClassName={cn(
-            "relative z-10 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
-            COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-          )}
-        />
-      </SidebarStickyTier>
+          />
+        </SidebarStickyTier>
+      </ProjectActionsContextMenu>
 
       {!isCollapsed ? (
         threadListState.status === "loading" ? (

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -261,12 +261,18 @@ describe("ThreadRow", () => {
 
     const browserMenuAllowed = fireEvent.contextMenu(
       screen.getByRole("link", { name: "Open Pending interaction thread" }),
+      { clientX: 80, clientY: 64 },
     );
 
     expect(browserMenuAllowed).toBe(false);
     expect(
       await screen.findByRole("menuitem", { name: "Mark as read" }),
     ).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { hidden: true, name: "Thread actions" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
   });
 
   it("opens the thread actions menu from a manager row context menu gesture", async () => {
@@ -284,6 +290,7 @@ describe("ThreadRow", () => {
 
     const browserMenuAllowed = fireEvent.contextMenu(
       screen.getByRole("link", { name: "Open Manager thread" }),
+      { clientX: 90, clientY: 72 },
     );
 
     expect(browserMenuAllowed).toBe(false);

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Provider as JotaiProvider } from "jotai";
 import type { ThreadListEntry } from "@bb/domain";
@@ -26,6 +32,7 @@ interface TestWrapperProps {
 interface RenderThreadRowOptions {
   isActive?: boolean;
   isPromoted?: boolean;
+  onProjectSelect?: () => void;
   rowOptions?: ThreadRowOptions;
 }
 
@@ -110,6 +117,7 @@ function createThreadRowElement({
       thread={thread}
       isActive={rowOptions.isActive ?? false}
       isPromoted={rowOptions.isPromoted}
+      onProjectSelect={rowOptions.onProjectSelect}
       options={rowOptions.rowOptions ?? { kind: "default" }}
     />
   );
@@ -213,11 +221,92 @@ describe("ThreadRow", () => {
   it.each(environmentIconCases)(
     "shows the $label icon label",
     ({ kind, label }) => {
-      renderThreadRow(
-        createThread({ environmentWorkspaceDisplayKind: kind }),
-      );
+      renderThreadRow(createThread({ environmentWorkspaceDisplayKind: kind }));
 
       expect(screen.getByLabelText(label)).not.toBeNull();
     },
   );
+
+  it("preserves left-click thread opening", () => {
+    const onProjectSelect = vi.fn();
+
+    renderThreadRow(createThread(), { onProjectSelect });
+
+    fireEvent.click(
+      screen.getByRole("link", { name: "Open Pending interaction thread" }),
+    );
+
+    expect(onProjectSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menuitem", { name: "Mark as read" })).toBeNull();
+  });
+
+  it("opens the thread actions menu from the ellipsis trigger", async () => {
+    renderThreadRow(createThread());
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Thread actions" }),
+      {
+        button: 0,
+        ctrlKey: false,
+      },
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Mark as read" }),
+    ).not.toBeNull();
+  });
+
+  it("opens the thread actions menu from the row context menu gesture", async () => {
+    renderThreadRow(createThread());
+
+    const browserMenuAllowed = fireEvent.contextMenu(
+      screen.getByRole("link", { name: "Open Pending interaction thread" }),
+    );
+
+    expect(browserMenuAllowed).toBe(false);
+    expect(
+      await screen.findByRole("menuitem", { name: "Mark as read" }),
+    ).not.toBeNull();
+  });
+
+  it("opens the thread actions menu from a manager row context menu gesture", async () => {
+    renderThreadRow(
+      createThread({
+        id: "thr_manager",
+        type: "manager",
+        title: "Manager thread",
+        titleFallback: "Manager thread",
+      }),
+      {
+        rowOptions: createManagerRowOptions(),
+      },
+    );
+
+    const browserMenuAllowed = fireEvent.contextMenu(
+      screen.getByRole("link", { name: "Open Manager thread" }),
+    );
+
+    expect(browserMenuAllowed).toBe(false);
+    expect(
+      await screen.findByRole("menuitem", { name: "Mark as read" }),
+    ).not.toBeNull();
+  });
+
+  it("closes a right-click-opened actions menu with Escape", async () => {
+    renderThreadRow(createThread());
+
+    fireEvent.contextMenu(
+      screen.getByRole("link", { name: "Open Pending interaction thread" }),
+    );
+
+    const menu = await screen.findByRole("menu", { name: "Thread actions" });
+
+    fireEvent.keyDown(menu, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("menuitem", { name: "Mark as read" }),
+      ).toBeNull();
+    });
+  });
 });

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -15,6 +15,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppQueryClient } from "@/lib/query-client";
 import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider";
+import { installFetchRoutes, jsonResponse } from "@/test/http-test-utils";
 import { ThreadRow, type ThreadRowOptions } from "./ThreadRow";
 
 vi.mock("sonner", () => ({
@@ -151,6 +152,7 @@ function renderThreadRow(
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("ThreadRow", () => {
@@ -273,6 +275,60 @@ describe("ThreadRow", () => {
         .getByRole("button", { hidden: true, name: "Thread actions" })
         .getAttribute("aria-expanded"),
     ).toBe("false");
+  });
+
+  it("dismisses a right-click-opened thread actions menu after selecting an action", async () => {
+    const thread = createThread();
+    installFetchRoutes([
+      {
+        method: "POST",
+        pathname: `/api/v1/threads/${thread.id}/read`,
+        handler: () =>
+          jsonResponse({
+            ...thread,
+            lastReadAt: Date.now(),
+          }),
+      },
+    ]);
+
+    renderThreadRow(thread);
+
+    fireEvent.contextMenu(
+      screen.getByRole("link", { name: "Open Pending interaction thread" }),
+      { clientX: 80, clientY: 64 },
+    );
+
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Mark as read" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("menuitem", { name: "Mark as read" }),
+      ).toBeNull();
+    });
+  });
+
+  it("dismisses a right-click-opened thread actions menu when clicking outside", async () => {
+    renderThreadRow(createThread());
+
+    fireEvent.contextMenu(
+      screen.getByRole("link", { name: "Open Pending interaction thread" }),
+      { clientX: 80, clientY: 64 },
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Mark as read" }),
+    ).not.toBeNull();
+
+    fireEvent.pointerDown(document.body, { button: 0 });
+    fireEvent.click(document.body);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("menuitem", { name: "Mark as read" }),
+      ).toBeNull();
+    });
   });
 
   it("opens the thread actions menu from a manager row context menu gesture", async () => {

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -1,4 +1,4 @@
-import { memo, type MouseEvent, useState } from "react";
+import { memo, useState } from "react";
 import type { ThreadListEntry } from "@bb/domain";
 import {
   Pill,
@@ -14,7 +14,10 @@ import {
   UserRound,
 } from "lucide-react";
 import { NavLink } from "react-router-dom";
-import { ThreadActionsMenu } from "@/components/thread/ThreadActionsMenu";
+import {
+  ThreadActionsContextMenu,
+  ThreadActionsMenu,
+} from "@/components/thread/ThreadActionsMenu";
 import {
   COARSE_POINTER_DOT_SIZE_CLASS,
   COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
@@ -225,14 +228,6 @@ function ThreadLeadingStatusSlot({
   );
 }
 
-interface ThreadTrailingIconProps {
-  environmentIcon: LucideIcon | null;
-  environmentIconLabel: string | null;
-  isManager: boolean;
-}
-
-type ThreadRowContextMenuEvent = MouseEvent<HTMLElement>;
-
 function ThreadTrailingIcon({
   environmentIcon: EnvironmentIcon,
   environmentIconLabel,
@@ -261,6 +256,12 @@ function ThreadTrailingIcon({
   ) : null;
 }
 
+interface ThreadTrailingIconProps {
+  environmentIcon: LucideIcon | null;
+  environmentIconLabel: string | null;
+  isManager: boolean;
+}
+
 function ThreadRowComponent({
   projectId,
   thread,
@@ -269,7 +270,8 @@ function ThreadRowComponent({
   onProjectSelect,
   options,
 }: ThreadRowProps) {
-  const [isActionsOpen, setIsActionsOpen] = useState(false);
+  const [isDropdownActionsOpen, setIsDropdownActionsOpen] = useState(false);
+  const [isContextActionsOpen, setIsContextActionsOpen] = useState(false);
   const hasPendingInteraction = thread.hasPendingInteraction;
   const threadIsBusy = isBusyThread(thread) && !hasPendingInteraction;
   const showUnreadBadge = !hasPendingInteraction && isUnreadDoneThread(thread);
@@ -301,11 +303,7 @@ function ThreadRowComponent({
       ? "bg-sidebar-border text-sidebar-foreground"
       : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
   );
-  function handleContextMenu(event: ThreadRowContextMenuEvent) {
-    event.preventDefault();
-    event.stopPropagation();
-    setIsActionsOpen(true);
-  }
+  const isActionsOpen = isDropdownActionsOpen || isContextActionsOpen;
 
   const rowContent = (
     <>
@@ -402,12 +400,11 @@ function ThreadRowComponent({
           >
             <ThreadActionsMenu
               thread={thread}
-              open={isActionsOpen}
               triggerClassName={cn(
                 "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
                 COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
               )}
-              onOpenChange={setIsActionsOpen}
+              onOpenChange={setIsDropdownActionsOpen}
             />
           </div>
         </span>
@@ -415,22 +412,21 @@ function ThreadRowComponent({
     </>
   );
 
-  if (isManager) {
-    return (
-      <SidebarStickyTier
-        tier="manager"
-        className={rowClassName}
-        onContextMenu={handleContextMenu}
-      >
-        {rowContent}
-      </SidebarStickyTier>
-    );
-  }
+  const row = isManager ? (
+    <SidebarStickyTier tier="manager" className={rowClassName}>
+      {rowContent}
+    </SidebarStickyTier>
+  ) : (
+    <div className={rowClassName}>{rowContent}</div>
+  );
 
   return (
-    <div className={rowClassName} onContextMenu={handleContextMenu}>
-      {rowContent}
-    </div>
+    <ThreadActionsContextMenu
+      thread={thread}
+      onOpenChange={setIsContextActionsOpen}
+    >
+      {row}
+    </ThreadActionsContextMenu>
   );
 }
 

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, type MouseEvent, useState } from "react";
 import type { ThreadListEntry } from "@bb/domain";
 import {
   Pill,
@@ -231,6 +231,8 @@ interface ThreadTrailingIconProps {
   isManager: boolean;
 }
 
+type ThreadRowContextMenuEvent = MouseEvent<HTMLElement>;
+
 function ThreadTrailingIcon({
   environmentIcon: EnvironmentIcon,
   environmentIconLabel,
@@ -281,8 +283,7 @@ function ThreadRowComponent({
   const managedChildBusyCount = managerOptions?.managedChildBusyCount ?? 0;
   const isManagerBusy =
     isManager &&
-    (threadIsBusy ||
-      (isManagerCollapsed && managedChildBusyCount > 0));
+    (threadIsBusy || (isManagerCollapsed && managedChildBusyCount > 0));
   const EnvironmentIcon = getEnvironmentWorkspaceDisplayIcon(
     thread.environmentWorkspaceDisplayKind,
   );
@@ -300,6 +301,12 @@ function ThreadRowComponent({
       ? "bg-sidebar-border text-sidebar-foreground"
       : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
   );
+  function handleContextMenu(event: ThreadRowContextMenuEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsActionsOpen(true);
+  }
+
   const rowContent = (
     <>
       <NavLink
@@ -395,6 +402,7 @@ function ThreadRowComponent({
           >
             <ThreadActionsMenu
               thread={thread}
+              open={isActionsOpen}
               triggerClassName={cn(
                 "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
                 COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
@@ -409,13 +417,21 @@ function ThreadRowComponent({
 
   if (isManager) {
     return (
-      <SidebarStickyTier tier="manager" className={rowClassName}>
+      <SidebarStickyTier
+        tier="manager"
+        className={rowClassName}
+        onContextMenu={handleContextMenu}
+      >
         {rowContent}
       </SidebarStickyTier>
     );
   }
 
-  return <div className={rowClassName}>{rowContent}</div>;
+  return (
+    <div className={rowClassName} onContextMenu={handleContextMenu}>
+      {rowContent}
+    </div>
+  );
 }
 
 export const ThreadRow = memo(ThreadRowComponent);

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -26,6 +26,7 @@ interface ThreadActionsMenuProps {
   viewerToggleLabel?: string;
   viewerToggleChecked?: boolean;
   onViewerToggleCheckedChange?: (checked: boolean) => void;
+  open?: boolean;
   onOpenChange?: (open: boolean) => void;
   triggerClassName?: string;
   align?: "start" | "center" | "end";
@@ -37,6 +38,7 @@ export function ThreadActionsMenu({
   viewerToggleLabel,
   viewerToggleChecked,
   onViewerToggleCheckedChange,
+  open,
   onOpenChange,
   triggerClassName,
   align = "end",
@@ -49,7 +51,7 @@ export function ThreadActionsMenu({
   const isArchived = thread.archivedAt != null;
 
   return (
-    <DropdownMenu onOpenChange={onOpenChange}>
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           type="button"

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -151,7 +151,9 @@ function ThreadActionsMenuItems({
       <ThreadActionMenuItem
         surface={surface}
         onSelect={(event) => {
-          event.preventDefault();
+          if (surface === "dropdown") {
+            event.preventDefault();
+          }
           toggleRead(thread);
         }}
       >
@@ -170,7 +172,9 @@ function ThreadActionsMenuItems({
       <ThreadActionMenuItem
         surface={surface}
         onSelect={(event) => {
-          event.preventDefault();
+          if (surface === "dropdown") {
+            event.preventDefault();
+          }
           toggleArchive(thread);
         }}
       >
@@ -199,7 +203,9 @@ function ThreadActionsMenuItems({
               onViewerToggleCheckedChange(checked === true);
             }}
             onSelect={(event) => {
-              event.preventDefault();
+              if (surface === "dropdown") {
+                event.preventDefault();
+              }
             }}
           >
             {viewerToggleLabel}

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -1,6 +1,13 @@
 import type { Thread } from "@bb/domain";
+import type { ReactNode } from "react";
 import { MoreHorizontal } from "lucide-react";
 import {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -15,7 +22,7 @@ import { threadTypeLabel } from "@/lib/thread-title";
 import { isThreadRead } from "@/lib/thread-read-state";
 import { useThreadActions } from "./ThreadActionsProvider";
 
-interface ThreadActionsMenuProps {
+interface ThreadActionsMenuBaseProps {
   thread: Thread;
   /**
    * Pass `false` to hide the Delete entry (e.g. sidebar rows that intentionally
@@ -26,10 +33,181 @@ interface ThreadActionsMenuProps {
   viewerToggleLabel?: string;
   viewerToggleChecked?: boolean;
   onViewerToggleCheckedChange?: (checked: boolean) => void;
-  open?: boolean;
+}
+
+interface ThreadActionsMenuProps extends ThreadActionsMenuBaseProps {
   onOpenChange?: (open: boolean) => void;
   triggerClassName?: string;
   align?: "start" | "center" | "end";
+}
+
+interface ThreadActionsContextMenuProps extends ThreadActionsMenuBaseProps {
+  children: ReactNode;
+  onOpenChange?: (open: boolean) => void;
+}
+
+type ThreadActionsMenuSurface = "context" | "dropdown";
+type ThreadActionsMenuCheckedState = boolean | "indeterminate";
+
+interface ThreadActionsMenuItemsProps extends ThreadActionsMenuBaseProps {
+  surface: ThreadActionsMenuSurface;
+}
+
+interface ThreadActionMenuItemProps {
+  children: ReactNode;
+  className?: string;
+  onSelect?: (event: Event) => void;
+  surface: ThreadActionsMenuSurface;
+}
+
+interface ThreadActionMenuCheckboxItemProps {
+  checked?: ThreadActionsMenuCheckedState;
+  children: ReactNode;
+  onCheckedChange?: (checked: ThreadActionsMenuCheckedState) => void;
+  onSelect?: (event: Event) => void;
+  surface: ThreadActionsMenuSurface;
+}
+
+interface ThreadActionMenuSeparatorProps {
+  surface: ThreadActionsMenuSurface;
+}
+
+function ThreadActionMenuItem({
+  children,
+  className,
+  onSelect,
+  surface,
+}: ThreadActionMenuItemProps) {
+  if (surface === "context") {
+    return (
+      <ContextMenuItem className={className} onSelect={onSelect}>
+        {children}
+      </ContextMenuItem>
+    );
+  }
+
+  return (
+    <DropdownMenuItem className={className} onSelect={onSelect}>
+      {children}
+    </DropdownMenuItem>
+  );
+}
+
+function ThreadActionMenuCheckboxItem({
+  checked,
+  children,
+  onCheckedChange,
+  onSelect,
+  surface,
+}: ThreadActionMenuCheckboxItemProps) {
+  if (surface === "context") {
+    return (
+      <ContextMenuCheckboxItem
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        onSelect={onSelect}
+      >
+        {children}
+      </ContextMenuCheckboxItem>
+    );
+  }
+
+  return (
+    <DropdownMenuCheckboxItem
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      onSelect={onSelect}
+    >
+      {children}
+    </DropdownMenuCheckboxItem>
+  );
+}
+
+function ThreadActionMenuSeparator({
+  surface,
+}: ThreadActionMenuSeparatorProps) {
+  if (surface === "context") {
+    return <ContextMenuSeparator />;
+  }
+
+  return <DropdownMenuSeparator />;
+}
+
+function ThreadActionsMenuItems({
+  thread,
+  canDelete = true,
+  viewerToggleLabel,
+  viewerToggleChecked,
+  onViewerToggleCheckedChange,
+  surface,
+}: ThreadActionsMenuItemsProps) {
+  const { requestRename, requestDelete, toggleArchive, toggleRead } =
+    useThreadActions();
+  const isRead = isThreadRead(thread);
+  const isArchived = thread.archivedAt != null;
+
+  return (
+    <>
+      <ThreadActionMenuItem
+        surface={surface}
+        onSelect={(event) => {
+          event.preventDefault();
+          toggleRead(thread);
+        }}
+      >
+        {isRead ? "Mark as unread" : "Mark as read"}
+      </ThreadActionMenuItem>
+      <ThreadActionMenuItem
+        surface={surface}
+        onSelect={() => {
+          window.setTimeout(() => {
+            requestRename(thread);
+          }, 0);
+        }}
+      >
+        Rename
+      </ThreadActionMenuItem>
+      <ThreadActionMenuItem
+        surface={surface}
+        onSelect={(event) => {
+          event.preventDefault();
+          toggleArchive(thread);
+        }}
+      >
+        {isArchived ? "Unarchive" : "Archive"}
+      </ThreadActionMenuItem>
+      {canDelete ? (
+        <ThreadActionMenuItem
+          surface={surface}
+          className="text-destructive focus:text-destructive"
+          onSelect={() => {
+            window.setTimeout(() => {
+              requestDelete(thread);
+            }, 0);
+          }}
+        >
+          Delete
+        </ThreadActionMenuItem>
+      ) : null}
+      {viewerToggleLabel && onViewerToggleCheckedChange ? (
+        <>
+          <ThreadActionMenuSeparator surface={surface} />
+          <ThreadActionMenuCheckboxItem
+            surface={surface}
+            checked={viewerToggleChecked}
+            onCheckedChange={(checked) => {
+              onViewerToggleCheckedChange(checked === true);
+            }}
+            onSelect={(event) => {
+              event.preventDefault();
+            }}
+          >
+            {viewerToggleLabel}
+          </ThreadActionMenuCheckboxItem>
+        </>
+      ) : null}
+    </>
+  );
 }
 
 export function ThreadActionsMenu({
@@ -38,20 +216,15 @@ export function ThreadActionsMenu({
   viewerToggleLabel,
   viewerToggleChecked,
   onViewerToggleCheckedChange,
-  open,
   onOpenChange,
   triggerClassName,
   align = "end",
 }: ThreadActionsMenuProps) {
-  const { requestRename, requestDelete, toggleArchive, toggleRead } =
-    useThreadActions();
   const label = threadTypeLabel(thread.type);
   const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1);
-  const isRead = isThreadRead(thread);
-  const isArchived = thread.archivedAt != null;
 
   return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+    <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
@@ -71,60 +244,47 @@ export function ThreadActionsMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align={align} className="w-44">
-        <DropdownMenuItem
-          onSelect={(event) => {
-            event.preventDefault();
-            toggleRead(thread);
-          }}
-        >
-          {isRead ? "Mark as unread" : "Mark as read"}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={() => {
-            window.setTimeout(() => {
-              requestRename(thread);
-            }, 0);
-          }}
-        >
-          Rename
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={(event) => {
-            event.preventDefault();
-            toggleArchive(thread);
-          }}
-        >
-          {isArchived ? "Unarchive" : "Archive"}
-        </DropdownMenuItem>
-        {canDelete ? (
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            onSelect={() => {
-              window.setTimeout(() => {
-                requestDelete(thread);
-              }, 0);
-            }}
-          >
-            Delete
-          </DropdownMenuItem>
-        ) : null}
-        {viewerToggleLabel && onViewerToggleCheckedChange ? (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuCheckboxItem
-              checked={viewerToggleChecked}
-              onCheckedChange={(checked) => {
-                onViewerToggleCheckedChange(checked === true);
-              }}
-              onSelect={(event) => {
-                event.preventDefault();
-              }}
-            >
-              {viewerToggleLabel}
-            </DropdownMenuCheckboxItem>
-          </>
-        ) : null}
+        <ThreadActionsMenuItems
+          thread={thread}
+          canDelete={canDelete}
+          viewerToggleLabel={viewerToggleLabel}
+          viewerToggleChecked={viewerToggleChecked}
+          onViewerToggleCheckedChange={onViewerToggleCheckedChange}
+          surface="dropdown"
+        />
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+export function ThreadActionsContextMenu({
+  children,
+  thread,
+  canDelete = true,
+  viewerToggleLabel,
+  viewerToggleChecked,
+  onViewerToggleCheckedChange,
+  onOpenChange,
+}: ThreadActionsContextMenuProps) {
+  const label = threadTypeLabel(thread.type);
+  const capitalizedLabel = label.charAt(0).toUpperCase() + label.slice(1);
+
+  return (
+    <ContextMenu onOpenChange={onOpenChange}>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent
+        aria-label={`${capitalizedLabel} actions`}
+        className="w-44"
+      >
+        <ThreadActionsMenuItems
+          thread={thread}
+          canDelete={canDelete}
+          viewerToggleLabel={viewerToggleLabel}
+          viewerToggleChecked={viewerToggleChecked}
+          onViewerToggleCheckedChange={onViewerToggleCheckedChange}
+          surface="context"
+        />
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/apps/app/src/components/ui/context-menu.tsx
+++ b/apps/app/src/components/ui/context-menu.tsx
@@ -1,0 +1,255 @@
+/* shadcn/ui-derived */
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { COARSE_POINTER_CHECK_SLOT_CLASS } from "./coarse-pointer-sizing.js";
+
+type ContextMenuSubTriggerElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.SubTrigger
+>;
+type ContextMenuSubTriggerProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.SubTrigger
+> & {
+  inset?: boolean;
+};
+
+type ContextMenuSubContentElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.SubContent
+>;
+type ContextMenuSubContentProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.SubContent
+>;
+
+type ContextMenuContentElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.Content
+>;
+type ContextMenuContentProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.Content
+>;
+
+type ContextMenuItemElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.Item
+>;
+type ContextMenuItemProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.Item
+> & {
+  inset?: boolean;
+};
+
+type ContextMenuCheckboxItemElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.CheckboxItem
+>;
+type ContextMenuCheckboxItemProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.CheckboxItem
+>;
+
+type ContextMenuRadioItemElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.RadioItem
+>;
+type ContextMenuRadioItemProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.RadioItem
+>;
+
+type ContextMenuLabelElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.Label
+>;
+type ContextMenuLabelProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.Label
+> & {
+  inset?: boolean;
+};
+
+type ContextMenuSeparatorElement = React.ComponentRef<
+  typeof ContextMenuPrimitive.Separator
+>;
+type ContextMenuSeparatorProps = React.ComponentPropsWithoutRef<
+  typeof ContextMenuPrimitive.Separator
+>;
+
+type ContextMenuShortcutProps = React.HTMLAttributes<HTMLSpanElement>;
+
+const ContextMenu = ContextMenuPrimitive.Root;
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  ContextMenuSubTriggerElement,
+  ContextMenuSubTriggerProps
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none focus:bg-state-hover focus:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  ContextMenuSubContentElement,
+  ContextMenuSubContentProps
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = React.forwardRef<
+  ContextMenuContentElement,
+  ContextMenuContentProps
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  ContextMenuItemElement,
+  ContextMenuItemProps
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  ContextMenuCheckboxItemElement,
+  ContextMenuCheckboxItemProps
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-2 pr-8 text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span
+      className={cn(
+        "absolute right-2 flex items-center justify-center",
+        COARSE_POINTER_CHECK_SLOT_CLASS,
+      )}
+    >
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className={COARSE_POINTER_CHECK_SLOT_CLASS} />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuRadioItem = React.forwardRef<
+  ContextMenuRadioItemElement,
+  ContextMenuRadioItemProps
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-8 pr-2 text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
+const ContextMenuLabel = React.forwardRef<
+  ContextMenuLabelElement,
+  ContextMenuLabelProps
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-[0.3125rem] text-xs font-medium text-muted-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  ContextMenuSeparatorElement,
+  ContextMenuSeparatorProps
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: ContextMenuShortcutProps) {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  );
+}
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};

--- a/apps/app/src/components/ui/index.ts
+++ b/apps/app/src/components/ui/index.ts
@@ -1,8 +1,4 @@
-export {
-  Button,
-  buttonVariants,
-  type ButtonProps,
-} from "./button.js";
+export { Button, buttonVariants, type ButtonProps } from "./button.js";
 export { Input } from "./input.js";
 export { Separator } from "./separator.js";
 export { Skeleton } from "./skeleton.js";
@@ -53,6 +49,23 @@ export {
   DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
 } from "./dropdown-menu.js";
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+} from "./context-menu.js";
 export {
   Popover,
   PopoverTrigger,
@@ -160,10 +173,7 @@ export {
   type StatusPillProps,
   type StatusPillVariant,
 } from "./status-pill.js";
-export {
-  ExpandableLine,
-  type ExpandableLineProps,
-} from "./expandable-line.js";
+export { ExpandableLine, type ExpandableLineProps } from "./expandable-line.js";
 export {
   CollapsibleHeader,
   ExpandablePanel,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@radix-ui/react-compose-refs':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.16
+        version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2326,6 +2329,7 @@ packages:
   '@hono/node-ws@1.3.0':
     resolution: {integrity: sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q==}
     engines: {node: '>=18.14.1'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@hono/node-server': ^1.19.2
       hono: ^4.6.0
@@ -2582,20 +2586,24 @@ packages:
   '@mariozechner/pi-agent-core@0.70.5':
     resolution: {integrity: sha512-ZUnJ7fFeJog97KG8FewEyqaObY2sLWvfDurKHl9kImVEbgt3l1LJ9A5pb+4/5KXnCVsoF/Brd0h+7yBEd1Aj5g==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
 
   '@mariozechner/pi-ai@0.70.5':
     resolution: {integrity: sha512-eyeyOfu/YiqzY6q391oRYdmnPIIU1VTKAn3hWIvzqkRHkcArd41/YynG8mw6bgoLdmCnIBoY3fD6nzEHEHLIMA==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-ai instead going forward
     hasBin: true
 
   '@mariozechner/pi-coding-agent@0.70.5':
     resolution: {integrity: sha512-5sQjY2LQLvYfMjo4Dn6P6iy3LFm3MZYgrYmgCQSwQSUM5yqzWceidYYXS4knloW7gNkko+nnhKB2u4NF3w+dVw==}
     engines: {node: '>=20.6.0'}
+    deprecated: please use @earendil-works/pi-coding-agent instead going forward
     hasBin: true
 
   '@mariozechner/pi-tui@0.70.5':
     resolution: {integrity: sha512-5Ol9weTqpsQ85gg1C6Mo8M8o/HYz4uN7nM7QTPrw/Rm/UoFgO1/T/Irago5aGfzlIj/nmsGcqb7NlkWtT4vXUg==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-tui instead going forward
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -2830,6 +2838,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -8787,6 +8808,20 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.13
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.13)(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Summary
- Use the shared Radix/shadcn-style context-menu primitive so sidebar thread and project rows open their actions menus at the right-click pointer location.
- Keep the existing ellipsis dropdown menus intact while sharing the same menu item content/action handlers with the context menus.
- Preserve left-click navigation/selection behavior for thread and project rows.
- Dismiss right-click-opened menus on action selection, outside click, and Escape.
- Add focused coverage for default thread rows, manager thread rows, project rows, ellipsis menus, context-menu dismissal, and Escape close behavior.

## Validation
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/sidebar/ThreadRow.test.tsx src/components/sidebar/ProjectRow.test.tsx` passed: 2 files, 21 tests.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` passed.
- `pnpm exec turbo run lint --filter=@bb/app --force` passed.
