### PR TITLE
Remove icons from ask-user question tabs

### DIFF
--- a/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
+++ b/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
@@ -130,9 +130,6 @@ function QuestionTabs({
             <TabPill
               key={question.id}
               label={question.shortLabel ?? `Question ${index + 1}`}
-              leadingVisual={
-                <Icon name="FileQuestion" className="size-3.5" aria-hidden />
-              }
               labelClassName={answered ? "line-through" : undefined}
               title={question.prompt}
               isActive={index === currentIndex}

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -21,7 +21,7 @@ export interface TabPillCloseAction {
 
 export interface TabPillProps {
   label: string;
-  leadingVisual: ReactNode;
+  leadingVisual?: ReactNode;
   secondaryLabel?: string | null;
   /** Extra classes for the label text (e.g. `line-through` for a done tab). */
   labelClassName?: string;
@@ -60,16 +60,18 @@ export function TabPill({
         title={title}
         className="flex h-full min-w-0 items-center rounded-md pl-2 pr-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
-        <span
-          className={cn(
-            TAB_PILL_LEADING_VISUAL_CLASS,
-            closeAction
-              ? "group-hover/tab-pill:opacity-0 group-has-[[data-tab-pill-close]:focus-visible]/tab-pill:opacity-0 max-md:pointer-coarse:opacity-0"
-              : null,
-          )}
-        >
-          {leadingVisual}
-        </span>
+        {leadingVisual ? (
+          <span
+            className={cn(
+              TAB_PILL_LEADING_VISUAL_CLASS,
+              closeAction
+                ? "group-hover/tab-pill:opacity-0 group-has-[[data-tab-pill-close]:focus-visible]/tab-pill:opacity-0 max-md:pointer-coarse:opacity-0"
+                : null,
+            )}
+          >
+            {leadingVisual}
+          </span>
+        ) : null}
         <span className={cn("truncate", labelMaxWidthClass, labelClassName)}>
           {label}
         </span>


### PR DESCRIPTION
## Summary
- make `TabPill` leading visuals optional again
- remove the `FileQuestion` icon from ask-user question tabs
- keep existing file-tab leading visuals unchanged

## Testing
- `git diff --check`
- `pnpm exec turbo run typecheck --filter=@bb/app`