### PR TITLE
[codex] Fix thread header actions menu drag region

### DIFF
--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 
+import type { ReactNode } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MACOS_WINDOW_NO_DRAG_CLASS } from "@/lib/bb-desktop";
 import { ThreadDetailHeader } from "./ThreadDetailHeader";
 
 vi.mock("@/components/ui/hooks/use-compact-viewport.js", () => ({
@@ -14,6 +16,7 @@ vi.mock("@/components/ui/sidebar.js", () => ({
 }));
 
 interface RenderHeaderOverrides {
+  actionsMenu?: ReactNode;
   isSecondaryPanelOpen?: boolean;
   onToggleSecondaryPanel?: () => void;
 }
@@ -21,7 +24,7 @@ interface RenderHeaderOverrides {
 function renderHeader(overrides: RenderHeaderOverrides = {}) {
   const noop = () => {};
   const props = {
-    actionsMenu: null,
+    actionsMenu: overrides.actionsMenu ?? null,
     activeTerminalCount: 0,
     isManagedThread: false,
     isManagerThread: false,
@@ -70,5 +73,23 @@ describe("ThreadDetailHeader panel toggle", () => {
     expect(
       screen.queryByRole("button", { name: "Restore conversation" }),
     ).toBeNull();
+  });
+});
+
+describe("ThreadDetailHeader actions menu", () => {
+  it("keeps the title menu out of the macOS drag region", () => {
+    renderHeader({
+      actionsMenu: (
+        <button type="button" aria-label="Thread actions">
+          Actions
+        </button>
+      ),
+    });
+
+    const button = screen.getByRole("button", { name: "Thread actions" });
+
+    expect(button.parentElement?.className).toContain(
+      MACOS_WINDOW_NO_DRAG_CLASS,
+    );
   });
 });

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -9,6 +9,7 @@ import {
   AppPageHeader,
   HEADER_ICON_BUTTON_CLASS,
 } from "@/components/layout/AppPageHeader";
+import { MACOS_WINDOW_NO_DRAG_CLASS } from "@/lib/bb-desktop";
 import { resolveShowPanelControl } from "@/components/secondary-panel/panelToggleControlState";
 import type { ThreadGitActionDialogTarget } from "@/components/dialogs/ThreadGitActionDialog";
 
@@ -71,7 +72,9 @@ export function ThreadDetailHeader({
       {!isManagerThread && isManagedThread ? (
         <Pill variant="outline">managed</Pill>
       ) : null}
-      {actionsMenu}
+      {actionsMenu ? (
+        <span className={MACOS_WINDOW_NO_DRAG_CLASS}>{actionsMenu}</span>
+      ) : null}
     </>
   );
 


### PR DESCRIPTION
## Summary

Fix the thread title/header three-dot actions menu on macOS desktop by keeping the title-area menu trigger out of the frameless-window drag region.

## Root Cause

`ThreadDetailHeader` renders `ThreadActionsMenu` in the `AppPageHeader` center/title slot. On macOS desktop, `AppPageHeader` marks the whole header as `app-region: drag`, while only the right-side `actions` slot was marked `app-region: no-drag`. The title menu therefore lived inside a draggable region, allowing Electron to consume pointer interaction before Radix could open the dropdown. The standard manager timeline path made this especially visible because the menu is the only way to turn that view back off.

## Changes

- Wrap the title-area `actionsMenu` in `MACOS_WINDOW_NO_DRAG_CLASS`.
- Add a `ThreadDetailHeader` regression test that asserts the title menu is rendered outside the macOS drag region.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/views/thread-detail/ThreadDetailHeader.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app` was attempted, but this checkout currently fails before this patch with `Cannot find module '@bb/host-daemon-contract'` from `packages/server-contract/src/api-types.ts`; `packages/server-contract/node_modules/@bb` is missing that workspace link.
