### PR TITLE
[codex] allow localhost in in-app browser

### DIFF
--- a/apps/app/src/lib/browser-url.test.ts
+++ b/apps/app/src/lib/browser-url.test.ts
@@ -18,6 +18,7 @@ describe("looksLikeUrl", () => {
     expect(looksLikeUrl("news.ycombinator.com")).toBe(true);
     expect(looksLikeUrl("example.com:8080/path")).toBe(true);
     expect(looksLikeUrl("localhost:3000")).toBe(true);
+    expect(looksLikeUrl("app.localhost:3000")).toBe(true);
     expect(looksLikeUrl("127.0.0.1:38886")).toBe(true);
   });
 
@@ -47,12 +48,21 @@ describe("resolveBrowserAddressInput", () => {
     );
   });
 
-  it("prepends https:// to a bare host", () => {
+  it("prepends https:// to a public bare host", () => {
     expect(resolveBrowserAddressInput("example.com")).toBe(
       "https://example.com",
     );
+  });
+
+  it("prepends http:// to bare localhost and loopback hosts", () => {
     expect(resolveBrowserAddressInput("localhost:3000")).toBe(
-      "https://localhost:3000",
+      "http://localhost:3000",
+    );
+    expect(resolveBrowserAddressInput("app.localhost:5173/path")).toBe(
+      "http://app.localhost:5173/path",
+    );
+    expect(resolveBrowserAddressInput("127.0.0.1:38886")).toBe(
+      "http://127.0.0.1:38886",
     );
   });
 

--- a/apps/app/src/lib/browser-url.ts
+++ b/apps/app/src/lib/browser-url.ts
@@ -3,7 +3,8 @@
 
 const SEARCH_ENGINE_URL = "https://www.google.com/search";
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
-const LOCALHOST_PATTERN = /^localhost(:\d+)?(\/|$)/i;
+const LOCALHOST_PATTERN = /^([a-z0-9-]+\.)*localhost(:\d+)?(\/\S*)?$/i;
+const LOOPBACK_IPV4_PATTERN = /^(0|127)(\.\d{1,3}){3}(:\d+)?(\/\S*)?$/i;
 // host.tld (one or more dotted labels), optional port, optional path/query.
 const HOSTNAME_PATTERN = /^[a-z0-9-]+(\.[a-z0-9-]+)+(:\d+)?(\/\S*)?$/i;
 
@@ -28,8 +29,16 @@ function buildSearchUrl(query: string): string {
   return `${SEARCH_ENGINE_URL}?q=${encodeURIComponent(query)}`;
 }
 
+function isBareLocalHttpUrl(input: string): boolean {
+  return LOCALHOST_PATTERN.test(input) || LOOPBACK_IPV4_PATTERN.test(input);
+}
+
 function normalizeUrl(input: string): string {
-  return HTTP_SCHEME_PATTERN.test(input) ? input : `https://${input}`;
+  if (HTTP_SCHEME_PATTERN.test(input)) {
+    return input;
+  }
+  const scheme = isBareLocalHttpUrl(input) ? "http" : "https";
+  return `${scheme}://${input}`;
 }
 
 /**

--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -30,18 +30,17 @@ export function resolveWindowOpenAction(url: string): WindowOpenDecision {
   return { openTabUrl: isAllowedBrowserUrl(url) ? url : null };
 }
 
-// --- Loopback / LAN request firewall ---
+// --- Local / LAN request firewall ---
 //
-// Untrusted browsed pages must never be able to reach bb's own loopback
-// services (server `/ws`, host-daemon local API) or other hosts on the user's
-// LAN. CORS only filters responses; it does not stop the request from being
-// sent and acted on. So we block at the network layer (see the
-// `session.webRequest` wiring in desktop-browser-view) using these predicates,
-// which classify the request's URL host as loopback / link-local / private.
+// The in-app browser is meant to test local sites, so localhost / loopback
+// hosts are allowed. Private LAN and mDNS hosts remain blocked at the network
+// layer (see the `session.webRequest` wiring in desktop-browser-view).
 //
 // Residual: this classifies the URL host, not the DNS-resolved address, so a
 // public name that resolves to a private IP (DNS rebinding) is not caught here.
 // That is a deeper, separate mitigation and out of scope for v1.
+
+const NETWORK_REQUEST_PROTOCOLS = new Set(["http:", "https:", "ws:", "wss:"]);
 
 function parseIpv4Octets(host: string): number[] | null {
   const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
@@ -54,10 +53,29 @@ function parseIpv4Octets(host: string): number[] | null {
   return octets.some((octet) => octet > 255) ? null : octets;
 }
 
+function normalizeRequestHost(rawHost: string): string | null {
+  let host = rawHost.trim().toLowerCase();
+  if (host.length === 0) {
+    return null;
+  }
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+  const zoneIndex = host.indexOf("%");
+  if (zoneIndex !== -1) {
+    host = host.slice(0, zoneIndex);
+  }
+  return host;
+}
+
+function isLocalIpv4(octets: readonly number[]): boolean {
+  const [a] = octets;
+  return a === 0 || a === 127;
+}
+
 function isBlockedIpv4(octets: readonly number[]): boolean {
   const [a, b] = octets;
-  if (a === 0) return true; // 0.0.0.0/8 "this host"
-  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (isLocalIpv4(octets)) return true; // 0.0.0.0/8, 127.0.0.0/8
   if (a === 10) return true; // 10.0.0.0/8 private
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
   if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
@@ -115,48 +133,84 @@ function expandIpv6(host: string): number[] | null {
   return hextets;
 }
 
+function ipv4TailFromIpv6(hextets: readonly number[]): number[] | null {
+  const firstFiveZero = hextets.slice(0, 5).every((value) => value === 0);
+  if (!firstFiveZero || (hextets[5] !== 0xffff && hextets[5] !== 0)) {
+    return null;
+  }
+  return [
+    hextets[6] >> 8,
+    hextets[6] & 0xff,
+    hextets[7] >> 8,
+    hextets[7] & 0xff,
+  ];
+}
+
+function isLocalIpv6(hextets: readonly number[]): boolean {
+  const leadingZeros = hextets.slice(0, 7).every((value) => value === 0);
+  if (leadingZeros && hextets[7] === 1) return true; // ::1 loopback
+  if (hextets.every((value) => value === 0)) return true; // :: unspecified
+  const ipv4Tail = ipv4TailFromIpv6(hextets);
+  return ipv4Tail !== null && isLocalIpv4(ipv4Tail);
+}
+
+function isLocalIpv6Literal(host: string): boolean {
+  const hextets = expandIpv6(host);
+  return hextets !== null && isLocalIpv6(hextets);
+}
+
 function isBlockedIpv6Literal(host: string): boolean {
   const hextets = expandIpv6(host);
   if (hextets === null) {
     return true; // unparseable IPv6 literal → block to be safe
   }
-  const leadingZeros = hextets.slice(0, 7).every((value) => value === 0);
-  if (leadingZeros && hextets[7] === 1) return true; // ::1 loopback
-  if (hextets.every((value) => value === 0)) return true; // :: unspecified
+  if (isLocalIpv6(hextets)) return true;
   if ((hextets[0] & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
   if ((hextets[0] & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
   // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d).
-  const firstFiveZero = hextets.slice(0, 5).every((value) => value === 0);
-  if (firstFiveZero && (hextets[5] === 0xffff || hextets[5] === 0)) {
-    return isBlockedIpv4([
-      hextets[6] >> 8,
-      hextets[6] & 0xff,
-      hextets[7] >> 8,
-      hextets[7] & 0xff,
-    ]);
+  const ipv4Tail = ipv4TailFromIpv6(hextets);
+  if (ipv4Tail !== null) {
+    return isBlockedIpv4(ipv4Tail);
+  }
+  return false;
+}
+
+/**
+ * Whether a request host names the user's own machine. The in-app browser is
+ * intended for local testing, so these hosts are not blocked by the request
+ * firewall.
+ */
+export function isLocalBrowserRequestHost(rawHost: string): boolean {
+  const host = normalizeRequestHost(rawHost);
+  if (host === null) {
+    return false;
+  }
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    return true;
+  }
+  const ipv4 = parseIpv4Octets(host);
+  if (ipv4 !== null) {
+    return isLocalIpv4(ipv4);
+  }
+  if (host.includes(":")) {
+    return isLocalIpv6Literal(host);
   }
   return false;
 }
 
 /**
  * Whether a request host (URL hostname, no port) must be blocked because it
- * targets loopback, link-local, private/LAN, or mDNS `.local` space. Public
- * names and addresses return false. Exported for unit testing.
+ * targets link-local, private/LAN, or mDNS `.local` space. Localhost,
+ * loopback, public names, and public addresses return false. Exported for unit
+ * testing.
  */
 export function isBlockedBrowserRequestHost(rawHost: string): boolean {
-  let host = rawHost.trim().toLowerCase();
-  if (host.length === 0) {
+  const host = normalizeRequestHost(rawHost);
+  if (host === null) {
     return true;
   }
-  if (host.startsWith("[") && host.endsWith("]")) {
-    host = host.slice(1, -1);
-  }
-  const zoneIndex = host.indexOf("%");
-  if (zoneIndex !== -1) {
-    host = host.slice(0, zoneIndex);
-  }
-  if (host === "localhost" || host.endsWith(".localhost")) {
-    return true;
+  if (isLocalBrowserRequestHost(host)) {
+    return false;
   }
   if (host === "local" || host.endsWith(".local")) {
     return true;
@@ -183,13 +237,7 @@ export function isBlockedBrowserRequestUrl(url: string): boolean {
   } catch {
     return false;
   }
-  const protocol = parsed.protocol;
-  if (
-    protocol !== "http:" &&
-    protocol !== "https:" &&
-    protocol !== "ws:" &&
-    protocol !== "wss:"
-  ) {
+  if (!NETWORK_REQUEST_PROTOCOLS.has(parsed.protocol)) {
     return false;
   }
   return isBlockedBrowserRequestHost(parsed.hostname);

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -332,10 +332,8 @@ export function createDesktopBrowserViewManager(
     browserSession.on("will-download", (event) => {
       event.preventDefault();
     });
-    // Network firewall: untrusted pages must not be able to reach bb's loopback
-    // services or the user's LAN. This fires for ALL resource types — top-level
-    // navigation, subresources, fetch/XHR, and WebSockets — so CORS-bypassing
-    // requests to 127.0.0.1 / private ranges are cancelled before they are sent.
+    // Network firewall: localhost/loopback is allowed for local testing, but
+    // private LAN and mDNS targets are still cancelled before requests are sent.
     browserSession.webRequest.onBeforeRequest((details, callback) => {
       callback({ cancel: isBlockedBrowserRequestUrl(details.url) });
     });
@@ -368,11 +366,13 @@ export function createDesktopBrowserViewManager(
     webContents.on("will-navigate", (event, url) => {
       if (!isAllowedBrowserUrl(url)) {
         event.preventDefault();
+        return;
       }
     });
     webContents.on("will-redirect", (event, url) => {
       if (!isAllowedBrowserUrl(url)) {
         event.preventDefault();
+        return;
       }
     });
 

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -10,6 +10,7 @@ import {
   isAllowedBrowserUrl,
   isBlockedBrowserRequestHost,
   isBlockedBrowserRequestUrl,
+  isLocalBrowserRequestHost,
   resolveWindowOpenAction,
 } from "../src/desktop-browser-policy.js";
 
@@ -134,7 +135,7 @@ describe("browser IPC payload schemas", () => {
 });
 
 describe("isBlockedBrowserRequestHost (loopback / LAN firewall)", () => {
-  it("blocks loopback hosts", () => {
+  it("allows localhost and loopback hosts", () => {
     for (const host of [
       "127.0.0.1",
       "127.1.2.3",
@@ -145,7 +146,7 @@ describe("isBlockedBrowserRequestHost (loopback / LAN firewall)", () => {
       "[::1]",
       "::ffff:127.0.0.1",
     ]) {
-      expect(isBlockedBrowserRequestHost(host)).toBe(true);
+      expect(isBlockedBrowserRequestHost(host)).toBe(false);
     }
   });
 
@@ -183,13 +184,46 @@ describe("isBlockedBrowserRequestHost (loopback / LAN firewall)", () => {
   });
 });
 
+describe("isLocalBrowserRequestHost", () => {
+  it("recognizes loopback and localhost names", () => {
+    for (const host of [
+      "localhost",
+      "app.localhost",
+      "127.0.0.1",
+      "127.1.2.3",
+      "0.0.0.0",
+      "::1",
+      "[::1]",
+      "::ffff:127.0.0.1",
+    ]) {
+      expect(isLocalBrowserRequestHost(host)).toBe(true);
+    }
+  });
+
+  it("does not treat LAN and public hosts as localhost", () => {
+    for (const host of [
+      "example.com",
+      "10.0.0.5",
+      "192.168.1.1",
+      "printer.local",
+      "fc00::1",
+    ]) {
+      expect(isLocalBrowserRequestHost(host)).toBe(false);
+    }
+  });
+});
+
 describe("isBlockedBrowserRequestUrl", () => {
-  it("blocks requests to loopback/LAN over http(s)/ws(s)", () => {
-    expect(isBlockedBrowserRequestUrl("http://127.0.0.1:38886/")).toBe(true);
-    expect(isBlockedBrowserRequestUrl("https://127.0.0.1/x")).toBe(true);
-    expect(isBlockedBrowserRequestUrl("ws://localhost:38886/ws")).toBe(true);
+  it("allows requests to localhost and loopback over http(s)/ws(s)", () => {
+    expect(isBlockedBrowserRequestUrl("http://127.0.0.1:38886/")).toBe(false);
+    expect(isBlockedBrowserRequestUrl("https://127.0.0.1/x")).toBe(false);
+    expect(isBlockedBrowserRequestUrl("ws://localhost:38886/ws")).toBe(false);
+    expect(isBlockedBrowserRequestUrl("http://[::1]/")).toBe(false);
+  });
+
+  it("blocks requests to private LAN over http(s)/ws(s)", () => {
     expect(isBlockedBrowserRequestUrl("wss://10.0.0.5/socket")).toBe(true);
-    expect(isBlockedBrowserRequestUrl("http://[::1]/")).toBe(true);
+    expect(isBlockedBrowserRequestUrl("http://192.168.1.1/")).toBe(true);
   });
 
   it("allows requests to public hosts and non-network schemes", () => {

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -1,6 +1,9 @@
 import type { WebContentsView } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { BbDesktopBrowserViewBounds } from "@bb/server-contract";
+import type {
+  BbDesktopBrowserOpenTabRequest,
+  BbDesktopBrowserViewBounds,
+} from "@bb/server-contract";
 import {
   createDesktopBrowserViewManager,
   type DesktopBrowserHostContentBounds,
@@ -24,6 +27,28 @@ type FakeWindowOpenHandler = (
   details: FakeWindowOpenDetails,
 ) => FakeWindowOpenDecision;
 
+interface FakeBeforeRequestDetails {
+  url: string;
+  webContentsId?: number;
+}
+
+interface FakeBeforeRequestDecision {
+  cancel: boolean;
+}
+
+interface FakeBeforeRequestDecisionHolder {
+  value: FakeBeforeRequestDecision | null;
+}
+
+type FakeBeforeRequestCallback = (
+  decision: FakeBeforeRequestDecision,
+) => void;
+
+type FakeBeforeRequestHandler = (
+  details: FakeBeforeRequestDetails,
+  callback: FakeBeforeRequestCallback,
+) => void;
+
 const electronMock = vi.hoisted(() => {
   interface FakeNativeImage {
     isEmpty(): boolean;
@@ -34,11 +59,15 @@ const electronMock = vi.hoisted(() => {
     isEmpty: () => false,
     toJPEG: () => Buffer.from("jpeg-bytes"),
   };
+  const beforeRequestHandlers: FakeBeforeRequestHandler[] = [];
+  let nextWebContentsId = 1;
 
   class FakeWebContents {
+    public readonly id = nextWebContentsId++;
     public readonly pendingCaptureResolvers: Array<
       (image: FakeNativeImage) => void
     > = [];
+    public windowOpenHandler: FakeWindowOpenHandler | null = null;
 
     public readonly navigationHistory = {
       canGoBack() {
@@ -83,7 +112,9 @@ const electronMock = vi.hoisted(() => {
 
     reload(): void {}
 
-    setWindowOpenHandler(_handler: FakeWindowOpenHandler): void {}
+    setWindowOpenHandler(handler: FakeWindowOpenHandler): void {
+      this.windowOpenHandler = handler;
+    }
 
     stop(): void {}
   }
@@ -105,6 +136,7 @@ const electronMock = vi.hoisted(() => {
   const fakeViews: FakeWebContentsView[] = [];
 
   return {
+    beforeRequestHandlers,
     fakeCapturedImage,
     fakeViews,
     FakeWebContentsView: class extends FakeWebContentsView {
@@ -120,7 +152,9 @@ const electronMock = vi.hoisted(() => {
           setPermissionCheckHandler() {},
           setPermissionRequestHandler() {},
           webRequest: {
-            onBeforeRequest() {},
+            onBeforeRequest(handler: FakeBeforeRequestHandler) {
+              beforeRequestHandlers.push(handler);
+            },
           },
         };
       },
@@ -190,6 +224,7 @@ class FakeHostWindow implements DesktopBrowserHostWindow {
 }
 
 beforeEach(() => {
+  electronMock.beforeRequestHandlers.length = 0;
   electronMock.fakeViews.length = 0;
 });
 
@@ -216,6 +251,46 @@ function snapshotPushesOf(
     }
   }
   return pushes;
+}
+
+function openTabPushesOf(
+  hostWindow: FakeHostWindow,
+): BbDesktopBrowserOpenTabRequest[] {
+  const pushes: BbDesktopBrowserOpenTabRequest[] = [];
+  for (const payload of hostWindow.webContents.sentPayloads) {
+    if ("url" in payload && !("tabId" in payload)) {
+      pushes.push(payload);
+    }
+  }
+  return pushes;
+}
+
+function runBeforeRequest(details: FakeBeforeRequestDetails): boolean {
+  const handler = electronMock.beforeRequestHandlers.at(-1);
+  expect(handler).toBeDefined();
+  if (handler === undefined) {
+    throw new Error("Expected a webRequest handler to be registered.");
+  }
+  const decision: FakeBeforeRequestDecisionHolder = { value: null };
+  handler(details, (nextDecision) => {
+    decision.value = nextDecision;
+  });
+  expect(decision.value).not.toBeNull();
+  if (decision.value === null) {
+    throw new Error("Expected the webRequest handler to return a decision.");
+  }
+  return decision.value.cancel;
+}
+
+function getWindowOpenHandler(
+  view: (typeof electronMock.fakeViews)[number],
+): FakeWindowOpenHandler {
+  const handler = view.webContents.windowOpenHandler;
+  expect(handler).not.toBeNull();
+  if (handler === null) {
+    throw new Error("Expected the window.open handler to be registered.");
+  }
+  return handler;
 }
 
 describe("DesktopBrowserViewManager", () => {
@@ -483,5 +558,81 @@ describe("DesktopBrowserViewManager", () => {
 
     expect(view.boundsCalls).toHaveLength(1);
     expect(view.visible).toBe(false);
+  });
+
+  it("allows localhost requests through the session firewall", () => {
+    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 47,
+    });
+
+    manager.attach({
+      hostWindow,
+      request: {
+        tabId: "browser:a",
+        url: "https://example.com",
+        bounds: { x: 100, y: 50, width: 500, height: 350 },
+        visible: true,
+      },
+    });
+
+    const view = electronMock.fakeViews[0];
+    expect(view).toBeDefined();
+    if (view === undefined) {
+      throw new Error("Expected the browser view to be created.");
+    }
+
+    expect(
+      runBeforeRequest({
+        url: "http://localhost:3000/",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+    expect(
+      runBeforeRequest({
+        url: "ws://127.0.0.1:3000/socket",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+    expect(
+      runBeforeRequest({
+        url: "http://192.168.1.1/",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+    expect(runBeforeRequest({ url: "http://localhost:3000/" })).toBe(false);
+  });
+
+  it("allows localhost popup tabs", () => {
+    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 48,
+    });
+
+    manager.attach({
+      hostWindow,
+      request: {
+        tabId: "browser:a",
+        url: "https://example.com",
+        bounds: { x: 100, y: 50, width: 500, height: 350 },
+        visible: true,
+      },
+    });
+
+    const view = electronMock.fakeViews[0];
+    expect(view).toBeDefined();
+    if (view === undefined) {
+      throw new Error("Expected the browser view to be created.");
+    }
+    const handler = getWindowOpenHandler(view);
+
+    expect(handler({ url: "http://localhost:3000/" })).toEqual({
+      action: "deny",
+    });
+    expect(openTabPushesOf(hostWindow)).toEqual([
+      { url: "http://localhost:3000/" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Allow the in-app browser request policy to load localhost and loopback targets for local testing.
- Keep private LAN and mDNS targets blocked by the desktop browser request firewall.
- Resolve bare local address-bar inputs like `localhost:3000`, `app.localhost:5173/path`, and `127.0.0.1:38886` to `http://...` instead of `https://...`.

## Why

The in-app browser is intended for testing local things, but the previous request firewall treated localhost and loopback addresses as blocked network targets.

## Validation

- `pnpm exec turbo run test --filter=@bb/desktop --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/desktop --filter=@bb/app`