### PR TITLE
Add Threads header new thread action

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -82,6 +82,7 @@ import {
 } from "./sidebarCollapsedAtoms";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
+  SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
 import {
@@ -178,6 +179,7 @@ interface TopLevelSidebarSectionProps {
   children: ReactNode;
   actions?: ReactNode;
   actionsAlwaysVisible?: boolean;
+  actionsMobileAlways?: boolean;
   collapseControl?: TopLevelSidebarSectionCollapseControl;
   dragBindings?: SidebarSortableDragBindings;
   sectionRef?: (element: HTMLDivElement | null) => void;
@@ -390,6 +392,7 @@ function TopLevelSidebarSection({
   children,
   actions,
   actionsAlwaysVisible = false,
+  actionsMobileAlways = false,
   collapseControl,
   dragBindings,
   sectionRef,
@@ -492,6 +495,11 @@ function TopLevelSidebarSection({
         {actions ? (
           <span className="absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center">
             <span
+              data-sidebar-hover-actions-mobile={
+                actionsMobileAlways
+                  ? SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+                  : undefined
+              }
               className={cn(
                 "inline-flex shrink-0 items-center",
                 !actionsAlwaysVisible && SIDEBAR_HOVER_ACTIONS_CLASS,
@@ -1041,6 +1049,7 @@ function ProjectListComponent({
                   label="Threads"
                   disabled={visibleSidebarSectionOrder.length < 2}
                   actions={threadsSectionActions}
+                  actionsMobileAlways
                   collapseControl={{
                     isCollapsed: collapsedSidebarSectionIds.has("threads"),
                     onToggleCollapsed: () =>


### PR DESCRIPTION
Summary:
- Add a mobile-always hover-action option to top-level sidebar section actions.
- Show the Threads header new-thread icon always on mobile/coarse pointers while keeping desktop hover/focus behavior.

Tests:
- pnpm exec turbo run typecheck --filter=@bb/app