### PR TITLE
Remove archived thread filters

### DIFF
--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -155,14 +155,6 @@ function isArchivedThreadsListFilters(
   if (!("projectId" in candidate) || typeof candidate.projectId !== "string") {
     return false;
   }
-  if (
-    !("kind" in candidate) ||
-    (candidate.kind !== "all" &&
-      candidate.kind !== "root" &&
-      candidate.kind !== "child")
-  ) {
-    return false;
-  }
 
   return true;
 }

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -66,11 +66,8 @@ export interface ThreadListQueryFilters {
   limit?: number;
 }
 
-export type ArchivedThreadsKindFilter = "all" | "root" | "child";
-
 export interface ArchivedThreadsListFilters {
   projectId: string;
-  kind: ArchivedThreadsKindFilter;
 }
 
 export const ARCHIVED_THREADS_LIST_KIND = "archivedList";

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -64,7 +64,6 @@ import {
   threadTimelineTurnSummaryDetailsQueryKey,
   threadsQueryKey,
   type ThreadTimelineTurnSummaryDetailsQueryIdentity,
-  type ArchivedThreadsKindFilter,
 } from "./query-keys";
 import { ARCHIVED_THREADS_PAGE_SIZE } from "./archived-threads-page-size";
 import { ingestThreadDetailBootstrap } from "../cache-owners/thread-detail-cache-owner";
@@ -234,28 +233,14 @@ function getThreadMentionCandidatePlaceholder({
 
 export interface UseArchivedThreadsFilters {
   projectId: string | undefined;
-  kind: ArchivedThreadsKindFilter;
-}
-
-interface ArchivedThreadsApiFilters {
-  hasParent?: ThreadListFilters["hasParent"];
-}
-
-function archivedThreadsKindToApiFilters(
-  kind: ArchivedThreadsKindFilter,
-): ArchivedThreadsApiFilters {
-  if (kind === "root") return { hasParent: false };
-  if (kind === "child") return { hasParent: true };
-  return {};
 }
 
 export function useArchivedThreads(
   filters: UseArchivedThreadsFilters,
   options?: QueryOptions,
 ) {
-  const { projectId, kind } = filters;
+  const { projectId } = filters;
   const enabled = (options?.enabled ?? true) && Boolean(projectId);
-  const apiFilters = archivedThreadsKindToApiFilters(kind);
   useThreadListRealtimeSubscription({ enabled });
 
   return useInfiniteQuery<
@@ -267,14 +252,12 @@ export function useArchivedThreads(
   >({
     queryKey: archivedThreadsListQueryKey({
       projectId: projectId ?? "",
-      kind,
     }),
     queryFn: ({ pageParam, signal }) =>
       api.listThreads(
         {
           projectId: requireThreadId(projectId ?? "", "useArchivedThreads"),
           archived: true,
-          ...apiFilters,
           limit: ARCHIVED_THREADS_PAGE_SIZE,
           offset: pageParam,
         },

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -209,7 +209,6 @@ describe("createRealtimeCacheEffects", () => {
       projectId: "project-1",
     });
     const firstProjectArchivedThreadListKey = archivedThreadsListQueryKey({
-      kind: "all",
       projectId: "project-1",
     });
     const secondProjectThreadListKey = threadListQueryKey({
@@ -311,7 +310,6 @@ describe("createRealtimeCacheEffects", () => {
       hasParent: false,
     });
     const archivedThreadListKey = archivedThreadsListQueryKey({
-      kind: "all",
       projectId: "project-1",
     });
     queryClient.setQueryData(activeProjectThreadListKey, []);

--- a/apps/app/src/views/ProjectArchivedThreadsView.tsx
+++ b/apps/app/src/views/ProjectArchivedThreadsView.tsx
@@ -1,28 +1,15 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import type { ThreadListEntry } from "@bb/domain";
 import { Button } from "@/components/ui/button.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
-import { OverflowFade } from "@/components/ui/overflow-fade.js";
 import { PageShell } from "@/components/ui/page-shell.js";
 import { Pill } from "@/components/ui/pill.js";
 import { ThreadUnarchiveButton } from "@/components/thread/ThreadUnarchiveButton";
 import { useUnarchiveThread } from "@/hooks/mutations/thread-state-mutations";
 import { useArchivedThreads } from "@/hooks/queries/thread-queries";
-import type { ArchivedThreadsKindFilter } from "@/hooks/queries/query-keys";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getThreadRoutePath } from "@/lib/route-paths";
-
-interface FilterOption {
-  value: ArchivedThreadsKindFilter;
-  label: string;
-}
-
-const FILTER_OPTIONS: readonly FilterOption[] = [
-  { value: "all", label: "All" },
-  { value: "root", label: "Root" },
-  { value: "child", label: "Children" },
-];
 
 type ArchivedThreadPillLabel = "child";
 
@@ -35,12 +22,7 @@ function getArchivedThreadPillLabel(
 
 export function ProjectArchivedThreadsView() {
   const { projectId } = useParams<{ projectId: string }>();
-  const [kindFilter, setKindFilter] =
-    useState<ArchivedThreadsKindFilter>("all");
-  const archivedThreadsQuery = useArchivedThreads({
-    projectId,
-    kind: kindFilter,
-  });
+  const archivedThreadsQuery = useArchivedThreads({ projectId });
   const unarchiveThread = useUnarchiveThread();
 
   const archivedThreads = useMemo(() => {
@@ -66,35 +48,7 @@ export function ProjectArchivedThreadsView() {
   return (
     <PageShell contentClassName="pt-0">
       <div className="mx-auto w-full max-w-3xl">
-        <div className="sticky top-0 z-10 -mx-4 bg-background px-4 pt-4 md:-mx-5 md:px-5 md:pt-5">
-          <OverflowFade placement="below" tone="background" />
-          <div
-            className="inline-flex items-center gap-1 rounded-lg border border-border p-0.5"
-            role="tablist"
-            aria-label="Filter archived threads"
-          >
-            {FILTER_OPTIONS.map((option) => {
-              const isActive = kindFilter === option.value;
-              return (
-                <Button
-                  key={option.value}
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-pressed={isActive}
-                  className="h-7 rounded-md px-2 text-xs font-medium text-muted-foreground sm:px-3"
-                  onClick={() => setKindFilter(option.value)}
-                >
-                  {option.label}
-                </Button>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className="space-y-3 pt-3">
+        <div className="space-y-3 pt-4 md:pt-5">
           {isInitialLoading ? (
             <p className="text-sm text-muted-foreground">
               Loading archived threads…


### PR DESCRIPTION
## Summary
- remove the All / Root / Children filter controls from the archived threads page
- simplify the archived threads query and cache key so it only lists archived threads for the project
- update realtime cache tests for the simplified archived-list key

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/realtime-cache-effects.test.ts
- git diff --check