### PR TITLE
[codex] Fix turn detail hydration for overlapping turns

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -26,10 +26,7 @@ import {
   listStoredTurnStartedRowsByTurnIdsUpToSequence,
   listTimelineSegmentAnchorsDescending,
 } from "@bb/db";
-import type {
-  DbConnection,
-  StoredEventRow,
-} from "@bb/db";
+import type { DbConnection, StoredEventRow } from "@bb/db";
 import { ApiError } from "../../errors.js";
 import { parseStoredEvent } from "./thread-data.js";
 import {
@@ -79,6 +76,7 @@ interface PartitionAcceptedInputRowsByRequestedTurnResult {
 interface FilterExactEventRowsForRequestedTurnArgs {
   acceptedClientRequestIdsForOtherTurns: ReadonlySet<ClientTurnRequestId>;
   exactEventRows: readonly StoredEventRow[];
+  turnId: string;
 }
 
 interface FilterExactEventRowsForRequestedTurnResult {
@@ -123,9 +121,7 @@ export type ThreadTimelineBuildProfileStage =
   | "pagination-segmentation"
   | "response-serialization";
 
-export type ThreadTimelineEventSelectionStrategy =
-  | "full"
-  | "standard-window";
+export type ThreadTimelineEventSelectionStrategy = "full" | "standard-window";
 
 export interface ThreadTimelineBuildProfileStageTiming {
   durationMs: number;
@@ -377,13 +373,12 @@ function partitionAcceptedInputRowsByRequestedTurn(
     if (row.scopeKind !== "turn" || row.turnId === null) {
       throw new Error(`Expected turn-scoped turn/input/accepted row ${row.id}`);
     }
+    const clientRequestId = parseAcceptedInputClientRequestId(row);
     if (row.turnId === args.turnId) {
       requestedTurnRows.push(row);
       continue;
     }
-    acceptedClientRequestIdsForOtherTurns.add(
-      parseAcceptedInputClientRequestId(row),
-    );
+    acceptedClientRequestIdsForOtherTurns.add(clientRequestId);
   }
 
   return {
@@ -395,16 +390,14 @@ function partitionAcceptedInputRowsByRequestedTurn(
 function filterExactEventRowsForRequestedTurn(
   args: FilterExactEventRowsForRequestedTurnArgs,
 ): FilterExactEventRowsForRequestedTurnResult {
-  if (args.acceptedClientRequestIdsForOtherTurns.size === 0) {
-    return {
-      removedRows: false,
-      rows: args.exactEventRows,
-    };
-  }
-
   const rows: StoredEventRow[] = [];
   let removedRows = false;
   for (const row of args.exactEventRows) {
+    if (row.scopeKind === "turn" && row.turnId !== args.turnId) {
+      removedRows = true;
+      continue;
+    }
+
     const requestId = tryReadClientTurnRequestedRequestId(row);
     if (
       requestId !== null &&
@@ -932,37 +925,29 @@ export function buildTimelineTurnSummaryDetails(
     seqStart: options.sourceSeqStart,
     seqEnd: options.sourceSeqEnd,
   });
-  const acceptedInputRows = listStoredTurnInputAcceptedRowsByClientRequestIds(
-    db,
-    {
+  const exactAcceptedInputRows = exactEventRows.filter(
+    (row) => row.type === "turn/input/accepted",
+  );
+  const futureAcceptedInputRows =
+    listStoredTurnInputAcceptedRowsByClientRequestIds(db, {
       threadId: thread.id,
       afterSequence: options.sourceSeqEnd,
       clientRequestIds,
-    },
-  );
+    });
   const acceptedInputRowsByTurn = partitionAcceptedInputRowsByRequestedTurn({
-    acceptedInputRows,
+    acceptedInputRows: [...exactAcceptedInputRows, ...futureAcceptedInputRows],
     turnId: options.turnId,
   });
   const exactEventRowsForRequestedTurn = filterExactEventRowsForRequestedTurn({
     acceptedClientRequestIdsForOtherTurns:
       acceptedInputRowsByTurn.acceptedClientRequestIdsForOtherTurns,
     exactEventRows,
+    turnId: options.turnId,
   });
-  const eventRows = [
+  const eventRows = mergeStoredEventRowsById([
     ...exactEventRowsForRequestedTurn.rows,
     ...acceptedInputRowsByTurn.requestedTurnRows,
-  ];
-  const mismatchedTurnRow = eventRows.find(
-    (row) => row.scopeKind === "turn" && row.turnId !== options.turnId,
-  );
-  if (mismatchedTurnRow) {
-    throw new ApiError(
-      400,
-      "invalid_request",
-      `Timeline turn summary details range ${options.sourceSeqStart}-${options.sourceSeqEnd} includes turn ${mismatchedTurnRow.turnId ?? "unknown"} instead of ${options.turnId}`,
-    );
-  }
+  ]);
 
   const hasTurnScopedRowsForRequestedTurn = eventRows.some(
     (row) => row.scopeKind === "turn" && row.turnId === options.turnId,

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -481,6 +481,270 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("hydrates turn-summary details when the range overlaps another turn", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("parent-turn"),
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("child-turn"),
+        sequence: 2,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("child-turn"),
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "child-tool",
+            tool: "exec_command",
+            arguments: { cmd: "pnpm test" },
+            status: "completed",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("parent-turn"),
+        sequence: 4,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "agentMessage",
+            id: "parent-message",
+            text: "Parent is still working.",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("child-turn"),
+        sequence: 5,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "agentMessage",
+            id: "child-message",
+            text: "Child done.",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("child-turn"),
+        sequence: 6,
+        type: "turn/completed",
+        data: {
+          status: "completed",
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("parent-turn"),
+        sequence: 7,
+        type: "turn/completed",
+        data: {
+          status: "completed",
+        },
+      });
+
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+      expect(timelineResponse.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(timelineResponse),
+      );
+      const childTurnRow = timeline.rows.find(
+        (row): row is TimelineTurnRow =>
+          row.kind === "turn" && row.turnId === "child-turn",
+      );
+      expect(childTurnRow).toBeDefined();
+      if (!childTurnRow) {
+        throw new Error("Expected child turn row");
+      }
+
+      const detailsResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=${childTurnRow.turnId}&sourceSeqStart=${childTurnRow.sourceSeqStart}&sourceSeqEnd=${childTurnRow.sourceSeqEnd}`,
+      );
+      expect(detailsResponse.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(detailsResponse),
+      );
+
+      expect(details.rows.map((row) => row.kind)).toEqual(["work"]);
+      expect(details.rows[0]?.kind).toBe("work");
+      const detailRow = details.rows[0];
+      if (detailRow?.kind === "work" && detailRow.workKind === "tool") {
+        expect(detailRow.callId).toBe("child-tool");
+      } else {
+        throw new Error("Expected child tool detail row");
+      }
+    });
+  });
+
+  it("hydrates turn-summary details with future accepted input context", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        sequence: 1,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        data: {
+          direction: "outbound",
+          requestId: encodeClientTurnRequestIdNumber({ value: 101 }),
+          input: [{ type: "text", text: "Requested turn prompt" }],
+          target: { kind: "new-turn" },
+          execution: {
+            model: "gpt-4o-mini",
+            reasoningLevel: "medium",
+            permissionMode: "full",
+            serviceTier: "fast",
+            source: "client/turn/requested",
+          },
+          initiator: "user",
+          senderThreadId: null,
+          request: {
+            method: "turn/start",
+            params: {},
+          },
+          source: "tell",
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("requested-turn"),
+        sequence: 2,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("requested-turn"),
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "requested-tool",
+            tool: "exec_command",
+            arguments: { cmd: "pnpm test" },
+            status: "completed",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        sequence: 4,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        data: {
+          direction: "outbound",
+          requestId: encodeClientTurnRequestIdNumber({ value: 202 }),
+          input: [{ type: "text", text: "Other turn prompt" }],
+          target: { kind: "new-turn" },
+          execution: {
+            model: "gpt-4o-mini",
+            reasoningLevel: "medium",
+            permissionMode: "full",
+            serviceTier: "fast",
+            source: "client/turn/requested",
+          },
+          initiator: "user",
+          senderThreadId: null,
+          request: {
+            method: "turn/start",
+            params: {},
+          },
+          source: "tell",
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("requested-turn"),
+        sequence: 5,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "agentMessage",
+            id: "requested-message",
+            text: "Requested turn done.",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("requested-turn"),
+        sequence: 6,
+        type: "turn/input/accepted",
+        data: {
+          clientRequestId: encodeClientTurnRequestIdNumber({ value: 101 }),
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("other-turn"),
+        sequence: 7,
+        type: "turn/input/accepted",
+        data: {
+          clientRequestId: encodeClientTurnRequestIdNumber({ value: 202 }),
+        },
+      });
+
+      const detailsResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=requested-turn&sourceSeqStart=1&sourceSeqEnd=5`,
+      );
+      expect(detailsResponse.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(detailsResponse),
+      );
+
+      const detailText = JSON.stringify(details.rows);
+      expect(detailText).toContain("Requested turn prompt");
+      expect(detailText).toContain("requested-tool");
+      expect(detailText).not.toContain("Other turn prompt");
+    });
+  });
+
   it("hydrates a single-event turn-summary detail range", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedThreadFixture(harness);


### PR DESCRIPTION
Fixes lazy turn detail hydration for overlapping parent/child agent turns. The details endpoint was rejecting valid ranges when a collapsed turn summary span also contained rows from another overlapping turn, which surfaced as `Failed to load turn details` and caused bottom-of-thread jumpiness as lazy rows swapped height near active updates.

## Changes

- Filters exact-range detail rows down to the requested `turnId` instead of rejecting the whole request when another turn appears in the range.
- Keeps accepted input context for the requested turn even when the accepted row falls just outside the summary range.
- Suppresses accepted-input prompt rows belonging to overlapping turns so collapsed details do not leak child/parent prompts.
- Adds public thread timeline regression coverage for overlapping detail hydration and future accepted-input context.

## Validation

- `pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-thread-data.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `$review staged`: no issues found after adding the requested accepted-input/suppression regression coverage.