### PR TITLE
Sync terminal tabs and active badge counts

### DIFF
--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import type { TerminalSession } from "@bb/server-contract";
+import { isVisibleTerminalSessionStatus } from "@bb/domain";
 import { getThreadSecondaryPanelOpenAtom } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
 import {
   useCloseThreadTerminal,
@@ -58,7 +59,7 @@ export type ThreadTerminalTitleChangeHandler = (title: string) => void;
 type TerminalTitleRenameTimeout = number;
 
 function isVisibleTerminalSession(session: TerminalSession): boolean {
-  return session.status !== "exited";
+  return isVisibleTerminalSessionStatus(session.status);
 }
 
 function pickActiveTerminalId(

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -46,7 +46,7 @@ export function TabPill({
   return (
     <div
       className={cn(
-        "group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md transition-colors",
+        "group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md transition-colors max-md:pointer-coarse:h-9",
         COARSE_POINTER_TEXT_SM_CLASS,
         isActive
           ? "bg-muted text-foreground"

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -122,6 +122,7 @@ import { useThreadTimelinePages } from "./useThreadTimelinePages";
 import {
   buildTerminalSyncedSecondaryFileTabs,
   findActiveTerminalIdInSecondaryFileTabs,
+  syncTerminalTabsInFixedPanelState,
 } from "./threadTerminalTabs";
 import {
   buildOpenInEditorHandler,
@@ -144,6 +145,7 @@ import {
   useRemoveFixedRightTerminalTab,
   useSetFixedRightTerminalActiveTerminal,
   useTouchFixedPanelTabsState,
+  useUpdateFixedPanelTabsState,
 } from "@/lib/fixed-panel-tabs";
 import {
   buildParentSelectorOptions,
@@ -315,6 +317,7 @@ export function ThreadDetailView() {
   const setActiveFixedTerminal =
     useSetFixedRightTerminalActiveTerminal(threadId);
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(threadId);
+  const updateFixedPanelTabsState = useUpdateFixedPanelTabsState(threadId);
   const setThreadSecondaryPanel = useSetThreadSecondaryPanelSelection(threadId);
   const toggleDefaultPersistedSecondaryPanel =
     useToggleThreadSecondaryPanelSelection(threadId);
@@ -531,6 +534,17 @@ export function ThreadDetailView() {
       }),
     [orderedSecondaryFileTabs, terminalSessions],
   );
+  useEffect(() => {
+    if (terminalsListQuery.data === undefined) {
+      return;
+    }
+    updateFixedPanelTabsState((state) =>
+      syncTerminalTabsInFixedPanelState({
+        state,
+        terminalSessions,
+      }),
+    );
+  }, [terminalSessions, terminalsListQuery.data, updateFixedPanelTabsState]);
   const hostConnectionNotice = useMemo(
     () => (thread ? buildHostConnectionNotice(thread) : null),
     [thread],

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -13,6 +13,7 @@ import {
   type ThreadListEntry,
   type ThreadWithRuntime,
 } from "@bb/domain";
+import type { TerminalSession } from "@bb/server-contract";
 import { appToast } from "@/components/ui/app-toast";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import { useRequestEnvironmentAction } from "../../hooks/mutations/environment-mutations";
@@ -119,6 +120,10 @@ import { useThreadReadTracking } from "./useThreadReadTracking";
 import { useThreadUnreadDividerState } from "./useThreadUnreadDividerState";
 import { useThreadTimelinePages } from "./useThreadTimelinePages";
 import {
+  buildTerminalSyncedSecondaryFileTabs,
+  findActiveTerminalIdInSecondaryFileTabs,
+} from "./threadTerminalTabs";
+import {
   buildOpenInEditorHandler,
   resolveWorkspaceChangedFileOpenTarget,
   resolveThreadLocalWorkspaceRootPath,
@@ -163,6 +168,7 @@ import { resolveThreadComposerBootstrapReady } from "./threadDetailComposerBoots
 const EMPTY_PARENT_THREADS: readonly ThreadListEntry[] = [];
 const EMPTY_PROJECT_THREAD_SUBSET_FILTERS =
   {} satisfies ProjectThreadSubsetFilters;
+const EMPTY_TERMINAL_SESSIONS: readonly TerminalSession[] = [];
 
 type MergeBasePickerOpenChangeHandler = NonNullable<
   ContextBannerMergeBaseConfig["onPickerOpenChange"]
@@ -501,22 +507,29 @@ export function ThreadDetailView() {
   const terminalsListQuery = useThreadTerminals(threadId ?? "");
   const createTerminal = useCreateThreadTerminal();
   const closeTerminal = useCloseThreadTerminal();
+  const terminalSessions =
+    terminalsListQuery.data?.sessions ?? EMPTY_TERMINAL_SESSIONS;
   const activeTerminalCount = useMemo(
     () =>
-      terminalsListQuery.data?.sessions.filter(
-        (session) => isActiveTerminalSessionStatus(session.status),
-      ).length ?? 0,
-    [terminalsListQuery.data],
+      terminalSessions.filter((session) =>
+        isActiveTerminalSessionStatus(session.status),
+      ).length,
+    [terminalSessions],
   );
   const terminalsById = useMemo(
     () =>
       new Map(
-        (terminalsListQuery.data?.sessions ?? []).map((session) => [
-          session.id,
-          session,
-        ]),
+        terminalSessions.map((session) => [session.id, session]),
       ),
-    [terminalsListQuery.data],
+    [terminalSessions],
+  );
+  const syncedOrderedSecondaryFileTabs = useMemo(
+    () =>
+      buildTerminalSyncedSecondaryFileTabs({
+        orderedTabs: orderedSecondaryFileTabs,
+        terminalSessions,
+      }),
+    [orderedSecondaryFileTabs, terminalSessions],
   );
   const hostConnectionNotice = useMemo(
     () => (thread ? buildHostConnectionNotice(thread) : null),
@@ -754,97 +767,100 @@ export function ThreadDetailView() {
   );
   const fileTabs = useMemo<SecondaryPanelFileTab[] | undefined>(() => {
     const filenameOf = (path: string) => path.split("/").at(-1) ?? path;
-    const tabs = orderedSecondaryFileTabs.map((tab): SecondaryPanelFileTab => {
-      switch (tab.kind) {
-        case "browser": {
-          const browserLabel =
-            tab.title ?? (tab.url.length > 0 ? getBrowserUrlHost(tab.url) : "");
-          return {
-            id: tab.id,
-            filename: browserLabel.length > 0 ? browserLabel : "Browser",
-            isActive: tab.id === activeFixedSecondaryTabId,
-            leadingVisual: (
-              <Icon
-                name="Globe"
-                className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-                aria-hidden
-              />
-            ),
-            statusLabel: null,
-            onSelect: () => activateBrowserTab(tab.id),
-            onClose: () => closeBrowserTab(tab.id),
-          };
+    const tabs = syncedOrderedSecondaryFileTabs.map(
+      (tab): SecondaryPanelFileTab => {
+        switch (tab.kind) {
+          case "browser": {
+            const browserLabel =
+              tab.title ??
+              (tab.url.length > 0 ? getBrowserUrlHost(tab.url) : "");
+            return {
+              id: tab.id,
+              filename: browserLabel.length > 0 ? browserLabel : "Browser",
+              isActive: tab.id === activeFixedSecondaryTabId,
+              leadingVisual: (
+                <Icon
+                  name="Globe"
+                  className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+                  aria-hidden
+                />
+              ),
+              statusLabel: null,
+              onSelect: () => activateBrowserTab(tab.id),
+              onClose: () => closeBrowserTab(tab.id),
+            };
+          }
+          case "terminal": {
+            const session = terminalsById.get(tab.terminalId);
+            return {
+              id: tab.id,
+              filename: session?.title ?? "Terminal",
+              isActive: tab.id === activeFixedSecondaryTabId,
+              leadingVisual: (
+                <Icon
+                  name="Terminal"
+                  className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+                  aria-hidden
+                />
+              ),
+              statusLabel:
+                session === undefined || session.status === "running"
+                  ? null
+                  : terminalStatusLabel(session),
+              onSelect: () => handleActivateTerminalTab(tab.terminalId),
+              onClose: () => handleCloseTerminalTab(tab.terminalId),
+            };
+          }
+          case "workspace-file-preview":
+            return {
+              id: tab.id,
+              filename: filenameOf(tab.path),
+              isActive: tab.id === activeFixedSecondaryTabId,
+              leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
+              statusLabel: tab.statusLabel,
+              onSelect: () => activateWorkspaceFileTab(tab.path),
+              onClose: () => closeWorkspaceFileTab(tab.path),
+            };
+          case "host-file-preview":
+            return {
+              id: tab.id,
+              filename: filenameOf(tab.path),
+              isActive: tab.id === activeFixedSecondaryTabId,
+              leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
+              statusLabel: null,
+              onSelect: () => activateHostFileTab(tab.path),
+              onClose: () => closeHostFileTab(tab.path),
+            };
+          case "thread-storage-file-preview":
+            return {
+              id: tab.id,
+              filename: filenameOf(tab.path),
+              isActive: tab.id === activeFixedSecondaryTabId,
+              isPinned: tab.isPinned,
+              leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
+              statusLabel: null,
+              onSelect: () => activateStorageFileTab(tab.path),
+              onClose: () => closeStorageFileTab(tab.path),
+            };
+          case "new-tab":
+            return {
+              id: tab.id,
+              filename: "New tab",
+              isActive: tab.id === activeFixedSecondaryTabId,
+              leadingVisual: (
+                <Icon
+                  name="NewTab"
+                  className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+                  aria-hidden
+                />
+              ),
+              statusLabel: null,
+              onSelect: activateNewTab,
+              onClose: closeNewTab,
+            };
         }
-        case "terminal": {
-          const session = terminalsById.get(tab.terminalId);
-          return {
-            id: tab.id,
-            filename: session?.title ?? "Terminal",
-            isActive: tab.id === activeFixedSecondaryTabId,
-            leadingVisual: (
-              <Icon
-                name="Terminal"
-                className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-                aria-hidden
-              />
-            ),
-            statusLabel:
-              session === undefined || session.status === "running"
-                ? null
-                : terminalStatusLabel(session),
-            onSelect: () => handleActivateTerminalTab(tab.terminalId),
-            onClose: () => handleCloseTerminalTab(tab.terminalId),
-          };
-        }
-        case "workspace-file-preview":
-          return {
-            id: tab.id,
-            filename: filenameOf(tab.path),
-            isActive: tab.id === activeFixedSecondaryTabId,
-            leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
-            statusLabel: tab.statusLabel,
-            onSelect: () => activateWorkspaceFileTab(tab.path),
-            onClose: () => closeWorkspaceFileTab(tab.path),
-          };
-        case "host-file-preview":
-          return {
-            id: tab.id,
-            filename: filenameOf(tab.path),
-            isActive: tab.id === activeFixedSecondaryTabId,
-            leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
-            statusLabel: null,
-            onSelect: () => activateHostFileTab(tab.path),
-            onClose: () => closeHostFileTab(tab.path),
-          };
-        case "thread-storage-file-preview":
-          return {
-            id: tab.id,
-            filename: filenameOf(tab.path),
-            isActive: tab.id === activeFixedSecondaryTabId,
-            isPinned: tab.isPinned,
-            leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
-            statusLabel: null,
-            onSelect: () => activateStorageFileTab(tab.path),
-            onClose: () => closeStorageFileTab(tab.path),
-          };
-        case "new-tab":
-          return {
-            id: tab.id,
-            filename: "New tab",
-            isActive: tab.id === activeFixedSecondaryTabId,
-            leadingVisual: (
-              <Icon
-                name="NewTab"
-                className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-                aria-hidden
-              />
-            ),
-            statusLabel: null,
-            onSelect: activateNewTab,
-            onClose: closeNewTab,
-          };
-      }
-    });
+      },
+    );
     return tabs.length > 0 ? tabs : undefined;
   }, [
     activateBrowserTab,
@@ -860,7 +876,7 @@ export function ThreadDetailView() {
     closeWorkspaceFileTab,
     handleActivateTerminalTab,
     handleCloseTerminalTab,
-    orderedSecondaryFileTabs,
+    syncedOrderedSecondaryFileTabs,
     terminalsById,
   ]);
   const requestedMergeBaseBranch =
@@ -1452,9 +1468,10 @@ export function ThreadDetailView() {
     />
   );
   const activeTerminalId =
-    activeFixedSecondaryTab?.kind === "terminal"
-      ? activeFixedSecondaryTab.terminalId
-      : null;
+    findActiveTerminalIdInSecondaryFileTabs({
+      activeTabId: activeFixedSecondaryTabId,
+      tabs: syncedOrderedSecondaryFileTabs,
+    });
   const fileTabContent = activeTerminalId ? (
     <ThreadTerminalPanel
       canCreateTerminal={canCreateTerminal}

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -8,6 +8,7 @@ import type {
   TimelineTitleActionResolver,
 } from "@/components/thread/timeline";
 import {
+  isActiveTerminalSessionStatus,
   resolveEnvironmentMergeBaseBranch,
   type ThreadListEntry,
   type ThreadWithRuntime,
@@ -503,7 +504,7 @@ export function ThreadDetailView() {
   const activeTerminalCount = useMemo(
     () =>
       terminalsListQuery.data?.sessions.filter(
-        (session) => session.status !== "exited",
+        (session) => isActiveTerminalSessionStatus(session.status),
       ).length ?? 0,
     [terminalsListQuery.data],
   );

--- a/apps/app/src/views/thread-detail/threadTerminalTabs.test.ts
+++ b/apps/app/src/views/thread-detail/threadTerminalTabs.test.ts
@@ -1,16 +1,21 @@
 import type { TerminalSession } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import {
+  createEmptyFixedPanelTabsState,
   createHostFilePreviewFixedPanelTab,
   createTerminalFixedPanelTab,
-  type SecondaryFileFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
 import {
   buildTerminalSyncedSecondaryFileTabs,
   findActiveTerminalIdInSecondaryFileTabs,
+  syncTerminalTabsInFixedPanelState,
 } from "./threadTerminalTabs";
 
 type TerminalSessionOverrides = Partial<TerminalSession>;
+
+interface TabIdentity {
+  id: string;
+}
 
 function terminalSession(
   overrides: TerminalSessionOverrides,
@@ -34,7 +39,7 @@ function terminalSession(
   };
 }
 
-function tabIds(tabs: readonly SecondaryFileFixedPanelTab[]): string[] {
+function tabIds(tabs: readonly TabIdentity[]): string[] {
   return tabs.map((tab) => tab.id);
 }
 
@@ -116,5 +121,74 @@ describe("buildTerminalSyncedSecondaryFileTabs", () => {
         tabs: [fileTab, terminalTab],
       }),
     ).toBeNull();
+  });
+
+  it("syncs missing server terminal sessions into fixed panel state", () => {
+    const fileTab = createHostFilePreviewFixedPanelTab({
+      lineRange: null,
+      path: "/workspace/file.ts",
+    });
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: fileTab.id,
+        isOpen: true,
+        tabs: [fileTab],
+      },
+    });
+    const nextState = syncTerminalTabsInFixedPanelState({
+      state,
+      terminalSessions: [
+        terminalSession({ id: "term_1" }),
+        terminalSession({ id: "term_2" }),
+      ],
+    });
+
+    expect(tabIds(nextState.secondary.tabs)).toEqual([
+      "host-file-preview:%2Fworkspace%2Ffile.ts",
+      "terminal:term_1",
+      "terminal:term_2",
+    ]);
+    expect(nextState.secondary.activeTabId).toBe(fileTab.id);
+  });
+
+  it("removes stale fixed terminal tabs and clears stale active state", () => {
+    const staleTerminalTab = createTerminalFixedPanelTab({
+      terminalId: "term_stale",
+    });
+    const currentTerminalTab = createTerminalFixedPanelTab({
+      terminalId: "term_1",
+    });
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: staleTerminalTab.id,
+        isOpen: true,
+        tabs: [staleTerminalTab, currentTerminalTab],
+      },
+    });
+    const nextState = syncTerminalTabsInFixedPanelState({
+      state,
+      terminalSessions: [terminalSession({ id: "term_1" })],
+    });
+
+    expect(tabIds(nextState.secondary.tabs)).toEqual(["terminal:term_1"]);
+    expect(nextState.secondary.activeTabId).toBeNull();
+  });
+
+  it("keeps fixed panel state identity when terminal tabs already match", () => {
+    const terminalTab = createTerminalFixedPanelTab({ terminalId: "term_1" });
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: terminalTab.id,
+        isOpen: true,
+        tabs: [terminalTab],
+      },
+    });
+
+    expect(
+      syncTerminalTabsInFixedPanelState({
+        state,
+        terminalSessions: [terminalSession({ id: "term_1" })],
+      }),
+    ).toBe(state);
   });
 });

--- a/apps/app/src/views/thread-detail/threadTerminalTabs.test.ts
+++ b/apps/app/src/views/thread-detail/threadTerminalTabs.test.ts
@@ -1,0 +1,120 @@
+import type { TerminalSession } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import {
+  createHostFilePreviewFixedPanelTab,
+  createTerminalFixedPanelTab,
+  type SecondaryFileFixedPanelTab,
+} from "@/lib/fixed-panel-tabs-state";
+import {
+  buildTerminalSyncedSecondaryFileTabs,
+  findActiveTerminalIdInSecondaryFileTabs,
+} from "./threadTerminalTabs";
+
+type TerminalSessionOverrides = Partial<TerminalSession>;
+
+function terminalSession(
+  overrides: TerminalSessionOverrides,
+): TerminalSession {
+  return {
+    id: "term_1",
+    threadId: "thr_1",
+    environmentId: "env_1",
+    hostId: "host_1",
+    title: "Terminal",
+    initialCwd: "/workspace",
+    cols: 100,
+    rows: 30,
+    status: "running",
+    exitCode: null,
+    closeReason: null,
+    createdAt: 1,
+    updatedAt: 1,
+    lastUserInputAt: null,
+    ...overrides,
+  };
+}
+
+function tabIds(tabs: readonly SecondaryFileFixedPanelTab[]): string[] {
+  return tabs.map((tab) => tab.id);
+}
+
+describe("buildTerminalSyncedSecondaryFileTabs", () => {
+  it("adds server terminal sessions missing from local tabs", () => {
+    const tabs = buildTerminalSyncedSecondaryFileTabs({
+      orderedTabs: [],
+      terminalSessions: [
+        terminalSession({ id: "term_1" }),
+        terminalSession({ id: "term_2" }),
+      ],
+    });
+
+    expect(tabIds(tabs)).toEqual(["terminal:term_1", "terminal:term_2"]);
+  });
+
+  it("preserves local terminal tab order when sessions still exist", () => {
+    const localTerminal2 = createTerminalFixedPanelTab({
+      terminalId: "term_2",
+    });
+    const localFile = createHostFilePreviewFixedPanelTab({
+      lineRange: null,
+      path: "/workspace/file.ts",
+    });
+    const localTerminal1 = createTerminalFixedPanelTab({
+      terminalId: "term_1",
+    });
+    const tabs = buildTerminalSyncedSecondaryFileTabs({
+      orderedTabs: [localTerminal2, localFile, localTerminal1],
+      terminalSessions: [
+        terminalSession({ id: "term_1" }),
+        terminalSession({ id: "term_2" }),
+        terminalSession({ id: "term_3" }),
+      ],
+    });
+
+    expect(tabIds(tabs)).toEqual([
+      "terminal:term_2",
+      "host-file-preview:%2Fworkspace%2Ffile.ts",
+      "terminal:term_1",
+      "terminal:term_3",
+    ]);
+  });
+
+  it("drops stale local terminal tabs when sessions disappear elsewhere", () => {
+    const tabs = buildTerminalSyncedSecondaryFileTabs({
+      orderedTabs: [
+        createTerminalFixedPanelTab({ terminalId: "term_stale" }),
+        createTerminalFixedPanelTab({ terminalId: "term_1" }),
+      ],
+      terminalSessions: [terminalSession({ id: "term_1" })],
+    });
+
+    expect(tabIds(tabs)).toEqual(["terminal:term_1"]);
+  });
+
+  it("finds the active terminal id only for displayed terminal tabs", () => {
+    const terminalTab = createTerminalFixedPanelTab({ terminalId: "term_1" });
+    const fileTab = createHostFilePreviewFixedPanelTab({
+      lineRange: null,
+      path: "/workspace/file.ts",
+    });
+
+    expect(
+      findActiveTerminalIdInSecondaryFileTabs({
+        activeTabId: terminalTab.id,
+        tabs: [fileTab, terminalTab],
+      }),
+    ).toBe("term_1");
+    expect(
+      findActiveTerminalIdInSecondaryFileTabs({
+        activeTabId: fileTab.id,
+        tabs: [fileTab, terminalTab],
+      }),
+    ).toBeNull();
+    expect(
+      findActiveTerminalIdInSecondaryFileTabs({
+        activeTabId: "terminal:term_stale",
+        tabs: [fileTab, terminalTab],
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/views/thread-detail/threadTerminalTabs.ts
+++ b/apps/app/src/views/thread-detail/threadTerminalTabs.ts
@@ -1,7 +1,9 @@
 import type { TerminalSession } from "@bb/server-contract";
 import {
   createTerminalFixedPanelTab,
+  type FixedPanelTabsState,
   type SecondaryFileFixedPanelTab,
+  type SecondaryFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
 
 interface BuildTerminalSyncedSecondaryFileTabsArgs {
@@ -12,6 +14,11 @@ interface BuildTerminalSyncedSecondaryFileTabsArgs {
 interface FindActiveTerminalIdInSecondaryFileTabsArgs {
   activeTabId: string | null;
   tabs: readonly SecondaryFileFixedPanelTab[];
+}
+
+interface SyncTerminalTabsInFixedPanelStateArgs {
+  state: FixedPanelTabsState;
+  terminalSessions: readonly TerminalSession[];
 }
 
 export function buildTerminalSyncedSecondaryFileTabs({
@@ -65,4 +72,61 @@ export function findActiveTerminalIdInSecondaryFileTabs({
   }
 
   return null;
+}
+
+export function syncTerminalTabsInFixedPanelState({
+  state,
+  terminalSessions,
+}: SyncTerminalTabsInFixedPanelStateArgs): FixedPanelTabsState {
+  const terminalSessionIds = new Set(
+    terminalSessions.map((session) => session.id),
+  );
+  const seenTerminalIds = new Set<string>();
+  const tabs: SecondaryFixedPanelTab[] = [];
+  let changed = false;
+
+  for (const tab of state.secondary.tabs) {
+    if (tab.kind === "terminal") {
+      if (
+        !terminalSessionIds.has(tab.terminalId) ||
+        seenTerminalIds.has(tab.terminalId)
+      ) {
+        changed = true;
+        continue;
+      }
+      seenTerminalIds.add(tab.terminalId);
+    }
+    tabs.push(tab);
+  }
+
+  for (const session of terminalSessions) {
+    if (seenTerminalIds.has(session.id)) {
+      continue;
+    }
+    seenTerminalIds.add(session.id);
+    tabs.push(createTerminalFixedPanelTab({ terminalId: session.id }));
+    changed = true;
+  }
+
+  const activeTabId =
+    state.secondary.activeTabId !== null &&
+    tabs.some((tab) => tab.id === state.secondary.activeTabId)
+      ? state.secondary.activeTabId
+      : null;
+  if (activeTabId !== state.secondary.activeTabId) {
+    changed = true;
+  }
+
+  if (!changed) {
+    return state;
+  }
+
+  return {
+    ...state,
+    secondary: {
+      ...state.secondary,
+      activeTabId,
+      tabs,
+    },
+  };
 }

--- a/apps/app/src/views/thread-detail/threadTerminalTabs.ts
+++ b/apps/app/src/views/thread-detail/threadTerminalTabs.ts
@@ -1,0 +1,68 @@
+import type { TerminalSession } from "@bb/server-contract";
+import {
+  createTerminalFixedPanelTab,
+  type SecondaryFileFixedPanelTab,
+} from "@/lib/fixed-panel-tabs-state";
+
+interface BuildTerminalSyncedSecondaryFileTabsArgs {
+  orderedTabs: readonly SecondaryFileFixedPanelTab[];
+  terminalSessions: readonly TerminalSession[];
+}
+
+interface FindActiveTerminalIdInSecondaryFileTabsArgs {
+  activeTabId: string | null;
+  tabs: readonly SecondaryFileFixedPanelTab[];
+}
+
+export function buildTerminalSyncedSecondaryFileTabs({
+  orderedTabs,
+  terminalSessions,
+}: BuildTerminalSyncedSecondaryFileTabsArgs): readonly SecondaryFileFixedPanelTab[] {
+  const terminalSessionIds = new Set(
+    terminalSessions.map((session) => session.id),
+  );
+  const seenTerminalIds = new Set<string>();
+  const syncedTabs: SecondaryFileFixedPanelTab[] = [];
+
+  for (const tab of orderedTabs) {
+    if (tab.kind !== "terminal") {
+      syncedTabs.push(tab);
+      continue;
+    }
+    if (
+      !terminalSessionIds.has(tab.terminalId) ||
+      seenTerminalIds.has(tab.terminalId)
+    ) {
+      continue;
+    }
+    seenTerminalIds.add(tab.terminalId);
+    syncedTabs.push(tab);
+  }
+
+  for (const session of terminalSessions) {
+    if (seenTerminalIds.has(session.id)) {
+      continue;
+    }
+    seenTerminalIds.add(session.id);
+    syncedTabs.push(createTerminalFixedPanelTab({ terminalId: session.id }));
+  }
+
+  return syncedTabs;
+}
+
+export function findActiveTerminalIdInSecondaryFileTabs({
+  activeTabId,
+  tabs,
+}: FindActiveTerminalIdInSecondaryFileTabsArgs): string | null {
+  if (activeTabId === null) {
+    return null;
+  }
+
+  for (const tab of tabs) {
+    if (tab.id === activeTabId && tab.kind === "terminal") {
+      return tab.terminalId;
+    }
+  }
+
+  return null;
+}

--- a/packages/domain/src/terminal.ts
+++ b/packages/domain/src/terminal.ts
@@ -22,6 +22,32 @@ export type TerminalSessionStatus = z.infer<
   typeof terminalSessionStatusSchema
 >;
 
+export function isActiveTerminalSessionStatus(
+  status: TerminalSessionStatus,
+): boolean {
+  switch (status) {
+    case "starting":
+    case "running":
+      return true;
+    case "disconnected":
+    case "exited":
+      return false;
+  }
+}
+
+export function isVisibleTerminalSessionStatus(
+  status: TerminalSessionStatus,
+): boolean {
+  switch (status) {
+    case "starting":
+    case "running":
+    case "disconnected":
+      return true;
+    case "exited":
+      return false;
+  }
+}
+
 export const terminalSessionCloseReasonValues = [
   "user",
   "process-exit",

--- a/packages/domain/test/terminal.test.ts
+++ b/packages/domain/test/terminal.test.ts
@@ -1,8 +1,43 @@
 import { describe, expect, it } from "vitest";
 import {
   createTerminalOutputLineReader,
+  isActiveTerminalSessionStatus,
+  isVisibleTerminalSessionStatus,
   readTerminalOutputLines,
+  type TerminalSessionStatus,
 } from "../src/index.js";
+
+interface TerminalSessionStatusExpectation {
+  active: boolean;
+  status: TerminalSessionStatus;
+  visible: boolean;
+}
+
+const TERMINAL_SESSION_STATUS_EXPECTATIONS: TerminalSessionStatusExpectation[] =
+  [
+    { active: true, status: "starting", visible: true },
+    { active: true, status: "running", visible: true },
+    { active: false, status: "disconnected", visible: true },
+    { active: false, status: "exited", visible: false },
+  ];
+
+describe("terminal session status helpers", () => {
+  it("treats only starting and running terminals as active", () => {
+    for (const expectation of TERMINAL_SESSION_STATUS_EXPECTATIONS) {
+      expect(isActiveTerminalSessionStatus(expectation.status)).toBe(
+        expectation.active,
+      );
+    }
+  });
+
+  it("keeps disconnected terminals visible without counting them as active", () => {
+    for (const expectation of TERMINAL_SESSION_STATUS_EXPECTATIONS) {
+      expect(isVisibleTerminalSessionStatus(expectation.status)).toBe(
+        expectation.visible,
+      );
+    }
+  });
+});
 
 describe("terminal output line helpers", () => {
   it("compacts carriage-return progress updates to the final display line", () => {


### PR DESCRIPTION
## Summary
- add domain helpers for active vs visible terminal session statuses
- count only starting/running terminal sessions in the thread header badge
- render right-panel terminal tabs from the server session list so multiple clients stay in sync while preserving local tab order where possible
- materialize synced terminal tabs into local fixed-panel state so selection/reorder/close behavior converges after terminal query data lands
- drop stale local terminal tabs when another client closes/removes the session
- align mobile text tab pills with the icon-only Info/Diff controls

## Validation
- pnpm exec turbo run test --filter=@bb/domain
- pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app