### PR TITLE
[codex] Prevent EMFILE startup failures and stale workspace WARNs

### DIFF
--- a/apps/host-daemon/src/command-handlers/file-read.ts
+++ b/apps/host-daemon/src/command-handlers/file-read.ts
@@ -222,6 +222,19 @@ async function resolveReadablePath(
   return realResolvedPath;
 }
 
+async function resolveRootRelativeReadablePath(
+  args: ReadFileForTransportArgs,
+): Promise<string> {
+  try {
+    return await resolveReadablePath(args);
+  } catch (error) {
+    if (error instanceof CommandDispatchError && error.code === "ENOENT") {
+      throw createMissingTargetError(args.resultPath);
+    }
+    throw error;
+  }
+}
+
 /**
  * Read a file's contents at a specific git ref via `git cat-file`. Mirrors
  * `readFileForTransport`'s result shape (same caps, same utf-8/base64
@@ -353,7 +366,7 @@ export async function readRootRelativeFileForTransport(
     resultPath: relativePath.resultPath,
     rootPath: args.rootPath,
   };
-  const readablePath = await resolveReadablePath(readArgs);
+  const readablePath = await resolveRootRelativeReadablePath(readArgs);
   const stat = await fs
     .stat(readablePath)
     .catch((error: unknown) => throwMissingTargetOrRethrow(readArgs, error));

--- a/apps/host-daemon/src/command-handlers/host-files.test.ts
+++ b/apps/host-daemon/src/command-handlers/host-files.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   readHostFile,
   readHostFileMetadata,
+  readHostRelativeFile,
   readHostStatusVersion,
   writeHostRelativeFile,
   deleteHostRelativeFile,
@@ -71,6 +72,18 @@ async function captureReadHostFileError(
   }
 
   throw new Error("Expected readHostFile to fail");
+}
+
+async function captureReadHostRelativeFileError(
+  command: CommandOf<"host.read_file_relative">,
+): Promise<unknown> {
+  try {
+    await readHostRelativeFile(command);
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("Expected readHostRelativeFile to fail");
 }
 
 function makeStatusVersionCommand(
@@ -225,6 +238,24 @@ describe("readHostFile (no ref — disk read)", () => {
       name: "CommandDispatchError",
     });
     expect(isExpectedCommandDispatchError(thrown)).toBe(false);
+  });
+
+  it("marks missing relative read roots as expected", async () => {
+    const parentPath = await makeTempDir("bb-host-files-relative-root-");
+    const rootPath = path.join(parentPath, "STATUS");
+    const thrown = await captureReadHostRelativeFileError({
+      type: "host.read_file_relative",
+      rootPath,
+      path: "index.html",
+      dotfiles: "deny",
+    });
+
+    expect(thrown).toMatchObject({
+      code: "ENOENT",
+      message: "Path does not exist: index.html",
+      name: "ExpectedCommandDispatchError",
+    });
+    expect(isExpectedCommandDispatchError(thrown)).toBe(true);
   });
 
   it("rejects rootless directory paths", async () => {

--- a/apps/host-daemon/src/command-router.ts
+++ b/apps/host-daemon/src/command-router.ts
@@ -67,6 +67,11 @@ interface CommandLifecycleTiming {
   totalMs: number;
 }
 
+interface CommandExecutionWarningInput {
+  command: HostDaemonCommand;
+  error: unknown;
+}
+
 type ReadCommandFetchedAt = (
   envelope: HostDaemonCommandEnvelope,
 ) => number | undefined;
@@ -106,6 +111,21 @@ function readCommandEnvironmentId(
     return command.environmentId;
   }
   return undefined;
+}
+
+function shouldWarnCommandExecutionFailure(
+  input: CommandExecutionWarningInput,
+): boolean {
+  if (isExpectedCommandDispatchError(input.error)) {
+    return false;
+  }
+  if (
+    input.command.type === "workspace.status" &&
+    getErrorCode(input.error) === "path_not_found"
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export class CommandRouter {
@@ -310,7 +330,12 @@ export class CommandRouter {
       };
     } catch (error) {
       const errorCode = getErrorCode(error);
-      if (!isExpectedCommandDispatchError(error)) {
+      if (
+        shouldWarnCommandExecutionFailure({
+          command: envelope.command,
+          error,
+        })
+      ) {
         this.logger.warn(
           {
             commandId: envelope.id,

--- a/apps/host-daemon/test/command/command-router.test.ts
+++ b/apps/host-daemon/test/command/command-router.test.ts
@@ -7,13 +7,14 @@ import {
   type ClientTurnRequestId,
 } from "@bb/domain";
 import type { HostDaemonCommandResultReportWithoutSession } from "@bb/host-daemon-contract";
-import type {
-  CommitOptions,
-  CommitResult,
-  HostWorkspace,
-  ProvisionWorkspaceArgs,
-  SquashMergeOptions,
-  SquashMergeResult,
+import {
+  WorkspaceError,
+  type CommitOptions,
+  type CommitResult,
+  type HostWorkspace,
+  type ProvisionWorkspaceArgs,
+  type SquashMergeOptions,
+  type SquashMergeResult,
 } from "@bb/host-workspace";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CommandRouter } from "../../src/command-router.js";
@@ -366,6 +367,98 @@ describe("CommandRouter", () => {
         errorMessage: `Path does not exist: ${missingPath}`,
         ok: false,
         type: "host.read_file",
+      }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("reports missing host relative file reads without warning", async () => {
+    const parentPath = await makeTempDir("bb-command-router-relative-file-");
+    const rootPath = path.join(parentPath, "STATUS");
+    const reportResult = vi.fn(async () => undefined);
+    const logger = createLogger();
+    const router = new CommandRouter({
+      dataDir: "/tmp/bb-test-data",
+      fetchProjectAttachment: unexpectedProjectAttachmentFetch,
+      reportResult,
+      runtimeManager: new RuntimeManager({
+        provisionWorkspace: async () => createFakeWorkspace("/tmp/env-1"),
+      }),
+      eventSink: noopEventSink,
+      threadStorageRootPath: "/tmp/bb-test-thread-storage",
+      logger,
+    });
+
+    await router.handleCommands([
+      {
+        id: "read-missing-relative-index",
+        cursor: 1,
+        command: {
+          type: "host.read_file_relative",
+          rootPath,
+          path: "index.html",
+          dotfiles: "deny",
+        },
+      },
+    ]);
+
+    expect(reportResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandId: "read-missing-relative-index",
+        errorCode: "ENOENT",
+        errorMessage: "Path does not exist: index.html",
+        ok: false,
+        type: "host.read_file_relative",
+      }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("reports missing workspace status paths without warning", async () => {
+    const parentPath = await makeTempDir("bb-command-router-workspace-");
+    const missingPath = path.join(parentPath, "missing-worktree");
+    const reportResult = vi.fn(async () => undefined);
+    const logger = createLogger();
+    const router = new CommandRouter({
+      dataDir: "/tmp/bb-test-data",
+      fetchProjectAttachment: unexpectedProjectAttachmentFetch,
+      reportResult,
+      runtimeManager: new RuntimeManager({
+        provisionWorkspace: async () => {
+          throw new WorkspaceError(
+            "path_not_found",
+            `Managed workspace path does not exist: ${missingPath}`,
+          );
+        },
+      }),
+      eventSink: noopEventSink,
+      threadStorageRootPath: "/tmp/bb-test-thread-storage",
+      logger,
+    });
+
+    await router.handleCommands([
+      {
+        id: "status-missing-workspace",
+        cursor: 1,
+        command: {
+          type: "workspace.status",
+          environmentId: "env-missing",
+          workspaceContext: {
+            workspacePath: missingPath,
+            workspaceProvisionType: "managed-worktree",
+          },
+          mergeBaseBranch: "main",
+        },
+      },
+    ]);
+
+    expect(reportResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandId: "status-missing-workspace",
+        errorCode: "path_not_found",
+        errorMessage: `Managed workspace path does not exist: ${missingPath}`,
+        ok: false,
+        type: "workspace.status",
       }),
     );
     expect(logger.warn).not.toHaveBeenCalled();

--- a/apps/server/src/services/threads/status-state-watcher.ts
+++ b/apps/server/src/services/threads/status-state-watcher.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { watch, type FSWatcher } from "chokidar";
@@ -87,12 +88,22 @@ interface StartStatusStateFileWatcherArgs {
   rootPath: string;
 }
 
+interface RelativeStatusDataPathArgs {
+  filePath: string;
+  rootPath: string;
+}
+
+interface IsIgnoredStatusDataWatchPathArgs extends RelativeStatusDataPathArgs {
+  stats?: Stats;
+}
+
 export interface StatusStateFileWatcher {
   close(): Promise<void>;
 }
 
 const STATUS_DATA_AWAIT_WRITE_FINISH_MS = 25;
 const STATUS_DATA_AWAIT_WRITE_POLL_MS = 10;
+const STATUS_DATA_WATCH_DEPTH = 2;
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) {
@@ -117,6 +128,46 @@ function isHiddenStatusDataFile(filePath: string): boolean {
   return path.basename(filePath).startsWith(".");
 }
 
+function relativeStatusDataWatchPath(
+  args: RelativeStatusDataPathArgs,
+): string | null {
+  const relativePath = path.relative(args.rootPath, args.filePath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+  return relativePath;
+}
+
+function isIgnoredStatusDataWatchPath(
+  args: IsIgnoredStatusDataWatchPathArgs,
+): boolean {
+  const relativePath = relativeStatusDataWatchPath(args);
+  if (relativePath === null) {
+    return true;
+  }
+  if (relativePath.length === 0) {
+    return false;
+  }
+  if (isHiddenStatusDataFile(args.filePath)) {
+    return true;
+  }
+
+  const parts = relativePath.split(path.sep);
+  if (parts.length === 1) {
+    return args.stats?.isFile() === true;
+  }
+  if (parts[1] !== STATUS_DATA_DIRECTORY_NAME) {
+    return true;
+  }
+  if (parts.length === 2) {
+    return false;
+  }
+  if (parts.length !== 3 || args.stats?.isDirectory() === true) {
+    return true;
+  }
+  return !args.filePath.endsWith(STATUS_DATA_FILE_EXTENSION);
+}
+
 function parseStatusDataFilePath(
   args: ParseStatusDataFilePathArgs,
 ): StatusDataFilePathParts | null {
@@ -127,12 +178,8 @@ function parseStatusDataFilePath(
     return null;
   }
 
-  const relativePath = path.relative(args.rootPath, args.filePath);
-  if (
-    relativePath.length === 0 ||
-    relativePath.startsWith("..") ||
-    path.isAbsolute(relativePath)
-  ) {
+  const relativePath = relativeStatusDataWatchPath(args);
+  if (relativePath === null || relativePath.length === 0) {
     return null;
   }
 
@@ -325,12 +372,11 @@ async function handleStatusDataFileUnlink(
 async function handleStatusDataDirectoryAdd(
   args: HandleStatusDataDirectoryAddArgs,
 ): Promise<void> {
-  const relativePath = path.relative(args.rootPath, args.dirPath);
-  if (
-    relativePath.length === 0 ||
-    relativePath.startsWith("..") ||
-    path.isAbsolute(relativePath)
-  ) {
+  const relativePath = relativeStatusDataWatchPath({
+    filePath: args.dirPath,
+    rootPath: args.rootPath,
+  });
+  if (relativePath === null || relativePath.length === 0) {
     return;
   }
 
@@ -454,8 +500,14 @@ export async function startStatusStateFileWatcher(
       stabilityThreshold: STATUS_DATA_AWAIT_WRITE_FINISH_MS,
       pollInterval: STATUS_DATA_AWAIT_WRITE_POLL_MS,
     },
+    depth: STATUS_DATA_WATCH_DEPTH,
     ignoreInitial: true,
-    ignored: isHiddenStatusDataFile,
+    ignored: (filePath, stats) =>
+      isIgnoredStatusDataWatchPath({
+        filePath,
+        rootPath: args.rootPath,
+        stats,
+      }),
   });
 
   watcher.on("addDir", (dirPath) => {

--- a/apps/server/test/services/threads/status-state-watcher.test.ts
+++ b/apps/server/test/services/threads/status-state-watcher.test.ts
@@ -27,6 +27,10 @@ interface TestWatcherContext {
   watcher: Awaited<ReturnType<typeof startStatusStateFileWatcher>>;
 }
 
+interface CreateContextArgs {
+  precreateStatusDataDir: boolean;
+}
+
 interface AtomicWriteArgs {
   content: string;
   key: string;
@@ -47,6 +51,9 @@ interface WaitForBroadcastArgs {
 }
 
 const contexts: TestWatcherContext[] = [];
+const DEFAULT_CREATE_CONTEXT_ARGS: CreateContextArgs = {
+  precreateStatusDataDir: true,
+};
 
 function createMockSocket(): MockSocket {
   const messages: string[] = [];
@@ -78,11 +85,15 @@ function sha256Text(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-async function createContext(): Promise<TestWatcherContext> {
+async function createContext(
+  args: CreateContextArgs = DEFAULT_CREATE_CONTEXT_ARGS,
+): Promise<TestWatcherContext> {
   const rootPath = await fs.mkdtemp(path.join(tmpdir(), "bb-status-watch-"));
-  await fs.mkdir(path.join(rootPath, "thr_watch", "STATUS-data"), {
-    recursive: true,
-  });
+  if (args.precreateStatusDataDir) {
+    await fs.mkdir(path.join(rootPath, "thr_watch", "STATUS-data"), {
+      recursive: true,
+    });
+  }
   const hub = new NotificationHub();
   const socket = createMockSocket();
   const logger = createLogger();
@@ -172,6 +183,32 @@ describe("status state file watcher", () => {
         threadId: "thr_watch",
         key: "tasks",
         value: { done: false },
+        deleted: false,
+        previousValue: null,
+        previousValuePresent: false,
+        version: sha256Text(content),
+        writerClientId: null,
+        operationId: null,
+      },
+    );
+  });
+
+  it("broadcasts writes when the STATUS-data directory is created after startup", async () => {
+    const context = await createContext({ precreateStatusDataDir: false });
+    const content = canonicalizeStatusJson({ createdLate: true });
+    await writeStatusFile({
+      content,
+      key: "late",
+      rootPath: context.rootPath,
+      threadId: "thr_watch",
+    });
+
+    await expect(waitForBroadcast({ socket: context.socket })).resolves.toEqual(
+      {
+        type: "status-data.changed",
+        threadId: "thr_watch",
+        key: "late",
+        value: { createdLate: true },
         deleted: false,
         previousValue: null,
         previousValuePresent: false,


### PR DESCRIPTION
## Summary

Fixes two startup-facing failure modes that showed up as terminal errors while starting `bb`:

1. The server could fail its health check with `EMFILE: too many open files, watch` because the STATUS-data watcher recursively watched the full thread-storage tree.
2. The host daemon logged a scary `command execution failed` WARN for `workspace.status` when probing a stale managed worktree path that no longer exists.

## Bugs And Failure Modes

### EMFILE health-check timeout

The server started a recursive watcher at the full thread storage root, usually `~/.bb/thread-storage`, even though the watcher only needs durable STATUS state files under each thread's `STATUS-data/*.json` directory.

On machines with many retained thread-storage artifacts, generated reports, screenshots, browser user-data directories, or archived worktrees, that recursive watch could consume too many file descriptors or watch handles. The observable failure mode was:

```text
Error: EMFILE: too many open files, watch
  at FSWatcher._handle.onchange (node:internal/fs/watchers:207:21)
✗ Server failed to start (health check timed out)
```

Because the watcher starts before the HTTP server reports healthy, the launcher timed out while waiting for `/health`.

### Stale managed-worktree status warning

After the server starts, the daemon may receive `workspace.status` for an environment whose managed worktree was already removed, for example an archived/destroyed environment still referenced by retained history. The command correctly returns `path_not_found`, and server cleanup/status callers can handle that result, but the host daemon also logged it as:

```text
WARN: [host-daemon] command execution failed {"type":"workspace.status"}
WorkspaceError: Managed workspace path does not exist: ...
```

That made an expected stale-workspace probe look like another startup failure even though the server and daemon were already healthy.

## Fix

- Added a STATUS-data-specific ignore predicate for the server watcher.
- Limited watcher traversal to the only required shape: `<thread-id>/STATUS-data/<key>.json`.
- Kept thread directories and `STATUS-data` directories watchable so late-created STATUS-data directories still emit broadcasts.
- Reused the same relative-path guard for parsing and directory-add handling.
- Suppressed host-daemon WARN logging only for `workspace.status` failures whose structured error code is `path_not_found`.
- Kept the `workspace.status` command result as `ok: false` with `errorCode: "path_not_found"`, so server/UI logic still receives the real failure.

## Testing And Validation

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server -- test/services/threads/status-state-watcher.test.ts`
- `pnpm exec turbo run build --filter=@bb/server`
- Startup smoke with `BB_THREAD_STORAGE=/Users/brsbl/.bb/thread-storage`: server `/health` returned OK.
- `pnpm exec turbo run test --filter=@bb/host-daemon -- test/command/command-router.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run build --filter=@bb/host-daemon`
- Packaged `bb-app` rebuild plus packaged-server smoke using `packages/bb-app/server/dist/index.js` with `BB_THREAD_STORAGE=/Users/brsbl/.bb/thread-storage`: `/health` returned OK.\n### STATUS fallback read warning\n\nThe unified status route intentionally probes `STATUS/index.html` before falling back to `STATUS.html`. When the `STATUS/` directory is absent, `host.read_file_relative` returned `ENOENT` correctly but classified the miss as a normal command failure, causing the daemon to log `WARN: command execution failed` even though the server expected and handled the fallback.\n\nThe fix now classifies missing relative-read roots as expected `ENOENT` failures. The command result is unchanged (`ok: false`, `errorCode: "ENOENT"`), but the daemon no longer emits a WARN for that expected read miss.\n\nAdditional validation:\n\n- `pnpm exec turbo run test --filter=@bb/host-daemon -- test/command/command-router.test.ts src/command-handlers/host-files.test.ts`\n- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`\n- `pnpm exec turbo run build --filter=@bb/host-daemon`\n- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-data.test.ts`\n- `pnpm exec turbo run build --filter=bb-app`