### PR TITLE
Refine childThread parent notifications

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -149,6 +149,13 @@ interface ArchiveCompletedAutomationThreadIfNeededArgs {
   turnStatus: ThreadEventTurnStatus;
 }
 
+interface AddParentTurnNotificationFollowUpArgs {
+  failedParentNotificationThreadIds: Set<string>;
+  followUps: EventEffectFollowUp[];
+  thread: NonNullable<ReturnType<typeof getThread>>;
+  turnStatus: ThreadEventTurnStatus;
+}
+
 interface ParentTurnNotificationFollowUp {
   kind: "parent-turn-notification";
   childThreadId: string;
@@ -297,6 +304,28 @@ async function archiveCompletedAutomationThreadIfNeeded(
   }
 }
 
+function addParentTurnNotificationFollowUp(
+  args: AddParentTurnNotificationFollowUpArgs,
+): void {
+  if (!args.thread.parentThreadId) {
+    return;
+  }
+  if (args.turnStatus === "failed") {
+    if (args.failedParentNotificationThreadIds.has(args.thread.id)) {
+      return;
+    }
+    args.failedParentNotificationThreadIds.add(args.thread.id);
+  }
+  args.followUps.push({
+    kind: "parent-turn-notification",
+    childThreadId: args.thread.id,
+    projectId: args.thread.projectId,
+    parentThreadId: args.thread.parentThreadId,
+    title: args.thread.title,
+    turnStatus: args.turnStatus,
+  });
+}
+
 async function applyEventEffects(
   deps: LoggedPendingInteractionWorkSessionDeps,
   events: HostDaemonEventEnvelope[],
@@ -305,6 +334,7 @@ async function applyEventEffects(
   // immediately visible thread state agree. Follow-ups that may queue daemon
   // work stay deferred to avoid command waits inside daemon ingress.
   const followUps: EventEffectFollowUp[] = [];
+  const failedParentNotificationThreadIds = new Set<string>();
   for (const entry of events) {
     try {
       const event = entry.event;
@@ -358,12 +388,10 @@ async function applyEventEffects(
               turnId,
             });
           if (!alreadyHandledByCommandFailure) {
-            followUps.push({
-              kind: "parent-turn-notification",
-              childThreadId: turnCompleted.thread.id,
-              projectId: turnCompleted.thread.projectId,
-              parentThreadId: turnCompleted.thread.parentThreadId,
-              title: turnCompleted.thread.title,
+            addParentTurnNotificationFollowUp({
+              failedParentNotificationThreadIds,
+              followUps,
+              thread: turnCompleted.thread,
               turnStatus: event.status,
             });
           }
@@ -399,10 +427,18 @@ async function applyEventEffects(
           reason:
             "Provider process exited while awaiting user interaction; retry the thread to continue",
         });
-        applyLoggedThreadLifecycleEvent(deps, {
+        const outcome = applyLoggedThreadLifecycleEvent(deps, {
           event: { type: "run.failed" },
           threadId: entry.threadId,
         });
+        if (outcome.applied) {
+          addParentTurnNotificationFollowUp({
+            failedParentNotificationThreadIds,
+            followUps,
+            thread: outcome.thread,
+            turnStatus: "failed",
+          });
+        }
         continue;
       }
 

--- a/apps/server/src/internal/interactive-requests.ts
+++ b/apps/server/src/internal/interactive-requests.ts
@@ -4,6 +4,9 @@ import {
   typedRoutes,
   type HostDaemonInternalSchema,
 } from "@bb/host-daemon-contract";
+import { formatPendingInteractionSubjectDetailLines } from "@bb/core-ui";
+import type { PendingInteraction } from "@bb/domain";
+import { isApprovalPendingInteractionPayload } from "@bb/domain";
 import { getThread, hasStoredTurnStarted } from "@bb/db";
 import type { Hono } from "hono";
 import type { AppDeps } from "../types.js";
@@ -16,7 +19,63 @@ import {
 import { requireAuthenticatedDaemonSession } from "./session-state.js";
 
 interface RequestChildThreadNeedsAttentionNotificationArgs {
+  blockerSummary: string | null;
   childThreadId: string;
+}
+
+const CHILD_THREAD_BLOCKER_SUMMARY_MAX_LINES = 4;
+const CHILD_THREAD_BLOCKER_SUMMARY_MAX_CHARS = 700;
+const CHILD_THREAD_BLOCKER_SUMMARY_TRUNCATION_MARKER =
+  "\n[... summary truncated ...]";
+
+function pendingInteractionBlockerLabel(
+  interaction: PendingInteraction,
+): string {
+  if (!isApprovalPendingInteractionPayload(interaction.payload)) {
+    return "user question";
+  }
+  switch (interaction.payload.subject.kind) {
+    case "command":
+      return "command approval";
+    case "file_change":
+      return "file-change approval";
+    case "permission_grant":
+      return "permission grant";
+    default: {
+      const exhaustiveCheck: never = interaction.payload.subject;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+function truncateChildThreadBlockerSummary(summary: string): string {
+  if (summary.length <= CHILD_THREAD_BLOCKER_SUMMARY_MAX_CHARS) {
+    return summary;
+  }
+  const retainedLength = Math.max(
+    0,
+    CHILD_THREAD_BLOCKER_SUMMARY_MAX_CHARS -
+      CHILD_THREAD_BLOCKER_SUMMARY_TRUNCATION_MARKER.length,
+  );
+  return `${summary.slice(0, retainedLength).trimEnd()}${CHILD_THREAD_BLOCKER_SUMMARY_TRUNCATION_MARKER}`;
+}
+
+function buildChildThreadBlockerSummary(
+  interaction: PendingInteraction,
+): string | null {
+  const details = formatPendingInteractionSubjectDetailLines(interaction)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(0, CHILD_THREAD_BLOCKER_SUMMARY_MAX_LINES);
+  if (details.length === 0) {
+    return null;
+  }
+  return truncateChildThreadBlockerSummary(
+    [
+      `Blocked on ${pendingInteractionBlockerLabel(interaction)}:`,
+      ...details,
+    ].join("\n"),
+  );
 }
 
 function requestChildThreadNeedsAttentionNotification(
@@ -39,6 +98,7 @@ function requestChildThreadNeedsAttentionNotification(
     name: "Child thread needs-attention notification",
     work: () =>
       queueChildThreadNeedsAttentionNotificationBestEffort(deps, {
+        blockerSummary: args.blockerSummary,
         childThread,
         parentThreadId,
       }),
@@ -112,6 +172,7 @@ export function registerInternalInteractiveRequestRoutes(
       }
       if (registered.outcome === "created") {
         requestChildThreadNeedsAttentionNotification(deps, {
+          blockerSummary: buildChildThreadBlockerSummary(registered.interaction),
           childThreadId: registered.interaction.threadId,
         });
       }

--- a/apps/server/src/services/threads/child-thread-notifications.ts
+++ b/apps/server/src/services/threads/child-thread-notifications.ts
@@ -9,10 +9,7 @@ import {
   type ParentSystemRenderedMention,
   type ParentSystemThreadMentionSource,
 } from "./parent-system-messages.js";
-import {
-  getLastThreadCommandFailureOutput,
-  getLastThreadOutput,
-} from "./thread-data.js";
+import { getLastThreadOutput } from "./thread-data.js";
 
 export type ChildThreadNotificationSource = ParentSystemThreadMentionSource;
 
@@ -41,8 +38,6 @@ interface RenderChildThreadTurnStatusBatchTextArgs {
 }
 
 interface FormatChildThreadTurnStatusLineArgs {
-  excerptLimit: number;
-  includeInterruptedGuidance: boolean;
   line: ChildThreadTurnStatusBatchLine;
 }
 
@@ -51,6 +46,7 @@ interface BuildChildThreadTurnStatusBatchInputArgs {
 }
 
 interface BuildChildThreadNeedsAttentionInputArgs {
+  blockerSummary: string | null;
   childThread: ChildThreadNotificationSource;
 }
 
@@ -61,6 +57,7 @@ interface QueueChildThreadTurnNotificationArgs {
 }
 
 interface QueueChildThreadNeedsAttentionNotificationArgs {
+  blockerSummary: string | null;
   childThread: ChildThreadNotificationSource;
   parentThreadId: string;
 }
@@ -70,57 +67,29 @@ const CHILD_THREAD_OUTCOME_BATCH_UPDATES_SLOT =
   "__BB_CHILD_THREAD_OUTCOME_BATCH_UPDATES__";
 const CHILD_THREAD_MENTION_SLOT = "__BB_CHILD_THREAD_MENTION__";
 const CHILD_THREAD_TERMINAL_OUTPUT_EXCERPT_CHAR_LIMIT = 4_000;
-const CHILD_THREAD_BATCH_TERMINAL_OUTPUT_EXCERPT_CHAR_LIMIT = 1_200;
-const CHILD_THREAD_BATCH_MESSAGE_CHAR_LIMIT = 6_000;
 const CHILD_THREAD_OUTPUT_TRUNCATION_MARKER =
   "\n\n[... output truncated ...]";
-const CHILD_THREAD_OUTPUT_OMITTED_MARKER =
-  "[... output omitted; message limit reached ...]";
+const CHILD_THREAD_INSPECTION_GUIDANCE =
+  "Inspect this childThread before deciding next steps.";
 const CHILD_THREAD_INTERRUPTED_GUIDANCE =
   "If the user stopped it manually, do not resume, restart, retry, replace, or continue the work unless the user explicitly asks.";
 const CHILD_THREAD_BATCH_INTERRUPTED_GUIDANCE =
-  "If the user stopped any interrupted thread manually, do not resume, restart, retry, replace, or continue the work unless the user explicitly asks.";
+  "If the user stopped any interrupted childThread manually, do not resume, restart, retry, replace, or continue the work unless the user explicitly asks.";
+const CHILD_THREAD_NEEDS_ATTENTION_FALLBACK_SUMMARY =
+  "It is blocked on a pending interaction.";
 const childThreadTurnNotificationBatches = new Map<
   string,
   ChildThreadTurnNotificationBatch
 >();
 
-function buildChildThreadTurnStatusHeadingSegments(
-  args: FormatChildThreadTurnStatusLineArgs,
-): ParentSystemInputSegment[] {
-  switch (args.line.item.turnStatus) {
-    case "completed":
-      return [
-        { kind: "mention", mention: args.line.mention },
-        { kind: "text", text: " completed:" },
-      ];
-    case "failed":
-      return [
-        { kind: "mention", mention: args.line.mention },
-        { kind: "text", text: " failed:" },
-      ];
-    case "interrupted":
-      return [
-        { kind: "mention", mention: args.line.mention },
-        { kind: "text", text: " was interrupted:" },
-      ];
-    default: {
-      const exhaustiveCheck: never = args.line.item.turnStatus;
-      return exhaustiveCheck;
-    }
-  }
-}
-
-function childThreadEmptyOutputFallback(
-  turnStatus: ThreadEventTurnStatus,
-): string {
+function childThreadTurnStatusLabel(turnStatus: ThreadEventTurnStatus): string {
   switch (turnStatus) {
     case "completed":
-      return "No final output was recorded.";
+      return "completed";
     case "failed":
-      return "No failure output was recorded.";
+      return "failed";
     case "interrupted":
-      return "No interruption output was recorded.";
+      return "was interrupted";
     default: {
       const exhaustiveCheck: never = turnStatus;
       return exhaustiveCheck;
@@ -129,9 +98,6 @@ function childThreadEmptyOutputFallback(
 }
 
 function truncateChildThreadOutput(text: string, limit: number): string {
-  if (limit <= CHILD_THREAD_OUTPUT_OMITTED_MARKER.length) {
-    return CHILD_THREAD_OUTPUT_OMITTED_MARKER;
-  }
   if (text.length <= limit) {
     return text;
   }
@@ -146,14 +112,108 @@ function truncateChildThreadOutput(text: string, limit: number): string {
   return `${text.slice(0, retainedLength).trimEnd()}${CHILD_THREAD_OUTPUT_TRUNCATION_MARKER}`;
 }
 
-function formatChildThreadOutputExcerpt(
-  args: FormatChildThreadTurnStatusLineArgs,
+function formatChildThreadCompletionOutputExcerpt(
+  output: string | null,
 ): string {
-  const output = args.line.item.terminalOutput?.trim();
-  if (!output) {
-    return childThreadEmptyOutputFallback(args.line.item.turnStatus);
+  const trimmedOutput = output?.trim();
+  if (!trimmedOutput) {
+    return "No final output was recorded.";
   }
-  return truncateChildThreadOutput(output, args.excerptLimit);
+  return truncateChildThreadOutput(
+    trimmedOutput,
+    CHILD_THREAD_TERMINAL_OUTPUT_EXCERPT_CHAR_LIMIT,
+  );
+}
+
+function formatChildThreadNeedsAttentionSummary(summary: string | null): string {
+  const trimmedSummary = summary?.trim();
+  if (!trimmedSummary) {
+    return CHILD_THREAD_NEEDS_ATTENTION_FALLBACK_SUMMARY;
+  }
+  return trimmedSummary;
+}
+
+function buildSingleChildThreadTurnStatusSegments(
+  args: FormatChildThreadTurnStatusLineArgs,
+): ParentSystemInputSegment[] {
+  const { line } = args;
+  switch (line.item.turnStatus) {
+    case "completed":
+      return [
+        { kind: "mention", mention: line.mention },
+        {
+          kind: "text",
+          text: ` completed:\n\n${formatChildThreadCompletionOutputExcerpt(line.item.terminalOutput)}`,
+        },
+      ];
+    case "failed":
+      return [
+        { kind: "mention", mention: line.mention },
+        {
+          kind: "text",
+          text: ` failed. ${CHILD_THREAD_INSPECTION_GUIDANCE}`,
+        },
+      ];
+    case "interrupted":
+      return [
+        { kind: "mention", mention: line.mention },
+        {
+          kind: "text",
+          text: ` was interrupted. ${CHILD_THREAD_INSPECTION_GUIDANCE}\n\n${CHILD_THREAD_INTERRUPTED_GUIDANCE}`,
+        },
+      ];
+    default: {
+      const exhaustiveCheck: never = line.item.turnStatus;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+function buildChildThreadBatchStatusLineSegments(
+  args: FormatChildThreadTurnStatusLineArgs,
+): ParentSystemInputSegment[] {
+  const { line } = args;
+  return [
+    { kind: "mention", mention: line.mention },
+    {
+      kind: "text",
+      text: ` ${childThreadTurnStatusLabel(line.item.turnStatus)}.`,
+    },
+  ];
+}
+
+function getChildThreadCompletionOutput(
+  deps: LoggedPendingInteractionWorkSessionDeps,
+  args: QueueChildThreadTurnNotificationArgs,
+): string | null {
+  if (args.turnStatus !== "completed") {
+    return null;
+  }
+  return getLastThreadOutput(deps.db, args.childThread.id);
+}
+
+function buildChildThreadTurnStatusBatchSegments(
+  args: RenderChildThreadTurnStatusBatchTextArgs,
+): ParentSystemInputSegment[] {
+  if (args.lines.length === 1 && args.lines[0]) {
+    return buildSingleChildThreadTurnStatusSegments({
+      line: args.lines[0],
+    });
+  }
+
+  const segments: ParentSystemInputSegment[] = [];
+  segments.push({ kind: "text", text: "childThread updates:" });
+  args.lines.forEach((line, index) => {
+    segments.push({ kind: "text", text: index === 0 ? "\n\n- " : "\n- " });
+    segments.push(...buildChildThreadBatchStatusLineSegments({ line }));
+  });
+  if (args.lines.some((line) => line.item.turnStatus === "interrupted")) {
+    segments.push({
+      kind: "text",
+      text: `\n\n${CHILD_THREAD_BATCH_INTERRUPTED_GUIDANCE}`,
+    });
+  }
+  return segments;
 }
 
 function parentSystemSegmentText(segment: ParentSystemInputSegment): string {
@@ -173,12 +233,6 @@ function parentSystemSegmentsText(
   segments: readonly ParentSystemInputSegment[],
 ): string {
   return segments.map(parentSystemSegmentText).join("");
-}
-
-function parentSystemSegmentsTextLength(
-  segments: readonly ParentSystemInputSegment[],
-): number {
-  return parentSystemSegmentsText(segments).length;
 }
 
 function buildChildThreadTurnStatusBatchLines(
@@ -201,86 +255,6 @@ function renderChildThreadTurnStatusBatchText(
   return renderTemplate("systemMessageChildThreadOutcomeBatch", {
     updates,
   });
-}
-
-function buildChildThreadTurnStatusLineSegments(
-  args: FormatChildThreadTurnStatusLineArgs,
-): ParentSystemInputSegment[] {
-  const segments: ParentSystemInputSegment[] = [
-    ...buildChildThreadTurnStatusHeadingSegments(args),
-    {
-      kind: "text",
-      text: `\n\n${formatChildThreadOutputExcerpt(args)}`,
-    },
-  ];
-  if (
-    args.includeInterruptedGuidance &&
-    args.line.item.turnStatus === "interrupted"
-  ) {
-    segments.push({
-      kind: "text",
-      text: `\n\n${CHILD_THREAD_INTERRUPTED_GUIDANCE}`,
-    });
-  }
-  return segments;
-}
-
-function childThreadBatchExcerptLimit(
-  segments: readonly ParentSystemInputSegment[],
-): number {
-  const remaining =
-    CHILD_THREAD_BATCH_MESSAGE_CHAR_LIMIT -
-    parentSystemSegmentsTextLength(segments);
-  return Math.min(
-    CHILD_THREAD_BATCH_TERMINAL_OUTPUT_EXCERPT_CHAR_LIMIT,
-    Math.max(0, remaining),
-  );
-}
-
-function getChildThreadTerminalOutput(
-  deps: LoggedPendingInteractionWorkSessionDeps,
-  args: QueueChildThreadTurnNotificationArgs,
-): string | null {
-  const lastThreadOutput = getLastThreadOutput(deps.db, args.childThread.id);
-  if (args.turnStatus !== "failed") {
-    return lastThreadOutput;
-  }
-  return (
-    getLastThreadCommandFailureOutput(deps.db, args.childThread.id) ??
-    lastThreadOutput
-  );
-}
-
-function buildChildThreadTurnStatusBatchSegments(
-  args: RenderChildThreadTurnStatusBatchTextArgs,
-): ParentSystemInputSegment[] {
-  if (args.lines.length === 1 && args.lines[0]) {
-    return buildChildThreadTurnStatusLineSegments({
-      excerptLimit: CHILD_THREAD_TERMINAL_OUTPUT_EXCERPT_CHAR_LIMIT,
-      includeInterruptedGuidance: true,
-      line: args.lines[0],
-    });
-  }
-
-  const segments: ParentSystemInputSegment[] = [];
-  segments.push({ kind: "text", text: "Managed thread updates:" });
-  for (const line of args.lines) {
-    segments.push({ kind: "text", text: "\n\n" });
-    segments.push(
-      ...buildChildThreadTurnStatusLineSegments({
-        excerptLimit: childThreadBatchExcerptLimit(segments),
-        includeInterruptedGuidance: false,
-        line,
-      }),
-    );
-  }
-  if (args.lines.some((line) => line.item.turnStatus === "interrupted")) {
-    segments.push({
-      kind: "text",
-      text: `\n\n${CHILD_THREAD_BATCH_INTERRUPTED_GUIDANCE}`,
-    });
-  }
-  return segments;
 }
 
 export function renderChildThreadTurnStatusBatchMessage(
@@ -314,6 +288,9 @@ export function buildChildThreadNeedsAttentionInput(
   const renderedText = renderTemplate(
     "systemMessageChildThreadNeedsAttention",
     {
+      blockerSummary: formatChildThreadNeedsAttentionSummary(
+        args.blockerSummary,
+      ),
       threadMention: CHILD_THREAD_MENTION_SLOT,
     },
   );
@@ -392,7 +369,7 @@ function queueChildThreadTurnNotificationBatchItem(
   if (existingBatch) {
     existingBatch.items.push({
       childThread: args.childThread,
-      terminalOutput: getChildThreadTerminalOutput(deps, args),
+      terminalOutput: getChildThreadCompletionOutput(deps, args),
       turnStatus: args.turnStatus,
     });
     clearTimeout(existingBatch.timer);
@@ -407,7 +384,7 @@ function queueChildThreadTurnNotificationBatchItem(
     items: [
       {
         childThread: args.childThread,
-        terminalOutput: getChildThreadTerminalOutput(deps, args),
+        terminalOutput: getChildThreadCompletionOutput(deps, args),
         turnStatus: args.turnStatus,
       },
     ],
@@ -450,6 +427,7 @@ export async function queueChildThreadNeedsAttentionNotificationBestEffort(
   try {
     await queueParentSystemMessage(deps, {
       input: buildChildThreadNeedsAttentionInput({
+        blockerSummary: args.blockerSummary,
         childThread: args.childThread,
       }),
       parentThreadId: args.parentThreadId,

--- a/apps/server/src/services/threads/thread-data.ts
+++ b/apps/server/src/services/threads/thread-data.ts
@@ -1,7 +1,6 @@
 import {
   findStoredEventRow as findStoredEventRowRecord,
   getLatestThreadOutputEventRow,
-  getLatestThreadSystemErrorEventRow,
   listStoredEventRows as listStoredEventRowRecords,
 } from "@bb/db";
 import type { DbConnection, StoredEventRow } from "@bb/db";
@@ -156,32 +155,4 @@ export function getLastThreadOutput(
   }
 
   return null;
-}
-
-export function getLastThreadCommandFailureOutput(
-  db: DbConnection,
-  threadId: string,
-): string | null {
-  const row = getLatestThreadSystemErrorEventRow(db, { threadId });
-
-  if (!row) return null;
-
-  const eventRow = parseStoredEventRow(row);
-
-  if (
-    eventRow.type !== "system/error" ||
-    eventRow.data.code !== "thread_command_failed"
-  ) {
-    return null;
-  }
-
-  const detail = eventRow.data.detail?.trim();
-  const message = eventRow.data.message.trim();
-  if (detail && message) {
-    return `${message}\n\n${detail}`;
-  }
-  if (detail) {
-    return detail;
-  }
-  return message.length > 0 ? message : null;
 }

--- a/apps/server/test/internal/internal-event-append-ownership.test.ts
+++ b/apps/server/test/internal/internal-event-append-ownership.test.ts
@@ -6,7 +6,10 @@ import {
   type HostDaemonEventEnvelope,
 } from "@bb/host-daemon-contract";
 import { describe, expect, it } from "vitest";
-import { internalAuthHeaders } from "../helpers/commands.js";
+import {
+  internalAuthHeaders,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
   seedEnvironment,
@@ -14,6 +17,7 @@ import {
   seedHostSession,
   seedProjectWithSource,
   seedThread,
+  seedThreadRuntimeState,
 } from "../helpers/seed.js";
 import { createTestAppHarness } from "../helpers/test-app.js";
 import type { TestAppHarness } from "../helpers/test-app.js";
@@ -349,6 +353,95 @@ describe("internal event append ownership", () => {
           .where(eq(events.threadId, "thr_missing"))
           .all(),
       ).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("notifies a parent when a child provider process exits", async () => {
+    const { environment, harness, project, session } = await setupEventRoute();
+    const parentThread = seedThread(harness.deps, {
+      environmentId: environment.id,
+      projectId: project.id,
+      status: "idle",
+      title: "Project coordinator",
+    });
+    seedThreadRuntimeState(harness.deps, {
+      environmentId: environment.id,
+      inputText: "Coordinate child work",
+      providerThreadId: "provider-parent-provider-exit",
+      threadId: parentThread.id,
+    });
+    const childThread = seedThread(harness.deps, {
+      environmentId: environment.id,
+      parentThreadId: parentThread.id,
+      projectId: project.id,
+      status: "active",
+      title: "Child provider exit worker",
+    });
+    try {
+      const response = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          {
+            threadId: childThread.id,
+            event: {
+              type: "system/error",
+              threadId: childThread.id,
+              scope: threadScope(),
+              code: "provider_process_exited",
+              message: "Provider process exited",
+            },
+          },
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toEqual({
+        acceptedEvents: [
+          {
+            eventIndex: 0,
+            threadId: childThread.id,
+            sequence: 1,
+          },
+        ],
+        rejectedEvents: [],
+      });
+      expect(getThread(harness.db, childThread.id)?.status).toBe("error");
+
+      const parentTurnCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "turn.submit" && command.threadId === parentThread.id,
+        3_000,
+      );
+      if (parentTurnCommand.command.type !== "turn.submit") {
+        throw new Error(
+          `Expected parent turn command, got ${parentTurnCommand.command.type}`,
+        );
+      }
+      const [input] = parentTurnCommand.command.input;
+      if (!input || input.type !== "text") {
+        throw new Error("Expected parent notification text input");
+      }
+      const threadMention = `@thread:${childThread.id}`;
+      expect(input.text).toContain(
+        `${threadMention} failed. Inspect this childThread before deciding next steps.`,
+      );
+      expect(input.text).not.toContain("No failure output was recorded.");
+      expect(input.mentions).toEqual([
+        {
+          start: input.text.indexOf(threadMention),
+          end: input.text.indexOf(threadMention) + threadMention.length,
+          resource: {
+            kind: "thread",
+            label: "Child provider exit worker",
+            projectId: project.id,
+            threadId: childThread.id,
+          },
+        },
+      ]);
     } finally {
       await harness.cleanup();
     }

--- a/apps/server/test/internal/internal-interactive-requests.test.ts
+++ b/apps/server/test/internal/internal-interactive-requests.test.ts
@@ -474,6 +474,11 @@ describe("internal interactive request lifecycle", () => {
       const expectedText = renderTemplate(
         "systemMessageChildThreadNeedsAttention",
         {
+          blockerSummary: [
+            "Blocked on command approval:",
+            "Command: git push",
+            "Cwd: /tmp/project",
+          ].join("\n"),
           threadMention,
         },
       );

--- a/apps/server/test/public/public-thread-parenting.test.ts
+++ b/apps/server/test/public/public-thread-parenting.test.ts
@@ -6,12 +6,14 @@ import {
   threadChildSummaryResponseSchema,
 } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
+import { waitForQueuedCommand } from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
   seedEnvironment,
   seedHostSession,
   seedProjectWithSource,
   seedThread,
+  seedThreadRuntimeState,
 } from "../helpers/seed.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
@@ -29,6 +31,12 @@ describe("public thread parenting routes", () => {
       const parentThread = seedThread(harness.deps, {
         environmentId: environment.id,
         projectId: project.id,
+      });
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        inputText: "Coordinate child work",
+        providerThreadId: "provider-parent-create-child",
+        threadId: parentThread.id,
       });
 
       const response = await harness.app.request("/api/v1/threads", {
@@ -51,6 +59,14 @@ describe("public thread parenting routes", () => {
       expect(response.status).toBe(201);
       const createdThread = threadSchema.parse(await readJson(response));
       expect(createdThread.parentThreadId).toBe(parentThread.id);
+      await expect(
+        waitForQueuedCommand(
+          harness,
+          ({ command }) =>
+            command.type === "turn.submit" && command.threadId === parentThread.id,
+          100,
+        ),
+      ).rejects.toThrow("Timed out waiting for queued command");
     });
   });
 

--- a/apps/server/test/services/threads/child-thread-notifications.test.ts
+++ b/apps/server/test/services/threads/child-thread-notifications.test.ts
@@ -20,7 +20,51 @@ function testThread(args: TestThreadArgs): ChildThreadNotificationSource {
 }
 
 describe("child thread notifications", () => {
-  it("preserves manual-stop safety guidance for interrupted batched outcomes", () => {
+  it("keeps final output for a single completed outcome", () => {
+    const message = renderChildThreadTurnStatusBatchMessage({
+      items: [
+        {
+          childThread: testThread({
+            id: "thr_child",
+            title: "Fix checkout flow",
+          }),
+          terminalOutput: "Implemented the requested change.",
+          turnStatus: "completed",
+        },
+      ],
+    });
+
+    expect(message).toContain(
+      [
+        "@thread:thr_child completed:",
+        "",
+        "Implemented the requested change.",
+      ].join("\n"),
+    );
+    expect(message).not.toContain("childThread updates:");
+  });
+
+  it("omits output for a single failed outcome", () => {
+    const message = renderChildThreadTurnStatusBatchMessage({
+      items: [
+        {
+          childThread: testThread({
+            id: "thr_child",
+            title: "Patch deploy script",
+          }),
+          terminalOutput: "Deploy script failed on preflight.",
+          turnStatus: "failed",
+        },
+      ],
+    });
+
+    expect(message).toContain(
+      "@thread:thr_child failed. Inspect this childThread before deciding next steps.",
+    );
+    expect(message).not.toContain("Deploy script failed on preflight.");
+  });
+
+  it("omits output and preserves manual-stop safety guidance for a single interrupted outcome", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
@@ -36,18 +80,16 @@ describe("child thread notifications", () => {
 
     expect(message).toContain(
       [
-        "@thread:thr_child was interrupted:",
+        "@thread:thr_child was interrupted. Inspect this childThread before deciding next steps.",
         "",
-        "Stopped after writing the checkout summary.",
+        "If the user stopped it manually, do not resume, restart, retry, replace, or continue the work unless the user explicitly asks.",
       ].join("\n"),
     );
-    expect(message).not.toContain("Managed thread updates:");
-    expect(message).toContain(
-      "If the user stopped it manually, do not resume, restart, retry, replace, or continue the work unless the user explicitly asks.",
-    );
+    expect(message).not.toContain("childThread updates:");
+    expect(message).not.toContain("Stopped after writing the checkout summary.");
   });
 
-  it("renders multiple child outcomes with excerpt sections", () => {
+  it("renders multiple child outcomes as status-only bullet lines", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
@@ -73,17 +115,14 @@ describe("child thread notifications", () => {
       [
         "[bb system]",
         "",
-        "Managed thread updates:",
+        "childThread updates:",
         "",
-        "@thread:thr_child_one completed:",
-        "",
-        "Checkout flow is fixed.",
-        "",
-        "@thread:thr_child_two failed:",
-        "",
-        "Deploy script failed on preflight.",
+        "- @thread:thr_child_one completed.",
+        "- @thread:thr_child_two failed.",
       ].join("\n"),
     );
+    expect(message).not.toContain("Checkout flow is fixed.");
+    expect(message).not.toContain("Deploy script failed on preflight.");
   });
 
   it("builds mention ranges for batched outcome thread references", () => {
@@ -140,7 +179,7 @@ describe("child thread notifications", () => {
       ],
     });
     expect(textInput.text).toContain("@thread:thr_child_two");
-    expect(textInput.text).toContain("Managed thread updates:");
+    expect(textInput.text).toContain("childThread updates:");
     expect(
       textInput.mentions.map((mention) =>
         textInput.text.slice(mention.start, mention.end),
@@ -190,7 +229,7 @@ describe("child thread notifications", () => {
     ).toEqual(["@thread:thr_child_one", nestedToken]);
   });
 
-  it("renders terminal output fallbacks for missing child output", () => {
+  it("renders a final output fallback for a completed child without output", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
@@ -199,13 +238,13 @@ describe("child thread notifications", () => {
             title: "Patch deploy script",
           }),
           terminalOutput: null,
-          turnStatus: "failed",
+          turnStatus: "completed",
         },
       ],
     });
 
     expect(message).toContain(
-      ["@thread:thr_child failed:", "", "No failure output was recorded."].join(
+      ["@thread:thr_child completed:", "", "No final output was recorded."].join(
         "\n",
       ),
     );
@@ -213,6 +252,7 @@ describe("child thread notifications", () => {
 
   it("builds mention ranges for needs-attention thread references", () => {
     const input = buildChildThreadNeedsAttentionInput({
+      blockerSummary: null,
       childThread: testThread({
         id: "thr_child",
         title: "Backend cleanup",
@@ -239,7 +279,29 @@ describe("child thread notifications", () => {
       },
     ]);
     expect(textInput.text).toContain(
-      "Inspect the thread and decide if you can answer or resolve the question from existing context.",
+      "Inspect this childThread and decide if you can answer or resolve the question from existing context.",
+    );
+  });
+
+  it("renders needs-attention blocker summaries when provided", () => {
+    const input = buildChildThreadNeedsAttentionInput({
+      blockerSummary: ["Blocked on command approval:", "git push"].join("\n"),
+      childThread: testThread({
+        id: "thr_child",
+        title: "Backend cleanup",
+      }),
+    });
+
+    const [textInput] = input;
+    if (!textInput || textInput.type !== "text") {
+      throw new Error("Expected one text input");
+    }
+
+    expect(textInput.text).toContain(
+      ["Blocked on command approval:", "git push"].join("\n"),
+    );
+    expect(textInput.text).not.toContain(
+      "It is blocked on a pending interaction.",
     );
   });
 });

--- a/apps/server/test/threads/thread-data.test.ts
+++ b/apps/server/test/threads/thread-data.test.ts
@@ -8,12 +8,7 @@ import {
   noopNotifier,
   upsertHost,
 } from "@bb/db";
-import { threadScope } from "@bb/domain";
-import {
-  getLastThreadCommandFailureOutput,
-  parseStoredEvent,
-} from "../../src/services/threads/thread-data.js";
-import { appendSystemErrorEventInTransaction } from "../../src/services/threads/thread-events.js";
+import { parseStoredEvent } from "../../src/services/threads/thread-data.js";
 
 function setup() {
   const db = createConnection(":memory:");
@@ -117,38 +112,4 @@ describe("thread data stored event parsing", () => {
     }
   });
 
-  it("returns the latest command failure system error message and detail", () => {
-    const { db, thread } = setup();
-
-    try {
-      db.transaction((tx) => {
-        appendSystemErrorEventInTransaction(
-          { db: tx, hub: noopNotifier },
-          {
-            code: "thread_command_failed",
-            detail: "first detail",
-            message: "First error",
-            scope: threadScope(),
-            threadId: thread.id,
-          },
-        );
-        appendSystemErrorEventInTransaction(
-          { db: tx, hub: noopNotifier },
-          {
-            code: "thread_command_failed",
-            detail: "latest detail",
-            message: "Latest error",
-            scope: threadScope(),
-            threadId: thread.id,
-          },
-        );
-      });
-
-      expect(getLastThreadCommandFailureOutput(db, thread.id)).toBe(
-        "Latest error\n\nlatest detail",
-      );
-    } finally {
-      db.$client.close();
-    }
-  });
 });

--- a/packages/templates/src/generated/templates.generated.ts
+++ b/packages/templates/src/generated/templates.generated.ts
@@ -124,14 +124,15 @@ export const templateDefinitions = [
   },
   {
     "id": "systemMessageChildThreadNeedsAttention",
-    "body": "[bb system]\n\n{{threadMention}} needs attention.\nIt is blocked on a pending interaction. Inspect the thread and decide if you can answer or resolve the question from existing context. If not, ask the user for the missing decision. If the worker is stuck on the wrong assumption, send it a clarifying instruction.",
+    "body": "[bb system]\n\n{{threadMention}} needs attention.\n{{blockerSummary}}\n\nInspect this childThread and decide if you can answer or resolve the question from existing context. If not, ask the user for the missing decision. If the childThread is stuck on the wrong assumption, send it a clarifying instruction.",
     "fileName": "system-message-child-thread-needs-attention.md",
     "kind": "prompt",
-    "title": "Child Thread Needs Attention",
-    "summary": "Notifies a parent thread that one of its child threads is blocked on a pending interaction.",
-    "intent": "Prompt the parent thread to inspect the blocker and either resolve it from context, ask the user, or clarify the worker's assumption.",
+    "title": "childThread Needs Attention",
+    "summary": "Notifies a parent thread that one of its childThreads is blocked on a pending interaction.",
+    "intent": "Prompt the parent thread to inspect the blocker and either resolve it from context, ask the user, or clarify the childThread's assumption.",
     "editingNotes": "Keep this focused on parent-thread triage; do not imply the parent can approve or reject on the user's behalf.",
     "variables": {
+      "blockerSummary": "Compact summary of the pending interaction, or a fallback sentence when no safe summary is available.",
       "threadMention": "Serialized thread mention token, e.g. '@thread:thr_abc123'."
     }
   },
@@ -140,21 +141,21 @@ export const templateDefinitions = [
     "body": "[bb system]\n\n{{updates}}",
     "fileName": "system-message-child-thread-outcome-batch.md",
     "kind": "prompt",
-    "title": "Child Thread Outcome Batch",
-    "summary": "Notifies a parent thread about one or more child thread outcomes.",
-    "intent": "Give the parent thread batched outcome context without forcing immediate action for every child thread.",
+    "title": "childThread Outcome Batch",
+    "summary": "Notifies a parent thread about one or more childThread outcomes.",
+    "intent": "Give the parent thread compact outcome context without forcing immediate action for every childThread.",
     "editingNotes": "Keep this concise. The updates variable is a server-formatted singular or plural outcome body with rich thread mention ranges attached by the server.",
     "variables": {
-      "updates": "Rendered child thread outcome message body."
+      "updates": "Rendered childThread outcome message body."
     }
   },
   {
     "id": "systemMessageThreadOwnershipAssigned",
-    "body": "[bb system]\n\n{{threadMention}} was assigned to you.",
+    "body": "[bb system]\n\n{{threadMention}} was assigned to you as a childThread.",
     "fileName": "system-message-thread-ownership-assigned.md",
     "kind": "prompt",
     "title": "Thread Ownership Assigned",
-    "summary": "Notifies a parent thread that a child thread is now assigned to it.",
+    "summary": "Notifies a parent thread that a childThread is now assigned to it.",
     "intent": "Let the new parent know a thread is now assigned to it.",
     "editingNotes": "Keep the thread mention first in the visible body so collapsed previews show the affected thread.",
     "variables": {
@@ -163,11 +164,11 @@ export const templateDefinitions = [
   },
   {
     "id": "systemMessageThreadOwnershipRemoved",
-    "body": "[bb system]\n\n{{threadMention}} was unassigned from you.",
+    "body": "[bb system]\n\n{{threadMention}} was unassigned from you as a childThread.",
     "fileName": "system-message-thread-ownership-removed.md",
     "kind": "prompt",
     "title": "Thread Ownership Removed",
-    "summary": "Notifies a parent thread that a child thread is no longer assigned to it.",
+    "summary": "Notifies a parent thread that a childThread is no longer assigned to it.",
     "intent": "Let the previous parent know a thread is no longer assigned to it.",
     "editingNotes": "Keep the thread mention first in the visible body so collapsed previews show the affected thread.",
     "variables": {
@@ -254,6 +255,7 @@ export interface TemplateVariables {
   };
   standardAgentAppendInstructions: Record<string, never>;
   systemMessageChildThreadNeedsAttention: {
+    blockerSummary: string;
     threadMention: string;
   };
   systemMessageChildThreadOutcomeBatch: {

--- a/packages/templates/src/templates/system-message-child-thread-needs-attention.md
+++ b/packages/templates/src/templates/system-message-child-thread-needs-attention.md
@@ -1,13 +1,16 @@
 ---
 kind: prompt
-title: Child Thread Needs Attention
-summary: Notifies a parent thread that one of its child threads is blocked on a pending interaction.
-intent: Prompt the parent thread to inspect the blocker and either resolve it from context, ask the user, or clarify the worker's assumption.
+title: childThread Needs Attention
+summary: Notifies a parent thread that one of its childThreads is blocked on a pending interaction.
+intent: Prompt the parent thread to inspect the blocker and either resolve it from context, ask the user, or clarify the childThread's assumption.
 editingNotes: Keep this focused on parent-thread triage; do not imply the parent can approve or reject on the user's behalf.
 variables:
+  blockerSummary: Compact summary of the pending interaction, or a fallback sentence when no safe summary is available.
   threadMention: Serialized thread mention token, e.g. '@thread:thr_abc123'.
 ---
 [bb system]
 
 {{threadMention}} needs attention.
-It is blocked on a pending interaction. Inspect the thread and decide if you can answer or resolve the question from existing context. If not, ask the user for the missing decision. If the worker is stuck on the wrong assumption, send it a clarifying instruction.
+{{blockerSummary}}
+
+Inspect this childThread and decide if you can answer or resolve the question from existing context. If not, ask the user for the missing decision. If the childThread is stuck on the wrong assumption, send it a clarifying instruction.

--- a/packages/templates/src/templates/system-message-child-thread-outcome-batch.md
+++ b/packages/templates/src/templates/system-message-child-thread-outcome-batch.md
@@ -1,11 +1,11 @@
 ---
 kind: prompt
-title: Child Thread Outcome Batch
-summary: Notifies a parent thread about one or more child thread outcomes.
-intent: Give the parent thread batched outcome context without forcing immediate action for every child thread.
+title: childThread Outcome Batch
+summary: Notifies a parent thread about one or more childThread outcomes.
+intent: Give the parent thread compact outcome context without forcing immediate action for every childThread.
 editingNotes: Keep this concise. The updates variable is a server-formatted singular or plural outcome body with rich thread mention ranges attached by the server.
 variables:
-  updates: "Rendered child thread outcome message body."
+  updates: "Rendered childThread outcome message body."
 ---
 [bb system]
 

--- a/packages/templates/src/templates/system-message-thread-ownership-assigned.md
+++ b/packages/templates/src/templates/system-message-thread-ownership-assigned.md
@@ -1,7 +1,7 @@
 ---
 kind: prompt
 title: Thread Ownership Assigned
-summary: Notifies a parent thread that a child thread is now assigned to it.
+summary: Notifies a parent thread that a childThread is now assigned to it.
 intent: Let the new parent know a thread is now assigned to it.
 editingNotes: Keep the thread mention first in the visible body so collapsed previews show the affected thread.
 variables:
@@ -9,4 +9,4 @@ variables:
 ---
 [bb system]
 
-{{threadMention}} was assigned to you.
+{{threadMention}} was assigned to you as a childThread.

--- a/packages/templates/src/templates/system-message-thread-ownership-removed.md
+++ b/packages/templates/src/templates/system-message-thread-ownership-removed.md
@@ -1,7 +1,7 @@
 ---
 kind: prompt
 title: Thread Ownership Removed
-summary: Notifies a parent thread that a child thread is no longer assigned to it.
+summary: Notifies a parent thread that a childThread is no longer assigned to it.
 intent: Let the previous parent know a thread is no longer assigned to it.
 editingNotes: Keep the thread mention first in the visible body so collapsed previews show the affected thread.
 variables:
@@ -9,4 +9,4 @@ variables:
 ---
 [bb system]
 
-{{threadMention}} was unassigned from you.
+{{threadMention}} was unassigned from you as a childThread.

--- a/packages/templates/test/templates.test.ts
+++ b/packages/templates/test/templates.test.ts
@@ -102,6 +102,52 @@ describe("@bb/templates", () => {
     );
   });
 
+  it("renders childThread needs-attention messages with blocker summaries", () => {
+    const rendered = renderTemplate("systemMessageChildThreadNeedsAttention", {
+      blockerSummary: ["Blocked on command approval:", "Command: git push"].join(
+        "\n",
+      ),
+      threadMention: "@thread:thr_child",
+    });
+
+    expect(rendered).toBe(
+      [
+        "[bb system]",
+        "",
+        "@thread:thr_child needs attention.",
+        "Blocked on command approval:",
+        "Command: git push",
+        "",
+        "Inspect this childThread and decide if you can answer or resolve the question from existing context. If not, ask the user for the missing decision. If the childThread is stuck on the wrong assumption, send it a clarifying instruction.",
+      ].join("\n"),
+    );
+  });
+
+  it("renders childThread ownership messages", () => {
+    expect(
+      renderTemplate("systemMessageThreadOwnershipAssigned", {
+        threadMention: "@thread:thr_child",
+      }),
+    ).toBe(
+      [
+        "[bb system]",
+        "",
+        "@thread:thr_child was assigned to you as a childThread.",
+      ].join("\n"),
+    );
+    expect(
+      renderTemplate("systemMessageThreadOwnershipRemoved", {
+        threadMention: "@thread:thr_child",
+      }),
+    ).toBe(
+      [
+        "[bb system]",
+        "",
+        "@thread:thr_child was unassigned from you as a childThread.",
+      ].join("\n"),
+    );
+  });
+
   it("renders all templates without error", () => {
     const templates = listTemplates();
 


### PR DESCRIPTION
## Summary
- refine parent notifications for childThread completion, failure, interruption, batching, and needs-attention states
- add blocker summaries for pending childThread interactions
- notify parents when a child provider process exits while awaiting interaction
- update templates/generated output and regression coverage

Implements the plan from #173.

## Validation
- pnpm exec turbo run test --filter=@bb/templates
- pnpm exec turbo run test --filter=@bb/server -- child-thread-notifications.test.ts internal-interactive-requests.test.ts internal-event-append-ownership.test.ts public-thread-parenting.test.ts thread-data.test.ts
- pnpm exec turbo run typecheck --filter=@bb/templates
- pnpm exec turbo run typecheck --filter=@bb/server
- git diff --check