### PR TITLE
Preserve path suggestion ranking ties

### DIFF
--- a/apps/app/src/hooks/usePathSuggestions.test.ts
+++ b/apps/app/src/hooks/usePathSuggestions.test.ts
@@ -1,0 +1,60 @@
+import type { WorkspacePathEntry } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { buildPathSuggestions } from "./usePathSuggestions";
+
+interface PathEntryFixture {
+  kind?: WorkspacePathEntry["kind"];
+  path: string;
+  score: number;
+}
+
+function makePathEntry(fixture: PathEntryFixture): WorkspacePathEntry {
+  const name = fixture.path.split("/").at(-1) ?? fixture.path;
+  return {
+    kind: fixture.kind ?? "file",
+    path: fixture.path,
+    name,
+    score: fixture.score,
+    positions: [],
+  };
+}
+
+describe("buildPathSuggestions", () => {
+  it("preserves backend order instead of alphabetizing equal-score paths", () => {
+    const suggestions = buildPathSuggestions({
+      workspacePaths: [
+        makePathEntry({ path: "README.md", score: 100 }),
+        makePathEntry({ path: "APPS/DESKTOP/README.md", score: 100 }),
+        makePathEntry({ path: "PACKAGES/DB/README.md", score: 100 }),
+      ],
+      threadStoragePaths: [],
+      limit: 8,
+    });
+
+    expect(suggestions.map((suggestion) => suggestion.path)).toEqual([
+      "README.md",
+      "APPS/DESKTOP/README.md",
+      "PACKAGES/DB/README.md",
+    ]);
+  });
+
+  it("keeps workspace paths before thread-storage paths when scores tie", () => {
+    const suggestions = buildPathSuggestions({
+      workspacePaths: [
+        makePathEntry({ path: "packages/db/README.md", score: 100 }),
+      ],
+      threadStoragePaths: [makePathEntry({ path: "README.md", score: 100 })],
+      limit: 8,
+    });
+
+    expect(
+      suggestions.map((suggestion) => ({
+        source: suggestion.source,
+        path: suggestion.path,
+      })),
+    ).toEqual([
+      { source: "workspace", path: "packages/db/README.md" },
+      { source: "thread-storage", path: "README.md" },
+    ]);
+  });
+});

--- a/apps/app/src/hooks/usePathSuggestions.ts
+++ b/apps/app/src/hooks/usePathSuggestions.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import type { WorkspacePathEntry } from "@bb/server-contract";
 import { useDebounceValue } from "usehooks-ts";
 import { useEnvironmentPathSuggestions } from "./queries/environment-queries";
 import { useProjectPathSuggestions } from "./queries/project-queries";
@@ -43,6 +44,7 @@ export interface UsePathSuggestionsResult {
 
 interface RankedPathSuggestion extends PathSuggestion {
   sourceRank: number;
+  sourceOrder: number;
 }
 
 function getSourceRank(source: PathSuggestionSource): number {
@@ -62,6 +64,9 @@ function comparePathSuggestions(
   if (left.entryKind !== right.entryKind) {
     return left.entryKind === "directory" ? -1 : 1;
   }
+  if (left.sourceOrder !== right.sourceOrder) {
+    return left.sourceOrder - right.sourceOrder;
+  }
   return left.path.localeCompare(right.path);
 }
 
@@ -76,6 +81,63 @@ function toPathSuggestion(
     score: rankedSuggestion.score,
     positions: rankedSuggestion.positions,
   };
+}
+
+interface ToRankedPathSuggestionArgs {
+  pathEntry: WorkspacePathEntry;
+  source: PathSuggestionSource;
+  sourceOrder: number;
+}
+
+interface BuildPathSuggestionsArgs {
+  workspacePaths: readonly WorkspacePathEntry[];
+  threadStoragePaths: readonly WorkspacePathEntry[];
+  limit: number;
+}
+
+function toRankedPathSuggestion(
+  args: ToRankedPathSuggestionArgs,
+): RankedPathSuggestion {
+  return {
+    source: args.source,
+    sourceRank: getSourceRank(args.source),
+    sourceOrder: args.sourceOrder,
+    entryKind: args.pathEntry.kind,
+    path: args.pathEntry.path,
+    name: args.pathEntry.name,
+    score: args.pathEntry.score,
+    positions: args.pathEntry.positions,
+  };
+}
+
+export function buildPathSuggestions(
+  args: BuildPathSuggestionsArgs,
+): PathSuggestion[] {
+  const rankedSuggestions: RankedPathSuggestion[] = [];
+
+  for (const [sourceOrder, pathEntry] of args.workspacePaths.entries()) {
+    rankedSuggestions.push(
+      toRankedPathSuggestion({
+        pathEntry,
+        source: "workspace",
+        sourceOrder,
+      }),
+    );
+  }
+  for (const [sourceOrder, pathEntry] of args.threadStoragePaths.entries()) {
+    rankedSuggestions.push(
+      toRankedPathSuggestion({
+        pathEntry,
+        source: "thread-storage",
+        sourceOrder,
+      }),
+    );
+  }
+
+  return rankedSuggestions
+    .sort(comparePathSuggestions)
+    .slice(0, args.limit)
+    .map(toPathSuggestion);
 }
 
 export function usePathSuggestions(
@@ -152,38 +214,13 @@ export function usePathSuggestions(
       return [];
     }
 
-    const rankedSuggestions: RankedPathSuggestion[] = [];
-    if (includeWorkspace) {
-      for (const pathEntry of workspaceQuery.data?.paths ?? []) {
-        rankedSuggestions.push({
-          source: "workspace",
-          sourceRank: getSourceRank("workspace"),
-          entryKind: pathEntry.kind,
-          path: pathEntry.path,
-          name: pathEntry.name,
-          score: pathEntry.score,
-          positions: pathEntry.positions,
-        });
-      }
-    }
-    if (includeThreadStorage) {
-      for (const pathEntry of threadStorageQuery.data?.paths ?? []) {
-        rankedSuggestions.push({
-          source: "thread-storage",
-          sourceRank: getSourceRank("thread-storage"),
-          entryKind: pathEntry.kind,
-          path: pathEntry.path,
-          name: pathEntry.name,
-          score: pathEntry.score,
-          positions: pathEntry.positions,
-        });
-      }
-    }
-
-    return rankedSuggestions
-      .sort(comparePathSuggestions)
-      .slice(0, limit)
-      .map(toPathSuggestion);
+    return buildPathSuggestions({
+      workspacePaths: includeWorkspace ? (workspaceQuery.data?.paths ?? []) : [],
+      threadStoragePaths: includeThreadStorage
+        ? (threadStorageQuery.data?.paths ?? [])
+        : [],
+      limit,
+    });
   }, [
     hasQuery,
     includeThreadStorage,


### PR DESCRIPTION
## Summary
- Preserve backend ordering for equal-score path suggestions instead of alphabetizing by full path
- Keep existing workspace/thread-storage and directory/file tie-breakers intact
- Add regression coverage for root README staying ahead of nested README results

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/usePathSuggestions.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app --force
- pnpm exec turbo run lint --filter=@bb/app