### PR TITLE
Fix Claude follow-ups after SDK stream errors

### DIFF
--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -122,7 +122,19 @@ interface TempClaudeExecutable {
   executablePath: string;
 }
 
-type ControlledClaudeQueryResult = IteratorResult<SDKMessage> | Error;
+interface ControlledClaudeQueryMessageResult {
+  result: IteratorResult<SDKMessage>;
+  type: "result";
+}
+
+interface ControlledClaudeQueryErrorResult {
+  error: Error;
+  type: "error";
+}
+
+type ControlledClaudeQueryResult =
+  | ControlledClaudeQueryMessageResult
+  | ControlledClaudeQueryErrorResult;
 
 const tempDirs: string[] = [];
 
@@ -271,41 +283,43 @@ function invokeReadonlyBashHook(args: ReadonlyBashHookArgs) {
 
 function createControlledClaudeQuery(): ControlledClaudeQuery {
   let finishNext: ((result: IteratorResult<SDKMessage>) => void) | undefined;
-  let rejectNext: ((error: Error) => void) | undefined;
+  let failNext: ((error: Error) => void) | undefined;
   const pendingResults: ControlledClaudeQueryResult[] = [];
-  function pushResult(result: ControlledClaudeQueryResult): void {
-    if (result instanceof Error && rejectNext) {
-      const reject = rejectNext;
-      finishNext = undefined;
-      rejectNext = undefined;
-      reject(result);
-      return;
-    }
+  function pushResult(result: IteratorResult<SDKMessage>): void {
     if (finishNext) {
       const resolve = finishNext;
       finishNext = undefined;
-      rejectNext = undefined;
-      if (result instanceof Error) {
-        throw new Error("Expected pending SDK result, got Error");
-      }
+      failNext = undefined;
       resolve(result);
       return;
     }
-    pendingResults.push(result);
+    pendingResults.push({ type: "result", result });
+  }
+  function pushError(error: Error): void {
+    if (failNext) {
+      const reject = failNext;
+      finishNext = undefined;
+      failNext = undefined;
+      reject(error);
+      return;
+    }
+    pendingResults.push({ type: "error", error });
   }
   const iterator: AsyncIterator<SDKMessage> = {
     next: () => {
-      const result = pendingResults.shift();
-      if (result instanceof Error) {
-        return Promise.reject(result);
-      }
-      if (result) return Promise.resolve(result);
+      const pending = pendingResults.shift();
+      if (pending?.type === "result") return Promise.resolve(pending.result);
+      if (pending?.type === "error") return Promise.reject(pending.error);
       return new Promise<IteratorResult<SDKMessage>>((resolve, reject) => {
         finishNext = resolve;
-        rejectNext = reject;
+        failNext = reject;
       });
     },
-    return: async () => ({ value: undefined, done: true }),
+    return: async () => {
+      finishNext = undefined;
+      failNext = undefined;
+      return { value: undefined, done: true };
+    },
   };
   return {
     close: vi.fn(() => {
@@ -315,7 +329,7 @@ function createControlledClaudeQuery(): ControlledClaudeQuery {
       pushResult({ value: message, done: false });
     },
     fail(error: Error): void {
-      pushResult(error);
+      pushError(error);
     },
     finish() {
       pushResult({ value: undefined, done: true });
@@ -1812,6 +1826,70 @@ describe("bridge", () => {
       await bridge.flushWork();
       queries[0]?.finish();
       await bridge.waitForResponse(2);
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("resumes a Claude session when follow-up arrives after an SDK stream error", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-sdk-error-follow-up";
+      const inputText = "Continue after the provider error";
+      bridge.sendRequest(1, "thread/start", {
+        workflowsEnabled: false,
+        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
+        baseInstructions: "test",
+        cwd: "/tmp/worktree",
+        instructionMode: "append",
+        permissionEscalation: "ask",
+        permissionMode: "default",
+        threadId,
+      });
+      const startResponse = await bridge.waitForResponse(1);
+      const providerThreadId = getProviderThreadIdFromResult(startResponse);
+
+      queries[0]?.fail(new Error("Claude SDK exploded"));
+      await bridge.flushWork();
+
+      expect(
+        bridge.messages.some(
+          (message) =>
+            message.method === "error" &&
+            isRecord(message.params) &&
+            message.params.threadId === threadId &&
+            message.params.message === "Claude SDK exploded",
+        ),
+      ).toBe(true);
+
+      bridge.sendRequest(2, "turn/start", {
+        input: [{ type: "text", text: inputText }],
+        providerThreadId,
+        threadId,
+      });
+      await bridge.waitForResponse(2);
+
+      expect(queries).toHaveLength(2);
+      expect(getLatestQueryOptions()).toMatchObject({
+        resume: providerThreadId,
+      });
+      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+        inputText,
+      );
+
+      bridge.sendRequest(3, "thread/stop", {
+        threadId,
+      });
+      await bridge.flushWork();
+      queries[1]?.finish();
+      await bridge.waitForResponse(3);
     } finally {
       bridge.restore();
     }

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -112,11 +112,6 @@ interface StaleResumeErrorMessageArgs {
   sessionId: string;
 }
 
-interface SuccessResultMessageArgs {
-  result: string;
-  sessionId: string;
-}
-
 interface TempClaudeExecutable {
   binDir: string;
   executablePath: string;
@@ -391,39 +386,6 @@ function createStaleResumeErrorMessage(
     permission_denials: [],
     errors: [`No conversation found with session ID: ${args.missingSessionId}`],
     uuid: "00000000-0000-4000-8000-000000000001",
-    session_id: args.sessionId,
-  };
-}
-
-function createLegacyStaleResumeResultMessage(
-  args: StaleResumeErrorMessageArgs,
-): SDKMessage {
-  const message = createStaleResumeErrorMessage(args);
-  const legacyMessage = {
-    ...message,
-    errors: [],
-    result: `No conversation found with session ID: ${args.missingSessionId}`,
-  };
-  return legacyMessage;
-}
-
-function createSuccessResultMessage(
-  args: SuccessResultMessageArgs,
-): SDKMessage {
-  return {
-    type: "result",
-    subtype: "success",
-    duration_ms: 0,
-    duration_api_ms: 0,
-    is_error: false,
-    num_turns: 1,
-    result: args.result,
-    stop_reason: null,
-    total_cost_usd: 0,
-    usage: createResultUsage(),
-    modelUsage: {},
-    permission_denials: [],
-    uuid: "00000000-0000-4000-8000-000000000002",
     session_id: args.sessionId,
   };
 }
@@ -1895,7 +1857,7 @@ describe("bridge", () => {
     }
   });
 
-  it("retries a stale Claude resume once with a fresh session", async () => {
+  it("does not resume an ended Claude session for invalid follow-up input", async () => {
     const bridge = createBridgeJsonRpcTestHarness(handleLine);
     const queries: ControlledClaudeQuery[] = [];
     queryMock.mockImplementation(() => {
@@ -1905,7 +1867,55 @@ describe("bridge", () => {
     });
 
     try {
-      const threadId = "thread-stale-resume-recovery";
+      const threadId = "thread-sdk-error-invalid-follow-up";
+      bridge.sendRequest(1, "thread/start", {
+        workflowsEnabled: false,
+        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
+        baseInstructions: "test",
+        cwd: "/tmp/worktree",
+        instructionMode: "append",
+        permissionEscalation: "ask",
+        permissionMode: "default",
+        threadId,
+      });
+      const startResponse = await bridge.waitForResponse(1);
+      const providerThreadId = getProviderThreadIdFromResult(startResponse);
+
+      queries[0]?.fail(new Error("Claude SDK exploded"));
+      await bridge.flushWork();
+
+      bridge.sendRequest(2, "turn/start", {
+        input: [{ type: "text", text: "" }],
+        providerThreadId,
+        threadId,
+      });
+      const response = await bridge.waitForResponse(2);
+
+      expect(response).toMatchObject({
+        error: { code: -32602, message: "Missing input text" },
+      });
+      expect(queries).toHaveLength(1);
+
+      bridge.sendRequest(3, "thread/stop", {
+        threadId,
+      });
+      await bridge.waitForResponse(3);
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("forwards stale Claude resume errors without starting a fresh session", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-stale-resume-error";
       const staleProviderThreadId = "stale-provider-thread";
       const staleErrorText = `No conversation found with session ID: ${staleProviderThreadId}`;
       const inputText = "Reply READY";
@@ -1944,147 +1954,13 @@ describe("bridge", () => {
       );
       await bridge.flushWork();
 
-      expect(queries).toHaveLength(2);
-      const replacementOptions = getLatestQueryOptions();
-      const replacementProviderThreadId = replacementOptions.sessionId;
-      if (!replacementProviderThreadId) {
-        throw new Error("Expected fresh Claude session ID");
-      }
-      expect(replacementProviderThreadId).not.toBe(staleProviderThreadId);
-      expect(replacementOptions).not.toHaveProperty("resume");
-      expect(
-        bridge.messages.some(
-          (message) =>
-            message.method === "thread/identity" &&
-            isRecord(message.params) &&
-            message.params.threadId === threadId &&
-            message.params.providerThreadId === replacementProviderThreadId,
-        ),
-      ).toBe(true);
+      expect(queries).toHaveLength(1);
       expect(
         getSdkResultErrorMessages(bridge.messages, staleErrorText),
-      ).toHaveLength(0);
+      ).toHaveLength(1);
       expect(
         bridge.messages.some((message) => message.method === "error"),
       ).toBe(false);
-      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
-        inputText,
-      );
-
-      bridge.sendRequest(3, "thread/stop", {
-        threadId,
-      });
-      await bridge.flushWork();
-      queries[1]?.finish();
-      await bridge.waitForResponse(3);
-    } finally {
-      bridge.restore();
-    }
-  });
-
-  it("retries a stale Claude resume from the legacy result text field", async () => {
-    const bridge = createBridgeJsonRpcTestHarness(handleLine);
-    const queries: ControlledClaudeQuery[] = [];
-    queryMock.mockImplementation(() => {
-      const query = createControlledClaudeQuery();
-      queries.push(query);
-      return query;
-    });
-
-    try {
-      const threadId = "thread-stale-resume-legacy-result";
-      const staleProviderThreadId = "stale-provider-thread-legacy-result";
-      const staleErrorText = `No conversation found with session ID: ${staleProviderThreadId}`;
-      bridge.sendRequest(1, "thread/resume", {
-        workflowsEnabled: false,
-        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
-        baseInstructions: "test",
-        cwd: "/tmp/worktree",
-        instructionMode: "append",
-        permissionEscalation: "ask",
-        permissionMode: "default",
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(1);
-
-      bridge.sendRequest(2, "turn/start", {
-        input: [{ type: "text", text: "Reply READY" }],
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(2);
-
-      queries[0]?.emit(
-        createLegacyStaleResumeResultMessage({
-          missingSessionId: staleProviderThreadId,
-          sessionId: staleProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      expect(queries).toHaveLength(2);
-      expect(
-        getSdkResultErrorMessages(bridge.messages, staleErrorText),
-      ).toHaveLength(0);
-
-      bridge.sendRequest(3, "thread/stop", {
-        threadId,
-      });
-      await bridge.flushWork();
-      queries[1]?.finish();
-      await bridge.waitForResponse(3);
-    } finally {
-      bridge.restore();
-    }
-  });
-
-  it("does not retry non-matching Claude resume errors", async () => {
-    const bridge = createBridgeJsonRpcTestHarness(handleLine);
-    const queries: ControlledClaudeQuery[] = [];
-    queryMock.mockImplementation(() => {
-      const query = createControlledClaudeQuery();
-      queries.push(query);
-      return query;
-    });
-
-    try {
-      const threadId = "thread-stale-resume-non-match";
-      const staleProviderThreadId = "stale-provider-thread-non-match";
-      const differentProviderThreadId = "different-provider-thread";
-      const differentErrorText = `No conversation found with session ID: ${differentProviderThreadId}`;
-      bridge.sendRequest(1, "thread/resume", {
-        workflowsEnabled: false,
-        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
-        baseInstructions: "test",
-        cwd: "/tmp/worktree",
-        instructionMode: "append",
-        permissionEscalation: "ask",
-        permissionMode: "default",
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(1);
-
-      bridge.sendRequest(2, "turn/start", {
-        input: [{ type: "text", text: "Reply READY" }],
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(2);
-
-      queries[0]?.emit(
-        createStaleResumeErrorMessage({
-          missingSessionId: differentProviderThreadId,
-          sessionId: staleProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      expect(queries).toHaveLength(1);
-      expect(
-        getSdkResultErrorMessages(bridge.messages, differentErrorText),
-      ).toHaveLength(1);
 
       bridge.sendRequest(3, "thread/stop", {
         threadId,
@@ -2092,229 +1968,6 @@ describe("bridge", () => {
       await bridge.flushWork();
       queries[0]?.finish();
       await bridge.waitForResponse(3);
-    } finally {
-      bridge.restore();
-    }
-  });
-
-  it("does not retry stale errors after the fresh recovery session starts", async () => {
-    const bridge = createBridgeJsonRpcTestHarness(handleLine);
-    const queries: ControlledClaudeQuery[] = [];
-    queryMock.mockImplementation(() => {
-      const query = createControlledClaudeQuery();
-      queries.push(query);
-      return query;
-    });
-
-    try {
-      const threadId = "thread-stale-resume-retry-cap";
-      const staleProviderThreadId = "stale-provider-thread-retry-cap";
-      bridge.sendRequest(1, "thread/resume", {
-        workflowsEnabled: false,
-        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
-        baseInstructions: "test",
-        cwd: "/tmp/worktree",
-        instructionMode: "append",
-        permissionEscalation: "ask",
-        permissionMode: "default",
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(1);
-
-      bridge.sendRequest(2, "turn/start", {
-        input: [{ type: "text", text: "Reply READY" }],
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(2);
-
-      queries[0]?.emit(
-        createStaleResumeErrorMessage({
-          missingSessionId: staleProviderThreadId,
-          sessionId: staleProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      expect(queries).toHaveLength(2);
-      const replacementProviderThreadId = getLatestQueryOptions().sessionId;
-      if (!replacementProviderThreadId) {
-        throw new Error("Expected fresh Claude session ID");
-      }
-      const replacementErrorText = `No conversation found with session ID: ${replacementProviderThreadId}`;
-
-      queries[1]?.emit(
-        createStaleResumeErrorMessage({
-          missingSessionId: replacementProviderThreadId,
-          sessionId: replacementProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      expect(queries).toHaveLength(2);
-      expect(
-        getSdkResultErrorMessages(bridge.messages, replacementErrorText),
-      ).toHaveLength(1);
-
-      bridge.sendRequest(3, "thread/stop", {
-        threadId,
-      });
-      await bridge.flushWork();
-      queries[1]?.finish();
-      await bridge.waitForResponse(3);
-    } finally {
-      bridge.restore();
-    }
-  });
-
-  it("clears stale resume recovery state after a non-stale result", async () => {
-    const bridge = createBridgeJsonRpcTestHarness(handleLine);
-    const queries: ControlledClaudeQuery[] = [];
-    queryMock.mockImplementation(() => {
-      const query = createControlledClaudeQuery();
-      queries.push(query);
-      return query;
-    });
-
-    try {
-      const threadId = "thread-stale-resume-clears-state";
-      const staleProviderThreadId = "stale-provider-thread-clears-state";
-      const staleErrorText = `No conversation found with session ID: ${staleProviderThreadId}`;
-      bridge.sendRequest(1, "thread/resume", {
-        workflowsEnabled: false,
-        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
-        baseInstructions: "test",
-        cwd: "/tmp/worktree",
-        instructionMode: "append",
-        permissionEscalation: "ask",
-        permissionMode: "default",
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(1);
-
-      bridge.sendRequest(2, "turn/start", {
-        input: [{ type: "text", text: "Reply READY" }],
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(2);
-
-      queries[0]?.emit(
-        createSuccessResultMessage({
-          result: "ok",
-          sessionId: staleProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      queries[0]?.emit(
-        createStaleResumeErrorMessage({
-          missingSessionId: staleProviderThreadId,
-          sessionId: staleProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      expect(queries).toHaveLength(1);
-      expect(
-        getSdkResultErrorMessages(bridge.messages, staleErrorText),
-      ).toHaveLength(1);
-
-      bridge.sendRequest(3, "thread/stop", {
-        threadId,
-      });
-      await bridge.flushWork();
-      queries[0]?.finish();
-      await bridge.waitForResponse(3);
-    } finally {
-      bridge.restore();
-    }
-  });
-
-  it("stops the replacement session after stale resume recovery", async () => {
-    const bridge = createBridgeJsonRpcTestHarness(handleLine);
-    const queries: ControlledClaudeQuery[] = [];
-    queryMock.mockImplementation(() => {
-      const query = createControlledClaudeQuery();
-      queries.push(query);
-      return query;
-    });
-
-    try {
-      const threadId = "thread-stale-resume-stop-replacement";
-      const staleProviderThreadId = "stale-provider-thread-stop-replacement";
-      bridge.sendRequest(1, "thread/resume", {
-        workflowsEnabled: false,
-        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
-        baseInstructions: "test",
-        cwd: "/tmp/worktree",
-        instructionMode: "append",
-        permissionEscalation: "ask",
-        permissionMode: "default",
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(1);
-
-      bridge.sendRequest(2, "turn/start", {
-        input: [{ type: "text", text: "Reply READY" }],
-        providerThreadId: staleProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(2);
-
-      queries[0]?.emit(
-        createStaleResumeErrorMessage({
-          missingSessionId: staleProviderThreadId,
-          sessionId: staleProviderThreadId,
-        }),
-      );
-      await bridge.flushWork();
-
-      const replacementProviderThreadId = getLatestQueryOptions().sessionId;
-      if (!replacementProviderThreadId) {
-        throw new Error("Expected fresh Claude session ID");
-      }
-      expect(queries).toHaveLength(2);
-      expect(queries[0]?.close).toHaveBeenCalledTimes(1);
-
-      bridge.sendRequest(3, "thread/stop", {
-        threadId,
-      });
-      await bridge.flushWork();
-
-      expect(bridge.hasResponse(3)).toBe(false);
-      expect(queries[1]?.close).not.toHaveBeenCalled();
-
-      queries[1]?.finish();
-      await bridge.waitForResponse(3);
-
-      bridge.sendRequest(4, "thread/resume", {
-        workflowsEnabled: false,
-        claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
-        baseInstructions: "test",
-        cwd: "/tmp/worktree",
-        instructionMode: "append",
-        permissionEscalation: "ask",
-        permissionMode: "default",
-        providerThreadId: replacementProviderThreadId,
-        threadId,
-      });
-      await bridge.waitForResponse(4);
-
-      expect(queries).toHaveLength(3);
-      expect(getLatestQueryOptions()).toMatchObject({
-        resume: replacementProviderThreadId,
-      });
-
-      bridge.sendRequest(5, "thread/stop", {
-        threadId,
-      });
-      await bridge.flushWork();
-      queries[2]?.finish();
-      await bridge.waitForResponse(5);
     } finally {
       bridge.restore();
     }

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -29,7 +29,6 @@ import type {
   CanUseTool,
   PermissionResult,
   SDKMessage,
-  SDKResultMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import {
@@ -104,15 +103,6 @@ const promptInputItemSchema = z.discriminatedUnion("type", [
     mimeType: z.string().optional(),
   }),
 ]);
-
-// Claude Agent SDK 0.2.111 types stale resume failures as generic
-// SDKResultError.errors. The bundled Claude Code CLI can also emit the same
-// text on a legacy result field; keep that compatibility at this boundary.
-const legacyClaudeErrorResultTextSchema = z
-  .object({
-    result: z.string(),
-  })
-  .passthrough();
 
 interface JsonRpcResponse {
   jsonrpc: "2.0";
@@ -202,7 +192,6 @@ interface ThreadSession {
   permissionEscalation: PermissionEscalation | null;
   permissionMode: ClaudePermissionMode;
   providerThreadId?: string;
-  resumeRecovery: ClaudeResumeRecoveryState | null;
   sessionPermissionGrants: ClaudeSessionPermissionGrant[];
   threadIdRef: ThreadIdRef;
 }
@@ -213,32 +202,14 @@ interface CloseThreadSessionArgs {
   threadId: string;
 }
 
-interface ClaudeResumeRecoveryState {
-  acceptedInputTexts: string[];
-  attemptedProviderThreadId: string;
-  retryAttempted: boolean;
-}
-
 interface CreateThreadSessionArgs {
   mockCliTrafficProxy: ClaudeCodeMockCliTrafficProxy | null;
   permissionEscalation: PermissionEscalation | null;
   permissionMode: ClaudePermissionMode;
   providerThreadId?: string;
-  resumeRecovery: ClaudeResumeRecoveryState | null;
   sessionOptions: SdkSessionOptions;
   sessionPermissionGrants?: ClaudeSessionPermissionGrant[];
   threadIdRef: ThreadIdRef;
-}
-
-interface RecoverStaleResumeArgs {
-  message: SDKMessage;
-  threadId: string;
-  threadSession: ThreadSession;
-}
-
-interface StartFreshSessionAfterStaleResumeArgs {
-  threadId: string;
-  threadSession: ThreadSession;
 }
 
 interface PreparedSessionEnv {
@@ -253,11 +224,9 @@ interface PrepareSessionEnvParams {
 }
 
 interface ReplaceThreadSessionArgs {
-  acceptedInputTexts: string[];
   providerThreadId: string;
   replacementSession: ThreadSession;
   reason: string;
-  startMode: "fresh" | "resume";
   threadId: string;
   threadSession: ThreadSession;
 }
@@ -266,8 +235,6 @@ interface ReplaceEndedThreadSessionArgs {
   threadId: string;
   threadSession: ThreadSession;
 }
-
-type StaleResumeRecoveryOutcome = "forward" | "suppress";
 
 interface ClaudeCodeThreadStopResult {
   ok: true;
@@ -484,85 +451,9 @@ function createThreadSession(args: CreateThreadSessionArgs): ThreadSession {
     ...(args.providerThreadId
       ? { providerThreadId: args.providerThreadId }
       : {}),
-    resumeRecovery: args.resumeRecovery,
     sessionPermissionGrants: [...(args.sessionPermissionGrants ?? [])],
     threadIdRef: args.threadIdRef,
   };
-}
-
-function readLegacyClaudeErrorResultText(
-  message: SDKResultMessage,
-): string | null {
-  const parsed = legacyClaudeErrorResultTextSchema.safeParse(message);
-  return parsed.success ? parsed.data.result : null;
-}
-
-function readSingleClaudeErrorText(message: SDKResultMessage): string | null {
-  if (message.subtype !== "error_during_execution") {
-    return null;
-  }
-  const typedErrorText =
-    Array.isArray(message.errors) && message.errors.length === 1
-      ? message.errors[0]
-      : null;
-  const legacyResultText =
-    !Array.isArray(message.errors) || message.errors.length === 0
-      ? readLegacyClaudeErrorResultText(message)
-      : null;
-  return typedErrorText ?? legacyResultText;
-}
-
-function readExactClaudeStaleResumeError(
-  args: Pick<ClaudeResumeRecoveryState, "attemptedProviderThreadId"> & {
-    message: SDKMessage;
-  },
-): string | null {
-  const expectedMessage = `No conversation found with session ID: ${args.attemptedProviderThreadId}`;
-  const { message } = args;
-  if (message.type !== "result") {
-    return null;
-  }
-  if (message.is_error !== true) {
-    return null;
-  }
-  const errorText = readSingleClaudeErrorText(message);
-  if (errorText !== expectedMessage) {
-    return null;
-  }
-  return expectedMessage;
-}
-
-function startFreshSessionAfterStaleResume(
-  args: StartFreshSessionAfterStaleResumeArgs,
-): void {
-  const providerThreadId = randomUUID();
-  const replacementOptions: SdkSessionOptions = {
-    ...args.threadSession.sessionOptions,
-    sessionId: providerThreadId,
-  };
-  const acceptedInputTexts = [
-    ...(args.threadSession.resumeRecovery?.acceptedInputTexts ?? []),
-  ];
-  const replacementSession = createThreadSession({
-    mockCliTrafficProxy: args.threadSession.mockCliTrafficProxy,
-    permissionEscalation: args.threadSession.permissionEscalation,
-    permissionMode: args.threadSession.permissionMode,
-    providerThreadId,
-    resumeRecovery: null,
-    sessionOptions: replacementOptions,
-    sessionPermissionGrants: args.threadSession.sessionPermissionGrants,
-    threadIdRef: args.threadSession.threadIdRef,
-  });
-
-  replaceThreadSession({
-    acceptedInputTexts,
-    providerThreadId,
-    replacementSession,
-    reason: "Thread session replaced after stale Claude resume",
-    startMode: "fresh",
-    threadId: args.threadId,
-    threadSession: args.threadSession,
-  });
 }
 
 function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
@@ -576,16 +467,8 @@ function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
   // external stop/replace requests, so a stop after this point should target
   // the replacement, not wait on the poisoned resume session.
   sessions.set(args.threadId, args.replacementSession);
-  args.replacementSession.session.start(
-    args.startMode === "resume" ? args.providerThreadId : undefined,
-  );
+  args.replacementSession.session.start(args.providerThreadId);
   sendThreadIdentity(args.threadId, args.providerThreadId);
-
-  for (const inputText of args.acceptedInputTexts) {
-    ignoreInputConsumption(
-      args.replacementSession.session.pushInput(inputText),
-    );
-  }
 }
 
 function replaceEndedThreadSession(
@@ -603,18 +486,15 @@ function replaceEndedThreadSession(
     permissionEscalation: args.threadSession.permissionEscalation,
     permissionMode: args.threadSession.permissionMode,
     providerThreadId,
-    resumeRecovery: null,
     sessionOptions: args.threadSession.sessionOptions,
     sessionPermissionGrants: args.threadSession.sessionPermissionGrants,
     threadIdRef: args.threadSession.threadIdRef,
   });
 
   replaceThreadSession({
-    acceptedInputTexts: [],
     providerThreadId,
     replacementSession,
     reason: "Thread session replaced after Claude SDK stream ended",
-    startMode: "resume",
     threadId: args.threadId,
     threadSession: args.threadSession,
   });
@@ -630,33 +510,6 @@ function getWritableThreadSession(threadId: string): ThreadSession | undefined {
     return threadSession;
   }
   return replaceEndedThreadSession({ threadId, threadSession });
-}
-
-function handleStaleResumeRecovery(
-  args: RecoverStaleResumeArgs,
-): StaleResumeRecoveryOutcome {
-  const { resumeRecovery } = args.threadSession;
-  if (!resumeRecovery || resumeRecovery.retryAttempted) {
-    return "forward";
-  }
-
-  const staleErrorMessage = readExactClaudeStaleResumeError({
-    attemptedProviderThreadId: resumeRecovery.attemptedProviderThreadId,
-    message: args.message,
-  });
-  if (!staleErrorMessage) {
-    if (args.message.type === "result") {
-      args.threadSession.resumeRecovery = null;
-    }
-    return "forward";
-  }
-
-  resumeRecovery.retryAttempted = true;
-  startFreshSessionAfterStaleResume({
-    threadId: args.threadId,
-    threadSession: args.threadSession,
-  });
-  return "suppress";
 }
 
 function getCurrentThreadSession(
@@ -682,14 +535,6 @@ function createOnSdkMessage(
       threadId: args.threadIdRef.current,
     });
     if (!threadSession) return;
-    const recoveryOutcome = handleStaleResumeRecovery({
-      message,
-      threadId: args.threadIdRef.current,
-      threadSession,
-    });
-    if (recoveryOutcome === "suppress") {
-      return;
-    }
     const providerThreadId = message.session_id?.trim() ?? "";
     if (
       providerThreadId.length > 0 &&
@@ -1346,7 +1191,6 @@ async function handleThreadStart(
     permissionEscalation: params.permissionEscalation,
     permissionMode: params.permissionMode,
     providerThreadId,
-    resumeRecovery: null,
     sessionOptions,
     sessionPermissionGrants: [],
     threadIdRef,
@@ -1393,13 +1237,6 @@ async function handleThreadResume(
     ...(requestedProviderThreadId
       ? { providerThreadId: requestedProviderThreadId }
       : {}),
-    resumeRecovery: requestedProviderThreadId
-      ? {
-          acceptedInputTexts: [],
-          attemptedProviderThreadId: requestedProviderThreadId,
-          retryAttempted: false,
-        }
-      : null,
     sessionOptions,
     sessionPermissionGrants: [],
     threadIdRef,
@@ -1414,19 +1251,18 @@ async function handleThreadResume(
 }
 
 function handleTurnStart(id: string | number, params: TurnStartParams): void {
-  const threadSession = getWritableThreadSession(params.threadId);
-  if (!threadSession) {
-    sendError(id, -32000, "No active session");
-    return;
-  }
-
   const input = buildPromptText(params.input);
   if (!input) {
     sendError(id, -32602, "Missing input text");
     return;
   }
 
-  threadSession.resumeRecovery?.acceptedInputTexts.push(input);
+  const threadSession = getWritableThreadSession(params.threadId);
+  if (!threadSession) {
+    sendError(id, -32000, "No active session");
+    return;
+  }
+
   ignoreInputConsumption(threadSession.session.pushInput(input));
   sendResult(id, { threadId: params.threadId });
 }
@@ -1435,21 +1271,20 @@ async function handleTurnSteer(
   id: string | number,
   params: TurnSteerParams,
 ): Promise<void> {
-  const threadSession = getWritableThreadSession(params.threadId);
-  if (!threadSession) {
-    sendError(id, -32000, "No active session");
-    return;
-  }
-
   const input = buildPromptText(params.input);
   if (!input) {
     sendError(id, -32602, "Missing input text");
     return;
   }
 
+  const threadSession = getWritableThreadSession(params.threadId);
+  if (!threadSession) {
+    sendError(id, -32000, "No active session");
+    return;
+  }
+
   try {
     await threadSession.session.pushInput(input);
-    threadSession.resumeRecovery?.acceptedInputTexts.push(input);
     sendResult(id, { threadId: params.threadId });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -195,6 +195,7 @@ interface ThreadSession {
   sessionOptions: SdkSessionOptions;
   sessionSerial: number;
   closing: boolean;
+  streamEnded: boolean;
   mockCliTrafficProxy: ClaudeCodeMockCliTrafficProxy | null;
   pendingToolCalls: Map<string | number, PendingToolCall>;
   pendingInteractiveRequests: Map<string | number, PendingInteractiveRequest>;
@@ -255,6 +256,13 @@ interface ReplaceThreadSessionArgs {
   acceptedInputTexts: string[];
   providerThreadId: string;
   replacementSession: ThreadSession;
+  reason: string;
+  startMode: "fresh" | "resume";
+  threadId: string;
+  threadSession: ThreadSession;
+}
+
+interface ReplaceEndedThreadSessionArgs {
   threadId: string;
   threadSession: ThreadSession;
 }
@@ -467,6 +475,7 @@ function createThreadSession(args: CreateThreadSessionArgs): ThreadSession {
     sessionOptions: args.sessionOptions,
     sessionSerial,
     closing: false,
+    streamEnded: false,
     mockCliTrafficProxy: args.mockCliTrafficProxy,
     pendingToolCalls: new Map(),
     pendingInteractiveRequests: new Map(),
@@ -549,6 +558,8 @@ function startFreshSessionAfterStaleResume(
     acceptedInputTexts,
     providerThreadId,
     replacementSession,
+    reason: "Thread session replaced after stale Claude resume",
+    startMode: "fresh",
     threadId: args.threadId,
     threadSession: args.threadSession,
   });
@@ -557,10 +568,7 @@ function startFreshSessionAfterStaleResume(
 function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
   args.threadSession.closing = true;
   args.threadSession.mockCliTrafficProxy = null;
-  resolvePendingSessionWork(
-    args.threadSession,
-    "Thread session replaced after stale Claude resume",
-  );
+  resolvePendingSessionWork(args.threadSession, args.reason);
   args.threadSession.session.stop();
 
   // This is not a user-requested thread close: the thread remains active and
@@ -568,7 +576,9 @@ function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
   // external stop/replace requests, so a stop after this point should target
   // the replacement, not wait on the poisoned resume session.
   sessions.set(args.threadId, args.replacementSession);
-  args.replacementSession.session.start();
+  args.replacementSession.session.start(
+    args.startMode === "resume" ? args.providerThreadId : undefined,
+  );
   sendThreadIdentity(args.threadId, args.providerThreadId);
 
   for (const inputText of args.acceptedInputTexts) {
@@ -576,6 +586,50 @@ function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
       args.replacementSession.session.pushInput(inputText),
     );
   }
+}
+
+function replaceEndedThreadSession(
+  args: ReplaceEndedThreadSessionArgs,
+): ThreadSession | undefined {
+  const providerThreadId =
+    args.threadSession.providerThreadId ??
+    args.threadSession.session.getSessionId();
+  if (!providerThreadId) {
+    return undefined;
+  }
+
+  const replacementSession = createThreadSession({
+    mockCliTrafficProxy: args.threadSession.mockCliTrafficProxy,
+    permissionEscalation: args.threadSession.permissionEscalation,
+    permissionMode: args.threadSession.permissionMode,
+    providerThreadId,
+    resumeRecovery: null,
+    sessionOptions: args.threadSession.sessionOptions,
+    sessionPermissionGrants: args.threadSession.sessionPermissionGrants,
+    threadIdRef: args.threadSession.threadIdRef,
+  });
+
+  replaceThreadSession({
+    acceptedInputTexts: [],
+    providerThreadId,
+    replacementSession,
+    reason: "Thread session replaced after Claude SDK stream ended",
+    startMode: "resume",
+    threadId: args.threadId,
+    threadSession: args.threadSession,
+  });
+  return replacementSession;
+}
+
+function getWritableThreadSession(threadId: string): ThreadSession | undefined {
+  const threadSession = sessions.get(threadId);
+  if (!threadSession || threadSession.closing) {
+    return undefined;
+  }
+  if (!threadSession.streamEnded) {
+    return threadSession;
+  }
+  return replaceEndedThreadSession({ threadId, threadSession });
 }
 
 function handleStaleResumeRecovery(
@@ -652,12 +706,19 @@ function createOnSdkDone(
   args: CreateSdkCallbackArgs,
 ): (error?: unknown) => void {
   return (error?: unknown) => {
-    if (!error) return;
     const threadSession = getCurrentThreadSession({
       sessionSerial: args.sessionSerial,
       threadId: args.threadIdRef.current,
     });
     if (!threadSession) return;
+
+    threadSession.streamEnded = true;
+    resolvePendingSessionWork(
+      threadSession,
+      "Claude SDK stream ended before pending work completed",
+    );
+
+    if (!error) return;
 
     const message = error instanceof Error ? error.message : String(error);
 
@@ -1353,8 +1414,8 @@ async function handleThreadResume(
 }
 
 function handleTurnStart(id: string | number, params: TurnStartParams): void {
-  const threadSession = sessions.get(params.threadId);
-  if (!threadSession || threadSession.closing) {
+  const threadSession = getWritableThreadSession(params.threadId);
+  if (!threadSession) {
     sendError(id, -32000, "No active session");
     return;
   }
@@ -1374,8 +1435,8 @@ async function handleTurnSteer(
   id: string | number,
   params: TurnSteerParams,
 ): Promise<void> {
-  const threadSession = sessions.get(params.threadId);
-  if (!threadSession || threadSession.closing) {
+  const threadSession = getWritableThreadSession(params.threadId);
+  if (!threadSession) {
     sendError(id, -32000, "No active session");
     return;
   }


### PR DESCRIPTION
## Summary
- Mark Claude SDK streams as ended when they finish or fail, and resolve pending session work instead of leaving callers hanging.
- Allow follow-up turns and steers after a stream failure by replacing the ended session and resuming the existing provider thread.
- Surface SDK stream failures through the bridge error channel, including captured Claude stderr when available.
- Remove the older stale-resume recovery path and legacy error parsing/replay behavior.

## Validation
- [x] `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- [x] `pnpm exec turbo run test --filter=@bb/agent-runtime`