### PR TITLE
Hide personal labels for projectless thread UI

### DIFF
--- a/apps/app/src/hooks/threadMentionSuggestions.test.ts
+++ b/apps/app/src/hooks/threadMentionSuggestions.test.ts
@@ -1,4 +1,4 @@
-import type { Thread } from "@bb/domain";
+import { PERSONAL_PROJECT_ID, type Thread } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import { buildThreadMentionSuggestions } from "./threadMentionSuggestions";
 
@@ -301,6 +301,49 @@ describe("buildThreadMentionSuggestions", () => {
         projectId: "proj-2",
         projectName: "Docs Site",
         threadId: "thr_second_project",
+      },
+    ]);
+  });
+
+  it("does not add the personal project name to projectless thread suggestions", () => {
+    const suggestions = buildThreadMentionSuggestions({
+      threads: [
+        makeThread({
+          id: "thr_personal",
+          projectId: PERSONAL_PROJECT_ID,
+          title: "Shared context",
+        }),
+        makeThread({
+          id: "thr_project",
+          projectId: "proj-2",
+          title: "Shared context",
+        }),
+      ],
+      query: "shared",
+      currentProjectId: "proj-1",
+      projectNamesById: new Map([
+        [PERSONAL_PROJECT_ID, "Personal"],
+        ["proj-2", "Docs Site"],
+      ]),
+      limit: 8,
+    });
+
+    expect(
+      suggestions.map((suggestion) => ({
+        projectId: suggestion.projectId,
+        projectName: suggestion.projectName,
+        threadId: suggestion.threadId,
+      })),
+    ).toEqual([
+      {
+        projectId: PERSONAL_PROJECT_ID,
+        projectName: undefined,
+        threadId: "thr_personal",
+      },
+      {
+        projectId: "proj-2",
+        projectName: "Docs Site",
+        threadId: "thr_project",
       },
     ]);
   });

--- a/apps/app/src/hooks/threadMentionSuggestions.ts
+++ b/apps/app/src/hooks/threadMentionSuggestions.ts
@@ -1,5 +1,5 @@
 import { fuzzyMatchText } from "@bb/fuzzy-match";
-import type { Thread } from "@bb/domain";
+import { PERSONAL_PROJECT_ID, type Thread } from "@bb/domain";
 import type { PromptMentionSuggestion } from "@/components/promptbox/mentions/types";
 import { compareCodepoint } from "@/lib/codepoint-compare";
 
@@ -62,6 +62,10 @@ function shouldShowProjectName(
   thread: Thread,
   context: ThreadMentionContext,
 ): boolean {
+  if (thread.projectId === PERSONAL_PROJECT_ID) {
+    return false;
+  }
+
   return (
     context.currentProjectId === undefined ||
     thread.projectId !== context.currentProjectId

--- a/apps/app/src/hooks/usePromptMentions.ts
+++ b/apps/app/src/hooks/usePromptMentions.ts
@@ -45,10 +45,6 @@ function buildProjectNamesById(
     return projectNamesById;
   }
 
-  projectNamesById.set(
-    sidebarNavigation.personalProject.id,
-    sidebarNavigation.personalProject.name,
-  );
   for (const project of sidebarNavigation.projects) {
     projectNamesById.set(project.id, project.name);
   }

--- a/apps/app/src/views/AutomationsView.test.tsx
+++ b/apps/app/src/views/AutomationsView.test.tsx
@@ -1,0 +1,124 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import type {
+  AutomationsOverviewProject,
+  AutomationsOverviewThread,
+  AutomationsOverviewThreadSchedule,
+  ThreadSchedule,
+} from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { AutomationsOverview } from "./AutomationsView";
+
+interface MakeProjectArgs {
+  id: string;
+  name: string;
+}
+
+interface MakeThreadArgs {
+  id: string;
+  projectId: string;
+  title: string;
+}
+
+interface MakeScheduleArgs {
+  id: string;
+  projectId: string;
+  threadId: string;
+  name: string;
+}
+
+function makeProject(args: MakeProjectArgs): AutomationsOverviewProject {
+  return {
+    id: args.id,
+    name: args.name,
+  };
+}
+
+function makeThread(args: MakeThreadArgs): AutomationsOverviewThread {
+  return {
+    id: args.id,
+    projectId: args.projectId,
+    title: args.title,
+    titleFallback: args.title,
+  };
+}
+
+function makeSchedule(args: MakeScheduleArgs): ThreadSchedule {
+  return {
+    id: args.id,
+    projectId: args.projectId,
+    threadId: args.threadId,
+    name: args.name,
+    enabled: true,
+    kind: "cron",
+    cron: "0 9 * * 1-5",
+    timezone: "America/Los_Angeles",
+    prompt: "Summarize recent changes.",
+    nextFireAt: 1_700_003_600_000,
+    lastFiredAt: null,
+    createdAt: 0,
+    updatedAt: 100,
+  };
+}
+
+function renderAutomationsOverview(
+  schedules: readonly AutomationsOverviewThreadSchedule[],
+): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <AutomationsOverview
+        hasInitialLoadError={false}
+        schedules={schedules}
+        isLoading={false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("AutomationsOverview", () => {
+  it("omits the personal project label for projectless scheduled threads", () => {
+    const projectlessThread = makeThread({
+      id: "thr_projectless",
+      projectId: PERSONAL_PROJECT_ID,
+      title: "Projectless schedule",
+    });
+    const projectThread = makeThread({
+      id: "thr_project",
+      projectId: "proj_app",
+      title: "Project schedule",
+    });
+
+    const markup = renderAutomationsOverview([
+      {
+        project: makeProject({
+          id: PERSONAL_PROJECT_ID,
+          name: "Personal",
+        }),
+        thread: projectlessThread,
+        schedule: makeSchedule({
+          id: "sched_projectless",
+          projectId: PERSONAL_PROJECT_ID,
+          threadId: projectlessThread.id,
+          name: "Projectless schedule",
+        }),
+      },
+      {
+        project: makeProject({
+          id: "proj_app",
+          name: "App",
+        }),
+        thread: projectThread,
+        schedule: makeSchedule({
+          id: "sched_project",
+          projectId: "proj_app",
+          threadId: projectThread.id,
+          name: "Project schedule",
+        }),
+      },
+    ]);
+
+    expect(markup).not.toContain(">Personal<");
+    expect(markup).toContain(">App<");
+  });
+});

--- a/apps/app/src/views/AutomationsView.tsx
+++ b/apps/app/src/views/AutomationsView.tsx
@@ -8,7 +8,7 @@ import type {
 import { PageShell } from "@/components/ui/page-shell.js";
 import { TruncatedList } from "@/components/ui/truncated-list.js";
 import { useAutomationsOverview } from "@/hooks/queries/thread-queries";
-import { getThreadRoutePath } from "@/lib/route-paths";
+import { getThreadRoutePath, isProjectlessProjectId } from "@/lib/route-paths";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import {
   formatCronCadence,
@@ -51,6 +51,7 @@ function ThreadScheduleGroupSection({
   group,
 }: ThreadScheduleGroupSectionProps) {
   const { thread, project, schedules } = group;
+  const projectLabel = isProjectlessProjectId(project.id) ? null : project.name;
 
   return (
     <section>
@@ -64,9 +65,11 @@ function ThreadScheduleGroupSection({
         >
           {getThreadDisplayTitle(thread)}
         </Link>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {project.name}
-        </span>
+        {projectLabel ? (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {projectLabel}
+          </span>
+        ) : null}
       </div>
       <TruncatedList
         className="mt-1.5"

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
+
+interface MakeThreadArgs {
+  id: string;
+  projectId: string;
+  title: string;
+}
+
+function makeThread(args: MakeThreadArgs): ThreadListEntry {
+  return {
+    id: args.id,
+    projectId: args.projectId,
+    environmentId: null,
+    automationId: null,
+    providerId: "codex",
+    title: args.title,
+    titleFallback: args.title,
+    status: "idle",
+    parentThreadId: null,
+    archivedAt: null,
+    pinnedAt: null,
+    pinSortKey: null,
+    stopRequestedAt: null,
+    deletedAt: null,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    createdAt: 100,
+    updatedAt: 100,
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+  };
+}
+
+function renderMobileRecents(threads: readonly ThreadListEntry[]): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <RootComposeMobileRecents
+        highlightedThreadId={null}
+        projectNamesById={
+          new Map([
+            [PERSONAL_PROJECT_ID, "Personal"],
+            ["proj_app", "App"],
+          ])
+        }
+        showCreatingRow={false}
+        threads={threads}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("RootComposeMobileRecents", () => {
+  it("omits the personal project label from projectless thread rows", () => {
+    const markup = renderMobileRecents([
+      makeThread({
+        id: "thr_personal",
+        projectId: PERSONAL_PROJECT_ID,
+        title: "Personal thread",
+      }),
+      makeThread({
+        id: "thr_project",
+        projectId: "proj_app",
+        title: "Project thread",
+      }),
+    ]);
+
+    expect(markup).not.toContain(">Personal<");
+    expect(markup).toContain(">App<");
+  });
+});

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import type { ThreadListEntry } from "@bb/domain";
 import { ThreadStatusGlyph } from "@/components/sidebar/ThreadRow";
 import { Icon } from "@/components/ui/icon.js";
-import { getThreadRoutePath } from "@/lib/route-paths";
+import { getThreadRoutePath, isProjectlessProjectId } from "@/lib/route-paths";
 import { isBusyThread, isUnreadDoneThread } from "@/lib/thread-activity";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@/lib/utils";
@@ -176,7 +176,11 @@ export function RootComposeMobileRecents({
             <MobileRecentThreadRow
               key={thread.id}
               highlighted={thread.id === highlightedThreadId}
-              projectName={projectNamesById.get(thread.projectId) ?? null}
+              projectName={
+                isProjectlessProjectId(thread.projectId)
+                  ? null
+                  : (projectNamesById.get(thread.projectId) ?? null)
+              }
               thread={thread}
             />
           ))}

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -1,0 +1,112 @@
+import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
+import type {
+  ProjectWithThreadsResponse,
+  SidebarBootstrapResponse,
+} from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { buildMobileRecentThreads } from "./RootComposeView";
+
+interface MakeThreadArgs {
+  id: string;
+  projectId: string;
+}
+
+interface MakeProjectArgs {
+  id: string;
+  kind: ProjectWithThreadsResponse["kind"];
+  name: string;
+  threads: readonly ThreadListEntry[];
+}
+
+function makeThread(args: MakeThreadArgs): ThreadListEntry {
+  return {
+    id: args.id,
+    projectId: args.projectId,
+    environmentId: null,
+    automationId: null,
+    providerId: "codex",
+    title: args.id,
+    titleFallback: args.id,
+    status: "idle",
+    parentThreadId: null,
+    archivedAt: null,
+    pinnedAt: null,
+    pinSortKey: null,
+    stopRequestedAt: null,
+    deletedAt: null,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    createdAt: 100,
+    updatedAt: 100,
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+  };
+}
+
+function makeProject(args: MakeProjectArgs): ProjectWithThreadsResponse {
+  return {
+    id: args.id,
+    kind: args.kind,
+    name: args.name,
+    sources: [],
+    threads: [...args.threads],
+    defaultExecutionOptions: null,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+describe("buildMobileRecentThreads", () => {
+  it("includes projectless and every project thread", () => {
+    const sidebarNavigation: SidebarBootstrapResponse = {
+      personalProject: makeProject({
+        id: PERSONAL_PROJECT_ID,
+        kind: "personal",
+        name: "Personal",
+        threads: [
+          makeThread({
+            id: "thr_personal",
+            projectId: PERSONAL_PROJECT_ID,
+          }),
+        ],
+      }),
+      projects: [
+        makeProject({
+          id: "proj_app",
+          kind: "standard",
+          name: "App",
+          threads: [
+            makeThread({
+              id: "thr_app",
+              projectId: "proj_app",
+            }),
+          ],
+        }),
+        makeProject({
+          id: "proj_docs",
+          kind: "standard",
+          name: "Docs",
+          threads: [
+            makeThread({
+              id: "thr_docs",
+              projectId: "proj_docs",
+            }),
+          ],
+        }),
+      ],
+    };
+
+    const threadIds = buildMobileRecentThreads({ sidebarNavigation }).map(
+      (thread) => thread.id,
+    );
+
+    expect(threadIds).toEqual(["thr_personal", "thr_app", "thr_docs"]);
+  });
+});

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import {
   NewThreadPromptBox,
   type NewThreadProjectConfig,
@@ -61,6 +62,10 @@ type ProjectSelectionChangeHandler = NewThreadProjectConfig["onChange"];
 
 interface LegacyProjectComposeRedirectProps {
   projectId: string;
+}
+
+interface BuildMobileRecentThreadsArgs {
+  sidebarNavigation: SidebarBootstrapResponse | undefined;
 }
 
 // react-router's location.state is freeform unknown — narrow it here at the
@@ -133,6 +138,20 @@ function buildReuseThreadOptions(
     return left.environmentId.localeCompare(right.environmentId);
   });
   return options;
+}
+
+export function buildMobileRecentThreads({
+  sidebarNavigation,
+}: BuildMobileRecentThreadsArgs): ThreadListEntry[] {
+  if (!sidebarNavigation) return [];
+
+  const threads: ThreadListEntry[] = [
+    ...sidebarNavigation.personalProject.threads,
+  ];
+  for (const project of sidebarNavigation.projects) {
+    threads.push(...project.threads);
+  }
+  return threads;
 }
 
 function LegacyProjectComposeRedirect({
@@ -323,6 +342,13 @@ export function RootComposeView() {
   const reuseThreadOptions = useMemo(
     () => buildReuseThreadOptions(threadsQuery.data ?? []),
     [threadsQuery.data],
+  );
+  const mobileRecentThreads = useMemo(
+    () =>
+      buildMobileRecentThreads({
+        sidebarNavigation: sidebarNavigationQuery.data,
+      }),
+    [sidebarNavigationQuery.data],
   );
 
   // Projectless threads choose a host directly, not an environment mode. Keep
@@ -939,7 +965,7 @@ export function RootComposeView() {
         highlightedThreadId={lastCreatedThreadId}
         projectNamesById={mobileRecentProjectNamesById}
         showCreatingRow={createThread.isPending}
-        threads={threadsQuery.data ?? []}
+        threads={mobileRecentThreads}
       />
     </PageShell>
   );


### PR DESCRIPTION
## Summary
- hide the seeded Personal project label for projectless recent rows, prompt thread mentions, and automations schedule rows
- source mobile recents from all sidebar-visible active threads instead of the selected project query
- add regression coverage for projectless labels and all-project mobile recents

## Tests
- pnpm exec turbo run test --filter=@bb/app -- --run src/views/RootComposeMobileRecents.test.tsx src/views/RootComposeView.test.ts src/hooks/threadMentionSuggestions.test.ts src/views/AutomationsView.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app