### PR TITLE
ship manager-friendly default built-in template (PREFERENCES.md + STATUS.html)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --templates --copy-dir ../../packages/db/drizzle dist/drizzle",
+    "build": "node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --templates --copy-dir ../../packages/db/drizzle dist/drizzle --copy-dir src/services/threads/default-template dist/default-template",
     "bench": "vitest bench --config vitest.config.ts",
     "start": "node dist/index.js",
     "start:prod": "cross-env NODE_ENV=production node dist/index.js",

--- a/apps/server/src/services/threads/default-template/PREFERENCES.md
+++ b/apps/server/src/services/threads/default-template/PREFERENCES.md
@@ -1,0 +1,35 @@
+# User Preferences
+
+This file is the manager's durable memory of how the user wants to be worked with. Edit it as you learn — keep it current.
+
+## Identity
+
+- Preferred name: _(not yet provided — ask when natural)_
+
+## Workflow
+
+- **Delegator workflow**: never do substantive work in the manager thread. Always spawn a child thread for coding, edits, investigations, or multi-step analysis.
+- **Fresh main before every spawn**: before every `bb thread spawn`, ensure the local `main` is current with `origin/main` so workers start from the latest base.
+  - Run first: `git -C <project-root> fetch origin main && git -C <project-root> pull --ff-only origin main` (works because `main` is typically the checked-out branch).
+  - Pass `--base-branch main` to `bb thread spawn` so the worker's worktree branches off the just-pulled commit.
+  - Skip this only if the user explicitly tells you the worker should branch off something else (e.g. chaining off another PR's branch).
+- **Landing changes**: when a worker finishes work that should be applied to the codebase, ask the user once how they want it landed, then record the answer right here in this bullet under the chosen mode. Two common modes:
+  - **Open PRs** — open them automatically and report the URL. Default to `gh pr create --draft`; switch to non-draft if the user prefers. Worker-thread completion notifications should trigger refreshing the open-PR view in `STATUS.html`.
+  - **No PRs — local merge, push on request** — merge the worker's branch into the local checkout, but only push to `origin` when the user explicitly says so. Keep branches local; do not open any PR.
+  - _Chosen mode:_ _(not yet decided — ask when natural)_
+
+  Adjust `STATUS.html` to match the chosen mode (see next bullet).
+- **STATUS.html mode**: if the user opens PRs, `STATUS.html` tracks open PRs in its primary section. If the user does NOT use PRs, replace the `Open PRs` section with two sections instead: **In progress** (branches actively being worked on by workers) and **Ready for review** (branches that are validated and waiting for the user's go-ahead to push or merge). Snippet patterns for both modes live in the HTML comment block at the bottom of `STATUS.html` — copy/paste as needed.
+- **STATUS.html refresh**: keep `STATUS.html` (canonical) current — do not also keep a `STATUS.md`. Refresh:
+  - periodically via a schedule in `ASYNC.md` (create one when scheduled refreshes are wanted; e.g. a `pr-refresh` schedule under PR mode).
+  - after any state-affecting action (worker spawn, branch ready, PR opened, merge, close, push).
+  - **after every child thread completion notification** (on any `[bb system] Thread complete/failed/interrupted`), even if the thread didn't obviously touch the tracked state — reconcile the relevant section.
+- **STATUS.html styling**: run `bb guide styling` for the bb design tokens, fonts, and a starter `<style>` snippet so the iframe-rendered HTML matches the rest of the app.
+
+## Open questions to resolve when natural
+
+- Preferred name / how to address the user
+- Worker defaults (provider / reasoning level / permission mode / preferred model) — ask the user when it comes up; do not assume a default.
+- Anything else the user wants surfaced in `STATUS.html` (extra sections, custom info, integrations) — ask once when natural and update the template accordingly.
+- Update verbosity preference (terse vs detailed)
+- Any specific area of the codebase that's currently the focus

--- a/apps/server/src/services/threads/default-template/STATUS.html
+++ b/apps/server/src/services/threads/default-template/STATUS.html
@@ -1,0 +1,380 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manager Status</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* bb design tokens, mirrored from apps/app/src/components/ui/theme.css.
+         See also: `bb guide styling`. */
+      :root {
+        color-scheme: light;
+        --background: oklch(0.9551 0 0);
+        --foreground: oklch(0.3211 0 0);
+        --card: oklch(0.9702 0 0);
+        --muted-foreground: oklch(0.5103 0 0);
+        --secondary: oklch(0.9067 0 0);
+        --border: oklch(0.8576 0 0);
+        --success: oklch(0.7 0.15 155);
+        --attention: oklch(0.74 0.15 80);
+        --destructive: oklch(0.5594 0.19 25.8625);
+        --primary: oklch(0.4891 0 0);
+        --font-sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        --font-mono: "Fira Code", ui-monospace, Menlo, monospace;
+        --radius: 0.35rem;
+        --radius-sm: calc(var(--radius) - 4px);
+        --shadow-sm:
+          0px 2px 0px 0px hsl(0 0% 20% / 0.12),
+          0px 1px 2px -1px hsl(0 0% 20% / 0.12);
+        --text-xs: 0.75rem;
+        --text-sm: 0.8125rem;
+        --text-base: 0.9375rem;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+          --background: oklch(0.195 0 0);
+          --foreground: oklch(0.8853 0 0);
+          --card: oklch(0.2435 0 0);
+          --muted-foreground: oklch(0.66 0 0);
+          --secondary: oklch(0.3092 0 0);
+          --border: oklch(0.329 0 0);
+          --success: oklch(0.74 0.15 155);
+          --attention: oklch(0.8 0.15 80);
+          --destructive: oklch(0.56 0.19 22.1703);
+          --primary: oklch(0.7058 0 0);
+        }
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html {
+        height: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+        scrollbar-width: thin;
+        scrollbar-color: var(--border) transparent;
+      }
+      html::-webkit-scrollbar {
+        width: 10px;
+      }
+      html::-webkit-scrollbar-thumb {
+        background: var(--border);
+        border-radius: 999px;
+        border: 2px solid var(--background);
+      }
+      html::-webkit-scrollbar-thumb:hover {
+        background: var(--muted-foreground);
+      }
+
+      body {
+        margin: 0;
+        padding: 16px 16px 20px;
+        background: var(--background);
+        color: var(--foreground);
+        font-family: var(--font-sans);
+        font-size: var(--text-base);
+        line-height: 1.45;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+      }
+
+      code,
+      .mono {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--muted-foreground);
+      }
+
+      /* header */
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding-bottom: 10px;
+        border-bottom: 1px solid var(--border);
+      }
+      .brand {
+        width: 20px;
+        height: 20px;
+        border: 1px solid var(--border);
+        background: var(--card);
+        border-radius: var(--radius-sm);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-mono);
+        font-weight: 500;
+        font-size: 10px;
+      }
+      .title {
+        font-size: var(--text-sm);
+        font-weight: 600;
+        letter-spacing: -0.005em;
+        flex: 1;
+        min-width: 0;
+      }
+      .ts {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        color: var(--muted-foreground);
+      }
+
+      /* sections */
+      section {
+        margin-top: 16px;
+      }
+      .sect-title {
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--muted-foreground);
+        margin-bottom: 8px;
+      }
+
+      /* row */
+      .row {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 10px 12px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+      }
+      .row + .row {
+        margin-top: 6px;
+      }
+      .row .main {
+        min-width: 0;
+        flex: 1;
+      }
+      .row .label {
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        color: var(--muted-foreground);
+        margin-bottom: 3px;
+      }
+      .row .name {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1.35;
+        color: var(--foreground);
+        word-break: break-word;
+      }
+
+      /* pill */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        font-weight: 500;
+        line-height: 1;
+        padding: 3px 7px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: var(--secondary);
+        color: var(--muted-foreground);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+      .pill .dot {
+        width: 5px;
+        height: 5px;
+        border-radius: 999px;
+        background: currentColor;
+      }
+      .pill.open {
+        color: var(--success);
+        background: color-mix(in srgb, var(--success) 12%, var(--background));
+        border-color: color-mix(in srgb, var(--success) 32%, var(--border));
+      }
+      .pill.running {
+        color: var(--attention);
+        background: color-mix(in srgb, var(--attention) 14%, var(--background));
+        border-color: color-mix(in srgb, var(--attention) 32%, var(--border));
+      }
+      .pill.failed {
+        color: var(--destructive);
+        background: color-mix(in srgb, var(--destructive) 12%, var(--background));
+        border-color: color-mix(in srgb, var(--destructive) 32%, var(--border));
+      }
+
+      .empty {
+        padding: 10px 12px;
+        font-size: var(--text-sm);
+        color: var(--muted-foreground);
+        font-style: italic;
+        border: 1px dashed var(--border);
+        border-radius: var(--radius);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="header">
+      <span class="brand">bb</span>
+      <span class="title">Manager status</span>
+      <span class="ts">—</span>
+    </header>
+
+    <section>
+      <div class="sect-title">Open PRs · 0</div>
+      <div class="empty">No open PRs.</div>
+    </section>
+
+    <section>
+      <div class="sect-title">Active workers · 0</div>
+      <div class="empty">No active workers.</div>
+    </section>
+
+    <!--
+      =====================================================================
+      SNIPPET LIBRARY — copy/paste from these patterns when populating
+      STATUS.html. Keep them in sync if you change the styles above. For the
+      design tokens themselves, run `bb guide styling`.
+      =====================================================================
+
+      ---- Refresh timestamp (header right) ----
+      Update <span class="ts"> on every refresh:
+        <span class="ts">YYYY-MM-DD · HH:MM TZ</span>
+
+      ---- Section: open PRs (with count) ----
+      <section>
+        <div class="sect-title">Open PRs · 2</div>
+        <div class="row"> ...PR row... </div>
+        <div class="row"> ...PR row... </div>
+      </section>
+
+      ---- PR row ----
+      <div class="row">
+        <div class="main">
+          <div class="label">#42</div>
+          <div class="name">
+            <a href="https://github.com/OWNER/REPO/pull/42" target="_blank" rel="noopener">PR title goes here</a>
+          </div>
+        </div>
+        <span class="pill open"><span class="dot"></span>Open</span>
+      </div>
+
+      ---- Active worker row ----
+      <div class="row">
+        <div class="main">
+          <div class="label">thr_xxxxxxxxxx</div>
+          <div class="name">One-line description of what the worker is doing</div>
+        </div>
+        <span class="pill running"><span class="dot"></span>Running</span>
+      </div>
+
+      ---- Empty state ----
+      <div class="empty">No open PRs.</div>
+      <div class="empty">No active workers.</div>
+
+      ---- Pill variants ----
+      <span class="pill open"><span class="dot"></span>Open</span>            (success / green)
+      <span class="pill running"><span class="dot"></span>Running</span>      (attention / amber)
+      <span class="pill failed"><span class="dot"></span>Failed</span>        (destructive / red)
+      <span class="pill"><span class="dot"></span>Neutral</span>              (muted)
+
+      ---- Inline status annotation on a name (e.g. "Superseded by #99") ----
+      <span class="pill" style="margin-left:6px; color:var(--destructive); border-color:color-mix(in srgb,var(--destructive) 32%,var(--border)); background:color-mix(in srgb,var(--destructive) 12%,var(--background))">Superseded by #99</span>
+
+      =====================================================================
+      No-PR landing mode — use these two sections in place of "Open PRs"
+      when the user has opted out of PRs. "In progress" tracks worker
+      branches in flight; "Ready for review" tracks validated branches
+      waiting for the user to push or merge.
+      =====================================================================
+
+      ---- Section: in-progress work (no-PR mode) ----
+      <section>
+        <div class="sect-title">In progress · N</div>
+        <div class="row">
+          <div class="main">
+            <div class="label">branch-name</div>
+            <div class="name">One-line description of the work in flight</div>
+          </div>
+          <span class="pill running"><span class="dot"></span>WIP</span>
+        </div>
+      </section>
+
+      ---- Section: ready for review (no-PR mode) ----
+      <section>
+        <div class="sect-title">Ready for review · N</div>
+        <div class="row">
+          <div class="main">
+            <div class="label">branch-name</div>
+            <div class="name">One-line description · validated and waiting for user OK</div>
+          </div>
+          <span class="pill open"><span class="dot"></span>Ready</span>
+        </div>
+      </section>
+
+      ---- Optional sections you may want later ----
+
+      Active workers entry with provider/base meta (use a card-style row with extra meta block):
+      <article class="row" style="flex-direction:column; align-items:stretch; gap:6px">
+        <div style="display:flex; justify-content:space-between; gap:10px; align-items:flex-start">
+          <span class="label">thr_xxxxxxxxxx</span>
+          <span class="pill running"><span class="dot"></span>Running</span>
+        </div>
+        <div class="name">Description</div>
+        <div style="display:flex; flex-direction:column; gap:3px; font-family:var(--font-mono); font-size:10.5px; color:var(--muted-foreground)">
+          <span>provider · codex · xhigh · full perms</span>
+          <span>base · origin/main</span>
+        </div>
+      </article>
+
+      Dev-instance callout:
+      <section>
+        <div class="sect-title">Dev instance</div>
+        <div class="row">
+          <div class="main">
+            <div class="label">~/.bb-dev/</div>
+            <div class="name">Running PR #NN worktree.</div>
+          </div>
+          <span class="pill running"><span class="dot"></span>Up</span>
+        </div>
+      </section>
+
+      Recently completed feed (compact list — keep short, e.g. last 3):
+      <section>
+        <div class="sect-title">Recently completed · 2</div>
+        <div class="row">
+          <div class="main">
+            <div class="label">thr_xxxxxxxxxx</div>
+            <div class="name">
+              One-line outcome — <a href="https://github.com/OWNER/REPO/pull/41" target="_blank" rel="noopener">PR #41</a>
+              <span class="pill" style="margin-left:6px">Merged</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    -->
+  </body>
+</html>

--- a/apps/server/src/services/threads/manager-storage-templates.ts
+++ b/apps/server/src/services/threads/manager-storage-templates.ts
@@ -1,4 +1,4 @@
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, readFileSync } from "node:fs";
 import type { Dirent } from "node:fs";
 import {
   copyFile,
@@ -9,6 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   managerTemplateNameSchema,
   type ManagerTemplateName,
@@ -20,25 +21,12 @@ export const MANAGER_TEMPLATE_DIR_NAME = "manager-templates";
 export const ACTIVE_MANAGER_TEMPLATE_FILE_NAME = "active";
 export const DEFAULT_MANAGER_TEMPLATE_NAME: ManagerTemplateName = "default";
 
-const DEFAULT_PREFERENCES_CONTENT = `# Preferences
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultTemplateAssetDir = path.join(moduleDir, "default-template");
 
-No user-specific preferences have been recorded yet. On first welcome, ask what the user prefers to be called and how they like updates, then replace this starter note with durable preferences.
-`;
-
-const DEFAULT_STATUS_CONTENT = `# Status
-
-No active work yet.
-`;
-
-const DEFAULT_ASYNC_CONTENT = `---
-timezone: UTC
-schedules: []
----
-
-# Scheduled nudges
-
-No scheduled nudges yet.
-`;
+function loadDefaultTemplateAsset(fileName: string): string {
+  return readFileSync(path.join(defaultTemplateAssetDir, fileName), "utf8");
+}
 
 type ManagerTemplateLogger = Pick<ServerLogger, "debug" | "warn">;
 
@@ -106,15 +94,11 @@ const BUILT_IN_MANAGER_TEMPLATE_SETS: readonly BuiltInManagerTemplateSet[] = [
     files: [
       {
         fileName: "PREFERENCES.md",
-        content: DEFAULT_PREFERENCES_CONTENT,
+        content: loadDefaultTemplateAsset("PREFERENCES.md"),
       },
       {
-        fileName: "STATUS.md",
-        content: DEFAULT_STATUS_CONTENT,
-      },
-      {
-        fileName: "ASYNC.md",
-        content: DEFAULT_ASYNC_CONTENT,
+        fileName: "STATUS.html",
+        content: loadDefaultTemplateAsset("STATUS.html"),
       },
     ],
   },

--- a/apps/server/test/threads/manager-storage-templates.test.ts
+++ b/apps/server/test/threads/manager-storage-templates.test.ts
@@ -25,18 +25,23 @@ describe("manager storage templates", () => {
       await expect(
         readFile(path.join(templateRootPath, "active"), "utf8"),
       ).resolves.toBe("default\n");
+      const preferencesContent = await readFile(
+        path.join(templateRootPath, "default", "PREFERENCES.md"),
+        "utf8",
+      );
+      expect(preferencesContent).toContain(
+        "## Open questions to resolve when natural",
+      );
+      expect(preferencesContent).toContain("Landing changes");
       await expect(
-        readFile(
-          path.join(templateRootPath, "default", "PREFERENCES.md"),
-          "utf8",
-        ),
-      ).resolves.toContain("No user-specific preferences");
-      await expect(
-        readFile(path.join(templateRootPath, "default", "STATUS.md"), "utf8"),
-      ).resolves.toContain("No active work yet");
+        readFile(path.join(templateRootPath, "default", "STATUS.html"), "utf8"),
+      ).resolves.toContain('<div class="sect-title">Open PRs · 0</div>');
       await expect(
         readFile(path.join(templateRootPath, "default", "ASYNC.md"), "utf8"),
-      ).resolves.toContain("schedules: []");
+      ).rejects.toThrow();
+      await expect(
+        readFile(path.join(templateRootPath, "default", "STATUS.md"), "utf8"),
+      ).rejects.toThrow();
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }
@@ -63,7 +68,7 @@ describe("manager storage templates", () => {
         readFile(path.join(defaultTemplatePath, "PREFERENCES.md"), "utf8"),
       ).resolves.toBe("custom prefs\n");
       await expect(
-        readFile(path.join(defaultTemplatePath, "STATUS.md"), "utf8"),
+        readFile(path.join(defaultTemplatePath, "STATUS.html"), "utf8"),
       ).rejects.toThrow();
     } finally {
       await rm(dataDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Replaces the minimal starter content from #24 with two richer files reflecting how this manager flow actually operates — better first-run experience for new managers.
- The bundle's `default/` now ships **exactly** `PREFERENCES.md` and `STATUS.html` — no `STATUS.md` and no `ASYNC.md`.
  - `STATUS.md` would conflict with `STATUS.html`; the manager prompt requires one or the other, not both.
  - `ASYNC.md` is intentionally not part of the default seed. A manager can write its own `ASYNC.md` from the meet-and-greet when it wants schedules.
- The bundled PREFERENCES.md is **non-prescriptive** about how the user wants to work:
  - Worker defaults (provider / reasoning level / permission mode / preferred model) live under "Open questions to resolve when natural" — the manager asks, never assumes.
  - There is **no assumed PR mode**. A new `Landing changes` Workflow bullet describes two common modes — **Open PRs** (with `gh pr create --draft` as the default, switchable to non-draft) and **No PRs — local merge, push on request** — and tells the manager to ask the user once and record the chosen mode in the bullet itself.
  - The follow-up `STATUS.html mode` bullet explains that STATUS.html tracks open PRs in PR mode, and switches to two sections (`In progress` and `Ready for review`) in no-PR mode.
  - A new open question covers anything else the user wants surfaced in `STATUS.html` (extra sections, custom info, integrations).
- The bundled `STATUS.html` snippet library now has a clearly-marked no-PR-mode group with copy/paste blocks for `In progress · N` and `Ready for review · N` sections, in addition to the existing PR-mode patterns.
- Install behaviour is unchanged from #24: `ensureBuiltInManagerTemplatesInstalled` still only writes the `default/` directory when it is absent, never overwriting a user-edited one.

## What changes

- `apps/server/src/services/threads/default-template/{PREFERENCES.md, STATUS.html}` — new asset files (the canonical source of truth for the bundled default).
  - `PREFERENCES.md` — `Identity` placeholder, `Workflow` (delegator pattern, fresh-`main`-before-spawn, `Landing changes` with two modes, `STATUS.html mode`, `STATUS.html refresh`, `STATUS.html styling`), and `Open questions to resolve when natural` (incl. worker defaults and STATUS.html extras).
  - `STATUS.html` — zero-state dashboard with header/section/row/pill primitives styled from the bb design tokens, plus an inlined snippet library: refresh timestamp, Open-PRs section + PR row, active-worker row, empty states, pill variants, inline status annotation, a no-PR-mode group (In progress + Ready for review sections), and optional extras (active workers with meta, dev-instance callout, recently completed feed). Tokens mirror `apps/app/src/components/ui/theme.css`; see `bb guide styling`.
- `apps/server/src/services/threads/manager-storage-templates.ts` — `BUILT_IN_MANAGER_TEMPLATE_SETS` lists exactly `PREFERENCES.md` and `STATUS.html`, and loads each file's contents via `readFileSync` from a directory resolved off `import.meta.url`. The install/seeding logic itself is untouched.
- `apps/server/package.json` — build script gains `--copy-dir src/services/threads/default-template dist/default-template`, mirroring the existing drizzle copy so the prod bundle finds the assets next to `dist/index.js`.
- `apps/server/test/threads/manager-storage-templates.test.ts` — assertions updated to match the new content: `PREFERENCES.md` contains both `## Open questions to resolve when natural` and `Landing changes`; `STATUS.html` contains the `Open PRs · 0` sect-title; the bundle ships neither `STATUS.md` nor `ASYNC.md`.

## Test plan

- [x] `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/templates`
- [x] `pnpm exec turbo run test --filter=@bb/server --filter=@bb/templates` (668 server tests pass)
- [x] Sanity sweep: `pnpm exec turbo run test --filter=@bb/cli --filter=@bb/app --filter=@bb/host-daemon` — all pass
- [x] `pnpm exec turbo run build --filter=@bb/server` — confirms `dist/default-template/` contains exactly `PREFERENCES.md` and `STATUS.html` (no `ASYNC.md`, no `STATUS.md`); `Landing changes` and the no-PR-mode snippet group are present in dist
- [x] `git diff --check` — clean
- [ ] Manual: start a fresh data dir, run the server, and confirm exactly two files (`PREFERENCES.md`, `STATUS.html`) land in `<dataDir>/manager-templates/default/`. Then create a new manager thread and confirm storage is seeded from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)