### PR TITLE
Add committed changes diff option

### DIFF
--- a/apps/app/src/components/secondary-panel/git-diff/gitDiffPanelHelpers.test.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/gitDiffPanelHelpers.test.ts
@@ -4,11 +4,13 @@ import {
   buildGitDiffParsePlan,
   buildGitDiffSelectionOptions,
   buildGitDiffTarget,
+  COMMITTED_GIT_DIFF_SELECTION,
   GIT_DIFF_PARSE_BATCH_THRESHOLD,
   reconcileGitDiffCollapsedFileKeys,
   resolveGitDiffPreparationState,
   shouldCollapseGitDiffFileByDefault,
-  shouldResetSelectedGitDiffCommit,
+  shouldResetSelectedGitDiffSelection,
+  UNCOMMITTED_GIT_DIFF_SELECTION,
 } from "./gitDiffPanelHelpers";
 import {
   buildParsedGitDiffFileEntries,
@@ -71,15 +73,26 @@ function buildEntries(diff: string): ParsedGitDiffFileEntry[] {
 }
 
 describe("gitDiffPanelHelpers", () => {
-  it("builds git diff targets from commit, uncommitted, and merge-base selections", () => {
+  it("builds git diff targets from commit, committed, uncommitted, and merge-base selections", () => {
     expect(buildGitDiffTarget("commit-sha", "main")).toEqual({
       sha: "commit-sha",
       type: "commit",
     });
-    expect(buildGitDiffTarget("uncommitted", "main")).toEqual({
+    expect(
+      buildGitDiffTarget(COMMITTED_GIT_DIFF_SELECTION, "main"),
+    ).toEqual({
+      mergeBaseBranch: "main",
+      type: "branch_committed",
+    });
+    expect(
+      buildGitDiffTarget(COMMITTED_GIT_DIFF_SELECTION, undefined),
+    ).toBeUndefined();
+    expect(buildGitDiffTarget(UNCOMMITTED_GIT_DIFF_SELECTION, "main")).toEqual({
       type: "uncommitted",
     });
-    expect(buildGitDiffTarget("uncommitted", undefined)).toEqual({
+    expect(
+      buildGitDiffTarget(UNCOMMITTED_GIT_DIFF_SELECTION, undefined),
+    ).toEqual({
       type: "uncommitted",
     });
     expect(buildGitDiffTarget(null, "main")).toEqual({
@@ -105,6 +118,7 @@ describe("gitDiffPanelHelpers", () => {
 
     expect(buildGitDiffSelectionOptions(commits)).toEqual([
       { value: "all", label: "All changes" },
+      { value: "branch_committed", label: "Committed changes" },
       { value: "abc123", label: "Initial change", monoPrefix: "abc123" },
       { value: "def456", label: "Follow-up", monoPrefix: "def456" },
     ]);
@@ -112,6 +126,7 @@ describe("gitDiffPanelHelpers", () => {
       buildGitDiffSelectionOptions(commits, { hasUncommittedChanges: true }),
     ).toEqual([
       { value: "all", label: "All changes" },
+      { value: "branch_committed", label: "Committed changes" },
       { value: "uncommitted", label: "Uncommitted changes" },
       { value: "abc123", label: "Initial change", monoPrefix: "abc123" },
       { value: "def456", label: "Follow-up", monoPrefix: "def456" },
@@ -122,16 +137,28 @@ describe("gitDiffPanelHelpers", () => {
       { value: "all", label: "All changes" },
       { value: "uncommitted", label: "Uncommitted changes" },
     ]);
-    expect(shouldResetSelectedGitDiffCommit("missing", commits)).toBe(true);
-    expect(shouldResetSelectedGitDiffCommit("abc123", commits)).toBe(false);
-    expect(shouldResetSelectedGitDiffCommit(null, commits)).toBe(false);
     expect(
-      shouldResetSelectedGitDiffCommit("uncommitted", [], {
+      buildGitDiffSelectionOptions([], { hasUncommittedChanges: false }),
+    ).toEqual([{ value: "all", label: "All changes" }]);
+    expect(shouldResetSelectedGitDiffSelection("missing", commits)).toBe(true);
+    expect(shouldResetSelectedGitDiffSelection("abc123", commits)).toBe(false);
+    expect(shouldResetSelectedGitDiffSelection(null, commits)).toBe(false);
+    expect(
+      shouldResetSelectedGitDiffSelection(
+        COMMITTED_GIT_DIFF_SELECTION,
+        commits,
+      ),
+    ).toBe(false);
+    expect(
+      shouldResetSelectedGitDiffSelection(COMMITTED_GIT_DIFF_SELECTION, []),
+    ).toBe(true);
+    expect(
+      shouldResetSelectedGitDiffSelection(UNCOMMITTED_GIT_DIFF_SELECTION, [], {
         hasUncommittedChanges: true,
       }),
     ).toBe(false);
     expect(
-      shouldResetSelectedGitDiffCommit("uncommitted", [], {
+      shouldResetSelectedGitDiffSelection(UNCOMMITTED_GIT_DIFF_SELECTION, [], {
         hasUncommittedChanges: false,
       }),
     ).toBe(true);

--- a/apps/app/src/components/secondary-panel/git-diff/gitDiffPanelHelpers.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/gitDiffPanelHelpers.ts
@@ -13,11 +13,20 @@ export const GIT_DIFF_PARSE_INITIAL_BATCH_SIZE = 6;
 export const GIT_DIFF_PARSE_BATCH_SIZE = 18;
 export const GIT_DIFF_PARSE_BATCH_DELAY_MS = 24;
 
+export const ALL_GIT_DIFF_SELECTION = "all";
+export const COMMITTED_GIT_DIFF_SELECTION = "branch_committed";
 export const UNCOMMITTED_GIT_DIFF_SELECTION = "uncommitted";
+
+export type GitDiffSelectionValue = string | null;
+
+export interface GitDiffSelectionAvailability {
+  hasUncommittedChanges: boolean;
+}
 
 export type GitDiffTarget =
   | { type: "commit"; sha: string }
   | { type: "uncommitted" }
+  | { type: "branch_committed"; mergeBaseBranch: string }
   | { type: "all"; mergeBaseBranch: string }
   | undefined;
 
@@ -64,15 +73,24 @@ export interface ReconcileGitDiffCollapsedFileKeysParams {
 }
 
 export function buildGitDiffTarget(
-  selectedGitDiffCommitSha: string | null,
+  selectedGitDiffSelection: GitDiffSelectionValue,
   effectiveMergeBaseBranch: string | undefined,
 ): GitDiffTarget {
-  if (selectedGitDiffCommitSha === UNCOMMITTED_GIT_DIFF_SELECTION) {
+  if (selectedGitDiffSelection === UNCOMMITTED_GIT_DIFF_SELECTION) {
     return { type: "uncommitted" };
   }
 
-  if (selectedGitDiffCommitSha) {
-    return { type: "commit", sha: selectedGitDiffCommitSha };
+  if (selectedGitDiffSelection === COMMITTED_GIT_DIFF_SELECTION) {
+    return effectiveMergeBaseBranch
+      ? {
+          type: "branch_committed",
+          mergeBaseBranch: effectiveMergeBaseBranch,
+        }
+      : undefined;
+  }
+
+  if (selectedGitDiffSelection) {
+    return { type: "commit", sha: selectedGitDiffSelection };
   }
 
   if (effectiveMergeBaseBranch) {
@@ -87,11 +105,18 @@ export function buildGitDiffTarget(
 
 export function buildGitDiffSelectionOptions(
   diffCommits: readonly WorkspaceCommitSummary[],
-  options: { hasUncommittedChanges: boolean } = {
+  options: GitDiffSelectionAvailability = {
     hasUncommittedChanges: false,
   },
 ): GitDiffSelectionOption[] {
-  const allChangesOption = { value: "all", label: "All changes" };
+  const allChangesOption = {
+    value: ALL_GIT_DIFF_SELECTION,
+    label: "All changes",
+  };
+  const committedOption = {
+    value: COMMITTED_GIT_DIFF_SELECTION,
+    label: "Committed changes",
+  };
   const uncommittedOption = {
     value: UNCOMMITTED_GIT_DIFF_SELECTION,
     label: "Uncommitted changes",
@@ -110,25 +135,29 @@ export function buildGitDiffSelectionOptions(
 
   return [
     allChangesOption,
+    ...(diffCommits.length > 0 ? [committedOption] : []),
     ...(options.hasUncommittedChanges ? [uncommittedOption] : []),
     ...commitOptions,
   ];
 }
 
-export function shouldResetSelectedGitDiffCommit(
-  selectedGitDiffCommitSha: string | null,
+export function shouldResetSelectedGitDiffSelection(
+  selectedGitDiffSelection: GitDiffSelectionValue,
   diffCommits: readonly WorkspaceCommitSummary[],
-  options: { hasUncommittedChanges: boolean } = {
+  options: GitDiffSelectionAvailability = {
     hasUncommittedChanges: false,
   },
 ): boolean {
-  if (!selectedGitDiffCommitSha) {
+  if (!selectedGitDiffSelection) {
     return false;
   }
-  if (selectedGitDiffCommitSha === UNCOMMITTED_GIT_DIFF_SELECTION) {
+  if (selectedGitDiffSelection === COMMITTED_GIT_DIFF_SELECTION) {
+    return diffCommits.length === 0;
+  }
+  if (selectedGitDiffSelection === UNCOMMITTED_GIT_DIFF_SELECTION) {
     return !options.hasUncommittedChanges;
   }
-  return !diffCommits.some((commit) => commit.sha === selectedGitDiffCommitSha);
+  return !diffCommits.some((commit) => commit.sha === selectedGitDiffSelection);
 }
 
 export function resolveGitDiffPreparationState(

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
@@ -45,7 +45,9 @@ import {
   GIT_DIFF_PARSE_BATCH_SIZE,
   GIT_DIFF_PARSE_INITIAL_BATCH_SIZE,
   resolveGitDiffPreparationState,
-  shouldResetSelectedGitDiffCommit,
+  shouldResetSelectedGitDiffSelection,
+  ALL_GIT_DIFF_SELECTION,
+  type GitDiffSelectionValue,
 } from "./gitDiffPanelHelpers";
 import { useGitDiffFileRenderQueue } from "./useGitDiffFileRenderQueue";
 
@@ -125,9 +127,8 @@ export function useGitDiffPanelState({
   const collapsedGitDiffFileKeys = useAtomValue(gitDiffCollapsedFileKeysAtom);
   const loadingGitDiffFileKeys = useAtomValue(gitDiffLoadingFileKeysAtom);
   const lastFocusedScrollPathRef = useRef<string | null>(null);
-  const [selectedGitDiffCommitSha, setSelectedGitDiffCommitSha] = useState<
-    string | null
-  >(null);
+  const [selectedGitDiffSelection, setSelectedGitDiffSelection] =
+    useState<GitDiffSelectionValue>(null);
   const [parsedGitDiffFiles, setParsedGitDiffFiles] = useState<
     ParsedGitDiffFile[]
   >([]);
@@ -143,8 +144,8 @@ export function useGitDiffPanelState({
     selectedMergeBaseBranch ?? defaultMergeBaseBranch;
   const gitDiffTarget = useMemo(
     () =>
-      buildGitDiffTarget(selectedGitDiffCommitSha, effectiveMergeBaseBranch),
-    [effectiveMergeBaseBranch, selectedGitDiffCommitSha],
+      buildGitDiffTarget(selectedGitDiffSelection, effectiveMergeBaseBranch),
+    [effectiveMergeBaseBranch, selectedGitDiffSelection],
   );
   const gitDiffRequestIdentity = useMemo(
     () => buildGitDiffRequestIdentity({ environmentId, target: gitDiffTarget }),
@@ -397,7 +398,7 @@ export function useGitDiffPanelState({
   // --- Reset on environment change ---
 
   useEffect(() => {
-    setSelectedGitDiffCommitSha(null);
+    setSelectedGitDiffSelection(null);
   }, [environmentId]);
 
   useEffect(() => {
@@ -412,7 +413,7 @@ export function useGitDiffPanelState({
 
   useEffect(() => {
     if (pendingGitDiffScrollPath) {
-      setSelectedGitDiffCommitSha(null);
+      setSelectedGitDiffSelection(null);
     }
   }, [pendingGitDiffScrollPath]);
 
@@ -420,7 +421,7 @@ export function useGitDiffPanelState({
 
   useEffect(() => {
     if (pendingGitDiffCommitSha) {
-      setSelectedGitDiffCommitSha(pendingGitDiffCommitSha);
+      setSelectedGitDiffSelection(pendingGitDiffCommitSha);
       setPendingGitDiffCommitSha(null);
     }
   }, [pendingGitDiffCommitSha, setPendingGitDiffCommitSha]);
@@ -430,17 +431,17 @@ export function useGitDiffPanelState({
 
   useEffect(() => {
     if (
-      shouldResetSelectedGitDiffCommit(
-        selectedGitDiffCommitSha,
+      shouldResetSelectedGitDiffSelection(
+        selectedGitDiffSelection,
         workspaceStatus?.mergeBase?.commits ?? [],
         { hasUncommittedChanges },
       )
     ) {
-      setSelectedGitDiffCommitSha(null);
+      setSelectedGitDiffSelection(null);
     }
   }, [
     hasUncommittedChanges,
-    selectedGitDiffCommitSha,
+    selectedGitDiffSelection,
     workspaceStatus?.mergeBase?.commits,
   ]);
 
@@ -519,7 +520,7 @@ export function useGitDiffPanelState({
     () => workspaceStatus?.mergeBase?.commits ?? [],
     [workspaceStatus?.mergeBase?.commits],
   );
-  const gitDiffSelectValue = selectedGitDiffCommitSha ?? "all";
+  const gitDiffSelectValue = selectedGitDiffSelection ?? ALL_GIT_DIFF_SELECTION;
   const gitDiffSelectOptions: GitDiffSelectionOption[] = useMemo(
     () => buildGitDiffSelectionOptions(diffCommits, { hasUncommittedChanges }),
     [diffCommits, hasUncommittedChanges],
@@ -531,7 +532,9 @@ export function useGitDiffPanelState({
   const { hasParsedGitDiffFiles, isPreparingGitDiff } = gitDiffPreparationState;
 
   const onGitDiffSelectionChange = useCallback((value: string) => {
-    setSelectedGitDiffCommitSha(value === "all" ? null : value);
+    setSelectedGitDiffSelection(
+      value === ALL_GIT_DIFF_SELECTION ? null : value,
+    );
   }, []);
 
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Summary
- Add a `Committed changes` option to the diff panel selector.
- Map that selection to the existing `branch_committed` diff target while preserving all/uncommitted/per-commit selections.
- Update helper coverage for option visibility, target building, and stale selection reset behavior.

## Validation
- `pnpm exec turbo run test --filter=@bb/app -- src/components/secondary-panel/git-diff/gitDiffPanelHelpers.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`