### PR TITLE
Show live checkout state in branch UI

### DIFF
--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -394,6 +394,11 @@ export function makeWorkspaceStatus(
       currentBranch: BRANCH_NAMES.feature,
       defaultBranch: BRANCH_NAMES.default,
     },
+    checkout: {
+      kind: "branch",
+      branchName: BRANCH_NAMES.feature,
+      headSha: null,
+    },
     mergeBase: {
       mergeBaseBranch: BRANCH_NAMES.default,
       baseRef: null,

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -25,6 +25,10 @@ import {
 import { ThreadPromptContextBanner } from "@/components/promptbox/banner/ThreadPromptContextBanner";
 import { QueuedMessagesList } from "@/components/promptbox/banner/QueuedMessagesList";
 import { ThreadEnvironmentSummary } from "@/components/promptbox/ThreadEnvironmentSummary";
+import {
+  formatWorkspaceCheckoutDisplay,
+  type WorkspaceCheckoutDisplay,
+} from "@/lib/workspace-checkout-display";
 import type { PickerOption } from "@/components/pickers/OptionPicker";
 import { selectWorkspaceChangedFilesSection } from "@/components/workspace/workspace-change-summary";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
@@ -81,6 +85,7 @@ interface EnvironmentSummaryArgs {
   environment: Environment;
   host: EnvironmentDisplayHostContext;
   branchName?: string;
+  environmentCheckout?: WorkspaceCheckoutDisplay;
   onCreateNewThreadInWorktree?: () => void;
 }
 
@@ -88,12 +93,24 @@ function makeEnvironmentSummary({
   environment,
   host,
   branchName,
+  environmentCheckout,
   onCreateNewThreadInWorktree,
 }: EnvironmentSummaryArgs): ReactNode {
   const display = formatEnvironmentDisplay({
     environment,
     host,
   });
+  const checkoutDisplay =
+    environmentCheckout ??
+    (branchName
+      ? formatWorkspaceCheckoutDisplay({
+          checkout: {
+            kind: "branch",
+            branchName,
+            headSha: null,
+          },
+        })
+      : undefined);
   return (
     <ThreadEnvironmentSummary
       environmentLabel={display.modeLabel}
@@ -101,7 +118,7 @@ function makeEnvironmentSummary({
       environmentIcon={getEnvironmentWorkspaceLabelIconName(
         display.workspaceDisplayKind,
       )}
-      environmentBranchName={branchName}
+      environmentCheckout={checkoutDisplay}
       onCreateNewThreadInWorktree={onCreateNewThreadInWorktree}
     />
   );
@@ -148,6 +165,22 @@ const worktreeEnvironmentSummary: ReactNode = makeEnvironmentSummary({
   // Worktree threads expose a "new thread in this worktree" affordance —
   // production wires it to the new-thread route. The story just needs a
   // non-null handler so the MessageSquarePlus icon renders.
+  onCreateNewThreadInWorktree: noop,
+});
+
+const detachedWorktreeEnvironmentSummary: ReactNode = makeEnvironmentSummary({
+  environment: makeEnvironment({
+    isWorktree: true,
+    workspaceProvisionType: "managed-worktree",
+    status: "ready",
+  }),
+  host: localEnvironmentDisplayHost,
+  environmentCheckout: formatWorkspaceCheckoutDisplay({
+    checkout: {
+      kind: "detached",
+      headSha: "abcdef1234567890",
+    },
+  }),
   onCreateNewThreadInWorktree: noop,
 });
 
@@ -235,6 +268,11 @@ const dirtyWorkspaceStatus: WorkspaceStatus = {
   branch: {
     currentBranch: "bb/promptbox-stories",
     defaultBranch: "main",
+  },
+  checkout: {
+    kind: "branch",
+    branchName: "bb/promptbox-stories",
+    headSha: null,
   },
   mergeBase: null,
 };
@@ -489,6 +527,12 @@ export function Overview() {
         <Row
           submitMode={{ kind: "ready" }}
           environmentSummary={worktreeEnvironmentSummary}
+        />
+      </StoryRow>
+      <StoryRow label="env: detached" hint="detached checkout label">
+        <Row
+          submitMode={{ kind: "ready" }}
+          environmentSummary={detachedWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow label="env: remote direct" hint="remote label + icon">

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -2,6 +2,11 @@ import { memo } from "react";
 import { OptionDisplay } from "@/components/pickers/OptionPicker";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
 import { Icon, type IconName } from "@/components/ui/icon.js";
+import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
+
+const CHECKOUT_CHIP_BASE_CLASS_NAME =
+  "flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground";
+const CHECKOUT_CHIP_BUTTON_CLASS_NAME = `${CHECKOUT_CHIP_BASE_CLASS_NAME} transition-colors hover:bg-state-hover hover:text-foreground`;
 
 export interface ThreadEnvironmentSummaryProps {
   /** Mode label (e.g. "Working locally" / "Worktree"). Never truncates. */
@@ -10,8 +15,8 @@ export interface ThreadEnvironmentSummaryProps {
   environmentCompactLabel?: string;
   /** Icon for the environment (e.g. monitor / git branch). */
   environmentIcon?: IconName;
-  /** Branch name if the environment runs on a worktree. Renders a copy-to-clipboard button. */
-  environmentBranchName?: string;
+  /** Live checkout label for this environment. Branch checkouts are copyable. */
+  environmentCheckout?: WorkspaceCheckoutDisplay;
   /** When set, render a "new thread in this worktree" affordance beside the
    * environment label. Caller is responsible for only providing this when the
    * environment is a worktree. */
@@ -34,12 +39,14 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
   environmentLabel,
   environmentCompactLabel,
   environmentIcon,
-  environmentBranchName,
+  environmentCheckout,
   onCreateNewThreadInWorktree,
 }: ThreadEnvironmentSummaryProps) {
   if (!environmentLabel) {
     return null;
   }
+
+  const checkoutCopyValue = environmentCheckout?.copyValue ?? null;
 
   return (
     <div className="flex min-w-0 max-w-full items-center gap-2 pr-1.5">
@@ -60,22 +67,33 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
         className="h-6 min-w-0"
         muted
       />
-      {environmentBranchName ? (
+      {environmentCheckout && checkoutCopyValue !== null ? (
         <button
           type="button"
           data-promptbox-hide-compact=""
-          className="flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
-          title={`Copy branch name: ${environmentBranchName}`}
+          className={CHECKOUT_CHIP_BUTTON_CLASS_NAME}
+          title={environmentCheckout.title}
           onClick={() => {
-            void copyToClipboardWithToast(environmentBranchName, {
-              successMessage: "Branch name copied",
-              errorMessage: "Failed to copy branch name",
+            void copyToClipboardWithToast(checkoutCopyValue, {
+              successMessage:
+                environmentCheckout.copySuccessMessage ?? "Value copied",
+              errorMessage:
+                environmentCheckout.copyErrorMessage ?? "Failed to copy value",
             });
           }}
         >
           <Icon name="GitBranch" className="size-3.5 shrink-0" />
-          <span className="truncate">{environmentBranchName}</span>
+          <span className="truncate">{environmentCheckout.label}</span>
         </button>
+      ) : environmentCheckout ? (
+        <span
+          data-promptbox-hide-compact=""
+          className={CHECKOUT_CHIP_BASE_CLASS_NAME}
+          title={environmentCheckout.title}
+        >
+          <Icon name="GitBranch" className="size-3.5 shrink-0" />
+          <span className="truncate">{environmentCheckout.label}</span>
+        </span>
       ) : null}
       {onCreateNewThreadInWorktree ? (
         <button

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -80,6 +80,11 @@ const dirtyUncommittedStatus: WorkspaceStatus = {
     currentBranch: "bb/promptbox-stories",
     defaultBranch: "main",
   },
+  checkout: {
+    kind: "branch",
+    branchName: "bb/promptbox-stories",
+    headSha: null,
+  },
   mergeBase: null,
 };
 
@@ -117,6 +122,11 @@ const dirtyUncommittedManyStatus: WorkspaceStatus = {
     currentBranch: "bb/promptbox-stories",
     defaultBranch: "main",
   },
+  checkout: {
+    kind: "branch",
+    branchName: "bb/promptbox-stories",
+    headSha: null,
+  },
   mergeBase: null,
 };
 
@@ -145,6 +155,11 @@ const untrackedOnlyStatus: WorkspaceStatus = {
     currentBranch: "bb/promptbox-stories",
     defaultBranch: "main",
   },
+  checkout: {
+    kind: "branch",
+    branchName: "bb/promptbox-stories",
+    headSha: null,
+  },
   mergeBase: null,
 };
 
@@ -159,6 +174,11 @@ const committedUnmergedStatus: WorkspaceStatus = {
   branch: {
     currentBranch: "bb/promptbox-stories",
     defaultBranch: "main",
+  },
+  checkout: {
+    kind: "branch",
+    branchName: "bb/promptbox-stories",
+    headSha: null,
   },
   mergeBase: {
     mergeBaseBranch: "main",

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.rows.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.rows.stories.tsx
@@ -244,9 +244,32 @@ export function Branch() {
           <BranchRow
             thread={makeThread()}
             workspaceStatus={makeWorkspaceStatus({
+              checkout: {
+                kind: "branch",
+                branchName:
+                  "feat/sidebar-rail/extract-row-components-and-add-info-row-stories",
+                headSha: null,
+              },
               branch: {
                 currentBranch:
                   "feat/sidebar-rail/extract-row-components-and-add-info-row-stories",
+                defaultBranch: "main",
+              },
+            })}
+          />
+        </RowStage>
+      </StoryRow>
+      <StoryRow label="detached checkout">
+        <RowStage>
+          <BranchRow
+            thread={makeThread()}
+            workspaceStatus={makeWorkspaceStatus({
+              checkout: {
+                kind: "detached",
+                headSha: "abcdef1234567890",
+              },
+              branch: {
+                currentBranch: null,
                 defaultBranch: "main",
               },
             })}

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -19,6 +19,7 @@ import {
   type EnvironmentDisplayHostContext,
 } from "@bb/core-ui";
 import { cn } from "@/lib/utils";
+import { formatWorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
 import { Button } from "@/components/ui/button.js";
 import {
   COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
@@ -348,19 +349,36 @@ export interface BranchRowProps {
 }
 
 export function BranchRow({ thread, workspaceStatus }: BranchRowProps) {
-  const branchName = workspaceStatus?.branch.currentBranch ?? null;
-  if (!branchName) return null;
+  const checkoutDisplay = workspaceStatus
+    ? formatWorkspaceCheckoutDisplay({ checkout: workspaceStatus.checkout })
+    : null;
+  if (checkoutDisplay === null) return null;
   return (
     <DetailRow
-      label={<DetailRowIconLabel icon="GitBranch">Branch</DetailRowIconLabel>}
+      label={
+        <DetailRowIconLabel icon="GitBranch">
+          {checkoutDisplay.rowLabel}
+        </DetailRowIconLabel>
+      }
       valueClassName="min-w-0 truncate"
     >
-      <CopyableInlineLabel
-        text={branchName}
-        label="Copy branch name"
-        successMessage="Branch name copied"
-        errorMessage="Failed to copy branch name"
-      />
+      {checkoutDisplay.copyValue !== null ? (
+        <CopyableInlineLabel
+          text={checkoutDisplay.copyValue}
+          label={checkoutDisplay.copyLabel ?? "Copy checkout value"}
+          title={checkoutDisplay.title}
+          successMessage={checkoutDisplay.copySuccessMessage ?? "Value copied"}
+          errorMessage={
+            checkoutDisplay.copyErrorMessage ?? "Failed to copy value"
+          }
+        >
+          {checkoutDisplay.label}
+        </CopyableInlineLabel>
+      ) : (
+        <span className="block truncate" title={checkoutDisplay.title}>
+          {checkoutDisplay.label}
+        </span>
+      )}
     </DetailRow>
   );
 }

--- a/apps/app/src/components/secondary-panel/git-diff/useEnvironmentMergeBase.test.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useEnvironmentMergeBase.test.ts
@@ -41,6 +41,11 @@ function makeWorkspaceStatus(
       currentBranch: "bb/thread",
       defaultBranch: "main",
     },
+    checkout: {
+      kind: "branch",
+      branchName: "bb/thread",
+      headSha: null,
+    },
     mergeBase: null,
     workingTree: {
       deletions: 0,

--- a/apps/app/src/components/workspace/workspace-status.test.ts
+++ b/apps/app/src/components/workspace/workspace-status.test.ts
@@ -39,6 +39,11 @@ function makeStatus(options: MakeStatusOptions): WorkspaceStatus {
       deletions: options.deletions ?? 0,
       files,
     }),
+    checkout: {
+      kind: "branch",
+      branchName: "feature",
+      headSha: null,
+    },
     branch: {
       currentBranch: "feature",
       defaultBranch: "main",

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -77,6 +77,7 @@ function makeStatusResponse(
     outcome: "available",
     workspace: makeWorkspaceStatus({
       workingTree: makeWorkspaceWorkingTree({ state }),
+      checkout: { kind: "branch", branchName: "feature", headSha: null },
       branch: { currentBranch: "feature", defaultBranch: "main" },
       mergeBase: makeWorkspaceMergeBase({ baseRef: "origin/main" }),
     }),

--- a/apps/app/src/lib/workspace-checkout-display.test.ts
+++ b/apps/app/src/lib/workspace-checkout-display.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { formatWorkspaceCheckoutDisplay } from "./workspace-checkout-display";
+
+describe("formatWorkspaceCheckoutDisplay", () => {
+  it("formats a branch checkout as a copyable branch label", () => {
+    expect(
+      formatWorkspaceCheckoutDisplay({
+        checkout: {
+          kind: "branch",
+          branchName: "bb/thread",
+          headSha: "1234567890abcdef",
+        },
+      }),
+    ).toMatchObject({
+      copyValue: "bb/thread",
+      label: "bb/thread",
+      rowLabel: "Branch",
+      title: "Copy branch name: bb/thread",
+    });
+  });
+
+  it("formats detached HEAD with a short SHA label and copyable full SHA", () => {
+    expect(
+      formatWorkspaceCheckoutDisplay({
+        checkout: {
+          kind: "detached",
+          headSha: "abcdef1234567890",
+        },
+      }),
+    ).toMatchObject({
+      copyValue: "abcdef1234567890",
+      label: "detached abcdef1",
+      rowLabel: "Checkout",
+      title: "Detached HEAD: abcdef1234567890",
+    });
+  });
+
+  it("formats detached HEAD without a SHA", () => {
+    expect(
+      formatWorkspaceCheckoutDisplay({
+        checkout: {
+          kind: "detached",
+          headSha: null,
+        },
+      }),
+    ).toMatchObject({
+      copyValue: null,
+      label: "detached HEAD",
+      rowLabel: "Checkout",
+      title: "Detached HEAD",
+    });
+  });
+
+  it("formats an unborn checkout with a branch name", () => {
+    expect(
+      formatWorkspaceCheckoutDisplay({
+        checkout: {
+          kind: "unborn",
+          branchName: "main",
+        },
+      }),
+    ).toMatchObject({
+      copyValue: null,
+      label: "main (empty)",
+      rowLabel: "Checkout",
+      title: "Empty branch: main",
+    });
+  });
+
+  it("formats an unborn checkout without a branch name", () => {
+    expect(
+      formatWorkspaceCheckoutDisplay({
+        checkout: {
+          kind: "unborn",
+          branchName: null,
+        },
+      }),
+    ).toMatchObject({
+      copyValue: null,
+      label: "empty repo",
+      rowLabel: "Checkout",
+      title: "Empty repository",
+    });
+  });
+
+  it("formats an unknown checkout", () => {
+    expect(
+      formatWorkspaceCheckoutDisplay({
+        checkout: {
+          kind: "unknown",
+          reason: "HEAD is missing",
+        },
+      }),
+    ).toMatchObject({
+      copyValue: null,
+      label: "unknown checkout",
+      rowLabel: "Checkout",
+      title: "Unknown checkout: HEAD is missing",
+    });
+  });
+});

--- a/apps/app/src/lib/workspace-checkout-display.ts
+++ b/apps/app/src/lib/workspace-checkout-display.ts
@@ -1,0 +1,85 @@
+import type { GitCheckoutRef } from "@bb/domain";
+
+const SHORT_SHA_LENGTH = 7;
+
+export interface WorkspaceCheckoutDisplay {
+  copyErrorMessage: string | null;
+  copyLabel: string | null;
+  copySuccessMessage: string | null;
+  copyValue: string | null;
+  label: string;
+  rowLabel: "Branch" | "Checkout";
+  title: string;
+}
+
+export interface FormatWorkspaceCheckoutDisplayArgs {
+  checkout: GitCheckoutRef;
+}
+
+function shortSha(sha: string): string {
+  return sha.slice(0, SHORT_SHA_LENGTH);
+}
+
+export function formatWorkspaceCheckoutDisplay({
+  checkout,
+}: FormatWorkspaceCheckoutDisplayArgs): WorkspaceCheckoutDisplay {
+  switch (checkout.kind) {
+    case "branch":
+      return {
+        copyErrorMessage: "Failed to copy branch name",
+        copyLabel: "Copy branch name",
+        copySuccessMessage: "Branch name copied",
+        copyValue: checkout.branchName,
+        label: checkout.branchName,
+        rowLabel: "Branch",
+        title: `Copy branch name: ${checkout.branchName}`,
+      };
+    case "detached":
+      if (checkout.headSha === null) {
+        return {
+          copyErrorMessage: null,
+          copyLabel: null,
+          copySuccessMessage: null,
+          copyValue: null,
+          label: "detached HEAD",
+          rowLabel: "Checkout",
+          title: "Detached HEAD",
+        };
+      }
+      return {
+        copyErrorMessage: "Failed to copy commit SHA",
+        copyLabel: "Copy commit SHA",
+        copySuccessMessage: "Commit SHA copied",
+        copyValue: checkout.headSha,
+        label: `detached ${shortSha(checkout.headSha)}`,
+        rowLabel: "Checkout",
+        title: `Detached HEAD: ${checkout.headSha}`,
+      };
+    case "unborn":
+      return {
+        copyErrorMessage: null,
+        copyLabel: null,
+        copySuccessMessage: null,
+        copyValue: null,
+        label:
+          checkout.branchName !== null
+            ? `${checkout.branchName} (empty)`
+            : "empty repo",
+        rowLabel: "Checkout",
+        title:
+          checkout.branchName !== null
+            ? `Empty branch: ${checkout.branchName}`
+            : "Empty repository",
+      };
+    case "unknown":
+      return {
+        copyErrorMessage: null,
+        copyLabel: null,
+        copySuccessMessage: null,
+        copyValue: null,
+        label: "unknown checkout",
+        rowLabel: "Checkout",
+        title: `Unknown checkout: ${checkout.reason}`,
+      };
+  }
+}

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/promptbox/banner/QueuedMessagesList";
 import type { QueuedMessageReorderRequest } from "@/lib/queued-message-reorder";
 import { ThreadEnvironmentSummary } from "@/components/promptbox/ThreadEnvironmentSummary";
+import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { usePromptMentions } from "@/hooks/usePromptMentions";
 import { useCommandSuggestions } from "@/hooks/useCommandSuggestions";
@@ -77,7 +78,7 @@ interface ThreadDetailPromptAreaProps {
   composerQueriesEnabled: boolean;
   composerQueriesStaleTime?: number;
   contextWindowUsage?: ThreadTimelineResponse["contextWindowUsage"];
-  environmentBranchName?: string;
+  environmentCheckout?: WorkspaceCheckoutDisplay;
   environmentCompactLabel?: string;
   environmentIcon?: IconName;
   environmentLabel?: string;
@@ -129,7 +130,7 @@ export function ThreadDetailPromptArea({
   composerQueriesEnabled,
   composerQueriesStaleTime,
   contextWindowUsage,
-  environmentBranchName,
+  environmentCheckout,
   environmentCompactLabel,
   environmentIcon,
   environmentLabel,
@@ -820,12 +821,12 @@ export function ThreadDetailPromptArea({
           environmentLabel={environmentLabel}
           environmentCompactLabel={environmentCompactLabel}
           environmentIcon={environmentIcon}
-          environmentBranchName={environmentBranchName}
+          environmentCheckout={environmentCheckout}
           onCreateNewThreadInWorktree={onCreateNewThreadInWorktree}
         />
       ) : null,
     [
-      environmentBranchName,
+      environmentCheckout,
       environmentCompactLabel,
       environmentIcon,
       environmentLabel,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -58,6 +58,7 @@ import {
   useThreadTerminals,
 } from "@/hooks/queries/thread-terminal-queries";
 import { getEnvironmentWorkspaceLabelIconName } from "@/lib/environment-workspace-display";
+import { formatWorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
 import {
   getAbsoluteDirname,
   isAbsoluteFilePathWithinRoot,
@@ -1402,6 +1403,9 @@ export function ThreadDetailView() {
       : undefined;
   const promptBannerMergeBaseBranch = effectiveMergeBaseBranch;
   const threadBranchName = workspaceBranch?.currentBranch ?? undefined;
+  const threadCheckoutDisplay = workspaceStatus
+    ? formatWorkspaceCheckoutDisplay({ checkout: workspaceStatus.checkout })
+    : undefined;
   const isWorkspaceDeleted = environment?.status === "destroyed";
   const threadGitStatusDisplay = getGitStatusDisplay(workspaceStatus, {
     mergeBaseBranch,
@@ -1462,7 +1466,7 @@ export function ThreadDetailView() {
     <ThreadDetailPromptArea
       canUseGitUi={canUseGitUi}
       contextWindowUsage={contextWindowUsage}
-      environmentBranchName={threadBranchName}
+      environmentCheckout={threadCheckoutDisplay}
       environmentIcon={threadEnvironmentIcon ?? undefined}
       environmentLabel={threadEnvironmentDisplay?.modeLabel}
       environmentCompactLabel={threadEnvironmentDisplay?.compactModeLabel}

--- a/apps/host-daemon/test/command/environment-dispatch.test.ts
+++ b/apps/host-daemon/test/command/environment-dispatch.test.ts
@@ -923,6 +923,11 @@ describe("environment command dispatch", () => {
     });
     harness.workspace.getStatus = async () => ({
       branch: { currentBranch: "bb/thread", defaultBranch: "main" },
+      checkout: {
+        kind: "branch",
+        branchName: "bb/thread",
+        headSha: null,
+      },
       mergeBase: null,
       workingTree: {
         deletions: 0,

--- a/apps/server/test/ai/commit-message.test.ts
+++ b/apps/server/test/ai/commit-message.test.ts
@@ -280,6 +280,11 @@ describe("commit message generation", () => {
             currentBranch: "feature",
             defaultBranch: "main",
           },
+          checkout: {
+            kind: "branch",
+            branchName: "feature",
+            headSha: null,
+          },
           mergeBase: null,
           workingTree: {
             deletions: 0,
@@ -371,6 +376,11 @@ describe("commit message generation", () => {
           branch: {
             currentBranch: "feature",
             defaultBranch: "main",
+          },
+          checkout: {
+            kind: "branch",
+            branchName: "feature",
+            headSha: null,
           },
           mergeBase: null,
           workingTree: {

--- a/packages/domain/src/thread.ts
+++ b/packages/domain/src/thread.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { environmentWorkspaceDisplayKindSchema } from "./environment.js";
+import { gitCheckoutRefSchema } from "./git-checkout.js";
 import {
   promptInputSchema,
   permissionModeSchema,
@@ -120,6 +121,7 @@ export type WorkspaceMergeBase = z.infer<typeof workspaceMergeBaseSchema>;
 
 export const workspaceStatusSchema = z.object({
   workingTree: workspaceWorkingTreeSchema,
+  checkout: gitCheckoutRefSchema,
   branch: workspaceBranchSchema,
   mergeBase: workspaceMergeBaseSchema.nullable(),
 });

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -81,6 +81,11 @@ const WORKSPACE_STATUS_AVAILABLE_RESULT: JsonObject = {
       currentBranch: "feature/host-rpc",
       defaultBranch: "main",
     },
+    checkout: {
+      kind: "branch",
+      branchName: "feature/host-rpc",
+      headSha: null,
+    },
     mergeBase: {
       insertions: 5,
       deletions: 0,
@@ -1676,6 +1681,11 @@ describe("host-daemon command schemas", () => {
           branch: {
             currentBranch: "bb/env-123",
             defaultBranch: "main",
+          },
+          checkout: {
+            kind: "branch",
+            branchName: "bb/env-123",
+            headSha: null,
           },
           mergeBase: null,
         },

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -430,10 +430,14 @@ export async function ensureGitRepo(
   );
 }
 
-async function readHeadSha(cwd: string): Promise<string | null> {
+async function readHeadSha(
+  cwd: string,
+  options: GitTimeoutOptions = {},
+): Promise<string | null> {
   const result = await runGit(["rev-parse", "--verify", "HEAD"], {
     cwd,
     allowFailure: true,
+    timeoutMs: options.timeoutMs,
   });
   if (result.exitCode !== 0) {
     return null;
@@ -464,8 +468,11 @@ export async function getCurrentBranch(
   return branchName || undefined;
 }
 
-export async function getCheckoutRef(cwd: string): Promise<GitCheckoutRef> {
-  if (!(await detectGitRepo(cwd))) {
+export async function getCheckoutRef(
+  cwd: string,
+  options: GitTimeoutOptions = {},
+): Promise<GitCheckoutRef> {
+  if (!(await detectGitRepo(cwd, options))) {
     return { kind: "unknown", reason: "Path is not a git repository" };
   }
 
@@ -473,8 +480,9 @@ export async function getCheckoutRef(cwd: string): Promise<GitCheckoutRef> {
     runGit(["symbolic-ref", "--quiet", "--short", "HEAD"], {
       cwd,
       allowFailure: true,
+      timeoutMs: options.timeoutMs,
     }),
-    readHeadSha(cwd),
+    readHeadSha(cwd, options),
   ]);
 
   const branchName = trimOutput(symbolicRef.stdout);

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -13,6 +13,7 @@ import {
   createTempDir,
   detectGitRepo,
   ensureGitRepo,
+  getCheckoutRef,
   getCurrentBranch,
   hasRef,
   hasUncommittedChanges,
@@ -523,7 +524,7 @@ export class Workspace {
     const [
       statusOutput,
       diffOutput,
-      currentBranch,
+      checkout,
       defaultBranch,
       mergeBaseData,
     ] = await Promise.all([
@@ -540,7 +541,7 @@ export class Workspace {
         { cwd: this.path, timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS },
       ),
       readHeadNumstat(this.path, WORKSPACE_STATUS_GIT_TIMEOUT_MS),
-      getCurrentBranch(this.path, {
+      getCheckoutRef(this.path, {
         timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS,
       }),
       readDefaultBranch(this.path, {
@@ -608,9 +609,17 @@ export class Workspace {
         files,
       },
       branch: {
-        currentBranch: currentBranch ?? null,
-        defaultBranch: defaultBranch ?? currentBranch ?? "",
+        currentBranch:
+          checkout.kind === "branch" || checkout.kind === "unborn"
+            ? checkout.branchName
+            : null,
+        defaultBranch:
+          defaultBranch ??
+          (checkout.kind === "branch" || checkout.kind === "unborn"
+            ? (checkout.branchName ?? "")
+            : ""),
       },
+      checkout,
       mergeBase: mergeBaseData,
     };
   }
@@ -621,6 +630,7 @@ export class Workspace {
       this.getStatus(),
     ]);
     return JSON.stringify({
+      checkout: status.checkout,
       currentBranch: status.branch.currentBranch,
       headSha,
       workingTree: status.workingTree,

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -514,6 +514,7 @@ describe("Workspace", () => {
 
     expect(status.workingTree.state).toBe("untracked");
     expect(status.branch.currentBranch).toBe("main");
+    expect(status.checkout).toEqual({ kind: "unborn", branchName: "main" });
     expect(status.workingTree.files).toEqual([
       {
         path: "notes.txt",

--- a/packages/test-helpers/src/workspace-status.ts
+++ b/packages/test-helpers/src/workspace-status.ts
@@ -39,6 +39,7 @@ export function makeWorkspaceStatus(
 ): WorkspaceStatus {
   return {
     workingTree: makeWorkspaceWorkingTree(),
+    checkout: { kind: "branch", branchName: "main", headSha: null },
     branch: { currentBranch: "main", defaultBranch: "main" },
     mergeBase: null,
     ...overrides,


### PR DESCRIPTION
## Summary
- add live checkout state to workspace status so branch UI can distinguish branch, detached, unborn, and unknown checkouts
- render the prompt branch chip and Info tab branch row from the live checkout display
- keep the branch picker unchanged and preserve existing branch compatibility fields

## Validation
- pnpm exec turbo run typecheck --filter=@bb/domain
- pnpm exec turbo run typecheck --filter=@bb/host-workspace
- pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract
- pnpm exec turbo run typecheck --filter=@bb/server-contract
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/host-daemon
- pnpm exec turbo run test --filter=@bb/host-workspace --force > /tmp/host-workspace-checkout-display-test-out.txt 2>&1
- pnpm exec turbo run test --filter=@bb/server-contract --force > /tmp/server-contract-checkout-display-test-out.txt 2>&1
- pnpm exec turbo run test --filter=@bb/host-daemon-contract --force > /tmp/host-daemon-contract-checkout-display-test-out.txt 2>&1
- pnpm exec turbo run test --filter=@bb/app --force > /tmp/app-checkout-display-test-out.txt 2>&1
- pnpm exec turbo run test --filter=@bb/server --force > /tmp/server-checkout-display-test-out.txt 2>&1
- pnpm exec turbo run test --filter=@bb/host-daemon --force > /tmp/host-daemon-checkout-display-test-out.txt 2>&1

<!-- release-integration-152:start -->
## Release Integration

This PR is part of the combined release integration PR: https://github.com/ymichael/bb/pull/152

Related PRs in this release set:

- #142: De-amplify contract definitions
- #135: Timeline 2.0 feed pipeline
- #123: Improve watcher lease hygiene
- #130: Run Codex app-server per thread
- #144: Handle stale host daemon sessions
- #150: Fix terminal CTA session selection
- #151: Clarify promptbox model loading state
- #155: Show live checkout state in branch UI

Role of this PR in the stack: Live checkout state and branch UI. This lands after #151 because its prompt branch display changes resolve against the current promptbox/thread-detail app surface.

Proposed landing order: #142 -> #135 -> #123 -> #130 -> #144 -> #150 -> #151 -> #155. The integration PR documents the conflict resolutions and combined validation. For final landing, use the repo rebase + fast-forward flow so the result is a linear stack with meaningful per-PR commits.
<!-- release-integration-152:end -->
