### PR TITLE
[codex] Track landing downloads server-side

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -58,6 +58,17 @@ jobs:
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
         run: pnpm exec turbo run build --filter=@bb/landing --cache-dir=.turbo/cache --output-logs=new-only
 
+      - name: Sync landing analytics secret
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          LANDING_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+        run: |
+          if [ -z "$LANDING_POSTHOG_KEY" ]; then
+            echo "VITE_POSTHOG_KEY is required for landing download tracking."
+            exit 1
+          fi
+          printf '%s' "$LANDING_POSTHOG_KEY" | pnpm --filter @bb/landing exec wrangler secret put LANDING_POSTHOG_KEY
+
       - name: Deploy landing
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -34,14 +34,21 @@ Requires a wrangler login with workers write access (`wrangler login`).
 
 ## Analytics
 
-PostHog, explicit events only (autocapture off). Disabled entirely unless
-`VITE_POSTHOG_KEY` is set at build time; `VITE_POSTHOG_HOST` overrides the
-ingestion host (default `https://us.i.posthog.com`).
+PostHog, explicit events only (autocapture off). Client analytics are disabled
+entirely unless `VITE_POSTHOG_KEY` is set at build time; `VITE_POSTHOG_HOST`
+overrides the ingestion host (default `https://us.i.posthog.com`).
+
+Download CTAs point at the first-party `/download/macos` Worker redirect. The
+Worker sends the download click event server-side with the runtime
+`LANDING_POSTHOG_KEY` secret, then returns a non-cacheable 302 to the GitHub
+release URL. This keeps download click counting working when client-side
+analytics is blocked, while the download still succeeds if server-side tracking
+is unavailable.
 
 | Event | Trigger | Properties |
 | --- | --- | --- |
 | `$pageview` / `$pageleave` | page load / unload | UTM params + referrer, captured automatically |
-| `landing_download_macos_clicked` | Download buttons | `placement`: nav / hero / closer / footer |
+| `landing_download_macos_clicked` | `/download/macos` redirect Worker | `placement`: nav / hero / closer / footer / direct, `download_target`, UTM params when available |
 | `landing_github_clicked` | GitHub links | `placement` |
 | `landing_cli_command_copied` | Copy button on the install command | `placement`, `command` |
 

--- a/apps/landing/src/analytics.ts
+++ b/apps/landing/src/analytics.ts
@@ -1,4 +1,5 @@
 import type { PostHog } from "posthog-js";
+import type { CtaPlacement } from "./site";
 
 /**
  * PostHog wiring for the landing page.
@@ -14,14 +15,7 @@ import type { PostHog } from "posthog-js";
  * build time, so local dev and forks ship with analytics disabled by default.
  */
 
-/** Where on the page a CTA lives, for click-through comparison. */
-export type CtaPlacement = "nav" | "hero" | "closer" | "footer";
-
 export type LandingEvent =
-  | {
-      name: "landing_download_macos_clicked";
-      properties: { placement: CtaPlacement };
-    }
   | {
       name: "landing_github_clicked";
       properties: { placement: CtaPlacement };

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -3,11 +3,11 @@ import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { trackLandingEvent } from "../analytics";
-import type { CtaPlacement } from "../analytics";
 import appScreenshot from "../assets/bb-app.webp";
 import bbIcon from "../assets/bb-icon.png";
 import { ClaudeIcon, OpenAiIcon, PiIcon } from "../icons";
-import { CLI_COMMAND, DOWNLOAD_MACOS_URL, GITHUB_URL } from "../site";
+import type { CtaPlacement } from "../site";
+import { CLI_COMMAND, GITHUB_URL, downloadMacosHref } from "../site";
 
 export const Route = createFileRoute("/")({
   component: LandingPage,
@@ -22,16 +22,7 @@ type CtaLinkProps = {
 
 function DownloadLink({ placement, className, children }: CtaLinkProps) {
   return (
-    <a
-      className={className}
-      href={DOWNLOAD_MACOS_URL}
-      onClick={() =>
-        trackLandingEvent({
-          name: "landing_download_macos_clicked",
-          properties: { placement },
-        })
-      }
-    >
+    <a className={className} href={downloadMacosHref(placement)}>
       {children}
     </a>
   );

--- a/apps/landing/src/site.ts
+++ b/apps/landing/src/site.ts
@@ -1,7 +1,15 @@
 export const GITHUB_URL = "https://github.com/ymichael/bb";
 export const DOWNLOAD_MACOS_URL =
   "https://github.com/ymichael/bb/releases/tag/desktop-latest";
+export const DOWNLOAD_MACOS_REDIRECT_PATH = "/download/macos";
 export const CLI_COMMAND = "npx bb-app@latest";
+
+/** Where on the page a CTA lives, for click-through comparison. */
+export type CtaPlacement = "nav" | "hero" | "closer" | "footer";
+
+export function downloadMacosHref(placement: CtaPlacement): string {
+  return `${DOWNLOAD_MACOS_REDIRECT_PATH}?placement=${placement}`;
+}
 
 export const SITE_TITLE = "bb: the IDE built for humans and agents";
 export const SITE_DESCRIPTION =

--- a/apps/landing/src/worker.ts
+++ b/apps/landing/src/worker.ts
@@ -1,0 +1,262 @@
+import { DOWNLOAD_MACOS_REDIRECT_PATH, DOWNLOAD_MACOS_URL } from "./site";
+import type { CtaPlacement } from "./site";
+
+const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/?ip=0";
+const DOWNLOAD_EVENT_NAME = "landing_download_macos_clicked";
+const DOWNLOAD_TARGET = "macos";
+const TRACKING_SOURCE = "landing_worker_redirect";
+const MAX_URL_PROPERTY_LENGTH = 2048;
+
+type DownloadPlacement = CtaPlacement | "direct";
+
+type LandingWorkerEnv = {
+  ASSETS: AssetFetcher;
+  LANDING_POSTHOG_KEY?: string;
+};
+
+type AssetFetcher = {
+  fetch: (request: Request) => Promise<Response>;
+};
+
+type WorkerExecutionContext = {
+  waitUntil: (promise: Promise<void>) => void;
+};
+
+type LandingWorker = {
+  fetch: (
+    request: Request,
+    env: LandingWorkerEnv,
+    context: WorkerExecutionContext,
+  ) => Promise<Response>;
+};
+
+type DownloadEventProperties = {
+  "$current_url": string;
+  "$referrer"?: string;
+  download_target: typeof DOWNLOAD_TARGET;
+  placement: DownloadPlacement;
+  tracking_source: typeof TRACKING_SOURCE;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_medium?: string;
+  utm_source?: string;
+  utm_term?: string;
+};
+
+type PostHogCapturePayload = {
+  api_key: string;
+  distinct_id: string;
+  event: typeof DOWNLOAD_EVENT_NAME;
+  properties: DownloadEventProperties;
+  timestamp: string;
+};
+
+type TrackDownloadClickArgs = {
+  postHogKey: string | undefined;
+  request: Request;
+  requestUrl: URL;
+};
+
+const worker: LandingWorker = {
+  async fetch(request, env, context) {
+    const requestUrl = new URL(request.url);
+    if (isDownloadMacosRequest(requestUrl)) {
+      context.waitUntil(
+        trackDownloadClick({
+          postHogKey: env.LANDING_POSTHOG_KEY,
+          request,
+          requestUrl,
+        }),
+      );
+      return redirectToMacosDownload();
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};
+
+export default worker;
+
+function isDownloadMacosRequest(requestUrl: URL): boolean {
+  return (
+    requestUrl.pathname === DOWNLOAD_MACOS_REDIRECT_PATH ||
+    requestUrl.pathname === `${DOWNLOAD_MACOS_REDIRECT_PATH}/`
+  );
+}
+
+function redirectToMacosDownload(): Response {
+  return new Response(null, {
+    headers: {
+      "Cache-Control": "no-store",
+      Location: DOWNLOAD_MACOS_URL,
+    },
+    status: 302,
+  });
+}
+
+async function trackDownloadClick(
+  args: TrackDownloadClickArgs,
+): Promise<void> {
+  if (!args.postHogKey) {
+    return;
+  }
+
+  const payload: PostHogCapturePayload = {
+    api_key: args.postHogKey,
+    distinct_id: crypto.randomUUID(),
+    event: DOWNLOAD_EVENT_NAME,
+    properties: buildDownloadEventProperties({
+      request: args.request,
+      requestUrl: args.requestUrl,
+    }),
+    timestamp: new Date().toISOString(),
+  };
+
+  await fetch(POSTHOG_CAPTURE_URL, {
+    body: JSON.stringify(payload),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  }).catch(() => {});
+}
+
+type BuildDownloadEventPropertiesArgs = {
+  request: Request;
+  requestUrl: URL;
+};
+
+function buildDownloadEventProperties(
+  args: BuildDownloadEventPropertiesArgs,
+): DownloadEventProperties {
+  const referrer = args.request.headers.get("referer");
+  const referrerSearchParams = readReferrerSearchParams(referrer);
+  const properties: DownloadEventProperties = {
+    $current_url: truncateProperty(args.requestUrl.href),
+    download_target: DOWNLOAD_TARGET,
+    placement: parseDownloadPlacement(args.requestUrl.searchParams),
+    tracking_source: TRACKING_SOURCE,
+  };
+
+  if (referrer) {
+    properties.$referrer = truncateProperty(referrer);
+  }
+
+  addUtmProperties({
+    properties,
+    referrerSearchParams,
+    requestSearchParams: args.requestUrl.searchParams,
+  });
+
+  return properties;
+}
+
+function parseDownloadPlacement(
+  searchParams: URLSearchParams,
+): DownloadPlacement {
+  switch (searchParams.get("placement")) {
+    case "nav":
+      return "nav";
+    case "hero":
+      return "hero";
+    case "closer":
+      return "closer";
+    case "footer":
+      return "footer";
+    default:
+      return "direct";
+  }
+}
+
+function readReferrerSearchParams(referrer: string | null): URLSearchParams | null {
+  if (!referrer) {
+    return null;
+  }
+
+  try {
+    return new URL(referrer).searchParams;
+  } catch {
+    return null;
+  }
+}
+
+type AddUtmPropertiesArgs = {
+  properties: DownloadEventProperties;
+  referrerSearchParams: URLSearchParams | null;
+  requestSearchParams: URLSearchParams;
+};
+
+function addUtmProperties(args: AddUtmPropertiesArgs): void {
+  const source = getTrackingParam({
+    name: "utm_source",
+    referrerSearchParams: args.referrerSearchParams,
+    requestSearchParams: args.requestSearchParams,
+  });
+  const medium = getTrackingParam({
+    name: "utm_medium",
+    referrerSearchParams: args.referrerSearchParams,
+    requestSearchParams: args.requestSearchParams,
+  });
+  const campaign = getTrackingParam({
+    name: "utm_campaign",
+    referrerSearchParams: args.referrerSearchParams,
+    requestSearchParams: args.requestSearchParams,
+  });
+  const term = getTrackingParam({
+    name: "utm_term",
+    referrerSearchParams: args.referrerSearchParams,
+    requestSearchParams: args.requestSearchParams,
+  });
+  const content = getTrackingParam({
+    name: "utm_content",
+    referrerSearchParams: args.referrerSearchParams,
+    requestSearchParams: args.requestSearchParams,
+  });
+
+  if (source) {
+    args.properties.utm_source = source;
+  }
+  if (medium) {
+    args.properties.utm_medium = medium;
+  }
+  if (campaign) {
+    args.properties.utm_campaign = campaign;
+  }
+  if (term) {
+    args.properties.utm_term = term;
+  }
+  if (content) {
+    args.properties.utm_content = content;
+  }
+}
+
+type GetTrackingParamArgs = {
+  name: string;
+  referrerSearchParams: URLSearchParams | null;
+  requestSearchParams: URLSearchParams;
+};
+
+function getTrackingParam(args: GetTrackingParamArgs): string | undefined {
+  return (
+    getNonEmptySearchParam(args.requestSearchParams, args.name) ??
+    getNonEmptySearchParam(args.referrerSearchParams, args.name)
+  );
+}
+
+function getNonEmptySearchParam(
+  searchParams: URLSearchParams | null,
+  name: string,
+): string | undefined {
+  const value = searchParams?.get(name);
+  if (!value) {
+    return undefined;
+  }
+
+  return truncateProperty(value);
+}
+
+function truncateProperty(value: string): string {
+  if (value.length <= MAX_URL_PROPERTY_LENGTH) {
+    return value;
+  }
+
+  return value.slice(0, MAX_URL_PROPERTY_LENGTH);
+}

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,6 +1,15 @@
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { DOWNLOAD_MACOS_REDIRECT_PATH } from "./src/site";
+
+type PrerenderPage = {
+  path: string;
+};
+
+function shouldPrerenderPage(page: PrerenderPage): boolean {
+  return !page.path.startsWith(DOWNLOAD_MACOS_REDIRECT_PATH);
+}
 
 // Static marketing site: every route is prerendered to HTML at build time, so
 // the dist/client output can be deployed to any static host.
@@ -12,6 +21,7 @@ export default defineConfig({
         enabled: true,
         crawlLinks: true,
         failOnError: true,
+        filter: shouldPrerenderPage,
       },
     }),
     // react's vite plugin must come after start's vite plugin

--- a/apps/landing/wrangler.jsonc
+++ b/apps/landing/wrangler.jsonc
@@ -1,14 +1,21 @@
 // Cloudflare Workers static-assets deploy of the prerendered landing site.
 // The site is fully prerendered at build time (see vite.config.ts), so this
-// is an assets-only Worker — no server runtime, just dist/client.
+// Worker only runs for first-party download redirects; other requests are
+// served directly from dist/client assets.
 // Deploy: pnpm exec turbo run build --filter=@bb/landing && pnpm --filter @bb/landing run deploy
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "bb-landing",
+  "main": "./src/worker.ts",
   "account_id": "7bb84c630057dafa53e2aacbe6bd094f",
   "compatibility_date": "2026-06-11",
   "assets": {
-    "directory": "./dist/client"
+    "directory": "./dist/client",
+    "binding": "ASSETS",
+    "run_worker_first": ["/download/macos*"]
+  },
+  "secrets": {
+    "required": ["LANDING_POSTHOG_KEY"]
   },
   "routes": [
     { "pattern": "getbb.app", "custom_domain": true },


### PR DESCRIPTION
## Summary

- Route landing page macOS download CTAs through a first-party `/download/macos` Worker redirect.
- Record `landing_download_macos_clicked` server-side with PostHog before redirecting to the GitHub release URL.
- Keep static asset serving direct through Cloudflare assets, and document the analytics/deploy secret flow.

## Why

Client-side PostHog download click events can be blocked by ad blockers because they load and send to PostHog domains from the browser. A first-party redirect lets the download continue normally while recording the click from the Worker runtime.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/landing`
- `pnpm exec turbo run build --filter=@bb/landing`
- `pnpm exec turbo run lint --filter=@bb/landing`
- `pnpm --filter @bb/landing exec wrangler deploy --dry-run --outdir /tmp/bb-landing-worker-dry-run`
- `git diff --check`