### PR TITLE
Fix pending interaction queue send guard

### DIFF
--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -221,7 +221,7 @@ describe("desktop preload browser API", () => {
     expect(electronMock.invokeCalls).toContain(
       BB_DESKTOP_INSTALL_UPDATE_CHANNEL,
     );
-  });
+  }, 10_000);
 
   it("validates browser event payloads before notifying renderer listeners", async () => {
     const api = await loadPreload();

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -213,6 +213,7 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
     async (context, payload) => {
       const thread = requirePublicThread(deps.db, context.req.param("id"));
       if (payload.mode === "queue-if-active" && thread.status === "active") {
+        ensureThreadIsNotAwaitingUserInteraction(deps, thread.id);
         await createQueuedMessageForThread(deps, {
           payload: queuedMessagePayloadFromSendRequest(payload),
           thread,

--- a/apps/server/test/public/public-thread-interactions.test.ts
+++ b/apps/server/test/public/public-thread-interactions.test.ts
@@ -1,4 +1,4 @@
-import { createQueuedThreadMessage } from "@bb/db";
+import { createQueuedThreadMessage, listQueuedThreadMessages } from "@bb/db";
 import {
   turnScope,
   USER_QUESTION_MAX_FREE_TEXT_LENGTH,
@@ -899,6 +899,57 @@ describe("public thread interaction routes", () => {
         message:
           "Thread is awaiting user interaction. Resolve the pending interaction before sending another prompt.",
       });
+
+      const activeThread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        status: "active",
+      });
+      const activeThreadPending = registerPendingInteraction(
+        harness.deps,
+        harness.deps.pendingInteractions,
+        {
+          threadId: activeThread.id,
+          turnId: "turn-active-blocked-send",
+          providerId: "codex",
+          providerThreadId: "provider-thread-active-blocked",
+          providerRequestId: "request-active-blocked",
+          payload: createCommandApprovalPayload({
+            itemId: "item-active-blocked",
+            reason: "Approve command",
+            command: "git push",
+            cwd: "/tmp/project",
+          }),
+        },
+      );
+      if (activeThreadPending.outcome === "rejected") {
+        throw new Error(
+          `Expected active interaction registration to succeed: ${activeThreadPending.reason}`,
+        );
+      }
+
+      const activeSendResponse = await harness.app.request(
+        `/api/v1/threads/${activeThread.id}/send`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            mode: "queue-if-active",
+            input: [{ type: "text", text: "Try to queue while blocked" }],
+          }),
+        },
+      );
+      expect(activeSendResponse.status).toBe(409);
+      await expect(readJson(activeSendResponse)).resolves.toEqual({
+        code: "awaiting_user_interaction",
+        message:
+          "Thread is awaiting user interaction. Resolve the pending interaction before sending another prompt.",
+      });
+      expect(listQueuedThreadMessages(harness.db, activeThread.id)).toHaveLength(
+        0,
+      );
     });
   });
 

--- a/packages/db/test/data/pending-interactions.test.ts
+++ b/packages/db/test/data/pending-interactions.test.ts
@@ -210,20 +210,18 @@ describe("pending interactions", () => {
 
   it("chunks provider-thread interrupts to stay under SQLite variable limits", () => {
     const { db, thread } = setup();
-    const manyThreads = [thread];
-    for (let index = 0; index < 1_050; index += 1) {
-      manyThreads.push(
-        createThread(db, noopNotifier, {
-          projectId: thread.projectId,
-          environmentId: thread.environmentId,
-          providerId: "codex",
-        }),
-      );
-    }
-
-    const targetThreadIds = [manyThreads[0], manyThreads[1_000]]
-      .filter((currentThread) => currentThread !== undefined)
-      .map((currentThread) => currentThread.id);
+    const secondBatchThread = createThread(db, noopNotifier, {
+      projectId: thread.projectId,
+      environmentId: thread.environmentId,
+      providerId: "codex",
+    });
+    const threadIds = Array.from(
+      { length: 1_001 },
+      (_value, index) => `missing-provider-thread-${index}`,
+    );
+    threadIds[0] = thread.id;
+    threadIds[1_000] = secondBatchThread.id;
+    const targetThreadIds = [thread.id, secondBatchThread.id];
 
     for (const [index, threadId] of targetThreadIds.entries()) {
       createPendingInteraction(db, {
@@ -243,7 +241,7 @@ describe("pending interactions", () => {
       new Set(
         interruptPendingInteractionsForThreads(db, {
           providerId: "codex",
-          threadIds: manyThreads.map((currentThread) => currentThread.id),
+          threadIds,
           statusReason: "Provider exited",
         }).map((row) => row.threadId),
       ),
@@ -252,20 +250,18 @@ describe("pending interactions", () => {
 
   it("chunks thread-id interrupts to stay under SQLite variable limits", () => {
     const { db, thread } = setup();
-    const manyThreads = [thread];
-    for (let index = 0; index < 1_050; index += 1) {
-      manyThreads.push(
-        createThread(db, noopNotifier, {
-          projectId: thread.projectId,
-          environmentId: thread.environmentId,
-          providerId: "codex",
-        }),
-      );
-    }
-
-    const targetThreadIds = [manyThreads[0], manyThreads[1_000]]
-      .filter((currentThread) => currentThread !== undefined)
-      .map((currentThread) => currentThread.id);
+    const secondBatchThread = createThread(db, noopNotifier, {
+      projectId: thread.projectId,
+      environmentId: thread.environmentId,
+      providerId: "codex",
+    });
+    const threadIds = Array.from(
+      { length: 1_001 },
+      (_value, index) => `missing-thread-${index}`,
+    );
+    threadIds[0] = thread.id;
+    threadIds[1_000] = secondBatchThread.id;
+    const targetThreadIds = [thread.id, secondBatchThread.id];
 
     for (const [index, threadId] of targetThreadIds.entries()) {
       createPendingInteraction(db, {
@@ -284,7 +280,7 @@ describe("pending interactions", () => {
     expect(
       new Set(
         interruptPendingInteractionsForThreadIds(db, {
-          threadIds: manyThreads.map((currentThread) => currentThread.id),
+          threadIds,
           statusReason: "Thread stopped",
         }).map((row) => row.threadId),
       ),

--- a/qa/manual-pass-log.md
+++ b/qa/manual-pass-log.md
@@ -646,3 +646,36 @@ Cleanup:
 
 - Teardown succeeded: `pnpm qa:standalone:stop --state ...` killed PIDs `39234` and `39286` and removed the standalone root.
 - `pnpm qa:standalone:cleanup` reported no remaining roots.
+
+## Full Lint/Test/Build/Runbook Pass With Real Providers
+
+Date: 2026-06-12
+Operator: Codex
+Status: passed after fixes
+Standalone workflow: `pnpm qa:standalone:start` / `pnpm qa:standalone:stop`
+Run logs: `qa/logs/2026-06-12-full-qa/`
+
+Resolved models:
+
+- `codex`: `gpt-5.5`
+- `claude-code`: `claude-haiku-4-5`
+- `pi`: `openai-codex/gpt-5.5`
+
+Validated:
+
+- Final `lint`, `typecheck`, `test`, `test:integration`, and root `build` gates all passed through Turbo.
+- Real-provider integration exercised Codex, Claude Code, and Pi registry, turn, control, concurrency, and workspace scenarios.
+- Standalone manual runbook coverage exercised health/model resolution, API prompt attachments, smoke/follow-up, parent/child protocol, worktree/diff routes, archive safety, automations, multi-thread shared environments, mixed-provider worktrees, recovery probes, provider-specific chat/follow-up/stop/worktree flows, and pending-interaction approval/denial.
+- The final pending-interaction rerun confirmed `bb thread tell` now returns HTTP 409 while a command approval is pending, then approval and denial both resolve through the real Codex provider flow.
+
+Fixes made during the pass:
+
+- Added a focused timeout to the desktop preload browser API test that timed out under full-suite load.
+- Reduced pending-interaction batching test setup cost while preserving coverage across SQLite variable-limit chunks.
+- Installed/verified local QA prerequisites for real providers (`socat`, Pi auth, and the `pi` CLI wrapper).
+- Fixed `/api/v1/threads/:id/send` so `queue-if-active` cannot enqueue a prompt while the active thread awaits user interaction, with a public API regression test.
+
+Cleanup:
+
+- Standalone teardown and cleanup succeeded after the final manual rerun.
+- No `/tmp/bb-standalone-*` roots remained after cleanup.


### PR DESCRIPTION
## Summary
- reject `/threads/:id/send` `queue-if-active` requests while an active thread is awaiting user interaction
- add a public API regression proving no queued message is created in that pending-interaction state
- stabilize two full-suite tests observed during the QA pass and record the manual runbook results

## Validation
- `pnpm exec turbo run lint`
- `pnpm exec turbo run typecheck`
- `pnpm exec turbo run test`
- `pnpm exec turbo run test:integration`
- `pnpm exec turbo run build --filter=@bb/scripts --filter=@bb/app --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/cli --filter=bb-app`
- `qa/manual-runbook.md` standalone pass, including real Codex, Claude Code, and Pi provider probes

## Notes
- raw local QA logs were captured under `qa/logs/2026-06-12-full-qa/` but are intentionally not committed
