### PR TITLE
Fix blank in-app browser page for localhost SPA dev servers

### DIFF
--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -356,6 +356,39 @@ export function localRequestOriginKey(url: string): string | null {
   return `${protocolClass}|${parsed.originHost}|${parsed.port}`;
 }
 
+export interface ResolveRequestingFrameLocalOriginKeyArgs {
+  /** The requesting frame's reported origin (`details.frame?.origin`). */
+  origin: string | undefined;
+  /** The requesting frame's committed URL (`details.frame?.url`). */
+  url: string | undefined;
+  /** Whether the requesting frame is the top frame (`frame.parent === null`). */
+  isTopFrame: boolean;
+}
+
+/**
+ * Resolves the comparable local-origin key for the frame that initiated a
+ * request. Prefers the frame's reported `origin`; for a **top** frame whose
+ * origin is not yet populated — Electron reports an empty origin for a
+ * document's initial subresource requests, before it has run script and
+ * committed its origin (which blanks SPA dev servers like Vite) — it falls
+ * back to the frame's committed `url`. The URL fallback is restricted to the
+ * top frame so a sub-iframe presenting an empty origin can never be mistaken
+ * for the trusted main frame.
+ */
+export function resolveRequestingFrameLocalOriginKey(
+  args: ResolveRequestingFrameLocalOriginKeyArgs,
+): string | null {
+  const fromOrigin =
+    args.origin === undefined ? null : localRequestOriginKey(args.origin);
+  if (fromOrigin !== null) {
+    return fromOrigin;
+  }
+  if (args.isTopFrame && args.url !== undefined) {
+    return localRequestOriginKey(args.url);
+  }
+  return null;
+}
+
 /**
  * Trusted top-level local navigations may only target loopback `http(s)` URLs.
  */

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -23,6 +23,7 @@ import {
   isAllowedBrowserUrl,
   isAllowedTrustedLocalTopLevelUrl,
   localRequestOriginKey,
+  resolveRequestingFrameLocalOriginKey,
   resolveWindowOpenAction,
   shouldBlockBrowserRequest,
 } from "./desktop-browser-policy.js";
@@ -505,9 +506,14 @@ export function createDesktopBrowserViewManager(
             liveEntry?.pendingTrustedLocalTopLevelOriginKey ?? null,
           currentMainFrameLocalOriginKey:
             liveEntry?.currentMainFrameLocalOriginKey ?? null,
-          requestingFrameOriginKey: requestingFrameOriginKey(
-            details.frame?.origin,
-          ),
+          requestingFrameOriginKey: resolveRequestingFrameLocalOriginKey({
+            origin: details.frame?.origin,
+            url: details.frame?.url,
+            // Electron blanks `frame.origin` for a document's initial
+            // subresources; fall back to the top frame's URL so a same-origin
+            // SPA dev server (Vite, etc.) is not blocked into a blank page.
+            isTopFrame: details.frame?.parent === null,
+          }),
           mainFrameInitiatorOriginKey:
             liveEntry === null || !isMainFrameRequest
               ? null

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -14,6 +14,7 @@ import {
   isLoopbackBrowserRequestHost,
   isPrivateBrowserRequestHost,
   localRequestOriginKey,
+  resolveRequestingFrameLocalOriginKey,
   resolveWindowOpenAction,
   shouldBlockBrowserRequest,
   type ShouldBlockBrowserRequestArgs,
@@ -586,5 +587,104 @@ describe("evaluatePopupRate", () => {
     const decision = evaluatePopupRate({ ...args, timestamps, now: 11_000 });
     expect(decision.allowed).toBe(true);
     expect(decision.timestamps).toEqual([11_000]);
+  });
+});
+
+describe("resolveRequestingFrameLocalOriginKey", () => {
+  const loopbackKey = localRequestOriginKey("http://localhost:5173/");
+
+  it("uses the frame origin when it is reported", () => {
+    expect(
+      resolveRequestingFrameLocalOriginKey({
+        origin: "http://localhost:5173",
+        url: "http://localhost:5173/src/main.tsx",
+        isTopFrame: true,
+      }),
+    ).toBe(loopbackKey);
+  });
+
+  it("falls back to the top frame's URL when the origin is blank (Vite initial load)", () => {
+    expect(
+      resolveRequestingFrameLocalOriginKey({
+        origin: "",
+        url: "http://localhost:5173/@vite/client",
+        isTopFrame: true,
+      }),
+    ).toBe(loopbackKey);
+  });
+
+  it("does not fall back for a sub-iframe with a blank origin", () => {
+    expect(
+      resolveRequestingFrameLocalOriginKey({
+        origin: "",
+        url: "http://localhost:5173/embedded",
+        isTopFrame: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not resolve a non-loopback top-frame URL", () => {
+    expect(
+      resolveRequestingFrameLocalOriginKey({
+        origin: "",
+        url: "https://example.com/app.js",
+        isTopFrame: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when neither origin nor URL is available", () => {
+    expect(
+      resolveRequestingFrameLocalOriginKey({
+        origin: undefined,
+        url: undefined,
+        isTopFrame: true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("loopback SPA subresource firewall (regression)", () => {
+  const originKey = localRequestOriginKey("http://localhost:5173/");
+  const baseArgs: Omit<
+    ShouldBlockBrowserRequestArgs,
+    "requestingFrameOriginKey"
+  > = {
+    url: "http://localhost:5173/src/main.tsx",
+    resourceType: "script",
+    isMainFrame: false,
+    targetWebContentsId: 1,
+    entryWebContentsId: 1,
+    pendingTrustedLocalTopLevelOriginKey: null,
+    currentMainFrameLocalOriginKey: originKey,
+    mainFrameInitiatorOriginKey: null,
+  };
+
+  it("allows a same-origin top-frame subresource resolved via the URL fallback", () => {
+    // Reproduces the blank-Vite-page bug: the page's own JS module, requested
+    // with a blank frame origin during initial load, must not be blocked.
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseArgs,
+        requestingFrameOriginKey: resolveRequestingFrameLocalOriginKey({
+          origin: "",
+          url: "http://localhost:5173/",
+          isTopFrame: true,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("still blocks a blank-origin sub-iframe reaching the loopback origin", () => {
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseArgs,
+        requestingFrameOriginKey: resolveRequestingFrameLocalOriginKey({
+          origin: "",
+          url: "https://ads.example.com/frame",
+          isTopFrame: false,
+        }),
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem
Opening a local SPA dev server (Vite, Next, CRA, …) in bb's in-app browser shows a **blank page**: the main-frame HTML loads but the app never mounts.

## Cause
The loopback/LAN request firewall (`desktop-browser-view.ts` → `shouldBlockBrowserRequest`) allows a same-origin loopback subresource only when the **requesting frame's origin** equals the committed main-frame origin. That origin is derived from `details.frame.origin` — but Electron reports a **blank origin** for a document's *initial* subresource requests (before it has run script and committed its origin). So a Vite page's own `/@vite/client` and `/src/main.tsx` module requests come back with `requestingFrameOriginKey === null` and get cancelled → no JS → blank page. A static page (no subresources) never hits this, which is why the existing fixtures didn't catch it.

## Fix
Add `resolveRequestingFrameLocalOriginKey({ origin, url, isTopFrame })` to the (Electron-free) policy module: prefer the frame's reported origin, and **for a top frame whose origin is blank, fall back to the frame's committed URL**. The fallback is **top-frame-only**, so a sub-iframe presenting a blank origin can never be mistaken for the trusted main frame. The `onBeforeRequest` firewall now uses it (passing `details.frame?.url` and `details.frame?.parent === null`).

## Tests
`@bb/desktop` typecheck + browser policy / view-manager / main-ipc suites green, including:
- new `resolveRequestingFrameLocalOriginKey` unit tests (origin used when present; URL fallback for a blank-origin top frame; **no** fallback for a sub-iframe; non-loopback URL → null; nothing available → null);
- an end-to-end firewall regression: a same-origin SPA subresource resolved via the URL fallback is **allowed**, while a blank-origin sub-iframe reaching the loopback origin is still **blocked**.

## Note
The root cause (Electron blanking `frame.origin` during initial load) is inferred from the blank-page signature + the firewall logic — runtime confirmation is loading a Vite dev server in the desktop in-app browser after this change. The fix is also defensively correct: resolving the requesting frame's origin robustly is right regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)