### PR TITLE
Fix Claude Code root full-mode startup

### DIFF
--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -87,6 +87,7 @@ interface CanUseToolPolicyCase {
 interface ControlledClaudeQuery {
   close: ReturnType<typeof vi.fn>;
   emit(message: SDKMessage): void;
+  fail(error: Error): void;
   finish(): void;
   initializationResult: ReturnType<typeof vi.fn>;
   [Symbol.asyncIterator](): AsyncIterator<SDKMessage>;
@@ -98,6 +99,7 @@ interface ClaudeQueryCallOptions {
   resume?: string;
   sessionId?: string;
   settingSources?: string[];
+  stderr?: (data: string) => void;
 }
 
 interface ClaudeQueryCall {
@@ -119,6 +121,8 @@ interface TempClaudeExecutable {
   binDir: string;
   executablePath: string;
 }
+
+type ControlledClaudeQueryResult = IteratorResult<SDKMessage> | Error;
 
 const tempDirs: string[] = [];
 
@@ -225,6 +229,19 @@ function getSdkResultErrorMessages(
   );
 }
 
+function getBridgeErrorMessages(
+  messages: BridgeJsonRpcOutputMessage[],
+): string[] {
+  return messages.flatMap((message) => {
+    if (message.method !== "error" || !isRecord(message.params)) {
+      return [];
+    }
+    return typeof message.params.message === "string"
+      ? [message.params.message]
+      : [];
+  });
+}
+
 function getLastCanUseTool(): CanUseTool {
   const latestCall = queryMock.mock.calls.at(-1)?.[0];
   if (!isClaudeQueryCall(latestCall) || !latestCall.options.canUseTool) {
@@ -254,11 +271,23 @@ function invokeReadonlyBashHook(args: ReadonlyBashHookArgs) {
 
 function createControlledClaudeQuery(): ControlledClaudeQuery {
   let finishNext: ((result: IteratorResult<SDKMessage>) => void) | undefined;
-  const pendingResults: IteratorResult<SDKMessage>[] = [];
-  function pushResult(result: IteratorResult<SDKMessage>): void {
+  let rejectNext: ((error: Error) => void) | undefined;
+  const pendingResults: ControlledClaudeQueryResult[] = [];
+  function pushResult(result: ControlledClaudeQueryResult): void {
+    if (result instanceof Error && rejectNext) {
+      const reject = rejectNext;
+      finishNext = undefined;
+      rejectNext = undefined;
+      reject(result);
+      return;
+    }
     if (finishNext) {
       const resolve = finishNext;
       finishNext = undefined;
+      rejectNext = undefined;
+      if (result instanceof Error) {
+        throw new Error("Expected pending SDK result, got Error");
+      }
       resolve(result);
       return;
     }
@@ -267,9 +296,13 @@ function createControlledClaudeQuery(): ControlledClaudeQuery {
   const iterator: AsyncIterator<SDKMessage> = {
     next: () => {
       const result = pendingResults.shift();
+      if (result instanceof Error) {
+        return Promise.reject(result);
+      }
       if (result) return Promise.resolve(result);
-      return new Promise<IteratorResult<SDKMessage>>((resolve) => {
+      return new Promise<IteratorResult<SDKMessage>>((resolve, reject) => {
         finishNext = resolve;
+        rejectNext = reject;
       });
     },
     return: async () => ({ value: undefined, done: true }),
@@ -280,6 +313,9 @@ function createControlledClaudeQuery(): ControlledClaudeQuery {
     }),
     emit(message: SDKMessage): void {
       pushResult({ value: message, done: false });
+    },
+    fail(error: Error): void {
+      pushResult(error);
     },
     finish() {
       pushResult({ value: undefined, done: true });
@@ -1531,6 +1567,52 @@ describe("bridge", () => {
       } else {
         process.env.HOME = originalHome;
       }
+      bridge.restore();
+    }
+  });
+
+  it("includes captured Claude stderr when the SDK stream fails", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-sdk-stderr-error";
+      bridge.sendRequest(1, "thread/start", {
+        workflowsEnabled: false,
+        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
+        baseInstructions: "test",
+        cwd: "/tmp/worktree",
+        instructionMode: "append",
+        permissionEscalation: "ask",
+        permissionMode: "default",
+        threadId,
+      });
+      await bridge.waitForResponse(1);
+
+      getLatestQueryOptions().stderr?.(
+        "--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons\n",
+      );
+      queries[0]?.fail(new Error("Claude Code process exited with code 1"));
+      await bridge.flushWork();
+
+      const errorMessages = getBridgeErrorMessages(bridge.messages);
+      expect(errorMessages).toHaveLength(1);
+      expect(errorMessages[0]).toContain(
+        "Claude Code process exited with code 1",
+      );
+      expect(errorMessages[0]).toContain("Claude Code stderr:");
+      expect(errorMessages[0]).toContain(
+        "cannot be used with root/sudo privileges",
+      );
+
+      bridge.sendRequest(2, "thread/stop", { threadId });
+      await bridge.waitForResponse(2);
+    } finally {
       bridge.restore();
     }
   });

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/sdk-session.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/sdk-session.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  Options,
   SDKMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -25,20 +26,40 @@ const defaultOptions: SdkSessionOptions = {
 };
 
 interface ClaudeQueryPromptCall {
+  options: Options;
   prompt: AsyncIterable<SDKUserMessage>;
 }
 
-function getLatestPrompt(): AsyncIterable<SDKUserMessage> {
+interface RejectSdkStreamArgs {
+  error: Error;
+}
+
+function isClaudeQueryPromptCall(value: unknown): value is ClaudeQueryPromptCall {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "options" in value &&
+    "prompt" in value
+  );
+}
+
+function getLatestQueryCall(): ClaudeQueryPromptCall {
   const latestCall = queryMock.mock.calls.at(-1)?.[0];
-  if (
-    latestCall === null ||
-    typeof latestCall !== "object" ||
-    !("prompt" in latestCall)
-  ) {
-    throw new Error("Expected Claude SDK prompt");
+  if (!isClaudeQueryPromptCall(latestCall)) {
+    throw new Error("Expected Claude SDK query call");
   }
-  const call: ClaudeQueryPromptCall = latestCall;
-  return call.prompt;
+  return latestCall;
+}
+
+function getLatestPrompt(): AsyncIterable<SDKUserMessage> {
+  return getLatestQueryCall().prompt;
+}
+
+function rejectSdkStream(args: RejectSdkStreamArgs): void {
+  mockQueryInstance[Symbol.asyncIterator].mockReturnValue({
+    next: vi.fn().mockRejectedValue(args.error),
+    return: vi.fn().mockResolvedValue({ value: undefined, done: true }),
+  });
 }
 
 function keepSdkStreamOpen(): void {
@@ -46,6 +67,14 @@ function keepSdkStreamOpen(): void {
     next: vi.fn(() => new Promise<IteratorResult<SDKMessage>>(() => {})),
     return: vi.fn().mockResolvedValue({ value: undefined, done: true }),
   });
+}
+
+function mockProcessUid(uid: number): void {
+  vi.spyOn(process, "getuid").mockReturnValue(uid);
+}
+
+function waitForAsyncWork(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("SdkSession", () => {
@@ -57,6 +86,10 @@ describe("SdkSession", () => {
       next: vi.fn().mockResolvedValue({ value: undefined, done: true }),
       return: vi.fn().mockResolvedValue({ value: undefined, done: true }),
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("starts with no session id", () => {
@@ -299,6 +332,7 @@ describe("SdkSession", () => {
   });
 
   it("only enables dangerous permission skipping for bypass mode", () => {
+    mockProcessUid(1000);
     const onMessage = vi.fn();
     const onDone = vi.fn();
     const session = new SdkSession(
@@ -319,6 +353,60 @@ describe("SdkSession", () => {
           allowDangerouslySkipPermissions: true,
         }),
       }),
+    );
+  });
+
+  it("does not send root-forbidden bypass flags when running as root", () => {
+    mockProcessUid(0);
+    const onMessage = vi.fn();
+    const onDone = vi.fn();
+    const session = new SdkSession(
+      {
+        ...defaultOptions,
+        permissionMode: "bypassPermissions",
+      },
+      onMessage,
+      onDone,
+    );
+
+    session.start();
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          permissionMode: "default",
+        }),
+      }),
+    );
+    expect(queryMock.mock.calls[0]?.[0]?.options).not.toHaveProperty(
+      "allowDangerouslySkipPermissions",
+    );
+  });
+
+  it("includes captured Claude stderr in SDK stream failures", async () => {
+    rejectSdkStream({
+      error: new Error("Claude Code process exited with code 1"),
+    });
+    const onMessage = vi.fn();
+    const onDone = vi.fn();
+    const session = new SdkSession(defaultOptions, onMessage, onDone);
+
+    session.start();
+    getLatestQueryCall().options.stderr?.(
+      "--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons\n",
+    );
+    await waitForAsyncWork();
+
+    const doneError = onDone.mock.calls[0]?.[0];
+    if (!(doneError instanceof Error)) {
+      throw new Error("Expected onDone to receive an Error");
+    }
+    expect(doneError.message).toContain(
+      "Claude Code process exited with code 1",
+    );
+    expect(doneError.message).toContain("Claude Code stderr:");
+    expect(doneError.message).toContain(
+      "cannot be used with root/sudo privileges",
     );
   });
 

--- a/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
@@ -41,6 +41,73 @@ interface QueuedSdkInputMessage {
   resolveConsumed: () => void;
 }
 
+interface SdkPermissionOptions {
+  allowDangerouslySkipPermissions?: true;
+  permissionMode: ClaudePermissionMode;
+}
+
+interface BuildSdkPermissionOptionsArgs {
+  permissionMode: ClaudePermissionMode | undefined;
+}
+
+interface AppendBoundedTextArgs {
+  chunk: string;
+  current: string;
+}
+
+interface BuildSdkDoneErrorMessageArgs {
+  error: unknown;
+  stderrTail: string;
+}
+
+const SDK_STDERR_TAIL_MAX_CHARS = 4_000;
+
+function isCurrentProcessRoot(): boolean {
+  return process.getuid?.() === 0;
+}
+
+function appendBoundedText(args: AppendBoundedTextArgs): string {
+  const next = `${args.current}${args.chunk}`;
+  if (next.length <= SDK_STDERR_TAIL_MAX_CHARS) {
+    return next;
+  }
+  return next.slice(next.length - SDK_STDERR_TAIL_MAX_CHARS);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildSdkDoneErrorMessage(args: BuildSdkDoneErrorMessageArgs): string {
+  const errorMessage = getErrorMessage(args.error);
+  const stderrTail = args.stderrTail.trim();
+  if (stderrTail.length === 0 || errorMessage.includes(stderrTail)) {
+    return errorMessage;
+  }
+  return `${errorMessage}\n\nClaude Code stderr:\n${stderrTail}`;
+}
+
+function buildSdkPermissionOptions(
+  args: BuildSdkPermissionOptionsArgs,
+): SdkPermissionOptions {
+  const permissionMode = args.permissionMode ?? "default";
+  if (permissionMode !== "bypassPermissions") {
+    return { permissionMode };
+  }
+
+  // Claude Code refuses dangerous permission skipping under root. Keep bb's
+  // logical bypass policy in the bridge canUseTool handler, but avoid sending
+  // the SDK flags that make the CLI exit before the session starts.
+  if (isCurrentProcessRoot()) {
+    return { permissionMode: "default" };
+  }
+
+  return {
+    permissionMode,
+    allowDangerouslySkipPermissions: true,
+  };
+}
+
 export class SdkSession {
   private query: Query | undefined;
   private sessionId: string | undefined;
@@ -53,6 +120,7 @@ export class SdkSession {
   private isProcessing = false;
   private readonly completion: Promise<void>;
   private complete: (() => void) | null = null;
+  private stderrTail = "";
 
   constructor(
     private readonly options: SdkSessionOptions,
@@ -79,11 +147,15 @@ export class SdkSession {
       this.sessionId = this.options.sessionId;
     }
 
+    this.stderrTail = "";
+    const permissionOptions = buildSdkPermissionOptions({
+      permissionMode: this.options.permissionMode,
+    });
     const sdkOptions: Options = {
       abortController: this.abortController,
       cwd: this.options.cwd,
       systemPrompt: this.options.systemPrompt,
-      permissionMode: this.options.permissionMode ?? "default",
+      ...permissionOptions,
       includePartialMessages: true,
       // Mirror the Claude CLI cascade so the SDK loads both the user's global
       // configuration (~/.claude/settings.json, ~/.claude/CLAUDE.md) and the
@@ -92,6 +164,12 @@ export class SdkSession {
       settingSources: ["user", "project", "local"],
       persistSession: true,
       env: this.options.env ?? process.env,
+      stderr: (data) => {
+        this.stderrTail = appendBoundedText({
+          current: this.stderrTail,
+          chunk: data,
+        });
+      },
       ...(this.options.mcpServers
         ? { mcpServers: this.options.mcpServers }
         : {}),
@@ -107,9 +185,6 @@ export class SdkSession {
         : {}),
       ...(this.options.sandbox ? { sandbox: this.options.sandbox } : {}),
       ...(this.options.hooks ? { hooks: this.options.hooks } : {}),
-      ...(this.options.permissionMode === "bypassPermissions"
-        ? { allowDangerouslySkipPermissions: true }
-        : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
       ...(!resumeSessionId && this.options.sessionId
         ? { sessionId: this.options.sessionId }
@@ -278,7 +353,14 @@ export class SdkSession {
       this.onDone();
     } catch (error) {
       this.isProcessing = false;
-      this.onDone(error);
+      this.onDone(
+        new Error(
+          buildSdkDoneErrorMessage({
+            error,
+            stderrTail: this.stderrTail,
+          }),
+        ),
+      );
     } finally {
       this.inputDone = true;
       this.rejectQueuedInputs("Claude SDK stream ended before input consumed");


### PR DESCRIPTION
## Summary
- avoid passing Claude Code root-forbidden bypass flags when bb full-mode sessions run as UID 0
- keep bb logical bypass policy in the bridge while sending the SDK a safe default permission mode under root
- capture a bounded Claude Code stderr tail and include it in bridge stream-failure errors so timeline rows show the real CLI failure reason

## Validation
- pnpm exec turbo run test --filter=@bb/agent-runtime -- src/claude-code/bridge/__tests__/sdk-session.test.ts
- pnpm exec turbo run test --filter=@bb/agent-runtime -- src/claude-code/bridge/__tests__/bridge.test.ts
- pnpm exec turbo run typecheck --filter=@bb/agent-runtime
- git diff --check