### PR TITLE
[codex] Update in-app browser localhost handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ output.txt
 # codex, claude code
 .claude/settings.local.json
 .codex
+.otto/
 
 # turborepo
 .turbo

--- a/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
@@ -15,10 +15,17 @@ import type {
 } from "@bb/server-contract";
 import { clampBbDesktopBrowserViewBounds } from "@bb/server-contract";
 import { Icon } from "@/components/ui/icon.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip.js";
 import { getDesktopBrowserApi } from "@/lib/bb-desktop";
 import {
   getBrowserUrlSecurity,
   resolveBrowserAddressInput,
+  type BrowserUrlSecurity,
 } from "@/lib/browser-url";
 import { useBrowserHistory } from "@/lib/browser-history";
 import { BROWSER_VIEW_BOUNDS_SYNC_EVENT } from "@/lib/browser-view-bounds-sync";
@@ -69,6 +76,10 @@ interface NavButtonProps {
   label: string;
   disabled?: boolean;
   onClick: () => void;
+}
+
+interface BrowserSecurityIndicatorProps {
+  security: BrowserUrlSecurity;
 }
 
 interface BrowserViewBoundsFromElementArgs {
@@ -152,6 +163,50 @@ function NavButton({ icon, label, disabled, onClick }: NavButtonProps) {
   );
 }
 
+function BrowserSecurityIndicator({ security }: BrowserSecurityIndicatorProps) {
+  const indicator =
+    security === "secure"
+      ? {
+          icon: "Lock" as const,
+          className: "text-success",
+          label: "Secure connection",
+          tooltip: "HTTPS connection. Traffic is encrypted.",
+        }
+      : security === "insecure"
+        ? {
+            icon: "AlertTriangle" as const,
+            className: "text-warning",
+            label: "Connection not secure",
+            tooltip:
+              "HTTP connection. Traffic is not encrypted; localhost pages are still isolated by bb's local-request sandbox.",
+          }
+        : {
+            icon: "Search" as const,
+            className: "text-muted-foreground",
+            label: "Address or search",
+            tooltip: "Enter a URL or search query.",
+          };
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex shrink-0 items-center">
+            <Icon
+              name={indicator.icon}
+              className={`size-3.5 shrink-0 ${indicator.className}`}
+              aria-label={indicator.label}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="start" className="max-w-72">
+          {indicator.tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function BrowserChrome({
   addressDraft,
   isEditing,
@@ -193,25 +248,7 @@ function BrowserChrome({
       />
       <form onSubmit={onSubmit} className="min-w-0 flex-1">
         <div className="flex h-8 items-center gap-2 rounded-full border border-border bg-background px-3">
-          {security === "secure" ? (
-            <Icon
-              name="Lock"
-              className="size-3.5 shrink-0 text-success"
-              aria-label="Secure connection"
-            />
-          ) : security === "insecure" ? (
-            <Icon
-              name="AlertTriangle"
-              className="size-3.5 shrink-0 text-warning"
-              aria-label="Connection not secure"
-            />
-          ) : (
-            <Icon
-              name="Search"
-              className="size-3.5 shrink-0 text-muted-foreground"
-              aria-hidden
-            />
-          )}
+          <BrowserSecurityIndicator security={security} />
           <input
             type="text"
             value={addressValue}

--- a/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
@@ -15,17 +15,10 @@ import type {
 } from "@bb/server-contract";
 import { clampBbDesktopBrowserViewBounds } from "@bb/server-contract";
 import { Icon } from "@/components/ui/icon.js";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip.js";
 import { getDesktopBrowserApi } from "@/lib/bb-desktop";
 import {
   getBrowserUrlSecurity,
   resolveBrowserAddressInput,
-  type BrowserUrlSecurity,
 } from "@/lib/browser-url";
 import { useBrowserHistory } from "@/lib/browser-history";
 import { BROWSER_VIEW_BOUNDS_SYNC_EVENT } from "@/lib/browser-view-bounds-sync";
@@ -76,10 +69,6 @@ interface NavButtonProps {
   label: string;
   disabled?: boolean;
   onClick: () => void;
-}
-
-interface BrowserSecurityIndicatorProps {
-  security: BrowserUrlSecurity;
 }
 
 interface BrowserViewBoundsFromElementArgs {
@@ -163,50 +152,6 @@ function NavButton({ icon, label, disabled, onClick }: NavButtonProps) {
   );
 }
 
-function BrowserSecurityIndicator({ security }: BrowserSecurityIndicatorProps) {
-  const indicator =
-    security === "secure"
-      ? {
-          icon: "Lock" as const,
-          className: "text-success",
-          label: "Secure connection",
-          tooltip: "HTTPS connection. Traffic is encrypted.",
-        }
-      : security === "insecure"
-        ? {
-            icon: "AlertTriangle" as const,
-            className: "text-warning",
-            label: "Connection not secure",
-            tooltip:
-              "HTTP connection. Traffic is not encrypted; localhost pages are still isolated by bb's local-request sandbox.",
-          }
-        : {
-            icon: "Search" as const,
-            className: "text-muted-foreground",
-            label: "Address or search",
-            tooltip: "Enter a URL or search query.",
-          };
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="inline-flex shrink-0 items-center">
-            <Icon
-              name={indicator.icon}
-              className={`size-3.5 shrink-0 ${indicator.className}`}
-              aria-label={indicator.label}
-            />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" align="start" className="max-w-72">
-          {indicator.tooltip}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
 function BrowserChrome({
   addressDraft,
   isEditing,
@@ -248,7 +193,25 @@ function BrowserChrome({
       />
       <form onSubmit={onSubmit} className="min-w-0 flex-1">
         <div className="flex h-8 items-center gap-2 rounded-full border border-border bg-background px-3">
-          <BrowserSecurityIndicator security={security} />
+          {security === "secure" ? (
+            <Icon
+              name="Lock"
+              className="size-3.5 shrink-0 text-success"
+              aria-label="Secure connection"
+            />
+          ) : security === "insecure" ? (
+            <Icon
+              name="AlertTriangle"
+              className="size-3.5 shrink-0 text-warning"
+              aria-label="Connection not secure"
+            />
+          ) : (
+            <Icon
+              name="Search"
+              className="size-3.5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          )}
           <input
             type="text"
             value={addressValue}

--- a/apps/app/src/lib/browser-url.test.ts
+++ b/apps/app/src/lib/browser-url.test.ts
@@ -13,19 +13,32 @@ describe("looksLikeUrl", () => {
     expect(looksLikeUrl("HTTPS://EXAMPLE.COM")).toBe(true);
   });
 
-  it("treats bare host.tld and localhost shapes as URLs", () => {
+  it("treats bare public hosts and loopback shapes as URLs", () => {
     expect(looksLikeUrl("example.com")).toBe(true);
     expect(looksLikeUrl("news.ycombinator.com")).toBe(true);
     expect(looksLikeUrl("example.com:8080/path")).toBe(true);
     expect(looksLikeUrl("localhost:3000")).toBe(true);
-    expect(looksLikeUrl("app.localhost:3000")).toBe(true);
+    expect(looksLikeUrl("localhost:3000?debug=1")).toBe(true);
+    expect(looksLikeUrl("foo.localhost:3000/path")).toBe(true);
     expect(looksLikeUrl("127.0.0.1:38886")).toBe(true);
+    expect(looksLikeUrl("[::1]:5173/#/route")).toBe(true);
   });
 
-  it("treats queries and non-http schemes as searches, not URLs", () => {
+  it("treats queries, blocked local hosts, and non-http schemes as searches", () => {
     expect(looksLikeUrl("how to center a div")).toBe(false);
     expect(looksLikeUrl("electron webcontentsview")).toBe(false);
     expect(looksLikeUrl("single")).toBe(false);
+    expect(looksLikeUrl("https://example.com\t@evil.com")).toBe(false);
+    expect(looksLikeUrl("https://example.com @evil.com")).toBe(false);
+    expect(looksLikeUrl("0.0.0.0:5173")).toBe(false);
+    expect(looksLikeUrl("192.168.1.12:3000")).toBe(false);
+    expect(looksLikeUrl("127.1:3000")).toBe(false);
+    expect(looksLikeUrl("192.168.1:3000")).toBe(false);
+    expect(looksLikeUrl("0xc0.0xa8.1.12:3000")).toBe(false);
+    expect(looksLikeUrl("192.168.0x1.12:3000")).toBe(false);
+    expect(looksLikeUrl("0127.0.0.1:5173")).toBe(false);
+    expect(looksLikeUrl("0x7f.0.0.1:5173")).toBe(false);
+    expect(looksLikeUrl("printer.local")).toBe(false);
     expect(looksLikeUrl("javascript:alert(1)")).toBe(false);
     expect(looksLikeUrl("file:///etc/passwd")).toBe(false);
     expect(looksLikeUrl("data:text/html,<h1>x</h1>")).toBe(false);
@@ -52,17 +65,39 @@ describe("resolveBrowserAddressInput", () => {
     expect(resolveBrowserAddressInput("example.com")).toBe(
       "https://example.com",
     );
+    expect(resolveBrowserAddressInput("example.com:8080/path")).toBe(
+      "https://example.com:8080/path",
+    );
   });
 
-  it("prepends http:// to bare localhost and loopback hosts", () => {
-    expect(resolveBrowserAddressInput("localhost:3000")).toBe(
-      "http://localhost:3000",
+  it("prepends http:// to bare localhost inputs", () => {
+    expect(resolveBrowserAddressInput("localhost:5173")).toBe(
+      "http://localhost:5173",
     );
-    expect(resolveBrowserAddressInput("app.localhost:5173/path")).toBe(
-      "http://app.localhost:5173/path",
+    expect(resolveBrowserAddressInput("localhost:5173?debug=1")).toBe(
+      "http://localhost:5173?debug=1",
     );
-    expect(resolveBrowserAddressInput("127.0.0.1:38886")).toBe(
-      "http://127.0.0.1:38886",
+    expect(resolveBrowserAddressInput("localhost:5173/#/route")).toBe(
+      "http://localhost:5173/#/route",
+    );
+  });
+
+  it("prepends http:// to bare localhost subdomains", () => {
+    expect(resolveBrowserAddressInput("foo.localhost")).toBe(
+      "http://foo.localhost",
+    );
+    expect(resolveBrowserAddressInput("foo.localhost:5173/path")).toBe(
+      "http://foo.localhost:5173/path",
+    );
+  });
+
+  it("prepends http:// to bare loopback IP literals", () => {
+    expect(resolveBrowserAddressInput("127.0.0.1:3000/path")).toBe(
+      "http://127.0.0.1:3000/path",
+    );
+    expect(resolveBrowserAddressInput("[::1]:5173")).toBe("http://[::1]:5173");
+    expect(resolveBrowserAddressInput("[::1]:5173/#/route")).toBe(
+      "http://[::1]:5173/#/route",
     );
   });
 
@@ -75,6 +110,48 @@ describe("resolveBrowserAddressInput", () => {
   it("routes a non-http scheme to search rather than navigating to it", () => {
     expect(resolveBrowserAddressInput("javascript:alert(1)")).toBe(
       "https://www.google.com/search?q=javascript%3Aalert(1)",
+    );
+    expect(resolveBrowserAddressInput("file:///etc/passwd")).toBe(
+      "https://www.google.com/search?q=file%3A%2F%2F%2Fetc%2Fpasswd",
+    );
+  });
+
+  it("routes explicit http(s) inputs with embedded whitespace to search", () => {
+    expect(resolveBrowserAddressInput("https://example.com\t@evil.com")).toBe(
+      "https://www.google.com/search?q=https%3A%2F%2Fexample.com%09%40evil.com",
+    );
+    expect(resolveBrowserAddressInput("https://example.com @evil.com")).toBe(
+      "https://www.google.com/search?q=https%3A%2F%2Fexample.com%20%40evil.com",
+    );
+    expect(resolveBrowserAddressInput("https://example.com\n@evil.com")).toBe(
+      "https://www.google.com/search?q=https%3A%2F%2Fexample.com%0A%40evil.com",
+    );
+  });
+
+  it("routes blocked local hosts to search rather than navigating to them", () => {
+    expect(resolveBrowserAddressInput("0.0.0.0:5173")).toBe(
+      "https://www.google.com/search?q=0.0.0.0%3A5173",
+    );
+    expect(resolveBrowserAddressInput("192.168.1.12:3000")).toBe(
+      "https://www.google.com/search?q=192.168.1.12%3A3000",
+    );
+    expect(resolveBrowserAddressInput("127.1:3000")).toBe(
+      "https://www.google.com/search?q=127.1%3A3000",
+    );
+    expect(resolveBrowserAddressInput("192.168.1:3000")).toBe(
+      "https://www.google.com/search?q=192.168.1%3A3000",
+    );
+    expect(resolveBrowserAddressInput("0xc0.0xa8.1.12:3000")).toBe(
+      "https://www.google.com/search?q=0xc0.0xa8.1.12%3A3000",
+    );
+    expect(resolveBrowserAddressInput("192.168.0x1.12:3000")).toBe(
+      "https://www.google.com/search?q=192.168.0x1.12%3A3000",
+    );
+    expect(resolveBrowserAddressInput("0127.0.0.1:5173")).toBe(
+      "https://www.google.com/search?q=0127.0.0.1%3A5173",
+    );
+    expect(resolveBrowserAddressInput("0x7f.0.0.1:5173")).toBe(
+      "https://www.google.com/search?q=0x7f.0.0.1%3A5173",
     );
   });
 });

--- a/apps/app/src/lib/browser-url.test.ts
+++ b/apps/app/src/lib/browser-url.test.ts
@@ -17,6 +17,8 @@ describe("looksLikeUrl", () => {
     expect(looksLikeUrl("example.com")).toBe(true);
     expect(looksLikeUrl("news.ycombinator.com")).toBe(true);
     expect(looksLikeUrl("example.com:8080/path")).toBe(true);
+    expect(looksLikeUrl("8.8.8.8")).toBe(true);
+    expect(looksLikeUrl("8.8.8.8:443/path")).toBe(true);
     expect(looksLikeUrl("localhost:3000")).toBe(true);
     expect(looksLikeUrl("localhost:3000?debug=1")).toBe(true);
     expect(looksLikeUrl("foo.localhost:3000/path")).toBe(true);
@@ -67,6 +69,10 @@ describe("resolveBrowserAddressInput", () => {
     );
     expect(resolveBrowserAddressInput("example.com:8080/path")).toBe(
       "https://example.com:8080/path",
+    );
+    expect(resolveBrowserAddressInput("8.8.8.8")).toBe("https://8.8.8.8");
+    expect(resolveBrowserAddressInput("1.1.1.1/dns-query")).toBe(
+      "https://1.1.1.1/dns-query",
     );
   });
 

--- a/apps/app/src/lib/browser-url.ts
+++ b/apps/app/src/lib/browser-url.ts
@@ -3,42 +3,179 @@
 
 const SEARCH_ENGINE_URL = "https://www.google.com/search";
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
-const LOCALHOST_PATTERN = /^([a-z0-9-]+\.)*localhost(:\d+)?(\/\S*)?$/i;
-const LOOPBACK_IPV4_PATTERN = /^(0|127)(\.\d{1,3}){3}(:\d+)?(\/\S*)?$/i;
-// host.tld (one or more dotted labels), optional port, optional path/query.
-const HOSTNAME_PATTERN = /^[a-z0-9-]+(\.[a-z0-9-]+)+(:\d+)?(\/\S*)?$/i;
+const WHITESPACE_PATTERN = /\s/u;
+const BARE_ADDRESS_PATTERN =
+  /^(\[[^\]]+\](?::\d+)?|[a-z0-9-]+(?:\.[a-z0-9-]+)*(?::\d+)?)(?:[/?#]\S*)?$/i;
+const BRACKETED_HOST_AUTHORITY_PATTERN = /^\[([^\]]+)\](?::\d+)?$/u;
+const HOST_AUTHORITY_PATTERN = /^([a-z0-9-]+(?:\.[a-z0-9-]+)*)(?::\d+)?$/i;
+const DOTTED_HOSTNAME_PATTERN = /^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i;
+const DECIMAL_OCTET_PATTERN = /^\d+$/u;
+
+function parseBareAddressHost(input: string): string | null {
+  const bareAddressMatch = BARE_ADDRESS_PATTERN.exec(input);
+  if (bareAddressMatch === null) {
+    return null;
+  }
+
+  const authority = bareAddressMatch[1] ?? "";
+  if (authority.length === 0) {
+    return null;
+  }
+
+  const bracketedHostMatch = BRACKETED_HOST_AUTHORITY_PATTERN.exec(authority);
+  if (bracketedHostMatch !== null) {
+    return (bracketedHostMatch[1] ?? "").toLowerCase();
+  }
+
+  const hostMatch = HOST_AUTHORITY_PATTERN.exec(authority);
+  if (hostMatch === null) {
+    return null;
+  }
+
+  return (hostMatch[1] ?? "").toLowerCase();
+}
+
+function normalizeParsedHost(host: string): string {
+  const lower = host.toLowerCase();
+  return lower.startsWith("[") && lower.endsWith("]")
+    ? lower.slice(1, -1)
+    : lower;
+}
+
+function parseUrlHost(url: string): string | null {
+  try {
+    return normalizeParsedHost(new URL(url).hostname);
+  } catch {
+    return null;
+  }
+}
+
+function parseIpv4Octets(host: string): number[] | null {
+  const parts = host.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!DECIMAL_OCTET_PATTERN.test(part)) {
+      return null;
+    }
+
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) {
+      return null;
+    }
+
+    octets.push(octet);
+  }
+
+  return octets;
+}
+
+function isIpv4LoopbackHost(host: string): boolean {
+  const octets = parseIpv4Octets(host);
+  return octets !== null && octets[0] === 127;
+}
+
+function isBareLoopbackHost(host: string): boolean {
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "::1" ||
+    isIpv4LoopbackHost(host)
+  );
+}
+
+function isBlockedIpv4Host(host: string): boolean {
+  const octets = parseIpv4Octets(host);
+  if (octets === null) {
+    return false;
+  }
+
+  const firstOctet = octets[0] ?? -1;
+  const secondOctet = octets[1] ?? -1;
+  return (
+    firstOctet === 0 ||
+    firstOctet === 10 ||
+    (firstOctet === 169 && secondOctet === 254) ||
+    (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) ||
+    (firstOctet === 192 && secondOctet === 168) ||
+    (firstOctet === 100 && secondOctet >= 64 && secondOctet <= 127) ||
+    (firstOctet === 198 && (secondOctet === 18 || secondOctet === 19)) ||
+    firstOctet >= 224
+  );
+}
+
+function isBlockedBareHost(host: string): boolean {
+  return host.endsWith(".local") || isBlockedIpv4Host(host);
+}
+
+function isNumericDottedHost(host: string): boolean {
+  const parts = host.split(".");
+  return (
+    parts.length > 1 && parts.every((part) => DECIMAL_OCTET_PATTERN.test(part))
+  );
+}
+
+function isPublicBareHost(host: string): boolean {
+  return (
+    !isBareLoopbackHost(host) &&
+    !isBlockedBareHost(host) &&
+    !isNumericDottedHost(host) &&
+    DOTTED_HOSTNAME_PATTERN.test(host)
+  );
+}
 
 /**
  * Whether the trimmed input should be treated as a URL to navigate to (vs. a
- * search query). Only an explicit `http(s)://` scheme or a bare `host.tld` /
- * `localhost` shape counts — anything with whitespace, or a non-http scheme
- * such as `file:`/`javascript:`/`data:`, is treated as a search.
+ * search query). Only an explicit `http(s)://` scheme, recognized bare
+ * loopback host, or public bare host counts — anything with whitespace,
+ * unsupported schemes, or private/local bare hosts is treated as a search.
  */
 export function looksLikeUrl(input: string): boolean {
   const trimmed = input.trim();
-  if (trimmed.length === 0 || /\s/u.test(trimmed)) {
+  if (trimmed.length === 0 || WHITESPACE_PATTERN.test(trimmed)) {
     return false;
   }
-  if (HTTP_SCHEME_PATTERN.test(trimmed)) {
-    return true;
-  }
-  return LOCALHOST_PATTERN.test(trimmed) || HOSTNAME_PATTERN.test(trimmed);
+  return normalizeUrl(trimmed) !== null;
 }
 
 function buildSearchUrl(query: string): string {
   return `${SEARCH_ENGINE_URL}?q=${encodeURIComponent(query)}`;
 }
 
-function isBareLocalHttpUrl(input: string): boolean {
-  return LOCALHOST_PATTERN.test(input) || LOOPBACK_IPV4_PATTERN.test(input);
-}
+function normalizeUrl(input: string): string | null {
+  if (WHITESPACE_PATTERN.test(input)) {
+    return null;
+  }
 
-function normalizeUrl(input: string): string {
   if (HTTP_SCHEME_PATTERN.test(input)) {
+    if (parseUrlHost(input) === null) {
+      return null;
+    }
     return input;
   }
-  const scheme = isBareLocalHttpUrl(input) ? "http" : "https";
-  return `${scheme}://${input}`;
+
+  const rawHost = parseBareAddressHost(input);
+  const host = parseUrlHost(`http://${input}`);
+  if (rawHost === null || host === null) {
+    return null;
+  }
+
+  if (parseIpv4Octets(host) !== null && rawHost !== host) {
+    return null;
+  }
+
+  if (isBareLoopbackHost(host)) {
+    return `http://${input}`;
+  }
+
+  if (isPublicBareHost(host)) {
+    return `https://${input}`;
+  }
+
+  return null;
 }
 
 /**
@@ -51,7 +188,7 @@ export function resolveBrowserAddressInput(rawInput: string): string | null {
   if (input.length === 0) {
     return null;
   }
-  return looksLikeUrl(input) ? normalizeUrl(input) : buildSearchUrl(input);
+  return normalizeUrl(input) ?? buildSearchUrl(input);
 }
 
 /** Security posture of a loaded URL, for the address-bar indicator. */

--- a/apps/app/src/lib/browser-url.ts
+++ b/apps/app/src/lib/browser-url.ts
@@ -111,18 +111,15 @@ function isBlockedBareHost(host: string): boolean {
   return host.endsWith(".local") || isBlockedIpv4Host(host);
 }
 
-function isNumericDottedHost(host: string): boolean {
-  const parts = host.split(".");
-  return (
-    parts.length > 1 && parts.every((part) => DECIMAL_OCTET_PATTERN.test(part))
-  );
-}
-
 function isPublicBareHost(host: string): boolean {
+  const ipv4 = parseIpv4Octets(host);
+  if (ipv4 !== null) {
+    return !isIpv4LoopbackHost(host) && !isBlockedIpv4Host(host);
+  }
+
   return (
     !isBareLoopbackHost(host) &&
     !isBlockedBareHost(host) &&
-    !isNumericDottedHost(host) &&
     DOTTED_HOSTNAME_PATTERN.test(host)
   );
 }

--- a/apps/desktop/src/desktop-browser-main-ipc.ts
+++ b/apps/desktop/src/desktop-browser-main-ipc.ts
@@ -1,0 +1,135 @@
+import { BrowserWindow, ipcMain, type IpcMainEvent } from "electron";
+import {
+  bbDesktopBrowserAttachRequestSchema,
+  bbDesktopBrowserNavigateRequestSchema,
+  bbDesktopBrowserSetBoundsRequestSchema,
+  bbDesktopBrowserSetVisibleRequestSchema,
+  bbDesktopBrowserTabRefSchema,
+} from "@bb/server-contract";
+import {
+  BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+  BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+  BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+  BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
+  BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_STOP_CHANNEL,
+} from "./desktop-browser-ipc.js";
+import type { DesktopBrowserViewManager } from "./desktop-browser-view.js";
+
+interface DesktopBrowserTabCommandArgs {
+  hostWindow: BrowserWindow;
+  tabId: string;
+}
+
+type DesktopBrowserTabCommand = (args: DesktopBrowserTabCommandArgs) => void;
+
+interface RegisterDesktopBrowserTabCommandArgs {
+  channel: string;
+  run: DesktopBrowserTabCommand;
+}
+
+function hostWindowFromBrowserIpcEvent(
+  event: IpcMainEvent,
+): BrowserWindow | null {
+  return BrowserWindow.fromWebContents(event.sender);
+}
+
+function registerTabCommand(args: RegisterDesktopBrowserTabCommandArgs): void {
+  ipcMain.on(args.channel, (event, payload: unknown) => {
+    const hostWindow = hostWindowFromBrowserIpcEvent(event);
+    if (hostWindow === null) {
+      return;
+    }
+    const parsed = bbDesktopBrowserTabRefSchema.safeParse(payload);
+    if (!parsed.success) {
+      return;
+    }
+    args.run({ hostWindow, tabId: parsed.data.tabId });
+  });
+}
+
+export function registerDesktopBrowserIpc(
+  manager: DesktopBrowserViewManager,
+): void {
+  // Every browser command is renderer -> main fire-and-forget; navigation state
+  // flows back over `BB_DESKTOP_BROWSER_STATE_CHANNEL`. Each handler resolves
+  // its own host window from the sender, so multi-window is safe, and zod-parses
+  // the untrusted-content-adjacent payload before touching the view.
+  ipcMain.on(BB_DESKTOP_BROWSER_ATTACH_CHANNEL, (event, payload: unknown) => {
+    const hostWindow = hostWindowFromBrowserIpcEvent(event);
+    if (hostWindow === null) {
+      return;
+    }
+    const parsed = bbDesktopBrowserAttachRequestSchema.safeParse(payload);
+    if (!parsed.success) {
+      return;
+    }
+    manager.attach({ hostWindow, request: parsed.data });
+  });
+
+  ipcMain.on(BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL, (event, payload: unknown) => {
+    const hostWindow = hostWindowFromBrowserIpcEvent(event);
+    if (hostWindow === null) {
+      return;
+    }
+    const parsed = bbDesktopBrowserNavigateRequestSchema.safeParse(payload);
+    if (!parsed.success) {
+      return;
+    }
+    manager.navigate({ hostWindow, request: parsed.data });
+  });
+
+  ipcMain.on(
+    BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+    (event, payload: unknown) => {
+      const hostWindow = hostWindowFromBrowserIpcEvent(event);
+      if (hostWindow === null) {
+        return;
+      }
+      const parsed = bbDesktopBrowserSetBoundsRequestSchema.safeParse(payload);
+      if (!parsed.success) {
+        return;
+      }
+      manager.setBounds({ hostWindow, request: parsed.data });
+    },
+  );
+
+  ipcMain.on(
+    BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+    (event, payload: unknown) => {
+      const hostWindow = hostWindowFromBrowserIpcEvent(event);
+      if (hostWindow === null) {
+        return;
+      }
+      const parsed = bbDesktopBrowserSetVisibleRequestSchema.safeParse(payload);
+      if (!parsed.success) {
+        return;
+      }
+      manager.setVisible({ hostWindow, request: parsed.data });
+    },
+  );
+
+  registerTabCommand({
+    channel: BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+    run: (args) => manager.detach(args),
+  });
+  registerTabCommand({
+    channel: BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+    run: (args) => manager.goBack(args),
+  });
+  registerTabCommand({
+    channel: BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+    run: (args) => manager.goForward(args),
+  });
+  registerTabCommand({
+    channel: BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+    run: (args) => manager.reload(args),
+  });
+  registerTabCommand({
+    channel: BB_DESKTOP_BROWSER_STOP_CHANNEL,
+    run: (args) => manager.stop(args),
+  });
+}

--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -27,20 +27,39 @@ export interface WindowOpenDecision {
  * the renderer can open it as a new in-panel browser tab.
  */
 export function resolveWindowOpenAction(url: string): WindowOpenDecision {
-  return { openTabUrl: isAllowedBrowserUrl(url) ? url : null };
+  return { openTabUrl: isAllowedPublicBrowserPopupUrl(url) ? url : null };
 }
 
-// --- Local / LAN request firewall ---
+// --- Loopback / LAN request firewall ---
 //
-// The in-app browser is meant to test local sites, so localhost / loopback
-// hosts are allowed. Private LAN and mDNS hosts remain blocked at the network
-// layer (see the `session.webRequest` wiring in desktop-browser-view).
+// Untrusted browsed pages must never be able to reach bb's own loopback
+// services (server `/ws`, host-daemon local API) or other hosts on the user's
+// LAN. CORS only filters responses; it does not stop the request from being
+// sent and acted on. So we block at the network layer (see the
+// `session.webRequest` wiring in desktop-browser-view) using these predicates,
+// which classify the request's URL host as loopback / link-local / private.
 //
 // Residual: this classifies the URL host, not the DNS-resolved address, so a
 // public name that resolves to a private IP (DNS rebinding) is not caught here.
 // That is a deeper, separate mitigation and out of scope for v1.
 
-const NETWORK_REQUEST_PROTOCOLS = new Set(["http:", "https:", "ws:", "wss:"]);
+export interface ShouldBlockBrowserRequestArgs {
+  url: string;
+  resourceType: string;
+  isMainFrame: boolean;
+  targetWebContentsId: number | null;
+  entryWebContentsId: number | null;
+  pendingTrustedLocalTopLevelOriginKey: string | null;
+  currentMainFrameLocalOriginKey: string | null;
+  requestingFrameOriginKey: string | null;
+  mainFrameInitiatorOriginKey: string | null;
+}
+
+interface ParsedBrowserRequestUrl {
+  protocol: string;
+  host: string;
+  port: string;
+}
 
 function parseIpv4Octets(host: string): number[] | null {
   const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
@@ -53,34 +72,24 @@ function parseIpv4Octets(host: string): number[] | null {
   return octets.some((octet) => octet > 255) ? null : octets;
 }
 
-function normalizeRequestHost(rawHost: string): string | null {
-  let host = rawHost.trim().toLowerCase();
-  if (host.length === 0) {
-    return null;
-  }
-  if (host.startsWith("[") && host.endsWith("]")) {
-    host = host.slice(1, -1);
-  }
-  const zoneIndex = host.indexOf("%");
-  if (zoneIndex !== -1) {
-    host = host.slice(0, zoneIndex);
-  }
-  return host;
+function isLoopbackIpv4(octets: readonly number[]): boolean {
+  return octets[0] === 127; // 127.0.0.0/8 loopback
 }
 
-function isLocalIpv4(octets: readonly number[]): boolean {
-  const [a] = octets;
-  return a === 0 || a === 127;
-}
-
-function isBlockedIpv4(octets: readonly number[]): boolean {
+function isPrivateIpv4(octets: readonly number[]): boolean {
   const [a, b] = octets;
-  if (isLocalIpv4(octets)) return true; // 0.0.0.0/8, 127.0.0.0/8
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
   if (a === 10) return true; // 10.0.0.0/8 private
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
   if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
   if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
   if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 192 && b === 0 && octets[2] === 0) return true; // 192.0.0.0/24
+  if (a === 192 && b === 0 && octets[2] === 2) return true; // TEST-NET-1
+  if (a === 198 && b === 18) return true; // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 19) return true; // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && octets[2] === 100) return true; // TEST-NET-2
+  if (a === 203 && b === 0 && octets[2] === 113) return true; // TEST-NET-3
   if (a >= 224) return true; // multicast / reserved / broadcast
   return false;
 }
@@ -133,114 +142,272 @@ function expandIpv6(host: string): number[] | null {
   return hextets;
 }
 
-function ipv4TailFromIpv6(hextets: readonly number[]): number[] | null {
-  const firstFiveZero = hextets.slice(0, 5).every((value) => value === 0);
-  if (!firstFiveZero || (hextets[5] !== 0xffff && hextets[5] !== 0)) {
-    return null;
-  }
-  return [
-    hextets[6] >> 8,
-    hextets[6] & 0xff,
-    hextets[7] >> 8,
-    hextets[7] & 0xff,
-  ];
-}
-
-function isLocalIpv6(hextets: readonly number[]): boolean {
-  const leadingZeros = hextets.slice(0, 7).every((value) => value === 0);
-  if (leadingZeros && hextets[7] === 1) return true; // ::1 loopback
-  if (hextets.every((value) => value === 0)) return true; // :: unspecified
-  const ipv4Tail = ipv4TailFromIpv6(hextets);
-  return ipv4Tail !== null && isLocalIpv4(ipv4Tail);
-}
-
-function isLocalIpv6Literal(host: string): boolean {
-  const hextets = expandIpv6(host);
-  return hextets !== null && isLocalIpv6(hextets);
-}
-
-function isBlockedIpv6Literal(host: string): boolean {
+function isLoopbackIpv6Literal(host: string): boolean {
   const hextets = expandIpv6(host);
   if (hextets === null) {
-    return true; // unparseable IPv6 literal → block to be safe
+    return false;
   }
-  if (isLocalIpv6(hextets)) return true;
+  const leadingZeros = hextets.slice(0, 7).every((value) => value === 0);
+  return leadingZeros && hextets[7] === 1; // ::1 loopback
+}
+
+function isPrivateIpv6Literal(host: string): boolean {
+  const hextets = expandIpv6(host);
+  if (hextets === null) {
+    return true; // unparseable IPv6 literal -> block to be safe
+  }
+  if (hextets.every((value) => value === 0)) return true; // :: unspecified
+  if (isLoopbackIpv6Literal(host)) return false; // ::1 is handled as loopback
   if ((hextets[0] & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
   if ((hextets[0] & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((hextets[0] & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  if (hextets[0] === 0x2001 && hextets[1] === 0x0db8) return true; // docs
   // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d).
-  const ipv4Tail = ipv4TailFromIpv6(hextets);
-  if (ipv4Tail !== null) {
-    return isBlockedIpv4(ipv4Tail);
+  const firstFiveZero = hextets.slice(0, 5).every((value) => value === 0);
+  if (firstFiveZero && (hextets[5] === 0xffff || hextets[5] === 0)) {
+    const mappedOctets = [
+      hextets[6] >> 8,
+      hextets[6] & 0xff,
+      hextets[7] >> 8,
+      hextets[7] & 0xff,
+    ];
+    return isLoopbackIpv4(mappedOctets) || isPrivateIpv4(mappedOctets);
   }
   return false;
 }
 
-/**
- * Whether a request host names the user's own machine. The in-app browser is
- * intended for local testing, so these hosts are not blocked by the request
- * firewall.
- */
-export function isLocalBrowserRequestHost(rawHost: string): boolean {
-  const host = normalizeRequestHost(rawHost);
-  if (host === null) {
-    return false;
+function normalizeBrowserRequestHost(rawHost: string): string | null {
+  let host = rawHost.trim().toLowerCase();
+  if (host.length === 0) {
+    return null;
   }
-  if (host === "localhost" || host.endsWith(".localhost")) {
-    return true;
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
   }
-  const ipv4 = parseIpv4Octets(host);
-  if (ipv4 !== null) {
-    return isLocalIpv4(ipv4);
+  const zoneIndex = host.indexOf("%");
+  if (zoneIndex !== -1) {
+    host = host.slice(0, zoneIndex);
   }
-  if (host.includes(":")) {
-    return isLocalIpv6Literal(host);
+  while (host.endsWith(".") && host.length > 1) {
+    host = host.slice(0, -1);
   }
-  return false;
+  return host.length === 0 ? null : host;
 }
 
-/**
- * Whether a request host (URL hostname, no port) must be blocked because it
- * targets link-local, private/LAN, or mDNS `.local` space. Localhost,
- * loopback, public names, and public addresses return false. Exported for unit
- * testing.
- */
-export function isBlockedBrowserRequestHost(rawHost: string): boolean {
-  const host = normalizeRequestHost(rawHost);
-  if (host === null) {
-    return true;
-  }
-  if (isLocalBrowserRequestHost(host)) {
-    return false;
-  }
-  if (host === "local" || host.endsWith(".local")) {
-    return true;
-  }
-  const ipv4 = parseIpv4Octets(host);
-  if (ipv4 !== null) {
-    return isBlockedIpv4(ipv4);
-  }
-  if (host.includes(":")) {
-    return isBlockedIpv6Literal(host);
-  }
-  return false;
+function isLocalhostName(host: string): boolean {
+  return host === "localhost" || host.endsWith(".localhost");
 }
 
-/**
- * Whether a network request URL must be blocked. Only `http(s)`/`ws(s)` carry a
- * remote host worth guarding; `data:`/`blob:`/`about:` have none and are
- * allowed (`webSecurity` guards `file:`). Exported for unit testing.
- */
-export function isBlockedBrowserRequestUrl(url: string): boolean {
+function isMdnsName(host: string): boolean {
+  return host === "local" || host.endsWith(".local");
+}
+
+function parseBrowserRequestUrl(url: string): ParsedBrowserRequestUrl | null {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
+    return null;
+  }
+  const host = normalizeBrowserRequestHost(parsed.hostname);
+  if (host === null) {
+    return null;
+  }
+  return { protocol: parsed.protocol, host, port: parsed.port };
+}
+
+function isGuardedRequestProtocol(protocol: string): boolean {
+  return (
+    protocol === "http:" ||
+    protocol === "https:" ||
+    protocol === "ws:" ||
+    protocol === "wss:"
+  );
+}
+
+function requestUrlTargetsLoopbackOrPrivate(url: string): boolean {
+  const parsed = parseBrowserRequestUrl(url);
+  if (parsed === null || !isGuardedRequestProtocol(parsed.protocol)) {
     return false;
   }
-  if (!NETWORK_REQUEST_PROTOCOLS.has(parsed.protocol)) {
+  return (
+    isLoopbackBrowserRequestHost(parsed.host) ||
+    isPrivateBrowserRequestHost(parsed.host)
+  );
+}
+
+function browserRequestHasEntryAttribution(
+  args: ShouldBlockBrowserRequestArgs,
+): boolean {
+  return (
+    args.targetWebContentsId !== null &&
+    args.entryWebContentsId !== null &&
+    args.targetWebContentsId === args.entryWebContentsId
+  );
+}
+
+function localRequestProtocolClass(protocol: string): string | null {
+  if (protocol === "http:" || protocol === "ws:") {
+    return "local";
+  }
+  if (protocol === "https:" || protocol === "wss:") {
+    return "secure-local";
+  }
+  return null;
+}
+
+function isAllowedPublicBrowserPopupUrl(url: string): boolean {
+  const parsed = parseBrowserRequestUrl(url);
+  return (
+    parsed !== null &&
+    (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+    !isLoopbackBrowserRequestHost(parsed.host) &&
+    !isPrivateBrowserRequestHost(parsed.host)
+  );
+}
+
+/**
+ * Whether a request host (URL hostname, no port) is a loopback host that may be
+ * allowed only through explicit trusted browser-chrome navigation.
+ */
+export function isLoopbackBrowserRequestHost(rawHost: string): boolean {
+  const host = normalizeBrowserRequestHost(rawHost);
+  if (host === null) {
     return false;
   }
-  return isBlockedBrowserRequestHost(parsed.hostname);
+  if (isLocalhostName(host)) {
+    return true;
+  }
+  const ipv4 = parseIpv4Octets(host);
+  if (ipv4 !== null) {
+    return isLoopbackIpv4(ipv4);
+  }
+  return host.includes(":") && isLoopbackIpv6Literal(host);
+}
+
+/**
+ * Whether a request host targets private/LAN, link-local, mDNS, CGNAT,
+ * multicast/reserved, unspecified, or otherwise ambiguous local address space.
+ * Loopback hosts are intentionally classified separately.
+ */
+export function isPrivateBrowserRequestHost(rawHost: string): boolean {
+  const host = normalizeBrowserRequestHost(rawHost);
+  if (host === null) {
+    return true;
+  }
+  if (isLocalhostName(host)) {
+    return false;
+  }
+  if (isMdnsName(host)) {
+    return true;
+  }
+  const ipv4 = parseIpv4Octets(host);
+  if (ipv4 !== null) {
+    return !isLoopbackIpv4(ipv4) && isPrivateIpv4(ipv4);
+  }
+  if (host.includes(":")) {
+    return isPrivateIpv6Literal(host);
+  }
+  return false;
+}
+
+/**
+ * Whether a request host (URL hostname, no port) must be blocked by the legacy
+ * coarse firewall because it targets loopback, private/LAN, or related local
+ * address space. Public names and addresses return false.
+ */
+export function isBlockedBrowserRequestHost(rawHost: string): boolean {
+  return (
+    isLoopbackBrowserRequestHost(rawHost) ||
+    isPrivateBrowserRequestHost(rawHost)
+  );
+}
+
+/**
+ * Returns the comparable local origin key for loopback `http(s)`/`ws(s)` URLs.
+ * `http` and `ws` share one transport class; `https` and `wss` share another.
+ */
+export function localRequestOriginKey(url: string): string | null {
+  const parsed = parseBrowserRequestUrl(url);
+  if (parsed === null || !isLoopbackBrowserRequestHost(parsed.host)) {
+    return null;
+  }
+  const protocolClass = localRequestProtocolClass(parsed.protocol);
+  if (protocolClass === null) {
+    return null;
+  }
+  return `${protocolClass}|${parsed.host}|${parsed.port}`;
+}
+
+/**
+ * Trusted top-level local navigations may only target loopback `http(s)` URLs.
+ */
+export function isAllowedTrustedLocalTopLevelUrl(url: string): boolean {
+  const parsed = parseBrowserRequestUrl(url);
+  return (
+    parsed !== null &&
+    (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+    isLoopbackBrowserRequestHost(parsed.host)
+  );
+}
+
+/**
+ * Whether a network request URL must be blocked by the current coarse
+ * loopback/LAN firewall. Only `http(s)`/`ws(s)` carry a remote host worth
+ * guarding; `data:`/`blob:`/`about:` have none and are allowed (`webSecurity`
+ * guards `file:`). Exported for unit testing and current native wiring.
+ */
+export function isBlockedBrowserRequestUrl(url: string): boolean {
+  return requestUrlTargetsLoopbackOrPrivate(url);
+}
+
+/**
+ * Pure same-origin loopback/private request decision. The caller is responsible
+ * for resolving Electron's `webContentsId` to exactly one live browser entry
+ * before passing the entry id and local-origin state here.
+ */
+export function shouldBlockBrowserRequest(
+  args: ShouldBlockBrowserRequestArgs,
+): boolean {
+  const parsed = parseBrowserRequestUrl(args.url);
+  if (parsed === null || !isGuardedRequestProtocol(parsed.protocol)) {
+    return false;
+  }
+  if (isPrivateBrowserRequestHost(parsed.host)) {
+    return true;
+  }
+  if (!isLoopbackBrowserRequestHost(parsed.host)) {
+    return false;
+  }
+  if (!browserRequestHasEntryAttribution(args)) {
+    return true;
+  }
+  const targetOriginKey = localRequestOriginKey(args.url);
+  if (targetOriginKey === null) {
+    return true;
+  }
+  const isMainFrameRequest =
+    args.isMainFrame || args.resourceType === "mainFrame";
+  if (isMainFrameRequest) {
+    if (!isAllowedTrustedLocalTopLevelUrl(args.url)) {
+      return true;
+    }
+    if (targetOriginKey === args.pendingTrustedLocalTopLevelOriginKey) {
+      return false;
+    }
+    return (
+      targetOriginKey !== args.currentMainFrameLocalOriginKey ||
+      args.mainFrameInitiatorOriginKey !== args.currentMainFrameLocalOriginKey
+    );
+  }
+  if (
+    args.currentMainFrameLocalOriginKey === null ||
+    args.requestingFrameOriginKey === null ||
+    args.requestingFrameOriginKey !== args.currentMainFrameLocalOriginKey
+  ) {
+    return true;
+  }
+  return targetOriginKey !== args.currentMainFrameLocalOriginKey;
 }
 
 // --- Popup-tab rate limiting ---

--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -58,6 +58,7 @@ export interface ShouldBlockBrowserRequestArgs {
 interface ParsedBrowserRequestUrl {
   protocol: string;
   host: string;
+  originHost: string;
   port: string;
 }
 
@@ -194,6 +195,21 @@ function normalizeBrowserRequestHost(rawHost: string): string | null {
   return host.length === 0 ? null : host;
 }
 
+function normalizeBrowserOriginHost(rawHost: string): string | null {
+  let host = rawHost.trim().toLowerCase();
+  if (host.length === 0) {
+    return null;
+  }
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+  const zoneIndex = host.indexOf("%");
+  if (zoneIndex !== -1) {
+    host = host.slice(0, zoneIndex);
+  }
+  return host.length === 0 ? null : host;
+}
+
 function isLocalhostName(host: string): boolean {
   return host === "localhost" || host.endsWith(".localhost");
 }
@@ -210,10 +226,11 @@ function parseBrowserRequestUrl(url: string): ParsedBrowserRequestUrl | null {
     return null;
   }
   const host = normalizeBrowserRequestHost(parsed.hostname);
-  if (host === null) {
+  const originHost = normalizeBrowserOriginHost(parsed.hostname);
+  if (host === null || originHost === null) {
     return null;
   }
-  return { protocol: parsed.protocol, host, port: parsed.port };
+  return { protocol: parsed.protocol, host, originHost, port: parsed.port };
 }
 
 function isGuardedRequestProtocol(protocol: string): boolean {
@@ -336,7 +353,7 @@ export function localRequestOriginKey(url: string): string | null {
   if (protocolClass === null) {
     return null;
   }
-  return `${protocolClass}|${parsed.host}|${parsed.port}`;
+  return `${protocolClass}|${parsed.originHost}|${parsed.port}`;
 }
 
 /**

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -246,6 +246,11 @@ function clearEntryPendingMainFrameNavigation(entry: BrowserViewEntry): void {
   entry.pendingMainFrameNavigationInitiatorOriginKey = null;
 }
 
+function clearEntryPendingLocalNavigationState(entry: BrowserViewEntry): void {
+  entry.pendingTrustedLocalTopLevelOriginKey = null;
+  clearEntryPendingMainFrameNavigation(entry);
+}
+
 function prepareEntryForTrustedTopLevelLoad(
   entry: BrowserViewEntry,
   url: string,
@@ -258,7 +263,7 @@ function prepareEntryForTrustedTopLevelLoad(
     entry.pendingTrustedLocalTopLevelOriginKey = localRequestOriginKey(url);
     return true;
   }
-  clearEntryLocalOriginState(entry);
+  clearEntryPendingLocalNavigationState(entry);
   return true;
 }
 
@@ -282,8 +287,35 @@ function clearBlockedLocalTopLevelLoad(
   url: string,
 ): void {
   if (localRequestOriginKey(url) !== null) {
-    clearEntryLocalOriginState(entry);
+    clearEntryPendingLocalNavigationState(entry);
   }
+}
+
+function historyNavigationTargetUrl(
+  entry: BrowserViewEntry,
+  offset: number,
+): string | null {
+  const history = entry.view.webContents.navigationHistory;
+  const targetEntry = history.getEntryAtIndex(history.getActiveIndex() + offset);
+  return typeof targetEntry?.url === "string" ? targetEntry.url : null;
+}
+
+function prepareEntryForHistoryNavigation(
+  entry: BrowserViewEntry,
+  offset: number,
+): void {
+  const targetUrl = historyNavigationTargetUrl(entry, offset);
+  const targetOriginKey =
+    targetUrl === null ? null : localRequestOriginKey(targetUrl);
+  if (
+    targetOriginKey !== null &&
+    targetOriginKey === entry.currentMainFrameLocalOriginKey
+  ) {
+    clearEntryPendingMainFrameNavigation(entry);
+    entry.pendingTrustedLocalTopLevelOriginKey = targetOriginKey;
+    return;
+  }
+  clearEntryPendingLocalNavigationState(entry);
 }
 
 function shouldBlockEntryTopLevelRequest(
@@ -616,6 +648,9 @@ export function createDesktopBrowserViewManager(
       "did-fail-load",
       (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
         if (!isMainFrame || errorCode === ERR_ABORTED) {
+          if (isMainFrame && errorCode === ERR_ABORTED) {
+            clearEntryPendingLocalNavigationState(entry);
+          }
           return;
         }
         clearBlockedLocalTopLevelLoad(entry, validatedURL);
@@ -672,7 +707,8 @@ export function createDesktopBrowserViewManager(
     }
     entry.lastErrorText = null;
     entry.view.webContents.loadURL(url).catch(() => {
-      // Surfaced through `did-fail-load`; swallow the rejection.
+      clearEntryPendingLocalNavigationState(entry);
+      // Usually surfaced through `did-fail-load`; swallow the rejection.
     });
   }
 
@@ -733,6 +769,7 @@ export function createDesktopBrowserViewManager(
     goBack({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
         if (entry.view.webContents.navigationHistory.canGoBack()) {
+          prepareEntryForHistoryNavigation(entry, -1);
           entry.view.webContents.navigationHistory.goBack();
         }
       });
@@ -740,6 +777,7 @@ export function createDesktopBrowserViewManager(
     goForward({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
         if (entry.view.webContents.navigationHistory.canGoForward()) {
+          prepareEntryForHistoryNavigation(entry, 1);
           entry.view.webContents.navigationHistory.goForward();
         }
       });
@@ -761,6 +799,7 @@ export function createDesktopBrowserViewManager(
     },
     stop({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
+        clearEntryPendingLocalNavigationState(entry);
         entry.view.webContents.stop();
       });
     },

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -1,8 +1,4 @@
-import {
-  WebContentsView,
-  session,
-  type Session,
-} from "electron";
+import { WebContentsView, session, type Session } from "electron";
 import {
   BB_DESKTOP_BROWSER_MAX_TITLE_LENGTH,
   BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
@@ -25,8 +21,10 @@ import {
 import {
   evaluatePopupRate,
   isAllowedBrowserUrl,
-  isBlockedBrowserRequestUrl,
+  isAllowedTrustedLocalTopLevelUrl,
+  localRequestOriginKey,
   resolveWindowOpenAction,
+  shouldBlockBrowserRequest,
 } from "./desktop-browser-policy.js";
 
 // At most this many popup → in-panel tabs may be spawned per view in a sliding
@@ -62,6 +60,10 @@ const ERR_ABORTED = -3;
 interface BrowserViewEntry {
   view: WebContentsView;
   lastErrorText: string | null;
+  pendingTrustedLocalTopLevelOriginKey: string | null;
+  currentMainFrameLocalOriginKey: string | null;
+  pendingMainFrameNavigationOriginKey: string | null;
+  pendingMainFrameNavigationInitiatorOriginKey: string | null;
   /**
    * The last renderer-measured panel rect. The renderer is the placement
    * authority — it re-measures and pushes whenever its layout actually moves
@@ -232,6 +234,117 @@ function setEntryDesiredBounds(args: SetEntryDesiredBoundsArgs): void {
   applyEntryDesiredBounds(args.entry, args.hostWindow);
 }
 
+function clearEntryLocalOriginState(entry: BrowserViewEntry): void {
+  entry.pendingTrustedLocalTopLevelOriginKey = null;
+  entry.currentMainFrameLocalOriginKey = null;
+  entry.pendingMainFrameNavigationOriginKey = null;
+  entry.pendingMainFrameNavigationInitiatorOriginKey = null;
+}
+
+function clearEntryPendingMainFrameNavigation(entry: BrowserViewEntry): void {
+  entry.pendingMainFrameNavigationOriginKey = null;
+  entry.pendingMainFrameNavigationInitiatorOriginKey = null;
+}
+
+function prepareEntryForTrustedTopLevelLoad(
+  entry: BrowserViewEntry,
+  url: string,
+): boolean {
+  if (!isAllowedBrowserUrl(url)) {
+    return false;
+  }
+  if (isAllowedTrustedLocalTopLevelUrl(url)) {
+    clearEntryPendingMainFrameNavigation(entry);
+    entry.pendingTrustedLocalTopLevelOriginKey = localRequestOriginKey(url);
+    return true;
+  }
+  clearEntryLocalOriginState(entry);
+  return true;
+}
+
+function commitEntryMainFrameUrl(entry: BrowserViewEntry, url: string): void {
+  const committedOriginKey = localRequestOriginKey(url);
+  clearEntryPendingMainFrameNavigation(entry);
+  if (
+    committedOriginKey !== null &&
+    (committedOriginKey === entry.pendingTrustedLocalTopLevelOriginKey ||
+      committedOriginKey === entry.currentMainFrameLocalOriginKey)
+  ) {
+    entry.pendingTrustedLocalTopLevelOriginKey = null;
+    entry.currentMainFrameLocalOriginKey = committedOriginKey;
+    return;
+  }
+  clearEntryLocalOriginState(entry);
+}
+
+function clearBlockedLocalTopLevelLoad(
+  entry: BrowserViewEntry,
+  url: string,
+): void {
+  if (localRequestOriginKey(url) !== null) {
+    clearEntryLocalOriginState(entry);
+  }
+}
+
+function shouldBlockEntryTopLevelRequest(
+  entry: BrowserViewEntry,
+  url: string,
+  mainFrameInitiatorOriginKey: string | null,
+): boolean {
+  if (!isAllowedBrowserUrl(url)) {
+    return true;
+  }
+  const webContentsId = entry.view.webContents.id;
+  return shouldBlockBrowserRequest({
+    url,
+    resourceType: "mainFrame",
+    isMainFrame: true,
+    targetWebContentsId: webContentsId,
+    entryWebContentsId: webContentsId,
+    pendingTrustedLocalTopLevelOriginKey:
+      entry.pendingTrustedLocalTopLevelOriginKey,
+    currentMainFrameLocalOriginKey: entry.currentMainFrameLocalOriginKey,
+    requestingFrameOriginKey: null,
+    mainFrameInitiatorOriginKey,
+  });
+}
+
+function requestingFrameOriginKey(origin: string | undefined): string | null {
+  return origin === undefined ? null : localRequestOriginKey(origin);
+}
+
+function rememberAllowedTopLevelNavigation(
+  entry: BrowserViewEntry,
+  url: string,
+  mainFrameInitiatorOriginKey: string | null,
+): void {
+  const targetOriginKey = localRequestOriginKey(url);
+  if (
+    targetOriginKey !== null &&
+    targetOriginKey !== entry.pendingTrustedLocalTopLevelOriginKey
+  ) {
+    entry.pendingMainFrameNavigationOriginKey = targetOriginKey;
+    entry.pendingMainFrameNavigationInitiatorOriginKey =
+      mainFrameInitiatorOriginKey;
+    return;
+  }
+  clearEntryPendingMainFrameNavigation(entry);
+}
+
+function pendingMainFrameInitiatorOriginKey(
+  entry: BrowserViewEntry,
+  url: string,
+): string | null {
+  const targetOriginKey = localRequestOriginKey(url);
+  if (
+    targetOriginKey === null ||
+    targetOriginKey !== entry.pendingMainFrameNavigationOriginKey
+  ) {
+    return null;
+  }
+  return entry.pendingMainFrameNavigationInitiatorOriginKey;
+}
+
 function buildBrowserState(
   tabId: string,
   entry: BrowserViewEntry,
@@ -245,7 +358,10 @@ function buildBrowserState(
   return {
     tabId,
     url: truncate(url, BB_DESKTOP_BROWSER_MAX_URL_LENGTH),
-    title: title === null ? null : truncate(title, BB_DESKTOP_BROWSER_MAX_TITLE_LENGTH),
+    title:
+      title === null
+        ? null
+        : truncate(title, BB_DESKTOP_BROWSER_MAX_TITLE_LENGTH),
     isLoading: webContents.isLoadingMainFrame(),
     canGoBack: webContents.navigationHistory.canGoBack(),
     canGoForward: webContents.navigationHistory.canGoForward(),
@@ -261,6 +377,7 @@ export function createDesktopBrowserViewManager(
 ): DesktopBrowserViewManager {
   const partition = args.partition ?? BB_BROWSER_PARTITION;
   const entries = new Map<string, BrowserViewEntry>();
+  const entriesByWebContentsId = new Map<number, BrowserViewEntry>();
   // Host webContents ids with a native resize burst in flight: views of these
   // windows stay hidden regardless of renderer-declared visibility.
   const resizingHostIds = new Set<number>();
@@ -332,10 +449,39 @@ export function createDesktopBrowserViewManager(
     browserSession.on("will-download", (event) => {
       event.preventDefault();
     });
-    // Network firewall: localhost/loopback is allowed for local testing, but
-    // private LAN and mDNS targets are still cancelled before requests are sent.
+    // Network firewall: untrusted pages must not be able to reach bb's loopback
+    // services or the user's LAN. This fires for ALL resource types — top-level
+    // navigation, subresources, fetch/XHR, and WebSockets — so CORS-bypassing
+    // requests to 127.0.0.1 / private ranges are cancelled before they are sent.
     browserSession.webRequest.onBeforeRequest((details, callback) => {
-      callback({ cancel: isBlockedBrowserRequestUrl(details.url) });
+      const targetWebContentsId = details.webContentsId ?? null;
+      const entry =
+        targetWebContentsId === null
+          ? null
+          : (entriesByWebContentsId.get(targetWebContentsId) ?? null);
+      const liveEntry =
+        entry === null || entry.view.webContents.isDestroyed() ? null : entry;
+      const isMainFrameRequest = details.resourceType === "mainFrame";
+      callback({
+        cancel: shouldBlockBrowserRequest({
+          url: details.url,
+          resourceType: details.resourceType,
+          isMainFrame: isMainFrameRequest,
+          targetWebContentsId,
+          entryWebContentsId: liveEntry?.view.webContents.id ?? null,
+          pendingTrustedLocalTopLevelOriginKey:
+            liveEntry?.pendingTrustedLocalTopLevelOriginKey ?? null,
+          currentMainFrameLocalOriginKey:
+            liveEntry?.currentMainFrameLocalOriginKey ?? null,
+          requestingFrameOriginKey: requestingFrameOriginKey(
+            details.frame?.origin,
+          ),
+          mainFrameInitiatorOriginKey:
+            liveEntry === null || !isMainFrameRequest
+              ? null
+              : pendingMainFrameInitiatorOriginKey(liveEntry, details.url),
+        }),
+      });
     });
     hardenedSession = browserSession;
     return browserSession;
@@ -363,17 +509,66 @@ export function createDesktopBrowserViewManager(
   ): void {
     const webContents = entry.view.webContents;
 
-    webContents.on("will-navigate", (event, url) => {
-      if (!isAllowedBrowserUrl(url)) {
-        event.preventDefault();
+    webContents.on("will-frame-navigate", (event) => {
+      if (!event.isMainFrame) {
         return;
       }
+      const mainFrameInitiatorOriginKey = requestingFrameOriginKey(
+        event.initiator?.origin,
+      );
+      if (
+        shouldBlockEntryTopLevelRequest(
+          entry,
+          event.url,
+          mainFrameInitiatorOriginKey,
+        )
+      ) {
+        event.preventDefault();
+        clearBlockedLocalTopLevelLoad(entry, event.url);
+        return;
+      }
+      rememberAllowedTopLevelNavigation(
+        entry,
+        event.url,
+        mainFrameInitiatorOriginKey,
+      );
     });
-    webContents.on("will-redirect", (event, url) => {
-      if (!isAllowedBrowserUrl(url)) {
+    webContents.on("will-navigate", (event, url) => {
+      const mainFrameInitiatorOriginKey = requestingFrameOriginKey(
+        event.initiator?.origin,
+      );
+      if (
+        shouldBlockEntryTopLevelRequest(entry, url, mainFrameInitiatorOriginKey)
+      ) {
         event.preventDefault();
+        clearBlockedLocalTopLevelLoad(entry, url);
         return;
       }
+      rememberAllowedTopLevelNavigation(
+        entry,
+        url,
+        mainFrameInitiatorOriginKey,
+      );
+    });
+    webContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
+      if (!isMainFrame) {
+        return;
+      }
+      const mainFrameInitiatorOriginKey = requestingFrameOriginKey(
+        event.initiator?.origin,
+      );
+      if (
+        shouldBlockEntryTopLevelRequest(entry, url, mainFrameInitiatorOriginKey)
+      ) {
+        event.preventDefault();
+        clearBlockedLocalTopLevelLoad(entry, url);
+        return;
+      }
+      rememberAllowedTopLevelNavigation(
+        entry,
+        url,
+        mainFrameInitiatorOriginKey,
+      );
     });
 
     webContents.setWindowOpenHandler((details) => {
@@ -398,11 +593,17 @@ export function createDesktopBrowserViewManager(
     const refresh = () => pushState(hostWindow, tabId);
     webContents.on("did-start-loading", refresh);
     webContents.on("did-stop-loading", refresh);
-    webContents.on("did-navigate", () => {
+    webContents.on("did-navigate", (_event, url) => {
+      commitEntryMainFrameUrl(entry, url);
       entry.lastErrorText = null;
       refresh();
     });
-    webContents.on("did-navigate-in-page", refresh);
+    webContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+      if (isMainFrame) {
+        commitEntryMainFrameUrl(entry, url);
+      }
+      refresh();
+    });
     webContents.on("did-start-navigation", () => {
       entry.lastErrorText = null;
       refresh();
@@ -413,12 +614,15 @@ export function createDesktopBrowserViewManager(
     // surface. The renderer shows a generic globe icon instead.
     webContents.on(
       "did-fail-load",
-      (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+      (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
         if (!isMainFrame || errorCode === ERR_ABORTED) {
           return;
         }
+        clearBlockedLocalTopLevelLoad(entry, validatedURL);
         entry.lastErrorText =
-          errorDescription.length > 0 ? errorDescription : "Failed to load page";
+          errorDescription.length > 0
+            ? errorDescription
+            : "Failed to load page";
         refresh();
       },
     );
@@ -441,6 +645,10 @@ export function createDesktopBrowserViewManager(
     const entry: BrowserViewEntry = {
       view,
       lastErrorText: null,
+      pendingTrustedLocalTopLevelOriginKey: null,
+      currentMainFrameLocalOriginKey: null,
+      pendingMainFrameNavigationOriginKey: null,
+      pendingMainFrameNavigationInitiatorOriginKey: null,
       desiredBounds: args.desiredBounds,
       popupTimestamps: [],
       visible: false,
@@ -448,14 +656,18 @@ export function createDesktopBrowserViewManager(
     wireWebContents(args.hostWindow, args.tabId, entry);
     args.hostWindow.contentView.addChildView(view);
     entries.set(browserViewKey(args.hostWindow, args.tabId), entry);
+    entriesByWebContentsId.set(view.webContents.id, entry);
     return entry;
   }
 
   function loadIfNeeded(entry: BrowserViewEntry, url: string): void {
-    if (url.length === 0 || !isAllowedBrowserUrl(url)) {
+    if (url.length === 0) {
       return;
     }
     if (entry.view.webContents.getURL() === url) {
+      return;
+    }
+    if (!prepareEntryForTrustedTopLevelLoad(entry, url)) {
       return;
     }
     entry.lastErrorText = null;
@@ -473,6 +685,8 @@ export function createDesktopBrowserViewManager(
       return;
     }
     entries.delete(key);
+    entriesByWebContentsId.delete(entry.view.webContents.id);
+    clearEntryLocalOriginState(entry);
     if (!hostWindow.isDestroyed()) {
       hostWindow.contentView.removeChildView(entry.view);
     }
@@ -532,6 +746,16 @@ export function createDesktopBrowserViewManager(
     },
     reload({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
+        const currentOriginKey = localRequestOriginKey(
+          entry.view.webContents.getURL(),
+        );
+        if (
+          currentOriginKey !== null &&
+          currentOriginKey === entry.currentMainFrameLocalOriginKey
+        ) {
+          clearEntryPendingMainFrameNavigation(entry);
+          entry.pendingTrustedLocalTopLevelOriginKey = currentOriginKey;
+        }
         entry.view.webContents.reload();
       });
     },
@@ -594,6 +818,8 @@ export function createDesktopBrowserViewManager(
           continue;
         }
         entries.delete(key);
+        entriesByWebContentsId.delete(entry.view.webContents.id);
+        clearEntryLocalOriginState(entry);
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();
         }
@@ -603,6 +829,8 @@ export function createDesktopBrowserViewManager(
       resizingHostIds.clear();
       for (const [key, entry] of [...entries.entries()]) {
         entries.delete(key);
+        entriesByWebContentsId.delete(entry.view.webContents.id);
+        clearEntryLocalOriginState(entry);
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();
         }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,15 +13,7 @@ import {
   type Event,
 } from "electron";
 import { autoUpdater } from "electron-updater";
-import {
-  bbDesktopBrowserAttachRequestSchema,
-  bbDesktopBrowserNavigateRequestSchema,
-  bbDesktopBrowserSetBoundsRequestSchema,
-  bbDesktopBrowserSetVisibleRequestSchema,
-  bbDesktopBrowserTabRefSchema,
-  bbDesktopThemeSchema,
-  type BbDesktopInfo,
-} from "@bb/server-contract";
+import { bbDesktopThemeSchema, type BbDesktopInfo } from "@bb/server-contract";
 import { z } from "zod";
 import {
   assertPathExists,
@@ -77,20 +69,10 @@ import {
   BB_DESKTOP_SET_THEME_CHANNEL,
 } from "./desktop-update-ipc.js";
 import {
-  BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
-  BB_DESKTOP_BROWSER_DETACH_CHANNEL,
-  BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
-  BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
-  BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
-  BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
-  BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
-  BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
-  BB_DESKTOP_BROWSER_STOP_CHANNEL,
-} from "./desktop-browser-ipc.js";
-import {
   createDesktopBrowserViewManager,
   type DesktopBrowserViewManager,
 } from "./desktop-browser-view.js";
+import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
 import { clearPackagedSessionHttpCache } from "./desktop-session-cache.js";
 import {
@@ -726,11 +708,6 @@ function registerDesktopUpdateIpc(): void {
   });
 }
 
-interface DesktopBrowserTabCommandArgs {
-  hostWindow: BrowserWindow;
-  tabId: string;
-}
-
 interface DesktopBrowserWindowLifecycleArgs {
   browserWindow: BrowserWindow;
   manager: DesktopBrowserViewManager;
@@ -784,99 +761,6 @@ function registerDesktopBrowserWindowLifecycle({
     }
     manager.releaseWindow(hostWebContentsId);
   });
-}
-
-function registerDesktopBrowserIpc(manager: DesktopBrowserViewManager): void {
-  // Every browser command is renderer → main fire-and-forget; navigation state
-  // flows back over `BB_DESKTOP_BROWSER_STATE_CHANNEL`. Each handler resolves
-  // its own host window from the sender, so multi-window is safe, and zod-parses
-  // the (untrusted-content-adjacent) payload before touching the view.
-  const registerTabCommand = (
-    channel: string,
-    run: (args: DesktopBrowserTabCommandArgs) => void,
-  ): void => {
-    ipcMain.on(channel, (event, payload: unknown) => {
-      const hostWindow = BrowserWindow.fromWebContents(event.sender);
-      if (hostWindow === null) {
-        return;
-      }
-      const parsed = bbDesktopBrowserTabRefSchema.safeParse(payload);
-      if (!parsed.success) {
-        return;
-      }
-      run({ hostWindow, tabId: parsed.data.tabId });
-    });
-  };
-
-  ipcMain.on(BB_DESKTOP_BROWSER_ATTACH_CHANNEL, (event, payload: unknown) => {
-    const hostWindow = BrowserWindow.fromWebContents(event.sender);
-    if (hostWindow === null) {
-      return;
-    }
-    const parsed = bbDesktopBrowserAttachRequestSchema.safeParse(payload);
-    if (!parsed.success) {
-      return;
-    }
-    manager.attach({ hostWindow, request: parsed.data });
-  });
-
-  ipcMain.on(BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL, (event, payload: unknown) => {
-    const hostWindow = BrowserWindow.fromWebContents(event.sender);
-    if (hostWindow === null) {
-      return;
-    }
-    const parsed = bbDesktopBrowserNavigateRequestSchema.safeParse(payload);
-    if (!parsed.success) {
-      return;
-    }
-    manager.navigate({ hostWindow, request: parsed.data });
-  });
-
-  ipcMain.on(
-    BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
-    (event, payload: unknown) => {
-      const hostWindow = BrowserWindow.fromWebContents(event.sender);
-      if (hostWindow === null) {
-        return;
-      }
-      const parsed = bbDesktopBrowserSetBoundsRequestSchema.safeParse(payload);
-      if (!parsed.success) {
-        return;
-      }
-      manager.setBounds({ hostWindow, request: parsed.data });
-    },
-  );
-
-  ipcMain.on(
-    BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
-    (event, payload: unknown) => {
-      const hostWindow = BrowserWindow.fromWebContents(event.sender);
-      if (hostWindow === null) {
-        return;
-      }
-      const parsed = bbDesktopBrowserSetVisibleRequestSchema.safeParse(payload);
-      if (!parsed.success) {
-        return;
-      }
-      manager.setVisible({ hostWindow, request: parsed.data });
-    },
-  );
-
-  registerTabCommand(BB_DESKTOP_BROWSER_DETACH_CHANNEL, (args) =>
-    manager.detach(args),
-  );
-  registerTabCommand(BB_DESKTOP_BROWSER_GO_BACK_CHANNEL, (args) =>
-    manager.goBack(args),
-  );
-  registerTabCommand(BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL, (args) =>
-    manager.goForward(args),
-  );
-  registerTabCommand(BB_DESKTOP_BROWSER_RELOAD_CHANNEL, (args) =>
-    manager.reload(args),
-  );
-  registerTabCommand(BB_DESKTOP_BROWSER_STOP_CHANNEL, (args) =>
-    manager.stop(args),
-  );
 }
 
 async function startOwnedRuntime(

--- a/apps/desktop/test/desktop-browser-main-ipc.test.ts
+++ b/apps/desktop/test/desktop-browser-main-ipc.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
+  type BbDesktopBrowserAttachRequest,
+  type BbDesktopBrowserNavigateRequest,
+  type BbDesktopBrowserSetBoundsRequest,
+  type BbDesktopBrowserSetVisibleRequest,
+} from "@bb/server-contract";
+import {
+  BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+  BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+  BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+  BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
+  BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_STOP_CHANNEL,
+} from "../src/desktop-browser-ipc.js";
+import { registerDesktopBrowserIpc } from "../src/desktop-browser-main-ipc.js";
+import type { DesktopBrowserViewManager } from "../src/desktop-browser-view.js";
+
+const electronMock = vi.hoisted(() => {
+  interface FakeWebContents {
+    id: number;
+  }
+
+  interface FakeBrowserWindow {
+    label: string;
+  }
+
+  interface FakeIpcEvent {
+    sender: FakeWebContents;
+  }
+
+  type FakeIpcListener = (event: FakeIpcEvent, payload: unknown) => void;
+
+  const listeners = new Map<string, FakeIpcListener>();
+  const windowsBySender = new Map<FakeWebContents, FakeBrowserWindow>();
+
+  return {
+    listeners,
+    windowsBySender,
+    BrowserWindow: {
+      fromWebContents(sender: FakeWebContents): FakeBrowserWindow | null {
+        return windowsBySender.get(sender) ?? null;
+      },
+    },
+    ipcMain: {
+      on(channel: string, listener: FakeIpcListener): void {
+        listeners.set(channel, listener);
+      },
+    },
+  };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow: electronMock.BrowserWindow,
+  ipcMain: electronMock.ipcMain,
+}));
+
+type AttachCall = Parameters<DesktopBrowserViewManager["attach"]>[0];
+type DetachCall = Parameters<DesktopBrowserViewManager["detach"]>[0];
+type NavigateCall = Parameters<DesktopBrowserViewManager["navigate"]>[0];
+type SetBoundsCall = Parameters<DesktopBrowserViewManager["setBounds"]>[0];
+type SetVisibleCall = Parameters<DesktopBrowserViewManager["setVisible"]>[0];
+type TabCommandCall = Parameters<DesktopBrowserViewManager["reload"]>[0];
+type WindowResizeCall = Parameters<
+  DesktopBrowserViewManager["beginWindowResize"]
+>[0];
+
+interface FakeWebContents {
+  id: number;
+}
+
+interface FakeBrowserWindow {
+  label: string;
+}
+
+interface FakeRenderer {
+  hostWindow: FakeBrowserWindow;
+  sender: FakeWebContents;
+}
+
+interface SendBrowserIpcArgs {
+  channel: string;
+  payload: unknown;
+  sender: FakeWebContents;
+}
+
+class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
+  public readonly attachCalls: AttachCall[] = [];
+  public readonly beginWindowResizeCalls: WindowResizeCall[] = [];
+  public readonly destroyAllCalls: string[] = [];
+  public readonly detachCalls: DetachCall[] = [];
+  public readonly endWindowResizeCalls: WindowResizeCall[] = [];
+  public readonly goBackCalls: TabCommandCall[] = [];
+  public readonly goForwardCalls: TabCommandCall[] = [];
+  public readonly navigateCalls: NavigateCall[] = [];
+  public readonly releaseWindowCalls: number[] = [];
+  public readonly reloadCalls: TabCommandCall[] = [];
+  public readonly setBoundsCalls: SetBoundsCall[] = [];
+  public readonly setVisibleCalls: SetVisibleCall[] = [];
+  public readonly stopCalls: TabCommandCall[] = [];
+
+  attach(args: AttachCall): void {
+    this.attachCalls.push(args);
+  }
+
+  beginWindowResize(hostWindow: WindowResizeCall): void {
+    this.beginWindowResizeCalls.push(hostWindow);
+  }
+
+  destroyAll(): void {
+    this.destroyAllCalls.push("destroyAll");
+  }
+
+  detach(args: DetachCall): void {
+    this.detachCalls.push(args);
+  }
+
+  endWindowResize(hostWindow: WindowResizeCall): void {
+    this.endWindowResizeCalls.push(hostWindow);
+  }
+
+  goBack(args: TabCommandCall): void {
+    this.goBackCalls.push(args);
+  }
+
+  goForward(args: TabCommandCall): void {
+    this.goForwardCalls.push(args);
+  }
+
+  navigate(args: NavigateCall): void {
+    this.navigateCalls.push(args);
+  }
+
+  releaseWindow(hostWebContentsId: number): void {
+    this.releaseWindowCalls.push(hostWebContentsId);
+  }
+
+  reload(args: TabCommandCall): void {
+    this.reloadCalls.push(args);
+  }
+
+  setBounds(args: SetBoundsCall): void {
+    this.setBoundsCalls.push(args);
+  }
+
+  setVisible(args: SetVisibleCall): void {
+    this.setVisibleCalls.push(args);
+  }
+
+  stop(args: TabCommandCall): void {
+    this.stopCalls.push(args);
+  }
+}
+
+let nextWebContentsId = 1;
+
+beforeEach(() => {
+  electronMock.listeners.clear();
+  electronMock.windowsBySender.clear();
+  nextWebContentsId = 1;
+});
+
+function createTrustedRenderer(label: string): FakeRenderer {
+  const sender = { id: nextWebContentsId };
+  nextWebContentsId += 1;
+  const hostWindow = { label };
+  electronMock.windowsBySender.set(sender, hostWindow);
+  return { hostWindow, sender };
+}
+
+function createUntrustedSender(): FakeWebContents {
+  const sender = { id: nextWebContentsId };
+  nextWebContentsId += 1;
+  return sender;
+}
+
+function sendBrowserIpc(args: SendBrowserIpcArgs): void {
+  const listener = electronMock.listeners.get(args.channel);
+  expect(listener).toBeDefined();
+  if (listener === undefined) {
+    throw new Error(`Expected listener for ${args.channel}.`);
+  }
+  listener({ sender: args.sender }, args.payload);
+}
+
+function oversizedBrowserUrl(): string {
+  return `https://example.com/${"a".repeat(BB_DESKTOP_BROWSER_MAX_URL_LENGTH)}`;
+}
+
+describe("registerDesktopBrowserIpc", () => {
+  it("dispatches valid browser commands only from BrowserWindow-owned senders", () => {
+    const manager = new RecordingDesktopBrowserViewManager();
+    registerDesktopBrowserIpc(manager);
+    const renderer = createTrustedRenderer("main-window");
+    const untrustedSender = createUntrustedSender();
+    const attachRequest: BbDesktopBrowserAttachRequest = {
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+    };
+    const navigateRequest: BbDesktopBrowserNavigateRequest = {
+      tabId: "browser:a",
+      url: "https://example.com/",
+    };
+
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+      payload: attachRequest,
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+      payload: attachRequest,
+      sender: untrustedSender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
+      payload: navigateRequest,
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+      payload: { tabId: "browser:a" },
+      sender: renderer.sender,
+    });
+
+    expect(manager.attachCalls).toHaveLength(1);
+    expect(manager.attachCalls[0]?.hostWindow).toBe(renderer.hostWindow);
+    expect(manager.attachCalls[0]?.request).toEqual(attachRequest);
+    expect(manager.navigateCalls).toHaveLength(1);
+    expect(manager.navigateCalls[0]?.hostWindow).toBe(renderer.hostWindow);
+    expect(manager.navigateCalls[0]?.request).toEqual(navigateRequest);
+    expect(manager.reloadCalls).toEqual([
+      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+    ]);
+  });
+
+  it("rejects malformed attach and navigate payloads before manager dispatch", () => {
+    const manager = new RecordingDesktopBrowserViewManager();
+    registerDesktopBrowserIpc(manager);
+    const renderer = createTrustedRenderer("main-window");
+    const validAttachRequest: BbDesktopBrowserAttachRequest = {
+      tabId: "browser:a",
+      url: "",
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: false,
+    };
+
+    for (const payload of [
+      { ...validAttachRequest, extra: true },
+      { ...validAttachRequest, tabId: "" },
+      { ...validAttachRequest, url: oversizedBrowserUrl() },
+      { ...validAttachRequest, bounds: { x: 0, y: 0, width: -1, height: 600 } },
+    ]) {
+      sendBrowserIpc({
+        channel: BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+        payload,
+        sender: renderer.sender,
+      });
+    }
+
+    for (const payload of [
+      { tabId: "browser:a", url: "" },
+      { tabId: "browser:a", url: oversizedBrowserUrl() },
+      { tabId: "browser:a", url: "https://example.com/", extra: true },
+    ]) {
+      sendBrowserIpc({
+        channel: BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
+        payload,
+        sender: renderer.sender,
+      });
+    }
+
+    expect(manager.attachCalls).toEqual([]);
+    expect(manager.navigateCalls).toEqual([]);
+  });
+
+  it("rejects malformed bounds, visibility, and tab-command payloads", () => {
+    const manager = new RecordingDesktopBrowserViewManager();
+    registerDesktopBrowserIpc(manager);
+    const renderer = createTrustedRenderer("main-window");
+    const boundsRequest: BbDesktopBrowserSetBoundsRequest = {
+      tabId: "browser:a",
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+    };
+    const visibleRequest: BbDesktopBrowserSetVisibleRequest = {
+      tabId: "browser:a",
+      visible: true,
+    };
+
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+      payload: {
+        ...boundsRequest,
+        bounds: { x: 0.5, y: 0, width: 1, height: 1 },
+      },
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+      payload: boundsRequest,
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+      payload: { tabId: "browser:a", visible: "yes" },
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+      payload: visibleRequest,
+      sender: renderer.sender,
+    });
+
+    for (const channel of [
+      BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+      BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+      BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+      BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+      BB_DESKTOP_BROWSER_STOP_CHANNEL,
+    ]) {
+      sendBrowserIpc({
+        channel,
+        payload: { tabId: "", extra: true },
+        sender: renderer.sender,
+      });
+    }
+
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+      payload: { tabId: "browser:a" },
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+      payload: { tabId: "browser:a" },
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+      payload: { tabId: "browser:a" },
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_STOP_CHANNEL,
+      payload: { tabId: "browser:a" },
+      sender: renderer.sender,
+    });
+
+    expect(manager.setBoundsCalls).toEqual([
+      { hostWindow: renderer.hostWindow, request: boundsRequest },
+    ]);
+    expect(manager.setVisibleCalls).toEqual([
+      { hostWindow: renderer.hostWindow, request: visibleRequest },
+    ]);
+    expect(manager.detachCalls).toEqual([
+      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+    ]);
+    expect(manager.goBackCalls).toEqual([
+      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+    ]);
+    expect(manager.goForwardCalls).toEqual([
+      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+    ]);
+    expect(manager.stopCalls).toEqual([
+      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+    ]);
+  });
+});

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -8,11 +8,24 @@ import {
 import {
   evaluatePopupRate,
   isAllowedBrowserUrl,
+  isAllowedTrustedLocalTopLevelUrl,
   isBlockedBrowserRequestHost,
   isBlockedBrowserRequestUrl,
-  isLocalBrowserRequestHost,
+  isLoopbackBrowserRequestHost,
+  isPrivateBrowserRequestHost,
+  localRequestOriginKey,
   resolveWindowOpenAction,
+  shouldBlockBrowserRequest,
+  type ShouldBlockBrowserRequestArgs,
 } from "../src/desktop-browser-policy.js";
+
+function requireLocalOriginKey(url: string): string {
+  const key = localRequestOriginKey(url);
+  if (key === null) {
+    throw new Error(`Expected local origin key for ${url}`);
+  }
+  return key;
+}
 
 describe("isAllowedBrowserUrl", () => {
   it("allows http and https", () => {
@@ -44,6 +57,19 @@ describe("resolveWindowOpenAction", () => {
     expect(resolveWindowOpenAction("javascript:alert(1)")).toEqual({
       openTabUrl: null,
     });
+  });
+
+  it("denies loopback and private popups (no new tab)", () => {
+    for (const url of [
+      "http://localhost:5173/",
+      "https://app.localhost/path",
+      "http://127.0.0.1:38886/",
+      "http://[::1]:5173/",
+      "http://192.168.1.1/",
+      "http://printer.local/",
+    ]) {
+      expect(resolveWindowOpenAction(url)).toEqual({ openTabUrl: null });
+    }
   });
 });
 
@@ -134,24 +160,39 @@ describe("browser IPC payload schemas", () => {
   });
 });
 
-describe("isBlockedBrowserRequestHost (loopback / LAN firewall)", () => {
-  it("allows localhost and loopback hosts", () => {
+describe("browser request host classification", () => {
+  it("detects only loopback hosts with localhost names and literals", () => {
     for (const host of [
       "127.0.0.1",
       "127.1.2.3",
-      "0.0.0.0",
       "localhost",
+      "localhost.",
       "app.localhost",
+      "deep.app.localhost",
       "::1",
       "[::1]",
+    ]) {
+      expect(isLoopbackBrowserRequestHost(host)).toBe(true);
+    }
+
+    for (const host of [
+      "0.0.0.0",
+      "10.0.0.1",
+      "192.168.1.1",
+      "printer.local",
+      "example.com",
+      "8.8.8.8",
+      "::",
+      "fe80::1",
       "::ffff:127.0.0.1",
     ]) {
-      expect(isBlockedBrowserRequestHost(host)).toBe(false);
+      expect(isLoopbackBrowserRequestHost(host)).toBe(false);
     }
   });
 
-  it("blocks private, link-local, CGNAT, and mDNS hosts", () => {
+  it("detects private, LAN, link-local, mDNS, CGNAT, reserved, and unspecified hosts", () => {
     for (const host of [
+      "0.0.0.0",
       "10.0.0.5",
       "172.16.0.1",
       "172.31.255.255",
@@ -159,16 +200,56 @@ describe("isBlockedBrowserRequestHost (loopback / LAN firewall)", () => {
       "169.254.10.10",
       "100.64.0.1",
       "printer.local",
+      "224.0.0.1",
+      "240.0.0.1",
+      "255.255.255.255",
+      "192.0.0.1",
+      "192.0.2.1",
+      "198.18.0.1",
+      "198.51.100.1",
+      "203.0.113.1",
+      "::",
       "fe80::1",
       "fc00::1",
       "fd12:3456::1",
+      "ff02::1",
+      "2001:db8::1",
       "::ffff:10.0.0.1",
+      "::ffff:127.0.0.1",
     ]) {
-      expect(isBlockedBrowserRequestHost(host)).toBe(true);
+      expect(isPrivateBrowserRequestHost(host)).toBe(true);
+    }
+
+    for (const host of [
+      "localhost",
+      "app.localhost",
+      "127.0.0.1",
+      "::1",
+      "example.com",
+      "8.8.8.8",
+      "172.32.0.1",
+      "11.0.0.1",
+      "100.63.0.1",
+      "2606:4700:4700::1111",
+    ]) {
+      expect(isPrivateBrowserRequestHost(host)).toBe(false);
     }
   });
 
-  it("allows public hosts and addresses", () => {
+  it("combines loopback and private classification for the coarse firewall", () => {
+    for (const host of [
+      "127.0.0.1",
+      "localhost",
+      "app.localhost",
+      "::1",
+      "::ffff:127.0.0.1",
+      "10.0.0.5",
+      "192.168.1.1",
+      "printer.local",
+    ]) {
+      expect(isBlockedBrowserRequestHost(host)).toBe(true);
+    }
+
     for (const host of [
       "example.com",
       "github.com",
@@ -184,46 +265,15 @@ describe("isBlockedBrowserRequestHost (loopback / LAN firewall)", () => {
   });
 });
 
-describe("isLocalBrowserRequestHost", () => {
-  it("recognizes loopback and localhost names", () => {
-    for (const host of [
-      "localhost",
-      "app.localhost",
-      "127.0.0.1",
-      "127.1.2.3",
-      "0.0.0.0",
-      "::1",
-      "[::1]",
-      "::ffff:127.0.0.1",
-    ]) {
-      expect(isLocalBrowserRequestHost(host)).toBe(true);
-    }
-  });
-
-  it("does not treat LAN and public hosts as localhost", () => {
-    for (const host of [
-      "example.com",
-      "10.0.0.5",
-      "192.168.1.1",
-      "printer.local",
-      "fc00::1",
-    ]) {
-      expect(isLocalBrowserRequestHost(host)).toBe(false);
-    }
-  });
-});
-
 describe("isBlockedBrowserRequestUrl", () => {
-  it("allows requests to localhost and loopback over http(s)/ws(s)", () => {
-    expect(isBlockedBrowserRequestUrl("http://127.0.0.1:38886/")).toBe(false);
-    expect(isBlockedBrowserRequestUrl("https://127.0.0.1/x")).toBe(false);
-    expect(isBlockedBrowserRequestUrl("ws://localhost:38886/ws")).toBe(false);
-    expect(isBlockedBrowserRequestUrl("http://[::1]/")).toBe(false);
-  });
-
-  it("blocks requests to private LAN over http(s)/ws(s)", () => {
+  it("blocks requests to loopback/LAN over http(s)/ws(s)", () => {
+    expect(isBlockedBrowserRequestUrl("http://127.0.0.1:38886/")).toBe(true);
+    expect(isBlockedBrowserRequestUrl("https://127.0.0.1/x")).toBe(true);
+    expect(isBlockedBrowserRequestUrl("http://0.0.0.0:38886/")).toBe(true);
+    expect(isBlockedBrowserRequestUrl("https://0.0.0.0/")).toBe(true);
+    expect(isBlockedBrowserRequestUrl("ws://localhost:38886/ws")).toBe(true);
     expect(isBlockedBrowserRequestUrl("wss://10.0.0.5/socket")).toBe(true);
-    expect(isBlockedBrowserRequestUrl("http://192.168.1.1/")).toBe(true);
+    expect(isBlockedBrowserRequestUrl("http://[::1]/")).toBe(true);
   });
 
   it("allows requests to public hosts and non-network schemes", () => {
@@ -233,6 +283,279 @@ describe("isBlockedBrowserRequestUrl", () => {
       isBlockedBrowserRequestUrl("data:image/png;base64,iVBORw0KGgo="),
     ).toBe(false);
     expect(isBlockedBrowserRequestUrl("about:blank")).toBe(false);
+  });
+});
+
+describe("localRequestOriginKey", () => {
+  it("returns comparable same-transport keys for loopback http(s) and ws(s)", () => {
+    expect(localRequestOriginKey("http://localhost:5173/path")).toBe(
+      localRequestOriginKey("ws://localhost:5173/socket"),
+    );
+    expect(localRequestOriginKey("https://localhost/")).toBe(
+      localRequestOriginKey("wss://localhost/updates"),
+    );
+    expect(localRequestOriginKey("http://localhost:80/")).toBe(
+      localRequestOriginKey("ws://localhost/"),
+    );
+  });
+
+  it("keeps scheme class, host, and port in the local origin key", () => {
+    expect(localRequestOriginKey("http://localhost:5173/")).not.toBe(
+      localRequestOriginKey("https://localhost:5173/"),
+    );
+    expect(localRequestOriginKey("http://localhost:5173/")).not.toBe(
+      localRequestOriginKey("http://localhost:38886/"),
+    );
+    expect(localRequestOriginKey("http://localhost:5173/")).not.toBe(
+      localRequestOriginKey("http://127.0.0.1:5173/"),
+    );
+  });
+
+  it("returns null for public, private, and unsupported URLs", () => {
+    expect(localRequestOriginKey("https://example.com/")).toBeNull();
+    expect(localRequestOriginKey("http://0.0.0.0:5173/")).toBeNull();
+    expect(localRequestOriginKey("http://192.168.1.1/")).toBeNull();
+    expect(localRequestOriginKey("file:///etc/passwd")).toBeNull();
+  });
+});
+
+describe("isAllowedTrustedLocalTopLevelUrl", () => {
+  it("allows only loopback http(s) top-level URLs", () => {
+    expect(isAllowedTrustedLocalTopLevelUrl("http://localhost:5173/")).toBe(
+      true,
+    );
+    expect(isAllowedTrustedLocalTopLevelUrl("https://app.localhost/")).toBe(
+      true,
+    );
+    expect(isAllowedTrustedLocalTopLevelUrl("http://127.0.0.1:3000/")).toBe(
+      true,
+    );
+    expect(isAllowedTrustedLocalTopLevelUrl("http://[::1]:5173/")).toBe(true);
+
+    expect(isAllowedTrustedLocalTopLevelUrl("ws://localhost:5173/ws")).toBe(
+      false,
+    );
+    expect(isAllowedTrustedLocalTopLevelUrl("https://example.com/")).toBe(
+      false,
+    );
+    expect(isAllowedTrustedLocalTopLevelUrl("http://0.0.0.0:5173/")).toBe(
+      false,
+    );
+    expect(isAllowedTrustedLocalTopLevelUrl("http://192.168.1.1/")).toBe(false);
+  });
+});
+
+describe("shouldBlockBrowserRequest", () => {
+  const localhost3000 = requireLocalOriginKey("http://localhost:3000/");
+  const localhost5173 = requireLocalOriginKey("http://localhost:5173/");
+  const localhostSecure3000 = requireLocalOriginKey("https://localhost:3000/");
+  const loopbackIpv4 = requireLocalOriginKey("http://127.0.0.1:3000/");
+
+  const baseRequest: ShouldBlockBrowserRequestArgs = {
+    url: "http://localhost:3000/",
+    resourceType: "mainFrame",
+    isMainFrame: true,
+    targetWebContentsId: 1,
+    entryWebContentsId: 1,
+    pendingTrustedLocalTopLevelOriginKey: null,
+    currentMainFrameLocalOriginKey: null,
+    requestingFrameOriginKey: null,
+    mainFrameInitiatorOriginKey: null,
+  };
+
+  it("allows public requests regardless of local attribution fields", () => {
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseRequest,
+        url: "https://example.com/app.js",
+        resourceType: "script",
+        isMainFrame: false,
+        targetWebContentsId: null,
+        entryWebContentsId: null,
+        pendingTrustedLocalTopLevelOriginKey: localhost3000,
+        currentMainFrameLocalOriginKey: localhost3000,
+        requestingFrameOriginKey: null,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseRequest,
+        url: "wss://example.com/socket",
+        resourceType: "webSocket",
+        isMainFrame: false,
+        targetWebContentsId: 2,
+        entryWebContentsId: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks explicit 0.0.0.0 firewall targets", () => {
+    for (const url of ["http://0.0.0.0:38886/", "https://0.0.0.0/"]) {
+      expect(shouldBlockBrowserRequest({ ...baseRequest, url })).toBe(true);
+    }
+  });
+
+  it("allows trusted pending loopback main-frame requests without an initiator", () => {
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseRequest,
+        pendingTrustedLocalTopLevelOriginKey: localhost3000,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows current same-origin loopback main-frame requests only from a matching local initiator", () => {
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseRequest,
+        isMainFrame: false,
+        resourceType: "mainFrame",
+        currentMainFrameLocalOriginKey: localhost3000,
+        mainFrameInitiatorOriginKey: localhost3000,
+      }),
+    ).toBe(false);
+
+    for (const mainFrameInitiatorOriginKey of [
+      null,
+      localRequestOriginKey("https://example.com/"),
+      localhost5173,
+      localhostSecure3000,
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          currentMainFrameLocalOriginKey: localhost3000,
+          mainFrameInitiatorOriginKey,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("blocks unapproved loopback requests", () => {
+    for (const resourceType of [
+      "mainFrame",
+      "subFrame",
+      "script",
+      "xhr",
+      "image",
+      "webSocket",
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          resourceType,
+          isMainFrame: resourceType === "mainFrame",
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("allows same-origin loopback subresources and WebSockets from the committed local frame", () => {
+    for (const request of [
+      { url: "http://localhost:3000/app.js", resourceType: "script" },
+      { url: "ws://localhost:3000/socket", resourceType: "webSocket" },
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          url: request.url,
+          resourceType: request.resourceType,
+          isMainFrame: false,
+          currentMainFrameLocalOriginKey: localhost3000,
+          requestingFrameOriginKey: localhost3000,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("isolates local approval by attributed webContents id", () => {
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseRequest,
+        pendingTrustedLocalTopLevelOriginKey: localhost3000,
+        targetWebContentsId: 2,
+        entryWebContentsId: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks local requests with missing or mismatched attribution", () => {
+    for (const request of [
+      { targetWebContentsId: null, entryWebContentsId: 1 },
+      { targetWebContentsId: 1, entryWebContentsId: null },
+      { targetWebContentsId: 2, entryWebContentsId: 1 },
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          targetWebContentsId: request.targetWebContentsId,
+          entryWebContentsId: request.entryWebContentsId,
+          pendingTrustedLocalTopLevelOriginKey: localhost3000,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("blocks non-main-frame local requests with missing, public, or mismatched requesting frame origin", () => {
+    for (const requestingFrameOriginKey of [
+      null,
+      localRequestOriginKey("https://example.com/"),
+      localhost5173,
+      localhostSecure3000,
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          url: "http://localhost:3000/app.js",
+          resourceType: "script",
+          isMainFrame: false,
+          currentMainFrameLocalOriginKey: localhost3000,
+          requestingFrameOriginKey,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("blocks cross-origin loopback requests from a committed local page", () => {
+    for (const url of [
+      "http://localhost:5173/api",
+      "http://127.0.0.1:3000/api",
+      "https://localhost:3000/api",
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          url,
+          resourceType: "xhr",
+          isMainFrame: false,
+          currentMainFrameLocalOriginKey: localhost3000,
+          requestingFrameOriginKey: localhost3000,
+        }),
+      ).toBe(true);
+    }
+
+    expect(loopbackIpv4).not.toBe(localhost3000);
+  });
+
+  it("blocks private requests even when attribution and frame origin are present", () => {
+    for (const url of [
+      "http://192.168.1.1/",
+      "http://printer.local/",
+      "http://100.64.0.1/",
+      "http://[fe80::1]/",
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          url,
+          resourceType: "image",
+          isMainFrame: false,
+          currentMainFrameLocalOriginKey: localhost3000,
+          requestingFrameOriginKey: localhost3000,
+        }),
+      ).toBe(true);
+    }
   });
 });
 

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -309,6 +309,12 @@ describe("localRequestOriginKey", () => {
     expect(localRequestOriginKey("http://localhost:5173/")).not.toBe(
       localRequestOriginKey("http://127.0.0.1:5173/"),
     );
+    expect(localRequestOriginKey("http://localhost.:5173/")).not.toBe(
+      localRequestOriginKey("http://localhost:5173/"),
+    );
+    expect(localRequestOriginKey("http://app.localhost.:5173/")).not.toBe(
+      localRequestOriginKey("http://app.localhost:5173/"),
+    );
   });
 
   it("returns null for public, private, and unsupported URLs", () => {
@@ -522,6 +528,7 @@ describe("shouldBlockBrowserRequest", () => {
       "http://localhost:5173/api",
       "http://127.0.0.1:3000/api",
       "https://localhost:3000/api",
+      "http://localhost.:3000/api",
     ]) {
       expect(
         shouldBlockBrowserRequest({

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -1,11 +1,9 @@
 import type { WebContentsView } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  BbDesktopBrowserOpenTabRequest,
-  BbDesktopBrowserViewBounds,
-} from "@bb/server-contract";
+import type { BbDesktopBrowserViewBounds } from "@bb/server-contract";
 import {
   createDesktopBrowserViewManager,
+  type DesktopBrowserViewManager,
   type DesktopBrowserHostContentBounds,
   type DesktopBrowserHostContentView,
   type DesktopBrowserHostWebContents,
@@ -13,7 +11,111 @@ import {
   type DesktopBrowserHostWindow,
 } from "../src/desktop-browser-view.js";
 
-type FakeWebContentsListener = (...args: never[]) => void;
+interface FakePreventableEvent {
+  defaultPrevented: boolean;
+  preventDefault(): void;
+}
+
+interface FakeWebContentsEvent {}
+
+interface FakeNavigationEvent extends FakePreventableEvent {
+  initiator?: FakeWebFrameMain | null;
+  isMainFrame: boolean;
+  url: string;
+}
+
+type FakeVoidWebContentsListener = () => void;
+
+type FakeWillFrameNavigateListener = (event: FakeNavigationEvent) => void;
+
+type FakeWillNavigateListener = (
+  event: FakeNavigationEvent,
+  url: string,
+) => void;
+
+type FakeWillRedirectListener = (
+  event: FakeNavigationEvent,
+  url: string,
+  isInPlace: boolean,
+  isMainFrame: boolean,
+) => void;
+
+type FakeDidNavigateListener = (
+  event: FakeWebContentsEvent,
+  url: string,
+) => void;
+
+type FakeDidNavigateInPageListener = (
+  event: FakeWebContentsEvent,
+  url: string,
+  isMainFrame: boolean,
+) => void;
+
+type FakeDidFailLoadListener = (
+  event: FakeWebContentsEvent,
+  errorCode: number,
+  errorDescription: string,
+  validatedURL: string,
+  isMainFrame: boolean,
+) => void;
+
+interface FakeWebContentsEventMap {
+  "will-frame-navigate": FakeWillFrameNavigateListener;
+  "will-navigate": FakeWillNavigateListener;
+  "will-redirect": FakeWillRedirectListener;
+  "did-start-loading": FakeVoidWebContentsListener;
+  "did-stop-loading": FakeVoidWebContentsListener;
+  "did-navigate": FakeDidNavigateListener;
+  "did-navigate-in-page": FakeDidNavigateInPageListener;
+  "did-start-navigation": FakeVoidWebContentsListener;
+  "page-title-updated": FakeVoidWebContentsListener;
+  "did-fail-load": FakeDidFailLoadListener;
+}
+
+type FakeResourceType =
+  | "mainFrame"
+  | "subFrame"
+  | "stylesheet"
+  | "script"
+  | "image"
+  | "font"
+  | "object"
+  | "xhr"
+  | "ping"
+  | "cspReport"
+  | "media"
+  | "webSocket"
+  | "other";
+
+interface FakeWebFrameMain {
+  origin: string;
+}
+
+interface FakeOnBeforeRequestDetails {
+  url: string;
+  resourceType: FakeResourceType;
+  webContentsId?: number;
+  frame?: FakeWebFrameMain | null;
+}
+
+interface FakeWebRequestCallbackResponse {
+  cancel: boolean;
+}
+
+type FakeOnBeforeRequestCallback = (
+  response: FakeWebRequestCallbackResponse,
+) => void;
+
+type FakeOnBeforeRequestListener = (
+  details: FakeOnBeforeRequestDetails,
+  callback: FakeOnBeforeRequestCallback,
+) => void;
+
+interface FakeSessionEvent {
+  preventDefault(): void;
+}
+
+type FakeSessionListener = (event: FakeSessionEvent) => void;
 
 interface FakeWindowOpenDetails {
   url: string;
@@ -27,57 +129,105 @@ type FakeWindowOpenHandler = (
   details: FakeWindowOpenDetails,
 ) => FakeWindowOpenDecision;
 
-interface FakeBeforeRequestDetails {
-  url: string;
-  webContentsId?: number;
-}
-
-interface FakeBeforeRequestDecision {
-  cancel: boolean;
-}
-
-interface FakeBeforeRequestDecisionHolder {
-  value: FakeBeforeRequestDecision | null;
-}
-
-type FakeBeforeRequestCallback = (
-  decision: FakeBeforeRequestDecision,
-) => void;
-
-type FakeBeforeRequestHandler = (
-  details: FakeBeforeRequestDetails,
-  callback: FakeBeforeRequestCallback,
-) => void;
-
 const electronMock = vi.hoisted(() => {
   interface FakeNativeImage {
     isEmpty(): boolean;
     toJPEG(quality: number): Buffer;
   }
 
+  interface FakeDidFailLoadArgs {
+    errorCode: number;
+    errorDescription: string;
+    isMainFrame: boolean;
+    validatedURL: string;
+  }
+
+  type FakeWebContentsListeners = {
+    [TEventName in keyof FakeWebContentsEventMap]: Array<
+      FakeWebContentsEventMap[TEventName]
+    >;
+  };
+
+  class FakePreventableEventImpl implements FakePreventableEvent {
+    public defaultPrevented = false;
+
+    preventDefault(): void {
+      this.defaultPrevented = true;
+    }
+  }
+
+  class FakeNavigationEventImpl
+    extends FakePreventableEventImpl
+    implements FakeNavigationEvent
+  {
+    public readonly initiator?: FakeWebFrameMain | null;
+    public readonly isMainFrame: boolean;
+    public readonly url: string;
+
+    constructor(args: {
+      initiatorOrigin?: string | null;
+      isMainFrame: boolean;
+      url: string;
+    }) {
+      super();
+      this.initiator =
+        args.initiatorOrigin === undefined
+          ? undefined
+          : args.initiatorOrigin === null
+            ? null
+            : { origin: args.initiatorOrigin };
+      this.isMainFrame = args.isMainFrame;
+      this.url = args.url;
+    }
+  }
+
+  const fakeWebContentsEvent: FakeWebContentsEvent = {};
+
   const fakeCapturedImage: FakeNativeImage = {
     isEmpty: () => false,
     toJPEG: () => Buffer.from("jpeg-bytes"),
   };
-  const beforeRequestHandlers: FakeBeforeRequestHandler[] = [];
-  let nextWebContentsId = 1;
 
   class FakeWebContents {
-    public readonly id = nextWebContentsId++;
+    public canGoBackResult = false;
+    public canGoForwardResult = false;
+    public destroyed = false;
+    public readonly goBackCalls: string[] = [];
+    public readonly goForwardCalls: string[] = [];
+    public readonly id: number;
+    public readonly loadURLCalls: string[] = [];
     public readonly pendingCaptureResolvers: Array<
       (image: FakeNativeImage) => void
     > = [];
-    public windowOpenHandler: FakeWindowOpenHandler | null = null;
+    private readonly listeners: FakeWebContentsListeners = {
+      "will-frame-navigate": [],
+      "will-navigate": [],
+      "will-redirect": [],
+      "did-start-loading": [],
+      "did-stop-loading": [],
+      "did-navigate": [],
+      "did-navigate-in-page": [],
+      "did-start-navigation": [],
+      "page-title-updated": [],
+      "did-fail-load": [],
+    };
+    private title = "";
+    private url = "";
+    private windowOpenHandler: FakeWindowOpenHandler | null = null;
+
+    constructor(id: number) {
+      this.id = id;
+    }
 
     public readonly navigationHistory = {
-      canGoBack() {
-        return false;
+      canGoBack: (): boolean => this.canGoBackResult,
+      canGoForward: (): boolean => this.canGoForwardResult,
+      goBack: (): void => {
+        this.goBackCalls.push("goBack");
       },
-      canGoForward() {
-        return false;
+      goForward: (): void => {
+        this.goForwardCalls.push("goForward");
       },
-      goBack() {},
-      goForward() {},
     };
 
     capturePage(): Promise<FakeNativeImage> {
@@ -86,29 +236,38 @@ const electronMock = vi.hoisted(() => {
       });
     }
 
-    close(): void {}
+    close(): void {
+      this.destroyed = true;
+    }
 
     getTitle(): string {
-      return "";
+      return this.title;
     }
 
     getURL(): string {
-      return "";
+      return this.url;
     }
 
     isDestroyed(): boolean {
-      return false;
+      return this.destroyed;
     }
 
     isLoadingMainFrame(): boolean {
       return false;
     }
 
-    loadURL(_url: string): Promise<void> {
+    loadURL(url: string): Promise<void> {
+      this.url = url;
+      this.loadURLCalls.push(url);
       return Promise.resolve();
     }
 
-    on(_eventName: string, _listener: FakeWebContentsListener): void {}
+    on<TEventName extends keyof FakeWebContentsEventMap>(
+      eventName: TEventName,
+      listener: FakeWebContentsEventMap[TEventName],
+    ): void {
+      this.listeners[eventName].push(listener);
+    }
 
     reload(): void {}
 
@@ -117,12 +276,89 @@ const electronMock = vi.hoisted(() => {
     }
 
     stop(): void {}
+
+    emitDidFailLoad(args: FakeDidFailLoadArgs): void {
+      for (const listener of this.listeners["did-fail-load"]) {
+        listener(
+          fakeWebContentsEvent,
+          args.errorCode,
+          args.errorDescription,
+          args.validatedURL,
+          args.isMainFrame,
+        );
+      }
+    }
+
+    emitDidNavigate(url: string): void {
+      this.url = url;
+      for (const listener of this.listeners["did-navigate"]) {
+        listener(fakeWebContentsEvent, url);
+      }
+    }
+
+    emitWillFrameNavigate(
+      url: string,
+      isMainFrame: boolean,
+      initiatorOrigin?: string | null,
+    ): boolean {
+      const event = new FakeNavigationEventImpl({
+        initiatorOrigin,
+        isMainFrame,
+        url,
+      });
+      for (const listener of this.listeners["will-frame-navigate"]) {
+        listener(event);
+      }
+      return event.defaultPrevented;
+    }
+
+    emitWillNavigate(url: string, initiatorOrigin?: string | null): boolean {
+      const event = new FakeNavigationEventImpl({
+        initiatorOrigin,
+        isMainFrame: true,
+        url,
+      });
+      for (const listener of this.listeners["will-navigate"]) {
+        listener(event, url);
+      }
+      return event.defaultPrevented;
+    }
+
+    emitWillRedirect(
+      url: string,
+      isMainFrame: boolean,
+      initiatorOrigin?: string | null,
+    ): boolean {
+      const event = new FakeNavigationEventImpl({
+        initiatorOrigin,
+        isMainFrame,
+        url,
+      });
+      for (const listener of this.listeners["will-redirect"]) {
+        listener(event, url, false, isMainFrame);
+      }
+      return event.defaultPrevented;
+    }
+
+    emitWindowOpen(url: string): FakeWindowOpenDecision {
+      if (this.windowOpenHandler === null) {
+        throw new Error("Expected a window open handler to be registered.");
+      }
+      return this.windowOpenHandler({ url });
+    }
   }
+
+  let nextWebContentsId = 1;
 
   class FakeWebContentsView {
     public readonly boundsCalls: BbDesktopBrowserViewBounds[] = [];
-    public readonly webContents = new FakeWebContents();
+    public readonly webContents: FakeWebContents;
     public visible = false;
+
+    constructor() {
+      this.webContents = new FakeWebContents(nextWebContentsId);
+      nextWebContentsId += 1;
+    }
 
     setBounds(bounds: BbDesktopBrowserViewBounds): void {
       this.boundsCalls.push(bounds);
@@ -133,11 +369,30 @@ const electronMock = vi.hoisted(() => {
     }
   }
 
+  class FakeSession {
+    public readonly willDownloadListeners: FakeSessionListener[] = [];
+    public beforeRequestListener: FakeOnBeforeRequestListener | null = null;
+    public readonly webRequest = {
+      onBeforeRequest: (listener: FakeOnBeforeRequestListener | null): void => {
+        this.beforeRequestListener = listener;
+      },
+    };
+
+    on(eventName: "will-download", listener: FakeSessionListener): void {
+      this.willDownloadListeners.push(listener);
+    }
+
+    setPermissionCheckHandler(): void {}
+
+    setPermissionRequestHandler(): void {}
+  }
+
+  const fakeSessions: FakeSession[] = [];
   const fakeViews: FakeWebContentsView[] = [];
 
   return {
-    beforeRequestHandlers,
     fakeCapturedImage,
+    fakeSessions,
     fakeViews,
     FakeWebContentsView: class extends FakeWebContentsView {
       constructor() {
@@ -147,16 +402,9 @@ const electronMock = vi.hoisted(() => {
     },
     session: {
       fromPartition() {
-        return {
-          on() {},
-          setPermissionCheckHandler() {},
-          setPermissionRequestHandler() {},
-          webRequest: {
-            onBeforeRequest(handler: FakeBeforeRequestHandler) {
-              beforeRequestHandlers.push(handler);
-            },
-          },
-        };
+        const fakeSession = new FakeSession();
+        fakeSessions.push(fakeSession);
+        return fakeSession;
       },
     },
   };
@@ -224,7 +472,7 @@ class FakeHostWindow implements DesktopBrowserHostWindow {
 }
 
 beforeEach(() => {
-  electronMock.beforeRequestHandlers.length = 0;
+  electronMock.fakeSessions.length = 0;
   electronMock.fakeViews.length = 0;
 });
 
@@ -253,49 +501,503 @@ function snapshotPushesOf(
   return pushes;
 }
 
-function openTabPushesOf(
-  hostWindow: FakeHostWindow,
-): BbDesktopBrowserOpenTabRequest[] {
-  const pushes: BbDesktopBrowserOpenTabRequest[] = [];
+interface AttachBrowserTabArgs {
+  hostWindow: FakeHostWindow;
+  manager: DesktopBrowserViewManager;
+  tabId: string;
+  url: string;
+}
+
+interface BrowserRequestBlockedArgs {
+  url: string;
+  resourceType: FakeResourceType;
+  frameOrigin?: string | null;
+  webContentsId?: number;
+}
+
+function attachBrowserTab(args: AttachBrowserTabArgs): void {
+  args.manager.attach({
+    hostWindow: args.hostWindow,
+    request: {
+      tabId: args.tabId,
+      url: args.url,
+      bounds: { x: 100, y: 50, width: 500, height: 350 },
+      visible: true,
+    },
+  });
+}
+
+function requireFakeView(
+  index: number,
+): (typeof electronMock.fakeViews)[number] {
+  const view = electronMock.fakeViews[index];
+  expect(view).toBeDefined();
+  if (view === undefined) {
+    throw new Error("Expected the browser view to be created.");
+  }
+  return view;
+}
+
+function requireOnBeforeRequestListener(): FakeOnBeforeRequestListener {
+  const fakeSession = electronMock.fakeSessions.at(-1);
+  expect(fakeSession).toBeDefined();
+  if (fakeSession === undefined) {
+    throw new Error("Expected a browser session to be created.");
+  }
+  const listener = fakeSession.beforeRequestListener;
+  expect(listener).not.toBeNull();
+  if (listener === null) {
+    throw new Error("Expected an onBeforeRequest listener to be registered.");
+  }
+  return listener;
+}
+
+function browserRequestBlocked(args: BrowserRequestBlockedArgs): boolean {
+  const details: FakeOnBeforeRequestDetails = {
+    url: args.url,
+    resourceType: args.resourceType,
+  };
+  if (args.webContentsId !== undefined) {
+    details.webContentsId = args.webContentsId;
+  }
+  if (args.frameOrigin !== undefined) {
+    details.frame =
+      args.frameOrigin === null ? null : { origin: args.frameOrigin };
+  }
+
+  const responses: FakeWebRequestCallbackResponse[] = [];
+  requireOnBeforeRequestListener()(details, (nextResponse) => {
+    responses.push(nextResponse);
+  });
+  const response = responses[0];
+  if (response === undefined) {
+    throw new Error("Expected onBeforeRequest to invoke its callback.");
+  }
+  return response.cancel;
+}
+
+function openTabPushesOf(hostWindow: FakeHostWindow): string[] {
+  const pushes: string[] = [];
   for (const payload of hostWindow.webContents.sentPayloads) {
     if ("url" in payload && !("tabId" in payload)) {
-      pushes.push(payload);
+      pushes.push(payload.url);
     }
   }
   return pushes;
 }
 
-function runBeforeRequest(details: FakeBeforeRequestDetails): boolean {
-  const handler = electronMock.beforeRequestHandlers.at(-1);
-  expect(handler).toBeDefined();
-  if (handler === undefined) {
-    throw new Error("Expected a webRequest handler to be registered.");
-  }
-  const decision: FakeBeforeRequestDecisionHolder = { value: null };
-  handler(details, (nextDecision) => {
-    decision.value = nextDecision;
-  });
-  expect(decision.value).not.toBeNull();
-  if (decision.value === null) {
-    throw new Error("Expected the webRequest handler to return a decision.");
-  }
-  return decision.value.cancel;
-}
-
-function getWindowOpenHandler(
-  view: (typeof electronMock.fakeViews)[number],
-): FakeWindowOpenHandler {
-  const handler = view.webContents.windowOpenHandler;
-  expect(handler).not.toBeNull();
-  if (handler === null) {
-    throw new Error("Expected the window.open handler to be registered.");
-  }
-  return handler;
-}
-
 describe("DesktopBrowserViewManager", () => {
+  it("allows trusted loopback navigations through pending local origin state", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 51,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "",
+    });
+    const view = requireFakeView(0);
+
+    manager.navigate({
+      hostWindow,
+      request: {
+        tabId: "browser:a",
+        url: "http://localhost:5173/",
+      },
+    });
+
+    expect(view.webContents.loadURLCalls).toEqual(["http://localhost:5173/"]);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+  });
+
+  it("clears pending local approval after a failed main-frame local load", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 52,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+
+    view.webContents.emitDidFailLoad({
+      errorCode: -102,
+      errorDescription: "Connection refused",
+      isMainFrame: true,
+      validatedURL: "http://localhost:5173/",
+    });
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows trusted reloads of the current local main frame", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 61,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://localhost:5173/");
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+
+    manager.reload({ hostWindow, tabId: "browser:a" });
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+  });
+
+  it("clears local approval after a local page commits to a public page", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 53,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://localhost:5173/");
+
+    expect(
+      view.webContents.emitWillFrameNavigate(
+        "http://localhost:5173/dashboard",
+        true,
+        "http://localhost:5173",
+      ),
+    ).toBe(false);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/dashboard",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/app.js",
+        resourceType: "script",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(false);
+
+    view.webContents.emitDidNavigate("https://example.com/");
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/app.js",
+        resourceType: "script",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks public-to-local redirects after public commit", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 54,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("https://example.com/");
+
+    expect(
+      view.webContents.emitWillRedirect("http://localhost:38886/", true),
+    ).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:38886/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not silently regrant localhost access through back or forward history", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 55,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://localhost:5173/");
+    view.webContents.emitDidNavigate("https://example.com/");
+    view.webContents.canGoBackResult = true;
+    view.webContents.canGoForwardResult = true;
+
+    manager.goBack({ hostWindow, tabId: "browser:a" });
+    manager.goForward({ hostWindow, tabId: "browser:a" });
+
+    expect(view.webContents.goBackCalls).toEqual(["goBack"]);
+    expect(view.webContents.goForwardCalls).toEqual(["goForward"]);
+    expect(view.webContents.emitWillNavigate("http://localhost:5173/")).toBe(
+      true,
+    );
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows same-origin local subresources and blocks cross-port loopback requests", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 56,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://localhost:5173/");
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/app.js",
+        resourceType: "script",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(false);
+    expect(
+      browserRequestBlocked({
+        url: "ws://localhost:5173/socket",
+        resourceType: "webSocket",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(false);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:38886/api",
+        resourceType: "xhr",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks localhost requests from public iframes inside a local page", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 57,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://localhost:5173/");
+
+    expect(
+      view.webContents.emitWillFrameNavigate(
+        "http://localhost:5173/dashboard",
+        true,
+        "https://example.com",
+      ),
+    ).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/dashboard",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/api",
+        resourceType: "xhr",
+        webContentsId: view.webContents.id,
+        frameOrigin: "https://example.com",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not surface loopback popups as trusted browser tabs", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 58,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    const view = requireFakeView(0);
+
+    expect(view.webContents.emitWindowOpen("http://localhost:38886/")).toEqual({
+      action: "deny",
+    });
+    expect(openTabPushesOf(hostWindow)).toEqual([]);
+  });
+
+  it("clears local attribution on release and destroy", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 59,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+    });
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:b",
+      url: "http://localhost:3000/",
+    });
+    const releasedView = requireFakeView(0);
+    const destroyedView = requireFakeView(1);
+    releasedView.webContents.emitDidNavigate("http://localhost:5173/");
+    destroyedView.webContents.emitDidNavigate("http://localhost:3000/");
+
+    manager.releaseWindow(hostWindow.webContents.id);
+
+    expect(releasedView.webContents.destroyed).toBe(true);
+    expect(destroyedView.webContents.destroyed).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: releasedView.webContents.id,
+      }),
+    ).toBe(true);
+
+    const secondHostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 60,
+    });
+    attachBrowserTab({
+      manager,
+      hostWindow: secondHostWindow,
+      tabId: "browser:c",
+      url: "http://localhost:5173/",
+    });
+    const destroyAllView = requireFakeView(2);
+    destroyAllView.webContents.emitDidNavigate("http://localhost:5173/");
+
+    manager.destroyAll();
+
+    expect(destroyAllView.webContents.destroyed).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: destroyAllView.webContents.id,
+      }),
+    ).toBe(true);
+  });
+
   it("snapshots then hides visible views on resize, revealing them clamped to the shrunken window", async () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
     const hostWindow = new FakeHostWindow({
       contentBounds: { width: 700, height: 450 },
       webContentsId: 41,
@@ -372,7 +1074,9 @@ describe("DesktopBrowserViewManager", () => {
   });
 
   it("drops a capture that resolves after the resize burst already ended", async () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
     const hostWindow = new FakeHostWindow({
       contentBounds: { width: 700, height: 450 },
       webContentsId: 46,
@@ -409,7 +1113,9 @@ describe("DesktopBrowserViewManager", () => {
   });
 
   it("never grows a view past its renderer-desired rect on a native window grow", async () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
     const hostWindow = new FakeHostWindow({
       contentBounds: { width: 700, height: 450 },
       webContentsId: 43,
@@ -448,7 +1154,9 @@ describe("DesktopBrowserViewManager", () => {
   });
 
   it("applies renderer pushes that land mid-resize on the reveal", async () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
     const hostWindow = new FakeHostWindow({
       contentBounds: { width: 700, height: 450 },
       webContentsId: 44,
@@ -494,7 +1202,9 @@ describe("DesktopBrowserViewManager", () => {
   });
 
   it("defers renderer visibility changes made during a resize burst to the reveal", () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
     const hostWindow = new FakeHostWindow({
       contentBounds: { width: 700, height: 450 },
       webContentsId: 45,
@@ -530,7 +1240,9 @@ describe("DesktopBrowserViewManager", () => {
   });
 
   it("keeps hidden views hidden and untouched across a resize burst", () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
     const hostWindow = new FakeHostWindow({
       contentBounds: { width: 700, height: 450 },
       webContentsId: 42,
@@ -558,81 +1270,5 @@ describe("DesktopBrowserViewManager", () => {
 
     expect(view.boundsCalls).toHaveLength(1);
     expect(view.visible).toBe(false);
-  });
-
-  it("allows localhost requests through the session firewall", () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
-    const hostWindow = new FakeHostWindow({
-      contentBounds: { width: 700, height: 450 },
-      webContentsId: 47,
-    });
-
-    manager.attach({
-      hostWindow,
-      request: {
-        tabId: "browser:a",
-        url: "https://example.com",
-        bounds: { x: 100, y: 50, width: 500, height: 350 },
-        visible: true,
-      },
-    });
-
-    const view = electronMock.fakeViews[0];
-    expect(view).toBeDefined();
-    if (view === undefined) {
-      throw new Error("Expected the browser view to be created.");
-    }
-
-    expect(
-      runBeforeRequest({
-        url: "http://localhost:3000/",
-        webContentsId: view.webContents.id,
-      }),
-    ).toBe(false);
-    expect(
-      runBeforeRequest({
-        url: "ws://127.0.0.1:3000/socket",
-        webContentsId: view.webContents.id,
-      }),
-    ).toBe(false);
-    expect(
-      runBeforeRequest({
-        url: "http://192.168.1.1/",
-        webContentsId: view.webContents.id,
-      }),
-    ).toBe(true);
-    expect(runBeforeRequest({ url: "http://localhost:3000/" })).toBe(false);
-  });
-
-  it("allows localhost popup tabs", () => {
-    const manager = createDesktopBrowserViewManager({ partition: "persist:test" });
-    const hostWindow = new FakeHostWindow({
-      contentBounds: { width: 700, height: 450 },
-      webContentsId: 48,
-    });
-
-    manager.attach({
-      hostWindow,
-      request: {
-        tabId: "browser:a",
-        url: "https://example.com",
-        bounds: { x: 100, y: 50, width: 500, height: 350 },
-        visible: true,
-      },
-    });
-
-    const view = electronMock.fakeViews[0];
-    expect(view).toBeDefined();
-    if (view === undefined) {
-      throw new Error("Expected the browser view to be created.");
-    }
-    const handler = getWindowOpenHandler(view);
-
-    expect(handler({ url: "http://localhost:3000/" })).toEqual({
-      action: "deny",
-    });
-    expect(openTabPushesOf(hostWindow)).toEqual([
-      { url: "http://localhost:3000/" },
-    ]);
   });
 });

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -189,11 +189,13 @@ const electronMock = vi.hoisted(() => {
   };
 
   class FakeWebContents {
+    public activeHistoryIndex = 0;
     public canGoBackResult = false;
     public canGoForwardResult = false;
     public destroyed = false;
     public readonly goBackCalls: string[] = [];
     public readonly goForwardCalls: string[] = [];
+    public historyEntries: Array<{ title: string; url: string }> = [];
     public readonly id: number;
     public readonly loadURLCalls: string[] = [];
     public readonly pendingCaptureResolvers: Array<
@@ -222,6 +224,11 @@ const electronMock = vi.hoisted(() => {
     public readonly navigationHistory = {
       canGoBack: (): boolean => this.canGoBackResult,
       canGoForward: (): boolean => this.canGoForwardResult,
+      getActiveIndex: (): number => this.activeHistoryIndex,
+      getEntryAtIndex: (
+        index: number,
+      ): { title: string; url: string } | null =>
+        this.historyEntries[index] ?? null,
       goBack: (): void => {
         this.goBackCalls.push("goBack");
       },
@@ -663,6 +670,104 @@ describe("DesktopBrowserViewManager", () => {
     ).toBe(true);
   });
 
+  it("clears pending local approval after an aborted main-frame local load", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 62,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("https://example.com/");
+
+    manager.navigate({
+      hostWindow,
+      request: {
+        tabId: "browser:a",
+        url: "http://localhost:5173/",
+      },
+    });
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+
+    view.webContents.emitDidFailLoad({
+      errorCode: -3,
+      errorDescription: "Aborted",
+      isMainFrame: true,
+      validatedURL: "http://localhost:5173/",
+    });
+
+    expect(view.webContents.emitWillNavigate("http://localhost:5173/")).toBe(
+      true,
+    );
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+  });
+
+  it("clears pending local approval when a local load is stopped", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 63,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("https://example.com/");
+
+    manager.navigate({
+      hostWindow,
+      request: {
+        tabId: "browser:a",
+        url: "http://localhost:5173/",
+      },
+    });
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+
+    manager.stop({ hostWindow, tabId: "browser:a" });
+
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+  });
+
   it("allows trusted reloads of the current local main frame", () => {
     const manager = createDesktopBrowserViewManager({
       partition: "persist:test",
@@ -801,13 +906,36 @@ describe("DesktopBrowserViewManager", () => {
     const view = requireFakeView(0);
     view.webContents.emitDidNavigate("http://localhost:5173/");
     view.webContents.emitDidNavigate("https://example.com/");
+    view.webContents.historyEntries = [
+      { title: "Local", url: "http://localhost:5173/" },
+      { title: "Public", url: "https://example.com/" },
+    ];
+    view.webContents.activeHistoryIndex = 1;
     view.webContents.canGoBackResult = true;
-    view.webContents.canGoForwardResult = true;
 
     manager.goBack({ hostWindow, tabId: "browser:a" });
-    manager.goForward({ hostWindow, tabId: "browser:a" });
 
     expect(view.webContents.goBackCalls).toEqual(["goBack"]);
+    expect(view.webContents.emitWillNavigate("http://localhost:5173/")).toBe(
+      true,
+    );
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(true);
+
+    view.webContents.historyEntries = [
+      { title: "Public", url: "https://example.com/" },
+      { title: "Local", url: "http://localhost:5173/" },
+    ];
+    view.webContents.activeHistoryIndex = 0;
+    view.webContents.canGoForwardResult = true;
+
+    manager.goForward({ hostWindow, tabId: "browser:a" });
+
     expect(view.webContents.goForwardCalls).toEqual(["goForward"]);
     expect(view.webContents.emitWillNavigate("http://localhost:5173/")).toBe(
       true,
@@ -819,6 +947,63 @@ describe("DesktopBrowserViewManager", () => {
         webContentsId: view.webContents.id,
       }),
     ).toBe(true);
+  });
+
+  it("allows same-origin local back and forward history", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 64,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://localhost:5173/route-b",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://localhost:5173/route-b");
+    view.webContents.historyEntries = [
+      { title: "Route A", url: "http://localhost:5173/route-a" },
+      { title: "Route B", url: "http://localhost:5173/route-b" },
+    ];
+    view.webContents.activeHistoryIndex = 1;
+    view.webContents.canGoBackResult = true;
+
+    manager.goBack({ hostWindow, tabId: "browser:a" });
+
+    expect(view.webContents.goBackCalls).toEqual(["goBack"]);
+    expect(
+      view.webContents.emitWillNavigate("http://localhost:5173/route-a"),
+    ).toBe(false);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/route-a",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
+
+    view.webContents.emitDidNavigate("http://localhost:5173/route-a");
+    view.webContents.activeHistoryIndex = 0;
+    view.webContents.canGoForwardResult = true;
+
+    manager.goForward({ hostWindow, tabId: "browser:a" });
+
+    expect(view.webContents.goForwardCalls).toEqual(["goForward"]);
+    expect(
+      view.webContents.emitWillNavigate("http://localhost:5173/route-b"),
+    ).toBe(false);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/route-b",
+        resourceType: "mainFrame",
+        webContentsId: view.webContents.id,
+      }),
+    ).toBe(false);
   });
 
   it("allows same-origin local subresources and blocks cross-port loopback requests", () => {
@@ -863,6 +1048,21 @@ describe("DesktopBrowserViewManager", () => {
         frameOrigin: "http://localhost:5173",
       }),
     ).toBe(true);
+    expect(
+      view.webContents.emitWillFrameNavigate(
+        "http://localhost:38886/",
+        true,
+        "http://localhost:5173",
+      ),
+    ).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/app.js",
+        resourceType: "script",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(false);
   });
 
   it("blocks localhost requests from public iframes inside a local page", () => {
@@ -898,6 +1098,14 @@ describe("DesktopBrowserViewManager", () => {
         frameOrigin: "http://localhost:5173",
       }),
     ).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://localhost:5173/app.js",
+        resourceType: "script",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://localhost:5173",
+      }),
+    ).toBe(false);
     expect(
       browserRequestBlocked({
         url: "http://localhost:5173/api",

--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  BbDesktopApi,
+  BbDesktopBrowserOpenTabRequest,
+  BbDesktopBrowserSnapshot,
+  BbDesktopBrowserState,
+  BbDesktopInfo,
+} from "@bb/server-contract";
+import {
+  BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL,
+  BB_DESKTOP_GET_INFO_CHANNEL,
+  BB_DESKTOP_INSTALL_UPDATE_CHANNEL,
+  BB_DESKTOP_SET_THEME_CHANNEL,
+} from "../src/desktop-update-ipc.js";
+import {
+  BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+  BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+  BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+  BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
+  BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,
+  BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
+  BB_DESKTOP_BROWSER_STATE_CHANNEL,
+  BB_DESKTOP_BROWSER_STOP_CHANNEL,
+} from "../src/desktop-browser-ipc.js";
+
+const electronMock = vi.hoisted(() => {
+  interface IpcRendererEvent {}
+
+  interface SendCall {
+    channel: string;
+    payload: unknown;
+  }
+
+  type IpcRendererListener = (
+    event: IpcRendererEvent,
+    payload: unknown,
+  ) => void;
+
+  const desktopInfo: BbDesktopInfo = {
+    lastCheckedAt: null,
+    latestVersion: null,
+    pendingVersion: null,
+    platform: "macos",
+    updateAvailable: false,
+    updateDownloaded: false,
+    version: "0.0.0-test",
+  };
+  const invokeCalls: string[] = [];
+  const listeners = new Map<string, IpcRendererListener>();
+  const sendCalls: SendCall[] = [];
+  let exposedApi: BbDesktopApi | null = null;
+  let exposedName: string | null = null;
+
+  return {
+    get exposedApi() {
+      return exposedApi;
+    },
+    get exposedName() {
+      return exposedName;
+    },
+    invokeCalls,
+    listeners,
+    sendCalls,
+    reset(): void {
+      exposedApi = null;
+      exposedName = null;
+      invokeCalls.length = 0;
+      listeners.clear();
+      sendCalls.length = 0;
+    },
+    contextBridge: {
+      exposeInMainWorld(name: string, api: BbDesktopApi): void {
+        exposedName = name;
+        exposedApi = api;
+      },
+    },
+    ipcRenderer: {
+      invoke(channel: string): Promise<BbDesktopInfo> {
+        invokeCalls.push(channel);
+        return Promise.resolve(desktopInfo);
+      },
+      on(channel: string, listener: IpcRendererListener): void {
+        listeners.set(channel, listener);
+      },
+      send(channel: string, payload: unknown): void {
+        sendCalls.push({ channel, payload });
+      },
+    },
+  };
+});
+
+vi.mock("electron", () => ({
+  contextBridge: electronMock.contextBridge,
+  ipcRenderer: electronMock.ipcRenderer,
+}));
+
+interface EmitIpcPayloadArgs {
+  channel: string;
+  payload: unknown;
+}
+
+async function loadPreload(): Promise<BbDesktopApi> {
+  electronMock.reset();
+  vi.resetModules();
+  process.env.BB_DESKTOP_VERSION = "0.0.0-test";
+  await import("../src/preload.js");
+  const api = electronMock.exposedApi;
+  expect(electronMock.exposedName).toBe("bbDesktop");
+  expect(api).not.toBeNull();
+  if (api === null) {
+    throw new Error("Expected preload to expose window.bbDesktop.");
+  }
+  return api;
+}
+
+function emitIpcPayload(args: EmitIpcPayloadArgs): void {
+  const listener = electronMock.listeners.get(args.channel);
+  expect(listener).toBeDefined();
+  if (listener === undefined) {
+    throw new Error(`Expected listener for ${args.channel}.`);
+  }
+  listener({}, args.payload);
+}
+
+describe("desktop preload browser API", () => {
+  it("exposes only the typed browser commands and forwards them over fixed channels", async () => {
+    const api = await loadPreload();
+    const attachRequest = {
+      tabId: "browser:a",
+      url: "http://localhost:5173/",
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+    };
+    const navigateRequest = {
+      tabId: "browser:a",
+      url: "https://example.com/",
+    };
+    const boundsRequest = {
+      tabId: "browser:a",
+      bounds: { x: 10, y: 20, width: 300, height: 200 },
+    };
+    const visibleRequest = {
+      tabId: "browser:a",
+      visible: false,
+    };
+
+    expect(Object.keys(api.browser).sort()).toEqual([
+      "attach",
+      "detach",
+      "goBack",
+      "goForward",
+      "navigate",
+      "onOpenTab",
+      "onSnapshot",
+      "onState",
+      "reload",
+      "setBounds",
+      "setVisible",
+      "stop",
+    ]);
+    expect(api.browser).not.toHaveProperty("send");
+    expect(api.browser).not.toHaveProperty("invoke");
+
+    api.browser.attach(attachRequest);
+    api.browser.detach("browser:a");
+    api.browser.navigate(navigateRequest);
+    api.browser.goBack("browser:a");
+    api.browser.goForward("browser:a");
+    api.browser.reload("browser:a");
+    api.browser.stop("browser:a");
+    api.browser.setBounds(boundsRequest);
+    api.browser.setVisible(visibleRequest);
+    api.setTheme("dark");
+    await api.checkForUpdates();
+    await api.installUpdate();
+
+    expect(electronMock.sendCalls).toEqual([
+      { channel: BB_DESKTOP_BROWSER_ATTACH_CHANNEL, payload: attachRequest },
+      {
+        channel: BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+        payload: { tabId: "browser:a" },
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL,
+        payload: navigateRequest,
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+        payload: { tabId: "browser:a" },
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+        payload: { tabId: "browser:a" },
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+        payload: { tabId: "browser:a" },
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_STOP_CHANNEL,
+        payload: { tabId: "browser:a" },
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
+        payload: boundsRequest,
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+        payload: visibleRequest,
+      },
+      { channel: BB_DESKTOP_SET_THEME_CHANNEL, payload: "dark" },
+    ]);
+    expect(electronMock.invokeCalls).toContain(BB_DESKTOP_GET_INFO_CHANNEL);
+    expect(electronMock.invokeCalls).toContain(
+      BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL,
+    );
+    expect(electronMock.invokeCalls).toContain(
+      BB_DESKTOP_INSTALL_UPDATE_CHANNEL,
+    );
+  });
+
+  it("validates browser event payloads before notifying renderer listeners", async () => {
+    const api = await loadPreload();
+    const states: BbDesktopBrowserState[] = [];
+    const openTabs: BbDesktopBrowserOpenTabRequest[] = [];
+    const snapshots: BbDesktopBrowserSnapshot[] = [];
+    const state: BbDesktopBrowserState = {
+      tabId: "browser:a",
+      url: "https://example.com/",
+      title: "Example",
+      isLoading: false,
+      canGoBack: false,
+      canGoForward: true,
+      errorText: null,
+    };
+    const openTab: BbDesktopBrowserOpenTabRequest = {
+      url: "https://example.com/popup",
+    };
+    const snapshot: BbDesktopBrowserSnapshot = {
+      tabId: "browser:a",
+      dataUrl: null,
+    };
+
+    api.browser.onState((nextState) => {
+      states.push(nextState);
+    });
+    api.browser.onOpenTab((request) => {
+      openTabs.push(request);
+    });
+    api.browser.onSnapshot?.((nextSnapshot) => {
+      snapshots.push(nextSnapshot);
+    });
+
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_STATE_CHANNEL,
+      payload: { ...state, extra: true },
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,
+      payload: { url: "" },
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
+      payload: { tabId: "browser:a", dataUrl: 42 },
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_STATE_CHANNEL,
+      payload: state,
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,
+      payload: openTab,
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
+      payload: snapshot,
+    });
+
+    expect(states).toEqual([state]);
+    expect(openTabs).toEqual([openTab]);
+    expect(snapshots).toEqual([snapshot]);
+  });
+});


### PR DESCRIPTION
## Summary

- Default bare loopback address-bar inputs (`localhost`, `*.localhost`, `127.x`, `[::1]`) to `http://` while keeping public hosts on `https://`.
- Route blocked local/private/mDNS/unsupported URL shapes to search instead of attempting unsafe navigation.
- Replace the coarse local-request firewall with a per-WebContents loopback policy: trusted browser chrome can top-level navigate to loopback, and same-origin local subresources/WebSockets are allowed only when tied to a matching committed local frame.
- Keep the Electron browser surface sandboxed and hardened: no preload, no Node integration, context isolation, web security, denied permissions/downloads, and added IPC/preload boundary coverage.
- Ignore `.otto/` workflow artifacts in git.

## Why

The in-app browser needs to support developer workflows against localhost without broadening the sandbox or allowing renderer-driven access to private network targets. This keeps local loopback browsing usable while preserving the previous private/LAN/mDNS protections and tightening the attribution checks around local subresources.

## Validation

Passed in the main workspace before preparing this clean PR branch:

- `pnpm exec turbo run test --filter=@bb/desktop -- --run test/desktop-browser-policy.test.ts test/desktop-browser-view-manager.test.ts test/preload-build.test.ts test/desktop-browser-main-ipc.test.ts test/preload-browser-api.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/desktop`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/lib/browser-url.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`

After the final conservative desktop-policy patch, these focused checks also passed in the main workspace:

- `pnpm exec turbo run test --filter=@bb/desktop -- --run test/desktop-browser-policy.test.ts test/desktop-browser-view-manager.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/desktop`

Clean PR worktree verification was attempted, but the temporary worktree could not resolve workspace dependencies such as `@bb/server-contract`, `@bb/tsconfig`, and app Vite plugins from the shared install. Those failures were dependency-resolution setup failures in the temp worktree, not test assertion failures.
