### PR TITLE
[codex] add dev auto multi-stack runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "scripts:prepare": "pnpm exec turbo run build --filter=@bb/scripts --output-logs=none --log-prefix=none --summarize=false",
     "cli:prepare": "pnpm exec turbo run build --filter=@bb/scripts --filter=@bb/cli --output-logs=none --log-prefix=none --summarize=false",
     "dev": "cross-env NODE_ENV=development dotenv -c development -- turbo run dev --filter=@bb/app --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/dev-env --ui tui --concurrency 20 --no-update-notifier",
+    "dev:auto": "cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev-auto.ts",
     "dev:restart": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts both",
     "dev:restart-server": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts server",
     "dev:restart-host-daemon": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts host-daemon",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -24,6 +24,11 @@
       "types": "./src/commands/run-host-daemon.ts",
       "import": "./dist/commands/run-host-daemon.js"
     },
+    "./run-dev-auto": {
+      "source": "./src/commands/run-dev-auto.ts",
+      "types": "./src/commands/run-dev-auto.ts",
+      "import": "./dist/commands/run-dev-auto.js"
+    },
     "./start-bb": {
       "source": "./src/commands/start-bb.ts",
       "types": "./src/commands/start-bb.ts",
@@ -55,6 +60,7 @@
     "test": "vitest run --config vitest.config.ts",
     "cli": "node dist/commands/run-cli.js",
     "dev:host-daemon": "node dist/commands/run-host-daemon.js --auto-join",
+    "dev:auto": "node dist/commands/run-dev-auto.js",
     "dev:restart": "node dist/commands/request-dev-restart.js both",
     "dev:restart-host-daemon": "node dist/commands/request-dev-restart.js host-daemon",
     "dev:restart-server": "node dist/commands/request-dev-restart.js server",

--- a/packages/scripts/src/commands/run-dev-auto.ts
+++ b/packages/scripts/src/commands/run-dev-auto.ts
@@ -1,0 +1,272 @@
+import type { StdioOptions } from "node:child_process";
+import { hostname } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PortableChildProcess } from "@bb/process-utils";
+import {
+  type DevAutoReservation,
+  type DevAutoStackEnvironment,
+  type RemoveDevAutoReservationArgs,
+  type ReserveDevAutoStackArgs,
+  type WriteDevAutoEnvFileArgs,
+  createDevAutoStackEnvironment,
+  removeDevAutoReservation,
+  reserveDevAutoStack,
+  writeDevAutoEnvFile,
+} from "../lib/dev-auto-registry.js";
+import {
+  type ForwardedSignal,
+  type ProcessExitResult,
+  installTerminationSignalForwarding,
+  killProcessIfRunning,
+  spawnScriptProcess,
+  toExitCode,
+  waitForProcessExit,
+} from "../lib/process-helpers.js";
+
+export interface DevAutoTurboCommand {
+  args: string[];
+  command: string;
+}
+
+export interface CreateDevAutoChildEnvArgs {
+  machineName: string;
+  parentEnv: NodeJS.ProcessEnv;
+  reservation: DevAutoReservation;
+  stackEnv: DevAutoStackEnvironment;
+}
+
+export interface RenderDevAutoStartupBannerArgs {
+  envFilePath: string;
+  reservation: DevAutoReservation;
+  stackEnv: DevAutoStackEnvironment;
+}
+
+export interface DevAutoSpawnProcessRequest {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  stdio: StdioOptions;
+}
+
+export interface DevAutoChildProcess {
+  readonly exitCode: number | null;
+  readonly signalCode: NodeJS.Signals | null;
+  kill(signal: NodeJS.Signals): void;
+  waitForExit(): Promise<ProcessExitResult>;
+}
+
+export type DevAutoSignalHandler = (signal: ForwardedSignal) => void;
+export type DevAutoSignalHandlerCleanup = () => void;
+
+export interface DevAutoCommandRuntime {
+  currentPid: number;
+  cwd(): string;
+  env(): NodeJS.ProcessEnv;
+  hostname(): string;
+  installTerminationSignalForwarding(
+    handler: DevAutoSignalHandler,
+  ): DevAutoSignalHandlerCleanup;
+  releaseStackReservation(args: RemoveDevAutoReservationArgs): Promise<void>;
+  reserveStack(args: ReserveDevAutoStackArgs): Promise<DevAutoReservation>;
+  setExitCode(code: number): void;
+  spawnDevProcess(request: DevAutoSpawnProcessRequest): DevAutoChildProcess;
+  writeStackEnvFile(args: WriteDevAutoEnvFileArgs): Promise<void>;
+  writeStdout(message: string): void;
+}
+
+const DEV_AUTO_TURBO_FILTERS = [
+  "@bb/app",
+  "@bb/server",
+  "@bb/host-daemon",
+  "@bb/dev-env",
+];
+const DEV_AUTO_ENV_FILE_NAME = "dev-auto.env";
+
+export function createDevAutoTurboCommand(): DevAutoTurboCommand {
+  const args = ["exec", "turbo", "run", "dev"];
+  for (const filter of DEV_AUTO_TURBO_FILTERS) {
+    args.push("--filter", filter);
+  }
+  args.push("--ui", "tui", "--concurrency", "20", "--no-update-notifier");
+
+  return {
+    args,
+    command: "pnpm",
+  };
+}
+
+export function createDevAutoChildEnv(
+  args: CreateDevAutoChildEnvArgs,
+): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {
+    ...args.parentEnv,
+    ...args.stackEnv,
+    NODE_ENV: "development",
+  };
+  delete childEnv.BB_HOST_ID;
+  delete childEnv.BB_HOST_ENROLL_KEY;
+
+  const explicitHostName = args.parentEnv.BB_HOST_NAME?.trim();
+  childEnv.BB_HOST_NAME =
+    explicitHostName && explicitHostName.length > 0
+      ? args.parentEnv.BB_HOST_NAME
+      : `${args.machineName} dev:auto slot ${args.reservation.slot}`;
+
+  return childEnv;
+}
+
+export function renderDevAutoStartupBanner(
+  args: RenderDevAutoStartupBannerArgs,
+): string {
+  return [
+    `[dev:auto] allocated ${args.reservation.stackId}`,
+    `  app         http://localhost:${args.reservation.ports.appPort}`,
+    `  server      ${args.stackEnv.BB_SERVER_URL}`,
+    `  host daemon http://localhost:${args.reservation.ports.hostDaemonPort}`,
+    `  dev-env     http://127.0.0.1:${args.reservation.ports.devEnvPort}`,
+    `  data        ${args.reservation.dataDir}`,
+    `  env         ${args.envFilePath}`,
+    "",
+    "[dev:auto] For this stack's CLI:",
+    `  BB_SERVER_URL=${args.stackEnv.BB_SERVER_URL} BB_HOST_DAEMON_PORT=${args.stackEnv.BB_HOST_DAEMON_PORT} pnpm bb:dev status`,
+    "",
+  ].join("\n");
+}
+
+function createNodeDevAutoChildProcess(
+  child: PortableChildProcess,
+): DevAutoChildProcess {
+  return {
+    get exitCode(): number | null {
+      return child.exitCode;
+    },
+    get signalCode(): NodeJS.Signals | null {
+      return child.signalCode;
+    },
+    kill(signal: NodeJS.Signals): void {
+      killProcessIfRunning(child, signal);
+    },
+    waitForExit(): Promise<ProcessExitResult> {
+      return waitForProcessExit(child);
+    },
+  };
+}
+
+function createNodeDevAutoRuntime(): DevAutoCommandRuntime {
+  return {
+    currentPid: process.pid,
+    cwd(): string {
+      return process.cwd();
+    },
+    env(): NodeJS.ProcessEnv {
+      return process.env;
+    },
+    hostname,
+    installTerminationSignalForwarding,
+    releaseStackReservation: removeDevAutoReservation,
+    reserveStack: reserveDevAutoStack,
+    setExitCode(code: number): void {
+      process.exitCode = code;
+    },
+    spawnDevProcess(request: DevAutoSpawnProcessRequest): DevAutoChildProcess {
+      return createNodeDevAutoChildProcess(
+        spawnScriptProcess({
+          args: request.args,
+          command: request.command,
+          cwd: request.cwd,
+          env: request.env,
+          stdio: request.stdio,
+        }),
+      );
+    },
+    writeStackEnvFile: writeDevAutoEnvFile,
+    writeStdout(message: string): void {
+      process.stdout.write(message);
+    },
+  };
+}
+
+export async function runDevAutoWithRuntime(
+  runtime: DevAutoCommandRuntime,
+): Promise<void> {
+  const repoRoot = runtime.cwd();
+  const parentEnv = runtime.env();
+  let reservation: DevAutoReservation | null = null;
+  let child: DevAutoChildProcess | null = null;
+  let removeSignalForwarding: DevAutoSignalHandlerCleanup = () => {};
+  let shuttingDown = false;
+
+  try {
+    reservation = await runtime.reserveStack({
+      env: parentEnv,
+      ownerPid: runtime.currentPid,
+      repoRoot,
+    });
+    const stackEnv = createDevAutoStackEnvironment(reservation);
+    const envFilePath = join(reservation.dataDir, DEV_AUTO_ENV_FILE_NAME);
+    await runtime.writeStackEnvFile({
+      envFilePath,
+      stackEnv,
+    });
+    runtime.writeStdout(
+      renderDevAutoStartupBanner({
+        envFilePath,
+        reservation,
+        stackEnv,
+      }),
+    );
+
+    const turboCommand = createDevAutoTurboCommand();
+    child = runtime.spawnDevProcess({
+      args: turboCommand.args,
+      command: turboCommand.command,
+      cwd: repoRoot,
+      env: createDevAutoChildEnv({
+        machineName: runtime.hostname(),
+        parentEnv,
+        reservation,
+        stackEnv,
+      }),
+      stdio: "inherit",
+    });
+
+    removeSignalForwarding = runtime.installTerminationSignalForwarding(
+      (signal) => {
+        if (shuttingDown) {
+          return;
+        }
+        shuttingDown = true;
+        child?.kill(signal);
+      },
+    );
+
+    const result = await child.waitForExit();
+    runtime.setExitCode(toExitCode(result));
+  } finally {
+    removeSignalForwarding();
+    if (reservation) {
+      await runtime.releaseStackReservation({
+        env: parentEnv,
+        reservation,
+      });
+    }
+  }
+}
+
+export async function main(): Promise<void> {
+  await runDevAutoWithRuntime(createNodeDevAutoRuntime());
+}
+
+if (
+  process.argv[1] != null &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  void main().catch((error) => {
+    const message =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/scripts/src/lib/dev-auto-ports.ts
+++ b/packages/scripts/src/lib/dev-auto-ports.ts
@@ -1,0 +1,175 @@
+import { createServer } from "node:net";
+import { DEFAULTS } from "@bb/config/defaults";
+
+export type DevAutoSlot = number;
+
+export interface DevAutoPortTuple {
+  appPort: number;
+  devEnvPort: number;
+  hostDaemonPort: number;
+  serverPort: number;
+}
+
+export interface DevAutoStackAssignment {
+  ports: DevAutoPortTuple;
+  slot: DevAutoSlot;
+  stackId: string;
+}
+
+export interface ProbePortAvailabilityArgs {
+  host: string;
+  port: number;
+}
+
+export type ProbePortAvailability = (
+  args: ProbePortAvailabilityArgs,
+) => Promise<boolean>;
+
+export interface CheckPortTupleAvailabilityArgs {
+  ports: DevAutoPortTuple;
+  probePort?: ProbePortAvailability;
+}
+
+export interface FindAvailableDevAutoSlotArgs {
+  firstSlot?: DevAutoSlot;
+  maxSlot?: DevAutoSlot;
+  probePort?: ProbePortAvailability;
+  reservedSlots: ReadonlySet<DevAutoSlot>;
+}
+
+type DevAutoPortKey = keyof DevAutoPortTuple;
+
+export const DEV_AUTO_PORT_STRIDE = 10;
+export const DEFAULT_DEV_AUTO_FIRST_SLOT = 0;
+export const DEFAULT_DEV_AUTO_MAX_SLOT = 99;
+const DEV_AUTO_PROBE_HOST = "127.0.0.1";
+const DEV_AUTO_PORT_KEYS: DevAutoPortKey[] = [
+  "serverPort",
+  "hostDaemonPort",
+  "appPort",
+  "devEnvPort",
+];
+
+function assertValidDevAutoSlot(slot: DevAutoSlot): void {
+  if (!Number.isInteger(slot) || slot < 0) {
+    throw new Error(`dev:auto slot must be a non-negative integer: ${slot}`);
+  }
+}
+
+export function createDevAutoStackId(slot: DevAutoSlot): string {
+  assertValidDevAutoSlot(slot);
+  return `bb-dev-auto-${slot}`;
+}
+
+export function deriveDevAutoPortTuple(slot: DevAutoSlot): DevAutoPortTuple {
+  assertValidDevAutoSlot(slot);
+  const offset = slot * DEV_AUTO_PORT_STRIDE;
+
+  return {
+    appPort: DEFAULTS.appPort.dev + offset,
+    devEnvPort: DEFAULTS.devEnvPort + offset,
+    hostDaemonPort: DEFAULTS.hostDaemonPort.dev + offset,
+    serverPort: DEFAULTS.serverPort.dev + offset,
+  };
+}
+
+export function listDevAutoPorts(ports: DevAutoPortTuple): number[] {
+  return DEV_AUTO_PORT_KEYS.map((key) => ports[key]);
+}
+
+export function hasForbiddenProductionPort(ports: DevAutoPortTuple): boolean {
+  const forbiddenPorts = new Set<number>([
+    DEFAULTS.serverPort.prod,
+    DEFAULTS.hostDaemonPort.prod,
+  ]);
+  return listDevAutoPorts(ports).some((port) => forbiddenPorts.has(port));
+}
+
+export async function probePortAvailability(
+  args: ProbePortAvailabilityArgs,
+): Promise<boolean> {
+  return new Promise<boolean>((resolvePromise) => {
+    const server = createServer();
+    let settled = false;
+
+    const finish = (available: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      server.removeAllListeners();
+
+      if (!available) {
+        resolvePromise(false);
+        return;
+      }
+
+      server.close(() => {
+        resolvePromise(true);
+      });
+    };
+
+    server.once("error", () => {
+      finish(false);
+    });
+    server.once("listening", () => {
+      finish(true);
+    });
+    server.listen(args.port, args.host);
+  });
+}
+
+export async function isDevAutoPortTupleAvailable(
+  args: CheckPortTupleAvailabilityArgs,
+): Promise<boolean> {
+  const probePort = args.probePort ?? probePortAvailability;
+  const results = await Promise.all(
+    listDevAutoPorts(args.ports).map((port) =>
+      probePort({ host: DEV_AUTO_PROBE_HOST, port }),
+    ),
+  );
+  return results.every((available) => available);
+}
+
+export async function findAvailableDevAutoSlot(
+  args: FindAvailableDevAutoSlotArgs,
+): Promise<DevAutoStackAssignment> {
+  const firstSlot = args.firstSlot ?? DEFAULT_DEV_AUTO_FIRST_SLOT;
+  const maxSlot = args.maxSlot ?? DEFAULT_DEV_AUTO_MAX_SLOT;
+  assertValidDevAutoSlot(firstSlot);
+  assertValidDevAutoSlot(maxSlot);
+
+  if (maxSlot < firstSlot) {
+    throw new Error(
+      `dev:auto max slot ${maxSlot} must be greater than or equal to first slot ${firstSlot}`,
+    );
+  }
+
+  for (let slot = firstSlot; slot <= maxSlot; slot += 1) {
+    if (args.reservedSlots.has(slot)) {
+      continue;
+    }
+
+    const ports = deriveDevAutoPortTuple(slot);
+    if (hasForbiddenProductionPort(ports)) {
+      continue;
+    }
+
+    if (
+      await isDevAutoPortTupleAvailable({
+        ports,
+        probePort: args.probePort,
+      })
+    ) {
+      return {
+        ports,
+        slot,
+        stackId: createDevAutoStackId(slot),
+      };
+    }
+  }
+
+  throw new Error(
+    `No available dev:auto port tuple found while checking slots ${firstSlot}..${maxSlot}`,
+  );
+}

--- a/packages/scripts/src/lib/dev-auto-registry.ts
+++ b/packages/scripts/src/lib/dev-auto-registry.ts
@@ -1,0 +1,633 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { resolveConfiguredDataDir } from "@bb/config/data-dir";
+import { DEFAULTS } from "@bb/config/defaults";
+import {
+  DEFAULT_DEV_AUTO_FIRST_SLOT,
+  DEFAULT_DEV_AUTO_MAX_SLOT,
+  type DevAutoPortTuple,
+  type DevAutoSlot,
+  type DevAutoStackAssignment,
+  type ProbePortAvailability,
+  findAvailableDevAutoSlot,
+} from "./dev-auto-ports.js";
+
+export interface DevAutoReservation extends DevAutoStackAssignment {
+  createdAt: string;
+  dataDir: string;
+  ownerPid: number;
+  repoRoot: string;
+  updatedAt: string;
+}
+
+export interface DevAutoRegistryFile {
+  reservations: DevAutoReservation[];
+  version: number;
+}
+
+export interface DevAutoRegistryPaths {
+  lockDir: string;
+  registryDir: string;
+  registryPath: string;
+}
+
+export interface ResolveDevAutoDevDataDirArgs {
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface ResolveDevAutoRegistryPathsArgs {
+  devDataDir: string;
+}
+
+export interface ResolveDevAutoStackDataDirArgs {
+  devDataDir: string;
+  slot: DevAutoSlot;
+}
+
+export interface AcquireDevAutoRegistryLockArgs {
+  maxWaitMs?: number;
+  now?: DevAutoNow;
+  ownerPid?: number;
+  paths: DevAutoRegistryPaths;
+  retryDelayMs?: number;
+  sleep?: DevAutoSleep;
+  staleLockMs?: number;
+  token?: string;
+}
+
+export interface DevAutoRegistryLock {
+  paths: DevAutoRegistryPaths;
+  release(): Promise<void>;
+  token: string;
+}
+
+export interface LoadDevAutoRegistryArgs {
+  paths: DevAutoRegistryPaths;
+}
+
+export interface SaveDevAutoRegistryArgs {
+  paths: DevAutoRegistryPaths;
+  registry: DevAutoRegistryFile;
+}
+
+export interface PruneStaleDevAutoReservationsArgs {
+  isProcessAlive?: DevAutoProcessAliveChecker;
+  registry: DevAutoRegistryFile;
+}
+
+export interface PruneStaleDevAutoReservationsResult {
+  prunedReservations: DevAutoReservation[];
+  registry: DevAutoRegistryFile;
+}
+
+export interface ReserveDevAutoStackArgs {
+  devDataDir?: string;
+  env?: NodeJS.ProcessEnv;
+  firstSlot?: DevAutoSlot;
+  isProcessAlive?: DevAutoProcessAliveChecker;
+  maxSlot?: DevAutoSlot;
+  now?: DevAutoNow;
+  ownerPid: number;
+  probePort?: ProbePortAvailability;
+  repoRoot: string;
+}
+
+export interface RemoveDevAutoReservationArgs {
+  devDataDir?: string;
+  env?: NodeJS.ProcessEnv;
+  reservation: DevAutoReservation;
+}
+
+export interface DevAutoStackEnvironment {
+  BB_DATABASE_URL: string;
+  BB_DATA_DIR: string;
+  BB_DEV_APP_PORT: string;
+  BB_DEV_AUTO_SLOT: string;
+  BB_DEV_AUTO_STACK_ID: string;
+  BB_DEV_ENV_PORT: string;
+  BB_HOST_DAEMON_PORT: string;
+  BB_SERVER_PORT: string;
+  BB_SERVER_URL: string;
+}
+
+export interface RenderDevAutoEnvFileArgs {
+  stackEnv: DevAutoStackEnvironment;
+}
+
+export interface WriteDevAutoEnvFileArgs {
+  envFilePath: string;
+  stackEnv: DevAutoStackEnvironment;
+}
+
+export type DevAutoNow = () => number;
+export type DevAutoSleep = (delayMs: number) => Promise<void>;
+export type DevAutoProcessAliveChecker = (pid: number) => boolean;
+
+type JsonRecord = Record<string, unknown>;
+type DevAutoEnvFileKey = keyof DevAutoStackEnvironment;
+
+const DEV_AUTO_REGISTRY_VERSION = 1;
+const DEV_AUTO_REGISTRY_DIR_NAME = "dev-auto";
+const DEV_AUTO_REGISTRY_FILE_NAME = "reservations.json";
+const DEV_AUTO_REGISTRY_LOCK_DIR_NAME = "reservations.lock";
+const DEV_AUTO_LOCK_TOKEN_FILE_NAME = "owner-token";
+const DEV_AUTO_STACKS_DIR_NAME = "stacks";
+const DEV_AUTO_LOCK_STALE_MS = 120_000;
+const DEV_AUTO_LOCK_MAX_WAIT_MS = 5_000;
+const DEV_AUTO_LOCK_RETRY_DELAY_MS = 50;
+const DEV_AUTO_ENV_FILE_KEYS: DevAutoEnvFileKey[] = [
+  "BB_DATA_DIR",
+  "BB_DATABASE_URL",
+  "BB_SERVER_URL",
+  "BB_SERVER_PORT",
+  "BB_HOST_DAEMON_PORT",
+  "BB_DEV_APP_PORT",
+  "BB_DEV_ENV_PORT",
+  "BB_DEV_AUTO_STACK_ID",
+  "BB_DEV_AUTO_SLOT",
+];
+
+function sleepMs(delayMs: number): Promise<void> {
+  return new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, delayMs);
+  });
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!isJsonRecord(error)) {
+    return undefined;
+  }
+  const code = error.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringProperty(record: JsonRecord, propertyName: string): string {
+  const value = record[propertyName];
+  if (typeof value !== "string") {
+    throw new Error(`Invalid dev:auto registry property ${propertyName}`);
+  }
+  return value;
+}
+
+function readIntegerProperty(record: JsonRecord, propertyName: string): number {
+  const value = record[propertyName];
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`Invalid dev:auto registry property ${propertyName}`);
+  }
+  return value;
+}
+
+function parsePortTuple(value: unknown): DevAutoPortTuple {
+  if (!isJsonRecord(value)) {
+    throw new Error("Invalid dev:auto registry ports");
+  }
+
+  return {
+    appPort: readIntegerProperty(value, "appPort"),
+    devEnvPort: readIntegerProperty(value, "devEnvPort"),
+    hostDaemonPort: readIntegerProperty(value, "hostDaemonPort"),
+    serverPort: readIntegerProperty(value, "serverPort"),
+  };
+}
+
+function parseReservation(value: unknown): DevAutoReservation {
+  if (!isJsonRecord(value)) {
+    throw new Error("Invalid dev:auto registry reservation");
+  }
+
+  return {
+    createdAt: readStringProperty(value, "createdAt"),
+    dataDir: readStringProperty(value, "dataDir"),
+    ownerPid: readIntegerProperty(value, "ownerPid"),
+    ports: parsePortTuple(value.ports),
+    repoRoot: readStringProperty(value, "repoRoot"),
+    slot: readIntegerProperty(value, "slot"),
+    stackId: readStringProperty(value, "stackId"),
+    updatedAt: readStringProperty(value, "updatedAt"),
+  };
+}
+
+function parseRegistryFile(value: unknown): DevAutoRegistryFile {
+  if (!isJsonRecord(value)) {
+    throw new Error("Invalid dev:auto registry file");
+  }
+
+  const version = readIntegerProperty(value, "version");
+  if (version !== DEV_AUTO_REGISTRY_VERSION) {
+    throw new Error(`Unsupported dev:auto registry version ${version}`);
+  }
+
+  if (!Array.isArray(value.reservations)) {
+    throw new Error("Invalid dev:auto registry reservations");
+  }
+
+  return {
+    reservations: value.reservations.map(parseReservation),
+    version,
+  };
+}
+
+function isExpectedMissingFileError(error: unknown): boolean {
+  return getErrorCode(error) === "ENOENT";
+}
+
+function isLockAlreadyExistsError(error: unknown): boolean {
+  return getErrorCode(error) === "EEXIST";
+}
+
+function createEmptyRegistry(): DevAutoRegistryFile {
+  return {
+    reservations: [],
+    version: DEV_AUTO_REGISTRY_VERSION,
+  };
+}
+
+function resolveNowIso(now: DevAutoNow | undefined): string {
+  return new Date(now ? now() : Date.now()).toISOString();
+}
+
+function quoteShellValue(value: string): string {
+  return `'${value.replace(/'/gu, `'\"'\"'`)}'`;
+}
+
+function createDevAutoServerUrl(ports: DevAutoPortTuple): string {
+  return `http://127.0.0.1:${ports.serverPort}`;
+}
+
+function createDatabasePath(dataDir: string): string {
+  return join(dataDir, "bb.db");
+}
+
+function createRegistryPaths(devDataDir: string): DevAutoRegistryPaths {
+  const registryDir = join(devDataDir, DEV_AUTO_REGISTRY_DIR_NAME);
+  return {
+    lockDir: join(registryDir, DEV_AUTO_REGISTRY_LOCK_DIR_NAME),
+    registryDir,
+    registryPath: join(registryDir, DEV_AUTO_REGISTRY_FILE_NAME),
+  };
+}
+
+function createStackDataDir(args: ResolveDevAutoStackDataDirArgs): string {
+  return join(args.devDataDir, DEV_AUTO_STACKS_DIR_NAME, `slot-${args.slot}`);
+}
+
+async function writeJsonFileAtomically(
+  args: SaveDevAutoRegistryArgs,
+): Promise<void> {
+  await mkdir(args.paths.registryDir, { recursive: true });
+  const tempPath = join(
+    dirname(args.paths.registryPath),
+    `${DEV_AUTO_REGISTRY_FILE_NAME}.${process.pid}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    await writeFile(
+      tempPath,
+      `${JSON.stringify(args.registry, null, 2)}\n`,
+      "utf8",
+    );
+    await rename(tempPath, args.paths.registryPath);
+  } catch (error) {
+    await rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+async function isLockStale(
+  args: AcquireDevAutoRegistryLockArgs,
+): Promise<boolean> {
+  const now = args.now ?? Date.now;
+  const staleLockMs = args.staleLockMs ?? DEV_AUTO_LOCK_STALE_MS;
+
+  try {
+    const lockStat = await stat(args.paths.lockDir);
+    return now() - lockStat.mtimeMs > staleLockMs;
+  } catch (error) {
+    if (isExpectedMissingFileError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function readLockToken(
+  paths: DevAutoRegistryPaths,
+): Promise<string | null> {
+  try {
+    return (
+      await readFile(join(paths.lockDir, DEV_AUTO_LOCK_TOKEN_FILE_NAME), "utf8")
+    ).trim();
+  } catch (error) {
+    if (isExpectedMissingFileError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function removeStaleLock(
+  args: AcquireDevAutoRegistryLockArgs,
+): Promise<void> {
+  if (await isLockStale(args)) {
+    await rm(args.paths.lockDir, { force: true, recursive: true });
+  }
+}
+
+async function createLock(
+  args: AcquireDevAutoRegistryLockArgs,
+  token: string,
+): Promise<void> {
+  await mkdir(args.paths.registryDir, { recursive: true });
+  await mkdir(args.paths.lockDir);
+  try {
+    await writeFile(
+      join(args.paths.lockDir, DEV_AUTO_LOCK_TOKEN_FILE_NAME),
+      token,
+      {
+        encoding: "utf8",
+        flag: "wx",
+      },
+    );
+    const nowMs = args.now ? args.now() : Date.now();
+    await utimes(args.paths.lockDir, nowMs / 1000, nowMs / 1000);
+  } catch (error) {
+    await rm(args.paths.lockDir, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function resolveDevAutoDevDataDir(
+  args: ResolveDevAutoDevDataDirArgs = {},
+): string {
+  return resolveConfiguredDataDir({
+    defaultDirName: DEFAULTS.dataDir.dev,
+    env: args.env,
+  });
+}
+
+export function resolveDevAutoRegistryPaths(
+  args: ResolveDevAutoRegistryPathsArgs,
+): DevAutoRegistryPaths {
+  return createRegistryPaths(args.devDataDir);
+}
+
+export function resolveDevAutoStackDataDir(
+  args: ResolveDevAutoStackDataDirArgs,
+): string {
+  return createStackDataDir(args);
+}
+
+export async function acquireDevAutoRegistryLock(
+  args: AcquireDevAutoRegistryLockArgs,
+): Promise<DevAutoRegistryLock> {
+  const now = args.now ?? Date.now;
+  const sleep = args.sleep ?? sleepMs;
+  const maxWaitMs = args.maxWaitMs ?? DEV_AUTO_LOCK_MAX_WAIT_MS;
+  const retryDelayMs = args.retryDelayMs ?? DEV_AUTO_LOCK_RETRY_DELAY_MS;
+  const startedAt = now();
+  const token = args.token ?? `${args.ownerPid ?? process.pid}:${randomUUID()}`;
+
+  while (true) {
+    try {
+      await createLock(args, token);
+      return {
+        paths: args.paths,
+        token,
+        async release(): Promise<void> {
+          await releaseDevAutoRegistryLock({
+            paths: args.paths,
+            token,
+          });
+        },
+      };
+    } catch (error) {
+      if (!isLockAlreadyExistsError(error)) {
+        throw error;
+      }
+
+      await removeStaleLock(args);
+      if (now() - startedAt >= maxWaitMs) {
+        throw new Error(
+          `Timed out waiting for dev:auto registry lock at ${args.paths.lockDir}`,
+        );
+      }
+      await sleep(retryDelayMs);
+    }
+  }
+}
+
+export interface ReleaseDevAutoRegistryLockArgs {
+  paths: DevAutoRegistryPaths;
+  token: string;
+}
+
+export async function releaseDevAutoRegistryLock(
+  args: ReleaseDevAutoRegistryLockArgs,
+): Promise<void> {
+  const token = await readLockToken(args.paths);
+  if (token === args.token) {
+    await rm(args.paths.lockDir, { force: true, recursive: true });
+  }
+}
+
+export async function loadDevAutoRegistry(
+  args: LoadDevAutoRegistryArgs,
+): Promise<DevAutoRegistryFile> {
+  try {
+    const raw = await readFile(args.paths.registryPath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    return parseRegistryFile(parsed);
+  } catch (error) {
+    if (isExpectedMissingFileError(error)) {
+      return createEmptyRegistry();
+    }
+    throw error;
+  }
+}
+
+export async function saveDevAutoRegistry(
+  args: SaveDevAutoRegistryArgs,
+): Promise<void> {
+  await writeJsonFileAtomically(args);
+}
+
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = getErrorCode(error);
+    if (code === "EPERM") {
+      return true;
+    }
+    return false;
+  }
+}
+
+export function pruneStaleDevAutoReservations(
+  args: PruneStaleDevAutoReservationsArgs,
+): PruneStaleDevAutoReservationsResult {
+  const processAlive = args.isProcessAlive ?? isProcessAlive;
+  const reservations: DevAutoReservation[] = [];
+  const prunedReservations: DevAutoReservation[] = [];
+
+  for (const reservation of args.registry.reservations) {
+    if (processAlive(reservation.ownerPid)) {
+      reservations.push(reservation);
+    } else {
+      prunedReservations.push(reservation);
+    }
+  }
+
+  return {
+    prunedReservations,
+    registry: {
+      reservations,
+      version: args.registry.version,
+    },
+  };
+}
+
+export async function reserveDevAutoStack(
+  args: ReserveDevAutoStackArgs,
+): Promise<DevAutoReservation> {
+  const devDataDir =
+    args.devDataDir ?? resolveDevAutoDevDataDir({ env: args.env });
+  const paths = resolveDevAutoRegistryPaths({ devDataDir });
+  const lock = await acquireDevAutoRegistryLock({
+    now: args.now,
+    ownerPid: args.ownerPid,
+    paths,
+  });
+
+  try {
+    const loadedRegistry = await loadDevAutoRegistry({ paths });
+    const pruned = pruneStaleDevAutoReservations({
+      isProcessAlive: args.isProcessAlive,
+      registry: loadedRegistry,
+    });
+    const reservedSlots = new Set<DevAutoSlot>(
+      pruned.registry.reservations.map((reservation) => reservation.slot),
+    );
+    const assignment = await findAvailableDevAutoSlot({
+      firstSlot: args.firstSlot ?? DEFAULT_DEV_AUTO_FIRST_SLOT,
+      maxSlot: args.maxSlot ?? DEFAULT_DEV_AUTO_MAX_SLOT,
+      probePort: args.probePort,
+      reservedSlots,
+    });
+    const dataDir = resolveDevAutoStackDataDir({
+      devDataDir,
+      slot: assignment.slot,
+    });
+    const nowIso = resolveNowIso(args.now);
+    const reservation: DevAutoReservation = {
+      ...assignment,
+      createdAt: nowIso,
+      dataDir,
+      ownerPid: args.ownerPid,
+      repoRoot: args.repoRoot,
+      updatedAt: nowIso,
+    };
+
+    await mkdir(dataDir, { recursive: true });
+    await saveDevAutoRegistry({
+      paths,
+      registry: {
+        reservations: [...pruned.registry.reservations, reservation],
+        version: pruned.registry.version,
+      },
+    });
+
+    return reservation;
+  } finally {
+    await lock.release();
+  }
+}
+
+export async function removeDevAutoReservation(
+  args: RemoveDevAutoReservationArgs,
+): Promise<void> {
+  const devDataDir =
+    args.devDataDir ?? resolveDevAutoDevDataDir({ env: args.env });
+  const paths = resolveDevAutoRegistryPaths({ devDataDir });
+  const lock = await acquireDevAutoRegistryLock({
+    ownerPid: process.pid,
+    paths,
+  });
+
+  try {
+    const registry = await loadDevAutoRegistry({ paths });
+    const reservations = registry.reservations.filter((reservation) => {
+      return !(
+        reservation.stackId === args.reservation.stackId &&
+        reservation.ownerPid === args.reservation.ownerPid &&
+        reservation.repoRoot === args.reservation.repoRoot
+      );
+    });
+
+    if (reservations.length === registry.reservations.length) {
+      return;
+    }
+
+    await saveDevAutoRegistry({
+      paths,
+      registry: {
+        reservations,
+        version: registry.version,
+      },
+    });
+  } finally {
+    await lock.release();
+  }
+}
+
+export function createDevAutoStackEnvironment(
+  reservation: DevAutoReservation,
+): DevAutoStackEnvironment {
+  return {
+    BB_DATABASE_URL: createDatabasePath(reservation.dataDir),
+    BB_DATA_DIR: reservation.dataDir,
+    BB_DEV_APP_PORT: String(reservation.ports.appPort),
+    BB_DEV_AUTO_SLOT: String(reservation.slot),
+    BB_DEV_AUTO_STACK_ID: reservation.stackId,
+    BB_DEV_ENV_PORT: String(reservation.ports.devEnvPort),
+    BB_HOST_DAEMON_PORT: String(reservation.ports.hostDaemonPort),
+    BB_SERVER_PORT: String(reservation.ports.serverPort),
+    BB_SERVER_URL: createDevAutoServerUrl(reservation.ports),
+  };
+}
+
+export function renderDevAutoEnvFile(args: RenderDevAutoEnvFileArgs): string {
+  const lines = DEV_AUTO_ENV_FILE_KEYS.map((key) => {
+    return `export ${key}=${quoteShellValue(args.stackEnv[key])}`;
+  });
+  return `${lines.join("\n")}\n`;
+}
+
+export async function writeDevAutoEnvFile(
+  args: WriteDevAutoEnvFileArgs,
+): Promise<void> {
+  await mkdir(dirname(args.envFilePath), { recursive: true });
+  await writeFile(
+    args.envFilePath,
+    renderDevAutoEnvFile({ stackEnv: args.stackEnv }),
+    "utf8",
+  );
+}

--- a/packages/scripts/test/dev-auto-ports.test.ts
+++ b/packages/scripts/test/dev-auto-ports.test.ts
@@ -1,0 +1,140 @@
+import { createServer, type AddressInfo, type Server } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULTS } from "@bb/config/defaults";
+import {
+  DEV_AUTO_PORT_STRIDE,
+  deriveDevAutoPortTuple,
+  findAvailableDevAutoSlot,
+  hasForbiddenProductionPort,
+  probePortAvailability,
+  type ProbePortAvailability,
+} from "../src/lib/dev-auto-ports.js";
+
+interface ListeningServer {
+  port: number;
+  server: Server;
+}
+
+const servers: Server[] = [];
+
+function readListeningPort(address: AddressInfo | string | null): number {
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected TCP listening address");
+  }
+  return address.port;
+}
+
+function listenOnLoopback(): Promise<ListeningServer> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const server = createServer();
+    server.once("error", rejectPromise);
+    server.listen(0, "127.0.0.1", () => {
+      servers.push(server);
+      resolvePromise({
+        port: readListeningPort(server.address()),
+        server,
+      });
+    });
+  });
+}
+
+function createProbe(
+  unavailablePorts: ReadonlySet<number>,
+): ProbePortAvailability {
+  return async (args) => !unavailablePorts.has(args.port);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolvePromise, rejectPromise) => {
+          server.close((error) => {
+            if (error) {
+              rejectPromise(error);
+              return;
+            }
+            resolvePromise();
+          });
+        }),
+    ),
+  );
+});
+
+describe("dev-auto ports", () => {
+  it("derives slot 0 from the existing development defaults", () => {
+    expect(deriveDevAutoPortTuple(0)).toEqual({
+      appPort: DEFAULTS.appPort.dev,
+      devEnvPort: DEFAULTS.devEnvPort,
+      hostDaemonPort: DEFAULTS.hostDaemonPort.dev,
+      serverPort: DEFAULTS.serverPort.dev,
+    });
+  });
+
+  it("derives later slots by adding the stride to every port", () => {
+    expect(deriveDevAutoPortTuple(1)).toEqual({
+      appPort: DEFAULTS.appPort.dev + DEV_AUTO_PORT_STRIDE,
+      devEnvPort: DEFAULTS.devEnvPort + DEV_AUTO_PORT_STRIDE,
+      hostDaemonPort: DEFAULTS.hostDaemonPort.dev + DEV_AUTO_PORT_STRIDE,
+      serverPort: DEFAULTS.serverPort.dev + DEV_AUTO_PORT_STRIDE,
+    });
+  });
+
+  it("reports occupied ports as unavailable", async () => {
+    const listener = await listenOnLoopback();
+
+    await expect(
+      probePortAvailability({
+        host: "127.0.0.1",
+        port: listener.port,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("skips a slot when any port in its tuple is occupied", async () => {
+    const unavailablePorts = new Set<number>([
+      deriveDevAutoPortTuple(0).serverPort,
+    ]);
+
+    await expect(
+      findAvailableDevAutoSlot({
+        probePort: createProbe(unavailablePorts),
+        reservedSlots: new Set(),
+      }),
+    ).resolves.toMatchObject({
+      slot: 1,
+    });
+  });
+
+  it("skips active reserved slots even when their ports look free", async () => {
+    await expect(
+      findAvailableDevAutoSlot({
+        probePort: createProbe(new Set()),
+        reservedSlots: new Set([0]),
+      }),
+    ).resolves.toMatchObject({
+      slot: 1,
+    });
+  });
+
+  it("identifies production ports as forbidden for dev-auto tuples", () => {
+    expect(
+      hasForbiddenProductionPort({
+        appPort: DEFAULTS.appPort.dev,
+        devEnvPort: DEFAULTS.devEnvPort,
+        hostDaemonPort: DEFAULTS.hostDaemonPort.prod,
+        serverPort: DEFAULTS.serverPort.prod,
+      }),
+    ).toBe(true);
+  });
+
+  it("fails clearly after the bounded slot search is exhausted", async () => {
+    await expect(
+      findAvailableDevAutoSlot({
+        maxSlot: 2,
+        probePort: async () => false,
+        reservedSlots: new Set(),
+      }),
+    ).rejects.toThrow("checking slots 0..2");
+  });
+});

--- a/packages/scripts/test/dev-auto-registry.test.ts
+++ b/packages/scripts/test/dev-auto-registry.test.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { deriveDevAutoPortTuple } from "../src/lib/dev-auto-ports.js";
+import {
+  acquireDevAutoRegistryLock,
+  createDevAutoStackEnvironment,
+  loadDevAutoRegistry,
+  removeDevAutoReservation,
+  renderDevAutoEnvFile,
+  reserveDevAutoStack,
+  resolveDevAutoRegistryPaths,
+  resolveDevAutoStackDataDir,
+  saveDevAutoRegistry,
+  type DevAutoProcessAliveChecker,
+  type DevAutoReservation,
+} from "../src/lib/dev-auto-registry.js";
+
+interface CreateReservationArgs {
+  devDataDir: string;
+  ownerPid: number;
+  slot: number;
+}
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createReservation(args: CreateReservationArgs): DevAutoReservation {
+  const ports = deriveDevAutoPortTuple(args.slot);
+  return {
+    createdAt: "2026-05-14T00:00:00.000Z",
+    dataDir: resolveDevAutoStackDataDir({
+      devDataDir: args.devDataDir,
+      slot: args.slot,
+    }),
+    ownerPid: args.ownerPid,
+    ports,
+    repoRoot: "/repo",
+    slot: args.slot,
+    stackId: `bb-dev-auto-${args.slot}`,
+    updatedAt: "2026-05-14T00:00:00.000Z",
+  };
+}
+
+const allPortsAvailable = async () => true;
+const allProcessesAlive: DevAutoProcessAliveChecker = () => true;
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => fs.rm(dir, { force: true, recursive: true })),
+  );
+});
+
+describe("dev-auto registry", () => {
+  it("honors active reservations when allocating a stack", async () => {
+    const devDataDir = await makeTempDir("bb-dev-auto-registry-");
+    const paths = resolveDevAutoRegistryPaths({ devDataDir });
+    await saveDevAutoRegistry({
+      paths,
+      registry: {
+        reservations: [
+          createReservation({
+            devDataDir,
+            ownerPid: process.pid,
+            slot: 0,
+          }),
+        ],
+        version: 1,
+      },
+    });
+
+    const reservation = await reserveDevAutoStack({
+      devDataDir,
+      isProcessAlive: allProcessesAlive,
+      ownerPid: process.pid,
+      probePort: allPortsAvailable,
+      repoRoot: "/repo",
+    });
+
+    expect(reservation.slot).toBe(1);
+    await expect(loadDevAutoRegistry({ paths })).resolves.toMatchObject({
+      reservations: [{ slot: 0 }, { slot: 1 }],
+    });
+  });
+
+  it("prunes dead owner reservations before allocating", async () => {
+    const devDataDir = await makeTempDir("bb-dev-auto-registry-");
+    const paths = resolveDevAutoRegistryPaths({ devDataDir });
+    const deadPid = 987_654_321;
+    await saveDevAutoRegistry({
+      paths,
+      registry: {
+        reservations: [
+          createReservation({
+            devDataDir,
+            ownerPid: deadPid,
+            slot: 0,
+          }),
+        ],
+        version: 1,
+      },
+    });
+
+    const reservation = await reserveDevAutoStack({
+      devDataDir,
+      isProcessAlive: (pid) => pid !== deadPid,
+      ownerPid: process.pid,
+      probePort: allPortsAvailable,
+      repoRoot: "/repo",
+    });
+    const registry = await loadDevAutoRegistry({ paths });
+
+    expect(reservation.slot).toBe(0);
+    expect(registry.reservations).toHaveLength(1);
+    expect(registry.reservations[0]?.ownerPid).toBe(process.pid);
+  });
+
+  it("uses an atomic directory lock for registry writers", async () => {
+    const devDataDir = await makeTempDir("bb-dev-auto-registry-");
+    const paths = resolveDevAutoRegistryPaths({ devDataDir });
+    const lock = await acquireDevAutoRegistryLock({
+      paths,
+      token: "first",
+    });
+
+    try {
+      await expect(
+        acquireDevAutoRegistryLock({
+          maxWaitMs: 0,
+          paths,
+          retryDelayMs: 0,
+          sleep: async () => {},
+          token: "second",
+        }),
+      ).rejects.toThrow("Timed out waiting for dev:auto registry lock");
+    } finally {
+      await lock.release();
+    }
+  });
+
+  it("removes stale lock directories before acquiring a new lock", async () => {
+    const devDataDir = await makeTempDir("bb-dev-auto-registry-");
+    const paths = resolveDevAutoRegistryPaths({ devDataDir });
+    await fs.mkdir(paths.lockDir, { recursive: true });
+    await fs.utimes(paths.lockDir, 1, 1);
+
+    const lock = await acquireDevAutoRegistryLock({
+      now: () => 10_000,
+      paths,
+      staleLockMs: 1_000,
+      token: "fresh",
+    });
+
+    try {
+      await expect(
+        fs.readFile(path.join(paths.lockDir, "owner-token"), "utf8"),
+      ).resolves.toBe("fresh");
+    } finally {
+      await lock.release();
+    }
+  });
+
+  it("removes reservations idempotently", async () => {
+    const devDataDir = await makeTempDir("bb-dev-auto-registry-");
+    const reservation = await reserveDevAutoStack({
+      devDataDir,
+      isProcessAlive: allProcessesAlive,
+      ownerPid: process.pid,
+      probePort: allPortsAvailable,
+      repoRoot: "/repo",
+    });
+    const paths = resolveDevAutoRegistryPaths({ devDataDir });
+
+    await removeDevAutoReservation({ devDataDir, reservation });
+    await removeDevAutoReservation({ devDataDir, reservation });
+
+    await expect(loadDevAutoRegistry({ paths })).resolves.toEqual({
+      reservations: [],
+      version: 1,
+    });
+  });
+
+  it("renders a sourceable env file for the reserved stack", () => {
+    const reservation = createReservation({
+      devDataDir: "/tmp/bb dev auto's data",
+      ownerPid: process.pid,
+      slot: 1,
+    });
+    const envFile = renderDevAutoEnvFile({
+      stackEnv: createDevAutoStackEnvironment(reservation),
+    });
+
+    expect(envFile).toContain(
+      `export BB_DATA_DIR='/tmp/bb dev auto'"'"'s data/stacks/slot-1'`,
+    );
+    expect(envFile).toContain("export BB_SERVER_PORT='3344'");
+    expect(envFile).toContain("export BB_DEV_AUTO_SLOT='1'");
+  });
+});

--- a/packages/scripts/test/run-dev-auto.test.ts
+++ b/packages/scripts/test/run-dev-auto.test.ts
@@ -1,0 +1,269 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { deriveDevAutoPortTuple } from "../src/lib/dev-auto-ports.js";
+import {
+  createDevAutoTurboCommand,
+  runDevAutoWithRuntime,
+  type DevAutoChildProcess,
+  type DevAutoCommandRuntime,
+  type DevAutoSignalHandler,
+  type DevAutoSignalHandlerCleanup,
+  type DevAutoSpawnProcessRequest,
+} from "../src/commands/run-dev-auto.js";
+import type {
+  DevAutoReservation,
+  RemoveDevAutoReservationArgs,
+  ReserveDevAutoStackArgs,
+  WriteDevAutoEnvFileArgs,
+} from "../src/lib/dev-auto-registry.js";
+import type {
+  ForwardedSignal,
+  ProcessExitResult,
+} from "../src/lib/process-helpers.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+interface CreateReservationArgs {
+  dataDir?: string;
+  ownerPid?: number;
+  repoRoot?: string;
+  slot: number;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value: T): void {
+      if (!resolvePromise) {
+        throw new Error("Deferred promise was not initialized");
+      }
+      resolvePromise(value);
+    },
+  };
+}
+
+function createReservation(args: CreateReservationArgs): DevAutoReservation {
+  const slot = args.slot;
+  return {
+    createdAt: "2026-05-14T00:00:00.000Z",
+    dataDir: args.dataDir ?? `/tmp/bb-dev-auto/slot-${slot}`,
+    ownerPid: args.ownerPid ?? 2468,
+    ports: deriveDevAutoPortTuple(slot),
+    repoRoot: args.repoRoot ?? "/repo",
+    slot,
+    stackId: `bb-dev-auto-${slot}`,
+    updatedAt: "2026-05-14T00:00:00.000Z",
+  };
+}
+
+class FakeDevAutoChildProcess implements DevAutoChildProcess {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly killedSignals: NodeJS.Signals[] = [];
+  private readonly exit = createDeferred<ProcessExitResult>();
+
+  kill(signal: NodeJS.Signals): void {
+    this.killedSignals.push(signal);
+    this.signalCode = signal;
+    this.exit.resolve({
+      code: 1,
+      signal,
+    });
+  }
+
+  resolveExit(result: ProcessExitResult): void {
+    this.exitCode = result.signal ? null : result.code;
+    this.signalCode = result.signal;
+    this.exit.resolve(result);
+  }
+
+  waitForExit(): Promise<ProcessExitResult> {
+    return this.exit.promise;
+  }
+}
+
+class FakeDevAutoRuntime implements DevAutoCommandRuntime {
+  readonly currentPid = 2468;
+  readonly child = new FakeDevAutoChildProcess();
+  readonly releaseRequests: RemoveDevAutoReservationArgs[] = [];
+  readonly reserveRequests: ReserveDevAutoStackArgs[] = [];
+  readonly spawnRequests: DevAutoSpawnProcessRequest[] = [];
+  readonly writeEnvRequests: WriteDevAutoEnvFileArgs[] = [];
+  exitCode: number | null = null;
+  stdout = "";
+  private signalHandler: DevAutoSignalHandler | null = null;
+  private readonly spawned = createDeferred<void>();
+
+  constructor(
+    private readonly reservation: DevAutoReservation,
+    private readonly parentEnv: NodeJS.ProcessEnv,
+  ) {}
+
+  cwd(): string {
+    return this.reservation.repoRoot;
+  }
+
+  env(): NodeJS.ProcessEnv {
+    return this.parentEnv;
+  }
+
+  hostname(): string {
+    return "dev-machine";
+  }
+
+  installTerminationSignalForwarding(
+    handler: DevAutoSignalHandler,
+  ): DevAutoSignalHandlerCleanup {
+    this.signalHandler = handler;
+    return () => {
+      this.signalHandler = null;
+    };
+  }
+
+  releaseStackReservation(args: RemoveDevAutoReservationArgs): Promise<void> {
+    this.releaseRequests.push(args);
+    return Promise.resolve();
+  }
+
+  reserveStack(args: ReserveDevAutoStackArgs): Promise<DevAutoReservation> {
+    this.reserveRequests.push(args);
+    return Promise.resolve(this.reservation);
+  }
+
+  setExitCode(code: number): void {
+    this.exitCode = code;
+  }
+
+  spawnDevProcess(request: DevAutoSpawnProcessRequest): DevAutoChildProcess {
+    this.spawnRequests.push(request);
+    this.spawned.resolve();
+    return this.child;
+  }
+
+  writeStackEnvFile(args: WriteDevAutoEnvFileArgs): Promise<void> {
+    this.writeEnvRequests.push(args);
+    return Promise.resolve();
+  }
+
+  writeStdout(message: string): void {
+    this.stdout += message;
+  }
+
+  emitSignal(signal: ForwardedSignal): void {
+    if (!this.signalHandler) {
+      throw new Error("Signal handler was not installed");
+    }
+    this.signalHandler(signal);
+  }
+
+  waitForSpawn(): Promise<void> {
+    return this.spawned.promise;
+  }
+}
+
+describe("run-dev-auto", () => {
+  it("spawns the existing Turbo dev pipeline", () => {
+    expect(createDevAutoTurboCommand()).toEqual({
+      args: [
+        "exec",
+        "turbo",
+        "run",
+        "dev",
+        "--filter",
+        "@bb/app",
+        "--filter",
+        "@bb/server",
+        "--filter",
+        "@bb/host-daemon",
+        "--filter",
+        "@bb/dev-env",
+        "--ui",
+        "tui",
+        "--concurrency",
+        "20",
+        "--no-update-notifier",
+      ],
+      command: "pnpm",
+    });
+  });
+
+  it("injects the selected stack environment and scrubs leaked host bootstrap values", async () => {
+    const reservation = createReservation({ slot: 1 });
+    const runtime = new FakeDevAutoRuntime(reservation, {
+      BB_HOST_ENROLL_KEY: "leaked-key",
+      BB_HOST_ID: "host_leaked",
+      PATH: "/bin",
+    });
+
+    const runPromise = runDevAutoWithRuntime(runtime);
+    await runtime.waitForSpawn();
+    const spawnRequest = runtime.spawnRequests[0];
+
+    expect(spawnRequest?.env.BB_DATA_DIR).toBe(reservation.dataDir);
+    expect(spawnRequest?.env.BB_DATABASE_URL).toBe(
+      path.join(reservation.dataDir, "bb.db"),
+    );
+    expect(spawnRequest?.env.BB_SERVER_URL).toBe("http://127.0.0.1:3344");
+    expect(spawnRequest?.env.BB_SERVER_PORT).toBe("3344");
+    expect(spawnRequest?.env.BB_HOST_DAEMON_PORT).toBe("3012");
+    expect(spawnRequest?.env.BB_DEV_APP_PORT).toBe("5183");
+    expect(spawnRequest?.env.BB_DEV_ENV_PORT).toBe("9122");
+    expect(spawnRequest?.env.BB_DEV_AUTO_STACK_ID).toBe("bb-dev-auto-1");
+    expect(spawnRequest?.env.BB_DEV_AUTO_SLOT).toBe("1");
+    expect(spawnRequest?.env.BB_HOST_ID).toBeUndefined();
+    expect(spawnRequest?.env.BB_HOST_ENROLL_KEY).toBeUndefined();
+    expect(spawnRequest?.env.BB_HOST_NAME).toBe("dev-machine dev:auto slot 1");
+    expect(runtime.writeEnvRequests[0]?.envFilePath).toBe(
+      path.join(reservation.dataDir, "dev-auto.env"),
+    );
+    expect(runtime.stdout).toContain("BB_SERVER_URL=http://127.0.0.1:3344");
+
+    runtime.child.resolveExit({ code: 0, signal: null });
+    await runPromise;
+    expect(runtime.exitCode).toBe(0);
+    expect(runtime.releaseRequests).toHaveLength(1);
+  });
+
+  it("preserves an explicit host name", async () => {
+    const reservation = createReservation({ slot: 2 });
+    const runtime = new FakeDevAutoRuntime(reservation, {
+      BB_HOST_NAME: "custom host",
+    });
+
+    const runPromise = runDevAutoWithRuntime(runtime);
+    await runtime.waitForSpawn();
+
+    expect(runtime.spawnRequests[0]?.env.BB_HOST_NAME).toBe("custom host");
+
+    runtime.child.resolveExit({ code: 0, signal: null });
+    await runPromise;
+  });
+
+  it("forwards shutdown signals and releases the reservation", async () => {
+    const reservation = createReservation({ slot: 0 });
+    const runtime = new FakeDevAutoRuntime(reservation, {});
+
+    const runPromise = runDevAutoWithRuntime(runtime);
+    await runtime.waitForSpawn();
+
+    runtime.emitSignal("SIGTERM");
+    await runPromise;
+
+    expect(runtime.child.killedSignals).toEqual(["SIGTERM"]);
+    expect(runtime.exitCode).toBe(1);
+    expect(runtime.releaseRequests).toEqual([
+      {
+        env: {},
+        reservation,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `pnpm dev:auto` for running isolated development stacks from one checkout. The new scripts package helpers deterministically allocate coherent slot-based port tuples, probe loopback port availability, coordinate active reservations through an atomic directory lock, prune stale PID-owned reservations, and write a sourceable `dev-auto.env` per stack.

The command wrapper reserves a stack, prints the selected app/server/daemon/dev-env URLs plus CLI guidance, spawns the existing Turbo dev pipeline with stack-specific environment, scrubs leaked `BB_HOST_ID` and `BB_HOST_ENROLL_KEY`, synthesizes `BB_HOST_NAME` when absent, forwards shutdown signals, and releases the reservation on exit.

## User impact

`pnpm dev` behavior is unchanged. `pnpm dev:auto` starts from slot 0 when available, keeps each stack under its own `BB_DATA_DIR`, and allows separate local server, app, host daemon, dev-env helper, database, daemon auth, host identity, logs, runtime material, and supervisor PID files.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/scripts`
- `pnpm exec turbo run test --filter=@bb/scripts`
- `pnpm exec turbo run build --filter=@bb/scripts`
- `pnpm exec turbo run typecheck --filter=@bb/scripts --filter=@bb/config --filter=@bb/dev-env --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/app`
- `pnpm exec prettier --check package.json packages/scripts/package.json packages/scripts/src/commands/run-dev-auto.ts packages/scripts/src/lib/dev-auto-ports.ts packages/scripts/src/lib/dev-auto-registry.ts packages/scripts/test/dev-auto-ports.test.ts packages/scripts/test/dev-auto-registry.test.ts packages/scripts/test/run-dev-auto.test.ts`

Lightweight smoke: ran `run-dev-auto.ts` with `BB_DATA_DIR=/tmp/bb-dev-auto-smoke-codex` and a restricted `PATH` so it allocated a stack, printed the banner, wrote `dev-auto.env`, failed the intentional `pnpm` spawn, and released the registry reservation. The smoke selected slot 1 because slot 0 ports were occupied on this machine, and the registry was empty after exit.

## Deviations / notes

- Did not add `pnpm dev:auto:clean`, per the plan default.
- Did not run the full two-stack long-lived manual smoke in this automated pass; starting two full dev stacks is heavier and would require keeping local processes alive for browser/API verification. The PR includes automated coverage for allocation, registry locking, stale cleanup, env injection, spawn shape, and shutdown cleanup.