### PR TITLE
[codex] Fix mobile drawer browser first show

### DIFF
--- a/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
@@ -41,11 +41,12 @@ export interface BrowserTabContentProps {
   tabId: string;
   initialUrl: string;
   /**
-   * Whether this browser tab is the visible, active panel tab. The native view
+   * Whether this browser tab's native view may be visible. The native view
    * stays attached (and its page intact) across deactivation; only its
-   * visibility follows this flag, so switching tabs never destroys/reloads it.
+   * visibility follows this readiness-gated flag, so switching tabs never
+   * destroys/reloads it.
    */
-  isActive: boolean;
+  canShowNativeBrowserView: boolean;
   /**
    * Deck-owned coordinator that serializes view visibility so the previously
    * shown view is always hidden before this one is shown (no two native overlays
@@ -90,6 +91,12 @@ interface BrowserViewBoundsEqualArgs {
 
 interface SyncBrowserViewPlacementArgs {
   force: boolean;
+}
+
+interface BrowserViewAttachIdentity {
+  environmentId: string | null;
+  tabId: string;
+  threadId: string;
 }
 
 const EMPTY_BROWSER_VIEW_BOUNDS: BbDesktopBrowserViewBounds = {
@@ -290,7 +297,7 @@ function BrowserUnavailable() {
 export function BrowserTabContent({
   tabId,
   initialUrl,
-  isActive,
+  canShowNativeBrowserView,
   visibilityCoordinator,
   environmentId,
   threadId,
@@ -327,10 +334,13 @@ export function BrowserTabContent({
   // (which updates the persisted `initialUrl` prop) never re-runs the attach
   // effect — and the live view keeps its page across tab switches.
   const initialUrlRef = useRef(initialUrl);
-  // Mount-time active state, read by the create-once attach effect without
-  // re-running it when activeness later changes (the visibility effect owns that).
-  const isActiveRef = useRef(isActive);
-  isActiveRef.current = isActive;
+  const [attachedBrowserViewIdentity, setAttachedBrowserViewIdentity] =
+    useState<BrowserViewAttachIdentity | null>(null);
+  const isBrowserViewAttached =
+    attachedBrowserViewIdentity !== null &&
+    attachedBrowserViewIdentity.environmentId === environmentId &&
+    attachedBrowserViewIdentity.tabId === tabId &&
+    attachedBrowserViewIdentity.threadId === threadId;
 
   const hasPage = currentUrl.length > 0;
   // A blocking modal (e.g. the git-action dialog) dims the panel with a DOM
@@ -416,9 +426,11 @@ export function BrowserTabContent({
       tabId,
       url: mountUrl,
       bounds: initialBounds,
-      // The active tab's view starts visible only while the panel is open.
-      visible: isActiveRef.current && mountUrl.length > 0,
+      // First show is coordinator-owned so it can sync bounds immediately
+      // before making the native overlay visible.
+      visible: false,
     });
+    setAttachedBrowserViewIdentity({ environmentId, tabId, threadId });
 
     const unsubscribe = desktopBrowser.onState((nextState) => {
       if (nextState.tabId !== tabId) {
@@ -510,14 +522,17 @@ export function BrowserTabContent({
     };
   }, [desktopBrowser, syncBoundsIfChanged]);
 
-  // The native view is shown whenever this tab is the active panel tab and has a
-  // page. It is NOT hidden during a drag-resize — the overlay tracks the live
-  // bounds (see the ResizeObserver and layout-sync effects) so it follows
-  // the panel smoothly instead of blanking and flashing. It stays attached when
-  // hidden, so deactivation never reloads it. (Collapse/expand of the panel
-  // toggles `isActive`, which hides the view outright rather than chasing a
-  // CSS transition the overlay cannot clip to.)
-  const isViewVisible = isActive && hasPage && !isBrowserDimmingModalOpen;
+  // The native view is shown whenever this tab has a page, has attached hidden,
+  // and the surrounding panel/drawer is ready for the native overlay. It is NOT
+  // hidden during a drag-resize — the overlay tracks the live bounds (see the
+  // ResizeObserver and layout-sync effects) so it follows the panel smoothly
+  // instead of blanking and flashing. It stays attached when hidden, so
+  // deactivation never reloads it.
+  const isViewVisible =
+    canShowNativeBrowserView &&
+    hasPage &&
+    isBrowserViewAttached &&
+    !isBrowserDimmingModalOpen;
   // A layout effect (pre-paint) declares visibility so showing/hiding lands in
   // the same frame as the DOM tab swap — no flash. Ordering across tabs (hide
   // the previously-visible view BEFORE showing this one) and bounds-before-show

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type {
+  BbDesktopBrowserApi,
+  BbDesktopBrowserAttachRequest,
+  BbDesktopBrowserSetBoundsRequest,
+  BbDesktopBrowserSetVisibleRequest,
+} from "@bb/desktop-contract";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { BrowserFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
+import {
+  createBbDesktopApi,
+  createNoopDesktopBrowserApi,
+} from "@/test/bb-desktop-test-utils";
+import { BrowserTabDeck } from "./BrowserTabDeck";
+import { resetBrowserViewPersistence } from "./browserViewVisibilityCoordinator";
+
+type BrowserCall =
+  | { type: "attach"; request: BbDesktopBrowserAttachRequest }
+  | { type: "setBounds"; request: BbDesktopBrowserSetBoundsRequest }
+  | { type: "setVisible"; request: BbDesktopBrowserSetVisibleRequest };
+
+interface RecordingBrowserApi {
+  api: BbDesktopBrowserApi;
+  calls: BrowserCall[];
+  attachments: BbDesktopBrowserAttachRequest[];
+  bounds: BbDesktopBrowserSetBoundsRequest[];
+  visibility: BbDesktopBrowserSetVisibleRequest[];
+}
+
+const BROWSER_PANEL_RECT = new DOMRect(12, 24, 420, 260);
+
+const desktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos" as const,
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.0-test",
+};
+
+function makeBrowserTab(id: string, url: string): BrowserFixedPanelTab {
+  return {
+    environmentId: "env-1",
+    id,
+    kind: "browser",
+    title: null,
+    url,
+  };
+}
+
+function createRecordingBrowserApi(): RecordingBrowserApi {
+  const calls: BrowserCall[] = [];
+  const attachments: BbDesktopBrowserAttachRequest[] = [];
+  const bounds: BbDesktopBrowserSetBoundsRequest[] = [];
+  const visibility: BbDesktopBrowserSetVisibleRequest[] = [];
+  const api: BbDesktopBrowserApi = {
+    ...createNoopDesktopBrowserApi(),
+    attach(request) {
+      attachments.push(request);
+      calls.push({ type: "attach", request });
+    },
+    setBounds(request) {
+      bounds.push(request);
+      calls.push({ type: "setBounds", request });
+    },
+    setVisible(request) {
+      visibility.push(request);
+      calls.push({ type: "setVisible", request });
+    },
+  };
+  return { api, calls, attachments, bounds, visibility };
+}
+
+function installDesktopBrowser(api: BbDesktopBrowserApi): void {
+  window.bbDesktop = createBbDesktopApi(desktopInfo, api);
+}
+
+function renderBrowserDeck({
+  canShowNativeBrowserView,
+}: {
+  canShowNativeBrowserView: boolean;
+}) {
+  const tab = makeBrowserTab("tab-url", "https://example.com");
+  return render(
+    <BrowserTabDeck
+      browserTabs={[tab]}
+      activeBrowserTabId={tab.id}
+      environmentId="env-1"
+      canShowNativeBrowserView={canShowNativeBrowserView}
+      threadId="thread-1"
+      onUpdate={() => {}}
+    />,
+  );
+}
+
+function callIndex(
+  calls: readonly BrowserCall[],
+  predicate: (call: BrowserCall) => boolean,
+): number {
+  return calls.findIndex(predicate);
+}
+
+describe("BrowserTabDeck native browser first-show ordering", () => {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+  beforeEach(() => {
+    Object.defineProperty(Element.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => BROWSER_PANEL_RECT,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetBrowserViewPersistence();
+    window.localStorage.clear();
+    delete window.bbDesktop;
+    Object.defineProperty(Element.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: originalGetBoundingClientRect,
+    });
+  });
+
+  it("attaches a URL-bearing tab hidden and shows only after attach plus compact readiness", async () => {
+    const { api, calls, attachments, bounds, visibility } =
+      createRecordingBrowserApi();
+    installDesktopBrowser(api);
+
+    const view = renderBrowserDeck({ canShowNativeBrowserView: false });
+
+    await waitFor(() => {
+      expect(attachments).toHaveLength(1);
+    });
+
+    expect(attachments[0]).toEqual({
+      tabId: "tab-url",
+      url: "https://example.com",
+      bounds: { x: 12, y: 24, width: 420, height: 260 },
+      visible: false,
+    });
+    expect(visibility.some((request) => request.visible)).toBe(false);
+    expect(bounds).toHaveLength(0);
+
+    view.rerender(
+      <BrowserTabDeck
+        browserTabs={[makeBrowserTab("tab-url", "https://example.com")]}
+        activeBrowserTabId="tab-url"
+        environmentId="env-1"
+        canShowNativeBrowserView={true}
+        threadId="thread-1"
+        onUpdate={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(visibility.some((request) => request.visible)).toBe(true);
+    });
+
+    const attachIndex = callIndex(calls, (call) => call.type === "attach");
+    const boundsIndex = callIndex(
+      calls,
+      (call) =>
+        call.type === "setBounds" && call.request.tabId === "tab-url",
+    );
+    const showIndex = callIndex(
+      calls,
+      (call) =>
+        call.type === "setVisible" &&
+        call.request.tabId === "tab-url" &&
+        call.request.visible,
+    );
+
+    expect(attachIndex).toBeGreaterThanOrEqual(0);
+    expect(boundsIndex).toBeGreaterThan(attachIndex);
+    expect(showIndex).toBeGreaterThan(boundsIndex);
+    expect(bounds.at(-1)).toEqual({
+      tabId: "tab-url",
+      bounds: { x: 12, y: 24, width: 420, height: 260 },
+    });
+    expect(visibility.at(-1)).toEqual({ tabId: "tab-url", visible: true });
+  });
+});

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
@@ -124,7 +124,7 @@ describe("BrowserTabDeck native browser first-show ordering", () => {
     });
   });
 
-  it("attaches a URL-bearing tab hidden and shows only after attach plus compact readiness", async () => {
+  it("attaches a URL-bearing tab hidden and shows only after attach plus compact drawer readiness", async () => {
     const { api, calls, attachments, bounds, visibility } =
       createRecordingBrowserApi();
     installDesktopBrowser(api);

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.stories.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.stories.tsx
@@ -86,7 +86,7 @@ function BrowserTabStage({ tab, threadId }: BrowserTabStageProps) {
       <BrowserTabDeck
         browserTabs={[tab]}
         activeBrowserTabId={tab.id}
-        isPanelOpen
+        canShowNativeBrowserView
         threadId={threadId}
         environmentId={null}
         onUpdate={noop}

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.tsx
@@ -12,8 +12,12 @@ export interface BrowserTabDeckProps {
   browserTabs: readonly BrowserFixedPanelTab[];
   activeBrowserTabId: string | null;
   environmentId: string | null;
-  /** Whether the secondary panel is open; gates the active view's visibility. */
-  isPanelOpen: boolean;
+  /**
+   * Readiness-gated permission for the active native browser view to become
+   * visible. Wide layout passes logical panel-open state; compact layout waits
+   * for drawer animation completion plus the post-open bounds sync.
+   */
+  canShowNativeBrowserView: boolean;
   threadId: string;
   onUpdate: (args: UpdateBrowserTabArgs) => void;
 }
@@ -68,7 +72,7 @@ export function BrowserTabDeck({
   browserTabs,
   activeBrowserTabId,
   environmentId,
-  isPanelOpen,
+  canShowNativeBrowserView,
   threadId,
   onUpdate,
 }: BrowserTabDeckProps) {
@@ -113,7 +117,7 @@ export function BrowserTabDeck({
         key={activeBrowserTab.id}
         tabId={activeBrowserTab.id}
         initialUrl={activeBrowserTab.url}
-        isActive={isPanelOpen}
+        canShowNativeBrowserView={canShowNativeBrowserView}
         visibilityCoordinator={visibilityCoordinator}
         environmentId={environmentId}
         threadId={threadId}

--- a/apps/app/src/components/secondary-panel/browserViewVisibilityCoordinator.ts
+++ b/apps/app/src/components/secondary-panel/browserViewVisibilityCoordinator.ts
@@ -17,7 +17,8 @@ export interface BrowserViewVisibilityCoordinator {
   /**
    * Make `tabId` the single visible view: hide whichever other tab is currently
    * visible, then sync bounds and show this one (bounds before show so it never
-   * appears at stale/zero bounds).
+   * appears at stale/zero bounds). `BrowserTabContent` calls this only after the
+   * hidden attach has been issued, making this the first-show path too.
    */
   show(tabId: string, syncBounds: () => void): void;
   /** Hide `tabId`'s view (no-op overlay-wise if it was already hidden). */

--- a/apps/app/src/components/ui/responsive-overlay.test.tsx
+++ b/apps/app/src/components/ui/responsive-overlay.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import type {
+  AnimationEvent as ReactAnimationEvent,
+  HTMLAttributes,
+  ReactNode,
+} from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ResponsiveDrawerShell } from "./responsive-overlay";
+
+type CapturedAnimationEnd = (args: {
+  currentTarget: HTMLElement;
+  target: EventTarget;
+}) => void;
+
+const drawerContentState = vi.hoisted(() => ({
+  fireAnimationEnd: undefined as CapturedAnimationEnd | undefined,
+}));
+
+vi.mock("./drawer.js", async () => {
+  const React = await import("react");
+
+  const Drawer = ({ children }: { children: ReactNode }) =>
+    React.createElement("div", { "data-testid": "drawer" }, children);
+
+  const DrawerContent = React.forwardRef<
+    HTMLDivElement,
+    HTMLAttributes<HTMLDivElement>
+  >(({ children, onAnimationEnd, ...props }, ref) => {
+    drawerContentState.fireAnimationEnd = ({ currentTarget, target }) => {
+      onAnimationEnd?.({
+        currentTarget,
+        target,
+      } as ReactAnimationEvent<HTMLDivElement>);
+    };
+
+    return React.createElement(
+      "div",
+      { ...props, ref, "data-testid": "drawer-content" },
+      children,
+    );
+  });
+  DrawerContent.displayName = "MockDrawerContent";
+
+  const DrawerTitle = ({
+    children,
+    ...props
+  }: HTMLAttributes<HTMLHeadingElement>) =>
+    React.createElement("h2", props, children);
+
+  return { Drawer, DrawerContent, DrawerTitle };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  drawerContentState.fireAnimationEnd = undefined;
+});
+
+function fireDrawerContentAnimationEnd(target: EventTarget) {
+  const fireAnimationEnd = drawerContentState.fireAnimationEnd;
+  if (fireAnimationEnd === undefined) {
+    throw new Error("DrawerContent did not receive an animation handler");
+  }
+  fireAnimationEnd({
+    currentTarget: screen.getByTestId("drawer-content"),
+    target,
+  });
+}
+
+describe("ResponsiveDrawerShell", () => {
+  it("forwards own content animation completion and ignores bubbled child animation events", () => {
+    const onContentAnimationEnd = vi.fn();
+
+    render(
+      <ResponsiveDrawerShell
+        open={true}
+        onOpenChange={() => {}}
+        onContentAnimationEnd={onContentAnimationEnd}
+      >
+        <div data-testid="animated-child" />
+      </ResponsiveDrawerShell>,
+    );
+
+    fireDrawerContentAnimationEnd(screen.getByTestId("animated-child"));
+    expect(onContentAnimationEnd).not.toHaveBeenCalled();
+
+    fireDrawerContentAnimationEnd(screen.getByTestId("drawer-content"));
+    expect(onContentAnimationEnd).toHaveBeenCalledTimes(1);
+    expect(onContentAnimationEnd).toHaveBeenCalledWith(true);
+  });
+
+  it("reports closed content animation completion with the current closed state", () => {
+    const onContentAnimationEnd = vi.fn();
+
+    render(
+      <ResponsiveDrawerShell
+        open={false}
+        onOpenChange={() => {}}
+        onContentAnimationEnd={onContentAnimationEnd}
+      >
+        <div />
+      </ResponsiveDrawerShell>,
+    );
+
+    fireDrawerContentAnimationEnd(screen.getByTestId("drawer-content"));
+    expect(onContentAnimationEnd).toHaveBeenCalledTimes(1);
+    expect(onContentAnimationEnd).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/app/src/components/ui/responsive-overlay.tsx
+++ b/apps/app/src/components/ui/responsive-overlay.tsx
@@ -223,6 +223,8 @@ interface ResponsiveDrawerShellProps {
    * parent drawer cannot distinguish a nested drawer's focused input.
    */
   repositionInputs?: boolean;
+  /** Called when the DrawerContent element's own animation completes. */
+  onContentAnimationEnd?: (open: boolean) => void;
   children: React.ReactNode;
 }
 
@@ -233,6 +235,7 @@ export function ResponsiveDrawerShell({
   contentClassName,
   handleOnly,
   repositionInputs,
+  onContentAnimationEnd,
   children,
 }: ResponsiveDrawerShellProps) {
   const parentDrawerDepth = React.useContext(ResponsiveDrawerDepthContext);
@@ -252,6 +255,16 @@ export function ResponsiveDrawerShell({
     },
     [onOpenChange, resetClosingKeyboardState],
   );
+  const handleContentAnimationEnd =
+    React.useCallback<React.AnimationEventHandler<HTMLDivElement>>(
+      (event) => {
+        if (event.currentTarget !== event.target) {
+          return;
+        }
+        onContentAnimationEnd?.(open);
+      },
+      [onContentAnimationEnd, open],
+    );
   const previousOpenRef = React.useRef(open);
 
   React.useLayoutEffect(() => {
@@ -269,7 +282,11 @@ export function ResponsiveDrawerShell({
       nested={isNestedDrawer}
       repositionInputs={shouldRepositionInputs}
     >
-      <DrawerContent ref={drawerContentRef} className={contentClassName}>
+      <DrawerContent
+        ref={drawerContentRef}
+        className={contentClassName}
+        onAnimationEnd={handleContentAnimationEnd}
+      >
         <ResponsiveDrawerDepthContext.Provider value={parentDrawerDepth + 1}>
           {srLabel !== undefined ? (
             <DrawerTitle className="sr-only">{srLabel}</DrawerTitle>

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -85,30 +85,39 @@ vi.mock("@/components/ui/responsive-overlay.js", async () => {
   return { ResponsiveDrawerShell };
 });
 
-vi.mock("@/components/secondary-panel/ThreadMetadataContent", async () => {
+vi.mock("@/components/secondary-panel/ThreadMetadataContent", async (importOriginal) => {
   const React = await import("react");
+  const actual =
+    await importOriginal<
+      typeof import("@/components/secondary-panel/ThreadMetadataContent")
+    >();
 
   return {
-    ThreadMetadataCard: ({ children }: { children?: ReactNode }) =>
+    ...actual,
+    ThreadMetadataCard: ({
+      children,
+    }: ComponentProps<typeof actual.ThreadMetadataCard>) =>
       React.createElement("div", { "data-testid": "metadata-card" }, children),
-    ThreadMetadataContent: () =>
+    ThreadMetadataContent: (
+      _props: ComponentProps<typeof actual.ThreadMetadataContent>,
+    ) =>
       React.createElement("div", { "data-testid": "metadata-content" }),
     hasAnyThreadMetadata: () => false,
   };
 });
 
-vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async () => {
+vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async (importOriginal) => {
   const React = await import("react");
+  const actual =
+    await importOriginal<
+      typeof import("@/components/secondary-panel/ThreadSecondaryPanel")
+    >();
 
   const ThreadSecondaryPanel = ({
     browserDeck,
     isOpen,
     renderAsDrawer,
-  }: {
-    browserDeck?: ReactNode;
-    isOpen: boolean;
-    renderAsDrawer: boolean;
-  }) =>
+  }: ComponentProps<typeof actual.ThreadSecondaryPanel>) =>
     React.createElement(
       "section",
       {
@@ -120,7 +129,7 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async () => {
       browserDeck,
     );
 
-  return { ThreadSecondaryPanel };
+  return { ...actual, ThreadSecondaryPanel };
 });
 
 vi.mock("@/components/secondary-panel/ConversationCollapsedRail", async () => {
@@ -134,16 +143,20 @@ vi.mock("@/components/secondary-panel/ConversationCollapsedRail", async () => {
   return { ConversationCollapsedRail };
 });
 
-vi.mock("./ThreadTimelinePane", async () => {
+vi.mock("./ThreadTimelinePane", async (importOriginal) => {
   const React = await import("react");
+  const actual =
+    await importOriginal<typeof import("./ThreadTimelinePane")>();
 
-  const ThreadTimelinePane = ({ threadId }: { threadId: string }) =>
+  const ThreadTimelinePane = ({
+    threadId,
+  }: ComponentProps<typeof actual.ThreadTimelinePane>) =>
     React.createElement("div", {
       "data-testid": "thread-timeline-pane",
       "data-thread-id": threadId,
     });
 
-  return { ThreadTimelinePane };
+  return { ...actual, ThreadTimelinePane };
 });
 
 interface QueuedAnimationFrames {
@@ -225,7 +238,7 @@ function makeThread(
     title: null,
     titleFallback: "Test thread",
     updatedAt: 0,
-  };
+  } as ThreadDetailSecondaryContentProps["metadata"]["thread"];
 }
 
 function createBrowserDeckRenderer(order?: string[]): RenderBrowserDeck {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -1,0 +1,607 @@
+// @vitest-environment jsdom
+
+import type { ComponentProps, ReactNode } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompactViewportOverrideProvider } from "@/components/ui/hooks/use-compact-viewport.js";
+import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import { ThreadDetailSecondaryContent } from "./ThreadDetailSecondaryContent";
+
+type ThreadDetailSecondaryContentProps = ComponentProps<
+  typeof ThreadDetailSecondaryContent
+>;
+type RenderBrowserDeck = NonNullable<
+  ThreadDetailSecondaryContentProps["secondaryPanel"]["renderBrowserDeck"]
+>;
+type DrawerShellCallback = (open: boolean) => void;
+
+const drawerShellState = vi.hoisted(() => ({
+  onContentAnimationEnd: undefined as DrawerShellCallback | undefined,
+}));
+
+vi.mock("@/lib/browser-view-bounds-sync", () => ({
+  dispatchBrowserViewBoundsSync: vi.fn(),
+}));
+
+vi.mock("@/lib/bb-desktop", () => ({
+  getBbDesktopInfo: () => null,
+  shouldUseMacosDesktopChrome: () => false,
+}));
+
+vi.mock("@/components/ui/sidebar.js", () => ({
+  useOptionalIsSidebarShowing: () => true,
+}));
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => 50,
+}));
+
+vi.mock("react-resizable-panels", async () => {
+  const React = await import("react");
+
+  const PanelGroup = React.forwardRef<
+    { setLayout: (layout: number[]) => void },
+    { children?: ReactNode }
+  >(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => ({ setLayout: () => {} }), []);
+    return React.createElement(
+      "div",
+      { "data-testid": "panel-group" },
+      children,
+    );
+  });
+  PanelGroup.displayName = "MockPanelGroup";
+
+  const Panel = ({ children }: { children?: ReactNode }) =>
+    React.createElement("div", { "data-testid": "panel" }, children);
+
+  return { Panel, PanelGroup };
+});
+
+vi.mock("@/components/ui/responsive-overlay.js", async () => {
+  const React = await import("react");
+
+  const ResponsiveDrawerShell = ({
+    children,
+    onContentAnimationEnd,
+    open,
+  }: {
+    children?: ReactNode;
+    onContentAnimationEnd?: DrawerShellCallback;
+    open: boolean;
+  }) => {
+    drawerShellState.onContentAnimationEnd = onContentAnimationEnd;
+    return React.createElement(
+      "div",
+      {
+        "data-open": String(open),
+        "data-testid": "responsive-drawer-shell",
+      },
+      children,
+    );
+  };
+
+  return { ResponsiveDrawerShell };
+});
+
+vi.mock("@/components/secondary-panel/ThreadMetadataContent", async () => {
+  const React = await import("react");
+
+  return {
+    ThreadMetadataCard: ({ children }: { children?: ReactNode }) =>
+      React.createElement("div", { "data-testid": "metadata-card" }, children),
+    ThreadMetadataContent: () =>
+      React.createElement("div", { "data-testid": "metadata-content" }),
+    hasAnyThreadMetadata: () => false,
+  };
+});
+
+vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async () => {
+  const React = await import("react");
+
+  const ThreadSecondaryPanel = ({
+    browserDeck,
+    isOpen,
+    renderAsDrawer,
+  }: {
+    browserDeck?: ReactNode;
+    isOpen: boolean;
+    renderAsDrawer: boolean;
+  }) =>
+    React.createElement(
+      "section",
+      {
+        "data-open": String(isOpen),
+        "data-testid": renderAsDrawer
+          ? "drawer-secondary-panel"
+          : "inline-secondary-panel",
+      },
+      browserDeck,
+    );
+
+  return { ThreadSecondaryPanel };
+});
+
+vi.mock("@/components/secondary-panel/ConversationCollapsedRail", async () => {
+  const React = await import("react");
+
+  const ConversationCollapsedRail = () =>
+    React.createElement("div", {
+      "data-testid": "conversation-collapsed-rail",
+    });
+
+  return { ConversationCollapsedRail };
+});
+
+vi.mock("./ThreadTimelinePane", async () => {
+  const React = await import("react");
+
+  const ThreadTimelinePane = ({ threadId }: { threadId: string }) =>
+    React.createElement("div", {
+      "data-testid": "thread-timeline-pane",
+      "data-thread-id": threadId,
+    });
+
+  return { ThreadTimelinePane };
+});
+
+interface QueuedAnimationFrames {
+  cancelAnimationFrame: ReturnType<typeof vi.spyOn>;
+  flushAll: () => void;
+  requestAnimationFrame: ReturnType<typeof vi.spyOn>;
+  size: () => number;
+}
+
+interface RenderThreadDetailArgs {
+  isCompactViewport: boolean;
+  isSecondaryPanelOpen: boolean;
+  renderBrowserDeck: RenderBrowserDeck;
+  threadId: string;
+}
+
+const noop = () => {};
+
+function installAnimationFrameQueue(order?: string[]): QueuedAnimationFrames {
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let nextFrameId = 1;
+
+  Object.defineProperty(window, "requestAnimationFrame", {
+    configurable: true,
+    value: noop,
+  });
+  Object.defineProperty(window, "cancelAnimationFrame", {
+    configurable: true,
+    value: noop,
+  });
+
+  const requestAnimationFrame = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => {
+      const frameId = nextFrameId;
+      nextFrameId += 1;
+      callbacks.set(frameId, callback);
+      order?.push("requestAnimationFrame");
+      return frameId;
+    });
+  const cancelAnimationFrame = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation((frameId) => {
+      callbacks.delete(frameId);
+    });
+
+  return {
+    cancelAnimationFrame,
+    flushAll() {
+      const pendingCallbacks = [...callbacks.entries()];
+      callbacks.clear();
+      for (const [, callback] of pendingCallbacks) {
+        callback(performance.now());
+      }
+    },
+    requestAnimationFrame,
+    size: () => callbacks.size,
+  };
+}
+
+function makeThread(
+  threadId: string,
+): ThreadDetailSecondaryContentProps["metadata"]["thread"] {
+  return {
+    archivedAt: null,
+    automationId: null,
+    createdAt: 0,
+    deletedAt: null,
+    environmentId: null,
+    id: threadId,
+    lastReadAt: null,
+    latestAttentionAt: 0,
+    parentThreadId: null,
+    pinnedAt: null,
+    projectId: "proj-test",
+    providerId: "codex",
+    status: "idle",
+    stopRequestedAt: null,
+    title: null,
+    titleFallback: "Test thread",
+    updatedAt: 0,
+  };
+}
+
+function createBrowserDeckRenderer(order?: string[]): RenderBrowserDeck {
+  return vi.fn(({ canShowNativeBrowserView }) => {
+    order?.push(`render:${String(canShowNativeBrowserView)}`);
+    return (
+      <div
+        data-can-show-native-browser-view={String(canShowNativeBrowserView)}
+        data-testid="browser-deck"
+      />
+    );
+  });
+}
+
+function createProps({
+  isSecondaryPanelOpen,
+  renderBrowserDeck,
+  threadId,
+}: Omit<
+  RenderThreadDetailArgs,
+  "isCompactViewport"
+>): ThreadDetailSecondaryContentProps {
+  return {
+    footer: <div data-testid="footer" />,
+    header: <div data-testid="header" />,
+    isConversationCollapsed: false,
+    isMetadataLoading: false,
+    isSecondaryPanelOpen,
+    metadata: {
+      canAssignToParent: false,
+      canTakeOverThread: false,
+      environment: null,
+      environmentDisplayHost: { locality: "local" },
+      isLoadingMergeBaseBranchOptions: false,
+      mergeBaseBranchOptions: undefined,
+      onAssignParent: noop,
+      onMergeBaseBranchChange: noop,
+      parentThreadDisplayName: null,
+      parentThreads: [],
+      projectId: "proj-test",
+      pullRequest: null,
+      selectedMergeBaseBranch: undefined,
+      thread: makeThread(threadId),
+      threadSchedules: [],
+      updateThreadPending: false,
+      workspaceStatus: undefined,
+      workspaceStatusError: null,
+    },
+    onToggleConversationCollapse: noop,
+    secondaryPanel: {
+      activeTab: null,
+      canUseGitUi: false,
+      fileTabs: [],
+      isBrowserTabActive: true,
+      isOpen: isSecondaryPanelOpen,
+      onCollapse: noop,
+      onClose: noop,
+      onFileTabReorder: noop,
+      onOpenNewTab: noop,
+      onPanelChange: noop,
+      onPanelFocus: noop,
+      renderBrowserDeck,
+      showGitDiffTab: false,
+    },
+    surface: "page",
+    timeline: {
+      activeThinking: null,
+      hasOlderTimelineRows: false,
+      isLoadingOlderTimelineRows: false,
+      isThreadTimelinePending: false,
+      onLoadOlderRows: noop,
+      resolveMentionLink: () => null,
+      showOngoingIndicator: false,
+      stopRequestedAt: null,
+      threadId,
+      threadRuntimeDisplayStatus: "idle",
+      timelineError: false,
+      timelineRows: [],
+      unreadDividerAutoScroll: false,
+      unreadDividerPlacement: null,
+      workspaceRootPath: undefined,
+    },
+  };
+}
+
+function renderThreadDetail(args: RenderThreadDetailArgs) {
+  let renderArgs = args;
+  const view = render(
+    <CompactViewportOverrideProvider
+      isCompactViewport={renderArgs.isCompactViewport}
+    >
+      <ThreadDetailSecondaryContent
+        {...createProps({
+          isSecondaryPanelOpen: renderArgs.isSecondaryPanelOpen,
+          renderBrowserDeck: renderArgs.renderBrowserDeck,
+          threadId: renderArgs.threadId,
+        })}
+      />
+    </CompactViewportOverrideProvider>,
+  );
+
+  return {
+    ...view,
+    rerenderWith(nextArgs: Partial<RenderThreadDetailArgs>) {
+      renderArgs = { ...renderArgs, ...nextArgs };
+      view.rerender(
+        <CompactViewportOverrideProvider
+          isCompactViewport={renderArgs.isCompactViewport}
+        >
+          <ThreadDetailSecondaryContent
+            {...createProps({
+              isSecondaryPanelOpen: renderArgs.isSecondaryPanelOpen,
+              renderBrowserDeck: renderArgs.renderBrowserDeck,
+              threadId: renderArgs.threadId,
+            })}
+          />
+        </CompactViewportOverrideProvider>,
+      );
+    },
+  };
+}
+
+function expectBrowserDeckVisibility(canShowNativeBrowserView: boolean) {
+  expect(
+    screen
+      .getByTestId("browser-deck")
+      .getAttribute("data-can-show-native-browser-view"),
+  ).toBe(String(canShowNativeBrowserView));
+}
+
+function scheduleCompactReadinessFrame() {
+  const callback = drawerShellState.onContentAnimationEnd;
+  if (callback === undefined) {
+    throw new Error("ResponsiveDrawerShell did not receive animation callback");
+  }
+  act(() => {
+    callback(true);
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  drawerShellState.onContentAnimationEnd = undefined;
+});
+
+beforeEach(() => {
+  vi.mocked(dispatchBrowserViewBoundsSync).mockReset();
+});
+
+describe("ThreadDetailSecondaryContent compact browser readiness", () => {
+  it("orders open-animation completion, rAF, bounds sync, and readiness true", () => {
+    const order: string[] = [];
+    const frames = installAnimationFrameQueue(order);
+    vi.mocked(dispatchBrowserViewBoundsSync).mockImplementation(() => {
+      order.push("dispatchBrowserViewBoundsSync");
+    });
+    const renderBrowserDeck = createBrowserDeckRenderer(order);
+
+    renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    expectBrowserDeckVisibility(false);
+
+    order.push("animationEnd:true");
+    scheduleCompactReadinessFrame();
+
+    expect(frames.requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+    expectBrowserDeckVisibility(false);
+
+    act(() => {
+      frames.flushAll();
+    });
+
+    expectBrowserDeckVisibility(true);
+    expect(order).toEqual([
+      "render:false",
+      "animationEnd:true",
+      "requestAnimationFrame",
+      "dispatchBrowserViewBoundsSync",
+      "render:true",
+    ]);
+  });
+
+  it("ignores close-animation completion without dispatching bounds sync", () => {
+    const frames = installAnimationFrameQueue();
+    const renderBrowserDeck = createBrowserDeckRenderer();
+
+    renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    const callback = drawerShellState.onContentAnimationEnd;
+    if (callback === undefined) {
+      throw new Error(
+        "ResponsiveDrawerShell did not receive animation callback",
+      );
+    }
+
+    act(() => {
+      callback(false);
+    });
+
+    expect(frames.requestAnimationFrame).not.toHaveBeenCalled();
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+    expectBrowserDeckVisibility(false);
+  });
+
+  it("does not schedule a stale open callback after the compact drawer closes", () => {
+    const frames = installAnimationFrameQueue();
+    const renderBrowserDeck = createBrowserDeckRenderer();
+    const view = renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    view.rerenderWith({ isSecondaryPanelOpen: false });
+    scheduleCompactReadinessFrame();
+
+    expect(frames.requestAnimationFrame).not.toHaveBeenCalled();
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+    expectBrowserDeckVisibility(false);
+  });
+
+  it("cancels a pending compact readiness rAF when the drawer closes", () => {
+    const frames = installAnimationFrameQueue();
+    const renderBrowserDeck = createBrowserDeckRenderer();
+    const view = renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    scheduleCompactReadinessFrame();
+    expect(frames.size()).toBe(1);
+
+    view.rerenderWith({ isSecondaryPanelOpen: false });
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledWith(1);
+
+    act(() => {
+      frames.flushAll();
+    });
+
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+    expectBrowserDeckVisibility(false);
+  });
+
+  it("cancels a pending compact readiness rAF when the thread changes", () => {
+    const frames = installAnimationFrameQueue();
+    const renderBrowserDeck = createBrowserDeckRenderer();
+    const view = renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    scheduleCompactReadinessFrame();
+    expect(frames.size()).toBe(1);
+
+    view.rerenderWith({ threadId: "thread-2" });
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledWith(1);
+
+    act(() => {
+      frames.flushAll();
+    });
+
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+    expectBrowserDeckVisibility(false);
+  });
+
+  it("cancels a pending compact readiness rAF on compact-to-wide transition", () => {
+    const frames = installAnimationFrameQueue();
+    const renderBrowserDeck = createBrowserDeckRenderer();
+    const view = renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    scheduleCompactReadinessFrame();
+    expect(frames.size()).toBe(1);
+
+    view.rerenderWith({ isCompactViewport: false });
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledWith(1);
+
+    act(() => {
+      frames.flushAll();
+    });
+
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+    expectBrowserDeckVisibility(true);
+  });
+
+  it("cancels a pending compact readiness rAF on unmount", () => {
+    const frames = installAnimationFrameQueue();
+    const renderBrowserDeck = createBrowserDeckRenderer();
+    const view = renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    scheduleCompactReadinessFrame();
+    expect(frames.size()).toBe(1);
+
+    view.unmount();
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(frames.cancelAnimationFrame).toHaveBeenCalledWith(1);
+
+    act(() => {
+      frames.flushAll();
+    });
+
+    expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+  });
+
+  it("passes compact opening and wide layout visibility values to the browser deck render prop", () => {
+    const frames = installAnimationFrameQueue();
+    vi.mocked(dispatchBrowserViewBoundsSync).mockImplementation(() => {});
+    const compactRenderBrowserDeck = createBrowserDeckRenderer();
+
+    renderThreadDetail({
+      isCompactViewport: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck: compactRenderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    expect(compactRenderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: false,
+    });
+    scheduleCompactReadinessFrame();
+    act(() => {
+      frames.flushAll();
+    });
+    expect(compactRenderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: true,
+    });
+
+    cleanup();
+
+    const wideRenderBrowserDeck = createBrowserDeckRenderer();
+    const wideView = renderThreadDetail({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: false,
+      renderBrowserDeck: wideRenderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    expect(wideRenderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: false,
+    });
+
+    wideView.rerenderWith({ isSecondaryPanelOpen: true });
+
+    expect(wideRenderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: true,
+    });
+    expect(dispatchBrowserViewBoundsSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -286,7 +286,7 @@ function createProps({
       updateThreadPending: false,
       workspaceStatus: undefined,
       workspaceStatusError: null,
-    },
+    } as ThreadDetailSecondaryContentProps["metadata"],
     onToggleConversationCollapse: noop,
     secondaryPanel: {
       activeTab: null,
@@ -320,7 +320,7 @@ function createProps({
       unreadDividerAutoScroll: false,
       unreadDividerPlacement: null,
       workspaceRootPath: undefined,
-    },
+    } as ThreadDetailSecondaryContentProps["timeline"],
   };
 }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -356,7 +356,7 @@ function expectBrowserDeckVisibility(canShowNativeBrowserView: boolean) {
   ).toBe(String(canShowNativeBrowserView));
 }
 
-function scheduleCompactReadinessFrame() {
+function scheduleCompactDrawerSettleFrame() {
   const callback = drawerShellState.onContentAnimationEnd;
   if (callback === undefined) {
     throw new Error("ResponsiveDrawerShell did not receive animation callback");
@@ -377,8 +377,8 @@ beforeEach(() => {
   vi.mocked(dispatchBrowserViewBoundsSync).mockReset();
 });
 
-describe("ThreadDetailSecondaryContent compact browser readiness", () => {
-  it("orders open-animation completion, rAF, bounds sync, and readiness true", () => {
+describe("ThreadDetailSecondaryContent compact drawer settling", () => {
+  it("orders open-animation completion, rAF, bounds sync, and drawer settled true", () => {
     const order: string[] = [];
     const frames = installAnimationFrameQueue(order);
     vi.mocked(dispatchBrowserViewBoundsSync).mockImplementation(() => {
@@ -396,7 +396,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
     expectBrowserDeckVisibility(false);
 
     order.push("animationEnd:true");
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
 
     expect(frames.requestAnimationFrame).toHaveBeenCalledTimes(1);
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
@@ -454,14 +454,14 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
     });
 
     view.rerenderWith({ isSecondaryPanelOpen: false });
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
 
     expect(frames.requestAnimationFrame).not.toHaveBeenCalled();
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
     expectBrowserDeckVisibility(false);
   });
 
-  it("cancels a pending compact readiness rAF when the drawer closes", () => {
+  it("cancels a pending compact drawer settle rAF when the drawer closes", () => {
     const frames = installAnimationFrameQueue();
     const renderBrowserDeck = createBrowserDeckRenderer();
     const view = renderThreadDetail({
@@ -471,7 +471,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
       threadId: "thread-1",
     });
 
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
     expect(frames.size()).toBe(1);
 
     view.rerenderWith({ isSecondaryPanelOpen: false });
@@ -486,7 +486,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
     expectBrowserDeckVisibility(false);
   });
 
-  it("cancels a pending compact readiness rAF when the thread changes", () => {
+  it("cancels a pending compact drawer settle rAF when the thread changes", () => {
     const frames = installAnimationFrameQueue();
     const renderBrowserDeck = createBrowserDeckRenderer();
     const view = renderThreadDetail({
@@ -496,7 +496,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
       threadId: "thread-1",
     });
 
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
     expect(frames.size()).toBe(1);
 
     view.rerenderWith({ threadId: "thread-2" });
@@ -511,7 +511,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
     expectBrowserDeckVisibility(false);
   });
 
-  it("cancels a pending compact readiness rAF on compact-to-wide transition", () => {
+  it("cancels a pending compact drawer settle rAF on compact-to-wide transition", () => {
     const frames = installAnimationFrameQueue();
     const renderBrowserDeck = createBrowserDeckRenderer();
     const view = renderThreadDetail({
@@ -521,7 +521,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
       threadId: "thread-1",
     });
 
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
     expect(frames.size()).toBe(1);
 
     view.rerenderWith({ isCompactViewport: false });
@@ -536,7 +536,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
     expectBrowserDeckVisibility(true);
   });
 
-  it("cancels a pending compact readiness rAF on unmount", () => {
+  it("cancels a pending compact drawer settle rAF on unmount", () => {
     const frames = installAnimationFrameQueue();
     const renderBrowserDeck = createBrowserDeckRenderer();
     const view = renderThreadDetail({
@@ -546,7 +546,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
       threadId: "thread-1",
     });
 
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
     expect(frames.size()).toBe(1);
 
     view.unmount();
@@ -575,7 +575,7 @@ describe("ThreadDetailSecondaryContent compact browser readiness", () => {
     expect(compactRenderBrowserDeck).toHaveBeenLastCalledWith({
       canShowNativeBrowserView: false,
     });
-    scheduleCompactReadinessFrame();
+    scheduleCompactDrawerSettleFrame();
     act(() => {
       frames.flushAll();
     });

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -320,7 +320,7 @@ function createProps({
       unreadDividerAutoScroll: false,
       unreadDividerPlacement: null,
       workspaceRootPath: undefined,
-    } as ThreadDetailSecondaryContentProps["timeline"],
+    } as unknown as ThreadDetailSecondaryContentProps["timeline"],
   };
 }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -34,6 +35,7 @@ import {
 import { ThreadTimelinePane } from "./ThreadTimelinePane";
 import { ConversationCollapsedRail } from "@/components/secondary-panel/ConversationCollapsedRail";
 import { PANEL_COLLAPSE_TRANSITION_CLASS } from "@/components/secondary-panel/panelTransitionTokens";
+import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
 
 const CLOSED_TIMELINE_PANEL_SIZE_PERCENT = 100;
 const COLLAPSED_TIMELINE_PANEL_SIZE_PERCENT = 0;
@@ -50,7 +52,12 @@ type ThreadSecondaryPanelProps = Omit<
   | "isConversationCollapsed"
   | "onToggleConversationCollapse"
   | "reserveLeftForDesktopTrafficLights"
->;
+  | "browserDeck"
+> & {
+  renderBrowserDeck?: (args: {
+    canShowNativeBrowserView: boolean;
+  }) => ReactNode;
+};
 
 interface ThreadDetailSecondaryContentProps {
   footer: ReactNode;
@@ -134,7 +141,7 @@ const areThreadSecondaryPanelPropsEqual: ThreadSecondaryPanelPropsEqual = (
   previous.workspaceRootPath === next.workspaceRootPath &&
   previous.fileTabs === next.fileTabs &&
   previous.fileTabContent === next.fileTabContent &&
-  previous.browserDeck === next.browserDeck &&
+  previous.renderBrowserDeck === next.renderBrowserDeck &&
   previous.isBrowserTabActive === next.isBrowserTabActive &&
   previous.isOpen === next.isOpen &&
   previous.showGitDiffTab === next.showGitDiffTab &&
@@ -242,6 +249,103 @@ export function ThreadDetailSecondaryContent({
   // Real, in-scope activity signal for the collapsed rail: the agent is running.
   const isConversationWorking =
     stableTimeline.threadRuntimeDisplayStatus === "active";
+  const [isCompactBrowserViewReady, setIsCompactBrowserViewReady] =
+    useState(false);
+  const compactBrowserReadinessFrameRef = useRef<number | null>(null);
+  const compactBrowserReadinessGenerationRef = useRef(0);
+  const compactBrowserReadinessStateRef = useRef({
+    isSecondaryPanelOpen,
+    renderAsDrawer,
+    threadId: stableTimeline.threadId,
+  });
+
+  useLayoutEffect(() => {
+    compactBrowserReadinessStateRef.current = {
+      isSecondaryPanelOpen,
+      renderAsDrawer,
+      threadId: stableTimeline.threadId,
+    };
+  }, [isSecondaryPanelOpen, renderAsDrawer, stableTimeline.threadId]);
+
+  const cancelCompactBrowserReadinessFrame = useCallback(() => {
+    compactBrowserReadinessGenerationRef.current += 1;
+    if (compactBrowserReadinessFrameRef.current === null) {
+      return;
+    }
+    window.cancelAnimationFrame(compactBrowserReadinessFrameRef.current);
+    compactBrowserReadinessFrameRef.current = null;
+  }, []);
+
+  useLayoutEffect(() => {
+    cancelCompactBrowserReadinessFrame();
+    setIsCompactBrowserViewReady(false);
+  }, [
+    cancelCompactBrowserReadinessFrame,
+    isSecondaryPanelOpen,
+    renderAsDrawer,
+    stableTimeline.threadId,
+  ]);
+
+  useLayoutEffect(
+    () => () => {
+      cancelCompactBrowserReadinessFrame();
+    },
+    [cancelCompactBrowserReadinessFrame],
+  );
+
+  const handleDrawerContentAnimationEnd = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        return;
+      }
+      const currentState = compactBrowserReadinessStateRef.current;
+      if (!currentState.isSecondaryPanelOpen || !currentState.renderAsDrawer) {
+        return;
+      }
+
+      cancelCompactBrowserReadinessFrame();
+      const requestGeneration = compactBrowserReadinessGenerationRef.current;
+      const requestThreadId = currentState.threadId;
+      compactBrowserReadinessFrameRef.current = window.requestAnimationFrame(
+        () => {
+          compactBrowserReadinessFrameRef.current = null;
+          const latestState = compactBrowserReadinessStateRef.current;
+          if (
+            compactBrowserReadinessGenerationRef.current !==
+              requestGeneration ||
+            latestState.threadId !== requestThreadId ||
+            !latestState.isSecondaryPanelOpen ||
+            !latestState.renderAsDrawer
+          ) {
+            return;
+          }
+
+          dispatchBrowserViewBoundsSync();
+
+          const stateAfterSync = compactBrowserReadinessStateRef.current;
+          if (
+            compactBrowserReadinessGenerationRef.current ===
+              requestGeneration &&
+            stateAfterSync.threadId === requestThreadId &&
+            stateAfterSync.isSecondaryPanelOpen &&
+            stateAfterSync.renderAsDrawer
+          ) {
+            setIsCompactBrowserViewReady(true);
+          }
+        },
+      );
+    },
+    [cancelCompactBrowserReadinessFrame],
+  );
+  const canShowNativeBrowserView = renderAsDrawer
+    ? isSecondaryPanelOpen && isCompactBrowserViewReady
+    : isSecondaryPanelOpen;
+  const { renderBrowserDeck, ...stableThreadSecondaryPanelProps } =
+    stableSecondaryPanel;
+  const browserDeck = useMemo(
+    () => renderBrowserDeck?.({ canShowNativeBrowserView }),
+    [canShowNativeBrowserView, renderBrowserDeck],
+  );
 
   const horizontalPanelGroupRef = useRef<ImperativePanelGroupHandle | null>(
     null,
@@ -291,7 +395,8 @@ export function ThreadDetailSecondaryContent({
   );
   const inlineSecondaryPanelContent = !renderAsDrawer ? (
     <ThreadSecondaryPanel
-      {...stableSecondaryPanel}
+      {...stableThreadSecondaryPanelProps}
+      browserDeck={browserDeck}
       renderAsDrawer={false}
       isConversationCollapsed={isConversationCollapsedActive}
       onToggleConversationCollapse={onToggleConversationCollapse}
@@ -305,7 +410,8 @@ export function ThreadDetailSecondaryContent({
   ) : null;
   const drawerSecondaryPanelContent = renderAsDrawer ? (
     <ThreadSecondaryPanel
-      {...stableSecondaryPanel}
+      {...stableThreadSecondaryPanelProps}
+      browserDeck={browserDeck}
       renderAsDrawer={true}
       isConversationCollapsed={false}
       onToggleConversationCollapse={onToggleConversationCollapse}
@@ -397,10 +503,11 @@ export function ThreadDetailSecondaryContent({
         <ResponsiveDrawerShell
           open={isSecondaryPanelOpen}
           onOpenChange={(open) => {
-            if (!open) stableSecondaryPanel.onClose();
+            if (!open) stableThreadSecondaryPanelProps.onClose();
           }}
           srLabel="Thread details"
           contentClassName="h-[92dvh] max-h-[92dvh]"
+          onContentAnimationEnd={handleDrawerContentAnimationEnd}
           // `handleOnly` keeps vaul from binding its pointerdown handler on
           // the drawer body. Without it, vaul calls setPointerCapture on the
           // click target, which captures the pointer on Pierre tree's host

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -249,38 +249,38 @@ export function ThreadDetailSecondaryContent({
   // Real, in-scope activity signal for the collapsed rail: the agent is running.
   const isConversationWorking =
     stableTimeline.threadRuntimeDisplayStatus === "active";
-  const [isCompactBrowserViewReady, setIsCompactBrowserViewReady] =
+  const [isCompactDrawerContentSettled, setIsCompactDrawerContentSettled] =
     useState(false);
-  const compactBrowserReadinessFrameRef = useRef<number | null>(null);
-  const compactBrowserReadinessGenerationRef = useRef(0);
-  const compactBrowserReadinessStateRef = useRef({
+  const compactDrawerContentSettleFrameRef = useRef<number | null>(null);
+  const compactDrawerContentSettleGenerationRef = useRef(0);
+  const compactDrawerContentSettleStateRef = useRef({
     isSecondaryPanelOpen,
     renderAsDrawer,
     threadId: stableTimeline.threadId,
   });
 
   useLayoutEffect(() => {
-    compactBrowserReadinessStateRef.current = {
+    compactDrawerContentSettleStateRef.current = {
       isSecondaryPanelOpen,
       renderAsDrawer,
       threadId: stableTimeline.threadId,
     };
   }, [isSecondaryPanelOpen, renderAsDrawer, stableTimeline.threadId]);
 
-  const cancelCompactBrowserReadinessFrame = useCallback(() => {
-    compactBrowserReadinessGenerationRef.current += 1;
-    if (compactBrowserReadinessFrameRef.current === null) {
+  const cancelCompactDrawerContentSettleFrame = useCallback(() => {
+    compactDrawerContentSettleGenerationRef.current += 1;
+    if (compactDrawerContentSettleFrameRef.current === null) {
       return;
     }
-    window.cancelAnimationFrame(compactBrowserReadinessFrameRef.current);
-    compactBrowserReadinessFrameRef.current = null;
+    window.cancelAnimationFrame(compactDrawerContentSettleFrameRef.current);
+    compactDrawerContentSettleFrameRef.current = null;
   }, []);
 
   useLayoutEffect(() => {
-    cancelCompactBrowserReadinessFrame();
-    setIsCompactBrowserViewReady(false);
+    cancelCompactDrawerContentSettleFrame();
+    setIsCompactDrawerContentSettled(false);
   }, [
-    cancelCompactBrowserReadinessFrame,
+    cancelCompactDrawerContentSettleFrame,
     isSecondaryPanelOpen,
     renderAsDrawer,
     stableTimeline.threadId,
@@ -288,9 +288,9 @@ export function ThreadDetailSecondaryContent({
 
   useLayoutEffect(
     () => () => {
-      cancelCompactBrowserReadinessFrame();
+      cancelCompactDrawerContentSettleFrame();
     },
-    [cancelCompactBrowserReadinessFrame],
+    [cancelCompactDrawerContentSettleFrame],
   );
 
   const handleDrawerContentAnimationEnd = useCallback(
@@ -298,20 +298,20 @@ export function ThreadDetailSecondaryContent({
       if (!open) {
         return;
       }
-      const currentState = compactBrowserReadinessStateRef.current;
+      const currentState = compactDrawerContentSettleStateRef.current;
       if (!currentState.isSecondaryPanelOpen || !currentState.renderAsDrawer) {
         return;
       }
 
-      cancelCompactBrowserReadinessFrame();
-      const requestGeneration = compactBrowserReadinessGenerationRef.current;
+      cancelCompactDrawerContentSettleFrame();
+      const requestGeneration = compactDrawerContentSettleGenerationRef.current;
       const requestThreadId = currentState.threadId;
-      compactBrowserReadinessFrameRef.current = window.requestAnimationFrame(
+      compactDrawerContentSettleFrameRef.current = window.requestAnimationFrame(
         () => {
-          compactBrowserReadinessFrameRef.current = null;
-          const latestState = compactBrowserReadinessStateRef.current;
+          compactDrawerContentSettleFrameRef.current = null;
+          const latestState = compactDrawerContentSettleStateRef.current;
           if (
-            compactBrowserReadinessGenerationRef.current !==
+            compactDrawerContentSettleGenerationRef.current !==
               requestGeneration ||
             latestState.threadId !== requestThreadId ||
             !latestState.isSecondaryPanelOpen ||
@@ -322,23 +322,23 @@ export function ThreadDetailSecondaryContent({
 
           dispatchBrowserViewBoundsSync();
 
-          const stateAfterSync = compactBrowserReadinessStateRef.current;
+          const stateAfterSync = compactDrawerContentSettleStateRef.current;
           if (
-            compactBrowserReadinessGenerationRef.current ===
+            compactDrawerContentSettleGenerationRef.current ===
               requestGeneration &&
             stateAfterSync.threadId === requestThreadId &&
             stateAfterSync.isSecondaryPanelOpen &&
             stateAfterSync.renderAsDrawer
           ) {
-            setIsCompactBrowserViewReady(true);
+            setIsCompactDrawerContentSettled(true);
           }
         },
       );
     },
-    [cancelCompactBrowserReadinessFrame],
+    [cancelCompactDrawerContentSettleFrame],
   );
   const canShowNativeBrowserView = renderAsDrawer
-    ? isSecondaryPanelOpen && isCompactBrowserViewReady
+    ? isSecondaryPanelOpen && isCompactDrawerContentSettled
     : isSecondaryPanelOpen;
   const { renderBrowserDeck, ...stableThreadSecondaryPanelProps } =
     stableSecondaryPanel;

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -120,7 +120,10 @@ import {
   useThreadStorageBrowser,
   type ThreadStoragePathSelectHandler,
 } from "@/components/secondary-panel/useThreadStorageBrowser";
-import { useThreadFileTabs } from "@/components/secondary-panel/useThreadFileTabs";
+import {
+  useThreadFileTabs,
+  type FileSearchSelection,
+} from "@/components/secondary-panel/useThreadFileTabs";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import type { SecondaryPanelFileTab } from "@/components/secondary-panel/ThreadSecondaryPanel";
 import { useEnvironmentMergeBase } from "@/components/secondary-panel/git-diff/useEnvironmentMergeBase";
@@ -587,27 +590,6 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     () => new Set(browserTabs.map((tab) => tab.id)),
     [browserTabs],
   );
-  // Popups (`window.open`/`target=_blank`) from a browser view open as a new
-  // in-panel browser tab; the native OS popup is denied in the main process.
-  useEffect(() => {
-    const browserApi = getDesktopBrowserApi();
-    if (browserApi === null) {
-      return;
-    }
-    if (browserApi.onScopedOpenTab) {
-      return browserApi.onScopedOpenTab(({ tabId, url }) => {
-        if (browserTabIds.has(tabId)) {
-          openBrowserTab(url);
-        }
-      });
-    }
-    return browserApi.onOpenTab(({ url }) => {
-      if (isRoutePath({ path: url })) {
-        return;
-      }
-      openBrowserTab(url);
-    });
-  }, [browserTabIds, openBrowserTab]);
   const isThreadRoot = isRootThread(thread);
   const shouldLoadParentThreads =
     threadQueryState.status === "ready" && isThreadRoot;
@@ -739,6 +721,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     closePanel: closeSecondaryPanel,
     isOpen: isSecondaryPanelOpen,
     openCommitDiff: openSecondaryPanelCommitDiff,
+    openCompactDrawer,
     openDiffFile: openSecondaryPanelDiffFile,
     openDiffPanel: openSecondaryPanelDiffPanel,
     openHostFile,
@@ -761,6 +744,48 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     threadId,
     togglePersistedPanel: toggleDefaultPersistedSecondaryPanel,
   });
+  const openBrowserTabAndReveal = useCallback(
+    (url?: string) => {
+      openBrowserTab(url);
+      openCompactDrawer();
+    },
+    [openBrowserTab, openCompactDrawer],
+  );
+  const handleSelectFileSearchResult = useCallback(
+    (selection: FileSearchSelection) => {
+      selectFileSearchResult(selection);
+      openCompactDrawer();
+    },
+    [openCompactDrawer, selectFileSearchResult],
+  );
+  const handleActivateFileTab = useCallback(
+    (tabId: string) => {
+      activateTab(tabId);
+      openCompactDrawer();
+    },
+    [activateTab, openCompactDrawer],
+  );
+  // Popups (`window.open`/`target=_blank`) from a browser view open as a new
+  // in-panel browser tab; the native OS popup is denied in the main process.
+  useEffect(() => {
+    const browserApi = getDesktopBrowserApi();
+    if (browserApi === null) {
+      return;
+    }
+    if (browserApi.onScopedOpenTab) {
+      return browserApi.onScopedOpenTab(({ tabId, url }) => {
+        if (browserTabIds.has(tabId)) {
+          openBrowserTabAndReveal(url);
+        }
+      });
+    }
+    return browserApi.onOpenTab(({ url }) => {
+      if (isRoutePath({ path: url })) {
+        return;
+      }
+      openBrowserTabAndReveal(url);
+    });
+  }, [browserTabIds, openBrowserTabAndReveal]);
   const handleSelectStorageBrowserPath =
     useCallback<ThreadStoragePathSelectHandler>(
       (path) => {
@@ -854,11 +879,12 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   );
   const handleOpenNewTab = useCallback(() => {
     openNewTab();
+    openCompactDrawer();
     setNewTabFocusRequest((current) => current + 1);
-  }, [openNewTab]);
+  }, [openCompactDrawer, openNewTab]);
   const handleOpenBrowser = useCallback(() => {
-    openBrowserTab();
-  }, [openBrowserTab]);
+    openBrowserTabAndReveal();
+  }, [openBrowserTabAndReveal]);
   const handleStartTerminal = useCallback(() => {
     if (!canCreateTerminal || createTerminal.isPending || !threadId) {
       return;
@@ -873,20 +899,23 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       .then((session) => {
         closeTab(newTab.id);
         setActiveFixedTerminal(session.id);
+        openCompactDrawer();
       })
       .catch(() => undefined);
   }, [
     canCreateTerminal,
     closeTab,
     createTerminal,
+    openCompactDrawer,
     setActiveFixedTerminal,
     threadId,
   ]);
   const handleActivateTerminalTab = useCallback(
     (terminalId: string) => {
       setActiveFixedTerminal(terminalId);
+      openCompactDrawer();
     },
-    [setActiveFixedTerminal],
+    [openCompactDrawer, setActiveFixedTerminal],
   );
   const handleCloseTerminalTab = useCallback(
     (terminalId: string) => {
@@ -948,7 +977,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
                 />
               ),
               statusLabel: null,
-              onSelect: () => activateTab(tab.id),
+              onSelect: () => handleActivateFileTab(tab.id),
               onClose: () => closeTab(tab.id),
             };
           }
@@ -980,7 +1009,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
               isActive: tab.id === activeFixedSecondaryTabId,
               leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
               statusLabel: tab.statusLabel,
-              onSelect: () => activateTab(tab.id),
+              onSelect: () => handleActivateFileTab(tab.id),
               onClose: () => closeTab(tab.id),
             };
           case "host-file-preview":
@@ -990,7 +1019,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
               isActive: tab.id === activeFixedSecondaryTabId,
               leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
               statusLabel: null,
-              onSelect: () => activateTab(tab.id),
+              onSelect: () => handleActivateFileTab(tab.id),
               onClose: () => closeTab(tab.id),
             };
           case "thread-storage-file-preview":
@@ -1001,7 +1030,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
               isPinned: tab.isPinned,
               leadingVisual: <RightPanelFileTabIcon path={tab.path} />,
               statusLabel: null,
-              onSelect: () => activateTab(tab.id),
+              onSelect: () => handleActivateFileTab(tab.id),
               onClose: () => closeTab(tab.id),
             };
           case "new-tab":
@@ -1017,7 +1046,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
                 />
               ),
               statusLabel: null,
-              onSelect: () => activateTab(tab.id),
+              onSelect: () => handleActivateFileTab(tab.id),
               onClose: () => closeTab(tab.id),
             };
         }
@@ -1025,9 +1054,9 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     );
     return tabs.length > 0 ? tabs : undefined;
   }, [
-    activateTab,
     activeFixedSecondaryTabId,
     closeTab,
+    handleActivateFileTab,
     handleActivateTerminalTab,
     handleCloseTerminalTab,
     syncedOrderedSecondaryFileTabs,
@@ -1314,10 +1343,10 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       ) {
         return false;
       }
-      openBrowserTab(href);
+      openBrowserTabAndReveal(href);
       return true;
     },
-    [desktopBrowserAvailable, openBrowserTab, openLinksInAppBrowser],
+    [desktopBrowserAvailable, openBrowserTabAndReveal, openLinksInAppBrowser],
   );
   const handleTimelineTitleAction = useCallback<TimelineTitleActionResolver>(
     (action) => {
@@ -1666,7 +1695,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       environmentId={thread.environmentId ?? null}
       currentThreadId={thread.id}
       focusRequest={newTabFocusRequest}
-      onSelect={selectFileSearchResult}
+      onSelect={handleSelectFileSearchResult}
       onOpenBrowser={handleOpenBrowser}
       onStartTerminal={canCreateTerminal ? handleStartTerminal : undefined}
     />

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -522,6 +522,39 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     storageFiles: threadStorageFiles?.files,
     terminalSessions: terminalsListQuery.data?.sessions,
   });
+  const browserDeckThreadId = thread?.id ?? null;
+  const browserDeckEnvironmentId = thread?.environmentId ?? null;
+  // Browser tabs are not rendered through the single `fileTabContent` slot:
+  // each one keeps a live native view that must persist across tab switches, so
+  // the deck stays mounted independently of which tab is active.
+  const renderBrowserDeck = useCallback(
+    ({
+      canShowNativeBrowserView,
+    }: {
+      canShowNativeBrowserView: boolean;
+    }) => {
+      if (browserDeckThreadId === null) {
+        return null;
+      }
+      return (
+        <BrowserTabDeck
+          browserTabs={browserTabs}
+          activeBrowserTabId={activeBrowserTab?.id ?? null}
+          environmentId={browserDeckEnvironmentId}
+          canShowNativeBrowserView={canShowNativeBrowserView}
+          threadId={browserDeckThreadId}
+          onUpdate={updateBrowserTab}
+        />
+      );
+    },
+    [
+      activeBrowserTab?.id,
+      browserTabs,
+      browserDeckEnvironmentId,
+      browserDeckThreadId,
+      updateBrowserTab,
+    ],
+  );
   const openPersistedWorkspaceFile =
     useCallback<ThreadSecondaryPanelWorkspaceFileOpenHandler>(
       (file) => openTab({ kind: "workspace-file-preview", tab: file }),
@@ -1669,33 +1702,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       threadId={thread.id}
     />
   ) : undefined;
-  // Browser tabs are not rendered through the single `fileTabContent` slot:
-  // each one keeps a live native view that must persist across tab switches, so
-  // the deck stays mounted independently of which tab is active.
   const isBrowserTabActive = activeBrowserTab !== null;
-  const renderBrowserDeck = useCallback(
-    ({
-      canShowNativeBrowserView,
-    }: {
-      canShowNativeBrowserView: boolean;
-    }) => (
-      <BrowserTabDeck
-        browserTabs={browserTabs}
-        activeBrowserTabId={activeBrowserTab?.id ?? null}
-        environmentId={thread.environmentId}
-        canShowNativeBrowserView={canShowNativeBrowserView}
-        threadId={thread.id}
-        onUpdate={updateBrowserTab}
-      />
-    ),
-    [
-      activeBrowserTab?.id,
-      browserTabs,
-      thread.environmentId,
-      thread.id,
-      updateBrowserTab,
-    ],
-  );
 
   return (
     <>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1683,7 +1683,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
         browserTabs={browserTabs}
         activeBrowserTabId={activeBrowserTab?.id ?? null}
         environmentId={thread.environmentId}
-        isPanelOpen={canShowNativeBrowserView}
+        canShowNativeBrowserView={canShowNativeBrowserView}
         threadId={thread.id}
         onUpdate={updateBrowserTab}
       />

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1673,15 +1673,28 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   // each one keeps a live native view that must persist across tab switches, so
   // the deck stays mounted independently of which tab is active.
   const isBrowserTabActive = activeBrowserTab !== null;
-  const browserDeck = (
-    <BrowserTabDeck
-      browserTabs={browserTabs}
-      activeBrowserTabId={activeBrowserTab?.id ?? null}
-      environmentId={thread.environmentId}
-      isPanelOpen={isSecondaryPanelOpen}
-      threadId={thread.id}
-      onUpdate={updateBrowserTab}
-    />
+  const renderBrowserDeck = useCallback(
+    ({
+      canShowNativeBrowserView,
+    }: {
+      canShowNativeBrowserView: boolean;
+    }) => (
+      <BrowserTabDeck
+        browserTabs={browserTabs}
+        activeBrowserTabId={activeBrowserTab?.id ?? null}
+        environmentId={thread.environmentId}
+        isPanelOpen={canShowNativeBrowserView}
+        threadId={thread.id}
+        onUpdate={updateBrowserTab}
+      />
+    ),
+    [
+      activeBrowserTab?.id,
+      browserTabs,
+      thread.environmentId,
+      thread.id,
+      updateBrowserTab,
+    ],
   );
 
   return (
@@ -1731,7 +1744,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
           workspaceRootPath: environment?.path,
           fileTabs,
           fileTabContent,
-          browserDeck,
+          renderBrowserDeck,
           isBrowserTabActive,
           isOpen: isSecondaryPanelOpen,
           onClose: closeSecondaryPanel,

--- a/apps/app/src/views/thread-detail/useThreadSecondaryPanelVisibility.test.tsx
+++ b/apps/app/src/views/thread-detail/useThreadSecondaryPanelVisibility.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  useThreadSecondaryPanelVisibility,
+  type UseThreadSecondaryPanelVisibilityArgs,
+} from "./useThreadSecondaryPanelVisibility";
+
+function createArgs(
+  overrides: Partial<UseThreadSecondaryPanelVisibilityArgs> = {},
+): UseThreadSecondaryPanelVisibilityArgs {
+  return {
+    closePersistedPanel: vi.fn(),
+    isCompactViewport: true,
+    isPersistedOpen: true,
+    openPersistedCommitDiff: vi.fn(),
+    openPersistedDiffFile: vi.fn(),
+    openPersistedDiffPanel: vi.fn(),
+    openPersistedHostFile: vi.fn(),
+    openPersistedPanel: vi.fn(),
+    openPersistedStorageFile: vi.fn(),
+    openPersistedWorkspaceFile: vi.fn(),
+    surface: "page",
+    threadId: "thr_1",
+    togglePersistedPanel: vi.fn(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useThreadSecondaryPanelVisibility", () => {
+  it("keeps persisted compact panels closed until an interaction reveals the drawer", () => {
+    const args = createArgs({
+      isCompactViewport: true,
+      isPersistedOpen: true,
+    });
+    const { result } = renderHook(() =>
+      useThreadSecondaryPanelVisibility(args),
+    );
+
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => {
+      result.current.openCompactDrawer();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("opens the compact drawer after persisted panel actions", () => {
+    const args = createArgs({
+      isCompactViewport: true,
+      isPersistedOpen: false,
+    });
+    const { result } = renderHook(() =>
+      useThreadSecondaryPanelVisibility(args),
+    );
+
+    act(() => {
+      result.current.openHostFile({
+        lineRange: null,
+        path: "/tmp/log.txt",
+      });
+    });
+
+    expect(args.openPersistedHostFile).toHaveBeenCalledWith({
+      lineRange: null,
+      path: "/tmp/log.txt",
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("does not reveal a compact drawer for popout surfaces", () => {
+    const args = createArgs({
+      isCompactViewport: true,
+      isPersistedOpen: true,
+      surface: "popout",
+    });
+    const { result } = renderHook(() =>
+      useThreadSecondaryPanelVisibility(args),
+    );
+
+    act(() => {
+      result.current.openCompactDrawer();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/apps/app/src/views/thread-detail/useThreadSecondaryPanelVisibility.ts
+++ b/apps/app/src/views/thread-detail/useThreadSecondaryPanelVisibility.ts
@@ -44,6 +44,7 @@ export interface ThreadSecondaryPanelVisibility {
   closePanel: () => void;
   isOpen: boolean;
   openCommitDiff: ThreadSecondaryPanelCommitDiffOpenHandler;
+  openCompactDrawer: () => void;
   openDiffFile: ThreadSecondaryPanelDiffFileOpenHandler;
   openDiffPanel: () => void;
   openHostFile: ThreadSecondaryPanelHostFileOpenHandler;
@@ -99,6 +100,13 @@ export function useThreadSecondaryPanelVisibility({
     );
   }, [threadId]);
 
+  const openCompactDrawer = useCallback(() => {
+    if (surface === "popout" || !isCompactViewport) {
+      return;
+    }
+    openDrawerForCurrentThread();
+  }, [isCompactViewport, openDrawerForCurrentThread, surface]);
+
   const isDrawerVisible =
     hasThreadId(threadId) && openDrawerThreadId === threadId;
   const isOpen =
@@ -114,11 +122,9 @@ export function useThreadSecondaryPanelVisibility({
         return;
       }
       openPersistedPanel(panel);
-      if (isCompactViewport) {
-        openDrawerForCurrentThread();
-      }
+      openCompactDrawer();
     },
-    [isCompactViewport, openDrawerForCurrentThread, openPersistedPanel, surface],
+    [openCompactDrawer, openPersistedPanel, surface],
   );
 
   const openDiffPanel = useCallback(() => {
@@ -126,15 +132,8 @@ export function useThreadSecondaryPanelVisibility({
       return;
     }
     openPersistedDiffPanel();
-    if (isCompactViewport) {
-      openDrawerForCurrentThread();
-    }
-  }, [
-    isCompactViewport,
-    openDrawerForCurrentThread,
-    openPersistedDiffPanel,
-    surface,
-  ]);
+    openCompactDrawer();
+  }, [openCompactDrawer, openPersistedDiffPanel, surface]);
 
   const openDiffFile = useCallback<ThreadSecondaryPanelDiffFileOpenHandler>(
     (path) => {
@@ -142,16 +141,9 @@ export function useThreadSecondaryPanelVisibility({
         return;
       }
       openPersistedDiffFile(path);
-      if (isCompactViewport) {
-        openDrawerForCurrentThread();
-      }
+      openCompactDrawer();
     },
-    [
-      isCompactViewport,
-      openDrawerForCurrentThread,
-      openPersistedDiffFile,
-      surface,
-    ],
+    [openCompactDrawer, openPersistedDiffFile, surface],
   );
 
   const openCommitDiff = useCallback<ThreadSecondaryPanelCommitDiffOpenHandler>(
@@ -160,16 +152,9 @@ export function useThreadSecondaryPanelVisibility({
         return;
       }
       openPersistedCommitDiff(sha);
-      if (isCompactViewport) {
-        openDrawerForCurrentThread();
-      }
+      openCompactDrawer();
     },
-    [
-      isCompactViewport,
-      openDrawerForCurrentThread,
-      openPersistedCommitDiff,
-      surface,
-    ],
+    [openCompactDrawer, openPersistedCommitDiff, surface],
   );
 
   const openWorkspaceFile =
@@ -179,16 +164,9 @@ export function useThreadSecondaryPanelVisibility({
           return;
         }
         openPersistedWorkspaceFile(file);
-        if (isCompactViewport) {
-          openDrawerForCurrentThread();
-        }
+        openCompactDrawer();
       },
-      [
-        isCompactViewport,
-        openDrawerForCurrentThread,
-        openPersistedWorkspaceFile,
-        surface,
-      ],
+      [openCompactDrawer, openPersistedWorkspaceFile, surface],
     );
 
   const openStorageFile =
@@ -198,16 +176,9 @@ export function useThreadSecondaryPanelVisibility({
           return;
         }
         openPersistedStorageFile(file);
-        if (isCompactViewport) {
-          openDrawerForCurrentThread();
-        }
+        openCompactDrawer();
       },
-      [
-        isCompactViewport,
-        openDrawerForCurrentThread,
-        openPersistedStorageFile,
-        surface,
-      ],
+      [openCompactDrawer, openPersistedStorageFile, surface],
     );
 
   const openHostFile = useCallback<ThreadSecondaryPanelHostFileOpenHandler>(
@@ -216,16 +187,9 @@ export function useThreadSecondaryPanelVisibility({
         return;
       }
       openPersistedHostFile(file);
-      if (isCompactViewport) {
-        openDrawerForCurrentThread();
-      }
+      openCompactDrawer();
     },
-    [
-      isCompactViewport,
-      openDrawerForCurrentThread,
-      openPersistedHostFile,
-      surface,
-    ],
+    [openCompactDrawer, openPersistedHostFile, surface],
   );
 
   const closePanel = useCallback(() => {
@@ -271,6 +235,7 @@ export function useThreadSecondaryPanelVisibility({
       closePanel,
       isOpen,
       openCommitDiff,
+      openCompactDrawer,
       openDiffFile,
       openDiffPanel,
       openHostFile,
@@ -283,6 +248,7 @@ export function useThreadSecondaryPanelVisibility({
       closePanel,
       isOpen,
       openCommitDiff,
+      openCompactDrawer,
       openDiffFile,
       openDiffPanel,
       openHostFile,


### PR DESCRIPTION
## Summary

Fixes compact/mobile secondary drawer behavior for tabs opened from user interactions. In compact mode, opening or selecting a tab now reveals the drawer immediately, and native browser tabs still wait for drawer readiness before their `WebContentsView` becomes visible.

This covers the original thread-link flow: clicking a URL at mobile width opens the in-app browser drawer directly, and the browser content renders on first show without needing to switch to another tab and back.

## Root Cause

Compact mode has two separate pieces of state: persisted secondary-panel tab state and the ephemeral mobile drawer visibility. Some direct tab paths created or activated a persisted tab without revealing the compact drawer, so tabs could open in the background.

Browser tabs had an additional native-view timing issue: the compact drawer could attach/show the Electron browser view before the drawer animation settled and before final bounds were synced. Switching away and back repaired the view because that path exercised the established hide/sync/show ordering.

## Changes

- Add a shared compact drawer reveal callback in `useThreadSecondaryPanelVisibility` and reuse it for persisted panel actions.
- Reveal the compact drawer from direct tab interactions: thread URL browser opens, browser popups, new tab, file-search selections, file/browser/new-tab tab-strip selection, terminal start, and terminal activation.
- Keep the browser fix from the original PR: compact native browser visibility is gated until drawer content open animation completes, then bounds are synced on the next animation frame before the browser deck may show.
- Attach browser views hidden first, then show only after page presence, attachment, drawer readiness, and modal visibility checks pass.
- Rename the browser visibility plumbing to `canShowNativeBrowserView` so the prop reflects the stricter readiness contract.
- Add regression coverage for compact drawer reveal behavior plus the browser drawer-readiness and attach-hidden ordering.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/views/thread-detail/useThreadSecondaryPanelVisibility.test.tsx src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- Manual QA passed on the PR branch dev app for the narrow/mobile flow.