### PR TITLE
Move new tab actions above recents

### DIFF
--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -50,13 +50,12 @@ export interface NewTabFileSearchProps {
   environmentId: string | null;
   currentThreadId: string;
   focusRequest: number;
+  idleActions: ReactNode;
   initialQuery?: string;
-  onSearchActiveChange?: SearchActiveChangeHandler;
   onSelect: (selection: FileSearchSelection) => void;
 }
 
 export type OpenBrowserHandler = () => void;
-export type SearchActiveChangeHandler = (isSearchActive: boolean) => void;
 export type StartTerminalHandler = () => void;
 
 export interface NewTabActionsProps {
@@ -504,8 +503,8 @@ export function NewTabFileSearch({
   environmentId,
   currentThreadId,
   focusRequest,
+  idleActions,
   initialQuery = "",
-  onSearchActiveChange,
   onSelect,
 }: NewTabFileSearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -589,9 +588,8 @@ export function NewTabFileSearch({
   const handleQueryChange = useCallback(
     (nextQuery: string) => {
       setQuery(nextQuery);
-      onSearchActiveChange?.(nextQuery.trim().length > 0);
     },
-    [onSearchActiveChange],
+    [],
   );
 
   const handleFileSelect = useCallback(
@@ -710,6 +708,7 @@ export function NewTabFileSearch({
           />
         ) : null}
       </div>
+      {hasQuery ? null : idleActions}
       {isUnavailable ? (
         <FileSearchMessage
           iconName="FileQuestion"

--- a/apps/app/src/components/secondary-panel/NewTabPage.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   NewTabActions,
   NewTabFileSearch,
@@ -9,7 +8,7 @@ import {
 
 type NewTabPageFileSearchProps = Omit<
   NewTabFileSearchProps,
-  "onSearchActiveChange"
+  "idleActions"
 >;
 
 export interface NewTabPageProps extends NewTabPageFileSearchProps {
@@ -32,10 +31,6 @@ export function NewTabPage({
   onStartTerminal,
   projectId,
 }: NewTabPageProps) {
-  const [isSearchActive, setIsSearchActive] = useState(
-    () => (initialQuery ?? "").trim().length > 0,
-  );
-
   return (
     <div className="flex min-h-full flex-col gap-3 px-4 pb-3 pt-1">
       <NewTabFileSearch
@@ -43,16 +38,15 @@ export function NewTabPage({
         environmentId={environmentId}
         currentThreadId={currentThreadId}
         focusRequest={focusRequest}
+        idleActions={
+          <NewTabActions
+            onOpenBrowser={onOpenBrowser}
+            onStartTerminal={onStartTerminal}
+          />
+        }
         initialQuery={initialQuery}
-        onSearchActiveChange={setIsSearchActive}
         onSelect={onSelect}
       />
-      {isSearchActive ? null : (
-        <NewTabActions
-          onOpenBrowser={onOpenBrowser}
-          onStartTerminal={onStartTerminal}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Render new-tab Actions inside the file search layout before Recents
- Remove the page-level search-active state now that the search component owns idle layout order

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app