### PR TITLE
Replace disconnected terminal on restart

### DIFF
--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -172,6 +172,37 @@ export function useThreadTerminalController({
     threadId,
   ]);
 
+  const replaceDisconnectedTerminal = useCallback(
+    (terminalId: string) => {
+      if (
+        !canCreateTerminal ||
+        createTerminal.isPending ||
+        closeTerminal.isPending
+      ) {
+        return;
+      }
+      closeTerminal.mutate(
+        { mode: "force", threadId, terminalId },
+        {
+          onSuccess: () => {
+            dirtyTerminalIdsRef.current.delete(terminalId);
+            closingCleanTerminalIdsRef.current.delete(terminalId);
+            removeFixedTerminalTab(terminalId);
+            startTerminal();
+          },
+        },
+      );
+    },
+    [
+      canCreateTerminal,
+      closeTerminal,
+      createTerminal.isPending,
+      removeFixedTerminalTab,
+      startTerminal,
+      threadId,
+    ],
+  );
+
   useEffect(() => {
     if (isRightPanelOpen) {
       return;
@@ -210,8 +241,12 @@ export function useThreadTerminalController({
   ]);
 
   const handleCreateTerminal = useCallback(() => {
+    if (activeSession?.status === "disconnected") {
+      replaceDisconnectedTerminal(activeSession.id);
+      return;
+    }
     startTerminal();
-  }, [startTerminal]);
+  }, [activeSession, replaceDisconnectedTerminal, startTerminal]);
 
   const handleSelectTerminal = useCallback(
     (terminalId: string) => {
@@ -301,7 +336,11 @@ export function useThreadTerminalController({
     closeFixedSecondaryPanel();
   }, [closeFixedSecondaryPanel]);
 
-  const terminalIsStarting = createTerminal.isPending;
+  const terminalIsReplacing =
+    activeSession?.status === "disconnected" &&
+    closeTerminal.isPending &&
+    closeTerminal.variables?.terminalId === activeSession.id;
+  const terminalIsStarting = createTerminal.isPending || terminalIsReplacing;
 
   const emptyTerminalMessage = terminalIsStarting
     ? "Starting terminal..."


### PR DESCRIPTION
## Summary
- close the active disconnected terminal before starting a replacement from the disconnected-state prompt
- remove the old fixed-panel terminal tab so terminal tab sync does not keep the stale session around
- keep the start button pending while the disconnected session is being replaced

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app