### PR TITLE
Use nanoid for optimistic IDs to support insecure-context browsers

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -45,6 +45,7 @@
     "hono": "^4.7.0",
     "jotai": "^2.19.0",
     "jotai-family": "^1.0.1",
+    "nanoid": "^5.1.6",
     "partysocket": "^1.1.16",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { nanoid } from "nanoid";
 import {
   type PromptHistoryEntry,
   type ThreadWithRuntime,
@@ -85,7 +86,7 @@ function buildAcceptedPromptHistoryEntry(args: {
   input: PromptHistoryEntry["input"];
 }): PromptHistoryEntry {
   return {
-    id: `optimistic-prompt-history:${crypto.randomUUID()}`,
+    id: `optimistic-prompt-history:${nanoid()}`,
     createdAt: args.createdAt,
     input: args.input,
   };
@@ -230,7 +231,7 @@ function buildOptimisticUserMessageRow({
   threadId,
   threadStatus,
 }: BuildOptimisticUserMessageRowParams): TimelineRow {
-  const id = `optimistic-user-${crypto.randomUUID()}`;
+  const id = `optimistic-user-${nanoid()}`;
   const text = input
     .filter(
       (entry): entry is Extract<typeof entry, { type: "text" }> =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       jotai-family:
         specifier: ^1.0.1
         version: 1.0.1(jotai@2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.13)(react@19.2.4))
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.6
       partysocket:
         specifier: ^1.1.16
         version: 1.1.16(react@19.2.4)


### PR DESCRIPTION
## Summary

- `crypto.randomUUID()` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), so remote devices loading bb over plain HTTP (e.g. another machine on the tailnet hitting `http://<host>.<tailnet>.ts.net:38886`) hit `TypeError: crypto.randomUUID is not a function` on the optimistic-update paths in `thread-runtime-mutations.ts` — meaning sending a prompt or queueing a message just fails on those devices.
- Swap to `nanoid`, which uses `crypto.getRandomValues` and is available in insecure contexts. These IDs are only used as local optimistic-update keys (prefixed `optimistic-prompt-history:` / `optimistic-user-`), so UUID shape is not required.
- `docs/multiple-devices.md` currently frames HTTPS via `tailscale serve` as optional ("for voice and clipboard"). With this change, the no-HTTPS path actually works for the core flow on remote devices too — a follow-up doc tweak might be worth it.

## Test plan

- [ ] `pnpm exec turbo run typecheck --filter=@bb/app` (passes locally)
- [ ] Send a prompt and queue a message from a remote tailnet device loading bb over `http://<host>.<tailnet>.ts.net:38886` — both should succeed with no console errors
- [ ] Same flows still work on `localhost` and over `https://` via `tailscale serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)