### PR TITLE
Support remote source dev access

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ checkout path. The checkout instance id is the sanitized path to the checkout,
 relative to your home directory, plus a short hash suffix. Separate worktrees
 can run alongside each other and the packaged `npx bb-app@latest` instance.
 
+To use the dev app from another machine, for example over Tailscale, run:
+
+```bash
+BB_DEV_REMOTE=true pnpm dev
+```
+
+Then open `http://<remote-host-or-tailscale-ip>:<app-port>`. Without
+`BB_DEV_REMOTE=true`, source dev keeps the browser app on localhost-only Vite
+defaults.
+
 Development behavior is intentionally split:
 
 - the app hot reloads itself

--- a/apps/app/src/components/thread/terminal/terminal-websocket-url.ts
+++ b/apps/app/src/components/thread/terminal/terminal-websocket-url.ts
@@ -1,3 +1,5 @@
+import { buildDevWebSocketUrl } from "@/lib/dev-websocket-url";
+
 interface BuildTerminalWebSocketUrlArgs {
   terminalId: string;
   threadId: string;
@@ -16,12 +18,9 @@ export function buildTerminalWebSocketUrl(
   args: BuildTerminalWebSocketUrlArgs,
 ): string {
   const path = buildTerminalWebSocketPath(args);
-  if (typeof __BB_DEV_WS_URL__ === "string") {
-    const url = new URL(__BB_DEV_WS_URL__);
-    url.pathname = path;
-    url.search = "";
-    url.hash = "";
-    return url.toString();
+  const devWebSocketUrl = buildDevWebSocketUrl({ path });
+  if (devWebSocketUrl !== undefined) {
+    return devWebSocketUrl;
   }
 
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";

--- a/apps/app/src/lib/dev-websocket-url.ts
+++ b/apps/app/src/lib/dev-websocket-url.ts
@@ -1,0 +1,37 @@
+interface BuildDevWebSocketUrlArgs {
+  path: string;
+}
+
+function resolveBrowserHostDevWebSocketBaseUrl(port: number): string {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.hostname}:${port}/ws`;
+}
+
+function resolveDevWebSocketBaseUrl(): string | undefined {
+  if (typeof __BB_DEV_WS_URL__ === "string") {
+    return __BB_DEV_WS_URL__;
+  }
+
+  if (typeof __BB_DEV_WS_BROWSER_HOST_PORT__ === "number") {
+    return resolveBrowserHostDevWebSocketBaseUrl(
+      __BB_DEV_WS_BROWSER_HOST_PORT__,
+    );
+  }
+
+  return undefined;
+}
+
+export function buildDevWebSocketUrl(
+  args: BuildDevWebSocketUrlArgs,
+): string | undefined {
+  const baseUrl = resolveDevWebSocketBaseUrl();
+  if (baseUrl === undefined) {
+    return undefined;
+  }
+
+  const url = new URL(baseUrl);
+  url.pathname = args.path;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}

--- a/apps/app/src/lib/ws.ts
+++ b/apps/app/src/lib/ws.ts
@@ -8,6 +8,7 @@ import type {
   ChangedMessage,
   RealtimeEntity,
 } from "@bb/server-contract";
+import { buildDevWebSocketUrl } from "./dev-websocket-url";
 
 type ChangeCallback = (message: ChangedMessage) => void;
 type ConnectedCallback = (event: { reconnected: boolean }) => void;
@@ -33,9 +34,8 @@ export class WebSocketManager {
     // which does not handle reconnection after backend restarts.
     // In production, use the same origin (server serves the app).
     const url =
-      typeof __BB_DEV_WS_URL__ === "string"
-        ? __BB_DEV_WS_URL__
-        : `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
+      buildDevWebSocketUrl({ path: "/ws" }) ??
+      `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
 
     this.socket = new ReconnectingWebSocket(url, undefined, {
       minReconnectionDelay: 1000,

--- a/apps/app/src/vite-env.d.ts
+++ b/apps/app/src/vite-env.d.ts
@@ -2,3 +2,4 @@
 
 /** Injected by vite.dev.config.ts to bypass Vite's WebSocket proxy. */
 declare const __BB_DEV_WS_URL__: string | undefined;
+declare const __BB_DEV_WS_BROWSER_HOST_PORT__: number | undefined;

--- a/apps/app/vite.dev.config.ts
+++ b/apps/app/vite.dev.config.ts
@@ -3,13 +3,23 @@ import { loadViteDevConfig } from "@bb/config/vite-dev";
 import { sharedViteConfig } from "./vite.config.js";
 
 const viteDevConfig = loadViteDevConfig();
+const undefinedDefineValue = "undefined";
+const devWebSocketUrlDefine =
+  viteDevConfig.serverWsOrigin.kind === "fixed"
+    ? JSON.stringify(`${viteDevConfig.serverWsOrigin.origin}/ws`)
+    : undefinedDefineValue;
+const devWebSocketBrowserHostPortDefine =
+  viteDevConfig.serverWsOrigin.kind === "browser-host"
+    ? JSON.stringify(viteDevConfig.serverWsOrigin.port)
+    : undefinedDefineValue;
 
 export default defineConfig({
   ...sharedViteConfig,
   define: {
     // Connect directly to the server in dev because Vite's WS proxy does not
     // handle upstream server restarts reliably.
-    __BB_DEV_WS_URL__: JSON.stringify(`${viteDevConfig.serverWsOrigin}/ws`),
+    __BB_DEV_WS_URL__: devWebSocketUrlDefine,
+    __BB_DEV_WS_BROWSER_HOST_PORT__: devWebSocketBrowserHostPortDefine,
   },
   server: {
     host: viteDevConfig.appHost,

--- a/packages/config/src/dev-app.ts
+++ b/packages/config/src/dev-app.ts
@@ -7,12 +7,15 @@ import {
 import {
   BB_DEV_APP_HOST_ENV,
   BB_DEV_APP_PORT_ENV,
+  BB_DEV_REMOTE_ENV,
   DEFAULT_BB_DEV_APP_HOST,
+  DEFAULT_BB_DEV_REMOTE,
 } from "./env-vars.js";
 import { assignIfDefined } from "./objects.js";
 
 export interface DevAppConfig {
   BB_DEV_APP_HOST: string;
+  BB_DEV_REMOTE: boolean;
   BB_DEV_APP_PORT?: number;
 }
 
@@ -27,6 +30,12 @@ export function loadDevAppConfig(
       context: loader.context,
       defaultValue: DEFAULT_BB_DEV_APP_HOST,
       definition: BB_DEV_APP_HOST_ENV,
+      env: loader.env,
+    }),
+    BB_DEV_REMOTE: readEnvVarWithDefault({
+      context: loader.context,
+      defaultValue: DEFAULT_BB_DEV_REMOTE,
+      definition: BB_DEV_REMOTE_ENV,
       env: loader.env,
     }),
   };

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -196,6 +196,13 @@ export const BB_DEV_APP_HOST_ENV = defineEnvVar<string>({
   parse: parseStringEnvValue,
 });
 
+export const BB_DEV_REMOTE_ENV = defineEnvVar<boolean>({
+  description:
+    "Development-only remote access mode. Set to true to bind the Vite app to all interfaces and make browser WebSockets use the page host.",
+  name: "BB_DEV_REMOTE",
+  parse: parseBooleanEnvValue,
+});
+
 export const BB_DEV_APP_PORT_ENV = defineEnvVar<number | undefined>({
   description: "Development-only Vite port for apps/app.",
   name: "BB_DEV_APP_PORT",
@@ -254,6 +261,7 @@ export const DEFAULT_BB_POSTHOG_API_KEY =
   "phc_tejoYoNLV6vG8QAd5eYXXvcsENFYnP4brpZDGqG7zvpy";
 export const DEFAULT_BB_TELEMETRY = true;
 export const DEFAULT_BB_DEV_APP_HOST = "";
+export const DEFAULT_BB_DEV_REMOTE = false;
 export const DEFAULT_BB_INFERENCE = DEFAULTS.inferenceModel;
 export const DEFAULT_BB_TRANSCRIPTION = DEFAULTS.transcriptionModel;
 export const DEFAULT_BB_FF_PLACEHOLDER = defaultFeatureFlags.placeholder;

--- a/packages/config/src/vite-dev.ts
+++ b/packages/config/src/vite-dev.ts
@@ -3,16 +3,56 @@ import { type EnvLoaderArgs } from "./env.js";
 import { assignIfDefined } from "./objects.js";
 import { loadServerPortConfig } from "./server-port.js";
 
+export type ViteDevServerWsOrigin =
+  | { kind: "browser-host"; port: number }
+  | { kind: "fixed"; origin: string };
+
 export interface ViteDevConfig {
   appPort: number;
   serverHttpOrigin: string;
   serverPort: number;
-  serverWsOrigin: string;
+  serverWsOrigin: ViteDevServerWsOrigin;
   appHost?: string;
 }
 
 export interface LoadViteDevConfigArgs extends EnvLoaderArgs {
   repoRoot?: string;
+}
+
+interface ResolveViteDevAppHostArgs {
+  configuredHost: string;
+  remote: boolean;
+}
+
+interface ResolveViteDevServerWsOriginArgs {
+  remote: boolean;
+  serverPort: number;
+}
+
+function resolveViteDevAppHost(
+  args: ResolveViteDevAppHostArgs,
+): string | undefined {
+  if (args.configuredHost !== "") {
+    return args.configuredHost;
+  }
+
+  return args.remote ? "0.0.0.0" : undefined;
+}
+
+function resolveViteDevServerWsOrigin(
+  args: ResolveViteDevServerWsOriginArgs,
+): ViteDevServerWsOrigin {
+  if (args.remote) {
+    return {
+      kind: "browser-host",
+      port: args.serverPort,
+    };
+  }
+
+  return {
+    kind: "fixed",
+    origin: `ws://localhost:${args.serverPort}`,
+  };
 }
 
 export function loadViteDevConfig(
@@ -30,16 +70,19 @@ export function loadViteDevConfig(
     appPort,
     serverHttpOrigin,
     serverPort: serverPortConfig.BB_SERVER_PORT,
-    serverWsOrigin: `ws://localhost:${serverPortConfig.BB_SERVER_PORT}`,
+    serverWsOrigin: resolveViteDevServerWsOrigin({
+      remote: devAppConfig.BB_DEV_REMOTE,
+      serverPort: serverPortConfig.BB_SERVER_PORT,
+    }),
   };
 
   assignIfDefined({
     key: "appHost",
     target: config,
-    value:
-      devAppConfig.BB_DEV_APP_HOST === ""
-        ? undefined
-        : devAppConfig.BB_DEV_APP_HOST,
+    value: resolveViteDevAppHost({
+      configuredHost: devAppConfig.BB_DEV_APP_HOST,
+      remote: devAppConfig.BB_DEV_REMOTE,
+    }),
   });
 
   return config;

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -621,6 +621,7 @@ describe("consumer-specific config", () => {
     });
 
     expect(devAppConfig.BB_DEV_APP_HOST).toBe("0.0.0.0");
+    expect(devAppConfig.BB_DEV_REMOTE).toBe(false);
     expect(devAppConfig.BB_DEV_APP_PORT).toBeUndefined();
   });
 
@@ -639,7 +640,32 @@ describe("consumer-specific config", () => {
       appPort: 4173,
       serverHttpOrigin: "http://localhost:4444",
       serverPort: 4444,
-      serverWsOrigin: "ws://localhost:4444",
+      serverWsOrigin: {
+        kind: "fixed",
+        origin: "ws://localhost:4444",
+      },
+    });
+  });
+
+  it("builds remote app Vite dev config from BB_DEV_REMOTE", () => {
+    const viteDevConfig = loadViteDevConfig({
+      env: {
+        BB_DEV_APP_PORT: "4173",
+        BB_DEV_REMOTE: "true",
+        BB_SERVER_PORT: "4444",
+        NODE_ENV: "development",
+      },
+    });
+
+    expect(viteDevConfig).toEqual({
+      appHost: "0.0.0.0",
+      appPort: 4173,
+      serverHttpOrigin: "http://localhost:4444",
+      serverPort: 4444,
+      serverWsOrigin: {
+        kind: "browser-host",
+        port: 4444,
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- add BB_DEV_REMOTE=true for source dev remote access
- bind the Vite dev app to all interfaces in remote mode
- make dev browser WebSockets target the page host on the server port instead of localhost
- document the remote dev flow

## Validation
- pnpm exec turbo run test --filter=@bb/config
- pnpm exec turbo run typecheck --filter=@bb/config
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/server