### PR TITLE
fix(ci): landing deploy workflow used pnpm's built-in deploy command

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Deploy landing
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: pnpm --filter @bb/landing deploy
+        run: pnpm --filter @bb/landing run deploy

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -27,7 +27,7 @@ see `wrangler.jsonc`), live at <https://getbb.app> (and
 
 ```bash
 pnpm exec turbo run build --filter=@bb/landing
-pnpm --filter @bb/landing deploy
+pnpm --filter @bb/landing run deploy
 ```
 
 Requires a wrangler login with workers write access (`wrangler login`).

--- a/apps/landing/wrangler.jsonc
+++ b/apps/landing/wrangler.jsonc
@@ -1,7 +1,7 @@
 // Cloudflare Workers static-assets deploy of the prerendered landing site.
 // The site is fully prerendered at build time (see vite.config.ts), so this
 // is an assets-only Worker — no server runtime, just dist/client.
-// Deploy: pnpm exec turbo run build --filter=@bb/landing && pnpm --filter @bb/landing deploy
+// Deploy: pnpm exec turbo run build --filter=@bb/landing && pnpm --filter @bb/landing run deploy
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "bb-landing",


### PR DESCRIPTION
The first post-merge run of Deploy Landing failed with ERR_PNPM_INVALID_DEPLOY_TARGET: bare `pnpm --filter @bb/landing deploy` invokes pnpm's built-in `deploy` command rather than the package script. Add the explicit `run` (workflow + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)