### PR TITLE
Remember new worktree base branch selection

### DIFF
--- a/apps/app/src/components/dialogs/ThreadGitActionDialog.tsx
+++ b/apps/app/src/components/dialogs/ThreadGitActionDialog.tsx
@@ -40,7 +40,6 @@ interface ThreadGitActionDialogProps {
   mergeBaseBranch?: string;
   mergeBaseBranchRef?: GitBranchRefClassification | null;
   mergeBaseBranchOptions?: string[];
-  mergeBaseBranchOptionsTruncated?: boolean;
   mergeBaseRemoteBranchOptions?: readonly string[];
   mergeBaseBranchOptionsLoading?: boolean;
   onMergeBaseBranchChange?: (branch: string) => void;
@@ -91,7 +90,6 @@ export function ThreadGitActionDialog({
   mergeBaseBranch,
   mergeBaseBranchRef,
   mergeBaseBranchOptions,
-  mergeBaseBranchOptionsTruncated,
   mergeBaseRemoteBranchOptions,
   mergeBaseBranchOptionsLoading = false,
   onMergeBaseBranchChange,
@@ -124,7 +122,6 @@ export function ThreadGitActionDialog({
             mergeBaseBranch={mergeBaseBranch}
             mergeBaseBranchRef={mergeBaseBranchRef}
             mergeBaseBranchOptions={mergeBaseBranchOptions}
-            mergeBaseBranchOptionsTruncated={mergeBaseBranchOptionsTruncated}
             mergeBaseRemoteBranchOptions={mergeBaseRemoteBranchOptions}
             mergeBaseBranchOptionsLoading={mergeBaseBranchOptionsLoading}
             onMergeBaseBranchChange={onMergeBaseBranchChange}
@@ -157,7 +154,6 @@ export function ThreadGitActionDialogContent({
   mergeBaseBranch,
   mergeBaseBranchRef,
   mergeBaseBranchOptions,
-  mergeBaseBranchOptionsTruncated,
   mergeBaseRemoteBranchOptions,
   mergeBaseBranchOptionsLoading,
   onMergeBaseBranchChange,
@@ -355,7 +351,6 @@ export function ThreadGitActionDialogContent({
                     selectedOptionKind={
                       mergeBaseCandidateGroups.selectedOptionKind
                     }
-                    optionsTruncated={mergeBaseBranchOptionsTruncated}
                     loading={mergeBaseBranchOptionsLoading}
                     onChange={(branch) => onMergeBaseBranchChange?.(branch)}
                     onSearchQueryChange={onMergeBaseBranchSearchQueryChange}

--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -654,7 +654,6 @@ export interface BranchPickerProps {
   onClear?: () => void;
   onCreateBaseChange?: (branch: string) => void;
   onSearchQueryChange?: (query: string) => void;
-  optionsTruncated?: boolean;
   /** When provided, branch-changing choices are disabled with this reason. */
   optionDisabledReason?: string | null;
   optionDisabledTitle?: string;
@@ -704,7 +703,6 @@ export function BranchPicker({
   onClear,
   onCreateBaseChange,
   onSearchQueryChange,
-  optionsTruncated = false,
   optionDisabledReason,
   optionDisabledTitle,
   createDisabledReason,
@@ -1143,11 +1141,6 @@ export function BranchPicker({
                           ) : null}
                         </>
                       )}
-                      {optionsTruncated ? (
-                        <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                          Search to narrow branch results.
-                        </p>
-                      ) : null}
                     </>
                   )}
                 </>
@@ -1229,11 +1222,6 @@ export function BranchPicker({
                           {loading
                             ? "Loading branches..."
                             : "No branches found."}
-                        </p>
-                      ) : null}
-                      {optionsTruncated ? (
-                        <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                          Search to narrow branch results.
                         </p>
                       ) : null}
                     </>

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -64,7 +64,6 @@ export interface NewThreadBranchConfig {
   isNew: boolean;
   options: readonly string[];
   remoteOptions?: readonly string[];
-  optionsTruncated?: boolean;
   loading?: boolean;
   placeholder?: string;
   triggerLabel?: string;
@@ -302,7 +301,6 @@ function ThreadEnvSlot({ environment, branch, worktree }: ThreadEnvSlotProps) {
           isCreatingNew={branch.isNew}
           options={branch.options}
           remoteOptions={branch.remoteOptions}
-          optionsTruncated={branch.optionsTruncated}
           loading={branch.loading}
           placeholder={branch.placeholder}
           triggerLabel={branch.triggerLabel}
@@ -349,7 +347,6 @@ export interface NewThreadConnectedBranchConfig {
   isNew: boolean;
   options: readonly string[];
   remoteOptions?: readonly string[];
-  optionsTruncated?: boolean;
   loading?: boolean;
   placeholder?: string;
   triggerLabel?: string;
@@ -436,7 +433,6 @@ function ConnectedThreadModeBranch({
       isNew: allowCreate && branch.isNew,
       options: branch.options,
       remoteOptions: branch.remoteOptions,
-      optionsTruncated: branch.optionsTruncated,
       loading: branch.loading,
       placeholder: branch.placeholder,
       triggerLabel: branch.triggerLabel,

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -28,7 +28,6 @@ export interface ContextBannerMergeBaseConfig {
   branchRef?: GitBranchRefClassification | null;
   options?: readonly string[];
   remoteOptions?: readonly string[];
-  optionsTruncated?: boolean;
   optionsLoading?: boolean;
   onChange: (branch: string) => void;
   onPickerOpenChange?: (open: boolean) => void;
@@ -657,7 +656,6 @@ export function ThreadPromptContextBanner({
               options={mergeBaseCandidates.options}
               remoteOptions={mergeBaseCandidates.remoteOptions}
               selectedOptionKind={mergeBaseCandidates.selectedOptionKind}
-              optionsTruncated={gitSection.mergeBase.optionsTruncated}
               variant="minimal"
               loading={gitSection.mergeBase.optionsLoading}
               onChange={gitSection.mergeBase.onChange}

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -426,7 +426,6 @@ export interface MergeBaseRowProps {
   selectedMergeBaseBranch: string | undefined;
   mergeBaseBranchRef?: GitBranchRefClassification | null;
   mergeBaseBranchOptions: readonly string[] | undefined;
-  mergeBaseBranchOptionsTruncated?: boolean;
   mergeBaseRemoteBranchOptions?: readonly string[];
   isLoadingMergeBaseBranchOptions: boolean;
   onMergeBaseBranchChange: (branch: string) => void;
@@ -442,7 +441,6 @@ export function MergeBaseRow({
   selectedMergeBaseBranch,
   mergeBaseBranchRef,
   mergeBaseBranchOptions,
-  mergeBaseBranchOptionsTruncated,
   mergeBaseRemoteBranchOptions,
   isLoadingMergeBaseBranchOptions,
   onMergeBaseBranchChange,
@@ -506,7 +504,6 @@ export function MergeBaseRow({
           options={mergeBaseCandidates}
           remoteOptions={remoteMergeBaseCandidates}
           selectedOptionKind={mergeBaseCandidateGroups.selectedOptionKind}
-          optionsTruncated={mergeBaseBranchOptionsTruncated}
           variant="minimal"
           loading={
             isLoadingMergeBaseBranchOptions || canRequestMergeBaseOptions
@@ -824,7 +821,6 @@ export interface ThreadMetadataContentProps {
   selectedMergeBaseBranch: string | undefined;
   mergeBaseBranchRef?: GitBranchRefClassification | null;
   mergeBaseBranchOptions: readonly string[] | undefined;
-  mergeBaseBranchOptionsTruncated?: boolean;
   mergeBaseRemoteBranchOptions?: readonly string[];
   isLoadingMergeBaseBranchOptions: boolean;
   threadSchedules: readonly ThreadSchedule[];
@@ -931,7 +927,6 @@ export function ThreadMetadataContent(props: ThreadMetadataContentProps) {
     selectedMergeBaseBranch,
     mergeBaseBranchRef,
     mergeBaseBranchOptions,
-    mergeBaseBranchOptionsTruncated,
     mergeBaseRemoteBranchOptions,
     isLoadingMergeBaseBranchOptions,
     threadSchedules,
@@ -970,7 +965,6 @@ export function ThreadMetadataContent(props: ThreadMetadataContentProps) {
         selectedMergeBaseBranch={selectedMergeBaseBranch}
         mergeBaseBranchRef={mergeBaseBranchRef}
         mergeBaseBranchOptions={mergeBaseBranchOptions}
-        mergeBaseBranchOptionsTruncated={mergeBaseBranchOptionsTruncated}
         mergeBaseRemoteBranchOptions={mergeBaseRemoteBranchOptions}
         isLoadingMergeBaseBranchOptions={isLoadingMergeBaseBranchOptions}
         onMergeBaseBranchChange={onMergeBaseBranchChange}

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.ts
@@ -73,11 +73,6 @@ export function useGitDiffPanel({
       ? [selectedMergeBaseBranchRef.name, ...mergeBaseRemoteBranchList]
       : mergeBaseRemoteBranchList;
   }, [mergeBaseRemoteBranchList, selectedMergeBaseBranchRef]);
-  const mergeBaseBranchOptionsTruncated = Boolean(
-    mergeBaseBranches?.branchesTruncated ||
-    mergeBaseBranches?.remoteBranchesTruncated,
-  );
-
   useEffect(() => {
     setSelectedMergeBaseBranch(undefined);
     setMergeBaseBranchSearchQuery("");
@@ -121,7 +116,6 @@ export function useGitDiffPanel({
     defaultMergeBaseBranch,
     isLoadingMergeBaseBranchOptions,
     mergeBaseBranchOptions,
-    mergeBaseBranchOptionsTruncated,
     mergeBaseRemoteBranchOptions,
     openCommitDiff,
     openDiffFile,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -444,12 +444,6 @@ export function RootComposeView() {
     activeBranchesQuery.data?.selectedBranch,
     branchEnvironmentMode,
   ]);
-  const branchOptionsTruncated = Boolean(
-    activeBranchesQuery.data?.branchesTruncated ||
-    ((branchEnvironmentMode === "local" ||
-      branchEnvironmentMode === "worktree") &&
-      activeBranchesQuery.data?.remoteBranchesTruncated),
-  );
   const branchSelectionSeed =
     branchEnvironmentMode === "local" &&
     activeBranchesQuery.data?.checkout.kind === "branch"
@@ -820,7 +814,6 @@ export function RootComposeView() {
       isNew: selectedBranch?.isNew ?? false,
       options: branchOptions,
       remoteOptions: remoteBranchOptions,
-      optionsTruncated: branchOptionsTruncated,
       loading: activeBranchesQuery.isFetching,
       placeholder: branchUiState.placeholder,
       triggerLabel: branchUiState.triggerLabel,
@@ -846,7 +839,6 @@ export function RootComposeView() {
     }),
     [
       activeBranchesQuery.isFetching,
-      branchOptionsTruncated,
       branchOptions,
       branchEnvironmentMode,
       remoteBranchOptions,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -386,6 +386,14 @@ export function RootComposeView() {
     setBranchSearchQuery("");
   }, [effectiveEnvironmentValue, projectId]);
   const isHostMode = parsedEnvironment?.type === "host";
+  const isHostLocalMode = isHostMode && parsedEnvironment.mode === "local";
+  const branchEnvironmentMode: RootComposeBranchEnvironmentMode = isProjectless
+    ? "other"
+    : isHostLocalMode
+      ? "local"
+      : isHostMode && parsedEnvironment.mode === "worktree"
+        ? "worktree"
+        : "other";
   const {
     selectedBranch,
     onBranchChange: handleBranchChange,
@@ -395,6 +403,7 @@ export function RootComposeView() {
   } = useScopedBranchSelection({
     environmentValue: effectiveEnvironmentValue,
     projectId,
+    rememberSelection: branchEnvironmentMode === "worktree",
   });
   const selectedBranchName = selectedBranch?.name ?? "";
   const hostBranchesQuery = useProjectSourceBranches(
@@ -417,14 +426,6 @@ export function RootComposeView() {
     activeBranchesQuery.data?.branches,
     activeBranchesQuery.data?.selectedBranch,
   ]);
-  const isHostLocalMode = isHostMode && parsedEnvironment.mode === "local";
-  const branchEnvironmentMode: RootComposeBranchEnvironmentMode = isProjectless
-    ? "other"
-    : isHostLocalMode
-      ? "local"
-      : isHostMode && parsedEnvironment.mode === "worktree"
-        ? "worktree"
-        : "other";
   const remoteBranchOptions = useMemo(() => {
     if (
       branchEnvironmentMode !== "local" &&

--- a/apps/app/src/views/root-compose-branch-selection.test.ts
+++ b/apps/app/src/views/root-compose-branch-selection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveSelectedBranch } from "./root-compose-branch-selection";
+
+describe("resolveSelectedBranch", () => {
+  it("hydrates remembered worktree base branches", () => {
+    expect(
+      resolveSelectedBranch({
+        rememberedBranchName: "origin/main",
+        rememberSelection: true,
+        selectedBranch: null,
+      }),
+    ).toEqual({
+      name: "origin/main",
+      isNew: false,
+    });
+  });
+
+  it("keeps branch remembering opt-in", () => {
+    expect(
+      resolveSelectedBranch({
+        rememberedBranchName: "origin/main",
+        rememberSelection: false,
+        selectedBranch: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("prefers the current in-memory selection", () => {
+    expect(
+      resolveSelectedBranch({
+        rememberedBranchName: "origin/main",
+        rememberSelection: true,
+        selectedBranch: {
+          name: "release/1.2",
+          isNew: true,
+        },
+      }),
+    ).toEqual({
+      name: "release/1.2",
+      isNew: true,
+    });
+  });
+});

--- a/apps/app/src/views/root-compose-branch-selection.ts
+++ b/apps/app/src/views/root-compose-branch-selection.ts
@@ -1,5 +1,14 @@
+import { useAtom } from "jotai";
+import { atomFamily } from "jotai-family";
+import { atomWithStorage } from "jotai/utils";
 import { useCallback, useMemo, useState } from "react";
+import { rawStringLocalStorage } from "@/lib/browser-storage";
+import { getProjectScopedStorageKey } from "@/lib/project-scoped-storage";
 import type { RootComposeSelectedBranch } from "./root-compose-thread-environment";
+
+const WORKTREE_BASE_BRANCH_STORAGE_KEY = "bb.promptbox.worktree-base-branch";
+const INACTIVE_WORKTREE_BASE_BRANCH_STORAGE_KEY =
+  "bb.promptbox.worktree-base-branch.inactive";
 
 interface BranchSelectionScope {
   environmentValue: string;
@@ -16,7 +25,11 @@ interface ScopedSelectedBranch {
   scope: BranchSelectionScope;
 }
 
-export type UseScopedBranchSelectionArgs = BranchSelectionScopeArgs;
+type PersistedBranchNameSetter = (value: string) => void;
+
+export interface UseScopedBranchSelectionArgs extends BranchSelectionScopeArgs {
+  rememberSelection: boolean;
+}
 
 export interface UseScopedBranchSelectionResult {
   onBranchChange: (name: string) => void;
@@ -24,6 +37,40 @@ export interface UseScopedBranchSelectionResult {
   onCreateBranch: (currentBranch: string | null) => void;
   onCreateBranchFrom: (name: string) => void;
   selectedBranch: RootComposeSelectedBranch | null;
+}
+
+export interface ResolveSelectedBranchArgs {
+  rememberedBranchName: string;
+  rememberSelection: boolean;
+  selectedBranch: RootComposeSelectedBranch | null;
+}
+
+interface PersistedWorktreeBaseBranchSelection {
+  setValue: PersistedBranchNameSetter;
+  value: string;
+}
+
+interface WorktreeBaseBranchStorageKeyArgs {
+  environmentValue: string;
+  projectId: string;
+}
+
+const worktreeBaseBranchAtomFamily = atomFamily((storageKey: string) =>
+  atomWithStorage<string>(storageKey, "", rawStringLocalStorage, {
+    getOnInit: true,
+  }),
+);
+
+function getWorktreeBaseBranchStorageKey({
+  environmentValue,
+  projectId,
+}: WorktreeBaseBranchStorageKeyArgs): string {
+  return getProjectScopedStorageKey(
+    `${WORKTREE_BASE_BRANCH_STORAGE_KEY}.${encodeURIComponent(
+      environmentValue.trim(),
+    )}`,
+    projectId,
+  );
 }
 
 function resolveBranchSelectionScope(
@@ -51,11 +98,61 @@ function matchesBranchSelectionScope(
   );
 }
 
+function usePersistedWorktreeBaseBranchSelection(
+  scope: BranchSelectionScope | null,
+): PersistedWorktreeBaseBranchSelection {
+  const storageKey = useMemo(
+    () =>
+      scope
+        ? getWorktreeBaseBranchStorageKey(scope)
+        : INACTIVE_WORKTREE_BASE_BRANCH_STORAGE_KEY,
+    [scope],
+  );
+  const [value, setAtomValue] = useAtom(
+    worktreeBaseBranchAtomFamily(storageKey),
+  );
+  const setValue = useCallback(
+    (nextValue: string) => {
+      if (!scope) {
+        return;
+      }
+
+      setAtomValue(nextValue);
+    },
+    [scope, setAtomValue],
+  );
+
+  return {
+    setValue,
+    value: scope ? value : "",
+  };
+}
+
+export function resolveSelectedBranch({
+  rememberedBranchName,
+  rememberSelection,
+  selectedBranch,
+}: ResolveSelectedBranchArgs): RootComposeSelectedBranch | null {
+  if (selectedBranch) {
+    return selectedBranch;
+  }
+
+  if (!rememberSelection || rememberedBranchName.length === 0) {
+    return null;
+  }
+
+  return {
+    name: rememberedBranchName,
+    isNew: false,
+  };
+}
+
 export function useScopedBranchSelection(
   args: UseScopedBranchSelectionArgs,
 ): UseScopedBranchSelectionResult {
   const [selectedBranchState, setSelectedBranchState] =
     useState<ScopedSelectedBranch | null>(null);
+  const rememberSelection = args.rememberSelection;
   const scope = useMemo(
     () =>
       resolveBranchSelectionScope({
@@ -64,11 +161,29 @@ export function useScopedBranchSelection(
       }),
     [args.environmentValue, args.projectId],
   );
-  const selectedBranch =
+  const { setValue: setRememberedBranchName, value: rememberedBranchName } =
+    usePersistedWorktreeBaseBranchSelection(
+      rememberSelection ? scope : null,
+    );
+  const selectedBranchFromState =
     selectedBranchState !== null &&
     matchesBranchSelectionScope(selectedBranchState.scope, scope)
       ? selectedBranchState.branch
       : null;
+  const selectedBranch = resolveSelectedBranch({
+    rememberedBranchName,
+    rememberSelection,
+    selectedBranch: selectedBranchFromState,
+  });
+
+  const rememberBranchName = useCallback(
+    (name: string) => {
+      if (rememberSelection) {
+        setRememberedBranchName(name);
+      }
+    },
+    [rememberSelection, setRememberedBranchName],
+  );
 
   const onBranchChange = useCallback(
     (name: string) => {
@@ -76,6 +191,7 @@ export function useScopedBranchSelection(
         return;
       }
 
+      rememberBranchName(name);
       setSelectedBranchState({
         scope,
         branch: {
@@ -84,7 +200,7 @@ export function useScopedBranchSelection(
         },
       });
     },
-    [scope],
+    [rememberBranchName, scope],
   );
 
   const onCreateBranch = useCallback(
@@ -93,30 +209,33 @@ export function useScopedBranchSelection(
         return;
       }
 
-      setSelectedBranchState((previous) => {
-        const scopedPrevious = matchesBranchSelectionScope(
-          previous?.scope,
-          scope,
-        )
-          ? previous?.branch
-          : null;
-        const branchName = scopedPrevious?.name ?? currentBranch;
-        if (!branchName) {
-          return matchesBranchSelectionScope(previous?.scope, scope)
-            ? null
-            : previous;
+      const branchName = selectedBranch?.name ?? currentBranch;
+      if (!branchName) {
+        if (rememberSelection) {
+          setRememberedBranchName("");
         }
+        setSelectedBranchState((previous) =>
+          matchesBranchSelectionScope(previous?.scope, scope) ? null : previous,
+        );
+        return;
+      }
 
-        return {
-          scope,
-          branch: {
-            name: branchName,
-            isNew: true,
-          },
-        };
+      rememberBranchName(branchName);
+      setSelectedBranchState({
+        scope,
+        branch: {
+          name: branchName,
+          isNew: true,
+        },
       });
     },
-    [scope],
+    [
+      rememberBranchName,
+      rememberSelection,
+      scope,
+      selectedBranch?.name,
+      setRememberedBranchName,
+    ],
   );
 
   const onCreateBranchFrom = useCallback(
@@ -125,12 +244,13 @@ export function useScopedBranchSelection(
         return;
       }
 
+      rememberBranchName(name);
       setSelectedBranchState({
         scope,
         branch: { name, isNew: true },
       });
     },
-    [scope],
+    [rememberBranchName, scope],
   );
 
   const onClearBranch = useCallback(() => {
@@ -138,10 +258,13 @@ export function useScopedBranchSelection(
       return;
     }
 
+    if (rememberSelection) {
+      setRememberedBranchName("");
+    }
     setSelectedBranchState((previous) =>
       matchesBranchSelectionScope(previous?.scope, scope) ? null : previous,
     );
-  }, [scope]);
+  }, [rememberSelection, scope, setRememberedBranchName]);
 
   return {
     onBranchChange,

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -108,8 +108,6 @@ const areThreadMetadataPropsEqual: ThreadMetadataPropsEqual = (
   previous.selectedMergeBaseBranch === next.selectedMergeBaseBranch &&
   previous.mergeBaseBranchRef === next.mergeBaseBranchRef &&
   previous.mergeBaseBranchOptions === next.mergeBaseBranchOptions &&
-  previous.mergeBaseBranchOptionsTruncated ===
-    next.mergeBaseBranchOptionsTruncated &&
   previous.mergeBaseRemoteBranchOptions === next.mergeBaseRemoteBranchOptions &&
   previous.isLoadingMergeBaseBranchOptions ===
     next.isLoadingMergeBaseBranchOptions &&

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -597,7 +597,6 @@ export function ThreadDetailView() {
     defaultMergeBaseBranch: resolvedDefaultMergeBaseBranch,
     isLoadingMergeBaseBranchOptions,
     mergeBaseBranchOptions,
-    mergeBaseBranchOptionsTruncated,
     mergeBaseRemoteBranchOptions,
     openCommitDiff: openPersistedCommitDiff,
     openDiffFile: openPersistedDiffFile,
@@ -1487,7 +1486,6 @@ export function ThreadDetailView() {
               branchRef: selectedMergeBaseBranchRef,
               options: mergeBaseBranchOptions,
               remoteOptions: mergeBaseRemoteBranchOptions,
-              optionsTruncated: mergeBaseBranchOptionsTruncated,
               optionsLoading: isLoadingMergeBaseBranchOptions,
               onChange: handleMergeBaseBranchChange,
               onPickerOpenChange: handleMergeBasePickerOpenChange,
@@ -1595,7 +1593,6 @@ export function ThreadDetailView() {
           selectedMergeBaseBranch,
           mergeBaseBranchRef: selectedMergeBaseBranchRef,
           mergeBaseBranchOptions,
-          mergeBaseBranchOptionsTruncated,
           mergeBaseRemoteBranchOptions,
           isLoadingMergeBaseBranchOptions,
           threadSchedules,
@@ -1676,7 +1673,6 @@ export function ThreadDetailView() {
           showMergeBaseDetails={showBranchComparisonUi}
           mergeBaseBranch={effectiveMergeBaseBranch}
           mergeBaseBranchOptions={mergeBaseBranchOptions}
-          mergeBaseBranchOptionsTruncated={mergeBaseBranchOptionsTruncated}
           mergeBaseBranchRef={selectedMergeBaseBranchRef}
           mergeBaseRemoteBranchOptions={mergeBaseRemoteBranchOptions}
           mergeBaseBranchOptionsLoading={isLoadingMergeBaseBranchOptions}

--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -24,6 +24,11 @@ interface LimitedBranchList {
   truncated: boolean;
 }
 
+interface PinBranchArgs {
+  branches: readonly string[];
+  branch: string | null | undefined;
+}
+
 interface ClassifySelectedBranchArgs {
   branches: readonly string[];
   remoteBranches: readonly string[];
@@ -46,6 +51,14 @@ function limitBranchList({
     branches: filteredBranches.slice(0, limit),
     truncated: filteredBranches.length > limit,
   };
+}
+
+function pinBranch({ branches, branch }: PinBranchArgs): string[] {
+  if (!branch || !branches.includes(branch)) {
+    return [...branches];
+  }
+
+  return [branch, ...branches.filter((candidate) => candidate !== branch)];
 }
 
 function classifySelectedBranch({
@@ -102,19 +115,20 @@ export async function listHostBranches(
       hasUncommittedChanges(command.path),
       getWorkspaceGitOperation(command.path),
     ]);
-  // Pin the source's default branch to the top of the list so the picker
-  // surfaces it first; everything else preserves git's alphabetical order.
-  const sorted =
-    defaultBranch && branches.includes(defaultBranch)
-      ? [defaultBranch, ...branches.filter((b) => b !== defaultBranch)]
-      : branches;
+  // Pin default refs to the first page so common picks like main and
+  // origin/main are available before the user searches.
+  const sorted = pinBranch({ branches, branch: defaultBranch });
+  const sortedRemoteBranches = pinBranch({
+    branches: remoteBranches,
+    branch: defaultBranch ? `origin/${defaultBranch}` : null,
+  });
   const limitedBranches = limitBranchList({
     branches: sorted,
     limit: command.limit,
     query: command.query,
   });
   const limitedRemoteBranches = limitBranchList({
-    branches: remoteBranches,
+    branches: sortedRemoteBranches,
     limit: command.limit,
     query: command.query,
   });

--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -79,6 +79,30 @@ describe("host.list_branches dispatch", () => {
     ]);
   });
 
+  it("pins origin default branch first in remote branch results", async () => {
+    const repoPath = await initBranchRepo();
+    const remotePath = await makeTempDir("bb-host-branches-origin-");
+    await runGitCommand(["init", "--bare"], { cwd: remotePath });
+    await runGitCommand(["remote", "add", "origin", remotePath], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["branch", "bb/aardvark"], { cwd: repoPath });
+    await runGitCommand(["push", "origin", "bb/aardvark", "main"], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["fetch", "origin"], { cwd: repoPath });
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      { type: "host.list_branches", path: repoPath, limit: 1 },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.defaultBranch).toBe("main");
+    expect(result.remoteBranches).toEqual(["origin/main"]);
+    expect(result.remoteBranchesTruncated).toBe(true);
+  });
+
   it("classifies a selected branch before filtering and pagination", async () => {
     const repoPath = await initBranchRepo();
     const remotePath = await makeTempDir("bb-host-branches-remote-");


### PR DESCRIPTION
## Summary
- Persist the root-compose managed worktree base branch per project/environment so refresh restores remote refs like `origin/main`.
- Keep remembering opt-in to worktree mode so local checkout branch selection remains session-only.
- Pin `origin/<default>` into the first remote branch page so common refs like `origin/main` are available without waiting for search.
- Remove the confusing `Search to narrow branch results.` branch picker hint and its dead prop plumbing.
- Add focused coverage for remembered branch hydration and remote default branch pagination behavior.

## Investigation notes
- The picker locally filters the currently loaded branch page immediately, while the server search query is debounced. If `origin/main` is not in the first page, typing it can briefly show an empty/loading state before the debounced branch query returns.
- There was no separate prefetch for `origin/<default>`; the first page only pinned the local default branch. This PR makes the host branch response include the matching origin remote ref up front.

## Validation
- `pnpm exec turbo run test --filter=@bb/app --force`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`