### PR TITLE
[codex] Fix Cmd+Enter submit when idle

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -102,6 +102,32 @@ describe("FollowUpPromptBox", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("uses the normal submit path for Cmd+Enter when steer is unavailable", () => {
+    const props = makeFollowUpPromptBoxProps();
+    const onSteerSubmit = vi.fn();
+    const onSubmit = vi.fn();
+    props.composer = {
+      ...props.composer,
+      canSteerSubmit: false,
+      onSteerSubmit,
+      onSubmit,
+      promptPlaceholder: "Ask for follow-up changes",
+      submitMode: { kind: "ready" },
+    };
+
+    render(<FollowUpPromptBox {...props} />);
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+    const wasNotCanceled = fireEvent.keyDown(textarea, {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(wasNotCanceled).toBe(false);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSteerSubmit).not.toHaveBeenCalled();
+  });
+
   it("preserves ordinary Enter submit behavior", () => {
     const props = makeFollowUpPromptBoxProps();
     const onSteerSubmit = vi.fn();

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -170,6 +170,9 @@ export function FollowUpPromptBox({
   const canStopRuntime = onStopRuntime !== undefined;
   const promptBoxRef = useRef<PromptBoxHandle>(null);
   const voice = usePromptVoice(promptBoxRef);
+  const onSteerSubmit = composer.canSteerSubmit
+    ? composer.onSteerSubmit
+    : undefined;
   const stackRef = useRef<HTMLDivElement>(null);
   const [stackHeight, setStackHeight] = useState(0);
   // Measure the stack synchronously after every render. useLayoutEffect runs
@@ -229,8 +232,7 @@ export function FollowUpPromptBox({
             onStop: onStopRuntime,
             isSubmitting: composer.isFollowUpSubmitting || isStopping,
             disabled: !canSubmit || composer.isFollowUpSubmitting,
-            onModifierSubmit: composer.onSteerSubmit,
-            modifierSubmitDisabled: !composer.canSteerSubmit,
+            onModifierSubmit: onSteerSubmit,
             title: canQueueFollowUp
               ? "Queue follow-up (Enter)"
               : isStopping

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -62,7 +62,6 @@ export interface PromptBoxSubmissionConfig {
   isRunning?: boolean;
   onStop?: () => void;
   onModifierSubmit?: () => void;
-  modifierSubmitDisabled?: boolean;
 }
 
 export interface MentionsConfig {
@@ -206,7 +205,6 @@ export function PromptBoxInternal({
     isRunning = false,
     onStop,
     onModifierSubmit,
-    modifierSubmitDisabled = false,
   } = submission;
   const {
     suggestions: mentionSuggestions,
@@ -584,7 +582,6 @@ export function PromptBoxInternal({
     onModifierSubmit !== undefined &&
     !isSubmitting &&
     !submitDisabled &&
-    !modifierSubmitDisabled &&
     !isVoiceBusy;
   const showStop = Boolean(isRunning && onStop && !canSubmit && !isVoiceBusy);
   const canStartVoiceInput =

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -50,6 +50,7 @@ interface MakeQueuedMessageArgs {
 
 interface RenderPromptAreaArgs {
   sendMessageMutateAsync: SendMessageMutationLike["mutateAsync"];
+  thread?: ThreadWithRuntime;
 }
 
 type ThreadOverrides = Partial<ThreadWithRuntime>;
@@ -271,7 +272,10 @@ function makeQueuedMessage(args: MakeQueuedMessageArgs): ThreadQueuedMessage {
   };
 }
 
-function renderPromptArea({ sendMessageMutateAsync }: RenderPromptAreaArgs) {
+function renderPromptArea({
+  sendMessageMutateAsync,
+  thread,
+}: RenderPromptAreaArgs) {
   return render(
     <ThreadDetailPromptArea
       canUseGitUi={true}
@@ -292,7 +296,7 @@ function renderPromptArea({ sendMessageMutateAsync }: RenderPromptAreaArgs) {
         isPending: false,
         mutateAsync: sendMessageMutateAsync,
       }}
-      thread={makeThread()}
+      thread={thread ?? makeThread()}
     />,
   );
 }
@@ -433,6 +437,59 @@ describe("ThreadDetailPromptArea steer submit", () => {
     expect(mocks.promptDraft.clearIfCurrentMatches).toHaveBeenCalledWith({
       attachments: [],
       text: "Current steer",
+    });
+  });
+
+  it("uses normal submit mode for Cmd+Enter on idle threads", async () => {
+    resetMocks();
+    const sendMessageMutateAsync = vi.fn<SendMessageMutationLike["mutateAsync"]>();
+    sendMessageMutateAsync.mockResolvedValue();
+    mocks.queuedMessages = [
+      makeQueuedMessage({
+        id: "queued-1",
+        input: [{ type: "text", text: "Queued follow-up" }],
+      }),
+    ];
+    mocks.promptDraft = createPromptDraftStorageMock({
+      attachments: [],
+      text: "Start a normal turn",
+    });
+
+    renderPromptArea({
+      sendMessageMutateAsync,
+      thread: makeThread({
+        status: "idle",
+        runtime: {
+          displayStatus: "idle",
+          hostReconnectGraceExpiresAt: null,
+        },
+      }),
+    });
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+    const wasNotCanceled = fireEvent.keyDown(textarea, {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(wasNotCanceled).toBe(false);
+    await waitFor(() => {
+      expect(sendMessageMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(sendMessageMutateAsync).toHaveBeenCalledWith({
+      id: "thread-1",
+      input: [{ type: "text", text: "Start a normal turn" }],
+      mode: "auto",
+      model: "gpt-5",
+      permissionMode: "full",
+      reasoningLevel: "medium",
+      serviceTier: "default",
+    });
+    expect(mocks.createDraftMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.sendDraftMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.promptDraft.clearIfCurrentMatches).toHaveBeenCalledWith({
+      attachments: [],
+      text: "Start a normal turn",
     });
   });
 


### PR DESCRIPTION
## Summary
- Wire the follow-up prompt modifier shortcut only when steer submit is actually available.
- Let Cmd+Enter fall through to the normal prompt submit path on idle/non-working threads.
- Add focused coverage for active steer behavior and idle normal-submit behavior with queued/current drafts.

## Validation
- `PATH="/Users/sawyerhood/Library/Caches/pnpm/dlx/mgdbhd5zwcpibuaobycjdzyaga/19e28e4c4fd-bb5d/node_modules/.pnpm/node@22.12.0/node_modules/node/bin:$PATH" pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/FollowUpPromptBox.test.tsx src/views/thread-detail/ThreadDetailPromptArea.test.tsx`
- `PATH="/Users/sawyerhood/Library/Caches/pnpm/dlx/mgdbhd5zwcpibuaobycjdzyaga/19e28e4c4fd-bb5d/node_modules/.pnpm/node@22.12.0/node_modules/node/bin:$PATH" pnpm exec turbo run typecheck --filter=@bb/app`

Note: the ambient shell is on Node 25.3.0, which breaks jsdom localStorage before tests load. Validation was run with Node 22.12.0 from `.nvmrc` first in `PATH`.