### PR TITLE
Link timeline file mention pills

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -1,8 +1,4 @@
-import {
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useMemo, useRef, useState } from "react";
 import type {
   TimelineConversationAttachments,
   TimelineUserConversationRow,
@@ -12,6 +8,7 @@ import { CopyButton } from "../../ui/copy-button.js";
 import { cn } from "@/lib/utils";
 import { MarkdownPreview } from "../../ui/markdown-preview.js";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { computeMutedPrefixLength } from "./compute-muted-prefix-length.js";
 import type { TimelineTitleLinkResolver } from "./TimelineTitleView.js";
 import type {
@@ -53,6 +50,7 @@ export interface ConversationMessageContentUserProps extends ConversationMessage
   role: "user";
   initiator: TimelineUserConversationRow["initiator"];
   mentions: readonly PromptTextMention[];
+  resolveMentionLink?: PromptMentionLinkResolver;
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
   senderThreadId: TimelineUserConversationRow["senderThreadId"];
   senderThreadTitle: string | null;
@@ -86,6 +84,7 @@ interface UserConversationMessageProps {
   mentions: readonly PromptTextMention[];
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   projectId?: string;
+  resolveMentionLink?: PromptMentionLinkResolver;
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
   senderThreadId: TimelineUserConversationRow["senderThreadId"];
   senderThreadTitle: string | null;
@@ -103,6 +102,7 @@ interface AssistantConversationMessageProps {
 
 interface CollapsibleMessageTextProps {
   mentions: readonly PromptTextMention[];
+  resolveMentionLink?: PromptMentionLinkResolver;
   text: string;
   /**
    * When set, the first `mutePrefixLength` characters of `text` are rendered
@@ -118,6 +118,7 @@ function splitPreWrappedLines(text: string): string[] {
 
 function CollapsibleMessageText({
   mentions,
+  resolveMentionLink,
   text,
   mutePrefixLength,
 }: CollapsibleMessageTextProps) {
@@ -178,6 +179,7 @@ function CollapsibleMessageText({
       >
         {renderMentionTextSegments({
           mentions: safeRenderedBody.mentions,
+          resolveMentionLink,
           text: safeRenderedBody.text,
         })}
         {isExpanded && isTruncated ? (
@@ -201,6 +203,7 @@ function UserConversationMessage({
   mentions,
   onOpenLocalFileLink,
   projectId,
+  resolveMentionLink,
   resolveSegmentLinkHref,
   senderThreadId,
   senderThreadTitle,
@@ -220,6 +223,7 @@ function UserConversationMessage({
         mentions={bodyMentions}
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
+        resolveMentionLink={resolveMentionLink}
         resolveSegmentLinkHref={resolveSegmentLinkHref}
         sourceKind="agent"
         sourceName={senderThreadTitle ?? "Agent"}
@@ -243,6 +247,7 @@ function UserConversationMessage({
         mentions={bodyMentions}
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
+        resolveMentionLink={resolveMentionLink}
         resolveSegmentLinkHref={resolveSegmentLinkHref}
         sourceKind="system"
         sourceName="BB"
@@ -272,6 +277,7 @@ function UserConversationMessage({
           {messageText ? (
             <CollapsibleMessageText
               mentions={mentions}
+              resolveMentionLink={resolveMentionLink}
               text={text}
               mutePrefixLength={mutePrefixLength || undefined}
             />
@@ -382,6 +388,7 @@ export function ConversationMessageContent(
         mentions={props.mentions}
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
+        resolveMentionLink={props.resolveMentionLink}
         resolveSegmentLinkHref={props.resolveSegmentLinkHref}
         senderThreadId={props.senderThreadId}
         senderThreadTitle={props.senderThreadTitle}

--- a/apps/app/src/components/thread/timeline/ConversationMessageMentions.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageMentions.tsx
@@ -10,9 +10,11 @@ import {
   promptMentionTooltipLabel,
 } from "@/components/promptbox/mentions/prompt-mention-display";
 import { promptMentionClipboardDataAttributes } from "@/components/promptbox/mentions/prompt-mention-clipboard";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 
 interface PromptMentionPillProps {
   resource: PromptMentionResource;
+  resolveMentionLink?: PromptMentionLinkResolver;
   serializedText: string;
 }
 
@@ -29,6 +31,7 @@ export interface ShiftMentionsToTextRangeArgs {
 
 export interface RenderMentionTextSegmentsArgs {
   mentions: readonly PromptTextMention[];
+  resolveMentionLink?: PromptMentionLinkResolver;
   text: string;
 }
 
@@ -104,12 +107,13 @@ function mentionPillClassName(interactive: boolean): string {
   return cn(
     PROMPT_MENTION_PILL_CLASS,
     "bg-surface-raised/50 no-underline hover:no-underline",
-    interactive && "hover:bg-state-hover",
+    interactive && "cursor-pointer hover:bg-state-hover",
   );
 }
 
 function PromptMentionPill({
   resource,
+  resolveMentionLink,
   serializedText,
 }: PromptMentionPillProps) {
   const title = promptMentionTooltipLabel(resource);
@@ -144,9 +148,26 @@ function PromptMentionPill({
     );
   }
 
+  if (resource.kind === "path") {
+    const activate = resolveMentionLink?.(resource) ?? null;
+    if (activate) {
+      return (
+        <button
+          type="button"
+          className={mentionPillClassName(true)}
+          {...clipboardAttributes}
+          onClick={activate}
+          title={title}
+        >
+          {labelNode}
+        </button>
+      );
+    }
+  }
+
   // Timeline path mentions are workspace/thread-storage-relative resources.
-  // Opening them needs the same environment and thread-storage context
-  // the composer resolver owns, so they are intentionally display-only here.
+  // Opening them needs environment and thread-storage context from the page
+  // owner; without a resolver, they stay display-only.
   // Thread mentions without project context are also display-only; linking
   // through the current page project can misroute cross-project mentions.
   return (
@@ -162,6 +183,7 @@ function PromptMentionPill({
 
 export function renderMentionTextSegments({
   mentions,
+  resolveMentionLink,
   text,
 }: RenderMentionTextSegmentsArgs): ReactNode {
   const normalizedMentions = normalizePromptTextMentions({
@@ -185,6 +207,7 @@ export function renderMentionTextSegments({
       <PromptMentionPill
         key={`${mention.start}:${mention.end}:${mention.resource.kind}`}
         resource={mention.resource}
+        resolveMentionLink={resolveMentionLink}
         serializedText={text.slice(mention.start, mention.end)}
       />,
     );

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -3,6 +3,7 @@ import type { TimelineUserConversationRow } from "@bb/server-contract";
 import type { PromptTextMention } from "@bb/domain";
 import type { TimelineTitle, TimelineTitleSegment } from "@bb/thread-view";
 import { type IconName } from "@/components/ui/icon.js";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import {
   ConversationAttachments,
   type ConversationAttachmentItems,
@@ -26,6 +27,7 @@ interface GeneratedConversationMessageProps {
   mentions: readonly PromptTextMention[];
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   projectId?: string;
+  resolveMentionLink?: PromptMentionLinkResolver;
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
   sourceKind: GeneratedConversationSourceKind;
   sourceName: string;
@@ -172,6 +174,7 @@ export const GeneratedConversationMessage = memo(
     mentions,
     onOpenLocalFileLink,
     projectId,
+    resolveMentionLink,
     resolveSegmentLinkHref,
     sourceKind,
     sourceName,
@@ -233,6 +236,7 @@ export const GeneratedConversationMessage = memo(
         >
           {renderMentionTextSegments({
             mentions: collapsedPreviewBody.mentions,
+            resolveMentionLink,
             text: collapsedPreviewBody.text,
           })}
           {expandable ? (
@@ -249,6 +253,7 @@ export const GeneratedConversationMessage = memo(
               <p className="whitespace-pre-wrap break-words">
                 {renderMentionTextSegments({
                   mentions: messageMentions,
+                  resolveMentionLink,
                   text: messageText,
                 })}
               </p>
@@ -279,6 +284,7 @@ export const GeneratedConversationMessage = memo(
         messageMentions,
         onOpenLocalFileLink,
         projectId,
+        resolveMentionLink,
         sourceKind,
         requestLabel,
         turnRequest,

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -58,6 +58,7 @@ import { TimelineDetailScroll } from "./TimelineDetailScroll.js";
 import { Button } from "../../ui/button.js";
 import { AutoHeightContainer } from "../../ui/height-transition.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
 import {
   joinSignatureParts,
@@ -91,6 +92,7 @@ export interface ThreadTimelineRowsProps {
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   onTitleAction?: TimelineTitleActionResolver;
   projectId?: string;
+  resolveMentionLink?: PromptMentionLinkResolver;
   resolveImageViewSrc?: ThreadTimelineImageViewSrcResolver;
   resolveUserAttachmentImageSrc?: UserAttachmentImageSrcResolver;
   themeType?: ThreadTimelineTheme;
@@ -122,6 +124,7 @@ interface TimelineRendererStaticContextValue {
   onTitleAction: TimelineTitleActionResolver | undefined;
   projectId: string | undefined;
   resolveImageViewSrc: ThreadTimelineImageViewSrcResolver | undefined;
+  resolveMentionLink: PromptMentionLinkResolver | undefined;
   resolveSegmentLinkHref: TimelineTitleLinkResolver | undefined;
   resolveUserAttachmentImageSrc: UserAttachmentImageSrcResolver | undefined;
   senderThreadMetadataById: ReadonlyMap<string, SenderThreadMetadata>;
@@ -656,6 +659,7 @@ function ConversationRow({ row }: ConversationRowProps) {
     onOpenLink,
     onOpenLocalFileLink,
     projectId,
+    resolveMentionLink,
     resolveSegmentLinkHref,
     resolveUserAttachmentImageSrc,
     senderThreadMetadataById,
@@ -672,6 +676,7 @@ function ConversationRow({ row }: ConversationRowProps) {
         mentions={row.mentions}
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
+        resolveMentionLink={resolveMentionLink}
         resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
         role="user"
         resolveSegmentLinkHref={resolveSegmentLinkHref}
@@ -1358,6 +1363,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       onTitleAction: props.onTitleAction,
       projectId,
       resolveImageViewSrc: props.resolveImageViewSrc,
+      resolveMentionLink: props.resolveMentionLink,
       resolveSegmentLinkHref,
       resolveUserAttachmentImageSrc: props.resolveUserAttachmentImageSrc,
       senderThreadMetadataById,
@@ -1372,6 +1378,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       props.onTitleAction,
       projectId,
       props.resolveImageViewSrc,
+      props.resolveMentionLink,
       resolveSegmentLinkHref,
       props.resolveUserAttachmentImageSrc,
       senderThreadMetadataById,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1519,6 +1519,7 @@ export function ThreadDetailView() {
           onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
           onTitleAction: handleTimelineTitleAction,
           projectId,
+          resolveMentionLink,
           showOngoingIndicator:
             thread.stopRequestedAt === null &&
             // A pending interaction (question or approval) already renders its

--- a/apps/app/src/views/thread-detail/ThreadTimelinePane.tsx
+++ b/apps/app/src/views/thread-detail/ThreadTimelinePane.tsx
@@ -20,6 +20,7 @@ import {
   type ThreadTimelineUnreadDividerPlacement,
   type TimelineTitleActionResolver,
 } from "@/components/thread/timeline";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { TimelineStatusIndicator } from "@/components/thread/timeline";
 import { TimelineWorkingIndicator } from "@/components/thread/timeline";
 import { Skeleton } from "@/components/ui/skeleton.js";
@@ -40,6 +41,7 @@ interface ThreadTimelinePaneProps {
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   onTitleAction?: TimelineTitleActionResolver;
   projectId?: string;
+  resolveMentionLink: PromptMentionLinkResolver;
   showOngoingIndicator: boolean;
   ongoingIndicatorLabel?: string;
   stopRequestedAt: number | null;
@@ -136,6 +138,7 @@ export function ThreadTimelinePane({
   onOpenLocalFileLink,
   onTitleAction,
   projectId,
+  resolveMentionLink,
   showOngoingIndicator,
   ongoingIndicatorLabel,
   stopRequestedAt,
@@ -197,6 +200,7 @@ export function ThreadTimelinePane({
               onOpenLocalFileLink={onOpenLocalFileLink}
               onTitleAction={onTitleAction}
               projectId={projectId}
+              resolveMentionLink={resolveMentionLink}
               resolveUserAttachmentImageSrc={toUserAttachmentImageSrc}
               themeType={preferredTheme}
               timelineRows={timelineRowsWithPendingStop}


### PR DESCRIPTION
## Summary
- pass the thread-detail mention link resolver into timeline user-message rendering
- make path mention pills clickable when the resolver can open them
- keep non-openable mentions display-only and preserve existing thread mention links

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app