### PR TITLE
Fix mobile drawer keyboard repositioning

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -14,7 +14,9 @@ import {
   COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
   COARSE_POINTER_ICON_SIZE_SHRINK_CLASS,
 } from "@/components/ui/coarse-pointer-sizing.js";
+import { useIsCompactViewport } from "@/components/ui/hooks/use-compact-viewport.js";
 import { Input } from "@/components/ui/input.js";
+import { blurActiveKeyboardInputWithin } from "@/components/ui/overlay-trigger.js";
 import {
   Popover,
   PopoverContent,
@@ -318,10 +320,7 @@ function BranchPickerText({
         >
           New
         </span>
-        <span
-          {...compactAffixProps}
-          className="shrink-0 text-muted-foreground"
-        >
+        <span {...compactAffixProps} className="shrink-0 text-muted-foreground">
           {" branch"}
         </span>
       </span>
@@ -346,19 +345,13 @@ function BranchPickerText({
   if (parts.kind === "parenthetical") {
     return (
       <span className={cn("flex min-w-0 items-baseline", className)}>
-        <span
-          {...compactAffixProps}
-          className="shrink-0 text-muted-foreground"
-        >
+        <span {...compactAffixProps} className="shrink-0 text-muted-foreground">
           {parts.prefix} (
         </span>
         <span className="min-w-0 truncate font-medium text-foreground">
           {parts.value}
         </span>
-        <span
-          {...compactAffixProps}
-          className="shrink-0 text-muted-foreground"
-        >
+        <span {...compactAffixProps} className="shrink-0 text-muted-foreground">
           )
         </span>
       </span>
@@ -367,10 +360,7 @@ function BranchPickerText({
 
   return (
     <span className={cn("flex min-w-0 items-baseline gap-1", className)}>
-      <span
-        {...compactAffixProps}
-        className="shrink-0 text-muted-foreground"
-      >
+      <span {...compactAffixProps} className="shrink-0 text-muted-foreground">
         {parts.prefix}
       </span>
       <span className="min-w-0 truncate font-medium text-foreground">
@@ -732,6 +722,7 @@ export function BranchPicker({
 }: BranchPickerProps) {
   const [open, setOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
+  const isCompactViewport = useIsCompactViewport();
   const selectedCheckoutIntent = resolveCheckoutIntent({
     isCreatingNew,
     value,
@@ -899,17 +890,27 @@ export function BranchPicker({
     menuCopy.optionsSectionLabel === null
       ? branchChooserDisabledTitle
       : undefined;
+  const updateOpen = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      blurActiveKeyboardInputWithin(inputRef.current);
+    }
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+  const closePicker = () => {
+    updateOpen(false);
+  };
   const selectBranchAndClose = (branch: string) => {
     if (isCheckoutMenu && activeCheckoutIntent === "new") {
       (onCreateBaseChange ?? onChange)(branch);
     } else {
       onChange(branch);
     }
-    setOpen(false);
+    closePicker();
   };
   const selectCheckoutTarget = (branch: string) => {
     onChange(branch);
-    setOpen(false);
+    closePicker();
   };
   const selectEnterBranch = (branch: string) => {
     if (isCheckoutMenu && activeCheckoutIntent === "checkout") {
@@ -941,7 +942,7 @@ export function BranchPicker({
   }, [debouncedNormalizedQuery, normalizedQuery, onSearchQueryChange, open]);
 
   useEffect(() => {
-    if (!open || !showOptionsSearch) {
+    if (!open || !showOptionsSearch || isCompactViewport) {
       return;
     }
 
@@ -952,17 +953,10 @@ export function BranchPicker({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [open, showOptionsSearch]);
+  }, [isCompactViewport, open, showOptionsSearch]);
 
   return (
-    <Popover
-      modal={modal}
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
-        onOpenChange?.(nextOpen);
-      }}
-    >
+    <Popover modal={modal} open={open} onOpenChange={updateOpen}>
       <PopoverTrigger asChild disabled={disabled}>
         <Button
           type="button"
@@ -1069,7 +1063,7 @@ export function BranchPicker({
                   onSelect={() => {
                     setCheckoutIntent("current");
                     onClear();
-                    setOpen(false);
+                    closePicker();
                   }}
                 />
               ) : null}
@@ -1177,7 +1171,7 @@ export function BranchPicker({
                       selected={!isCreatingNew && value === null}
                       onSelect={() => {
                         onClear();
-                        setOpen(false);
+                        closePicker();
                       }}
                     />
                   ) : null}
@@ -1219,7 +1213,7 @@ export function BranchPicker({
                             selected={isCreatingNew}
                             onSelect={() => {
                               onCreate();
-                              setOpen(false);
+                              closePicker();
                             }}
                           />
                         )

--- a/apps/app/src/components/ui/dropdown-menu.tsx
+++ b/apps/app/src/components/ui/dropdown-menu.tsx
@@ -139,59 +139,60 @@ const DropdownMenuContent = React.forwardRef<
     },
     ref,
   ) => {
-  const { isCompactViewport, open, onOpenChange } = useResponsiveMenu();
+    const { isCompactViewport, open, onOpenChange } = useResponsiveMenu();
 
-  if (isCompactViewport) {
-    const domProps = stripRadixContentProps(props);
+    if (isCompactViewport) {
+      const domProps = stripRadixContentProps(props);
+      return (
+        <ResponsiveDrawerShell
+          open={open}
+          onOpenChange={onOpenChange}
+          srLabel={mobileTitle ?? "Menu"}
+          repositionInputs={false}
+        >
+          <div
+            ref={ref}
+            className={cn(
+              "flex flex-col gap-0.5 overflow-y-auto p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]",
+              className,
+            )}
+            style={{ minWidth: "auto", maxWidth: "none", width: "auto" }}
+            {...domProps}
+          >
+            {children}
+          </div>
+        </ResponsiveDrawerShell>
+      );
+    }
+
     return (
-      <ResponsiveDrawerShell
-        open={open}
-        onOpenChange={onOpenChange}
-        srLabel={mobileTitle ?? "Menu"}
-      >
-        <div
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content
           ref={ref}
+          sideOffset={sideOffset}
+          onCloseAutoFocus={(event) => {
+            // Radix's DropdownMenu trigger preventDefaults pointerdown so the
+            // menu can claim focus on open; that leaves the trigger without
+            // mouse-set focus, and the close-time `.focus()` then trips the
+            // browser's :focus-visible heuristic — painting a ring after every
+            // mouse-driven close. Suppress the trigger refocus when the user's
+            // last input was a pointer; keep it for keyboard close so Tab order
+            // and focus indication stay intact for keyboard users.
+            if (!isLastInputKeyboard()) {
+              event.preventDefault();
+            }
+            onCloseAutoFocus?.(event);
+          }}
           className={cn(
-            "flex flex-col gap-0.5 overflow-y-auto p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]",
+            "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             className,
           )}
-          style={{ minWidth: "auto", maxWidth: "none", width: "auto" }}
-          {...domProps}
+          {...props}
         >
           {children}
-        </div>
-      </ResponsiveDrawerShell>
+        </DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
     );
-  }
-
-  return (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        onCloseAutoFocus={(event) => {
-          // Radix's DropdownMenu trigger preventDefaults pointerdown so the
-          // menu can claim focus on open; that leaves the trigger without
-          // mouse-set focus, and the close-time `.focus()` then trips the
-          // browser's :focus-visible heuristic — painting a ring after every
-          // mouse-driven close. Suppress the trigger refocus when the user's
-          // last input was a pointer; keep it for keyboard close so Tab order
-          // and focus indication stay intact for keyboard users.
-          if (!isLastInputKeyboard()) {
-            event.preventDefault();
-          }
-          onCloseAutoFocus?.(event);
-        }}
-        className={cn(
-          "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </DropdownMenuPrimitive.Content>
-    </DropdownMenuPrimitive.Portal>
-  );
   },
 );
 DropdownMenuContent.displayName = "DropdownMenuContent";

--- a/apps/app/src/components/ui/overlay-trigger.ts
+++ b/apps/app/src/components/ui/overlay-trigger.ts
@@ -44,13 +44,22 @@ function isKeyboardInputElement(element: Element): element is HTMLElement {
  * drawer, mobile Safari can restore the soft keyboard during the picker
  * interaction. Blur only text-editing targets, and only before opening.
  */
-export function blurActiveKeyboardInputBeforeOverlayOpen(): void {
+export function blurActiveKeyboardInputWithin(container: Element | null): void {
   if (typeof document === "undefined") return;
 
   const activeElement = document.activeElement;
   if (!activeElement || !isKeyboardInputElement(activeElement)) return;
+  if (container !== null && !container.contains(activeElement)) return;
 
   activeElement.blur();
+}
+
+export function blurActiveKeyboardInputBeforeOverlayOpen(): void {
+  blurActiveKeyboardInputWithin(null);
+}
+
+export function blurActiveKeyboardInputBeforeOverlayClose(): void {
+  blurActiveKeyboardInputWithin(null);
 }
 
 /**

--- a/apps/app/src/components/ui/popover.tsx
+++ b/apps/app/src/components/ui/popover.tsx
@@ -152,6 +152,7 @@ const PopoverContent = React.forwardRef<
           onOpenChange={onOpenChange}
           srLabel={mobileTitle ?? "Options"}
           contentClassName={mobileClassName}
+          repositionInputs={false}
         >
           <div
             ref={ref}

--- a/apps/app/src/components/ui/responsive-overlay.tsx
+++ b/apps/app/src/components/ui/responsive-overlay.tsx
@@ -4,6 +4,8 @@ import { Slot } from "@radix-ui/react-slot";
 import { Drawer, DrawerContent, DrawerTitle } from "./drawer.js";
 import {
   blurActiveKeyboardInputBeforeOverlayOpen,
+  blurActiveKeyboardInputBeforeOverlayClose,
+  blurActiveKeyboardInputWithin,
   getOverlayTriggerClassName,
   preventOverlayTriggerSelection,
 } from "./overlay-trigger.js";
@@ -17,6 +19,15 @@ export interface ResponsiveOverlayContextValue {
   isCompactViewport: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+}
+
+const ResponsiveDrawerDepthContext = React.createContext(0);
+
+function resetDrawerKeyboardStyles(drawerElement: HTMLElement | null): void {
+  if (drawerElement === null) return;
+
+  drawerElement.style.height = "";
+  drawerElement.style.bottom = "";
 }
 
 // ---------------------------------------------------------------------------
@@ -36,12 +47,15 @@ export function useResponsiveRoot(
 
   const onOpenChange = React.useCallback(
     (next: boolean) => {
+      if (open && !next && isCompactViewport) {
+        blurActiveKeyboardInputBeforeOverlayClose();
+      }
       if (!isControlled) {
         setInternalOpen(next);
       }
       controlledOnChange?.(next);
     },
-    [isControlled, controlledOnChange],
+    [isCompactViewport, isControlled, controlledOnChange, open],
   );
 
   return React.useMemo(
@@ -203,6 +217,12 @@ interface ResponsiveDrawerShellProps {
    * inside web components (e.g. Pierre tree's shadow DOM).
    */
   handleOnly?: boolean;
+  /**
+   * Whether Vaul should mutate drawer height/bottom around focused inputs when
+   * the visual viewport changes. Defaults off for nested drawers because the
+   * parent drawer cannot distinguish a nested drawer's focused input.
+   */
+  repositionInputs?: boolean;
   children: React.ReactNode;
 }
 
@@ -212,15 +232,50 @@ export function ResponsiveDrawerShell({
   srLabel,
   contentClassName,
   handleOnly,
+  repositionInputs,
   children,
 }: ResponsiveDrawerShellProps) {
+  const parentDrawerDepth = React.useContext(ResponsiveDrawerDepthContext);
+  const drawerContentRef = React.useRef<HTMLDivElement>(null);
+  const isNestedDrawer = parentDrawerDepth > 0;
+  const shouldRepositionInputs = repositionInputs ?? !isNestedDrawer;
+  const resetClosingKeyboardState = React.useCallback(() => {
+    blurActiveKeyboardInputWithin(drawerContentRef.current);
+    resetDrawerKeyboardStyles(drawerContentRef.current);
+  }, []);
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        resetClosingKeyboardState();
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, resetClosingKeyboardState],
+  );
+  const previousOpenRef = React.useRef(open);
+
+  React.useLayoutEffect(() => {
+    if (previousOpenRef.current && !open) {
+      resetClosingKeyboardState();
+    }
+    previousOpenRef.current = open;
+  }, [open, resetClosingKeyboardState]);
+
   return (
-    <Drawer open={open} onOpenChange={onOpenChange} handleOnly={handleOnly}>
-      <DrawerContent className={contentClassName}>
-        {srLabel !== undefined ? (
-          <DrawerTitle className="sr-only">{srLabel}</DrawerTitle>
-        ) : null}
-        {children}
+    <Drawer
+      open={open}
+      onOpenChange={handleOpenChange}
+      handleOnly={handleOnly}
+      nested={isNestedDrawer}
+      repositionInputs={shouldRepositionInputs}
+    >
+      <DrawerContent ref={drawerContentRef} className={contentClassName}>
+        <ResponsiveDrawerDepthContext.Provider value={parentDrawerDepth + 1}>
+          {srLabel !== undefined ? (
+            <DrawerTitle className="sr-only">{srLabel}</DrawerTitle>
+          ) : null}
+          {children}
+        </ResponsiveDrawerDepthContext.Provider>
       </DrawerContent>
     </Drawer>
   );

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -400,6 +400,9 @@ export function ThreadDetailSecondaryContent({
           // element and prevents the click from reaching rows inside the
           // shadow DOM. The drag handle bar still drags the drawer.
           handleOnly
+          // This drawer hosts nested picker drawers; Vaul's input repositioning
+          // reacts to any focused input, including nested search fields.
+          repositionInputs={false}
         >
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             {drawerSecondaryPanelContent}


### PR DESCRIPTION
## Summary
- stop branch picker search from auto-focusing on compact viewports
- blur active picker inputs before closing mobile overlays
- make mobile drawer nesting explicit and disable Vaul input repositioning for nested picker drawers

## Validation
- pnpm exec prettier --check apps/app/src/components/ui/overlay-trigger.ts apps/app/src/components/ui/responsive-overlay.tsx apps/app/src/components/ui/popover.tsx apps/app/src/components/ui/dropdown-menu.tsx apps/app/src/components/pickers/BranchPicker.tsx apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
- pnpm exec turbo run typecheck --filter=@bb/app