### PR TITLE
Speed up large event value migration

### DIFF
--- a/packages/db/drizzle/0031_mysterious_zaran.sql
+++ b/packages/db/drizzle/0031_mysterious_zaran.sql
@@ -233,62 +233,70 @@ WHERE events.type IN ('item/started', 'item/completed')
   AND events.item_kind = 'fileChange'
   AND json_type(changes.value, '$.diff') = 'text'
   AND length(json_extract(changes.value, '$.diff')) > 512;--> statement-breakpoint
+CREATE TEMP TABLE IF NOT EXISTS event_large_value_file_diff_backfill_targets (
+  event_id text NOT NULL,
+  patch_index integer NOT NULL,
+  json_path text NOT NULL,
+  PRIMARY KEY (event_id, patch_index)
+) WITHOUT ROWID;--> statement-breakpoint
+DELETE FROM event_large_value_file_diff_backfill_targets;--> statement-breakpoint
+INSERT INTO event_large_value_file_diff_backfill_targets (
+  event_id,
+  patch_index,
+  json_path
+)
+SELECT
+  event_id,
+  row_number() OVER (
+    PARTITION BY event_id
+    ORDER BY json_path
+  ) AS patch_index,
+  json_path
+FROM event_large_values
+WHERE item_kind = 'fileChange'
+  AND value_kind = 'file_change_diff';--> statement-breakpoint
 WITH RECURSIVE
-  target_file_diffs AS (
-    SELECT
-      events.id AS event_id,
-      '$.item.changes[' || changes.key || '].diff' AS json_path
-    FROM events, json_each(events.data, '$.item.changes') AS changes
-    WHERE events.type IN ('item/started', 'item/completed')
-      AND events.item_kind = 'fileChange'
-      AND json_type(changes.value, '$.diff') = 'text'
-      AND length(json_extract(changes.value, '$.diff')) > 512
-      AND EXISTS (
-        SELECT 1
-        FROM event_large_values
-        WHERE event_large_values.event_id = events.id
-          AND event_large_values.json_path = '$.item.changes[' || changes.key || '].diff'
-      )
-  ),
-  ranked_file_diffs AS (
-    SELECT
-      event_id,
-      json_path,
-      row_number() OVER (
-        PARTITION BY event_id
-        ORDER BY json_path
-      ) AS patch_index
-    FROM target_file_diffs
-  ),
   patched_events(event_id, patch_index, data) AS (
     SELECT
       events.id,
       0,
       events.data
     FROM events
-    WHERE events.id IN (
-      SELECT event_id
-      FROM target_file_diffs
+    WHERE EXISTS (
+      SELECT 1
+      FROM event_large_value_file_diff_backfill_targets AS targets
+      WHERE targets.event_id = events.id
+        AND targets.patch_index = 1
     )
     UNION ALL
     SELECT
       patched_events.event_id,
-      ranked_file_diffs.patch_index,
-      json_set(patched_events.data, ranked_file_diffs.json_path, '')
+      targets.patch_index,
+      json_set(patched_events.data, targets.json_path, '')
     FROM patched_events
-    JOIN ranked_file_diffs
-      ON ranked_file_diffs.event_id = patched_events.event_id
-     AND ranked_file_diffs.patch_index = patched_events.patch_index + 1
+    JOIN event_large_value_file_diff_backfill_targets AS targets
+      ON targets.event_id = patched_events.event_id
+     AND targets.patch_index = patched_events.patch_index + 1
+  ),
+  final_patched_events AS (
+    SELECT
+      patched_events.event_id,
+      patched_events.data
+    FROM patched_events
+    LEFT JOIN event_large_value_file_diff_backfill_targets AS next_targets
+      ON next_targets.event_id = patched_events.event_id
+     AND next_targets.patch_index = patched_events.patch_index + 1
+    WHERE patched_events.patch_index > 0
+      AND next_targets.event_id IS NULL
   )
 UPDATE events
 SET data = (
-  SELECT patched_events.data
-  FROM patched_events
-  WHERE patched_events.event_id = events.id
-  ORDER BY patched_events.patch_index DESC
-  LIMIT 1
+  SELECT final_patched_events.data
+  FROM final_patched_events
+  WHERE final_patched_events.event_id = events.id
 )
 WHERE events.id IN (
   SELECT event_id
-  FROM target_file_diffs
-);
+  FROM final_patched_events
+);--> statement-breakpoint
+DROP TABLE event_large_value_file_diff_backfill_targets;

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -4,7 +4,10 @@ import { dirname, join, resolve } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { DbConnection } from "./connection.js";
-import { publishedMigrationWhensByTag } from "./migration-history.js";
+import {
+  compatibleMigrationHashes,
+  publishedMigrationWhensByTag,
+} from "./migration-history.js";
 
 export interface ResolveMigrationsFolderForModuleDirArgs {
   moduleDir: string;
@@ -564,12 +567,32 @@ function hasAppliedMigrationHash(
   );
 }
 
+function hasCompatibleMigrationHash(
+  expectedMigration: ExpectedAppliedMigration,
+  appliedMigrations: AppliedMigrationIdentityRow[],
+): boolean {
+  return compatibleMigrationHashes.some(
+    (compatibleMigration) =>
+      compatibleMigration.tag === expectedMigration.tag &&
+      compatibleMigration.when === expectedMigration.createdAt &&
+      appliedMigrations.some(
+        (appliedMigration) =>
+          appliedMigration.createdAt === expectedMigration.createdAt &&
+          appliedMigration.hash === compatibleMigration.hash,
+      ),
+  );
+}
+
 function findAppliedMigrationHistoryViolation(
   expectedMigration: ExpectedAppliedMigration,
   appliedMigrations: AppliedMigrationIdentityRow[],
   appliedCreatedAts: Set<number>,
 ): AppliedMigrationHistoryViolation | null {
   if (hasAppliedMigrationHash(expectedMigration, appliedMigrations)) {
+    return null;
+  }
+
+  if (hasCompatibleMigrationHash(expectedMigration, appliedMigrations)) {
     return null;
   }
 

--- a/packages/db/src/migration-history.ts
+++ b/packages/db/src/migration-history.ts
@@ -3,11 +3,25 @@ export interface PublishedMigrationWhen {
   when: number;
 }
 
+export interface CompatibleMigrationHash {
+  hash: string;
+  tag: string;
+  when: number;
+}
+
 export const publishedMigrationWhens = [
   { tag: "0000_baseline", when: 1778891867195 },
   { tag: "0001_terminal_session_user_input", when: 1779139400000 },
   { tag: "0002_closed_session_prune_indexes", when: 1779139400001 },
 ] as const satisfies readonly PublishedMigrationWhen[];
+
+export const compatibleMigrationHashes = [
+  {
+    tag: "0031_mysterious_zaran",
+    when: 1781403656069,
+    hash: "bc111f5134183c37cf135af70231ec5a79823f9868818fdd8377e1ab3c05a23f",
+  },
+] as const satisfies readonly CompatibleMigrationHash[];
 
 export const publishedMigrationWhensByTag: ReadonlyMap<string, number> =
   new Map(publishedMigrationWhens.map((entry) => [entry.tag, entry.when]));

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -241,6 +241,8 @@ const terminalSessionRuntimeStateHonestyWhen = 1780718665310;
 const hostDaemonSessionObservabilityMigrationWhen = 1780719536955;
 const threadTypeRemovalMigrationWhen = 1780973302146;
 const eventLargeValuesMigrationWhen = 1781403656069;
+const eventLargeValuesPreOptimizationHash =
+  "bc111f5134183c37cf135af70231ec5a79823f9868818fdd8377e1ab3c05a23f";
 const queuedMessageSortKeyMigrationPath = resolve(
   __dirname,
   "..",
@@ -2925,6 +2927,23 @@ describe("migrate", () => {
         db,
         createdAt: closedSessionPruneIndexesWhen,
         hash: "published-0002-historical-hash",
+      });
+
+      expect(() => migrate(db)).not.toThrow();
+    } finally {
+      closeConnection(db);
+    }
+  });
+
+  it("accepts the pre-optimization event large values migration hash", () => {
+    const db = createConnection(":memory:");
+
+    try {
+      migrate(db);
+      replaceAppliedMigrationHash({
+        db,
+        createdAt: eventLargeValuesMigrationWhen,
+        hash: eventLargeValuesPreOptimizationHash,
       });
 
       expect(() => migrate(db)).not.toThrow();


### PR DESCRIPTION
## Summary
- Speed up the 0031 file-diff backfill by materializing rewrite targets into an indexed temp table before the recursive JSON update.
- Accept the pre-optimization 0031 migration hash so databases that already applied the old migration continue to pass migration validation.
- Add regression coverage for the historical hash compatibility path.

## Safety
This does hand-edit an already-landed migration. The change is scoped to the data backfill implementation, not the schema snapshot or journal timestamp. Databases that have not applied 0031 will run the faster SQL and record the new hash. Databases that already applied the old 0031 will skip rerunning it and are accepted by the explicit compatible-hash allowlist.

## Validation
- pnpm exec turbo run test --filter=@bb/db -- --run test/migrate.test.ts
- pnpm exec turbo run typecheck --filter=@bb/db
- pnpm exec turbo run test --filter=@bb/db