### PR TITLE
claude-code: pass prompt attachments as text markers (parity with Codex's reference-not-content model)

### DIFF
--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -7,7 +7,7 @@ import type {
   SDKMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
-import type { PermissionEscalation } from "@bb/domain";
+import type { JsonValue, PermissionEscalation } from "@bb/domain";
 
 const { queryMock } = vi.hoisted(() => ({
   queryMock: vi.fn(),
@@ -2085,5 +2085,185 @@ describe("bridge", () => {
     } finally {
       bridge.restore();
     }
+  });
+
+  describe("prompt attachment text markers", () => {
+    async function sendTurnAndReadPrompt(
+      bridge: BridgeJsonRpcTestHarness,
+      queries: ControlledClaudeQuery[],
+      threadId: string,
+      input: JsonValue[],
+    ): Promise<string> {
+      await startBridgeThread({ bridge, threadId });
+      bridge.sendRequest(2, "turn/start", {
+        input,
+        providerThreadId: null,
+        threadId,
+      });
+      await bridge.waitForResponse(2);
+      const text = await readNextPromptText(getLatestQueryCall());
+      await stopBridgeThread({ bridge, queries, threadId });
+      return text;
+    }
+
+    function withBridgeHarness(): {
+      bridge: BridgeJsonRpcTestHarness;
+      queries: ControlledClaudeQuery[];
+    } {
+      const bridge = createBridgeJsonRpcTestHarness(handleLine);
+      const queries: ControlledClaudeQuery[] = [];
+      queryMock.mockImplementation(() => {
+        const query = createControlledClaudeQuery();
+        queries.push(query);
+        return query;
+      });
+      return { bridge, queries };
+    }
+
+    it("forwards a text-only prompt unchanged", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-text",
+          [{ type: "text", text: "Hello there" }],
+        );
+        expect(text).toBe("Hello there");
+      } finally {
+        bridge.restore();
+      }
+    });
+
+    it("joins multiple text fragments with newlines", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-text-multi",
+          [
+            { type: "text", text: "Line one" },
+            { type: "text", text: "Line two" },
+          ],
+        );
+        expect(text).toBe("Line one\nLine two");
+      } finally {
+        bridge.restore();
+      }
+    });
+
+    it("emits a path-bearing marker for a localImage attachment", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-local-image",
+          [
+            { type: "text", text: "Describe this" },
+            {
+              type: "localImage",
+              path: "/staged/runtime-attachments/req-1/000-screenshot.png",
+            },
+          ],
+        );
+        expect(text).toBe(
+          "Describe this\n[Attached image. It is on disk at /staged/runtime-attachments/req-1/000-screenshot.png — use the Read tool to view it.]",
+        );
+      } finally {
+        bridge.restore();
+      }
+    });
+
+    it("emits a name+mime+size marker for a localFile with full metadata", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-local-file-full",
+          [
+            { type: "text", text: "Summarize this" },
+            {
+              type: "localFile",
+              path: "/staged/runtime-attachments/req-2/000-report.pdf",
+              name: "report.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 12345,
+            },
+          ],
+        );
+        expect(text).toBe(
+          'Summarize this\n[Attached file "report.pdf" (application/pdf, 12345 bytes). It is on disk at /staged/runtime-attachments/req-2/000-report.pdf — use the Read tool to view it.]',
+        );
+      } finally {
+        bridge.restore();
+      }
+    });
+
+    it("omits missing fields from the localFile marker", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-local-file-minimal",
+          [
+            {
+              type: "localFile",
+              path: "/staged/runtime-attachments/req-3/000-data.csv",
+            },
+          ],
+        );
+        expect(text).toBe(
+          "[Attached file. It is on disk at /staged/runtime-attachments/req-3/000-data.csv — use the Read tool to view it.]",
+        );
+      } finally {
+        bridge.restore();
+      }
+    });
+
+    it("emits a URL marker for a remote image attachment", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-image-url",
+          [
+            { type: "text", text: "Compare to:" },
+            { type: "image", url: "https://example.com/cat.png" },
+          ],
+        );
+        expect(text).toBe(
+          "Compare to:\n[Attached image: https://example.com/cat.png]",
+        );
+      } finally {
+        bridge.restore();
+      }
+    });
+
+    it("accepts an attachment-only turn (no text fragments)", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const text = await sendTurnAndReadPrompt(
+          bridge,
+          queries,
+          "thread-marker-attachment-only",
+          [
+            {
+              type: "localImage",
+              path: "/staged/runtime-attachments/req-4/000-only.png",
+            },
+          ],
+        );
+        expect(text).toBe(
+          "[Attached image. It is on disk at /staged/runtime-attachments/req-4/000-only.png — use the Read tool to view it.]",
+        );
+      } finally {
+        bridge.restore();
+      }
+    });
   });
 });

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -78,10 +78,27 @@ import {
 } from "../interactive-contract.js";
 export { buildSessionOptions } from "./session-options.js";
 
-const promptTextInputSchema = z.object({
-  type: z.literal("text"),
-  text: z.string(),
-});
+const promptInputItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal("image"),
+    url: z.string(),
+  }),
+  z.object({
+    type: z.literal("localImage"),
+    path: z.string(),
+  }),
+  z.object({
+    type: z.literal("localFile"),
+    path: z.string(),
+    name: z.string().optional(),
+    sizeBytes: z.number().optional(),
+    mimeType: z.string().optional(),
+  }),
+]);
 
 // Claude Agent SDK 0.2.111 types stale resume failures as generic
 // SDKResultError.errors. The bundled Claude Code CLI can also emit the same
@@ -1250,7 +1267,7 @@ function handleTurnStart(id: string | number, params: TurnStartParams): void {
     return;
   }
 
-  const input = extractInputText(params.input);
+  const input = buildPromptText(params.input);
   if (!input) {
     sendError(id, -32602, "Missing input text");
     return;
@@ -1268,7 +1285,7 @@ function handleTurnSteer(id: string | number, params: TurnSteerParams): void {
     return;
   }
 
-  const input = extractInputText(params.input);
+  const input = buildPromptText(params.input);
   if (!input) {
     sendError(id, -32602, "Missing input text");
     return;
@@ -1290,15 +1307,54 @@ async function handleThreadStop(
   return { ok: true };
 }
 
-function extractInputText(input: unknown): string | undefined {
-  if (typeof input === "string") return input;
+function localAttachmentMarker(args: {
+  kind: "image" | "file";
+  path: string;
+  name?: string | undefined;
+  mimeType?: string | undefined;
+  sizeBytes?: number | undefined;
+}): string {
+  const namePart =
+    args.name && args.name.length > 0 ? ` "${args.name}"` : "";
+  const details: string[] = [];
+  if (args.mimeType) details.push(args.mimeType);
+  if (args.sizeBytes !== undefined) details.push(`${args.sizeBytes} bytes`);
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return `[Attached ${args.kind}${namePart}${suffix}. It is on disk at ${args.path} — use the Read tool to view it.]`;
+}
+
+function buildPromptText(input: unknown): string | undefined {
+  if (typeof input === "string") {
+    return input.length > 0 ? input : undefined;
+  }
   if (!Array.isArray(input)) return undefined;
 
   const chunks: string[] = [];
   for (const item of input) {
-    const parsed = promptTextInputSchema.safeParse(item);
-    if (parsed.success) {
-      chunks.push(parsed.data.text);
+    const parsed = promptInputItemSchema.safeParse(item);
+    if (!parsed.success) continue;
+    const entry = parsed.data;
+    switch (entry.type) {
+      case "text":
+        if (entry.text.length > 0) chunks.push(entry.text);
+        break;
+      case "image":
+        chunks.push(`[Attached image: ${entry.url}]`);
+        break;
+      case "localImage":
+        chunks.push(localAttachmentMarker({ kind: "image", path: entry.path }));
+        break;
+      case "localFile":
+        chunks.push(
+          localAttachmentMarker({
+            kind: "file",
+            path: entry.path,
+            name: entry.name,
+            mimeType: entry.mimeType,
+            sizeBytes: entry.sizeBytes,
+          }),
+        );
+        break;
     }
   }
 


### PR DESCRIPTION
## Summary

- File attachments uploaded in the bb UI never reached Claude Code provider sessions: the bridge's `extractInputText` filter silently dropped every `localImage`, `localFile`, and `image` entry from `PromptInput[]` before building the SDK user message.
- Replace the text-only filter with `buildPromptText`, which forwards text fragments as-is and converts each attachment to a path / URL-bearing **text marker** rather than reading and inlining bytes. The bridge stays synchronous, no new dependencies, and `SdkSession.pushInput` still takes a plain `string`.
- This matches Codex's reference-not-content model (`packages/agent-runtime/src/codex/adapter.ts:650-655`) so attachment plumbing is provider-agnostic: the daemon stages files on disk and the adapter hands the model a path it can `Read`.

## Marker shape

| `PromptInput` variant | Bridge output |
|---|---|
| `text` | Plain text, joined with `\n` (unchanged from today) |
| `image` (URL) | `[Attached image: <url>]` |
| `localImage` (path only — no `name`/`mime`/`size` in the contract) | `[Attached image. It is on disk at <staged abs path> — use the Read tool to view it.]` |
| `localFile` (full metadata) | `[Attached file \"<name>\" (<mime>, <sizeBytes> bytes). It is on disk at <staged abs path> — use the Read tool to view it.]` |
| `localFile` (any of `name`/`mime`/`sizeBytes` missing) | Same shape, just that field's segment omitted |

## Supersedes

This PR replaces the now-closed multimodal-inlining PR (#29). The user has decided the simpler reference-passing approach is preferred — no base64 cache busts, uniform with Codex, and the agent uses its existing `Read` tool to inspect attachments.

## Test plan

- [x] `pnpm exec turbo run typecheck` across all 27 packages
- [x] `pnpm exec turbo run test --filter=@bb/agent-runtime` (504 tests pass, +7 new)
- [x] 7 new bridge integration tests cover: text-only passthrough, multi-text join, `localImage` marker, `localFile` with full metadata, `localFile` with missing optional fields, `image` URL marker, attachment-only turn
- [ ] Manual repro in dev (left to reviewer) — drag an image into a Claude Code manager and confirm the model sees the marker (and can `Read` the staged path if it chooses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)