### PR TITLE
Remove stale frontend compatibility paths

### DIFF
--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -2,7 +2,6 @@ import { atomWithStorage } from "jotai/utils";
 import { createJsonLocalStorage } from "@/lib/browser-storage";
 
 const COLLAPSED_PROJECTS_STORAGE_KEY = "bb.sidebar.collapsedProjects";
-const LEGACY_COLLAPSED_THREADS_STORAGE_KEY = "bb.sidebar.collapsedManagers";
 const COLLAPSED_THREADS_STORAGE_KEY = "bb.sidebar.collapsedThreads";
 const COLLAPSED_ENVIRONMENTS_STORAGE_KEY = "bb.sidebar.collapsedEnvironments";
 const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "bb.sidebar.collapsedSections";
@@ -29,69 +28,10 @@ export const collapsedProjectIdsAtom = atomWithStorage<string[]>(
   { getOnInit: true },
 );
 
-function parseStoredStringArray(storedValue: string): string[] | null {
-  try {
-    const parsedValue = JSON.parse(storedValue);
-    if (!Array.isArray(parsedValue)) {
-      return null;
-    }
-    const values: string[] = [];
-    for (const value of parsedValue) {
-      if (typeof value !== "string") {
-        return null;
-      }
-      values.push(value);
-    }
-    return values;
-  } catch {
-    return null;
-  }
-}
-
-function migrateLegacyCollapsedThreadsStorage(): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  const legacyStoredValue = window.localStorage.getItem(
-    LEGACY_COLLAPSED_THREADS_STORAGE_KEY,
-  );
-  if (legacyStoredValue === null) {
-    return;
-  }
-
-  const newStoredValue = window.localStorage.getItem(
-    COLLAPSED_THREADS_STORAGE_KEY,
-  );
-  if (newStoredValue !== null) {
-    window.localStorage.removeItem(LEGACY_COLLAPSED_THREADS_STORAGE_KEY);
-    return;
-  }
-
-  const collapsedThreadIds = parseStoredStringArray(legacyStoredValue);
-  if (collapsedThreadIds !== null) {
-    window.localStorage.setItem(
-      COLLAPSED_THREADS_STORAGE_KEY,
-      JSON.stringify(collapsedThreadIds),
-    );
-  }
-  window.localStorage.removeItem(LEGACY_COLLAPSED_THREADS_STORAGE_KEY);
-}
-
-const collapsedThreadIdsJsonStorage = createJsonLocalStorage<string[]>();
-
-const collapsedThreadIdsStorage: typeof collapsedThreadIdsJsonStorage = {
-  ...collapsedThreadIdsJsonStorage,
-  getItem: (key, initialValue) => {
-    migrateLegacyCollapsedThreadsStorage();
-    return collapsedThreadIdsJsonStorage.getItem(key, initialValue);
-  },
-};
-
 export const collapsedThreadIdsAtom = atomWithStorage<string[]>(
   COLLAPSED_THREADS_STORAGE_KEY,
   [],
-  collapsedThreadIdsStorage,
+  createJsonLocalStorage<string[]>(),
   { getOnInit: true },
 );
 

--- a/apps/app/src/lib/api-host-daemon.ts
+++ b/apps/app/src/lib/api-host-daemon.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST,
   providerCliInstallEventSchema,
   providerCliStatusResponseSchema,
-  workspaceOpenTargetIdSchema,
   workspaceOpenTargetsResponseSchema,
   type OpenInTargetRequest,
   type ProviderCliInstallEvent,
@@ -11,7 +10,6 @@ import {
   type ProviderCliStatusResponse,
   type StatusResponse,
   type WorkspaceOpenTarget,
-  type WorkspaceOpenTargetCapabilities,
 } from "@bb/host-daemon-contract";
 import { z } from "zod";
 
@@ -24,51 +22,6 @@ const hostDaemonErrorResponseSchema = z.object({
   message: z.string().min(1),
 });
 
-const fullFileOpenCapabilities: WorkspaceOpenTargetCapabilities = {
-  openDirectory: true,
-  openFile: true,
-  openFileAtLine: true,
-};
-
-const basicFileOpenCapabilities: WorkspaceOpenTargetCapabilities = {
-  openDirectory: true,
-  openFile: true,
-  openFileAtLine: false,
-};
-
-const directoryOpenCapabilities: WorkspaceOpenTargetCapabilities = {
-  openDirectory: true,
-  openFile: false,
-  openFileAtLine: false,
-};
-
-const legacyWorkspaceOpenTargetKindSchema = z.enum([
-  "editor",
-  "file-browser",
-  "terminal",
-]);
-const legacyWorkspaceOpenTargetSchema = z.object({
-  id: workspaceOpenTargetIdSchema,
-  kind: legacyWorkspaceOpenTargetKindSchema,
-  label: z.string().min(1),
-});
-const legacyWorkspaceOpenTargetsResponseSchema = z.object({
-  targets: z.array(legacyWorkspaceOpenTargetSchema),
-});
-
-type LegacyWorkspaceOpenTarget = z.infer<
-  typeof legacyWorkspaceOpenTargetSchema
->;
-
-const legacyLineAwareTargetIds = new Set([
-  "vscode",
-  "cursor",
-  "sublime-text",
-  "zed",
-  "windsurf",
-  "xcode",
-]);
-
 export type ProviderCliInstallEventHandler = (
   event: ProviderCliInstallEvent,
 ) => void;
@@ -78,28 +31,6 @@ export interface InstallProviderCliArgs {
   request: ProviderCliInstallRequest;
   onEvent: ProviderCliInstallEventHandler;
   signal?: AbortSignal;
-}
-
-function resolveLegacyWorkspaceOpenTargetCapabilities(
-  target: LegacyWorkspaceOpenTarget,
-): WorkspaceOpenTargetCapabilities {
-  if (target.kind !== "editor") {
-    return directoryOpenCapabilities;
-  }
-
-  return legacyLineAwareTargetIds.has(target.id)
-    ? fullFileOpenCapabilities
-    : basicFileOpenCapabilities;
-}
-
-function normalizeLegacyWorkspaceOpenTarget(
-  target: LegacyWorkspaceOpenTarget,
-): WorkspaceOpenTarget {
-  return {
-    id: target.id,
-    label: target.label,
-    capabilities: resolveLegacyWorkspaceOpenTargetCapabilities(target),
-  };
 }
 
 /**
@@ -159,17 +90,7 @@ export async function fetchWorkspaceOpenTargets(
     throw new Error(`Workspace open target discovery failed: HTTP ${status}`);
   }
   const body = await res.json();
-  const currentBody = workspaceOpenTargetsResponseSchema.safeParse(body);
-  if (currentBody.success) {
-    return currentBody.data.targets;
-  }
-
-  const legacyBody = legacyWorkspaceOpenTargetsResponseSchema.safeParse(body);
-  if (legacyBody.success) {
-    return legacyBody.data.targets.map(normalizeLegacyWorkspaceOpenTarget);
-  }
-
-  throw currentBody.error;
+  return workspaceOpenTargetsResponseSchema.parse(body).targets;
 }
 
 export async function fetchProviderCliStatus(

--- a/apps/app/src/lib/fixed-panel-tabs-state.test.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-state.test.ts
@@ -1,61 +1,58 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFixedPanelTabId,
+  createTerminalFixedPanelTab,
   createThreadInfoFixedPanelTab,
   createWorkspaceFilePreviewFixedPanelTab,
+  getFixedPanelTabsStateStorageKey,
+  isFixedPanelTabsStateStorageKey,
   parseFixedPanelTabsState,
+  FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
   type FixedPanelTabsState,
 } from "./fixed-panel-tabs-state";
 
 function makeInitialState(): FixedPanelTabsState {
   return {
-    version: 1,
+    version: FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
     secondary: {
       tabs: [],
       activeTabId: null,
       isOpen: false,
-    },
-    bottom: {
-      tabs: [],
-      activeTabId: null,
     },
     lastUsedAt: 0,
   };
 }
 
 describe("fixed-panel-tabs-state", () => {
-  it("migrates legacy secondary tab ids together with the active id", () => {
+  it("parses current secondary tab state", () => {
     const now = 1_000;
-    const workspaceTab = {
+    const workspaceTab = createWorkspaceFilePreviewFixedPanelTab({
       environmentId: "env-1",
-      id: "workspace-file-preview:src%2Findex.ts",
-      kind: "workspace-file-preview",
-      lineRange: null,
-      path: "src/index.ts",
-      source: { kind: "working-tree" },
-      statusLabel: null,
-    };
+      tab: {
+        lineRange: {
+          startLineNumber: 1,
+          endLineNumber: 3,
+        },
+        path: "src/index.ts",
+        source: { kind: "working-tree" },
+        statusLabel: null,
+      },
+    });
+    const terminalTab = createTerminalFixedPanelTab({ terminalId: "term-1" });
     const storedState = {
-      version: 1,
+      version: FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
       secondary: {
         tabs: [
-          { id: "thread-info", kind: "thread-info" },
+          createThreadInfoFixedPanelTab(),
           workspaceTab,
-          {
-            id: "browser:browser-instance",
-            kind: "browser",
-            title: null,
-            url: "",
-          },
+          terminalTab,
         ],
         activeTabId: workspaceTab.id,
         isOpen: true,
       },
       bottom: {
-        tabs: [
-          { id: "terminal:term-1", kind: "terminal", terminalId: "term-1" },
-        ],
-        activeTabId: "terminal:term-1",
+        tabs: [],
+        activeTabId: null,
       },
       lastUsedAt: now,
     };
@@ -81,15 +78,49 @@ describe("fixed-panel-tabs-state", () => {
       expectedWorkspaceTab.id,
       buildFixedPanelTabId({
         environmentId: null,
-        kind: "browser",
-        path: "browser-instance",
-      }),
-      buildFixedPanelTabId({
-        environmentId: null,
         kind: "terminal",
         path: "term-1",
       }),
     ]);
-    expect(parsed.bottom.tabs).toEqual([]);
+    expect(parsed.secondary.tabs[1]).toMatchObject({
+      lineRange: null,
+    });
+  });
+
+  it("drops old fixed panel state shapes instead of migrating them", () => {
+    const initialValue = makeInitialState();
+    const parsed = parseFixedPanelTabsState({
+      initialValue,
+      now: 1_000,
+      storedValue: JSON.stringify({
+        version: FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
+        secondary: {
+          tabs: [{ id: "thread-info", kind: "thread-info" }],
+          activeTabId: "thread-info",
+        },
+        bottom: {
+          tabs: [
+            { id: "terminal:term-1", kind: "terminal", terminalId: "term-1" },
+          ],
+          activeTabId: "terminal:term-1",
+        },
+        lastUsedAt: 1_000,
+      }),
+    });
+
+    expect(parsed).toBe(initialValue);
+  });
+
+  it("recognizes old versioned storage keys for pruning", () => {
+    expect(
+      isFixedPanelTabsStateStorageKey(
+        getFixedPanelTabsStateStorageKey({ threadId: "thr_current" }),
+      ),
+    ).toBe(true);
+    expect(
+      isFixedPanelTabsStateStorageKey(
+        "bb.thread.fixedPanelTabsState-thr_old-0",
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/app/src/lib/fixed-panel-tabs-state.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-state.ts
@@ -23,23 +23,6 @@ const SECONDARY_PANEL_TAB_ID_ENVIRONMENT_NONE = "none";
 const THREAD_INFO_TAB_ID = "thread-info:thread-info:none";
 const GIT_DIFF_TAB_ID = "git-diff:git-diff:none";
 const NEW_TAB_TAB_ID = "new-tab:new-tab:none";
-const LEGACY_THREAD_INFO_TAB_ID = "thread-info";
-const LEGACY_GIT_DIFF_TAB_ID = "git-diff";
-const LEGACY_NEW_TAB_TAB_ID = "new-tab";
-
-function stripLegacyLineNumberField(value: unknown): unknown {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return value;
-  }
-
-  const nextValue: Record<string, unknown> = {};
-  for (const [key, fieldValue] of Object.entries(value)) {
-    if (key !== "lineNumber") {
-      nextValue[key] = fieldValue;
-    }
-  }
-  return nextValue;
-}
 
 const environmentFilePreviewSourceSchema: z.ZodType<EnvironmentFilePreviewSource> =
   z.discriminatedUnion("kind", [
@@ -81,43 +64,34 @@ const gitDiffFixedPanelTabSchema = z
     kind: z.literal("git-diff"),
   })
   .strict();
-const workspaceFilePreviewFixedPanelTabSchema = z.preprocess(
-  stripLegacyLineNumberField,
-  z
-    .object({
-      environmentId: z.string().min(1).nullable(),
-      id: z.string().min(1),
-      kind: z.literal("workspace-file-preview"),
-      lineRange: filePreviewLineRangeSchema.nullable().default(null),
-      path: z.string().min(1),
-      source: environmentFilePreviewSourceSchema,
-      statusLabel: workspaceFilePreviewStatusLabelSchema,
-    })
-    .strict(),
-);
-const hostFilePreviewFixedPanelTabSchema = z.preprocess(
-  stripLegacyLineNumberField,
-  z
-    .object({
-      id: z.string().min(1),
-      kind: z.literal("host-file-preview"),
-      lineRange: filePreviewLineRangeSchema.nullable().default(null),
-      path: z.string().min(1),
-    })
-    .strict(),
-);
-const threadStorageFilePreviewFixedPanelTabSchema = z.preprocess(
-  stripLegacyLineNumberField,
-  z
-    .object({
-      id: z.string().min(1),
-      isPinned: z.boolean(),
-      kind: z.literal("thread-storage-file-preview"),
-      lineRange: filePreviewLineRangeSchema.nullable().default(null),
-      path: z.string().min(1),
-    })
-    .strict(),
-);
+const workspaceFilePreviewFixedPanelTabSchema = z
+  .object({
+    environmentId: z.string().min(1).nullable(),
+    id: z.string().min(1),
+    kind: z.literal("workspace-file-preview"),
+    lineRange: filePreviewLineRangeSchema.nullable().default(null),
+    path: z.string().min(1),
+    source: environmentFilePreviewSourceSchema,
+    statusLabel: workspaceFilePreviewStatusLabelSchema,
+  })
+  .strict();
+const hostFilePreviewFixedPanelTabSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.literal("host-file-preview"),
+    lineRange: filePreviewLineRangeSchema.nullable().default(null),
+    path: z.string().min(1),
+  })
+  .strict();
+const threadStorageFilePreviewFixedPanelTabSchema = z
+  .object({
+    id: z.string().min(1),
+    isPinned: z.boolean(),
+    kind: z.literal("thread-storage-file-preview"),
+    lineRange: filePreviewLineRangeSchema.nullable().default(null),
+    path: z.string().min(1),
+  })
+  .strict();
 const browserFixedPanelTabSchema = z
   .object({
     environmentId: z.string().min(1).nullable().default(null),
@@ -154,9 +128,6 @@ const secondaryFixedPanelTabSchema = z.union([
   newTabFixedPanelTabSchema,
   terminalFixedPanelTabSchema,
 ]);
-const bottomFixedPanelTabSchema = z.discriminatedUnion("kind", [
-  terminalFixedPanelTabSchema,
-]);
 const secondaryFixedPanelTabGroupStateSchema = z
   .object({
     tabs: z.array(secondaryFixedPanelTabSchema),
@@ -164,36 +135,13 @@ const secondaryFixedPanelTabGroupStateSchema = z
     isOpen: z.boolean(),
   })
   .strict();
-const legacySecondaryFixedPanelTabGroupStateSchema = z
-  .object({
-    tabs: z.array(secondaryFixedPanelTabSchema),
-    activeTabId: z.string().min(1).nullable(),
-  })
-  .strict();
-const bottomFixedPanelTabGroupStateSchema = z
-  .object({
-    tabs: z.array(bottomFixedPanelTabSchema),
-    activeTabId: z.string().min(1).nullable(),
-  })
-  .strict();
 const fixedPanelTabsStateSchema = z
   .object({
     version: z.literal(FIXED_PANEL_TABS_STATE_STORAGE_VERSION),
     secondary: secondaryFixedPanelTabGroupStateSchema,
-    bottom: bottomFixedPanelTabGroupStateSchema,
     lastUsedAt: z.number().int().nonnegative(),
   })
-  .strict();
-const legacyFixedPanelTabsStateSchema = z
-  .object({
-    version: z.literal(FIXED_PANEL_TABS_STATE_STORAGE_VERSION),
-    secondary: legacySecondaryFixedPanelTabGroupStateSchema,
-    bottom: bottomFixedPanelTabGroupStateSchema,
-    lastUsedAt: z.number().int().nonnegative(),
-  })
-  .strict();
-
-export type FixedPanelRegion = "secondary" | "bottom";
+  .passthrough();
 
 export interface ThreadInfoFixedPanelTab {
   id: string;
@@ -280,9 +228,7 @@ export type SecondaryFileFixedPanelTab =
   | NewTabFixedPanelTab
   | TerminalFixedPanelTab;
 
-export type BottomFixedPanelTab = TerminalFixedPanelTab;
-
-export type FixedPanelTab = SecondaryFixedPanelTab | BottomFixedPanelTab;
+export type FixedPanelTab = SecondaryFixedPanelTab;
 
 export interface FixedPanelTabGroupState {
   tabs: readonly FixedPanelTab[];
@@ -296,7 +242,6 @@ export interface FixedSecondaryPanelTabGroupState extends FixedPanelTabGroupStat
 export interface FixedPanelTabsState {
   version: typeof FIXED_PANEL_TABS_STATE_STORAGE_VERSION;
   secondary: FixedSecondaryPanelTabGroupState;
-  bottom: FixedPanelTabGroupState;
   lastUsedAt: number;
 }
 
@@ -305,7 +250,6 @@ interface FixedPanelTabsStorageKeyArgs {
 }
 
 interface CreateFixedPanelTabsStateArgs {
-  bottom?: FixedPanelTabGroupState;
   lastUsedAt?: number;
   secondary?: FixedSecondaryPanelTabGroupState;
 }
@@ -344,7 +288,6 @@ interface StripTransientFixedPanelTabsStateForStorageArgs {
 
 interface NormalizeFixedPanelTabGroupStateArgs {
   group: FixedPanelTabGroupState;
-  region: FixedPanelRegion;
 }
 
 interface CreateThreadStorageFilePreviewFixedPanelTabArgs {
@@ -375,11 +318,6 @@ interface BuildFixedPanelTabIdArgs {
 interface NormalizeFixedPanelTabGroupStateResult {
   activeTabId: string | null;
   tabs: readonly FixedPanelTab[];
-}
-
-interface IsLegacyFixedTabIdMatchArgs {
-  activeTabId: string;
-  tab: FixedPanelTab;
 }
 
 function getLocalStorage(): Storage | null {
@@ -567,9 +505,7 @@ function normalizeFixedPanelTabId(tab: FixedPanelTab): FixedPanelTab {
       const browserPath =
         idSegments.length === 3 && idSegments[0] === "browser"
           ? decodeStorageSegment(idSegments[1] ?? "")
-          : tab.id.startsWith("browser:")
-            ? tab.id.slice("browser:".length)
-            : tab.id;
+          : tab.id;
       const id = buildFixedPanelTabId({
         environmentId: tab.environmentId,
         kind: tab.kind,
@@ -595,40 +531,12 @@ function normalizeFixedPanelTabId(tab: FixedPanelTab): FixedPanelTab {
   }
 }
 
-function isTabSupportedInRegion(
-  region: FixedPanelRegion,
-  tab: FixedPanelTab,
-): boolean {
-  if (region === "bottom") {
-    return tab.kind === "terminal";
-  }
-  return true;
-}
-
 function isTransientFixedPanelTab(tab: FixedPanelTab): boolean {
   return tab.kind === "new-tab";
 }
 
-function isLegacyFixedTabIdMatch(args: IsLegacyFixedTabIdMatchArgs): boolean {
-  switch (args.tab.kind) {
-    case "thread-info":
-      return args.activeTabId === LEGACY_THREAD_INFO_TAB_ID;
-    case "git-diff":
-      return args.activeTabId === LEGACY_GIT_DIFF_TAB_ID;
-    case "new-tab":
-      return args.activeTabId === LEGACY_NEW_TAB_TAB_ID;
-    case "workspace-file-preview":
-    case "host-file-preview":
-    case "thread-storage-file-preview":
-    case "browser":
-    case "terminal":
-      return false;
-  }
-}
-
 function normalizeFixedPanelTabGroupState({
   group,
-  region,
 }: NormalizeFixedPanelTabGroupStateArgs): NormalizeFixedPanelTabGroupStateResult {
   const seenTabIds = new Set<string>();
   const tabs: FixedPanelTab[] = [];
@@ -637,7 +545,6 @@ function normalizeFixedPanelTabGroupState({
     const normalizedTab = normalizeFixedPanelTabId(tab);
     if (
       isTransientFixedPanelTab(normalizedTab) ||
-      !isTabSupportedInRegion(region, normalizedTab) ||
       seenTabIds.has(normalizedTab.id)
     ) {
       continue;
@@ -646,12 +553,7 @@ function normalizeFixedPanelTabGroupState({
     tabs.push(normalizedTab);
     if (
       group.activeTabId !== null &&
-      (tab.id === group.activeTabId ||
-        normalizedTab.id === group.activeTabId ||
-        isLegacyFixedTabIdMatch({
-          activeTabId: group.activeTabId,
-          tab: normalizedTab,
-        }))
+      (tab.id === group.activeTabId || normalizedTab.id === group.activeTabId)
     ) {
       activeTabId = normalizedTab.id;
     }
@@ -669,7 +571,6 @@ function normalizeFixedSecondaryPanelTabGroupState(
   return {
     ...normalizeFixedPanelTabGroupState({
       group,
-      region: "secondary",
     }),
     isOpen: group.isOpen,
   };
@@ -704,10 +605,6 @@ function stripTransientFixedPanelTabsStateForStorage({
       ...state.secondary,
       tabs: state.secondary.tabs.map(stripTransientFixedPanelTabForStorage),
     },
-    bottom: {
-      ...state.bottom,
-      tabs: state.bottom.tabs.map(stripTransientFixedPanelTabForStorage),
-    },
   };
 }
 
@@ -717,38 +614,11 @@ export function normalizeFixedPanelTabsState({
   const normalizedSecondary = normalizeFixedSecondaryPanelTabGroupState(
     state.secondary,
   );
-  const normalizedBottom = normalizeFixedPanelTabGroupState({
-    group: state.bottom,
-    region: "bottom",
-  });
-  const seenSecondaryTabIds = new Set(
-    normalizedSecondary.tabs.map((tab) => tab.id),
-  );
-  const migratedTerminalTabs = normalizedBottom.tabs.filter(
-    (tab) => !seenSecondaryTabIds.has(tab.id),
-  );
-  const secondaryTabs =
-    migratedTerminalTabs.length > 0
-      ? [...normalizedSecondary.tabs, ...migratedTerminalTabs]
-      : normalizedSecondary.tabs;
-  const activeTabId =
-    normalizedSecondary.activeTabId ??
-    (normalizedBottom.activeTabId !== null &&
-    secondaryTabs.some((tab) => tab.id === normalizedBottom.activeTabId)
-      ? normalizedBottom.activeTabId
-      : null);
 
   return {
-    ...state,
-    secondary: {
-      ...normalizedSecondary,
-      tabs: secondaryTabs,
-      activeTabId,
-    },
-    bottom: {
-      tabs: [],
-      activeTabId: null,
-    },
+    version: state.version,
+    secondary: normalizedSecondary,
+    lastUsedAt: state.lastUsedAt,
   };
 }
 
@@ -762,10 +632,6 @@ export function createEmptyFixedPanelTabsState(
         tabs: [],
         activeTabId: null,
         isOpen: false,
-      },
-      bottom: args.bottom ?? {
-        tabs: [],
-        activeTabId: null,
       },
       lastUsedAt: args.lastUsedAt ?? 0,
     },
@@ -783,10 +649,7 @@ export function getFixedPanelTabsStateStorageKey({
 }
 
 export function isFixedPanelTabsStateStorageKey(key: string): boolean {
-  return (
-    key.startsWith(`${FIXED_PANEL_TABS_STATE_STORAGE_PREFIX}-`) &&
-    key.endsWith(`-${FIXED_PANEL_TABS_STATE_STORAGE_VERSION}`)
-  );
+  return key.startsWith(`${FIXED_PANEL_TABS_STATE_STORAGE_PREFIX}-`);
 }
 
 export function isFixedPanelTabsStateExpired({
@@ -831,42 +694,16 @@ function parseFixedPanelTabsStateForStorage({
   }
 
   const stateResult = fixedPanelTabsStateSchema.safeParse(parsedValue);
-  if (stateResult.success) {
-    const normalizedState = stripTransientFixedPanelTabsStateForStorage({
-      state: normalizeFixedPanelTabsState({
-        state: stateResult.data,
-      }),
-    });
-    if (isFixedPanelTabsStateExpired({ now, state: normalizedState })) {
-      return {
-        shouldPrune: true,
-        state: initialValue,
-      };
-    }
-
-    return {
-      shouldPrune: false,
-      state: normalizedState,
-    };
-  }
-
-  const legacyStateResult =
-    legacyFixedPanelTabsStateSchema.safeParse(parsedValue);
-  if (!legacyStateResult.success) {
+  if (!stateResult.success) {
     return {
       shouldPrune: true,
       state: initialValue,
     };
   }
+
   const normalizedState = stripTransientFixedPanelTabsStateForStorage({
     state: normalizeFixedPanelTabsState({
-      state: {
-        ...legacyStateResult.data,
-        secondary: {
-          ...legacyStateResult.data.secondary,
-          isOpen: legacyStateResult.data.secondary.activeTabId !== null,
-        },
-      },
+      state: stateResult.data,
     }),
   });
   if (isFixedPanelTabsStateExpired({ now, state: normalizedState })) {

--- a/apps/app/src/lib/fixed-panel-tabs.ts
+++ b/apps/app/src/lib/fixed-panel-tabs.ts
@@ -249,8 +249,7 @@ export function useTouchFixedPanelTabsState(
     updateState((current) => {
       if (
         !current.secondary.isOpen &&
-        current.secondary.tabs.length === 0 &&
-        current.bottom.tabs.length === 0
+        current.secondary.tabs.length === 0
       ) {
         return current;
       }


### PR DESCRIPTION
## Summary
- remove legacy workspace-open-target response normalization from the app local-daemon client
- drop the old sidebar collapsedManagers localStorage migration
- simplify fixed panel tab state by removing pre-current migration paths and the unused bottom tab group
- keep current fixed-panel storage version at v1 so existing current client panel state is preserved while older invalid shapes are pruned

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app