### PR TITLE
server: append [bb system] tool-name reminder to manager turns

### DIFF
--- a/apps/server/src/services/threads/manager-tool-reminder.ts
+++ b/apps/server/src/services/threads/manager-tool-reminder.ts
@@ -1,0 +1,39 @@
+import type { AgentProviderId } from "@bb/agent-providers";
+import type { PromptInput } from "@bb/domain";
+
+export type ManagerUserMessageToolName =
+  | "mcp__bb-bridge__message_user"
+  | "message_user";
+
+export function resolveManagerUserMessageToolName(
+  providerId: AgentProviderId,
+): ManagerUserMessageToolName {
+  switch (providerId) {
+    case "claude-code":
+      return "mcp__bb-bridge__message_user";
+    case "codex":
+    case "pi":
+      return "message_user";
+  }
+  const unsupportedProviderId: never = providerId;
+  return unsupportedProviderId;
+}
+
+export function buildManagerToolReminderText(
+  providerId: AgentProviderId,
+): string {
+  return `[bb system] Reminder: call ${resolveManagerUserMessageToolName(providerId)} to send any user-visible message. Plain assistant text is internal and not shown to the user.`;
+}
+
+export function appendManagerToolReminder(
+  input: PromptInput[],
+  providerId: AgentProviderId,
+): PromptInput[] {
+  const reminderText = buildManagerToolReminderText(providerId);
+  const lastInput = input[input.length - 1];
+  if (lastInput?.type === "text" && lastInput.text === reminderText) {
+    return input;
+  }
+
+  return [...input, { type: "text", text: reminderText }];
+}

--- a/apps/server/src/services/threads/thread-commands.ts
+++ b/apps/server/src/services/threads/thread-commands.ts
@@ -11,6 +11,7 @@ import {
 } from "@bb/db";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
+  type AgentProviderId,
   getBuiltInAgentProviderInfo,
   isAgentProviderId,
 } from "@bb/agent-providers";
@@ -44,6 +45,7 @@ import {
   type ResolvedThreadRuntimeCommandConfig,
   type ThreadRuntimeCommandEnvironment,
 } from "./thread-runtime-config.js";
+import { appendManagerToolReminder } from "./manager-tool-reminder.js";
 
 export interface ExecutionOptionsRequest {
   model?: CreateThreadRequest["model"];
@@ -250,6 +252,18 @@ function toRuntimeExecutionOptions(
   };
 }
 
+function requireAgentProviderId(providerId: string): AgentProviderId {
+  if (isAgentProviderId(providerId)) {
+    return providerId;
+  }
+
+  throw new ApiError(
+    500,
+    "internal_error",
+    `Manager thread has unsupported provider ${providerId}`,
+  );
+}
+
 export async function buildExecutionOptions(
   deps: Pick<AppDeps, "db" | "hub">,
   request: ExecutionOptionsRequest,
@@ -362,11 +376,18 @@ export async function prepareTurnSubmitCommandPayload(
     thread: args.thread,
     environment: args.environment,
   });
+  const input =
+    args.thread.type === "manager"
+      ? appendManagerToolReminder(
+          args.input,
+          requireAgentProviderId(args.thread.providerId),
+        )
+      : args.input;
   return buildPreparedTurnSubmitCommandPayload({
     environmentId: args.environment.id,
     execution: args.execution,
     permissionEscalation: args.permissionEscalation,
-    input: args.input,
+    input,
     providerThreadId,
     runtimeContext,
     target: args.target,

--- a/apps/server/test/internal/internal-command-result-thread-failure.test.ts
+++ b/apps/server/test/internal/internal-command-result-thread-failure.test.ts
@@ -4,6 +4,7 @@ import { events, getThread, hostDaemonCommands, queueCommand } from "@bb/db";
 import { turnScope } from "@bb/domain";
 import { renderTemplate } from "@bb/templates";
 import { describe, expect, it } from "vitest";
+import { buildManagerToolReminderText } from "../../src/services/threads/manager-tool-reminder.js";
 import {
   createTestDaemonEventEnvelope,
   internalAuthHeaders,
@@ -47,6 +48,13 @@ interface QueueManagedTurnSubmitScenarioArgs {
   turnId: string;
 }
 
+function managerToolReminderInput() {
+  return {
+    type: "text",
+    text: buildManagerToolReminderText("codex"),
+  };
+}
+
 async function expectFailedManagerNotificationQueued(
   harness: TestAppHarness,
   args: ExpectFailedManagerNotificationArgs,
@@ -86,6 +94,7 @@ async function expectFailedManagerNotificationQueued(
           titleSuffix: ` (${args.childTitle})`,
         }),
       },
+      managerToolReminderInput(),
     ],
     options: {
       model: "gpt-5.4",
@@ -688,6 +697,7 @@ describe("thread command failure side effects", () => {
               titleSuffix: " (Completed event owns outcome)",
             }),
           },
+          managerToolReminderInput(),
         ],
         resumeContext: {
           providerId: "codex",
@@ -726,6 +736,7 @@ describe("thread command failure side effects", () => {
               titleSuffix: " (Completed event owns outcome)",
             }),
           },
+          managerToolReminderInput(),
         ],
       });
       const errorEvents = harness.db

--- a/apps/server/test/internal/internal-event-side-effects.test.ts
+++ b/apps/server/test/internal/internal-event-side-effects.test.ts
@@ -44,7 +44,15 @@ import {
 import { createCommandApprovalPayload } from "../helpers/pending-interactions.js";
 import { queueManagerSystemMessage } from "../../src/services/threads/manager-system-messages.js";
 import { sendNextQueuedMessageIfPresent } from "../../src/services/threads/queued-messages.js";
+import { buildManagerToolReminderText } from "../../src/services/threads/manager-tool-reminder.js";
 import { createTestAppHarness } from "../helpers/test-app.js";
+
+function managerToolReminderInput() {
+  return {
+    type: "text",
+    text: buildManagerToolReminderText("codex"),
+  };
+}
 
 describe("internal event side effects", () => {
   it("logs side-effect failures and continues processing the rest of the batch", async () => {
@@ -303,7 +311,10 @@ describe("internal event side effects", () => {
           command.type === "turn.submit" && command.threadId === thread.id,
       );
       expect(queuedCommand.command).toMatchObject({
-        input: [{ type: "text", text: "Queued manager follow-up" }],
+        input: [
+          { type: "text", text: "Queued manager follow-up" },
+          managerToolReminderInput(),
+        ],
         options: {
           model: "gpt-5",
           serviceTier: "default",
@@ -784,6 +795,7 @@ describe("internal event side effects", () => {
               titleSuffix: " (Backend port validation cleanup)",
             }),
           },
+          managerToolReminderInput(),
         ],
         options: {
           model: "gpt-5.4",
@@ -983,6 +995,7 @@ describe("internal event side effects", () => {
               titleSuffix: " (Backend port validation cleanup)",
             }),
           },
+          managerToolReminderInput(),
         ],
         options: {
           model: "gpt-5.4",
@@ -1134,6 +1147,7 @@ describe("internal event side effects", () => {
               titleSuffix: " (Command event duplicate guard)",
             }),
           },
+          managerToolReminderInput(),
         ],
       });
       expect(
@@ -1312,6 +1326,7 @@ describe("internal event side effects", () => {
               titleSuffix: " (Backend port validation cleanup)",
             }),
           },
+          managerToolReminderInput(),
         ],
         options: {
           model: "gpt-5.4",

--- a/apps/server/test/public/public-threads.manager-and-ownership.test.ts
+++ b/apps/server/test/public/public-threads.manager-and-ownership.test.ts
@@ -20,6 +20,7 @@ import {
   threadSchema,
 } from "@bb/domain";
 import { renderTemplate } from "@bb/templates";
+import { buildManagerToolReminderText } from "../../src/services/threads/manager-tool-reminder.js";
 import {
   reportQueuedCommandError,
   waitForQueuedCommand,
@@ -58,6 +59,13 @@ interface WriteActiveManagerTemplateArgs {
 
 function hostDataDir(args: HostDataDirArgs): string {
   return `/tmp/bb-host-data/${args.hostId}`;
+}
+
+function managerToolReminderInput() {
+  return {
+    type: "text",
+    text: buildManagerToolReminderText("codex"),
+  };
 }
 
 async function writeManagerTemplateSet(
@@ -787,6 +795,7 @@ describe("public thread manager and ownership routes", () => {
               threadLabel: `${thread.id}: Test Thread`,
             }),
           },
+          managerToolReminderInput(),
         ],
         options: {
           model: "gpt-5.4",
@@ -1169,6 +1178,7 @@ describe("public thread manager and ownership routes", () => {
               threadLabel: `${thread.id}: Test Thread`,
             }),
           },
+          managerToolReminderInput(),
         ],
         options: {
           model: "gpt-5.4",

--- a/apps/server/test/scheduling/nudge-sweep.test.ts
+++ b/apps/server/test/scheduling/nudge-sweep.test.ts
@@ -10,6 +10,7 @@ import {
 import { threadScope, turnRequestEventDataSchema, turnScope } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import { sweepDueNudges } from "../../src/services/scheduling/nudge-sweep.js";
+import { buildManagerToolReminderText } from "../../src/services/threads/manager-tool-reminder.js";
 import { appendClientTurnEvent } from "../../src/services/threads/thread-events.js";
 import {
   reportQueuedCommandError,
@@ -27,6 +28,13 @@ import {
 import { createTestAppHarness } from "../helpers/test-app.js";
 
 type TestHarness = Awaited<ReturnType<typeof createTestAppHarness>>;
+
+function managerToolReminderInput() {
+  return {
+    type: "text",
+    text: buildManagerToolReminderText("codex"),
+  };
+}
 
 function seedRunnableManagerThread(args: {
   environmentId: string;
@@ -133,6 +141,7 @@ describe("nudge sweep", () => {
           type: "text",
           text: "[bb system]\n\nScheduled nudge: daily-recap. Check ASYNC.md.",
         },
+        managerToolReminderInput(),
       ]);
       expect(
         harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
@@ -475,6 +484,7 @@ describe("nudge sweep", () => {
             type: "text",
             text: "[bb system]\n\nScheduled nudge: active-check. Check ASYNC.md.",
           },
+          managerToolReminderInput(),
         ],
         target: {
           mode: "auto",

--- a/apps/server/test/threads/manager-tool-reminder.test.ts
+++ b/apps/server/test/threads/manager-tool-reminder.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import type { AgentProviderId } from "@bb/agent-providers";
+import { getLatestThreadSequence } from "@bb/db";
+import type { PromptInput, ResolvedThreadExecutionOptions } from "@bb/domain";
+import type { ThreadType } from "@bb/domain";
+import type { TurnSubmitTarget } from "@bb/host-daemon-contract";
+import type { PreparedTurnSubmitCommandPayload } from "../../src/services/threads/thread-commands.js";
+import {
+  buildManagerToolReminderText,
+  resolveManagerUserMessageToolName,
+  type ManagerUserMessageToolName,
+} from "../../src/services/threads/manager-tool-reminder.js";
+import { prepareTurnSubmitCommandPayload } from "../../src/services/threads/thread-commands.js";
+import { findThreadEvent } from "../../src/services/threads/thread-data.js";
+import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
+import {
+  listQueuedThreadCommands,
+  reportQueuedCommandError,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedThread,
+  seedThreadRuntimeState,
+  seedTurnStarted,
+} from "../helpers/seed.js";
+import {
+  createTestAppHarness,
+  type TestAppHarness,
+} from "../helpers/test-app.js";
+
+interface ProviderReminderCase {
+  providerId: AgentProviderId;
+  toolName: ManagerUserMessageToolName;
+}
+
+interface PrepareTurnSubmitPayloadForThreadArgs {
+  input: PromptInput[];
+  providerId: AgentProviderId;
+  targetMode?: "auto" | "start" | "steer";
+  threadType: ThreadType;
+}
+
+interface PrepareTurnSubmitPayloadForThreadResult {
+  payload: PreparedTurnSubmitCommandPayload;
+}
+
+const providerReminderCases: ProviderReminderCase[] = [
+  {
+    providerId: "claude-code",
+    toolName: "mcp__bb-bridge__message_user",
+  },
+  {
+    providerId: "codex",
+    toolName: "message_user",
+  },
+  {
+    providerId: "pi",
+    toolName: "message_user",
+  },
+];
+
+const testExecution: ResolvedThreadExecutionOptions = {
+  model: "test-model",
+  serviceTier: "default",
+  reasoningLevel: "medium",
+  permissionMode: "full",
+  source: "client/turn/requested",
+};
+
+function buildTurnSubmitTarget(
+  mode: PrepareTurnSubmitPayloadForThreadArgs["targetMode"],
+): TurnSubmitTarget {
+  switch (mode) {
+    case "auto":
+      return { mode: "auto", expectedTurnId: null };
+    case "steer":
+      return { mode: "steer", expectedTurnId: null };
+    case "start":
+    case undefined:
+      return { mode: "start" };
+  }
+}
+
+async function respondToManagerPreferencesRead(
+  harness: TestAppHarness,
+  hostId: string,
+  threadId: string,
+): Promise<void> {
+  const preferencesPath = `/tmp/bb-host-data/${hostId}/thread-storage/${threadId}/PREFERENCES.md`;
+  const readPreferences = await waitForQueuedCommand(
+    harness,
+    ({ command }) =>
+      command.type === "host.read_file" && command.path === preferencesPath,
+  );
+  const response = await reportQueuedCommandError(harness, readPreferences, {
+    errorCode: "ENOENT",
+    errorMessage: "File not found",
+  });
+  expect(response.status).toBe(200);
+}
+
+async function prepareTurnSubmitPayloadForThread(
+  args: PrepareTurnSubmitPayloadForThreadArgs,
+): Promise<PrepareTurnSubmitPayloadForThreadResult> {
+  const harness = await createTestAppHarness();
+  try {
+    const hostId = `host-manager-reminder-${args.threadType}-${args.providerId}`;
+    const { host } = seedHostSession(harness.deps, { id: hostId });
+    const { project } = seedProjectWithSource(harness.deps, {
+      hostId: host.id,
+    });
+    const environment = seedEnvironment(harness.deps, {
+      hostId: host.id,
+      projectId: project.id,
+    });
+    const thread = seedThread(harness.deps, {
+      environmentId: environment.id,
+      projectId: project.id,
+      providerId: args.providerId,
+      type: args.threadType,
+    });
+
+    const payloadPromise = prepareTurnSubmitCommandPayload(harness.deps, {
+      environment,
+      execution: testExecution,
+      input: args.input,
+      permissionEscalation: "deny",
+      providerThreadId: "provider-thread-manager-reminder",
+      target: buildTurnSubmitTarget(args.targetMode),
+      thread,
+    });
+
+    if (args.threadType === "manager") {
+      await respondToManagerPreferencesRead(harness, host.id, thread.id);
+    }
+
+    return {
+      payload: await payloadPromise,
+    };
+  } finally {
+    await harness.cleanup();
+  }
+}
+
+function expectedReminderInput(providerId: AgentProviderId): PromptInput {
+  return {
+    type: "text",
+    text: buildManagerToolReminderText(providerId),
+  };
+}
+
+describe("manager tool reminders", () => {
+  it.each(providerReminderCases)(
+    "resolves $providerId manager user-message tool name",
+    ({ providerId, toolName }) => {
+      expect(resolveManagerUserMessageToolName(providerId)).toBe(toolName);
+    },
+  );
+
+  it.each(providerReminderCases)(
+    "appends a $providerId manager turn reminder with the provider-specific tool name",
+    async ({ providerId }) => {
+      const input: PromptInput[] = [{ type: "text", text: "continue work" }];
+
+      const { payload } = await prepareTurnSubmitPayloadForThread({
+        input,
+        providerId,
+        threadType: "manager",
+      });
+
+      expect(payload.input).toEqual([
+        ...input,
+        expectedReminderInput(providerId),
+      ]);
+    },
+  );
+
+  it("leaves standard thread input unchanged", async () => {
+    const input: PromptInput[] = [{ type: "text", text: "standard turn" }];
+
+    const { payload } = await prepareTurnSubmitPayloadForThread({
+      input,
+      providerId: "codex",
+      threadType: "standard",
+    });
+
+    expect(payload.input).toEqual(input);
+  });
+
+  it("does not double-append when input already ends with the exact reminder", async () => {
+    const input: PromptInput[] = [
+      { type: "text", text: "continue work" },
+      expectedReminderInput("codex"),
+    ];
+
+    const { payload } = await prepareTurnSubmitPayloadForThread({
+      input,
+      providerId: "codex",
+      threadType: "manager",
+    });
+
+    expect(payload.input).toEqual(input);
+  });
+
+  it("appends the reminder to empty manager input", async () => {
+    const { payload } = await prepareTurnSubmitPayloadForThread({
+      input: [],
+      providerId: "pi",
+      threadType: "manager",
+    });
+
+    expect(payload.input).toEqual([expectedReminderInput("pi")]);
+  });
+
+  it("appends the reminder on active manager steers without persisting it to the client turn event", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-manager-reminder-steer",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+        providerId: "codex",
+        status: "active",
+        type: "manager",
+      });
+      const providerThreadId = "provider-thread-manager-reminder-steer";
+      seedThreadRuntimeState(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+      });
+      seedTurnStarted(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        turnId: "turn-manager-reminder-steer",
+      });
+      const input: PromptInput[] = [{ type: "text", text: "adjust course" }];
+      const eventSequenceBeforeSend = getLatestThreadSequence(harness.db, {
+        threadId: thread.id,
+      });
+
+      const sendPromise = sendThreadMessage(harness.deps, {
+        environment,
+        payload: {
+          input,
+          mode: "steer",
+          model: "gpt-5.4",
+          permissionMode: "full",
+          reasoningLevel: "medium",
+          serviceTier: "default",
+        },
+        thread,
+        trigger: "user",
+      });
+
+      await respondToManagerPreferencesRead(harness, host.id, thread.id);
+      await sendPromise;
+
+      const commands = listQueuedThreadCommands(
+        harness,
+        "turn.submit",
+        thread.id,
+      );
+      expect(commands).toHaveLength(1);
+      const command = commands[0];
+      if (command?.type !== "turn.submit") {
+        throw new Error("Expected turn.submit command");
+      }
+      expect(command.target.mode).toBe("steer");
+      expect(command.input).toEqual([...input, expectedReminderInput("codex")]);
+
+      const turnRequestEvent = findThreadEvent(harness.db, {
+        afterSeq: eventSequenceBeforeSend,
+        threadId: thread.id,
+        type: "client/turn/requested",
+      });
+      if (turnRequestEvent?.type !== "client/turn/requested") {
+        throw new Error("Expected client turn requested event");
+      }
+      expect(turnRequestEvent.data.input).toEqual(input);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/agent-providers/src/index.ts
+++ b/packages/agent-providers/src/index.ts
@@ -5,3 +5,8 @@ export {
   PI_DEFAULT_MODEL_PER_PROVIDER,
   resolvePiDefaultModelId,
 } from "./catalog.js";
+export type {
+  AgentProviderId,
+  BuiltInAgentProviderCatalogEntry,
+  BuiltInAgentProviderInfo,
+} from "./catalog.js";


### PR DESCRIPTION
## Motivation

Managers can forget to call the user-message tool and emit plain assistant text that is internal only. This appends a fresh, provider-specific reminder to the daemon/provider payload so the exact tool name remains visible at the bottom of each manager turn.

## Appended text

`[bb system] Reminder: call <TOOL_NAME> to send any user-visible message. Plain assistant text is internal and not shown to the user.`

| Manager provider | Tool name |
| --- | --- |
| Claude Code | `mcp__bb-bridge__message_user` |
| Codex | `message_user` |
| Pi | `message_user` |

## Scope

- Manager threads only.
- Applies to `turn.submit` payload preparation, including new-turn, auto, and steer submissions.
- Covers user-initiated turns and lifecycle/system-triggered manager follow-ups.
- Does not apply to standard threads.
- Does not apply to `thread.start`.
- Skips appending when the input already ends with the exact reminder.

## Persistence

The reminder is appended only in `prepareTurnSubmitCommandPayload` after runtime config resolution and before building the host daemon command. The original input passed into client turn events and prompt history remains unchanged; tests assert the steer command payload includes the reminder while the persisted `client/turn/requested` event does not.

## Tests added/updated

- Added `apps/server/test/threads/manager-tool-reminder.test.ts` for provider-specific tool names, manager-only append, standard-thread no-op, steer payloads, dedupe, empty manager input, and no-persist behavior.
- Updated existing exact manager payload assertions for ownership, lifecycle, failure, and nudge flows.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/domain`
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/domain`
- `git diff --check`
