### PR TITLE
Preview video files in secondary panel

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -46,6 +46,7 @@ export type FilePreviewState =
   | { kind: "not-found" }
   | { kind: "error"; message?: string }
   | { kind: "image"; url: string }
+  | { kind: "video"; url: string }
   | ({ kind: "iframe" } & IframeFilePreviewTarget)
   | {
       kind: "html";
@@ -97,6 +98,11 @@ interface MarkdownFilePreviewProps {
 interface FilePreviewImageProps {
   url: string;
   alt: string;
+}
+
+interface FilePreviewVideoProps {
+  url: string;
+  title: string;
 }
 
 interface FilePreviewMessageProps {
@@ -316,6 +322,9 @@ function FilePreviewBody({
   if (state.kind === "image") {
     return <FilePreviewImage url={state.url} alt={path} />;
   }
+  if (state.kind === "video") {
+    return <FilePreviewVideo url={state.url} title={path} />;
+  }
   if (state.kind === "iframe") {
     return (
       <IframeFilePreview
@@ -478,6 +487,20 @@ function FilePreviewImage({ url, alt }: FilePreviewImageProps) {
         src={url}
         alt={alt}
         className="block max-h-[34rem] w-full object-contain"
+      />
+    </div>
+  );
+}
+
+function FilePreviewVideo({ url, title }: FilePreviewVideoProps) {
+  return (
+    <div className="pt-4">
+      <video
+        src={url}
+        title={title}
+        className="block max-h-[34rem] w-full bg-black"
+        controls
+        preload="metadata"
       />
     </div>
   );

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -169,6 +169,18 @@ export function SecondaryPanelFilePreview({
     );
   }
 
+  if (filePreview.kind === "video") {
+    return (
+      <FilePreviewSurface
+        path={activePath}
+        copyPath={copyPath}
+        onOpenInEditor={onOpenInEditor}
+        statusLabel={statusLabel}
+        state={{ kind: "video", url: filePreview.url }}
+      />
+    );
+  }
+
   return (
     <FilePreviewSurface
       path={activePath}

--- a/apps/app/src/lib/file-preview.test.ts
+++ b/apps/app/src/lib/file-preview.test.ts
@@ -57,6 +57,24 @@ describe("file-preview", () => {
     });
   });
 
+  it("builds video previews for video mime types", () => {
+    const preview = buildFilePreview({
+      contentBytes: Uint8Array.from([0, 0, 0, 24]),
+      mimeType: "video/mp4",
+      name: "demo.mp4",
+      path: "demo.mp4",
+      url: "/files/demo.mp4",
+    });
+
+    expect(preview).toEqual({
+      kind: "video",
+      mimeType: "video/mp4",
+      name: "demo.mp4",
+      path: "demo.mp4",
+      url: "/files/demo.mp4",
+    });
+  });
+
   it("marks null-byte text and non-text binary files as unsupported", () => {
     const textWithNullBytePreview = buildFilePreview({
       contentBytes: Uint8Array.from([97, 0, 98]),

--- a/apps/app/src/lib/file-preview.ts
+++ b/apps/app/src/lib/file-preview.ts
@@ -30,12 +30,16 @@ export interface FilePreviewTarget {
 }
 
 interface FilePreviewBase extends FilePreviewTarget {
-  kind: "image" | "text" | "unsupported";
+  kind: "image" | "text" | "unsupported" | "video";
   mimeType: string;
 }
 
 export interface ImageFilePreview extends FilePreviewBase {
   kind: "image";
+}
+
+export interface VideoFilePreview extends FilePreviewBase {
+  kind: "video";
 }
 
 export interface TextFilePreview extends FilePreviewBase {
@@ -49,6 +53,7 @@ export interface UnsupportedFilePreview extends FilePreviewBase {
 
 export type FilePreview =
   | ImageFilePreview
+  | VideoFilePreview
   | TextFilePreview
   | UnsupportedFilePreview;
 
@@ -221,6 +226,13 @@ export function buildFilePreview(args: BuildFilePreviewArgs): FilePreview {
   if (args.mimeType.startsWith("image/")) {
     return {
       kind: "image",
+      ...base,
+    };
+  }
+
+  if (args.mimeType.startsWith("video/")) {
+    return {
+      kind: "video",
       ...base,
     };
   }


### PR DESCRIPTION
## Summary
- classify `video/*` files as previewable media
- render video previews in the secondary panel with native controls
- add coverage for video MIME preview classification

## Test plan
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/lib/file-preview.test.ts`