### PR TITLE
manager-templates: stop installing defaults to disk; use bundle as fallback at seed time

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,7 +14,6 @@ import { createBbAppManagedConfigReloader } from "./services/system/bb-app-manag
 import { startEventLoopStallMonitor } from "./services/system/event-loop-stall-monitor.js";
 import { runPeriodicSweeps } from "./services/system/periodic-sweeps.js";
 import { TerminalSessionLifecycle } from "./services/terminals/terminal-session-lifecycle.js";
-import { ensureBuiltInManagerTemplatesInstalled } from "./services/threads/manager-storage-templates.js";
 import { createLifecycleDedupers } from "./lifecycle-dedupers.js";
 import type { ServerRuntimeConfig } from "./types.js";
 import { NotificationHub } from "./ws/hub.js";
@@ -57,10 +56,6 @@ async function main(): Promise<void> {
   if (appUrl !== undefined) {
     runtimeConfig.appUrl = appUrl;
   }
-  await ensureBuiltInManagerTemplatesInstalled({
-    dataDir: commonConfig.BB_DATA_DIR,
-    logger,
-  });
   const bbAppManagedConfig = await createBbAppManagedConfigReloader({
     config: runtimeConfig,
     hub,

--- a/apps/server/src/services/threads/manager-storage-templates.ts
+++ b/apps/server/src/services/threads/manager-storage-templates.ts
@@ -5,7 +5,6 @@ import {
   mkdir,
   readdir,
   readFile,
-  stat,
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
@@ -40,11 +39,6 @@ interface BuiltInManagerTemplateSet {
   name: ManagerTemplateName;
 }
 
-interface EnsureBuiltInManagerTemplatesInstalledArgs {
-  dataDir: string;
-  logger: ManagerTemplateLogger;
-}
-
 interface ResolveManagerTemplateNameArgs {
   dataDir: string;
   explicitTemplateName: ManagerTemplateName | null;
@@ -66,6 +60,14 @@ interface CopyTemplateFilesArgs {
   threadStoragePath: string;
 }
 
+interface CopyBuiltInTemplateFilesArgs {
+  files: readonly BuiltInManagerTemplateFile[];
+  logger: ManagerTemplateLogger;
+  templateName: ManagerTemplateName;
+  threadId: string;
+  threadStoragePath: string;
+}
+
 interface FsErrorWithCodeArgs {
   code: string;
   error: unknown;
@@ -79,26 +81,19 @@ interface ManagerTemplateSetPathArgs extends ManagerTemplateRootPathArgs {
   templateName: ManagerTemplateName;
 }
 
-interface PathExistsArgs {
-  filePath: string;
-}
+type CopyTemplateFilesResult = "copied" | "missing";
 
-interface WriteFileIfAbsentArgs {
-  content: string;
-  filePath: string;
-}
-
-const BUILT_IN_MANAGER_TEMPLATE_SETS: readonly BuiltInManagerTemplateSet[] = [
-  {
-    name: DEFAULT_MANAGER_TEMPLATE_NAME,
-    files: [
-      {
-        fileName: "STATUS.html",
-        content: loadDefaultTemplateAsset("STATUS.html"),
-      },
-    ],
-  },
-];
+// Built-in defaults stay in the server bundle. They are copied only as a
+// seed-time fallback when the user has not authored manager-templates/default.
+const BUILT_IN_DEFAULT_MANAGER_TEMPLATE_SET: BuiltInManagerTemplateSet = {
+  name: DEFAULT_MANAGER_TEMPLATE_NAME,
+  files: [
+    {
+      fileName: "STATUS.html",
+      content: loadDefaultTemplateAsset("STATUS.html"),
+    },
+  ],
+};
 
 function isFsErrorWithCode(args: FsErrorWithCodeArgs): boolean {
   return (
@@ -127,64 +122,6 @@ function activeManagerTemplatePath(args: ManagerTemplateRootPathArgs): string {
     managerTemplateRootPath({ dataDir: args.dataDir }),
     ACTIVE_MANAGER_TEMPLATE_FILE_NAME,
   );
-}
-
-async function pathExists(args: PathExistsArgs): Promise<boolean> {
-  try {
-    await stat(args.filePath);
-    return true;
-  } catch (error) {
-    if (isFsErrorWithCode({ error, code: "ENOENT" })) {
-      return false;
-    }
-    throw error;
-  }
-}
-
-async function writeFileIfAbsent(args: WriteFileIfAbsentArgs): Promise<void> {
-  try {
-    await writeFile(args.filePath, args.content, {
-      encoding: "utf8",
-      flag: "wx",
-    });
-  } catch (error) {
-    if (!isFsErrorWithCode({ error, code: "EEXIST" })) {
-      throw error;
-    }
-  }
-}
-
-export async function ensureBuiltInManagerTemplatesInstalled(
-  args: EnsureBuiltInManagerTemplatesInstalledArgs,
-): Promise<void> {
-  const templateRootPath = managerTemplateRootPath({ dataDir: args.dataDir });
-  await mkdir(templateRootPath, { recursive: true });
-  await writeFileIfAbsent({
-    filePath: activeManagerTemplatePath({ dataDir: args.dataDir }),
-    content: `${DEFAULT_MANAGER_TEMPLATE_NAME}\n`,
-  });
-
-  for (const templateSet of BUILT_IN_MANAGER_TEMPLATE_SETS) {
-    const templateSetPath = managerTemplateSetPath({
-      dataDir: args.dataDir,
-      templateName: templateSet.name,
-    });
-    if (await pathExists({ filePath: templateSetPath })) {
-      continue;
-    }
-    await mkdir(templateSetPath, { recursive: true });
-    for (const file of templateSet.files) {
-      await writeFile(
-        path.join(templateSetPath, file.fileName),
-        file.content,
-        "utf8",
-      );
-    }
-    args.logger.debug(
-      { templateName: templateSet.name, templateSetPath },
-      "Installed built-in manager template set",
-    );
-  }
 }
 
 async function readActiveManagerTemplateName(
@@ -227,21 +164,15 @@ async function readActiveManagerTemplateName(
   return DEFAULT_MANAGER_TEMPLATE_NAME;
 }
 
-async function copyTemplateFiles(args: CopyTemplateFilesArgs): Promise<void> {
+async function copyTemplateFiles(
+  args: CopyTemplateFilesArgs,
+): Promise<CopyTemplateFilesResult> {
   let entries: Dirent[];
   try {
     entries = await readdir(args.templateDirPath, { withFileTypes: true });
   } catch (error) {
     if (isFsErrorWithCode({ error, code: "ENOENT" })) {
-      args.logger.warn(
-        {
-          templateName: args.templateName,
-          templateDirPath: args.templateDirPath,
-          threadId: args.threadId,
-        },
-        "Manager template directory is missing; skipping storage seed",
-      );
-      return;
+      return "missing";
     }
     throw error;
   }
@@ -274,6 +205,38 @@ async function copyTemplateFiles(args: CopyTemplateFilesArgs): Promise<void> {
       throw error;
     }
   }
+
+  return "copied";
+}
+
+async function copyBuiltInTemplateFiles(
+  args: CopyBuiltInTemplateFilesArgs,
+): Promise<void> {
+  await mkdir(args.threadStoragePath, { recursive: true });
+
+  for (const file of args.files) {
+    const destinationPath = path.join(args.threadStoragePath, file.fileName);
+    try {
+      await writeFile(destinationPath, file.content, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+    } catch (error) {
+      if (isFsErrorWithCode({ error, code: "EEXIST" })) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  args.logger.debug(
+    {
+      templateName: args.templateName,
+      threadId: args.threadId,
+      threadStoragePath: args.threadStoragePath,
+    },
+    "Seeded manager storage from built-in template fallback",
+  );
 }
 
 export async function seedManagerThreadStorage(
@@ -288,14 +251,38 @@ export async function seedManagerThreadStorage(
     explicitTemplateName: args.explicitTemplateName,
     logger: deps.logger,
   });
-  await copyTemplateFiles({
+  const templateDirPath = managerTemplateSetPath({
+    dataDir: session.dataDir,
+    templateName,
+  });
+  const copyResult = await copyTemplateFiles({
     logger: deps.logger,
-    templateDirPath: managerTemplateSetPath({
-      dataDir: session.dataDir,
-      templateName,
-    }),
+    templateDirPath,
     templateName,
     threadId: args.threadId,
     threadStoragePath: args.threadStoragePath,
   });
+  if (copyResult === "copied") {
+    return;
+  }
+
+  if (templateName === BUILT_IN_DEFAULT_MANAGER_TEMPLATE_SET.name) {
+    await copyBuiltInTemplateFiles({
+      files: BUILT_IN_DEFAULT_MANAGER_TEMPLATE_SET.files,
+      logger: deps.logger,
+      templateName,
+      threadId: args.threadId,
+      threadStoragePath: args.threadStoragePath,
+    });
+    return;
+  }
+
+  deps.logger.warn(
+    {
+      templateName,
+      templateDirPath,
+      threadId: args.threadId,
+    },
+    "Manager template directory is missing; skipping storage seed",
+  );
 }

--- a/apps/server/test/public/public-threads.manager-and-ownership.test.ts
+++ b/apps/server/test/public/public-threads.manager-and-ownership.test.ts
@@ -387,19 +387,12 @@ describe("public thread manager and ownership routes", () => {
     }
   });
 
-  it("copies user-authored default preferences alongside bundled status into new manager thread storage", async () => {
+  it("copies user-authored default template files into new manager thread storage", async () => {
     const harness = await createTestAppHarness();
     const hostId = "host-manager-template-default";
     const dataDir = hostDataDir({ hostId });
     await rm(dataDir, { recursive: true, force: true });
     try {
-      const bundledStatusContent = await readFile(
-        new URL(
-          "../../src/services/threads/default-template/STATUS.html",
-          import.meta.url,
-        ),
-        "utf8",
-      );
       const { host } = seedHostSession(harness.deps, { id: hostId });
       const { project, source } = seedProjectWithSource(harness.deps, {
         hostId: host.id,
@@ -414,7 +407,7 @@ describe("public thread manager and ownership routes", () => {
         name: "default",
         files: {
           "PREFERENCES.md": "default prefs\n",
-          "STATUS.html": bundledStatusContent,
+          "STATUS.html": "default status\n",
         },
       });
 
@@ -448,7 +441,7 @@ describe("public thread manager and ownership routes", () => {
       ).resolves.toBe("default prefs\n");
       await expect(
         readFile(path.join(storagePath, "STATUS.html"), "utf8"),
-      ).resolves.toBe(bundledStatusContent);
+      ).resolves.toBe("default status\n");
     } finally {
       await harness.cleanup();
       await rm(dataDir, { recursive: true, force: true });

--- a/apps/server/test/threads/manager-storage-templates.test.ts
+++ b/apps/server/test/threads/manager-storage-templates.test.ts
@@ -1,89 +1,319 @@
 import {
-  mkdtemp,
   mkdir,
+  mkdtemp,
   readdir,
   readFile,
   rm,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { openSession } from "@bb/db";
+import type { ManagerTemplateName } from "@bb/domain";
+import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
+import { describe, expect, it, vi } from "vitest";
 import {
-  ensureBuiltInManagerTemplatesInstalled,
+  ACTIVE_MANAGER_TEMPLATE_FILE_NAME,
+  DEFAULT_MANAGER_TEMPLATE_NAME,
   managerTemplateRootPath,
+  seedManagerThreadStorage,
 } from "../../src/services/threads/manager-storage-templates.js";
-import { testLogger } from "../helpers/test-app.js";
+import type { TestAppHarness } from "../helpers/test-app.js";
+import { seedHost } from "../helpers/seed.js";
+import { createTestAppHarness, testLogger } from "../helpers/test-app.js";
+
+const MINE_MANAGER_TEMPLATE_NAME: ManagerTemplateName = "mine";
+
+interface SeedHarness {
+  dataDir: string;
+  harness: TestAppHarness;
+  hostId: string;
+}
+
+interface WriteManagerTemplateSetArgs {
+  dataDir: string;
+  files: Record<string, string>;
+  name: ManagerTemplateName;
+}
+
+interface WriteActiveManagerTemplateArgs {
+  dataDir: string;
+  name: ManagerTemplateName;
+}
+
+interface SeedStorageArgs {
+  dataDir: string;
+  explicitTemplateName: ManagerTemplateName | null;
+  harness: TestAppHarness;
+  hostId: string;
+  logger?: typeof testLogger;
+  threadId: string;
+}
 
 async function makeDataDir(): Promise<string> {
   return mkdtemp(path.join(tmpdir(), "bb-manager-templates-"));
 }
 
-describe("manager storage templates", () => {
-  it("installs the default built-in manager template set", async () => {
-    const dataDir = await makeDataDir();
-    try {
-      await ensureBuiltInManagerTemplatesInstalled({
-        dataDir,
-        logger: testLogger,
-      });
+async function createSeedHarness(): Promise<SeedHarness> {
+  const harness = await createTestAppHarness();
+  const dataDir = await makeDataDir();
+  const host = seedHost(harness.deps, { id: "host-manager-template" });
+  openSession(harness.db, harness.hub, {
+    hostId: host.id,
+    instanceId: "manager-template-test",
+    hostName: "Manager Template Test Host",
+    hostType: "persistent",
+    dataDir,
+    protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+    heartbeatIntervalMs: 5_000,
+    leaseTimeoutMs: 30_000,
+  });
+  return {
+    dataDir,
+    harness,
+    hostId: host.id,
+  };
+}
 
-      const templateRootPath = managerTemplateRootPath({ dataDir });
+async function readBundledStatusTemplate(): Promise<string> {
+  return readFile(
+    new URL(
+      "../../src/services/threads/default-template/STATUS.html",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+}
+
+async function writeManagerTemplateSet(
+  args: WriteManagerTemplateSetArgs,
+): Promise<void> {
+  const templateDir = path.join(
+    managerTemplateRootPath({ dataDir: args.dataDir }),
+    args.name,
+  );
+  await mkdir(templateDir, { recursive: true });
+  for (const [fileName, content] of Object.entries(args.files)) {
+    await writeFile(path.join(templateDir, fileName), content, "utf8");
+  }
+}
+
+async function writeActiveManagerTemplate(
+  args: WriteActiveManagerTemplateArgs,
+): Promise<void> {
+  const templateRootPath = managerTemplateRootPath({ dataDir: args.dataDir });
+  await mkdir(templateRootPath, { recursive: true });
+  await writeFile(
+    path.join(templateRootPath, ACTIVE_MANAGER_TEMPLATE_FILE_NAME),
+    `${args.name}\n`,
+    "utf8",
+  );
+}
+
+async function seedStorage(args: SeedStorageArgs): Promise<string> {
+  const threadStoragePath = path.join(
+    args.dataDir,
+    "thread-storage",
+    args.threadId,
+  );
+  await seedManagerThreadStorage(
+    {
+      ...args.harness.deps,
+      logger: args.logger ?? args.harness.deps.logger,
+    },
+    {
+      explicitTemplateName: args.explicitTemplateName,
+      hostId: args.hostId,
+      threadId: args.threadId,
+      threadStoragePath,
+    },
+  );
+  return threadStoragePath;
+}
+
+describe("manager storage templates", () => {
+  it("does not create manager templates during server bootstrap", async () => {
+    const harness = await createTestAppHarness();
+    try {
       await expect(
-        readFile(path.join(templateRootPath, "active"), "utf8"),
-      ).resolves.toBe("default\n");
-      await expect(
-        readdir(path.join(templateRootPath, "default")),
-      ).resolves.toEqual(["STATUS.html"]);
-      await expect(
-        readFile(path.join(templateRootPath, "default", "STATUS.html"), "utf8"),
-      ).resolves.toContain('<div class="sect-title">Open PRs · 0</div>');
-      await expect(
-        readFile(
-          path.join(templateRootPath, "default", "PREFERENCES.md"),
-          "utf8",
-        ),
-      ).rejects.toThrow();
-      await expect(
-        readFile(path.join(templateRootPath, "default", "ASYNC.md"), "utf8"),
-      ).rejects.toThrow();
-      await expect(
-        readFile(path.join(templateRootPath, "default", "STATUS.md"), "utf8"),
+        stat(managerTemplateRootPath({ dataDir: harness.config.dataDir })),
       ).rejects.toThrow();
     } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("seeds bundled status when default resolves and no user template directory exists", async () => {
+    const { dataDir, harness, hostId } = await createSeedHarness();
+    try {
+      const threadStoragePath = await seedStorage({
+        dataDir,
+        explicitTemplateName: null,
+        harness,
+        hostId,
+        threadId: "thr-default-fallback",
+      });
+
+      await expect(
+        readFile(path.join(threadStoragePath, "STATUS.html"), "utf8"),
+      ).resolves.toBe(await readBundledStatusTemplate());
+      await expect(
+        stat(managerTemplateRootPath({ dataDir })),
+      ).rejects.toThrow();
+    } finally {
+      await harness.cleanup();
       await rm(dataDir, { recursive: true, force: true });
     }
   });
 
-  it("does not overwrite an existing default manager template directory", async () => {
-    const dataDir = await makeDataDir();
+  it("seeds user-authored default files without bundled fallback", async () => {
+    const { dataDir, harness, hostId } = await createSeedHarness();
     try {
-      const templateRootPath = managerTemplateRootPath({ dataDir });
-      const defaultTemplatePath = path.join(templateRootPath, "default");
-      await mkdir(defaultTemplatePath, { recursive: true });
-      await writeFile(
-        path.join(defaultTemplatePath, "PREFERENCES.md"),
-        "custom prefs\n",
-        "utf8",
-      );
-      await writeFile(
-        path.join(defaultTemplatePath, "STATUS.html"),
-        "custom status\n",
-        "utf8",
-      );
-
-      await ensureBuiltInManagerTemplatesInstalled({
+      await writeManagerTemplateSet({
         dataDir,
-        logger: testLogger,
+        name: DEFAULT_MANAGER_TEMPLATE_NAME,
+        files: {
+          "STATUS.html": "user status\n",
+        },
+      });
+
+      const threadStoragePath = await seedStorage({
+        dataDir,
+        explicitTemplateName: null,
+        harness,
+        hostId,
+        threadId: "thr-user-default",
       });
 
       await expect(
-        readFile(path.join(defaultTemplatePath, "PREFERENCES.md"), "utf8"),
-      ).resolves.toBe("custom prefs\n");
-      await expect(
-        readFile(path.join(defaultTemplatePath, "STATUS.html"), "utf8"),
-      ).resolves.toBe("custom status\n");
+        readFile(path.join(threadStoragePath, "STATUS.html"), "utf8"),
+      ).resolves.toBe("user status\n");
     } finally {
+      await harness.cleanup();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mix bundled files into an existing empty default template directory", async () => {
+    const { dataDir, harness, hostId } = await createSeedHarness();
+    try {
+      await writeManagerTemplateSet({
+        dataDir,
+        name: DEFAULT_MANAGER_TEMPLATE_NAME,
+        files: {},
+      });
+
+      const threadStoragePath = await seedStorage({
+        dataDir,
+        explicitTemplateName: null,
+        harness,
+        hostId,
+        threadId: "thr-empty-default",
+      });
+
+      await expect(readdir(threadStoragePath)).resolves.toEqual([]);
+    } finally {
+      await harness.cleanup();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns and skips seeding when active points to a missing non-default template", async () => {
+    const { dataDir, harness, hostId } = await createSeedHarness();
+    const logger = {
+      ...testLogger,
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    try {
+      await writeActiveManagerTemplate({
+        dataDir,
+        name: MINE_MANAGER_TEMPLATE_NAME,
+      });
+
+      const threadStoragePath = await seedStorage({
+        dataDir,
+        explicitTemplateName: null,
+        harness,
+        hostId,
+        logger,
+        threadId: "thr-missing-active",
+      });
+
+      await expect(stat(threadStoragePath)).rejects.toThrow();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateName: MINE_MANAGER_TEMPLATE_NAME,
+          threadId: "thr-missing-active",
+        }),
+        "Manager template directory is missing; skipping storage seed",
+      );
+    } finally {
+      await harness.cleanup();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns and skips seeding when an explicit non-default template is missing", async () => {
+    const { dataDir, harness, hostId } = await createSeedHarness();
+    const logger = {
+      ...testLogger,
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    try {
+      const threadStoragePath = await seedStorage({
+        dataDir,
+        explicitTemplateName: MINE_MANAGER_TEMPLATE_NAME,
+        harness,
+        hostId,
+        logger,
+        threadId: "thr-missing-explicit",
+      });
+
+      await expect(stat(threadStoragePath)).rejects.toThrow();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateName: MINE_MANAGER_TEMPLATE_NAME,
+          threadId: "thr-missing-explicit",
+        }),
+        "Manager template directory is missing; skipping storage seed",
+      );
+    } finally {
+      await harness.cleanup();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds from the active non-default template when that directory exists", async () => {
+    const { dataDir, harness, hostId } = await createSeedHarness();
+    try {
+      await writeActiveManagerTemplate({
+        dataDir,
+        name: MINE_MANAGER_TEMPLATE_NAME,
+      });
+      await writeManagerTemplateSet({
+        dataDir,
+        name: MINE_MANAGER_TEMPLATE_NAME,
+        files: {
+          "STATUS.html": "mine status\n",
+        },
+      });
+
+      const threadStoragePath = await seedStorage({
+        dataDir,
+        explicitTemplateName: null,
+        harness,
+        hostId,
+        threadId: "thr-active-mine",
+      });
+
+      await expect(
+        readFile(path.join(threadStoragePath, "STATUS.html"), "utf8"),
+      ).resolves.toBe("mine status\n");
+    } finally {
+      await harness.cleanup();
       await rm(dataDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Motivation

Decouple bb's bundled manager-template defaults from user state. Built-in defaults now stay in the server bundle and are consulted only when seeding a manager whose resolved `default` template has not been authored on disk. This keeps the user's data dir clean for new installs while preserving existing users' `manager-templates/default/` directories exactly as user-owned state.

## Resolver Flow

1. Resolve the template name: explicit `--template` / `templateName` first, then `<dataDir>/manager-templates/active`, then literal `default`.
2. Try `<dataDir>/manager-templates/<name>/`. If it exists, copy its regular files into the new manager thread storage.
3. If that directory is missing and `<name>` is `default`, copy the bundled `default-template/STATUS.html` directly from the server bundle into thread storage.
4. If that directory is missing and `<name>` is not `default`, warn and skip seeding.

## Default Directory Fallback Decision

Fallback is all-or-nothing at the directory level. If `manager-templates/default/` exists, it is treated as fully user-authored, even if it is empty or missing `STATUS.html`. This avoids silently mixing bundle updates into a user's own template directory and makes the override model predictable: create `default/` to own the whole default template set.

## Files Changed

- `apps/server/src/index.ts`: removed the startup installer call.
- `apps/server/src/services/threads/manager-storage-templates.ts`: removed disk-install helpers and added seed-time bundled fallback for missing `default/` only.
- `apps/server/test/threads/manager-storage-templates.test.ts`: replaced installer tests with fallback/override/missing-template seed tests.
- `apps/server/test/public/public-threads.manager-and-ownership.test.ts`: updated stale wording and fixture content around user-authored default files.

## Tests Added

- No manager-template directory is created during server bootstrap.
- Empty data dir plus default resolution seeds bundled `STATUS.html` without creating `manager-templates/`.
- User-authored `default/STATUS.html` wins over bundled fallback.
- Existing empty `default/` directory gets no bundled per-file fallback.
- `active=mine` with no `mine/` directory warns and no-ops.
- Explicit `templateName=mine` with no `mine/` directory warns and no-ops.
- `active=mine` with a present `mine/` directory seeds from `mine/`.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server`
- `pnpm exec turbo run build --filter=@bb/server`
- Confirmed `apps/server/dist/default-template/STATUS.html` exists after build.
- `git diff --check`
