### PR TITLE
Make timeline unread divider red

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -732,7 +732,7 @@ function TimelineUnreadDivider({ autoScroll }: TimelineUnreadDividerProps) {
       role="separator"
       aria-label="New messages"
       className={cn(
-        "flex items-center gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-foreground",
+        "flex items-center gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-destructive-text",
       )}
       data-testid="thread-unread-divider"
     >

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -737,7 +737,7 @@ function TimelineUnreadDivider({ autoScroll }: TimelineUnreadDividerProps) {
       data-testid="thread-unread-divider"
     >
       <span className="shrink-0">New</span>
-      <span className="h-px min-w-0 flex-1 bg-border/50" aria-hidden />
+      <span className="h-px min-w-0 flex-1 bg-destructive" aria-hidden />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Change the timeline unread divider rule from neutral border gray to the destructive red token.
- Change the "New" divider label to the text-safe destructive red token.

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app