### PR TITLE
fix: nested managers regression in sidebar grouping/rendering

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -591,6 +591,88 @@ describe("ProjectList", () => {
     expect(await screen.findByText("Nested Child Task")).toBeTruthy();
   });
 
+  it("indents a depth-2 manager row deeper than its depth-1 parent", async () => {
+    // Three-level manager chain: root (depth 0) → nested (depth 1) →
+    // deeply-nested (depth 2). Each level must render at a distinct indent so
+    // the hierarchy is visually legible; without the depth-2 indent, depth-2
+    // managers visually appear as siblings of their depth-1 parent.
+    const rootManager: ProjectThreadListEntry = {
+      ...makeThreadListEntry("project-1", 1),
+      id: "thr_root_manager",
+      title: "Root Manager",
+      titleFallback: "Root Manager",
+      type: "manager",
+    };
+    const nestedManager: ProjectThreadListEntry = {
+      ...makeThreadListEntry("project-1", 2),
+      id: "thr_nested_manager",
+      parentThreadId: rootManager.id,
+      title: "Nested Manager",
+      titleFallback: "Nested Manager",
+      type: "manager",
+    };
+    const deeplyNestedManager: ProjectThreadListEntry = {
+      ...makeThreadListEntry("project-1", 3),
+      id: "thr_deeply_nested_manager",
+      parentThreadId: nestedManager.id,
+      title: "Deeply Nested Manager",
+      titleFallback: "Deeply Nested Manager",
+      type: "manager",
+    };
+    const projects = [makeProjectResponse({ id: "project-1" })];
+    const threadsByProjectId = new Map<string, ProjectThreadListEntry[]>([
+      [
+        "project-1",
+        [rootManager, nestedManager, deeplyNestedManager],
+      ],
+    ]);
+    installFetchRoutes([
+      {
+        pathname: "/api/v1/projects",
+        handler: buildProjectListHandler({ projects, threadsByProjectId }),
+      },
+      {
+        pathname: "/api/v1/threads",
+        handler: () => jsonResponse([]),
+      },
+      {
+        pathname: "/api/v1/system/config",
+        handler: () =>
+          jsonResponse({
+            hostDaemonPort: null,
+            voiceTranscriptionEnabled: false,
+          }),
+      },
+      {
+        pathname: "/api/v1/hosts",
+        handler: () => jsonResponse([]),
+      },
+    ]);
+
+    wsManager.connect();
+    FakeReconnectingWebSocket.latest().open();
+
+    await renderProjectList();
+
+    async function findRowFor(label: string): Promise<HTMLElement> {
+      const text = await screen.findByText(label);
+      const row = text.closest('[class*="group/thread-row"]');
+      if (!(row instanceof HTMLElement)) {
+        throw new Error(`Could not find row container for ${label}`);
+      }
+      return row;
+    }
+
+    const rootRow = await findRowFor("Root Manager");
+    const nestedRow = await findRowFor("Nested Manager");
+    const deeplyNestedRow = await findRowFor("Deeply Nested Manager");
+
+    expect(rootRow.className).toContain("pl-8");
+    expect(nestedRow.className).toContain("pl-14");
+    expect(deeplyNestedRow.className).toContain("pl-20");
+    expect(deeplyNestedRow.className).not.toContain("pl-14");
+  });
+
   it("shows threads unavailable when a project thread list fails after the websocket connects", async () => {
     installFetchRoutes([
       {

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -40,6 +40,8 @@ import {
   type ManagerThreadGroup,
 } from "./projectThreadGroups";
 import {
+  SIDEBAR_DEEPLY_NESTED_MANAGER_GROUP_LINE_CLASS,
+  SIDEBAR_DEEPLY_NESTED_MANAGER_LINE_CONTINUATION_CLASS,
   SIDEBAR_MANAGED_ENV_GROUP_LINE_CLASS,
   SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS,
   SIDEBAR_MANAGER_GROUP_LINE_CLASS,
@@ -61,11 +63,13 @@ const THREAD_ROW_ENV_GROUPED_CHILD_OPTIONS: ThreadRowOptions = {
 // Indent caps at depth 2 — chains deeper than nested-of-nested keep the
 // depth-2 padding so the sidebar never overflows horizontally. The manager
 // hierarchy itself can still recurse arbitrarily deep structurally.
-const MANAGER_DEPTH_CAP: ManagerRowDepth = 1;
+const MANAGER_DEPTH_CAP: ManagerRowDepth = 2;
 const MANAGED_CHILD_DEPTH_CAP: ManagedChildRowDepth = 2;
 
 function clampManagerDepth(depth: number): ManagerRowDepth {
-  return depth >= MANAGER_DEPTH_CAP ? MANAGER_DEPTH_CAP : 0;
+  if (depth >= MANAGER_DEPTH_CAP) return MANAGER_DEPTH_CAP;
+  if (depth >= 1) return 1;
+  return 0;
 }
 
 function clampManagedChildDepth(depth: number): ManagedChildRowDepth {
@@ -406,19 +410,23 @@ const ManagerThreadGroupRow = memo(function ManagerThreadGroupRow({
   const childGroupLineClass =
     depth === 0
       ? SIDEBAR_MANAGER_GROUP_LINE_CLASS
-      : SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS;
+      : depth === 1
+        ? SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS
+        : SIDEBAR_DEEPLY_NESTED_MANAGER_GROUP_LINE_CLASS;
   const envSubGroupHeaderPaddingClass =
     childDepth >= 2
       ? SIDEBAR_NESTED_MANAGER_CHILD_ROW_PADDING_CLASS
       : SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS;
   // The env sub-group header sits at the managed-child indent under its
-  // manager, so its parent-line continuation must match the depth-0
-  // managed-children hairline above it. For a root manager the continuation
-  // is left-10; for a nested manager it is left-16.
+  // manager, so its parent-line continuation must match the managed-children
+  // hairline above it. For a root manager that is left-10; for a nested
+  // manager left-16; for a deeply nested manager left-22.
   const envSubGroupParentLineClass =
     depth === 0
       ? SIDEBAR_MANAGER_LINE_CONTINUATION_CLASS
-      : SIDEBAR_NESTED_MANAGER_LINE_CONTINUATION_CLASS;
+      : depth === 1
+        ? SIDEBAR_NESTED_MANAGER_LINE_CONTINUATION_CLASS
+        : SIDEBAR_DEEPLY_NESTED_MANAGER_LINE_CONTINUATION_CLASS;
   const managerOptions = useMemo<ThreadRowOptions>(
     () => ({
       kind: "manager",

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -24,6 +24,7 @@ import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@/lib/utils";
 import {
   SIDEBAR_COLLAPSED_CHILD_COUNT_BADGE_CLASS,
+  SIDEBAR_DEEPLY_NESTED_MANAGER_ROW_PADDING_CLASS,
   SIDEBAR_MANAGER_CHILD_ROW_PADDING_CLASS,
   SIDEBAR_MANAGER_ENV_GROUPED_CHILD_ROW_PADDING_CLASS,
   SIDEBAR_MANAGER_ROW_PADDING_CLASS,
@@ -35,10 +36,11 @@ import {
 } from "./sidebarRowClasses";
 
 // Depth in the manager hierarchy. 0 = root manager (rendered at the project
-// level). 1+ = nested manager (rendered inside another manager's group).
-// Indent caps at 1: deeper chains keep the depth-1 padding so the sidebar
+// level). 1 = nested manager (rendered inside another manager's group).
+// 2+ = deeply nested manager (rendered inside a nested manager's group).
+// Indent caps at 2: deeper chains keep the depth-2 padding so the sidebar
 // can never overflow horizontally.
-export type ManagerRowDepth = 0 | 1;
+export type ManagerRowDepth = 0 | 1 | 2;
 
 // Depth of a managed child relative to the project root. 1 = direct child of
 // a root manager. 2+ = child of a nested manager. Indent caps at 2.
@@ -340,9 +342,13 @@ function ThreadRowComponent({
         thread.environmentWorkspaceDisplayKind,
       );
   const managerRowPaddingClass =
-    managerOptions !== null && managerOptions.depth >= 1
-      ? SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS
-      : SIDEBAR_MANAGER_ROW_PADDING_CLASS;
+    managerOptions === null
+      ? SIDEBAR_MANAGER_ROW_PADDING_CLASS
+      : managerOptions.depth >= 2
+        ? SIDEBAR_DEEPLY_NESTED_MANAGER_ROW_PADDING_CLASS
+        : managerOptions.depth >= 1
+          ? SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS
+          : SIDEBAR_MANAGER_ROW_PADDING_CLASS;
   const managedChildPaddingClass =
     options.kind === "managed-child"
       ? options.depth >= 2

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -15,6 +15,11 @@ export const SIDEBAR_MANAGER_ENV_GROUPED_CHILD_ROW_PADDING_CLASS = "pl-20";
 // the indent of a managed child so it lands inside the parent's child list.
 export const SIDEBAR_NESTED_MANAGER_ROW_PADDING_CLASS = "pl-14";
 
+// Manager nested at depth 2 or deeper. Sits one indent level past the first
+// nested manager so a 3-level chain is visually distinct. Padding caps here
+// for arbitrarily deep chains so the sidebar never overflows horizontally.
+export const SIDEBAR_DEEPLY_NESTED_MANAGER_ROW_PADDING_CLASS = "pl-20";
+
 // Direct child of a nested manager. Sits one indent level deeper than a root
 // manager's child, matching the env sub-group indent so the depth caps cleanly
 // even for 3+ level chains.
@@ -64,9 +69,7 @@ export const SIDEBAR_COLLAPSED_CHILD_COUNT_BADGE_CLASS =
 /**
  * Hairline that runs through a nested manager's child list. The nested
  * manager row sits at pl-14, so its UserRound icon center lands at left-16,
- * matching the env sub-group line. Reused for any chain of managers below
- * the first nested level since the indent caps at pl-14 for the manager row
- * itself.
+ * matching the env sub-group line.
  */
 export const SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS =
   "before:pointer-events-none before:absolute before:bottom-0 before:left-16 before:top-0 before:z-30 before:w-px before:bg-border-hairline before:content-['']";
@@ -77,3 +80,18 @@ export const SIDEBAR_NESTED_MANAGER_GROUP_LINE_CLASS =
 // participate in their parent's vertical guide.
 export const SIDEBAR_NESTED_MANAGER_LINE_CONTINUATION_CLASS =
   "pointer-events-none absolute bottom-0 left-16 top-0 z-[1] w-px bg-border-hairline";
+
+/**
+ * Hairline for a depth-2+ (deeply nested) manager's child list. The deeply
+ * nested manager row sits at pl-20, so its UserRound icon center lands at
+ * left-22. Reused for any chain of managers below depth 2 since both the
+ * row indent and child-list line cap here.
+ */
+export const SIDEBAR_DEEPLY_NESTED_MANAGER_GROUP_LINE_CLASS =
+  "before:pointer-events-none before:absolute before:bottom-0 before:left-[5.5rem] before:top-0 before:z-30 before:w-px before:bg-border-hairline before:content-['']";
+
+// Continuation line for a deeply nested manager group, matching the
+// left-[5.5rem] position used by SIDEBAR_DEEPLY_NESTED_MANAGER_GROUP_LINE_CLASS
+// so collapsed deeply nested managers still participate in the parent guide.
+export const SIDEBAR_DEEPLY_NESTED_MANAGER_LINE_CONTINUATION_CLASS =
+  "pointer-events-none absolute bottom-0 left-[5.5rem] top-0 z-[1] w-px bg-border-hairline";


### PR DESCRIPTION
## Summary
- PR #35's recursive nested-manager rendering shipped intact (grouping pass + recursive `ManagerThreadGroupRow` are correct, and the existing tests pass), but the manager-row indent cap stopped at depth 1: every manager at depth 1 *and* depth 2+ rendered at `pl-14`. A user with a 3-level chain (root → Layer 1 → Layer 2) saw Layer 2 managers visually appear as siblings of Layer 1 managers — "nested managers not rendering," from their perspective.
- The block was a one-line oversight: the constants block in `ProjectRow.tsx` already documented "Indent caps at depth 2", but `ManagerRowDepth = 0 | 1` and `MANAGER_DEPTH_CAP = 1` only supported one extra level.
- Extend `ManagerRowDepth` to `0 | 1 | 2`, bump the cap, add `SIDEBAR_DEEPLY_NESTED_MANAGER_ROW_PADDING_CLASS = "pl-20"` and the matching `left-[5.5rem]` connector hairline + continuation, and route depth-2+ manager rows + their child group lines through the new tier.
- Add a `ProjectList` regression test that builds a root → nested → deeply-nested chain and asserts each row renders at its own indent tier (`pl-8`, `pl-14`, `pl-20`). Pre-fix the deeply-nested row had `pl-14`; post-fix it has `pl-20`.

## Test plan
- [x] `pnpm exec turbo run typecheck --filter=@bb/app` — clean
- [x] `pnpm exec turbo run test --filter=@bb/app` — 460 / 460 (was 459 pre-fix)
- [x] `git diff --check` — clean
- [x] Verified the bug live: `dev-browser` against the running prod app showed Layer 2 manager rows at `pl-14` (same as Layer 1) under project `proj_55xtp72bhe`. The new failing-then-passing test reproduces that scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)