### PR TITLE
Fix Codex thread persistence for resume

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -546,9 +546,11 @@ describe("codex provider adapter", () => {
         approvalPolicy: "never",
         sandbox: "danger-full-access",
         cwd: "/tmp/worktree",
+        ephemeral: false,
         experimentalRawEvents: true,
       },
     });
+    expect(JSON.stringify(cmd)).not.toContain("persistExtendedHistory");
     expect(JSON.stringify(cmd)).not.toContain("baseInstructions");
     expect(JSON.stringify(cmd)).not.toContain("developerInstructions");
   });
@@ -1626,6 +1628,7 @@ describe("codex provider adapter", () => {
         cwd: "/tmp/worktree",
       },
     });
+    expect(JSON.stringify(cmd)).not.toContain("persistExtendedHistory");
     expect(JSON.stringify(cmd)).not.toContain("baseInstructions");
     expect(JSON.stringify(cmd)).not.toContain("developerInstructions");
   });

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -81,11 +81,6 @@ interface CodexThreadPermissionSettings {
 
 type BbThreadStartParams = ThreadStartParams & {
   experimentalRawEvents?: boolean;
-  persistExtendedHistory?: boolean;
-};
-
-type BbThreadResumeParams = ThreadResumeParams & {
-  persistExtendedHistory?: boolean;
 };
 
 interface ToCodexPermissionSettingsArgs {
@@ -1374,10 +1369,12 @@ export function createCodexProviderAdapter(
             ...resolveCodexInstructionOverrides(command),
             model: command.options?.model ?? undefined,
             serviceTier: toCodexServiceTier(command.options?.serviceTier),
+            // bb reaps idle thread-scoped Codex processes and later resumes by
+            // provider thread id, so Codex must materialize a rollout on disk.
+            ephemeral: false,
             config: preparedGitRoots.config ?? undefined,
             // Codex only exposes raw Responses items as a thread/start opt-in.
             experimentalRawEvents: true,
-            persistExtendedHistory: false,
             ...(dynamicTools && dynamicTools.length > 0
               ? { dynamicTools }
               : {}),
@@ -1391,7 +1388,7 @@ export function createCodexProviderAdapter(
         case "thread/resume": {
           const dynamicTools = toCodexDynamicTools(command.dynamicTools);
           const preparedGitRoots = prepareWorkspaceWriteGitRoots({ command });
-          const params: BbThreadResumeParams = {
+          const params: ThreadResumeParams = {
             threadId: command.providerThreadId,
             approvalPolicy: preparedGitRoots.permissionSettings.approvalPolicy,
             sandbox: preparedGitRoots.permissionSettings.sandbox,
@@ -1400,7 +1397,6 @@ export function createCodexProviderAdapter(
             model: command.options?.model ?? undefined,
             serviceTier: toCodexServiceTier(command.options?.serviceTier),
             config: preparedGitRoots.config ?? undefined,
-            persistExtendedHistory: false,
             ...(dynamicTools && dynamicTools.length > 0
               ? { dynamicTools }
               : {}),


### PR DESCRIPTION
## Summary

- start Codex app-server threads with `ephemeral: false` so bb's idle-reaped thread-scoped Codex processes can be resumed by provider thread id
- remove the obsolete `persistExtendedHistory` request field from Codex `thread/start` and `thread/resume`
- add adapter regression assertions for the durable start flag and stale field removal

## Context

A follow-up on an idle-reaped Codex thread failed with `no rollout found for thread id ...`. bb relies on Codex materializing the provider thread so a later `thread/resume` can reload it after the daemon reaps the live provider process. The current Codex app-server schema exposes `ephemeral` as the durability control, while `persistExtendedHistory` is no longer part of the generated/live schema.

I also checked pingdotgg/t3code: its generated Codex schema likewise uses `ephemeral` and has no `persistExtendedHistory` field. t3code relies on the default rather than setting `ephemeral: false` explicitly; bb is stricter here because it has an idle reaper that intentionally shuts down the live process and later resumes by provider thread id.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- src/codex/adapter.test.ts src/runtime.process-lifecycle.test.ts`
- `pnpm exec turbo run test --filter=@bb/agent-runtime`
- `git diff --check`
