### PR TITLE
Fix branch picker search visibility

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -879,8 +879,7 @@ export function BranchPicker({
     hasBranchOptions ||
     ((branchOptionsDisabled || createDisabled) &&
       options.length + remoteOptions.length > 0);
-  const showOptionsSearch =
-    showBranchChooser && hasBranchOptions && !branchChooserDisabled;
+  const showOptionsSearch = showBranchChooser && !branchChooserDisabled;
   const optionsSectionDisabled = branchChooserDisabled;
   const titleSubtitle =
     menuCopy.optionsSectionLabel === null && optionsSectionDisabled


### PR DESCRIPTION
## Summary
- keep the branch picker search input visible whenever branch choosing is active
- still hide search before checkout mode enters branch choosing, or when branch choosing is blocked

## Tests
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app