### PR TITLE
Hide file preview wrap toggle for rendered previews

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -274,10 +274,9 @@ export function FilePreview({
     (state.kind === "html" && viewMode === "preview");
   const bodyViewMode: FilePreviewViewMode =
     toggleKind === null ? "preview" : viewMode;
-  const showLineOverflowToggle =
-    state.kind === "html" || state.kind === "ready";
-  const usesFullHeightLayout =
-    usesIframeLayout || usesCodeViewLayout(state, bodyViewMode);
+  const usesCodeLayout = usesCodeViewLayout(state, bodyViewMode);
+  const showLineOverflowToggle = usesCodeLayout;
+  const usesFullHeightLayout = usesIframeLayout || usesCodeLayout;
   // The markdown preview renders on a raised "paper" surface that should fill
   // the panel to the bottom even for short documents. `min-h-full` (vs the
   // iframe layout's `h-full min-h-0`) keeps the column growable, so long


### PR DESCRIPTION
## Summary
- Hide the source line-wrap toggle when markdown/html file previews are in rendered preview mode
- Keep the toggle available for source/code views, including Raw mode

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app