### PR TITLE
[codex] prototype right panel new tab page

### DIFF
--- a/apps/app/src/components/right-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/right-panel/ThreadSecondaryPanel.stories.tsx
@@ -104,7 +104,7 @@ function ShellRow({
             onCollapse={noop}
             onClose={noop}
             onFileTabReorder={noop}
-            renderNewTabMenu={() => <div>New tab actions</div>}
+            onOpenNewTab={noop}
             isConversationCollapsed={false}
             onToggleConversationCollapse={noop}
             reserveLeftForDesktopTrafficLights={false}
@@ -226,7 +226,7 @@ function FileTabsShellInner({
         onCollapse={noop}
         onClose={noop}
         onFileTabReorder={noop}
-        renderNewTabMenu={() => <div>New tab actions</div>}
+        onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
         reserveLeftForDesktopTrafficLights={false}
@@ -336,7 +336,7 @@ function TerminalTabsShellInner({
         onCollapse={noop}
         onClose={noop}
         onFileTabReorder={noop}
-        renderNewTabMenu={() => <div>New tab actions</div>}
+        onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
         reserveLeftForDesktopTrafficLights={false}

--- a/apps/app/src/components/right-panel/ThreadSecondaryPanelNewTab.stories.tsx
+++ b/apps/app/src/components/right-panel/ThreadSecondaryPanelNewTab.stories.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/hooks/queries/query-keys";
 import { ThreadSecondaryPanel } from "../secondary-panel/ThreadSecondaryPanel";
 import type { SecondaryPanelFileTab } from "../secondary-panel/ThreadSecondaryPanel";
-import { NewTabActionMenu } from "../secondary-panel/NewTabFileSearch";
 import { NewTabPage } from "../secondary-panel/NewTabPage";
 import type { FileSearchSelection } from "../secondary-panel/useThreadFileTabs";
 import { Icon } from "@/components/ui/icon.js";
@@ -41,11 +40,9 @@ export default {
 const PROJECT_ID = "proj_bb";
 const ENVIRONMENT_ID = "env_open_file_story";
 const STORY_SOURCE_LIMIT = 40;
-const BLANK_THREAD_ID = "";
+const BLANK_THREAD_ID = "thr_new_tab_blank_story";
 const APPS_THREAD_ID = "thr_new_tab_apps_story";
-const RECENTS_THREAD_ID = "thr_new_tab_recents_story";
 const SEARCH_THREAD_ID = "thr_new_tab_search_story";
-const OPEN_BROWSER_THREAD_ID = "thr_new_tab_browser_story";
 const STORY_TERMINAL_ID = "term_new_tab_story";
 
 const noop = () => {};
@@ -135,6 +132,46 @@ const APPS_ROW_APPS: AppSummary[] = [
     entry: { path: "index.html", kind: "html" },
     capabilities: ["message"],
     icon: { kind: "builtin", name: "File" },
+    source: null,
+  },
+  {
+    applicationId: "app_session_notes",
+    name: "Session Notes",
+    entry: { path: "index.html", kind: "html" },
+    capabilities: ["data", "message"],
+    icon: { kind: "builtin", name: "File" },
+    source: null,
+  },
+  {
+    applicationId: "app_error_dashboard",
+    name: "Error Dashboard",
+    entry: { path: "index.html", kind: "html" },
+    capabilities: ["data"],
+    icon: { kind: "builtin", name: "AlertCircle" },
+    source: null,
+  },
+  {
+    applicationId: "app_release_tracker",
+    name: "Release Tracker",
+    entry: { path: "index.html", kind: "html" },
+    capabilities: ["message"],
+    icon: { kind: "builtin", name: "GitBranch" },
+    source: null,
+  },
+  {
+    applicationId: "app_prompt_library",
+    name: "Prompt Library",
+    entry: { path: "index.html", kind: "html" },
+    capabilities: ["data", "message"],
+    icon: { kind: "builtin", name: "GridView" },
+    source: null,
+  },
+  {
+    applicationId: "app_qa_checklist",
+    name: "QA Checklist",
+    entry: { path: "index.html", kind: "html" },
+    capabilities: ["data"],
+    icon: { kind: "builtin", name: "ListTodo" },
     source: null,
   },
 ];
@@ -249,7 +286,10 @@ interface SeedThreadRecentItemsArgs {
 interface SeededNewTabPageProps {
   currentThreadId: string;
   initialQuery: string;
+  onCreateAppPromptPrefill: () => void;
+  onOpenBrowser?: () => void;
   onSelect: (selection: FileSearchSelection) => void;
+  onStartTerminal: () => void;
   projectId: string | undefined;
   recentItems: readonly ThreadRecentItem[];
 }
@@ -354,7 +394,10 @@ function useStoryQueryClient({
 function SeededNewTabPage({
   currentThreadId,
   initialQuery,
+  onCreateAppPromptPrefill,
+  onOpenBrowser,
   onSelect,
+  onStartTerminal,
   projectId,
   recentItems,
 }: SeededNewTabPageProps) {
@@ -369,6 +412,9 @@ function SeededNewTabPage({
       focusRequest={0}
       initialQuery={initialQuery}
       onSelect={onSelect}
+      onCreateAppPromptPrefill={onCreateAppPromptPrefill}
+      onOpenBrowser={onOpenBrowser}
+      onStartTerminal={onStartTerminal}
     />
   );
 }
@@ -400,7 +446,7 @@ function NewTabPanelStory({
   const handleStartTerminal = useCallback(() => {
     setOutcome({ kind: "terminal" });
   }, []);
-  const handleOpenFileSearch = useCallback(() => {
+  const handleOpenNewTab = useCallback(() => {
     setOutcome(null);
   }, []);
   const activeTab = createStoryActiveTab(outcome);
@@ -476,7 +522,10 @@ function NewTabPanelStory({
           initialQuery={initialQuery}
           projectId={projectId}
           recentItems={recentItems}
+          onCreateAppPromptPrefill={noop}
+          onOpenBrowser={showOpenBrowser ? handleOpenBrowser : undefined}
           onSelect={handleSelect}
+          onStartTerminal={handleStartTerminal}
         />
       </QueryClientProvider>
     ) : outcome.kind === "browser" ? (
@@ -491,7 +540,7 @@ function NewTabPanelStory({
       <div className="flex min-h-full flex-col justify-center bg-neutral-950 px-4 font-mono text-xs text-emerald-100">
         <p>$ bb terminal start</p>
         <p className="pt-1 text-emerald-300">
-          Terminal tab opened from the New tab menu.
+          Terminal tab opened from the New tab page.
         </p>
       </div>
     ) : (
@@ -526,21 +575,7 @@ function NewTabPanelStory({
         onCollapse={noop}
         onClose={noop}
         onFileTabReorder={noop}
-        renderNewTabMenu={({ closeMenu }) => (
-          <QueryClientProvider client={queryClient}>
-            <NewTabActionMenu
-              projectId={projectId}
-              environmentId={ENVIRONMENT_ID}
-              currentThreadId={currentThreadId}
-              onSelect={handleSelect}
-              onOpenFileSearch={handleOpenFileSearch}
-              onCreateAppPromptPrefill={noop}
-              onOpenBrowser={showOpenBrowser ? handleOpenBrowser : undefined}
-              onStartTerminal={handleStartTerminal}
-              onCloseMenu={closeMenu}
-            />
-          </QueryClientProvider>
-        )}
+        onOpenNewTab={handleOpenNewTab}
         onPanelChange={noop}
         onPanelFocus={noop}
         isConversationCollapsed={false}
@@ -555,72 +590,15 @@ function NewTabPanelStory({
 
 export function NewTab() {
   return (
-    <StoryCard>
-      <StoryRow
-        label="blank state"
-        hint="workspace-capable new tab before the user types"
-      >
-        <NewTabPanelStory
-          apps={[]}
-          currentThreadId={BLANK_THREAD_ID}
-          initialQuery=""
-          projectId={PROJECT_ID}
-          recentItems={[]}
-          showOpenBrowser={false}
-          threadStoragePaths={[]}
-          workspacePaths={[]}
-        />
-      </StoryRow>
-      <StoryRow label="apps" hint="apps and Create App in the panel + menu">
-        <NewTabPanelStory
-          apps={APPS_ROW_APPS}
-          currentThreadId={APPS_THREAD_ID}
-          initialQuery="s"
-          projectId={PROJECT_ID}
-          recentItems={[]}
-          showOpenBrowser={false}
-          threadStoragePaths={[]}
-          workspacePaths={[]}
-        />
-      </StoryRow>
-      <StoryRow
-        label="recents"
-        hint="recent file rows across plan, mockup, report, and source kinds"
-      >
-        <NewTabPanelStory
-          apps={[]}
-          currentThreadId={RECENTS_THREAD_ID}
-          initialQuery="story"
-          projectId={PROJECT_ID}
-          recentItems={RECENT_ROW_ITEMS}
-          showOpenBrowser={false}
-          threadStoragePaths={[]}
-          workspacePaths={[]}
-        />
-      </StoryRow>
-      <StoryRow
-        label="search results"
-        hint="active New tab seeded with workspace and thread-storage matches"
-      >
-        <NewTabPanelStory
-          apps={APPS_RESPONSE}
-          currentThreadId={SEARCH_THREAD_ID}
-          initialQuery="thread"
-          projectId={PROJECT_ID}
-          recentItems={[]}
-          showOpenBrowser={false}
-          threadStoragePaths={THREAD_STORAGE_PATH_RESULTS}
-          workspacePaths={WORKSPACE_PATH_RESULTS}
-        />
-      </StoryRow>
-      <StoryRow
-        label="open browser"
-        hint="desktop-only Open browser action in the right-panel menu; Start terminal is available beside it"
-      >
-        <WithDesktopBrowser>
+    <WithDesktopBrowser>
+      <StoryCard>
+        <StoryRow
+          label="default"
+          hint="stable launcher: empty Recent, Actions, and Apps/Create App"
+        >
           <NewTabPanelStory
             apps={[]}
-            currentThreadId={OPEN_BROWSER_THREAD_ID}
+            currentThreadId={BLANK_THREAD_ID}
             initialQuery=""
             projectId={PROJECT_ID}
             recentItems={[]}
@@ -628,8 +606,38 @@ export function NewTab() {
             threadStoragePaths={[]}
             workspacePaths={[]}
           />
-        </WithDesktopBrowser>
-      </StoryRow>
-    </StoryCard>
+        </StoryRow>
+        <StoryRow
+          label="recents and apps"
+          hint="recent rows plus installed apps; Apps uses Show more when it grows"
+        >
+          <NewTabPanelStory
+            apps={APPS_ROW_APPS}
+            currentThreadId={APPS_THREAD_ID}
+            initialQuery=""
+            projectId={PROJECT_ID}
+            recentItems={RECENT_ROW_ITEMS}
+            showOpenBrowser
+            threadStoragePaths={[]}
+            workspacePaths={[]}
+          />
+        </StoryRow>
+        <StoryRow
+          label="search results"
+          hint="file matches appear above Recent while Actions and Apps stay available"
+        >
+          <NewTabPanelStory
+            apps={APPS_RESPONSE}
+            currentThreadId={SEARCH_THREAD_ID}
+            initialQuery="thread"
+            projectId={PROJECT_ID}
+            recentItems={RECENT_ROW_ITEMS}
+            showOpenBrowser
+            threadStoragePaths={THREAD_STORAGE_PATH_RESULTS}
+            workspacePaths={WORKSPACE_PATH_RESULTS}
+          />
+        </StoryRow>
+      </StoryCard>
+    </WithDesktopBrowser>
   );
 }

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.test.tsx
@@ -20,9 +20,9 @@ import type {
 import type { AppSummary, BbDesktopInfo } from "@bb/server-contract";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import {
-  NewTabActionMenu,
+  NewTabActions,
   NewTabFileSearch,
-  type NewTabActionMenuProps,
+  type NewTabActionsProps,
   type NewTabFileSearchProps,
 } from "./NewTabFileSearch";
 import { getThreadRecentItemsStorageKey } from "./threadRecentItems";
@@ -41,16 +41,13 @@ interface RenderLauncherArgs {
   onSelect?: NewTabFileSearchProps["onSelect"];
 }
 
-interface RenderActionMenuArgs {
+interface RenderActionsArgs {
   projectId?: string;
-  environmentId?: string | null;
   currentThreadId?: string;
-  onSelect?: NewTabActionMenuProps["onSelect"];
-  onOpenFileSearch?: NewTabActionMenuProps["onOpenFileSearch"];
-  onCreateAppPromptPrefill?: NewTabActionMenuProps["onCreateAppPromptPrefill"];
-  onOpenBrowser?: NewTabActionMenuProps["onOpenBrowser"];
-  onStartTerminal?: NewTabActionMenuProps["onStartTerminal"];
-  onCloseMenu?: NewTabActionMenuProps["onCloseMenu"];
+  onSelect?: NewTabActionsProps["onSelect"];
+  onCreateAppPromptPrefill?: NewTabActionsProps["onCreateAppPromptPrefill"];
+  onOpenBrowser?: NewTabActionsProps["onOpenBrowser"];
+  onStartTerminal?: NewTabActionsProps["onStartTerminal"];
 }
 
 type FileSearchMockState = UseFileSearchSuggestionsResult;
@@ -169,6 +166,15 @@ const DRAFT_WITH_ATTACHMENT = {
   ],
 } satisfies PromptDraftState;
 
+function makeAppSummary(index: number): AppSummary {
+  const applicationId = `app-${index}`;
+  return {
+    ...APP_SUGGESTION.app,
+    applicationId,
+    name: `App ${index}`,
+  } satisfies AppSummary;
+}
+
 function resetFileSearchMockState(): void {
   fileSearchMockState.suggestions = [];
   fileSearchMockState.isLoading = false;
@@ -220,21 +226,18 @@ function renderLauncher(args: RenderLauncherArgs = {}) {
   );
 }
 
-function renderActionMenu(args: RenderActionMenuArgs = {}) {
+function renderActions(args: RenderActionsArgs = {}) {
   const store = createStore();
   const wrapper = ({ children }: ProviderWrapperProps) =>
     createElement(Provider, { store }, children);
   return render(
-    createElement(NewTabActionMenu, {
+    createElement(NewTabActions, {
       projectId: args.projectId ?? "proj_1",
-      environmentId: args.environmentId ?? null,
       currentThreadId: args.currentThreadId ?? "thr_1",
       onSelect: args.onSelect ?? vi.fn(),
-      onOpenFileSearch: args.onOpenFileSearch ?? vi.fn(),
       onCreateAppPromptPrefill: args.onCreateAppPromptPrefill,
       onOpenBrowser: args.onOpenBrowser,
       onStartTerminal: args.onStartTerminal,
-      onCloseMenu: args.onCloseMenu ?? vi.fn(),
     }),
     { wrapper },
   );
@@ -249,65 +252,62 @@ afterEach(() => {
   resetPromptDraftMockState();
 });
 
-describe("NewTabActionMenu", () => {
+describe("NewTabActions", () => {
   it("does not render the old persistent apps-and-files search input", () => {
-    renderActionMenu();
+    renderActions();
 
     expect(
       screen.queryByRole("textbox", { name: "Search apps and files" }),
     ).toBeNull();
   });
 
-  it("omits the Apps header when Create App is the only app-related row", () => {
-    renderActionMenu();
+  it("shows the Apps header when Create App is the only app-related row", () => {
+    renderActions();
 
     expect(screen.getByRole("button", { name: "Create App..." })).toBeTruthy();
-    expect(screen.queryByText("Apps")).toBeNull();
+    expect(screen.getByText("Apps")).toBeTruthy();
   });
 
   it("shows the Apps header when actual installed app rows are present", () => {
     setAppSummaries([APP_SUGGESTION.app]);
 
-    renderActionMenu();
+    renderActions();
 
     expect(screen.getByText("Apps")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Review Board/u })).toBeTruthy();
   });
 
-  it("shows Open browser as a headerless action row on the desktop build", () => {
+  it("shows Open browser in the Actions section on the desktop build", () => {
     window.bbDesktop = createBbDesktopApi(DESKTOP_INFO);
 
-    renderActionMenu({ onOpenBrowser: vi.fn() });
+    renderActions({ onOpenBrowser: vi.fn() });
 
     expect(screen.getByRole("button", { name: /Open browser/u })).toBeTruthy();
-    expect(screen.queryByText("Open")).toBeNull();
+    expect(screen.getByText("Actions")).toBeTruthy();
   });
 
-  it("orders action rows as Open file, Open browser, Start terminal, Create App with no Apps section when no apps exist", () => {
+  it("orders action rows as Open browser, Start terminal, then Create App when no apps exist", () => {
     window.bbDesktop = createBbDesktopApi(DESKTOP_INFO);
 
-    renderActionMenu({ onOpenBrowser: vi.fn(), onStartTerminal: vi.fn() });
+    renderActions({ onOpenBrowser: vi.fn(), onStartTerminal: vi.fn() });
 
     expect(
       screen.getAllByRole("button").map((button) => button.textContent ?? ""),
-    ).toEqual(["Open file", "Open browser", "Start terminal", "Create App..."]);
-    // No installed apps ⇒ no divider and no Apps title; Create App still trails.
-    expect(screen.queryByRole("separator")).toBeNull();
-    expect(screen.queryByText("Apps")).toBeNull();
+    ).toEqual(["Open browser", "Start terminal", "Create App..."]);
+    expect(screen.getByRole("separator")).toBeTruthy();
+    expect(screen.getByText("Apps")).toBeTruthy();
   });
 
   it("orders installed apps between the open actions and Create App, with a divider and Apps title", () => {
     window.bbDesktop = createBbDesktopApi(DESKTOP_INFO);
     setAppSummaries([APP_SUGGESTION.app]);
 
-    renderActionMenu({ onOpenBrowser: vi.fn(), onStartTerminal: vi.fn() });
+    renderActions({ onOpenBrowser: vi.fn(), onStartTerminal: vi.fn() });
 
-    // Open file, Open browser, Start terminal, the installed app rows, then
-    // Create App last.
+    // Open actions, the installed app rows, then Create App last.
     expect(
       screen.getAllByRole("button").map((button) => button.textContent ?? ""),
     ).toEqual([
-      "Open file",
       "Open browser",
       "Start terminal",
       expect.stringContaining("Review Board"),
@@ -336,13 +336,39 @@ describe("NewTabActionMenu", () => {
     expect(orderedAfter(appsTitle, appRow)).toBe(true);
   });
 
+  it("caps installed apps behind show-more while keeping Create App last", () => {
+    setAppSummaries(
+      Array.from({ length: 8 }, (_value, index) => makeAppSummary(index + 1)),
+    );
+
+    renderActions();
+
+    const actions = screen.getByTestId("new-tab-actions");
+    expect(screen.getByRole("button", { name: /App 1/u })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /App 6/u })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /App 7/u })).toBeNull();
+    expect(screen.getByRole("button", { name: "Show 2 more" })).toBeTruthy();
+    expect(
+      within(actions).getAllByRole("button").at(-1)?.textContent,
+    ).toBe("Create App...");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 more" }));
+
+    expect(screen.getByRole("button", { name: /App 7/u })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /App 8/u })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+    expect(
+      within(actions).getAllByRole("button").at(-1)?.textContent,
+    ).toBe("Create App...");
+  });
+
   it("keeps Create App last while apps are loading", () => {
     appsQueryMockState.isLoading = true;
     appsQueryMockState.data = undefined;
 
-    renderActionMenu();
+    renderActions();
 
-    const menu = screen.getByTestId("new-tab-action-menu");
+    const actions = screen.getByTestId("new-tab-actions");
     const createApp = screen.getByRole("button", { name: "Create App..." });
     const status = screen.getByText("Loading apps...");
 
@@ -360,16 +386,16 @@ describe("NewTabActionMenu", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(false);
-    expect(within(menu).getAllByRole("button").at(-1)).toBe(createApp);
+    expect(within(actions).getAllByRole("button").at(-1)).toBe(createApp);
   });
 
   it("keeps Create App last when apps fail to load", () => {
     appsQueryMockState.isError = true;
     appsQueryMockState.data = undefined;
 
-    renderActionMenu();
+    renderActions();
 
-    const menu = screen.getByTestId("new-tab-action-menu");
+    const actions = screen.getByTestId("new-tab-actions");
     const createApp = screen.getByRole("button", { name: "Create App..." });
     const status = screen.getByText("Couldn't load apps.");
 
@@ -387,85 +413,65 @@ describe("NewTabActionMenu", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(false);
-    expect(within(menu).getAllByRole("button").at(-1)).toBe(createApp);
+    expect(within(actions).getAllByRole("button").at(-1)).toBe(createApp);
   });
 
-  it("keeps menu actions compact with native button semantics and non-ring focus", () => {
+  it("keeps page actions compact with native button semantics and non-ring focus", () => {
     window.bbDesktop = createBbDesktopApi(DESKTOP_INFO);
 
-    renderActionMenu({ onOpenBrowser: vi.fn() });
+    renderActions({ onOpenBrowser: vi.fn() });
 
-    const menu = screen.getByTestId("new-tab-action-menu");
-    expect(within(menu).queryByText(/Describe an idea/u)).toBeNull();
-    expect(within(menu).queryByText(/Open a new web browser tab/u)).toBeNull();
+    const actions = screen.getByTestId("new-tab-actions");
+    expect(within(actions).queryByText(/Describe an idea/u)).toBeNull();
     expect(
-      within(menu).queryByText(/Search workspace and thread files/u),
+      within(actions).queryByText(/Open a new web browser tab/u),
     ).toBeNull();
-    expect(within(menu).queryAllByRole("option")).toHaveLength(0);
-    for (const button of within(menu).getAllByRole("button")) {
+    expect(
+      within(actions).queryByText(/Search workspace and thread files/u),
+    ).toBeNull();
+    expect(within(actions).queryAllByRole("option")).toHaveLength(0);
+    for (const button of within(actions).getAllByRole("button")) {
       expect(button.getAttribute("aria-selected")).toBeNull();
       expect(button.className).not.toContain("focus-visible:ring");
-      // No row carries the active/selected highlight at rest — opening the menu
-      // must not leave the first action looking hovered/selected by default —
-      // while the non-ring keyboard-focus cue stays in place.
+      // No row carries the active/selected highlight at rest; the non-ring
+      // keyboard-focus cue stays in place.
       expect(button.className).not.toContain("bg-state-active");
       expect(button.className).toContain("focus-visible:bg-state-hover");
     }
   });
 
   it("hides the Open browser entry on the web build", () => {
-    renderActionMenu({ onOpenBrowser: vi.fn() });
+    renderActions({ onOpenBrowser: vi.fn() });
 
     expect(screen.queryByText("Open browser")).toBeNull();
   });
 
-  it("closes the popout before opening file search", () => {
-    const calls: string[] = [];
-    renderActionMenu({
-      onCloseMenu: () => calls.push("close"),
-      onOpenFileSearch: () => calls.push("open-file"),
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: /Open file/u }));
-
-    expect(calls).toEqual(["close", "open-file"]);
-  });
-
-  it("closes the popout before opening the browser", () => {
+  it("opens the browser directly", () => {
     window.bbDesktop = createBbDesktopApi(DESKTOP_INFO);
-    const calls: string[] = [];
-    renderActionMenu({
-      onCloseMenu: () => calls.push("close"),
-      onOpenBrowser: () => calls.push("open-browser"),
-    });
+    const onOpenBrowser = vi.fn();
+    renderActions({ onOpenBrowser });
 
     fireEvent.click(screen.getByRole("button", { name: /Open browser/u }));
 
-    expect(calls).toEqual(["close", "open-browser"]);
+    expect(onOpenBrowser).toHaveBeenCalledTimes(1);
   });
 
-  it("closes the popout before starting a terminal", () => {
-    const calls: string[] = [];
-    renderActionMenu({
-      onCloseMenu: () => calls.push("close"),
-      onStartTerminal: () => calls.push("start-terminal"),
-    });
+  it("starts a terminal directly", () => {
+    const onStartTerminal = vi.fn();
+    renderActions({ onStartTerminal });
 
     fireEvent.click(screen.getByRole("button", { name: /Start terminal/u }));
 
-    expect(calls).toEqual(["close", "start-terminal"]);
+    expect(onStartTerminal).toHaveBeenCalledTimes(1);
   });
 
-  it("closes the popout before starting Create App", () => {
-    const calls: string[] = [];
-    renderActionMenu({
-      onCloseMenu: () => calls.push("close"),
-      onCreateAppPromptPrefill: () => calls.push("create-app"),
-    });
+  it("starts Create App directly", () => {
+    const onCreateAppPromptPrefill = vi.fn();
+    renderActions({ onCreateAppPromptPrefill });
 
     fireEvent.click(screen.getByRole("button", { name: "Create App..." }));
 
-    expect(calls).toEqual(["close", "create-app"]);
+    expect(onCreateAppPromptPrefill).toHaveBeenCalledTimes(1);
     expect(promptDraftMockState.setDrafts).toEqual([
       {
         text: expect.stringContaining("You are creating a new global bb app."),
@@ -480,7 +486,7 @@ describe("NewTabActionMenu", () => {
     vi.spyOn(window, "confirm").mockReturnValue(false);
     const onCreateAppPromptPrefill = vi.fn();
 
-    renderActionMenu({ onCreateAppPromptPrefill });
+    renderActions({ onCreateAppPromptPrefill });
 
     fireEvent.click(screen.getByRole("button", { name: "Create App..." }));
 

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -45,7 +45,7 @@ import { isProjectlessProjectId } from "@/lib/app-route-paths";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { isPromptDraftEmpty, type PromptDraftState } from "@/lib/prompt-draft";
 import {
-  LAUNCHER_MENU_ROW_BASE_CLASS,
+  LAUNCHER_ACTION_ROW_BASE_CLASS,
   LAUNCHER_ROW_BASE_CLASS,
   LAUNCHER_ROW_ICON_CLASS,
   LauncherRowTrailing,
@@ -85,17 +85,18 @@ export interface NewTabFileSearchProps {
   onSelect: (selection: FileSearchSelection) => void;
 }
 
-export interface NewTabActionMenuProps {
+export type CreateAppPromptPrefillHandler = () => void;
+export type OpenBrowserHandler = () => void;
+export type StartTerminalHandler = () => void;
+
+export interface NewTabActionsProps {
   projectId: string | undefined;
-  environmentId: string | null;
   currentThreadId: string;
   onSelect: (selection: FileSearchSelection) => void;
-  onOpenFileSearch: () => void;
   onCreateAppPromptPrefill?: CreateAppPromptPrefillHandler;
   /** Desktop-only: open a new in-panel browser tab. Absent ⇒ no Browser entry. */
-  onOpenBrowser?: () => void;
-  onStartTerminal?: () => void;
-  onCloseMenu: () => void;
+  onOpenBrowser?: OpenBrowserHandler;
+  onStartTerminal?: StartTerminalHandler;
 }
 
 interface AppResultRowProps {
@@ -137,10 +138,6 @@ interface FileSearchMessageProps {
  */
 type FileSearchSectionEntry =
   | { kind: "suggestion"; suggestion: FileSearchSuggestion }
-  | { kind: "open-browser" }
-  | { kind: "open-file" }
-  | { kind: "start-terminal" }
-  | { kind: "create-app" }
   | { kind: "recent"; item: ThreadRecentItem };
 
 interface FileSearchSectionItem {
@@ -155,11 +152,9 @@ interface FileSearchSection {
 }
 
 type LauncherKeyDownHandler = (event: KeyboardEvent<HTMLElement>) => void;
-type CreateAppPromptPrefillHandler = () => void;
 type FileSearchSource = FileSearchSuggestion["source"];
 type FileSearchSectionKind = "actions" | "apps" | "files" | "recent";
-type CreateAppEntryPlacement = "actions" | "apps" | "none";
-type LauncherTileVariant = "result" | "menu";
+type LauncherTileVariant = "result" | "action";
 
 interface GetAvailableFileSearchSourcesArgs {
   projectId: string | undefined;
@@ -170,11 +165,6 @@ interface GetAvailableFileSearchSourcesArgs {
 interface GroupFileSearchSectionsArgs {
   suggestions: readonly FileSearchSuggestion[];
   availableSources: readonly FileSearchSource[];
-  includeOpenBrowserEntry: boolean;
-  includeOpenFileEntry: boolean;
-  includeStartTerminalEntry: boolean;
-  includeCreateAppEntry: boolean;
-  createAppPlacement: CreateAppEntryPlacement;
   recentEntries: readonly FileSearchSectionEntry[];
 }
 
@@ -202,18 +192,17 @@ interface OpenBrowserTileProps {
   onSelect: () => void;
 }
 
-interface OpenFileTileProps {
+interface StartTerminalTileProps {
   id: string;
   isActive: boolean;
   onActivate: () => void;
   onSelect: () => void;
 }
 
-interface StartTerminalTileProps {
-  id: string;
-  isActive: boolean;
-  onActivate: () => void;
-  onSelect: () => void;
+interface ShowMoreToggleProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  showMoreCount: number;
 }
 
 const FILE_SEARCH_LIMIT = 20;
@@ -239,13 +228,13 @@ const FILE_SEARCH_SOURCE_LABELS = {
 
 const CREATE_APP_ENTRY_ID = "file-search-result-create-app";
 const OPEN_BROWSER_ENTRY_ID = "file-search-result-open-browser";
-const OPEN_FILE_ENTRY_ID = "file-search-result-open-file";
 const START_TERMINAL_ENTRY_ID = "file-search-result-start-terminal";
 
 const LAUNCHER_TILE_ICON_CLASS_DASHED = `flex shrink-0 items-center justify-center text-muted-foreground group-hover:text-foreground ${COARSE_POINTER_ICON_SIZE_CLASS}`;
-const NEW_TAB_ACTION_MENU_SEPARATOR_CLASS = "mx-2 my-1.5 w-auto bg-border-seam";
+const NEW_TAB_ACTIONS_SEPARATOR_CLASS = "mx-2 my-2 w-auto bg-border-seam";
 
 const RECENT_ENTRY_ID_PREFIX = "file-search-result-recent";
+const NEW_TAB_APP_ROWS_VISIBLE_LIMIT = 6;
 
 function getAvailableFileSearchSources({
   projectId,
@@ -281,18 +270,6 @@ function getFileSearchResultId(suggestion: FileSearchSuggestion): string {
 }
 
 function getFileSearchEntryId(entry: FileSearchSectionEntry): string {
-  if (entry.kind === "create-app") {
-    return CREATE_APP_ENTRY_ID;
-  }
-  if (entry.kind === "open-browser") {
-    return OPEN_BROWSER_ENTRY_ID;
-  }
-  if (entry.kind === "open-file") {
-    return OPEN_FILE_ENTRY_ID;
-  }
-  if (entry.kind === "start-terminal") {
-    return START_TERMINAL_ENTRY_ID;
-  }
   if (entry.kind === "recent") {
     return `${RECENT_ENTRY_ID_PREFIX}-${entry.item.source}-${encodeURIComponent(
       entry.item.path,
@@ -316,11 +293,6 @@ function getFileSearchSectionKind(
 
 function groupFileSearchSections({
   availableSources,
-  includeOpenBrowserEntry,
-  includeOpenFileEntry,
-  includeStartTerminalEntry,
-  includeCreateAppEntry,
-  createAppPlacement,
   recentEntries,
   suggestions,
 }: GroupFileSearchSectionsArgs): FileSearchSection[] {
@@ -353,37 +325,8 @@ function groupFileSearchSections({
     });
   }
 
-  if (includeCreateAppEntry && createAppPlacement !== "none") {
-    ensureSection(createAppPlacement).items.push({
-      entry: { kind: "create-app" },
-      index: 0,
-    });
-  }
-
-  if (includeOpenBrowserEntry) {
-    ensureSection("actions").items.push({
-      entry: { kind: "open-browser" },
-      index: 0,
-    });
-  }
-
-  if (includeOpenFileEntry) {
-    ensureSection("actions").items.push({
-      entry: { kind: "open-file" },
-      index: 0,
-    });
-  }
-
-  if (includeStartTerminalEntry) {
-    ensureSection("actions").items.push({
-      entry: { kind: "start-terminal" },
-      index: 0,
-    });
-  }
-
-  // Recent rows trail the Apps and Files sections so the unified index space
-  // reads top-down: launch an app, open a new surface, then jump back to a
-  // recently-opened file.
+  // Recent rows trail file matches so the unified index space reads top-down:
+  // open a matching file first, then jump back to a recently-opened file.
   for (const entry of recentEntries) {
     ensureSection("recent").items.push({ entry, index: 0 });
   }
@@ -431,8 +374,8 @@ function FileSearchMessage({
 
 /**
  * Shared button shell for launcher rows. File-search result rows use listbox
- * option semantics; rows in the + popout keep native button semantics because
- * the popout is a simple action list rather than a composite widget.
+ * option semantics; secondary new-tab actions keep native button semantics
+ * because they are separate commands rather than part of the file combobox.
  */
 function LauncherTile({
   id,
@@ -444,7 +387,9 @@ function LauncherTile({
   children,
 }: LauncherTileProps) {
   const baseClass =
-    variant === "menu" ? LAUNCHER_MENU_ROW_BASE_CLASS : LAUNCHER_ROW_BASE_CLASS;
+    variant === "action"
+      ? LAUNCHER_ACTION_ROW_BASE_CLASS
+      : LAUNCHER_ROW_BASE_CLASS;
 
   return (
     <button
@@ -480,7 +425,7 @@ function AppResultRow({
     <LauncherTile
       id={id}
       isActive={isActive}
-      variant="menu"
+      variant="action"
       onActivate={onActivate}
       onSelect={handleSelect}
       title={getFileSearchResultTitle(suggestion)}
@@ -511,7 +456,7 @@ function CreateAppTile({
     <LauncherTile
       id={id}
       isActive={isActive}
-      variant="menu"
+      variant="action"
       onActivate={onActivate}
       onSelect={onSelect}
     >
@@ -539,7 +484,7 @@ function OpenBrowserTile({
     <LauncherTile
       id={id}
       isActive={isActive}
-      variant="menu"
+      variant="action"
       onActivate={onActivate}
       onSelect={onSelect}
     >
@@ -557,32 +502,6 @@ function OpenBrowserTile({
   );
 }
 
-function OpenFileTile({
-  id,
-  isActive,
-  onActivate,
-  onSelect,
-}: OpenFileTileProps) {
-  return (
-    <LauncherTile
-      id={id}
-      isActive={isActive}
-      variant="menu"
-      onActivate={onActivate}
-      onSelect={onSelect}
-    >
-      <span className={LAUNCHER_ROW_ICON_CLASS}>
-        <Icon
-          name="File"
-          className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-          aria-hidden
-        />
-      </span>
-      <span className="min-w-0 flex-1 truncate text-foreground">Open file</span>
-    </LauncherTile>
-  );
-}
-
 function StartTerminalTile({
   id,
   isActive,
@@ -593,7 +512,7 @@ function StartTerminalTile({
     <LauncherTile
       id={id}
       isActive={isActive}
-      variant="menu"
+      variant="action"
       onActivate={onActivate}
       onSelect={onSelect}
     >
@@ -713,6 +632,35 @@ function RecentResultRow({
   );
 }
 
+function ShowMoreToggle({
+  isExpanded,
+  onToggle,
+  showMoreCount,
+}: ShowMoreToggleProps) {
+  return (
+    <button
+      type="button"
+      aria-expanded={isExpanded}
+      onClick={onToggle}
+      className={cn(
+        "ml-1.5 mt-0.5 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground",
+        COARSE_POINTER_TEXT_SM_CLASS,
+      )}
+    >
+      <Icon
+        name="ChevronDown"
+        className={cn(
+          COARSE_POINTER_COMPACT_ICON_SIZE_CLASS,
+          "transition-transform",
+          isExpanded && "rotate-180",
+        )}
+        aria-hidden
+      />
+      <span>{isExpanded ? "Show less" : `Show ${showMoreCount} more`}</span>
+    </button>
+  );
+}
+
 export function NewTabFileSearch({
   projectId,
   environmentId,
@@ -764,8 +712,8 @@ export function NewTabFileSearch({
     [suggestions],
   );
   // Collapsed to the visible cap by default. Recents are file/artifact entries,
-  // so this section is owned by the Open file/search surface rather than the +
-  // action menu.
+  // so this section is owned by the Open file/search surface rather than the
+  // secondary action rows on the new-tab page.
   const visibleRecentItems = useMemo(
     () =>
       isRecentExpanded
@@ -781,11 +729,6 @@ export function NewTabFileSearch({
     () =>
       groupFileSearchSections({
         availableSources: fileSearchSources,
-        includeOpenBrowserEntry: false,
-        includeOpenFileEntry: false,
-        includeStartTerminalEntry: false,
-        includeCreateAppEntry: false,
-        createAppPlacement: "none",
         recentEntries,
         suggestions: fileSuggestions,
       }),
@@ -895,7 +838,7 @@ export function NewTabFileSearch({
   const hasListbox = !isSearchDisabled && navigableEntries.length > 0;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <div className="flex min-w-0 flex-col gap-3">
       <div className="relative min-w-0">
         <Icon
           name="Search"
@@ -972,34 +915,19 @@ export function NewTabFileSearch({
   );
 }
 
-export function NewTabActionMenu({
+export function NewTabActions({
   projectId,
-  environmentId,
   currentThreadId,
   onSelect,
-  onOpenFileSearch,
   onCreateAppPromptPrefill,
   onOpenBrowser,
   onStartTerminal,
-  onCloseMenu,
-}: NewTabActionMenuProps) {
+}: NewTabActionsProps) {
+  const [isAppsExpanded, setIsAppsExpanded] = useState(false);
   const promptDraft = usePromptDraftStorage({
     projectId,
     threadId: currentThreadId.length > 0 ? currentThreadId : null,
   });
-  const availableSources = useMemo(
-    () =>
-      getAvailableFileSearchSources({
-        projectId,
-        environmentId,
-        currentThreadId,
-      }),
-    [currentThreadId, environmentId, projectId],
-  );
-  const fileSearchSources = useMemo(
-    () => availableSources.filter((source) => source !== "app"),
-    [availableSources],
-  );
   const canSearchApps = currentThreadId.length > 0;
   const apps = useApps({ enabled: canSearchApps });
   const appSuggestions = useMemo<AppSearchSuggestion[]>(
@@ -1014,43 +942,41 @@ export function NewTabActionMenu({
       })),
     [apps.data],
   );
+  const visibleAppSuggestions = useMemo(
+    () =>
+      isAppsExpanded
+        ? appSuggestions
+        : appSuggestions.slice(0, NEW_TAB_APP_ROWS_VISIBLE_LIMIT),
+    [appSuggestions, isAppsExpanded],
+  );
   const canPrefillCreateAppPrompt =
     promptDraft.storageKey !== null && currentThreadId.length > 0;
-  const isMenuUnavailable = availableSources.length === 0;
   const showOpenBrowserEntry =
-    !isMenuUnavailable &&
     onOpenBrowser !== undefined &&
     isDesktopBrowserAvailable();
-  const showOpenFileEntry = !isMenuUnavailable && fileSearchSources.length > 0;
-  const showStartTerminalEntry =
-    !isMenuUnavailable && onStartTerminal !== undefined;
-  const showCreateAppEntry = !isMenuUnavailable && canPrefillCreateAppPrompt;
+  const showStartTerminalEntry = onStartTerminal !== undefined;
+  const showCreateAppEntry = canPrefillCreateAppPrompt;
 
   const handleAppSelect = useCallback(
     (suggestion: AppSearchSuggestion) => {
-      onCloseMenu();
       onSelect({ source: "app", applicationId: suggestion.applicationId });
     },
-    [onCloseMenu, onSelect],
+    [onSelect],
   );
 
-  const handleOpenFileSearch = useCallback(() => {
-    onCloseMenu();
-    onOpenFileSearch();
-  }, [onCloseMenu, onOpenFileSearch]);
-
   const handleOpenBrowser = useCallback(() => {
-    onCloseMenu();
     onOpenBrowser?.();
-  }, [onCloseMenu, onOpenBrowser]);
+  }, [onOpenBrowser]);
 
   const handleStartTerminal = useCallback(() => {
-    onCloseMenu();
     onStartTerminal?.();
-  }, [onCloseMenu, onStartTerminal]);
+  }, [onStartTerminal]);
+
+  const handleToggleAppsExpanded = useCallback(() => {
+    setIsAppsExpanded((current) => !current);
+  }, []);
 
   const handleCreateAppPromptPrefill = useCallback(() => {
-    onCloseMenu();
     if (!canPrefillCreateAppPrompt) {
       return;
     }
@@ -1067,108 +993,114 @@ export function NewTabActionMenu({
 
     promptDraft.setDraft(CREATE_APP_PROMPT_DRAFT);
     onCreateAppPromptPrefill?.();
-  }, [
-    canPrefillCreateAppPrompt,
-    onCloseMenu,
-    onCreateAppPromptPrefill,
-    promptDraft,
-  ]);
+  }, [canPrefillCreateAppPrompt, onCreateAppPromptPrefill, promptDraft]);
 
   const hasInstalledApps = appSuggestions.length > 0;
+  const showAppsToggle =
+    appSuggestions.length > NEW_TAB_APP_ROWS_VISIBLE_LIMIT;
+  const showAppsMoreCount = Math.max(
+    0,
+    appSuggestions.length - NEW_TAB_APP_ROWS_VISIBLE_LIMIT,
+  );
+  const hasOpenActions = showOpenBrowserEntry || showStartTerminalEntry;
+  const hasAppActions =
+    hasInstalledApps || apps.isLoading || apps.isError || showCreateAppEntry;
+
+  if (!hasOpenActions && !hasAppActions) {
+    return null;
+  }
 
   return (
-    <div data-testid="new-tab-action-menu" className="flex min-w-0 flex-col">
-      {/* Primary open actions lead the menu before installed apps. */}
-      <div className="flex flex-col gap-px">
-        {showOpenFileEntry ? (
-          <OpenFileTile
-            id={OPEN_FILE_ENTRY_ID}
-            isActive={false}
-            onActivate={() => undefined}
-            onSelect={handleOpenFileSearch}
+    <div data-testid="new-tab-actions" className="flex min-w-0 flex-col">
+      {hasOpenActions ? (
+        <section>
+          <LauncherSectionHeader
+            label={FILE_SEARCH_SECTION_LABELS.actions}
+            className="pb-1"
           />
-        ) : null}
-        {showOpenBrowserEntry ? (
-          <OpenBrowserTile
-            id={OPEN_BROWSER_ENTRY_ID}
-            isActive={false}
-            onActivate={() => undefined}
-            onSelect={handleOpenBrowser}
-          />
-        ) : null}
-        {showStartTerminalEntry ? (
-          <StartTerminalTile
-            id={START_TERMINAL_ENTRY_ID}
-            isActive={false}
-            onActivate={() => undefined}
-            onSelect={handleStartTerminal}
-          />
-        ) : null}
-      </div>
+          <div className="flex flex-col gap-px">
+            {showOpenBrowserEntry ? (
+              <OpenBrowserTile
+                id={OPEN_BROWSER_ENTRY_ID}
+                isActive={false}
+                onActivate={() => undefined}
+                onSelect={handleOpenBrowser}
+              />
+            ) : null}
+            {showStartTerminalEntry ? (
+              <StartTerminalTile
+                id={START_TERMINAL_ENTRY_ID}
+                isActive={false}
+                onActivate={() => undefined}
+                onSelect={handleStartTerminal}
+              />
+            ) : null}
+          </div>
+        </section>
+      ) : null}
 
-      {/* Installed apps get their own divided, titled section, present only
-          when at least one app exists. With no apps there is no divider or
-          title and Create App simply trails the open actions below. */}
-      {hasInstalledApps ? (
-        <>
-          <Separator
-            // A real (non-decorative) separator marks the boundary between the
-            // open actions and the apps group, matching the app's menu divider
-            // convention. Keep it inset to the row/content rail on the left,
-            // and use the same subtle seam token as horizontal top-nav dividers.
-            decorative={false}
-            className={NEW_TAB_ACTION_MENU_SEPARATOR_CLASS}
-          />
+      {hasOpenActions && hasAppActions ? (
+        <Separator
+          decorative={false}
+          className={NEW_TAB_ACTIONS_SEPARATOR_CLASS}
+        />
+      ) : null}
+
+      {hasAppActions ? (
+        <section>
           <LauncherSectionHeader
             label={FILE_SEARCH_SECTION_LABELS.apps}
             className="pb-1"
           />
-        </>
+          <div className="flex flex-col gap-px">
+            {visibleAppSuggestions.map((suggestion) => (
+              <AppResultRow
+                key={`app:${suggestion.applicationId}`}
+                id={getFileSearchResultId(suggestion)}
+                suggestion={suggestion}
+                isActive={false}
+                onActivate={() => undefined}
+                onSelect={handleAppSelect}
+              />
+            ))}
+            {canSearchApps && apps.isLoading && appSuggestions.length === 0 ? (
+              <p
+                className={cn(
+                  "px-2 py-1 text-muted-foreground",
+                  COARSE_POINTER_TEXT_SM_CLASS,
+                )}
+              >
+                Loading apps...
+              </p>
+            ) : null}
+            {canSearchApps && apps.isError ? (
+              <p
+                className={cn(
+                  "px-2 py-1 text-muted-foreground",
+                  COARSE_POINTER_TEXT_SM_CLASS,
+                )}
+              >
+                Couldn't load apps.
+              </p>
+            ) : null}
+            {showAppsToggle ? (
+              <ShowMoreToggle
+                isExpanded={isAppsExpanded}
+                onToggle={handleToggleAppsExpanded}
+                showMoreCount={showAppsMoreCount}
+              />
+            ) : null}
+            {showCreateAppEntry ? (
+              <CreateAppTile
+                id={CREATE_APP_ENTRY_ID}
+                isActive={false}
+                onActivate={() => undefined}
+                onSelect={handleCreateAppPromptPrefill}
+              />
+            ) : null}
+          </div>
+        </section>
       ) : null}
-
-      {/* Apps list, then any app-load status, then Create App. Create App is
-          always the final row, so the Loading/Couldn't-load notice sits above
-          it in every app state rather than trailing it. */}
-      <div className="flex flex-col gap-px">
-        {appSuggestions.map((suggestion) => (
-          <AppResultRow
-            key={`app:${suggestion.applicationId}`}
-            id={getFileSearchResultId(suggestion)}
-            suggestion={suggestion}
-            isActive={false}
-            onActivate={() => undefined}
-            onSelect={handleAppSelect}
-          />
-        ))}
-        {canSearchApps && apps.isLoading && appSuggestions.length === 0 ? (
-          <p
-            className={cn(
-              "px-2 py-1 text-muted-foreground",
-              COARSE_POINTER_TEXT_SM_CLASS,
-            )}
-          >
-            Loading apps...
-          </p>
-        ) : null}
-        {canSearchApps && apps.isError ? (
-          <p
-            className={cn(
-              "px-2 py-1 text-muted-foreground",
-              COARSE_POINTER_TEXT_SM_CLASS,
-            )}
-          >
-            Couldn't load apps.
-          </p>
-        ) : null}
-        {showCreateAppEntry ? (
-          <CreateAppTile
-            id={CREATE_APP_ENTRY_ID}
-            isActive={false}
-            onActivate={() => undefined}
-            onSelect={handleCreateAppPromptPrefill}
-          />
-        ) : null}
-      </div>
     </div>
   );
 }
@@ -1243,7 +1175,7 @@ function NewTabResults({
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto pb-1">
+    <div className="pb-1">
       {/* The loading/error message stands in for the Files group while no file
           rows exist, so it leads the results just as that group would. */}
       {showFileSearchMessage ? (
@@ -1332,8 +1264,8 @@ function NewTabResults({
       {recent.emptyHintVisible && recentSection === undefined ? (
         // Empty Recent zero-state. It is a framed dashed placeholder card, not a
         // selectable option, so it sits outside the listbox. This belongs to the
-        // Open file / search surface only; the browser new-tab and root + menu
-        // stay card-less.
+        // Open file / search surface only; the browser new-tab and secondary
+        // action rows stay card-less.
         <section className={cn(hasRecentSectionPredecessor && "mt-3")}>
           <LauncherSectionHeader
             label={FILE_SEARCH_SECTION_LABELS.recent}
@@ -1347,30 +1279,11 @@ function NewTabResults({
       ) : null}
 
       {recent.toggleVisible ? (
-        <button
-          type="button"
-          aria-expanded={recent.isExpanded}
-          onClick={recent.onToggleExpanded}
-          className={cn(
-            "ml-1.5 mt-0.5 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground",
-            COARSE_POINTER_TEXT_SM_CLASS,
-          )}
-        >
-          <Icon
-            name="ChevronDown"
-            className={cn(
-              COARSE_POINTER_COMPACT_ICON_SIZE_CLASS,
-              "transition-transform",
-              recent.isExpanded && "rotate-180",
-            )}
-            aria-hidden
-          />
-          <span>
-            {recent.isExpanded
-              ? "Show less"
-              : `Show ${recent.showMoreCount} more`}
-          </span>
-        </button>
+        <ShowMoreToggle
+          isExpanded={recent.isExpanded}
+          onToggle={recent.onToggleExpanded}
+          showMoreCount={recent.showMoreCount}
+        />
       ) : null}
     </div>
   );

--- a/apps/app/src/components/secondary-panel/NewTabPage.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.tsx
@@ -1,19 +1,52 @@
 import {
+  NewTabActions,
   NewTabFileSearch,
+  type CreateAppPromptPrefillHandler,
   type NewTabFileSearchProps,
+  type OpenBrowserHandler,
+  type StartTerminalHandler,
 } from "./NewTabFileSearch";
 
-export type NewTabPageProps = NewTabFileSearchProps;
+export interface NewTabPageProps extends NewTabFileSearchProps {
+  onCreateAppPromptPrefill?: CreateAppPromptPrefillHandler;
+  onOpenBrowser?: OpenBrowserHandler;
+  onStartTerminal?: StartTerminalHandler;
+}
 
 /**
  * Browser-style "New Tab" landing page for the secondary panel. The tab body
- * is the in-place file search surface; the panel `+` menu owns app/create and
- * open actions.
+ * keeps file search primary while secondary commands live in-page, avoiding
+ * overlays that can be occluded by native browser/webview surfaces.
  */
-export function NewTabPage(props: NewTabPageProps) {
+export function NewTabPage({
+  currentThreadId,
+  environmentId,
+  focusRequest,
+  initialQuery,
+  onCreateAppPromptPrefill,
+  onOpenBrowser,
+  onSelect,
+  onStartTerminal,
+  projectId,
+}: NewTabPageProps) {
   return (
-    <div className="flex min-h-full flex-col gap-3 px-4 pt-1">
-      <NewTabFileSearch {...props} />
+    <div className="flex min-h-full flex-col gap-3 px-4 pb-3 pt-1">
+      <NewTabFileSearch
+        projectId={projectId}
+        environmentId={environmentId}
+        currentThreadId={currentThreadId}
+        focusRequest={focusRequest}
+        initialQuery={initialQuery}
+        onSelect={onSelect}
+      />
+      <NewTabActions
+        projectId={projectId}
+        currentThreadId={currentThreadId}
+        onSelect={onSelect}
+        onCreateAppPromptPrefill={onCreateAppPromptPrefill}
+        onOpenBrowser={onOpenBrowser}
+        onStartTerminal={onStartTerminal}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.tsx
@@ -14,7 +14,6 @@ import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
-  type NewTabMenuRenderer,
   type SecondaryPanelFileTab,
   ThreadSecondaryPanel,
 } from "./ThreadSecondaryPanel";
@@ -42,7 +41,7 @@ interface RenderPanelArgs {
   isConversationCollapsed?: boolean;
   onToggleConversationCollapse?: () => void;
   reserveLeftForDesktopTrafficLights?: boolean;
-  renderNewTabMenu?: NewTabMenuRenderer;
+  onOpenNewTab?: () => void;
   showGitDiffTab?: boolean;
 }
 
@@ -65,7 +64,6 @@ interface BuildActiveFileTabArgs {
 }
 
 const noop = () => {};
-const renderEmptyNewTabMenu: NewTabMenuRenderer = () => <div>New tab menu</div>;
 const IFRAME_DRAG_GUARD_OVERLAY_TESTID = "iframe-drag-guard-overlay";
 // The class that used to disable iframe pointer-events during resize — asserted
 // absent so the regression that broke wheel-scroll can't be reintroduced.
@@ -128,7 +126,7 @@ function renderPanel({
   isConversationCollapsed = false,
   onToggleConversationCollapse = noop,
   reserveLeftForDesktopTrafficLights = false,
-  renderNewTabMenu = renderEmptyNewTabMenu,
+  onOpenNewTab = noop,
   showGitDiffTab = false,
 }: RenderPanelArgs = {}) {
   const { wrapper } = createQueryClientTestHarness();
@@ -146,7 +144,7 @@ function renderPanel({
       onCollapse={noop}
       onClose={noop}
       onFileTabReorder={noop}
-      renderNewTabMenu={renderNewTabMenu}
+      onOpenNewTab={onOpenNewTab}
       onPanelChange={noop}
       onPanelFocus={noop}
       isConversationCollapsed={isConversationCollapsed}
@@ -217,7 +215,7 @@ describe("ThreadSecondaryPanel", () => {
         screen.getByRole("button", { name: "Show thread info panel" }),
       );
       expectNoDragRegionOnElementOrAncestor(
-        screen.getByRole("button", { name: "Open tab menu" }),
+        screen.getByRole("button", { name: "Open new tab" }),
       );
       expectNoDragRegionOnElementOrAncestor(
         screen.getByRole("button", { name: "Hide right panel" }),
@@ -247,7 +245,7 @@ describe("ThreadSecondaryPanel", () => {
     });
 
     const strip = screen.getByTestId("secondary-panel-tab-strip");
-    const newTab = screen.getByRole("button", { name: "Open tab menu" });
+    const newTab = screen.getByRole("button", { name: "Open new tab" });
 
     // Browser-style: the + sits right after the last tab. It is the strip's
     // immediate next sibling, and the strip is sized to its tabs (no flex-grow),
@@ -298,13 +296,14 @@ describe("ThreadSecondaryPanel", () => {
     ).toBe("true");
   });
 
-  it("opens the new-tab action popout from the plus button", () => {
-    renderPanel();
+  it("opens the new-tab page from the plus button", () => {
+    const onOpenNewTab = vi.fn();
+    renderPanel({ onOpenNewTab });
 
     const infoButton = screen.getByRole("button", {
       name: "Show thread info panel",
     });
-    const newTabButton = screen.getByRole("button", { name: "Open tab menu" });
+    const newTabButton = screen.getByRole("button", { name: "Open new tab" });
     expect(infoButton.className).toContain(
       CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
     );
@@ -330,61 +329,8 @@ describe("ThreadSecondaryPanel", () => {
 
     fireEvent.click(newTabButton);
 
-    const menu = screen.getByText("New tab menu");
-    const surface = menu.parentElement;
-
-    expect(menu).toBeTruthy();
-    expect(surface?.className).toContain("w-auto");
-    expect(surface?.className).toContain("min-w-40");
-    expect(surface?.className).toContain("focus-visible:ring-0");
-    expect(surface?.className).not.toContain("w-80");
-    expect(surface?.className).not.toContain("w-96");
-  });
-
-  it("does not land focus on the first popout action when the menu opens", () => {
-    renderPanel({
-      renderNewTabMenu: () => (
-        <div data-testid="new-tab-action-menu">
-          <button type="button">Open file</button>
-          <button type="button">Open browser</button>
-        </div>
-      ),
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Open tab menu" }));
-
-    // Opening the popout must not autofocus the first row: that paints it with
-    // the keyboard-focus highlight and makes Open file read as already
-    // selected/hovered at rest. Focus rests on the dialog container instead, so
-    // the first Tab still reaches Open file with the visible focus cue.
-    const openFile = screen.getByRole("button", { name: "Open file" });
-    expect(document.activeElement).not.toBe(openFile);
-    expect(document.activeElement).toBe(screen.getByRole("dialog"));
-  });
-
-  it("closes the new-tab action popout after a menu action", async () => {
-    const onOpenFile = vi.fn();
-    renderPanel({
-      renderNewTabMenu: ({ closeMenu }) => (
-        <button
-          type="button"
-          onClick={() => {
-            closeMenu();
-            onOpenFile();
-          }}
-        >
-          Open file
-        </button>
-      ),
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Open tab menu" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open file" }));
-
-    expect(onOpenFile).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "Open file" })).toBeNull();
-    });
+    expect(onOpenNewTab).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("uses the vertical seam token for the panel resize-handle hairline", () => {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -4,7 +4,6 @@ import {
   type ReactNode,
   useCallback,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { useAtomValue } from "jotai";
@@ -14,11 +13,6 @@ import { Panel, PanelResizeHandle } from "react-resizable-panels";
 import { Button } from "@/components/ui/button.js";
 import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@/components/ui/chromeStyleTokens";
 import { COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover.js";
 import { cn } from "@/lib/utils";
 import {
   PANEL_COLLAPSE_TRANSITION_CLASS,
@@ -78,12 +72,6 @@ const SECONDARY_RESIZABLE_PANEL_STYLE: CSSProperties = {
 };
 const SECONDARY_PANEL_CHROME_ICON_BUTTON_CLASS = `${COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS} shrink-0 ${CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS}`;
 
-export interface NewTabMenuRenderProps {
-  closeMenu: () => void;
-}
-
-export type NewTabMenuRenderer = (props: NewTabMenuRenderProps) => ReactNode;
-
 interface ResolveActiveFixedPanelArgs {
   activeTab: SecondaryFixedPanelTab | null;
   canUseGitUi: boolean;
@@ -117,7 +105,7 @@ export interface ThreadSecondaryPanelProps {
   onPanelChange: (panel: ThreadSecondaryPanelTab) => void;
   onCollapse: () => void;
   onClose: () => void;
-  renderNewTabMenu: NewTabMenuRenderer;
+  onOpenNewTab: () => void;
   workspaceRootPath?: string | null;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
@@ -193,7 +181,7 @@ export function ThreadSecondaryPanel({
   onPanelChange,
   onCollapse,
   onClose,
-  renderNewTabMenu,
+  onOpenNewTab,
   workspaceRootPath,
   onOpenFileInEditor,
   onOpenFilePreview,
@@ -387,7 +375,7 @@ export function ThreadSecondaryPanel({
               />
             ) : null}
             <NewTabButton
-              renderNewTabMenu={renderNewTabMenu}
+              onOpenNewTab={onOpenNewTab}
               usesDesktopChrome={usesDesktopChrome}
             />
           </div>
@@ -548,58 +536,29 @@ export function ThreadSecondaryPanel({
 }
 
 interface NewTabButtonProps {
-  renderNewTabMenu: NewTabMenuRenderer;
+  onOpenNewTab: () => void;
   usesDesktopChrome: boolean;
 }
 
 function NewTabButton({
-  renderNewTabMenu,
+  onOpenNewTab,
   usesDesktopChrome,
 }: NewTabButtonProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const closeMenu = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-  const handleOpenAutoFocus = useCallback((event: Event) => {
-    // Radix focuses the first row on open, which paints it with the
-    // keyboard-focus highlight and makes the menu read as if Open file were
-    // already selected. Move focus to the popout container instead so no row is
-    // highlighted at rest; the first Tab still lands on Open file with the
-    // visible focus cue, and the menu stays keyboard-reachable inside the portal.
-    event.preventDefault();
-    contentRef.current?.focus();
-  }, []);
-
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className={cn(
-            SECONDARY_PANEL_CHROME_ICON_BUTTON_CLASS,
-            usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
-          )}
-          aria-label="Open tab menu"
-          title="New tab"
-        >
-          <Icon name="Plus" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        ref={contentRef}
-        align="start"
-        side="bottom"
-        sideOffset={6}
-        className="w-auto min-w-40 p-1 focus-visible:ring-0"
-        mobileTitle="New tab menu"
-        onOpenAutoFocus={handleOpenAutoFocus}
-      >
-        {renderNewTabMenu({ closeMenu })}
-      </PopoverContent>
-    </Popover>
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={cn(
+        SECONDARY_PANEL_CHROME_ICON_BUTTON_CLASS,
+        usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+      )}
+      onClick={onOpenNewTab}
+      aria-label="Open new tab"
+      title="New tab"
+    >
+      <Icon name="Plus" />
+    </Button>
   );
 }
 

--- a/apps/app/src/components/secondary-panel/launcherRow.tsx
+++ b/apps/app/src/components/secondary-panel/launcherRow.tsx
@@ -13,12 +13,12 @@ import { cn } from "@/lib/utils";
 // surfaces rather than drifting in two parallel class bundles.
 const LAUNCHER_ROW_SHELL_CLASS = `group flex w-full min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left transition-colors focus-visible:outline-none ${COARSE_POINTER_TEXT_SM_CLASS}`;
 export const LAUNCHER_ROW_BASE_CLASS = `${LAUNCHER_ROW_SHELL_CLASS} focus-visible:ring-1 focus-visible:ring-ring`;
-export const LAUNCHER_MENU_ROW_BASE_CLASS = `${LAUNCHER_ROW_SHELL_CLASS} focus-visible:bg-state-hover focus-visible:text-foreground`;
+export const LAUNCHER_ACTION_ROW_BASE_CLASS = `${LAUNCHER_ROW_SHELL_CLASS} focus-visible:bg-state-hover focus-visible:text-foreground`;
 export const LAUNCHER_ROW_ICON_CLASS = `flex shrink-0 items-center justify-center overflow-hidden text-muted-foreground ${COARSE_POINTER_ICON_SIZE_CLASS}`;
 
-// Section labels above launcher row groups (the + menu, file search, recents,
-// and the browser tab's recently-visited list). Mirrors the detail-card key
-// style rather than a loud uppercase, tracked header.
+// Section labels above launcher row groups (new-tab actions, file search,
+// recents, and the browser tab's recently-visited list). Mirrors the
+// detail-card key style rather than a loud uppercase, tracked header.
 const LAUNCHER_SECTION_LABEL_CLASS = CHROME_SECTION_LABEL_CLASS;
 
 interface LauncherRowTrailingProps {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -292,7 +292,7 @@ function buildSecondaryContentProps({
       onFileTabReorder: noop,
       onOpenFileInEditor: noopOpenFile,
       onOpenFilePreview: noopOpenFile,
-      renderNewTabMenu: () => <div>New tab menu</div>,
+      onOpenNewTab: noop,
       onPanelChange: noopSecondaryPanelChange,
       onPanelFocus: noop,
     },

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -97,7 +97,6 @@ import {
 } from "@/components/secondary-panel/ThreadSecondaryPanelTabContent";
 import { AppTabContent } from "@/components/secondary-panel/AppTabContent";
 import { BrowserTabDeck } from "@/components/secondary-panel/BrowserTabDeck";
-import { NewTabActionMenu } from "@/components/secondary-panel/NewTabFileSearch";
 import { NewTabPage } from "@/components/secondary-panel/NewTabPage";
 import { resolveRightPanelFileVisual } from "@/components/secondary-panel/rightPanelFileVisuals";
 import { COARSE_POINTER_COMPACT_ICON_SIZE_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
@@ -119,10 +118,7 @@ import {
 } from "@/components/secondary-panel/useThreadStorageBrowser";
 import { useThreadFileTabs } from "@/components/secondary-panel/useThreadFileTabs";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
-import type {
-  NewTabMenuRenderer,
-  SecondaryPanelFileTab,
-} from "@/components/secondary-panel/ThreadSecondaryPanel";
+import type { SecondaryPanelFileTab } from "@/components/secondary-panel/ThreadSecondaryPanel";
 import { useEnvironmentMergeBase } from "@/components/secondary-panel/git-diff/useEnvironmentMergeBase";
 import { useThreadGitActions } from "./useThreadGitActions";
 import { useThreadReadTracking } from "./useThreadReadTracking";
@@ -701,10 +697,13 @@ export function ThreadDetailView() {
       thread?.environmentId,
     ],
   );
-  const handleOpenFileSearch = useCallback(() => {
+  const handleOpenNewTab = useCallback(() => {
     openNewTab();
     setNewTabFocusRequest((current) => current + 1);
   }, [openNewTab]);
+  const handleOpenBrowser = useCallback(() => {
+    openBrowserTab();
+  }, [openBrowserTab]);
   const handleCreateAppPromptPrefill = useCallback(() => {
     closeNewTab();
     closeSecondaryPanel();
@@ -722,6 +721,7 @@ export function ThreadDetailView() {
       },
       {
         onSuccess: (session) => {
+          closeNewTab();
           setPersistedSecondaryPanelOpen(true);
           setActiveFixedTerminal(session.id);
         },
@@ -729,6 +729,7 @@ export function ThreadDetailView() {
     );
   }, [
     canCreateTerminal,
+    closeNewTab,
     createTerminal,
     setActiveFixedTerminal,
     setPersistedSecondaryPanelOpen,
@@ -757,32 +758,6 @@ export function ThreadDetailView() {
       );
     },
     [closeTerminal, removeFixedTerminalTab, threadId],
-  );
-  const renderNewTabMenu = useCallback<NewTabMenuRenderer>(
-    ({ closeMenu }) => (
-      <NewTabActionMenu
-        projectId={projectId ?? undefined}
-        environmentId={thread?.environmentId ?? null}
-        currentThreadId={threadId ?? ""}
-        onSelect={selectFileSearchResult}
-        onOpenFileSearch={handleOpenFileSearch}
-        onCreateAppPromptPrefill={handleCreateAppPromptPrefill}
-        onOpenBrowser={() => openBrowserTab()}
-        onStartTerminal={canCreateTerminal ? handleStartTerminal : undefined}
-        onCloseMenu={closeMenu}
-      />
-    ),
-    [
-      canCreateTerminal,
-      handleCreateAppPromptPrefill,
-      handleOpenFileSearch,
-      handleStartTerminal,
-      openBrowserTab,
-      projectId,
-      selectFileSearchResult,
-      thread?.environmentId,
-      threadId,
-    ],
   );
   const handleChangedFileClick = useCallback(
     (selection: WorkspaceChangedFileSelection) => {
@@ -1488,6 +1463,9 @@ export function ThreadDetailView() {
       currentThreadId={thread.id}
       focusRequest={newTabFocusRequest}
       onSelect={selectFileSearchResult}
+      onCreateAppPromptPrefill={handleCreateAppPromptPrefill}
+      onOpenBrowser={handleOpenBrowser}
+      onStartTerminal={canCreateTerminal ? handleStartTerminal : undefined}
     />
   ) : activeAppId ? (
     <AppTabContent applicationId={activeAppId} threadId={thread.id} />
@@ -1590,7 +1568,7 @@ export function ThreadDetailView() {
           onCollapse: closeSecondaryPanel,
           onOpenFileInEditor: handleOpenFileInEditor,
           onFileTabReorder: reorderFileTab,
-          renderNewTabMenu,
+          onOpenNewTab: handleOpenNewTab,
           onOpenFilePreview: (relativePath: string) => {
             openWorkspaceFile({
               lineRange: null,


### PR DESCRIPTION
## Summary

- Replace the right-panel `+` context menu with a real `new-tab` page.
- Keep file search as the primary action on the page, with secondary entries for opening a browser, starting a terminal, installed apps, and Create App.
- Update the secondary-panel integration, stories, and focused tests around the new flow.

## Why

The context menu adds friction to the primary file-opening workflow and can be occluded by the focused browser webview. Moving the launcher into the tab body gives the primary action a persistent surface and avoids overlay behavior over native browser content.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/secondary-panel/NewTabFileSearch.test.tsx src/components/secondary-panel/NewTabPage.test.tsx src/components/secondary-panel/ThreadSecondaryPanel.test.tsx src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
