### PR TITLE
[codex] Bundle Claude Code SDK CLI support file

### DIFF
--- a/apps/host-daemon/scripts/build-bundles.mjs
+++ b/apps/host-daemon/scripts/build-bundles.mjs
@@ -1,7 +1,7 @@
-import { chmod, mkdir, stat } from "node:fs/promises";
+import { chmod, copyFile, mkdir, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 import { build } from "esbuild";
-import { bundleTargets } from "./bundle-manifest.mjs";
+import { bundleSupportFileTargets, bundleTargets } from "./bundle-manifest.mjs";
 import {
   createNativeExternalPatterns,
   generateTemplatesIfRequested,
@@ -33,6 +33,13 @@ async function main() {
     }
     const bundleStats = await stat(target.outfile);
     console.log(`${target.label}: ${bundleStats.size} bytes`);
+  }
+
+  for (const target of bundleSupportFileTargets) {
+    await mkdir(dirname(target.outfile), { recursive: true });
+    await copyFile(target.source, target.outfile);
+    const fileStats = await stat(target.outfile);
+    console.log(`${target.label}: ${fileStats.size} bytes`);
   }
 }
 

--- a/apps/host-daemon/scripts/bundle-manifest.mjs
+++ b/apps/host-daemon/scripts/bundle-manifest.mjs
@@ -1,9 +1,13 @@
 import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptsDir, "..");
 const workspaceRoot = resolve(packageRoot, "..", "..");
+const requireFromAgentRuntime = createRequire(
+  resolve(workspaceRoot, "packages", "agent-runtime", "package.json"),
+);
 
 export const NODE_ESM_REQUIRE_BANNER = [
   'import { createRequire as __createRequire } from "node:module";',
@@ -55,5 +59,21 @@ export const bundleTargets = [
     executable: true,
     label: "bb cli",
     outfile: resolve(packageRoot, "dist", "bb"),
+  },
+];
+
+function resolveClaudeAgentSdkCliPath() {
+  return resolve(
+    dirname(requireFromAgentRuntime.resolve("@anthropic-ai/claude-agent-sdk")),
+    "cli.js",
+  );
+}
+
+export const bundleSupportFileTargets = [
+  {
+    label: "claude-code cli",
+    source: resolveClaudeAgentSdkCliPath(),
+    outfile: resolve(packageRoot, "dist", "cli.js"),
+    syntaxCheck: true,
   },
 ];

--- a/apps/host-daemon/scripts/check-bundles.mjs
+++ b/apps/host-daemon/scripts/check-bundles.mjs
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { promisify } from "node:util";
-import { bundleTargets } from "./bundle-manifest.mjs";
+import { bundleSupportFileTargets, bundleTargets } from "./bundle-manifest.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -13,6 +13,15 @@ async function main() {
     const bundleStats = await stat(target.outfile);
     totalBytes += bundleStats.size;
     console.log(`${target.label}: syntax ok (${bundleStats.size} bytes)`);
+  }
+
+  for (const target of bundleSupportFileTargets) {
+    if (target.syntaxCheck) {
+      await execFileAsync("node", ["--check", target.outfile]);
+    }
+    const fileStats = await stat(target.outfile);
+    totalBytes += fileStats.size;
+    console.log(`${target.label}: present (${fileStats.size} bytes)`);
   }
 
   console.log(`total bundle size: ${totalBytes} bytes`);

--- a/turbo.json
+++ b/turbo.json
@@ -130,6 +130,10 @@
       "dependsOn": [],
       "outputs": ["dist/**"]
     },
+    "bundle:check": {
+      "dependsOn": ["bundle"],
+      "outputs": []
+    },
     "template:build": {
       "dependsOn": [],
       "cache": false,


### PR DESCRIPTION
## Summary

- Copy the `@anthropic-ai/claude-agent-sdk` `cli.js` fallback support file beside the host-daemon Claude bridge bundle.
- Extend bundle checking so the copied Claude Code CLI support file is syntax-checked and reported.
- Add Turbo wiring for `bundle:check` so the package check can be run through the repo-standard Turbo path.

## Root Cause

The bundled Claude Code bridge relocates SDK code into `apps/host-daemon/dist`, but the SDK fallback executable `cli.js` was not copied into that directory. When the SDK could not resolve a native platform package, its fallback lookup also failed, producing the reported native-binary error before review execution started.

## Validation

- `pnpm exec prettier --check apps/host-daemon/scripts/bundle-manifest.mjs apps/host-daemon/scripts/build-bundles.mjs apps/host-daemon/scripts/check-bundles.mjs turbo.json`
- `pnpm exec turbo run bundle:check --filter=@bb/host-daemon`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run test --filter=@bb/host-daemon`
- Direct bundled bridge `thread/start` repro returned a `providerThreadId` instead of the native-binary error.
