### PR TITLE
Handle detached provider identity on watchdog stop

### DIFF
--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -84,6 +84,16 @@ function recordReplayThreadMetadata(
   });
 }
 
+function isMissingThreadProviderAssociationError(
+  error: unknown,
+  threadId: string,
+): boolean {
+  return (
+    error instanceof Error &&
+    error.message === `No provider associated with thread "${threadId}"`
+  );
+}
+
 /**
  * Translate runtime-shape execution options (which carry permissionEscalation
  * details and no source field) into the server-shape used by stored client
@@ -271,7 +281,13 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
-    await entry.runtime.stopThread({ threadId: command.threadId });
+    try {
+      await entry.runtime.stopThread({ threadId: command.threadId });
+    } catch (error) {
+      if (!isMissingThreadProviderAssociationError(error, command.threadId)) {
+        throw error;
+      }
+    }
     // Stop completion finalizes server-side thread state. Flush provider
     // events first so buffered lifecycle events cannot arrive after that.
     await options.eventSink.flush();

--- a/apps/host-daemon/test/command/thread-dispatch.test.ts
+++ b/apps/host-daemon/test/command/thread-dispatch.test.ts
@@ -781,6 +781,30 @@ describe("thread command dispatch", () => {
     expect(harness.manager.listActiveThreads()).toEqual([]);
   });
 
+  it("treats thread.stop as complete when provider identity is already detached", async () => {
+    const harness = createHarness();
+    await harness.manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+    harness.manager.markThreadActive("env-1", "thread-1", "provider-1");
+    harness.runtime.stopThread = async () => {
+      throw new Error('No provider associated with thread "thread-1"');
+    };
+
+    const result = await dispatchCommand(
+      {
+        type: "thread.stop",
+        environmentId: "env-1",
+        threadId: "thread-1",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result).toEqual({});
+    expect(harness.manager.listActiveThreads()).toEqual([]);
+  });
+
   it("creates the environment runtime for archive commands when needed", async () => {
     const harness = createHarness({ workspacePath: "/tmp/recreated-env" });
 


### PR DESCRIPTION
## Summary
- treat `thread.stop` as complete when the runtime has already detached provider identity for the same thread
- keep normal stop failures surfaced for any other error
- add host-daemon regression coverage for detached provider identity during stop

## Investigation
The 902s watchdog event was real provider inactivity: the manager accepted an automatic system tell after child thread `thr_nzet85hdw8` hit a Claude Code rate limit, then emitted no provider activity for 902423ms. The recovery path then got stuck because repeated `thread.stop` commands failed with `No provider associated with thread "thr_8wvfkbawbi"`.

## Tests
- `pnpm exec turbo run test --filter=@bb/host-daemon -- --run test/command/thread-dispatch.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`