### PR TITLE
chore: bump bb-app + @bb/desktop to 0.0.8

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bb/desktop",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "description": "macOS Electron shell for bb",
   "main": "dist/main.js",

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-app",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "bb app launcher for npx",
   "keywords": [
     "bb",


### PR DESCRIPTION
## Summary

Version bump for the v0.0.8 release. Both `packages/bb-app` and `apps/desktop` move together (lockstep is CI-enforced).

After this merges:
1. Run **"Publish bb-app"** workflow on `main` with `npm_tag=latest`, `dry_run=false` → publishes `bb-app@0.0.8` to npm.
2. Run **"Build Desktop"** workflow on `main` with `publish=true`, `release_channel=stable` → publishes the signed + notarized `desktop-v0.0.8` release with `latest-mac.yml`, `.dmg`, `.zip`, and `desktop-version.json`.

## Test plan

- [ ] CI green (version-lockstep check + all other checks)
- [ ] After merge: npm publish lands `bb-app@0.0.8`
- [ ] After merge: Build Desktop run publishes signed artifacts to `desktop-latest`
- [ ] Installed desktop launches without Gatekeeper warning
- [ ] In-app update toast triggers in older clients (0.0.7) once they hit the hourly check

🤖 Generated with [Claude Code](https://claude.com/claude-code)