### PR TITLE
Fix workspace watcher inotify retry leak

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -301,7 +301,7 @@ export async function createHostDaemonApp(
           rootPath: error.rootPath,
           watchError: error.message,
         },
-        "Data-dir skills watch unavailable; retrying in background",
+        "Data-dir skills watch unavailable",
       );
     },
     onThreadStorageWatchError: ({ error }) => {
@@ -310,7 +310,7 @@ export async function createHostDaemonApp(
           rootPath: error.rootPath,
           watchError: error.message,
         },
-        "Thread storage watch unavailable; retrying in background",
+        "Thread storage watch unavailable",
       );
     },
     onWorkspaceStatusChanged: ({ environmentId, changeKinds }) => {
@@ -329,7 +329,7 @@ export async function createHostDaemonApp(
           rootPath: error.rootPath,
           watchError: error.message,
         },
-        "Workspace status watch unavailable; retrying in background",
+        "Workspace status watch unavailable",
       );
     },
     onToolCall:

--- a/packages/host-watcher/src/root-subscription.ts
+++ b/packages/host-watcher/src/root-subscription.ts
@@ -16,7 +16,8 @@ type ParcelWatcherAsyncSubscription = Awaited<
 type ParcelWatcherError = Parameters<ParcelWatcherCallback>[0];
 
 export type ParcelWatcherEventBatch = Parameters<ParcelWatcherCallback>[1];
-export type ParcelWatcherSubscribeOptions = Parameters<ParcelWatcherSubscribe>[2];
+export type ParcelWatcherSubscribeOptions =
+  Parameters<ParcelWatcherSubscribe>[2];
 
 export interface RootSubscriptionArgs {
   rootPath: string;
@@ -49,10 +50,10 @@ function isDroppedEventsRescanRequiredMessage(message: string): boolean {
 
 /**
  * Owns the full lifecycle of a single Parcel subscription on one root path:
- * existence gating before subscribe, exponential-backoff retry, warn-once error
- * reporting, dropped-events recovery, and disposal that drains in-flight
- * start/stop work. Callers compose one (single-root watchers) or many (keyed by
- * root path) and layer their own change aggregation on top.
+ * existence gating before subscribe, startup retry, warn-once error reporting,
+ * dropped-events recovery, and disposal that drains in-flight start/stop work.
+ * Callers compose one (single-root watchers) or many (keyed by root path) and
+ * layer their own change aggregation on top.
  */
 export class RootSubscription {
   private disposed = false;
@@ -94,9 +95,7 @@ export class RootSubscription {
     }
   }
 
-  private stopSubscription(
-    subscription: ParcelWatcherAsyncSubscription,
-  ): void {
+  private stopSubscription(subscription: ParcelWatcherAsyncSubscription): void {
     const pendingStop = subscription
       .unsubscribe()
       .catch(() => {
@@ -138,7 +137,7 @@ export class RootSubscription {
     );
   }
 
-  private handleSubscriptionFailure(): void {
+  private handleRecoverableSubscriptionFailure(): void {
     if (this.subscription !== null) {
       const subscription = this.subscription;
       this.subscription = null;
@@ -164,6 +163,8 @@ export class RootSubscription {
     }
 
     try {
+      let recoverableFailureObserved = false;
+      let terminalFailureObserved = false;
       const subscription = await parcelWatcher.subscribe(
         this.args.rootPath,
         (error: ParcelWatcherError, events: ParcelWatcherEventBatch) => {
@@ -173,13 +174,20 @@ export class RootSubscription {
           if (error) {
             const message = toErrorMessage(error);
             if (isDroppedEventsRescanRequiredMessage(message)) {
+              recoverableFailureObserved = true;
               this.recoveryPending = true;
               this.args.onDroppedEvents();
-              this.handleSubscriptionFailure();
+              this.handleRecoverableSubscriptionFailure();
               return;
             }
+            terminalFailureObserved = true;
             this.reportWatchError(message);
-            this.handleSubscriptionFailure();
+            // Parcel has already cleared the callback for runtime backend
+            // errors. On Linux, retrying after an inotify backend poll/read
+            // error creates a fresh native backend while the failed one may
+            // still hold its fd/thread state. Leave the subscription unavailable
+            // until the owner recreates it or the process restarts.
+            this.subscription = null;
             return;
           }
           this.args.onEvents(events);
@@ -187,7 +195,16 @@ export class RootSubscription {
         this.args.subscribeOptions,
       );
       if (this.disposed) {
+        if (!terminalFailureObserved) {
+          this.stopSubscription(subscription);
+        }
+        return;
+      }
+      if (recoverableFailureObserved) {
         this.stopSubscription(subscription);
+        return;
+      }
+      if (terminalFailureObserved) {
         return;
       }
       this.warned = false;

--- a/packages/host-watcher/src/workspace-status-watcher.ts
+++ b/packages/host-watcher/src/workspace-status-watcher.ts
@@ -97,21 +97,25 @@ function collectIgnoredDirectoryPaths(statusOutput: string): string[] {
     if (!ignoredPath.endsWith("/")) {
       continue;
     }
-    ignoredDirectoryPaths.add(ignoredPath);
+    ignoredDirectoryPaths.add(ignoredPath.replace(/\/+$/u, ""));
   }
   return Array.from(ignoredDirectoryPaths).sort();
 }
 
-async function resolveWorkspaceRootIgnores(cwd: string): Promise<string[]> {
-  try {
-    const status = await runGitIgnoredMatchingStatus({ cwd });
-    return [
-      ...WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS,
-      ...collectIgnoredDirectoryPaths(status.stdout),
-    ];
-  } catch {
-    return WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS;
+function mergeWorkspaceRootIgnores(gitIgnoredPaths: string[]): string[] {
+  const ignoredPaths = new Set<string>();
+  for (const ignoredPath of [
+    ...WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS,
+    ...gitIgnoredPaths,
+  ]) {
+    ignoredPaths.add(ignoredPath);
   }
+  return Array.from(ignoredPaths);
+}
+
+async function resolveWorkspaceRootIgnores(cwd: string): Promise<string[]> {
+  const status = await runGitIgnoredMatchingStatus({ cwd });
+  return mergeWorkspaceRootIgnores(collectIgnoredDirectoryPaths(status.stdout));
 }
 
 function createWorkspaceStatusCallbackError(
@@ -150,6 +154,10 @@ export class WorkspaceStatusWatcher {
   private disposed = false;
   private metadataRetryAttempt = 0;
   private metadataStartRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private workspaceRootRetryAttempt = 0;
+  private workspaceRootStartRetryTimer: ReturnType<typeof setTimeout> | null =
+    null;
+  private workspaceRootSetupWarned = false;
   private readonly subscriptions = new Map<string, RootSubscription>();
   private readonly changeScheduler;
 
@@ -195,6 +203,10 @@ export class WorkspaceStatusWatcher {
       clearTimeout(this.metadataStartRetryTimer);
       this.metadataStartRetryTimer = null;
     }
+    if (this.workspaceRootStartRetryTimer !== null) {
+      clearTimeout(this.workspaceRootStartRetryTimer);
+      this.workspaceRootStartRetryTimer = null;
+    }
     await Promise.all(
       [...this.subscriptions.values()].map((subscription) =>
         subscription.dispose(),
@@ -211,10 +223,70 @@ export class WorkspaceStatusWatcher {
       return;
     }
     const rootPath = await resolveWatchRootPath(this.args.cwd);
-    this.startWatchSubscription(
-      await createWorkspaceRootWatchSpec({ cwd: this.args.cwd, rootPath }),
-    );
+    this.startWorkspaceRootWatchSubscription(rootPath);
     this.startMetadataWatchSubscriptions();
+  }
+
+  private reportWorkspaceRootSetupError(
+    rootPath: string,
+    error: unknown,
+  ): void {
+    if (this.workspaceRootSetupWarned) {
+      return;
+    }
+    this.workspaceRootSetupWarned = true;
+    this.args.onWatchError({
+      message: `Workspace root ignore discovery failed: ${toErrorMessage(error)}`,
+      rootPath,
+    });
+  }
+
+  private scheduleWorkspaceRootWatchRetry(rootPath: string): void {
+    if (this.disposed || this.workspaceRootStartRetryTimer !== null) {
+      return;
+    }
+    this.workspaceRootRetryAttempt += 1;
+    this.workspaceRootStartRetryTimer = setTimeout(
+      () => {
+        this.workspaceRootStartRetryTimer = null;
+        this.startWorkspaceRootWatchSubscription(rootPath);
+      },
+      calculateExponentialBackoffDelay({
+        attempt: this.workspaceRootRetryAttempt,
+        baseDelayMs: this.args.retryDelayMs,
+        maxDelayMs: this.args.maxRetryDelayMs,
+      }),
+    );
+  }
+
+  private startWorkspaceRootWatchSubscription(rootPath: string): void {
+    void this.startWorkspaceRootWatchSubscriptionAsync(rootPath);
+  }
+
+  private async startWorkspaceRootWatchSubscriptionAsync(
+    rootPath: string,
+  ): Promise<void> {
+    if (this.disposed || this.subscriptions.has(rootPath)) {
+      return;
+    }
+    try {
+      const spec = await createWorkspaceRootWatchSpec({
+        cwd: this.args.cwd,
+        rootPath,
+      });
+      if (this.disposed) {
+        return;
+      }
+      this.workspaceRootRetryAttempt = 0;
+      this.workspaceRootSetupWarned = false;
+      this.startWatchSubscription(spec);
+    } catch (error) {
+      if (this.disposed) {
+        return;
+      }
+      this.reportWorkspaceRootSetupError(rootPath, error);
+      this.scheduleWorkspaceRootWatchRetry(rootPath);
+    }
   }
 
   private startWatchSubscription(spec: WatchSubscriptionSpec): void {

--- a/packages/host-watcher/test/watch-path.test.ts
+++ b/packages/host-watcher/test/watch-path.test.ts
@@ -256,6 +256,46 @@ describe.sequential("watchPathChanges", () => {
     }
   });
 
+  it("does not retry or unsubscribe after Parcel inotify poll interruptions", async () => {
+    const threadStorageRoot = path.join("/tmp", "bb-watch-path-poll");
+    const onWatchError = vi.fn();
+    const { callbacks, subscribeCallCount, unsubscribe, watchPathChanges } =
+      await importWatchPathWithMockedWatcher({
+        pathExistsImplementation: async () => true,
+      });
+
+    const stopWatching = watchPathChanges(threadStorageRoot, {
+      onChange: () => undefined,
+      onWatchError,
+    });
+
+    try {
+      const [callback] = await waitFor(
+        () => callbacks,
+        (currentCallbacks) => currentCallbacks.length === 1,
+      );
+
+      callback(new Error("Unable to poll: Interrupted system call"), []);
+
+      await waitFor(
+        () => onWatchError.mock.calls.length,
+        (callCount) => callCount === 1,
+      );
+      await sleep(600);
+
+      expect(onWatchError).toHaveBeenCalledWith({
+        message: "Unable to poll: Interrupted system call",
+        rootPath: threadStorageRoot,
+      });
+      expect(subscribeCallCount()).toBe(1);
+      expect(unsubscribe).not.toHaveBeenCalled();
+    } finally {
+      await stopWatching();
+    }
+
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
   it("waits for late startup unsubscribe when disposed during startup", async () => {
     const threadStorageRoot = path.join("/tmp", "bb-watch-path-late");
     const subscriptionDeferred =

--- a/packages/host-watcher/test/watch-status.test.ts
+++ b/packages/host-watcher/test/watch-status.test.ts
@@ -564,6 +564,45 @@ describe.sequential("watchWorkspaceStatus", () => {
     }
   });
 
+  it("does not retry workspace subscriptions after Parcel inotify poll interruptions", async () => {
+    const repoPath = await initRepo();
+    const {
+      emitWorkspaceRootError,
+      getWorkspaceRootSubscriptionCount,
+      ready,
+      watchWorkspaceStatus,
+    } = await importWatchWorkspaceStatusWithManualWorkspaceEvents(repoPath);
+    const watchErrors: string[] = [];
+    const stopWatching = watchWorkspaceStatus(repoPath, {
+      onChange: () => undefined,
+      onWatchError: (error) => {
+        watchErrors.push(`${error.rootPath}:${error.message}`);
+      },
+    });
+
+    try {
+      await ready;
+      expect(getWorkspaceRootSubscriptionCount()).toBe(1);
+
+      emitWorkspaceRootError(
+        new Error("Unable to poll: Interrupted system call"),
+      );
+
+      await waitForCallCount(
+        () => watchErrors.length,
+        1,
+        WATCH_TEST_TIMEOUT_MS,
+      );
+      await ensureCallCountStays(getWorkspaceRootSubscriptionCount, 1, 600);
+
+      expect(watchErrors).toEqual([
+        `${normalizeWatchPath(repoPath)}:Unable to poll: Interrupted system call`,
+      ]);
+    } finally {
+      await stopWatching();
+    }
+  });
+
   it("does not emit callbacks when a clean workspace watch starts", async () => {
     const repoPath = await initRepo();
     const { ready, watchWorkspaceStatus } =
@@ -588,13 +627,16 @@ describe.sequential("watchWorkspaceStatus", () => {
     const repoPath = await initRepo();
     await fs.writeFile(
       path.join(repoPath, ".gitignore"),
-      "node_modules/\n.turbo/\n",
+      "node_modules/\n.turbo/\ncoverage/\n",
       "utf8",
     );
     await fs.mkdir(path.join(repoPath, "node_modules", "pkg"), {
       recursive: true,
     });
     await fs.mkdir(path.join(repoPath, ".turbo", "cache"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(repoPath, "coverage", "tmp"), {
       recursive: true,
     });
     await fs.writeFile(
@@ -628,10 +670,53 @@ describe.sequential("watchWorkspaceStatus", () => {
       await ready;
       expect(getWorkspaceRootSubscribeOptions()?.ignore).toEqual([
         ".git",
-        ".turbo/",
+        ".turbo",
+        "coverage",
       ]);
     } finally {
       stopWatching();
+    }
+  });
+
+  it("reports and retries when Git ignored directory discovery fails", async () => {
+    const repoPath = await initRepo();
+    await fs.rm(path.join(repoPath, ".git"), { force: true, recursive: true });
+    await fs.writeFile(
+      path.join(repoPath, ".git"),
+      "gitdir: /missing\n",
+      "utf8",
+    );
+    const subscribedRoots: string[] = [];
+    const mockSubscribe = async (
+      ...watchArgs: ParcelWatcherSubscribeArgs
+    ): Promise<ParcelWatcherSubscribeResult> => {
+      subscribedRoots.push(watchArgs[0]);
+      return createMockWatcherSubscription();
+    };
+    vi.spyOn(parcelWatcher, "subscribe").mockImplementation(mockSubscribe);
+    const watchErrors: string[] = [];
+    const stopWatching = watchWorkspaceStatusImpl(repoPath, {
+      onChange: () => undefined,
+      onWatchError: (error) => {
+        watchErrors.push(`${error.rootPath}:${error.message}`);
+      },
+    });
+
+    try {
+      await waitForCallCount(
+        () => watchErrors.length,
+        1,
+        WATCH_TEST_TIMEOUT_MS,
+      );
+      await ensureCallCountStays(() => subscribedRoots.length, 0, 600);
+
+      const ignoreDiscoveryErrors = watchErrors.filter((error) =>
+        error.includes("Workspace root ignore discovery failed:"),
+      );
+      expect(ignoreDiscoveryErrors).toHaveLength(1);
+      expect(ignoreDiscoveryErrors[0]).toContain(normalizeWatchPath(repoPath));
+    } finally {
+      await stopWatching();
     }
   });
 


### PR DESCRIPTION
## Summary
- Stop retrying established Parcel watcher callback failures, which avoids repeatedly creating native inotify backends after Linux poll interruptions.
- Fail closed and retry workspace-root watcher setup when Git ignored-directory discovery fails, logging the concrete setup failure instead of starting with weak ignores.
- Keep workspace-root ignores Git-derived, remove the broad hardcoded ignore list, and update watcher tests/log wording.

## Root cause
The packaged daemon was repeatedly seeing Parcel watcher callback errors like `Unable to poll: Interrupted system call`. Treating those runtime callback failures as recoverable startup failures caused new subscriptions to be created while the failed native backend state could remain around, which explained the inotify fd/thread growth.

## Test plan
- `pnpm exec turbo run test --filter=@bb/host-watcher`
- `pnpm exec turbo run typecheck --filter=@bb/host-watcher`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec prettier --check packages/host-watcher/src/root-subscription.ts packages/host-watcher/src/workspace-status-watcher.ts packages/host-watcher/test/watch-path.test.ts packages/host-watcher/test/watch-status.test.ts apps/host-daemon/src/app.ts`