### PR TITLE
Support remote storybook serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ Then open `http://<remote-host-or-tailscale-ip>:<app-port>`. Without
 `BB_DEV_REMOTE=true`, source dev keeps the browser app on localhost-only Vite
 defaults.
 
+To use the component storybook from another machine, run:
+
+```bash
+REMOTE=true pnpm storybook
+```
+
+That binds Ladle to all interfaces and configures its HMR WebSocket to use the
+browser's current host instead of `localhost`.
+
 Development behavior is intentionally split:
 
 - the app hot reloads itself

--- a/apps/app/.ladle/config.mjs
+++ b/apps/app/.ladle/config.mjs
@@ -1,8 +1,30 @@
+function parseRemoteEnv() {
+  const value = process.env.REMOTE;
+  if (value === undefined) return false;
+
+  const normalizedValue = value.trim().toLowerCase();
+  if (["true", "1", "yes", "y"].includes(normalizedValue)) return true;
+  if (["false", "0", "no", "n", ""].includes(normalizedValue)) return false;
+
+  throw new Error("REMOTE must be a boolean");
+}
+
+const remote = parseRemoteEnv();
+
 /** @type {import("@ladle/react").UserConfig} */
 export default {
   stories: ["src/**/*.stories.tsx"],
   defaultStory: "",
   viteConfig: "./.ladle/vite.config.ts",
+  ...(remote
+    ? {
+        host: "0.0.0.0",
+        // Ladle defaults Vite HMR to localhost independently of `host`.
+        // Empty string keeps Vite's websocket listener non-loopback and lets
+        // the browser use the page hostname for the websocket URL.
+        hmrHost: "",
+      }
+    : {}),
   addons: {
     theme: {
       defaultState: "dark",


### PR DESCRIPTION
## Summary
- Add REMOTE env handling to the Ladle config for app storybook
- Bind Ladle to all interfaces in remote mode and make HMR use the browser host instead of localhost
- Document `REMOTE=true pnpm storybook` for remote storybook access

## Validation
- `REMOTE=true pnpm storybook` served Ladle at `http://0.0.0.0:61001/`
- Verified generated Vite client uses `importMetaUrl.hostname` for `socketHost`
- Verified HMR listener binds on `*:24679` instead of loopback
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec prettier --check apps/app/.ladle/config.mjs`