### PR TITLE
Fix loading state for omitted timeline diffs

### DIFF
--- a/apps/app/src/components/thread/timeline/TerminalOutputBlock.tsx
+++ b/apps/app/src/components/thread/timeline/TerminalOutputBlock.tsx
@@ -10,6 +10,7 @@ export interface TerminalOutputBlockProps {
   commandLine?: string;
   exitCode?: number | null;
   metadataLines?: readonly string[];
+  outputLoading?: boolean;
   /**
    * Whether the producing row is still pending. Drives sticky-bottom for the
    * output scroll so newly streamed bytes land visible unless the user has
@@ -114,6 +115,7 @@ export function TerminalOutputBlock({
   exitCode = null,
   metadataLines = [],
   output,
+  outputLoading = false,
   streaming = false,
 }: TerminalOutputBlockProps) {
   const renderedOutputHtml = useMemo(
@@ -165,6 +167,15 @@ export function TerminalOutputBlock({
           >
             <div dangerouslySetInnerHTML={{ __html: renderedOutputHtml }} />
           </TimelineDetailScroll>
+        ) : outputLoading ? (
+          <div
+            className={cn(
+              commandLine || metadataLines.length > 0 ? "mt-1.5" : null,
+              "text-muted-foreground",
+            )}
+          >
+            Loading output...
+          </div>
         ) : null}
         {showExitCode ? (
           <div

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.test.ts
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineFeedDetailRef, TimelineRow } from "@bb/server-contract";
+import {
+  commandRow,
+  delegationRow,
+} from "@/test/fixtures/thread-timeline-rows";
+import { shouldShowDelegationDetailsLoading } from "./ThreadTimelineRows";
+
+type DelegationLoadingRow = Parameters<
+  typeof shouldShowDelegationDetailsLoading
+>[0]["row"];
+
+const DELEGATION_DETAIL_REF: TimelineFeedDetailRef = {
+  rowKey: "wd_1_delegation",
+  source: {
+    start: 1,
+    end: 1,
+  },
+  parts: ["children", "output"],
+};
+
+function omittedDelegationDetailsRow(
+  args: {
+    childRows?: TimelineRow[];
+    output?: string;
+  } = {},
+): DelegationLoadingRow {
+  return {
+    ...delegationRow({
+      childRows: args.childRows ?? [],
+      output: args.output ?? "",
+      sourceSeqEnd: 1,
+      sourceSeqStart: 1,
+      status: "completed",
+    }),
+    feedDetail: DELEGATION_DETAIL_REF,
+  };
+}
+
+describe("shouldShowDelegationDetailsLoading", () => {
+  it("treats an empty omitted delegation body as pending while detail loads", () => {
+    expect(
+      shouldShowDelegationDetailsLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: omittedDelegationDetailsRow(),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps showing existing children or output while detail loads", () => {
+    expect(
+      shouldShowDelegationDetailsLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: omittedDelegationDetailsRow({
+          childRows: [commandRow({ command: "pwd" })],
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDelegationDetailsLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: omittedDelegationDetailsRow({ output: "partial answer" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("stops loading once delegation detail has resolved or failed", () => {
+    const row = omittedDelegationDetailsRow();
+
+    expect(
+      shouldShowDelegationDetailsLoading({
+        detailError: false,
+        detailLoaded: true,
+        row,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDelegationDetailsLoading({
+        detailError: true,
+        detailLoaded: false,
+        row,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -37,6 +37,7 @@ import {
   type BuildTimelineViewRowsOptions,
   type ThreadTimelineViewRow,
   type TimelineFeedSummaryViewRow,
+  type TimelineFeedViewMetadata,
   type TimelineFeedViewRowsCache,
   type TimelineActivityIntentTitle,
   type TimelineTitle,
@@ -249,10 +250,15 @@ interface TurnRowBodyProps {
 }
 
 type LazyTurnRowBodyProps = TurnRowBodyProps;
+type TimelineDelegationViewWorkRow = Extract<
+  TimelineViewWorkRow,
+  { workKind: "delegation" }
+> &
+  Partial<TimelineFeedViewMetadata>;
 
 interface DelegationRowBodyProps {
   compactActivityIntents: boolean;
-  row: Extract<TimelineViewWorkRow, { workKind: "delegation" }>;
+  row: TimelineDelegationViewWorkRow;
 }
 
 interface TimelineSystemDetailBlockProps {
@@ -272,6 +278,12 @@ interface TimelineFeedRowDetailQueryArgs {
 interface TimelineRowDetailRetryProps {
   label: string;
   onRetry: () => void;
+}
+
+interface DelegationDetailsLoadingStateArgs {
+  detailError: boolean;
+  detailLoaded: boolean;
+  row: TimelineDelegationViewWorkRow;
 }
 
 interface BuildTimelineRowsListItemsArgs {
@@ -399,6 +411,21 @@ function useTimelineFeedRowDetail({
     parts,
     threadId: row.threadId,
   });
+}
+
+export function shouldShowDelegationDetailsLoading({
+  detailError,
+  detailLoaded,
+  row,
+}: DelegationDetailsLoadingStateArgs): boolean {
+  return (
+    !detailLoaded &&
+    !detailError &&
+    row.childRows.length === 0 &&
+    row.output.trim().length === 0 &&
+    (hasTimelineFeedDetailPart(row, "children") ||
+      hasTimelineFeedDetailPart(row, "output"))
+  );
 }
 
 function timelineRowTitleRenderStateKey({
@@ -1162,6 +1189,11 @@ function DelegationRowBody({
     void detailQuery.refetch();
   }, [detailQuery]);
   const delegationActive = row.status === "pending";
+  const detailsLoading = shouldShowDelegationDetailsLoading({
+    detailError: detailQuery.isError,
+    detailLoaded: detailQuery.data !== undefined,
+    row,
+  });
 
   if (detailQuery.isError && childRows.length === 0 && output.length === 0) {
     return (
@@ -1169,6 +1201,13 @@ function DelegationRowBody({
         label="Failed to load subagent details."
         onRetry={handleRetry}
       />
+    );
+  }
+  if (detailsLoading) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Loading subagent details...
+      </div>
     );
   }
 

--- a/apps/app/src/components/thread/timeline/TimelineRowDetails.test.ts
+++ b/apps/app/src/components/thread/timeline/TimelineRowDetails.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import type { TimelineFeedDetailRef } from "@bb/server-contract";
-import { fileChangeRow } from "@/test/fixtures/thread-timeline-rows";
-import { shouldShowTimelineFileDiffLoading } from "./TimelineRowDetails";
+import { commandRow, fileChangeRow } from "@/test/fixtures/thread-timeline-rows";
+import {
+  shouldShowTimelineFileDiffLoading,
+  shouldShowTimelineWorkOutputLoading,
+} from "./TimelineRowDetails";
 
 type FileChangeLoadingRow = Parameters<
   typeof shouldShowTimelineFileDiffLoading
+>[0]["row"];
+type WorkOutputLoadingRow = Parameters<
+  typeof shouldShowTimelineWorkOutputLoading
 >[0]["row"];
 
 const FILE_DIFF_DETAIL_REF: TimelineFeedDetailRef = {
@@ -25,6 +31,19 @@ function fileChangeLoadingRow(diff: string | null): FileChangeLoadingRow {
       status: "completed",
     }),
     feedDetail: FILE_DIFF_DETAIL_REF,
+  };
+}
+
+function omittedOutputRow(output: string): WorkOutputLoadingRow {
+  return {
+    ...commandRow({
+      command: "pnpm test",
+      output,
+    }),
+    outputDetail: {
+      fullLength: 10_000,
+      previewLength: output.length,
+    },
   };
 }
 
@@ -64,6 +83,57 @@ describe("shouldShowTimelineFileDiffLoading", () => {
         detailError: true,
         detailLoaded: false,
         row,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldShowTimelineWorkOutputLoading", () => {
+  it("treats an empty omitted output preview as pending while detail loads", () => {
+    expect(
+      shouldShowTimelineWorkOutputLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: omittedOutputRow(""),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps showing a non-empty output preview while detail loads", () => {
+    expect(
+      shouldShowTimelineWorkOutputLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: omittedOutputRow("partial output"),
+      }),
+    ).toBe(false);
+  });
+
+  it("stops loading once output detail has resolved or failed", () => {
+    const row = omittedOutputRow("");
+
+    expect(
+      shouldShowTimelineWorkOutputLoading({
+        detailError: false,
+        detailLoaded: true,
+        row,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowTimelineWorkOutputLoading({
+        detailError: true,
+        detailLoaded: false,
+        row,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not load for complete empty output", () => {
+    expect(
+      shouldShowTimelineWorkOutputLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: commandRow({ command: "true", output: "" }),
       }),
     ).toBe(false);
   });

--- a/apps/app/src/components/thread/timeline/TimelineRowDetails.test.ts
+++ b/apps/app/src/components/thread/timeline/TimelineRowDetails.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineFeedDetailRef } from "@bb/server-contract";
+import { fileChangeRow } from "@/test/fixtures/thread-timeline-rows";
+import { shouldShowTimelineFileDiffLoading } from "./TimelineRowDetails";
+
+type FileChangeLoadingRow = Parameters<
+  typeof shouldShowTimelineFileDiffLoading
+>[0]["row"];
+
+const FILE_DIFF_DETAIL_REF: TimelineFeedDetailRef = {
+  rowKey: "wf_1_file_change",
+  source: {
+    start: 1,
+    end: 1,
+  },
+  parts: ["file-diff"],
+};
+
+function fileChangeLoadingRow(diff: string | null): FileChangeLoadingRow {
+  return {
+    ...fileChangeRow({
+      diff,
+      sourceSeqEnd: 1,
+      sourceSeqStart: 1,
+      status: "completed",
+    }),
+    feedDetail: FILE_DIFF_DETAIL_REF,
+  };
+}
+
+describe("shouldShowTimelineFileDiffLoading", () => {
+  it("treats an empty omitted diff preview as pending while detail loads", () => {
+    expect(
+      shouldShowTimelineFileDiffLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: fileChangeLoadingRow(""),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps showing a non-empty preview while detail loads", () => {
+    expect(
+      shouldShowTimelineFileDiffLoading({
+        detailError: false,
+        detailLoaded: false,
+        row: fileChangeLoadingRow("@@ -1 +1 @@\n-before\n+after"),
+      }),
+    ).toBe(false);
+  });
+
+  it("stops loading once detail has resolved or failed", () => {
+    const row = fileChangeLoadingRow("");
+
+    expect(
+      shouldShowTimelineFileDiffLoading({
+        detailError: false,
+        detailLoaded: true,
+        row,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowTimelineFileDiffLoading({
+        detailError: true,
+        detailLoaded: false,
+        row,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
@@ -76,6 +76,17 @@ interface TimelineFileDiffLoadingStateArgs {
   row: TimelineFileChangeWorkViewRow;
 }
 
+interface TimelineWorkOutputLoadingStateArgs {
+  detailError: boolean;
+  detailLoaded: boolean;
+  row: TimelineOutputWorkRow;
+}
+
+interface TimelineWorkOutputState {
+  loading: boolean;
+  output: string;
+}
+
 interface TimelineFeedRowDetailQueryArgs {
   parts: readonly TimelineFeedDetailPart[];
   row: TimelineViewWorkRow;
@@ -95,7 +106,9 @@ function compactDetailLines(lines: readonly DetailLine[]): string[] {
   return compactedLines;
 }
 
-function useTimelineWorkOutput(row: TimelineOutputWorkRow): string {
+function useTimelineWorkOutput(
+  row: TimelineOutputWorkRow,
+): TimelineWorkOutputState {
   const outputDetailQuery = useThreadTimelineWorkOutputDetail(
     {
       callId: row.callId,
@@ -108,7 +121,14 @@ function useTimelineWorkOutput(row: TimelineOutputWorkRow): string {
       enabled: row.outputDetail !== undefined,
     },
   );
-  return outputDetailQuery.data?.output ?? row.output;
+  return {
+    loading: shouldShowTimelineWorkOutputLoading({
+      detailError: outputDetailQuery.isError,
+      detailLoaded: outputDetailQuery.data !== undefined,
+      row,
+    }),
+    output: outputDetailQuery.data?.output ?? row.output,
+  };
 }
 
 function useTimelineFeedRowDetail({
@@ -139,15 +159,29 @@ export function shouldShowTimelineFileDiffLoading({
   return previewDiff === null || previewDiff.trim().length === 0;
 }
 
+export function shouldShowTimelineWorkOutputLoading({
+  detailError,
+  detailLoaded,
+  row,
+}: TimelineWorkOutputLoadingStateArgs): boolean {
+  return (
+    !detailLoaded &&
+    !detailError &&
+    row.outputDetail !== undefined &&
+    row.output.trim().length === 0
+  );
+}
+
 function CommandWorkRowBody({ row }: CommandWorkRowBodyProps) {
-  const output = useTimelineWorkOutput(row);
+  const outputState = useTimelineWorkOutput(row);
   return (
     <TerminalOutputBlock
       commandLine={`$ ${row.command}`}
       metadataLines={compactDetailLines([
         row.source ? `source: ${row.source}` : null,
       ])}
-      output={output}
+      output={outputState.output}
+      outputLoading={outputState.loading}
       exitCode={row.exitCode}
       streaming={row.status === "pending"}
     />
@@ -155,14 +189,26 @@ function CommandWorkRowBody({ row }: CommandWorkRowBodyProps) {
 }
 
 function ToolWorkRowBody({ row }: ToolWorkRowBodyProps) {
-  const output = useTimelineWorkOutput(row);
-  return (
+  const outputState = useTimelineWorkOutput(row);
+  const detailBlock = (
     <ToolCallDetailBlock
       toolName={row.toolName}
       args={row.toolArgs}
-      output={output}
+      output={outputState.output}
       streaming={row.status === "pending"}
     />
+  );
+
+  if (!outputState.loading) {
+    return detailBlock;
+  }
+  return (
+    <div className="space-y-2">
+      {detailBlock}
+      <div className="rounded-md border border-border bg-surface-raised px-2 py-1.5 text-xs text-muted-foreground">
+        Loading output...
+      </div>
+    </div>
   );
 }
 

--- a/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
@@ -5,6 +5,7 @@ import {
   fileNameFromPath,
   getTimelineFeedDetail,
   hasTimelineFeedDetailPart,
+  type TimelineFeedViewMetadata,
   type TimelineImageViewViewWorkRow,
   type TimelineViewWorkflowWorkRow,
   type TimelineViewWorkRow,
@@ -49,6 +50,11 @@ type TimelineOutputWorkRow = Extract<
   TimelineViewWorkRow,
   { workKind: "command" | "tool" }
 >;
+type TimelineFileChangeWorkViewRow = Extract<
+  TimelineViewWorkRow,
+  { workKind: "file-change" }
+> &
+  Partial<TimelineFeedViewMetadata>;
 
 interface CommandWorkRowBodyProps {
   row: Extract<TimelineOutputWorkRow, { workKind: "command" }>;
@@ -59,9 +65,15 @@ interface ToolWorkRowBodyProps {
 }
 
 interface FileChangeWorkRowBodyProps {
-  row: Extract<TimelineViewWorkRow, { workKind: "file-change" }>;
+  row: TimelineFileChangeWorkViewRow;
   themeType: ThreadTimelineTheme;
   workspaceRootPath: string | undefined;
+}
+
+interface TimelineFileDiffLoadingStateArgs {
+  detailError: boolean;
+  detailLoaded: boolean;
+  row: TimelineFileChangeWorkViewRow;
 }
 
 interface TimelineFeedRowDetailQueryArgs {
@@ -110,6 +122,23 @@ function useTimelineFeedRowDetail({
   });
 }
 
+export function shouldShowTimelineFileDiffLoading({
+  detailError,
+  detailLoaded,
+  row,
+}: TimelineFileDiffLoadingStateArgs): boolean {
+  if (
+    detailLoaded ||
+    detailError ||
+    !hasTimelineFeedDetailPart(row, "file-diff")
+  ) {
+    return false;
+  }
+
+  const previewDiff = row.change.diff;
+  return previewDiff === null || previewDiff.trim().length === 0;
+}
+
 function CommandWorkRowBody({ row }: CommandWorkRowBodyProps) {
   const output = useTimelineWorkOutput(row);
   return (
@@ -146,11 +175,11 @@ function FileChangeWorkRowBody({
     row,
     parts: ["file-diff", "stderr", "stdout"],
   });
-  const hasPendingDiff =
-    row.change.diff === null &&
-    hasTimelineFeedDetailPart(row, "file-diff") &&
-    !detailQuery.data &&
-    !detailQuery.isError;
+  const hasPendingDiff = shouldShowTimelineFileDiffLoading({
+    detailError: detailQuery.isError,
+    detailLoaded: detailQuery.data !== undefined,
+    row,
+  });
   const diff = detailQuery.data
     ? detailQuery.data.parts.fileDiff
     : row.change.diff;

--- a/apps/app/src/components/thread/timeline/timelineRowSignatures.test.ts
+++ b/apps/app/src/components/thread/timeline/timelineRowSignatures.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineFeedDetailRef } from "@bb/server-contract";
+import { fileChangeRow } from "@/test/fixtures/thread-timeline-rows";
+import { timelineRowRenderSignature } from "./timelineRowSignatures";
+
+const FILE_DIFF_DETAIL_REF: TimelineFeedDetailRef = {
+  rowKey: "wf_1_file_change",
+  source: {
+    start: 1,
+    end: 1,
+  },
+  parts: ["file-diff"],
+};
+
+describe("timelineRowRenderSignature", () => {
+  it("changes when a file-change row gains lazy diff detail metadata", () => {
+    const baseRow = fileChangeRow({
+      diff: "",
+      sourceSeqEnd: 1,
+      sourceSeqStart: 1,
+    });
+    const detailRow = {
+      ...baseRow,
+      feedDetail: FILE_DIFF_DETAIL_REF,
+    };
+
+    expect(timelineRowRenderSignature(detailRow)).not.toBe(
+      timelineRowRenderSignature(baseRow),
+    );
+  });
+});

--- a/apps/app/src/components/thread/timeline/timelineRowSignatures.ts
+++ b/apps/app/src/components/thread/timeline/timelineRowSignatures.ts
@@ -1,6 +1,7 @@
 import type { TimelineActivityIntent } from "@bb/server-contract";
 import {
   assertNever,
+  getTimelineFeedDetail,
   isTimelineFeedSummaryViewRow,
   type ThreadTimelineViewRow,
   type TimelineViewWorkRow,
@@ -77,6 +78,7 @@ function timelineRowBaseSignature(row: ThreadTimelineViewRow): string {
   // sourceSeqEnd guards high-mutation fields omitted from signatures below,
   // including output, text, and diffs. In-place row content mutations must
   // advance the source sequence to avoid stale memoized UI.
+  const feedDetail = getTimelineFeedDetail(row);
   return joinSignatureParts([
     row.kind,
     row.id,
@@ -86,6 +88,10 @@ function timelineRowBaseSignature(row: ThreadTimelineViewRow): string {
     row.sourceSeqEnd,
     row.startedAt,
     row.createdAt,
+    feedDetail?.rowKey,
+    feedDetail?.source.start,
+    feedDetail?.source.end,
+    feedDetail?.parts.join(","),
   ]);
 }
 
@@ -130,6 +136,7 @@ function timelineWorkRowRenderSignature(row: TimelineViewWorkRow): string {
         row.change.kind,
         row.change.path,
         row.change.movePath,
+        row.change.diff === null ? null : row.change.diff.length,
         row.change.diffStats.added,
         row.change.diffStats.removed,
       ]);

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -898,6 +898,115 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("keeps small bundled file diffs lazy-loadable from summary details", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness, {
+        thread: { status: "active" },
+      });
+      const providerThreadId = "provider-thread-small-bundled-diffs";
+      const turnId = "turn-small-bundled-diffs";
+      const firstDiff = "@@ -1 +1 @@\n-before\n+after\n";
+      const secondDiff = "@@ -1 +1 @@\n-old\n+new\n";
+
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        inputText: "Apply bundled patches",
+        providerThreadId,
+        sequenceStart: 1,
+        threadId: thread.id,
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope(turnId),
+        sequence: 3,
+        type: "turn/started",
+        data: { providerThreadId },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope(turnId),
+        sequence: 4,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "fileChange",
+            id: "file-small-bundled-diffs",
+            status: "completed",
+            approvalStatus: null,
+            changes: [
+              {
+                path: "/repo/src/first.ts",
+                kind: "update",
+                diff: firstDiff,
+              },
+              {
+                path: "/repo/src/second.ts",
+                kind: "update",
+                diff: secondDiff,
+              },
+            ],
+          },
+        },
+      });
+
+      const feedResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/feed`,
+      );
+      expect(feedResponse.status).toBe(200);
+      const feed = threadTimelineFeedResponseSchema.parse(
+        await readJson(feedResponse),
+      );
+      const summaryRow = feed.rows.find(
+        (row): row is TimelineFeedWorkSummaryRow =>
+          row.kind === "bundle-summary" || row.kind === "step-summary",
+      );
+      expect(summaryRow).toBeDefined();
+      if (!summaryRow) {
+        throw new Error("Expected bundled file-change summary row");
+      }
+
+      const summaryDetailResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/rows/${summaryRow.key}/detail?parts=children&sourceSeqStart=${summaryRow.source.start}&sourceSeqEnd=${summaryRow.source.end}`,
+      );
+      expect(summaryDetailResponse.status).toBe(200);
+      const summaryDetail = timelineRowDetailResponseSchema.parse(
+        await readJson(summaryDetailResponse),
+      );
+      const fileRows = (summaryDetail.parts.children ?? []).filter(
+        (row): row is TimelineFeedFileChangeRow =>
+          row.kind === "work" && row.workKind === "file-change",
+      );
+      expect(fileRows).toHaveLength(2);
+      for (const fileRow of fileRows) {
+        expect(fileRow.change.diffPreview).toMatchObject({
+          complete: false,
+          text: "",
+        });
+        expect(fileRow.detail?.parts).toContain("file-diff");
+      }
+
+      const firstRow = fileRows.find(
+        (row) => row.change.path.endsWith("src/first.ts"),
+      );
+      expect(firstRow).toBeDefined();
+      if (!firstRow) {
+        throw new Error("Expected first file-change row");
+      }
+      const firstDetailResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/rows/${firstRow.key}/detail?parts=file-diff&sourceSeqStart=${firstRow.source.start}&sourceSeqEnd=${firstRow.source.end}`,
+      );
+      expect(firstDetailResponse.status).toBe(200);
+      const firstDetail = timelineRowDetailResponseSchema.parse(
+        await readJson(firstDetailResponse),
+      );
+      expect(firstDetail.parts.fileDiff).toBe(firstDiff);
+    });
+  });
+
   it("collapses large active work bursts in the timeline feed", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedThreadFixture(harness, {

--- a/packages/thread-view/src/timeline-feed-row-helpers.ts
+++ b/packages/thread-view/src/timeline-feed-row-helpers.ts
@@ -134,7 +134,7 @@ export function buildOmittedTimelineFeedTextPreview(
 ): TimelineTextPreview {
   const fullLength = outputDetail?.fullLength ?? text.length;
   return {
-    complete: fullLength <= text.length,
+    complete: fullLength === 0,
     fullLength,
     text: "",
   };

--- a/packages/thread-view/test/timeline-feed-row-helpers.test.ts
+++ b/packages/thread-view/test/timeline-feed-row-helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExpandableBodyFeedPreview,
+  timelineFeedDetailPartsForText,
+} from "../src/timeline-feed-row-helpers.js";
+
+describe("buildExpandableBodyFeedPreview", () => {
+  it("marks omitted completed non-empty bodies incomplete so detail can load", () => {
+    const text = "@@ -1 +1 @@\n-before\n+after";
+    const preview = buildExpandableBodyFeedPreview(text, "completed", undefined);
+
+    expect(preview).toEqual({
+      complete: false,
+      fullLength: text.length,
+      text: "",
+    });
+    expect(timelineFeedDetailPartsForText("file-diff", preview)).toEqual([
+      "file-diff",
+    ]);
+  });
+
+  it("marks omitted completed empty bodies complete", () => {
+    const preview = buildExpandableBodyFeedPreview(
+      "",
+      "completed",
+      undefined,
+    );
+
+    expect(preview).toEqual({
+      complete: true,
+      fullLength: 0,
+      text: "",
+    });
+    expect(timelineFeedDetailPartsForText("output", preview)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Treat empty omitted file diff previews as pending while timeline row detail is loading
- Mark omitted non-empty feed previews as incomplete so small completed diffs/output remain lazy-loadable, including inside bundles
- Refresh memoized timeline rows when lazy detail refs change, so file-change rows can become expandable once their diff detail is available
- Show loading placeholders for omitted command/tool output and empty omitted delegation details
- Add regression coverage for omitted diff previews, omitted output previews, omitted delegation details, bundled small file diffs, and file-change detail-ref render signatures

## Verification
- pnpm exec turbo run test --filter=@bb/thread-view -- --run test/timeline-feed-row-helpers.test.ts
- pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-thread-data.test.ts -t "keeps small bundled file diffs"
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/timeline/TimelineRowDetails.test.ts src/components/thread/timeline/ThreadTimelineRows.test.ts src/components/thread/timeline/timelineRowSignatures.test.ts
- pnpm exec turbo run typecheck --filter=@bb/thread-view
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run typecheck --filter=@bb/app