### PR TITLE
Ignore shell path terminal titles

### DIFF
--- a/apps/app/src/components/thread/terminal/thread-terminal-title.test.ts
+++ b/apps/app/src/components/thread/terminal/thread-terminal-title.test.ts
@@ -12,20 +12,28 @@ describe("terminal title normalization", () => {
     );
   });
 
-  it("collapses long shell path titles to their final path segments", () => {
+  it("ignores shell path titles without changing the terminal title", () => {
     expect(
       normalizeTerminalTitle({
         title:
           "michael@Michaels-MacBook-Pro:~/.bb-dev/worktrees/env_gj4ep9emi8/bb",
       }),
-    ).toBe(".../worktrees/env_gj4ep9emi8/bb");
+    ).toBeNull();
   });
 
-  it("keeps short shell path titles readable", () => {
+  it("ignores shell path titles with whitespace after the host separator", () => {
+    expect(
+      normalizeTerminalTitle({
+        title: "root@do-1: ~/.bb/worktrees/env_4gfkk8evua/bb",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores short shell path titles", () => {
     expect(
       normalizeTerminalTitle({
         title: "michael@host:~/bb",
       }),
-    ).toBe("~/bb");
+    ).toBeNull();
   });
 });

--- a/apps/app/src/components/thread/terminal/thread-terminal-title.ts
+++ b/apps/app/src/components/thread/terminal/thread-terminal-title.ts
@@ -1,12 +1,7 @@
 const TERMINAL_TITLE_MAX_LENGTH = 200;
-const TERMINAL_TITLE_PATH_SEGMENT_COUNT = 3;
 
 interface NormalizeTerminalTitleArgs {
   title: string;
-}
-
-interface FormatTerminalPathTitleArgs {
-  path: string;
 }
 
 interface IsPathLikeTerminalTitlePathArgs {
@@ -33,9 +28,7 @@ export function normalizeTerminalTitle({
 
   const pathTitle = parseShellPathTitle({ title: trimmedTitle });
   if (pathTitle !== null) {
-    return formatTerminalPathTitle({
-      path: pathTitle.path,
-    }).slice(0, TERMINAL_TITLE_MAX_LENGTH);
+    return null;
   }
 
   return trimmedTitle.slice(0, TERMINAL_TITLE_MAX_LENGTH);
@@ -45,7 +38,7 @@ function parseShellPathTitle({
   title,
 }: ParseShellPathTitleArgs): ShellPathTitleParts | null {
   const match = /^[^@\s:]+@[^:\s]+:(.+)$/u.exec(title);
-  const path = match?.[1];
+  const path = match?.[1]?.trimStart();
   if (!path || !isPathLikeTerminalTitlePath({ path })) {
     return null;
   }
@@ -62,19 +55,4 @@ function isPathLikeTerminalTitlePath({
     path.startsWith("/") ||
     path.startsWith("./")
   );
-}
-
-function formatTerminalPathTitle({
-  path,
-}: FormatTerminalPathTitleArgs): string {
-  if (path === "/" || path === "~" || path === ".") {
-    return path;
-  }
-
-  const segments = path.split("/").filter((segment) => segment.length > 0);
-  if (segments.length <= TERMINAL_TITLE_PATH_SEGMENT_COUNT) {
-    return path;
-  }
-
-  return `.../${segments.slice(-TERMINAL_TITLE_PATH_SEGMENT_COUNT).join("/")}`;
 }


### PR DESCRIPTION
## Summary
- Ignore automatic shell path titles like user@host:/worktree and user@host: /worktree
- Keep the daemon's initial shell-name terminal title instead of replacing it with a long worktree path
- Add regression coverage for Linux bash-style title spacing

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/thread/terminal/thread-terminal-title.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app