### PR TITLE
Handle stale host daemon sessions

### DIFF
--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentRuntime, AgentRuntimeOptions } from "@bb/agent-runtime";
-import type { PendingInteractionCreate, ToolCallRequest } from "@bb/domain";
+import {
+  turnScope,
+  type PendingInteractionCreate,
+  type ToolCallRequest,
+} from "@bb/domain";
 import {
   hostDaemonInteractiveInterruptRequestSchema,
   type HostDaemonInteractiveRequestResponse,
@@ -29,9 +33,11 @@ interface FetchRecorder {
 }
 
 interface CreateFetchRecorderArgs {
+  inactiveSessionOnFirstEventPost?: boolean;
   interactiveRequestError?: Error;
   interactiveRequestResponse?: HostDaemonInteractiveRequestResponse;
   retiredEnvironmentIds?: string[];
+  sessionIds?: string[];
 }
 
 interface RuntimeOptionsRef {
@@ -87,6 +93,8 @@ function createFetchRecorder(
   args: CreateFetchRecorderArgs = {},
 ): FetchRecorder {
   const requests: RecordedFetchRequest[] = [];
+  let eventPostCount = 0;
+  let sessionOpenCount = 0;
   const fetchFn: typeof fetch = async (input, init) => {
     const url = readFetchUrl(input);
     const request = {
@@ -97,9 +105,14 @@ function createFetchRecorder(
     requests.push(request);
 
     if (url.pathname === "/internal/session/open") {
+      const sessionId =
+        args.sessionIds?.[sessionOpenCount] ??
+        args.sessionIds?.at(-1) ??
+        "session-app-test";
+      sessionOpenCount += 1;
       return Response.json(
         {
-          sessionId: "session-app-test",
+          sessionId,
           heartbeatIntervalMs: 30000,
           leaseTimeoutMs: 90000,
           trackedThreadTargets: [],
@@ -109,6 +122,17 @@ function createFetchRecorder(
       );
     }
     if (url.pathname === "/internal/session/events") {
+      eventPostCount += 1;
+      if (args.inactiveSessionOnFirstEventPost && eventPostCount === 1) {
+        return Response.json(
+          {
+            code: "inactive_session",
+            message: "Session is not active",
+            retryable: false,
+          },
+          { status: 401 },
+        );
+      }
       return Response.json({
         acceptedEvents: [],
         rejectedEvents: [],
@@ -161,12 +185,19 @@ function createOpeningWebSocket(): CreateReconnectingWebSocket {
       }),
       reconnect: vi.fn(),
     };
-    void urlProvider().then(() => {
+    const openSocket = async () => {
+      await urlProvider();
       queueMicrotask(() => {
         readyState = 1;
         socket.onopen?.({ type: "open" });
       });
+    };
+    socket.reconnect = vi.fn(() => {
+      readyState = 3;
+      socket.onclose?.({ code: 1000, reason: "test-reconnect" });
+      void openSocket();
     });
+    void openSocket();
     return socket;
   };
 }
@@ -299,6 +330,43 @@ async function createAppFixture(
 
 
 describe("createHostDaemonApp", () => {
+  it("reconnects through the server connection when event posting sees an inactive session", async () => {
+    const { app, fetchRecorder, logger } = await createAppFixture({
+      inactiveSessionOnFirstEventPost: true,
+      sessionIds: ["session-app-test-1", "session-app-test-2"],
+    });
+    try {
+      await app.connection.start();
+
+      app.eventSink.emit({
+        threadId: "thr_app_inactive_session",
+        event: {
+          type: "turn/started",
+          threadId: "thr_app_inactive_session",
+          providerThreadId: "provider-thread-app-inactive-session",
+          scope: turnScope("turn-app-inactive-session"),
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          fetchRecorder.requests.filter(
+            (request) => request.pathname === "/internal/session/open",
+          ),
+        ).toHaveLength(2);
+      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          code: "inactive_session",
+          sessionId: "session-app-test-1",
+          source: "postEvents",
+        },
+        "Server reported inactive daemon session; reconnecting",
+      );
+    } finally {
+      await app.daemon.shutdown("test");
+    }
+  });
 
   it("forgets server-retired loaded environments when opening a session", async () => {
     const dataDir = await makeTempDir("bb-host-daemon-app-retired-");

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -26,13 +26,15 @@ import {
   TerminalManager,
   type TerminalManagerOptions,
 } from "./terminals/terminal-manager.js";
-import { createServerClient } from "./server-client.js";
+import { createServerClient, ServerResponseError } from "./server-client.js";
 import {
   cleanupInjectedSkillStagingDirs,
   ensureDataDirSkillsRootPath,
 } from "./injected-skills.js";
 import {
   ServerConnection,
+  type HandleServerSessionInvalidatedArgs,
+  type ServerSessionInvalidationSource,
   type CreateReconnectingWebSocket,
 } from "./server-connection.js";
 import { runtimeErrorLogFields, summarizeError } from "./error-utils.js";
@@ -91,6 +93,17 @@ interface PendingInteractiveInterruptRequest {
   threadIds: readonly string[];
 }
 
+interface SessionRequestArgs<TResult> {
+  request: () => Promise<TResult>;
+  source: ServerSessionInvalidationSource;
+}
+
+interface MaybeInvalidateSessionArgs {
+  error: unknown;
+  observedSessionId: string | null;
+  source: ServerSessionInvalidationSource;
+}
+
 export async function createHostDaemonApp(
   options: CreateHostDaemonAppOptions,
 ): Promise<HostDaemonApp> {
@@ -120,6 +133,41 @@ export async function createHostDaemonApp(
   let interactiveInterruptRetryTimeout: ReturnType<typeof setTimeout> | null =
     null;
   let eventSink: EventSink;
+  let handleServerSessionInvalidated = (
+    _args: HandleServerSessionInvalidatedArgs,
+  ): void => undefined;
+
+  function maybeInvalidateServerSession(args: MaybeInvalidateSessionArgs): void {
+    if (
+      args.observedSessionId === null ||
+      !(args.error instanceof ServerResponseError) ||
+      args.error.code !== "inactive_session"
+    ) {
+      return;
+    }
+
+    handleServerSessionInvalidated({
+      code: "inactive_session",
+      observedSessionId: args.observedSessionId,
+      source: args.source,
+    });
+  }
+
+  async function runSessionRequest<TResult>(
+    args: SessionRequestArgs<TResult>,
+  ): Promise<TResult> {
+    const observedSessionId = sessionState.value;
+    try {
+      return await args.request();
+    } catch (error) {
+      maybeInvalidateServerSession({
+        error,
+        observedSessionId,
+        source: args.source,
+      });
+      throw error;
+    }
+  }
 
   async function flushThreadEventsBeforeInteractiveRegistration(): Promise<void> {
     // Interactive registration creates server-owned turn-scoped timeline state,
@@ -197,7 +245,10 @@ export async function createHostDaemonApp(
 
         const [key, request] = nextEntry;
         try {
-          await serverClient.interruptInteractiveRequests(request);
+          await runSessionRequest({
+            source: "interruptInteractiveRequests",
+            request: () => serverClient.interruptInteractiveRequests(request),
+          });
           pendingInteractiveInterrupts.delete(key);
         } catch (error) {
           options.logger.warn(
@@ -234,12 +285,19 @@ export async function createHostDaemonApp(
   eventSink = createEventSink({
     isSessionOpen: () => sessionState.value !== null,
     logger: options.logger,
-    postEvents: (events) => serverClient.postEvents(events),
+    postEvents: (events) =>
+      runSessionRequest({
+        source: "postEvents",
+        request: () => serverClient.postEvents(events),
+      }),
   });
 
   const interactiveRequestRegistry = new InteractiveRequestRegistry({
     registerRequest: (request) =>
-      serverClient.registerInteractiveRequest(request),
+      runSessionRequest({
+        source: "registerInteractiveRequest",
+        request: () => serverClient.registerInteractiveRequest(request),
+      }),
     onRegistrationFailure: ({ error, request }) => {
       enqueueInteractiveInterrupt({
         providerId: request.providerId,
@@ -337,7 +395,10 @@ export async function createHostDaemonApp(
       (async (request) => {
         try {
           await flushThreadEventsBeforeToolCall();
-          return await serverClient.callTool(request);
+          return await runSessionRequest({
+            source: "callTool",
+            request: () => serverClient.callTool(request),
+          });
         } catch (error) {
           options.logger.error(
             {
@@ -440,7 +501,11 @@ export async function createHostDaemonApp(
 
   const router = new CommandRouter({
     dataDir: options.dataDir,
-    fetchProjectAttachment: (args) => serverClient.fetchProjectAttachment(args),
+    fetchProjectAttachment: (args) =>
+      runSessionRequest({
+        source: "fetchProjectAttachment",
+        request: () => serverClient.fetchProjectAttachment(args),
+      }),
     runtimeManager,
     terminalManager,
     listModels: (args) =>
@@ -514,6 +579,8 @@ export async function createHostDaemonApp(
     },
   });
   sendServerMessage = (message) => connection.sendMessage(message);
+  handleServerSessionInvalidated = (args) =>
+    connection.handleSessionInvalidated(args);
 
   const localApi = options.localApiConfig
     ? await startLocalApiServer({

--- a/apps/host-daemon/src/server-connection.test.ts
+++ b/apps/host-daemon/src/server-connection.test.ts
@@ -1,0 +1,245 @@
+import type { HostDaemonSessionOpenResponse } from "@bb/host-daemon-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HostDaemonLogger } from "./logger.js";
+import type { ServerClient } from "./server-client.js";
+import { ServerConnection } from "./server-connection.js";
+import type {
+  CreateReconnectingWebSocket,
+  ReconnectingWebSocketLike,
+} from "./server-connection-support.js";
+
+interface CreateServerClientFixtureArgs {
+  heartbeatIntervalMs?: number;
+  leaseTimeoutMs?: number;
+  sessionIds?: string[];
+}
+
+interface CreateWebSocketFixtureArgs {
+  autoReconnect?: boolean;
+}
+
+interface ConnectionFixtureArgs extends CreateServerClientFixtureArgs {
+  autoReconnect?: boolean;
+}
+
+interface CreateSessionArgs {
+  heartbeatIntervalMs: number;
+  leaseTimeoutMs: number;
+  sessionId: string;
+}
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  } satisfies HostDaemonLogger;
+}
+
+function createSession(args: CreateSessionArgs): HostDaemonSessionOpenResponse {
+  return {
+    heartbeatIntervalMs: args.heartbeatIntervalMs,
+    leaseTimeoutMs: args.leaseTimeoutMs,
+    retiredEnvironmentIds: [],
+    sessionId: args.sessionId,
+    trackedThreadTargets: [],
+  };
+}
+
+function createServerClientFixture(args: CreateServerClientFixtureArgs = {}) {
+  const sessionIds = args.sessionIds ?? ["session-1"];
+  let sessionIndex = 0;
+  const openSession = vi.fn(async () => {
+    const sessionId = sessionIds[sessionIndex] ?? sessionIds.at(-1);
+    sessionIndex += 1;
+    if (!sessionId) {
+      throw new Error("Expected at least one test session ID");
+    }
+    return createSession({
+      heartbeatIntervalMs: args.heartbeatIntervalMs ?? 5_000,
+      leaseTimeoutMs: args.leaseTimeoutMs ?? 30_000,
+      sessionId,
+    });
+  });
+  const unused = async () => {
+    throw new Error("Unexpected server client call");
+  };
+  const serverClient = {
+    openSession,
+    fetchProjectAttachment: unused,
+    postEvents: unused,
+    callTool: unused,
+    registerInteractiveRequest: unused,
+    interruptInteractiveRequests: unused,
+  } satisfies ServerClient;
+
+  return {
+    openSession,
+    serverClient,
+  };
+}
+
+function createWebSocketFixture(args: CreateWebSocketFixtureArgs = {}) {
+  const sockets: ReconnectingWebSocketLike[] = [];
+  const createWebSocket: CreateReconnectingWebSocket = (urlProvider) => {
+    let readyState = 0;
+    const socket: ReconnectingWebSocketLike = {
+      get readyState() {
+        return readyState;
+      },
+      onopen: null,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      send: vi.fn(),
+      close: vi.fn(() => {
+        readyState = 3;
+      }),
+      reconnect: vi.fn(() => {
+        if (args.autoReconnect === false) {
+          return;
+        }
+        readyState = 3;
+        socket.onclose?.({ code: 1000, reason: "test-reconnect" });
+        void openSocket();
+      }),
+    };
+
+    async function openSocket(): Promise<void> {
+      await urlProvider();
+      queueMicrotask(() => {
+        readyState = 1;
+        socket.onopen?.({ type: "open" });
+      });
+    }
+
+    sockets.push(socket);
+    void openSocket();
+    return socket;
+  };
+
+  return {
+    createWebSocket,
+    sockets,
+  };
+}
+
+function createConnectionFixture(args: ConnectionFixtureArgs = {}) {
+  const logger = createLogger();
+  const serverClient = createServerClientFixture(args);
+  const webSocket = createWebSocketFixture({
+    autoReconnect: args.autoReconnect,
+  });
+  const setSession = vi.fn();
+  const connection = new ServerConnection({
+    dataDir: "/tmp/bb-server-connection-test",
+    hostId: "host-server-connection-test",
+    hostKey: "host-key-server-connection-test",
+    hostName: "Server Connection Test Host",
+    hostType: "persistent",
+    instanceId: "instance-server-connection-test",
+    logger,
+    serverClient: serverClient.serverClient,
+    serverUrl: "http://127.0.0.1:3334",
+    setSession,
+    createWebSocket: webSocket.createWebSocket,
+  });
+
+  return {
+    connection,
+    logger,
+    openSession: serverClient.openSession,
+    setSession,
+    webSocket,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ServerConnection", () => {
+  it("logs delayed heartbeat timer ticks without logging normal heartbeats", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { connection, logger, webSocket } = createConnectionFixture({
+      heartbeatIntervalMs: 5_000,
+      leaseTimeoutMs: 30_000,
+    });
+    try {
+      await connection.start();
+      const socket = webSocket.sockets[0];
+      if (!socket) {
+        throw new Error("Expected test socket");
+      }
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: "heartbeat" }),
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      vi.setSystemTime(25_000);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          heartbeatIntervalMs: 5_000,
+          leaseTimeoutMs: 30_000,
+          sessionId: "session-1",
+          websocketReadyState: 1,
+        }),
+        "Host daemon heartbeat timer delayed",
+      );
+    } finally {
+      await connection.shutdown();
+    }
+  });
+
+  it("deduplicates inactive-session invalidation and reconnects only the current session", async () => {
+    const { connection, logger, setSession, webSocket } = createConnectionFixture({
+      autoReconnect: false,
+    });
+    try {
+      await connection.start();
+      const socket = webSocket.sockets[0];
+      if (!socket) {
+        throw new Error("Expected test socket");
+      }
+
+      connection.handleSessionInvalidated({
+        code: "inactive_session",
+        observedSessionId: "stale-session",
+        source: "postEvents",
+      });
+      expect(socket.reconnect).not.toHaveBeenCalled();
+
+      connection.handleSessionInvalidated({
+        code: "inactive_session",
+        observedSessionId: "session-1",
+        source: "postEvents",
+      });
+      connection.handleSessionInvalidated({
+        code: "inactive_session",
+        observedSessionId: "session-1",
+        source: "postEvents",
+      });
+
+      expect(socket.reconnect).toHaveBeenCalledTimes(1);
+      expect(socket.reconnect).toHaveBeenCalledWith(1000, "inactive-session");
+      expect(setSession).toHaveBeenLastCalledWith(null);
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          code: "inactive_session",
+          sessionId: "session-1",
+          source: "postEvents",
+        },
+        "Server reported inactive daemon session; reconnecting",
+      );
+    } finally {
+      await connection.shutdown();
+    }
+  });
+});

--- a/apps/host-daemon/src/server-connection.ts
+++ b/apps/host-daemon/src/server-connection.ts
@@ -40,6 +40,19 @@ interface ServerMessagePayloadSummary {
   payloadTruncated: boolean;
 }
 
+export type ServerSessionInvalidationSource =
+  | "callTool"
+  | "fetchProjectAttachment"
+  | "interruptInteractiveRequests"
+  | "postEvents"
+  | "registerInteractiveRequest";
+
+export interface HandleServerSessionInvalidatedArgs {
+  code: "inactive_session";
+  observedSessionId: string;
+  source: ServerSessionInvalidationSource;
+}
+
 const SERVER_MESSAGE_PAYLOAD_PREVIEW_CHARS = 512;
 
 /**
@@ -89,9 +102,11 @@ export class ServerConnection {
   private session: HostDaemonSessionOpenResponse | null = null;
   private websocket: ReconnectingWebSocketLike | null = null;
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  private lastHeartbeatTickAt: number | null = null;
   private stopped = false;
   private sessionCloseHandler: ServerConnectionOptions["onSessionClose"];
   private fatalConnectError: ServerResponseError | null = null;
+  private sessionInvalidationInProgress = false;
   private readonly pendingRecoverableMessages = new Map<
     string,
     HostDaemonDaemonWsMessage
@@ -130,6 +145,7 @@ export class ServerConnection {
   async shutdown(): Promise<void> {
     this.stopped = true;
     this.pendingRecoverableMessages.clear();
+    this.sessionInvalidationInProgress = false;
     this.clearHeartbeat();
     this.clearSession();
 
@@ -163,6 +179,29 @@ export class ServerConnection {
     handler: ServerConnectionOptions["onSessionClose"],
   ): void {
     this.sessionCloseHandler = handler;
+  }
+
+  handleSessionInvalidated(args: HandleServerSessionInvalidatedArgs): void {
+    if (this.stopped || this.sessionInvalidationInProgress) {
+      return;
+    }
+    const session = this.session;
+    if (!session || session.sessionId !== args.observedSessionId) {
+      return;
+    }
+
+    this.sessionInvalidationInProgress = true;
+    this.options.logger.info(
+      {
+        code: args.code,
+        sessionId: args.observedSessionId,
+        source: args.source,
+      },
+      "Server reported inactive daemon session; reconnecting",
+    );
+    this.clearHeartbeat();
+    this.clearSession();
+    this.websocket?.reconnect(1000, "inactive-session");
   }
 
   private async openSession(): Promise<HostDaemonSessionOpenResponse> {
@@ -269,6 +308,7 @@ export class ServerConnection {
 
         const handleOpen = async () => {
           hasOpened = true;
+          this.sessionInvalidationInProgress = false;
           this.clearTimeoutFn(startupTimer);
           this.resetHeartbeat();
           this.options.setSession?.(session);
@@ -458,7 +498,32 @@ export class ServerConnection {
       return;
     }
 
+    this.lastHeartbeatTickAt = Date.now();
     this.heartbeatInterval = this.setIntervalFn(() => {
+      const session = this.session;
+      if (!session) {
+        return;
+      }
+      const now = Date.now();
+      const lastTickAt = this.lastHeartbeatTickAt;
+      if (lastTickAt !== null) {
+        const gapMs = now - lastTickAt;
+        const thresholdMs = session.leaseTimeoutMs / 2;
+        if (gapMs > thresholdMs) {
+          this.options.logger.warn(
+            {
+              gapMs,
+              heartbeatIntervalMs: session.heartbeatIntervalMs,
+              leaseTimeoutMs: session.leaseTimeoutMs,
+              sessionId: session.sessionId,
+              websocketReadyState: this.websocket?.readyState ?? null,
+            },
+            "Host daemon heartbeat timer delayed",
+          );
+        }
+      }
+      this.lastHeartbeatTickAt = now;
+
       if (!this.websocket || this.websocket.readyState !== OPEN_READY_STATE) {
         return;
       }
@@ -473,6 +538,7 @@ export class ServerConnection {
     }
     this.clearIntervalFn(this.heartbeatInterval);
     this.heartbeatInterval = null;
+    this.lastHeartbeatTickAt = null;
   }
 
   private clearSession(): void {

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -55,7 +55,11 @@ import {
 import { isPreStartThreadStatus } from "../services/threads/thread-status.js";
 import { tryTransition } from "../services/threads/thread-transitions.js";
 import { applyTurnCompletedEvent } from "./turn-completed-events.js";
-import { requireAuthenticatedDaemonSession } from "./session-state.js";
+import {
+  getInactiveSessionLogFields,
+  requireAuthenticatedDaemonSession,
+} from "./session-state.js";
+import { getAuthenticatedDaemon } from "./auth.js";
 
 interface ToStoredEventArgs {
   envelope: HostDaemonEventEnvelope;
@@ -754,11 +758,26 @@ export function registerInternalEventRoutes(app: Hono, deps: AppDeps): void {
     "/session/events",
     hostDaemonEventBatchRequestSchema,
     async (context, payload) => {
-      const session = requireAuthenticatedDaemonSession({
-        context,
-        db: deps.db,
-        sessionId: payload.sessionId,
-      });
+      let session: ReturnType<typeof requireAuthenticatedDaemonSession>;
+      try {
+        session = requireAuthenticatedDaemonSession({
+          context,
+          db: deps.db,
+          sessionId: payload.sessionId,
+        });
+      } catch (error) {
+        if (error instanceof ApiError && error.body.code === "inactive_session") {
+          deps.logger.info(
+            getInactiveSessionLogFields(deps.db, {
+              authenticatedHostId: getAuthenticatedDaemon(context).hostId,
+              now: Date.now(),
+              sessionId: payload.sessionId,
+            }),
+            "Daemon event batch for inactive session",
+          );
+        }
+        throw error;
+      }
       const { entries, rejectedEvents } = resolvePostableEventBatchEntries(
         deps,
         {

--- a/apps/server/src/internal/session-state.ts
+++ b/apps/server/src/internal/session-state.ts
@@ -1,4 +1,5 @@
-import { getActiveSessionById } from "@bb/db";
+import { eq } from "drizzle-orm";
+import { getActiveSessionById, hostDaemonSessions } from "@bb/db";
 import type { DbConnection, HostDaemonSessionRow } from "@bb/db";
 import { ApiError } from "../errors.js";
 import { getAuthenticatedDaemon } from "./auth.js";
@@ -13,6 +14,26 @@ export interface RequireAuthorizedActiveSessionArgs {
 export interface RequireAuthenticatedDaemonSessionArgs {
   context: AuthenticatedDaemonContext;
   db: DbConnection;
+  sessionId: string;
+}
+
+export type InactiveSessionReason = "active" | "closed" | "expired" | "missing";
+
+export interface InactiveSessionLogFields {
+  authenticatedHostId?: string;
+  closeReason?: string | null;
+  closedAt?: number | null;
+  expiredByMs?: number;
+  inactiveSessionReason: InactiveSessionReason;
+  leaseExpiresAt?: number;
+  sessionHostId?: string;
+  sessionId: string;
+  sessionStatus?: string;
+}
+
+export interface GetInactiveSessionLogFieldsArgs {
+  authenticatedHostId?: string;
+  now: number;
   sessionId: string;
 }
 
@@ -50,4 +71,58 @@ export function requireAuthenticatedDaemonSession(
     hostId: daemon.hostId,
     sessionId: args.sessionId,
   });
+}
+
+export function getInactiveSessionLogFields(
+  db: DbConnection,
+  args: GetInactiveSessionLogFieldsArgs,
+): InactiveSessionLogFields {
+  const session =
+    db
+      .select()
+      .from(hostDaemonSessions)
+      .where(eq(hostDaemonSessions.id, args.sessionId))
+      .get() ?? null;
+
+  if (!session) {
+    return {
+      authenticatedHostId: args.authenticatedHostId,
+      inactiveSessionReason: "missing",
+      sessionId: args.sessionId,
+    };
+  }
+
+  if (session.status !== "active") {
+    return {
+      authenticatedHostId: args.authenticatedHostId,
+      closeReason: session.closeReason,
+      closedAt: session.closedAt,
+      inactiveSessionReason: "closed",
+      leaseExpiresAt: session.leaseExpiresAt,
+      sessionHostId: session.hostId,
+      sessionId: args.sessionId,
+      sessionStatus: session.status,
+    };
+  }
+
+  if (session.leaseExpiresAt <= args.now) {
+    return {
+      authenticatedHostId: args.authenticatedHostId,
+      expiredByMs: args.now - session.leaseExpiresAt,
+      inactiveSessionReason: "expired",
+      leaseExpiresAt: session.leaseExpiresAt,
+      sessionHostId: session.hostId,
+      sessionId: args.sessionId,
+      sessionStatus: session.status,
+    };
+  }
+
+  return {
+    authenticatedHostId: args.authenticatedHostId,
+    inactiveSessionReason: "active",
+    leaseExpiresAt: session.leaseExpiresAt,
+    sessionHostId: session.hostId,
+    sessionId: args.sessionId,
+    sessionStatus: session.status,
+  };
 }

--- a/apps/server/src/ws/daemon-protocol.ts
+++ b/apps/server/src/ws/daemon-protocol.ts
@@ -7,7 +7,10 @@ import { ApiError } from "../errors.js";
 import { verifyAuthenticatedDaemon } from "../internal/auth.js";
 import type { AppDeps } from "../types.js";
 import { runtimeErrorLogFields } from "../services/lib/error-log-fields.js";
-import { requireAuthorizedActiveSession } from "../internal/session-state.js";
+import {
+  getInactiveSessionLogFields,
+  requireAuthorizedActiveSession,
+} from "../internal/session-state.js";
 import { handleDaemonSocketClosed } from "../internal/session-owner-side-effects.js";
 import { notifyDaemonEnvironmentChange } from "../internal/environment-changes.js";
 import { decodeSocketPayload } from "./decode-payload.js";
@@ -158,7 +161,11 @@ export function onDaemonSocketMessage(
   } catch (error) {
     if (error instanceof ApiError && error.body.code === "inactive_session") {
       deps.logger.info(
-        { sessionId: args.sessionId },
+        getInactiveSessionLogFields(deps.db, {
+          authenticatedHostId: args.hostId,
+          now: Date.now(),
+          sessionId: args.sessionId,
+        }),
         "Daemon heartbeat for inactive session, closing socket",
       );
       args.socket.close(1008, "inactive-session");

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import {
+  closeSession,
   createAutomation,
   createEnvironment,
   createThread,
@@ -107,6 +108,39 @@ describe("internal event and tool-call routes", () => {
           .where(eq(events.threadId, thread.id))
           .all(),
       ).toHaveLength(2);
+    });
+  });
+
+  it("logs inactive session details when daemon event posting uses a closed session", async () => {
+    await withTestHarness(async (harness) => {
+      const info = vi.fn();
+      harness.deps.logger.info = info;
+      const { session } = seedHostSession(harness.deps, { id: "host-1" });
+      closeSession(
+        harness.deps.db,
+        harness.deps.hub,
+        session.id,
+        "daemon-disconnect",
+      );
+
+      const response = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [],
+      });
+
+      expect(response.status).toBe(401);
+      expect(info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticatedHostId: session.hostId,
+          closeReason: "daemon-disconnect",
+          inactiveSessionReason: "closed",
+          sessionHostId: session.hostId,
+          sessionId: session.id,
+          sessionStatus: "closed",
+        }),
+        "Daemon event batch for inactive session",
+      );
     });
   });
 


### PR DESCRIPTION
Summary:
- add delayed heartbeat timer anomaly logging in the host daemon
- reconnect through ServerConnection when session-bound HTTP calls receive inactive_session
- enrich server inactive-session logs with row state, close reason, and lease expiry details

Validation:
- pnpm exec turbo run typecheck --filter=@bb/host-daemon
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run test --filter=@bb/host-daemon
- pnpm exec turbo run test --filter=@bb/server
- git diff --check

<!-- release-integration-152:start -->
## Release Integration

This PR is part of the combined release integration PR: https://github.com/ymichael/bb/pull/152

Related PRs in this release set:

- #142: De-amplify contract definitions
- #135: Timeline 2.0 feed pipeline
- #123: Improve watcher lease hygiene
- #130: Run Codex app-server per thread
- #144: Handle stale host daemon sessions
- #150: Fix terminal CTA session selection
- #151: Clarify promptbox model loading state
- #155: Show live checkout state in branch UI

Role of this PR in the stack: Stale host daemon session handling. This lands after #123/#130 because it touches the same server/daemon session and runtime boundary.

Proposed landing order: #142 -> #135 -> #123 -> #130 -> #144 -> #150 -> #151 -> #155. The integration PR documents the conflict resolutions and combined validation. For final landing, use the repo rebase + fast-forward flow so the result is a linear stack with meaningful per-PR commits.
<!-- release-integration-152:end -->
