### PR TITLE
[codex] add timeline pointer cursors

### DIFF
--- a/apps/app/.ladle/vite.config.ts
+++ b/apps/app/.ladle/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   plugins: [tailwindcss()],
   // Keep app and Ladle dep optimization metadata from clobbering each other.
   cacheDir: "node_modules/.vite/ladle",
+  worker: {
+    format: "es",
+  },
   resolve: {
     conditions: ["source"],
     alias: {

--- a/apps/app/src/components/thread/timeline/ConversationAttachments.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationAttachments.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import type { TimelineConversationAttachments } from "@bb/server-contract";
 import { fileNameFromPath } from "@bb/thread-view";
-import { ImageLightbox, getWrappedImageIndex } from "../../ui/image-lightbox.js";
+import {
+  ImageLightbox,
+  getWrappedImageIndex,
+} from "../../ui/image-lightbox.js";
 import { cn } from "@/lib/utils";
 import { buildProjectAttachmentContentUrl } from "@/lib/file-content-urls";
 import type {
@@ -177,7 +180,10 @@ export function ConversationAttachments({
                   href={attachmentHref}
                   target="_blank"
                   rel="noreferrer"
-                  className={cn(className, "hover:bg-state-hover")}
+                  className={cn(
+                    className,
+                    "cursor-pointer hover:bg-state-hover",
+                  )}
                 >
                   {label}
                 </a>
@@ -196,7 +202,7 @@ export function ConversationAttachments({
               <button
                 key={path}
                 type="button"
-                className={cn(className, "hover:bg-state-hover")}
+                className={cn(className, "cursor-pointer hover:bg-state-hover")}
                 onClick={() => {
                   onOpenLocalFileLink({ lineRange: null, path });
                 }}

--- a/apps/app/src/components/thread/timeline/ThreadContextWindowIndicator.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadContextWindowIndicator.tsx
@@ -47,7 +47,7 @@ export function ThreadContextWindowIndicator({
           type="button"
           {...triggerHoverProps}
           className={cn(
-            "inline-flex size-6 items-center justify-center rounded-full transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "inline-flex size-6 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             className,
           )}
           aria-label={`Context window ${usedPercent}% used`}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -527,9 +527,7 @@ function buildSenderThreadMetadataById({
   return metadataById;
 }
 
-function shouldSyncSenderThreadMetadata(
-  event: QueryCacheNotifyEvent,
-): boolean {
+function shouldSyncSenderThreadMetadata(event: QueryCacheNotifyEvent): boolean {
   if (event.type !== "updated") {
     return false;
   }
@@ -990,7 +988,7 @@ function LazyTurnRowBody({
           variant="outline"
           size="sm"
           onClick={handleRetry}
-          className="h-7 border-destructive px-2 text-destructive hover:text-destructive"
+          className="h-7 cursor-pointer border-destructive px-2 text-destructive hover:text-destructive"
         >
           <Icon name="RotateCcw" />
           Retry

--- a/apps/app/src/components/thread/timeline/conversation-message-overflow.tsx
+++ b/apps/app/src/components/thread/timeline/conversation-message-overflow.tsx
@@ -1,8 +1,4 @@
-import {
-  useLayoutEffect,
-  useState,
-  type RefObject,
-} from "react";
+import { useLayoutEffect, useState, type RefObject } from "react";
 import { cn } from "@/lib/utils";
 
 interface UseOverflowMeasurementArgs {
@@ -96,7 +92,7 @@ export function ConversationMessageOverflowToggle({
       <button
         type="button"
         onClick={onToggle}
-        className="text-xs font-medium text-muted-foreground hover:text-foreground"
+        className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground"
         aria-expanded={expanded}
       >
         {expanded ? labels.expanded : labels.collapsed}
@@ -114,7 +110,10 @@ export function ConversationMessageInlineOverflowToggle({
   return (
     <span className="pointer-events-none absolute inset-x-0 bottom-0 flex h-[1lh] items-stretch justify-end">
       <span
-        className={cn("w-12 bg-gradient-to-l to-transparent", fadeFromClassName)}
+        className={cn(
+          "w-12 bg-gradient-to-l to-transparent",
+          fadeFromClassName,
+        )}
       />
       <button
         type="button"

--- a/apps/app/src/components/ui/copy-button.tsx
+++ b/apps/app/src/components/ui/copy-button.tsx
@@ -60,7 +60,7 @@ export function CopyButton({
     <button
       type="button"
       className={cn(
-        "inline-flex size-5 items-center justify-center text-muted-foreground hover:text-foreground focus-visible:opacity-100",
+        "inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground hover:text-foreground focus-visible:opacity-100",
         className,
       )}
       onClick={() => {
@@ -106,7 +106,7 @@ export function CopyableInlineLabel({
     <button
       type="button"
       className={cn(
-        "inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md text-left text-foreground transition-colors hover:text-foreground/80",
+        "inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md text-left text-foreground transition-colors hover:text-foreground/80",
         className,
       )}
       onClick={() => {

--- a/apps/app/src/components/ui/disclosure.tsx
+++ b/apps/app/src/components/ui/disclosure.tsx
@@ -71,7 +71,7 @@ export function CollapsibleHeader({
   const rootClassName = cn(
     COLLAPSIBLE_HEADER_BUTTON_BASE_CLASS,
     toneClassName,
-    onToggle ? "group/toggle" : null,
+    onToggle ? "group/toggle cursor-pointer" : null,
     className,
   );
   const summaryClass = summaryClassName ?? COLLAPSIBLE_HEADER_TEXT_CLASS;


### PR DESCRIPTION
## Summary

- Add uniform pointer cursors to clickable timeline row headers and timeline controls.
- Preserve non-clickable static timeline rows without misleading pointer affordances.
- Update the Ladle Vite config to build module workers with `worker.format: "es"`, which fixes the static Ladle build for the diff worker.

## Validation

- `pnpm --dir apps/app run storybook:build`
- `pnpm exec turbo run typecheck --filter=@bb/app`

## Notes

The timeline story IDs were verified through Ladle `meta.json`; the command story is `thread--timeline--rows--command--overview`.
