### PR TITLE
Widen timeline active/inactive prominence ramp

### DIFF
--- a/apps/app/src/components/thread/timeline/ProminenceRamp.stories.tsx
+++ b/apps/app/src/components/thread/timeline/ProminenceRamp.stories.tsx
@@ -1,0 +1,347 @@
+import type { TimelineRow, TimelineRowStatus } from "@bb/server-contract";
+import { ThreadTimelineRows } from "@/components/thread/timeline";
+import {
+  commandRow,
+  conversationRow,
+  fileChangeRow,
+  readIntent,
+  systemRow,
+  toolRow,
+} from "@/test/fixtures/thread-timeline-rows";
+import { StoryCard, StoryRow } from "../../../../.ladle/story-card";
+
+export default {
+  title: "thread/timeline/Prominence Ramp",
+};
+
+// ---------------------------------------------------------------------------
+// The timeline runs three prominence tiers, and this story exercises every row
+// kind against them so the active/inactive ramp can be judged comprehensively:
+//
+//   1. agent prose                       full `text-foreground`   (most prominent)
+//   2. the live frontier — active rows
+//      AND the active-latest bundle      full opacity             (next)
+//   3. the finished past — completed
+//      leaf rows, bundle/step/turn
+//      summaries, and done system rows    opacity-55              (receded)
+//
+// Errors, interruptions, and still-running rows deliberately stay at full
+// strength so failures and live work keep attention.
+// ---------------------------------------------------------------------------
+
+const THREAD_ID = "thr_ramp";
+const TURN_ID = "turn_ramp_1";
+
+function TimelineStage({ children }: { children: React.ReactNode }) {
+  return <div className="w-full max-w-[760px]">{children}</div>;
+}
+
+const baseProps = {
+  threadRuntimeDisplayStatus: "idle" as const,
+  workspaceRootPath: undefined,
+};
+
+// ---- Tier 1: agent prose --------------------------------------------------
+
+const proseRow: TimelineRow = conversationRow({
+  id: `${THREAD_ID}:assistant:1`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  role: "assistant",
+  sourceSeqStart: 1,
+  startedAt: 1777944000000,
+  createdAt: 1777944000000,
+  text: "The workspace watcher outlives the provider process, so it lingers for the daemon's lifetime. I'll confirm the two call sites, then tighten the idle TTL.",
+});
+
+// ---- Tier 2 vs 3: individual work rows ------------------------------------
+
+const runningTool: TimelineRow = toolRow({
+  id: `${THREAD_ID}:tool:active`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  sourceSeqStart: 10,
+  startedAt: Date.now(),
+  createdAt: Date.now(),
+  status: "pending",
+  callId: "toolu_ramp_active",
+  toolName: "ToolSearch",
+  toolArgs: { query: "select:Edit,Write", max_results: 2 },
+  output: "",
+  durationMs: null,
+});
+
+const doneTool: TimelineRow = toolRow({
+  id: `${THREAD_ID}:tool:done`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  sourceSeqStart: 11,
+  startedAt: 1777944001000,
+  createdAt: 1777944001100,
+  status: "completed",
+  callId: "toolu_ramp_done",
+  toolName: "ToolSearch",
+  toolArgs: { query: "select:Read", max_results: 1 },
+  output: "Matched tools: Read",
+  durationMs: 90,
+});
+
+const doneCommand: TimelineRow = commandRow({
+  id: `${THREAD_ID}:command:done`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  sourceSeqStart: 12,
+  startedAt: 1777944002000,
+  createdAt: 1777944004000,
+  status: "completed",
+  callId: "call_ramp_done_cmd",
+  command: "pnpm exec turbo run typecheck --filter=@bb/host-daemon",
+  source: null,
+  output: "",
+  exitCode: 0,
+  approvalStatus: null,
+  activityIntents: [],
+  durationMs: 2100,
+});
+
+const doneFileChange: TimelineRow = fileChangeRow({
+  id: `${THREAD_ID}:fileChange:done`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  sourceSeqStart: 13,
+  startedAt: 1777944005000,
+  createdAt: 1777944005600,
+  status: "completed",
+  callId: "call_ramp_done_edit",
+  change: {
+    path: "packages/host-daemon/src/workspace/watcher.ts",
+    kind: "update",
+    movePath: null,
+    diff: "@@ -42,3 +42,4 @@\n-  startWatcher(workspace);\n+  const lease = startWatcher(workspace);\n+  scheduleIdleRelease(lease);",
+    diffStats: { added: 2, removed: 1 },
+  },
+  stdout: null,
+  stderr: null,
+  approvalStatus: null,
+});
+
+const leafRampRows: TimelineRow[] = [
+  runningTool,
+  doneTool,
+  doneCommand,
+  doneFileChange,
+];
+
+// ---- Tier 2 vs 3: bundle summary ------------------------------------------
+// Consecutive same-concept work rows project into one bundle-summary. Idle
+// scope keeps it receded; active scope makes the trailing bundle the live
+// frontier (shimmering verb, full opacity).
+
+function bundleCommand(
+  seq: number,
+  command: string,
+  status: TimelineRowStatus = "completed",
+): TimelineRow {
+  const pending = status === "pending";
+  return commandRow({
+    id: `${THREAD_ID}:command:bundle_${seq}`,
+    threadId: THREAD_ID,
+    turnId: TURN_ID,
+    sourceSeqStart: seq,
+    startedAt: pending ? Date.now() : 1777944010000 + seq,
+    createdAt: pending ? Date.now() : 1777944012000 + seq,
+    status,
+    callId: `call_ramp_bundle_${seq}`,
+    command,
+    source: null,
+    output: "",
+    exitCode: pending ? null : 0,
+    approvalStatus: null,
+    activityIntents: [],
+    durationMs: pending ? null : 2300,
+  });
+}
+
+const commandBundleRows: TimelineRow[] = [
+  bundleCommand(20, "pnpm exec turbo run build --filter=@bb/host-daemon"),
+  bundleCommand(21, "pnpm exec turbo run test --filter=@bb/host-daemon"),
+  bundleCommand(22, "pnpm exec turbo run typecheck --filter=@bb/host-daemon"),
+];
+
+// Active-latest variant: the last command is still running, so the live
+// frontier's "Running 3 commands" label matches its in-flight child.
+const activeCommandBundleRows: TimelineRow[] = [
+  bundleCommand(23, "pnpm exec turbo run build --filter=@bb/host-daemon"),
+  bundleCommand(24, "pnpm exec turbo run test --filter=@bb/host-daemon"),
+  bundleCommand(
+    25,
+    "pnpm exec turbo run typecheck --filter=@bb/host-daemon",
+    "pending",
+  ),
+];
+
+// ---- Tier 3: step summary -------------------------------------------------
+// Multiple work rows closed by an assistant-message boundary collapse into a
+// step-summary recap ("Explored N files").
+
+function explorationRead(
+  seq: number,
+  path: string,
+  status: TimelineRowStatus = "completed",
+): TimelineRow {
+  const pending = status === "pending";
+  return toolRow({
+    id: `${THREAD_ID}:tool:explore_${seq}`,
+    threadId: THREAD_ID,
+    turnId: TURN_ID,
+    sourceSeqStart: seq,
+    startedAt: pending ? Date.now() : 1777944020000 + seq,
+    createdAt: pending ? Date.now() : 1777944020100 + seq,
+    status,
+    callId: `call_ramp_explore_${seq}`,
+    toolName: "Read",
+    toolArgs: { file_path: path },
+    output: pending ? "" : "...file contents...",
+    activityIntents: [readIntent({ path })],
+    durationMs: pending ? null : 60,
+  });
+}
+
+const stepExplorationRows: TimelineRow[] = [
+  explorationRead(30, "packages/host-daemon/src/workspace/watcher.ts"),
+  explorationRead(31, "packages/host-daemon/src/workspace/index.ts"),
+  explorationRead(32, "packages/host-daemon/src/runtime/session.ts"),
+];
+
+// Active-latest variant for the capstone frontier: the last read is still
+// running, so the live "Exploring 3 files" bundle has an in-flight child.
+const activeExplorationRows: TimelineRow[] = [
+  explorationRead(34, "packages/host-daemon/src/workspace/watcher.ts"),
+  explorationRead(35, "packages/host-daemon/src/runtime/session.ts"),
+  explorationRead(36, "packages/host-daemon/src/workspace/index.ts", "pending"),
+];
+
+const stepClosingMessage: TimelineRow = conversationRow({
+  id: `${THREAD_ID}:assistant:step-close`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  role: "assistant",
+  sourceSeqStart: 33,
+  startedAt: 1777944021000,
+  createdAt: 1777944021000,
+  text: "—",
+});
+
+const stepSummaryRows: TimelineRow[] = [
+  ...stepExplorationRows,
+  stepClosingMessage,
+];
+
+// ---- Tier 2 vs 3: system rows ---------------------------------------------
+
+const activeSystemRow: TimelineRow = systemRow({
+  id: `${THREAD_ID}:system:active`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  sourceSeqStart: 40,
+  startedAt: Date.now(),
+  createdAt: Date.now(),
+  status: "pending",
+  title: "Provisioning thread",
+  detail: "Running setup",
+});
+
+const doneSystemRow: TimelineRow = systemRow({
+  id: `${THREAD_ID}:system:done`,
+  threadId: THREAD_ID,
+  turnId: TURN_ID,
+  sourceSeqStart: 41,
+  startedAt: 1777944030000,
+  createdAt: 1777944030000,
+  status: "completed",
+  title: "Provisioned thread",
+  detail: "Running setup\nProvisioned thread (2s)",
+});
+
+const systemRampRows: TimelineRow[] = [activeSystemRow, doneSystemRow];
+
+// ---- Capstone: full stack -------------------------------------------------
+// A live turn under active scope: bright prose, a finished commands bundle that
+// recedes, then the trailing exploration bundle as the active-latest frontier.
+
+const fullStackRows: TimelineRow[] = [
+  proseRow,
+  ...commandBundleRows,
+  ...activeExplorationRows,
+];
+
+export function Overview() {
+  return (
+    <StoryCard labelWidth="260px">
+      <StoryRow label="tier 1 · agent prose" hint="full foreground — most prominent">
+        <TimelineStage>
+          <ThreadTimelineRows {...baseProps} timelineRows={[proseRow]} />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="tool calls · active vs done"
+        hint="running tool stays full strength; finished tool / command / file-change recede"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows {...baseProps} timelineRows={leafRampRows} />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="bundle summary · finished"
+        hint="idle scope — the rolled-up bundle recedes with the rest of the past layer"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows
+            {...baseProps}
+            timelineRows={commandBundleRows}
+          />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="bundle summary · active-latest"
+        hint="active scope, last command still running — the live frontier bundle stays full strength (shimmering verb), not receded"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows
+            {...baseProps}
+            threadRuntimeDisplayStatus="active"
+            timelineRows={activeCommandBundleRows}
+          />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="step summary · finished"
+        hint="an assistant boundary collapses the step into a receded recap"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows {...baseProps} timelineRows={stepSummaryRows} />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="system · active vs done"
+        hint="a pending operation stays prominent; the completed one recedes"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows {...baseProps} timelineRows={systemRampRows} />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="full stack · live turn"
+        hint="prose on top, the finished commands bundle receded, the trailing exploration bundle as the active-latest frontier"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows
+            {...baseProps}
+            threadRuntimeDisplayStatus="active"
+            timelineRows={fullStackRows}
+          />
+        </TimelineStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.dim.test.ts
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.dim.test.ts
@@ -1,0 +1,135 @@
+import type { ThreadTimelineViewRow } from "@bb/thread-view";
+import { buildTimelineViewRows } from "@bb/thread-view";
+import { describe, expect, it } from "vitest";
+import {
+  commandRow,
+  conversationRow,
+  systemRow,
+  toolRow,
+  turnRow,
+} from "@/test/fixtures/thread-timeline-rows";
+import {
+  PAST_ROW_DIM_CLASS_NAME,
+  pastRowDimClassName,
+} from "./ThreadTimelineRows";
+
+// `pastRowDimClassName` is the timeline's active/inactive prominence decision:
+// finished rows recede (get the dim class) while live and attention-worthy rows
+// stay at full strength. These cases lock in that contract — in particular the
+// two states that used to be wrong (completed system rows now recede; the
+// active-latest bundle stays prominent). The opacity *value* is intentionally
+// not asserted beyond "is the past-dim class" so visual tuning stays free.
+
+// The view rows the renderer actually decides over come out of the projection,
+// so build them the same way rather than hand-rolling view-row shapes.
+function viewRow(
+  rows: Parameters<typeof buildTimelineViewRows>[0],
+): ThreadTimelineViewRow {
+  const built = buildTimelineViewRows(rows);
+  const first = built[0];
+  if (!first) {
+    throw new Error("expected at least one view row");
+  }
+  return first;
+}
+
+const inactiveScope = { activeLatestBundleId: null, scopeActive: false } as const;
+
+describe("pastRowDimClassName", () => {
+  it("recedes a completed work row", () => {
+    const row = viewRow([toolRow({ status: "completed" })]);
+    expect(pastRowDimClassName({ ...inactiveScope, row })).toBe(
+      PAST_ROW_DIM_CLASS_NAME,
+    );
+  });
+
+  it("keeps running, errored, and interrupted work rows at full strength", () => {
+    for (const status of ["pending", "error", "interrupted"] as const) {
+      const row = viewRow([toolRow({ status })]);
+      expect(pastRowDimClassName({ ...inactiveScope, row })).toBeUndefined();
+    }
+  });
+
+  it("recedes a completed system row", () => {
+    const row = viewRow([systemRow({ status: "completed" })]);
+    expect(row.kind).toBe("system");
+    expect(pastRowDimClassName({ ...inactiveScope, row })).toBe(
+      PAST_ROW_DIM_CLASS_NAME,
+    );
+  });
+
+  it("keeps a still-running system row at full strength", () => {
+    const row = viewRow([systemRow({ status: "pending" })]);
+    expect(pastRowDimClassName({ ...inactiveScope, row })).toBeUndefined();
+  });
+
+  it("recedes a completed turn header", () => {
+    const row = viewRow([turnRow({ status: "completed" })]);
+    expect(row.kind).toBe("turn");
+    expect(pastRowDimClassName({ ...inactiveScope, row })).toBe(
+      PAST_ROW_DIM_CLASS_NAME,
+    );
+  });
+
+  it("recedes rolled-up bundle and step summaries", () => {
+    const bundle = viewRow([
+      commandRow({ id: "cmd-1", command: "pnpm build", sourceSeqStart: 1 }),
+      commandRow({ id: "cmd-2", command: "pnpm test", sourceSeqStart: 2 }),
+    ]);
+    expect(bundle.kind).toBe("bundle-summary");
+    expect(pastRowDimClassName({ ...inactiveScope, row: bundle })).toBe(
+      PAST_ROW_DIM_CLASS_NAME,
+    );
+
+    const step = viewRow([
+      commandRow({ id: "cmd-1", command: "pnpm build", sourceSeqStart: 1 }),
+      commandRow({ id: "cmd-2", command: "pnpm test", sourceSeqStart: 2 }),
+      conversationRow({
+        id: "msg-1",
+        role: "assistant",
+        text: "done",
+        sourceSeqStart: 3,
+      }),
+    ]);
+    expect(step.kind).toBe("step-summary");
+    expect(pastRowDimClassName({ ...inactiveScope, row: step })).toBe(
+      PAST_ROW_DIM_CLASS_NAME,
+    );
+  });
+
+  it("keeps the active-latest bundle prominent but recedes it once scope is idle", () => {
+    const bundle = viewRow([
+      commandRow({ id: "cmd-1", command: "pnpm build", sourceSeqStart: 1 }),
+      commandRow({ id: "cmd-2", command: "pnpm test", sourceSeqStart: 2 }),
+    ]);
+    expect(bundle.kind).toBe("bundle-summary");
+
+    // The live frontier: active scope + this bundle is the trailing one.
+    expect(
+      pastRowDimClassName({
+        activeLatestBundleId: bundle.id,
+        scopeActive: true,
+        row: bundle,
+      }),
+    ).toBeUndefined();
+
+    // Same bundle once the thread is idle (or it's no longer the frontier) recedes.
+    expect(
+      pastRowDimClassName({
+        activeLatestBundleId: bundle.id,
+        scopeActive: false,
+        row: bundle,
+      }),
+    ).toBe(PAST_ROW_DIM_CLASS_NAME);
+  });
+
+  it("never dims agent or user prose", () => {
+    const assistant = viewRow([
+      conversationRow({ role: "assistant", text: "answer" }),
+    ]);
+    expect(pastRowDimClassName({ ...inactiveScope, row: assistant })).toBeUndefined();
+
+    const user = viewRow([conversationRow({ role: "user", text: "question" })]);
+    expect(pastRowDimClassName({ ...inactiveScope, row: user })).toBeUndefined();
+  });
+});

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -195,6 +195,7 @@ interface TimelineRowViewProps {
 interface TimelineExpandableRowViewProps {
   activeLatestBundleId: string | null;
   compactActivityIntents: boolean;
+  scopeActive: boolean;
   title: TimelineTitle;
   horizontalPadding: TimelineRowHorizontalPadding;
   row: Exclude<ThreadTimelineViewRow, { kind: "conversation" }>;
@@ -414,6 +415,7 @@ function areTimelineExpandableRowViewPropsEqual(
   return (
     previous.activeLatestBundleId === next.activeLatestBundleId &&
     previous.compactActivityIntents === next.compactActivityIntents &&
+    previous.scopeActive === next.scopeActive &&
     previous.title === next.title &&
     previous.horizontalPadding === next.horizontalPadding &&
     // The view-row cache keys by the raw rows array, so unchanged query data
@@ -1015,30 +1017,69 @@ function LazyTurnRowBody({
 }
 
 /**
- * Completed work rows (tool / command / file-change calls) recede: once a call
- * is done its row dims so attention lands on active work and the model's prose.
+ * Opacity for the receded "past" layer — the bottom step of the timeline's
+ * three-tier prominence ramp:
+ *
+ *   tier 1 — agent prose ........ `text-foreground`, opacity 100   (most prominent)
+ *   tier 2 — live / active rows .. their title tones, opacity 100   (next)
+ *   tier 3 — finished / past rows  those same tones × this opacity  (least)
+ *
+ * The gap this controls — active vs. done — is the one that has to read
+ * clearly, since most of a timeline is finished work sitting next to a live
+ * row. It's a whole-row opacity step, so the contrast is identical in light and
+ * dark (unlike a tone step: the muted-vs-foreground token gap is wide in light
+ * but nearly nothing in dark). Pushed deep — `opacity-70` (~30% nudge) read
+ * "too tight", so finished work now drops well below the live frontier; a
+ * running verb additionally shimmers (`animate-shine`) so active reads as more
+ * alive still. Tune here if active vs. done needs more or less separation.
  */
-function completedWorkRowDimClassName(
-  row: ThreadTimelineViewRow,
-): string | undefined {
-  return row.kind === "work" && row.status === "completed"
-    ? "opacity-70"
-    : undefined;
-}
+const PAST_ROW_DIM_CLASS_NAME = "opacity-40";
 
 /**
- * Rolled-up section headers — the turn header ("Worked for …") and the
- * bundle/step summaries that aggregate finished tool calls ("Explored 3 files")
- * — dim so they recede beneath the live content they summarize.
+ * Whether a row sits in the receded past layer, and so takes
+ * `PAST_ROW_DIM_CLASS_NAME`. Applied uniformly across every timeline row kind so
+ * the active/inactive ramp is consistent — leaf tool/command/file rows, their
+ * rolled-up bundle/step/turn summaries, and operational system rows all recede
+ * together once finished. A row recedes only once it is done AND no longer the
+ * live frontier:
+ *  - completed `work` and `system` rows — errors, interruptions, and still-
+ *    pending rows stay at full strength so failures and live work keep
+ *    attention;
+ *  - turn headers and step-summaries, which only ever render as finished
+ *    recaps;
+ *  - bundle-summaries, EXCEPT the active-latest one (the live frontier), which
+ *    stays prominent.
+ * Conversation prose (the top tier) never recedes.
  */
-function rolledUpHeaderDimClassName(
-  row: ThreadTimelineViewRow,
-): string | undefined {
-  return row.kind === "turn" ||
-    row.kind === "bundle-summary" ||
-    row.kind === "step-summary"
-    ? "opacity-70"
-    : undefined;
+function pastRowDimClassName({
+  activeLatestBundleId,
+  row,
+  scopeActive,
+}: ActiveSummaryTreatmentArgs): string | undefined {
+  // The live frontier never recedes: the active-latest bundle stays prominent
+  // even once its children have finished, because more work may still land in
+  // it.
+  if (
+    row.kind === "bundle-summary" &&
+    isActiveLatestBundleSummary({ activeLatestBundleId, row, scopeActive })
+  ) {
+    return undefined;
+  }
+  switch (row.kind) {
+    case "work":
+    case "system":
+    case "turn":
+    case "bundle-summary":
+    case "step-summary":
+      // Finished rows recede; still-running, errored, and interrupted rows —
+      // whether a single leaf or a rolled-up summary that merged a failure —
+      // stay at full strength so live work and failures keep attention.
+      return row.status === "completed" ? PAST_ROW_DIM_CLASS_NAME : undefined;
+    case "conversation":
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -1126,7 +1167,11 @@ function TimelineRowView({
           <TimelineStaticRow
             key={entry.id}
             horizontalPadding={horizontalPadding}
-            className={completedWorkRowDimClassName(row)}
+            className={pastRowDimClassName({
+              activeLatestBundleId,
+              row,
+              scopeActive,
+            })}
           >
             <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
               <Icon
@@ -1151,7 +1196,11 @@ function TimelineRowView({
     return (
       <TimelineStaticRow
         horizontalPadding={horizontalPadding}
-        className={completedWorkRowDimClassName(row)}
+        className={pastRowDimClassName({
+          activeLatestBundleId,
+          row,
+          scopeActive,
+        })}
       >
         <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
           {staticLeadingIcon ? (
@@ -1175,6 +1224,7 @@ function TimelineRowView({
     <MemoizedTimelineExpandableRowView
       activeLatestBundleId={activeLatestBundleId}
       row={row}
+      scopeActive={scopeActive}
       title={titleState.title}
       horizontalPadding={horizontalPadding}
       compactActivityIntents={compactActivityIntents}
@@ -1190,6 +1240,7 @@ const MemoizedTimelineRowView = memo(
 function TimelineExpandableRowView({
   activeLatestBundleId,
   compactActivityIntents,
+  scopeActive,
   title,
   horizontalPadding,
   row,
@@ -1220,9 +1271,11 @@ function TimelineExpandableRowView({
       // Dim the row's title content (not the whole row) so the disclosure caret
       // keeps a uniform opacity across completed/header/normal rows instead of
       // compounding the row-level dim onto the caret.
-      summaryClassName={
-        rolledUpHeaderDimClassName(row) ?? completedWorkRowDimClassName(row)
-      }
+      summaryClassName={pastRowDimClassName({
+        activeLatestBundleId,
+        row,
+        scopeActive,
+      })}
       horizontalPadding={horizontalPadding}
       leadingIcon={leadingIcon}
       autoExpanded={

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -1033,7 +1033,7 @@ function LazyTurnRowBody({
  * running verb additionally shimmers (`animate-shine`) so active reads as more
  * alive still. Tune here if active vs. done needs more or less separation.
  */
-const PAST_ROW_DIM_CLASS_NAME = "opacity-40";
+export const PAST_ROW_DIM_CLASS_NAME = "opacity-40";
 
 /**
  * Whether a row sits in the receded past layer, and so takes
@@ -1051,7 +1051,7 @@ const PAST_ROW_DIM_CLASS_NAME = "opacity-40";
  *    stays prominent.
  * Conversation prose (the top tier) never recedes.
  */
-function pastRowDimClassName({
+export function pastRowDimClassName({
   activeLatestBundleId,
   row,
   scopeActive,

--- a/apps/app/src/components/thread/timeline/rows/BundleSummary.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/BundleSummary.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import { ThreadTimelineRows } from "@/components/thread/timeline";
 import {
   commandRow,
+  conversationRow,
   delegationRow,
   fileChangeRow,
   toolRow,
@@ -824,6 +825,160 @@ export function Overview() {
             {...baseProps}
             threadRuntimeDisplayStatus="active"
             timelineRows={commandBundleRows}
+          />
+        </TimelineStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Interleaved timeline. The states above, rendered as one continuous thread
+// with user + assistant messages, so the prominence ramp reads in context:
+//   - user/agent messages sit at full strength (the top tier);
+//   - finished work rolls up and recedes (the muted past layer);
+//   - the errored and interrupted clusters, and the live frontier, stay
+//     prominent.
+// Note on form: between two messages the projection closes a multi-row step
+// into a *step-summary* — that's the real product behavior, since a genuine
+// bundle-summary only survives at the live frontier. So the trailing
+// "Exploring…" cluster is the one true (active-latest) bundle-summary here.
+// ---------------------------------------------------------------------------
+
+const CONV_THREAD_ID = "thr_zeb7z9afmw";
+const CONV_TURN_ID = "conv-interleaved-turn";
+
+function userMessage(seq: number, text: string): TimelineRow {
+  return conversationRow({
+    id: `${CONV_THREAD_ID}:user:${seq}`,
+    threadId: CONV_THREAD_ID,
+    turnId: CONV_TURN_ID,
+    role: "user",
+    sourceSeqStart: seq,
+    startedAt: 1777337000000 + seq,
+    createdAt: 1777337000000 + seq,
+    text,
+  });
+}
+
+function assistantMessage(seq: number, text: string): TimelineRow {
+  return conversationRow({
+    id: `${CONV_THREAD_ID}:assistant:${seq}`,
+    threadId: CONV_THREAD_ID,
+    turnId: CONV_TURN_ID,
+    role: "assistant",
+    sourceSeqStart: seq,
+    startedAt: 1777337000000 + seq,
+    createdAt: 1777337000000 + seq,
+    text,
+  });
+}
+
+// Trailing exploration cluster left open under active scope — the one genuine
+// (active-latest) bundle-summary in the thread, shimmering as the frontier.
+function frontierRead(
+  idSuffix: string,
+  seq: number,
+  path: string,
+  status: TimelineRowStatus,
+): TimelineRow {
+  return toolRow({
+    id: `${CONV_THREAD_ID}:tool:frontier_${idSuffix}`,
+    threadId: CONV_THREAD_ID,
+    turnId: CONV_TURN_ID,
+    sourceSeqStart: seq,
+    startedAt: status === "pending" ? Date.now() : Date.now() - 4000,
+    createdAt: status === "pending" ? Date.now() : Date.now() - 4000,
+    status,
+    callId: `frontier_${idSuffix}`,
+    toolName: "Read",
+    toolArgs: { file_path: path },
+    output: status === "pending" ? "" : "...file contents...",
+    activityIntents: [
+      {
+        type: "read",
+        command: "Read",
+        name: path.split("/").pop() ?? path,
+        path,
+      },
+    ],
+    durationMs: status === "pending" ? null : 60,
+  });
+}
+
+const frontierExplorationRows: TimelineRow[] = [
+  frontierRead(
+    "watcher",
+    40001,
+    "packages/host-daemon/src/workspace/watcher.ts",
+    "completed",
+  ),
+  frontierRead(
+    "session",
+    40002,
+    "packages/host-daemon/src/runtime/session.ts",
+    "completed",
+  ),
+  frontierRead(
+    "index",
+    40003,
+    "packages/host-daemon/src/workspace/index.ts",
+    "pending",
+  ),
+];
+
+const interleavedConversationRows: TimelineRow[] = [
+  userMessage(40010, "Track down why the workspace watcher leaks and fix it."),
+  assistantMessage(
+    40011,
+    "Starting with a read through the watcher and its callers.",
+  ),
+  ...explorationBundleRows,
+  assistantMessage(
+    40020,
+    "Confirmed — the watcher outlives the provider process. Running the suite to verify.",
+  ),
+  ...commandBundleMixedStatusRows,
+  assistantMessage(
+    40030,
+    "First pass hit a failing server test; it needs the fix to land before it goes green. Editing the call sites now.",
+  ),
+  ...fileChangeBundleMixedStatusRows,
+  assistantMessage(
+    40040,
+    "Re-applied the interrupted edit and reran — clean. Tidying the todo list and reloading the tool schemas.",
+  ),
+  ...toolsBundleRows,
+  userMessage(
+    40050,
+    "Also confirm the recommended idle-TTL default from the editor docs.",
+  ),
+  assistantMessage(40051, "Researching the editor CLI docs now."),
+  ...webResearchBundleRows,
+  assistantMessage(
+    40060,
+    "Docs point to a 30s idle lease. Delegating the cross-package check and a merge-readiness review.",
+  ),
+  ...delegationsBundleRows,
+  assistantMessage(
+    40070,
+    "Subagents are back clean. Doing a final read-through of the changed files before I hand it off.",
+  ),
+  ...frontierExplorationRows,
+];
+
+export function Conversation() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="interleaved thread"
+        hint="user + agent messages at full strength; finished work rolled up and receded; errored/interrupted clusters and the live frontier kept prominent"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows
+            {...baseProps}
+            threadRuntimeDisplayStatus="active"
+            timelineRows={interleavedConversationRows}
           />
         </TimelineStage>
       </StoryRow>


### PR DESCRIPTION
## Summary

Finished/past tool rows weren't muted enough versus active rows — the active↔done gap read too tight. This widens the timeline prominence ramp and applies it consistently across every row kind.

Hierarchy (unchanged in intent, now clearer): **agent prose > active rows > finished/past rows**.

## Changes

- **`ThreadTimelineRows.tsx`** — replaced the two ad-hoc dim helpers (`completedWorkRowDimClassName` / `rolledUpHeaderDimClassName`) with one `pastRowDimClassName`, and deepened the past-layer opacity from `opacity-70` to `opacity-40`. It's a whole-row opacity step, so the active>done ordering is identical in light and dark (rather than leaning on the muted-vs-foreground token gap, which is wide in light but nearly nothing in dark).
- **Applied comprehensively across every row kind**, not just tool/command/file rows:
  - completed `work` and `system` rows, turn headers, and bundle/step summaries all recede;
  - errored, interrupted, and still-running rows stay at full strength so failures and live work keep attention;
  - the **active-latest bundle** (the live frontier) stays prominent.
  - Closes two gaps: completed **system** rows now recede, and the active-latest bundle is **no longer dimmed**.
- Diff counts (`+N −N`) keep their green/red color tokens and dim together with the row (mechanism unchanged from main).

## Stories

- New **ProminenceRamp** story walking the three tiers across every row kind — leaf tool calls, bundle/step/turn summaries, system rows, and the active-latest frontier.
- New interleaved **Conversation** story on the Bundle Summary story, showing the ramp in a realistic thread with user + agent messages (finished work receded, live "Exploring…" frontier prominent).

## Validation

- `@bb/app` typecheck + eslint pass.
- Visual review via Ladle (`pnpm storybook` in `apps/app`): `thread/timeline/Prominence Ramp`, `thread/timeline/rows/Bundle Summary` (Conversation), `thread/timeline/rows/File Change`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)