### PR TITLE
fix(app): restore dev WS URL rehosting lost in the workflows revert

### DIFF
--- a/apps/app/src/components/thread/terminal/terminal-websocket-url.ts
+++ b/apps/app/src/components/thread/terminal/terminal-websocket-url.ts
@@ -18,6 +18,9 @@ export function buildTerminalWebSocketUrl(
   const path = buildTerminalWebSocketPath(args);
   if (typeof __BB_DEV_WS_URL__ === "string") {
     const url = new URL(__BB_DEV_WS_URL__);
+    // The baked URL targets localhost; rehost it onto the page's hostname so
+    // remote devices (BB_DEV_APP_HOST=0.0.0.0) reach the same server.
+    url.hostname = window.location.hostname;
     url.pathname = path;
     url.search = "";
     url.hash = "";

--- a/apps/app/src/lib/ws.ts
+++ b/apps/app/src/lib/ws.ts
@@ -30,12 +30,19 @@ export class WebSocketManager {
     if (this.socket) return;
 
     // In dev mode, connect directly to the server to bypass Vite's WS proxy
-    // which does not handle reconnection after backend restarts.
+    // which does not handle reconnection after backend restarts. The baked
+    // URL targets localhost; rehost it onto the page's hostname so remote
+    // devices (BB_DEV_APP_HOST=0.0.0.0, e.g. over tailscale) reach the same
+    // server, which listens on all interfaces.
     // In production, use the same origin (server serves the app).
-    const url =
-      typeof __BB_DEV_WS_URL__ === "string"
-        ? __BB_DEV_WS_URL__
-        : `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
+    let url: string;
+    if (typeof __BB_DEV_WS_URL__ === "string") {
+      const devUrl = new URL(__BB_DEV_WS_URL__);
+      devUrl.hostname = window.location.hostname;
+      url = devUrl.toString();
+    } else {
+      url = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
+    }
 
     this.socket = new ReconnectingWebSocket(url, undefined, {
       minReconnectionDelay: 1000,


### PR DESCRIPTION
## Summary

The workflows revert (ee01a53a6) returned `apps/app/src/lib/ws.ts` and `terminal-websocket-url.ts` to a state predating da16d3c58, silently undoing the dev WS rehost fix as collateral damage.

**Symptom**: on a remote device (`BB_DEV_APP_HOST=0.0.0.0`, e.g. over tailscale), the app loads and `/api` works through the same-origin vite proxy, but the realtime socket dials the baked `ws://localhost:<server-port>/ws` — the *device's own* loopback — and never connects. No live updates arrive; timelines only move on refetch triggers (pressing stop, sending another message, window refocus). Provider-independent; it presents as "responses don't appear until I press stop and send another message."

## Fix

Reapplies da16d3c58's hunks verbatim: swap only the hostname of the baked dev URL for `window.location.hostname` on the realtime and terminal sockets. The intentional parts of the revert (dropping workflow subscription refcounting in the same file) are untouched.

## Verification

- `turbo run typecheck --filter=@bb/app` ✅
- Repro + fix verified end-to-end in a dev instance: before the fix, a browser pointed at the tailnet IP received zero realtime frames after subscribe (responses only appeared on refetch); after, the realtime socket dials `ws://<page-host>:20694/ws` and a mid-conversation agent response rendered live (~8s) with no interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)