### PR TITLE
[codex] disable manager claude tools and enable codex search

### DIFF
--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -81,6 +81,7 @@ export async function startThread(
       options: command.options,
       instructions: command.instructions,
       dynamicTools: command.dynamicTools,
+      disallowedTools: command.disallowedTools,
       instructionMode: command.instructionMode,
     });
     options.runtimeManager.markThreadActive(
@@ -129,6 +130,7 @@ export async function ensureThreadRuntime(
       options: command.options,
       instructions: resumeContext.instructions,
       dynamicTools: resumeContext.dynamicTools,
+      disallowedTools: resumeContext.disallowedTools,
       instructionMode: resumeContext.instructionMode,
     });
     providerThreadId = result.providerThreadId;

--- a/apps/server/src/services/threads/thread-commands.ts
+++ b/apps/server/src/services/threads/thread-commands.ts
@@ -297,6 +297,9 @@ export async function buildThreadStartCommand(
     options: toRuntimeExecutionOptions(args),
     instructions: runtimeContext.instructions,
     dynamicTools: runtimeContext.dynamicTools,
+    ...(runtimeContext.disallowedTools?.length
+      ? { disallowedTools: [...runtimeContext.disallowedTools] }
+      : {}),
     instructionMode: runtimeContext.instructionMode,
     threadStoragePath: runtimeContext.threadStoragePath,
   };
@@ -322,6 +325,9 @@ function buildPreparedTurnSubmitCommandPayload(
       providerThreadId: args.providerThreadId,
       instructions: args.runtimeContext.instructions,
       dynamicTools: args.runtimeContext.dynamicTools,
+      ...(args.runtimeContext.disallowedTools?.length
+        ? { disallowedTools: [...args.runtimeContext.disallowedTools] }
+        : {}),
       instructionMode: args.runtimeContext.instructionMode,
     },
   };

--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -57,6 +57,11 @@ const MANAGER_DYNAMIC_TOOLS: DynamicTool[] = [
     inputSchema: MESSAGE_USER_TOOL_SCHEMA,
   },
 ];
+const MANAGER_DISALLOWED_TOOLS = [
+  "ExitPlanMode",
+  "NotebookEdit",
+  "Task",
+] as const;
 
 function resolveLocalTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -97,6 +102,7 @@ export interface ResolvePermissionEscalationArgs {
 
 export interface ResolvedThreadRuntimeCommandConfig {
   dynamicTools: DynamicTool[];
+  disallowedTools?: readonly string[];
   instructionMode: InstructionMode;
   instructions: string;
   projectId: string;
@@ -278,6 +284,7 @@ export async function resolveThreadRuntimeCommandConfig(
 
   return {
     dynamicTools: MANAGER_DYNAMIC_TOOLS,
+    disallowedTools: MANAGER_DISALLOWED_TOOLS,
     instructionMode: "replace",
     instructions: renderTemplate("managerAgentInstructions", {
       hostId: args.environment.hostId,

--- a/apps/server/test/public/public-threads.manager-and-ownership.test.ts
+++ b/apps/server/test/public/public-threads.manager-and-ownership.test.ts
@@ -325,6 +325,11 @@ describe("public thread manager and ownership routes", () => {
       expect(managerStartCommand.command.dynamicTools).toEqual([
         expect.objectContaining({ name: "message_user" }),
       ]);
+      expect(managerStartCommand.command.disallowedTools).toEqual([
+        "ExitPlanMode",
+        "NotebookEdit",
+        "Task",
+      ]);
       expect(managerStartCommand.command.instructions).toContain(
         "You are a manager in a project inside bb",
       );

--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -249,6 +249,7 @@ describe("claude-code provider adapter", () => {
           },
         },
       ],
+      disallowedTools: ["ExitPlanMode", "NotebookEdit", "Task"],
     });
 
     expect(cmd).toMatchObject({
@@ -275,6 +276,7 @@ describe("claude-code provider adapter", () => {
             },
           },
         ],
+        disallowedTools: ["ExitPlanMode", "NotebookEdit", "Task"],
       },
     });
     expect(cmd?.params).toMatchObject({

--- a/packages/agent-runtime/src/claude-code/adapter.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.ts
@@ -816,6 +816,9 @@ export function createClaudeCodeProviderAdapter(
               ...(dynamicTools && dynamicTools.length > 0
                 ? { dynamicTools }
                 : {}),
+              ...(command.disallowedTools && command.disallowedTools.length > 0
+                ? { disallowedTools: [...command.disallowedTools] }
+                : {}),
             },
           };
         }
@@ -869,6 +872,9 @@ export function createClaudeCodeProviderAdapter(
                 : {}),
               ...(dynamicTools && dynamicTools.length > 0
                 ? { dynamicTools }
+                : {}),
+              ...(command.disallowedTools && command.disallowedTools.length > 0
+                ? { disallowedTools: [...command.disallowedTools] }
                 : {}),
             },
           };

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -401,6 +401,7 @@ describe("bridge", () => {
       {
         baseInstructions: "You are a manager.",
         cwd: "/tmp/worktree",
+        disallowedTools: ["ExitPlanMode", "NotebookEdit", "Task"],
         instructionMode: "replace",
         permissionEscalation: "ask",
         permissionMode: "default",
@@ -410,6 +411,11 @@ describe("bridge", () => {
 
     expect(options.tools).toBeUndefined();
     expect(options.cwd).toBe("/tmp/worktree");
+    expect(options.disallowedTools).toEqual([
+      "ExitPlanMode",
+      "NotebookEdit",
+      "Task",
+    ]);
     expect(options.systemPrompt).toBe("You are a manager.");
   });
 

--- a/packages/agent-runtime/src/claude-code/bridge/commands.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/commands.ts
@@ -49,6 +49,7 @@ const claudeCodeCommandSchema = z.discriminatedUnion("method", [
       reasoningLevel: bridgeReasoningLevelSchema.optional(),
       instructionMode: bridgeInstructionModeSchema,
       dynamicTools: z.array(dynamicToolSchema).optional(),
+      disallowedTools: z.array(z.string()).optional(),
     }),
   }),
   z.object({
@@ -66,6 +67,7 @@ const claudeCodeCommandSchema = z.discriminatedUnion("method", [
       reasoningLevel: bridgeReasoningLevelSchema.optional(),
       instructionMode: bridgeInstructionModeSchema,
       dynamicTools: z.array(dynamicToolSchema).optional(),
+      disallowedTools: z.array(z.string()).optional(),
     }),
   }),
   z.object({

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -14,6 +14,7 @@ export interface BuildSessionOptionsArgs {
   additionalWorkspaceWriteRoots?: readonly string[];
   baseInstructions?: string;
   cwd: string;
+  disallowedTools?: readonly string[];
   instructionMode: InstructionMode;
   model?: string;
   permissionEscalation: PermissionEscalation | null;
@@ -219,6 +220,9 @@ export function buildSessionOptions(
     ...(hooks ? { hooks } : {}),
     ...(additionalDirectories.length > 0
       ? { additionalDirectories: [...additionalDirectories] }
+      : {}),
+    ...(params.disallowedTools && params.disallowedTools.length > 0
+      ? { disallowedTools: [...params.disallowedTools] }
       : {}),
   };
 }

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -1369,6 +1369,11 @@ describe("codex provider adapter", () => {
       params: {
         config: {
           "features.default_mode_request_user_input": false,
+          "tools.web_search": {
+            allowed_domains: null,
+            context_size: null,
+            location: null,
+          },
         },
       },
     });

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -657,6 +657,11 @@ function buildCodexConfig(
     config["model_reasoning_effort"] = args.options.reasoningLevel;
   }
   config["features.default_mode_request_user_input"] = false;
+  config["tools.web_search"] = {
+    allowed_domains: null,
+    context_size: null,
+    location: null,
+  };
   if (args.options?.permissionMode === "workspace-write") {
     const writableRoots = combineWorkspaceWriteRoots(
       args.gitWritableRoots,

--- a/packages/agent-runtime/src/provider-adapter.ts
+++ b/packages/agent-runtime/src/provider-adapter.ts
@@ -117,6 +117,7 @@ export type AdapterCommand =
       input?: PromptInput[];
       options: ProviderExecutionContext;
       dynamicTools?: DynamicTool[];
+      disallowedTools?: readonly string[];
       instructionMode: InstructionMode;
     }
   | {
@@ -126,6 +127,7 @@ export type AdapterCommand =
       providerThreadId: string;
       options: ProviderExecutionContext;
       dynamicTools?: DynamicTool[];
+      disallowedTools?: readonly string[];
       instructionMode: InstructionMode;
     }
   | {

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -69,6 +69,7 @@ type ProviderProcess = RuntimeProviderProcess;
 
 interface ThreadRuntimeConfig {
   dynamicTools?: DynamicTool[];
+  disallowedTools?: readonly string[];
   environmentId: string;
   instructionMode: InstructionMode;
   instructions?: string;
@@ -342,6 +343,7 @@ function createAgentRuntimeInternal(
         instructions: nextInstructions,
       }),
       dynamicTools: currentConfig.dynamicTools,
+      disallowedTools: currentConfig.disallowedTools,
       instructionMode: currentConfig.instructionMode,
     };
     const plan = proc.adapter.buildCommandPlan(adapterCommand);
@@ -597,6 +599,7 @@ function createAgentRuntimeInternal(
       options: execOpts,
       instructions,
       dynamicTools,
+      disallowedTools,
       instructionMode = "append",
     }) {
       await runtime.ensureProvider({ providerId });
@@ -615,6 +618,7 @@ function createAgentRuntimeInternal(
       });
       setThreadRuntimeConfig(threadId, {
         dynamicTools,
+        disallowedTools,
         environmentId,
         instructionMode,
         instructions,
@@ -641,6 +645,7 @@ function createAgentRuntimeInternal(
           instructions,
         }),
         dynamicTools,
+        disallowedTools,
         instructionMode,
       };
       const cmd = requireProviderRequestPlan({
@@ -710,6 +715,7 @@ function createAgentRuntimeInternal(
       options: execOpts,
       instructions,
       dynamicTools,
+      disallowedTools,
       instructionMode = "append",
     }) {
       await runtime.ensureProvider({ providerId });
@@ -728,6 +734,7 @@ function createAgentRuntimeInternal(
       });
       setThreadRuntimeConfig(threadId, {
         dynamicTools,
+        disallowedTools,
         environmentId,
         instructionMode,
         instructions,
@@ -759,6 +766,7 @@ function createAgentRuntimeInternal(
           instructions,
         }),
         dynamicTools,
+        disallowedTools,
         instructionMode,
       };
       const plan = proc.adapter.buildCommandPlan(adapterCommand);

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -87,6 +87,7 @@ export interface StartThreadArgs {
   options: AgentRuntimeExecutionOptions;
   instructions?: string;
   dynamicTools?: DynamicTool[];
+  disallowedTools?: readonly string[];
   instructionMode?: InstructionMode;
 }
 
@@ -103,6 +104,7 @@ export interface ResumeThreadArgs {
   options: AgentRuntimeExecutionOptions;
   instructions?: string;
   dynamicTools?: DynamicTool[];
+  disallowedTools?: readonly string[];
   instructionMode?: InstructionMode;
 }
 

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -92,6 +92,7 @@ const hostDaemonThreadRuntimeContextSchema = z.object({
   options: hostDaemonExecutionOptionsSchema,
   instructions: z.string().min(1),
   dynamicTools: z.array(dynamicToolSchema),
+  disallowedTools: z.array(z.string()).optional(),
   instructionMode: instructionModeSchema,
 });
 

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -39,6 +39,10 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
     "host.read_file may omit ref to read from disk; setting ref switches to git history at that ref.",
   "hostDaemonCommandSchema.threadStoragePath":
     "thread.start may include a storage path for manager threads so the daemon creates the directory before the agent starts.",
+  "hostDaemonCommandSchema.disallowedTools":
+    "manager thread runtime context may omit provider-specific built-in tool removals for providers that do not need them.",
+  "hostDaemonCommandSchema.resumeContext.disallowedTools":
+    "turn.submit resume context may omit provider-specific built-in tool removals for providers that do not need them.",
 };
 
 describe("host-daemon local schemas", () => {


### PR DESCRIPTION
## Summary

- Add `disallowedTools` to the server/host-daemon/agent-runtime Claude Code thread-start and resume flow.
- Configure manager Claude Code threads to remove `ExitPlanMode`, `NotebookEdit`, and `Task` from the SDK tool set.
- Always enable Codex `tools.web_search` config for Codex threads.
- Add focused contract, adapter, bridge, and server coverage for the new behavior.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/server --filter=@bb/host-daemon-contract --filter=@bb/host-daemon`
- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/host-daemon-contract --filter=@bb/server --filter=@bb/host-daemon --force`
- `git diff --check`

## Notes

- Confirmed the installed Anthropic Claude Agent SDK binary exposes the case-sensitive tool names `Task`, `NotebookEdit`, and `ExitPlanMode`.
- Confirmed the Codex generated config schema exposes `ToolsV2.web_search`, matching the dotted `tools.web_search` config key path.
