### PR TITLE
Default dev servers to remote-friendly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,20 +94,20 @@ can run alongside each other and the packaged `npx bb-app@latest` instance.
 To use the dev app from another machine, for example over Tailscale, run:
 
 ```bash
-BB_DEV_REMOTE=true pnpm dev
+pnpm dev
 ```
 
-Then open `http://<remote-host-or-tailscale-ip>:<app-port>`. Without
-`BB_DEV_REMOTE=true`, source dev keeps the browser app on localhost-only Vite
-defaults.
+Then open `http://<remote-host-or-tailscale-ip>:<app-port>`. Source dev binds
+the browser app to all interfaces and uses the browser host for WebSockets by
+default.
 
 To use the component storybook from another machine, run:
 
 ```bash
-REMOTE=true pnpm storybook
+pnpm storybook
 ```
 
-That binds Ladle to all interfaces and configures its HMR WebSocket to use the
+Ladle also binds to all interfaces and configures its HMR WebSocket to use the
 browser's current host instead of `localhost`.
 
 Development behavior is intentionally split:

--- a/apps/app/.ladle/config.mjs
+++ b/apps/app/.ladle/config.mjs
@@ -1,30 +1,13 @@
-function parseRemoteEnv() {
-  const value = process.env.REMOTE;
-  if (value === undefined) return false;
-
-  const normalizedValue = value.trim().toLowerCase();
-  if (["true", "1", "yes", "y"].includes(normalizedValue)) return true;
-  if (["false", "0", "no", "n", ""].includes(normalizedValue)) return false;
-
-  throw new Error("REMOTE must be a boolean");
-}
-
-const remote = parseRemoteEnv();
-
 /** @type {import("@ladle/react").UserConfig} */
 export default {
   stories: ["src/**/*.stories.tsx"],
   defaultStory: "",
   viteConfig: "./.ladle/vite.config.ts",
-  ...(remote
-    ? {
-        host: "0.0.0.0",
-        // Ladle defaults Vite HMR to localhost independently of `host`.
-        // Empty string keeps Vite's websocket listener non-loopback and lets
-        // the browser use the page hostname for the websocket URL.
-        hmrHost: "",
-      }
-    : {}),
+  host: "0.0.0.0",
+  // Ladle defaults Vite HMR to localhost independently of `host`.
+  // Empty string keeps Vite's websocket listener non-loopback and lets
+  // the browser use the page hostname for the websocket URL.
+  hmrHost: "",
   addons: {
     theme: {
       defaultState: "dark",

--- a/apps/app/src/lib/dev-websocket-url.ts
+++ b/apps/app/src/lib/dev-websocket-url.ts
@@ -8,10 +8,6 @@ function resolveBrowserHostDevWebSocketBaseUrl(port: number): string {
 }
 
 function resolveDevWebSocketBaseUrl(): string | undefined {
-  if (typeof __BB_DEV_WS_URL__ === "string") {
-    return __BB_DEV_WS_URL__;
-  }
-
   if (typeof __BB_DEV_WS_BROWSER_HOST_PORT__ === "number") {
     return resolveBrowserHostDevWebSocketBaseUrl(
       __BB_DEV_WS_BROWSER_HOST_PORT__,

--- a/apps/app/src/vite-env.d.ts
+++ b/apps/app/src/vite-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
 
 /** Injected by vite.dev.config.ts to bypass Vite's WebSocket proxy. */
-declare const __BB_DEV_WS_URL__: string | undefined;
 declare const __BB_DEV_WS_BROWSER_HOST_PORT__: number | undefined;

--- a/apps/app/vite.dev.config.ts
+++ b/apps/app/vite.dev.config.ts
@@ -3,22 +3,15 @@ import { loadViteDevConfig } from "@bb/config/vite-dev";
 import { sharedViteConfig } from "./vite.config.js";
 
 const viteDevConfig = loadViteDevConfig();
-const undefinedDefineValue = "undefined";
-const devWebSocketUrlDefine =
-  viteDevConfig.serverWsOrigin.kind === "fixed"
-    ? JSON.stringify(`${viteDevConfig.serverWsOrigin.origin}/ws`)
-    : undefinedDefineValue;
-const devWebSocketBrowserHostPortDefine =
-  viteDevConfig.serverWsOrigin.kind === "browser-host"
-    ? JSON.stringify(viteDevConfig.serverWsOrigin.port)
-    : undefinedDefineValue;
+const devWebSocketBrowserHostPortDefine = JSON.stringify(
+  viteDevConfig.serverWsOrigin.port,
+);
 
 export default defineConfig({
   ...sharedViteConfig,
   define: {
     // Connect directly to the server in dev because Vite's WS proxy does not
     // handle upstream server restarts reliably.
-    __BB_DEV_WS_URL__: devWebSocketUrlDefine,
     __BB_DEV_WS_BROWSER_HOST_PORT__: devWebSocketBrowserHostPortDefine,
   },
   server: {

--- a/packages/config/src/dev-app.ts
+++ b/packages/config/src/dev-app.ts
@@ -7,15 +7,12 @@ import {
 import {
   BB_DEV_APP_HOST_ENV,
   BB_DEV_APP_PORT_ENV,
-  BB_DEV_REMOTE_ENV,
   DEFAULT_BB_DEV_APP_HOST,
-  DEFAULT_BB_DEV_REMOTE,
 } from "./env-vars.js";
 import { assignIfDefined } from "./objects.js";
 
 export interface DevAppConfig {
   BB_DEV_APP_HOST: string;
-  BB_DEV_REMOTE: boolean;
   BB_DEV_APP_PORT?: number;
 }
 
@@ -30,12 +27,6 @@ export function loadDevAppConfig(
       context: loader.context,
       defaultValue: DEFAULT_BB_DEV_APP_HOST,
       definition: BB_DEV_APP_HOST_ENV,
-      env: loader.env,
-    }),
-    BB_DEV_REMOTE: readEnvVarWithDefault({
-      context: loader.context,
-      defaultValue: DEFAULT_BB_DEV_REMOTE,
-      definition: BB_DEV_REMOTE_ENV,
       env: loader.env,
     }),
   };

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -191,16 +191,9 @@ export const BB_FF_PLACEHOLDER_ENV = defineEnvVar<boolean>({
 
 export const BB_DEV_APP_HOST_ENV = defineEnvVar<string>({
   description:
-    "Development-only Vite bind host for apps/app. Set to 0.0.0.0 to test from phones or other LAN devices.",
+    "Development-only Vite bind host override for apps/app. Defaults to 0.0.0.0 when unset.",
   name: "BB_DEV_APP_HOST",
   parse: parseStringEnvValue,
-});
-
-export const BB_DEV_REMOTE_ENV = defineEnvVar<boolean>({
-  description:
-    "Development-only remote access mode. Set to true to bind the Vite app to all interfaces and make browser WebSockets use the page host.",
-  name: "BB_DEV_REMOTE",
-  parse: parseBooleanEnvValue,
 });
 
 export const BB_DEV_APP_PORT_ENV = defineEnvVar<number | undefined>({
@@ -261,7 +254,6 @@ export const DEFAULT_BB_POSTHOG_API_KEY =
   "phc_tejoYoNLV6vG8QAd5eYXXvcsENFYnP4brpZDGqG7zvpy";
 export const DEFAULT_BB_TELEMETRY = true;
 export const DEFAULT_BB_DEV_APP_HOST = "";
-export const DEFAULT_BB_DEV_REMOTE = false;
 export const DEFAULT_BB_INFERENCE = DEFAULTS.inferenceModel;
 export const DEFAULT_BB_TRANSCRIPTION = DEFAULTS.transcriptionModel;
 export const DEFAULT_BB_FF_PLACEHOLDER = defaultFeatureFlags.placeholder;

--- a/packages/config/src/vite-dev.ts
+++ b/packages/config/src/vite-dev.ts
@@ -1,58 +1,27 @@
 import { loadDevAppConfig } from "./dev-app.js";
 import { type EnvLoaderArgs } from "./env.js";
-import { assignIfDefined } from "./objects.js";
 import { loadServerPortConfig } from "./server-port.js";
 
-export type ViteDevServerWsOrigin =
-  | { kind: "browser-host"; port: number }
-  | { kind: "fixed"; origin: string };
+export type ViteDevServerWsOrigin = { kind: "browser-host"; port: number };
 
 export interface ViteDevConfig {
   appPort: number;
   serverHttpOrigin: string;
   serverPort: number;
   serverWsOrigin: ViteDevServerWsOrigin;
-  appHost?: string;
+  appHost: string;
 }
 
 export interface LoadViteDevConfigArgs extends EnvLoaderArgs {
   repoRoot?: string;
 }
 
-interface ResolveViteDevAppHostArgs {
-  configuredHost: string;
-  remote: boolean;
-}
-
-interface ResolveViteDevServerWsOriginArgs {
-  remote: boolean;
-  serverPort: number;
-}
-
-function resolveViteDevAppHost(
-  args: ResolveViteDevAppHostArgs,
-): string | undefined {
-  if (args.configuredHost !== "") {
-    return args.configuredHost;
+function resolveViteDevAppHost(configuredHost: string): string {
+  if (configuredHost !== "") {
+    return configuredHost;
   }
 
-  return args.remote ? "0.0.0.0" : undefined;
-}
-
-function resolveViteDevServerWsOrigin(
-  args: ResolveViteDevServerWsOriginArgs,
-): ViteDevServerWsOrigin {
-  if (args.remote) {
-    return {
-      kind: "browser-host",
-      port: args.serverPort,
-    };
-  }
-
-  return {
-    kind: "fixed",
-    origin: `ws://localhost:${args.serverPort}`,
-  };
+  return "0.0.0.0";
 }
 
 export function loadViteDevConfig(
@@ -65,25 +34,15 @@ export function loadViteDevConfig(
   }
 
   const serverPortConfig = loadServerPortConfig(args);
-  const serverHttpOrigin = `http://localhost:${serverPortConfig.BB_SERVER_PORT}`;
-  const config: ViteDevConfig = {
+  const serverPort = serverPortConfig.BB_SERVER_PORT;
+  return {
+    appHost: resolveViteDevAppHost(devAppConfig.BB_DEV_APP_HOST),
     appPort,
-    serverHttpOrigin,
-    serverPort: serverPortConfig.BB_SERVER_PORT,
-    serverWsOrigin: resolveViteDevServerWsOrigin({
-      remote: devAppConfig.BB_DEV_REMOTE,
-      serverPort: serverPortConfig.BB_SERVER_PORT,
-    }),
+    serverHttpOrigin: `http://localhost:${serverPort}`,
+    serverPort,
+    serverWsOrigin: {
+      kind: "browser-host",
+      port: serverPort,
+    },
   };
-
-  assignIfDefined({
-    key: "appHost",
-    target: config,
-    value: resolveViteDevAppHost({
-      configuredHost: devAppConfig.BB_DEV_APP_HOST,
-      remote: devAppConfig.BB_DEV_REMOTE,
-    }),
-  });
-
-  return config;
 }

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -621,37 +621,13 @@ describe("consumer-specific config", () => {
     });
 
     expect(devAppConfig.BB_DEV_APP_HOST).toBe("0.0.0.0");
-    expect(devAppConfig.BB_DEV_REMOTE).toBe(false);
     expect(devAppConfig.BB_DEV_APP_PORT).toBeUndefined();
   });
 
   it("builds app Vite dev config from the app dev entrypoint scope", () => {
     const viteDevConfig = loadViteDevConfig({
       env: {
-        BB_DEV_APP_HOST: "0.0.0.0",
         BB_DEV_APP_PORT: "4173",
-        BB_SERVER_PORT: "4444",
-        NODE_ENV: "development",
-      },
-    });
-
-    expect(viteDevConfig).toEqual({
-      appHost: "0.0.0.0",
-      appPort: 4173,
-      serverHttpOrigin: "http://localhost:4444",
-      serverPort: 4444,
-      serverWsOrigin: {
-        kind: "fixed",
-        origin: "ws://localhost:4444",
-      },
-    });
-  });
-
-  it("builds remote app Vite dev config from BB_DEV_REMOTE", () => {
-    const viteDevConfig = loadViteDevConfig({
-      env: {
-        BB_DEV_APP_PORT: "4173",
-        BB_DEV_REMOTE: "true",
         BB_SERVER_PORT: "4444",
         NODE_ENV: "development",
       },


### PR DESCRIPTION
## Summary
- remove the BB_DEV_REMOTE dev config option
- make app dev bind to 0.0.0.0 and use browser-host WebSockets by default
- make Ladle remote-friendly by default and update README commands

## Validation
- pnpm exec turbo run test --filter=@bb/config
- pnpm exec turbo run typecheck --filter=@bb/config --filter=@bb/app