### PR TITLE
Add unread favicon indicator

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/hooks/queries/thread-queries";
 import { useRouteState } from "@/hooks/useRouteState";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
+import { isThreadRead } from "@/lib/thread-read-state";
 import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
 import { cn } from "@/lib/utils";
 import { ProjectPathDialog } from "@/components/dialogs/ProjectPathDialog";
@@ -55,6 +56,7 @@ import { useQuickCreateProjectController } from "@/hooks/useQuickCreateProject";
 import { useSetRootComposeProjectId } from "@/lib/root-compose-selection";
 import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import { useFaviconBadge } from "@/lib/favicon-color-preference";
 
 const SIDEBAR_WIDTH_KEY = "bb.sidebar.width";
 const SIDEBAR_OPEN_KEY = "bb.sidebar.open";
@@ -378,6 +380,16 @@ export function AppLayout({ children }: AppLayoutProps) {
     () => sidebarNavigationQuery.data?.projects.map(stripProjectThreads),
     [sidebarNavigationQuery.data],
   );
+  const sidebarThreads = useMemo(() => {
+    const sidebarNavigation = sidebarNavigationQuery.data;
+    if (!sidebarNavigation) {
+      return [];
+    }
+    return [
+      ...sidebarNavigation.projects.flatMap((project) => project.threads),
+      ...sidebarNavigation.personalProject.threads,
+    ];
+  }, [sidebarNavigationQuery.data]);
   const threadDetailBootstrapQuery = useThreadDetailBootstrap(threadId ?? "", {
     composerBootstrapPrefetch: isThreadView && Boolean(threadId),
     enabled: isThreadView && Boolean(threadId),
@@ -438,23 +450,23 @@ export function AppLayout({ children }: AppLayoutProps) {
           ],
         }
       : isSettingsView && projectId
+        ? {
+            title: "",
+            subtitle: undefined,
+            breadcrumbs: [
+              {
+                label: projectLabel ?? projectId,
+                to: getLegacyProjectComposeRoutePath(projectId),
+              },
+              { label: "Settings" },
+            ],
+          }
+        : projectId
           ? {
-              title: "",
+              title: projectLabel ?? projectId,
               subtitle: undefined,
-              breadcrumbs: [
-                {
-                  label: projectLabel ?? projectId,
-                  to: getLegacyProjectComposeRoutePath(projectId),
-                },
-                { label: "Settings" },
-              ],
             }
-          : projectId
-            ? {
-                title: projectLabel ?? projectId,
-                subtitle: undefined,
-              }
-            : (routeTitles[location.pathname] ?? { title: "" });
+          : (routeTitles[location.pathname] ?? { title: "" });
 
   const documentTitle = (() => {
     if (isThreadView) {
@@ -472,6 +484,13 @@ export function AppLayout({ children }: AppLayoutProps) {
     const routeTitle = routeTitles[location.pathname]?.title;
     return routeTitle && routeTitle.length > 0 ? routeTitle : "BB";
   })();
+  const unreadCount = isThreadView
+    ? thread && !isThreadRead(thread)
+      ? 1
+      : 0
+    : sidebarThreads.filter((candidate) => !isThreadRead(candidate)).length;
+  const faviconBadge = unreadCount > 0 ? "unread" : "none";
+  useFaviconBadge(faviconBadge);
 
   const handleResizeMouseDown = useCallback(
     (event: SidebarResizeMouseEvent) => {

--- a/apps/app/src/lib/favicon-color-preference.ts
+++ b/apps/app/src/lib/favicon-color-preference.ts
@@ -1,4 +1,5 @@
-import { getDefaultStore, useAtom } from "jotai";
+import { useEffect } from "react";
+import { atom, getDefaultStore, useAtom, useSetAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { createLocalStorageEnumStorage } from "./browser-storage";
 
@@ -17,6 +18,9 @@ export const FAVICON_COLORS = [
 
 export type FaviconColor = (typeof FAVICON_COLORS)[number];
 export type FaviconColorPreference = FaviconColor | "default";
+
+export const FAVICON_BADGES = ["none", "unread"] as const;
+export type FaviconBadge = (typeof FAVICON_BADGES)[number];
 
 export const FAVICON_COLOR_VALUES: Record<FaviconColor, string> = {
   red: "#e5484d",
@@ -46,12 +50,47 @@ const faviconColorPreferenceAtom = atomWithStorage<FaviconColorPreference>(
   faviconColorPreferenceStorage,
   { getOnInit: true },
 );
+const faviconBadgeAtom = atom<FaviconBadge>("none");
 
 export function useFaviconColorPreference() {
   return useAtom(faviconColorPreferenceAtom);
 }
 
+export function useFaviconBadge(badge: FaviconBadge): void {
+  const setFaviconBadge = useSetAtom(faviconBadgeAtom);
+
+  useEffect(() => {
+    setFaviconBadge(badge);
+    return () => {
+      setFaviconBadge("none");
+    };
+  }, [badge, setFaviconBadge]);
+}
+
 const FAVICON_SIZES = [32, 16] as const;
+const UNREAD_BADGE_FILL = "#e00000";
+
+type FaviconSize = (typeof FAVICON_SIZES)[number];
+
+interface FaviconRenderState {
+  badge: FaviconBadge;
+  colorPreference: FaviconColorPreference;
+}
+
+interface FaviconRenderRequest extends FaviconRenderState {
+  baseHref: string;
+}
+
+interface RenderedFaviconLink {
+  href: string;
+  size: FaviconSize;
+}
+
+interface UnreadBadgeDot {
+  centerX: number;
+  centerY: number;
+  radius: number;
+}
 
 /**
  * Favicon glyph used as a CSS mask when previewing colors in the UI. Only
@@ -94,10 +133,15 @@ function loadImage(src: string): Promise<HTMLImageElement> {
  * is a straight color replacement: draw the glyph, then fill with the target
  * color using "source-in" compositing to keep only the glyph's alpha.
  */
-async function createTintedFaviconHref(
-  baseHref: string,
-  color: string,
-): Promise<string> {
+async function createFaviconHref({
+  badge,
+  baseHref,
+  colorPreference,
+}: FaviconRenderRequest): Promise<string> {
+  if (badge === "none" && colorPreference === "default") {
+    return baseHref;
+  }
+
   const image = await loadImage(baseHref);
   const canvas = document.createElement("canvas");
   canvas.width = image.naturalWidth;
@@ -105,29 +149,58 @@ async function createTintedFaviconHref(
   const context = canvas.getContext("2d");
   if (!context) throw new Error("Canvas 2D context unavailable");
   context.drawImage(image, 0, 0);
-  context.globalCompositeOperation = "source-in";
-  context.fillStyle = color;
-  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (colorPreference !== "default") {
+    context.globalCompositeOperation = "source-in";
+    context.fillStyle = FAVICON_COLOR_VALUES[colorPreference];
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.globalCompositeOperation = "source-over";
+  }
+
+  if (badge === "unread") {
+    drawUnreadBadge(context, canvas.width, canvas.height);
+  }
+
   return canvas.toDataURL("image/png");
+}
+
+function getUnreadBadgeDot(width: number, height: number): UnreadBadgeDot {
+  const size = Math.min(width, height);
+  const scale = size / 32;
+  return {
+    centerX: 28 * scale,
+    centerY: 6 * scale,
+    radius: 3.5 * scale,
+  };
+}
+
+function drawUnreadBadge(
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+): void {
+  const badge = getUnreadBadgeDot(width, height);
+  context.save();
+  context.beginPath();
+  context.arc(badge.centerX, badge.centerY, badge.radius, 0, Math.PI * 2);
+  context.fillStyle = UNREAD_BADGE_FILL;
+  context.fill();
+  context.restore();
 }
 
 let applyToken = 0;
 
-async function applyFaviconColor(
-  preference: FaviconColorPreference,
-): Promise<void> {
+async function applyFaviconState(state: FaviconRenderState): Promise<void> {
   const token = ++applyToken;
   const suffix = getFaviconVariantSuffix();
   const links = await Promise.all(
-    FAVICON_SIZES.map(async (size) => {
+    FAVICON_SIZES.map(async (size): Promise<RenderedFaviconLink> => {
       const baseHref = `/favicon-${size}x${size}${suffix}.png`;
-      const href =
-        preference === "default"
-          ? baseHref
-          : await createTintedFaviconHref(
-              baseHref,
-              FAVICON_COLOR_VALUES[preference],
-            );
+      const href = await createFaviconHref({
+        badge: state.badge,
+        baseHref,
+        colorPreference: state.colorPreference,
+      });
       return { href, size };
     }),
   );
@@ -141,23 +214,25 @@ async function applyFaviconColor(
 let initialized = false;
 
 /**
- * Applies the stored favicon color on startup and re-applies it whenever the
- * preference or the system color scheme changes. The scheme listener runs
+ * Applies the favicon state on startup and re-applies it whenever the color
+ * preference, unread badge, or system color scheme changes. The scheme listener runs
  * after the index.html bootstrap listener (registered first), so a tinted
- * favicon survives that script resetting the hrefs on theme changes.
+ * or badged favicon survives that script resetting the hrefs on theme changes.
  */
-export function initializeFaviconColor(): void {
+export function initializeFavicon(): void {
   if (initialized || typeof window === "undefined") return;
   initialized = true;
   const store = getDefaultStore();
   const apply = () => {
     // On failure (e.g. the favicon image fails to load), keep whatever the
     // index.html bootstrap script already applied.
-    void applyFaviconColor(store.get(faviconColorPreferenceAtom)).catch(
-      () => {},
-    );
+    void applyFaviconState({
+      badge: store.get(faviconBadgeAtom),
+      colorPreference: store.get(faviconColorPreferenceAtom),
+    }).catch(() => {});
   };
   store.sub(faviconColorPreferenceAtom, apply);
+  store.sub(faviconBadgeAtom, apply);
   if (typeof window.matchMedia === "function") {
     window
       .matchMedia("(prefers-color-scheme: dark)")

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 import { AppToaster } from "./components/AppToaster";
 import { initializePreferredTheme } from "./hooks/useTheme";
-import { initializeFaviconColor } from "./lib/favicon-color-preference";
+import { initializeFavicon } from "./lib/favicon-color-preference";
 import { createAppQueryClient } from "./lib/query-client";
 import { takeOverPanelResizeCursor } from "./lib/resizeCursor";
 import "./app.css";
@@ -13,7 +13,7 @@ import "./app.css";
 const queryClient = createAppQueryClient();
 
 initializePreferredTheme();
-initializeFaviconColor();
+initializeFavicon();
 takeOverPanelResizeCursor();
 
 createRoot(document.getElementById("root")!).render(

--- a/apps/app/src/views/thread-detail/useThreadReadTracking.ts
+++ b/apps/app/src/views/thread-detail/useThreadReadTracking.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Thread } from "@bb/domain";
 import { isThreadRead } from "@/lib/thread-read-state";
 import { useMarkThreadRead } from "../../hooks/mutations/thread-state-mutations";
@@ -8,13 +8,44 @@ interface UseThreadReadTrackingParams {
   thread?: Thread;
 }
 
+function isDocumentVisible(): boolean {
+  return (
+    typeof document === "undefined" || document.visibilityState === "visible"
+  );
+}
+
+function useDocumentVisible(): boolean {
+  const [visible, setVisible] = useState(isDocumentVisible);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      setVisible(isDocumentVisible());
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
+  return visible;
+}
+
 export function useThreadReadTracking({
   markThreadRead,
   thread,
 }: UseThreadReadTrackingParams) {
   const markedReadKeysRef = useRef<Set<string>>(new Set());
+  const isVisible = useDocumentVisible();
 
   useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
     if (!thread) {
       return;
     }
@@ -33,5 +64,5 @@ export function useThreadReadTracking({
         markedReadKeysRef.current.delete(marker);
       },
     });
-  }, [markThreadRead, thread]);
+  }, [isVisible, markThreadRead, thread]);
 }


### PR DESCRIPTION
## Summary
- Add an unread favicon badge that composes with bb's dev/light/dark and custom-color favicon variants
- Prefix the document title with the unread count
- Keep background thread tabs unread until the tab becomes visible so the favicon signal is useful

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app
- pnpm exec turbo run build --filter=@bb/app