### PR TITLE
Hide worktree thread action until provisioned

### DIFF
--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -19,7 +19,7 @@ export interface ThreadEnvironmentSummaryProps {
   environmentCheckout?: WorkspaceCheckoutDisplay;
   /** When set, render a "new thread in this worktree" affordance beside the
    * environment label. Caller is responsible for only providing this when the
-   * environment is a worktree. */
+   * environment is a provisioned worktree. */
   onCreateNewThreadInWorktree?: () => void;
 }
 

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
@@ -1,0 +1,101 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { Environment, Thread } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { EnvironmentRow } from "./ThreadMetadataContent";
+
+const localHost = { locality: "local" } as const;
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "thr_test",
+    projectId: "proj_test",
+    environmentId: "env_test",
+    automationId: null,
+    providerId: "codex",
+    title: null,
+    titleFallback: null,
+    status: "idle",
+    parentThreadId: null,
+    archivedAt: null,
+    pinnedAt: null,
+    stopRequestedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeEnvironment(overrides: Partial<Environment> = {}): Environment {
+  return {
+    id: "env_test",
+    name: null,
+    projectId: "proj_test",
+    hostId: "host_test",
+    path: "/workspace",
+    managed: true,
+    isGitRepo: true,
+    isWorktree: true,
+    workspaceProvisionType: "managed-worktree",
+    branchName: "feature",
+    baseBranch: "main",
+    defaultBranch: "main",
+    mergeBaseBranch: null,
+    cleanupRequestedAt: null,
+    cleanupMode: null,
+    status: "ready",
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function renderEnvironmentRow(environment: Environment): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EnvironmentRow
+        thread={makeThread({ environmentId: environment.id })}
+        environment={environment}
+        environmentDisplayHost={localHost}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("EnvironmentRow", () => {
+  it("shows the create-thread action for a provisioned worktree", () => {
+    expect(renderEnvironmentRow(makeEnvironment())).toContain(
+      'aria-label="Create new thread in this worktree"',
+    );
+  });
+
+  it("hides the create-thread action while a managed worktree is provisioning", () => {
+    const markup = renderEnvironmentRow(
+      makeEnvironment({
+        status: "provisioning",
+        path: null,
+        isWorktree: false,
+      }),
+    );
+
+    expect(markup).not.toContain(
+      'aria-label="Create new thread in this worktree"',
+    );
+  });
+
+  it("hides the create-thread action before a prepared worktree has a path", () => {
+    const markup = renderEnvironmentRow(
+      makeEnvironment({
+        path: null,
+        isWorktree: false,
+      }),
+    );
+
+    expect(markup).not.toContain(
+      'aria-label="Create new thread in this worktree"',
+    );
+  });
+});

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -246,7 +246,8 @@ export function EnvironmentRow({
     environment,
     host: environmentDisplayHost,
   });
-  const showCreateThreadButton = isWorktreeEnvironment(environment);
+  const showCreateThreadButton =
+    isProvisionedWorktreeEnvironment(environment);
   return (
     <DetailRow
       label={
@@ -290,6 +291,14 @@ function isWorktreeEnvironment(environment: Environment): boolean {
   return (
     environment.isWorktree ||
     environment.workspaceProvisionType === "managed-worktree"
+  );
+}
+
+function isProvisionedWorktreeEnvironment(environment: Environment): boolean {
+  return (
+    environment.status === "ready" &&
+    environment.path !== null &&
+    isWorktreeEnvironment(environment)
   );
 }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1487,12 +1487,16 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
         threadEnvironmentDisplay.workspaceDisplayKind,
       )
     : null;
-  const isThreadOnWorktreeEnvironment =
+  const isThreadOnProvisionedWorktreeEnvironment =
     environment !== undefined &&
+    environment.status === "ready" &&
+    environment.path !== null &&
     (environment.isWorktree ||
       environment.workspaceProvisionType === "managed-worktree");
   const onCreateNewThreadInWorktree =
-    isThreadOnWorktreeEnvironment && projectId && thread.environmentId !== null
+    isThreadOnProvisionedWorktreeEnvironment &&
+    projectId &&
+    thread.environmentId !== null
       ? createThreadInWorktree
       : undefined;
   const promptBannerMergeBaseBranch = effectiveMergeBaseBranch;


### PR DESCRIPTION
## Summary
- Hide the "new thread in this worktree" action until the environment is ready and has a workspace path
- Apply the same readiness gate in the prompt composer affordance
- Add regression coverage for provisioned, provisioning, and pathless prepared worktree environments

## Validation
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/secondary-panel/ThreadMetadataContent.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app