### PR TITLE
[codex] Add default app open target

### DIFF
--- a/apps/app/src/components/thread/ThreadWorkspaceOpenButton.tsx
+++ b/apps/app/src/components/thread/ThreadWorkspaceOpenButton.tsx
@@ -17,6 +17,7 @@ import xcodeIcon from "@/assets/workspace-open-target-icons/xcode.png";
 import { SplitButton, type SplitButtonAction } from "@/components/ui/split-button.js";
 
 const WORKSPACE_OPEN_TARGET_ICONS: Record<WorkspaceOpenTargetId, string> = {
+  "default-app": finderIcon,
   vscode: vscodeIcon,
   cursor: cursorIcon,
   "sublime-text": sublimeTextIcon,

--- a/apps/app/src/hooks/useLocalOpenTargets.test.tsx
+++ b/apps/app/src/hooks/useLocalOpenTargets.test.tsx
@@ -292,6 +292,72 @@ describe("useLocalOpenTargets", () => {
     });
   });
 
+  it("opens editor requests in an editor target when the stored workspace target is Finder", async () => {
+    window.localStorage.setItem(WORKSPACE_OPEN_TARGET_STORAGE_KEY, "finder");
+    const state: LocalOpenTargetsFetchState = {
+      daemonStatus: {
+        connected: true,
+        hostId: "host-1",
+        protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+        serverUrl: "http://localhost:3334",
+        supportsNativeFolderPicker: false,
+        platform: "darwin",
+      },
+      hostDaemonPort: 4123,
+      workspaceOpenTargets: [
+        { id: "default-app", kind: "editor", label: "Default App" },
+        { id: "finder", kind: "file-browser", label: "Finder" },
+      ],
+      workspaceOpenTargetsStatus: 200,
+    };
+    const openTargetRequests: Array<
+      ReturnType<typeof openInTargetRequestSchema.parse>
+    > = [];
+    installLocalOpenTargetsFetchRoutes(state, openTargetRequests);
+    const modules = await importFreshLocalOpenTargetsModules();
+    const latestSnapshot: { current: LocalOpenTargetsSnapshot | null } = {
+      current: null,
+    };
+    await act(async () => {
+      render(
+        <LocalOpenTargetsCapture
+          modules={modules}
+          onSnapshot={(snapshot) => {
+            latestSnapshot.current = snapshot;
+          }}
+        />,
+        { wrapper: createSuspenseWrapper() },
+      );
+    });
+
+    await waitFor(() => {
+      const localOpenTargets = requireLocalOpenTargetsSnapshot(
+        latestSnapshot.current,
+      ).localOpenTargets;
+      expect(localOpenTargets.preferredTarget?.label).toBe("Finder");
+      expect(localOpenTargets.preferredEditorTarget?.label).toBe("Default App");
+    });
+
+    await act(async () => {
+      await requireLocalOpenTargetsSnapshot(
+        latestSnapshot.current,
+      ).localOpenTargets.openPathInPreferredEditorTarget({
+        lineNumber: 27,
+        path: "/tmp/workspace/file.md",
+      });
+    });
+
+    await waitFor(() => {
+      expect(openTargetRequests).toEqual([
+        {
+          lineNumber: 27,
+          path: "/tmp/workspace/file.md",
+          targetId: "default-app",
+        },
+      ]);
+    });
+  });
+
   it("stores an explicitly selected target for future opens", async () => {
     const state: LocalOpenTargetsFetchState = {
       daemonStatus: {

--- a/apps/app/src/hooks/useLocalOpenTargets.ts
+++ b/apps/app/src/hooks/useLocalOpenTargets.ts
@@ -32,10 +32,15 @@ export interface OpenPathInTargetArgs extends OpenLocalPathRequest {
 export interface OpenPathInPreferredTargetArgs extends OpenLocalPathRequest {}
 
 export interface UseLocalOpenTargetsResult {
+  canOpenPreferredEditorTarget: boolean;
   canOpenPreferredTarget: boolean;
+  openPathInPreferredEditorTarget: (
+    args: OpenPathInPreferredTargetArgs,
+  ) => Promise<boolean>;
   openPathInPreferredTarget: (
     args: OpenPathInPreferredTargetArgs,
   ) => Promise<boolean>;
+  preferredEditorTarget: WorkspaceOpenTarget | null;
   openPathInTarget: (args: OpenPathInTargetArgs) => Promise<boolean>;
   preferredTarget: WorkspaceOpenTarget | null;
   workspaceOpenTargets: WorkspaceOpenTarget[];
@@ -71,6 +76,16 @@ export function useLocalOpenTargets(
       resolvePreferredWorkspaceOpenTarget({
         preferredTargetId,
         targets: workspaceOpenTargets,
+      }),
+    [preferredTargetId, workspaceOpenTargets],
+  );
+  const preferredEditorTarget = useMemo(
+    () =>
+      resolvePreferredWorkspaceOpenTarget({
+        preferredTargetId,
+        targets: workspaceOpenTargets.filter(
+          (target) => target.kind === "editor",
+        ),
       }),
     [preferredTargetId, workspaceOpenTargets],
   );
@@ -140,10 +155,37 @@ export function useLocalOpenTargets(
       preferredTarget,
     ],
   );
+  const openPathInPreferredEditorTarget = useCallback(
+    async (request: OpenPathInPreferredTargetArgs) => {
+      if (!preferredEditorTarget) {
+        appToast.error(LOCAL_OPEN_FAILURE_TITLE, {
+          description: getOpenUnavailableDescription({
+            hasDaemon,
+          }),
+        });
+        return false;
+      }
+
+      return openPathInTarget({
+        lineNumber: request.lineNumber,
+        path: request.path,
+        rememberTarget: false,
+        targetId: preferredEditorTarget.id,
+      });
+    },
+    [
+      hasDaemon,
+      openPathInTarget,
+      preferredEditorTarget,
+    ],
+  );
 
   return {
+    canOpenPreferredEditorTarget: preferredEditorTarget !== null,
     canOpenPreferredTarget: preferredTarget !== null,
+    openPathInPreferredEditorTarget,
     openPathInPreferredTarget,
+    preferredEditorTarget,
     openPathInTarget,
     preferredTarget,
     workspaceOpenTargets,

--- a/apps/app/src/lib/workspace-open-target-preference.test.ts
+++ b/apps/app/src/lib/workspace-open-target-preference.test.ts
@@ -42,6 +42,27 @@ describe("resolvePreferredWorkspaceOpenTarget", () => {
         preferredTargetId: null,
         targets: [
           {
+            id: "default-app",
+            kind: "editor",
+            label: "Default App",
+          },
+          {
+            id: "finder",
+            kind: "file-browser",
+            label: "Finder",
+          },
+        ],
+      }),
+    ).toEqual({
+      id: "default-app",
+      kind: "editor",
+      label: "Default App",
+    });
+    expect(
+      resolvePreferredWorkspaceOpenTarget({
+        preferredTargetId: null,
+        targets: [
+          {
             id: "finder",
             kind: "file-browser",
             label: "Finder",

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -593,7 +593,9 @@ export function ThreadDetailView() {
     threadEnvironmentIsLocal,
   });
   const {
+    canOpenPreferredEditorTarget,
     canOpenPreferredTarget,
+    openPathInPreferredEditorTarget,
     openPathInPreferredTarget,
     openPathInTarget,
     preferredTarget,
@@ -1025,18 +1027,18 @@ export function ThreadDetailView() {
       : undefined;
   const handleOpenFileInEditor = buildOpenInEditorHandler({
     rootPath: localWorkspaceRootPath,
-    canOpenPreferredTarget,
-    openInPreferredTarget: openPathInPreferredTarget,
+    canOpenPreferredTarget: canOpenPreferredEditorTarget,
+    openInPreferredTarget: openPathInPreferredEditorTarget,
   });
   const handleOpenStorageFileInEditor = buildOpenInEditorHandler({
     rootPath: threadEnvironmentIsLocal ? threadStorageRootPath : null,
-    canOpenPreferredTarget,
-    openInPreferredTarget: openPathInPreferredTarget,
+    canOpenPreferredTarget: canOpenPreferredEditorTarget,
+    openInPreferredTarget: openPathInPreferredEditorTarget,
   });
   const handleOpenHostFileInEditor =
-    threadEnvironmentIsLocal && canOpenPreferredTarget
+    threadEnvironmentIsLocal && canOpenPreferredEditorTarget
       ? (path: string) => {
-          void openPathInPreferredTarget({
+          void openPathInPreferredEditorTarget({
             lineNumber: activeHostFileLineNumber,
             path,
           });

--- a/apps/host-daemon/src/workspace-open-targets.test.ts
+++ b/apps/host-daemon/src/workspace-open-targets.test.ts
@@ -100,6 +100,7 @@ describe("workspace open targets", () => {
 
     expect(targets.map((target) => target.id)).toEqual([
       "zed",
+      "default-app",
       "finder",
       "terminal",
     ]);
@@ -109,6 +110,34 @@ describe("workspace open targets", () => {
     expect(
       calls.some((call) => call.args.join(" ").includes("com.apple.Terminal")),
     ).toBe(false);
+  });
+
+  it("opens paths with the macOS default app", async () => {
+    const workspacePath = await mkdtemp(path.join(tmpdir(), "bb-workspace-"));
+    const filePath = path.join(workspacePath, "notes.md");
+    const calls: ExecFileCall[] = [];
+    const execFile = createAvailableExecFile({ calls });
+
+    try {
+      await writeFile(filePath, "# Notes\n");
+
+      await openPathInTargetWithRuntime(
+        {
+          lineNumber: 12,
+          path: filePath,
+          targetId: "default-app",
+        },
+        createRuntime({ execFile }),
+      );
+
+      expect(calls.find((call) => call.file === "open")).toEqual({
+        file: "open",
+        args: ["--", filePath],
+      });
+      expect(calls.some((call) => call.file === "which")).toBe(false);
+    } finally {
+      await rm(workspacePath, { force: true, recursive: true });
+    }
   });
 
   it("falls back to application bundle paths when bundle id lookup misses", async () => {

--- a/apps/host-daemon/src/workspace-open-targets.ts
+++ b/apps/host-daemon/src/workspace-open-targets.ts
@@ -54,12 +54,21 @@ export interface WorkspaceOpenTargetRuntime {
   platform: NodeJS.Platform;
 }
 
-interface MacWorkspaceOpenTargetDefinition {
+interface MacDefaultOpenTargetDefinition {
+  openMode: "default-app";
+}
+
+interface MacApplicationOpenTargetDefinition {
   appName: string;
   bundleIds: string[];
   builtIn: boolean;
   lineOpenCommand?: MacLineOpenCommandDefinition;
+  openMode: "application";
 }
+
+type MacWorkspaceOpenTargetDefinition =
+  | MacApplicationOpenTargetDefinition
+  | MacDefaultOpenTargetDefinition;
 
 interface WorkspaceOpenTargetDefinition {
   fileOpenBehavior: "direct" | "containing-directory";
@@ -106,6 +115,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "VS Code",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Visual Studio Code",
       bundleIds: ["com.microsoft.VSCode"],
       builtIn: false,
@@ -121,6 +131,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Cursor",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Cursor",
       // ToDesktop bundle IDs are generated; keep app-name path fallback below.
       bundleIds: ["com.todesktop.230313mzl4w4u92"],
@@ -137,6 +148,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Sublime Text",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Sublime Text",
       bundleIds: ["com.sublimetext.4", "com.sublimetext.3"],
       builtIn: false,
@@ -152,6 +164,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Zed",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Zed",
       bundleIds: ["dev.zed.Zed"],
       builtIn: false,
@@ -167,6 +180,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Windsurf",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Windsurf",
       bundleIds: ["com.exafunction.windsurf"],
       builtIn: false,
@@ -182,9 +196,35 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Antigravity",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Antigravity",
       bundleIds: ["com.google.antigravity", "com.googlelabs.antigravity"],
       builtIn: false,
+    },
+  },
+  {
+    id: "xcode",
+    kind: "editor",
+    label: "Xcode",
+    fileOpenBehavior: "direct",
+    macos: {
+      openMode: "application",
+      appName: "Xcode",
+      bundleIds: ["com.apple.dt.Xcode"],
+      builtIn: false,
+      lineOpenCommand: {
+        executable: "xed",
+        toArgs: (args) => ["-l", String(args.lineNumber), args.path],
+      },
+    },
+  },
+  {
+    id: "default-app",
+    kind: "editor",
+    label: "Default App",
+    fileOpenBehavior: "direct",
+    macos: {
+      openMode: "default-app",
     },
   },
   {
@@ -193,6 +233,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Finder",
     fileOpenBehavior: "direct",
     macos: {
+      openMode: "application",
       appName: "Finder",
       bundleIds: ["com.apple.finder"],
       builtIn: true,
@@ -204,6 +245,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Terminal",
     fileOpenBehavior: "containing-directory",
     macos: {
+      openMode: "application",
       appName: "Terminal",
       bundleIds: ["com.apple.Terminal"],
       builtIn: true,
@@ -215,6 +257,7 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "iTerm2",
     fileOpenBehavior: "containing-directory",
     macos: {
+      openMode: "application",
       appName: "iTerm",
       bundleIds: ["com.googlecode.iterm2"],
       builtIn: false,
@@ -226,24 +269,10 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
     label: "Ghostty",
     fileOpenBehavior: "containing-directory",
     macos: {
+      openMode: "application",
       appName: "Ghostty",
       bundleIds: ["com.mitchellh.ghostty"],
       builtIn: false,
-    },
-  },
-  {
-    id: "xcode",
-    kind: "editor",
-    label: "Xcode",
-    fileOpenBehavior: "direct",
-    macos: {
-      appName: "Xcode",
-      bundleIds: ["com.apple.dt.Xcode"],
-      builtIn: false,
-      lineOpenCommand: {
-        executable: "xed",
-        toArgs: (args) => ["-l", String(args.lineNumber), args.path],
-      },
     },
   },
 ];
@@ -287,6 +316,10 @@ function getMacApplicationCandidatePaths(
   definition: WorkspaceOpenTargetDefinition,
   runtime: WorkspaceOpenTargetRuntime,
 ): string[] {
+  if (definition.macos.openMode === "default-app") {
+    return [];
+  }
+
   const appBundleName = `${definition.macos.appName}.app`;
   return runtime.applicationDirectories.map((directory) =>
     path.join(directory, appBundleName),
@@ -333,6 +366,10 @@ async function isMacTargetAvailable(
   definition: WorkspaceOpenTargetDefinition,
   runtime: WorkspaceOpenTargetRuntime,
 ): Promise<boolean> {
+  if (definition.macos.openMode === "default-app") {
+    return true;
+  }
+
   if (definition.macos.builtIn) {
     return true;
   }
@@ -449,6 +486,10 @@ async function maybeResolveMacLineOpenInvocation(
     return null;
   }
 
+  if (args.definition.macos.openMode === "default-app") {
+    return null;
+  }
+
   const lineOpenCommand = args.definition.macos.lineOpenCommand;
   if (!lineOpenCommand) {
     return null;
@@ -479,16 +520,24 @@ async function resolveMacOpenInvocation(
     return lineOpenInvocation;
   }
 
+  const openPath = resolveTargetOpenPath({
+    definition: args.definition,
+    existingPath: args.existingPath,
+  });
+  if (args.definition.macos.openMode === "default-app") {
+    return {
+      file: "open",
+      args: ["--", openPath],
+    };
+  }
+
   return {
     file: "open",
     args: [
       "-a",
       args.definition.macos.appName,
       "--",
-      resolveTargetOpenPath({
-        definition: args.definition,
-        existingPath: args.existingPath,
-      }),
+      openPath,
     ],
   };
 }

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -26,7 +26,7 @@ import {
 } from "@bb/replay-capture/schema";
 import { z } from "zod";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 24 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 25 as const;
 
 export const FILE_LIST_QUERY_MAX_LENGTH = 256;
 export const FILE_LIST_LIMIT_MAX = 10_000;

--- a/packages/host-daemon-contract/src/local.ts
+++ b/packages/host-daemon-contract/src/local.ts
@@ -17,6 +17,7 @@ export const DEFAULT_EPHEMERAL_HOST_DAEMON_LOCAL_HEALTH_VALUE =
 export const DEFAULT_EPHEMERAL_HOST_DAEMON_LOCAL_PORT = 9111;
 
 export const workspaceOpenTargetIdValues = [
+  "default-app",
   "vscode",
   "cursor",
   "sublime-text",

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -74,6 +74,11 @@ describe("host-daemon local schemas", () => {
       contract.workspaceOpenTargetsResponseSchema.parse({
         targets: [
           {
+            id: "default-app",
+            kind: "editor",
+            label: "Default App",
+          },
+          {
             id: "finder",
             kind: "file-browser",
             label: "Finder",
@@ -87,6 +92,11 @@ describe("host-daemon local schemas", () => {
       }),
     ).toEqual({
       targets: [
+        {
+          id: "default-app",
+          kind: "editor",
+          label: "Default App",
+        },
         {
           id: "finder",
           kind: "file-browser",


### PR DESCRIPTION
## Summary

Adds a generic macOS `Default App` workspace open target that delegates file opening to LaunchServices with `open -- <path>`. This lets Markdown files open in the user's configured default editor, such as Moss, instead of falling back to Finder when no allowlisted editor is installed.

Separates file-preview "Open in editor" behavior from workspace-opening preferences so a stored Finder workspace target does not control file editor opens when an editor-like target is available.

## Root Cause

bb only offered explicit allowlisted open targets from the host daemon. On machines without one of those editors installed, the fallback target could be Finder, so file-preview editor buttons could focus Finder instead of opening Markdown in the configured default editor.

## Update Notes

- Rebased onto latest `origin/main` (`8ca421ae`).
- Bumped `HOST_DAEMON_PROTOCOL_VERSION` to `25` so dev restart/stale-daemon detection notices the local contract enum change.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/app` — passed, 3/3 packages.
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract` — passed, 32 tests.
- `pnpm exec turbo run test --filter=@bb/app` — passed, 619 tests.
- `pnpm exec turbo run test --filter=@bb/host-daemon -- src/workspace-open-targets.test.ts` — passed, 12 tests.

Note: full `@bb/host-daemon` package test was also attempted and hit unrelated integration timeout flakes; the touched host-daemon path is covered by the targeted workspace-open-target test above.
