### PR TITLE
Resolve composer defaults server-side

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -18,10 +18,8 @@ import {
 } from "@/components/ui/sidebar.js";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { AppPageHeader, HEADER_ICON_BUTTON_CLASS } from "./AppPageHeader";
-import {
-  useSidebarNavigation,
-  stripProjectThreads,
-} from "@/hooks/queries/project-queries";
+import { stripProjectThreads } from "@/hooks/queries/project-queries";
+import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import {
   useThread,
   useThreadDetailBootstrap,

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -27,10 +27,8 @@ import {
   useConnectionAwareQueryState,
   type ConnectionAwareQueryStatus,
 } from "@/hooks/queries/connection-aware-query-state";
-import {
-  stripProjectThreads,
-  useSidebarNavigation,
-} from "@/hooks/queries/project-queries";
+import { stripProjectThreads } from "@/hooks/queries/project-queries";
+import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useReorderProject } from "@/hooks/mutations/project-mutations";
 import { useReorderPinnedThread } from "@/hooks/mutations/thread-state-mutations";
 import {

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -71,7 +71,6 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "threadsQueryKey",
   ],
   "hooks/cache-owners/composer-cache-owner.ts": [
-    "threadDefaultExecutionOptionsQueryKey",
     "threadPendingInteractionsQueryKey",
     "threadPromptHistoryQueryKey",
     "threadQueuedMessagesQueryKey",
@@ -83,7 +82,6 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "environmentPathsQueryKeyPrefix",
     "environmentWorkStatusQueryKeyPrefix",
     "systemExecutionOptionsEnvironmentQueryKeyPrefix",
-    "threadComposerBootstrapEnvironmentQueryKeyPrefix",
   ],
   "hooks/cache-owners/environment-workspace-cache-owner.ts": [
     "environmentQueryKey",
@@ -91,7 +89,6 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
   "hooks/cache-owners/mutation-cache-effects.ts": [
     "projectPathsQueryKeyPrefix",
     "sidebarNavigationQueryKey",
-    "threadDefaultExecutionOptionsQueryKey",
     "threadPromptHistoryQueryKey",
     "threadQueryKey",
     "threadQueuedMessagesQueryKey",
@@ -157,7 +154,6 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "allHostQueryKeyPrefix",
     "allProjectPathsQueryKeyPrefix",
     "allSystemExecutionOptionsQueryKeyPrefix",
-    "allThreadDefaultExecutionOptionsQueryKeyPrefix",
     "allThreadPendingInteractionsQueryKeyPrefix",
     "allThreadQueryKeyPrefix",
     "allThreadQueuedMessagesQueryKeyPrefix",
@@ -186,7 +182,6 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "environmentQueryKey",
     "hostQueryKey",
     "hostsQueryKey",
-    "threadComposerBootstrapQueryKey",
     "threadQueryKey",
     "threadTimelineQueryKey",
   ],

--- a/apps/app/src/hooks/cache-owners/composer-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/composer-cache-owner.ts
@@ -1,8 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { ThreadComposerBootstrapResponse } from "@bb/server-contract";
-import * as api from "@/lib/api";
+import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default-execution-options-query";
 import {
-  threadDefaultExecutionOptionsQueryKey,
   threadPendingInteractionsQueryKey,
   threadPromptHistoryQueryKey,
   threadQueuedMessagesQueryKey,
@@ -11,13 +10,6 @@ import { seedSystemExecutionOptionsCache } from "./system-cache-effects";
 
 interface ThreadComposerBootstrapHydrationArgs {
   bootstrap: ThreadComposerBootstrapResponse;
-  environmentId: string | null;
-  providerId: string | null;
-  queryClient: QueryClient;
-  threadId: string;
-}
-
-interface FetchAndHydrateThreadComposerBootstrapArgs {
   environmentId: string | null;
   providerId: string | null;
   queryClient: QueryClient;
@@ -63,21 +55,4 @@ export function hydrateThreadComposerBootstrap({
       queryClient,
     });
   }
-}
-
-export async function fetchAndHydrateThreadComposerBootstrap({
-  environmentId,
-  providerId,
-  queryClient,
-  threadId,
-}: FetchAndHydrateThreadComposerBootstrapArgs): Promise<ThreadComposerBootstrapResponse> {
-  const bootstrap = await api.getThreadComposerBootstrap(threadId);
-  hydrateThreadComposerBootstrap({
-    bootstrap,
-    environmentId,
-    providerId,
-    queryClient,
-    threadId,
-  });
-  return bootstrap;
 }

--- a/apps/app/src/hooks/cache-owners/environment-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/environment-cache-effects.ts
@@ -9,8 +9,8 @@ import {
   environmentPathsQueryKeyPrefix,
   environmentWorkStatusQueryKeyPrefix,
   systemExecutionOptionsEnvironmentQueryKeyPrefix,
-  threadComposerBootstrapEnvironmentQueryKeyPrefix,
 } from "../queries/query-keys";
+import { threadComposerBootstrapEnvironmentQueryKeyPrefix } from "../queries/thread-composer-bootstrap-query";
 import type {
   EnvironmentArg,
   OptionalEnvironmentArg,

--- a/apps/app/src/hooks/cache-owners/mutation-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/mutation-cache-effects.ts
@@ -1,7 +1,6 @@
 import {
   projectPathsQueryKeyPrefix,
   sidebarNavigationQueryKey,
-  threadDefaultExecutionOptionsQueryKey,
   threadQueuedMessagesQueryKey,
   threadPromptHistoryQueryKey,
   threadQueryKey,
@@ -12,6 +11,7 @@ import {
   threadTimelineQueryKeyPrefix,
   threadTimelineTurnSummaryDetailsQueryKeyPrefix,
 } from "../queries/query-keys";
+import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default-execution-options-query";
 import type {
   ProjectArg,
   QueryClientArg,

--- a/apps/app/src/hooks/cache-owners/system-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/system-cache-effects.ts
@@ -9,7 +9,6 @@ import {
   allHostQueryKeyPrefix,
   allProjectPathsQueryKeyPrefix,
   allSystemExecutionOptionsQueryKeyPrefix,
-  allThreadDefaultExecutionOptionsQueryKeyPrefix,
   allThreadQueuedMessagesQueryKeyPrefix,
   allThreadPendingInteractionsQueryKeyPrefix,
   allThreadQueryKeyPrefix,
@@ -28,6 +27,7 @@ import {
   threadPromptHistoryQueryKeyPrefix,
   threadsQueryKey,
 } from "../queries/query-keys";
+import { allThreadDefaultExecutionOptionsQueryKeyPrefix } from "../queries/thread-default-execution-options-query";
 import type { QueryClientArg } from "../cache-effect-types";
 import {
   invalidateQueryKeys,

--- a/apps/app/src/hooks/cache-owners/thread-detail-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-detail-cache-owner.ts
@@ -6,12 +6,14 @@ import type {
 } from "@bb/server-contract";
 import * as api from "@/lib/api";
 import { getCachedThreadListPlaceholder } from "./query-cache";
-import { fetchAndHydrateThreadComposerBootstrap } from "./composer-cache-owner";
+import {
+  fetchAndHydrateThreadComposerBootstrap,
+  threadComposerBootstrapQueryKey,
+} from "../queries/thread-composer-bootstrap-query";
 import {
   environmentQueryKey,
   hostQueryKey,
   hostsQueryKey,
-  threadComposerBootstrapQueryKey,
   threadQueryKey,
   threadTimelineQueryKey,
 } from "../queries/query-keys";

--- a/apps/app/src/hooks/queries/project-default-execution-options-query.ts
+++ b/apps/app/src/hooks/queries/project-default-execution-options-query.ts
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ProjectExecutionDefaults } from "@bb/domain";
+import { apiClient } from "@/lib/api-server";
+import { request } from "@/lib/api";
+import { requireEnabledQueryArg } from "./query-helpers";
+
+export const PROJECT_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY =
+  "projectDefaultExecutionOptions";
+
+export type ProjectDefaultExecutionOptionsQueryKey = readonly [
+  typeof PROJECT_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY,
+  string,
+];
+
+interface QueryOptions {
+  enabled?: boolean;
+}
+
+interface ProjectDefaultExecutionOptionsQueryKeyArgs {
+  projectId: string;
+}
+
+interface UseProjectDefaultExecutionOptionsArgs {
+  projectId: string | undefined;
+}
+
+interface FetchProjectDefaultExecutionOptionsArgs {
+  projectId: string;
+}
+
+function requireProjectId(
+  projectId: string | undefined,
+  hookName: string,
+): string {
+  return requireEnabledQueryArg({
+    value: projectId,
+    hookName,
+    argName: "projectId",
+  });
+}
+
+export function projectDefaultExecutionOptionsQueryKey({
+  projectId,
+}: ProjectDefaultExecutionOptionsQueryKeyArgs): ProjectDefaultExecutionOptionsQueryKey {
+  return [PROJECT_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY, projectId];
+}
+
+export function fetchProjectDefaultExecutionOptions({
+  projectId,
+}: FetchProjectDefaultExecutionOptionsArgs): Promise<ProjectExecutionDefaults | null> {
+  return request<ProjectExecutionDefaults | null>(
+    apiClient.projects[":id"]["default-execution-options"].$get({
+      param: { id: projectId },
+      query: {},
+    }),
+  );
+}
+
+export function useProjectDefaultExecutionOptions(
+  args: UseProjectDefaultExecutionOptionsArgs,
+  options?: QueryOptions,
+) {
+  const { projectId } = args;
+  return useQuery<ProjectExecutionDefaults | null>({
+    queryKey: projectDefaultExecutionOptionsQueryKey({
+      projectId: projectId ?? "",
+    }),
+    queryFn: () =>
+      fetchProjectDefaultExecutionOptions({
+        projectId: requireProjectId(
+          projectId,
+          "useProjectDefaultExecutionOptions",
+        ),
+      }),
+    enabled: (options?.enabled ?? true) && Boolean(projectId),
+    staleTime: 10_000,
+    placeholderData: (previousData) => (projectId ? previousData : undefined),
+  });
+}

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -1,21 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import type { ProjectExecutionDefaults } from "@bb/domain";
 import type {
   CommandListResponse,
   ProjectBranchesResponse,
   ProjectWithThreadsResponse,
   PromptHistoryResponse,
-  SidebarBootstrapResponse,
   WorkspacePathListResponse,
 } from "@bb/server-contract";
 import * as api from "@/lib/api";
 import {
   projectCommandsQueryKey,
-  projectDefaultExecutionOptionsQueryKey,
   projectPathsQueryKey,
   projectPromptHistoryQueryKey,
   projectSourceBranchesQueryKey,
-  sidebarNavigationQueryKey,
 } from "./query-keys";
 import { resolveProjectSourceBranchesPlaceholder } from "./query-placeholders";
 import {
@@ -31,10 +27,6 @@ interface BranchQueryOptions extends QueryOptions {
   limit?: number;
   query?: string;
   selectedBranch?: string;
-}
-
-interface UseProjectDefaultExecutionOptionsArgs {
-  projectId: string | undefined;
 }
 
 interface UseProjectPathSuggestionsArgs {
@@ -85,15 +77,6 @@ export function stripProjectThreads(
 ): SidebarProject {
   const { threads, ...rest } = project;
   return rest;
-}
-
-export function useSidebarNavigation(options?: QueryOptions) {
-  return useQuery<SidebarBootstrapResponse>({
-    queryKey: sidebarNavigationQueryKey(),
-    queryFn: ({ signal }) => api.listProjectsWithThreads(signal),
-    enabled: options?.enabled ?? true,
-    staleTime: Infinity,
-  });
 }
 
 export function useProjectSourceBranches(
@@ -155,28 +138,6 @@ export function useProjectPromptHistory(
       ),
     enabled: (options?.enabled ?? true) && Boolean(projectId),
     staleTime: PROMPT_HISTORY_STALE_TIME_MS,
-  });
-}
-
-export function useProjectDefaultExecutionOptions(
-  args: UseProjectDefaultExecutionOptionsArgs,
-  options?: QueryOptions,
-) {
-  const { projectId } = args;
-  return useQuery<ProjectExecutionDefaults | null>({
-    queryKey: projectDefaultExecutionOptionsQueryKey({
-      projectId: projectId ?? "",
-    }),
-    queryFn: () =>
-      api.getProjectDefaultExecutionOptions({
-        projectId: requireProjectId(
-          projectId,
-          "useProjectDefaultExecutionOptions",
-        ),
-      }),
-    enabled: (options?.enabled ?? true) && Boolean(projectId),
-    staleTime: 10_000,
-    placeholderData: (previousData) => (projectId ? previousData : undefined),
   });
 }
 

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { apiClient } from "@/lib/api-server";
+import { request, requestOptions } from "@/lib/api";
+
+export const SIDEBAR_NAVIGATION_QUERY_KEY = "sidebarNavigation";
+
+export type SidebarNavigationQueryKey = readonly [
+  typeof SIDEBAR_NAVIGATION_QUERY_KEY,
+];
+
+interface QueryOptions {
+  enabled?: boolean;
+}
+
+export function sidebarNavigationQueryKey(): SidebarNavigationQueryKey {
+  return [SIDEBAR_NAVIGATION_QUERY_KEY];
+}
+
+export function fetchSidebarNavigation(
+  signal?: AbortSignal,
+): Promise<SidebarBootstrapResponse> {
+  return request<SidebarBootstrapResponse>(
+    apiClient["sidebar-bootstrap"].$get(undefined, requestOptions(signal)),
+  );
+}
+
+export function useSidebarNavigation(options?: QueryOptions) {
+  return useQuery<SidebarBootstrapResponse>({
+    queryKey: sidebarNavigationQueryKey(),
+    queryFn: ({ signal }) => fetchSidebarNavigation(signal),
+    enabled: options?.enabled ?? true,
+    staleTime: Infinity,
+  });
+}

--- a/apps/app/src/hooks/queries/thread-composer-bootstrap-query.ts
+++ b/apps/app/src/hooks/queries/thread-composer-bootstrap-query.ts
@@ -1,0 +1,109 @@
+import {
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
+import type { ThreadComposerBootstrapResponse } from "@bb/server-contract";
+import { apiClient } from "@/lib/api-server";
+import { request } from "@/lib/api";
+import { hydrateThreadComposerBootstrap } from "../cache-owners/composer-cache-owner";
+import { requireEnabledQueryArg } from "./query-helpers";
+
+export const THREAD_COMPOSER_BOOTSTRAP_QUERY_KEY = "threadComposerBootstrap";
+
+export type ThreadComposerBootstrapQueryKey = readonly [
+  typeof THREAD_COMPOSER_BOOTSTRAP_QUERY_KEY,
+  string | null,
+  string,
+];
+export type ThreadComposerBootstrapEnvironmentQueryKeyPrefix = readonly [
+  typeof THREAD_COMPOSER_BOOTSTRAP_QUERY_KEY,
+  string | null,
+];
+
+interface ThreadComposerBootstrapQueryOptions {
+  enabled?: boolean;
+  environmentId?: string;
+  providerId?: string;
+  refetchOnMount?: boolean | "always";
+  staleTime?: number;
+}
+
+interface FetchAndHydrateThreadComposerBootstrapArgs {
+  environmentId: string | null;
+  providerId: string | null;
+  queryClient: QueryClient;
+  threadId: string;
+}
+
+const THREAD_COMPOSER_BOOTSTRAP_STALE_TIME_MS = 10_000;
+const THREAD_COMPOSER_BOOTSTRAP_GC_TIME_MS = 30_000;
+
+function requireThreadId(id: string, hookName: string): string {
+  return requireEnabledQueryArg({ value: id, hookName, argName: "thread id" });
+}
+
+export function threadComposerBootstrapQueryKey(
+  threadId: string,
+  environmentId: string | null,
+): ThreadComposerBootstrapQueryKey {
+  return [THREAD_COMPOSER_BOOTSTRAP_QUERY_KEY, environmentId, threadId];
+}
+
+export function threadComposerBootstrapEnvironmentQueryKeyPrefix(
+  environmentId: string | null,
+): ThreadComposerBootstrapEnvironmentQueryKeyPrefix {
+  return [THREAD_COMPOSER_BOOTSTRAP_QUERY_KEY, environmentId];
+}
+
+export function fetchThreadComposerBootstrap(
+  threadId: string,
+): Promise<ThreadComposerBootstrapResponse> {
+  return request<ThreadComposerBootstrapResponse>(
+    apiClient.threads[":id"]["composer-bootstrap"].$get({
+      param: { id: threadId },
+    }),
+  );
+}
+
+export async function fetchAndHydrateThreadComposerBootstrap({
+  environmentId,
+  providerId,
+  queryClient,
+  threadId,
+}: FetchAndHydrateThreadComposerBootstrapArgs): Promise<ThreadComposerBootstrapResponse> {
+  const bootstrap = await fetchThreadComposerBootstrap(threadId);
+  hydrateThreadComposerBootstrap({
+    bootstrap,
+    environmentId,
+    providerId,
+    queryClient,
+    threadId,
+  });
+  return bootstrap;
+}
+
+export function useThreadComposerBootstrap(
+  id: string,
+  options?: ThreadComposerBootstrapQueryOptions,
+) {
+  const queryClient = useQueryClient();
+  const environmentId = options?.environmentId ?? null;
+  const providerId = options?.providerId ?? null;
+
+  return useQuery<ThreadComposerBootstrapResponse>({
+    queryKey: threadComposerBootstrapQueryKey(id, environmentId),
+    queryFn: () =>
+      fetchAndHydrateThreadComposerBootstrap({
+        environmentId,
+        providerId,
+        queryClient,
+        threadId: requireThreadId(id, "useThreadComposerBootstrap"),
+      }),
+    enabled: (options?.enabled ?? true) && Boolean(id),
+    refetchOnMount: options?.refetchOnMount ?? true,
+    refetchOnWindowFocus: false,
+    staleTime: options?.staleTime ?? THREAD_COMPOSER_BOOTSTRAP_STALE_TIME_MS,
+    gcTime: THREAD_COMPOSER_BOOTSTRAP_GC_TIME_MS,
+  });
+}

--- a/apps/app/src/hooks/queries/thread-default-execution-options-query.ts
+++ b/apps/app/src/hooks/queries/thread-default-execution-options-query.ts
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ResolvedThreadExecutionOptions } from "@bb/domain";
+import { apiClient } from "@/lib/api-server";
+import { request } from "@/lib/api";
+import { requireEnabledQueryArg } from "./query-helpers";
+
+export const THREAD_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY =
+  "threadDefaultExecutionOptions";
+
+export type ThreadDefaultExecutionOptionsQueryKeyPrefix = readonly [
+  typeof THREAD_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY,
+];
+export type ThreadDefaultExecutionOptionsQueryKey = readonly [
+  typeof THREAD_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY,
+  string,
+];
+
+interface ThreadDefaultExecutionOptionsQueryOptions {
+  enabled?: boolean;
+  refetchOnMount?: boolean | "always";
+  staleTime?: number;
+}
+
+function requireThreadId(id: string, hookName: string): string {
+  return requireEnabledQueryArg({ value: id, hookName, argName: "thread id" });
+}
+
+export function threadDefaultExecutionOptionsQueryKey(
+  threadId: string,
+): ThreadDefaultExecutionOptionsQueryKey {
+  return [THREAD_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY, threadId];
+}
+
+export function allThreadDefaultExecutionOptionsQueryKeyPrefix(): ThreadDefaultExecutionOptionsQueryKeyPrefix {
+  return [THREAD_DEFAULT_EXECUTION_OPTIONS_QUERY_KEY];
+}
+
+export function fetchThreadDefaultExecutionOptions(
+  threadId: string,
+): Promise<ResolvedThreadExecutionOptions | null> {
+  return request<ResolvedThreadExecutionOptions | null>(
+    apiClient.threads[":id"]["default-execution-options"].$get({
+      param: { id: threadId },
+    }),
+  );
+}
+
+export function useThreadDefaultExecutionOptions(
+  id: string,
+  options?: ThreadDefaultExecutionOptionsQueryOptions,
+) {
+  return useQuery<ResolvedThreadExecutionOptions | null>({
+    queryKey: threadDefaultExecutionOptionsQueryKey(id),
+    queryFn: () =>
+      fetchThreadDefaultExecutionOptions(
+        requireThreadId(id, "useThreadDefaultExecutionOptions"),
+      ),
+    enabled: (options?.enabled ?? true) && Boolean(id),
+    refetchOnMount: options?.refetchOnMount ?? true,
+    refetchOnWindowFocus: false,
+    staleTime: options?.staleTime,
+  });
+}

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -5,14 +5,10 @@ import {
   type QueryClient,
 } from "@tanstack/react-query";
 import { useMemo } from "react";
-import type {
-  PendingInteraction,
-  ResolvedThreadExecutionOptions,
-} from "@bb/domain";
+import type { PendingInteraction } from "@bb/domain";
 import type {
   AutomationsOverviewResponse,
   PromptHistoryResponse,
-  ThreadComposerBootstrapResponse,
   ThreadQueuedMessageListResponse,
   ThreadListResponse,
   ThreadPendingInteractionsResponse,
@@ -28,7 +24,6 @@ import type { ThreadListFilters, FilePreview } from "@/lib/api";
 import type { PathListOptions } from "@/lib/path-list-options";
 import type { ThreadStorageFileListOptions } from "@/lib/thread-storage-files";
 import * as api from "@/lib/api";
-import { fetchAndHydrateThreadComposerBootstrap } from "../cache-owners/composer-cache-owner";
 import {
   getCachedSidebarNavigationThreads,
   getCachedThreadListPlaceholder,
@@ -49,9 +44,7 @@ import {
   archivedThreadsListQueryKey,
   automationsOverviewQueryKey,
   disabledThreadListQueryKey,
-  threadComposerBootstrapQueryKey,
   threadDetailBootstrapQueryKey,
-  threadDefaultExecutionOptionsQueryKey,
   threadQueuedMessagesQueryKey,
   threadListQueryKey,
   threadPendingInteractionsQueryKey,
@@ -78,14 +71,7 @@ interface QueryOptions {
 }
 
 const THREAD_LIST_STALE_TIME_MS = 10_000;
-const THREAD_COMPOSER_BOOTSTRAP_STALE_TIME_MS = 10_000;
-const THREAD_COMPOSER_BOOTSTRAP_GC_TIME_MS = 30_000;
 export const THREAD_MENTION_CANDIDATE_LIMIT = 200;
-
-interface ThreadComposerBootstrapQueryOptions extends QueryOptions {
-  environmentId?: string;
-  providerId?: string;
-}
 
 interface ThreadDetailBootstrapQueryOptions extends QueryOptions {
   composerBootstrapPrefetch?: boolean;
@@ -95,8 +81,6 @@ interface ThreadDetailBootstrapQueryOptions extends QueryOptions {
 type ThreadTimelineQueryOptions = QueryOptions;
 
 type ThreadTimelineTurnSummaryDetailsQueryOptions = QueryOptions;
-
-type ThreadDefaultExecutionOptionsQueryOptions = QueryOptions;
 
 type ThreadQueuedMessagesQueryOptions = QueryOptions;
 
@@ -458,48 +442,6 @@ export function useThreadDetailBootstrap(
     },
     enabled: (options?.enabled ?? true) && Boolean(id),
     staleTime: Infinity,
-  });
-}
-
-export function useThreadComposerBootstrap(
-  id: string,
-  options?: ThreadComposerBootstrapQueryOptions,
-) {
-  const queryClient = useQueryClient();
-  const environmentId = options?.environmentId ?? null;
-  const providerId = options?.providerId ?? null;
-
-  return useQuery<ThreadComposerBootstrapResponse>({
-    queryKey: threadComposerBootstrapQueryKey(id, environmentId),
-    queryFn: () =>
-      fetchAndHydrateThreadComposerBootstrap({
-        environmentId,
-        providerId,
-        queryClient,
-        threadId: requireThreadId(id, "useThreadComposerBootstrap"),
-      }),
-    enabled: (options?.enabled ?? true) && Boolean(id),
-    refetchOnMount: options?.refetchOnMount ?? true,
-    refetchOnWindowFocus: false,
-    staleTime: options?.staleTime ?? THREAD_COMPOSER_BOOTSTRAP_STALE_TIME_MS,
-    gcTime: THREAD_COMPOSER_BOOTSTRAP_GC_TIME_MS,
-  });
-}
-
-export function useThreadDefaultExecutionOptions(
-  id: string,
-  options?: ThreadDefaultExecutionOptionsQueryOptions,
-) {
-  return useQuery<ResolvedThreadExecutionOptions | null>({
-    queryKey: threadDefaultExecutionOptionsQueryKey(id),
-    queryFn: () =>
-      api.getThreadDefaultExecutionOptions(
-        requireThreadId(id, "useThreadDefaultExecutionOptions"),
-      ),
-    enabled: (options?.enabled ?? true) && Boolean(id),
-    refetchOnMount: options?.refetchOnMount ?? true,
-    refetchOnWindowFocus: false,
-    staleTime: options?.staleTime,
   });
 }
 

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -1,0 +1,189 @@
+import { useAtom } from "jotai";
+import { useCallback } from "react";
+import type { PermissionMode, ReasoningLevel, ServiceTier } from "@bb/domain";
+import {
+  createPersistedEnumAtom,
+  createProjectScopedStorageAtomFamily,
+  rawStringLocalStorage,
+} from "@/lib/browser-storage";
+
+const MODEL_STORAGE_KEY = "bb.promptbox.model";
+const SERVICE_TIER_STORAGE_KEY = "bb.promptbox.service-tier";
+const REASONING_STORAGE_KEY = "bb.promptbox.reasoning";
+const PERMISSION_MODE_STORAGE_KEY = "bb.promptbox.permission-mode";
+const ENVIRONMENT_STORAGE_KEY = "bb.promptbox.environment";
+const PROVIDER_STORAGE_KEY = "bb.promptbox.provider";
+
+export type StoredServiceTier = "" | ServiceTier;
+export type StoredReasoningLevel = "" | ReasoningLevel;
+export type StoredPermissionMode = "" | PermissionMode;
+
+type ProjectScopedStorageParam = string | null | undefined;
+type StringSelectionSetter = (value: string) => void;
+type StoredServiceTierSetter = (value: StoredServiceTier) => void;
+type StoredReasoningLevelSetter = (value: StoredReasoningLevel) => void;
+type StoredPermissionModeSetter = (value: StoredPermissionMode) => void;
+
+export interface PersistedStringSelectionField {
+  setValue: StringSelectionSetter;
+  value: string;
+}
+
+export interface PersistedServiceTierSelectionField {
+  setValue: StoredServiceTierSetter;
+  value: StoredServiceTier;
+}
+
+export interface PersistedReasoningLevelSelectionField {
+  setValue: StoredReasoningLevelSetter;
+  value: StoredReasoningLevel;
+}
+
+export interface PersistedPermissionModeSelectionField {
+  setValue: StoredPermissionModeSetter;
+  value: StoredPermissionMode;
+}
+
+function isReasoningLevel(value: string): value is ReasoningLevel {
+  return (
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh" ||
+    value === "ultracode" ||
+    value === "max"
+  );
+}
+
+function isPermissionMode(value: string): value is PermissionMode {
+  return (
+    value === "readonly" || value === "workspace-write" || value === "full"
+  );
+}
+
+function isServiceTier(value: string): value is ServiceTier {
+  return value === "fast" || value === "default";
+}
+
+function isStoredServiceTier(value: string): value is StoredServiceTier {
+  return value === "" || isServiceTier(value);
+}
+
+function isStoredReasoningLevel(value: string): value is StoredReasoningLevel {
+  return value === "" || isReasoningLevel(value);
+}
+
+function isStoredPermissionMode(value: string): value is StoredPermissionMode {
+  return value === "" || isPermissionMode(value);
+}
+
+const providerIdAtomFamily = createProjectScopedStorageAtomFamily(
+  PROVIDER_STORAGE_KEY,
+  "",
+  rawStringLocalStorage,
+);
+const modelAtomFamily = createProjectScopedStorageAtomFamily(
+  MODEL_STORAGE_KEY,
+  "",
+  rawStringLocalStorage,
+);
+const serviceTierAtomFamily = createPersistedEnumAtom<StoredServiceTier>({
+  baseKey: SERVICE_TIER_STORAGE_KEY,
+  initialValue: "",
+  isValue: isStoredServiceTier,
+});
+const reasoningLevelAtomFamily = createPersistedEnumAtom<StoredReasoningLevel>({
+  baseKey: REASONING_STORAGE_KEY,
+  initialValue: "",
+  isValue: isStoredReasoningLevel,
+});
+const permissionModeAtomFamily = createPersistedEnumAtom<StoredPermissionMode>({
+  baseKey: PERMISSION_MODE_STORAGE_KEY,
+  initialValue: "",
+  isValue: isStoredPermissionMode,
+});
+const environmentSelectionAtomFamily = createProjectScopedStorageAtomFamily(
+  ENVIRONMENT_STORAGE_KEY,
+  "",
+  rawStringLocalStorage,
+);
+
+export function usePersistedProviderSelection(
+  projectId: ProjectScopedStorageParam,
+): PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(providerIdAtomFamily(projectId));
+  const setValue = useCallback(
+    (nextValue: string) => {
+      setAtomValue(nextValue);
+    },
+    [setAtomValue],
+  );
+  return { setValue, value };
+}
+
+export function usePersistedModelSelection(
+  projectId: ProjectScopedStorageParam,
+): PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(modelAtomFamily(projectId));
+  const setValue = useCallback(
+    (nextValue: string) => {
+      setAtomValue(nextValue);
+    },
+    [setAtomValue],
+  );
+  return { setValue, value };
+}
+
+export function usePersistedServiceTierSelection(
+  projectId: ProjectScopedStorageParam,
+): PersistedServiceTierSelectionField {
+  const [value, setAtomValue] = useAtom(serviceTierAtomFamily(projectId));
+  const setValue = useCallback(
+    (nextValue: StoredServiceTier) => {
+      setAtomValue(nextValue);
+    },
+    [setAtomValue],
+  );
+  return { setValue, value };
+}
+
+export function usePersistedReasoningLevelSelection(
+  projectId: ProjectScopedStorageParam,
+): PersistedReasoningLevelSelectionField {
+  const [value, setAtomValue] = useAtom(reasoningLevelAtomFamily(projectId));
+  const setValue = useCallback(
+    (nextValue: StoredReasoningLevel) => {
+      setAtomValue(nextValue);
+    },
+    [setAtomValue],
+  );
+  return { setValue, value };
+}
+
+export function usePersistedPermissionModeSelection(
+  projectId: ProjectScopedStorageParam,
+): PersistedPermissionModeSelectionField {
+  const [value, setAtomValue] = useAtom(permissionModeAtomFamily(projectId));
+  const setValue = useCallback(
+    (nextValue: StoredPermissionMode) => {
+      setAtomValue(nextValue);
+    },
+    [setAtomValue],
+  );
+  return { setValue, value };
+}
+
+export function usePersistedEnvironmentSelection(
+  projectId: ProjectScopedStorageParam,
+): PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(
+    environmentSelectionAtomFamily(projectId),
+  );
+  const setValue = useCallback(
+    (nextValue: string) => {
+      setAtomValue(nextValue);
+    },
+    [setAtomValue],
+  );
+  return { setValue, value };
+}

--- a/apps/app/src/hooks/thread-creation-options/selection-state.ts
+++ b/apps/app/src/hooks/thread-creation-options/selection-state.ts
@@ -1,0 +1,312 @@
+import type { PermissionMode, ReasoningLevel, ServiceTier } from "@bb/domain";
+import type {
+  CreateExecutionInputSources,
+  ExecutionInputFieldSource,
+  ExistingThreadExecutionInputSources,
+} from "@bb/server-contract";
+import type {
+  StoredPermissionMode,
+  StoredReasoningLevel,
+  StoredServiceTier,
+} from "./persisted-selection-fields";
+
+export type ThreadCreationOptionsScope = "new-thread" | "component-local";
+
+export interface ThreadPromptSelections {
+  selectedProviderId: string;
+  selectedModel: string;
+  serviceTier: ServiceTier | undefined;
+  reasoningLevel: ReasoningLevel;
+  permissionMode: PermissionMode;
+  environmentSelectionValue: string;
+}
+
+export type ThreadPromptField = keyof ThreadPromptSelections;
+
+export type ScopedExecutionInputSources =
+  | CreateExecutionInputSources
+  | ExistingThreadExecutionInputSources;
+
+export interface UsePromptModelReasoningOptions {
+  enabled?: boolean;
+  environmentId?: string;
+  scope?: ThreadCreationOptionsScope;
+  projectId?: string | null;
+  resetKey?: string | number | null;
+  initialProviderId?: string;
+  initialModel?: string;
+  initialServiceTier?: ServiceTier;
+  initialReasoningLevel?: ReasoningLevel;
+  initialPermissionMode?: PermissionMode;
+  initialEnvironmentSelectionValue?: string;
+}
+
+export interface UseNewThreadCreationOptions extends UsePromptModelReasoningOptions {
+  scope?: "new-thread";
+}
+
+export interface UseComponentLocalCreationOptions extends UsePromptModelReasoningOptions {
+  scope: "component-local";
+}
+
+export interface StoredCreateExecutionValues {
+  selectedProviderId: string;
+  selectedModel: string;
+  serviceTier: StoredServiceTier;
+  reasoningLevel: StoredReasoningLevel;
+  permissionMode: StoredPermissionMode;
+}
+
+export interface EffectiveCreateExecutionValues {
+  selectedProviderId: string;
+  selectedModel: string;
+  serviceTier: ServiceTier | undefined;
+  reasoningLevel: ReasoningLevel;
+  permissionMode: PermissionMode;
+}
+
+export interface BuildExecutionInputSourcesArgs {
+  effectiveValues: EffectiveCreateExecutionValues;
+  scope: ThreadCreationOptionsScope;
+  storedValues: StoredCreateExecutionValues;
+  touchedFields: ReadonlySet<ThreadPromptField>;
+}
+
+export interface SyncThreadPromptSelectionsArgs {
+  currentSelections: ThreadPromptSelections;
+  nextSelections: ThreadPromptSelections;
+  touchedFields: ReadonlySet<ThreadPromptField>;
+}
+
+export interface UpdateThreadPromptSelectionsArgs {
+  currentSelections: ThreadPromptSelections;
+  field: ThreadPromptField;
+  value: ThreadPromptSelections[ThreadPromptField];
+}
+
+interface ResolveCreateExecutionInputSourceArgs {
+  hasStoredValue: boolean;
+  hasValue: boolean;
+  touched: boolean;
+}
+
+interface ResolvePermissionModeSelectionArgs {
+  rawPermissionMode: PermissionMode;
+  supportedPermissionModes: readonly PermissionMode[];
+}
+
+function hasValue(value: string): boolean {
+  return value.length > 0;
+}
+
+function resolveCreateExecutionInputSource({
+  hasStoredValue,
+  hasValue,
+  touched,
+}: ResolveCreateExecutionInputSourceArgs):
+  | ExecutionInputFieldSource
+  | undefined {
+  if (!hasValue) {
+    return undefined;
+  }
+  if (touched) {
+    return "explicit";
+  }
+  if (hasStoredValue) {
+    return "client-preference";
+  }
+  return undefined;
+}
+
+export function getInitialThreadPromptSelections(
+  options?: UsePromptModelReasoningOptions,
+): ThreadPromptSelections {
+  return {
+    selectedProviderId: options?.initialProviderId ?? "",
+    selectedModel: options?.initialModel ?? "",
+    serviceTier: options?.initialServiceTier,
+    reasoningLevel: options?.initialReasoningLevel ?? "medium",
+    permissionMode: options?.initialPermissionMode ?? "full",
+    environmentSelectionValue: options?.initialEnvironmentSelectionValue ?? "",
+  };
+}
+
+export function syncUntouchedThreadPromptSelections({
+  currentSelections,
+  nextSelections,
+  touchedFields,
+}: SyncThreadPromptSelectionsArgs): ThreadPromptSelections {
+  let changed = false;
+  const updatedSelections = { ...currentSelections };
+
+  if (
+    !touchedFields.has("selectedProviderId") &&
+    currentSelections.selectedProviderId !== nextSelections.selectedProviderId
+  ) {
+    updatedSelections.selectedProviderId = nextSelections.selectedProviderId;
+    changed = true;
+  }
+  if (
+    !touchedFields.has("selectedModel") &&
+    currentSelections.selectedModel !== nextSelections.selectedModel
+  ) {
+    updatedSelections.selectedModel = nextSelections.selectedModel;
+    changed = true;
+  }
+  if (
+    !touchedFields.has("serviceTier") &&
+    currentSelections.serviceTier !== nextSelections.serviceTier
+  ) {
+    updatedSelections.serviceTier = nextSelections.serviceTier;
+    changed = true;
+  }
+  if (
+    !touchedFields.has("reasoningLevel") &&
+    currentSelections.reasoningLevel !== nextSelections.reasoningLevel
+  ) {
+    updatedSelections.reasoningLevel = nextSelections.reasoningLevel;
+    changed = true;
+  }
+  if (
+    !touchedFields.has("permissionMode") &&
+    currentSelections.permissionMode !== nextSelections.permissionMode
+  ) {
+    updatedSelections.permissionMode = nextSelections.permissionMode;
+    changed = true;
+  }
+  if (
+    !touchedFields.has("environmentSelectionValue") &&
+    currentSelections.environmentSelectionValue !==
+      nextSelections.environmentSelectionValue
+  ) {
+    updatedSelections.environmentSelectionValue =
+      nextSelections.environmentSelectionValue;
+    changed = true;
+  }
+
+  return changed ? updatedSelections : currentSelections;
+}
+
+export function updateThreadPromptSelections({
+  currentSelections,
+  field,
+  value,
+}: UpdateThreadPromptSelectionsArgs): ThreadPromptSelections {
+  if (currentSelections[field] === value) {
+    return currentSelections;
+  }
+
+  return {
+    ...currentSelections,
+    [field]: value,
+  };
+}
+
+export function buildExecutionInputSources({
+  effectiveValues,
+  scope,
+  storedValues,
+  touchedFields,
+}: BuildExecutionInputSourcesArgs): ScopedExecutionInputSources {
+  const usesStoredValues = scope === "new-thread";
+  const hasTouchedExecutionField =
+    touchedFields.has("selectedProviderId") ||
+    touchedFields.has("selectedModel") ||
+    touchedFields.has("serviceTier") ||
+    touchedFields.has("reasoningLevel") ||
+    touchedFields.has("permissionMode");
+  // Existing-thread submissions are all-or-nothing once an execution control is
+  // touched, so the server never merges stale last-run values with new UI picks.
+  const forcesExplicitExecutionFields =
+    scope === "component-local" && hasTouchedExecutionField;
+
+  if (!usesStoredValues && scope !== "component-local") {
+    return {};
+  }
+
+  const providerSource = resolveCreateExecutionInputSource({
+    hasStoredValue:
+      usesStoredValues &&
+      hasValue(storedValues.selectedProviderId) &&
+      storedValues.selectedProviderId === effectiveValues.selectedProviderId,
+    hasValue: hasValue(effectiveValues.selectedProviderId),
+    touched: touchedFields.has("selectedProviderId"),
+  });
+  const modelSource = resolveCreateExecutionInputSource({
+    hasStoredValue:
+      usesStoredValues &&
+      hasValue(storedValues.selectedModel) &&
+      storedValues.selectedModel === effectiveValues.selectedModel,
+    hasValue: hasValue(effectiveValues.selectedModel),
+    touched:
+      forcesExplicitExecutionFields || touchedFields.has("selectedModel"),
+  });
+  const serviceTierSource = resolveCreateExecutionInputSource({
+    hasStoredValue:
+      usesStoredValues &&
+      storedValues.serviceTier !== "" &&
+      storedValues.serviceTier === effectiveValues.serviceTier,
+    hasValue: effectiveValues.serviceTier !== undefined,
+    touched: forcesExplicitExecutionFields || touchedFields.has("serviceTier"),
+  });
+  const reasoningLevelSource = resolveCreateExecutionInputSource({
+    hasStoredValue: usesStoredValues && storedValues.reasoningLevel !== "",
+    hasValue: hasValue(effectiveValues.reasoningLevel),
+    touched:
+      forcesExplicitExecutionFields || touchedFields.has("reasoningLevel"),
+  });
+  const permissionModeSource = resolveCreateExecutionInputSource({
+    hasStoredValue: usesStoredValues && storedValues.permissionMode !== "",
+    hasValue: hasValue(effectiveValues.permissionMode),
+    touched:
+      forcesExplicitExecutionFields || touchedFields.has("permissionMode"),
+  });
+
+  if (scope === "component-local") {
+    return {
+      ...(modelSource ? { model: modelSource } : {}),
+      ...(serviceTierSource ? { serviceTier: serviceTierSource } : {}),
+      ...(reasoningLevelSource ? { reasoningLevel: reasoningLevelSource } : {}),
+      ...(permissionModeSource ? { permissionMode: permissionModeSource } : {}),
+    };
+  }
+
+  return {
+    ...(providerSource ? { providerId: providerSource } : {}),
+    ...(modelSource ? { model: modelSource } : {}),
+    ...(serviceTierSource ? { serviceTier: serviceTierSource } : {}),
+    ...(reasoningLevelSource ? { reasoningLevel: reasoningLevelSource } : {}),
+    ...(permissionModeSource ? { permissionMode: permissionModeSource } : {}),
+  };
+}
+
+export function resolvePermissionModeSelection({
+  rawPermissionMode,
+  supportedPermissionModes,
+}: ResolvePermissionModeSelectionArgs): PermissionMode {
+  if (supportedPermissionModes.includes(rawPermissionMode)) {
+    return rawPermissionMode;
+  }
+  if (supportedPermissionModes.includes("full")) {
+    return "full";
+  }
+  return supportedPermissionModes[0] ?? "full";
+}
+
+export function formatModelLabel(value: string): string {
+  // Case-normalises a raw model id into a displayable label. The brand prefix
+  // strip ("Claude " / "GPT-") is a presentation rule applied by the picker
+  // itself (see `stripModelBrandPrefix`) so stories and prod render identically
+  // without anyone having to remember to format.
+  return value
+    .split("-")
+    .map((part) => {
+      if (part.toLowerCase() === "gpt") return "GPT";
+      if (/^\d+(\.\d+)*$/.test(part)) return part;
+      if (/^[a-z]+$/i.test(part)) {
+        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+      }
+      return part;
+    })
+    .join("-");
+}

--- a/apps/app/src/hooks/usePromptMentions.ts
+++ b/apps/app/src/hooks/usePromptMentions.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { buildPathMentionSuggestions } from "./pathMentionSuggestions";
-import { useSidebarNavigation } from "./queries/project-queries";
+import { useSidebarNavigation } from "./queries/sidebar-navigation-query";
 import { useThreadMentionCandidates } from "./queries/thread-queries";
 import { buildThreadMentionSuggestions } from "./threadMentionSuggestions";
 import { usePathSuggestions } from "./usePathSuggestions";

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -1,4 +1,3 @@
-import { useAtom } from "jotai";
 import {
   type ComponentType,
   useCallback,
@@ -16,30 +15,39 @@ import type {
 } from "@bb/domain";
 import type {
   CreateExecutionInputSources,
-  ExecutionInputFieldSource,
   ExistingThreadExecutionInputSources,
   SystemExecutionOptionsModelLoadError,
 } from "@bb/server-contract";
 import { parseEnvironmentValue } from "@/components/pickers/environment-picker-value";
-import {
-  createLocalStorageEnumStorage,
-  createProjectScopedStorageAtomFamily,
-  rawStringLocalStorage,
-} from "@/lib/browser-storage";
 import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { getProviderIconInfo } from "@/lib/provider-icon";
 import { reconcileReasoningLevel } from "@bb/domain";
 import { useSystemExecutionOptions } from "./queries/system-queries";
+import {
+  usePersistedEnvironmentSelection,
+  usePersistedModelSelection,
+  usePersistedPermissionModeSelection,
+  usePersistedProviderSelection,
+  usePersistedReasoningLevelSelection,
+  usePersistedServiceTierSelection,
+} from "./thread-creation-options/persisted-selection-fields";
+import {
+  buildExecutionInputSources,
+  formatModelLabel,
+  getInitialThreadPromptSelections,
+  resolvePermissionModeSelection,
+  syncUntouchedThreadPromptSelections,
+  type ScopedExecutionInputSources,
+  type ThreadPromptField,
+  type ThreadPromptSelections,
+  type UseComponentLocalCreationOptions,
+  type UseNewThreadCreationOptions,
+  type UsePromptModelReasoningOptions,
+  updateThreadPromptSelections,
+} from "./thread-creation-options/selection-state";
 
-const MODEL_STORAGE_KEY = "bb.promptbox.model";
-const SERVICE_TIER_STORAGE_KEY = "bb.promptbox.service-tier";
-const REASONING_STORAGE_KEY = "bb.promptbox.reasoning";
-const PERMISSION_MODE_STORAGE_KEY = "bb.promptbox.permission-mode";
-const ENVIRONMENT_STORAGE_KEY = "bb.promptbox.environment";
-const PROVIDER_STORAGE_KEY = "bb.promptbox.provider";
-type StoredServiceTier = "" | ServiceTier;
-type StoredReasoningLevel = "" | ReasoningLevel;
-type StoredPermissionMode = "" | PermissionMode;
+export { formatModelLabel, resolvePermissionModeSelection };
+
 const EMPTY_PROVIDERS: ProviderInfo[] = [];
 
 const REASONING_LABELS: Record<ReasoningLevel, string> = {
@@ -77,37 +85,6 @@ interface PickerOption<T extends string> {
   icon?: ComponentType<{ className?: string }>;
 }
 
-type ThreadCreationOptionsScope =
-  | "new-thread"
-  | "component-local";
-
-interface UsePromptModelReasoningOptions {
-  enabled?: boolean;
-  environmentId?: string;
-  scope?: ThreadCreationOptionsScope;
-  projectId?: string | null;
-  resetKey?: string | number | null;
-  initialProviderId?: string;
-  initialModel?: string;
-  initialServiceTier?: ServiceTier;
-  initialReasoningLevel?: ReasoningLevel;
-  initialPermissionMode?: PermissionMode;
-  initialEnvironmentSelectionValue?: string;
-}
-
-interface UseNewThreadCreationOptions extends UsePromptModelReasoningOptions {
-  scope?: "new-thread";
-}
-
-interface UseComponentLocalCreationOptions
-  extends UsePromptModelReasoningOptions {
-  scope: "component-local";
-}
-
-type ScopedExecutionInputSources =
-  | CreateExecutionInputSources
-  | ExistingThreadExecutionInputSources;
-
 type StringSelectionSetter = (value: string) => void;
 type ServiceTierSelectionSetter = (value: ServiceTier | undefined) => void;
 type ReasoningLevelSelectionSetter = (value: ReasoningLevel) => void;
@@ -142,353 +119,7 @@ interface UseThreadCreationOptionsResult<TExecutionInputSources> {
   executionInputSources: TExecutionInputSources;
 }
 
-interface ThreadPromptSelections {
-  selectedProviderId: string;
-  selectedModel: string;
-  serviceTier: ServiceTier | undefined;
-  reasoningLevel: ReasoningLevel;
-  permissionMode: PermissionMode;
-  environmentSelectionValue: string;
-}
-
-type ThreadPromptField = keyof ThreadPromptSelections;
-
-interface ResolveCreateExecutionInputSourceArgs {
-  hasStoredValue: boolean;
-  hasValue: boolean;
-  touched: boolean;
-}
-
-interface StoredCreateExecutionValues {
-  selectedProviderId: string;
-  selectedModel: string;
-  serviceTier: StoredServiceTier;
-  reasoningLevel: StoredReasoningLevel;
-  permissionMode: StoredPermissionMode;
-}
-
-interface EffectiveCreateExecutionValues {
-  selectedProviderId: string;
-  selectedModel: string;
-  serviceTier: ServiceTier | undefined;
-  reasoningLevel: ReasoningLevel;
-  permissionMode: PermissionMode;
-}
-
-interface BuildExecutionInputSourcesArgs {
-  effectiveValues: EffectiveCreateExecutionValues;
-  scope: ThreadCreationOptionsScope;
-  storedValues: StoredCreateExecutionValues;
-  touchedFields: ReadonlySet<ThreadPromptField>;
-}
-
-interface SyncThreadPromptSelectionsArgs {
-  currentSelections: ThreadPromptSelections;
-  nextSelections: ThreadPromptSelections;
-  touchedFields: ReadonlySet<ThreadPromptField>;
-}
-
-interface UpdateThreadPromptSelectionsArgs {
-  currentSelections: ThreadPromptSelections;
-  field: ThreadPromptField;
-  value: ThreadPromptSelections[ThreadPromptField];
-}
-
-interface ResolvePermissionModeSelectionArgs {
-  rawPermissionMode: PermissionMode;
-  supportedPermissionModes: readonly PermissionMode[];
-}
-
 const NO_MODEL_LOAD_ERROR: SystemExecutionOptionsModelLoadError | null = null;
-
-function isReasoningLevel(value: unknown): value is ReasoningLevel {
-  return (
-    value === "low" ||
-    value === "medium" ||
-    value === "high" ||
-    value === "xhigh" ||
-    value === "max"
-  );
-}
-
-function isPermissionMode(value: unknown): value is PermissionMode {
-  return (
-    value === "readonly" || value === "workspace-write" || value === "full"
-  );
-}
-
-function isServiceTier(value: unknown): value is ServiceTier {
-  return value === "fast" || value === "default";
-}
-
-function isStoredServiceTier(value: string): value is StoredServiceTier {
-  return value === "" || isServiceTier(value);
-}
-
-function isStoredReasoningLevel(value: string): value is StoredReasoningLevel {
-  return value === "" || isReasoningLevel(value);
-}
-
-function isStoredPermissionMode(value: string): value is StoredPermissionMode {
-  return value === "" || isPermissionMode(value);
-}
-
-const storedServiceTierStorage =
-  createLocalStorageEnumStorage<StoredServiceTier>(isStoredServiceTier);
-const storedReasoningLevelStorage =
-  createLocalStorageEnumStorage<StoredReasoningLevel>(isStoredReasoningLevel);
-const storedPermissionModeStorage =
-  createLocalStorageEnumStorage<StoredPermissionMode>(isStoredPermissionMode);
-const providerIdAtomFamily = createProjectScopedStorageAtomFamily(
-  PROVIDER_STORAGE_KEY,
-  "",
-  rawStringLocalStorage,
-);
-const modelAtomFamily = createProjectScopedStorageAtomFamily(
-  MODEL_STORAGE_KEY,
-  "",
-  rawStringLocalStorage,
-);
-const serviceTierAtomFamily =
-  createProjectScopedStorageAtomFamily<StoredServiceTier>(
-    SERVICE_TIER_STORAGE_KEY,
-    "",
-    storedServiceTierStorage,
-  );
-const reasoningLevelAtomFamily = createProjectScopedStorageAtomFamily(
-  REASONING_STORAGE_KEY,
-  "",
-  storedReasoningLevelStorage,
-);
-const permissionModeAtomFamily = createProjectScopedStorageAtomFamily(
-  PERMISSION_MODE_STORAGE_KEY,
-  "",
-  storedPermissionModeStorage,
-);
-const environmentSelectionAtomFamily = createProjectScopedStorageAtomFamily(
-  ENVIRONMENT_STORAGE_KEY,
-  "",
-  rawStringLocalStorage,
-);
-
-function getInitialThreadPromptSelections(
-  options?: UsePromptModelReasoningOptions,
-): ThreadPromptSelections {
-  return {
-    selectedProviderId: options?.initialProviderId ?? "",
-    selectedModel: options?.initialModel ?? "",
-    serviceTier: options?.initialServiceTier,
-    reasoningLevel: options?.initialReasoningLevel ?? "medium",
-    permissionMode: options?.initialPermissionMode ?? "full",
-    environmentSelectionValue: options?.initialEnvironmentSelectionValue ?? "",
-  };
-}
-
-function syncUntouchedThreadPromptSelections({
-  currentSelections,
-  nextSelections,
-  touchedFields,
-}: SyncThreadPromptSelectionsArgs): ThreadPromptSelections {
-  let changed = false;
-  const updatedSelections = { ...currentSelections };
-
-  if (
-    !touchedFields.has("selectedProviderId") &&
-    currentSelections.selectedProviderId !== nextSelections.selectedProviderId
-  ) {
-    updatedSelections.selectedProviderId = nextSelections.selectedProviderId;
-    changed = true;
-  }
-  if (
-    !touchedFields.has("selectedModel") &&
-    currentSelections.selectedModel !== nextSelections.selectedModel
-  ) {
-    updatedSelections.selectedModel = nextSelections.selectedModel;
-    changed = true;
-  }
-  if (
-    !touchedFields.has("serviceTier") &&
-    currentSelections.serviceTier !== nextSelections.serviceTier
-  ) {
-    updatedSelections.serviceTier = nextSelections.serviceTier;
-    changed = true;
-  }
-  if (
-    !touchedFields.has("reasoningLevel") &&
-    currentSelections.reasoningLevel !== nextSelections.reasoningLevel
-  ) {
-    updatedSelections.reasoningLevel = nextSelections.reasoningLevel;
-    changed = true;
-  }
-  if (
-    !touchedFields.has("permissionMode") &&
-    currentSelections.permissionMode !== nextSelections.permissionMode
-  ) {
-    updatedSelections.permissionMode = nextSelections.permissionMode;
-    changed = true;
-  }
-  if (
-    !touchedFields.has("environmentSelectionValue") &&
-    currentSelections.environmentSelectionValue !==
-      nextSelections.environmentSelectionValue
-  ) {
-    updatedSelections.environmentSelectionValue =
-      nextSelections.environmentSelectionValue;
-    changed = true;
-  }
-
-  return changed ? updatedSelections : currentSelections;
-}
-
-function updateThreadPromptSelections({
-  currentSelections,
-  field,
-  value,
-}: UpdateThreadPromptSelectionsArgs): ThreadPromptSelections {
-  if (currentSelections[field] === value) {
-    return currentSelections;
-  }
-
-  return {
-    ...currentSelections,
-    [field]: value,
-  };
-}
-
-function hasValue(value: string): boolean {
-  return value.length > 0;
-}
-
-function resolveCreateExecutionInputSource({
-  hasStoredValue,
-  hasValue,
-  touched,
-}: ResolveCreateExecutionInputSourceArgs): ExecutionInputFieldSource | undefined {
-  if (!hasValue) {
-    return undefined;
-  }
-  if (touched) {
-    return "explicit";
-  }
-  if (hasStoredValue) {
-    return "client-preference";
-  }
-  return undefined;
-}
-
-function buildExecutionInputSources({
-  effectiveValues,
-  scope,
-  storedValues,
-  touchedFields,
-}: BuildExecutionInputSourcesArgs): ScopedExecutionInputSources {
-  const usesStoredValues = scope === "new-thread";
-  const hasTouchedExecutionField =
-    touchedFields.has("selectedProviderId") ||
-    touchedFields.has("selectedModel") ||
-    touchedFields.has("serviceTier") ||
-    touchedFields.has("reasoningLevel") ||
-    touchedFields.has("permissionMode");
-  // Existing-thread submissions are all-or-nothing once an execution control is
-  // touched, so the server never merges stale last-run values with new UI picks.
-  const forcesExplicitExecutionFields =
-    scope === "component-local" && hasTouchedExecutionField;
-
-  if (!usesStoredValues && scope !== "component-local") {
-    return {};
-  }
-
-  const providerSource = resolveCreateExecutionInputSource({
-    hasStoredValue:
-      usesStoredValues &&
-      hasValue(storedValues.selectedProviderId) &&
-      storedValues.selectedProviderId === effectiveValues.selectedProviderId,
-    hasValue: hasValue(effectiveValues.selectedProviderId),
-    touched: touchedFields.has("selectedProviderId"),
-  });
-  const modelSource = resolveCreateExecutionInputSource({
-    hasStoredValue:
-      usesStoredValues &&
-      hasValue(storedValues.selectedModel) &&
-      storedValues.selectedModel === effectiveValues.selectedModel,
-    hasValue: hasValue(effectiveValues.selectedModel),
-    touched:
-      forcesExplicitExecutionFields || touchedFields.has("selectedModel"),
-  });
-  const serviceTierSource = resolveCreateExecutionInputSource({
-    hasStoredValue:
-      usesStoredValues &&
-      storedValues.serviceTier !== "" &&
-      storedValues.serviceTier === effectiveValues.serviceTier,
-    hasValue: effectiveValues.serviceTier !== undefined,
-    touched:
-      forcesExplicitExecutionFields || touchedFields.has("serviceTier"),
-  });
-  const reasoningLevelSource = resolveCreateExecutionInputSource({
-    hasStoredValue: usesStoredValues && storedValues.reasoningLevel !== "",
-    hasValue: hasValue(effectiveValues.reasoningLevel),
-    touched:
-      forcesExplicitExecutionFields || touchedFields.has("reasoningLevel"),
-  });
-  const permissionModeSource = resolveCreateExecutionInputSource({
-    hasStoredValue: usesStoredValues && storedValues.permissionMode !== "",
-    hasValue: hasValue(effectiveValues.permissionMode),
-    touched:
-      forcesExplicitExecutionFields || touchedFields.has("permissionMode"),
-  });
-
-  if (scope === "component-local") {
-    return {
-      ...(modelSource ? { model: modelSource } : {}),
-      ...(serviceTierSource ? { serviceTier: serviceTierSource } : {}),
-      ...(reasoningLevelSource ? { reasoningLevel: reasoningLevelSource } : {}),
-      ...(permissionModeSource
-        ? { permissionMode: permissionModeSource }
-        : {}),
-    };
-  }
-
-  return {
-    ...(providerSource ? { providerId: providerSource } : {}),
-    ...(modelSource ? { model: modelSource } : {}),
-    ...(serviceTierSource ? { serviceTier: serviceTierSource } : {}),
-    ...(reasoningLevelSource ? { reasoningLevel: reasoningLevelSource } : {}),
-    ...(permissionModeSource
-      ? { permissionMode: permissionModeSource }
-      : {}),
-  };
-}
-
-export function resolvePermissionModeSelection({
-  rawPermissionMode,
-  supportedPermissionModes,
-}: ResolvePermissionModeSelectionArgs): PermissionMode {
-  if (supportedPermissionModes.includes(rawPermissionMode)) {
-    return rawPermissionMode;
-  }
-  if (supportedPermissionModes.includes("full")) {
-    return "full";
-  }
-  return supportedPermissionModes[0] ?? "full";
-}
-
-export function formatModelLabel(value: string): string {
-  // Case-normalises a raw model id into a displayable label. The brand prefix
-  // strip ("Claude " / "GPT-") is a presentation rule applied by the picker
-  // itself (see `stripModelBrandPrefix`) so stories and prod render identically
-  // without anyone having to remember to format.
-  return value
-    .split("-")
-    .map((part) => {
-      if (part.toLowerCase() === "gpt") return "GPT";
-      if (/^\d+(\.\d+)*$/.test(part)) return part;
-      if (/^[a-z]+$/i.test(part)) {
-        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
-      }
-      return part;
-    })
-    .join("-");
-}
 
 function sanitizeStoredEnvironmentValue(stored: string): string {
   // Legacy guard: earlier iterations briefly persisted `reuse:<envId>` to
@@ -522,23 +153,20 @@ export function useThreadCreationOptions(
     resetKey,
     scope = "new-thread",
   } = options ?? {};
-  const [storedProviderId, setStoredProviderId] = useAtom(
-    providerIdAtomFamily(projectId),
-  );
-  const [storedSelectedModel, setStoredSelectedModel] = useAtom(
-    modelAtomFamily(projectId),
-  );
-  const [storedServiceTier, setStoredServiceTier] = useAtom(
-    serviceTierAtomFamily(projectId),
-  );
-  const [storedReasoningLevel, setStoredReasoningLevel] = useAtom(
-    reasoningLevelAtomFamily(projectId),
-  );
-  const [storedPermissionMode, setStoredPermissionMode] = useAtom(
-    permissionModeAtomFamily(projectId),
-  );
-  const [storedEnvironmentSelectionValue, setStoredEnvironmentSelectionValue] =
-    useAtom(environmentSelectionAtomFamily(projectId));
+  const { setValue: setStoredProviderId, value: storedProviderId } =
+    usePersistedProviderSelection(projectId);
+  const { setValue: setStoredSelectedModel, value: storedSelectedModel } =
+    usePersistedModelSelection(projectId);
+  const { setValue: setStoredServiceTier, value: storedServiceTier } =
+    usePersistedServiceTierSelection(projectId);
+  const { setValue: setStoredReasoningLevel, value: storedReasoningLevel } =
+    usePersistedReasoningLevelSelection(projectId);
+  const { setValue: setStoredPermissionMode, value: storedPermissionMode } =
+    usePersistedPermissionModeSelection(projectId);
+  const {
+    setValue: setStoredEnvironmentSelectionValue,
+    value: storedEnvironmentSelectionValue,
+  } = usePersistedEnvironmentSelection(projectId);
   // Reuse env values are intentionally NEVER persisted to localStorage —
   // they represent a transient "create one thread in this worktree" intent,
   // not a project default.
@@ -603,26 +231,21 @@ export function useThreadCreationOptions(
     usesLocalThreadSelections,
   ]);
 
-  const rawSelectedProviderId =
-    usesStoredCreateSelections
-      ? storedProviderId || renderedThreadSelections.selectedProviderId
-      : renderedThreadSelections.selectedProviderId;
-  const rawSelectedModel =
-    usesStoredCreateSelections
-      ? storedSelectedModel || renderedThreadSelections.selectedModel
-      : renderedThreadSelections.selectedModel;
-  const rawServiceTier =
-    usesStoredCreateSelections
-      ? storedServiceTier || renderedThreadSelections.serviceTier
-      : renderedThreadSelections.serviceTier;
-  const rawReasoningLevel =
-    usesStoredCreateSelections
-      ? storedReasoningLevel || renderedThreadSelections.reasoningLevel
-      : renderedThreadSelections.reasoningLevel;
-  const rawPermissionMode =
-    usesStoredCreateSelections
-      ? storedPermissionMode || renderedThreadSelections.permissionMode
-      : renderedThreadSelections.permissionMode;
+  const rawSelectedProviderId = usesStoredCreateSelections
+    ? storedProviderId || renderedThreadSelections.selectedProviderId
+    : renderedThreadSelections.selectedProviderId;
+  const rawSelectedModel = usesStoredCreateSelections
+    ? storedSelectedModel || renderedThreadSelections.selectedModel
+    : renderedThreadSelections.selectedModel;
+  const rawServiceTier = usesStoredCreateSelections
+    ? storedServiceTier || renderedThreadSelections.serviceTier
+    : renderedThreadSelections.serviceTier;
+  const rawReasoningLevel = usesStoredCreateSelections
+    ? storedReasoningLevel || renderedThreadSelections.reasoningLevel
+    : renderedThreadSelections.reasoningLevel;
+  const rawPermissionMode = usesStoredCreateSelections
+    ? storedPermissionMode || renderedThreadSelections.permissionMode
+    : renderedThreadSelections.permissionMode;
   const rawEnvironmentSelectionValue =
     scope === "new-thread"
       ? (rootComposeReuseValue ??

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -4,9 +4,7 @@ import type {
   Experiments,
   Host,
   PendingInteraction,
-  ProjectExecutionDefaults,
   ProjectSource,
-  ResolvedThreadExecutionOptions,
   ThreadQueuedMessage,
   WorkspaceDiffTarget,
 } from "@bb/domain";
@@ -30,7 +28,6 @@ import type {
   CreateThreadTerminalRequest,
   ProjectBranchesResponse,
   ProjectResponse,
-  SidebarBootstrapResponse,
   PromptHistoryResponse,
   ReorderPinnedThreadRequest,
   ReorderProjectRequest,
@@ -46,7 +43,6 @@ import type {
   SystemVoiceTranscriptionResponse,
   ThreadArchiveAllResponse,
   ThreadChildSummaryResponse,
-  ThreadComposerBootstrapResponse,
   ThreadPendingInteractionsResponse,
   ThreadQueuedMessageListResponse,
   ThreadListResponse,
@@ -123,10 +119,6 @@ export type ProjectBranchListRequest = EnvironmentBranchListRequest;
 
 export type AppCreateThreadRequest = Omit<CreateThreadRequest, "origin">;
 
-export interface GetProjectDefaultExecutionOptionsRequest {
-  projectId: string;
-}
-
 const HTML_DOCUMENT_PATTERN = /<!doctype html|<html[\s>]/i;
 const ERROR_EXTRACT_OPTS = {
   legacyKeys: ["detail"] as const,
@@ -136,7 +128,7 @@ function normalizeErrorText(raw: string): string {
   return raw.replace(/\s+/g, " ").trim();
 }
 
-function requestOptions(signal?: AbortSignal) {
+export function requestOptions(signal?: AbortSignal) {
   return signal ? { init: { signal } } : undefined;
 }
 
@@ -280,7 +272,9 @@ async function throwHttpError(res: Response): Promise<never> {
   });
 }
 
-async function request<T>(responsePromise: Promise<Response>): Promise<T> {
+export async function request<T>(
+  responsePromise: Promise<Response>,
+): Promise<T> {
   const res = await requestResponse(responsePromise);
   const text = await res.text();
   return JSON.parse(text) as T;
@@ -478,14 +472,6 @@ export async function reorderProject(
   );
 }
 
-export async function listProjectsWithThreads(
-  signal?: AbortSignal,
-): Promise<SidebarBootstrapResponse> {
-  return request<SidebarBootstrapResponse>(
-    apiClient["sidebar-bootstrap"].$get(undefined, requestOptions(signal)),
-  );
-}
-
 export async function listAutomationsOverview(
   signal?: AbortSignal,
 ): Promise<AutomationsOverviewResponse> {
@@ -503,17 +489,6 @@ export async function listProjectPromptHistory(
       { param: { id: projectId } },
       requestOptions(signal),
     ),
-  );
-}
-
-export async function getProjectDefaultExecutionOptions(
-  args: GetProjectDefaultExecutionOptionsRequest,
-): Promise<ProjectExecutionDefaults | null> {
-  return request<ProjectExecutionDefaults | null>(
-    apiClient.projects[":id"]["default-execution-options"].$get({
-      param: { id: args.projectId },
-      query: {},
-    }),
   );
 }
 
@@ -924,16 +899,6 @@ export async function updateThread(
   );
 }
 
-export async function getThreadDefaultExecutionOptions(
-  id: string,
-): Promise<ResolvedThreadExecutionOptions | null> {
-  return request<ResolvedThreadExecutionOptions | null>(
-    apiClient.threads[":id"]["default-execution-options"].$get({
-      param: { id },
-    }),
-  );
-}
-
 export async function listThreadTerminals(
   id: string,
   signal?: AbortSignal,
@@ -1002,14 +967,6 @@ export async function createThreadQueuedMessage(
       param: { id },
       json: req,
     }),
-  );
-}
-
-export async function getThreadComposerBootstrap(
-  id: string,
-): Promise<ThreadComposerBootstrapResponse> {
-  return request<ThreadComposerBootstrapResponse>(
-    apiClient.threads[":id"]["composer-bootstrap"].$get({ param: { id } }),
   );
 }
 

--- a/apps/app/src/lib/browser-storage.ts
+++ b/apps/app/src/lib/browser-storage.ts
@@ -32,6 +32,12 @@ interface LocalStorageValueCodec<T> {
   serialize: (value: T) => string;
 }
 
+export interface CreatePersistedEnumAtomArgs<T extends string> {
+  baseKey: string;
+  initialValue: T;
+  isValue: StringValueGuard<T>;
+}
+
 function getLocalStorage(): Storage | null {
   if (typeof window === "undefined") {
     return null;
@@ -174,5 +180,17 @@ export function createProjectScopedStorageAtomFamily<T>(
       storage,
       { getOnInit: true },
     ),
+  );
+}
+
+export function createPersistedEnumAtom<T extends string>({
+  baseKey,
+  initialValue,
+  isValue,
+}: CreatePersistedEnumAtomArgs<T>) {
+  return createProjectScopedStorageAtomFamily(
+    baseKey,
+    initialValue,
+    createLocalStorageEnumStorage(isValue),
   );
 }

--- a/apps/app/src/views/ProjectSettingsView.tsx
+++ b/apps/app/src/views/ProjectSettingsView.tsx
@@ -30,10 +30,8 @@ import {
   useLocalPathPicker,
   type LocalPathSubmitParams,
 } from "@/hooks/useLocalPathPicker";
-import {
-  stripProjectThreads,
-  useSidebarNavigation,
-} from "@/hooks/queries/project-queries";
+import { stripProjectThreads } from "@/hooks/queries/project-queries";
+import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 
 export function ProjectSettingsView() {
   const { projectId } = useParams<{ projectId: string }>();

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -20,9 +20,10 @@ import { useCreateThread } from "@/hooks/mutations/thread-runtime-mutations";
 import {
   useProjectPromptHistory,
   useProjectSourceBranches,
-  useSidebarNavigation,
   stripProjectThreads,
 } from "@/hooks/queries/project-queries";
+import { useProjectDefaultExecutionOptions } from "@/hooks/queries/project-default-execution-options-query";
+import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useThreads } from "@/hooks/queries/thread-queries";
 import { useCommandSuggestions } from "@/hooks/useCommandSuggestions";
 import { usePrimaryHost } from "@/hooks/queries/host-queries";
@@ -248,17 +249,23 @@ export function RootComposeView() {
     () => currentProject?.sources ?? [],
     [currentProject?.sources],
   );
-  // Seed the picker with the project's stored execution defaults so the
-  // visible default matches what the server will use when the user submits
-  // without touching anything. Without this, the picker would show the
-  // system-wide first-provider/default-model (e.g. Codex / GPT-5.5) while
-  // the server falls back to the project's stored provider (e.g. Claude
-  // Code) — see resolveRequestedCreateExecutionValue, which discards
-  // submitted values that the client hasn't claimed in `executionInputSources`.
-  // Values ride along with the sidebar bootstrap so there's no extra
-  // round-trip per visit.
+  // Seed the picker from the server-resolved project defaults so the visible
+  // default matches what create-thread will use when the user submits without
+  // touching execution controls. Values normally ride along with sidebar
+  // bootstrap; optimistic sidebar entries use a one-off fallback fetch because
+  // their null means "not loaded into this cache entry", not a client default.
+  const projectDefaultExecutionOptionsQuery = useProjectDefaultExecutionOptions(
+    { projectId },
+    {
+      enabled:
+        currentProject !== undefined &&
+        currentProject.defaultExecutionOptions === null,
+    },
+  );
   const projectDefaultExecutionOptions =
-    currentProject?.defaultExecutionOptions ?? null;
+    currentProject?.defaultExecutionOptions ??
+    projectDefaultExecutionOptionsQuery.data ??
+    null;
   const creationOptions = useThreadCreationOptions({
     scope: "new-thread",
     projectId,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -41,10 +41,10 @@ import {
 } from "@/hooks/mutations/thread-runtime-mutations";
 import {
   getLatestPendingInteraction,
-  useThreadDefaultExecutionOptions,
   useThreadQueuedMessages,
   useThreadPromptHistory,
 } from "@/hooks/queries/thread-queries";
+import { useThreadDefaultExecutionOptions } from "@/hooks/queries/thread-default-execution-options-query";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { promptHistoryEntriesToDrafts } from "@/lib/prompt-history";
 import { promptDraftToInput } from "@/lib/prompt-draft";

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -30,12 +30,12 @@ import {
   getLatestPendingInteraction,
   useProjectThreadSubset,
   useThread,
-  useThreadComposerBootstrap,
   useThreadDetailBootstrap,
   useThreadPendingInteractions,
   useThreadSchedules,
   type ProjectThreadSubsetFilters,
 } from "../../hooks/queries/thread-queries";
+import { useThreadComposerBootstrap } from "../../hooks/queries/thread-composer-bootstrap-query";
 import { ThreadGitActionDialog } from "@/components/dialogs/ThreadGitActionDialog";
 import { PageShell } from "@/components/ui/page-shell.js";
 import { HEADER_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -53,10 +53,9 @@ import {
   requireReadyEnvironment,
 } from "../services/lib/entity-lookup.js";
 import { PROMPT_HISTORY_ENTRY_LIMIT } from "@bb/domain";
+import { resolveCreateThreadExecutionDefaults } from "../services/threads/thread-default-policy.js";
 import { resolveProjectCreateDefaultExecutionPlan } from "../services/threads/thread-execution-plan.js";
-import {
-  toThreadListEntryResponses,
-} from "../services/threads/thread-runtime-display.js";
+import { toThreadListEntryResponses } from "../services/threads/thread-runtime-display.js";
 import { callHostRetryableOnlineRpc } from "../services/hosts/online-rpc.js";
 import { parseBoundedPositiveOptionalInteger } from "../services/lib/validation.js";
 import {
@@ -208,7 +207,9 @@ function buildProjectsWithThreadsResponseFromRows(
   return projects.map((project) => ({
     ...project,
     threads: threadsByProjectId.get(project.id) ?? [],
-    defaultExecutionOptions: defaultsByProjectId.get(project.id) ?? null,
+    defaultExecutionOptions: resolveCreateThreadExecutionDefaults({
+      storedDefaults: defaultsByProjectId.get(project.id) ?? null,
+    }).executionDefaults,
   }));
 }
 
@@ -566,7 +567,10 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       // Project-source listing only: used by the new-thread compose box before
       // any environment exists. Once a thread has an environment, workspace
       // path search goes through `GET /environments/:id/paths` instead.
-      const target = resolveProjectSourcePath(deps, { projectId, hostId: null });
+      const target = resolveProjectSourcePath(deps, {
+        projectId,
+        hostId: null,
+      });
       const inclusion = parsePathKindInclusion({
         includeFiles: query.includeFiles,
         includeDirectories: query.includeDirectories,

--- a/apps/server/test/public/public-threads.defaults.test.ts
+++ b/apps/server/test/public/public-threads.defaults.test.ts
@@ -10,6 +10,7 @@ import {
   upsertProjectExecutionDefaults,
 } from "@bb/db";
 import { threadSchema } from "@bb/domain";
+import { sidebarBootstrapResponseSchema } from "@bb/server-contract";
 import { waitForQueuedCommand } from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
@@ -463,6 +464,38 @@ describe("public thread default routes", () => {
         reasoningLevel: "medium",
         permissionMode: "full",
       });
+    });
+  });
+
+  it("returns resolved project defaults in sidebar bootstrap without persisting them", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/thread-defaults-sidebar",
+      });
+
+      const response = await harness.app.request("/api/v1/sidebar-bootstrap");
+
+      expect(response.status).toBe(200);
+      const bootstrap = sidebarBootstrapResponseSchema.parse(
+        await readJson(response),
+      );
+      const sidebarProject = bootstrap.projects.find(
+        (candidate) => candidate.id === project.id,
+      );
+      expect(sidebarProject?.defaultExecutionOptions).toEqual({
+        providerId: "codex",
+        model: "gpt-5.5",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        permissionMode: "full",
+      });
+      expect(
+        getProjectExecutionDefaults(harness.db, {
+          projectId: project.id,
+        }),
+      ).toBeNull();
     });
   });
 });

--- a/packages/server-contract/src/api-types.ts
+++ b/packages/server-contract/src/api-types.ts
@@ -1878,11 +1878,11 @@ export type ProjectResponse = z.infer<typeof projectResponseSchema>;
 export const projectWithThreadsResponseSchema = projectResponseSchema.extend({
   threads: z.array(threadListEntrySchema),
   /**
-   * Project's stored execution defaults (provider/model/reasoning/permission/
-   * tier). `null` when the project has never had a thread created in the app
-   * UI. Inlined here so the new-thread composer can seed its picker without a
-   * second round-trip per visit — the value comes from the sidebar bootstrap
-   * the page is already loading.
+   * Resolved provider/model/reasoning/permission/tier defaults for creating a
+   * root thread in this project. Inlined so the new-thread composer can render
+   * exactly what the server will use without a second round-trip per visit.
+   * `null` means the server cannot form concrete defaults for the current
+   * policy/provider combination.
    */
   defaultExecutionOptions: projectExecutionDefaultsSchema.nullable(),
 });

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -155,7 +155,7 @@ export type PublicApiSchema = {
     >;
   };
   "/projects/:id/default-execution-options": {
-    /** Returns the last remembered provider and execution options for the project and thread type. */
+    /** Returns resolved provider and execution defaults for creating a root thread in the project. */
     $get: Endpoint<
       PathProjectId & { query: ProjectDefaultExecutionOptionsQuery },
       ProjectExecutionDefaults | null


### PR DESCRIPTION
## Summary
- resolve root composer project defaults in server sidebar bootstrap instead of exposing raw stored rows for the client to complete
- split thread creation option persistence/source-resolution helpers out of useThreadCreationOptions and add a generic persisted enum atom helper
- co-locate composer/default query keys, fetchers, and hooks for the touched endpoints

## Validation
- pnpm exec turbo run test --filter=@bb/server -- test/public/public-threads.defaults.test.ts
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/cache-owners/composer-cache-owner.test.ts src/hooks/cache-owners/cache-owner-registry.test.ts src/hooks/environment-cache-effects.test.ts src/hooks/system-cache-effects.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run typecheck --filter=@bb/server-contract