### PR TITLE
Only truncate the branch selector in new thread promptbox

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -58,6 +58,7 @@ export interface EnvironmentPickerUIProps {
   reuseDisabled?: boolean;
   /** Render with the dim, hover-to-foreground treatment used inside the prompt box. */
   muted?: boolean;
+  className?: string;
   /** Render with the menu open on mount. Story-only escape hatch. */
   defaultOpen?: boolean;
   /** Whether the menu blocks page interaction. Defaults to Radix's true; pass false in stories. */
@@ -72,6 +73,7 @@ export function EnvironmentPickerUI({
   isLocal,
   reuseDisabled,
   muted,
+  className,
   defaultOpen,
   modal,
 }: EnvironmentPickerUIProps) {
@@ -153,6 +155,7 @@ export function EnvironmentPickerUI({
             OPTION_BASE_CLASS_NAME,
             OPTION_INTERACTIVE_CLASS_NAME,
             muted && OPTION_MUTED_CLASS_NAME,
+            className,
           )}
         >
           <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -244,6 +244,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
               onChange={project.onChange}
               allowNoProject={project.allowNoProject ?? false}
               createProject={project.createProject}
+              className="shrink-0"
             />
           ) : null}
           {project?.value !== null ? (
@@ -290,6 +291,7 @@ function ThreadEnvSlot({ environment, branch, worktree }: ThreadEnvSlotProps) {
         host={environment.host}
         isLocal={environment.isLocal}
         reuseDisabled={environment.reuseDisabled}
+        className="shrink-0"
         muted
       />
       {showBranchPicker ? (


### PR DESCRIPTION
## What

In the new-thread promptbox strip, the project, env, and branch selectors all shared `min-w-0 truncate` and a default `flex-shrink: 1`, so when the row got tight any of them could truncate. This pins the **project** and **env** selectors to `shrink-0` so they always render their full label, leaving the **branch selector** as the only flexible item that absorbs the squeeze and truncates.

## Changes

- `NewThreadPromptBox.tsx` — pass `className="shrink-0"` to both `ProjectSelector` and `EnvironmentPickerUI`.
- `EnvironmentPicker.tsx` — add a `className` prop to `EnvironmentPickerUI` (`ProjectSelector` already had one) and merge it into the trigger's class list.

The branch selector keeps its existing `min-w-0` + `truncate` + default shrink, so with its neighbors pinned it's the only one that ellipsizes. Pre-existing narrow-width container queries (env→icon-only, project capped at 10rem below 34rem) are unaffected.

## Tradeoff

Since project/env now never shrink here, an extremely long project name could push the row wider rather than truncating — which is exactly what "only truncate the branch selector" asks for. The existing `<34rem` container rule still caps project width as a safety net at very small widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)