### PR TITLE
[codex] Disable telemetry in bb-app smoke tests

### DIFF
--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -14,6 +14,9 @@ const DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST = "127.0.0.1";
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptsDir, "..");
 const tempRoot = await mkdtemp(join(tmpdir(), "bb-app-tarball-"));
+const smokeProcessEnv = {
+  BB_TELEMETRY: "false",
+};
 
 function delay(ms) {
   return new Promise((resolvePromise) => {
@@ -64,6 +67,7 @@ async function runCommand({ args, command, env = {}, label }) {
     env: {
       ...process.env,
       ...env,
+      ...smokeProcessEnv,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -85,6 +89,7 @@ function spawnManagedProcess({ args, command, env = {}, label }) {
     env: {
       ...process.env,
       ...env,
+      ...smokeProcessEnv,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });


### PR DESCRIPTION
## Summary

- Set `BB_TELEMETRY=false` for every subprocess launched by the `bb-app` tarball smoke script.
- Keep production telemetry defaults unchanged for real `bb-app` and desktop users.

## Root Cause

The tarball smoke test starts production `bb-app` and `bb-server` processes with temporary data directories. Because production telemetry defaults to enabled, each CI smoke run could create a fresh anonymous `telemetry-id` and report `app_started` as a new PostHog user.

## Impact

CI and publish validation runs stop polluting PostHog `app_started` unique-user counts.

## Validation

- `node --check packages/bb-app/scripts/smoke-tarball.mjs`
