### PR TITLE
desktop UX batch: drag/terminal/logs viewer/HTML preview/server probe

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -22,6 +22,8 @@ export interface FilePreviewFile {
   lang?: SupportedLanguages;
 }
 
+export type IframePreviewSandbox = "allow-scripts";
+
 export type FilePreviewState =
   | { kind: "loading" }
   | { kind: "empty" }
@@ -29,8 +31,12 @@ export type FilePreviewState =
   | { kind: "manager-status-pending" }
   | { kind: "error"; message?: string }
   | { kind: "image"; url: string }
-  | { kind: "html"; file: FilePreviewFile }
-  | { kind: "iframe"; title: string; url: string }
+  | {
+      kind: "iframe";
+      sandbox: IframePreviewSandbox | null;
+      title: string;
+      url: string;
+    }
   | { kind: "ready"; file: FilePreviewFile; lineNumber: number | null };
 
 export interface FilePreviewProps {
@@ -56,16 +62,14 @@ interface FilePreviewHeaderProps {
   onMarkdownModeChange: (mode: MarkdownViewMode) => void;
 }
 
-interface HtmlFilePreviewProps {
-  file: FilePreviewFile;
-}
-
 interface IframeFilePreviewProps {
+  sandbox: IframePreviewSandbox | null;
   title: string;
   url: string;
 }
 
 type MarkdownViewMode = "preview" | "source";
+type IframeLoadState = "loading" | "loaded" | "error";
 
 const MARKDOWN_EXTENSIONS: ReadonlySet<string> = new Set([
   "md",
@@ -122,7 +126,7 @@ export function FilePreview({
   return (
     <div
       className={
-        state.kind === "html" || state.kind === "iframe"
+        state.kind === "iframe"
           ? "@container/page flex h-full min-h-0 flex-col"
           : "@container/page"
       }
@@ -171,11 +175,14 @@ function FilePreviewBody({ state, path, markdownMode }: FilePreviewBodyProps) {
   if (state.kind === "image") {
     return <FilePreviewImage url={state.url} alt={path} />;
   }
-  if (state.kind === "html") {
-    return <HtmlFilePreview file={state.file} />;
-  }
   if (state.kind === "iframe") {
-    return <IframeFilePreview title={state.title} url={state.url} />;
+    return (
+      <IframeFilePreview
+        sandbox={state.sandbox}
+        title={state.title}
+        url={state.url}
+      />
+    );
   }
   if (isMarkdownFile(state.file.name) && markdownMode === "preview") {
     return <MarkdownFilePreview file={state.file} />;
@@ -290,22 +297,39 @@ function FilePreviewImage({ url, alt }: { url: string; alt: string }) {
   );
 }
 
-function HtmlFilePreview({ file }: HtmlFilePreviewProps) {
-  return (
-    <div className="min-h-0 flex-1">
-      <iframe
-        title={file.name}
-        srcDoc={file.contents}
-        style={HTML_FILE_PREVIEW_IFRAME_STYLE}
-      />
-    </div>
-  );
-}
+function IframeFilePreview({ sandbox, title, url }: IframeFilePreviewProps) {
+  const [loadState, setLoadState] = useState<IframeLoadState>("loading");
 
-function IframeFilePreview({ title, url }: IframeFilePreviewProps) {
+  useEffect(() => {
+    setLoadState("loading");
+  }, [url]);
+
+  if (loadState === "error") {
+    return (
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <FilePreviewMessage
+          message="Failed to load HTML preview."
+          role="alert"
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className="min-h-0 flex-1">
-      <iframe title={title} src={url} style={HTML_FILE_PREVIEW_IFRAME_STYLE} />
+    <div className="relative min-h-0 flex-1 overflow-hidden">
+      {loadState === "loading" ? (
+        <div className="absolute inset-x-0 top-0 z-10">
+          <FilePreviewLoading />
+        </div>
+      ) : null}
+      <iframe
+        title={title}
+        src={url}
+        sandbox={sandbox === null ? undefined : sandbox}
+        style={HTML_FILE_PREVIEW_IFRAME_STYLE}
+        onLoad={() => setLoadState("loaded")}
+        onError={() => setLoadState("error")}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -24,6 +24,12 @@ export interface FilePreviewFile {
 
 export type IframePreviewSandbox = "allow-scripts";
 
+export interface IframeFilePreviewTarget {
+  sandbox: IframePreviewSandbox | null;
+  title: string;
+  url: string;
+}
+
 export type FilePreviewState =
   | { kind: "loading" }
   | { kind: "empty" }
@@ -31,11 +37,12 @@ export type FilePreviewState =
   | { kind: "manager-status-pending" }
   | { kind: "error"; message?: string }
   | { kind: "image"; url: string }
+  | ({ kind: "iframe" } & IframeFilePreviewTarget)
   | {
-      kind: "iframe";
-      sandbox: IframePreviewSandbox | null;
-      title: string;
-      url: string;
+      kind: "html";
+      file: FilePreviewFile;
+      iframe: IframeFilePreviewTarget;
+      lineNumber: number | null;
     }
   | { kind: "ready"; file: FilePreviewFile; lineNumber: number | null };
 
@@ -50,7 +57,7 @@ export interface FilePreviewProps {
 interface FilePreviewBodyProps {
   state: FilePreviewState;
   path: string;
-  markdownMode: MarkdownViewMode;
+  viewMode: FilePreviewViewMode;
 }
 
 interface FilePreviewHeaderProps {
@@ -58,17 +65,13 @@ interface FilePreviewHeaderProps {
   copyPath: string | null;
   onOpenInEditor?: (path: string) => void;
   statusLabel: WorkspaceFilePreviewStatusLabel | null;
-  markdownMode: MarkdownViewMode | null;
-  onMarkdownModeChange: (mode: MarkdownViewMode) => void;
+  toggleKind: FilePreviewToggleKind | null;
+  viewMode: FilePreviewViewMode;
+  onViewModeChange: (mode: FilePreviewViewMode) => void;
 }
 
-interface IframeFilePreviewProps {
-  sandbox: IframePreviewSandbox | null;
-  title: string;
-  url: string;
-}
-
-type MarkdownViewMode = "preview" | "source";
+type FilePreviewViewMode = "preview" | "source";
+type FilePreviewToggleKind = "html" | "markdown";
 type IframeLoadState = "loading" | "loaded" | "error";
 
 const MARKDOWN_EXTENSIONS: ReadonlySet<string> = new Set([
@@ -105,6 +108,26 @@ function isMarkdownFile(name: string): boolean {
   return extension !== undefined && MARKDOWN_EXTENSIONS.has(extension);
 }
 
+function getFilePreviewToggleKind(
+  state: FilePreviewState,
+): FilePreviewToggleKind | null {
+  if (state.kind === "html") {
+    return "html";
+  }
+  if (state.kind === "ready" && isMarkdownFile(state.file.name)) {
+    return "markdown";
+  }
+  return null;
+}
+
+function getToggleAriaLabel(kind: FilePreviewToggleKind): string {
+  return kind === "html" ? "HTML view mode" : "Markdown view mode";
+}
+
+function getRawToggleTitle(kind: FilePreviewToggleKind): string {
+  return kind === "html" ? "HTML source" : "Markdown source";
+}
+
 export function FilePreview({
   state,
   path,
@@ -112,21 +135,24 @@ export function FilePreview({
   onOpenInEditor,
   statusLabel = null,
 }: FilePreviewProps) {
-  const isReadyMarkdown =
-    state.kind === "ready" && isMarkdownFile(state.file.name);
-  const [markdownMode, setMarkdownMode] = useState<MarkdownViewMode>("preview");
+  const toggleKind = getFilePreviewToggleKind(state);
+  const [viewMode, setViewMode] = useState<FilePreviewViewMode>("preview");
   // Each new file opens in rendered preview by default; the user re-toggles per
   // file rather than carrying their last choice across unrelated files.
   useEffect(() => {
-    setMarkdownMode("preview");
+    setViewMode("preview");
   }, [path]);
+
+  const usesIframeLayout =
+    state.kind === "iframe" ||
+    (state.kind === "html" && viewMode === "preview");
 
   // Establish a `@container/page` scope so MarkdownPreview's `100cqw`-based
   // table breakout sizes against this panel, not the viewport.
   return (
     <div
       className={
-        state.kind === "iframe"
+        usesIframeLayout
           ? "@container/page flex h-full min-h-0 flex-col"
           : "@container/page"
       }
@@ -137,19 +163,20 @@ export function FilePreview({
         copyPath={copyPath}
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
-        markdownMode={isReadyMarkdown ? markdownMode : null}
-        onMarkdownModeChange={setMarkdownMode}
+        toggleKind={toggleKind}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
       />
       <FilePreviewBody
         state={state}
         path={path}
-        markdownMode={isReadyMarkdown ? markdownMode : "preview"}
+        viewMode={toggleKind === null ? "preview" : viewMode}
       />
     </div>
   );
 }
 
-function FilePreviewBody({ state, path, markdownMode }: FilePreviewBodyProps) {
+function FilePreviewBody({ state, path, viewMode }: FilePreviewBodyProps) {
   if (state.kind === "loading") {
     return <FilePreviewLoading />;
   }
@@ -184,7 +211,19 @@ function FilePreviewBody({ state, path, markdownMode }: FilePreviewBodyProps) {
       />
     );
   }
-  if (isMarkdownFile(state.file.name) && markdownMode === "preview") {
+  if (state.kind === "html") {
+    if (viewMode === "preview") {
+      return (
+        <IframeFilePreview
+          sandbox={state.iframe.sandbox}
+          title={state.iframe.title}
+          url={state.iframe.url}
+        />
+      );
+    }
+    return <FilePreviewCode file={state.file} lineNumber={state.lineNumber} />;
+  }
+  if (isMarkdownFile(state.file.name) && viewMode === "preview") {
     return <MarkdownFilePreview file={state.file} />;
   }
   return (
@@ -197,8 +236,9 @@ function FilePreviewHeader({
   copyPath,
   onOpenInEditor,
   statusLabel,
-  markdownMode,
-  onMarkdownModeChange,
+  toggleKind,
+  viewMode,
+  onViewModeChange,
 }: FilePreviewHeaderProps) {
   // The fade is `absolute top-full` so the bar's bottom border is the actual
   // overflow edge — content scrolls under right at the border. The fade lives
@@ -238,19 +278,19 @@ function FilePreviewHeader({
             </button>
           ) : null}
         </div>
-        {markdownMode !== null ? (
+        {toggleKind !== null ? (
           <div
             className="ml-auto inline-flex shrink-0 items-center gap-0.5 rounded-md border border-border p-0.5"
             role="tablist"
-            aria-label="Markdown view mode"
+            aria-label={getToggleAriaLabel(toggleKind)}
           >
             <Button
               type="button"
               variant="ghost"
               size="sm"
               className="h-5 rounded-sm px-2 text-xs text-muted-foreground"
-              onClick={() => onMarkdownModeChange("preview")}
-              aria-pressed={markdownMode === "preview"}
+              onClick={() => onViewModeChange("preview")}
+              aria-pressed={viewMode === "preview"}
               title="Rendered preview"
             >
               Preview
@@ -260,9 +300,9 @@ function FilePreviewHeader({
               variant="ghost"
               size="sm"
               className="h-5 rounded-sm px-2 text-xs text-muted-foreground"
-              onClick={() => onMarkdownModeChange("source")}
-              aria-pressed={markdownMode === "source"}
-              title="Markdown source"
+              onClick={() => onViewModeChange("source")}
+              aria-pressed={viewMode === "source"}
+              title={getRawToggleTitle(toggleKind)}
             >
               Raw
             </Button>
@@ -297,7 +337,7 @@ function FilePreviewImage({ url, alt }: { url: string; alt: string }) {
   );
 }
 
-function IframeFilePreview({ sandbox, title, url }: IframeFilePreviewProps) {
+function IframeFilePreview({ sandbox, title, url }: IframeFilePreviewTarget) {
   const [loadState, setLoadState] = useState<IframeLoadState>("loading");
 
   useEffect(() => {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.tsx
@@ -9,12 +9,21 @@ import {
 } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
+import type {
+  BbDesktopApi,
+  BbDesktopInfo,
+  BbDesktopInfoChangeHandler,
+} from "@bb/server-contract";
 import { afterEach, describe, expect, it } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
   type SecondaryPanelFileTab,
   ThreadSecondaryPanel,
 } from "./ThreadSecondaryPanel";
+import {
+  MACOS_WINDOW_DRAG_CLASS,
+  MACOS_WINDOW_NO_DRAG_CLASS,
+} from "@/lib/bb-desktop";
 
 interface RenderPanelArgs {
   fileTabContent?: ReactNode;
@@ -27,8 +36,83 @@ interface ResizeDragEndScenario {
   finishDrag: () => void;
 }
 
+interface SecondaryPanelChromeDragScenario {
+  name: string;
+  activeTab: SecondaryPanelFileTab;
+  iframeTitle: string;
+  closeButtonLabel: string | null;
+}
+
+interface BuildActiveFileTabArgs {
+  filename: string;
+  id: string;
+  isPinned: boolean;
+}
+
 const noop = () => {};
 const IFRAME_POINTER_EVENTS_NONE_CLASS = "[&_iframe]:pointer-events-none";
+const MACOS_DESKTOP_INFO: BbDesktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos",
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.1",
+};
+
+function createBbDesktopApi(info: BbDesktopInfo): BbDesktopApi {
+  return {
+    ...info,
+    async checkForUpdates() {
+      return info;
+    },
+    async getInfo() {
+      return info;
+    },
+    async installUpdate() {
+      return undefined;
+    },
+    onChange(_listener: BbDesktopInfoChangeHandler) {
+      return () => undefined;
+    },
+  };
+}
+
+function setBbDesktopInfo(desktopInfo: BbDesktopApi | null): void {
+  if (desktopInfo === null) {
+    delete window.bbDesktop;
+    return;
+  }
+  window.bbDesktop = desktopInfo;
+}
+
+function buildActiveFileTab({
+  filename,
+  id,
+  isPinned,
+}: BuildActiveFileTabArgs): SecondaryPanelFileTab {
+  return {
+    id,
+    filename,
+    isActive: true,
+    isPinned,
+    statusLabel: null,
+    onSelect: noop,
+    onClose: noop,
+  };
+}
+
+function expectNoDragRegionOnElementOrAncestor(element: HTMLElement): void {
+  let current: HTMLElement | null = element;
+  while (current !== null) {
+    if (current.className.includes(MACOS_WINDOW_NO_DRAG_CLASS)) {
+      return;
+    }
+    current = current.parentElement;
+  }
+  throw new Error("Expected element or ancestor to opt out of window drag");
+}
 
 function renderPanel({
   fileTabContent,
@@ -72,9 +156,66 @@ function renderPanel({
 
 afterEach(() => {
   cleanup();
+  setBbDesktopInfo(null);
 });
 
 describe("ThreadSecondaryPanel", () => {
+  it.each<SecondaryPanelChromeDragScenario>([
+    {
+      name: "STATUS iframe",
+      activeTab: buildActiveFileTab({
+        id: "storage:STATUS",
+        filename: "STATUS",
+        isPinned: true,
+      }),
+      iframeTitle: "Manager status",
+      closeButtonLabel: null,
+    },
+    {
+      name: "HTML preview iframe",
+      activeTab: buildActiveFileTab({
+        id: "workspace:index.html",
+        filename: "index.html",
+        isPinned: false,
+      }),
+      iframeTitle: "index.html preview",
+      closeButtonLabel: "Close index.html",
+    },
+  ])(
+    "makes the secondary panel top chrome draggable above the $name on macOS",
+    ({ activeTab, closeButtonLabel, iframeTitle }) => {
+      setBbDesktopInfo(createBbDesktopApi(MACOS_DESKTOP_INFO));
+
+      renderPanel({
+        fileTabs: [activeTab],
+        fileTabContent: <iframe title={iframeTitle} />,
+        renderAsDrawer: false,
+      });
+
+      const topChrome = screen.getByTestId("thread-secondary-panel-top-chrome");
+      expect(topChrome.className).toContain(MACOS_WINDOW_DRAG_CLASS);
+      expect(screen.getByTitle(iframeTitle)).not.toBeNull();
+      expectNoDragRegionOnElementOrAncestor(
+        screen.getByRole("button", { name: "Show thread info panel" }),
+      );
+      expectNoDragRegionOnElementOrAncestor(
+        screen.getByRole("button", { name: "Open a new tab" }),
+      );
+      expectNoDragRegionOnElementOrAncestor(
+        screen.getByRole("button", { name: "Hide secondary panel" }),
+      );
+      expectNoDragRegionOnElementOrAncestor(
+        screen.getByRole("button", { name: activeTab.filename }),
+      );
+
+      if (closeButtonLabel !== null) {
+        expectNoDragRegionOnElementOrAncestor(
+          screen.getByRole("button", { name: closeButtonLabel }),
+        );
+      }
+    },
+  );
+
   it.each<ResizeDragEndScenario>([
     {
       name: "pointerup",

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -3,6 +3,7 @@ import {
   type FocusEvent,
   type ReactNode,
   useMemo,
+  useState,
 } from "react";
 import { useAtomValue } from "jotai";
 import { Icon } from "@/components/ui/icon.js";
@@ -26,6 +27,12 @@ import {
   GitDiffTabContent,
   ThreadInfoTabContent,
 } from "./ThreadSecondaryPanelTabContent";
+import {
+  getBbDesktopInfo,
+  MACOS_WINDOW_DRAG_CLASS,
+  MACOS_WINDOW_NO_DRAG_CLASS,
+  shouldUseMacosDesktopChrome,
+} from "@/lib/bb-desktop";
 export type {
   GitDiffDisplayMode,
   GitDiffSelectionOption,
@@ -75,10 +82,6 @@ export interface ThreadSecondaryPanelProps {
    * Caller is responsible for wrapping the content in a Drawer in that case.
    */
   renderAsDrawer: boolean;
-}
-
-interface NewTabButtonProps {
-  onOpenNewTab: () => void;
 }
 
 export function ThreadSecondaryPanel({
@@ -146,6 +149,8 @@ export function ThreadSecondaryPanel({
   const isSecondaryPanelResizing = useAtomValue(
     threadSecondaryPanelResizingAtom,
   );
+  const [desktopInfo] = useState(getBbDesktopInfo);
+  const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   const areAllGitDiffFilesCollapsed = useMemo(
     () =>
       hasParsedGitDiffFiles &&
@@ -192,7 +197,13 @@ export function ThreadSecondaryPanel({
       )}
     >
       <div className="bg-background">
-        <div className="flex h-12 min-w-0 items-center justify-between gap-2 px-4">
+        <div
+          data-testid="thread-secondary-panel-top-chrome"
+          className={cn(
+            "flex h-12 min-w-0 items-center justify-between gap-2 px-4",
+            usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
+          )}
+        >
           <div
             className="flex min-w-0 flex-1 items-center gap-1"
             role="tablist"
@@ -202,7 +213,10 @@ export function ThreadSecondaryPanel({
               type="button"
               variant="ghost"
               size="sm"
-              className="h-7 w-7 shrink-0 rounded-md p-0"
+              className={cn(
+                "h-7 w-7 shrink-0 rounded-md p-0",
+                usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+              )}
               onClick={() => onPanelChange("thread-info")}
               aria-label="Show thread info panel"
               aria-pressed={activePanel === "thread-info" && !hasActiveFileTab}
@@ -215,7 +229,10 @@ export function ThreadSecondaryPanel({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="h-7 w-7 shrink-0 rounded-md p-0"
+                className={cn(
+                  "h-7 w-7 shrink-0 rounded-md p-0",
+                  usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+                )}
                 onClick={() => onPanelChange("git-diff")}
                 aria-label="Show diff panel"
                 aria-pressed={isDiffPanelActive && !hasActiveFileTab}
@@ -227,17 +244,31 @@ export function ThreadSecondaryPanel({
             {fileTabs && fileTabs.length > 0 ? (
               <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
                 {fileTabs.map((tab) => (
-                  <FileTab key={tab.id} tab={tab} />
+                  <div
+                    key={tab.id}
+                    className={cn(
+                      "shrink-0",
+                      usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+                    )}
+                  >
+                    <FileTab tab={tab} />
+                  </div>
                 ))}
               </div>
             ) : null}
-            <NewTabButton onOpenNewTab={onOpenNewTab} />
+            <NewTabButton
+              onOpenNewTab={onOpenNewTab}
+              usesDesktopChrome={usesDesktopChrome}
+            />
           </div>
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="h-7 w-7 shrink-0 rounded-md p-0"
+            className={cn(
+              "h-7 w-7 shrink-0 rounded-md p-0",
+              usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+            )}
             onClick={onClose}
             aria-label={
               renderAsDrawer ? "Close secondary panel" : "Hide secondary panel"
@@ -340,13 +371,21 @@ export function ThreadSecondaryPanel({
   );
 }
 
-function NewTabButton({ onOpenNewTab }: NewTabButtonProps) {
+interface NewTabButtonProps {
+  onOpenNewTab: () => void;
+  usesDesktopChrome: boolean;
+}
+
+function NewTabButton({ onOpenNewTab, usesDesktopChrome }: NewTabButtonProps) {
   return (
     <Button
       type="button"
       variant="ghost"
       size="sm"
-      className="h-7 w-7 shrink-0 rounded-md p-0"
+      className={cn(
+        "h-7 w-7 shrink-0 rounded-md p-0",
+        usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+      )}
       onClick={onOpenNewTab}
       aria-label="Open a new tab"
       title="New tab"

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -6,7 +6,10 @@ import {
   useThreadHostFilePreview,
   useThreadStorageFilePreview,
 } from "@/hooks/queries/thread-queries";
-import { buildThreadWorktreeRawContentUrl } from "@/lib/file-content-urls";
+import {
+  buildRawFilesystemHtmlContentUrl,
+  buildThreadWorktreeRawContentUrl,
+} from "@/lib/file-content-urls";
 import type {
   EnvironmentFilePreviewSource,
   WorkspaceFilePreviewStatusLabel,
@@ -319,6 +322,7 @@ export function HostFilePreviewTabContent({
       activePath={activePath}
       error={hostFilePreviewError}
       filePreview={hostFilePreview}
+      htmlPreviewUrl={buildRawFilesystemHtmlContentUrl(threadId, activePath)}
       isLoading={isHostFilePreviewLoading}
       lineNumber={lineNumber}
       onOpenInEditor={onOpenInEditor}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -6,6 +6,7 @@ import {
   useThreadHostFilePreview,
   useThreadStorageFilePreview,
 } from "@/hooks/queries/thread-queries";
+import { buildThreadWorktreeRawContentUrl } from "@/lib/file-content-urls";
 import type {
   EnvironmentFilePreviewSource,
   WorkspaceFilePreviewStatusLabel,
@@ -80,6 +81,7 @@ export interface WorkspaceFilePreviewTabContentProps {
   onOpenInEditor?: (path: string) => void;
   source: EnvironmentFilePreviewSource | null;
   statusLabel: WorkspaceFilePreviewStatusLabel | null;
+  threadId: string;
 }
 
 export interface HostFilePreviewTabContentProps {
@@ -272,6 +274,7 @@ export function WorkspaceFilePreviewTabContent({
   onOpenInEditor,
   source,
   statusLabel,
+  threadId,
 }: WorkspaceFilePreviewTabContentProps) {
   const {
     data: workspaceFilePreview,
@@ -285,6 +288,11 @@ export function WorkspaceFilePreviewTabContent({
       copyPath={copyPath}
       error={workspaceFilePreviewError}
       filePreview={workspaceFilePreview}
+      htmlPreviewUrl={
+        source?.kind === "working-tree"
+          ? buildThreadWorktreeRawContentUrl(threadId, activePath)
+          : null
+      }
       isLoading={isWorkspaceFilePreviewLoading}
       lineNumber={lineNumber}
       onOpenInEditor={onOpenInEditor}

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FilePreview } from "@/lib/file-preview";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
@@ -60,6 +66,50 @@ describe("ThreadStorageFilePreview", () => {
     expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
     expect(iframe?.getAttribute("srcdoc")).toBeNull();
     expect(container.textContent).not.toContain("<!doctype html>");
+  });
+
+  it("toggles HTML files between rendered preview and raw source", () => {
+    const htmlContent = "<!doctype html><h1>Report</h1>";
+    const { container } = render(
+      <SecondaryPanelFilePreview
+        activePath="public/report.html"
+        filePreview={makeTextPreview({
+          content: htmlContent,
+          path: "public/report.html",
+        })}
+        htmlPreviewUrl="/api/v1/threads/thr_standard/worktree/files/public/report.html"
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("tablist", { name: "HTML view mode" }),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Preview" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(container.querySelector("iframe")).not.toBeNull();
+    expect(container.textContent).not.toContain(htmlContent);
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    expect(container.querySelector("iframe")).toBeNull();
+    expect(container.querySelector("diffs-container")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Raw" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toBe(
+      "/api/v1/threads/thr_standard/worktree/files/public/report.html",
+    );
+    expect(container.querySelector("diffs-container")).toBeNull();
+    expect(container.textContent).not.toContain(htmlContent);
   });
 
   it("renders empty HTML files as blank sandboxed iframes", () => {

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FilePreview } from "@/lib/file-preview";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
@@ -11,7 +11,10 @@ import {
   MANAGER_STATUS_INDEX_FILE_PATH,
   MANAGER_STATUS_MARKDOWN_FILE_PATH,
 } from "./managerStorage";
-import { ThreadStorageFilePreview } from "./ThreadStorageFilePreview";
+import {
+  SecondaryPanelFilePreview,
+  ThreadStorageFilePreview,
+} from "./ThreadStorageFilePreview";
 
 interface MakeTextPreviewArgs {
   content: string;
@@ -36,6 +39,51 @@ afterEach(() => {
 });
 
 describe("ThreadStorageFilePreview", () => {
+  it("renders worktree HTML files through a sandboxed raw iframe", () => {
+    const { container } = render(
+      <SecondaryPanelFilePreview
+        activePath="public/report.html"
+        filePreview={makeTextPreview({
+          content: "<!doctype html><h1>Report</h1>",
+          path: "public/report.html",
+        })}
+        htmlPreviewUrl="/api/v1/threads/thr_standard/worktree/files/public/report.html"
+        isLoading={false}
+      />,
+    );
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toBe(
+      "/api/v1/threads/thr_standard/worktree/files/public/report.html",
+    );
+    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe?.getAttribute("srcdoc")).toBeNull();
+    expect(container.textContent).not.toContain("<!doctype html>");
+  });
+
+  it("renders empty HTML files as blank sandboxed iframes", () => {
+    const { container } = render(
+      <SecondaryPanelFilePreview
+        activePath="empty.html"
+        filePreview={makeTextPreview({
+          content: "",
+          path: "empty.html",
+        })}
+        htmlPreviewUrl="/api/v1/threads/thr_standard/worktree/files/empty.html"
+        isLoading={false}
+      />,
+    );
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toBe(
+      "/api/v1/threads/thr_standard/worktree/files/empty.html",
+    );
+    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(screen.queryByText("Empty file.")).toBeNull();
+  });
+
   it("renders the unified STATUS route in an unsandboxed iframe", async () => {
     let resolveVersion = (response: Response) => response;
     const versionResponse = new Promise<Response>((resolve) => {
@@ -124,6 +172,33 @@ describe("ThreadStorageFilePreview", () => {
       { timeout: 2_500 },
     );
   }, 8_000);
+
+  it("renders generic storage HTML files through a sandboxed raw iframe", () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <ThreadStorageFilePreview
+        activePath="reports/status.html"
+        filePreview={makeTextPreview({
+          content: "<script>window.preview = true</script>",
+          path: "reports/status.html",
+        })}
+        isLoading={false}
+        pinnedPath={MANAGER_STATUS_FILE_PATH}
+        threadId="thr_manager"
+      />,
+      { wrapper },
+    );
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toBe(
+      "/api/v1/threads/thr_manager/thread-storage/files/reports/status.html",
+    );
+    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe?.getAttribute("srcdoc")).toBeNull();
+    expect(container.textContent).not.toContain("bbStatusState");
+    expect(container.textContent).not.toContain("bbThreadTell");
+  });
 
   it.each([
     MANAGER_STATUS_HTML_FILE_PATH,

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -1,4 +1,7 @@
-import { FilePreview as FilePreviewSurface } from "./FilePreview";
+import {
+  FilePreview as FilePreviewSurface,
+  type FilePreviewFile,
+} from "./FilePreview";
 import { isManagerStatusStorageFilePath } from "./managerStorage";
 import { useThreadStatusVersion } from "@/hooks/queries/thread-queries";
 import { HttpError } from "@/lib/api";
@@ -7,7 +10,8 @@ import {
   buildThreadStorageRawContentUrl,
 } from "@/lib/file-content-urls";
 import type {
-  FilePreview,
+  FilePreview as ApiFilePreview,
+  TextFilePreview,
   WorkspaceFilePreviewStatusLabel,
 } from "@/lib/file-preview";
 import { isHtmlFilePreviewPath } from "@/lib/file-preview";
@@ -21,7 +25,7 @@ interface FilePreviewBaseProps {
   activePath: string;
   copyPath?: string | null;
   error?: Error | null;
-  filePreview: FilePreview | undefined;
+  filePreview: ApiFilePreview | undefined;
   isLoading: boolean;
   lineNumber?: number | null;
   onOpenInEditor?: (path: string) => void;
@@ -36,6 +40,21 @@ interface SecondaryPanelFilePreviewProps extends FilePreviewBaseProps {
   htmlPreviewUrl?: string | null;
   pendingNotFoundPath?: string;
   statusLabel?: WorkspaceFilePreviewStatusLabel | null;
+}
+
+interface BuildTextPreviewFileArgs {
+  activePath: string;
+  filePreview: TextFilePreview;
+}
+
+function buildTextPreviewFile({
+  activePath,
+  filePreview,
+}: BuildTextPreviewFileArgs): FilePreviewFile {
+  return {
+    name: filePreview.name ?? activePath,
+    contents: filePreview.content,
+  };
 }
 
 export function SecondaryPanelFilePreview({
@@ -87,6 +106,23 @@ export function SecondaryPanelFilePreview({
   }
 
   if (htmlPreviewUrl !== null && isHtmlFilePreviewPath(activePath)) {
+    if (filePreview.kind !== "text") {
+      return (
+        <FilePreviewSurface
+          path={activePath}
+          copyPath={copyPath}
+          onOpenInEditor={onOpenInEditor}
+          statusLabel={statusLabel}
+          state={{
+            kind: "iframe",
+            sandbox: GENERIC_HTML_IFRAME_SANDBOX,
+            title: activePath,
+            url: htmlPreviewUrl,
+          }}
+        />
+      );
+    }
+
     return (
       <FilePreviewSurface
         path={activePath}
@@ -94,10 +130,14 @@ export function SecondaryPanelFilePreview({
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{
-          kind: "iframe",
-          sandbox: GENERIC_HTML_IFRAME_SANDBOX,
-          title: activePath,
-          url: htmlPreviewUrl,
+          kind: "html",
+          file: buildTextPreviewFile({ activePath, filePreview }),
+          iframe: {
+            sandbox: GENERIC_HTML_IFRAME_SANDBOX,
+            title: activePath,
+            url: htmlPreviewUrl,
+          },
+          lineNumber,
         }}
       />
     );
@@ -124,10 +164,7 @@ export function SecondaryPanelFilePreview({
         state={{
           kind: "ready",
           lineNumber,
-          file: {
-            name: filePreview.name ?? activePath,
-            contents: filePreview.content,
-          },
+          file: buildTextPreviewFile({ activePath, filePreview }),
         }}
       />
     );

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -2,11 +2,20 @@ import { FilePreview as FilePreviewSurface } from "./FilePreview";
 import { isManagerStatusStorageFilePath } from "./managerStorage";
 import { useThreadStatusVersion } from "@/hooks/queries/thread-queries";
 import { HttpError } from "@/lib/api";
-import { buildThreadStatusContentUrl } from "@/lib/file-content-urls";
+import {
+  buildThreadStatusContentUrl,
+  buildThreadStorageRawContentUrl,
+} from "@/lib/file-content-urls";
 import type {
   FilePreview,
   WorkspaceFilePreviewStatusLabel,
 } from "@/lib/file-preview";
+import { isHtmlFilePreviewPath } from "@/lib/file-preview";
+
+// Generic HTML comes from arbitrary worktree/storage files. Allow scripts for
+// realistic previews, but omit allow-same-origin so the frame gets an opaque
+// origin and cannot read bb app cookies, storage, or same-origin APIs.
+const GENERIC_HTML_IFRAME_SANDBOX = "allow-scripts";
 
 interface FilePreviewBaseProps {
   activePath: string;
@@ -24,6 +33,7 @@ interface ThreadStorageFilePreviewProps extends FilePreviewBaseProps {
 }
 
 interface SecondaryPanelFilePreviewProps extends FilePreviewBaseProps {
+  htmlPreviewUrl?: string | null;
   pendingNotFoundPath?: string;
   statusLabel?: WorkspaceFilePreviewStatusLabel | null;
 }
@@ -33,6 +43,7 @@ export function SecondaryPanelFilePreview({
   copyPath = null,
   error,
   filePreview,
+  htmlPreviewUrl = null,
   isLoading,
   lineNumber = null,
   onOpenInEditor,
@@ -71,6 +82,23 @@ export function SecondaryPanelFilePreview({
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{ kind: "loading" }}
+      />
+    );
+  }
+
+  if (htmlPreviewUrl !== null && isHtmlFilePreviewPath(activePath)) {
+    return (
+      <FilePreviewSurface
+        path={activePath}
+        copyPath={copyPath}
+        onOpenInEditor={onOpenInEditor}
+        statusLabel={statusLabel}
+        state={{
+          kind: "iframe",
+          sandbox: GENERIC_HTML_IFRAME_SANDBOX,
+          title: activePath,
+          url: htmlPreviewUrl,
+        }}
       />
     );
   }
@@ -154,6 +182,7 @@ export function ThreadStorageFilePreview({
         copyPath={copyPath}
         state={{
           kind: "iframe",
+          sandbox: null,
           title: "Manager status",
           url: buildThreadStatusContentUrl(threadId, statusVersion.data?.hash),
         }}
@@ -167,6 +196,7 @@ export function ThreadStorageFilePreview({
       copyPath={copyPath}
       error={error}
       filePreview={filePreview}
+      htmlPreviewUrl={buildThreadStorageRawContentUrl(threadId, activePath)}
       isLoading={isLoading}
       lineNumber={lineNumber}
       onOpenInEditor={onOpenInEditor}

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
@@ -30,6 +30,7 @@ export function useThreadStorageViewer({
     data: threadStorageFiles,
     isLoading: isThreadStorageFilesLoading,
     error: threadStorageFilesError,
+    refetch: refetchThreadStorageFiles,
   } = useThreadStorageFiles(threadId ?? "", fileListOptions, {
     enabled: isManagerThread && fileListEnabled,
   });
@@ -49,5 +50,6 @@ export function useThreadStorageViewer({
     threadStorageFilesError,
     threadStorageFiles,
     threadStorageRootPath: threadStorageFiles?.storageRootPath ?? null,
+    refetchThreadStorageFiles,
   };
 }

--- a/apps/app/src/lib/file-content-urls.ts
+++ b/apps/app/src/lib/file-content-urls.ts
@@ -1,5 +1,9 @@
 import { apiClient, toRelativeUrl } from "./api-server";
 
+function encodePathSegments(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
 export function buildProjectAttachmentContentUrl(
   projectId: string,
   path: string,
@@ -24,6 +28,13 @@ export function buildThreadStorageContentUrl(
   );
 }
 
+export function buildThreadStorageRawContentUrl(
+  threadId: string,
+  path: string,
+): string {
+  return `/api/v1/threads/${encodeURIComponent(threadId)}/thread-storage/files/${encodePathSegments(path)}`;
+}
+
 export function buildThreadStatusContentUrl(
   threadId: string,
   hash?: string,
@@ -44,4 +55,11 @@ export function buildThreadHostFileContentUrl(
       query: { path },
     }),
   );
+}
+
+export function buildThreadWorktreeRawContentUrl(
+  threadId: string,
+  path: string,
+): string {
+  return `/api/v1/threads/${encodeURIComponent(threadId)}/worktree/files/${encodePathSegments(path)}`;
 }

--- a/apps/app/src/lib/file-content-urls.ts
+++ b/apps/app/src/lib/file-content-urls.ts
@@ -57,6 +57,13 @@ export function buildThreadHostFileContentUrl(
   );
 }
 
+export function buildRawFilesystemHtmlContentUrl(
+  threadId: string,
+  path: string,
+): string {
+  return `/api/v1/threads/${encodeURIComponent(threadId)}/files/raw?path=${encodeURIComponent(path)}`;
+}
+
 export function buildThreadWorktreeRawContentUrl(
   threadId: string,
   path: string,

--- a/apps/app/src/lib/file-preview.ts
+++ b/apps/app/src/lib/file-preview.ts
@@ -20,6 +20,7 @@ const UTF8_TEXT_MIME_TYPES = new Set([
 
 const MARKDOWN_FILE_EXTENSIONS = [".md", ".markdown"];
 const MARKDOWN_MIME_TYPES = new Set(["text/markdown", "text/x-markdown"]);
+const HTML_FILE_EXTENSION = ".html";
 const NULL_CHARACTER = "\u0000";
 
 export interface FilePreviewTarget {
@@ -124,6 +125,10 @@ function hasMarkdownExtension(path: string): boolean {
   return MARKDOWN_FILE_EXTENSIONS.some((extension) =>
     normalizedPath.endsWith(extension),
   );
+}
+
+export function isHtmlFilePreviewPath(path: string): boolean {
+  return path.toLowerCase().endsWith(HTML_FILE_EXTENSION);
 }
 
 export function normalizeFilePreviewMimeType(value: string | null): string {

--- a/apps/app/src/lib/thread-local-file-links.test.ts
+++ b/apps/app/src/lib/thread-local-file-links.test.ts
@@ -10,6 +10,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: null,
           path: "/projects/proj_gyz9przugq/threads/thr_rq7r4uv8zg",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: "/Users/me/project",
       }),
     ).toEqual({
@@ -25,6 +26,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: null,
           path: "/Users/me/project/src/file.ts",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: null,
       }),
     ).toEqual({
@@ -44,6 +46,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: 12,
           path: "/Users/me/.ssh/id_rsa",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: "/Users/me/project",
       }),
     ).toEqual({
@@ -61,6 +64,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: 12,
           path: "/Users/me/.ssh/id_rsa",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: "/Users/me/project",
       }),
     ).toEqual({
@@ -80,6 +84,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: 12,
           path: "/Users/me/project/src/../src/file.ts",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: "/Users/me/project/",
       }),
     ).toEqual({
@@ -101,6 +106,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: 7,
           path: "apps/app/src/main.tsx",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: "/Users/me/project",
       }),
     ).toEqual({
@@ -117,6 +123,7 @@ describe("resolveThreadLocalFileLink", () => {
           lineNumber: null,
           path: "/projects/my-repo/src/file.ts",
         },
+        threadStorageRootPath: null,
         workspaceRootPath: "/projects/my-repo",
       }),
     ).toEqual({
@@ -126,6 +133,28 @@ describe("resolveThreadLocalFileLink", () => {
         path: "/projects/my-repo/src/file.ts",
         relativePath: "src/file.ts",
         workspaceRootPath: "/projects/my-repo",
+      },
+    });
+  });
+
+  it("opens paths inside the known thread storage root as storage files", () => {
+    expect(
+      resolveThreadLocalFileLink({
+        hostFileLinksAvailable: true,
+        link: {
+          lineNumber: 4,
+          path: "/Users/me/.bb/thread-storage/thr_one/reports/preview.html",
+        },
+        threadStorageRootPath: "/Users/me/.bb/thread-storage/thr_one",
+        workspaceRootPath: "/Users/me/project",
+      }),
+    ).toEqual({
+      kind: "open-thread-storage-path",
+      request: {
+        lineNumber: 4,
+        path: "/Users/me/.bb/thread-storage/thr_one/reports/preview.html",
+        relativePath: "reports/preview.html",
+        threadStorageRootPath: "/Users/me/.bb/thread-storage/thr_one",
       },
     });
   });

--- a/apps/app/src/lib/thread-local-file-links.ts
+++ b/apps/app/src/lib/thread-local-file-links.ts
@@ -10,6 +10,7 @@ const THREAD_LOCAL_FILE_LINK_INVALID_PATH_DESCRIPTION =
 export interface ResolveThreadLocalFileLinkArgs {
   hostFileLinksAvailable: boolean;
   link: ThreadTimelineLocalFileLink;
+  threadStorageRootPath: string | null;
   workspaceRootPath: string | null;
 }
 
@@ -23,6 +24,13 @@ export interface ThreadWorkspaceFileLinkOpenRequest {
 export interface ThreadHostFileLinkOpenRequest {
   lineNumber: number | null;
   path: string;
+}
+
+export interface ThreadStorageFileLinkOpenRequest {
+  lineNumber: number | null;
+  path: string;
+  relativePath: string;
+  threadStorageRootPath: string;
 }
 
 interface ThreadLocalFileLinkAppRouteResolution {
@@ -44,27 +52,33 @@ interface ThreadHostFileLinkOpenResolution {
   request: ThreadHostFileLinkOpenRequest;
 }
 
-interface WorkspacePathWithinRootArgs {
+interface ThreadStorageFileLinkOpenResolution {
+  kind: "open-thread-storage-path";
+  request: ThreadStorageFileLinkOpenRequest;
+}
+
+interface PathWithinRootArgs {
   candidatePath: string;
-  workspaceRootPath: string;
+  rootPath: string;
 }
 
-interface NormalizeThreadLocalFileLinkPathArgs {
+interface NormalizeLocalFilePathWithinRootArgs {
   linkPath: string;
-  workspaceRootPath: string;
+  rootPath: string;
 }
 
-interface NormalizedThreadLocalFileLinkPath {
+interface NormalizedLocalFilePathWithinRoot {
   path: string;
   relativePath: string;
-  workspaceRootPath: string;
+  rootPath: string;
 }
 
 export type ThreadLocalFileLinkResolution =
   | ThreadLocalFileLinkAppRouteResolution
   | ThreadLocalFileLinkErrorResolution
   | ThreadWorkspaceFileLinkOpenResolution
-  | ThreadHostFileLinkOpenResolution;
+  | ThreadHostFileLinkOpenResolution
+  | ThreadStorageFileLinkOpenResolution;
 
 function isAppRoutePath(path: string): boolean {
   return APP_ROUTE_PATTERNS.some(
@@ -96,13 +110,11 @@ function normalizeAbsolutePath(candidatePath: string): string | null {
     : `/${normalizedSegments.join("/")}`;
 }
 
-function normalizeThreadLocalFileLinkPath(
-  args: NormalizeThreadLocalFileLinkPathArgs,
-): NormalizedThreadLocalFileLinkPath | null {
-  const normalizedWorkspaceRootPath = normalizeAbsolutePath(
-    args.workspaceRootPath,
-  );
-  if (!normalizedWorkspaceRootPath) {
+function normalizeLocalFilePathWithinRoot(
+  args: NormalizeLocalFilePathWithinRootArgs,
+): NormalizedLocalFilePathWithinRoot | null {
+  const normalizedRootPath = normalizeAbsolutePath(args.rootPath);
+  if (!normalizedRootPath) {
     return null;
   }
 
@@ -112,35 +124,35 @@ function normalizeThreadLocalFileLinkPath(
   }
 
   if (
-    !isPathWithinWorkspaceRoot({
+    !isPathWithinRoot({
       candidatePath: normalizedPath,
-      workspaceRootPath: normalizedWorkspaceRootPath,
+      rootPath: normalizedRootPath,
     }) ||
-    normalizedPath === normalizedWorkspaceRootPath
+    normalizedPath === normalizedRootPath
   ) {
     return null;
   }
 
   const relativePath =
-    normalizedWorkspaceRootPath === "/"
+    normalizedRootPath === "/"
       ? normalizedPath.slice(1)
-      : normalizedPath.slice(normalizedWorkspaceRootPath.length + 1);
+      : normalizedPath.slice(normalizedRootPath.length + 1);
 
   return {
     path: normalizedPath,
     relativePath,
-    workspaceRootPath: normalizedWorkspaceRootPath,
+    rootPath: normalizedRootPath,
   };
 }
 
-function isPathWithinWorkspaceRoot(args: WorkspacePathWithinRootArgs): boolean {
-  if (args.workspaceRootPath === "/") {
+function isPathWithinRoot(args: PathWithinRootArgs): boolean {
+  if (args.rootPath === "/") {
     return args.candidatePath.startsWith("/");
   }
 
   return (
-    args.candidatePath === args.workspaceRootPath ||
-    args.candidatePath.startsWith(`${args.workspaceRootPath}/`)
+    args.candidatePath === args.rootPath ||
+    args.candidatePath.startsWith(`${args.rootPath}/`)
   );
 }
 
@@ -164,9 +176,9 @@ export function resolveThreadLocalFileLink(
   const openRequest =
     args.workspaceRootPath === null
       ? null
-      : normalizeThreadLocalFileLinkPath({
+      : normalizeLocalFilePathWithinRoot({
           linkPath: normalizedPath,
-          workspaceRootPath: args.workspaceRootPath,
+          rootPath: args.workspaceRootPath,
         });
 
   if (openRequest) {
@@ -176,7 +188,27 @@ export function resolveThreadLocalFileLink(
         lineNumber: args.link.lineNumber,
         path: openRequest.path,
         relativePath: openRequest.relativePath,
-        workspaceRootPath: openRequest.workspaceRootPath,
+        workspaceRootPath: openRequest.rootPath,
+      },
+    };
+  }
+
+  const storageOpenRequest =
+    args.threadStorageRootPath === null
+      ? null
+      : normalizeLocalFilePathWithinRoot({
+          linkPath: normalizedPath,
+          rootPath: args.threadStorageRootPath,
+        });
+
+  if (storageOpenRequest) {
+    return {
+      kind: "open-thread-storage-path",
+      request: {
+        lineNumber: args.link.lineNumber,
+        path: storageOpenRequest.path,
+        relativePath: storageOpenRequest.relativePath,
+        threadStorageRootPath: storageOpenRequest.rootPath,
       },
     };
   }

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1014,6 +1014,7 @@ export function ThreadDetailView() {
       onOpenInEditor={handleOpenFileInEditor}
       source={activeWorkspaceFileSource}
       statusLabel={activeWorkspaceFileStatusLabel}
+      threadId={thread.id}
     />
   ) : activeHostFilePath ? (
     <HostFilePreviewTabContent

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -94,7 +94,10 @@ import {
   resolveThreadLocalWorkspaceRootPath,
   resolveThreadWorkspaceOpenPath,
 } from "./threadWorkspaceOpenPath";
-import { resolveThreadLocalFileLink } from "@/lib/thread-local-file-links";
+import {
+  resolveThreadLocalFileLink,
+  type ThreadLocalFileLinkResolution,
+} from "@/lib/thread-local-file-links";
 import {
   useFixedPanelTabsSecondaryPanelUrlSync,
   useFixedPanelTabsState,
@@ -245,11 +248,10 @@ export function ThreadDetailView() {
   const [hasRequestedMergeBaseOptions, setHasRequestedMergeBaseOptions] =
     useState(false);
   const [newTabFocusRequest, setNewTabFocusRequest] = useState(0);
-  const isSecondaryPanelActive = activeSecondaryPanel !== null;
-  const shouldLoadManagerStorageFiles =
-    isSecondaryPanelActive && isManagerThread;
+  const shouldLoadManagerStorageFiles = isManagerThread;
   const {
     isThreadStorageFilesLoading,
+    refetchThreadStorageFiles,
     threadStorageFiles,
     threadStorageFilesError,
     threadStorageRootPath,
@@ -713,14 +715,8 @@ export function ThreadDetailView() {
     },
     [thread, updateThread],
   );
-  const handleOpenTimelineLocalFileLink = useCallback(
-    (link: ThreadTimelineLocalFileLink) => {
-      const resolution = resolveThreadLocalFileLink({
-        hostFileLinksAvailable:
-          thread?.environmentId !== null && thread?.environmentId !== undefined,
-        link,
-        workspaceRootPath: localWorkspaceRootPath,
-      });
+  const handleTimelineLocalFileLinkResolution = useCallback(
+    (resolution: ThreadLocalFileLinkResolution) => {
       if (resolution.kind === "app-route") {
         return false;
       }
@@ -741,17 +737,71 @@ export function ThreadDetailView() {
         return true;
       }
 
+      if (resolution.kind === "open-thread-storage-path") {
+        openStorageFile(resolution.request.relativePath);
+        return true;
+      }
+
       openHostFile({
         lineNumber: resolution.request.lineNumber,
         path: resolution.request.path,
       });
       return true;
     },
+    [openHostFile, openStorageFile, openWorkspaceFile],
+  );
+  const handleOpenTimelineLocalFileLink = useCallback(
+    (link: ThreadTimelineLocalFileLink) => {
+      const resolution = resolveThreadLocalFileLink({
+        hostFileLinksAvailable:
+          thread?.environmentId !== null && thread?.environmentId !== undefined,
+        link,
+        threadStorageRootPath,
+        workspaceRootPath: localWorkspaceRootPath,
+      });
+
+      if (
+        resolution.kind !== "open-host-path" ||
+        !isManagerThread ||
+        threadStorageRootPath !== null
+      ) {
+        return handleTimelineLocalFileLinkResolution(resolution);
+      }
+
+      void refetchThreadStorageFiles()
+        .then((result) => {
+          const resolvedThreadStorageRootPath =
+            result.data?.storageRootPath ?? null;
+          if (resolvedThreadStorageRootPath === null) {
+            toast.error("Failed to open file locally", {
+              description: "Thread storage path is not available yet.",
+            });
+            return;
+          }
+
+          const resolvedResolution = resolveThreadLocalFileLink({
+            hostFileLinksAvailable: true,
+            link,
+            threadStorageRootPath: resolvedThreadStorageRootPath,
+            workspaceRootPath: localWorkspaceRootPath,
+          });
+          handleTimelineLocalFileLinkResolution(resolvedResolution);
+        })
+        .catch((error: Error) => {
+          toast.error("Failed to open file locally", {
+            description: error.message,
+          });
+        });
+
+      return true;
+    },
     [
+      handleTimelineLocalFileLinkResolution,
+      isManagerThread,
       localWorkspaceRootPath,
-      openHostFile,
-      openWorkspaceFile,
+      refetchThreadStorageFiles,
       thread?.environmentId,
+      threadStorageRootPath,
     ],
   );
   const handleTimelineTitleAction = useCallback<TimelineTitleActionResolver>(

--- a/apps/app/src/views/thread-detail/threadLocalFileHtmlPreviewRouting.test.tsx
+++ b/apps/app/src/views/thread-detail/threadLocalFileHtmlPreviewRouting.test.tsx
@@ -1,0 +1,407 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useCallback, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HostFilePreviewTabContent,
+  ThreadStorageFilePreviewTabContent,
+} from "@/components/secondary-panel/ThreadSecondaryPanelTabContent";
+import { MANAGER_STATUS_FILE_PATH } from "@/components/secondary-panel/managerStorage";
+import { useThreadStorageViewer } from "@/components/secondary-panel/useThreadStorageViewer";
+import type { ThreadTimelineLocalFileLink } from "@/components/thread/timeline";
+import { MarkdownPreview } from "@/components/ui/markdown-preview";
+import { resolveThreadLocalFileLink } from "@/lib/thread-local-file-links";
+import { installFetchRoutes, jsonResponse } from "@/test/http-test-utils";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+
+interface MarkdownHtmlPreviewHarnessProps {
+  markdownPath: string;
+  threadStorageRootPath: string | null;
+  workspaceRootPath: string | null;
+}
+
+interface HostOpenedFile {
+  kind: "host";
+  lineNumber: number | null;
+  path: string;
+}
+
+interface ThreadStorageOpenedFile {
+  kind: "thread-storage";
+  path: string;
+}
+
+type OpenedFile = HostOpenedFile | ThreadStorageOpenedFile;
+
+interface Deferred<TValue> {
+  promise: Promise<TValue>;
+  reject: (reason?: Error) => void;
+  resolve: (value: TValue) => void;
+}
+
+const THREAD_ID = "thread-1";
+const ENVIRONMENT_ID = "env-1";
+
+function createDeferred<TValue>(): Deferred<TValue> {
+  let resolveDeferred: ((value: TValue) => void) | null = null;
+  let rejectDeferred: ((reason?: Error) => void) | null = null;
+  const promise = new Promise<TValue>((resolve, reject) => {
+    resolveDeferred = resolve;
+    rejectDeferred = reject;
+  });
+
+  if (resolveDeferred === null || rejectDeferred === null) {
+    throw new Error("Failed to initialize deferred promise");
+  }
+
+  return {
+    promise,
+    reject: rejectDeferred,
+    resolve: resolveDeferred,
+  };
+}
+
+function MarkdownHtmlPreviewHarness({
+  markdownPath,
+  threadStorageRootPath,
+  workspaceRootPath,
+}: MarkdownHtmlPreviewHarnessProps) {
+  const [openedFile, setOpenedFile] = useState<OpenedFile | null>(null);
+  const handleOpenLocalFileLink = useCallback(
+    (link: ThreadTimelineLocalFileLink) => {
+      const resolution = resolveThreadLocalFileLink({
+        hostFileLinksAvailable: true,
+        link,
+        threadStorageRootPath,
+        workspaceRootPath,
+      });
+
+      if (resolution.kind === "open-host-path") {
+        setOpenedFile({
+          kind: "host",
+          lineNumber: resolution.request.lineNumber,
+          path: resolution.request.path,
+        });
+        return true;
+      }
+
+      if (resolution.kind === "open-thread-storage-path") {
+        setOpenedFile({
+          kind: "thread-storage",
+          path: resolution.request.relativePath,
+        });
+        return true;
+      }
+
+      return false;
+    },
+    [threadStorageRootPath, workspaceRootPath],
+  );
+
+  return (
+    <>
+      <MarkdownPreview
+        content={`[file](${markdownPath})`}
+        onOpenLocalFileLink={handleOpenLocalFileLink}
+      />
+      {openedFile?.kind === "host" ? (
+        <HostFilePreviewTabContent
+          activePath={openedFile.path}
+          environmentId={ENVIRONMENT_ID}
+          lineNumber={openedFile.lineNumber}
+          threadId={THREAD_ID}
+        />
+      ) : null}
+      {openedFile?.kind === "thread-storage" ? (
+        <ThreadStorageFilePreviewTabContent
+          activePath={openedFile.path}
+          isManagerThread
+          pinnedPath={MANAGER_STATUS_FILE_PATH}
+          threadId={THREAD_ID}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function PanelClosedThreadStorageMarkdownLinkHarness({
+  markdownPath,
+  workspaceRootPath,
+}: Omit<MarkdownHtmlPreviewHarnessProps, "threadStorageRootPath">) {
+  const [openedFile, setOpenedFile] = useState<OpenedFile | null>(null);
+  const { refetchThreadStorageFiles, threadStorageRootPath } =
+    useThreadStorageViewer({
+      activePath: null,
+      fileListEnabled: true,
+      filePreviewEnabled: false,
+      threadId: THREAD_ID,
+      threadType: "manager",
+    });
+  const openResolvedLink = useCallback(
+    (
+      link: ThreadTimelineLocalFileLink,
+      resolvedThreadStorageRootPath: string | null,
+    ) => {
+      const resolution = resolveThreadLocalFileLink({
+        hostFileLinksAvailable: true,
+        link,
+        threadStorageRootPath: resolvedThreadStorageRootPath,
+        workspaceRootPath,
+      });
+
+      if (resolution.kind === "open-thread-storage-path") {
+        setOpenedFile({
+          kind: "thread-storage",
+          path: resolution.request.relativePath,
+        });
+        return true;
+      }
+
+      if (resolution.kind === "open-host-path") {
+        setOpenedFile({
+          kind: "host",
+          lineNumber: resolution.request.lineNumber,
+          path: resolution.request.path,
+        });
+        return true;
+      }
+
+      return false;
+    },
+    [workspaceRootPath],
+  );
+  const handleOpenLocalFileLink = useCallback(
+    (link: ThreadTimelineLocalFileLink) => {
+      const resolution = resolveThreadLocalFileLink({
+        hostFileLinksAvailable: true,
+        link,
+        threadStorageRootPath,
+        workspaceRootPath,
+      });
+
+      if (
+        resolution.kind !== "open-host-path" ||
+        threadStorageRootPath !== null
+      ) {
+        return openResolvedLink(link, threadStorageRootPath);
+      }
+
+      void refetchThreadStorageFiles().then((result) => {
+        openResolvedLink(link, result.data?.storageRootPath ?? null);
+      });
+      return true;
+    },
+    [
+      openResolvedLink,
+      refetchThreadStorageFiles,
+      threadStorageRootPath,
+      workspaceRootPath,
+    ],
+  );
+
+  return (
+    <>
+      <MarkdownPreview
+        content={`[file](${markdownPath})`}
+        onOpenLocalFileLink={handleOpenLocalFileLink}
+      />
+      {openedFile?.kind === "host" ? (
+        <HostFilePreviewTabContent
+          activePath={openedFile.path}
+          environmentId={ENVIRONMENT_ID}
+          lineNumber={openedFile.lineNumber}
+          threadId={THREAD_ID}
+        />
+      ) : null}
+      {openedFile?.kind === "thread-storage" ? (
+        <ThreadStorageFilePreviewTabContent
+          activePath={openedFile.path}
+          isManagerThread
+          pinnedPath={MANAGER_STATUS_FILE_PATH}
+          threadId={THREAD_ID}
+        />
+      ) : null}
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("thread local HTML preview routing", () => {
+  it("opens markdown links to outside HTML files in the sandboxed iframe preview", async () => {
+    const outsidePath = "/Users/me/Downloads/report.html";
+    installFetchRoutes([
+      {
+        pathname: `/api/v1/threads/${THREAD_ID}/host-files/content`,
+        handler: (request) => {
+          expect(new URL(request.url).searchParams.get("path")).toBe(
+            outsidePath,
+          );
+          return new Response("<!doctype html><h1>Report</h1>", {
+            headers: { "content-type": "text/html" },
+          });
+        },
+      },
+    ]);
+    const { wrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <MarkdownHtmlPreviewHarness
+        markdownPath={outsidePath}
+        threadStorageRootPath="/Users/me/.bb/thread-storage/thread-1"
+        workspaceRootPath="/Users/me/workspace"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /file/u }));
+
+    await waitFor(() => {
+      expect(container.querySelector("iframe")).not.toBeNull();
+    });
+    const iframe = container.querySelector("iframe");
+    expect(
+      screen.getByRole("tablist", { name: "HTML view mode" }),
+    ).toBeTruthy();
+    expect(iframe?.getAttribute("src")).toBe(
+      `/api/v1/threads/${THREAD_ID}/files/raw?path=${encodeURIComponent(outsidePath)}`,
+    );
+    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe?.getAttribute("sandbox")).not.toContain("allow-same-origin");
+  });
+
+  it("opens markdown links inside thread storage through the storage HTML preview route", async () => {
+    const threadStorageRootPath = "/Users/me/.bb/thread-storage/thread-1";
+    const storagePath = `${threadStorageRootPath}/reports/preview.html`;
+    installFetchRoutes([
+      {
+        pathname: `/api/v1/threads/${THREAD_ID}/thread-storage/content`,
+        handler: (request) => {
+          expect(new URL(request.url).searchParams.get("path")).toBe(
+            "reports/preview.html",
+          );
+          return new Response("<!doctype html><h1>Storage</h1>", {
+            headers: { "content-type": "text/html" },
+          });
+        },
+      },
+    ]);
+    const { wrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <MarkdownHtmlPreviewHarness
+        markdownPath={storagePath}
+        threadStorageRootPath={threadStorageRootPath}
+        workspaceRootPath="/Users/me/workspace"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /file/u }));
+
+    await waitFor(() => {
+      expect(container.querySelector("iframe")).not.toBeNull();
+    });
+    const iframe = container.querySelector("iframe");
+    expect(
+      screen.getByRole("tablist", { name: "HTML view mode" }),
+    ).toBeTruthy();
+    expect(iframe?.getAttribute("src")).toBe(
+      `/api/v1/threads/${THREAD_ID}/thread-storage/files/reports/preview.html`,
+    );
+    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+  });
+
+  it("preloads thread storage root so a panel-closed first click uses the storage HTML preview route", async () => {
+    const threadStorageRootPath = "/Users/me/.bb/thread-storage/thread-1";
+    const storagePath = `${threadStorageRootPath}/reports/preview.html`;
+    const storageFilesResponse = createDeferred<Response>();
+    installFetchRoutes([
+      {
+        pathname: `/api/v1/threads/${THREAD_ID}/thread-storage/files`,
+        handler: () => storageFilesResponse.promise,
+      },
+      {
+        pathname: `/api/v1/threads/${THREAD_ID}/thread-storage/content`,
+        handler: (request) => {
+          expect(new URL(request.url).searchParams.get("path")).toBe(
+            "reports/preview.html",
+          );
+          return new Response("<!doctype html><h1>Storage</h1>", {
+            headers: { "content-type": "text/html" },
+          });
+        },
+      },
+    ]);
+    const { wrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <PanelClosedThreadStorageMarkdownLinkHarness
+        markdownPath={storagePath}
+        workspaceRootPath="/Users/me/workspace"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /file/u }));
+    storageFilesResponse.resolve(
+      jsonResponse({
+        files: [],
+        storageRootPath: threadStorageRootPath,
+        truncated: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("iframe")).not.toBeNull();
+    });
+    const iframe = container.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toBe(
+      `/api/v1/threads/${THREAD_ID}/thread-storage/files/reports/preview.html`,
+    );
+  });
+
+  it("keeps markdown links to non-HTML host files on the normal host-file preview path", async () => {
+    const outsidePath = "/Users/me/Downloads/report.txt";
+    const fetchMock = installFetchRoutes([
+      {
+        pathname: `/api/v1/threads/${THREAD_ID}/host-files/content`,
+        handler: (request) => {
+          expect(new URL(request.url).searchParams.get("path")).toBe(
+            outsidePath,
+          );
+          return new Response("plain text report", {
+            headers: { "content-type": "text/plain" },
+          });
+        },
+      },
+    ]);
+    const { wrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <MarkdownHtmlPreviewHarness
+        markdownPath={outsidePath}
+        threadStorageRootPath="/Users/me/.bb/thread-storage/thread-1"
+        workspaceRootPath="/Users/me/workspace"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /file/u }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(container.querySelector("iframe")).toBeNull();
+      expect(
+        screen.queryByRole("tablist", { name: "HTML view mode" }),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/electron-builder.config.json
+++ b/apps/desktop/electron-builder.config.json
@@ -2,6 +2,7 @@
   "appId": "dev.bb.desktop",
   "productName": "bb",
   "artifactName": "${productName}-${version}-${arch}.${ext}",
+  "afterPack": "scripts/prepare-native-modules.cjs",
   "asar": true,
   "asarUnpack": ["dist/bb-app-bridge.mjs", "node_modules/**"],
   "directories": {

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -53,6 +53,13 @@ await Promise.all([
   }),
   build({
     ...commonOptions,
+    entryPoints: [resolve(packageRoot, "src", "log-viewer-preload.ts")],
+    external: ["electron"],
+    format: "cjs",
+    outfile: resolve(distDir, "log-viewer-preload.cjs"),
+  }),
+  build({
+    ...commonOptions,
     entryPoints: [resolve(packageRoot, "src", "bb-app-bridge.ts")],
     external: ["bb-app", "bb-app/*"],
     format: "esm",

--- a/apps/desktop/scripts/prepare-native-modules.cjs
+++ b/apps/desktop/scripts/prepare-native-modules.cjs
@@ -1,0 +1,158 @@
+const { chmod, readFile, readdir, writeFile } = require("node:fs/promises");
+const path = require("node:path");
+
+const NODE_PTY_PACKAGE_NAME = "node-pty";
+const NODE_MODULES_DIRECTORY = "node_modules";
+const NODE_PTY_PREBUILD_PLATFORMS = ["darwin-arm64", "darwin-x64"];
+const NODE_PTY_SPAWN_HELPER_RELATIVE_PATHS = [
+  path.join("build", "Release", "spawn-helper"),
+  ...NODE_PTY_PREBUILD_PLATFORMS.map((platform) =>
+    path.join("prebuilds", platform, "spawn-helper"),
+  ),
+];
+const NODE_PTY_ASAR_HELPER_PATH_REWRITE =
+  "helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');";
+const NODE_PTY_IDEMPOTENT_ASAR_HELPER_PATH_REWRITE =
+  "helperPath = helperPath.replace(/app\\.asar(?!\\.unpacked)/g, 'app.asar.unpacked');";
+
+async function isDirectory(directoryPath) {
+  try {
+    const entry = await readdir(directoryPath, { withFileTypes: true });
+    return Array.isArray(entry);
+  } catch {
+    return false;
+  }
+}
+
+function isNodePtyPackageDirectory(directoryPath) {
+  return (
+    path.basename(directoryPath) === NODE_PTY_PACKAGE_NAME &&
+    path.basename(path.dirname(directoryPath)) === NODE_MODULES_DIRECTORY
+  );
+}
+
+async function findNodePtyPackageDirectories(rootPath) {
+  const matches = [];
+  const pending = [rootPath];
+
+  while (pending.length > 0) {
+    const directoryPath = pending.pop();
+    if (directoryPath === undefined) {
+      continue;
+    }
+
+    let entries;
+    try {
+      entries = await readdir(directoryPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const childPath = path.join(directoryPath, entry.name);
+      if (isNodePtyPackageDirectory(childPath)) {
+        matches.push(childPath);
+        continue;
+      }
+      pending.push(childPath);
+    }
+  }
+
+  return matches;
+}
+
+async function chmodIfPresent(filePath, mode) {
+  try {
+    await chmod(filePath, mode);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function patchNodePtyHelperPath(packageDirectory) {
+  const unixTerminalPath = path.join(
+    packageDirectory,
+    "lib",
+    "unixTerminal.js",
+  );
+  const source = await readFile(unixTerminalPath, "utf8");
+
+  if (source.includes(NODE_PTY_IDEMPOTENT_ASAR_HELPER_PATH_REWRITE)) {
+    return;
+  }
+  if (!source.includes(NODE_PTY_ASAR_HELPER_PATH_REWRITE)) {
+    throw new Error(
+      `Unable to patch ${NODE_PTY_PACKAGE_NAME} helper path rewrite in ${unixTerminalPath}`,
+    );
+  }
+
+  await writeFile(
+    unixTerminalPath,
+    source.replace(
+      NODE_PTY_ASAR_HELPER_PATH_REWRITE,
+      NODE_PTY_IDEMPOTENT_ASAR_HELPER_PATH_REWRITE,
+    ),
+  );
+}
+
+async function prepareNodePtyPackageDirectory(packageDirectory) {
+  await patchNodePtyHelperPath(packageDirectory);
+
+  await Promise.all(
+    NODE_PTY_SPAWN_HELPER_RELATIVE_PATHS.map((relativePath) =>
+      chmodIfPresent(path.join(packageDirectory, relativePath), 0o755),
+    ),
+  );
+}
+
+async function preparePackagedNativeModules(appOutDir) {
+  if (!(await isDirectory(appOutDir))) {
+    throw new Error(`Packaged app output does not exist: ${appOutDir}`);
+  }
+
+  const packageDirectories = await findNodePtyPackageDirectories(appOutDir);
+  if (packageDirectories.length === 0) {
+    throw new Error(
+      `Unable to find ${NODE_PTY_PACKAGE_NAME} under ${appOutDir}`,
+    );
+  }
+
+  await Promise.all(packageDirectories.map(prepareNodePtyPackageDirectory));
+  return packageDirectories;
+}
+
+async function afterPack(context) {
+  await preparePackagedNativeModules(context.appOutDir);
+}
+
+async function main() {
+  const appOutDir = process.argv[2];
+  if (appOutDir === undefined || appOutDir.length === 0) {
+    throw new Error(
+      "Usage: node apps/desktop/scripts/prepare-native-modules.cjs <appOutDir>",
+    );
+  }
+
+  await preparePackagedNativeModules(path.resolve(appOutDir));
+}
+
+module.exports = afterPack;
+module.exports.findNodePtyPackageDirectories = findNodePtyPackageDirectories;
+module.exports.prepareNodePtyPackageDirectory = prepareNodePtyPackageDirectory;
+module.exports.preparePackagedNativeModules = preparePackagedNativeModules;
+
+if (require.main === module) {
+  main().catch((error) => {
+    const message =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/desktop/src/local-view.ts
+++ b/apps/desktop/src/local-view.ts
@@ -87,6 +87,31 @@ function renderLocalView(viewModel: LocalViewModel): string {
       margin: 0;
     }
 
+    .titlebar-drag-region {
+      app-region: drag;
+      -webkit-app-region: drag;
+      background: transparent;
+      border: 0;
+      height: 28px;
+      left: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
+      user-select: none;
+      z-index: 10;
+    }
+
+    button,
+    a,
+    input,
+    textarea,
+    select,
+    summary,
+    pre {
+      app-region: no-drag;
+      -webkit-app-region: no-drag;
+    }
+
     .shell {
       max-width: 680px;
       padding: 32px;
@@ -143,6 +168,7 @@ function renderLocalView(viewModel: LocalViewModel): string {
   </style>
 </head>
 <body>
+<div class="titlebar-drag-region" data-testid="bb-local-view-window-drag-region" aria-hidden="true"></div>
 ${body}
 </body>
 </html>`;

--- a/apps/desktop/src/log-viewer-contract.ts
+++ b/apps/desktop/src/log-viewer-contract.ts
@@ -1,0 +1,44 @@
+export const LOG_VIEWER_APPEND_CHANNEL = "bb:log-viewer:append";
+export const LOG_VIEWER_COPY_CHANNEL = "bb:log-viewer:copy";
+export const LOG_VIEWER_OPEN_LOGS_FOLDER_CHANNEL =
+  "bb:log-viewer:open-logs-folder";
+export const LOG_VIEWER_SNAPSHOT_CHANNEL = "bb:log-viewer:snapshot";
+export const LOG_VIEWER_VISIBLE_LINE_LIMIT = 10_000;
+
+export type LogViewerComponent = "host-daemon" | "server";
+export type LogViewerLineSource = LogViewerComponent | "system";
+
+export interface LogViewerLine {
+  source: LogViewerLineSource;
+  text: string;
+}
+
+export interface LogViewerAppendEvent {
+  lines: LogViewerLine[];
+}
+
+export interface LogViewerSnapshotEvent {
+  lines: LogViewerLine[];
+  logDir: string;
+}
+
+export interface LogViewerCopyRequest {
+  text: string;
+}
+
+export interface LogViewerOpenLogsFolderResult {
+  path: string;
+}
+
+export type LogViewerAppendHandler = (event: LogViewerAppendEvent) => void;
+export type LogViewerSnapshotHandler = (
+  event: LogViewerSnapshotEvent,
+) => void;
+export type LogViewerUnsubscribe = () => void;
+
+export interface LogViewerApi {
+  copyLogs(request: LogViewerCopyRequest): Promise<void>;
+  onAppend(handler: LogViewerAppendHandler): LogViewerUnsubscribe;
+  onSnapshot(handler: LogViewerSnapshotHandler): LogViewerUnsubscribe;
+  openLogsFolder(): Promise<LogViewerOpenLogsFolderResult>;
+}

--- a/apps/desktop/src/log-viewer-preload.ts
+++ b/apps/desktop/src/log-viewer-preload.ts
@@ -1,0 +1,66 @@
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from "electron";
+import {
+  LOG_VIEWER_APPEND_CHANNEL,
+  LOG_VIEWER_COPY_CHANNEL,
+  LOG_VIEWER_OPEN_LOGS_FOLDER_CHANNEL,
+  LOG_VIEWER_SNAPSHOT_CHANNEL,
+  type LogViewerApi,
+  type LogViewerAppendEvent,
+  type LogViewerAppendHandler,
+  type LogViewerCopyRequest,
+  type LogViewerOpenLogsFolderResult,
+  type LogViewerSnapshotEvent,
+  type LogViewerSnapshotHandler,
+  type LogViewerUnsubscribe,
+} from "./log-viewer-contract.js";
+
+interface SnapshotListenerArgs {
+  handler: LogViewerSnapshotHandler;
+}
+
+interface AppendListenerArgs {
+  handler: LogViewerAppendHandler;
+}
+
+function onSnapshot(args: SnapshotListenerArgs): LogViewerUnsubscribe {
+  const listener = (
+    _event: IpcRendererEvent,
+    payload: LogViewerSnapshotEvent,
+  ): void => {
+    args.handler(payload);
+  };
+  ipcRenderer.on(LOG_VIEWER_SNAPSHOT_CHANNEL, listener);
+  return () => {
+    ipcRenderer.removeListener(LOG_VIEWER_SNAPSHOT_CHANNEL, listener);
+  };
+}
+
+function onAppend(args: AppendListenerArgs): LogViewerUnsubscribe {
+  const listener = (
+    _event: IpcRendererEvent,
+    payload: LogViewerAppendEvent,
+  ): void => {
+    args.handler(payload);
+  };
+  ipcRenderer.on(LOG_VIEWER_APPEND_CHANNEL, listener);
+  return () => {
+    ipcRenderer.removeListener(LOG_VIEWER_APPEND_CHANNEL, listener);
+  };
+}
+
+const logViewerApi: LogViewerApi = {
+  async copyLogs(request: LogViewerCopyRequest): Promise<void> {
+    await ipcRenderer.invoke(LOG_VIEWER_COPY_CHANNEL, request);
+  },
+  onAppend(handler) {
+    return onAppend({ handler });
+  },
+  onSnapshot(handler) {
+    return onSnapshot({ handler });
+  },
+  async openLogsFolder(): Promise<LogViewerOpenLogsFolderResult> {
+    return ipcRenderer.invoke(LOG_VIEWER_OPEN_LOGS_FOLDER_CHANNEL);
+  },
+};
+
+contextBridge.exposeInMainWorld("bbLogViewer", logViewerApi);

--- a/apps/desktop/src/log-viewer.ts
+++ b/apps/desktop/src/log-viewer.ts
@@ -217,7 +217,7 @@ export function createLogViewerViewUrl(args: CreateLogViewerViewUrlArgs): string
   <meta charset="utf-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Server & Daemon Logs</title>
+  <title>bb - Server & Daemon Logs</title>
   <style>
     :root {
       color-scheme: light dark;

--- a/apps/desktop/src/log-viewer.ts
+++ b/apps/desktop/src/log-viewer.ts
@@ -1,0 +1,705 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, readdir, stat } from "node:fs/promises";
+import { watch, type FSWatcher } from "node:fs";
+import { join } from "node:path";
+import {
+  LOG_VIEWER_VISIBLE_LINE_LIMIT,
+  type LogViewerComponent,
+  type LogViewerLine,
+} from "./log-viewer-contract.js";
+
+export const LOG_VIEWER_IPC_BATCH_INTERVAL_MS = 50;
+export const LOG_VIEWER_IPC_BATCH_LINE_LIMIT = 250;
+
+const LOG_VIEWER_INITIAL_TAIL_LINES = 400;
+const LOG_VIEWER_ROTATION_POLL_INTERVAL_MS = 2_000;
+const LOG_VIEWER_COMPONENTS: LogViewerComponent[] = ["server", "host-daemon"];
+
+export interface CreateLogViewerViewUrlArgs {
+  logDir: string;
+}
+
+export interface ResolveCurrentLogFileArgs {
+  component: LogViewerComponent;
+  logDir: string;
+}
+
+export interface CreateLogTailerArgs {
+  logDir: string;
+  onLines(lines: LogViewerLine[]): void;
+}
+
+export interface LogTailer {
+  processIds(): number[];
+  start(): Promise<void>;
+  stop(): void;
+}
+
+export interface CreateLogLineBufferArgs {
+  flushIntervalMs: number;
+  flushLineCount: number;
+  maxLines: number;
+  onFlush(lines: LogViewerLine[]): void;
+}
+
+export interface LogLineBuffer {
+  append(lines: LogViewerLine[]): void;
+  clear(): void;
+  flush(): void;
+  lines(): LogViewerLine[];
+  stop(): void;
+}
+
+interface EscapeHtmlArgs {
+  value: string;
+}
+
+interface ParseLogFileCandidateArgs {
+  component: LogViewerComponent;
+  fileName: string;
+}
+
+interface LogFileCandidate {
+  fileName: string;
+  sequence: number;
+  timestampMs: number;
+}
+
+interface TailProcess {
+  childProcess: ChildProcess;
+  filePath: string;
+}
+
+interface ComponentTailState {
+  component: LogViewerComponent;
+  currentFilePath: string | null;
+  pendingText: string;
+  tailProcess: TailProcess | null;
+}
+
+interface RestartTailProcessArgs {
+  filePath: string;
+  state: ComponentTailState;
+}
+
+interface StopTailProcessArgs {
+  state: ComponentTailState;
+}
+
+interface HandleTailChunkArgs {
+  chunk: string;
+  state: ComponentTailState;
+}
+
+interface EmitSystemLineArgs {
+  text: string;
+}
+
+interface EmitComponentLinesArgs {
+  component: LogViewerComponent;
+  lines: string[];
+}
+
+interface CreateComponentTailStateArgs {
+  component: LogViewerComponent;
+}
+
+interface ScheduleBufferFlushArgs {
+  buffer: LogLineBufferState;
+}
+
+interface LogLineBufferState {
+  flushTimer: NodeJS.Timeout | null;
+  pendingLines: LogViewerLine[];
+  visibleLines: LogViewerLine[];
+}
+
+function escapeHtml(args: EscapeHtmlArgs): string {
+  return args.value.replace(/[&<>"']/gu, (character) => {
+    if (character === "&") {
+      return "&amp;";
+    }
+    if (character === "<") {
+      return "&lt;";
+    }
+    if (character === ">") {
+      return "&gt;";
+    }
+    if (character === '"') {
+      return "&quot;";
+    }
+    return "&#39;";
+  });
+}
+
+export function createLogLineBuffer(
+  args: CreateLogLineBufferArgs,
+): LogLineBuffer {
+  const state: LogLineBufferState = {
+    flushTimer: null,
+    pendingLines: [],
+    visibleLines: [],
+  };
+
+  function clearFlushTimer(): void {
+    if (state.flushTimer === null) {
+      return;
+    }
+    clearTimeout(state.flushTimer);
+    state.flushTimer = null;
+  }
+
+  function flush(): void {
+    clearFlushTimer();
+    if (state.pendingLines.length === 0) {
+      return;
+    }
+
+    const pendingLines = state.pendingLines;
+    state.pendingLines = [];
+    args.onFlush(pendingLines);
+  }
+
+  function scheduleBufferFlush(
+    scheduleArgs: ScheduleBufferFlushArgs,
+  ): void {
+    if (scheduleArgs.buffer.flushTimer !== null) {
+      return;
+    }
+    scheduleArgs.buffer.flushTimer = setTimeout(() => {
+      scheduleArgs.buffer.flushTimer = null;
+      flush();
+    }, args.flushIntervalMs);
+  }
+
+  return {
+    append(lines) {
+      if (lines.length === 0) {
+        return;
+      }
+
+      state.visibleLines.push(...lines);
+      if (state.visibleLines.length > args.maxLines) {
+        state.visibleLines.splice(
+          0,
+          state.visibleLines.length - args.maxLines,
+        );
+      }
+
+      state.pendingLines.push(...lines);
+      if (state.pendingLines.length >= args.flushLineCount) {
+        flush();
+        return;
+      }
+      scheduleBufferFlush({ buffer: state });
+    },
+    clear() {
+      clearFlushTimer();
+      state.pendingLines = [];
+      state.visibleLines = [];
+    },
+    flush,
+    lines() {
+      return [...state.visibleLines];
+    },
+    stop() {
+      flush();
+      clearFlushTimer();
+    },
+  };
+}
+
+export function createLogViewerViewUrl(args: CreateLogViewerViewUrlArgs): string {
+  const escapedLogDir = escapeHtml({ value: args.logDir });
+  const html = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Server & Daemon Logs</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      background: Canvas;
+      color: CanvasText;
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      height: 100vh;
+      margin: 0;
+    }
+
+    header {
+      align-items: center;
+      border-bottom: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+      display: grid;
+      gap: 12px;
+      grid-template-columns: minmax(0, 1fr) auto;
+      padding: 16px 18px 12px;
+    }
+
+    h1 {
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: 0;
+      line-height: 1.25;
+      margin: 0 0 4px;
+    }
+
+    .path {
+      color: color-mix(in srgb, CanvasText 60%, transparent);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      line-height: 1.35;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .actions {
+      align-items: center;
+      display: flex;
+      gap: 8px;
+    }
+
+    button {
+      appearance: none;
+      background: color-mix(in srgb, CanvasText 7%, transparent);
+      border: 1px solid color-mix(in srgb, CanvasText 18%, transparent);
+      border-radius: 6px;
+      color: CanvasText;
+      cursor: default;
+      font: inherit;
+      font-size: 12px;
+      line-height: 1;
+      padding: 8px 10px;
+    }
+
+    button:active {
+      background: color-mix(in srgb, CanvasText 13%, transparent);
+    }
+
+    label {
+      align-items: center;
+      color: color-mix(in srgb, CanvasText 72%, transparent);
+      display: inline-flex;
+      font-size: 12px;
+      gap: 6px;
+      white-space: nowrap;
+    }
+
+    input {
+      margin: 0;
+    }
+
+    main {
+      min-height: 0;
+      padding: 12px;
+    }
+
+    pre {
+      background: color-mix(in srgb, CanvasText 5%, transparent);
+      border: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+      border-radius: 8px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      height: 100%;
+      line-height: 1.45;
+      margin: 0;
+      overflow: auto;
+      padding: 12px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .status {
+      color: color-mix(in srgb, CanvasText 64%, transparent);
+      font-size: 12px;
+      min-width: 58px;
+      text-align: right;
+      white-space: nowrap;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>Server & Daemon Logs</h1>
+      <div class="path" title="${escapedLogDir}">${escapedLogDir}</div>
+    </div>
+    <div class="actions">
+      <label><input id="autoscroll" type="checkbox" checked> Auto-scroll</label>
+      <button id="copy" type="button">Copy Logs</button>
+      <button id="open" type="button">Open Logs Folder</button>
+      <button id="clear" type="button">Clear</button>
+      <div id="status" class="status">0 lines</div>
+    </div>
+  </header>
+  <main>
+    <pre id="log" aria-live="polite"></pre>
+  </main>
+  <script>
+    const maxLines = ${LOG_VIEWER_VISIBLE_LINE_LIMIT};
+    const api = window.bbLogViewer;
+    const autoscroll = document.getElementById("autoscroll");
+    const clearButton = document.getElementById("clear");
+    const copyButton = document.getElementById("copy");
+    const logElement = document.getElementById("log");
+    const openButton = document.getElementById("open");
+    const statusElement = document.getElementById("status");
+    const lines = [];
+
+    function shouldStickToBottom() {
+      return autoscroll.checked &&
+        logElement.scrollTop + logElement.clientHeight >= logElement.scrollHeight - 24;
+    }
+
+    function render(stickToBottom) {
+      logElement.textContent = lines.join("\\n");
+      statusElement.textContent = String(lines.length) + " lines";
+      if (stickToBottom) {
+        logElement.scrollTop = logElement.scrollHeight;
+      }
+    }
+
+    function appendEntries(entries) {
+      const stickToBottom = shouldStickToBottom();
+      for (const entry of entries) {
+        lines.push(entry.text);
+      }
+      if (lines.length > maxLines) {
+        lines.splice(0, lines.length - maxLines);
+      }
+      render(stickToBottom);
+    }
+
+    api.onSnapshot((event) => {
+      lines.splice(0, lines.length);
+      appendEntries(event.lines);
+    });
+
+    api.onAppend((event) => {
+      appendEntries(event.lines);
+    });
+
+    clearButton.addEventListener("click", () => {
+      lines.splice(0, lines.length);
+      render(true);
+    });
+
+    copyButton.addEventListener("click", async () => {
+      await api.copyLogs({ text: lines.join("\\n") });
+      const previousLabel = copyButton.textContent;
+      copyButton.textContent = "Copied";
+      setTimeout(() => {
+        copyButton.textContent = previousLabel;
+      }, 900);
+    });
+
+    openButton.addEventListener("click", async () => {
+      await api.openLogsFolder();
+    });
+  </script>
+</body>
+</html>`;
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+}
+
+function parseLogFileCandidate(
+  args: ParseLogFileCandidateArgs,
+): LogFileCandidate | null {
+  const exactFileName = `${args.component}.log`;
+  if (args.fileName === exactFileName) {
+    return {
+      fileName: args.fileName,
+      sequence: 0,
+      timestampMs: 0,
+    };
+  }
+
+  const prefix = `${args.component}.`;
+  const suffix = ".log";
+  if (!args.fileName.startsWith(prefix) || !args.fileName.endsWith(suffix)) {
+    return null;
+  }
+
+  const rawSequence = args.fileName.slice(
+    prefix.length,
+    args.fileName.length - suffix.length,
+  );
+  const sequence = /^\d+$/u.test(rawSequence) ? Number(rawSequence) : 0;
+  return {
+    fileName: args.fileName,
+    sequence,
+    timestampMs: 0,
+  };
+}
+
+export async function resolveCurrentLogFile(
+  args: ResolveCurrentLogFileArgs,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(args.logDir);
+  } catch {
+    return null;
+  }
+
+  const candidates: LogFileCandidate[] = [];
+  for (const entry of entries) {
+    const candidate = parseLogFileCandidate({
+      component: args.component,
+      fileName: entry,
+    });
+    if (candidate === null) {
+      continue;
+    }
+
+    try {
+      const fileStats = await stat(join(args.logDir, candidate.fileName));
+      if (!fileStats.isFile()) {
+        continue;
+      }
+      candidates.push({
+        fileName: candidate.fileName,
+        sequence: candidate.sequence,
+        timestampMs: Math.max(
+          fileStats.birthtimeMs,
+          fileStats.ctimeMs,
+          fileStats.mtimeMs,
+        ),
+      });
+    } catch {}
+  }
+
+  candidates.sort((left, right) => {
+    if (left.timestampMs !== right.timestampMs) {
+      return right.timestampMs - left.timestampMs;
+    }
+    if (left.sequence !== right.sequence) {
+      return right.sequence - left.sequence;
+    }
+    return right.fileName.localeCompare(left.fileName);
+  });
+
+  const candidate = candidates[0];
+  return candidate === undefined ? null : join(args.logDir, candidate.fileName);
+}
+
+function createComponentTailState(
+  args: CreateComponentTailStateArgs,
+): ComponentTailState {
+  return {
+    component: args.component,
+    currentFilePath: null,
+    pendingText: "",
+    tailProcess: null,
+  };
+}
+
+export function createLogTailer(args: CreateLogTailerArgs): LogTailer {
+  const componentStates = LOG_VIEWER_COMPONENTS.map((component) =>
+    createComponentTailState({ component }),
+  );
+  let directoryWatcher: FSWatcher | null = null;
+  let pollTimer: NodeJS.Timeout | null = null;
+  let refreshInProgress = false;
+  let refreshAgain = false;
+  let stopped = false;
+
+  function emitSystemLine(emitArgs: EmitSystemLineArgs): void {
+    args.onLines([{ source: "system", text: `[system] ${emitArgs.text}` }]);
+  }
+
+  function emitComponentLines(emitArgs: EmitComponentLinesArgs): void {
+    args.onLines(
+      emitArgs.lines
+        .filter((line) => line.length > 0)
+        .map((line) => ({
+          source: emitArgs.component,
+          text: `[${emitArgs.component}] ${line}`,
+        })),
+    );
+  }
+
+  function handleTailChunk(handleArgs: HandleTailChunkArgs): void {
+    const combinedText = `${handleArgs.state.pendingText}${handleArgs.chunk}`;
+    const lines = combinedText.split(/\r?\n/u);
+    if (combinedText.endsWith("\n") || combinedText.endsWith("\r")) {
+      handleArgs.state.pendingText = "";
+      emitComponentLines({
+        component: handleArgs.state.component,
+        lines,
+      });
+      return;
+    }
+
+    handleArgs.state.pendingText = lines.pop() ?? "";
+    emitComponentLines({
+      component: handleArgs.state.component,
+      lines,
+    });
+  }
+
+  function stopTailProcess(stopArgs: StopTailProcessArgs): void {
+    const tailProcess = stopArgs.state.tailProcess;
+    stopArgs.state.tailProcess = null;
+    stopArgs.state.currentFilePath = null;
+    stopArgs.state.pendingText = "";
+    if (tailProcess === null) {
+      return;
+    }
+    tailProcess.childProcess.kill("SIGTERM");
+  }
+
+  function restartTailProcess(restartArgs: RestartTailProcessArgs): void {
+    stopTailProcess({ state: restartArgs.state });
+    restartArgs.state.currentFilePath = restartArgs.filePath;
+
+    const childProcess = spawn(
+      "tail",
+      [
+        "-n",
+        String(LOG_VIEWER_INITIAL_TAIL_LINES),
+        "-F",
+        restartArgs.filePath,
+      ],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const tailProcess: TailProcess = {
+      childProcess,
+      filePath: restartArgs.filePath,
+    };
+    restartArgs.state.tailProcess = tailProcess;
+
+    if (childProcess.stdout !== null) {
+      childProcess.stdout.setEncoding("utf8");
+      childProcess.stdout.on("data", (chunk: string) => {
+        handleTailChunk({ chunk, state: restartArgs.state });
+      });
+    }
+
+    if (childProcess.stderr !== null) {
+      childProcess.stderr.setEncoding("utf8");
+      childProcess.stderr.on("data", (chunk: string) => {
+        const text = chunk.trim();
+        if (text.length > 0) {
+          emitSystemLine({
+            text: `${restartArgs.state.component} tail: ${text}`,
+          });
+        }
+      });
+    }
+
+    childProcess.once("error", (error) => {
+      emitSystemLine({
+        text: `${restartArgs.state.component} tail failed: ${error.message}`,
+      });
+    });
+
+    childProcess.once("exit", (code, signal) => {
+      if (stopped || restartArgs.state.tailProcess !== tailProcess) {
+        return;
+      }
+      restartArgs.state.tailProcess = null;
+      emitSystemLine({
+        text: `${restartArgs.state.component} tail stopped with ${
+          code === null ? `signal ${signal ?? "unknown"}` : `exit code ${code}`
+        }`,
+      });
+    });
+  }
+
+  async function refreshTailProcesses(): Promise<void> {
+    if (stopped) {
+      return;
+    }
+
+    for (const state of componentStates) {
+      const currentFilePath = await resolveCurrentLogFile({
+        component: state.component,
+        logDir: args.logDir,
+      });
+      if (currentFilePath === null) {
+        if (state.currentFilePath !== null) {
+          stopTailProcess({ state });
+        }
+        continue;
+      }
+      if (currentFilePath !== state.currentFilePath) {
+        restartTailProcess({
+          filePath: currentFilePath,
+          state,
+        });
+      }
+    }
+  }
+
+  function scheduleRefresh(): void {
+    if (stopped) {
+      return;
+    }
+    if (refreshInProgress) {
+      refreshAgain = true;
+      return;
+    }
+
+    refreshInProgress = true;
+    void refreshTailProcesses()
+      .catch((error) => {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        emitSystemLine({ text: `log refresh failed: ${message}` });
+      })
+      .finally(() => {
+        refreshInProgress = false;
+        if (refreshAgain) {
+          refreshAgain = false;
+          scheduleRefresh();
+        }
+      });
+  }
+
+  return {
+    processIds() {
+      return componentStates.flatMap((state) => {
+        const pid = state.tailProcess?.childProcess.pid;
+        return pid === undefined ? [] : [pid];
+      });
+    },
+    async start() {
+      stopped = false;
+      await mkdir(args.logDir, { recursive: true });
+      directoryWatcher = watch(args.logDir, () => {
+        scheduleRefresh();
+      });
+      pollTimer = setInterval(
+        scheduleRefresh,
+        LOG_VIEWER_ROTATION_POLL_INTERVAL_MS,
+      );
+      await refreshTailProcesses();
+    },
+    stop() {
+      stopped = true;
+      directoryWatcher?.close();
+      directoryWatcher = null;
+      if (pollTimer !== null) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+      for (const state of componentStates) {
+        stopTailProcess({ state });
+      }
+    },
+  };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -446,12 +446,8 @@ async function loadLogViewerWindow(
     minHeight: 520,
     minWidth: 840,
     show: false,
-    title: "Server & Daemon Logs",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: {
-      x: 12,
-      y: 18,
-    },
+    title: "bb - Server & Daemon Logs",
+    titleBarStyle: "default",
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import {
   app,
   BrowserWindow,
+  clipboard,
   ipcMain,
   nativeImage,
   shell,
@@ -11,6 +12,7 @@ import {
 } from "electron";
 import { autoUpdater } from "electron-updater";
 import type { BbDesktopInfo } from "@bb/server-contract";
+import { z } from "zod";
 import {
   assertPathExists,
   resolveDesktopAssetPath,
@@ -64,6 +66,25 @@ import {
 } from "./desktop-update-ipc.js";
 import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
 import {
+  createLogTailer,
+  createLogLineBuffer,
+  createLogViewerViewUrl,
+  LOG_VIEWER_IPC_BATCH_INTERVAL_MS,
+  LOG_VIEWER_IPC_BATCH_LINE_LIMIT,
+  type LogLineBuffer,
+  type LogTailer,
+} from "./log-viewer.js";
+import {
+  LOG_VIEWER_APPEND_CHANNEL,
+  LOG_VIEWER_COPY_CHANNEL,
+  LOG_VIEWER_OPEN_LOGS_FOLDER_CHANNEL,
+  LOG_VIEWER_SNAPSHOT_CHANNEL,
+  LOG_VIEWER_VISIBLE_LINE_LIMIT,
+  type LogViewerLine,
+  type LogViewerCopyRequest,
+  type LogViewerOpenLogsFolderResult,
+} from "./log-viewer-contract.js";
+import {
   ATTACH_PROBE_TIMEOUT_MS,
   DEFAULT_BB_SERVER_URL,
   PROCESS_LOG_LINE_LIMIT,
@@ -103,6 +124,25 @@ interface StartOwnedRuntimeArgs {
   userDataPath: string;
 }
 
+interface AppendLogViewerLinesArgs {
+  lines: LogViewerLine[];
+}
+
+interface SendLogViewerSnapshotArgs {
+  browserWindow: BrowserWindow;
+  lines: LogViewerLine[];
+  logDir: string;
+}
+
+interface HandleCopyLogsArgs {
+  request: LogViewerCopyRequest;
+}
+
+interface LoadLogViewerWindowArgs {
+  logDir: string;
+  preloadPath: string;
+}
+
 type StartupRaceResult =
   | ProcessExitedStartupRaceResult
   | ServerProbeStartupRaceResult;
@@ -135,11 +175,22 @@ interface MergeDesktopUpdateInfoArgs {
   feedInfo: BbDesktopInfo | null;
 }
 
+const logViewerCopyRequestSchema = z
+  .object({
+    text: z.string(),
+  })
+  .strict();
+
 let desktopWindowFactory: DesktopWindowFactory | null = null;
 let desktopUpdateService: DesktopUpdateService | null = null;
 let desktopAutoUpdateService: DesktopAutoUpdateService | null = null;
 let currentRuntime: DesktopRuntime | null = null;
 let currentWindowUrl: string | null = null;
+let logViewerIpcHandlersInstalled = false;
+let logViewerLineBuffer: LogLineBuffer | null = null;
+let logViewerPreloadPath: string | null = null;
+let logViewerTailer: LogTailer | null = null;
+let logViewerWindow: BrowserWindow | null = null;
 let bbAppLoaded = false;
 let stoppingForQuit = false;
 let quitting = false;
@@ -292,6 +343,189 @@ function createDesktopPathContext(): DesktopPathContext {
   };
 }
 
+function shouldEnableServerDaemonLogsMenu(): boolean {
+  // Attached runtimes are owned by an external bb-app, so the desktop has no
+  // reliable server/daemon log lifecycle to tail.
+  return (
+    process.platform === "darwin" && currentRuntime?.ownership === "spawned"
+  );
+}
+
+function refreshApplicationMenu(): void {
+  installApplicationMenu({
+    createNewWindow() {
+      void createApplicationWindow({ stateKey: null });
+    },
+    openServerDaemonLogs() {
+      void openServerDaemonLogs();
+    },
+    serverDaemonLogsMenuEnabled: shouldEnableServerDaemonLogsMenu(),
+  });
+}
+
+function setCurrentRuntime(runtime: DesktopRuntime | null): void {
+  currentRuntime = runtime;
+  refreshApplicationMenu();
+  if (runtime?.ownership !== "spawned") {
+    closeServerDaemonLogsWindow();
+  }
+}
+
+function sendLogViewerSnapshot(args: SendLogViewerSnapshotArgs): void {
+  if (args.browserWindow.isDestroyed()) {
+    return;
+  }
+  args.browserWindow.webContents.send(LOG_VIEWER_SNAPSHOT_CHANNEL, {
+    lines: args.lines,
+    logDir: args.logDir,
+  });
+}
+
+function appendLogViewerLines(args: AppendLogViewerLinesArgs): void {
+  if (args.lines.length === 0) {
+    return;
+  }
+
+  logViewerLineBuffer?.append(args.lines);
+}
+
+function closeServerDaemonLogsWindow(): void {
+  logViewerTailer?.stop();
+  logViewerTailer = null;
+  logViewerLineBuffer?.stop();
+  logViewerLineBuffer = null;
+
+  const browserWindow = logViewerWindow;
+  logViewerWindow = null;
+  if (browserWindow !== null && !browserWindow.isDestroyed()) {
+    browserWindow.close();
+  }
+}
+
+function handleCopyLogs(args: HandleCopyLogsArgs): void {
+  const request = logViewerCopyRequestSchema.parse(args.request);
+  clipboard.writeText(request.text);
+}
+
+async function handleOpenLogsFolder(): Promise<LogViewerOpenLogsFolderResult> {
+  if (!shouldEnableServerDaemonLogsMenu()) {
+    throw new Error(
+      "Server and daemon logs are only available for owned runtimes",
+    );
+  }
+
+  const logDir = formatLogDirectory();
+  const errorMessage = await shell.openPath(logDir);
+  if (errorMessage.length > 0) {
+    throw new Error(errorMessage);
+  }
+  return { path: logDir };
+}
+
+function installLogViewerIpcHandlers(): void {
+  if (logViewerIpcHandlersInstalled) {
+    return;
+  }
+  logViewerIpcHandlersInstalled = true;
+  ipcMain.handle(
+    LOG_VIEWER_COPY_CHANNEL,
+    (_event, request: LogViewerCopyRequest) => {
+      handleCopyLogs({ request });
+    },
+  );
+  ipcMain.handle(LOG_VIEWER_OPEN_LOGS_FOLDER_CHANNEL, () =>
+    handleOpenLogsFolder(),
+  );
+}
+
+async function loadLogViewerWindow(
+  args: LoadLogViewerWindowArgs,
+): Promise<void> {
+  const browserWindow = new BrowserWindow({
+    height: 720,
+    minHeight: 520,
+    minWidth: 840,
+    show: false,
+    title: "Server & Daemon Logs",
+    titleBarStyle: "hiddenInset",
+    trafficLightPosition: {
+      x: 12,
+      y: 18,
+    },
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: args.preloadPath,
+      sandbox: true,
+    },
+    width: 1180,
+  });
+  const tailer = createLogTailer({
+    logDir: args.logDir,
+    onLines(lines) {
+      appendLogViewerLines({ lines });
+    },
+  });
+  const lineBuffer = createLogLineBuffer({
+    flushIntervalMs: LOG_VIEWER_IPC_BATCH_INTERVAL_MS,
+    flushLineCount: LOG_VIEWER_IPC_BATCH_LINE_LIMIT,
+    maxLines: LOG_VIEWER_VISIBLE_LINE_LIMIT,
+    onFlush(lines) {
+      if (logViewerWindow === null || logViewerWindow.isDestroyed()) {
+        return;
+      }
+      logViewerWindow.webContents.send(LOG_VIEWER_APPEND_CHANNEL, {
+        lines,
+      });
+    },
+  });
+
+  logViewerLineBuffer = lineBuffer;
+  logViewerTailer = tailer;
+  logViewerWindow = browserWindow;
+
+  browserWindow.once("ready-to-show", () => {
+    browserWindow.show();
+  });
+  browserWindow.on("closed", () => {
+    if (logViewerTailer === tailer) {
+      logViewerTailer = null;
+      tailer.stop();
+    }
+    if (logViewerWindow === browserWindow) {
+      logViewerWindow = null;
+    }
+    if (logViewerLineBuffer === lineBuffer) {
+      logViewerLineBuffer = null;
+    }
+    lineBuffer.stop();
+  });
+
+  await browserWindow.loadURL(createLogViewerViewUrl({ logDir: args.logDir }));
+  sendLogViewerSnapshot({
+    browserWindow,
+    lines: lineBuffer.lines(),
+    logDir: args.logDir,
+  });
+  await tailer.start();
+}
+
+async function openServerDaemonLogs(): Promise<void> {
+  if (!shouldEnableServerDaemonLogsMenu() || logViewerPreloadPath === null) {
+    return;
+  }
+
+  if (logViewerWindow !== null && !logViewerWindow.isDestroyed()) {
+    logViewerWindow.focus();
+    return;
+  }
+
+  await loadLogViewerWindow({
+    logDir: formatLogDirectory(),
+    preloadPath: logViewerPreloadPath,
+  });
+}
+
 async function loadWindowUrl(args: LoadWindowUrlArgs): Promise<void> {
   currentWindowUrl = args.url;
   if (desktopWindowFactory === null) {
@@ -360,11 +594,11 @@ async function createApplicationWindow(
 async function stopOwnedRuntime(): Promise<void> {
   const runtime = currentRuntime;
   if (runtime === null || runtime.ownership !== "spawned") {
-    currentRuntime = null;
+    setCurrentRuntime(null);
     return;
   }
 
-  currentRuntime = null;
+  setCurrentRuntime(null);
   try {
     await runtime.bbProcess?.stop({
       killSignal: "SIGKILL",
@@ -446,13 +680,14 @@ async function startOwnedRuntime(
     serverUrl: args.serverUrl,
     userDataPath: args.userDataPath,
   });
-  currentRuntime = runtime;
+  setCurrentRuntime(runtime);
 
   void bbProcess.exit.then((exit) => {
     void clearOwnedRuntimePidFile({ userDataPath: args.userDataPath });
     if (quitting || currentRuntime !== runtime) {
       return;
     }
+    setCurrentRuntime(null);
     void loadStartupError({
       details: `The Electron-owned bb-app process stopped with ${formatExitResult(
         exit,
@@ -485,7 +720,7 @@ async function startOwnedRuntime(
       logs: bbProcess.logs.text(),
       title: "Could not start bb",
     });
-    currentRuntime = null;
+    setCurrentRuntime(null);
     return null;
   }
 
@@ -518,13 +753,14 @@ async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
   });
 
   if (existingProbe.kind === "compatible") {
-    currentRuntime = {
+    setCurrentRuntime({
       bbProcess: null,
       ownership: "attached",
       serverUrl: existingProbe.serverUrl,
       userDataPath: null,
-    };
+    });
     await loadBbApp(existingProbe.serverUrl);
+    refreshApplicationMenu();
     return;
   }
 
@@ -544,6 +780,7 @@ async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
   });
   if (runtime !== null) {
     await loadBbApp(runtime.serverUrl);
+    refreshApplicationMenu();
   }
 }
 
@@ -606,6 +843,11 @@ async function runDesktopApp(): Promise<void> {
     paths,
   });
   const bridgePath = resolveDesktopBridgePath({ paths });
+  const resolvedLogViewerPreloadPath = join(
+    paths.appPath,
+    "dist",
+    "log-viewer-preload.cjs",
+  );
   const preloadPath = join(paths.appPath, "dist", "preload.cjs");
   const serverUrl = resolveDesktopServerUrl({ env: process.env });
   const desktopVersion = getDesktopVersion(process.env.BB_DESKTOP_VERSION);
@@ -615,6 +857,10 @@ async function runDesktopApp(): Promise<void> {
   const userDataPath = app.getPath("userData");
 
   assertPathExists({ label: "bb-app bridge", path: bridgePath });
+  assertPathExists({
+    label: "log viewer preload script",
+    path: resolvedLogViewerPreloadPath,
+  });
   assertPathExists({ label: "preload script", path: preloadPath });
   assertPathExists({ label: "app icon", path: iconPath });
 
@@ -675,12 +921,10 @@ async function runDesktopApp(): Promise<void> {
     preloadPath,
     userDataPath,
   });
+  logViewerPreloadPath = resolvedLogViewerPreloadPath;
+  installLogViewerIpcHandlers();
 
-  installApplicationMenu({
-    createNewWindow() {
-      void createApplicationWindow({ stateKey: null });
-    },
-  });
+  refreshApplicationMenu();
   await loadLoadingView();
   await desktopWindowFactory.restoreSavedWindows({
     initialUrl: currentWindowUrl,

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -1,11 +1,32 @@
 import { app, Menu, type MenuItemConstructorOptions } from "electron";
 
+export const SERVER_DAEMON_LOGS_MENU_LABEL = "Server & Daemon Logs";
+
 export interface InstallApplicationMenuArgs {
   createNewWindow(): void;
+  openServerDaemonLogs(): void;
+  serverDaemonLogsMenuEnabled: boolean;
 }
 
-export function installApplicationMenu(args: InstallApplicationMenuArgs): void {
-  const template: MenuItemConstructorOptions[] = [
+function createServerDaemonLogsMenuItems(
+  args: InstallApplicationMenuArgs,
+): MenuItemConstructorOptions[] {
+  return [
+    { type: "separator" },
+    {
+      enabled: args.serverDaemonLogsMenuEnabled,
+      label: SERVER_DAEMON_LOGS_MENU_LABEL,
+      click() {
+        args.openServerDaemonLogs();
+      },
+    },
+  ];
+}
+
+export function buildApplicationMenuTemplate(
+  args: InstallApplicationMenuArgs,
+): MenuItemConstructorOptions[] {
+  return [
     {
       label: app.name,
       submenu: [
@@ -55,6 +76,7 @@ export function installApplicationMenu(args: InstallApplicationMenuArgs): void {
         { role: "resetZoom" },
         { role: "zoomIn" },
         { role: "zoomOut" },
+        ...createServerDaemonLogsMenuItems(args),
       ],
     },
     {
@@ -67,6 +89,10 @@ export function installApplicationMenu(args: InstallApplicationMenuArgs): void {
       ],
     },
   ];
+}
 
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+export function installApplicationMenu(args: InstallApplicationMenuArgs): void {
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate(buildApplicationMenuTemplate(args)),
+  );
 }

--- a/apps/desktop/src/server-probe.ts
+++ b/apps/desktop/src/server-probe.ts
@@ -14,15 +14,6 @@ const systemConfigResponseSchema = z
   })
   .passthrough();
 
-const semverPattern =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
-
-const systemVersionResponseSchema = z
-  .object({
-    currentVersion: z.string().regex(semverPattern),
-  })
-  .passthrough();
-
 export type ServerProbeResult =
   | CompatibleServerProbeResult
   | IncompatibleServerProbeResult
@@ -199,20 +190,6 @@ export async function probeBbServer(
     return {
       kind: "incompatible",
       reason: `/api/v1/system/config returned ${formatFetchFailure(configResult)}`,
-      serverUrl: args.serverUrl,
-    };
-  }
-
-  const versionResult = await fetchJson({
-    schema: systemVersionResponseSchema,
-    timeoutMs: args.timeoutMs,
-    url: endpointUrl(args.serverUrl, "/api/v1/system/version"),
-  });
-
-  if (versionResult.kind !== "success") {
-    return {
-      kind: "incompatible",
-      reason: `/api/v1/system/version returned ${formatFetchFailure(versionResult)}`,
       serverUrl: args.serverUrl,
     };
   }

--- a/apps/desktop/test/electron-builder-config.test.ts
+++ b/apps/desktop/test/electron-builder-config.test.ts
@@ -1,6 +1,16 @@
 import { spawn } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
 import { z } from "zod";
 import { describe, expect, it } from "vitest";
 import { DESKTOP_AUTO_UPDATE_FEED_CONFIG } from "../src/desktop-update-provider.js";
@@ -20,6 +30,7 @@ const macConfigSchema = z
 
 const electronBuilderConfigSchema = z
   .object({
+    afterPack: z.string().min(1),
     asarUnpack: z.array(z.string().min(1)),
     dmg: z
       .object({
@@ -75,6 +86,7 @@ type RunConfigScript = (
 type ReadResolvedConfig = (
   overrides: EnvironmentOverrides,
 ) => Promise<ReadResolvedConfigResult>;
+type RunNativePrepScript = (appOutDir: string) => Promise<ScriptRunResult>;
 
 const createScriptEnvironment: CreateScriptEnvironment = (overrides) => {
   const env = { ...process.env };
@@ -101,6 +113,35 @@ const runConfigScript: RunConfigScript = async (overrides) => {
     {
       cwd: desktopPackageRoot,
       env: createScriptEnvironment(overrides),
+    },
+  );
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  child.stdout.on("data", (chunk) => {
+    stdoutChunks.push(String(chunk));
+  });
+  child.stderr.on("data", (chunk) => {
+    stderrChunks.push(String(chunk));
+  });
+
+  const exitCode = await new Promise<number | null>((resolveExitCode) => {
+    child.on("close", resolveExitCode);
+  });
+
+  return {
+    exitCode,
+    stderr: stderrChunks.join(""),
+    stdout: stdoutChunks.join(""),
+  };
+};
+
+const runNativePrepScript: RunNativePrepScript = async (appOutDir) => {
+  const child = spawn(
+    process.execPath,
+    ["scripts/prepare-native-modules.cjs", appOutDir],
+    {
+      cwd: desktopPackageRoot,
     },
   );
   const stdoutChunks: string[] = [];
@@ -156,6 +197,77 @@ describe("electron-builder signing config", () => {
 
     expect(config.asarUnpack).toContain("dist/bb-app-bridge.mjs");
     expect(config.asarUnpack).not.toContain("dist/bb-app-bridge.js");
+  });
+
+  it("runs a native module preparation hook after packaging", async () => {
+    const configText = await readFile(
+      resolve(desktopPackageRoot, "electron-builder.config.json"),
+      "utf8",
+    );
+    const config = electronBuilderConfigSchema.parse(JSON.parse(configText));
+    const hookPath = "scripts/prepare-native-modules.cjs";
+
+    expect(config.afterPack).toBe(hookPath);
+    await expect(
+      access(resolve(desktopPackageRoot, hookPath)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("patches packaged node-pty helper path handling", async () => {
+    const appOutDir = await mkdtemp(
+      resolve(tmpdir(), "bb-desktop-native-modules-"),
+    );
+    const nodePtyPackageDir = resolve(
+      appOutDir,
+      "bb.app",
+      "Contents",
+      "Resources",
+      "app.asar.unpacked",
+      "node_modules",
+      "node-pty",
+    );
+    const rebuiltNativeDir = resolve(nodePtyPackageDir, "build", "Release");
+    const unixTerminalPath = resolve(
+      nodePtyPackageDir,
+      "lib",
+      "unixTerminal.js",
+    );
+    const helperPath = resolve(
+      nodePtyPackageDir,
+      "prebuilds",
+      "darwin-arm64",
+      "spawn-helper",
+    );
+    const rebuiltHelperPath = resolve(rebuiltNativeDir, "spawn-helper");
+
+    try {
+      await mkdir(rebuiltNativeDir, { recursive: true });
+      await writeFile(resolve(rebuiltNativeDir, "pty.node"), "rebuilt");
+      await writeFile(rebuiltHelperPath, "rebuilt-helper");
+      await chmod(rebuiltHelperPath, 0o644);
+      await mkdir(dirname(unixTerminalPath), { recursive: true });
+      await writeFile(
+        unixTerminalPath,
+        "helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+      );
+      await mkdir(dirname(helperPath), { recursive: true });
+      await writeFile(helperPath, "helper");
+      await chmod(helperPath, 0o644);
+
+      const result = await runNativePrepScript(appOutDir);
+
+      expect(result.exitCode).toBe(0);
+      await expect(
+        access(resolve(rebuiltNativeDir, "pty.node")),
+      ).resolves.toBeUndefined();
+      await expect(readFile(unixTerminalPath, "utf8")).resolves.toContain(
+        "helperPath.replace(/app\\.asar(?!\\.unpacked)/g, 'app.asar.unpacked')",
+      );
+      expect((await stat(helperPath)).mode & 0o777).toBe(0o755);
+      expect((await stat(rebuiltHelperPath)).mode & 0o777).toBe(0o755);
+    } finally {
+      await rm(appOutDir, { force: true, recursive: true });
+    }
   });
 
   it("points mac signing entitlements at checked-in plist files", async () => {

--- a/apps/desktop/test/local-view.test.ts
+++ b/apps/desktop/test/local-view.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLocalViewUrl,
+  type LocalViewModel,
+} from "../src/local-view.js";
+
+interface DecodeLocalViewHtmlArgs {
+  viewModel: LocalViewModel;
+}
+
+interface LocalViewTestCase {
+  label: string;
+  viewModel: LocalViewModel;
+}
+
+const LOCAL_VIEW_URL_PREFIX = "data:text/html;charset=utf-8,";
+
+const localViewTestCases: LocalViewTestCase[] = [
+  {
+    label: "loading",
+    viewModel: {
+      kind: "loading",
+      message: "Starting local services.",
+      title: "Opening bb",
+    },
+  },
+  {
+    label: "error",
+    viewModel: {
+      details: "The local service failed to start.",
+      kind: "error",
+      logText: "Failed to bind port",
+      title: "Could not open bb",
+    },
+  },
+];
+
+function decodeLocalViewHtml(args: DecodeLocalViewHtmlArgs): string {
+  const url = createLocalViewUrl({ viewModel: args.viewModel });
+
+  expect(url.startsWith(LOCAL_VIEW_URL_PREFIX)).toBe(true);
+
+  return decodeURIComponent(url.slice(LOCAL_VIEW_URL_PREFIX.length));
+}
+
+describe("local desktop views", () => {
+  it.each(localViewTestCases)(
+    "renders an invisible window drag region for the $label view",
+    (testCase) => {
+      const html = decodeLocalViewHtml({ viewModel: testCase.viewModel });
+
+      expect(html).toContain(
+        '<div class="titlebar-drag-region" data-testid="bb-local-view-window-drag-region" aria-hidden="true"></div>',
+      );
+      expect(html).toMatch(
+        /\.titlebar-drag-region\s+\{[\s\S]*app-region: drag;[\s\S]*-webkit-app-region: drag;[\s\S]*background: transparent;[\s\S]*border: 0;[\s\S]*height: 28px;/u,
+      );
+      expect(html).toMatch(
+        /button,\s+a,\s+input,\s+textarea,\s+select,\s+summary,\s+pre\s+\{[\s\S]*app-region: no-drag;[\s\S]*-webkit-app-region: no-drag;/u,
+      );
+    },
+  );
+});

--- a/apps/desktop/test/log-viewer.test.ts
+++ b/apps/desktop/test/log-viewer.test.ts
@@ -1,0 +1,230 @@
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLogLineBuffer,
+  createLogTailer,
+  resolveCurrentLogFile,
+  type LogTailer,
+} from "../src/log-viewer.js";
+import type { LogViewerLine } from "../src/log-viewer-contract.js";
+
+interface TempDir {
+  path: string;
+}
+
+interface WaitForArgs {
+  predicate(): boolean;
+  timeoutMs?: number;
+}
+
+interface CreateTestLogLineArgs {
+  index: number;
+}
+
+const tempDirs: TempDir[] = [];
+const tailers: LogTailer[] = [];
+
+async function createTempDir(): Promise<TempDir> {
+  const path = await mkdtemp(join(tmpdir(), "bb-desktop-log-viewer-"));
+  const tempDir = { path };
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(async () => {
+  while (tailers.length > 0) {
+    tailers.pop()?.stop();
+  }
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir !== undefined) {
+      await rm(tempDir.path, { force: true, recursive: true });
+    }
+  }
+});
+
+async function waitFor(args: WaitForArgs): Promise<void> {
+  const timeoutMs = args.timeoutMs ?? 5_000;
+  const startedAt = Date.now();
+  while (!args.predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolvePromise) => {
+      setTimeout(resolvePromise, 25);
+    });
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createTestLogLine(args: CreateTestLogLineArgs): LogViewerLine {
+  return {
+    source: "server",
+    text: `line-${args.index}`,
+  };
+}
+
+describe("log viewer", () => {
+  it("selects the newest matching server log file", async () => {
+    const tempDir = await createTempDir();
+    const firstServerLog = join(tempDir.path, "server.1.log");
+    const nextServerLog = join(tempDir.path, "server.2.log");
+    await writeFile(firstServerLog, "older\n");
+    await new Promise((resolvePromise) => {
+      setTimeout(resolvePromise, 10);
+    });
+    await writeFile(nextServerLog, "newer\n");
+    await writeFile(join(tempDir.path, "host-daemon.9.log"), "ignored\n");
+
+    await expect(
+      resolveCurrentLogFile({
+        component: "server",
+        logDir: tempDir.path,
+      }),
+    ).resolves.toBe(nextServerLog);
+  });
+
+  it("returns null when no matching component log exists", async () => {
+    const tempDir = await createTempDir();
+    await writeFile(join(tempDir.path, "host-daemon.1.log"), "daemon\n");
+
+    await expect(
+      resolveCurrentLogFile({
+        component: "server",
+        logDir: tempDir.path,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("streams appended log lines from the active server log", async () => {
+    const tempDir = await createTempDir();
+    const lines: LogViewerLine[] = [];
+    await writeFile(join(tempDir.path, "server.1.log"), "");
+    const tailer = createLogTailer({
+      logDir: tempDir.path,
+      onLines(newLines) {
+        lines.push(...newLines);
+      },
+    });
+    tailers.push(tailer);
+    await tailer.start();
+
+    await appendFile(join(tempDir.path, "server.1.log"), "streamed\n");
+
+    await waitFor({
+      predicate() {
+        return lines.some((line) => line.text.includes("streamed"));
+      },
+    });
+    expect(lines.some((line) => line.text === "[server] streamed")).toBe(true);
+  });
+
+  it("follows a newer rotated server log file", async () => {
+    const tempDir = await createTempDir();
+    const lines: LogViewerLine[] = [];
+    await writeFile(join(tempDir.path, "server.1.log"), "first\n");
+    const tailer = createLogTailer({
+      logDir: tempDir.path,
+      onLines(newLines) {
+        lines.push(...newLines);
+      },
+    });
+    tailers.push(tailer);
+    await tailer.start();
+    await waitFor({
+      predicate() {
+        return lines.some((line) => line.text === "[server] first");
+      },
+    });
+
+    await new Promise((resolvePromise) => {
+      setTimeout(resolvePromise, 25);
+    });
+    await writeFile(join(tempDir.path, "server.2.log"), "second\n");
+
+    await waitFor({
+      predicate() {
+        return lines.some((line) => line.text === "[server] second");
+      },
+    });
+  });
+
+  it("kills tail child processes when stopped", async () => {
+    const tempDir = await createTempDir();
+    await writeFile(join(tempDir.path, "server.1.log"), "");
+    await writeFile(join(tempDir.path, "host-daemon.1.log"), "");
+    const tailer = createLogTailer({
+      logDir: tempDir.path,
+      onLines() {},
+    });
+    tailers.push(tailer);
+    await tailer.start();
+
+    const processIds = tailer.processIds();
+    expect(processIds).toHaveLength(2);
+    expect(processIds.every(isProcessRunning)).toBe(true);
+
+    tailer.stop();
+    await waitFor({
+      predicate() {
+        return processIds.every((pid) => !isProcessRunning(pid));
+      },
+    });
+  });
+
+  it("caps the in-memory line buffer to the configured line limit", () => {
+    const buffer = createLogLineBuffer({
+      flushIntervalMs: 1_000,
+      flushLineCount: 20_000,
+      maxLines: 10_000,
+      onFlush() {},
+    });
+    const lines = Array.from({ length: 11_000 }, (_value, index) =>
+      createTestLogLine({ index }),
+    );
+
+    buffer.append(lines);
+
+    const bufferedLines = buffer.lines();
+    expect(bufferedLines).toHaveLength(10_000);
+    expect(bufferedLines[0]?.text).toBe("line-1000");
+    expect(bufferedLines[9_999]?.text).toBe("line-10999");
+    buffer.stop();
+  });
+
+  it("batches appended lines before flushing to the renderer", async () => {
+    const flushedBatches: LogViewerLine[][] = [];
+    const buffer = createLogLineBuffer({
+      flushIntervalMs: 25,
+      flushLineCount: 10,
+      maxLines: 100,
+      onFlush(lines) {
+        flushedBatches.push(lines);
+      },
+    });
+
+    buffer.append([createTestLogLine({ index: 1 })]);
+    buffer.append([createTestLogLine({ index: 2 })]);
+
+    await waitFor({
+      predicate() {
+        return flushedBatches.length === 1;
+      },
+    });
+    expect(flushedBatches[0]?.map((line) => line.text)).toEqual([
+      "line-1",
+      "line-2",
+    ]);
+    buffer.stop();
+  });
+});

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -1,0 +1,77 @@
+import type { MenuItemConstructorOptions } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SERVER_DAEMON_LOGS_MENU_LABEL,
+  buildApplicationMenuTemplate,
+} from "../src/menu.js";
+
+vi.mock("electron", () => ({
+  app: {
+    name: "bb",
+  },
+  Menu: {
+    buildFromTemplate(template: MenuItemConstructorOptions[]) {
+      return template;
+    },
+    setApplicationMenu() {},
+  },
+}));
+
+interface FindSubmenuItemArgs {
+  itemLabel: string;
+  parentLabel: string;
+  template: MenuItemConstructorOptions[];
+}
+
+function findSubmenuItem(
+  args: FindSubmenuItemArgs,
+): MenuItemConstructorOptions | null {
+  const parentItem = args.template.find(
+    (templateItem) => templateItem.label === args.parentLabel,
+  );
+  if (parentItem === undefined || !Array.isArray(parentItem.submenu)) {
+    return null;
+  }
+
+  return (
+    parentItem.submenu.find(
+      (submenuItem) => submenuItem.label === args.itemLabel,
+    ) ?? null
+  );
+}
+
+describe("application menu", () => {
+  it("shows an enabled server and daemon logs item for owned runtimes", () => {
+    const template = buildApplicationMenuTemplate({
+      createNewWindow() {},
+      openServerDaemonLogs() {},
+      serverDaemonLogsMenuEnabled: true,
+    });
+
+    const menuItem = findSubmenuItem({
+      itemLabel: SERVER_DAEMON_LOGS_MENU_LABEL,
+      parentLabel: "View",
+      template,
+    });
+
+    expect(menuItem).not.toBeNull();
+    expect(menuItem?.enabled).toBe(true);
+  });
+
+  it("shows a disabled server and daemon logs item for attached runtimes", () => {
+    const template = buildApplicationMenuTemplate({
+      createNewWindow() {},
+      openServerDaemonLogs() {},
+      serverDaemonLogsMenuEnabled: false,
+    });
+
+    const menuItem = findSubmenuItem({
+      itemLabel: SERVER_DAEMON_LOGS_MENU_LABEL,
+      parentLabel: "View",
+      template,
+    });
+
+    expect(menuItem).not.toBeNull();
+    expect(menuItem?.enabled).toBe(false);
+  });
+});

--- a/apps/desktop/test/server-probe.test.ts
+++ b/apps/desktop/test/server-probe.test.ts
@@ -84,17 +84,6 @@ describe("probeBbServer", () => {
           );
           return;
         }
-        if (request.url === "/api/v1/system/version") {
-          writeJson(
-            response,
-            200,
-            JSON.stringify({
-              currentVersion: "0.0.6",
-              isDevelopment: false,
-            }),
-          );
-          return;
-        }
         writeJson(response, 404, JSON.stringify({ message: "not found" }));
       },
     });
@@ -126,7 +115,7 @@ describe("probeBbServer", () => {
     expect(result.kind).toBe("incompatible");
   });
 
-  it("rejects a service without a semver bb version as incompatible", async () => {
+  it("does not depend on the production version endpoint for startup compatibility", async () => {
     const testServer = await startTestServer({
       handler(request, response) {
         if (request.url === "/health") {
@@ -146,25 +135,18 @@ describe("probeBbServer", () => {
           return;
         }
         if (request.url === "/api/v1/system/version") {
-          writeJson(
-            response,
-            200,
-            JSON.stringify({
-              currentVersion: "not-bb-semver",
-            }),
-          );
           return;
         }
         writeJson(response, 404, JSON.stringify({ message: "not found" }));
       },
     });
 
-    const result = await probeBbServer({
+    await expect(
+      probeBbServer({ serverUrl: testServer.url, timeoutMs: 50 }),
+    ).resolves.toEqual({
+      kind: "compatible",
       serverUrl: testServer.url,
-      timeoutMs: 500,
     });
-
-    expect(result.kind).toBe("incompatible");
   });
 
   it("reports unavailable when nothing is listening", async () => {

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -6,8 +6,11 @@ import type { HostDaemonDaemonWsMessage } from "@bb/host-daemon-contract";
 import type { HostWorkspace } from "@bb/host-workspace";
 import { makeWorkspaceMergeBase, makeWorkspaceStatus } from "@bb/test-helpers";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HostDaemonLogger } from "../logger.js";
 import { RuntimeManager } from "../runtime-manager.js";
 import {
+  ensureNodePtySpawnHelpersExecutableInPackage,
+  resolveNodePtySpawnHelperPaths,
   TerminalManager,
   type SpawnTerminalPtyArgs,
   type TerminalPtyAdapter,
@@ -48,6 +51,20 @@ async function makeTempDir(prefix: string): Promise<string> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   tempDirs.push(tempDir);
   return tempDir;
+}
+
+async function writeEmptyFile(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, "");
+}
+
+function createFakeLogger(): HostDaemonLogger {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
 }
 
 async function cleanupTempDirs(): Promise<void> {
@@ -212,12 +229,7 @@ function createHarness(): TerminalManagerHarness {
     },
   });
   const manager = new TerminalManager({
-    logger: {
-      debug: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-    },
+    logger: createFakeLogger(),
     ptyAdapter: adapter,
     resolveShell: async () => "/bin/zsh",
     runtimeManager,
@@ -342,6 +354,132 @@ describe("TerminalManager", () => {
     expect(env?.BB_DATA_DIR).toBeUndefined();
     expect(env?.BB_HOST_DAEMON_PORT).toBeUndefined();
     expect(env?.NODE_ENV).toBeUndefined();
+  });
+
+  it("makes every available node-pty spawn-helper executable", async () => {
+    const logger = createFakeLogger();
+    const packageDirectory = await makeTempDir("bb-node-pty-package-");
+    const buildNativePath = path.join(
+      packageDirectory,
+      "build",
+      "Release",
+      "pty.node",
+    );
+    const buildHelperPath = path.join(
+      packageDirectory,
+      "build",
+      "Release",
+      "spawn-helper",
+    );
+    const prebuildHelperPath = path.join(
+      packageDirectory,
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+      "spawn-helper",
+    );
+    await writeEmptyFile(buildNativePath);
+    await writeEmptyFile(buildHelperPath);
+    await fs.chmod(buildHelperPath, 0o644);
+    await writeEmptyFile(
+      path.join(
+        packageDirectory,
+        "prebuilds",
+        `${process.platform}-${process.arch}`,
+        "pty.node",
+      ),
+    );
+    await writeEmptyFile(prebuildHelperPath);
+    await fs.chmod(prebuildHelperPath, 0o644);
+
+    expect(resolveNodePtySpawnHelperPaths({ packageDirectory })).toEqual([
+      buildHelperPath,
+      prebuildHelperPath,
+    ]);
+
+    ensureNodePtySpawnHelpersExecutableInPackage({
+      logger,
+      packageDirectory,
+    });
+
+    const buildHelperMode = (await fs.stat(buildHelperPath)).mode;
+    const prebuildHelperMode = (await fs.stat(prebuildHelperPath)).mode;
+    expect(buildHelperMode & 0o111).not.toBe(0);
+    expect(prebuildHelperMode & 0o111).not.toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("makes an available prebuild-only node-pty spawn-helper executable", async () => {
+    const logger = createFakeLogger();
+    const packageDirectory = await makeTempDir("bb-node-pty-package-");
+    const prebuildHelperPath = path.join(
+      packageDirectory,
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+      "spawn-helper",
+    );
+    await writeEmptyFile(
+      path.join(
+        packageDirectory,
+        "prebuilds",
+        `${process.platform}-${process.arch}`,
+        "pty.node",
+      ),
+    );
+    await writeEmptyFile(prebuildHelperPath);
+    await fs.chmod(prebuildHelperPath, 0o644);
+
+    expect(resolveNodePtySpawnHelperPaths({ packageDirectory })).toEqual([
+      prebuildHelperPath,
+    ]);
+
+    ensureNodePtySpawnHelpersExecutableInPackage({
+      logger,
+      packageDirectory,
+    });
+
+    const prebuildHelperMode = (await fs.stat(prebuildHelperPath)).mode;
+    expect(prebuildHelperMode & 0o111).not.toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs and skips when no node-pty spawn-helper is present", async () => {
+    const logger = createFakeLogger();
+    const packageDirectory = await makeTempDir("bb-node-pty-package-");
+    const buildHelperPath = path.join(
+      packageDirectory,
+      "build",
+      "Release",
+      "spawn-helper",
+    );
+    const prebuildHelperPath = path.join(
+      packageDirectory,
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+      "spawn-helper",
+    );
+    await writeEmptyFile(
+      path.join(packageDirectory, "build", "Release", "pty.node"),
+    );
+    await writeEmptyFile(
+      path.join(
+        packageDirectory,
+        "prebuilds",
+        `${process.platform}-${process.arch}`,
+        "pty.node",
+      ),
+    );
+
+    expect(() =>
+      ensureNodePtySpawnHelpersExecutableInPackage({
+        logger,
+        packageDirectory,
+      }),
+    ).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith({
+      component: "terminal-manager",
+      msg: "no node-pty spawn-helper found at known paths",
+      searched: expect.arrayContaining([buildHelperPath, prebuildHelperPath]),
+    });
   });
 
   it("forwards output and replays scrollback on attach", async () => {

--- a/apps/host-daemon/src/terminals/terminal-manager.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.ts
@@ -1,4 +1,4 @@
-import { chmodSync, constants, existsSync } from "node:fs";
+import { accessSync, chmodSync, constants, existsSync } from "node:fs";
 import { access } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -14,6 +14,14 @@ import { runtimeErrorLogFields } from "../error-utils.js";
 const DEFAULT_SCROLLBACK_MAX_BYTES = 4 * 1024 * 1024;
 const DEFAULT_SCROLLBACK_MAX_CHUNKS = 10_000;
 const MAX_OUTPUT_CHUNK_BYTES = 64 * 1024;
+const NODE_PTY_NATIVE_DIRS: readonly string[] = [
+  path.join("build", "Release"),
+  path.join("build", "Debug"),
+  path.join("prebuilds", `${process.platform}-${process.arch}`),
+];
+const NODE_PTY_NATIVE_RELATIVE_ROOTS: readonly string[] = ["..", "."];
+const NODE_PTY_SPAWN_HELPER_MISSING_MESSAGE =
+  "no node-pty spawn-helper found at known paths";
 const requireForNodePty = createRequire(import.meta.url);
 let nodePtySpawnHelperChecked = false;
 
@@ -38,6 +46,7 @@ export interface SpawnTerminalPtyArgs {
   cwd: string;
   env: NodeJS.ProcessEnv;
   file: string;
+  logger: HostDaemonLogger;
   rows: number;
 }
 
@@ -118,7 +127,7 @@ interface FinishTerminalSessionArgs {
 
 export const nodePtyAdapter: TerminalPtyAdapter = {
   spawn(args) {
-    ensureNodePtySpawnHelperExecutable();
+    ensureNodePtySpawnHelperExecutable(args.logger);
     const pty = spawnPty(args.file, [], {
       cols: args.cols,
       cwd: args.cwd,
@@ -141,22 +150,91 @@ export const nodePtyAdapter: TerminalPtyAdapter = {
   },
 };
 
-function ensureNodePtySpawnHelperExecutable(): void {
+interface ResolveNodePtySpawnHelperPathArgs {
+  packageDirectory: string;
+}
+
+interface EnsureNodePtySpawnHelperExecutableInPackageArgs {
+  logger: HostDaemonLogger;
+  packageDirectory: string;
+}
+
+type NodePtySpawnHelperPathList = string[];
+
+export function resolveNodePtySpawnHelperCandidatePaths(
+  args: ResolveNodePtySpawnHelperPathArgs,
+): NodePtySpawnHelperPathList {
+  const helperPaths: string[] = [];
+  for (const nativeDir of NODE_PTY_NATIVE_DIRS) {
+    for (const relativeRoot of NODE_PTY_NATIVE_RELATIVE_ROOTS) {
+      const nativeModuleDir = path.resolve(
+        args.packageDirectory,
+        "lib",
+        relativeRoot,
+        nativeDir,
+      );
+      helperPaths.push(path.join(nativeModuleDir, "spawn-helper"));
+    }
+  }
+
+  return helperPaths;
+}
+
+export function resolveNodePtySpawnHelperPaths(
+  args: ResolveNodePtySpawnHelperPathArgs,
+): NodePtySpawnHelperPathList {
+  return resolveNodePtySpawnHelperCandidatePaths(args).filter((helperPath) =>
+    existsSync(helperPath),
+  );
+}
+
+function pathIsExecutableSync(filePath: string): boolean {
+  try {
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function ensureNodePtySpawnHelpersExecutableInPackage(
+  args: EnsureNodePtySpawnHelperExecutableInPackageArgs,
+): void {
+  const helperPaths = resolveNodePtySpawnHelperPaths({
+    packageDirectory: args.packageDirectory,
+  });
+  if (helperPaths.length === 0) {
+    args.logger.warn({
+      component: "terminal-manager",
+      msg: NODE_PTY_SPAWN_HELPER_MISSING_MESSAGE,
+      searched: resolveNodePtySpawnHelperCandidatePaths({
+        packageDirectory: args.packageDirectory,
+      }),
+    });
+    return;
+  }
+
+  for (const helperPath of helperPaths) {
+    if (!pathIsExecutableSync(helperPath)) {
+      chmodSync(helperPath, 0o755);
+    }
+    if (!pathIsExecutableSync(helperPath)) {
+      throw new Error(`node-pty spawn-helper is not executable: ${helperPath}`);
+    }
+  }
+}
+
+function ensureNodePtySpawnHelperExecutable(logger: HostDaemonLogger): void {
   if (nodePtySpawnHelperChecked || process.platform !== "darwin") {
     return;
   }
   nodePtySpawnHelperChecked = true;
 
   const packageJsonPath = requireForNodePty.resolve("node-pty/package.json");
-  const helperPath = path.join(
-    path.dirname(packageJsonPath),
-    "prebuilds",
-    `${process.platform}-${process.arch}`,
-    "spawn-helper",
-  );
-  if (existsSync(helperPath)) {
-    chmodSync(helperPath, 0o755);
-  }
+  ensureNodePtySpawnHelpersExecutableInPackage({
+    logger,
+    packageDirectory: path.dirname(packageJsonPath),
+  });
 }
 
 async function pathIsExecutable(filePath: string): Promise<boolean> {
@@ -326,6 +404,7 @@ export class TerminalManager {
           terminalId: message.terminalId,
         }),
         file: shell,
+        logger: this.options.logger,
         rows: message.rows,
       });
       const session: TerminalSession = {

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import type { HostDaemonCommand } from "@bb/host-daemon-contract";
+import type { Hono } from "hono";
+import mimeTypes from "mime-types";
+import { COMMAND_TIMEOUT_MS } from "../constants.js";
+import { ApiError } from "../errors.js";
+import type { AppDeps, LoggedWorkSessionDeps } from "../types.js";
+import { queueCommandAndWait } from "../services/hosts/command-wait.js";
+import {
+  createDaemonFileContentResponse,
+  type DaemonFileReadResult,
+  remapDaemonFileRouteError,
+} from "../services/hosts/daemon-file-response.js";
+import { requirePublicThreadEnvironment } from "../services/lib/entity-lookup.js";
+
+type HostReadFileCommand = Extract<
+  HostDaemonCommand,
+  { type: "host.read_file" }
+>;
+
+const FILES_RAW_PATH_QUERY_KEY = "path";
+const HTML_PREVIEW_MAX_BYTES = 5 * 1024 * 1024;
+const HTML_PREVIEW_CONTENT_TYPE = "text/html; charset=utf-8";
+const HTML_PREVIEW_CSP = "sandbox allow-scripts";
+const NO_STORE_CACHE_CONTROL = "no-store";
+const NOSNIFF_CONTENT_TYPE_OPTIONS = "nosniff";
+const HTML_MIME_TYPE = "text/html";
+
+function normalizeMimeType(value: string | null | undefined): string | null {
+  const normalizedValue = value?.split(";")[0]?.trim().toLowerCase();
+  return normalizedValue && normalizedValue.length > 0 ? normalizedValue : null;
+}
+
+function isHtmlMimeType(value: string | null | undefined): boolean {
+  return normalizeMimeType(value) === HTML_MIME_TYPE;
+}
+
+function createRawFilesystemPathInvalidError(): ApiError {
+  return new ApiError(400, "invalid_path", "Invalid file path", false);
+}
+
+function createRawFilesystemPathUnsupportedError(): ApiError {
+  return new ApiError(
+    415,
+    "unsupported_media_type",
+    "HTML preview only supports text/html files",
+    false,
+  );
+}
+
+function parseRawFilesystemPath(rawPath: string | undefined): string {
+  if (
+    rawPath === undefined ||
+    rawPath.length === 0 ||
+    rawPath.includes("\0") ||
+    !path.isAbsolute(rawPath)
+  ) {
+    throw createRawFilesystemPathInvalidError();
+  }
+  return path.resolve(rawPath);
+}
+
+function assertHtmlPreviewPath(filePath: string): void {
+  if (!isHtmlMimeType(mimeTypes.lookup(filePath) || null)) {
+    throw createRawFilesystemPathUnsupportedError();
+  }
+}
+
+function assertRawFilesystemHtmlPreviewResult(
+  result: DaemonFileReadResult,
+): void {
+  if (!isHtmlMimeType(result.mimeType) || result.contentEncoding !== "utf8") {
+    throw createRawFilesystemPathUnsupportedError();
+  }
+
+  if (result.sizeBytes > HTML_PREVIEW_MAX_BYTES) {
+    throw new ApiError(
+      413,
+      "file_too_large",
+      "HTML preview exceeds the 5 MB limit",
+      false,
+    );
+  }
+}
+
+function createRawFilesystemHtmlPreviewResponse(
+  result: DaemonFileReadResult,
+): Response {
+  assertRawFilesystemHtmlPreviewResult(result);
+  return createDaemonFileContentResponse(result, {
+    headers: {
+      "cache-control": NO_STORE_CACHE_CONTROL,
+      "content-security-policy": HTML_PREVIEW_CSP,
+      "content-type": HTML_PREVIEW_CONTENT_TYPE,
+      "x-content-type-options": NOSNIFF_CONTENT_TYPE_OPTIONS,
+    },
+  });
+}
+
+async function serveRawFilesystemHtmlFile(
+  deps: LoggedWorkSessionDeps,
+  threadId: string,
+  rawPath: string | undefined,
+): Promise<Response> {
+  const filePath = parseRawFilesystemPath(rawPath);
+  assertHtmlPreviewPath(filePath);
+  const { environment } = requirePublicThreadEnvironment(deps.db, threadId);
+  const command: HostReadFileCommand = {
+    type: "host.read_file",
+    path: filePath,
+  };
+
+  try {
+    const result = await queueCommandAndWait(deps, {
+      hostId: environment.hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command,
+    });
+    return createRawFilesystemHtmlPreviewResponse(result);
+  } catch (error) {
+    return remapDaemonFileRouteError(error);
+  }
+}
+
+export function registerFileRoutes(app: Hono, deps: AppDeps): void {
+  // Contract-private, not network-private: this endpoint is intentionally
+  // outside @bb/server-contract because it serves local user-authored HTML
+  // bytes for the desktop/dev app shell, scoped to the clicked thread's host.
+  // It must remain protected by bb's local-only deployment assumptions; do
+  // not expose /api/v1 on public HTTP without adding an auth boundary.
+  app.get("/threads/:id/files/raw", async (context) =>
+    serveRawFilesystemHtmlFile(
+      deps,
+      context.req.param("id"),
+      context.req.query(FILES_RAW_PATH_QUERY_KEY),
+    ),
+  );
+}

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -35,6 +35,7 @@ import { ApiError } from "../../errors.js";
 import {
   requireEnvironment,
   requirePublicThread,
+  requireReadyEnvironment,
 } from "../../services/lib/entity-lookup.js";
 import { queueCommandAndWait } from "../../services/hosts/command-wait.js";
 import {
@@ -159,14 +160,22 @@ interface StatusAssetPath {
   relativePath: string;
 }
 
+interface RawFileRoutePath {
+  relativePath: string;
+}
+
 const STATUS_DIRECTORY_NAME = "STATUS";
 const STATUS_INDEX_FILE_PATH = "index.html";
 const STATUS_HTML_FILE_PATH = "STATUS.html";
 const STATUS_MARKDOWN_FILE_PATH = "STATUS.md";
 const STATUS_ROUTE_SEGMENT = "/status/";
+const THREAD_STORAGE_FILE_ROUTE_SEGMENT = "/thread-storage/files/";
+const THREAD_WORKTREE_FILE_ROUTE_SEGMENT = "/worktree/files/";
 const STATUS_NO_STORE_CACHE_CONTROL = "no-store";
 const STATUS_HTML_CONTENT_TYPE = "text/html; charset=utf-8";
 const STATUS_CONTENT_TYPE_OPTIONS = "nosniff";
+const HTML_PREVIEW_MAX_BYTES = 5 * 1024 * 1024;
+const GENERIC_HTML_PREVIEW_CSP = "sandbox allow-scripts";
 const UNUSABLE_STATUS_SOURCE_ERROR_CODES = new Set([
   "EACCES",
   "ELOOP",
@@ -319,6 +328,43 @@ function parseStatusAssetPath(rawPath: string): StatusAssetPath {
   };
 }
 
+function createRawFileInvalidPathError(): ApiError {
+  return new ApiError(400, "invalid_path", "Invalid file path");
+}
+
+function decodeRawFileRoutePath(rawPath: string): string {
+  try {
+    return decodeURIComponent(rawPath);
+  } catch {
+    throw createRawFileInvalidPathError();
+  }
+}
+
+function parseRawFileRoutePath(rawPath: string): RawFileRoutePath {
+  const relativePath = decodeRawFileRoutePath(rawPath);
+  if (
+    relativePath.length === 0 ||
+    relativePath.includes("\0") ||
+    relativePath.includes("\\") ||
+    path.posix.isAbsolute(relativePath)
+  ) {
+    throw createRawFileInvalidPathError();
+  }
+
+  const segments = relativePath.split("/");
+  if (
+    segments.some(
+      (segment) => segment.length === 0 || segment === "." || segment === "..",
+    )
+  ) {
+    throw createRawFileInvalidPathError();
+  }
+
+  return {
+    relativePath: segments.join("/"),
+  };
+}
+
 function extractThreadStatusPath(requestUrl: string): string {
   const requestPath = new URL(requestUrl).pathname;
   const statusSegmentIndex = requestPath.indexOf(STATUS_ROUTE_SEGMENT);
@@ -326,6 +372,18 @@ function extractThreadStatusPath(requestUrl: string): string {
     return "";
   }
   return requestPath.slice(statusSegmentIndex + STATUS_ROUTE_SEGMENT.length);
+}
+
+function extractRawFileRoutePath(
+  requestUrl: string,
+  routeSegment: string,
+): string {
+  const requestPath = new URL(requestUrl).pathname;
+  const routeSegmentIndex = requestPath.indexOf(routeSegment);
+  if (routeSegmentIndex === -1) {
+    return "";
+  }
+  return requestPath.slice(routeSegmentIndex + routeSegment.length);
 }
 
 function shouldFallbackStatusRead(error: unknown): boolean {
@@ -500,6 +558,37 @@ function createStatusFileResponse(
       "x-content-type-options": STATUS_CONTENT_TYPE_OPTIONS,
     },
   });
+}
+
+function isHtmlPreviewPath(relativePath: string): boolean {
+  return relativePath.toLowerCase().endsWith(".html");
+}
+
+function assertHtmlPreviewSize(relativePath: string, sizeBytes: number): void {
+  if (isHtmlPreviewPath(relativePath) && sizeBytes > HTML_PREVIEW_MAX_BYTES) {
+    throw new ApiError(
+      413,
+      "file_too_large",
+      "HTML preview exceeds the 5 MB limit",
+      false,
+    );
+  }
+}
+
+function createRawFilePreviewResponse(
+  result: DaemonFileReadResult,
+  relativePath: string,
+): Response {
+  assertHtmlPreviewSize(relativePath, result.sizeBytes);
+  const headers = new Headers({
+    "cache-control": STATUS_NO_STORE_CACHE_CONTROL,
+    "x-content-type-options": STATUS_CONTENT_TYPE_OPTIONS,
+  });
+  if (isHtmlPreviewPath(relativePath)) {
+    headers.set("content-security-policy", GENERIC_HTML_PREVIEW_CSP);
+    headers.set("content-type", STATUS_HTML_CONTENT_TYPE);
+  }
+  return createDaemonFileContentResponse(result, { headers });
 }
 
 function decodeDaemonTextFile(result: DaemonFileReadResult): string {
@@ -846,6 +935,58 @@ async function serveThreadStatusAsset(
   }
 }
 
+async function serveThreadStorageRawFile(
+  deps: LoggedWorkSessionDeps,
+  threadId: string,
+  rawPath: string,
+): Promise<Response> {
+  const filePath = parseRawFileRoutePath(rawPath);
+  const target = await requireThreadStorageTarget(deps, { threadId });
+
+  try {
+    const result = await queueCommandAndWait(deps, {
+      hostId: target.hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command: {
+        type: "host.read_file",
+        path: path.join(target.storagePath, filePath.relativePath),
+        rootPath: target.storagePath,
+      },
+    });
+    return createRawFilePreviewResponse(result, filePath.relativePath);
+  } catch (error) {
+    return remapDaemonFileRouteError(error);
+  }
+}
+
+async function serveThreadWorktreeRawFile(
+  deps: LoggedWorkSessionDeps,
+  threadId: string,
+  rawPath: string,
+): Promise<Response> {
+  const filePath = parseRawFileRoutePath(rawPath);
+  const thread = requirePublicThread(deps.db, threadId);
+  if (!thread.environmentId) {
+    throw new ApiError(409, "invalid_request", "Thread has no environment");
+  }
+  const environment = requireReadyEnvironment(deps.db, thread.environmentId);
+
+  try {
+    const result = await queueCommandAndWait(deps, {
+      hostId: environment.hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command: {
+        type: "host.read_file",
+        path: path.join(environment.path, filePath.relativePath),
+        rootPath: environment.path,
+      },
+    });
+    return createRawFilePreviewResponse(result, filePath.relativePath);
+  } catch (error) {
+    return remapDaemonFileRouteError(error);
+  }
+}
+
 export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
   const { get } = typedRoutes<PublicApiSchema>(app, {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
@@ -1027,6 +1168,19 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     return serveThreadStatusAsset(deps, context.req.param("id"), rawStatusPath);
   });
 
+  // Generic iframe previews use path-shaped raw URLs so relative links resolve
+  // beside the HTML file. Unlike STATUS, these routes never inject bb globals.
+  app.get("/threads/:id/worktree/files/*", async (context) =>
+    serveThreadWorktreeRawFile(
+      deps,
+      context.req.param("id"),
+      extractRawFileRoutePath(
+        context.req.url,
+        THREAD_WORKTREE_FILE_ROUTE_SEGMENT,
+      ),
+    ),
+  );
+
   get(
     "/threads/:id/thread-storage/files",
     threadStorageFilesQuerySchema,
@@ -1063,6 +1217,17 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
         throw error;
       }
     },
+  );
+
+  app.get("/threads/:id/thread-storage/files/*", async (context) =>
+    serveThreadStorageRawFile(
+      deps,
+      context.req.param("id"),
+      extractRawFileRoutePath(
+        context.req.url,
+        THREAD_STORAGE_FILE_ROUTE_SEGMENT,
+      ),
+    ),
   );
 
   get(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -12,6 +12,7 @@ import type { AppDeps, ServerAppDeps } from "./types.js";
 import { ApiError, errorToResponse } from "./errors.js";
 import { registerAutomationRoutes } from "./routes/automations.js";
 import { registerEnvironmentRoutes } from "./routes/environments.js";
+import { registerFileRoutes } from "./routes/files.js";
 import { registerHostRoutes } from "./routes/hosts.js";
 import { registerManagerTemplateRoutes } from "./routes/manager-templates.js";
 import { registerProjectRoutes } from "./routes/projects.js";
@@ -226,6 +227,7 @@ export function createApp(
   const publicApi = new Hono();
   registerProjectRoutes(publicApi, deps);
   registerAutomationRoutes(publicApi, deps);
+  registerFileRoutes(publicApi, deps);
   registerHostRoutes(publicApi, deps);
   registerEnvironmentRoutes(publicApi, deps);
   registerThreadRoutes(publicApi, deps);

--- a/apps/server/test/public/public-files.test.ts
+++ b/apps/server/test/public/public-files.test.ts
@@ -1,0 +1,166 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import {
+  reportQueuedCommandSuccess,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import { readJson } from "../helpers/json.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedThread,
+} from "../helpers/seed.js";
+import { createTestAppHarness } from "../helpers/test-app.js";
+
+function rawFileUrl(threadId: string, filePath: string): string {
+  return `/api/v1/threads/${threadId}/files/raw?path=${encodeURIComponent(filePath)}`;
+}
+
+describe("public file routes", () => {
+  it("serves arbitrary absolute HTML files as sandboxed raw preview content", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      seedHostSession(harness.deps, { id: "default-host" });
+      const { host: threadHost } = seedHostSession(harness.deps, {
+        id: "thread-host",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: threadHost.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: threadHost.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+      });
+      const filePath = "/Users/me/Downloads/report.html";
+      const html = "<!doctype html><h1>Report</h1>";
+
+      const filePromise = harness.app.request(rawFileUrl(thread.id, filePath));
+      const fileCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "host.read_file" && command.path === filePath,
+      );
+      expect(fileCommand.row.hostId).toBe(threadHost.id);
+      expect(fileCommand.command).toEqual({
+        type: "host.read_file",
+        path: filePath,
+      });
+      await reportQueuedCommandSuccess(
+        harness,
+        fileCommand,
+        {
+          path: filePath,
+          content: html,
+          contentEncoding: "utf8",
+          mimeType: "text/html",
+          sizeBytes: Buffer.byteLength(html),
+        },
+        { hostId: threadHost.id },
+      );
+
+      const fileResponse = await filePromise;
+      expect(fileResponse.status).toBe(200);
+      expect(fileResponse.headers.get("content-type")).toBe(
+        "text/html; charset=utf-8",
+      );
+      expect(fileResponse.headers.get("content-security-policy")).toBe(
+        "sandbox allow-scripts",
+      );
+      expect(fileResponse.headers.get("cache-control")).toBe("no-store");
+      expect(fileResponse.headers.get("x-content-type-options")).toBe(
+        "nosniff",
+      );
+      expect(await fileResponse.text()).toBe(html);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("rejects non-HTML arbitrary raw file preview paths before queueing a read", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+      });
+
+      const fileResponse = await harness.app.request(
+        rawFileUrl(thread.id, "/Users/me/Downloads/report.txt"),
+      );
+
+      expect(fileResponse.status).toBe(415);
+      await expect(readJson(fileResponse)).resolves.toEqual({
+        code: "unsupported_media_type",
+        message: "HTML preview only supports text/html files",
+        retryable: false,
+      });
+      await expect(
+        waitForQueuedCommand(
+          harness,
+          ({ command }) => {
+            return command.type === "host.read_file";
+          },
+          25,
+        ),
+      ).rejects.toThrow("Timed out waiting for queued command");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("caps arbitrary raw HTML preview responses at 5 MB", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+      });
+      const filePath = "/Users/me/Downloads/large.html";
+
+      const filePromise = harness.app.request(rawFileUrl(thread.id, filePath));
+      const fileCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "host.read_file" && command.path === filePath,
+      );
+      await reportQueuedCommandSuccess(harness, fileCommand, {
+        path: filePath,
+        content: "",
+        contentEncoding: "utf8",
+        mimeType: "text/html",
+        sizeBytes: 5 * 1024 * 1024 + 1,
+      });
+
+      const fileResponse = await filePromise;
+      expect(fileResponse.status).toBe(413);
+      await expect(readJson(fileResponse)).resolves.toEqual({
+        code: "file_too_large",
+        message: "HTML preview exceeds the 5 MB limit",
+        retryable: false,
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -2356,6 +2356,7 @@ describe("public thread data routes", () => {
       );
       const statusBody = await statusResponse.text();
       expect(statusBody).toContain("window.bbStatusState");
+      expect(statusBody).toContain("window.bbThreadTell");
       expect(statusBody).toContain(statusHtml);
 
       const assetBytes = Uint8Array.from([137, 80, 78, 71]);
@@ -2394,6 +2395,169 @@ describe("public thread data routes", () => {
       expect(new Uint8Array(await assetResponse.arrayBuffer())).toEqual(
         assetBytes,
       );
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("serves worktree HTML preview content as raw text/html without STATUS injection", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/project-source",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/project-source",
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+      });
+      const html = "<!doctype html><script>window.localOnly = true</script>";
+
+      const filePromise = harness.app.request(
+        `/api/v1/threads/${thread.id}/worktree/files/public/report.html`,
+      );
+      const fileCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "host.read_file" &&
+          command.path === "/tmp/project-source/public/report.html",
+      );
+      expect(fileCommand.command).toMatchObject({
+        type: "host.read_file",
+        path: "/tmp/project-source/public/report.html",
+        rootPath: "/tmp/project-source",
+      });
+      await reportQueuedCommandSuccess(harness, fileCommand, {
+        path: "/tmp/project-source/public/report.html",
+        content: html,
+        contentEncoding: "utf8",
+        mimeType: "text/html",
+        sizeBytes: Buffer.byteLength(html),
+      });
+
+      const fileResponse = await filePromise;
+      expect(fileResponse.status).toBe(200);
+      expect(fileResponse.headers.get("content-type")).toBe(
+        "text/html; charset=utf-8",
+      );
+      expect(fileResponse.headers.get("content-security-policy")).toBe(
+        "sandbox allow-scripts",
+      );
+      expect(fileResponse.headers.get("cache-control")).toBe("no-store");
+      const body = await fileResponse.text();
+      expect(body).toBe(html);
+      expect(body).not.toContain("window.bbStatusState");
+      expect(body).not.toContain("window.bbThreadTell");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("serves thread storage HTML preview content as raw text/html without STATUS injection", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/project-source",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/project-source",
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        type: "manager",
+      });
+      const threadStorageRoot = `/tmp/bb-host-data/${host.id}/thread-storage/${thread.id}`;
+      const html = "<!doctype html><h1>Preview</h1>";
+
+      const filePromise = harness.app.request(
+        `/api/v1/threads/${thread.id}/thread-storage/files/reports/preview.html`,
+      );
+      const fileCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "host.read_file" &&
+          command.path === `${threadStorageRoot}/reports/preview.html`,
+      );
+      expect(fileCommand.command).toMatchObject({
+        type: "host.read_file",
+        path: `${threadStorageRoot}/reports/preview.html`,
+        rootPath: threadStorageRoot,
+      });
+      await reportQueuedCommandSuccess(harness, fileCommand, {
+        path: `${threadStorageRoot}/reports/preview.html`,
+        content: html,
+        contentEncoding: "utf8",
+        mimeType: "text/html",
+        sizeBytes: Buffer.byteLength(html),
+      });
+
+      const fileResponse = await filePromise;
+      expect(fileResponse.status).toBe(200);
+      expect(fileResponse.headers.get("content-type")).toBe(
+        "text/html; charset=utf-8",
+      );
+      expect(fileResponse.headers.get("content-security-policy")).toBe(
+        "sandbox allow-scripts",
+      );
+      expect(await fileResponse.text()).toBe(html);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("caps generic HTML preview responses at 5 MB", async () => {
+    const harness = await createTestAppHarness();
+    try {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/project-source",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/project-source",
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+      });
+
+      const filePromise = harness.app.request(
+        `/api/v1/threads/${thread.id}/worktree/files/large.html`,
+      );
+      const fileCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "host.read_file" &&
+          command.path === "/tmp/project-source/large.html",
+      );
+      await reportQueuedCommandSuccess(harness, fileCommand, {
+        path: "/tmp/project-source/large.html",
+        content: "",
+        contentEncoding: "utf8",
+        mimeType: "text/html",
+        sizeBytes: 5 * 1024 * 1024 + 1,
+      });
+
+      const fileResponse = await filePromise;
+      expect(fileResponse.status).toBe(413);
+      await expect(readJson(fileResponse)).resolves.toEqual({
+        code: "file_too_large",
+        message: "HTML preview exceeds the 5 MB limit",
+        retryable: false,
+      });
     } finally {
       await harness.cleanup();
     }
@@ -2580,8 +2744,14 @@ describe("public thread data routes", () => {
       const tasksJson = '["one"]\n';
       const prefsJson = '{"compact":true}\n';
       await fs.mkdir(statusDataRootPath, { recursive: true });
-      await fs.writeFile(path.join(statusDataRootPath, "tasks.json"), tasksJson);
-      await fs.writeFile(path.join(statusDataRootPath, "prefs.json"), prefsJson);
+      await fs.writeFile(
+        path.join(statusDataRootPath, "tasks.json"),
+        tasksJson,
+      );
+      await fs.writeFile(
+        path.join(statusDataRootPath, "prefs.json"),
+        prefsJson,
+      );
       await fs.mkdir(path.join(statusDataRootPath, "nested"));
       await fs.writeFile(
         path.join(statusDataRootPath, "nested", "ignored.json"),


### PR DESCRIPTION
## Summary

10 commits from `sawyer-next` polishing macOS desktop UX + HTML preview UX:

**macOS desktop chrome / UX**
- `df6e985c` fix(desktop): add drag region to loading views
- `a46a9e87` fix(desktop): restore terminal in packaged app (afterPack patch for node-pty asar-unpacked rewrite)
- `41604120` fix(app+desktop): make secondary panel chrome draggable
- `4a58a24a` desktop: add server and daemon logs viewer (View → Server & Daemon Logs menu + live tail panel)
- `68e7e32c` desktop: use normal title bar for logs viewer (native draggable title)
- `e1f0cc58` fix(host-daemon): guard node-pty spawn helpers (chmod both build/Release + prebuilds; log+skip on missing)
- `43bc48bd` desktop: drop /api/v1/system/version check from server probe

**HTML preview**
- `d62003dc` app+server: preview arbitrary HTML files (iframe sandbox `allow-scripts` only, no bbStatusState/bbThreadTell injection)
- `4248f411` app: add HTML preview raw toggle (default Preview, mirror markdown)
- `61af5677` app+server: preview HTML links from markdown (per-thread scoped raw endpoint, preload thread-storage root for link routing)

## Test plan

- [ ] CI green
- [ ] Desktop installs cleanly, drag region works on loading view, terminal opens + runs commands, secondary panel + iframe top chrome both draggable, View → Server & Daemon Logs menu opens a native-title-bar window with live tail
- [ ] Click a markdown link to a thread-storage HTML file with the secondary panel closed → iframe preview with Preview/Raw toggle opens (uses `thread-storage/files/*`, not `/files/raw`)
- [ ] Click a markdown link to an arbitrary filesystem HTML path → iframe preview with toggle (uses per-thread `/threads/:id/files/raw`)
- [ ] Iframe sandbox confirmed: no `window.bbStatusState` / `window.bbThreadTell` for generic HTML
- [ ] Multi-host: clicking from a non-default-host thread reads from the correct host

🤖 Generated with [Claude Code](https://claude.com/claude-code)