### PR TITLE
Clarify promptbox model loading state

### DIFF
--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -226,6 +226,7 @@ export function makeExecutionControlsProps(
       active: { model: "gpt-5.5" },
       selected: "gpt-5.5",
       options: STORY_CODEX_MODELS,
+      isLoading: false,
       onChange: noop,
     },
     serviceTier: {

--- a/apps/app/src/components/promptbox/ExecutionControls.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import type { PermissionMode, ReasoningLevel, ServiceTier } from "@bb/domain";
 import type { SystemExecutionOptionsModelLoadError } from "@bb/server-contract";
 import { formatModelLabel } from "@/hooks/useThreadCreationOptions";
@@ -8,6 +8,8 @@ import {
   OptionDisplay,
   type PickerOption,
 } from "@/components/pickers/OptionPicker";
+
+const MODEL_LOADING_VISIBLE_DELAY_MS = 180;
 
 export interface ExecutionProviderConfig {
   options?: readonly PickerOption<string>[];
@@ -22,6 +24,7 @@ export interface ExecutionModelConfig {
   active?: { model: string } | null;
   selected: string;
   options: readonly PickerOption<string>[];
+  isLoading: boolean;
   loadError?: SystemExecutionOptionsModelLoadError | null;
   onChange: (value: string) => void;
 }
@@ -53,12 +56,43 @@ export interface ExecutionControlsProps {
   reasoning: ExecutionReasoningConfig;
 }
 
+interface UseDelayedVisibleArgs {
+  visible: boolean;
+  delayMs: number;
+}
+
+function useDelayedVisible({
+  visible,
+  delayMs,
+}: UseDelayedVisibleArgs): boolean {
+  const [delayedVisible, setDelayedVisible] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setDelayedVisible(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDelayedVisible(true);
+    }, delayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [delayMs, visible]);
+
+  return delayedVisible;
+}
+
 export const ExecutionControls = memo(function ExecutionControls({
   provider,
   model,
   serviceTier,
   reasoning,
 }: ExecutionControlsProps) {
+  const showModelLoading = useDelayedVisible({
+    visible: model.isLoading,
+    delayMs: MODEL_LOADING_VISIBLE_DELAY_MS,
+  });
   const handleServiceTierChange = serviceTier?.onChange ?? (() => {});
   const isProviderLocked = provider.onChange === undefined;
   const selectedProviderId = provider.selectedId ?? "";
@@ -82,11 +116,14 @@ export const ExecutionControls = memo(function ExecutionControls({
     provider.options &&
     provider.options.length > 1,
   );
-  const showModelPicker = model.options.length > 0 || canSwitchProviders;
+  const showModelPicker =
+    !model.isLoading && (model.options.length > 0 || canSwitchProviders);
   const selectedProviderModelLoadError =
     model.loadError?.providerId === selectedProviderId ? model.loadError : null;
   const showModelLoadError =
-    !showModelPicker && selectedProviderModelLoadError !== null;
+    !model.isLoading &&
+    !showModelPicker &&
+    selectedProviderModelLoadError !== null;
 
   return (
     <>
@@ -95,6 +132,21 @@ export const ExecutionControls = memo(function ExecutionControls({
           label="Provider"
           value={provider.displayName}
           icon={selectedProviderOption?.icon}
+          muted
+        />
+      ) : null}
+      {showModelLoading ? (
+        <OptionDisplay
+          label="Model"
+          value={
+            <span className="animate-shine whitespace-nowrap">
+              Loading models...
+            </span>
+          }
+          compactValue={
+            <span className="animate-shine whitespace-nowrap">Loading</span>
+          }
+          title="Loading models..."
           muted
         />
       ) : null}

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -168,6 +168,9 @@ export const FollowUpPromptBox = memo(function FollowUpPromptBox({
   const canSubmit = submitMode.kind === "ready" || submitMode.kind === "queue";
   const isStopping =
     submitMode.kind === "blocked" && submitMode.reason === "stopping";
+  const isLoadingExecutionOptions =
+    submitMode.kind === "blocked" &&
+    submitMode.reason === "loading-execution-options";
   const onStopRuntime =
     submitMode.kind === "queue" || submitMode.kind === "stop-only"
       ? submitMode.onStop
@@ -247,7 +250,9 @@ export const FollowUpPromptBox = memo(function FollowUpPromptBox({
               ? "Queue follow-up (Enter)"
               : isStopping
                 ? "Stopping run..."
-                : "Submit (Enter)",
+                : isLoadingExecutionOptions
+                  ? "Loading models..."
+                  : "Submit (Enter)",
             isRunning: canStopRuntime,
           }}
           typeahead={typeahead}

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
@@ -167,6 +167,41 @@ function SubmittingRow() {
   );
 }
 
+function LoadingModelsRow() {
+  const { value, mentionRanges, onChange } = useControlledValue(
+    "Investigate the timeline pagination flicker.",
+  );
+  return (
+    <PromptStage>
+      <NewThreadPromptBoxUI
+        id="story-new-thread-loading-models"
+        value={value}
+        mentionRanges={mentionRanges}
+        onChange={onChange}
+        onSubmit={noop}
+        isSubmitting={false}
+        disabled
+        zenModeStorageKey="bb.story.new-thread.loading-models"
+        history={baseHistory}
+        typeahead={makeTypeahead()}
+        attachments={makeAttachments()}
+        modeConfig={baseModeConfig}
+        project={baseProject}
+        execution={{
+          ...baseExecution,
+          model: {
+            ...baseExecution.model,
+            active: null,
+            selected: "",
+            options: [],
+            isLoading: true,
+          },
+        }}
+      />
+    </PromptStage>
+  );
+}
+
 function ClaudeProviderRow() {
   const { value, mentionRanges, onChange } = useControlledValue("");
   return (
@@ -196,6 +231,7 @@ function ClaudeProviderRow() {
               { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
               { value: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
             ],
+            isLoading: false,
             onChange: noop,
           },
           serviceTier: { ...baseExecution.serviceTier!, supported: false },
@@ -271,6 +307,12 @@ export function Overview() {
       </StoryRow>
       <StoryRow label="submitting" hint="create-thread mutation in flight">
         <SubmittingRow />
+      </StoryRow>
+      <StoryRow
+        label="loading models"
+        hint="model options are loading; submit is disabled"
+      >
+        <LoadingModelsRow />
       </StoryRow>
       <StoryRow label="claude-code provider" hint="no fast mode toggle">
         <ClaudeProviderRow />

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -202,6 +202,11 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   const voice = usePromptVoice(promptBoxRef);
   const isProjectlessPrompt = project?.value === null;
   const placeholder = getNewThreadPromptPlaceholder(isProjectlessPrompt);
+  const submitTitle = isSubmitting
+    ? "Submitting..."
+    : execution.model.isLoading
+      ? "Loading models..."
+      : "Submit (Enter)";
   return (
     <div data-promptbox-shell="" className="w-full">
       <PromptBoxInternal
@@ -219,7 +224,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
         submission={{
           isSubmitting,
           disabled,
-          title: isSubmitting ? "Submitting..." : "Submit (Enter)",
+          title: submitTitle,
         }}
         zenMode={{
           layout: "root-compose",

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -110,6 +110,7 @@ interface UseThreadCreationOptionsResult<TExecutionInputSources> {
   clearReuseEnvironment: ClearSelectionHandler;
   activeModel: AvailableModel | undefined;
   modelOptions: PickerOption<string>[];
+  isLoadingModels: boolean;
   modelLoadError: SystemExecutionOptionsModelLoadError | null;
   reasoningOptions: PickerOption<ReasoningLevel>[];
   permissionModeOptions: PickerOption<PermissionMode>[];
@@ -268,6 +269,8 @@ export function useThreadCreationOptions(
     providerId: executionOptionsProviderId,
   });
   const providers = executionOptionsQuery.data?.providers ?? EMPTY_PROVIDERS;
+  const isLoadingModels =
+    executionOptionsQueryEnabled && executionOptionsQuery.isLoading;
   const modelLoadError =
     executionOptionsQuery.data?.modelLoadError ?? NO_MODEL_LOAD_ERROR;
   const hasMultipleProviders = providers.length >= 2;
@@ -614,6 +617,7 @@ export function useThreadCreationOptions(
     clearReuseEnvironment,
     activeModel,
     modelOptions,
+    isLoadingModels,
     modelLoadError,
     reasoningOptions,
     permissionModeOptions,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -325,6 +325,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     clearReuseEnvironment,
     activeModel,
     modelOptions,
+    isLoadingModels,
     modelLoadError,
     reasoningOptions,
     permissionModeOptions,
@@ -646,6 +647,7 @@ export function RootComposeView(props: RootComposeViewProps) {
 
   const isSubmitDisabled =
     !selectedProviderId ||
+    isLoadingModels ||
     !selectedThreadModel ||
     createThread.isPending ||
     promptInput.length === 0 ||
@@ -777,6 +779,7 @@ export function RootComposeView(props: RootComposeViewProps) {
         active: activeModel,
         selected: selectedModel,
         options: modelOptions,
+        isLoading: isLoadingModels,
         loadError: modelLoadError,
         onChange: setSelectedModel,
       },
@@ -795,6 +798,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     [
       activeModel,
       hasMultipleProviders,
+      isLoadingModels,
       modelLoadError,
       modelOptions,
       providerOptions,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -271,6 +271,7 @@ export function ThreadDetailPromptArea({
     setPermissionMode,
     activeModel,
     modelOptions,
+    isLoadingModels,
     modelLoadError,
     reasoningOptions,
     permissionModeOptions,
@@ -746,6 +747,7 @@ export function ThreadDetailPromptArea({
         active: activeModel,
         selected: selectedModel,
         options: modelOptions,
+        isLoading: isLoadingModels,
         loadError: modelLoadError,
         onChange: setSelectedModel,
       },
@@ -764,6 +766,7 @@ export function ThreadDetailPromptArea({
     [
       activeModel,
       hasMultipleProviders,
+      isLoadingModels,
       modelLoadError,
       modelOptions,
       providerOptions,


### PR DESCRIPTION
## Summary
- surface model-loading state in shared promptbox execution controls instead of hiding the selector silently
- disable root-compose submit while models are loading and keep follow-up submit titles explicit
- delay the visible loading label to avoid flicker, using a subtle shimmer label instead of a spinner
- add a NewThreadPromptBox story for the loading state

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force

<!-- release-integration-152:start -->
## Release Integration

This PR is part of the combined release integration PR: https://github.com/ymichael/bb/pull/152

Related PRs in this release set:

- #142: De-amplify contract definitions
- #135: Timeline 2.0 feed pipeline
- #123: Improve watcher lease hygiene
- #130: Run Codex app-server per thread
- #144: Handle stale host daemon sessions
- #150: Fix terminal CTA session selection
- #151: Clarify promptbox model loading state
- #155: Show live checkout state in branch UI

Role of this PR in the stack: Promptbox model-loading state app fix. This lands after #150 so promptbox and terminal CTA app behavior are validated in the same app surface.

Proposed landing order: #142 -> #135 -> #123 -> #130 -> #144 -> #150 -> #151 -> #155. The integration PR documents the conflict resolutions and combined validation. For final landing, use the repo rebase + fast-forward flow so the result is a linear stack with meaningful per-PR commits.
<!-- release-integration-152:end -->
