### PR TITLE
app: render nested managers in the thread tree

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -531,6 +531,66 @@ describe("ProjectList", () => {
     expect(screen.queryByText("No projects")).toBeNull();
   });
 
+  it("renders a nested manager under its parent and exposes its children", async () => {
+    const rootManager: ProjectThreadListEntry = {
+      ...makeThreadListEntry("project-1", 1),
+      id: "thr_root_manager",
+      title: "Root Manager",
+      titleFallback: "Root Manager",
+      type: "manager",
+    };
+    const nestedManager: ProjectThreadListEntry = {
+      ...makeThreadListEntry("project-1", 2),
+      id: "thr_nested_manager",
+      parentThreadId: rootManager.id,
+      title: "Nested Manager",
+      titleFallback: "Nested Manager",
+      type: "manager",
+    };
+    const nestedChild: ProjectThreadListEntry = {
+      ...makeThreadListEntry("project-1", 3),
+      id: "thr_nested_child",
+      parentThreadId: nestedManager.id,
+      title: "Nested Child Task",
+      titleFallback: "Nested Child Task",
+    };
+    const projects = [makeProjectResponse({ id: "project-1" })];
+    const threadsByProjectId = new Map<string, ProjectThreadListEntry[]>([
+      ["project-1", [rootManager, nestedManager, nestedChild]],
+    ]);
+    installFetchRoutes([
+      {
+        pathname: "/api/v1/projects",
+        handler: buildProjectListHandler({ projects, threadsByProjectId }),
+      },
+      {
+        pathname: "/api/v1/threads",
+        handler: () => jsonResponse([]),
+      },
+      {
+        pathname: "/api/v1/system/config",
+        handler: () =>
+          jsonResponse({
+            hostDaemonPort: null,
+            voiceTranscriptionEnabled: false,
+          }),
+      },
+      {
+        pathname: "/api/v1/hosts",
+        handler: () => jsonResponse([]),
+      },
+    ]);
+
+    wsManager.connect();
+    FakeReconnectingWebSocket.latest().open();
+
+    await renderProjectList();
+
+    expect(await screen.findByText("Root Manager")).toBeTruthy();
+    expect(await screen.findByText("Nested Manager")).toBeTruthy();
+    expect(await screen.findByText("Nested Child Task")).toBeTruthy();
+  });
+
   it("shows threads unavailable when a project thread list fails after the websocket connects", async () => {
     installFetchRoutes([
       {

--- a/apps/app/src/components/sidebar/ProjectRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.stories.tsx
@@ -335,6 +335,54 @@ export function Overview() {
         })}
       </StoryRow>
       <StoryRow
+        label="nested manager"
+        hint="manager-of-managers: a root manager owns one standard child and one nested manager that owns its own children — each level keeps the user icon + chevron and indents one step further"
+      >
+        {singleProject({
+          threadListState: {
+            status: "ready",
+            threads: [
+              makeThread({
+                id: "thr_root_manager",
+                type: "manager",
+                title: "Release Coordinator",
+                titleFallback: "Release Coordinator",
+              }),
+              makeThread({
+                id: "thr_root_child",
+                title: "Audit release blockers",
+                titleFallback: "Audit release blockers",
+                parentThreadId: "thr_root_manager",
+              }),
+              makeThread({
+                id: "thr_nested_manager",
+                type: "manager",
+                title: "Frontend Sub-Team",
+                titleFallback: "Frontend Sub-Team",
+                parentThreadId: "thr_root_manager",
+              }),
+              makeThread({
+                id: "thr_nested_child_a",
+                title: "Update Timeline Row Types",
+                titleFallback: "Update Timeline Row Types",
+                parentThreadId: "thr_nested_manager",
+              }),
+              makeThread({
+                id: "thr_nested_child_b",
+                title: "Fix Timeline Pagination Bugs",
+                titleFallback: "Fix Timeline Pagination Bugs",
+                parentThreadId: "thr_nested_manager",
+                status: "active",
+                runtime: {
+                  displayStatus: "active",
+                  hostReconnectGraceExpiresAt: null,
+                },
+              }),
+            ],
+          },
+        })}
+      </StoryRow>
+      <StoryRow
         label="environment group"
         hint="two unmanaged standard threads sharing one worktree environment — grouped under a worktree header that surfaces the branch"
       >

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -14,15 +14,24 @@ import {
   ProjectActionsContextMenu,
   ProjectActionsMenu,
 } from "@/components/project/ProjectActionsMenu";
-import { SidebarMenuItem, SidebarMenuSkeleton } from "@/components/ui/sidebar.js";
-import { COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS, COARSE_POINTER_GLYPH_BOX_CLASS, COARSE_POINTER_ICON_SIZE_CLASS, COARSE_POINTER_PROJECT_ROW_ACTION_SIZE_CLASS, COARSE_POINTER_ROW_ACTION_SIZE_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
-import { cn } from "@/lib/utils";
 import {
-  getEnvironmentWorkspaceLabelIconName,
-} from "@/lib/environment-workspace-display";
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+} from "@/components/ui/sidebar.js";
+import {
+  COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
+  COARSE_POINTER_GLYPH_BOX_CLASS,
+  COARSE_POINTER_ICON_SIZE_CLASS,
+  COARSE_POINTER_PROJECT_ROW_ACTION_SIZE_CLASS,
+  COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+} from "@/components/ui/coarse-pointer-sizing.js";
+import { cn } from "@/lib/utils";
+import { getEnvironmentWorkspaceLabelIconName } from "@/lib/environment-workspace-display";
 import {
   CollapsedChildCountBadge,
   ThreadRow,
+  type ManagedChildRowDepth,
+  type ManagerRowDepth,
   type ThreadRowOptions,
 } from "./ThreadRow";
 import {
@@ -36,21 +45,32 @@ import {
   SIDEBAR_MANAGER_GROUP_LINE_CLASS,
   SIDEBAR_MANAGER_LINE_CONTINUATION_CLASS,
   SIDEBAR_MANAGER_ROW_PADDING_CLASS,
+  SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS,
+  SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS,
+  SIDEBAR_NESTED_MANAGER_LINE_CONTINUATION_CLASS,
   SIDEBAR_PROJECT_GROUP_LINE_CLASS,
   SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
 } from "./sidebarRowClasses";
 
 const THREAD_ROW_DEFAULT_OPTIONS: ThreadRowOptions = { kind: "default" };
-const THREAD_ROW_MANAGED_CHILD_OPTIONS: ThreadRowOptions = {
-  kind: "managed-child",
-};
 const THREAD_ROW_ENV_GROUPED_CHILD_OPTIONS: ThreadRowOptions = {
   kind: "env-grouped-child",
 };
-const THREAD_ROW_ENV_GROUPED_MANAGED_CHILD_OPTIONS: ThreadRowOptions = {
-  kind: "env-grouped-managed-child",
-};
+
+// Indent caps at depth 2 — chains deeper than nested-of-nested keep the
+// depth-2 padding so the sidebar never overflows horizontally. The manager
+// hierarchy itself can still recurse arbitrarily deep structurally.
+const MANAGER_DEPTH_CAP: ManagerRowDepth = 1;
+const MANAGED_CHILD_DEPTH_CAP: ManagedChildRowDepth = 2;
+
+function clampManagerDepth(depth: number): ManagerRowDepth {
+  return depth >= MANAGER_DEPTH_CAP ? MANAGER_DEPTH_CAP : 0;
+}
+
+function clampManagedChildDepth(depth: number): ManagedChildRowDepth {
+  return depth >= MANAGED_CHILD_DEPTH_CAP ? MANAGED_CHILD_DEPTH_CAP : 1;
+}
 
 type EnvironmentStickyTier = Extract<
   SidebarStickyTierKind,
@@ -90,8 +110,11 @@ interface ManagerThreadGroupRowProps {
   projectId: string;
   managerThreadGroup: ManagerThreadGroup;
   selectedThreadId?: string;
-  isManagerCollapsed: boolean;
+  collapsedManagerIds: Set<string>;
   collapsedEnvironmentIds: Set<string>;
+  // Depth in the manager hierarchy. 0 = root manager. 1+ = nested manager.
+  // Padding caps at depth 1 but the renderer still recurses structurally.
+  depth: number;
   onProjectSelect?: () => void;
   onToggleManagerCollapsed: (threadId: string) => void;
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
@@ -217,7 +240,10 @@ function EnvironmentThreadGroupHeader({
             COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
           )}
         >
-          <Icon name="MessageSquarePlus" className={COARSE_POINTER_ICON_SIZE_CLASS} />
+          <Icon
+            name="MessageSquarePlus"
+            className={COARSE_POINTER_ICON_SIZE_CLASS}
+          />
         </Button>
       ) : (
         <span
@@ -269,7 +295,10 @@ const EnvironmentThreadGroupRow = memo(function EnvironmentThreadGroupRow({
       />
       {!isCollapsed ? (
         <div
-          className={cn("relative space-y-px", SIDEBAR_MANAGER_GROUP_LINE_CLASS)}
+          className={cn(
+            "relative space-y-px",
+            SIDEBAR_MANAGER_GROUP_LINE_CLASS,
+          )}
         >
           {threads.map((thread) => (
             <ThreadRow
@@ -292,6 +321,9 @@ interface ManagedEnvironmentThreadSubGroupProps {
   environmentThreadGroup: EnvironmentThreadGroup;
   selectedThreadId?: string;
   isCollapsed: boolean;
+  childDepth: ManagedChildRowDepth;
+  headerPaddingClass: string;
+  parentLineClass: string;
   onProjectSelect?: () => void;
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
 }
@@ -301,6 +333,9 @@ function ManagedEnvironmentThreadSubGroup({
   environmentThreadGroup,
   selectedThreadId,
   isCollapsed,
+  childDepth,
+  headerPaddingClass,
+  parentLineClass,
   onProjectSelect,
   onToggleEnvironmentCollapsed,
 }: ManagedEnvironmentThreadSubGroupProps) {
@@ -313,14 +348,18 @@ function ManagedEnvironmentThreadSubGroup({
     onProjectSelect?.();
     createThreadInWorktree();
   }, [createThreadInWorktree, onProjectSelect]);
+  const childOptions = useMemo<ThreadRowOptions>(
+    () => ({ kind: "env-grouped-managed-child", depth: childDepth }),
+    [childDepth],
+  );
   return (
     <>
       <EnvironmentThreadGroupHeader
         environmentId={environmentId}
         representativeThread={threads[0]}
-        paddingClass={SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS}
+        paddingClass={headerPaddingClass}
         stickyTier="environment"
-        parentLineClass={SIDEBAR_MANAGER_LINE_CONTINUATION_CLASS}
+        parentLineClass={parentLineClass}
         childCount={threads.length}
         isCollapsed={isCollapsed}
         onCreateNewThread={handleCreateNewThread}
@@ -340,7 +379,7 @@ function ManagedEnvironmentThreadSubGroup({
               thread={thread}
               isActive={selectedThreadId === thread.id}
               onProjectSelect={onProjectSelect}
-              options={THREAD_ROW_ENV_GROUPED_MANAGED_CHILD_OPTIONS}
+              options={childOptions}
             />
           ))}
         </div>
@@ -353,21 +392,51 @@ const ManagerThreadGroupRow = memo(function ManagerThreadGroupRow({
   projectId,
   managerThreadGroup,
   selectedThreadId,
-  isManagerCollapsed,
+  collapsedManagerIds,
   collapsedEnvironmentIds,
+  depth,
   onProjectSelect,
   onToggleManagerCollapsed,
   onToggleEnvironmentCollapsed,
 }: ManagerThreadGroupRowProps) {
   const { managerThread, managedItems, stats } = managerThreadGroup;
+  const isManagerCollapsed = collapsedManagerIds.has(managerThread.id);
+  const managerDepth = clampManagerDepth(depth);
+  const childDepth = clampManagedChildDepth(depth + 1);
+  const childGroupLineClass =
+    depth === 0
+      ? SIDEBAR_MANAGER_GROUP_LINE_CLASS
+      : SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS;
+  const envSubGroupHeaderPaddingClass =
+    childDepth >= 2
+      ? SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS
+      : SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS;
+  // The env sub-group header sits at the managed-child indent under its
+  // manager, so its parent-line continuation must match the depth-0
+  // managed-children hairline above it. For a root manager the continuation
+  // is left-10; for a nested manager it is left-16.
+  const envSubGroupParentLineClass =
+    depth === 0
+      ? SIDEBAR_MANAGER_LINE_CONTINUATION_CLASS
+      : SIDEBAR_NESTED_MANAGER_LINE_CONTINUATION_CLASS;
   const managerOptions = useMemo<ThreadRowOptions>(
     () => ({
       kind: "manager",
+      depth: managerDepth,
       isCollapsed: isManagerCollapsed,
       managedChildCount: stats.managedChildCount,
       onToggleCollapsed: onToggleManagerCollapsed,
     }),
-    [isManagerCollapsed, onToggleManagerCollapsed, stats.managedChildCount],
+    [
+      isManagerCollapsed,
+      managerDepth,
+      onToggleManagerCollapsed,
+      stats.managedChildCount,
+    ],
+  );
+  const managedChildOptions = useMemo<ThreadRowOptions>(
+    () => ({ kind: "managed-child", depth: childDepth }),
+    [childDepth],
   );
   const showManagedChildren = !isManagerCollapsed && managedItems.length > 0;
   return (
@@ -380,36 +449,53 @@ const ManagerThreadGroupRow = memo(function ManagerThreadGroupRow({
         options={managerOptions}
       />
       {showManagedChildren ? (
-        <div
-          className={cn(
-            "relative space-y-px",
-            SIDEBAR_MANAGER_GROUP_LINE_CLASS,
-          )}
-        >
-          {managedItems.map((item) =>
-            item.kind === "thread" ? (
-              <ThreadRow
-                key={`thread:${item.thread.id}`}
+        <div className={cn("relative space-y-px", childGroupLineClass)}>
+          {managedItems.map((item) => {
+            if (item.kind === "thread") {
+              return (
+                <ThreadRow
+                  key={`thread:${item.thread.id}`}
+                  projectId={projectId}
+                  thread={item.thread}
+                  isActive={selectedThreadId === item.thread.id}
+                  onProjectSelect={onProjectSelect}
+                  options={managedChildOptions}
+                />
+              );
+            }
+            if (item.kind === "environment") {
+              return (
+                <ManagedEnvironmentThreadSubGroup
+                  key={`env:${item.group.environmentId}`}
+                  projectId={projectId}
+                  environmentThreadGroup={item.group}
+                  selectedThreadId={selectedThreadId}
+                  isCollapsed={collapsedEnvironmentIds.has(
+                    item.group.environmentId,
+                  )}
+                  childDepth={childDepth}
+                  headerPaddingClass={envSubGroupHeaderPaddingClass}
+                  parentLineClass={envSubGroupParentLineClass}
+                  onProjectSelect={onProjectSelect}
+                  onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+                />
+              );
+            }
+            return (
+              <ManagerThreadGroupRow
+                key={`manager:${item.group.managerThread.id}`}
                 projectId={projectId}
-                thread={item.thread}
-                isActive={selectedThreadId === item.thread.id}
-                onProjectSelect={onProjectSelect}
-                options={THREAD_ROW_MANAGED_CHILD_OPTIONS}
-              />
-            ) : (
-              <ManagedEnvironmentThreadSubGroup
-                key={`env:${item.group.environmentId}`}
-                projectId={projectId}
-                environmentThreadGroup={item.group}
+                managerThreadGroup={item.group}
                 selectedThreadId={selectedThreadId}
-                isCollapsed={collapsedEnvironmentIds.has(
-                  item.group.environmentId,
-                )}
+                collapsedManagerIds={collapsedManagerIds}
+                collapsedEnvironmentIds={collapsedEnvironmentIds}
+                depth={depth + 1}
                 onProjectSelect={onProjectSelect}
+                onToggleManagerCollapsed={onToggleManagerCollapsed}
                 onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
               />
-            ),
-          )}
+            );
+          })}
         </div>
       ) : null}
     </div>
@@ -489,7 +575,8 @@ function ProjectRowComponent({
                 COARSE_POINTER_ICON_SIZE_CLASS,
               )}
             >
-              <Icon name="ChevronRight"
+              <Icon
+                name="ChevronRight"
                 className={cn(
                   "absolute opacity-0 transition-all duration-150 group-hover/project-row:opacity-100",
                   COARSE_POINTER_ICON_SIZE_CLASS,
@@ -497,14 +584,16 @@ function ProjectRowComponent({
                 )}
               />
               {isCollapsed ? (
-                <Icon name="Folder"
+                <Icon
+                  name="Folder"
                   className={cn(
                     "absolute opacity-100 transition-opacity duration-150 group-hover/project-row:opacity-0",
                     COARSE_POINTER_ICON_SIZE_CLASS,
                   )}
                 />
               ) : (
-                <Icon name="FolderOpen"
+                <Icon
+                  name="FolderOpen"
                   className={cn(
                     "absolute opacity-100 transition-opacity duration-150 group-hover/project-row:opacity-0",
                     COARSE_POINTER_ICON_SIZE_CLASS,
@@ -530,7 +619,10 @@ function ProjectRowComponent({
                 COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
               )}
             >
-              <Icon name="AlertTriangle" className={COARSE_POINTER_ICON_SIZE_CLASS} />
+              <Icon
+                name="AlertTriangle"
+                className={COARSE_POINTER_ICON_SIZE_CLASS}
+              />
             </NavLink>
           ) : null}
           <ProjectActionsMenu
@@ -565,39 +657,61 @@ function ProjectRowComponent({
                 projectId={project.id}
                 managerThreadGroup={managerThreadGroup}
                 selectedThreadId={selectedThreadId}
-                isManagerCollapsed={collapsedManagerIds.has(
-                  managerThreadGroup.managerThread.id,
-                )}
+                collapsedManagerIds={collapsedManagerIds}
                 collapsedEnvironmentIds={collapsedEnvironmentIds}
+                depth={0}
                 onProjectSelect={onProjectSelect}
                 onToggleManagerCollapsed={onToggleManagerCollapsed}
                 onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
               />
             ))}
-            {unmanagedItems.map((item) =>
-              item.kind === "thread" ? (
-                <ThreadRow
-                  key={`thread:${item.thread.id}`}
+            {unmanagedItems.map((item) => {
+              if (item.kind === "thread") {
+                return (
+                  <ThreadRow
+                    key={`thread:${item.thread.id}`}
+                    projectId={project.id}
+                    thread={item.thread}
+                    isActive={selectedThreadId === item.thread.id}
+                    onProjectSelect={onProjectSelect}
+                    options={THREAD_ROW_DEFAULT_OPTIONS}
+                  />
+                );
+              }
+              if (item.kind === "environment") {
+                return (
+                  <EnvironmentThreadGroupRow
+                    key={`env:${item.group.environmentId}`}
+                    projectId={project.id}
+                    environmentThreadGroup={item.group}
+                    selectedThreadId={selectedThreadId}
+                    isCollapsed={collapsedEnvironmentIds.has(
+                      item.group.environmentId,
+                    )}
+                    onProjectSelect={onProjectSelect}
+                    onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+                  />
+                );
+              }
+              // unmanagedItems is built from standard threads only, so a
+              // manager item never reaches this branch in practice. The
+              // exhaustive switch keeps the type system happy if the
+              // ProjectThreadItem union ever grows another variant.
+              return (
+                <ManagerThreadGroupRow
+                  key={`manager:${item.group.managerThread.id}`}
                   projectId={project.id}
-                  thread={item.thread}
-                  isActive={selectedThreadId === item.thread.id}
-                  onProjectSelect={onProjectSelect}
-                  options={THREAD_ROW_DEFAULT_OPTIONS}
-                />
-              ) : (
-                <EnvironmentThreadGroupRow
-                  key={`env:${item.group.environmentId}`}
-                  projectId={project.id}
-                  environmentThreadGroup={item.group}
+                  managerThreadGroup={item.group}
                   selectedThreadId={selectedThreadId}
-                  isCollapsed={collapsedEnvironmentIds.has(
-                    item.group.environmentId,
-                  )}
+                  collapsedManagerIds={collapsedManagerIds}
+                  collapsedEnvironmentIds={collapsedEnvironmentIds}
+                  depth={0}
                   onProjectSelect={onProjectSelect}
+                  onToggleManagerCollapsed={onToggleManagerCollapsed}
                   onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
                 />
-              ),
-            )}
+              );
+            })}
           </div>
         ) : (
           <EmptyState

--- a/apps/app/src/components/sidebar/ThreadRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.stories.tsx
@@ -32,12 +32,20 @@ const makeThread = (overrides: Partial<ThreadListEntry> = {}) =>
 const noop = () => {};
 
 const defaultOption: ThreadRowOptions = { kind: "default" };
-const managedChildOption: ThreadRowOptions = { kind: "managed-child" };
+const managedChildOption: ThreadRowOptions = {
+  kind: "managed-child",
+  depth: 1,
+};
+const nestedManagedChildOption: ThreadRowOptions = {
+  kind: "managed-child",
+  depth: 2,
+};
 function managerOption(
   overrides: Partial<Extract<ThreadRowOptions, { kind: "manager" }>> = {},
 ): ThreadRowOptions {
   return {
     kind: "manager",
+    depth: 0,
     isCollapsed: false,
     managedChildCount: 0,
     onToggleCollapsed: noop,
@@ -279,6 +287,44 @@ export function Overview() {
             })}
             isActive={false}
             options={managedChildOption}
+          />
+        </SidebarStage>
+      </StoryRow>
+      <StoryRow
+        label="nested manager"
+        hint="manager that is itself a child of another manager — indented like a managed child but keeps the user icon + chevron, and its own children indent one level deeper"
+      >
+        <SidebarStage>
+          <ThreadRow
+            projectId="proj_demo"
+            thread={managerThread}
+            isActive={false}
+            options={managerOption({
+              depth: 0,
+              isCollapsed: false,
+              managedChildCount: 1,
+            })}
+          />
+          <ThreadRow
+            projectId="proj_demo"
+            thread={makeThread({
+              id: "thr_nested_manager",
+              type: "manager",
+              title: "Codex Sub-Manager",
+              titleFallback: "Codex Sub-Manager",
+            })}
+            isActive={false}
+            options={managerOption({
+              depth: 1,
+              isCollapsed: false,
+              managedChildCount: 1,
+            })}
+          />
+          <ThreadRow
+            projectId="proj_demo"
+            thread={childThread}
+            isActive={false}
+            options={nestedManagedChildOption}
           />
         </SidebarStage>
       </StoryRow>

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -23,14 +23,26 @@ import { isBusyThread, isUnreadDoneThread } from "@/lib/thread-activity";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@/lib/utils";
 import {
+  SIDEBAR_COLLAPSED_CHILD_COUNT_BADGE_CLASS,
   SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS,
   SIDEBAR_MANAGER_ENV_GROUPED_CHILD_ROW_PADDING_CLASS,
   SIDEBAR_MANAGER_ROW_PADDING_CLASS,
-  SIDEBAR_COLLAPSED_CHILD_COUNT_BADGE_CLASS,
+  SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS,
+  SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS,
   SIDEBAR_PROJECT_THREAD_ROW_PADDING_CLASS,
   SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
 } from "./sidebarRowClasses";
+
+// Depth in the manager hierarchy. 0 = root manager (rendered at the project
+// level). 1+ = nested manager (rendered inside another manager's group).
+// Indent caps at 1: deeper chains keep the depth-1 padding so the sidebar
+// can never overflow horizontally.
+export type ManagerRowDepth = 0 | 1;
+
+// Depth of a managed child relative to the project root. 1 = direct child of
+// a root manager. 2+ = child of a nested manager. Indent caps at 2.
+export type ManagedChildRowDepth = 1 | 2;
 
 export type ThreadRowOptions =
   | {
@@ -38,15 +50,18 @@ export type ThreadRowOptions =
     }
   | {
       kind: "managed-child";
+      depth: ManagedChildRowDepth;
     }
   | {
       kind: "env-grouped-child";
     }
   | {
       kind: "env-grouped-managed-child";
+      depth: ManagedChildRowDepth;
     }
   | {
       kind: "manager";
+      depth: ManagerRowDepth;
       isCollapsed: boolean;
       managedChildCount: number;
       onToggleCollapsed: (threadId: string) => void;
@@ -277,10 +292,7 @@ function ThreadTrailingIcon({
   return environmentIcon ? (
     <Icon
       name={environmentIcon}
-      className={cn(
-        "text-muted-foreground",
-        COARSE_POINTER_ICON_SIZE_CLASS,
-      )}
+      className={cn("text-muted-foreground", COARSE_POINTER_ICON_SIZE_CLASS)}
       aria-label={environmentIconLabel ?? undefined}
     />
   ) : null;
@@ -327,9 +339,25 @@ function ThreadRowComponent({
     : getEnvironmentWorkspaceDisplayIconLabel(
         thread.environmentWorkspaceDisplayKind,
       );
+  const managerRowPaddingClass =
+    managerOptions !== null && managerOptions.depth >= 1
+      ? SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS
+      : SIDEBAR_MANAGER_ROW_PADDING_CLASS;
+  const managedChildPaddingClass =
+    options.kind === "managed-child"
+      ? options.depth >= 2
+        ? SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS
+        : SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS
+      : SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS;
+  const envGroupedManagedChildPaddingClass =
+    options.kind === "env-grouped-managed-child" && options.depth >= 2
+      ? SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS
+      : SIDEBAR_MANAGER_ENV_GROUPED_CHILD_ROW_PADDING_CLASS;
   const childPaddingClass = isEnvGroupedManagedChild
-    ? SIDEBAR_MANAGER_ENV_GROUPED_CHILD_ROW_PADDING_CLASS
-    : SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS;
+    ? envGroupedManagedChildPaddingClass
+    : isManagedChild
+      ? managedChildPaddingClass
+      : SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS;
   const rowClassName = cn(
     "group/thread-row",
     SIDEBAR_ROW_BASE_CLASS,
@@ -338,7 +366,7 @@ function ThreadRowComponent({
       ? COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS
       : COARSE_POINTER_ROW_HEIGHT_CLASS,
     isManager
-      ? SIDEBAR_MANAGER_ROW_PADDING_CLASS
+      ? managerRowPaddingClass
       : isCompactChild
         ? childPaddingClass
         : SIDEBAR_PROJECT_THREAD_ROW_PADDING_CLASS,

--- a/apps/app/src/components/sidebar/projectThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.test.ts
@@ -40,24 +40,40 @@ function createThread(
   };
 }
 
-type ItemSummary = string | { env: string; threads: string[] };
+type ItemSummary =
+  | string
+  | { env: string; threads: string[] }
+  | { manager: string; items: ItemSummary[] };
 
 function summarizeItems(items: readonly ProjectThreadItem[]): ItemSummary[] {
-  return items.map((item) =>
-    item.kind === "thread"
-      ? item.thread.id
-      : {
+  return items.map((item) => {
+    switch (item.kind) {
+      case "thread":
+        return item.thread.id;
+      case "environment":
+        return {
           env: item.group.environmentId,
           threads: item.group.threads.map((thread) => thread.id),
-        },
-  );
+        };
+      case "manager":
+        return {
+          manager: item.group.managerThread.id,
+          items: summarizeItems(item.group.managedItems),
+        };
+    }
+  });
 }
 
 function looseThreadIds(items: readonly ProjectThreadItem[]): string[] {
   return items.map((item) => {
-    if (item.kind !== "thread") {
+    if (item.kind === "environment") {
       throw new Error(
         `expected thread item, got env group ${item.group.environmentId}`,
+      );
+    }
+    if (item.kind === "manager") {
+      throw new Error(
+        `expected thread item, got nested manager ${item.group.managerThread.id}`,
       );
     }
     return item.thread.id;
@@ -549,6 +565,228 @@ describe("buildProjectThreadGroups", () => {
     expect(
       summarizeItems(groups.managerThreadGroups[0]?.managedItems ?? []),
     ).toEqual(["managed-env-solo"]);
+  });
+
+  it("nests a manager whose parent is another manager under its parent's group", () => {
+    const groups = buildProjectThreadGroups([
+      createThread({
+        id: "root-manager",
+        type: "manager",
+        createdAt: 100,
+      }),
+      createThread({
+        id: "nested-manager",
+        type: "manager",
+        parentThreadId: "root-manager",
+        createdAt: 200,
+      }),
+      createThread({
+        id: "nested-child",
+        parentThreadId: "nested-manager",
+        createdAt: 300,
+        latestAttentionAt: 500,
+      }),
+      createThread({
+        id: "root-child",
+        parentThreadId: "root-manager",
+        createdAt: 250,
+        latestAttentionAt: 400,
+      }),
+    ]);
+
+    expect(groups.managerThreadGroups).toHaveLength(1);
+    expect(groups.managerThreadGroups[0]?.managerThread.id).toBe(
+      "root-manager",
+    );
+    expect(groups.managerThreadGroups[0]?.stats).toEqual({
+      managedChildBusyCount: 0,
+      managedChildCount: 2,
+    });
+    expect(
+      summarizeItems(groups.managerThreadGroups[0]?.managedItems ?? []),
+    ).toEqual([
+      "root-child",
+      {
+        manager: "nested-manager",
+        items: ["nested-child"],
+      },
+    ]);
+    expect(summarizeItems(groups.unmanagedItems)).toEqual([]);
+  });
+
+  it("renders a manager whose parent is missing as a root manager", () => {
+    const groups = buildProjectThreadGroups([
+      createThread({
+        id: "orphan-manager",
+        type: "manager",
+        parentThreadId: "deleted-manager",
+        createdAt: 100,
+      }),
+      createThread({
+        id: "orphan-child",
+        parentThreadId: "orphan-manager",
+        createdAt: 50,
+      }),
+    ]);
+
+    expect(groups.managerThreadGroups).toHaveLength(1);
+    expect(groups.managerThreadGroups[0]?.managerThread.id).toBe(
+      "orphan-manager",
+    );
+    expect(looseThreadIds(groups.managerThreadGroups[0]?.managedItems ?? []))
+      .toEqual(["orphan-child"]);
+    expect(summarizeItems(groups.unmanagedItems)).toEqual([]);
+  });
+
+  it("recurses through 3+ levels of nested managers", () => {
+    const groups = buildProjectThreadGroups([
+      createThread({
+        id: "m-root",
+        type: "manager",
+        createdAt: 100,
+      }),
+      createThread({
+        id: "m-mid",
+        type: "manager",
+        parentThreadId: "m-root",
+        createdAt: 200,
+      }),
+      createThread({
+        id: "m-deep",
+        type: "manager",
+        parentThreadId: "m-mid",
+        createdAt: 300,
+      }),
+      createThread({
+        id: "leaf",
+        parentThreadId: "m-deep",
+        createdAt: 400,
+      }),
+    ]);
+
+    expect(summarizeItems(groups.managerThreadGroups.map((group) => ({
+      kind: "manager" as const,
+      group,
+    })))).toEqual([
+      {
+        manager: "m-root",
+        items: [
+          {
+            manager: "m-mid",
+            items: [
+              {
+                manager: "m-deep",
+                items: ["leaf"],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("does not infinite-loop when a manager forms a cycle with another manager", () => {
+    const groups = buildProjectThreadGroups([
+      createThread({
+        id: "m-a",
+        type: "manager",
+        parentThreadId: "m-b",
+        createdAt: 100,
+      }),
+      createThread({
+        id: "m-b",
+        type: "manager",
+        parentThreadId: "m-a",
+        createdAt: 200,
+      }),
+    ]);
+
+    // Both managers reference each other as parent, so each is an in-project
+    // parent for the other. The grouping pass picks the first manager visited
+    // as the root and breaks the cycle when it would recurse back into a
+    // visited manager. Either ordering is fine, but the renderer must not
+    // hang and each manager must appear exactly once.
+    const managerIds = new Set<string>();
+    function collectManagerIds(items: readonly ProjectThreadItem[]): void {
+      for (const item of items) {
+        if (item.kind === "manager") {
+          managerIds.add(item.group.managerThread.id);
+          collectManagerIds(item.group.managedItems);
+        }
+      }
+    }
+    for (const group of groups.managerThreadGroups) {
+      managerIds.add(group.managerThread.id);
+      collectManagerIds(group.managedItems);
+    }
+    expect(managerIds).toEqual(new Set(["m-a", "m-b"]));
+  });
+
+  it("counts both standard and nested-manager direct children in stats", () => {
+    const groups = buildProjectThreadGroups([
+      createThread({
+        id: "root-manager",
+        type: "manager",
+        createdAt: 100,
+      }),
+      createThread({
+        id: "nested-manager",
+        type: "manager",
+        parentThreadId: "root-manager",
+        createdAt: 200,
+      }),
+      createThread({
+        id: "standard-child",
+        parentThreadId: "root-manager",
+        createdAt: 300,
+      }),
+    ]);
+
+    expect(groups.managerThreadGroups[0]?.stats).toEqual({
+      managedChildBusyCount: 0,
+      managedChildCount: 2,
+    });
+  });
+
+  it("interleaves a nested manager between standard children by recency", () => {
+    const groups = buildProjectThreadGroups([
+      createThread({
+        id: "root-manager",
+        type: "manager",
+        createdAt: 100,
+      }),
+      createThread({
+        id: "older-child",
+        parentThreadId: "root-manager",
+        createdAt: 200,
+        latestAttentionAt: 200,
+      }),
+      createThread({
+        id: "nested-manager",
+        type: "manager",
+        parentThreadId: "root-manager",
+        createdAt: 300,
+        latestAttentionAt: 500,
+      }),
+      createThread({
+        id: "newer-child",
+        parentThreadId: "root-manager",
+        createdAt: 400,
+        latestAttentionAt: 700,
+      }),
+    ]);
+
+    // newer-child (attention 700) > nested-manager (attention 500) > older-child (attention 200)
+    expect(
+      summarizeItems(groups.managerThreadGroups[0]?.managedItems ?? []),
+    ).toEqual([
+      "newer-child",
+      {
+        manager: "nested-manager",
+        items: [],
+      },
+      "older-child",
+    ]);
   });
 
   it("keeps managed children inside their manager group instead of globally interleaving them", () => {

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -14,12 +14,13 @@ export interface EnvironmentThreadGroup {
   threads: ThreadListEntry[];
 }
 
-// A single render slot in a project's or manager's thread list. Threads and
-// env groups interleave by recency, so the renderer iterates one ordered list
-// rather than two parallel arrays.
+// A single render slot in a project's or manager's thread list. Threads,
+// env groups, and nested manager groups interleave by recency, so the
+// renderer iterates one ordered list rather than three parallel arrays.
 export type ProjectThreadItem =
   | { kind: "thread"; thread: ThreadListEntry }
-  | { kind: "environment"; group: EnvironmentThreadGroup };
+  | { kind: "environment"; group: EnvironmentThreadGroup }
+  | { kind: "manager"; group: ManagerThreadGroup };
 
 export interface ManagerThreadGroup {
   managerThread: ThreadListEntry;
@@ -38,11 +39,6 @@ function isWorktreeDisplayKind(
   kind: EnvironmentWorkspaceDisplayKind,
 ): kind is WorktreeDisplayKind {
   return kind === "managed-worktree" || kind === "unmanaged-worktree";
-}
-
-interface KnownManagerParentArgs {
-  managerThreadIds: ReadonlySet<string>;
-  thread: ThreadListEntry;
 }
 
 function compareByCreatedAtDescending(
@@ -93,7 +89,14 @@ function compareStandardThreads(
 }
 
 function representativeThread(item: ProjectThreadItem): ThreadListEntry {
-  return item.kind === "thread" ? item.thread : item.group.threads[0];
+  switch (item.kind) {
+    case "thread":
+      return item.thread;
+    case "environment":
+      return item.group.threads[0];
+    case "manager":
+      return item.group.managerThread;
+  }
 }
 
 function compareProjectThreadItems(
@@ -106,7 +109,7 @@ function compareProjectThreadItems(
   );
 }
 
-function buildSortedItems(
+function buildSortedStandardItems(
   threads: ThreadListEntry[],
 ): ProjectThreadItem[] {
   const { environmentThreadGroups, looseThreads } =
@@ -122,72 +125,138 @@ function buildSortedItems(
   return items;
 }
 
-function getKnownManagerParentId({
-  managerThreadIds,
-  thread,
-}: KnownManagerParentArgs): string | null {
-  if (thread.type !== "standard") return null;
-  if (thread.parentThreadId === null) return null;
-  if (!managerThreadIds.has(thread.parentThreadId)) return null;
+interface BuildManagerGroupArgs {
+  managerThread: ThreadListEntry;
+  childrenByParentId: ReadonlyMap<string, ThreadListEntry[]>;
+  visited: Set<string>;
+}
 
-  return thread.parentThreadId;
+function buildManagerGroup({
+  managerThread,
+  childrenByParentId,
+  visited,
+}: BuildManagerGroupArgs): ManagerThreadGroup {
+  // Defensive cycle guard. The server enforces parent must be a live manager
+  // in the same project, but does not prevent a manager from being its own
+  // ancestor. If we revisit, drop the cycle edge rather than recurse.
+  if (visited.has(managerThread.id)) {
+    return {
+      managerThread,
+      managedItems: [],
+      stats: { managedChildBusyCount: 0, managedChildCount: 0 },
+    };
+  }
+  visited.add(managerThread.id);
+
+  const directChildren = childrenByParentId.get(managerThread.id) ?? [];
+  const standardChildren: ThreadListEntry[] = [];
+  const managerChildren: ThreadListEntry[] = [];
+  for (const child of directChildren) {
+    if (child.type === "manager") {
+      managerChildren.push(child);
+    } else {
+      standardChildren.push(child);
+    }
+  }
+
+  const standardItems = buildSortedStandardItems(standardChildren);
+  const nestedManagerItems: ProjectThreadItem[] = managerChildren
+    .slice()
+    .sort(compareByCreatedAtDescending)
+    .map((child) => ({
+      kind: "manager" as const,
+      group: buildManagerGroup({
+        managerThread: child,
+        childrenByParentId,
+        visited,
+      }),
+    }));
+  const managedItems: ProjectThreadItem[] = [
+    ...standardItems,
+    ...nestedManagerItems,
+  ];
+  managedItems.sort(compareProjectThreadItems);
+
+  let managedChildBusyCount = 0;
+  for (const child of directChildren) {
+    if (isBusyThread(child)) {
+      managedChildBusyCount += 1;
+    }
+  }
+
+  return {
+    managerThread,
+    managedItems,
+    stats: {
+      managedChildBusyCount,
+      managedChildCount: directChildren.length,
+    },
+  };
 }
 
 export function buildProjectThreadGroups(
   projectThreads: ThreadListEntry[],
 ): ProjectThreadGroups {
-  const managerThreads = projectThreads
-    .filter((thread) => thread.type === "manager")
-    .sort(compareByCreatedAtDescending);
+  const managerThreads = projectThreads.filter(
+    (thread) => thread.type === "manager",
+  );
   const managerThreadIds = new Set(managerThreads.map((thread) => thread.id));
-  const childrenByManagerId = new Map<string, ThreadListEntry[]>();
-  const statsByManagerId = new Map<string, ManagerThreadStats>();
+
+  const childrenByParentId = new Map<string, ThreadListEntry[]>();
   const unmanagedStandardThreads: ThreadListEntry[] = [];
 
-  for (const managerThread of managerThreads) {
-    childrenByManagerId.set(managerThread.id, []);
-    statsByManagerId.set(managerThread.id, {
-      managedChildBusyCount: 0,
-      managedChildCount: 0,
-    });
-  }
-
   for (const thread of projectThreads) {
-    if (thread.type !== "standard") continue;
-
-    const managerId = getKnownManagerParentId({ managerThreadIds, thread });
-    if (managerId === null) {
-      unmanagedStandardThreads.push(thread);
+    const parentId = thread.parentThreadId;
+    // A child sits under a manager only when its parent is a live manager in
+    // this project. Children of unknown parents (cross-project, deleted) fall
+    // through to the project-root unmanaged bucket so they remain reachable.
+    if (parentId !== null && managerThreadIds.has(parentId)) {
+      let bucket = childrenByParentId.get(parentId);
+      if (!bucket) {
+        bucket = [];
+        childrenByParentId.set(parentId, bucket);
+      }
+      bucket.push(thread);
       continue;
     }
-
-    const children = childrenByManagerId.get(managerId);
-    const stats = statsByManagerId.get(managerId);
-    if (!children || !stats) continue;
-
-    children.push(thread);
-    stats.managedChildCount += 1;
-    if (isBusyThread(thread)) {
-      stats.managedChildBusyCount += 1;
+    if (thread.type === "standard") {
+      unmanagedStandardThreads.push(thread);
     }
+    // Manager threads without an in-project manager parent become root
+    // managers in the next pass; standard threads without one are unmanaged.
   }
 
-  const managerThreadGroups: ManagerThreadGroup[] = managerThreads.map(
-    (managerThread) => ({
-      managerThread,
-      managedItems: buildSortedItems(
-        childrenByManagerId.get(managerThread.id) ?? [],
-      ),
-      stats: statsByManagerId.get(managerThread.id) ?? {
-        managedChildBusyCount: 0,
-        managedChildCount: 0,
-      },
-    }),
-  );
+  const rootManagerThreads = managerThreads
+    .filter((manager) => {
+      const parentId = manager.parentThreadId;
+      return parentId === null || !managerThreadIds.has(parentId);
+    })
+    .sort(compareByCreatedAtDescending);
+
+  const visited = new Set<string>();
+  const managerThreadGroups: ManagerThreadGroup[] = [];
+  for (const managerThread of rootManagerThreads) {
+    managerThreadGroups.push(
+      buildManagerGroup({ managerThread, childrenByParentId, visited }),
+    );
+  }
+  // Any manager not reached from an explicit root is part of a cycle with no
+  // entry point. Promote each unvisited manager to a root so it still
+  // surfaces in the tree — buildManagerGroup's visited guard breaks the
+  // cycle when it would recurse back into a placed manager.
+  const orphanedCycleManagers = managerThreads
+    .filter((manager) => !visited.has(manager.id))
+    .sort(compareByCreatedAtDescending);
+  for (const managerThread of orphanedCycleManagers) {
+    if (visited.has(managerThread.id)) continue;
+    managerThreadGroups.push(
+      buildManagerGroup({ managerThread, childrenByParentId, visited }),
+    );
+  }
 
   return {
     managerThreadGroups,
-    unmanagedItems: buildSortedItems(unmanagedStandardThreads),
+    unmanagedItems: buildSortedStandardItems(unmanagedStandardThreads),
   };
 }
 

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -11,6 +11,15 @@ export const SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS = "pl-14";
 
 export const SIDEBAR_MANAGER_ENV_GROUPED_CHILD_ROW_PADDING_CLASS = "pl-20";
 
+// Nested manager renders one indent level deeper than a root manager, sharing
+// the indent of a managed child so it lands inside the parent's child list.
+export const SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS = "pl-14";
+
+// Direct child of a nested manager. Sits one indent level deeper than a root
+// manager's child, matching the env sub-group indent so the depth caps cleanly
+// even for 3+ level chains.
+export const SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS = "pl-20";
+
 export const SIDEBAR_ROW_INTERACTIVE_STATE_CLASS =
   "text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground";
 
@@ -51,3 +60,20 @@ export const SIDEBAR_MANAGER_LINE_CONTINUATION_CLASS =
 
 export const SIDEBAR_COLLAPSED_CHILD_COUNT_BADGE_CLASS =
   "pointer-events-none absolute -bottom-0.5 -right-1 flex h-3 min-w-3 items-center justify-center rounded-full bg-primary px-0.5 text-[8px] font-semibold leading-none text-primary-foreground transition-opacity duration-150";
+
+/**
+ * Hairline that runs through a nested manager's child list. The nested
+ * manager row sits at pl-14, so its UserRound icon center lands at left-16,
+ * matching the env sub-group line. Reused for any chain of managers below
+ * the first nested level since the indent caps at pl-14 for the manager row
+ * itself.
+ */
+export const SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS =
+  "before:pointer-events-none before:absolute before:bottom-0 before:left-16 before:top-0 before:z-30 before:w-px before:bg-border-hairline before:content-['']";
+
+// Continuation line for a nested manager group. Sits at the same x position
+// as SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS (left-16, center of the nested
+// manager's UserRound icon at pl-14) so collapsed nested managers can still
+// participate in their parent's vertical guide.
+export const SIDEBAR_NESTED_MANAGER_LINE_CONTINUATION_CLASS =
+  "pointer-events-none absolute bottom-0 left-16 top-0 z-[1] w-px bg-border-hairline";


### PR DESCRIPTION
## Motivation

Manager threads can have other manager threads as children (nested managers), but the sidebar didn't render that hierarchy. The grouping pass in `projectThreadGroups.ts:156` filtered children to `thread.type !== "standard"`, so a nested manager fell through to the root manager list and appeared as a sibling of its parent at the project root — losing the hierarchy entirely.

## Design

Recursive grouping + recursive rendering, reusing the existing thread-row primitives.

- **Data**: `ProjectThreadItem` now includes `{ kind: "manager"; group: ManagerThreadGroup }`. `buildProjectThreadGroups` identifies root managers (those without a live in-project manager parent) and walks each subtree, interleaving standard children, env groups, and nested manager groups by recency.
- **Rendering**: `ManagerThreadGroupRow` takes a `depth` prop and recurses into itself for nested manager items. The manager row uses the `manager` `ThreadRow` kind with the same `UserRound` icon + chevron at every level, so a nested manager still looks like a manager — just indented under its parent.
- **Indent cap**: depth 0 manager at `pl-8`; depth 1+ manager at `pl-14` (same as a managed child); their children at `pl-20`. Chains beyond depth 1 keep the depth-1 padding so deeply nested chains don't overflow horizontally — the chevron and hairline guide still convey the structure.
- **Cycles**: defensive `visited` guard in the recursive walk drops the cycle edge. Any manager unreachable from an explicit root (entire cycle, no entry point) gets promoted to a root group in a fallback pass so it stays reachable.

### Before / After

```
Before (nested manager appears as a sibling at project root):
└─ Project foo
   ├─ Root Manager        [UserRound icon]
   │  └─ Standard child A
   └─ Nested Manager      [UserRound icon — wrong, should be inside Root]
      └─ Nested child

After:
└─ Project foo
   └─ Root Manager        [UserRound icon, chevron expanded]
      ├─ Standard child A
      └─ Nested Manager   [UserRound icon, chevron expanded — indented under root]
         └─ Nested child  [indented one further step]
```

## Files changed

- `apps/app/src/components/sidebar/projectThreadGroups.ts` — recursive `buildProjectThreadGroups` + cycle protection.
- `apps/app/src/components/sidebar/projectThreadGroups.test.ts` — 6 new unit tests covering nested managers, orphaned-parent managers, 3+ level chains, cycle defense, stats counting, and recency-interleaving.
- `apps/app/src/components/sidebar/ProjectRow.tsx` — `ManagerThreadGroupRow` takes a `depth` prop, recurses for nested manager items, plumbs `collapsedManagerIds` through so every level toggles independently.
- `apps/app/src/components/sidebar/ThreadRow.tsx` — adds `depth: ManagerRowDepth | ManagedChildRowDepth` to manager / managed-child / env-grouped-managed-child kinds; padding switches on depth.
- `apps/app/src/components/sidebar/sidebarRowClasses.ts` — adds `SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS`, `SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS`, and `SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS`.
- `apps/app/src/components/sidebar/ProjectRow.stories.tsx` — adds a "nested manager" story.
- `apps/app/src/components/sidebar/ThreadRow.stories.tsx` — adds a "nested manager" row story.
- `apps/app/src/components/sidebar/ProjectList.test.tsx` — integration test: renders a root manager → nested manager → nested child and asserts all three titles appear.

## Tests added

- `projectThreadGroups.test.ts`
  - `nests a manager whose parent is another manager under its parent's group`
  - `renders a manager whose parent is missing as a root manager`
  - `recurses through 3+ levels of nested managers`
  - `does not infinite-loop when a manager forms a cycle with another manager`
  - `counts both standard and nested-manager direct children in stats`
  - `interleaves a nested manager between standard children by recency`
- `ProjectList.test.tsx`
  - `renders a nested manager under its parent and exposes its children`

## Validation

- `NODE_ENV=development pnpm exec turbo run typecheck --filter=@bb/app` — clean.
- `NODE_ENV=development pnpm exec turbo run test --filter=@bb/app` — 443 tests pass (84 files).
- `git diff --check` — clean.

## Test plan

- [ ] Open a project that has a manager with a nested manager (or seed one via SQL). Confirm the nested manager renders inside its parent's collapsible group rather than at the project root.
- [ ] Expand/collapse both the root manager and the nested manager independently.
- [ ] Click a standard child of the nested manager and confirm navigation works.
- [ ] Verify deep chains (3+ levels) still render readably and don't overflow horizontally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)