### PR TITLE
Fix copy path for remote workspace previews

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -96,6 +96,7 @@ export interface WorkspaceFilePreviewTabContentProps {
 
 export interface HostFilePreviewTabContentProps {
   activePath: string;
+  copyPath: string;
   environmentId?: string | null;
   lineRange: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
@@ -363,6 +364,7 @@ export function WorkspaceFilePreviewTabContent({
 
 export function HostFilePreviewTabContent({
   activePath,
+  copyPath,
   environmentId,
   lineRange,
   markdownLinkRouting,
@@ -378,6 +380,7 @@ export function HostFilePreviewTabContent({
   return (
     <SecondaryPanelFilePreview
       activePath={activePath}
+      copyPath={copyPath}
       error={hostFilePreviewError}
       filePreview={hostFilePreview}
       htmlPreviewUrl={buildRawFilesystemHtmlContentUrl(threadId, activePath)}

--- a/apps/app/src/lib/file-preview.test.ts
+++ b/apps/app/src/lib/file-preview.test.ts
@@ -75,6 +75,25 @@ describe("file-preview", () => {
     });
   });
 
+  it("prefers UTF-8 text over ambiguous video mime types", () => {
+    const preview = buildFilePreview({
+      contentBytes: new TextEncoder().encode("export const value = 1;\n"),
+      mimeType: "video/mp2t",
+      name: "commands.ts",
+      path: "apps/server/test/helpers/commands.ts",
+      url: "/files/commands.ts",
+    });
+
+    expect(preview).toEqual({
+      kind: "text",
+      mimeType: "video/mp2t",
+      name: "commands.ts",
+      path: "apps/server/test/helpers/commands.ts",
+      url: "/files/commands.ts",
+      content: "export const value = 1;\n",
+    });
+  });
+
   it("marks null-byte text and non-text binary files as unsupported", () => {
     const textWithNullBytePreview = buildFilePreview({
       contentBytes: Uint8Array.from([97, 0, 98]),

--- a/apps/app/src/lib/file-preview.ts
+++ b/apps/app/src/lib/file-preview.ts
@@ -230,13 +230,6 @@ export function buildFilePreview(args: BuildFilePreviewArgs): FilePreview {
     };
   }
 
-  if (args.mimeType.startsWith("video/")) {
-    return {
-      kind: "video",
-      ...base,
-    };
-  }
-
   if (isKnownTextMimeType(args.mimeType)) {
     const textContent = decodeDeclaredTextContent(args.contentBytes);
     if (textContent === null) {
@@ -258,6 +251,13 @@ export function buildFilePreview(args: BuildFilePreviewArgs): FilePreview {
       kind: "text",
       ...base,
       content: fallbackTextContent,
+    };
+  }
+
+  if (args.mimeType.startsWith("video/")) {
+    return {
+      kind: "video",
+      ...base,
     };
   }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -121,6 +121,7 @@ import {
   buildOpenInEditorHandler,
   resolveWorkspaceChangedFileOpenTarget,
   resolveThreadLocalWorkspaceRootPath,
+  resolveThreadWorkspacePreviewRootPath,
   resolveThreadWorkspaceOpenPath,
 } from "./threadWorkspaceOpenPath";
 import {
@@ -915,6 +916,9 @@ export function ThreadDetailView() {
     environment,
     threadEnvironmentIsLocal,
   });
+  const workspacePreviewRootPath = resolveThreadWorkspacePreviewRootPath({
+    environment,
+  });
   const {
     canOpenPreferredDirectoryTarget,
     canOpenPreferredFileTarget,
@@ -1077,7 +1081,7 @@ export function ThreadDetailView() {
           thread?.environmentId !== null && thread?.environmentId !== undefined,
         link,
         threadStorageRootPath,
-        workspaceRootPath: localWorkspaceRootPath,
+        workspaceRootPath: workspacePreviewRootPath,
       });
 
       if (
@@ -1102,7 +1106,7 @@ export function ThreadDetailView() {
             hostFileLinksAvailable: true,
             link,
             threadStorageRootPath: resolvedThreadStorageRootPath,
-            workspaceRootPath: localWorkspaceRootPath,
+            workspaceRootPath: workspacePreviewRootPath,
           });
           handleTimelineLocalFileLinkResolution(resolvedResolution);
         })
@@ -1116,10 +1120,10 @@ export function ThreadDetailView() {
     },
     [
       handleTimelineLocalFileLinkResolution,
-      localWorkspaceRootPath,
       refetchThreadStorageFiles,
       thread?.environmentId,
       threadStorageRootPath,
+      workspacePreviewRootPath,
     ],
   );
   const handleOpenTimelineLink = useCallback<ThreadTimelineLinkHandler>(
@@ -1216,7 +1220,7 @@ export function ThreadDetailView() {
   const workspaceFileCopyPath = activeWorkspaceFilePath
     ? resolveAbsoluteFilePath({
         path: activeWorkspaceFilePath,
-        rootPath: environment?.path,
+        rootPath: workspacePreviewRootPath,
       })
     : null;
   const storageFileCopyPath = activeStorageFilePath
@@ -1239,7 +1243,7 @@ export function ThreadDetailView() {
   const hostFileLinkRootPath = resolveHostFilePreviewLinkRootPath({
     baseDir: hostFileLinkBaseDir,
     threadStorageRootPath,
-    workspaceRootPath: localWorkspaceRootPath,
+    workspaceRootPath: workspacePreviewRootPath,
   });
   const workspaceMarkdownLinkRouting = useMemo(
     () =>
@@ -1247,13 +1251,13 @@ export function ThreadDetailView() {
         baseDir: workspaceFileLinkBaseDir,
         onOpenLink: handleOpenTimelineLink,
         onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
-        rootPath: environment?.path,
+        rootPath: workspacePreviewRootPath,
       }),
     [
-      environment?.path,
       handleOpenTimelineLink,
       handleOpenTimelineLocalFileLink,
       workspaceFileLinkBaseDir,
+      workspacePreviewRootPath,
     ],
   );
   const hostMarkdownLinkRouting = useMemo(
@@ -1484,6 +1488,7 @@ export function ThreadDetailView() {
   ) : activeHostFilePath ? (
     <HostFilePreviewTabContent
       activePath={activeHostFilePath}
+      copyPath={activeHostFilePath}
       environmentId={thread.environmentId}
       lineRange={activeHostFileLineRange}
       markdownLinkRouting={hostMarkdownLinkRouting}

--- a/apps/app/src/views/thread-detail/threadWorkspaceOpenPath.test.ts
+++ b/apps/app/src/views/thread-detail/threadWorkspaceOpenPath.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveWorkspaceChangedFileOpenTarget,
   resolveThreadLocalWorkspaceRootPath,
+  resolveThreadWorkspacePreviewRootPath,
   resolveThreadWorkspaceOpenPath,
 } from "./threadWorkspaceOpenPath";
 
@@ -115,6 +116,20 @@ describe("resolveThreadWorkspaceOpenPath", () => {
         threadEnvironmentIsLocal: true,
       }),
     ).toBeNull();
+  });
+
+  it("keeps the workspace preview root independent from local editor availability", () => {
+    const environment = makeEnvironment();
+
+    expect(
+      resolveThreadLocalWorkspaceRootPath({
+        environment,
+        threadEnvironmentIsLocal: false,
+      }),
+    ).toBeNull();
+    expect(resolveThreadWorkspacePreviewRootPath({ environment })).toBe(
+      "/tmp/workspace",
+    );
   });
 
   it("still resolves when the environment is not ready, as long as it has a path", () => {

--- a/apps/app/src/views/thread-detail/threadWorkspaceOpenPath.ts
+++ b/apps/app/src/views/thread-detail/threadWorkspaceOpenPath.ts
@@ -48,6 +48,10 @@ export interface ResolveThreadLocalWorkspaceRootPathArgs {
   threadEnvironmentIsLocal: boolean;
 }
 
+export interface ResolveThreadWorkspacePreviewRootPathArgs {
+  environment: Environment | null | undefined;
+}
+
 export type WorkspaceChangedFileOpenTarget =
   | { kind: "diff" }
   | {
@@ -99,6 +103,17 @@ export function resolveThreadLocalWorkspaceRootPath(
     return null;
   }
 
+  return args.environment?.path ?? null;
+}
+
+/**
+ * Workspace previews are served by the thread host through the server, so path
+ * containment should use the environment's host path even when the browser
+ * cannot use that path for local editor integration.
+ */
+export function resolveThreadWorkspacePreviewRootPath(
+  args: ResolveThreadWorkspacePreviewRootPathArgs,
+): string | null {
   return args.environment?.path ?? null;
 }
 


### PR DESCRIPTION
## Summary
- classify workspace preview links against the environment workspace path instead of the browser-local editor path
- keep editor-open behavior gated on local daemon availability
- pass absolute paths through to host-file previews so existing host tabs can copy their path
- prefer UTF-8 text previews before video previews so MIME collisions like TypeScript `.ts`/MPEG transport stream do not render source files as video players

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- src/lib/file-preview.test.ts src/views/thread-detail/threadWorkspaceOpenPath.test.ts src/lib/thread-local-file-links.test.ts
- pnpm exec turbo run lint --filter=@bb/app