### PR TITLE
app: fix NewManagerDialog CI timeout

### DIFF
--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -18,5 +18,6 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     setupFiles: ["src/test/setup.ts"],
+    testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## Summary
- NewManagerDialog app integration tests were exceeding Vitest's default 5s timeout under main CI load even though the route submission flow completed normally.
- Set @bb/app's Vitest test timeout to 15s so the app suite remains strict on behavior without failing from CI resource contention.

## Test plan
- [ ] CI on main passes after merge
- [ ] Local `pnpm exec turbo run test --filter=@bb/app --force` passes (logged at /tmp/app-test-pass.txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)