### PR TITLE
Move new chat and manager actions into sidebar

### DIFF
--- a/apps/app/src/components/dialogs/HireManagerDialog.test.tsx
+++ b/apps/app/src/components/dialogs/HireManagerDialog.test.tsx
@@ -42,6 +42,7 @@ vi.mock("partysocket/ws", async () => {
 interface InstallHireManagerRoutesArgs {
   managerThread?: Thread;
   modelResponsesByProvider?: Record<string, AvailableModel[]>;
+  projects?: ProjectResponse[];
   systemProviders?: SystemProvidersFixture;
 }
 
@@ -114,6 +115,27 @@ function makeProjectResponse(): ProjectResponse {
         isDefault: true,
         createdAt: 1,
         updatedAt: 1,
+      },
+    ],
+  };
+}
+
+function makeSecondProjectResponse(): ProjectResponse {
+  return {
+    id: "proj-2",
+    name: "Second Demo",
+    createdAt: 2,
+    updatedAt: 2,
+    sources: [
+      {
+        id: "src-2",
+        projectId: "proj-2",
+        type: "local_path",
+        hostId: "host-local",
+        path: "/tmp/second-demo",
+        isDefault: true,
+        createdAt: 2,
+        updatedAt: 2,
       },
     ],
   };
@@ -221,10 +243,11 @@ function resolveSystemProviders(
 function installHireManagerRoutes(args: InstallHireManagerRoutesArgs = {}) {
   const managerThread = args.managerThread ?? makeThread();
   const managerRequests: CreateManagerThreadRequest[] = [];
+  const managerRequestProjectIds: string[] = [];
   const requestedModelProviders: Array<string | null> = [];
   const systemProviders =
     args.systemProviders ?? createDefaultSystemProviders();
-  const projects = [makeProjectResponse()];
+  const projects = args.projects ?? [makeProjectResponse()];
   const hosts = [makeHost("host-local", "Local Host")];
 
   const routes: FetchRoute[] = [
@@ -263,15 +286,19 @@ function installHireManagerRoutes(args: InstallHireManagerRoutesArgs = {}) {
       handler: async () =>
         jsonResponse(resolveSystemProviders(systemProviders)),
     },
-    {
+  ];
+
+  for (const project of projects) {
+    routes.push({
       method: "POST",
-      pathname: "/api/v1/projects/proj-1/managers",
+      pathname: `/api/v1/projects/${project.id}/managers`,
       handler: async (request: Request) => {
+        managerRequestProjectIds.push(project.id);
         managerRequests.push(await request.json());
         return jsonResponse(managerThread);
       },
-    },
-  ];
+    });
+  }
 
   if (args.modelResponsesByProvider) {
     routes.push({
@@ -291,6 +318,7 @@ function installHireManagerRoutes(args: InstallHireManagerRoutesArgs = {}) {
 
   return {
     managerRequests,
+    managerRequestProjectIds,
     managerThread,
     requestedModelProviders,
   };
@@ -396,6 +424,73 @@ describe("HireManagerDialog", () => {
       managerThread,
     );
     expect(requestedModelProviders).toEqual(["pi"]);
+  });
+
+  it("submits the manager hire for the project selected in the dialog", async () => {
+    const piModels = [
+      makeModel("anthropic/claude-opus-4-7", {
+        displayName: "Claude Opus 4.7",
+        isDefault: true,
+      }),
+    ];
+    const managerThread = { ...makeThread(), projectId: "proj-2" };
+    const { managerRequests, managerRequestProjectIds } =
+      installHireManagerRoutes({
+        managerThread,
+        modelResponsesByProvider: {
+          pi: piModels,
+        },
+        projects: [makeProjectResponse(), makeSecondProjectResponse()],
+      });
+    const { wrapper } = createSuspenseWrapper();
+
+    await renderOpenHireManagerDialog({
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Project" }).title).toContain(
+        "Demo",
+      );
+    });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Second Demo" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Project" }).title).toContain(
+        "Second Demo",
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Host" }).title).toContain(
+        "Local Host",
+      );
+    });
+    await waitFor(() => {
+      expectProviderModelTitle(["Pi", "Claude Opus 4.7"]);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Hire Manager" }));
+
+    await waitFor(() => {
+      expect(managerRequestProjectIds).toEqual(["proj-2"]);
+      expect(managerRequests).toEqual([
+        {
+          origin: "app",
+          providerId: "pi",
+          model: "anthropic/claude-opus-4-7",
+          reasoningLevel: "medium",
+          environment: { type: "host", hostId: "host-local" },
+        },
+      ]);
+    });
   });
 
   it("keeps the visible fallback provider selected when a stale provider returns", async () => {

--- a/apps/app/src/components/dialogs/HireManagerDialog.tsx
+++ b/apps/app/src/components/dialogs/HireManagerDialog.tsx
@@ -6,13 +6,7 @@ import {
   useState,
   type FormEvent,
 } from "react";
-import type {
-  AvailableModel,
-  Host,
-  ProjectSource,
-  ReasoningLevel,
-  Thread,
-} from "@bb/domain";
+import type { AvailableModel, Host, ReasoningLevel, Thread } from "@bb/domain";
 import type { ProjectResponse, SystemProviderInfo } from "@bb/server-contract";
 import { findLocalPathProjectSourceForHost } from "@bb/domain";
 import type { HireProjectManagerRequest } from "@/hooks/mutations/project-mutations";
@@ -80,41 +74,8 @@ export function HireManagerDialog({
   const projectsQuery = useProjects();
   const projects = projectsQuery.data ?? EMPTY_PROJECTS;
   const projectsAreLoaded = projectsQuery.data !== undefined;
-  const [selectedProjectId, setSelectedProjectId] = useState(projectId);
   const { data: hosts = [] } = useEffectiveHosts();
   const { isLocalHost } = useHostDaemon();
-
-  useEffect(() => {
-    setSelectedProjectId(projectId);
-  }, [projectId]);
-
-  useEffect(() => {
-    if (!projectsAreLoaded) return;
-    if (projects.some((project) => project.id === selectedProjectId)) return;
-
-    const nextProjectId = projects.some((project) => project.id === projectId)
-      ? projectId
-      : (projects[0]?.id ?? projectId);
-    if (nextProjectId !== selectedProjectId) {
-      setSelectedProjectId(nextProjectId);
-    }
-  }, [projectId, projects, projectsAreLoaded, selectedProjectId]);
-
-  const selectedProject = useMemo(
-    () => projects.find((project) => project.id === selectedProjectId) ?? null,
-    [projects, selectedProjectId],
-  );
-
-  const projectOptions = useMemo(
-    (): readonly PickerOption<string>[] =>
-      projects.map((project) => ({
-        value: project.id,
-        label: project.name,
-      })),
-    [projects],
-  );
-
-  const projectSources = selectedProject?.sources ?? [];
 
   const resolvedProvider = useMemo(() => {
     if (selectedProviderId) {
@@ -151,10 +112,10 @@ export function HireManagerDialog({
     >
       <DialogContent className="max-w-[34rem] gap-0 overflow-hidden border-border/80 bg-background p-0 shadow-xl">
         <HireManagerDialogContent
-          projectId={selectedProjectId}
-          projectOptions={projectOptions}
+          key={projectId}
+          initialProjectId={projectId}
+          projects={projects}
           projectsAreLoaded={projectsAreLoaded}
-          projectSources={projectSources}
           providers={providers}
           providersAreLoaded={providersAreLoaded}
           hosts={hosts}
@@ -162,7 +123,6 @@ export function HireManagerDialog({
           models={models}
           selectedProviderId={selectedProviderId}
           onSelectedProviderIdChange={setSelectedProviderId}
-          onProjectIdChange={setSelectedProjectId}
           onHire={handleHire}
         />
       </DialogContent>
@@ -171,10 +131,9 @@ export function HireManagerDialog({
 }
 
 export interface HireManagerDialogContentProps {
-  projectId: string;
-  projectOptions: readonly PickerOption<string>[];
+  initialProjectId: string;
+  projects: readonly ProjectResponse[];
   projectsAreLoaded: boolean;
-  projectSources: readonly ProjectSource[];
   providers: readonly SystemProviderInfo[];
   providersAreLoaded: boolean;
   hosts: Host[];
@@ -182,15 +141,13 @@ export interface HireManagerDialogContentProps {
   models: readonly AvailableModel[];
   selectedProviderId: string;
   onSelectedProviderIdChange: (providerId: string) => void;
-  onProjectIdChange: (projectId: string) => void;
   onHire: (params: HireProjectManagerRequest) => Promise<void>;
 }
 
 export function HireManagerDialogContent({
-  projectId,
-  projectOptions,
+  initialProjectId,
+  projects,
   projectsAreLoaded,
-  projectSources,
   providers,
   providersAreLoaded,
   hosts,
@@ -198,11 +155,11 @@ export function HireManagerDialogContent({
   models,
   selectedProviderId,
   onSelectedProviderIdChange,
-  onProjectIdChange,
   onHire,
 }: HireManagerDialogContentProps) {
   const nameInputId = useId();
 
+  const [selectedProjectId, setSelectedProjectId] = useState(initialProjectId);
   const [managerName, setManagerName] = useState("");
   const [selectedModel, setSelectedModel] = useState<string>("");
   const [selectedReasoningLevel, setSelectedReasoningLevel] = useState<
@@ -231,6 +188,32 @@ export function HireManagerDialogContent({
   const unavailableProjectMessage = projectsAreLoaded
     ? "No projects available"
     : "Loading projects…";
+
+  const effectiveProjectId = useMemo(() => {
+    if (projects.some((project) => project.id === selectedProjectId)) {
+      return selectedProjectId;
+    }
+    if (projects.some((project) => project.id === initialProjectId)) {
+      return initialProjectId;
+    }
+    return projects[0]?.id ?? initialProjectId;
+  }, [initialProjectId, projects, selectedProjectId]);
+
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === effectiveProjectId) ?? null,
+    [effectiveProjectId, projects],
+  );
+
+  const projectOptions = useMemo(
+    (): readonly PickerOption<string>[] =>
+      projects.map((project) => ({
+        value: project.id,
+        label: project.name,
+      })),
+    [projects],
+  );
+
+  const projectSources = selectedProject?.sources ?? [];
 
   const selectedModelData = useMemo(
     () => models.find((m) => m.model === selectedModel),
@@ -355,13 +338,10 @@ export function HireManagerDialogContent({
     [onSelectedProviderIdChange],
   );
 
-  const handleProjectChange = useCallback(
-    (value: string) => {
-      onProjectIdChange(value);
-      setError(null);
-    },
-    [onProjectIdChange],
-  );
+  const handleProjectChange = useCallback((value: string) => {
+    setSelectedProjectId(value);
+    setError(null);
+  }, []);
 
   const handleModelChange = useCallback((model: string) => {
     setSelectedModel(model);
@@ -381,7 +361,7 @@ export function HireManagerDialogContent({
   const handleHire = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      if (!projectId || isPending) return;
+      if (!effectiveProjectId || isPending) return;
       if (!selectedProvider) {
         setError("A provider is required");
         return;
@@ -399,7 +379,7 @@ export function HireManagerDialogContent({
       try {
         const trimmedManagerName = managerName.trim();
         await onHire({
-          projectId,
+          projectId: effectiveProjectId,
           ...(trimmedManagerName ? { name: trimmedManagerName } : {}),
           providerId: selectedProvider.id,
           model: selectedModel,
@@ -421,10 +401,10 @@ export function HireManagerDialogContent({
     },
     [
       effectiveReasoningLevel,
+      effectiveProjectId,
       isPending,
       managerName,
       onHire,
-      projectId,
       selectedHostId,
       selectedModel,
       selectedProvider,
@@ -445,7 +425,7 @@ export function HireManagerDialogContent({
             {projectOptions.length > 0 ? (
               <OptionPicker
                 label="Project"
-                value={projectId}
+                value={effectiveProjectId}
                 options={projectOptions}
                 onChange={handleProjectChange}
               />

--- a/apps/app/src/components/dialogs/HireManagerDialog.tsx
+++ b/apps/app/src/components/dialogs/HireManagerDialog.tsx
@@ -13,7 +13,7 @@ import type {
   ReasoningLevel,
   Thread,
 } from "@bb/domain";
-import type { SystemProviderInfo } from "@bb/server-contract";
+import type { ProjectResponse, SystemProviderInfo } from "@bb/server-contract";
 import { findLocalPathProjectSourceForHost } from "@bb/domain";
 import type { HireProjectManagerRequest } from "@/hooks/mutations/project-mutations";
 import { DetailCard, DetailRow } from "@/components/ui";
@@ -53,6 +53,7 @@ const REASONING_LABELS: Record<ReasoningLevel, string> = {
   xhigh: "Extra High",
 };
 const EMPTY_SYSTEM_PROVIDERS: SystemProviderInfo[] = [];
+const EMPTY_PROJECTS: ProjectResponse[] = [];
 type ReasoningSelectionSource = "default" | "user";
 
 type IsLocalHostFn = (id: string | null | undefined) => boolean;
@@ -76,14 +77,44 @@ export function HireManagerDialog({
   const providers = providersQuery.data ?? EMPTY_SYSTEM_PROVIDERS;
   const providersAreLoaded = providersQuery.data !== undefined;
 
-  const { data: projects } = useProjects();
+  const projectsQuery = useProjects();
+  const projects = projectsQuery.data ?? EMPTY_PROJECTS;
+  const projectsAreLoaded = projectsQuery.data !== undefined;
+  const [selectedProjectId, setSelectedProjectId] = useState(projectId);
   const { data: hosts = [] } = useEffectiveHosts();
   const { isLocalHost } = useHostDaemon();
 
-  const projectSources = useMemo(() => {
-    const project = projects?.find((p) => p.id === projectId);
-    return project?.sources ?? [];
-  }, [projects, projectId]);
+  useEffect(() => {
+    setSelectedProjectId(projectId);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!projectsAreLoaded) return;
+    if (projects.some((project) => project.id === selectedProjectId)) return;
+
+    const nextProjectId = projects.some((project) => project.id === projectId)
+      ? projectId
+      : (projects[0]?.id ?? projectId);
+    if (nextProjectId !== selectedProjectId) {
+      setSelectedProjectId(nextProjectId);
+    }
+  }, [projectId, projects, projectsAreLoaded, selectedProjectId]);
+
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
+  );
+
+  const projectOptions = useMemo(
+    (): readonly PickerOption<string>[] =>
+      projects.map((project) => ({
+        value: project.id,
+        label: project.name,
+      })),
+    [projects],
+  );
+
+  const projectSources = selectedProject?.sources ?? [];
 
   const resolvedProvider = useMemo(() => {
     if (selectedProviderId) {
@@ -120,7 +151,9 @@ export function HireManagerDialog({
     >
       <DialogContent className="max-w-[34rem] gap-0 overflow-hidden border-border/80 bg-background p-0 shadow-xl">
         <HireManagerDialogContent
-          projectId={projectId}
+          projectId={selectedProjectId}
+          projectOptions={projectOptions}
+          projectsAreLoaded={projectsAreLoaded}
           projectSources={projectSources}
           providers={providers}
           providersAreLoaded={providersAreLoaded}
@@ -129,6 +162,7 @@ export function HireManagerDialog({
           models={models}
           selectedProviderId={selectedProviderId}
           onSelectedProviderIdChange={setSelectedProviderId}
+          onProjectIdChange={setSelectedProjectId}
           onHire={handleHire}
         />
       </DialogContent>
@@ -138,6 +172,8 @@ export function HireManagerDialog({
 
 export interface HireManagerDialogContentProps {
   projectId: string;
+  projectOptions: readonly PickerOption<string>[];
+  projectsAreLoaded: boolean;
   projectSources: readonly ProjectSource[];
   providers: readonly SystemProviderInfo[];
   providersAreLoaded: boolean;
@@ -146,11 +182,14 @@ export interface HireManagerDialogContentProps {
   models: readonly AvailableModel[];
   selectedProviderId: string;
   onSelectedProviderIdChange: (providerId: string) => void;
+  onProjectIdChange: (projectId: string) => void;
   onHire: (params: HireProjectManagerRequest) => Promise<void>;
 }
 
 export function HireManagerDialogContent({
   projectId,
+  projectOptions,
+  projectsAreLoaded,
   projectSources,
   providers,
   providersAreLoaded,
@@ -159,6 +198,7 @@ export function HireManagerDialogContent({
   models,
   selectedProviderId,
   onSelectedProviderIdChange,
+  onProjectIdChange,
   onHire,
 }: HireManagerDialogContentProps) {
   const nameInputId = useId();
@@ -188,6 +228,9 @@ export function HireManagerDialogContent({
   const unavailableProviderMessage = providersAreLoaded
     ? "No providers available"
     : "Loading providers…";
+  const unavailableProjectMessage = projectsAreLoaded
+    ? "No projects available"
+    : "Loading projects…";
 
   const selectedModelData = useMemo(
     () => models.find((m) => m.model === selectedModel),
@@ -292,10 +335,13 @@ export function HireManagerDialogContent({
   );
 
   useEffect(() => {
-    if (
-      eligibleHosts.length > 0 &&
-      !eligibleHosts.some((h) => h.id === selectedHostId)
-    ) {
+    if (eligibleHosts.length === 0) {
+      if (selectedHostId) {
+        setSelectedHostId("");
+      }
+      return;
+    }
+    if (!eligibleHosts.some((h) => h.id === selectedHostId)) {
       const local = eligibleHosts.find((h) => isLocalHost(h.id));
       setSelectedHostId(local?.id ?? eligibleHosts[0]!.id);
     }
@@ -307,6 +353,14 @@ export function HireManagerDialogContent({
       setError(null);
     },
     [onSelectedProviderIdChange],
+  );
+
+  const handleProjectChange = useCallback(
+    (value: string) => {
+      onProjectIdChange(value);
+      setError(null);
+    },
+    [onProjectIdChange],
   );
 
   const handleModelChange = useCallback((model: string) => {
@@ -387,6 +441,20 @@ export function HireManagerDialogContent({
       </DialogHeader>
       <form className="space-y-5 px-6 pb-5" onSubmit={handleHire}>
         <DetailCard className="border-border/70 bg-muted/20" labelWidth="60px">
+          <DetailRow label="Project" valueClassName="min-w-0">
+            {projectOptions.length > 0 ? (
+              <OptionPicker
+                label="Project"
+                value={projectId}
+                options={projectOptions}
+                onChange={handleProjectChange}
+              />
+            ) : (
+              <span className="text-sm text-muted-foreground">
+                {unavailableProjectMessage}
+              </span>
+            )}
+          </DetailRow>
           <DetailRow label="Name" valueClassName="min-w-0">
             <Input
               id={nameInputId}

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -1,15 +1,16 @@
 import { Fragment, type CSSProperties, type Ref, type ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useIsMutating } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Archive, ChevronRight, Settings, UserRoundPlus } from "lucide-react";
+import { Archive, ChevronRight, Settings } from "lucide-react";
 import type { Thread } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { AppPageHeader, HEADER_ICON_BUTTON_CLASS } from "./AppPageHeader";
-import { useHireProjectManager } from "@/hooks/mutations/project-mutations";
+import { HIRE_PROJECT_MANAGER_MUTATION_KEY } from "@/hooks/mutations/project-mutations";
 import { useProjects } from "@/hooks/queries/project-queries";
 import { useThread } from "@/hooks/queries/thread-queries";
 import { useAppRoute } from "@/hooks/useAppRoute";
@@ -106,11 +107,8 @@ const routeTitles: Record<string, { title: string; subtitle?: string }> = {
 
 interface AppHeaderProps {
   isProjectMainView: boolean;
-  projectName?: string;
   projectId?: string;
   project?: ProjectResponse;
-  isManagerActionPending?: boolean;
-  onOpenManager?: () => void;
   meta: {
     title: string;
     subtitle?: string;
@@ -120,11 +118,8 @@ interface AppHeaderProps {
 
 function AppHeader({
   isProjectMainView,
-  projectName,
   projectId,
   project,
-  isManagerActionPending = false,
-  onOpenManager,
   meta,
 }: AppHeaderProps) {
   const showProjectMenuButton = isProjectMainView && !!project;
@@ -191,19 +186,6 @@ function AppHeader({
   const actions =
     isProjectMainView && projectId ? (
       <>
-        <button
-          type="button"
-          className={cn(
-            HEADER_ICON_BUTTON_CLASS,
-            "inline-flex items-center justify-center text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60",
-          )}
-          aria-label="Hire manager"
-          title="Hire manager"
-          disabled={!projectId || isManagerActionPending}
-          onClick={() => onOpenManager?.()}
-        >
-          <UserRoundPlus />
-        </button>
         <Link
           to={`/projects/${projectId}/settings`}
           className={cn(
@@ -253,7 +235,9 @@ export function AppLayout({ children }: AppLayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { data: projects, isLoading: projectsLoading } = useProjects();
-  const hireProjectManager = useHireProjectManager();
+  const activeHireManagerRequests = useIsMutating({
+    mutationKey: HIRE_PROJECT_MANAGER_MUTATION_KEY,
+  });
   const hireManagerDialog = useDialogState<string>();
   const [sidebarWidth, setSidebarWidth] = useAtom(sidebarWidthAtom);
   const [isSidebarResizing, setIsSidebarResizing] = useState(false);
@@ -417,6 +401,8 @@ export function AppLayout({ children }: AppLayoutProps) {
     if (typeof document === "undefined") return;
     document.title = documentTitle;
   }, [documentTitle]);
+  const isManagerActionPending =
+    activeHireManagerRequests > 0 || hireManagerDialog.isOpen;
 
   return (
     <ProjectActionsProvider>
@@ -432,6 +418,12 @@ export function AppLayout({ children }: AppLayoutProps) {
           <AppSidebar
             onResizeMouseDown={handleResizeMouseDown}
             isResizing={isSidebarResizing}
+            selectedProjectId={projectId}
+            isManagerActionPending={isManagerActionPending}
+            onNewManager={(targetProjectId) => {
+              if (isManagerActionPending) return;
+              hireManagerDialog.onOpen(targetProjectId);
+            }}
           />
           <SidebarInset>
             <div className="relative flex h-[100dvh] min-w-0 w-full flex-col">
@@ -443,16 +435,8 @@ export function AppLayout({ children }: AppLayoutProps) {
               {showHeader ? (
                 <AppHeader
                   isProjectMainView={isProjectMainView}
-                  projectName={projectLabel}
                   projectId={projectId}
                   project={project}
-                  isManagerActionPending={
-                    hireProjectManager.isPending || hireManagerDialog.isOpen
-                  }
-                  onOpenManager={() => {
-                    if (!projectId || hireManagerDialog.isOpen) return;
-                    hireManagerDialog.onOpen(projectId);
-                  }}
                   meta={meta}
                 />
               ) : null}

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Settings } from "lucide-react";
 import {
   Sidebar,
@@ -18,11 +18,20 @@ import { useQuickCreateProjectController } from "@/hooks/useQuickCreateProject";
 interface AppSidebarProps {
   onResizeMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
   isResizing: boolean;
+  selectedProjectId?: string;
+  isManagerActionPending?: boolean;
+  onNewManager?: (projectId: string) => void;
 }
 
-export function AppSidebar({ onResizeMouseDown, isResizing }: AppSidebarProps) {
+export function AppSidebar({
+  onResizeMouseDown,
+  isResizing,
+  selectedProjectId,
+  isManagerActionPending = false,
+  onNewManager,
+}: AppSidebarProps) {
   const quickCreateProject = useQuickCreateProjectController();
-  const location = useLocation();
+  const navigate = useNavigate();
   const { isCompactViewport, setOpenMobile } = useSidebar();
   const isCompactViewportRef = useRef(isCompactViewport);
   // Keep the ProjectList callback stable while reading the latest breakpoint.
@@ -34,16 +43,32 @@ export function AppSidebar({ onResizeMouseDown, isResizing }: AppSidebarProps) {
     }
   }, [setOpenMobile]);
 
-  const selectedProjectId = useMemo(
-    () => location.pathname.match(/^\/projects\/([^/]+)/)?.[1],
-    [location.pathname],
+  const handleNewChat = useCallback(() => {
+    if (!selectedProjectId) return;
+    closeOnMobile();
+    void navigate(`/projects/${selectedProjectId}`);
+  }, [closeOnMobile, navigate, selectedProjectId]);
+
+  const handleNewManager = useCallback(
+    (managerProjectId: string) => {
+      if (!onNewManager) return;
+      closeOnMobile();
+      onNewManager(managerProjectId);
+    },
+    [closeOnMobile, onNewManager],
   );
+
+  const newChatAction = selectedProjectId ? handleNewChat : undefined;
+  const newManagerAction =
+    selectedProjectId && onNewManager ? handleNewManager : undefined;
 
   return (
     <>
       <Sidebar>
         <SidebarContent>
           <ProjectList
+            onNewChat={newChatAction}
+            onNewManager={newManagerAction}
             onNewProject={
               quickCreateProject.isAvailable
                 ? quickCreateProject.openCreateDialog
@@ -52,6 +77,7 @@ export function AppSidebar({ onResizeMouseDown, isResizing }: AppSidebarProps) {
             onProjectSelect={closeOnMobile}
             selectedProjectId={selectedProjectId}
             isCreatingProject={quickCreateProject.isCreating}
+            isManagerActionPending={isManagerActionPending}
           />
         </SidebarContent>
         <SidebarFooter>

--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -162,6 +162,10 @@ describe("ProjectList", () => {
       screen.queryByRole("button", { name: "Manager project" }),
     ).toBeNull();
     expect(newManagerButton.hasAttribute("disabled")).toBe(false);
+    expect(newManagerButton.closest("[data-sidebar-sticky-stack]")).toBeNull();
+    expect(
+      projectHeading.closest("[data-sidebar-sticky-stack]"),
+    ).not.toBeNull();
 
     expect(
       newChatButton.compareDocumentPosition(newManagerButton) &

--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -163,9 +163,13 @@ describe("ProjectList", () => {
     ).toBeNull();
     expect(newManagerButton.hasAttribute("disabled")).toBe(false);
     expect(newManagerButton.closest("[data-sidebar-sticky-stack]")).toBeNull();
+    const projectStickyStack = projectHeading.closest(
+      "[data-sidebar-sticky-stack]",
+    );
+    expect(projectStickyStack).not.toBeNull();
     expect(
-      projectHeading.closest("[data-sidebar-sticky-stack]"),
-    ).not.toBeNull();
+      projectStickyStack?.getAttribute("data-sidebar-sticky-density"),
+    ).toBe("compact-actions");
 
     expect(
       newChatButton.compareDocumentPosition(newManagerButton) &

--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 
 import { Suspense, type ReactNode } from "react";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import type { QueryClient } from "@tanstack/react-query";
 import type { ProjectResponse } from "@bb/server-contract";
@@ -71,12 +78,27 @@ function createProjectListWrapper() {
   };
 }
 
-async function renderProjectList(): Promise<ProjectListRenderResult> {
+interface RenderProjectListArgs {
+  onNewChat?: () => void;
+  onNewManager?: (projectId: string) => void;
+  selectedProjectId?: string;
+}
+
+async function renderProjectList(
+  args: RenderProjectListArgs = {},
+): Promise<ProjectListRenderResult> {
   const { queryClient, wrapper } = createProjectListWrapper();
   let container: HTMLElement | null = null;
 
   await act(async () => {
-    const result = render(<ProjectList />, { wrapper });
+    const result = render(
+      <ProjectList
+        onNewChat={args.onNewChat}
+        onNewManager={args.onNewManager}
+        selectedProjectId={args.selectedProjectId}
+      />,
+      { wrapper },
+    );
     container = result.container;
   });
 
@@ -96,6 +118,67 @@ afterEach(() => {
 });
 
 describe("ProjectList", () => {
+  it("renders new chat and manager actions above the projects heading", async () => {
+    installFetchRoutes([
+      {
+        pathname: "/api/v1/projects",
+        handler: () => jsonResponse([makeProjectResponse()]),
+      },
+      {
+        pathname: "/api/v1/threads",
+        handler: () => jsonResponse([]),
+      },
+      {
+        pathname: "/api/v1/system/config",
+        handler: () =>
+          jsonResponse({
+            githubConnected: false,
+            hostDaemonPort: null,
+            sandboxHostSupported: false,
+            voiceTranscriptionEnabled: false,
+          }),
+      },
+      {
+        pathname: "/api/v1/hosts",
+        handler: () => jsonResponse([]),
+      },
+    ]);
+    const onNewChat = vi.fn();
+    const onNewManager = vi.fn<(projectId: string) => void>();
+
+    await renderProjectList({
+      onNewChat,
+      onNewManager,
+      selectedProjectId: "project-1",
+    });
+
+    const newChatButton = screen.getByRole("button", { name: "New Chat" });
+    const newManagerButton = screen.getByRole("button", {
+      name: "New Manager",
+    });
+    const projectHeading = screen.getByText("Projects");
+
+    expect(
+      screen.queryByRole("button", { name: "Manager project" }),
+    ).toBeNull();
+    expect(newManagerButton.hasAttribute("disabled")).toBe(false);
+
+    expect(
+      newChatButton.compareDocumentPosition(newManagerButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      newManagerButton.compareDocumentPosition(projectHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.click(newChatButton);
+    fireEvent.click(newManagerButton);
+
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+    expect(onNewManager).toHaveBeenCalledWith("project-1");
+  });
+
   it("renders the sticky project heading without a sidebar overflow fade", async () => {
     installFetchRoutes([
       {

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -203,7 +203,7 @@ function ProjectListActionButtons({
         : "New Manager";
 
   return (
-    <div className="space-y-0.5 pb-1 group-data-[collapsible=icon]:hidden">
+    <div className="space-y-0.5">
       <Button
         type="button"
         size="sm"
@@ -432,92 +432,96 @@ function ProjectListComponent({
   );
 
   return (
-    <SidebarStickyStack>
-      <ProjectListActionButtons
-        onNewChat={onNewChat}
-        onNewManager={onNewManager}
-        selectedProjectId={selectedProjectId}
-        isManagerActionPending={isManagerActionPending}
-      />
-      <SidebarStickyTier tier="label" className="justify-between pr-1">
-        Projects
-        {onNewProject ? (
-          <button
-            type="button"
-            onClick={onNewProject}
-            disabled={isCreatingProject}
-            title={isCreatingProject ? "Creating project..." : "Add project"}
-            aria-label="Add project"
-            className={cn(
-              "inline-flex items-center justify-center rounded text-sidebar-foreground/50 transition-colors hover:text-sidebar-foreground disabled:opacity-50",
-              COARSE_POINTER_ADD_PROJECT_BUTTON_SIZE_CLASS,
-            )}
-          >
-            <Plus className={COARSE_POINTER_ICON_SIZE_CLASS} />
-          </button>
-        ) : null}
-      </SidebarStickyTier>
-      <SidebarGroupContent>
-        <SidebarMenu className="gap-1">
-          {projectsState.status === "loading" ? (
-            <>
-              <SidebarMenuSkeleton />
-              <SidebarMenuSkeleton />
-            </>
-          ) : projects && projects.length > 0 ? (
-            projects.map((project) => {
-              const threadState = threadStatesByProjectId.get(project.id);
-              const threadListState = getProjectThreadListState({
-                status: threadState?.status,
-                threads: threadsByProject.get(project.id),
-              });
-              const localSourcePath = localSourcePathsByProjectId.get(
-                project.id,
-              );
-              const isLocalPathInvalid = isLocalPathMissing(
-                pathExistence,
-                localSourcePath,
-              );
-              return (
-                <ProjectRow
-                  key={project.id}
-                  project={project}
-                  threadListState={threadListState}
-                  selectedThreadId={selectedThreadId}
-                  isActive={
-                    selectedProjectId === project.id && !selectedThreadId
+    <>
+      <div className="px-2 pt-2 pb-1 group-data-[collapsible=icon]:hidden">
+        <ProjectListActionButtons
+          onNewChat={onNewChat}
+          onNewManager={onNewManager}
+          selectedProjectId={selectedProjectId}
+          isManagerActionPending={isManagerActionPending}
+        />
+      </div>
+      <SidebarStickyStack>
+        <SidebarStickyTier tier="label" className="justify-between pr-1">
+          Projects
+          {onNewProject ? (
+            <button
+              type="button"
+              onClick={onNewProject}
+              disabled={isCreatingProject}
+              title={isCreatingProject ? "Creating project..." : "Add project"}
+              aria-label="Add project"
+              className={cn(
+                "inline-flex items-center justify-center rounded text-sidebar-foreground/50 transition-colors hover:text-sidebar-foreground disabled:opacity-50",
+                COARSE_POINTER_ADD_PROJECT_BUTTON_SIZE_CLASS,
+              )}
+            >
+              <Plus className={COARSE_POINTER_ICON_SIZE_CLASS} />
+            </button>
+          ) : null}
+        </SidebarStickyTier>
+        <SidebarGroupContent>
+          <SidebarMenu className="gap-1">
+            {projectsState.status === "loading" ? (
+              <>
+                <SidebarMenuSkeleton />
+                <SidebarMenuSkeleton />
+              </>
+            ) : projects && projects.length > 0 ? (
+              projects.map((project) => {
+                const threadState = threadStatesByProjectId.get(project.id);
+                const threadListState = getProjectThreadListState({
+                  status: threadState?.status,
+                  threads: threadsByProject.get(project.id),
+                });
+                const localSourcePath = localSourcePathsByProjectId.get(
+                  project.id,
+                );
+                const isLocalPathInvalid = isLocalPathMissing(
+                  pathExistence,
+                  localSourcePath,
+                );
+                return (
+                  <ProjectRow
+                    key={project.id}
+                    project={project}
+                    threadListState={threadListState}
+                    selectedThreadId={selectedThreadId}
+                    isActive={
+                      selectedProjectId === project.id && !selectedThreadId
+                    }
+                    isCollapsed={collapsedProjectIds.has(project.id)}
+                    collapsedManagerIds={collapsedManagerIds}
+                    isLocalPathInvalid={isLocalPathInvalid}
+                    localHostId={localHostId}
+                    onProjectSelect={onProjectSelect}
+                    onToggleProjectCollapsed={toggleProjectCollapsed}
+                    onToggleManagerCollapsed={toggleManagerCollapsed}
+                    promotedBranchName={
+                      promotedBranchNamesByProjectId.get(project.id) ?? null
+                    }
+                  />
+                );
+              })
+            ) : (
+              <SidebarMenuItem>
+                <EmptyState
+                  message={
+                    projectsState.status === "unavailable"
+                      ? "Projects unavailable"
+                      : "No projects"
                   }
-                  isCollapsed={collapsedProjectIds.has(project.id)}
-                  collapsedManagerIds={collapsedManagerIds}
-                  isLocalPathInvalid={isLocalPathInvalid}
-                  localHostId={localHostId}
-                  onProjectSelect={onProjectSelect}
-                  onToggleProjectCollapsed={toggleProjectCollapsed}
-                  onToggleManagerCollapsed={toggleManagerCollapsed}
-                  promotedBranchName={
-                    promotedBranchNamesByProjectId.get(project.id) ?? null
-                  }
+                  icon={Folder}
+                  className="px-2 py-1.5"
+                  iconClassName="size-3.5"
+                  messageClassName="text-xs"
                 />
-              );
-            })
-          ) : (
-            <SidebarMenuItem>
-              <EmptyState
-                message={
-                  projectsState.status === "unavailable"
-                    ? "Projects unavailable"
-                    : "No projects"
-                }
-                icon={Folder}
-                className="px-2 py-1.5"
-                iconClassName="size-3.5"
-                messageClassName="text-xs"
-              />
-            </SidebarMenuItem>
-          )}
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarStickyStack>
+              </SidebarMenuItem>
+            )}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarStickyStack>
+    </>
   );
 }
 

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -10,7 +10,7 @@ import {
   type ThreadListEntry,
 } from "@bb/domain";
 import type { ProjectSourceWorkspaceStatusResponse } from "@bb/server-contract";
-import { Folder, Plus } from "lucide-react";
+import { Folder, MessageSquarePlus, Plus, UserRoundPlus } from "lucide-react";
 import { useLocation } from "react-router-dom";
 import {
   getConnectionAwareQueryState,
@@ -33,7 +33,7 @@ import { useServerConnectionState } from "@/hooks/useServerConnectionState";
 import type { WebSocketConnectionState } from "@/lib/ws";
 import * as api from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { EmptyState } from "@/components/ui";
+import { Button, EmptyState } from "@/components/ui";
 import {
   SidebarGroupContent,
   SidebarMenu,
@@ -45,6 +45,8 @@ import {
 import {
   COARSE_POINTER_ADD_PROJECT_BUTTON_SIZE_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
+  COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+  COARSE_POINTER_ROW_HEIGHT_CLASS,
 } from "@/components/ui";
 import { ProjectRow } from "./ProjectRow";
 import type { ProjectThreadListState } from "./ProjectRow";
@@ -52,12 +54,27 @@ import {
   collapsedManagerIdsAtom,
   collapsedProjectIdsAtom,
 } from "./sidebarCollapsedAtoms";
+import {
+  SIDEBAR_ROW_BASE_CLASS,
+  SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
+} from "./sidebarRowClasses";
 
 interface ProjectListProps {
+  onNewChat?: () => void;
+  onNewManager?: (projectId: string) => void;
   onNewProject?: () => void;
   onProjectSelect?: () => void;
   selectedProjectId?: string;
   isCreatingProject?: boolean;
+  isManagerActionPending?: boolean;
+}
+
+interface ProjectListActionButtonsProps {
+  onNewChat?: () => void;
+  onNewManager?: (projectId: string) => void;
+  selectedProjectId?: string;
+  isManagerActionPending: boolean;
 }
 
 interface ProjectSourceStatusTarget {
@@ -93,6 +110,19 @@ interface BuildProjectThreadQueryAggregationArgs {
   serverConnectionState: WebSocketConnectionState;
   connectionGracePeriodElapsed: boolean;
 }
+
+const PROJECT_LIST_ACTION_BUTTON_CLASS = cn(
+  SIDEBAR_ROW_BASE_CLASS,
+  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
+  SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+  COARSE_POINTER_ROW_HEIGHT_CLASS,
+  "min-w-0 justify-start overflow-hidden font-normal ring-sidebar-ring focus-visible:ring-2 max-md:pointer-coarse:[&_svg]:size-5",
+);
+
+const PROJECT_LIST_ACTION_TRAILING_SLOT_CLASS = cn(
+  "inline-flex shrink-0 items-center justify-center",
+  COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+);
 
 interface ProjectThreadListStateArgs {
   status: ConnectionAwareQueryStatus | undefined;
@@ -153,11 +183,74 @@ function getProjectThreadListState({
   }
 }
 
+function ProjectListActionButtons({
+  onNewChat,
+  onNewManager,
+  selectedProjectId,
+  isManagerActionPending,
+}: ProjectListActionButtonsProps) {
+  const isNewChatDisabled = !onNewChat;
+  const isNewManagerDisabled =
+    !onNewManager || !selectedProjectId || isManagerActionPending;
+  const newChatTitle = isNewChatDisabled
+    ? "Select a project to start a new chat"
+    : "New Chat";
+  const newManagerTitle =
+    !onNewManager || !selectedProjectId
+      ? "Select a project to hire a new manager"
+      : isManagerActionPending
+        ? "Hiring manager..."
+        : "New Manager";
+
+  return (
+    <div className="space-y-0.5 pb-1 group-data-[collapsible=icon]:hidden">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className={PROJECT_LIST_ACTION_BUTTON_CLASS}
+        onClick={onNewChat}
+        disabled={isNewChatDisabled}
+        title={newChatTitle}
+      >
+        <MessageSquarePlus />
+        <span className="min-w-0 flex-1 truncate text-left">New Chat</span>
+        <span
+          className={PROJECT_LIST_ACTION_TRAILING_SLOT_CLASS}
+          aria-hidden="true"
+        />
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className={PROJECT_LIST_ACTION_BUTTON_CLASS}
+        onClick={() => {
+          if (!selectedProjectId) return;
+          onNewManager?.(selectedProjectId);
+        }}
+        disabled={isNewManagerDisabled}
+        title={newManagerTitle}
+      >
+        <UserRoundPlus />
+        <span className="min-w-0 flex-1 truncate text-left">New Manager</span>
+        <span
+          className={PROJECT_LIST_ACTION_TRAILING_SLOT_CLASS}
+          aria-hidden="true"
+        />
+      </Button>
+    </div>
+  );
+}
+
 function ProjectListComponent({
+  onNewChat,
+  onNewManager,
   onNewProject,
   onProjectSelect,
   selectedProjectId,
   isCreatingProject = false,
+  isManagerActionPending = false,
 }: ProjectListProps) {
   const projectsQuery = useProjects();
   const {
@@ -340,6 +433,12 @@ function ProjectListComponent({
 
   return (
     <SidebarStickyStack>
+      <ProjectListActionButtons
+        onNewChat={onNewChat}
+        onNewManager={onNewManager}
+        selectedProjectId={selectedProjectId}
+        isManagerActionPending={isManagerActionPending}
+      />
       <SidebarStickyTier tier="label" className="justify-between pr-1">
         Projects
         {onNewProject ? (

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -433,7 +433,7 @@ function ProjectListComponent({
 
   return (
     <>
-      <div className="px-2 pt-2 pb-1 group-data-[collapsible=icon]:hidden">
+      <div className="px-2 pt-2 group-data-[collapsible=icon]:hidden">
         <ProjectListActionButtons
           onNewChat={onNewChat}
           onNewManager={onNewManager}
@@ -441,7 +441,7 @@ function ProjectListComponent({
           isManagerActionPending={isManagerActionPending}
         />
       </div>
-      <SidebarStickyStack>
+      <SidebarStickyStack data-sidebar-sticky-density="compact-actions">
         <SidebarStickyTier tier="label" className="justify-between pr-1">
           Projects
           {onNewProject ? (

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -30,6 +30,11 @@ import {
 import { isBusyThread, isUnreadDoneThread } from "@/lib/thread-activity";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@/lib/utils";
+import {
+  SIDEBAR_ROW_BASE_CLASS,
+  SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
+} from "./sidebarRowClasses";
 
 export type ThreadRowOptions =
   | {
@@ -281,8 +286,7 @@ function ThreadRowComponent({
   const managedChildBusyCount = managerOptions?.managedChildBusyCount ?? 0;
   const isManagerBusy =
     isManager &&
-    (threadIsBusy ||
-      (isManagerCollapsed && managedChildBusyCount > 0));
+    (threadIsBusy || (isManagerCollapsed && managedChildBusyCount > 0));
   const EnvironmentIcon = getEnvironmentWorkspaceDisplayIcon(
     thread.environmentWorkspaceDisplayKind,
   );
@@ -290,15 +294,16 @@ function ThreadRowComponent({
     thread.environmentWorkspaceDisplayKind,
   );
   const rowClassName = cn(
-    "group/thread-row flex w-full items-center gap-2 rounded-md pr-0 text-sm transition-colors",
+    "group/thread-row",
+    SIDEBAR_ROW_BASE_CLASS,
     !isManager && "relative",
     isManagedChild
       ? COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS
       : COARSE_POINTER_ROW_HEIGHT_CLASS,
-    isManagedChild ? "pl-1" : "pl-2",
+    isManagedChild ? "pl-1" : SIDEBAR_STANDARD_ROW_PADDING_CLASS,
     isActive
       ? "bg-sidebar-border text-sidebar-foreground"
-      : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+      : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   );
   const rowContent = (
     <>

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -1,0 +1,7 @@
+export const SIDEBAR_ROW_BASE_CLASS =
+  "flex w-full items-center gap-2 rounded-md pr-0 text-sm transition-colors";
+
+export const SIDEBAR_STANDARD_ROW_PADDING_CLASS = "pl-2";
+
+export const SIDEBAR_ROW_INTERACTIVE_STATE_CLASS =
+  "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground";

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -104,11 +104,14 @@
      * sizing, gaps, and derived offsets for its descendant sticky tiers.
      */
     --bb-sidebar-sticky-stack-padding: 0.5rem;
+    --bb-sidebar-sticky-stack-padding-top: var(
+      --bb-sidebar-sticky-stack-padding
+    );
     --bb-sidebar-sticky-label-height: 2rem;
     --bb-sidebar-sticky-label-gap: 0.25rem;
     --bb-sidebar-sticky-row-height: var(--bb-sidebar-row-height);
     --bb-sidebar-sticky-row-gap: 0.125rem;
-    --bb-sidebar-sticky-label-top: var(--bb-sidebar-sticky-stack-padding);
+    --bb-sidebar-sticky-label-top: var(--bb-sidebar-sticky-stack-padding-top);
     --bb-sidebar-sticky-project-top: calc(
       var(--bb-sidebar-sticky-label-top) +
         var(--bb-sidebar-sticky-label-height) +
@@ -119,7 +122,13 @@
         var(--bb-sidebar-sticky-row-height) + var(--bb-sidebar-sticky-row-gap)
     );
 
-    padding: var(--bb-sidebar-sticky-stack-padding);
+    padding: var(--bb-sidebar-sticky-stack-padding-top)
+      var(--bb-sidebar-sticky-stack-padding)
+      var(--bb-sidebar-sticky-stack-padding);
+  }
+
+  [data-sidebar-sticky-stack][data-sidebar-sticky-density="compact-actions"] {
+    --bb-sidebar-sticky-stack-padding-top: 0.25rem;
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier] {

--- a/apps/app/src/hooks/mutations/project-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/project-mutations.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { Suspense, useState, type ReactNode } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useIsMutating } from "@tanstack/react-query";
+import type { ThreadWithRuntime } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { installFetchRoutes, jsonResponse } from "@/test/http-test-utils";
+import {
+  HIRE_PROJECT_MANAGER_MUTATION_KEY,
+  useHireProjectManager,
+} from "./project-mutations";
+
+interface ProjectMutationsWrapperProps {
+  children: ReactNode;
+}
+
+interface DeferredResponse {
+  promise: Promise<Response>;
+  resolve: (response: Response) => void;
+}
+
+interface HireManagerSubmitterProps {
+  onSubmitted: () => void;
+}
+
+function createDeferredResponse(): DeferredResponse {
+  let resolveResponse: (response: Response) => void = () => {};
+  const promise = new Promise<Response>((resolve) => {
+    resolveResponse = resolve;
+  });
+
+  return {
+    promise,
+    resolve: resolveResponse,
+  };
+}
+
+function makeManagerThread(): ThreadWithRuntime {
+  return {
+    id: "thr-manager-1",
+    projectId: "proj-1",
+    environmentId: "env-1",
+    automationId: null,
+    providerId: "pi",
+    type: "manager",
+    title: "Manager",
+    titleFallback: "Manager",
+    status: "active",
+    parentThreadId: null,
+    archivedAt: null,
+    stopRequestedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    runtime: {
+      displayStatus: "active",
+      hostReconnectGraceExpiresAt: null,
+    },
+  };
+}
+
+function createProjectMutationsWrapper() {
+  const harness = createQueryClientTestHarness();
+
+  function ProjectMutationsWrapper({ children }: ProjectMutationsWrapperProps) {
+    return harness.wrapper({
+      children: <Suspense fallback={null}>{children}</Suspense>,
+    });
+  }
+
+  return ProjectMutationsWrapper;
+}
+
+function HireManagerSubmitter({ onSubmitted }: HireManagerSubmitterProps) {
+  const hireProjectManager = useHireProjectManager();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        hireProjectManager.mutate({
+          projectId: "proj-1",
+          providerId: "pi",
+          model: "model-1",
+          reasoningLevel: "medium",
+          environment: { type: "host", hostId: "host-local" },
+        });
+        onSubmitted();
+      }}
+    >
+      Submit hire
+    </button>
+  );
+}
+
+function PendingObserverHarness() {
+  const [showSubmitter, setShowSubmitter] = useState(true);
+  const activeHireManagerRequests = useIsMutating({
+    mutationKey: HIRE_PROJECT_MANAGER_MUTATION_KEY,
+  });
+
+  return (
+    <>
+      {showSubmitter ? (
+        <HireManagerSubmitter onSubmitted={() => setShowSubmitter(false)} />
+      ) : null}
+      <span>
+        {activeHireManagerRequests > 0 ? "hire pending" : "hire idle"}
+      </span>
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("project mutations", () => {
+  it("reports hire manager pending after the submitting component unmounts", async () => {
+    const pendingResponse = createDeferredResponse();
+    installFetchRoutes([
+      {
+        method: "POST",
+        pathname: "/api/v1/projects/proj-1/managers",
+        handler: () => pendingResponse.promise,
+      },
+    ]);
+    const wrapper = createProjectMutationsWrapper();
+
+    await act(async () => {
+      render(<PendingObserverHarness />, { wrapper });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit hire" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Submit hire" })).toBeNull();
+      expect(screen.getByText("hire pending")).toBeTruthy();
+    });
+
+    await act(async () => {
+      pendingResponse.resolve(jsonResponse(makeManagerThread()));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("hire idle")).toBeTruthy();
+    });
+  });
+});

--- a/apps/app/src/hooks/mutations/project-mutations.ts
+++ b/apps/app/src/hooks/mutations/project-mutations.ts
@@ -38,6 +38,10 @@ export interface HireProjectManagerRequest {
   environment: ManagerEnvironmentArgs;
 }
 
+export const HIRE_PROJECT_MANAGER_MUTATION_KEY = [
+  "hireProjectManager",
+] as const;
+
 interface UpdateProjectMutationRequest extends UpdateProjectRequest {
   id: string;
 }
@@ -65,6 +69,7 @@ export function useHireProjectManager() {
   const queryClient = useQueryClient();
 
   return useMutation({
+    mutationKey: HIRE_PROJECT_MANAGER_MUTATION_KEY,
     meta: {
       errorMessage: "Failed to hire manager.",
       showErrorToast: false,


### PR DESCRIPTION
## Summary
- Add matching ghost New Chat and New Manager actions above Projects in the sidebar, aligned with thread row spacing and height through shared row classes.
- Keep those sidebar actions outside the sticky project stack so the Projects sticky tier cannot clip the New Manager row.
- Tighten the gap between the sidebar action buttons and the Projects heading with a compact sticky-stack top padding mode.
- Remove the header New Manager action and route New Manager through the currently selected project by default.
- Add a Project picker inside the Hire Manager dialog so the manager can be created for a different project before submitting, with project selection derived instead of synchronized through extra effects.
- Use a shared hire-manager mutation key with `useIsMutating` so pending hires keep the action disabled after the dialog closes.
- Add focused tests for sidebar actions, dialog project selection, and shared pending-state behavior.

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec turbo run test --filter=@bb/app -- src/components/dialogs/HireManagerDialog.test.tsx src/components/sidebar/ProjectList.test.tsx src/components/sidebar/AppSidebar.test.tsx src/hooks/mutations/project-mutations.test.tsx`
- `pnpm exec turbo run build --filter=@bb/app`
- `git diff --check`
