### PR TITLE
fix(agent-runtime): expose user/global ~/.claude settings to Claude SDK

### DIFF
--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1052,6 +1052,56 @@ describe("bridge", () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 
+  it("exposes the host HOME and CLAUDE settings cascade to the Claude SDK on thread/start", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/Users/test-bb";
+    try {
+      bridge.sendRequest(1, "thread/start", {
+        baseInstructions: "test",
+        cwd: "/tmp/worktree",
+        instructionMode: "append",
+        permissionEscalation: "ask",
+        permissionMode: "default",
+        threadId: "thread-home-config",
+      });
+      await bridge.waitForResponse(1);
+
+      const queryOptions = getLatestQueryOptions() as ClaudeQueryCallOptions & {
+        env?: Record<string, string | undefined>;
+        settingSources?: string[];
+      };
+      expect(queryOptions.env?.HOME).toBe("/Users/test-bb");
+      expect(queryOptions.env?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe("bb/1.0.0");
+      expect(queryOptions.settingSources).toEqual([
+        "user",
+        "project",
+        "local",
+      ]);
+
+      bridge.sendRequest(2, "thread/stop", {
+        threadId: "thread-home-config",
+      });
+      await bridge.flushWork();
+      queries[0]?.finish();
+      await bridge.waitForResponse(2);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      bridge.restore();
+    }
+  });
+
   it("passes thread/start reasoningLevel through to Claude SDK effort and thinking display", async () => {
     const bridge = createBridgeJsonRpcTestHarness(handleLine);
     const queries: ControlledClaudeQuery[] = [];

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/sdk-session.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/sdk-session.test.ts
@@ -111,7 +111,7 @@ describe("SdkSession", () => {
     );
   });
 
-  it("loads project settings so Claude Code discovers repo CLAUDE.md files", () => {
+  it("mirrors the Claude CLI settings cascade so user, project, and local settings all load", () => {
     const onMessage = vi.fn();
     const onDone = vi.fn();
     const session = new SdkSession(defaultOptions, onMessage, onDone);
@@ -121,7 +121,7 @@ describe("SdkSession", () => {
     expect(queryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
-          settingSources: ["project"],
+          settingSources: ["user", "project", "local"],
         }),
       }),
     );

--- a/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
@@ -76,7 +76,11 @@ export class SdkSession {
       systemPrompt: this.options.systemPrompt,
       permissionMode: this.options.permissionMode ?? "default",
       includePartialMessages: true,
-      settingSources: ["project"],
+      // Mirror the Claude CLI cascade so the SDK loads both the user's global
+      // configuration (~/.claude/settings.json, ~/.claude/CLAUDE.md) and the
+      // workspace's project and local settings. Restricting this to "project"
+      // hid global home configuration from bb-managed sessions.
+      settingSources: ["user", "project", "local"],
       persistSession: true,
       env: this.options.env ?? process.env,
       ...(this.options.mcpServers


### PR DESCRIPTION
## Summary
- The Claude Agent SDK bridge hard-coded `settingSources: [\"project\"]`, so the SDK silently dropped the user's global `~/.claude/settings.json` and `~/.claude/CLAUDE.md` when loading settings for bb-managed sessions. Permission allowlists, model defaults, hooks, and global instructions defined per-user never reached the agent.
- Switch the bridge to the full CLI cascade (`[\"user\", \"project\", \"local\"]`) so global home configuration layers in alongside the workspace's project/local settings. `HOME` (and the rest of `process.env`) was already forwarded through the bridge to the SDK process, so no env wiring change is needed — only the explicit allowlist had to widen.

## Root cause
`packages/agent-runtime/src/claude-code/bridge/sdk-session.ts` set `settingSources: [\"project\"]` when invoking `query()`. The SDK treats this as an allowlist; the `\"user\"` source (`~/.claude/...`) is therefore skipped even though `HOME` is available.

## Test plan
- [x] `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- [x] `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- [x] `pnpm exec turbo run test --filter=@bb/agent-runtime --force` (465 passing)
- [x] `pnpm exec turbo run test --filter=@bb/host-daemon --force` (255 passing)
- [x] New focused tests:
  - `SdkSession` asserts the SDK is launched with `settingSources: [\"user\", \"project\", \"local\"]`.
  - Bridge end-to-end test asserts `process.env.HOME` and the cascade reach the SDK via `query()` options on `thread/start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)