### PR TITLE
[codex] Fix Fable context window metadata

### DIFF
--- a/packages/agent-runtime/src/claude-code/sdk-extraction.test.ts
+++ b/packages/agent-runtime/src/claude-code/sdk-extraction.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveClaudeModelContextWindowHint } from "./sdk-extraction.js";
+
+describe("resolveClaudeModelContextWindowHint", () => {
+  it.each(["claude-fable-5", "fable", "best"])(
+    "treats %s as a 1M-context Fable model",
+    (model) => {
+      expect(resolveClaudeModelContextWindowHint(model)).toBe(1_000_000);
+    },
+  );
+
+  it("keeps the ambiguous default model context unknown", () => {
+    expect(resolveClaudeModelContextWindowHint("default")).toBeNull();
+  });
+
+  it("uses the default Claude context window for non-1M models", () => {
+    expect(resolveClaudeModelContextWindowHint("claude-sonnet-4-6")).toBe(
+      200_000,
+    );
+  });
+});

--- a/packages/agent-runtime/src/claude-code/sdk-extraction.ts
+++ b/packages/agent-runtime/src/claude-code/sdk-extraction.ts
@@ -79,6 +79,11 @@ const CLAUDE_EMPTY_BASH_OUTPUT_PLACEHOLDERS = [
 ] as const;
 const DEFAULT_CLAUDE_CONTEXT_WINDOW = 200_000;
 const LARGE_CLAUDE_CONTEXT_WINDOW = 1_000_000;
+const LARGE_CLAUDE_CONTEXT_MODELS = new Set([
+  "best",
+  "claude-fable-5",
+  "fable",
+]);
 
 export function getNestedParentToolUseId(
   message: unknown,
@@ -379,7 +384,10 @@ function extractModelContextWindow(
 export function resolveClaudeModelContextWindowHint(
   selectedModel: string,
 ): number | null {
-  if (selectedModel.endsWith("[1m]")) {
+  if (
+    selectedModel.endsWith("[1m]") ||
+    LARGE_CLAUDE_CONTEXT_MODELS.has(selectedModel)
+  ) {
     return LARGE_CLAUDE_CONTEXT_WINDOW;
   }
   if (selectedModel === "default") {


### PR DESCRIPTION
## Summary
- Keep Fable 5 advertised as `claude-fable-5` with no `[1m]` suffix and no model-description copy changes.
- Treat `claude-fable-5`, `fable`, and `best` as 1,000,000-token models for Claude context-window fallback estimates.
- Add focused context-window hint coverage for Fable model strings and aliases.

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/agent-runtime`
- `git diff --check`