### PR TITLE
Prototype git directory typeahead

### DIFF
--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -1,13 +1,29 @@
-import { useEffect, useId, useState, type FormEvent } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   deriveProjectNameFromPath,
   getProjectPathValidationMessage,
   normalizeProjectPathInput,
 } from "@bb/domain";
-import type { HostPlatform } from "@bb/host-daemon-contract";
+import type {
+  GitDirectorySuggestion,
+  GitDirectorySuggestionsRequest,
+  GitDirectorySuggestionsResponse,
+  HostPlatform,
+} from "@bb/host-daemon-contract";
+import { useDebounceValue } from "usehooks-ts";
 import { Button } from "@/components/ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog.js";
+import { Icon } from "@/components/ui/icon.js";
 import { Input } from "@/components/ui/input.js";
+import { cn } from "@/lib/utils";
 
 export type ProjectPathDialogTarget =
   | {
@@ -30,11 +46,16 @@ export type ProjectPathDialogSubmitHandler = (
   path: string,
 ) => Promise<void> | void;
 
+export type ProjectGitDirectorySuggestionLoader = (
+  request: GitDirectorySuggestionsRequest,
+) => Promise<GitDirectorySuggestionsResponse>;
+
 interface ProjectPathDialogProps {
   target: ProjectPathDialogTarget | null;
   pending?: boolean;
   platform: HostPlatform | null;
   hostName: string | null;
+  listGitDirectories?: ProjectGitDirectorySuggestionLoader | null;
   onOpenChange: (open: boolean) => void;
   onSubmit: ProjectPathDialogSubmitHandler;
 }
@@ -44,6 +65,7 @@ export function ProjectPathDialog({
   pending = false,
   platform,
   hostName,
+  listGitDirectories,
   onOpenChange,
   onSubmit,
 }: ProjectPathDialogProps) {
@@ -57,6 +79,7 @@ export function ProjectPathDialog({
             pending={pending}
             platform={platform}
             hostName={hostName}
+            listGitDirectories={listGitDirectories}
             onSubmit={onSubmit}
           />
         ) : null}
@@ -70,6 +93,7 @@ export interface ProjectPathDialogContentProps {
   pending: boolean;
   platform: HostPlatform | null;
   hostName: string | null;
+  listGitDirectories?: ProjectGitDirectorySuggestionLoader | null;
   onSubmit: ProjectPathDialogSubmitHandler;
 }
 
@@ -77,6 +101,9 @@ interface PlatformCopy {
   description: string;
   placeholder: string;
 }
+
+const PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_LIMIT = 8;
+const PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_DEBOUNCE_MS = 120;
 
 function getDialogTitle(kind: ProjectPathDialogTarget["kind"]): string {
   switch (kind) {
@@ -120,11 +147,138 @@ function getPlatformCopy(
   };
 }
 
+function getAbsolutePathSuggestionRequest(
+  input: string,
+): GitDirectorySuggestionsRequest | null {
+  if (!input.startsWith("/")) {
+    return null;
+  }
+
+  if (input === "/") {
+    return {
+      mode: "children",
+      parentPath: "/",
+      limit: PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_LIMIT,
+    };
+  }
+
+  if (input.endsWith("/")) {
+    return {
+      mode: "children",
+      parentPath: normalizeProjectPathInput(input),
+      limit: PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_LIMIT,
+    };
+  }
+
+  const lastSlashIndex = input.lastIndexOf("/");
+  const parentPath =
+    lastSlashIndex === 0 ? "/" : input.slice(0, lastSlashIndex);
+  const query = input.slice(lastSlashIndex + 1);
+  return {
+    mode: "children",
+    parentPath,
+    ...(query ? { query } : {}),
+    limit: PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_LIMIT,
+  };
+}
+
+function getProjectPathSuggestionRequest(
+  input: string,
+): GitDirectorySuggestionsRequest | null {
+  const trimmedInput = input.trim();
+  if (!trimmedInput) {
+    return null;
+  }
+
+  const absoluteRequest = getAbsolutePathSuggestionRequest(trimmedInput);
+  if (absoluteRequest) {
+    return absoluteRequest;
+  }
+
+  if (trimmedInput.includes("/") || trimmedInput.length < 2) {
+    return null;
+  }
+
+  return {
+    mode: "known-roots",
+    query: trimmedInput,
+    limit: PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_LIMIT,
+  };
+}
+
+interface ProjectPathGitDirectorySuggestionsProps {
+  activeIndex: number;
+  isError: boolean;
+  isLoading: boolean;
+  onSelect: (suggestion: GitDirectorySuggestion) => void;
+  suggestions: readonly GitDirectorySuggestion[];
+}
+
+function ProjectPathGitDirectorySuggestions({
+  activeIndex,
+  isError,
+  isLoading,
+  onSelect,
+  suggestions,
+}: ProjectPathGitDirectorySuggestionsProps) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-popover text-popover-foreground">
+      {isLoading && suggestions.length === 0 ? (
+        <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
+          <Icon name="Spinner" className="size-3.5 animate-spin" />
+          <span>Searching repositories...</span>
+        </div>
+      ) : null}
+      {isError ? (
+        <div className="px-3 py-2 text-xs text-destructive">
+          Failed to load repository suggestions
+        </div>
+      ) : null}
+      {suggestions.length > 0 ? (
+        <div role="listbox" className="max-h-48 overflow-y-auto p-1">
+          {suggestions.map((suggestion, index) => (
+            <button
+              key={suggestion.path}
+              type="button"
+              role="option"
+              aria-selected={index === activeIndex}
+              title={suggestion.path}
+              className={cn(
+                "flex w-full min-w-0 items-center gap-2 rounded px-2 py-1.5 text-left text-xs",
+                index === activeIndex
+                  ? "bg-state-active text-foreground"
+                  : "hover:bg-state-hover",
+              )}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onSelect(suggestion);
+              }}
+            >
+              <Icon
+                name="FolderGit"
+                className="size-3.5 shrink-0 text-muted-foreground"
+                aria-hidden
+              />
+              <span className="shrink-0 font-medium text-foreground">
+                {suggestion.name}
+              </span>
+              <span className="truncate text-muted-foreground">
+                {suggestion.path}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function ProjectPathDialogContent({
   target,
   pending,
   platform,
   hostName,
+  listGitDirectories,
   onSubmit,
 }: ProjectPathDialogContentProps) {
   const inputId = useId();
@@ -134,6 +288,11 @@ export function ProjectPathDialogContent({
   const [validationMessage, setValidationMessage] = useState<string | null>(
     null,
   );
+  const [suggestionsOpen, setSuggestionsOpen] = useState(true);
+  const [dismissedSuggestionPath, setDismissedSuggestionPath] = useState<
+    string | null
+  >(null);
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
   const derivedProjectName = deriveProjectNameFromPath(pathValue);
   const copy = getPlatformCopy(platform, hostName);
   const placeholder =
@@ -144,6 +303,96 @@ export function ProjectPathDialogContent({
   useEffect(() => {
     setValidationMessage(null);
   }, [pathValue]);
+
+  const [debouncedPathValue] = useDebounceValue(
+    pathValue,
+    PROJECT_PATH_GIT_DIRECTORY_SUGGESTION_DEBOUNCE_MS,
+  );
+  const suggestionRequest = useMemo(
+    () => getProjectPathSuggestionRequest(debouncedPathValue),
+    [debouncedPathValue],
+  );
+  const suggestionsEnabled =
+    target.kind === "create" &&
+    !pending &&
+    listGitDirectories != null &&
+    suggestionRequest !== null;
+  const suggestionsQuery = useQuery({
+    queryKey: ["project-path-git-directories", suggestionRequest],
+    queryFn: () => {
+      if (!listGitDirectories || !suggestionRequest) {
+        throw new Error("Git directory suggestions are unavailable");
+      }
+      return listGitDirectories(suggestionRequest);
+    },
+    enabled: suggestionsEnabled,
+    staleTime: 5_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+    placeholderData: (previousData) => previousData,
+  });
+  const suggestions = suggestionsQuery.data?.directories ?? [];
+  const visibleSuggestions =
+    suggestionsOpen &&
+    pathValue !== dismissedSuggestionPath &&
+    suggestionsEnabled &&
+    (suggestionsQuery.isLoading ||
+      suggestionsQuery.isError ||
+      suggestions.length > 0);
+  const clampedActiveSuggestionIndex =
+    suggestions.length === 0
+      ? -1
+      : Math.min(activeSuggestionIndex, suggestions.length - 1);
+
+  useEffect(() => {
+    setActiveSuggestionIndex(0);
+  }, [debouncedPathValue]);
+
+  const applySuggestion = (suggestion: GitDirectorySuggestion) => {
+    const normalizedPath = normalizeProjectPathInput(suggestion.path);
+    setPathValue(normalizedPath);
+    setValidationMessage(null);
+    setSuggestionsOpen(false);
+    setDismissedSuggestionPath(normalizedPath);
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!visibleSuggestions || suggestions.length === 0) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveSuggestionIndex((current) =>
+        current >= suggestions.length - 1 ? 0 : current + 1,
+      );
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveSuggestionIndex((current) =>
+        current <= 0 ? suggestions.length - 1 : current - 1,
+      );
+      return;
+    }
+
+    if (event.key === "Enter" && clampedActiveSuggestionIndex >= 0) {
+      const suggestion = suggestions[clampedActiveSuggestionIndex];
+      if (!suggestion) {
+        return;
+      }
+      event.preventDefault();
+      applySuggestion(suggestion);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setSuggestionsOpen(false);
+      setDismissedSuggestionPath(pathValue);
+    }
+  };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -185,8 +434,20 @@ export function ProjectPathDialogContent({
             placeholder={placeholder}
             onChange={(event) => {
               setPathValue(event.target.value);
+              setSuggestionsOpen(true);
+              setDismissedSuggestionPath(null);
             }}
+            onKeyDown={handleInputKeyDown}
           />
+          {visibleSuggestions ? (
+            <ProjectPathGitDirectorySuggestions
+              activeIndex={clampedActiveSuggestionIndex}
+              isError={suggestionsQuery.isError}
+              isLoading={suggestionsQuery.isLoading}
+              suggestions={suggestions}
+              onSelect={applySuggestion}
+            />
+          ) : null}
           {target.kind === "create" && derivedProjectName ? (
             <p className="text-sm text-muted-foreground">
               Project name:{" "}

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -614,6 +614,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           pending={quickCreateProject.isCreating}
           platform={quickCreateProject.platform}
           hostName={quickCreateProject.hostName}
+          listGitDirectories={quickCreateProject.listGitDirectories}
           onOpenChange={quickCreateProject.projectPathDialog.onOpenChange}
           onSubmit={quickCreateProject.submitProjectPath}
         />

--- a/apps/app/src/components/project/ProjectActionsProvider.tsx
+++ b/apps/app/src/components/project/ProjectActionsProvider.tsx
@@ -182,6 +182,7 @@ export function ProjectActionsProvider({
         pending={addLocalSource.isPending}
         platform={addLocalSourcePicker.platform}
         hostName={addLocalSourcePicker.hostName}
+        listGitDirectories={addLocalSourcePicker.listGitDirectories}
         onOpenChange={addLocalSourcePicker.projectPathDialog.onOpenChange}
         onSubmit={addLocalSourcePicker.submitProjectPath}
       />

--- a/apps/app/src/hooks/useHostDaemon.ts
+++ b/apps/app/src/hooks/useHostDaemon.ts
@@ -6,7 +6,10 @@ import {
   localHostIdAtom,
   localHostStatusAtom,
 } from "@/lib/system-config-atoms";
-import { pickFolder as daemonPickFolder } from "@/lib/api-host-daemon";
+import {
+  listGitDirectories as daemonListGitDirectories,
+  pickFolder as daemonPickFolder,
+} from "@/lib/api-host-daemon";
 import { useAsyncAtomValue } from "@/lib/use-async-atom-value";
 
 /**
@@ -49,6 +52,13 @@ export function useHostDaemon() {
     return () => daemonPickFolder(port);
   }, [hasDaemon, daemonPort, supportsNativeFolderPicker]);
 
+  const listGitDirectories = useMemo(() => {
+    if (!hasDaemon || !daemonPort || supportsNativeFolderPicker) return null;
+    const port = daemonPort;
+    return (request: Parameters<typeof daemonListGitDirectories>[1]) =>
+      daemonListGitDirectories(port, request);
+  }, [daemonPort, hasDaemon, supportsNativeFolderPicker]);
+
   return {
     localDaemonHostId,
     localHostId,
@@ -57,5 +67,6 @@ export function useHostDaemon() {
     platform,
     isLocalDaemonHost,
     pickFolder,
+    listGitDirectories,
   };
 }

--- a/apps/app/src/hooks/useLocalPathPicker.tsx
+++ b/apps/app/src/hooks/useLocalPathPicker.tsx
@@ -25,6 +25,7 @@ export interface LocalPathPickerController {
   isAvailable: boolean;
   hostId: string | null;
   hostName: string | null;
+  listGitDirectories: ReturnType<typeof useHostDaemon>["listGitDirectories"];
   openPicker: (target: ProjectPathDialogTarget) => void;
   platform: HostPlatform | null;
   projectPathDialog: ReturnType<typeof useDialogState<ProjectPathDialogTarget>>;
@@ -60,7 +61,7 @@ export function useLocalPathPicker({
   isPending,
   submit,
 }: UseLocalPathPickerOptions): LocalPathPickerController {
-  const { pickFolder, platform } = useHostDaemon();
+  const { listGitDirectories, pickFolder, platform } = useHostDaemon();
   const { hostId, hostName } = usePathPickerHost();
   const projectPathDialog = useDialogState<ProjectPathDialogTarget>();
   const closeDialog = projectPathDialog.onClose;
@@ -102,6 +103,7 @@ export function useLocalPathPicker({
     isAvailable: hostId != null,
     hostId,
     hostName,
+    listGitDirectories,
     openPicker,
     platform,
     projectPathDialog,

--- a/apps/app/src/hooks/useQuickCreateProject.tsx
+++ b/apps/app/src/hooks/useQuickCreateProject.tsx
@@ -32,6 +32,9 @@ export interface QuickCreateProjectDialogState {
 export interface QuickCreateProjectController {
   isAvailable: boolean;
   isCreating: boolean;
+  listGitDirectories: ReturnType<
+    typeof useLocalPathPicker
+  >["listGitDirectories"];
   openCreateDialog: () => void;
   platform: HostPlatform | null;
   hostName: string | null;
@@ -87,6 +90,7 @@ export function useQuickCreateProject(): QuickCreateProjectController {
     () => ({
       isAvailable: controller.isAvailable,
       isCreating: isPending,
+      listGitDirectories: controller.listGitDirectories,
       openCreateDialog,
       platform: controller.platform,
       hostName: controller.hostName,

--- a/apps/app/src/lib/api-host-daemon.ts
+++ b/apps/app/src/lib/api-host-daemon.ts
@@ -3,8 +3,11 @@ import {
   DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST,
   providerCliInstallEventSchema,
   providerCliStatusResponseSchema,
+  gitDirectorySuggestionsResponseSchema,
   workspaceOpenTargetIdSchema,
   workspaceOpenTargetsResponseSchema,
+  type GitDirectorySuggestionsRequest,
+  type GitDirectorySuggestionsResponse,
   type OpenInTargetRequest,
   type ProviderCliInstallEvent,
   type ProviderCliInstallRequest,
@@ -330,4 +333,18 @@ export async function checkPathsExist(
   }
   const body = await res.json();
   return body.existence;
+}
+
+export async function listGitDirectories(
+  port: number,
+  request: GitDirectorySuggestionsRequest,
+): Promise<GitDirectorySuggestionsResponse> {
+  const daemon = getHostDaemonClient(port);
+  const res = await daemon.paths["git-directories"].$post({
+    json: request,
+  });
+  if (!res.ok) {
+    throw new Error(`Git directory suggestions failed: HTTP ${res.status}`);
+  }
+  return gitDirectorySuggestionsResponseSchema.parse(await res.json());
 }

--- a/apps/app/src/views/ProjectSettingsView.tsx
+++ b/apps/app/src/views/ProjectSettingsView.tsx
@@ -189,6 +189,7 @@ export function ProjectSettingsView() {
         pending={localSourcePickerPending}
         platform={localSourcePicker.platform}
         hostName={localSourcePicker.hostName}
+        listGitDirectories={localSourcePicker.listGitDirectories}
         onOpenChange={localSourcePicker.projectPathDialog.onOpenChange}
         onSubmit={localSourcePicker.submitProjectPath}
       />

--- a/apps/host-daemon/src/git-directory-suggestions.ts
+++ b/apps/host-daemon/src/git-directory-suggestions.ts
@@ -1,0 +1,249 @@
+import fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fuzzyMatchPaths } from "@bb/fuzzy-match";
+import type {
+  GitDirectorySuggestion,
+  GitDirectorySuggestionsRequest,
+  GitDirectorySuggestionsResponse,
+} from "@bb/host-daemon-contract";
+
+const DEFAULT_KNOWN_ROOT_MAX_DEPTH = 2;
+const DEFAULT_INDEX_TTL_MS = 30_000;
+const EXCLUDED_DIRECTORY_NAMES = new Set([
+  "node_modules",
+  "bower_components",
+  "jspm_packages",
+  "vendor",
+]);
+
+export interface GitDirectorySuggestionServiceOptions {
+  searchRoots?: readonly string[];
+  maxDepth?: number;
+  indexTtlMs?: number;
+  now?: () => number;
+}
+
+export interface GitDirectorySuggestionService {
+  suggest(
+    request: GitDirectorySuggestionsRequest,
+  ): Promise<GitDirectorySuggestionsResponse>;
+}
+
+interface GitDirectoryIndex {
+  directories: GitDirectorySuggestion[];
+  updatedAt: number;
+}
+
+function isHiddenDirectoryName(name: string): boolean {
+  return name.startsWith(".");
+}
+
+function shouldPruneDirectoryName(name: string): boolean {
+  return isHiddenDirectoryName(name) || EXCLUDED_DIRECTORY_NAMES.has(name);
+}
+
+function isMissingOrUnreadableDirectoryError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM")
+  );
+}
+
+async function safeReadDirectory(
+  dirPath: string,
+): Promise<Dirent[] | null> {
+  try {
+    return await fs.readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingOrUnreadableDirectoryError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function hasGitMarker(directoryPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(path.join(directoryPath, ".git"));
+    return stat.isDirectory() || stat.isFile();
+  } catch (error) {
+    if (isMissingOrUnreadableDirectoryError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function toSuggestion(directoryPath: string): GitDirectorySuggestion {
+  return {
+    path: directoryPath,
+    name: path.basename(directoryPath),
+  };
+}
+
+function rankSuggestions(
+  directories: readonly GitDirectorySuggestion[],
+  query: string | undefined,
+  limit: number,
+): GitDirectorySuggestionsResponse {
+  const matches = fuzzyMatchPaths({
+    items: directories,
+    query: query ?? "",
+    getPath: (directory) => directory.path,
+    limit: limit + 1,
+  });
+  const limitedMatches = matches.slice(0, limit);
+  return {
+    directories: limitedMatches.map((match) => match.item),
+    truncated: matches.length > limit,
+  };
+}
+
+async function listDirectGitDirectoryChildren(
+  parentPath: string,
+): Promise<GitDirectorySuggestion[]> {
+  if (!path.isAbsolute(parentPath)) {
+    return [];
+  }
+
+  const entries = await safeReadDirectory(parentPath);
+  if (!entries) {
+    return [];
+  }
+
+  const directories: GitDirectorySuggestion[] = [];
+  for (const entry of entries) {
+    if (
+      !entry.isDirectory() ||
+      entry.isSymbolicLink() ||
+      shouldPruneDirectoryName(entry.name)
+    ) {
+      continue;
+    }
+
+    const directoryPath = path.join(parentPath, entry.name);
+    if (await hasGitMarker(directoryPath)) {
+      directories.push(toSuggestion(directoryPath));
+    }
+  }
+  return directories.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function scanKnownRoot(
+  rootPath: string,
+  maxDepth: number,
+): Promise<GitDirectorySuggestion[]> {
+  const root = path.resolve(rootPath);
+  const directories: GitDirectorySuggestion[] = [];
+
+  async function scanDirectory(dirPath: string, depth: number): Promise<void> {
+    const entries = await safeReadDirectory(dirPath);
+    if (!entries) {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (
+        !entry.isDirectory() ||
+        entry.isSymbolicLink() ||
+        shouldPruneDirectoryName(entry.name)
+      ) {
+        continue;
+      }
+
+      const directoryPath = path.join(dirPath, entry.name);
+      if (await hasGitMarker(directoryPath)) {
+        directories.push(toSuggestion(directoryPath));
+        continue;
+      }
+
+      if (depth < maxDepth) {
+        await scanDirectory(directoryPath, depth + 1);
+      }
+    }
+  }
+
+  await scanDirectory(root, 1);
+  return directories;
+}
+
+async function scanKnownRootGitDirectories(
+  roots: readonly string[],
+  maxDepth: number,
+): Promise<GitDirectorySuggestion[]> {
+  const byPath = new Map<string, GitDirectorySuggestion>();
+  for (const root of roots) {
+    for (const directory of await scanKnownRoot(root, maxDepth)) {
+      byPath.set(directory.path, directory);
+    }
+  }
+
+  return Array.from(byPath.values()).sort((left, right) =>
+    left.path.localeCompare(right.path),
+  );
+}
+
+export function createGitDirectorySuggestionService(
+  options: GitDirectorySuggestionServiceOptions = {},
+): GitDirectorySuggestionService {
+  const roots = options.searchRoots ?? [os.homedir()];
+  const maxDepth = options.maxDepth ?? DEFAULT_KNOWN_ROOT_MAX_DEPTH;
+  const indexTtlMs = options.indexTtlMs ?? DEFAULT_INDEX_TTL_MS;
+  const now = options.now ?? Date.now;
+  let index: GitDirectoryIndex | null = null;
+  let refreshPromise: Promise<GitDirectoryIndex> | null = null;
+
+  async function refreshIndex(): Promise<GitDirectoryIndex> {
+    if (refreshPromise) {
+      return refreshPromise;
+    }
+
+    refreshPromise = scanKnownRootGitDirectories(roots, maxDepth)
+      .then((directories) => {
+        const nextIndex = { directories, updatedAt: now() };
+        index = nextIndex;
+        return nextIndex;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+    return refreshPromise;
+  }
+
+  async function getKnownRootIndex(): Promise<GitDirectoryIndex> {
+    if (!index) {
+      return refreshIndex();
+    }
+
+    if (now() - index.updatedAt > indexTtlMs) {
+      void refreshIndex().catch(() => undefined);
+    }
+
+    return index;
+  }
+
+  return {
+    async suggest(request) {
+      if (request.mode === "children") {
+        return rankSuggestions(
+          await listDirectGitDirectoryChildren(request.parentPath),
+          request.query,
+          request.limit,
+        );
+      }
+
+      const currentIndex = await getKnownRootIndex();
+      return rankSuggestions(
+        currentIndex.directories,
+        request.query,
+        request.limit,
+      );
+    },
+  };
+}

--- a/apps/host-daemon/src/local-api.test.ts
+++ b/apps/host-daemon/src/local-api.test.ts
@@ -227,6 +227,93 @@ describe("local API server", () => {
     }
   });
 
+  it("suggests git directories from an on-demand known-root index", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bb-git-dirs-"));
+    const projectsDir = path.join(root, "Projects");
+    const repoDir = path.join(projectsDir, "bb");
+    const otherRepoDir = path.join(projectsDir, "bb-tools");
+    const nonRepoDir = path.join(projectsDir, "bb-not-repo");
+    const hiddenRepoDir = path.join(root, ".hidden", "bb-hidden");
+    const packageRepoDir = path.join(root, "node_modules", "bb-package");
+
+    try {
+      server = await startLocalApiServer({
+        hostId: "host-1",
+        localApiConfig: createLocalApiConfig(),
+        serverUrl: "http://server.test",
+        serverPort: 3334,
+        devAppPort: 5173,
+        getConnected: () => true,
+        gitDirectorySuggestionRoots: [root],
+      });
+      await mkdir(path.join(repoDir, ".git"), { recursive: true });
+      await mkdir(otherRepoDir, { recursive: true });
+      await writeFile(
+        path.join(otherRepoDir, ".git"),
+        "gitdir: ../.git/worktrees/bb-tools\n",
+      );
+      await mkdir(nonRepoDir, { recursive: true });
+      await mkdir(path.join(hiddenRepoDir, ".git"), { recursive: true });
+      await mkdir(path.join(packageRepoDir, ".git"), { recursive: true });
+
+      const client = createHostDaemonLocalClient(
+        `http://localhost:${server.port}`,
+      );
+
+      const response = await client.paths["git-directories"].$post({
+        json: { mode: "known-roots", query: "bb", limit: 10 },
+      });
+
+      expect(response.ok).toBe(true);
+      expect(await response.json()).toEqual({
+        directories: [
+          { path: repoDir, name: "bb" },
+          { path: otherRepoDir, name: "bb-tools" },
+        ],
+        truncated: false,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("suggests direct git directory children for absolute path completion", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "bb-git-dir-children-"));
+    const repoDir = path.join(root, "bb");
+    const otherRepoDir = path.join(root, "bb-tools");
+    const nonRepoDir = path.join(root, "bb-not-repo");
+    await mkdir(path.join(repoDir, ".git"), { recursive: true });
+    await mkdir(path.join(otherRepoDir, ".git"), { recursive: true });
+    await mkdir(nonRepoDir);
+
+    try {
+      server = await startLocalApiServer({
+        hostId: "host-1",
+        localApiConfig: createLocalApiConfig(),
+        serverUrl: "http://server.test",
+        serverPort: 3334,
+        devAppPort: 5173,
+        getConnected: () => true,
+        gitDirectorySuggestionRoots: [path.join(root, "unused")],
+      });
+      const client = createHostDaemonLocalClient(
+        `http://localhost:${server.port}`,
+      );
+
+      const response = await client.paths["git-directories"].$post({
+        json: { mode: "children", parentPath: root, query: "tools", limit: 10 },
+      });
+
+      expect(response.ok).toBe(true);
+      expect(await response.json()).toEqual({
+        directories: [{ path: otherRepoDir, name: "bb-tools" }],
+        truncated: false,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("lists workspace open targets and delegates target-aware open requests", async () => {
     const workspacePath = await mkdtemp(path.join(tmpdir(), "bb-workspace-"));
     const targets: WorkspaceOpenTarget[] = [

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -10,6 +10,7 @@ import { assignIfDefined } from "@bb/config/objects";
 import {
   healthResponseSchema,
   HOST_DAEMON_PROTOCOL_VERSION,
+  gitDirectorySuggestionsRequestSchema,
   openInTargetRequestSchema,
   pathsExistRequestSchema,
   providerCliInstallRequestSchema,
@@ -35,6 +36,7 @@ import {
   ProviderCliInstallInProgressError,
   streamProviderCliInstall,
 } from "./provider-cli-health.js";
+import { createGitDirectorySuggestionService } from "./git-directory-suggestions.js";
 
 const execFileAsync = promisify(execFile);
 export type WorkspaceOpenTargetListHandler = () => Promise<
@@ -61,6 +63,7 @@ export interface StartLocalApiServerOptions {
   listWorkspaceOpenTargets?: WorkspaceOpenTargetListHandler;
   openInTarget?: OpenInTargetHandler;
   pickFolder?: () => Promise<string | null>;
+  gitDirectorySuggestionRoots?: readonly string[];
 }
 
 export interface LocalApiServer {
@@ -145,6 +148,11 @@ export async function startLocalApiServer(
   const nativeFolderPicker = resolveNativeFolderPicker({
     pickFolder: options.pickFolder,
   });
+  const gitDirectorySuggestionService = createGitDirectorySuggestionService({
+    ...(options.gitDirectorySuggestionRoots
+      ? { searchRoots: options.gitDirectorySuggestionRoots }
+      : {}),
+  });
   const platform = resolveHostPlatform();
 
   get("/status", (c) =>
@@ -204,6 +212,12 @@ export async function startLocalApiServer(
     );
     return c.json({ existence: Object.fromEntries(entries) });
   });
+
+  post(
+    "/paths/git-directories",
+    gitDirectorySuggestionsRequestSchema,
+    async (c, payload) => c.json(await gitDirectorySuggestionService.suggest(payload)),
+  );
 
   get("/workspace-open-targets", async (c) =>
     c.json({

--- a/packages/host-daemon-contract/src/local.ts
+++ b/packages/host-daemon-contract/src/local.ts
@@ -82,6 +82,65 @@ export const pathsExistResponseSchema = z.object({
 });
 export type PathsExistResponse = z.infer<typeof pathsExistResponseSchema>;
 
+export const GIT_DIRECTORY_SUGGESTION_LIMIT_MAX = 20;
+export const GIT_DIRECTORY_SUGGESTION_QUERY_MAX_LENGTH = 120;
+
+export const gitDirectorySuggestionSchema = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+});
+export type GitDirectorySuggestion = z.infer<
+  typeof gitDirectorySuggestionSchema
+>;
+
+const gitDirectorySuggestionLimitSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(GIT_DIRECTORY_SUGGESTION_LIMIT_MAX);
+
+const gitDirectorySuggestionQuerySchema = z
+  .string()
+  .trim()
+  .min(2)
+  .max(GIT_DIRECTORY_SUGGESTION_QUERY_MAX_LENGTH);
+
+export const gitDirectorySuggestionsRequestSchema = z.discriminatedUnion(
+  "mode",
+  [
+    z
+      .object({
+        mode: z.literal("children"),
+        parentPath: z.string().min(1),
+        query: z
+          .string()
+          .trim()
+          .max(GIT_DIRECTORY_SUGGESTION_QUERY_MAX_LENGTH)
+          .optional(),
+        limit: gitDirectorySuggestionLimitSchema,
+      })
+      .strict(),
+    z
+      .object({
+        mode: z.literal("known-roots"),
+        query: gitDirectorySuggestionQuerySchema,
+        limit: gitDirectorySuggestionLimitSchema,
+      })
+      .strict(),
+  ],
+);
+export type GitDirectorySuggestionsRequest = z.infer<
+  typeof gitDirectorySuggestionsRequestSchema
+>;
+
+export const gitDirectorySuggestionsResponseSchema = z.object({
+  directories: z.array(gitDirectorySuggestionSchema),
+  truncated: z.boolean(),
+});
+export type GitDirectorySuggestionsResponse = z.infer<
+  typeof gitDirectorySuggestionsResponseSchema
+>;
+
 export const hostPlatformSchema = z.enum(["darwin", "linux", "wsl", "unknown"]);
 export type HostPlatform = z.infer<typeof hostPlatformSchema>;
 
@@ -240,6 +299,12 @@ export type HostDaemonLocalSchema = {
   };
   "/paths/exist": {
     $post: Endpoint<{ json: PathsExistRequest }, PathsExistResponse>;
+  };
+  "/paths/git-directories": {
+    $post: Endpoint<
+      { json: GitDirectorySuggestionsRequest },
+      GitDirectorySuggestionsResponse
+    >;
   };
   "/status": {
     $get: Endpoint<EmptyInput, StatusResponse>;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -587,6 +587,69 @@ describe("host-daemon local schemas", () => {
       }),
     ).toThrow();
   });
+
+  it("parses git directory suggestion routes", () => {
+    expect(
+      contract.gitDirectorySuggestionsRequestSchema.parse({
+        mode: "known-roots",
+        query: "bb",
+        limit: 10,
+      }),
+    ).toEqual({
+      mode: "known-roots",
+      query: "bb",
+      limit: 10,
+    });
+
+    expect(
+      contract.gitDirectorySuggestionsRequestSchema.parse({
+        mode: "children",
+        parentPath: "/root/Projects",
+        query: "bb",
+        limit: 10,
+      }),
+    ).toEqual({
+      mode: "children",
+      parentPath: "/root/Projects",
+      query: "bb",
+      limit: 10,
+    });
+
+    expect(
+      contract.gitDirectorySuggestionsResponseSchema.parse({
+        directories: [{ path: "/root/Projects/bb", name: "bb" }],
+        truncated: false,
+      }),
+    ).toEqual({
+      directories: [{ path: "/root/Projects/bb", name: "bb" }],
+      truncated: false,
+    });
+  });
+
+  it("rejects malformed git directory suggestion payloads", () => {
+    expect(() =>
+      contract.gitDirectorySuggestionsRequestSchema.parse({
+        mode: "known-roots",
+        query: "b",
+        limit: 10,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      contract.gitDirectorySuggestionsRequestSchema.parse({
+        mode: "children",
+        parentPath: "/root/Projects",
+        limit: contract.GIT_DIRECTORY_SUGGESTION_LIMIT_MAX + 1,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      contract.gitDirectorySuggestionsResponseSchema.parse({
+        directories: [{ path: "", name: "bb" }],
+        truncated: false,
+      }),
+    ).toThrow();
+  });
 });
 
 describe("host-daemon command schemas", () => {


### PR DESCRIPTION
## Summary
- add a local daemon `/paths/git-directories` endpoint for git repo directory suggestions
- build the known-root repo index lazily on first request, scanning max depth 2 from the host home directory and pruning hidden/package folders
- wire fallback Add project path entry to show git repo suggestions when the native folder picker is unavailable

## Validation
- pnpm exec turbo run test --filter=@bb/host-daemon-contract -- local
- pnpm exec turbo run test --filter=@bb/host-daemon -- local-api
- pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/app

## Notes
- The dev app launcher could not be run in this container because `scripts/bb-dev-app` uses `/bin/zsh`, which is unavailable here.