### PR TITLE
ui: tighten the hover action row under agent messages

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -339,7 +339,10 @@ function AssistantConversationMessage({
         projectId={projectId}
       />
       {messageText ? (
-        <div className="mt-1 flex justify-start">
+        // Pull the hover action row up to reclaim the gap below the message
+        // rather than stacking on top of it, so the copy button (and future
+        // icon buttons in this row) sit in space the message already reserves.
+        <div className="-mt-1 flex justify-start">
           <CopyButton
             text={text}
             label="Copy message"


### PR DESCRIPTION
Reduces the reserved gap below assistant messages so the hover copy button (and future icon buttons in that row) sit in space the message already reserves, rather than adding padding on top of the inter-row gap.

`mt-1` → `-mt-1` on the assistant action row in `ConversationMessageContent.tsx`. Conservative first pass — easy to pull tighter or also trim the inter-row `gap-4` if more is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)