### PR TITLE
fix(claude-code): stop rendering SDK system noise as unhandled debug rows

### DIFF
--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -2164,6 +2164,36 @@ describe("claude-code provider adapter", () => {
     expect(events).toMatchObject([]);
   });
 
+  it("translateEvent ignores async hook lifecycle system events from the SDK envelope", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+
+    for (const subtype of [
+      "hook_started",
+      "hook_progress",
+      "hook_response",
+      "commands_changed",
+      "permission_denied",
+    ] as const) {
+      const events = adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "sdk/message",
+        params: {
+          threadId: "claude-thread-1",
+          message: {
+            type: "system",
+            subtype,
+            hook_name: "SessionStart:startup",
+            hook_event: "SessionStart",
+            uuid: "message-1",
+            session_id: "session-1",
+          },
+        },
+      });
+
+      expect(events).toMatchObject([]);
+    }
+  });
+
   it("translateEvent maps thread identity envelopes", () => {
     const adapter = createClaudeCodeProviderAdapter();
 

--- a/packages/agent-runtime/src/claude-code/visibility.ts
+++ b/packages/agent-runtime/src/claude-code/visibility.ts
@@ -25,8 +25,20 @@ type ClaudeMessageContentType =
   | "unknown";
 
 type ClaudeSystemSubtype =
+  | "commands_changed"
   | "compact_boundary"
+  | "elicitation_complete"
+  | "files_persisted"
+  | "hook_progress"
+  | "hook_response"
+  | "hook_started"
   | "init"
+  | "local_command_output"
+  | "memory_recall"
+  | "mirror_error"
+  | "notification"
+  | "permission_denied"
+  | "plugin_install"
   | "session_state_changed"
   | "status"
   | "task_notification"
@@ -171,8 +183,20 @@ function toClaudeSystemSubtype(
   subtype: string | undefined,
 ): ClaudeSystemSubtype {
   switch (subtype) {
+    case "commands_changed":
     case "compact_boundary":
+    case "elicitation_complete":
+    case "files_persisted":
+    case "hook_progress":
+    case "hook_response":
+    case "hook_started":
     case "init":
+    case "local_command_output":
+    case "memory_recall":
+    case "mirror_error":
+    case "notification":
+    case "permission_denied":
+    case "plugin_install":
     case "session_state_changed":
     case "status":
     case "task_notification":
@@ -419,9 +443,23 @@ function describeParsedClaudeRawEvent(
         case "task_updated":
           return { kind: `sdk/system:${event.subtype}`, coverage: "normalized" };
         case "init":
-        // The bg-agent turn-over signal and the live thinking-token estimate
-        // are intentionally unrendered; classified so they never surface as
-        // provider/unhandled debug rows.
+        // Known SDK system signals bb intentionally does not render — async
+        // hook lifecycle (hook_started/progress/response), slash-command list
+        // changes, the bg-agent turn-over signal, the live thinking-token
+        // estimate, and assorted control-channel notices. Classified as noise
+        // so they never surface as provider/unhandled debug rows.
+        case "commands_changed":
+        case "elicitation_complete":
+        case "files_persisted":
+        case "hook_progress":
+        case "hook_response":
+        case "hook_started":
+        case "local_command_output":
+        case "memory_recall":
+        case "mirror_error":
+        case "notification":
+        case "permission_denied":
+        case "plugin_install":
         case "session_state_changed":
         case "thinking_tokens":
           return { kind: `sdk/system:${event.subtype}`, coverage: "noise" };


### PR DESCRIPTION
## Problem

Threads were showing raw-JSON **"Unhandled Claude Code event"** blocks (see the `sdk/system` / `hook_started` payloads). These are routine Claude Code `system` lifecycle messages — most visibly the security plugin's **async SessionStart hook** reporting progress.

bb's visibility classifier (`visibility.ts`) only recognized a subset of `system` subtypes. Unrecognized ones fell to `coverage: "unknown"`, which is exactly the bucket that emits a persisted `provider/unhandled` event and renders as a debug block. With async hooks now common, these appeared on nearly every thread (confirmed in prod: live `hook_*`, `commands_changed`, `permission_denied` rows).

## Fix

Classify the full set of known SDK `type:"system"` subtypes that bb intentionally doesn't render as **`noise`** (cross-checked against the SDK `sdk.d.ts` message union), so they're suppressed instead of dumped. Genuinely new/unrecognized subtypes still fall to `unknown` as a forward-compat safety net.

Only the classifier changes — `translate-message.ts` already produced no events for these subtypes; the bug was the unhandled-event fallback re-reading "no events" as "unknown".

## Per-decision rationale

| Subtype | Decision | Why |
|---|---|---|
| `hook_started` / `hook_progress` / `hook_response` | **noise** | Async hook execution telemetry (e.g. security plugin bootstrap). No product meaning. |
| `commands_changed` | **noise** | Slash-command list changed mid-session. Not timeline-worthy. |
| `permission_denied` | **noise (not surfaced separately)** | The denied tool **already renders as a failed tool call** carrying the full denial reason — verified in prod: `status:"failed"`, `result:` = denial message. A separate note would duplicate it. |
| `mirror_error` | **noise** | Error from the SDK's optional external transcript-mirror feature, which bb does not use (SDK default = no mirroring). Dead signal. |
| `elicitation_complete`, `files_persisted`, `local_command_output`, `memory_recall`, `notification`, `plugin_install` | **noise** | Known control-channel notices with no bb rendering path. |
| unrecognized future subtypes | **unknown** (unchanged) | Keep the debug-row safety net for genuinely new SDK messages. |

## Scope / notes

- Stops **new** occurrences. ~6.8k already-persisted `provider/unhandled` rows in existing threads are left as-is (no data migration).
- Denied-tool visibility is unchanged — still shown as a failed tool call.

## Test

- New `adapter.test.ts` case asserting these system subtypes translate to `[]` (mirrors the existing `thinking_tokens` test).
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime` ✅
- `pnpm exec turbo run test --filter=@bb/agent-runtime` ✅ (321 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)