### PR TITLE
Ship sawyer-next: desktop sidebar title-bar polish

### DIFF
--- a/apps/app/src/components/layout/AppLayout.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.test.tsx
@@ -23,9 +23,11 @@ import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { installFetchRoutes, jsonResponse } from "@/test/http-test-utils";
 import { AppLayout } from "./AppLayout";
 import {
+  MACOS_APP_REGION_NO_DRAG_CLASS,
   MACOS_COLLAPSED_HEADER_RESERVE_CLASS,
   MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
   MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
+  MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
 } from "@/lib/bb-desktop";
@@ -143,6 +145,8 @@ describe("AppLayout desktop chrome", () => {
     expect(screen.queryByTestId("bb-desktop-titlebar")).toBeNull();
     expect(screen.queryByTestId("bb-desktop-window-drag-region")).toBeNull();
     expect(screen.queryByTestId("bb-desktop-sidebar-trigger")).toBeNull();
+    expect(screen.queryByTestId("app-desktop-sidebar-trigger")).toBeNull();
+    expect(screen.queryByTestId("app-page-header-trigger-spacer")).toBeNull();
     expect(
       screen.getByTestId("app-sidebar-inline-trigger-row").className,
     ).not.toContain(MACOS_TRAFFIC_LIGHT_RESERVE_CLASS);
@@ -160,7 +164,7 @@ describe("AppLayout desktop chrome", () => {
     );
   });
 
-  it("keeps the normal sidebar trigger and reserves the traffic-light area in desktop sidebar chrome", async () => {
+  it("pins the sidebar trigger at the window root while the expanded sidebar row stays a drag spacer in desktop chrome", async () => {
     await renderAppLayout({
       desktopInfo: createBbDesktopApi({
         lastCheckedAt: null,
@@ -181,32 +185,49 @@ describe("AppLayout desktop chrome", () => {
     );
     const primaryActions = screen.getByTestId("app-sidebar-primary-actions");
     const sidebarPanel = document.querySelector("[data-sidebar='panel']");
-    const sidebarTrigger = within(inlineTriggerRow).getByRole("button", {
+    const overlay = screen.getByTestId("app-desktop-sidebar-trigger");
+    const sidebarTrigger = within(overlay).getByRole("button", {
       name: "Toggle Sidebar",
     });
 
     expect(screen.queryByTestId("bb-desktop-titlebar")).toBeNull();
     expect(screen.queryByTestId("bb-desktop-sidebar-trigger")).toBeNull();
     expect(screen.queryByTestId("bb-desktop-window-drag-region")).toBeNull();
+    // The pinned overlay is the only toggle; the sidebar's top row no longer
+    // hosts one (it just clears the traffic lights and stays draggable).
     expect(
       screen.getAllByRole("button", { name: "Toggle Sidebar" }),
     ).toHaveLength(1);
+    expect(
+      within(inlineTriggerRow).queryByRole("button", {
+        name: "Toggle Sidebar",
+      }),
+    ).toBeNull();
     expect(contentShell.className).not.toContain("pt-10");
     expect(sidebarPanel?.className).toContain("md:z-10");
     expect(inlineTriggerRow.className).toContain(MACOS_WINDOW_DRAG_CLASS);
-    expect(inlineTriggerRow.className).toContain(
+    expect(inlineTriggerRow.className).not.toContain(
       MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
     );
     expect(primaryActions.className).not.toContain(
       MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
     );
+    // Overlay wrapper is offset clear of the traffic lights and stays a
+    // window-drag region; only the button itself is no-drag, so the title
+    // strip above/below the shorter button stays draggable instead of
+    // becoming an oversized dead zone.
+    expect(overlay.className).toContain(
+      MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
+    );
+    expect(overlay.className).toContain(MACOS_WINDOW_DRAG_CLASS);
+    expect(overlay.className).not.toContain(MACOS_APP_REGION_NO_DRAG_CLASS);
     expect(sidebarTrigger.className).toContain(MACOS_WINDOW_NO_DRAG_CLASS);
     expect(sidebarTrigger.className).toContain(
       MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
     );
   });
 
-  it("uses the normal collapsed header trigger with a traffic-light reserve on desktop", async () => {
+  it("keeps the pinned trigger and reserves its footprint in the collapsed header on desktop", async () => {
     await renderAppLayout({
       desktopInfo: createBbDesktopApi({
         lastCheckedAt: null,
@@ -227,17 +248,27 @@ describe("AppLayout desktop chrome", () => {
     fireEvent.click(initialSidebarTrigger);
 
     const headerRow = screen.getByTestId("app-page-header-content-row");
-    const headerSidebarTrigger = within(headerRow).getByRole("button", {
+    const overlay = screen.getByTestId("app-desktop-sidebar-trigger");
+    const sidebarTrigger = within(overlay).getByRole("button", {
       name: "Toggle Sidebar",
     });
+    const triggerSpacer = screen.getByTestId("app-page-header-trigger-spacer");
     const sidebarTriggers = screen.getAllByRole("button", {
       name: "Toggle Sidebar",
     });
 
     expect(screen.queryByTestId("bb-desktop-sidebar-trigger")).toBeNull();
     expect(screen.queryByTestId("app-sidebar-inline-trigger-row")).toBeNull();
+    // Collapsing keeps the single pinned overlay toggle. The header reserves
+    // the toggle's footprint with a non-interactive spacer instead of a second
+    // trigger, so its content lines up the same as when the sidebar is open.
     expect(sidebarTriggers).toHaveLength(1);
-    expect(sidebarTriggers[0]).toBe(headerSidebarTrigger);
+    expect(sidebarTriggers[0]).toBe(sidebarTrigger);
+    expect(
+      within(headerRow).queryByRole("button", { name: "Toggle Sidebar" }),
+    ).toBeNull();
+    expect(triggerSpacer.getAttribute("aria-hidden")).toBe("true");
+    expect(headerRow.contains(triggerSpacer)).toBe(true);
     expect(document.querySelectorAll("[data-sidebar='trigger']")).toHaveLength(
       1,
     );
@@ -248,10 +279,14 @@ describe("AppLayout desktop chrome", () => {
     expect(headerRow.className).not.toContain(
       MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
     );
-    expect(headerSidebarTrigger.className).toContain(
-      MACOS_WINDOW_NO_DRAG_CLASS,
+    // No-drag is scoped to the button; the offset wrapper stays draggable.
+    expect(overlay.className).toContain(
+      MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
     );
-    expect(headerSidebarTrigger.className).toContain(
+    expect(overlay.className).toContain(MACOS_WINDOW_DRAG_CLASS);
+    expect(overlay.className).not.toContain(MACOS_APP_REGION_NO_DRAG_CLASS);
+    expect(sidebarTrigger.className).toContain(MACOS_WINDOW_NO_DRAG_CLASS);
+    expect(sidebarTrigger.className).toContain(
       MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
     );
   });

--- a/apps/app/src/components/layout/AppLayout.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.test.tsx
@@ -253,12 +253,25 @@ describe("AppLayout desktop chrome", () => {
       name: "Toggle Sidebar",
     });
     const triggerSpacer = screen.getByTestId("app-page-header-trigger-spacer");
+    const inlineTriggerRow = screen.getByTestId(
+      "app-sidebar-inline-trigger-row",
+    );
     const sidebarTriggers = screen.getAllByRole("button", {
       name: "Toggle Sidebar",
     });
 
     expect(screen.queryByTestId("bb-desktop-sidebar-trigger")).toBeNull();
-    expect(screen.queryByTestId("app-sidebar-inline-trigger-row")).toBeNull();
+    // The sidebar's top reserve stays mounted while collapsed so its content
+    // (New Thread / New Manager / Projects) holds the same vertical position
+    // below the title-bar chrome as when expanded, instead of riding up under
+    // the pinned trigger during the collapse animation. It remains a pure
+    // window-drag spacer with no second toggle.
+    expect(inlineTriggerRow.className).toContain(MACOS_WINDOW_DRAG_CLASS);
+    expect(
+      within(inlineTriggerRow).queryByRole("button", {
+        name: "Toggle Sidebar",
+      }),
+    ).toBeNull();
     // Collapsing keeps the single pinned overlay toggle. The header reserves
     // the toggle's footprint with a non-interactive spacer instead of a second
     // trigger, so its content lines up the same as when the sidebar is open.

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -36,6 +36,9 @@ import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider
 import { createLocalStorageSyncStorage } from "@/lib/browser-storage";
 import {
   getBbDesktopInfo,
+  MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
+  MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
+  MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
@@ -127,6 +130,38 @@ function FloatingSidebarTrigger() {
   return (
     <div className="absolute left-3 top-3.5 z-20">
       <SidebarTrigger className="h-5 w-5 rounded-md p-0" />
+    </div>
+  );
+}
+
+/**
+ * Desktop-only sidebar toggle, pinned to the window's top-left just right of
+ * the macOS traffic lights. Rendered once at the layout root — outside the
+ * sliding sidebar panel and the content inset — so it holds a constant
+ * window position while the sidebar animates in/out behind it, instead of
+ * riding whichever container would otherwise host it.
+ *
+ * The wrapper is offset clear of the traffic lights and stays a window-drag
+ * region; only the button itself is no-drag, so the title strip above and
+ * below the (shorter) button stays draggable rather than becoming an
+ * oversized dead zone.
+ */
+function DesktopSidebarTriggerOverlay() {
+  return (
+    <div
+      data-testid="app-desktop-sidebar-trigger"
+      className={cn(
+        "fixed top-0 z-50 flex h-12 items-center",
+        MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
+        MACOS_WINDOW_DRAG_CLASS,
+      )}
+    >
+      <SidebarTrigger
+        className={cn(
+          MACOS_WINDOW_NO_DRAG_CLASS,
+          MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
+        )}
+      />
     </div>
   );
 }
@@ -323,8 +358,9 @@ export function AppLayout({ children }: AppLayoutProps) {
   const projects = projectsQuery.data ?? sidebarBootstrapProjects;
   const [storedUseStandardManagerTimeline] =
     useStandardManagerTimelinePreference();
-  const prefetchedManagerTimelineView =
-    storedUseStandardManagerTimeline ? "standard" : undefined;
+  const prefetchedManagerTimelineView = storedUseStandardManagerTimeline
+    ? "standard"
+    : undefined;
   const threadDetailBootstrapQuery = useThreadDetailBootstrap(threadId ?? "", {
     composerBootstrapPrefetch: isThreadView && Boolean(threadId),
     enabled: isThreadView && Boolean(threadId),
@@ -538,6 +574,7 @@ export function AppLayout({ children }: AppLayoutProps) {
               </main>
             </div>
           </SidebarInset>
+          {usesDesktopChrome ? <DesktopSidebarTriggerOverlay /> : null}
         </SidebarStateBridge>
         <ProjectPathDialog
           target={quickCreateProject.projectPathDialog.target}

--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -8,7 +8,6 @@ import {
   getBbDesktopInfo,
   MACOS_COLLAPSED_HEADER_RESERVE_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
-  MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
@@ -57,20 +56,23 @@ export function AppPageHeader({
         )}
       >
         {showSidebarTrigger ? (
-          <SidebarTrigger
-            className={cn(
-              "shrink-0 md:ml-0",
-              usesDesktopChrome ? "ml-0" : "-ml-2",
-              usesDesktopChrome &&
-                `${MACOS_WINDOW_NO_DRAG_CLASS} ${MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS}`,
-            )}
-          />
+          usesDesktopChrome ? (
+            // The visible toggle is pinned at the window root (see AppLayout's
+            // DesktopSidebarTriggerOverlay). Reserve its footprint here so the
+            // header content lines up identically whether the sidebar is open
+            // or collapsed.
+            <div
+              aria-hidden
+              data-testid="app-page-header-trigger-spacer"
+              className={cn("shrink-0", HEADER_ICON_BUTTON_CLASS)}
+            />
+          ) : (
+            <SidebarTrigger className="-ml-2 shrink-0 md:ml-0" />
+          )
         ) : null}
         {center ? (
           <div className="flex min-w-0 flex-1 items-center">
-            <div
-              className="flex min-w-0 max-w-full items-center gap-2"
-            >
+            <div className="flex min-w-0 max-w-full items-center gap-2">
               {center}
             </div>
           </div>

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -11,7 +11,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarTrigger,
-  useIsSidebarShowing,
   useSidebar,
 } from "@/components/ui/sidebar.js";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
@@ -43,11 +42,8 @@ export function AppSidebar({
   const newManagerDialog = useNewManagerDialog();
   const navigate = useNavigate();
   const { isCompactViewport, setOpenMobile } = useSidebar();
-  const isSidebarShowing = useIsSidebarShowing();
   const [desktopInfo] = useState(getBbDesktopInfo);
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
-  const shouldShowInlineTrigger =
-    showInlineTrigger && (!usesDesktopChrome || isSidebarShowing);
   const isCompactViewportRef = useRef(isCompactViewport);
   // Keep the ProjectList callback stable while reading the latest breakpoint.
   isCompactViewportRef.current = isCompactViewport;
@@ -78,12 +74,18 @@ export function AppSidebar({
   return (
     <>
       <Sidebar>
-        {shouldShowInlineTrigger ? (
-          /* Matches the page-header height so the sidebar's top region mirrors
-             the chrome on the right of the sidebar. In desktop chrome the
-             visible toggle is pinned at the window root (see AppLayout's
-             DesktopSidebarTriggerOverlay), so here the row is just the
-             traffic-light clearance and window-drag strip. */
+        {showInlineTrigger ? (
+          /* Top reserve that keeps the sidebar's content (New Thread / New
+             Manager / Projects) anchored below the title-bar chrome. Matches
+             the page-header height so the sidebar's top region mirrors the
+             chrome on the content side. In desktop chrome the visible toggle is
+             pinned at the window root (see AppLayout's
+             DesktopSidebarTriggerOverlay), so this row is just the window-drag
+             strip — and it stays mounted in every sidebar state, including
+             while the panel collapses off-canvas, so the content holds its
+             vertical position instead of riding up under the pinned trigger
+             during the animation. In browser chrome it hosts the inline
+             trigger. */
           <div
             data-testid="app-sidebar-inline-trigger-row"
             className={cn(

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -20,10 +20,7 @@ import { useNewManagerDialog } from "@/hooks/useNewManagerDialog";
 import { useQuickCreateProjectController } from "@/hooks/useQuickCreateProject";
 import {
   getBbDesktopInfo,
-  MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS,
-  MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
-  MACOS_WINDOW_NO_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
 
@@ -83,23 +80,18 @@ export function AppSidebar({
       <Sidebar>
         {shouldShowInlineTrigger ? (
           /* Matches the page-header height so the sidebar's top region mirrors
-             the chrome on the right of the sidebar. */
+             the chrome on the right of the sidebar. In desktop chrome the
+             visible toggle is pinned at the window root (see AppLayout's
+             DesktopSidebarTriggerOverlay), so here the row is just the
+             traffic-light clearance and window-drag strip. */
           <div
             data-testid="app-sidebar-inline-trigger-row"
             className={cn(
               "flex h-12 shrink-0 items-center",
-              usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
-              usesDesktopChrome
-                ? `${MACOS_TRAFFIC_LIGHT_RESERVE_CLASS} pr-2`
-                : "px-2",
+              usesDesktopChrome ? MACOS_WINDOW_DRAG_CLASS : "px-2",
             )}
           >
-            <SidebarTrigger
-              className={cn(
-                usesDesktopChrome &&
-                  `${MACOS_WINDOW_NO_DRAG_CLASS} ${MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS}`,
-              )}
-            />
+            {usesDesktopChrome ? null : <SidebarTrigger />}
           </div>
         ) : null}
         <div

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -1,12 +1,18 @@
 import type { BbDesktopApi } from "@bb/server-contract";
 
+// The macOS traffic-light cluster sits in a fixed strip on the left of the
+// frameless window. In-flow chrome clears it with left padding; the pinned
+// sidebar trigger clears it with a matching left offset. Keep the `pl-*` and
+// `left-*` steps in sync so the trigger lands just right of the lights.
 export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-20";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-20";
 export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-16";
 export const MACOS_WINDOW_DRAG_CLASS =
   "select-none [app-region:drag] [-webkit-app-region:drag]";
-export const MACOS_WINDOW_NO_DRAG_CLASS =
-  "relative z-50 [app-region:no-drag] [-webkit-app-region:no-drag]";
-export const MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS = "mt-0";
+export const MACOS_APP_REGION_NO_DRAG_CLASS =
+  "[app-region:no-drag] [-webkit-app-region:no-drag]";
+export const MACOS_WINDOW_NO_DRAG_CLASS = `relative z-50 ${MACOS_APP_REGION_NO_DRAG_CLASS}`;
+export const MACOS_SIDEBAR_TRIGGER_OFFSET_CLASS = "mt-px";
 
 export type BbDesktopInfoResult = BbDesktopApi | null;
 


### PR DESCRIPTION
## Summary

Ships the desktop sidebar title-bar polish from `sawyer-next`. Two squash commits:

- **`desktop: pin sidebar trigger in title bar`** — the macOS sidebar-toggle button is now rendered once as a fixed overlay pinned to the window's top-left (clear of the traffic lights), so it holds a constant position while the sidebar slides in/out behind it instead of riding the collapse/expand animation between two mount points. Vertically centered with the traffic lights (1px nudge), and only the 28×28 button is `no-drag` so the rest of the title strip stays draggable.
- **`desktop: keep sidebar content below chrome`** — fixes a regression where collapsing the sidebar made the New Thread / New Manager / Projects block jump up under the title-bar chrome. The top reserve row was gated on `isSidebarShowing` (a holdover from when it hosted the trigger); with the trigger now pinned at the root, the gate is removed so the reserve stays mounted in every state and content holds its vertical position.

Both are desktop-chrome only (`usesDesktopChrome`); browser/non-desktop layout is unchanged.

## Test plan

- [ ] `pnpm exec turbo run typecheck --filter=@bb/app` + `pnpm exec turbo run test --filter=@bb/app` — pass (614 tests).
- [ ] In the desktop app: toggle the sidebar collapse/expand and confirm the toggle button holds a constant position (centered with the traffic lights), the title strip stays draggable around it, and the New Thread / New Manager / Projects block does not move vertically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)