### PR TITLE
Fix terminal CTA session selection

### DIFF
--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -153,24 +153,17 @@ export function useThreadTerminalController({
     if (!canCreateTerminal || createTerminal.isPending) {
       return;
     }
-    createTerminal.mutate(
-      {
+    void createTerminal
+      .mutateAsync({
         threadId,
         cols: DEFAULT_TERMINAL_COLS,
         rows: DEFAULT_TERMINAL_ROWS,
-      },
-      {
-        onSuccess: (session) => {
-          setActiveFixedTerminal(session.id);
-        },
-      },
-    );
-  }, [
-    canCreateTerminal,
-    createTerminal,
-    setActiveFixedTerminal,
-    threadId,
-  ]);
+      })
+      .then((session) => {
+        setActiveFixedTerminal(session.id);
+      })
+      .catch(() => undefined);
+  }, [canCreateTerminal, createTerminal, setActiveFixedTerminal, threadId]);
 
   useEffect(() => {
     if (isRightPanelOpen) {

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -741,19 +741,17 @@ export function ThreadDetailView() {
       return;
     }
     const newTab = createNewTabFixedPanelTab();
-    createTerminal.mutate(
-      {
+    void createTerminal
+      .mutateAsync({
         threadId,
         cols: DEFAULT_TERMINAL_COLS,
         rows: DEFAULT_TERMINAL_ROWS,
-      },
-      {
-        onSuccess: (session) => {
-          closeTab(newTab.id);
-          setActiveFixedTerminal(session.id);
-        },
-      },
-    );
+      })
+      .then((session) => {
+        closeTab(newTab.id);
+        setActiveFixedTerminal(session.id);
+      })
+      .catch(() => undefined);
   }, [
     canCreateTerminal,
     closeTab,


### PR DESCRIPTION
Summary
- Keep terminal creation side effects alive when the disconnected terminal panel unmounts mid-request.
- Apply the same mutateAsync flow to the New Tab start-terminal action for consistency.

Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- --run src/views/thread-detail/threadTerminalTabs.test.ts src/components/secondary-panel/useThreadFileTabs.test.ts src/components/thread/terminal/thread-terminal-title.test.ts
- pnpm exec turbo run lint --filter=@bb/app

<!-- release-integration-152:start -->
## Release Integration

This PR is part of the combined release integration PR: https://github.com/ymichael/bb/pull/152

Related PRs in this release set:

- #142: De-amplify contract definitions
- #135: Timeline 2.0 feed pipeline
- #123: Improve watcher lease hygiene
- #130: Run Codex app-server per thread
- #144: Handle stale host daemon sessions
- #150: Fix terminal CTA session selection
- #151: Clarify promptbox model loading state
- #155: Show live checkout state in branch UI

Role of this PR in the stack: Terminal CTA/session selection app fix. This is app-side and was added after the daemon/runtime stack was resolved.

Proposed landing order: #142 -> #135 -> #123 -> #130 -> #144 -> #150 -> #151 -> #155. The integration PR documents the conflict resolutions and combined validation. For final landing, use the repo rebase + fast-forward flow so the result is a linear stack with meaningful per-PR commits.
<!-- release-integration-152:end -->
