### PR TITLE
[codex] app: collapse sidebar sections

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -666,7 +666,7 @@ describe("ProjectList", () => {
     const appsLabel = screen.getByText("Apps");
     const managerLabel = screen.getByText("Sidebar Manager");
     expect(
-      appsLabel.closest("[data-sidebar-sticky-tier=\"label\"]")?.className,
+      appsLabel.closest('[data-sidebar-sticky-tier="label"]')?.className,
     ).toContain(CHROME_SECTION_LABEL_CLASS);
 
     // One global app → exactly one app row, regardless of the manager present.
@@ -1236,7 +1236,7 @@ describe("ProjectList", () => {
     const threadsLabel = screen.getByText("Threads");
     for (const label of [projectsLabel, threadsLabel]) {
       expect(
-        label.closest("[data-sidebar-sticky-tier=\"label\"]")?.className,
+        label.closest('[data-sidebar-sticky-tier="label"]')?.className,
       ).toContain(CHROME_SECTION_LABEL_CLASS);
     }
     const sectionStack = projectsLabel.closest(
@@ -1251,6 +1251,117 @@ describe("ProjectList", () => {
     expect(sectionStack?.classList.contains("space-y-4")).toBe(true);
     expect(projectlessThreadRow?.parentElement?.className).not.toContain(
       "before:bg-border-hairline",
+    );
+  });
+
+  it("collapses top-level Apps, Threads, and Projects sections", async () => {
+    const project = makeProjectResponse({
+      id: "project-1",
+      name: "Project One",
+    });
+    const projectlessThread = makeThreadListEntry(PERSONAL_PROJECT_ID, 10, {
+      title: "Projectless Thread",
+      titleFallback: "Projectless Thread",
+    });
+    const personalProject = makeProjectWithThreadsResponse({
+      id: PERSONAL_PROJECT_ID,
+      kind: "personal",
+      name: "Personal",
+      threads: [projectlessThread],
+    });
+    installProjectListFetchRoutes([
+      {
+        pathname: "/api/v1/sidebar-bootstrap",
+        handler: () =>
+          jsonResponse(
+            buildSidebarNavigationResponse({
+              personalProject,
+              projects: [project],
+            }),
+          ),
+      },
+      {
+        pathname: "/api/v1/apps",
+        handler: () => jsonResponse([REVIEW_BOARD_APP]),
+      },
+      {
+        pathname: "/api/v1/projects",
+        handler: () => jsonResponse([project]),
+      },
+      {
+        pathname: "/api/v1/threads",
+        handler: () => jsonResponse([]),
+      },
+      {
+        pathname: "/api/v1/system/config",
+        handler: () =>
+          jsonResponse({
+            hostDaemonPort: null,
+            voiceTranscriptionEnabled: false,
+          }),
+      },
+      {
+        pathname: "/api/v1/hosts",
+        handler: () => jsonResponse([]),
+      },
+    ]);
+
+    await renderProjectList();
+
+    expect(await screen.findByText("Project One")).toBeTruthy();
+    expect(screen.getByText("Projectless Thread")).toBeTruthy();
+    expect(await findReviewBoardAppButton()).toBeTruthy();
+
+    const collapseAppsButton = screen.getByRole("button", {
+      name: "Collapse Apps section",
+    });
+    const collapseThreadsButton = screen.getByRole("button", {
+      name: "Collapse Threads section",
+    });
+    const collapseProjectsButton = screen.getByRole("button", {
+      name: "Collapse Projects section",
+    });
+
+    expect(collapseAppsButton.getAttribute("aria-expanded")).toBe("true");
+    expect(collapseThreadsButton.getAttribute("aria-expanded")).toBe("true");
+    expect(collapseProjectsButton.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(collapseAppsButton);
+    fireEvent.click(collapseThreadsButton);
+    fireEvent.click(collapseProjectsButton);
+
+    expect(
+      screen.queryByRole("button", { name: "Open Review Board app" }),
+    ).toBeNull();
+    expect(screen.queryByText("Projectless Thread")).toBeNull();
+    expect(screen.queryByText("Project One")).toBeNull();
+
+    expect(
+      screen
+        .getByRole("button", { name: "Expand Apps section" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: "Expand Threads section" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: "Expand Projects section" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(window.localStorage.getItem("bb.sidebar.collapsedSections")).toBe(
+      JSON.stringify(["apps", "threads", "projects"]),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand Threads section" }),
+    );
+
+    expect(await screen.findByText("Projectless Thread")).toBeTruthy();
+    expect(window.localStorage.getItem("bb.sidebar.collapsedSections")).toBe(
+      JSON.stringify(["apps", "projects"]),
     );
   });
 
@@ -1633,7 +1744,9 @@ describe("ProjectList", () => {
       innerHeader instanceof HTMLElement ? innerHeader.style.paddingLeft : null,
     ).toBe("80px");
     expect(
-      innerThreadRow instanceof HTMLElement ? innerThreadRow.style.paddingLeft : null,
+      innerThreadRow instanceof HTMLElement
+        ? innerThreadRow.style.paddingLeft
+        : null,
     ).toBe("104px");
     expect(
       outerHeader instanceof HTMLElement

--- a/apps/app/src/components/sidebar/ProjectList.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.test.tsx
@@ -38,6 +38,7 @@ import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { encodeReuseValue } from "@/components/pickers/environment-picker-value";
 import { CHROME_SECTION_LABEL_CLASS } from "@/components/ui/chromeStyleTokens";
+import { SIDEBAR_HOVER_ACTIONS_CLASS } from "@/components/ui/sidebar-hover-actions";
 import {
   projectsQueryKey,
   sidebarNavigationQueryKey,
@@ -1321,10 +1322,24 @@ describe("ProjectList", () => {
     const collapseProjectsButton = screen.getByRole("button", {
       name: "Collapse Projects section",
     });
+    const sectionDisclosureButtons = [
+      { label: screen.getByText("Apps"), button: collapseAppsButton },
+      { label: screen.getByText("Threads"), button: collapseThreadsButton },
+      { label: screen.getByText("Projects"), button: collapseProjectsButton },
+    ];
 
     expect(collapseAppsButton.getAttribute("aria-expanded")).toBe("true");
     expect(collapseThreadsButton.getAttribute("aria-expanded")).toBe("true");
     expect(collapseProjectsButton.getAttribute("aria-expanded")).toBe("true");
+    for (const { label, button } of sectionDisclosureButtons) {
+      expect(
+        Boolean(
+          label.compareDocumentPosition(button) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+        ),
+      ).toBe(true);
+      expect(button.classList.contains(SIDEBAR_HOVER_ACTIONS_CLASS)).toBe(true);
+    }
 
     fireEvent.click(collapseAppsButton);
     fireEvent.click(collapseThreadsButton);

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -450,42 +450,45 @@ function TopLevelSidebarSection({
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
       >
-        {collapseControl ? (
-          <button
-            type="button"
-            aria-expanded={!collapseControl.isCollapsed}
-            aria-label={
-              collapseControl.isCollapsed
-                ? `Expand ${label} section`
-                : `Collapse ${label} section`
-            }
-            title={
-              collapseControl.isCollapsed
-                ? `Expand ${label}`
-                : `Collapse ${label}`
-            }
-            className="relative z-20 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2"
-            onClick={handleCollapseControlClick}
-            onPointerDown={stopCollapseControlPointerDown}
-            onKeyDown={stopCollapseControlKeyDown}
-          >
-            <Icon
-              name="ChevronRight"
-              className={cn(
-                "size-3 transition-transform duration-150",
-                !collapseControl.isCollapsed && "rotate-90",
-              )}
-              aria-hidden="true"
-            />
-          </button>
-        ) : null}
         <span
           className={cn(
-            "relative z-10 min-w-0 flex-1 truncate text-left",
+            "relative z-10 flex min-w-0 flex-1 items-center gap-1 text-left",
             actions && "pr-14",
           )}
         >
-          {label}
+          <span className="min-w-0 truncate">{label}</span>
+          {collapseControl ? (
+            <button
+              type="button"
+              aria-expanded={!collapseControl.isCollapsed}
+              aria-label={
+                collapseControl.isCollapsed
+                  ? `Expand ${label} section`
+                  : `Collapse ${label} section`
+              }
+              title={
+                collapseControl.isCollapsed
+                  ? `Expand ${label}`
+                  : `Collapse ${label}`
+              }
+              className={cn(
+                SIDEBAR_HOVER_ACTIONS_CLASS,
+                "relative z-20 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2",
+              )}
+              onClick={handleCollapseControlClick}
+              onPointerDown={stopCollapseControlPointerDown}
+              onKeyDown={stopCollapseControlKeyDown}
+            >
+              <Icon
+                name="ChevronRight"
+                className={cn(
+                  "size-3 transition-transform duration-150",
+                  !collapseControl.isCollapsed && "rotate-90",
+                )}
+                aria-hidden="true"
+              />
+            </button>
+          ) : null}
         </span>
         {actions ? (
           <span className="absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center">

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -4,7 +4,9 @@ import {
   useEffect,
   useMemo,
   type CSSProperties,
+  type KeyboardEventHandler,
   type MouseEventHandler,
+  type PointerEventHandler,
   type ReactNode,
 } from "react";
 import { useNavigate } from "react-router-dom";
@@ -71,10 +73,7 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { ProjectRow, ProjectThreadTree } from "./ProjectRow";
 import { SidebarAppsSection } from "./SidebarAppsSection";
-import type {
-  ProjectRowProps,
-  ProjectThreadListState,
-} from "./ProjectRow";
+import type { ProjectRowProps, ProjectThreadListState } from "./ProjectRow";
 import {
   PinnedThreadTree,
   type PinnedThreadTreeProps,
@@ -84,8 +83,10 @@ import {
   collapsedEnvironmentIdsAtom,
   collapsedThreadIdsAtom,
   collapsedProjectIdsAtom,
+  collapsedSidebarSectionIdsAtom,
   DEFAULT_SIDEBAR_SECTION_ORDER,
   sidebarSectionOrderAtom,
+  type CollapsibleSidebarSectionId,
   type SidebarSectionId,
 } from "./sidebarCollapsedAtoms";
 import {
@@ -181,6 +182,9 @@ interface ToggleCollapsedIdListArgs {
 }
 
 type ToggleCollapsedId = (id: string) => void;
+type ToggleCollapsedSidebarSectionId = (
+  id: CollapsibleSidebarSectionId,
+) => void;
 
 interface SortableProjectRowProps extends ProjectRowProps {
   reorderDisabled: boolean;
@@ -191,6 +195,7 @@ interface TopLevelSidebarSectionProps {
   children: ReactNode;
   actions?: ReactNode;
   actionsAlwaysVisible?: boolean;
+  collapseControl?: TopLevelSidebarSectionCollapseControl;
   dragBindings?: SidebarSortableDragBindings;
   sectionRef?: (element: HTMLDivElement | null) => void;
   sectionStyle?: CSSProperties;
@@ -202,9 +207,14 @@ interface SortableSidebarSectionProps extends TopLevelSidebarSectionProps {
   disabled: boolean;
 }
 
-function hasSameSidebarSectionOrder(
-  left: readonly SidebarSectionId[],
-  right: readonly SidebarSectionId[],
+interface TopLevelSidebarSectionCollapseControl {
+  isCollapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+function hasSameStringList(
+  left: readonly string[],
+  right: readonly string[],
 ): boolean {
   if (left.length !== right.length) {
     return false;
@@ -219,6 +229,12 @@ function isSidebarSectionId(value: string): value is SidebarSectionId {
     value === "threads" ||
     value === "apps"
   );
+}
+
+function isCollapsibleSidebarSectionId(
+  value: string,
+): value is CollapsibleSidebarSectionId {
+  return value === "projects" || value === "threads" || value === "apps";
 }
 
 function normalizeSidebarSectionOrder(
@@ -287,6 +303,21 @@ function toggleCollapsedIdList({
   }
 
   return Array.from(next);
+}
+
+function normalizeCollapsedSidebarSectionIds(
+  sectionIds: readonly CollapsibleSidebarSectionId[],
+): CollapsibleSidebarSectionId[] {
+  const seen = new Set<CollapsibleSidebarSectionId>();
+  const normalized: CollapsibleSidebarSectionId[] = [];
+  for (const sectionId of sectionIds) {
+    if (!isCollapsibleSidebarSectionId(sectionId) || seen.has(sectionId)) {
+      continue;
+    }
+    seen.add(sectionId);
+    normalized.push(sectionId);
+  }
+  return normalized;
 }
 
 function ProjectListSectionIconButton({
@@ -360,6 +391,7 @@ function TopLevelSidebarSection({
   children,
   actions,
   actionsAlwaysVisible = false,
+  collapseControl,
   dragBindings,
   sectionRef,
   sectionStyle,
@@ -375,6 +407,27 @@ function TopLevelSidebarSection({
     },
     [consumeClickSuppression],
   );
+  const handleCollapseControlClick = useCallback<
+    MouseEventHandler<HTMLButtonElement>
+  >(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      collapseControl?.onToggleCollapsed();
+    },
+    [collapseControl],
+  );
+  const stopCollapseControlPointerDown = useCallback<
+    PointerEventHandler<HTMLButtonElement>
+  >((event) => {
+    event.stopPropagation();
+  }, []);
+  const stopCollapseControlKeyDown = useCallback<
+    KeyboardEventHandler<HTMLButtonElement>
+  >((event) => {
+    event.stopPropagation();
+  }, []);
+
   return (
     <SidebarStickyGroup
       ref={sectionRef}
@@ -397,6 +450,35 @@ function TopLevelSidebarSection({
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
       >
+        {collapseControl ? (
+          <button
+            type="button"
+            aria-expanded={!collapseControl.isCollapsed}
+            aria-label={
+              collapseControl.isCollapsed
+                ? `Expand ${label} section`
+                : `Collapse ${label} section`
+            }
+            title={
+              collapseControl.isCollapsed
+                ? `Expand ${label}`
+                : `Collapse ${label}`
+            }
+            className="relative z-20 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2"
+            onClick={handleCollapseControlClick}
+            onPointerDown={stopCollapseControlPointerDown}
+            onKeyDown={stopCollapseControlKeyDown}
+          >
+            <Icon
+              name="ChevronRight"
+              className={cn(
+                "size-3 transition-transform duration-150",
+                !collapseControl.isCollapsed && "rotate-90",
+              )}
+              aria-hidden="true"
+            />
+          </button>
+        ) : null}
         <span
           className={cn(
             "relative z-10 min-w-0 flex-1 truncate text-left",
@@ -418,7 +500,9 @@ function TopLevelSidebarSection({
           </span>
         ) : null}
       </SidebarStickyTier>
-      <div className="mt-1">{children}</div>
+      {collapseControl?.isCollapsed ? null : (
+        <div className="mt-1">{children}</div>
+      )}
     </SidebarStickyGroup>
   );
 }
@@ -728,6 +812,8 @@ function ProjectListComponent({
   const [collapsedEnvironmentIdList, setCollapsedEnvironmentIdList] = useAtom(
     collapsedEnvironmentIdsAtom,
   );
+  const [collapsedSidebarSectionIdList, setCollapsedSidebarSectionIdList] =
+    useAtom(collapsedSidebarSectionIdsAtom);
   const [sidebarSectionOrderList, setSidebarSectionOrderList] = useAtom(
     sidebarSectionOrderAtom,
   );
@@ -747,10 +833,16 @@ function ProjectListComponent({
     () => normalizeSidebarSectionOrder(sidebarSectionOrderList),
     [sidebarSectionOrderList],
   );
+  const normalizedCollapsedSidebarSectionIds = useMemo(
+    () => normalizeCollapsedSidebarSectionIds(collapsedSidebarSectionIdList),
+    [collapsedSidebarSectionIdList],
+  );
+  const collapsedSidebarSectionIds = useMemo(
+    () => new Set(normalizedCollapsedSidebarSectionIds),
+    [normalizedCollapsedSidebarSectionIds],
+  );
   useEffect(() => {
-    if (
-      hasSameSidebarSectionOrder(sidebarSectionOrderList, sidebarSectionOrder)
-    ) {
+    if (hasSameStringList(sidebarSectionOrderList, sidebarSectionOrder)) {
       return;
     }
     setSidebarSectionOrderList(sidebarSectionOrder);
@@ -758,6 +850,21 @@ function ProjectListComponent({
     setSidebarSectionOrderList,
     sidebarSectionOrder,
     sidebarSectionOrderList,
+  ]);
+  useEffect(() => {
+    if (
+      hasSameStringList(
+        collapsedSidebarSectionIdList,
+        normalizedCollapsedSidebarSectionIds,
+      )
+    ) {
+      return;
+    }
+    setCollapsedSidebarSectionIdList(normalizedCollapsedSidebarSectionIds);
+  }, [
+    collapsedSidebarSectionIdList,
+    normalizedCollapsedSidebarSectionIds,
+    setCollapsedSidebarSectionIdList,
   ]);
   const pinnedSidebarState = useMemo(
     () => buildPinnedSidebarState({ threads }),
@@ -837,6 +944,18 @@ function ProjectListComponent({
     },
     [setCollapsedEnvironmentIdList],
   );
+
+  const toggleSidebarSectionCollapsed =
+    useCallback<ToggleCollapsedSidebarSectionId>(
+      (sectionId) => {
+        setCollapsedSidebarSectionIdList((current) => {
+          return toggleCollapsedIdList({ current, id: sectionId }).filter(
+            isCollapsibleSidebarSectionId,
+          );
+        });
+      },
+      [setCollapsedSidebarSectionIdList],
+    );
 
   const handleReorderSidebarSection = useCallback(
     (event: DragEndEvent) => {
@@ -1052,6 +1171,11 @@ function ProjectListComponent({
                   disabled={visibleSidebarSectionOrder.length < 2}
                   actions={projectsSectionActions}
                   actionsAlwaysVisible={projectsSectionActionsAlwaysVisible}
+                  collapseControl={{
+                    isCollapsed: collapsedSidebarSectionIds.has("projects"),
+                    onToggleCollapsed: () =>
+                      toggleSidebarSectionCollapsed("projects"),
+                  }}
                   consumeClickSuppression={
                     consumeSidebarSectionClickSuppression
                   }
@@ -1065,6 +1189,11 @@ function ProjectListComponent({
                   label="Threads"
                   disabled={visibleSidebarSectionOrder.length < 2}
                   actions={threadsSectionActions}
+                  collapseControl={{
+                    isCollapsed: collapsedSidebarSectionIds.has("threads"),
+                    onToggleCollapsed: () =>
+                      toggleSidebarSectionCollapsed("threads"),
+                  }}
                   consumeClickSuppression={
                     consumeSidebarSectionClickSuppression
                   }
@@ -1077,6 +1206,11 @@ function ProjectListComponent({
                   id={sectionId}
                   label="Apps"
                   disabled={visibleSidebarSectionOrder.length < 2}
+                  collapseControl={{
+                    isCollapsed: collapsedSidebarSectionIds.has("apps"),
+                    onToggleCollapsed: () =>
+                      toggleSidebarSectionCollapsed("apps"),
+                  }}
                   consumeClickSuppression={
                     consumeSidebarSectionClickSuppression
                   }

--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -5,9 +5,11 @@ const COLLAPSED_PROJECTS_STORAGE_KEY = "bb.sidebar.collapsedProjects";
 const COLLAPSED_MANAGERS_STORAGE_KEY = "bb.sidebar.collapsedManagers";
 const COLLAPSED_THREADS_STORAGE_KEY = "bb.sidebar.collapsedThreads";
 const COLLAPSED_ENVIRONMENTS_STORAGE_KEY = "bb.sidebar.collapsedEnvironments";
+const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "bb.sidebar.collapsedSections";
 const SIDEBAR_SECTION_ORDER_STORAGE_KEY = "bb.sidebar.sectionOrder";
 
 export type SidebarSectionId = "pinned" | "projects" | "threads" | "apps";
+export type CollapsibleSidebarSectionId = "projects" | "threads" | "apps";
 
 export const DEFAULT_SIDEBAR_SECTION_ORDER: readonly SidebarSectionId[] = [
   "pinned",
@@ -93,6 +95,15 @@ export const collapsedEnvironmentIdsAtom = atomWithStorage<string[]>(
   COLLAPSED_ENVIRONMENTS_STORAGE_KEY,
   [],
   createJsonLocalStorage<string[]>(),
+  { getOnInit: true },
+);
+
+export const collapsedSidebarSectionIdsAtom = atomWithStorage<
+  CollapsibleSidebarSectionId[]
+>(
+  COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
+  [],
+  createJsonLocalStorage<CollapsibleSidebarSectionId[]>(),
   { getOnInit: true },
 );
 


### PR DESCRIPTION
## Summary

Adds persisted top-level collapse controls for the sidebar's Projects, Threads, and Apps sections. The existing Pinned section remains unchanged.

## Details

- Adds `bb.sidebar.collapsedSections` storage for Projects, Threads, and Apps section state.
- Adds chevron disclosure controls to the existing draggable sidebar section headers.
- Keeps section header actions available while a section is collapsed.
- Covers collapsing all three sections and re-expanding Threads in the existing ProjectList test suite.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ProjectList.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- Live dev server started for this branch at `http://localhost:16190` with server `http://localhost:24190`.

Note: `scripts/bb-dev-app current` rejected this Git worktree because it checks for a `.git` directory; I started `pnpm dev` directly in a detached screen session instead.