### PR TITLE
Reduce workspace watcher inotify usage

### DIFF
--- a/packages/host-watcher/src/workspace-status-watcher.ts
+++ b/packages/host-watcher/src/workspace-status-watcher.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { calculateExponentialBackoffDelay } from "@bb/domain";
@@ -23,6 +24,9 @@ const WORKSPACE_STATUS_WATCH_DEBOUNCE_MS = 75;
 const WORKSPACE_STATUS_WATCH_MAX_WAIT_MS = 500;
 const WORKSPACE_STATUS_WATCH_RETRY_DELAY_MS = 250;
 const WORKSPACE_STATUS_WATCH_MAX_RETRY_DELAY_MS = 30_000;
+const WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS = [".git"];
+const WORKSPACE_ROOT_IGNORE_STATUS_TIMEOUT_MS = 5_000;
+const WORKSPACE_ROOT_IGNORE_STATUS_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 interface WorkspaceStatusWatcherArgs extends WorkspaceStatusWatchArgs {
   cwd: string;
@@ -32,11 +36,82 @@ interface WorkspaceStatusWatcherArgs extends WorkspaceStatusWatchArgs {
   retryDelayMs: number;
 }
 
+interface GitStatusCommandArgs {
+  cwd: string;
+}
+
+interface GitStatusCommandResult {
+  stdout: string;
+}
+
+interface WorkspaceRootWatchSpecArgs {
+  cwd: string;
+  rootPath: string;
+}
+
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) {
     return error.message;
   }
   return "Unknown watch error";
+}
+
+function runGitIgnoredMatchingStatus(
+  args: GitStatusCommandArgs,
+): Promise<GitStatusCommandResult> {
+  return new Promise<GitStatusCommandResult>((resolve, reject) => {
+    execFile(
+      "git",
+      [
+        "--no-optional-locks",
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--ignored=matching",
+        "--untracked-files=normal",
+      ],
+      {
+        cwd: args.cwd,
+        encoding: "utf8",
+        maxBuffer: WORKSPACE_ROOT_IGNORE_STATUS_MAX_BUFFER_BYTES,
+        timeout: WORKSPACE_ROOT_IGNORE_STATUS_TIMEOUT_MS,
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve({ stdout });
+      },
+    );
+  });
+}
+
+function collectIgnoredDirectoryPaths(statusOutput: string): string[] {
+  const ignoredDirectoryPaths = new Set<string>();
+  for (const record of statusOutput.split("\0")) {
+    if (!record.startsWith("!! ")) {
+      continue;
+    }
+    const ignoredPath = record.slice("!! ".length);
+    if (!ignoredPath.endsWith("/")) {
+      continue;
+    }
+    ignoredDirectoryPaths.add(ignoredPath);
+  }
+  return Array.from(ignoredDirectoryPaths).sort();
+}
+
+async function resolveWorkspaceRootIgnores(cwd: string): Promise<string[]> {
+  try {
+    const status = await runGitIgnoredMatchingStatus({ cwd });
+    return [
+      ...WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS,
+      ...collectIgnoredDirectoryPaths(status.stdout),
+    ];
+  } catch {
+    return WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS;
+  }
 }
 
 function createWorkspaceStatusCallbackError(
@@ -49,13 +124,15 @@ function createWorkspaceStatusCallbackError(
   };
 }
 
-function createWorkspaceRootWatchSpec(cwd: string): WatchSubscriptionSpec {
+async function createWorkspaceRootWatchSpec(
+  args: WorkspaceRootWatchSpecArgs,
+): Promise<WatchSubscriptionSpec> {
   return {
     kind: "workspace-root",
     options: {
-      ignore: [".git"],
+      ignore: await resolveWorkspaceRootIgnores(args.cwd),
     },
-    rootPath: cwd,
+    rootPath: args.rootPath,
   };
 }
 
@@ -133,8 +210,9 @@ export class WorkspaceStatusWatcher {
     if (this.disposed) {
       return;
     }
+    const rootPath = await resolveWatchRootPath(this.args.cwd);
     this.startWatchSubscription(
-      createWorkspaceRootWatchSpec(await resolveWatchRootPath(this.args.cwd)),
+      await createWorkspaceRootWatchSpec({ cwd: this.args.cwd, rootPath }),
     );
     this.startMetadataWatchSubscriptions();
   }

--- a/packages/host-watcher/test/watch-status.test.ts
+++ b/packages/host-watcher/test/watch-status.test.ts
@@ -17,6 +17,7 @@ type WorkspaceStatusChangeEvent = Parameters<
 type ParcelWatcherSubscribe = (typeof import("@parcel/watcher"))["subscribe"];
 type ParcelWatcherCallback = Parameters<ParcelWatcherSubscribe>[1];
 type ParcelWatcherSubscribeArgs = Parameters<ParcelWatcherSubscribe>;
+type ParcelWatcherSubscribeOptions = ParcelWatcherSubscribeArgs[2];
 type ParcelWatcherEventBatch = Parameters<ParcelWatcherCallback>[1];
 type ParcelWatcherSubscribeResult = Awaited<ReturnType<ParcelWatcherSubscribe>>;
 
@@ -44,6 +45,7 @@ interface WatchWorkspaceStatusImport {
 interface ManualWorkspaceEventsImport extends WatchWorkspaceStatusImport {
   emitWorkspaceRootError: (error: Error) => void;
   emitWorkspaceRootEvents: (events: ParcelWatcherEventBatch) => void;
+  getWorkspaceRootSubscribeOptions: () => ParcelWatcherSubscribeOptions;
   getWorkspaceRootSubscriptionCount: () => number;
 }
 
@@ -214,6 +216,7 @@ async function importWatchWorkspaceStatusWithTransientWorkspaceSubscriptionFailu
 ): Promise<ManualWorkspaceEventsImport> {
   let failedWorkspaceSubscription = false;
   let workspaceRootCallback: ParcelWatcherCallback | null = null;
+  let workspaceRootSubscribeOptions: ParcelWatcherSubscribeOptions;
   let workspaceRootSubscriptionCount = 0;
   const ready = createDeferredPromise<void>();
   let readyScheduled = false;
@@ -230,6 +233,7 @@ async function importWatchWorkspaceStatusWithTransientWorkspaceSubscriptionFailu
       throw new Error("workspace subscription unavailable");
     }
     if (isWorkspaceRoot) {
+      workspaceRootSubscribeOptions = watchArgs[2];
       workspaceRootSubscriptionCount += 1;
       workspaceRootCallback = callback;
       if (!readyScheduled) {
@@ -255,6 +259,7 @@ async function importWatchWorkspaceStatusWithTransientWorkspaceSubscriptionFailu
       }
       workspaceRootCallback(null, normalizeEventBatch(events));
     },
+    getWorkspaceRootSubscribeOptions: () => workspaceRootSubscribeOptions,
     getWorkspaceRootSubscriptionCount: () => workspaceRootSubscriptionCount,
     ready: ready.promise,
     watchWorkspaceStatus: watchWorkspaceStatusImpl,
@@ -295,6 +300,7 @@ async function importWatchWorkspaceStatusWithManualWorkspaceEvents(
   workspaceRootPath: string,
 ): Promise<ManualWorkspaceEventsImport> {
   let workspaceRootCallback: ParcelWatcherCallback | null = null;
+  let workspaceRootSubscribeOptions: ParcelWatcherSubscribeOptions;
   let workspaceRootSubscriptionCount = 0;
   const ready = createDeferredPromise<void>();
   const mockSubscribe = (
@@ -307,6 +313,7 @@ async function importWatchWorkspaceStatusWithManualWorkspaceEvents(
         workspaceRootPath,
       );
       if (isWorkspaceRoot) {
+        workspaceRootSubscribeOptions = watchArgs[2];
         workspaceRootSubscriptionCount += 1;
         workspaceRootCallback = callback;
         ready.resolve(undefined);
@@ -327,6 +334,7 @@ async function importWatchWorkspaceStatusWithManualWorkspaceEvents(
       }
       workspaceRootCallback(null, normalizeEventBatch(events));
     },
+    getWorkspaceRootSubscribeOptions: () => workspaceRootSubscribeOptions,
     getWorkspaceRootSubscriptionCount: () => workspaceRootSubscriptionCount,
     ready: ready.promise,
     watchWorkspaceStatus: watchWorkspaceStatusImpl,
@@ -571,6 +579,57 @@ describe.sequential("watchWorkspaceStatus", () => {
     try {
       await ready;
       await ensureCallCountStays(() => calls.length, 0);
+    } finally {
+      stopWatching();
+    }
+  });
+
+  it("uses Git ignored directories for workspace root subscription ignores", async () => {
+    const repoPath = await initRepo();
+    await fs.writeFile(
+      path.join(repoPath, ".gitignore"),
+      "node_modules/\n.turbo/\n",
+      "utf8",
+    );
+    await fs.mkdir(path.join(repoPath, "node_modules", "pkg"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(repoPath, ".turbo", "cache"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(repoPath, "node_modules", "pkg", "tracked.txt"),
+      "tracked\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(repoPath, ".turbo", "cache", "output.txt"),
+      "ignored\n",
+      "utf8",
+    );
+    await runGit({ args: ["add", ".gitignore"], cwd: repoPath });
+    await runGit({
+      args: ["add", "-f", "node_modules/pkg/tracked.txt"],
+      cwd: repoPath,
+    });
+    await runGit({
+      args: ["commit", "-m", "Add ignored directory fixtures"],
+      cwd: repoPath,
+    });
+
+    const { getWorkspaceRootSubscribeOptions, ready, watchWorkspaceStatus } =
+      await importWatchWorkspaceStatusWithManualWorkspaceEvents(repoPath);
+    const stopWatching = watchWorkspaceStatus(repoPath, {
+      onChange: () => undefined,
+      onWatchError: ignoreWatchError,
+    });
+
+    try {
+      await ready;
+      expect(getWorkspaceRootSubscribeOptions()?.ignore).toEqual([
+        ".git",
+        ".turbo/",
+      ]);
     } finally {
       stopWatching();
     }


### PR DESCRIPTION
## Summary
- derive workspace-root Parcel ignore paths from Git ignored directory output instead of a fixed directory list
- keep .git excluded while avoiding pruning directories that contain tracked files
- cover the Git-ignore behavior in host-watcher tests

## Measurement
On this checkout, a workspace-root Parcel subscription drops from 11,168 inotify marks to 225 marks. Full watchWorkspaceStatus drops from 11,179 to 236 marks.

## Validation
- pnpm exec turbo run test --filter=@bb/host-watcher
- pnpm exec turbo run typecheck --filter=@bb/host-watcher
- git diff --check