### PR TITLE
Fix context banner change stats

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -128,17 +128,17 @@ const untrackedOnlyStatus: WorkspaceStatus = {
       {
         path: "apps/app/notes/triage.md",
         status: "??",
-        insertions: null,
-        deletions: null,
+        insertions: 18,
+        deletions: 0,
       },
       {
         path: "apps/app/scripts/dev-bb-worktree.sh",
         status: "??",
-        insertions: null,
-        deletions: null,
+        insertions: 42,
+        deletions: 0,
       },
     ],
-    insertions: 0,
+    insertions: 60,
     deletions: 0,
   },
   branch: {
@@ -437,7 +437,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="untracked only"
-        hint='workingTree.state = "untracked" — no insertions/deletions tally'
+        hint='workingTree.state = "untracked" with synthesized insertion stats'
       >
         <Row section={untrackedSection} initiallyExpandedSection="git" />
       </StoryRow>

--- a/apps/app/src/components/workspace/workspace-change-summary.tsx
+++ b/apps/app/src/components/workspace/workspace-change-summary.tsx
@@ -95,9 +95,8 @@ export interface WorkspaceChangedFileSelection {
  * the result has at most one entry.
  *
  * Each section carries its own stats so callers don't have to re-derive
- * which bucket the numbers came from. Untracked-only state surfaces
- * working-tree stats (insertions/deletions are expected to be 0 there —
- * git diff doesn't count untracked content).
+ * which bucket the numbers came from. Untracked-only state surfaces the
+ * working-tree stats synthesized by the workspace status command.
  */
 export function selectWorkspaceChangedFilesSections(
   workspaceStatus: WorkspaceStatus | undefined,

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -793,7 +793,7 @@ export function parseNumstatEntriesZ(output: string): NumstatEntry[] {
   return entries;
 }
 
-function parseNumstatCount(text: string): number | null {
+export function parseNumstatCount(text: string): number | null {
   const value = Number.parseInt(text, 10);
   return Number.isFinite(value) ? value : null;
 }

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -18,6 +18,7 @@ import {
   hasUncommittedChanges,
   listBranches,
   parseNameStatusEntries,
+  parseNumstatCount,
   parseNumstatEntriesZ,
   parsePorcelainEntries,
   pathExists,
@@ -26,6 +27,7 @@ import {
   parsePatchId,
   revParse,
   runGit,
+  type NumstatEntry,
   type RunGitOptions,
   runShellPipeline,
   summarizeNumstat,
@@ -113,6 +115,12 @@ type ReadUntrackedDiffArtifactsArgs = DiffOutputLimits & {
 
 type ReadUntrackedDiffArtifactArgs = DiffOutputLimits & {
   relativePath: string;
+};
+
+type ReadUntrackedNumstatEntriesArgs = {
+  workspacePath: string;
+  relativePaths: readonly string[];
+  timeoutMs?: number;
 };
 
 type TruncatedOutput = {
@@ -411,6 +419,55 @@ async function readHeadNumstat(
   );
 }
 
+async function readUntrackedNumstatEntries(
+  args: ReadUntrackedNumstatEntriesArgs,
+): Promise<NumstatEntry[]> {
+  if (args.relativePaths.length === 0) {
+    return [];
+  }
+
+  const entries: NumstatEntry[] = [];
+  for (
+    let index = 0;
+    index < args.relativePaths.length;
+    index += UNTRACKED_DIFF_BATCH_SIZE
+  ) {
+    const batchPaths = args.relativePaths.slice(
+      index,
+      index + UNTRACKED_DIFF_BATCH_SIZE,
+    );
+    entries.push(
+      ...(await Promise.all(
+        batchPaths.map(async (relativePath) => {
+          const result = await runGit(
+            [
+              "diff",
+              "--no-index",
+              "--numstat",
+              "--",
+              "/dev/null",
+              relativePath,
+            ],
+            {
+              cwd: args.workspacePath,
+              allowFailure: true,
+              timeoutMs: args.timeoutMs,
+            },
+          );
+          const [line = ""] = result.stdout.split("\n");
+          const [insertionsText = "", deletionsText = ""] = line.split("\t");
+          return {
+            path: relativePath,
+            insertions: parseNumstatCount(insertionsText),
+            deletions: parseNumstatCount(deletionsText),
+          };
+        }),
+      )),
+    );
+  }
+  return entries;
+}
+
 export class Workspace {
   readonly path: string;
 
@@ -498,7 +555,17 @@ export class Workspace {
     ]);
 
     const entries = parsePorcelainEntries(statusOutput.stdout);
-    const numstatEntries = parseNumstatEntriesZ(diffOutput);
+    const untrackedPaths = entries
+      .filter((entry) => entry.status === "??")
+      .map((entry) => entry.path);
+    const numstatEntries = [
+      ...parseNumstatEntriesZ(diffOutput),
+      ...(await readUntrackedNumstatEntries({
+        workspacePath: this.path,
+        relativePaths: untrackedPaths,
+        timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS,
+      })),
+    ];
     const numstatByPath = new Map(
       numstatEntries.map((entry) => [entry.path, entry] as const),
     );

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { WorkspaceChangeStats } from "@bb/domain";
 import { Workspace } from "../src/workspace.js";
 import { WorkspaceError } from "../src/git.js";
 import { runGit } from "../src/git.js";
@@ -19,6 +20,12 @@ const tempDirs: string[] = [];
 type Deferred = {
   promise: Promise<void>;
   resolve: () => void;
+};
+
+type DiffStats = {
+  filesCount: number;
+  insertions: number;
+  deletions: number;
 };
 
 function createDeferred(): Deferred {
@@ -62,6 +69,30 @@ async function initBareRemoteFrom(repoPath: string): Promise<string> {
   await runGit(["remote", "add", "origin", barePath], { cwd: repoPath });
   await runGit(["push", "-u", "origin", "main"], { cwd: repoPath });
   return barePath;
+}
+
+function parseFirstIntegerMatch(text: string, pattern: RegExp): number {
+  const value = Number.parseInt(text.match(pattern)?.[1] ?? "0", 10);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function parseShortstat(shortstat: string): DiffStats {
+  return {
+    filesCount: parseFirstIntegerMatch(shortstat, /(\d+)\s+files?\s+changed/u),
+    insertions: parseFirstIntegerMatch(
+      shortstat,
+      /(\d+)\s+insertions?\(\+\)/u,
+    ),
+    deletions: parseFirstIntegerMatch(shortstat, /(\d+)\s+deletions?\(-\)/u),
+  };
+}
+
+function tallyWorkspaceStats(stats: WorkspaceChangeStats): DiffStats {
+  return {
+    filesCount: stats.files.length,
+    insertions: stats.insertions,
+    deletions: stats.deletions,
+  };
 }
 
 type PrimaryAndFeatureWorktree = {
@@ -108,7 +139,16 @@ describe("Workspace", () => {
     await fs.writeFile(path.join(repoPath, "notes.txt"), "note\n", "utf8");
     const untrackedStatus = await workspace.getStatus();
     expect(untrackedStatus.workingTree.state).toBe("untracked");
-    expect(untrackedStatus.workingTree.files).toHaveLength(1);
+    expect(untrackedStatus.workingTree.files).toEqual([
+      {
+        path: "notes.txt",
+        status: "??",
+        insertions: 1,
+        deletions: 0,
+      },
+    ]);
+    expect(untrackedStatus.workingTree.insertions).toBe(1);
+    expect(untrackedStatus.workingTree.deletions).toBe(0);
 
     await fs.writeFile(
       path.join(repoPath, "README.md"),
@@ -275,8 +315,8 @@ describe("Workspace", () => {
       {
         path: "notes.txt",
         status: "??",
-        insertions: null,
-        deletions: null,
+        insertions: 1,
+        deletions: 0,
       },
     ]);
     expect(status.mergeBase).toMatchObject({
@@ -478,10 +518,12 @@ describe("Workspace", () => {
       {
         path: "notes.txt",
         status: "??",
-        insertions: null,
-        deletions: null,
+        insertions: 1,
+        deletions: 0,
       },
     ]);
+    expect(status.workingTree.insertions).toBe(1);
+    expect(status.workingTree.deletions).toBe(0);
   });
 
   it("returns diff content for each supported target", async () => {
@@ -533,6 +575,88 @@ describe("Workspace", () => {
       target: { type: "commit", sha: commitSha! },
     });
     expect(commitOnly.diff).toContain("+feature");
+  });
+
+  it("aligns committed-only status stats with all and committed diffs", async () => {
+    const repoPath = await initRepo();
+    await runGit(["checkout", "-b", "feature"], { cwd: repoPath });
+    await fs.writeFile(path.join(repoPath, "README.md"), "feature\n", "utf8");
+    await runGit(["add", "README.md"], { cwd: repoPath });
+    await runGit(["commit", "-m", "Feature commit"], { cwd: repoPath });
+
+    const workspace = new Workspace(repoPath);
+    const status = await workspace.getStatus({ mergeBaseBranch: "main" });
+    expect(status.workingTree.files).toEqual([]);
+    const mergeBase = status.mergeBase;
+    expect(mergeBase).not.toBeNull();
+    if (!mergeBase) {
+      throw new Error("Expected merge-base status");
+    }
+
+    const allChanges = await workspace.getDiff({
+      target: { type: "all", mergeBaseBranch: "main" },
+    });
+    const committedChanges = await workspace.getDiff({
+      target: { type: "branch_committed", mergeBaseBranch: "main" },
+    });
+    const bannerStats = tallyWorkspaceStats(mergeBase);
+
+    expect(bannerStats).toEqual(parseShortstat(allChanges.shortstat));
+    expect(bannerStats).toEqual(parseShortstat(committedChanges.shortstat));
+  });
+
+  it("aligns uncommitted-only status stats with all and uncommitted diffs", async () => {
+    const repoPath = await initRepo();
+    await fs.writeFile(
+      path.join(repoPath, "README.md"),
+      "hello\npending\n",
+      "utf8",
+    );
+    await fs.writeFile(path.join(repoPath, "notes.txt"), "note\n", "utf8");
+
+    const workspace = new Workspace(repoPath);
+    const status = await workspace.getStatus({ mergeBaseBranch: "main" });
+    expect(status.mergeBase?.files ?? []).toEqual([]);
+
+    const allChanges = await workspace.getDiff({
+      target: { type: "all", mergeBaseBranch: "main" },
+    });
+    const uncommittedChanges = await workspace.getDiff({
+      target: { type: "uncommitted" },
+    });
+    const bannerStats = tallyWorkspaceStats(status.workingTree);
+
+    expect(bannerStats).toEqual(parseShortstat(allChanges.shortstat));
+    expect(bannerStats).toEqual(parseShortstat(uncommittedChanges.shortstat));
+  });
+
+  it("aligns mixed status working-tree stats with uncommitted diffs", async () => {
+    const repoPath = await initRepo();
+    await runGit(["checkout", "-b", "feature"], { cwd: repoPath });
+    await fs.writeFile(path.join(repoPath, "README.md"), "feature\n", "utf8");
+    await runGit(["add", "README.md"], { cwd: repoPath });
+    await runGit(["commit", "-m", "Feature commit"], { cwd: repoPath });
+    await fs.writeFile(
+      path.join(repoPath, "README.md"),
+      "feature\npending\n",
+      "utf8",
+    );
+    await fs.writeFile(path.join(repoPath, "notes.txt"), "note\n", "utf8");
+
+    const workspace = new Workspace(repoPath);
+    const status = await workspace.getStatus({ mergeBaseBranch: "main" });
+    expect(status.workingTree.state).toBe("dirty_and_committed_unmerged");
+
+    const allChanges = await workspace.getDiff({
+      target: { type: "all", mergeBaseBranch: "main" },
+    });
+    const uncommittedChanges = await workspace.getDiff({
+      target: { type: "uncommitted" },
+    });
+    const bannerStats = tallyWorkspaceStats(status.workingTree);
+
+    expect(bannerStats).toEqual(parseShortstat(uncommittedChanges.shortstat));
+    expect(bannerStats).not.toEqual(parseShortstat(allChanges.shortstat));
   });
 
   it("truncates large git diff output before the process buffer fails", async () => {


### PR DESCRIPTION
## Summary
- include synthesized untracked-file numstat entries in workspace status so context banner line stats match diff output for untracked files
- add regression coverage for committed-only, uncommitted-only, and mixed committed/uncommitted scope comparisons
- refresh prompt banner story/comment fixtures for untracked stats

## Tests
- pnpm exec turbo run test --filter=@bb/host-workspace
- pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app