### PR TITLE
fix: forward prompt attachments to Claude Code adapter

### DIFF
--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -297,6 +297,18 @@ async function readNextPromptText(call: ClaudeQueryCall): Promise<string> {
   return content;
 }
 
+type ClaudePromptContent = SDKUserMessage["message"]["content"];
+
+async function readNextPromptContent(
+  call: ClaudeQueryCall,
+): Promise<ClaudePromptContent> {
+  const result = await call.prompt[Symbol.asyncIterator]().next();
+  if (result.done) {
+    throw new Error("Expected Claude prompt input");
+  }
+  return result.value.message.content;
+}
+
 function createResultUsage(): SdkResultUsage {
   return {
     cache_creation: {
@@ -2082,6 +2094,145 @@ describe("bridge", () => {
       await bridge.flushWork();
       queries[1]?.finish();
       await bridge.waitForResponse(14);
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("forwards prompt text as a plain string to preserve SDK cache hits", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-prompt-text-only";
+      await startBridgeThread({ bridge, threadId });
+
+      bridge.sendRequest(2, "turn/start", {
+        input: [{ type: "text", text: "Hello there" }],
+        providerThreadId: null,
+        threadId,
+      });
+      await bridge.waitForResponse(2);
+
+      await expect(readNextPromptContent(getLatestQueryCall())).resolves.toBe(
+        "Hello there",
+      );
+
+      await stopBridgeThread({ bridge, queries, threadId });
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("forwards a localImage attachment as a base64 ImageBlockParam", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    const stagingDir = mkdtempSync(join(tmpdir(), "bb-bridge-attach-"));
+    tempDirs.push(stagingDir);
+    const imagePath = join(stagingDir, "000-screenshot.png");
+    const imageBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    writeFileSync(imagePath, Buffer.from(imageBase64, "base64"));
+
+    try {
+      const threadId = "thread-prompt-local-image";
+      await startBridgeThread({ bridge, threadId });
+
+      bridge.sendRequest(2, "turn/start", {
+        input: [
+          { type: "text", text: "Describe this image" },
+          { type: "localImage", path: imagePath },
+        ],
+        providerThreadId: null,
+        threadId,
+      });
+      await bridge.waitForResponse(2);
+
+      const content = await readNextPromptContent(getLatestQueryCall());
+      if (typeof content === "string") {
+        throw new Error("Expected ContentBlockParam[] content for attachments");
+      }
+      expect(content).toEqual([
+        { type: "text", text: "Describe this image" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: imageBase64,
+          },
+        },
+      ]);
+
+      await stopBridgeThread({ bridge, queries, threadId });
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("forwards a text localFile attachment as a DocumentBlockParam", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    const stagingDir = mkdtempSync(join(tmpdir(), "bb-bridge-attach-"));
+    tempDirs.push(stagingDir);
+    const filePath = join(stagingDir, "000-notes.md");
+    const fileBody = "# Title\n\nthe body";
+    writeFileSync(filePath, fileBody);
+
+    try {
+      const threadId = "thread-prompt-local-file";
+      await startBridgeThread({ bridge, threadId });
+
+      bridge.sendRequest(2, "turn/start", {
+        input: [
+          { type: "text", text: "Summarize this doc" },
+          {
+            type: "localFile",
+            path: filePath,
+            name: "notes.md",
+            sizeBytes: fileBody.length,
+          },
+        ],
+        providerThreadId: null,
+        threadId,
+      });
+      await bridge.waitForResponse(2);
+
+      const content = await readNextPromptContent(getLatestQueryCall());
+      if (typeof content === "string") {
+        throw new Error("Expected ContentBlockParam[] content for attachments");
+      }
+      expect(content).toEqual([
+        { type: "text", text: "Summarize this doc" },
+        {
+          type: "document",
+          source: {
+            type: "text",
+            media_type: "text/plain",
+            data: fileBody,
+          },
+          title: "notes.md",
+        },
+      ]);
+
+      await stopBridgeThread({ bridge, queries, threadId });
     } finally {
       bridge.restore();
     }

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/prompt-input-content.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/prompt-input-content.test.ts
@@ -1,0 +1,210 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildUserMessageContent,
+  type ClaudeContentBlockParam,
+} from "../prompt-input-content.js";
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+const tempDirs: string[] = [];
+
+async function createStagingDir(): Promise<string> {
+  const dir = await mkdtemp(
+    path.join(tmpdir(), "bb-prompt-input-content-test-"),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+function isContentBlockArray(
+  content: unknown,
+): content is ClaudeContentBlockParam[] {
+  return Array.isArray(content);
+}
+
+describe("buildUserMessageContent", () => {
+  afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("returns a plain string for a text-only input array", async () => {
+    const content = await buildUserMessageContent([
+      { type: "text", text: "hello" },
+      { type: "text", text: "world" },
+    ]);
+    expect(content).toBe("hello\nworld");
+  });
+
+  it("returns undefined for an empty input array", async () => {
+    expect(await buildUserMessageContent([])).toBeUndefined();
+  });
+
+  it("returns undefined when no text or attachments are present", async () => {
+    expect(await buildUserMessageContent([{ type: "unsupported" }])).toBeUndefined();
+  });
+
+  it("inlines a local PNG image as a base64 ImageBlockParam", async () => {
+    const dir = await createStagingDir();
+    const imagePath = path.join(dir, "000-screenshot.png");
+    await writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    const content = await buildUserMessageContent([
+      { type: "text", text: "look at this" },
+      { type: "localImage", path: imagePath },
+    ]);
+
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: "text", text: "look at this" });
+    expect(content[1]).toEqual({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: TINY_PNG_BASE64,
+      },
+    });
+  });
+
+  it("inlines a JPEG image and preserves jpeg media_type from extension", async () => {
+    const dir = await createStagingDir();
+    const imagePath = path.join(dir, "000-photo.jpeg");
+    await writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    const content = await buildUserMessageContent([
+      { type: "localImage", path: imagePath },
+    ]);
+
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content[0]).toMatchObject({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg" },
+    });
+  });
+
+  it("passes a URL image through as an ImageBlockParam with url source", async () => {
+    const content = await buildUserMessageContent([
+      { type: "image", url: "https://example.com/cat.png" },
+    ]);
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content[0]).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://example.com/cat.png" },
+    });
+  });
+
+  it("renders a text-like local file as a DocumentBlockParam with PlainTextSource", async () => {
+    const dir = await createStagingDir();
+    const filePath = path.join(dir, "000-notes.md");
+    await writeFile(filePath, "# Hello\nthis is the doc body");
+
+    const content = await buildUserMessageContent([
+      {
+        type: "localFile",
+        path: filePath,
+        name: "notes.md",
+        sizeBytes: 28,
+      },
+    ]);
+
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content[0]).toEqual({
+      type: "document",
+      source: {
+        type: "text",
+        media_type: "text/plain",
+        data: "# Hello\nthis is the doc body",
+      },
+      title: "notes.md",
+    });
+  });
+
+  it("renders a PDF local file as a DocumentBlockParam with Base64PDFSource", async () => {
+    const dir = await createStagingDir();
+    const filePath = path.join(dir, "000-paper.pdf");
+    const pdfBytes = Buffer.from("%PDF-1.4 hello", "utf8");
+    await writeFile(filePath, pdfBytes);
+
+    const content = await buildUserMessageContent([
+      {
+        type: "localFile",
+        path: filePath,
+        name: "paper.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: pdfBytes.length,
+      },
+    ]);
+
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content[0]).toEqual({
+      type: "document",
+      source: {
+        type: "base64",
+        media_type: "application/pdf",
+        data: pdfBytes.toString("base64"),
+      },
+      title: "paper.pdf",
+    });
+  });
+
+  it("falls back to a text marker for unsupported binary file types", async () => {
+    const dir = await createStagingDir();
+    const filePath = path.join(dir, "000-archive.zip");
+    await writeFile(filePath, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+
+    const content = await buildUserMessageContent([
+      {
+        type: "localFile",
+        path: filePath,
+        name: "archive.zip",
+        mimeType: "application/zip",
+        sizeBytes: 4,
+      },
+    ]);
+
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: "text" });
+    const block = content[0];
+    if (block.type !== "text") throw new Error("expected text block");
+    expect(block.text).toContain("archive.zip");
+    expect(block.text).toContain(filePath);
+  });
+
+  it("emits a text marker (not a thrown error) when a local image is missing on disk", async () => {
+    const content = await buildUserMessageContent([
+      { type: "text", text: "see image" },
+      { type: "localImage", path: "/nonexistent/path/missing.png" },
+    ]);
+    if (!isContentBlockArray(content)) {
+      throw new Error("Expected ContentBlockParam[] content");
+    }
+    expect(content[0]).toEqual({ type: "text", text: "see image" });
+    expect(content[1]).toMatchObject({ type: "text" });
+    const block = content[1];
+    if (block.type !== "text") throw new Error("expected text block");
+    expect(block.text).toContain("/nonexistent/path/missing.png");
+  });
+
+  it("returns the raw string for a string input (legacy code path)", async () => {
+    expect(await buildUserMessageContent("just a string")).toBe("just a string");
+  });
+});

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -40,6 +40,10 @@ import { shouldAutoDenyInteractiveRequest } from "../../shared/permission-policy
 import { SdkSession, type SdkSessionOptions } from "./sdk-session.js";
 import { listClaudeCodeBridgeModels } from "./model-list.js";
 import {
+  buildUserMessageContent,
+  type ClaudeMessageContent,
+} from "./prompt-input-content.js";
+import {
   decodeClaudeCodeJsonRpcRequest,
   type ClaudeCodeJsonRpcRequest,
   type ThreadResumeParams,
@@ -77,11 +81,6 @@ import {
   toPendingInteractionPermissionProfile,
 } from "../interactive-contract.js";
 export { buildSessionOptions } from "./session-options.js";
-
-const promptTextInputSchema = z.object({
-  type: z.literal("text"),
-  text: z.string(),
-});
 
 // Claude Agent SDK 0.2.111 types stale resume failures as generic
 // SDKResultError.errors. The bundled Claude Code CLI can also emit the same
@@ -190,7 +189,7 @@ interface CloseThreadSessionArgs {
 }
 
 interface ClaudeResumeRecoveryState {
-  acceptedInputTexts: string[];
+  acceptedInputs: ClaudeMessageContent[];
   attemptedProviderThreadId: string;
   retryAttempted: boolean;
 }
@@ -217,7 +216,7 @@ interface StartFreshSessionAfterStaleResumeArgs {
 }
 
 interface ReplaceThreadSessionArgs {
-  acceptedInputTexts: string[];
+  acceptedInputs: ClaudeMessageContent[];
   providerThreadId: string;
   replacementSession: ThreadSession;
   threadId: string;
@@ -492,8 +491,8 @@ function startFreshSessionAfterStaleResume(
     ...args.threadSession.sessionOptions,
     sessionId: providerThreadId,
   };
-  const acceptedInputTexts = [
-    ...(args.threadSession.resumeRecovery?.acceptedInputTexts ?? []),
+  const acceptedInputs = [
+    ...(args.threadSession.resumeRecovery?.acceptedInputs ?? []),
   ];
   const replacementSession = createThreadSession({
     permissionEscalation: args.threadSession.permissionEscalation,
@@ -506,7 +505,7 @@ function startFreshSessionAfterStaleResume(
   });
 
   replaceThreadSession({
-    acceptedInputTexts,
+    acceptedInputs,
     providerThreadId,
     replacementSession,
     threadId: args.threadId,
@@ -530,8 +529,8 @@ function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
   args.replacementSession.session.start();
   sendThreadIdentity(args.threadId, args.providerThreadId);
 
-  for (const inputText of args.acceptedInputTexts) {
-    args.replacementSession.session.pushInput(inputText);
+  for (const inputContent of args.acceptedInputs) {
+    args.replacementSession.session.pushInput(inputContent);
   }
 }
 
@@ -1131,10 +1130,10 @@ async function handleRequest(request: ClaudeCodeJsonRpcRequest): Promise<void> {
       await handleThreadResume(request.id, request.params);
       break;
     case "turn/start":
-      handleTurnStart(request.id, request.params);
+      await handleTurnStart(request.id, request.params);
       break;
     case "turn/steer":
-      handleTurnSteer(request.id, request.params);
+      await handleTurnSteer(request.id, request.params);
       break;
     case "thread/stop":
       sendResult(request.id, await handleThreadStop(request.params));
@@ -1225,7 +1224,7 @@ async function handleThreadResume(
       : {}),
     resumeRecovery: requestedProviderThreadId
       ? {
-          acceptedInputTexts: [],
+          acceptedInputs: [],
           attemptedProviderThreadId: requestedProviderThreadId,
           retryAttempted: false,
         }
@@ -1243,39 +1242,45 @@ async function handleThreadResume(
   });
 }
 
-function handleTurnStart(id: string | number, params: TurnStartParams): void {
+async function handleTurnStart(
+  id: string | number,
+  params: TurnStartParams,
+): Promise<void> {
   const threadSession = sessions.get(params.threadId);
   if (!threadSession || threadSession.closing) {
     sendError(id, -32000, "No active session");
     return;
   }
 
-  const input = extractInputText(params.input);
-  if (!input) {
+  const content = await buildUserMessageContent(params.input);
+  if (content === undefined) {
     sendError(id, -32602, "Missing input text");
     return;
   }
 
-  threadSession.resumeRecovery?.acceptedInputTexts.push(input);
-  threadSession.session.pushInput(input);
+  threadSession.resumeRecovery?.acceptedInputs.push(content);
+  threadSession.session.pushInput(content);
   sendResult(id, { threadId: params.threadId });
 }
 
-function handleTurnSteer(id: string | number, params: TurnSteerParams): void {
+async function handleTurnSteer(
+  id: string | number,
+  params: TurnSteerParams,
+): Promise<void> {
   const threadSession = sessions.get(params.threadId);
   if (!threadSession || threadSession.closing) {
     sendError(id, -32000, "No active session");
     return;
   }
 
-  const input = extractInputText(params.input);
-  if (!input) {
+  const content = await buildUserMessageContent(params.input);
+  if (content === undefined) {
     sendError(id, -32602, "Missing input text");
     return;
   }
 
-  threadSession.resumeRecovery?.acceptedInputTexts.push(input);
-  threadSession.session.pushInput(input);
+  threadSession.resumeRecovery?.acceptedInputs.push(content);
+  threadSession.session.pushInput(content);
   sendResult(id, { threadId: params.threadId });
 }
 
@@ -1288,21 +1293,6 @@ async function handleThreadStop(
     threadId: params.threadId,
   });
   return { ok: true };
-}
-
-function extractInputText(input: unknown): string | undefined {
-  if (typeof input === "string") return input;
-  if (!Array.isArray(input)) return undefined;
-
-  const chunks: string[] = [];
-  for (const item of input) {
-    const parsed = promptTextInputSchema.safeParse(item);
-    if (parsed.success) {
-      chunks.push(parsed.data.text);
-    }
-  }
-
-  return chunks.length > 0 ? chunks.join("\n") : undefined;
 }
 
 export function handleLine(line: string): void {

--- a/packages/agent-runtime/src/claude-code/bridge/prompt-input-content.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/prompt-input-content.ts
@@ -1,0 +1,311 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+export type ClaudeMessageContent = SDKUserMessage["message"]["content"];
+export type ClaudeContentBlockParam = Exclude<
+  ClaudeMessageContent,
+  string
+>[number];
+
+type SupportedImageMediaType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/webp";
+
+const promptInputItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal("image"),
+    url: z.string(),
+  }),
+  z.object({
+    type: z.literal("localImage"),
+    path: z.string(),
+  }),
+  z.object({
+    type: z.literal("localFile"),
+    path: z.string(),
+    name: z.string().optional(),
+    sizeBytes: z.number().optional(),
+    mimeType: z.string().optional(),
+  }),
+]);
+
+type PromptInputItem = z.infer<typeof promptInputItemSchema>;
+
+const IMAGE_MEDIA_TYPES_BY_EXT: Record<string, SupportedImageMediaType> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+const TEXT_FILE_EXTENSIONS = new Set([
+  ".bash",
+  ".c",
+  ".cc",
+  ".cjs",
+  ".clj",
+  ".cpp",
+  ".cs",
+  ".css",
+  ".csv",
+  ".dart",
+  ".env",
+  ".ex",
+  ".exs",
+  ".fish",
+  ".go",
+  ".graphql",
+  ".gql",
+  ".h",
+  ".hpp",
+  ".hs",
+  ".htm",
+  ".html",
+  ".ini",
+  ".java",
+  ".js",
+  ".json",
+  ".jsonl",
+  ".jsx",
+  ".kt",
+  ".less",
+  ".lock",
+  ".log",
+  ".lua",
+  ".markdown",
+  ".md",
+  ".mdx",
+  ".mjs",
+  ".php",
+  ".pl",
+  ".proto",
+  ".ps1",
+  ".py",
+  ".r",
+  ".rb",
+  ".rs",
+  ".sass",
+  ".scala",
+  ".scss",
+  ".sh",
+  ".sql",
+  ".svelte",
+  ".swift",
+  ".text",
+  ".toml",
+  ".ts",
+  ".tsv",
+  ".tsx",
+  ".txt",
+  ".vue",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".zsh",
+]);
+
+function inferImageMediaType(
+  filePath: string,
+  declared: string | undefined,
+): SupportedImageMediaType | null {
+  if (
+    declared === "image/png" ||
+    declared === "image/jpeg" ||
+    declared === "image/gif" ||
+    declared === "image/webp"
+  ) {
+    return declared;
+  }
+  const ext = path.extname(filePath).toLowerCase();
+  return IMAGE_MEDIA_TYPES_BY_EXT[ext] ?? null;
+}
+
+function isPdfAttachment(item: {
+  mimeType?: string | undefined;
+  path: string;
+}): boolean {
+  if (item.mimeType === "application/pdf") return true;
+  return path.extname(item.path).toLowerCase() === ".pdf";
+}
+
+function isTextAttachment(item: {
+  mimeType?: string | undefined;
+  path: string;
+}): boolean {
+  const mime = item.mimeType;
+  if (mime) {
+    if (
+      mime.startsWith("text/") ||
+      mime === "application/json" ||
+      mime === "application/xml" ||
+      mime === "application/javascript" ||
+      mime === "application/x-yaml" ||
+      mime === "application/x-sh" ||
+      mime === "application/x-typescript"
+    ) {
+      return true;
+    }
+  }
+  const ext = path.extname(item.path).toLowerCase();
+  return TEXT_FILE_EXTENSIONS.has(ext);
+}
+
+function attachmentDisplayName(item: {
+  name?: string | undefined;
+  path: string;
+}): string {
+  if (item.name && item.name.length > 0) return item.name;
+  return path.basename(item.path);
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parsePromptInputItems(input: unknown): PromptInputItem[] {
+  if (!Array.isArray(input)) return [];
+  const items: PromptInputItem[] = [];
+  for (const raw of input) {
+    const parsed = promptInputItemSchema.safeParse(raw);
+    if (parsed.success) items.push(parsed.data);
+  }
+  return items;
+}
+
+function plainTextFromTextOnlyItems(
+  items: ReadonlyArray<PromptInputItem>,
+): string | undefined {
+  const chunks: string[] = [];
+  for (const item of items) {
+    if (item.type === "text") chunks.push(item.text);
+  }
+  return chunks.length > 0 ? chunks.join("\n") : undefined;
+}
+
+async function blocksFromLocalImage(
+  item: Extract<PromptInputItem, { type: "localImage" }>,
+): Promise<ClaudeContentBlockParam> {
+  const mediaType = inferImageMediaType(item.path, undefined);
+  if (!mediaType) {
+    return {
+      type: "text",
+      text: `[Attached image at ${item.path} could not be encoded — unsupported image extension]`,
+    };
+  }
+  try {
+    const bytes = await readFile(item.path);
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: mediaType,
+        data: bytes.toString("base64"),
+      },
+    };
+  } catch (error) {
+    return {
+      type: "text",
+      text: `[Failed to read attached image at ${item.path}: ${describeError(error)}]`,
+    };
+  }
+}
+
+async function blocksFromLocalFile(
+  item: Extract<PromptInputItem, { type: "localFile" }>,
+): Promise<ClaudeContentBlockParam> {
+  const displayName = attachmentDisplayName(item);
+  try {
+    if (isPdfAttachment(item)) {
+      const bytes = await readFile(item.path);
+      return {
+        type: "document",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: bytes.toString("base64"),
+        },
+        title: displayName,
+      };
+    }
+    if (isTextAttachment(item)) {
+      const text = await readFile(item.path, "utf8");
+      return {
+        type: "document",
+        source: {
+          type: "text",
+          media_type: "text/plain",
+          data: text,
+        },
+        title: displayName,
+      };
+    }
+    const detail = item.mimeType ? `, type ${item.mimeType}` : "";
+    return {
+      type: "text",
+      text: `[Attached file: ${displayName} (path: ${item.path}${detail}). The file format is not supported as inline content — use the Read tool to view it.]`,
+    };
+  } catch (error) {
+    return {
+      type: "text",
+      text: `[Failed to read attached file ${displayName} at ${item.path}: ${describeError(error)}]`,
+    };
+  }
+}
+
+/**
+ * Convert the bridge's `params.input` array into a Claude `MessageParam`
+ * `content` value (either a plain string for text-only turns, or an array of
+ * `ContentBlockParam` when attachments are present).
+ *
+ * Returns `undefined` when the input would produce no model-visible content.
+ */
+export async function buildUserMessageContent(
+  input: unknown,
+): Promise<ClaudeMessageContent | undefined> {
+  if (typeof input === "string") {
+    return input.length > 0 ? input : undefined;
+  }
+
+  const items = parsePromptInputItems(input);
+  if (items.length === 0) return undefined;
+
+  const hasAttachment = items.some((item) => item.type !== "text");
+  if (!hasAttachment) {
+    return plainTextFromTextOnlyItems(items);
+  }
+
+  const blocks: ClaudeContentBlockParam[] = [];
+  for (const item of items) {
+    switch (item.type) {
+      case "text":
+        if (item.text.length > 0) {
+          blocks.push({ type: "text", text: item.text });
+        }
+        break;
+      case "image":
+        blocks.push({
+          type: "image",
+          source: { type: "url", url: item.url },
+        });
+        break;
+      case "localImage":
+        blocks.push(await blocksFromLocalImage(item));
+        break;
+      case "localFile":
+        blocks.push(await blocksFromLocalFile(item));
+        break;
+    }
+  }
+
+  if (blocks.length === 0) return undefined;
+  return blocks;
+}

--- a/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
@@ -8,6 +8,7 @@ import {
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { ClaudePermissionMode } from "../interactive-contract.js";
+import type { ClaudeMessageContent } from "./prompt-input-content.js";
 
 export interface SdkSessionOptions {
   cwd: string;
@@ -124,10 +125,10 @@ export class SdkSession {
     void this.consumeStream();
   }
 
-  pushInput(text: string): void {
+  pushInput(content: ClaudeMessageContent): void {
     const message: SDKUserMessage = {
       type: "user",
-      message: { role: "user", content: text },
+      message: { role: "user", content },
       parent_tool_use_id: null,
       session_id: this.sessionId ?? "",
     };


### PR DESCRIPTION
## Summary

- File attachments uploaded in the bb UI never reached Claude Code provider sessions: the bridge's `extractInputText` filter silently dropped every `localImage`, `localFile`, and `image` entry before building the SDK user message.
- Replace the text-only filter with a multimodal `buildUserMessageContent` that reads each staged attachment from disk and emits the right Claude Agent SDK content blocks (`text`, base64 `image`, base64 PDF, plain-text `document`, or a path-bearing text marker for unsupported binary types).
- Text-only turns still produce a plain `string` content, so cache hits and existing flows are unchanged.

## Root cause

`packages/agent-runtime/src/claude-code/bridge/bridge.ts:1293-1305` (pre-fix). The upload, server intake, daemon staging, runtime dispatch, and adapter all forward attachments correctly — the bridge then throws away everything that is not `{ type: "text" }` before calling `SdkSession.pushInput`. Codex and Pi at least preserve a text marker; Claude Code was the odd one out.

Full bug report (trace, comparison vs other providers, file:line): `~/.bb/thread-storage/thr_6ww2pwqsd7/reports/attachment-claude-code-bug.md`.

## Test plan

- [x] `pnpm exec turbo run typecheck` across all packages
- [x] `pnpm exec turbo run test --filter=@bb/agent-runtime` (511 tests pass — 14 new)
- [x] Full repo test run (`pnpm exec turbo run test`) — all 26 packages green
- [x] New unit tests for `buildUserMessageContent` cover text-only, missing input, base64 image (PNG/JPEG), URL image, plain-text document, PDF document, unsupported binary fallback, missing-file fallback, and the legacy string code path
- [x] New bridge integration tests assert the SDK receives `content: string` for text-only turns and the correct `ContentBlockParam[]` for `localImage` and `localFile` turns
- [ ] Manual repro in dev (left to reviewer) — drag an image into a Claude Code manager chat and confirm the model sees it

🤖 Generated with [Claude Code](https://claude.com/claude-code)