### PR TITLE
Simplify agent and review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,31 @@
 # Codebase Guidelines
 
-## Default Bias
+## Simplicity First
 
-- Choose the smallest change that fully solves the request.
-- Do not do broad cleanup, opportunistic refactors, or architecture rewrites unless they are required to make the current change correct.
-- Add no abstraction, wrapper, option, config flag, registry, interface, dependency, or shared component for one caller or a hypothetical future.
-- Reuse existing code only when it already fits. Do not bend unrelated callers together just to avoid a little duplication.
-- Keep code local until reuse is real. If adjacent debt is real but not required, mention it as follow-up.
+- Solve the requested problem with the smallest correct change.
+- Prefer deleting code, fields, branches, and surfaces over adding new ones.
+- Keep code local until reuse is proven by real callers. A little duplication is better than a shared abstraction that bends callers together.
+- Do not do broad cleanup, opportunistic refactors, or architecture rewrites unless they are required for the current change to be correct.
+- Do not turn a local bug fix into a descriptor system, registry, lifecycle table, coordinator, queue, cache framework, package split, compatibility adapter, migration/backfill framework, or generalized pipeline.
+- If adjacent debt is real but not required, mention it as follow-up instead of fixing it.
 - When renaming a domain concept, search project-wide for stale names in variables, files, query keys, constants, tests, and docs. TypeScript only catches type references.
 
 ## Types And Contracts
 
 - Validate and parse data at system boundaries, then pass typed values internally.
 - Avoid `unknown` and `as X` casts inside the system. Use them only at genuinely unknowable boundaries such as freeform tool input, then narrow immediately.
-- Keep one-off types near the code that uses them. Shared contract types belong in the appropriate shared package.
+- Keep one-off types near the code that uses them. Move types to a shared package only for a real cross-package contract.
 - Optional contract fields are allowed only when omission has real semantic meaning. Do not use optional or nullable fields to hide defaults.
 - If a field has a default, fill it in once at the server boundary and pass the explicit value through internal routes, commands, and persisted events.
 - Accepted-but-ignored route or command fields are forbidden. Delete them or implement them end to end.
-- Add or update route and command documentation only when behavior is non-obvious: side effects, multi-step flows, guards, or context the type signature does not show.
+- Add or update route and command documentation only when behavior is non-obvious.
 
-## Boundaries And Lifecycles
+## Server And Daemon
 
 - The server owns product policy: defaults, instructions, manager behavior, tool lists, and thread behavior.
 - The host daemon owns host-local primitives, provider translation, runtime/session management, and workspace execution.
 - If the server needs host-local data, the daemon should return raw data and the server should assemble product behavior.
 - Do not move responsibility across the server/daemon boundary unless the current change requires it.
-- Durable async lifecycles are for durable async work. Do not introduce lifecycle machinery for simple synchronous or one-shot behavior.
-- Routes may request lifecycle work, but server-owned lifecycle modules advance it, reconcile it, and handle recovery.
-- `status` fields represent current resource state only. Do not grow them into queue-state ladders such as `requested`, `queued`, or `fetched`.
-- Commands are live host RPCs that succeed, fail, or time out. There is no persisted command queue; durability lives in persisted intent recovered by periodic sweeps in `apps/server/src/services/system/periodic-sweeps.ts`.
-- Every new async lifecycle must define lost-result handling, reconnect reconciliation, and idempotent repeated requests.
-- Generic metadata update helpers must not accept lifecycle fields such as `status`, `stopRequestedAt`, `cleanupRequestedAt`, or `cleanupMode`.
 
 ## Data Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,88 @@
 # Codebase Guidelines
 
-## Type Safety
+## Default Bias
 
-- No `unknown`, no `as X` casts unless the type is genuinely unknowable (e.g., freeform tool input). Our boundaries validate and parse; everything inside the system is strongly typed.
-- Never inline types in function signatures. Define them in the appropriate shared package.
-- When renaming a domain type, search project-wide for the old name in variables, functions, files, query keys, and constants — not just type references. TypeScript only validates types; stale identifiers compile fine. Rename everything in the same commit.
+- Choose the smallest change that fully solves the request.
+- Do not do broad cleanup, opportunistic refactors, or architecture rewrites unless they are required to make the current change correct.
+- Add no abstraction, wrapper, option, config flag, registry, interface, dependency, or shared component for one caller or a hypothetical future.
+- Reuse existing code only when it already fits. Do not bend unrelated callers together just to avoid a little duplication.
+- Keep code local until reuse is real. If adjacent debt is real but not required, mention it as follow-up.
+- When renaming a domain concept, search project-wide for stale names in variables, files, query keys, constants, tests, and docs. TypeScript only catches type references.
 
-## Code Quality
+## Types And Contracts
 
-- Prefer maintainability and readability over speed. No one-off hacks — ask whether it would pass code review. We are never in a rush.
-- Reuse before duplicating. If a pattern exists N times, extract a shared component or utility so consistency is structural, not aspirational. When fixing a bug, check whether the same pattern is repeated elsewhere.
-- Leave the code better than you found it. When a change touches code with a weak abstraction, fix or improve it in the same change — don't add another caller to a pattern you wouldn't design today.
-- Right-size the solution. Write the simplest thing that fully works; let abstraction, layers, and configurability arrive when a second real caller demands them. A single-use wrapper, a one-implementation interface, an options bag every caller fills identically, or config nobody sets is over-engineering — as much a defect as a hack. This pulls against "reuse before duplicating": prefer a little duplication over the wrong abstraction, and don't extract before the third occurrence. (Single-use options-object parameter types are the required call style, not bloat — see Type Safety.)
-- No dead optionality. An optional parameter, field, or flag no caller ever sets to a non-default is dead configurability — delete it. The general form of "Accepted-but-ignored route or command fields are forbidden," applied to every function and component.
-- Separate concerns. When a substantial concern is better handled by a well-known, battle-tested library, install and use it — but only when the dependency saves materially more than the lines it replaces.
-- Prefer a single object argument over multiple positional arguments, especially when a function takes 3+ parameters of the same type.
-- No inline dynamic imports unless for genuine performance reasons. If it's working around a circular dependency, fix the dependency graph instead.
-- Never load all rows and filter in JS when a targeted query with WHERE/JOIN is possible. Use the indexes defined in the schema.
+- Validate and parse data at system boundaries, then pass typed values internally.
+- Avoid `unknown` and `as X` casts inside the system. Use them only at genuinely unknowable boundaries such as freeform tool input, then narrow immediately.
+- Keep one-off types near the code that uses them. Shared contract types belong in the appropriate shared package.
+- Optional contract fields are allowed only when omission has real semantic meaning. Do not use optional or nullable fields to hide defaults.
+- If a field has a default, fill it in once at the server boundary and pass the explicit value through internal routes, commands, and persisted events.
+- Accepted-but-ignored route or command fields are forbidden. Delete them or implement them end to end.
+- Add or update route and command documentation only when behavior is non-obvious: side effects, multi-step flows, guards, or context the type signature does not show.
 
-## UI Consistency
+## Boundaries And Lifecycles
 
-- Reuse shared primitives before introducing view-local class bundles (page shell, detail card/rows, collapsible headers, status pill).
-- Avoid arbitrary `text-[Npx]` classes; prefer sanctioned typography tokens.
-- Keep one canonical rendering path per concept; remove or deprecate parallel/legacy surfaces.
+- The server owns product policy: defaults, instructions, manager behavior, tool lists, and thread behavior.
+- The host daemon owns host-local primitives, provider translation, runtime/session management, and workspace execution.
+- If the server needs host-local data, the daemon should return raw data and the server should assemble product behavior.
+- Do not move responsibility across the server/daemon boundary unless the current change requires it.
+- Durable async lifecycles are for durable async work. Do not introduce lifecycle machinery for simple synchronous or one-shot behavior.
+- Routes may request lifecycle work, but server-owned lifecycle modules advance it, reconcile it, and handle recovery.
+- `status` fields represent current resource state only. Do not grow them into queue-state ladders such as `requested`, `queued`, or `fetched`.
+- Commands are live host RPCs that succeed, fail, or time out. There is no persisted command queue; durability lives in persisted intent recovered by periodic sweeps in `apps/server/src/services/system/periodic-sweeps.ts`.
+- Every new async lifecycle must define lost-result handling, reconnect reconciliation, and idempotent repeated requests.
+- Generic metadata update helpers must not accept lifecycle fields such as `status`, `stopRequestedAt`, `cleanupRequestedAt`, or `cleanupMode`.
 
-## Build and Typecheck
+## Data Access
 
-- Always use Turbo: `pnpm exec turbo run <task> --filter=@bb/<pkg>`. Turbo ensures upstream `^build` dependencies run first. Running package scripts directly (e.g., `pnpm --filter @bb/foo test`) or raw `npx tsc` skips these and will often fail with spurious module-not-found errors.
-- Typecheck: `pnpm exec turbo run typecheck --filter=@bb/<pkg>`. Do not run `npx tsc --noEmit` directly — cross-package references require upstream builds.
+- Do not load all rows and filter in JavaScript when a targeted query with `WHERE` or `JOIN` is possible.
+- Add indexes only when they are required by the new or changed query.
+- Never mock the database in tests. Use in-memory SQLite via `createConnection(":memory:")` plus `migrate(db)`.
+
+## UI
+
+- Use existing shared primitives when they already fit. Do not create a new shared primitive from a single use.
+- Avoid adding a second rendering path for the same concept. Remove an old path only when the current change directly replaces it.
+- Prefer sanctioned typography tokens over arbitrary `text-[Npx]` classes.
+
+## Build And Typecheck
+
+- Always use Turbo: `pnpm exec turbo run <task> --filter=@bb/<pkg>`. Turbo ensures upstream `^build` dependencies run first.
+- Typecheck with `pnpm exec turbo run typecheck --filter=@bb/<pkg>`.
+- Do not run package scripts directly, such as `pnpm --filter @bb/foo test`, or raw `npx tsc --noEmit` unless you are deliberately bypassing repo orchestration for investigation.
 
 ## Testing
 
-- Quality over quantity. Tests that pass when the package is broken are worse than no tests — they create false confidence. Every test should be able to catch a real bug.
-- Test real behavior and outcomes — resulting state, return values, persisted data, response bodies. Not call sequences.
-- Never mock the database. Use in-memory SQLite via `createConnection(":memory:")` + `migrate(db)`.
-- Almost never mock our own code. Mock only at true external boundaries: network calls to third-party providers, timers, and similar unpredictable externals.
-- Never mock the module under test or its private methods.
-- Pipe slow test output to a file, then read the file. Never grep or tail inline on slow tests — if the pattern misses, you've wasted an entire run. Example: `pnpm exec turbo run test --filter=@bb/integration-tests --force > /tmp/test-out.txt 2>&1`, then read `/tmp/test-out.txt`.
+- Match validation to risk. Docs-only and fixture-text changes usually do not need behavior tests.
+- Test real behavior and outcomes: resulting state, return values, persisted data, response bodies, and visible UI state.
+- Mock only true external boundaries such as third-party network calls, timers, and provider APIs. Do not mock the module under test or its private methods.
+- Bug fixes should usually include a regression test that would have failed before the fix. If a test is not practical, state why.
+- Pipe slow test output to a file, then read the file. Example: `pnpm exec turbo run test --filter=@bb/integration-tests --force > /tmp/test-out.txt 2>&1`.
 
-## Debugging Tips
+## Debugging And QA
 
-- Don't assume — instrument and observe. Add logging, read logs, inspect the database, repeat.
-- Prefer server API, CLI, direct SQL queries, or log files over browser-based debugging. Use the browser only for browser-specific issues.
-
-  | -           | Dev                                        | Prod           |
-  | ----------- | ------------------------------------------ | -------------- |
-  | Frontend    | printed by `pnpm dev`                      | `:38886`       |
-  | Server API  | printed by `pnpm dev`                      | `:38886`       |
-  | Host daemon | printed by `pnpm dev`                      | `:38887`       |
-  | Data dir    | `~/.bb-dev/<checkout-instance>/`           | `~/.bb/`       |
-  | Database    | `<data>/bb.db`                             | `<data>/bb.db` |
-  | Logs        | `<data>/logs/`                             | `<data>/logs/` |
-
-- `pnpm dev` derives deterministic high ports and the checkout-scoped data dir from the checkout path, then prints them at startup. The checkout instance id is the sanitized home-relative checkout path plus a short hash suffix. Do not assume the old flat dev ports.
+- Do not assume. Inspect logs, query the database, call server APIs, or use the CLI to observe real state.
+- Prefer server API, CLI, direct SQL queries, and log files over browser debugging except for browser-specific issues.
+- `pnpm dev` prints the active frontend URL, server API URL, host daemon port, data dir, and logs dir. Do not assume fixed dev ports.
+- The packaged app defaults to server/frontend `:38886`, host daemon `:38887`, data dir `~/.bb/`, and logs under `~/.bb/logs/`.
 - Entity IDs in URLs (`proj_*`, `thr_*`) are primary keys. Query them directly against the active data dir: `sqlite3 <data>/bb.db "SELECT * FROM threads WHERE id = 'thr_xxx';"`.
-- API routes are under `/api/v1/` — e.g. `GET /api/v1/threads/:id`. `curl` the server directly to isolate frontend vs server bugs.
-- Use the CLI to inspect state: `pnpm bb thread show <id>`, `pnpm bb project list`, `pnpm bb status`. From source: `pnpm bb:dev`.
+- API routes are under `/api/v1/`, for example `GET /api/v1/threads/:id`.
+- Use `curl` against the server API to isolate frontend issues from server behavior.
+- Use the CLI to inspect state: `pnpm bb thread show <id>`, `pnpm bb project list`, `pnpm bb status`. From source, use `pnpm bb:dev`.
 
 ### Local Dev QA Launcher
 
-Use `scripts/bb-dev-app` when validating changes in the desktop dev app or
-helping QA from this single checkout:
+Use `scripts/bb-dev-app` when validating changes in the desktop dev app or helping QA from this checkout:
 
-- `scripts/bb-dev-app status` prints the active branch, dev URLs, data dir, and
-  logs.
-- `scripts/bb-dev-app current` restarts dev server + desktop on the current
-  branch.
-- `scripts/bb-dev-app main` fetches `origin/main`, fast-forwards `main`, and
-  launches dev server + desktop from this same checkout.
-- `scripts/bb-dev-app branch <branch>` switches to a local branch, or creates
-  it from `origin/<branch>`, then launches dev server + desktop.
+- `scripts/bb-dev-app status` prints the active branch, dev URLs, data dir, and logs.
+- `scripts/bb-dev-app current` restarts dev server and desktop on the current branch.
+- `scripts/bb-dev-app main` fetches `origin/main`, fast-forwards `main`, and launches dev server and desktop from this checkout.
+- `scripts/bb-dev-app branch <branch>` switches to a local branch, or creates it from `origin/<branch>`, then launches dev server and desktop.
 - `scripts/bb-dev-app stop` stops the launcher-managed dev server and desktop.
-- `scripts/bb-dev-app logs dev` and `scripts/bb-dev-app logs desktop` follow
-  logs.
+- `scripts/bb-dev-app logs dev` and `scripts/bb-dev-app logs desktop` follow logs.
 
-Branch switches intentionally keep dirty work in this single checkout; git will
-stop if a local file would be overwritten. Set `BB_DEV_APP_STASH_DIRTY=1` for a
-one-off launch that stashes first.
+Branch switches intentionally keep dirty work in this checkout; git will stop if a local file would be overwritten. Set `BB_DEV_APP_STASH_DIRTY=1` for a one-off launch that stashes first.
 
-For CLI QA against the dev instance, run `eval "$(scripts/bb-dev-app env)"`
-first. This sets `BB_SERVER_URL`, `BB_HOST_DAEMON_PORT`, and
-`BB_PROJECT_ID=proj_personal` so `pnpm bb:dev ...` does not accidentally target
-the packaged/prod app.
+For CLI QA against the dev instance, run `eval "$(scripts/bb-dev-app env)"` first. This sets `BB_SERVER_URL`, `BB_HOST_DAEMON_PORT`, and `BB_PROJECT_ID=proj_personal` so `pnpm bb:dev ...` does not accidentally target the packaged app.
 
 Smoke-test agents with:
 
@@ -90,41 +91,8 @@ eval "$(scripts/bb-dev-app env)"
 pnpm bb:dev thread spawn --project proj_personal --provider codex --permission-mode readonly --title "Smoke test" --prompt "Reply only with ok." --no-context-parent-thread --json
 ```
 
-## Contract Documentation
-
-- Routes and commands that are self-evident from their name and type signature don't need comments. Add JSDoc only when the behavior is non-obvious — side effects, multi-step flows, guards, or context that the type signature doesn't convey.
-- When adding a new route or command type with non-obvious behavior, add the documentation in the same commit.
-- When changing a route's behavior, update any existing documentation to match.
-
-## Contracts And Boundaries
-
-- Optional contract fields are allowed only when leaving the field out has its own real semantic meaning. Do not use optional fields to hide defaults.
-- Use `required + nullable` only when `null` has a distinct meaning such as “clear this value” or “unknown”. Do not use nullable as a stand-in for defaulting.
-- If a field has a default, fill it in once at the server boundary, then pass an explicit value through internal routes, commands, and persisted events.
-- Accepted-but-ignored route or command fields are forbidden. Delete them or implement them end to end in the same change.
-- For new APIs and commands, answer “why is this optional?” during design and review.
-
-## Async Lifecycle Ownership
-
-- `status` fields represent current resource state only. Do not grow them into queue-state ladders like `requested`, `queued`, or `fetched`.
-- Durable async lifecycles belong to server-owned lifecycle modules. Routes may request lifecycle work, but only lifecycle owners may advance it, mark it in progress, handle command results, or reconcile it after reconnect.
-- Generic metadata update helpers must not accept lifecycle fields such as `status`, `stopRequestedAt`, `cleanupRequestedAt`, `cleanupMode`, or similar workflow state.
-- Model lifecycle intent and progress explicitly. Do not rely on a resource `status` field alone to represent requested work, queued work, and recovery state.
-- Commands are live host RPCs that succeed, fail, or time out; there is no persisted command queue. Durability lives in intent persisted on resource rows, recovered by the periodic sweeps in `apps/server/src/services/system/periodic-sweeps.ts` (`durable-intent-retry` and `orphan-cleanup` categories). Every new async lifecycle must define how it handles lost results from failed or timed-out RPCs, reconnect reconciliation, and idempotent repeated requests.
-
-## Server And Daemon Ownership
-
-- The server owns product policy: defaults, instructions, manager behavior, tool lists, and thread behavior.
-- The host daemon owns host-local primitives, provider translation, runtime/session management, and workspace execution.
-- If the server needs host-local data, the daemon should return the raw data and the server should assemble the final behavior.
-- When changing a server/daemon boundary, ask “should this decision live on the server instead?”
-
-## Reuse Discipline
-
-- Do not add optional arguments just to support a new caller. First ask whether the new caller should share this code at all — a small, honest duplicate often beats a shared surface bent to fit two callers. If sharing is right, prefer a wrapper, a new object type, or a separate helper over an optional flag. Aim for the fewest clear surfaces, not the most reuse.
-
 ## Planning Workflow
 
-- When asked to "make a plan", create or update a Markdown file under `plans/`.
-- Plans must have clear exit criteria and concrete validation instructions.
+- When asked to make a plan, create or update a Markdown file under `plans/`.
+- Plans must include concrete exit criteria and validation instructions.
 - Delete plan files once completed or superseded.

--- a/apps/app/src/components/thread/timeline/rows/Delegation.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/Delegation.stories.tsx
@@ -23,8 +23,8 @@ const baseProps = {
 //
 //   1. toolu_01LKp2KK7kaTCi5vi15VZYvw — Correctness review (14 toolCalls,
 //      4 commandExecutions)
-//   2. toolu_012rpTKMPCmiRnZnYXLA5Vy9 — Maintainability and AGENTS.md
-//      compliance review (12 toolCalls, 10 commandExecutions)
+//   2. toolu_012rpTKMPCmiRnZnYXLA5Vy9 — Maintainability and
+//      repo-guidance review (12 toolCalls, 10 commandExecutions)
 //   3. toolu_01VfaFeGbfjGckpp9LZNpd5a — Test quality review (19 toolCalls,
 //      3 commandExecutions)
 //
@@ -561,7 +561,7 @@ const correctnessChild17: TimelineRow = {
       "/Users/michael/.bb-dev/worktrees/env_stt3jzymfp/bb/docs/CODE_REVIEW.md",
   },
   output:
-    "1\t# Code Review Checklist\n2\t\n3\tThis document defines the dimensions of a thorough code review. Each section is designed to be evaluated independently — reviewers may delegate sections to separate agents working in parallel.\n4\t\n5\t## Unbiased Review Protocol\n6\t\n7\tA code review must be unbiased. Do not... [truncated]",
+    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. Prefer the simplest correct change.\n4\t\n5\t## Review Scope\n6\t\n7\t- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main... [truncated]",
   completedAt: 1778174324388,
   approvalStatus: null,
   activityIntents: [
@@ -645,7 +645,7 @@ const completedDelegation: TimelineRow = {
 };
 
 // =============================================================================
-// Dispatch 2 — toolu_012rpTKMPCmiRnZnYXLA5Vy9, "Maintainability and AGENTS.md compliance review".
+// Dispatch 2 — toolu_012rpTKMPCmiRnZnYXLA5Vy9, "Maintainability and repo-guidance review".
 // SYNTHESIZED STATUS — real dispatch toolu_012rpTKMPCmiRnZnYXLA5Vy9 completed;
 // lifecycle synthesized for the running variant. childRows are real.
 // startedAt/createdAt use Date.now() so "running for N seconds" stays plausible.
@@ -1094,7 +1094,7 @@ const maintainabilityChild16: TimelineRow = {
     limit: 200,
   },
   output:
-    "1\t# Code Review Checklist\n2\t\n3\tThis document defines the dimensions of a thorough code review. Each section is designed to be evaluated independently — reviewers may delegate sections to separate agents working in parallel.\n4\t\n5\t## Unbiased Review Protocol\n6\t\n7\tA code review must be unbiased. Do not... [truncated]",
+    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. Prefer the simplest correct change.\n4\t\n5\t## Review Scope\n6\t\n7\t- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main... [truncated]",
   completedAt: 1778174337233,
   approvalStatus: null,
   activityIntents: [
@@ -1308,7 +1308,7 @@ const runningDelegation: TimelineRow = {
   callId: "toolu_012rpTKMPCmiRnZnYXLA5Vy9",
   toolName: "Agent",
   subagentType: "Explore",
-  description: "Maintainability and AGENTS.md compliance review",
+  description: "Maintainability and repo-guidance review",
   output: "",
   completedAt: null,
   childRows: [
@@ -2018,7 +2018,7 @@ const testQualityChild22: TimelineRow = {
     limit: 150,
   },
   output:
-    "1\t# Code Review Checklist\n2\t\n3\tThis document defines the dimensions of a thorough code review. Each section is designed to be evaluated independently — reviewers may delegate sections to separate agents working in parallel.\n4\t\n5\t## Unbiased Review Protocol\n6\t\n7\tA code review must be unbiased. Do not... [truncated]",
+    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. Prefer the simplest correct change.\n4\t\n5\t## Review Scope\n6\t\n7\t- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main... [truncated]",
   completedAt: 1778174351117,
   approvalStatus: null,
   activityIntents: [
@@ -2137,7 +2137,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="running"
-        hint="maintainability + AGENTS.md compliance review (real dispatch, status synthesized as pending)"
+        hint="maintainability + repo-guidance review (real dispatch, status synthesized as pending)"
       >
         <TimelineStage>
           <ThreadTimelineRows

--- a/apps/app/src/components/thread/timeline/rows/Delegation.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/Delegation.stories.tsx
@@ -561,7 +561,7 @@ const correctnessChild17: TimelineRow = {
       "/Users/michael/.bb-dev/worktrees/env_stt3jzymfp/bb/docs/CODE_REVIEW.md",
   },
   output:
-    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. Prefer the simplest correct change.\n4\t\n5\t## Review Scope\n6\t\n7\t- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main... [truncated]",
+    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. The best review usually asks: what will break, and what is the smallest correction?\n4\t\n5\t## Scope\n6\t\n7\t- Stay inside the changed behavior.\n8\t- Expand only to prove a concrete correctness... [truncated]",
   completedAt: 1778174324388,
   approvalStatus: null,
   activityIntents: [
@@ -1094,7 +1094,7 @@ const maintainabilityChild16: TimelineRow = {
     limit: 200,
   },
   output:
-    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. Prefer the simplest correct change.\n4\t\n5\t## Review Scope\n6\t\n7\t- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main... [truncated]",
+    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. The best review usually asks: what will break, and what is the smallest correction?\n4\t\n5\t## Scope\n6\t\n7\t- Stay inside the changed behavior.\n8\t- Expand only to prove a concrete correctness... [truncated]",
   completedAt: 1778174337233,
   approvalStatus: null,
   activityIntents: [
@@ -2018,7 +2018,7 @@ const testQualityChild22: TimelineRow = {
     limit: 150,
   },
   output:
-    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. Prefer the simplest correct change.\n4\t\n5\t## Review Scope\n6\t\n7\t- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main... [truncated]",
+    "1\t# Code Review Guide\n2\t\n3\tUse this guide to find defects without expanding scope. The best review usually asks: what will break, and what is the smallest correction?\n4\t\n5\t## Scope\n6\t\n7\t- Stay inside the changed behavior.\n8\t- Expand only to prove a concrete correctness... [truncated]",
   completedAt: 1778174351117,
   approvalStatus: null,
   activityIntents: [

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,15 +1,15 @@
 # Code Review Guide
 
-Use this guide to find defects without expanding scope. Prefer the simplest correct change.
+Use this guide to find defects without expanding scope. The best review usually asks: what will break, and what is the smallest correction?
 
-## Review Scope
+## Scope
 
-- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main.
-- Stay inside the changed behavior. Expand only to prove a concrete correctness, security, data, or lifecycle risk.
-- If you are verifying a known fix and also doing a fresh review, keep those tasks separate so the known issue does not narrow the review.
-- Treat `AGENTS.md` as background repo guidance, not a standalone checklist item.
+- Stay inside the changed behavior.
+- Expand only to prove a concrete correctness, security, or data-loss risk.
+- Do not ask for architecture work when a local fix would be correct.
+- Treat `AGENTS.md` as background guidance, not a checklist.
 
-## Findings First
+## Findings
 
 Report findings before summaries. Order them by severity and include file and line references.
 
@@ -22,43 +22,24 @@ A useful finding explains:
 
 If there are no findings, say so directly and mention any meaningful test gap or residual risk.
 
-## Correctness And Data Safety
+## Check
 
 - Does the change do what it claims to do?
-- Trace edge cases: nulls, empty collections, missing rows, concurrent requests, retries, reconnects, and error paths.
-- Follow untrusted input from the boundary through validation, mutation, persistence, and response.
-- Check query filters, joins, pagination, ordering, authorization, and data-loss risk at the layer that enforces them.
-
-## Contracts And Lifecycles
-
-Review this section when the change touches routes, commands, events, database fields, async work, or the server/daemon boundary.
-
-- Are changed fields implemented end to end?
+- Are authorization, validation, query filters, ordering, pagination, and persistence correct at the layer that enforces them?
+- Are changed route, command, event, and database fields implemented end to end?
 - Are accepted fields actually used?
 - Are defaults applied once at the boundary instead of hidden behind optional internal fields?
-- For async work, is ownership clear, recovery idempotent, and lost command-result handling defined?
-- Did responsibility stay on the correct side of the server/daemon boundary?
+- Do tests assert outcomes that would fail for the bug or regression?
 
-## Security
+## Simplicity Red Flags
 
-- Are authorization checks enforced server-side?
-- Is user input validated before it reaches queries, commands, templates, or filesystem paths?
-- Are secrets kept out of logs, errors, telemetry, and client responses?
+Flag these when they are not required for the current change:
 
-## Tests
+- New descriptor tables, registries, coordinators, managers, generators, state machines, or dependency injection.
+- New packages or cross-package contract moves.
+- Compatibility adapters that keep old and new paths alive together.
+- Generic helpers, options, config flags, or abstractions with one real caller.
+- Broad migrations or backfills bundled with a local behavior change.
+- File splits that increase the number of places a reader must visit without deleting an older path.
 
-- Do tests assert outcomes instead of call sequences?
-- Would the tests fail for the bug or regression the change is meant to prevent?
-- Are database paths tested with in-memory SQLite rather than mocks?
-- Are external systems mocked only at true boundaries such as network providers or timers?
-- If a risky path is untested, is the reason explicit and credible?
-
-## Simplicity
-
-Default to fewer concepts, fewer surfaces, and fewer knobs.
-
-- Flag complexity only when it affects this change or creates a real maintenance risk.
-- Reject single-use abstractions, options, configuration, interfaces, registries, dependency injection, generics, or shared components.
-- Direct local code is better than a shared helper that bends unrelated callers together.
-- A small scoped workaround can be better than a broad architectural fix. Ask for the architecture change only when the workaround is riskier, larger, or leaks into future callers.
-- Do not request cleanup unrelated to the changed behavior. If adjacent debt matters, call it out as follow-up.
+Put unrelated cleanup in follow-up notes.

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,93 +1,64 @@
-# Code Review Checklist
+# Code Review Guide
 
-This document defines the dimensions of a thorough code review. Each section is designed to be evaluated independently — reviewers may delegate sections to separate agents working in parallel.
+Use this guide to find defects without expanding scope. Prefer the simplest correct change.
 
-## Unbiased Review Protocol
+## Review Scope
 
-A code review must be unbiased. Do not prime the reviewer with known issues, hints, or narrowed scope. Specifically:
+- Review the diff against the intended base. Use `git merge-base main <branch>` when reviewing a branch that may have diverged from main.
+- Stay inside the changed behavior. Expand only to prove a concrete correctness, security, data, or lifecycle risk.
+- If you are verifying a known fix and also doing a fresh review, keep those tasks separate so the known issue does not narrow the review.
+- Treat `AGENTS.md` as background repo guidance, not a standalone checklist item.
 
-- **Full branch scope.** Review all commits on the branch, not just the latest. A bug introduced in commit 2 and masked by a workaround in commit 9 is still a design problem — the workaround should be removed and the root cause fixed.
-- **Use the correct merge base.** Don't naively diff the branch against the current tip of main — main may have moved since the branch was created. Use `git merge-base main <branch>` to find the actual fork point, then diff against that. Otherwise you'll review unrelated changes that landed on main after the branch diverged, or miss context about what the branch was built on top of.
-- **No leading the witness.** Do not tell the reviewer what bugs were previously found or where to look. Let them discover issues independently.
-- **Separate verification from discovery.** If you need to confirm a specific fix _and_ do a general review, use two agents: one scoped to verify the fix, one with zero prior context doing a fresh review. Mixing the two biases the reviewer toward the known issue and away from finding new ones.
+## Findings First
 
----
+Report findings before summaries. Order them by severity and include file and line references.
 
-## 1. Plan Adherence
+A useful finding explains:
 
-If the work is driven by a plan (in `plans/`), verify. If there is no plan, skip this section.
+- What can go wrong.
+- Where it is introduced.
+- What user-visible, persisted, security, or maintenance impact it has.
+- What evidence supports the claim.
 
-- Does the implementation match the plan's scope and approach?
-- Are there deviations? If so, are they justified or accidental drift?
-- Are the plan's exit criteria met?
+If there are no findings, say so directly and mention any meaningful test gap or residual risk.
 
-## 2. Correctness
+## Correctness And Data Safety
 
-- Does the code do what it claims to do?
-- Trace edge cases: nulls, empty collections, concurrent access, error paths.
-- Follow untrusted input from entry point through every mutation — don't just confirm the happy path.
-- Check boundary conditions in queries, loops, and conditionals.
+- Does the change do what it claims to do?
+- Trace edge cases: nulls, empty collections, missing rows, concurrent requests, retries, reconnects, and error paths.
+- Follow untrusted input from the boundary through validation, mutation, persistence, and response.
+- Check query filters, joins, pagination, ordering, authorization, and data-loss risk at the layer that enforces them.
 
-## 3. Maintainability
+## Contracts And Lifecycles
 
-- Will this code be easy to modify when requirements change?
-- Is the foundation solid, or are we building on something brittle that will cost us later?
-- Are responsibilities clearly separated, or is logic entangled across concerns?
-- Would a new contributor understand _why_ this code exists, not just _what_ it does?
-- Is a substantial concern hand-rolled when a battle-tested library handles it? Flag it — but weigh the dependency's cost; one that saves only a few lines isn't worth the supply-chain and maintenance burden.
-- Is complexity abstracted at the right altitude — neither one tangled blob nor so many layers you chase logic through indirection? Favor well-named, well-scoped functions — and no more structure than the change needs.
-- Are files a reasonable size, or is there a thousand-line module that no one will want to touch?
-- Are names precise? A function called `process` or `handle` is a smell — what does it _actually_ do?
+Review this section when the change touches routes, commands, events, database fields, async work, or the server/daemon boundary.
 
-## 4. Shortcuts and Workarounds
+- Are changed fields implemented end to end?
+- Are accepted fields actually used?
+- Are defaults applied once at the boundary instead of hidden behind optional internal fields?
+- For async work, is ownership clear, recovery idempotent, and lost command-result handling defined?
+- Did responsibility stay on the correct side of the server/daemon boundary?
 
-This is its own section because shortcuts are the single most common source of accumulated debt. Every shortcut that lands becomes the foundation for the next feature.
+## Security
 
-- Is any part of this change working around an architectural limitation?
-- Would this complexity disappear if we changed the protocol, schema, or data model instead?
-- If a workaround is genuinely necessary, is it explicitly marked and scoped, or is it hiding as normal code?
-- Watch for: type casts, string manipulation of structured data, defensive parsing of typed values, compatibility shims for problems that should be fixed upstream.
+- Are authorization checks enforced server-side?
+- Is user input validated before it reaches queries, commands, templates, or filesystem paths?
+- Are secrets kept out of logs, errors, telemetry, and client responses?
 
-## 5. Security
+## Tests
 
-- Are authorization checks enforced at the right layer? Don't rely on the UI to gate access — verify server-side.
-- Is user input validated and sanitized at system boundaries before it reaches queries, commands, or templates?
-- Are secrets, tokens, or credentials kept out of logs, error messages, and client-facing responses?
-- Check for OWASP top 10: injection, broken auth, sensitive data exposure, mass assignment.
+- Do tests assert outcomes instead of call sequences?
+- Would the tests fail for the bug or regression the change is meant to prevent?
+- Are database paths tested with in-memory SQLite rather than mocks?
+- Are external systems mocked only at true boundaries such as network providers or timers?
+- If a risky path is untested, is the reason explicit and credible?
 
-## 6. Performance
+## Simplicity
 
-- Are there N+1 query patterns? Unbounded result sets missing pagination or limits?
-- Is work being done in JS that the database could do with a targeted query?
-- On the UI side: unnecessary re-renders, missing memoization on expensive computations, large bundles loaded eagerly when they could be lazy?
-- Does the change scale with data growth, or does it assume small inputs?
+Default to fewer concepts, fewer surfaces, and fewer knobs.
 
-## 7. AGENTS.md Compliance
-
-Verify the change does not violate any guideline in `AGENTS.md`. Pay particular attention to type safety, mocking discipline, and database query patterns.
-
-## 8. Test Quality
-
-- **Regression tests for correctness fixes:** Every bug fix in section 2 should have a corresponding test that would have caught the bug. If there is no test, the reviewer should ask why. Valid reasons exist — the test infrastructure doesn't support it yet, the bug is in a thin integration layer that can only be tested end-to-end, etc. — but the reason must be stated explicitly, not left implicit.
-- **Coverage:** Are the important branches tested? Not line count — are the meaningful decision points covered?
-- **Behavior over implementation:** Tests should assert on outcomes (state, return values, persisted data), not call sequences or internal structure.
-- **Mocking discipline:** Only mock at true external boundaries (network, timers). Never mock the database — use in-memory SQLite. Never mock the module under test.
-- **Failure value:** Could this test catch a real bug? A test that passes when the code is broken is worse than no test.
-
-## 9. Readability and Cognitive Load
-
-- Can you hold the entire change in your head and form a clear mental model?
-- Is the code structured so that _reading order_ matches _execution order_ where possible?
-- Is there a clear narrative to the change, or do you have to jump between files to understand what's happening?
-
-## 10. Simplicity and Right-Sizing
-
-Every other dimension pushes toward _adding_; this one removes. Over-engineering is a defect as real as a hack — it just hides behind respectable-looking structure. Review it with the same seriousness.
-
-But calibrate, or you'll flag the codebase's own conventions as waste: single-use options-object parameter types (AGENTS.md requires them), explicit lifecycle/dedupe layers, and a helper centralizing one fact across many callers are _house style, not bloat_. The target is structure built for a hypothetical future, not structure that serves the present cleanly.
-
-- **No dead optionality.** Highest-confidence smell, and verifiable: an optional parameter, field, flag, or injected interface _no caller ever sets to a non-default_. Grep the call sites, prove it, delete it. (The general form of "accepted-but-ignored fields are forbidden.")
-- **Earn the abstraction.** Flag a layer, interface, generic, or registry that enables variation that _doesn't exist_ — one implementer with no DI/test/boundary reason, a generic at a single type, a one-entry registry. "Might need it later" doesn't count.
-- **Right-size.** Managers that only forward, generic machinery serving one case, config nobody sets — would a competent engineer write it this way?
-- **Net complexity, not net lines.** A refactor must reduce complexity, not relocate it behind a new surface.
-- **Would the simplest version be wrong?** If the straightforward version works, the complex one must justify the difference _here_, with a concrete reason.
+- Flag complexity only when it affects this change or creates a real maintenance risk.
+- Reject single-use abstractions, options, configuration, interfaces, registries, dependency injection, generics, or shared components.
+- Direct local code is better than a shared helper that bends unrelated callers together.
+- A small scoped workaround can be better than a broad architectural fix. Ask for the architecture change only when the workaround is riskier, larger, or leaks into future callers.
+- Do not request cleanup unrelated to the changed behavior. If adjacent debt matters, call it out as follow-up.


### PR DESCRIPTION
## Summary
- Rework AGENTS.md around the smallest correct change and deletion-first guidance
- Replace CODE_REVIEW.md with a shorter defect-focused review guide that stays inside changed behavior
- Add explicit simplicity red flags based on the current open PR patterns: descriptors, registries, coordinators, package moves, compatibility adapters, broad migrations, and single-caller abstractions
- Update stale Storybook fixture labels/snippets that referenced the old review framing

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check