### PR TITLE
Make new-thread prompt defaults project agnostic

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -988,6 +988,7 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
   );
   const showChildren = !isCollapsed && hasChildren;
   const hasComposerDraft = usePromptDraftHasInput({
+    kind: "thread",
     projectId,
     threadId: node.thread.id,
   });

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -1,9 +1,9 @@
 import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 import { useCallback } from "react";
 import type { PermissionMode, ReasoningLevel, ServiceTier } from "@bb/domain";
 import {
-  createPersistedEnumAtom,
-  createProjectScopedStorageAtomFamily,
+  createLocalStorageEnumStorage,
   rawStringLocalStorage,
 } from "@/lib/browser-storage";
 
@@ -18,7 +18,6 @@ export type StoredServiceTier = "" | ServiceTier;
 export type StoredReasoningLevel = "" | ReasoningLevel;
 export type StoredPermissionMode = "" | PermissionMode;
 
-type ProjectScopedStorageParam = string | null | undefined;
 type StringSelectionSetter = (value: string) => void;
 type StoredServiceTierSetter = (value: StoredServiceTier) => void;
 type StoredReasoningLevelSetter = (value: StoredReasoningLevel) => void;
@@ -77,41 +76,45 @@ function isStoredPermissionMode(value: string): value is StoredPermissionMode {
   return value === "" || isPermissionMode(value);
 }
 
-const providerIdAtomFamily = createProjectScopedStorageAtomFamily(
+const providerIdAtom = atomWithStorage<string>(
   PROVIDER_STORAGE_KEY,
   "",
   rawStringLocalStorage,
+  { getOnInit: true },
 );
-const modelAtomFamily = createProjectScopedStorageAtomFamily(
+const modelAtom = atomWithStorage<string>(
   MODEL_STORAGE_KEY,
   "",
   rawStringLocalStorage,
+  { getOnInit: true },
 );
-const serviceTierAtomFamily = createPersistedEnumAtom<StoredServiceTier>({
-  baseKey: SERVICE_TIER_STORAGE_KEY,
-  initialValue: "",
-  isValue: isStoredServiceTier,
-});
-const reasoningLevelAtomFamily = createPersistedEnumAtom<StoredReasoningLevel>({
-  baseKey: REASONING_STORAGE_KEY,
-  initialValue: "",
-  isValue: isStoredReasoningLevel,
-});
-const permissionModeAtomFamily = createPersistedEnumAtom<StoredPermissionMode>({
-  baseKey: PERMISSION_MODE_STORAGE_KEY,
-  initialValue: "",
-  isValue: isStoredPermissionMode,
-});
-const environmentSelectionAtomFamily = createProjectScopedStorageAtomFamily(
+const serviceTierAtom = atomWithStorage<StoredServiceTier>(
+  SERVICE_TIER_STORAGE_KEY,
+  "",
+  createLocalStorageEnumStorage(isStoredServiceTier),
+  { getOnInit: true },
+);
+const reasoningLevelAtom = atomWithStorage<StoredReasoningLevel>(
+  REASONING_STORAGE_KEY,
+  "",
+  createLocalStorageEnumStorage(isStoredReasoningLevel),
+  { getOnInit: true },
+);
+const permissionModeAtom = atomWithStorage<StoredPermissionMode>(
+  PERMISSION_MODE_STORAGE_KEY,
+  "",
+  createLocalStorageEnumStorage(isStoredPermissionMode),
+  { getOnInit: true },
+);
+const environmentSelectionAtom = atomWithStorage<string>(
   ENVIRONMENT_STORAGE_KEY,
   "",
   rawStringLocalStorage,
+  { getOnInit: true },
 );
 
-export function usePersistedProviderSelection(
-  projectId: ProjectScopedStorageParam,
-): PersistedStringSelectionField {
-  const [value, setAtomValue] = useAtom(providerIdAtomFamily(projectId));
+export function usePromptBoxProviderPreference(): PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(providerIdAtom);
   const setValue = useCallback(
     (nextValue: string) => {
       setAtomValue(nextValue);
@@ -121,10 +124,8 @@ export function usePersistedProviderSelection(
   return { setValue, value };
 }
 
-export function usePersistedModelSelection(
-  projectId: ProjectScopedStorageParam,
-): PersistedStringSelectionField {
-  const [value, setAtomValue] = useAtom(modelAtomFamily(projectId));
+export function usePromptBoxModelPreference(): PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(modelAtom);
   const setValue = useCallback(
     (nextValue: string) => {
       setAtomValue(nextValue);
@@ -134,10 +135,9 @@ export function usePersistedModelSelection(
   return { setValue, value };
 }
 
-export function usePersistedServiceTierSelection(
-  projectId: ProjectScopedStorageParam,
-): PersistedServiceTierSelectionField {
-  const [value, setAtomValue] = useAtom(serviceTierAtomFamily(projectId));
+export function usePromptBoxServiceTierPreference():
+  PersistedServiceTierSelectionField {
+  const [value, setAtomValue] = useAtom(serviceTierAtom);
   const setValue = useCallback(
     (nextValue: StoredServiceTier) => {
       setAtomValue(nextValue);
@@ -147,10 +147,9 @@ export function usePersistedServiceTierSelection(
   return { setValue, value };
 }
 
-export function usePersistedReasoningLevelSelection(
-  projectId: ProjectScopedStorageParam,
-): PersistedReasoningLevelSelectionField {
-  const [value, setAtomValue] = useAtom(reasoningLevelAtomFamily(projectId));
+export function usePromptBoxReasoningLevelPreference():
+  PersistedReasoningLevelSelectionField {
+  const [value, setAtomValue] = useAtom(reasoningLevelAtom);
   const setValue = useCallback(
     (nextValue: StoredReasoningLevel) => {
       setAtomValue(nextValue);
@@ -160,10 +159,9 @@ export function usePersistedReasoningLevelSelection(
   return { setValue, value };
 }
 
-export function usePersistedPermissionModeSelection(
-  projectId: ProjectScopedStorageParam,
-): PersistedPermissionModeSelectionField {
-  const [value, setAtomValue] = useAtom(permissionModeAtomFamily(projectId));
+export function usePromptBoxPermissionModePreference():
+  PersistedPermissionModeSelectionField {
+  const [value, setAtomValue] = useAtom(permissionModeAtom);
   const setValue = useCallback(
     (nextValue: StoredPermissionMode) => {
       setAtomValue(nextValue);
@@ -173,12 +171,9 @@ export function usePersistedPermissionModeSelection(
   return { setValue, value };
 }
 
-export function usePersistedEnvironmentSelection(
-  projectId: ProjectScopedStorageParam,
-): PersistedStringSelectionField {
-  const [value, setAtomValue] = useAtom(
-    environmentSelectionAtomFamily(projectId),
-  );
+export function usePromptBoxEnvironmentPreference():
+  PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(environmentSelectionAtom);
   const setValue = useCallback(
     (nextValue: string) => {
       setAtomValue(nextValue);

--- a/apps/app/src/hooks/thread-creation-options/selection-state.ts
+++ b/apps/app/src/hooks/thread-creation-options/selection-state.ts
@@ -31,7 +31,6 @@ export interface UsePromptModelReasoningOptions {
   enabled?: boolean;
   environmentId?: string;
   scope?: ThreadCreationOptionsScope;
-  projectId?: string | null;
   resetKey?: string | number | null;
   initialProviderId?: string;
   initialModel?: string;

--- a/apps/app/src/hooks/usePromptDraftStorage.test.tsx
+++ b/apps/app/src/hooks/usePromptDraftStorage.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { usePromptDraftStorage } from "./usePromptDraftStorage";
+
+const NEW_THREAD_DRAFT_KEY = "bb.promptbox.contents-draft-3";
+const LEGACY_PROJECT_DRAFT_KEY = "bb.promptbox.contents-proj_prompt-draft-3";
+
+function storedDraft(text: string): string {
+  return JSON.stringify({ text, attachments: [] });
+}
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe("usePromptDraftStorage", () => {
+  it("uses project-agnostic storage for new-thread prompt contents", () => {
+    window.localStorage.setItem(
+      LEGACY_PROJECT_DRAFT_KEY,
+      storedDraft("project draft"),
+    );
+    window.localStorage.setItem(NEW_THREAD_DRAFT_KEY, storedDraft("global draft"));
+
+    const { result } = renderHook(() =>
+      usePromptDraftStorage({ kind: "new-thread" }),
+    );
+
+    expect(result.current.storageKey).toBe(NEW_THREAD_DRAFT_KEY);
+    expect(result.current.text).toBe("global draft");
+
+    act(() => {
+      result.current.setDraft({
+        text: "updated global draft",
+        mentions: [],
+        attachments: [],
+      });
+    });
+
+    expect(window.localStorage.getItem(NEW_THREAD_DRAFT_KEY)).toBe(
+      storedDraft("updated global draft"),
+    );
+    expect(window.localStorage.getItem(LEGACY_PROJECT_DRAFT_KEY)).toBe(
+      storedDraft("project draft"),
+    );
+  });
+
+  it("keeps thread follow-up drafts scoped to the thread", () => {
+    const { result } = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "thread",
+        projectId: "proj_prompt",
+        threadId: "thr_followup",
+      }),
+    );
+
+    expect(result.current.storageKey).toBe(
+      "bb.promptbox.contents-proj_prompt-thr_followup-3",
+    );
+  });
+});

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -16,10 +16,9 @@ const PROMPT_DRAFT_STORAGE_PREFIX = "bb.promptbox.contents";
 const PROMPT_DRAFT_STORAGE_VERSION = "3";
 const PROMPT_DRAFT_PERSIST_DEBOUNCE_MS = 250;
 
-export interface PromptDraftScope {
-  projectId?: string | null;
-  threadId?: string | null;
-}
+export type PromptDraftScope =
+  | { kind: "new-thread" }
+  | { kind: "thread"; projectId: string; threadId: string };
 
 interface PromptDraftCacheEntry {
   rawValue: string | null;
@@ -220,28 +219,18 @@ function restorePromptDraftIfEmpty(
   return true;
 }
 
-function getPromptDraftStorageKey({
-  projectId,
-  threadId,
-}: PromptDraftScope): string | null {
-  if (!projectId) return null;
-  const normalizedProjectId = normalizeStorageSegment(projectId);
-  if (threadId) {
-    const normalizedThreadId = normalizeStorageSegment(threadId);
-    return `${PROMPT_DRAFT_STORAGE_PREFIX}-${normalizedProjectId}-${normalizedThreadId}-${PROMPT_DRAFT_STORAGE_VERSION}`;
+function getPromptDraftStorageKey(scope: PromptDraftScope): string | null {
+  if (scope.kind === "new-thread") {
+    return `${PROMPT_DRAFT_STORAGE_PREFIX}-draft-${PROMPT_DRAFT_STORAGE_VERSION}`;
   }
-  return `${PROMPT_DRAFT_STORAGE_PREFIX}-${normalizedProjectId}-draft-${PROMPT_DRAFT_STORAGE_VERSION}`;
+
+  const normalizedProjectId = normalizeStorageSegment(scope.projectId);
+  const normalizedThreadId = normalizeStorageSegment(scope.threadId);
+  return `${PROMPT_DRAFT_STORAGE_PREFIX}-${normalizedProjectId}-${normalizedThreadId}-${PROMPT_DRAFT_STORAGE_VERSION}`;
 }
 
 export function usePromptDraftStorage(scope: PromptDraftScope) {
-  const storageKey = useMemo(
-    () =>
-      getPromptDraftStorageKey({
-        projectId: scope.projectId,
-        threadId: scope.threadId,
-      }),
-    [scope.projectId, scope.threadId],
-  );
+  const storageKey = getPromptDraftStorageKey(scope);
   const draft = useSyncExternalStore(
     useCallback(
       (listener) => subscribePromptDraft(storageKey, listener),
@@ -382,14 +371,7 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
 }
 
 export function usePromptDraftHasInput(scope: PromptDraftScope): boolean {
-  const storageKey = useMemo(
-    () =>
-      getPromptDraftStorageKey({
-        projectId: scope.projectId,
-        threadId: scope.threadId,
-      }),
-    [scope.projectId, scope.threadId],
-  );
+  const storageKey = getPromptDraftStorageKey(scope);
 
   return useSyncExternalStore(
     useCallback(

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { SystemExecutionOptionsResponse } from "@bb/server-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/api";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { getProjectScopedStorageKey } from "@/lib/project-scoped-storage";
+import { useThreadCreationOptions } from "./useThreadCreationOptions";
+
+const PROJECT_ID = "proj_prompt_defaults";
+const GLOBAL_PROVIDER_ID = "global-provider";
+const PROJECT_PROVIDER_ID = "project-provider";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getSystemExecutionOptions: vi.fn(),
+  };
+});
+
+function executionOptionsResponse(): SystemExecutionOptionsResponse {
+  return {
+    providers: [
+      {
+        id: GLOBAL_PROVIDER_ID,
+        displayName: "Global Provider",
+        available: true,
+        capabilities: {
+          supportsArchive: true,
+          supportsRename: true,
+          supportsServiceTier: true,
+          supportsUserQuestion: true,
+          supportedPermissionModes: ["readonly", "workspace-write", "full"],
+        },
+      },
+      {
+        id: PROJECT_PROVIDER_ID,
+        displayName: "Project Provider",
+        available: true,
+        capabilities: {
+          supportsArchive: true,
+          supportsRename: true,
+          supportsServiceTier: true,
+          supportsUserQuestion: true,
+          supportedPermissionModes: ["readonly", "workspace-write", "full"],
+        },
+      },
+    ],
+    models: [
+      {
+        id: "global-model",
+        model: "global-model",
+        displayName: "Global Model",
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+        ],
+        defaultReasoningEffort: "medium",
+        isDefault: true,
+      },
+      {
+        id: "project-model",
+        model: "project-model",
+        displayName: "Project Model",
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+        ],
+        defaultReasoningEffort: "medium",
+        isDefault: false,
+      },
+    ],
+    selectedOnlyModels: [],
+    modelLoadError: null,
+  };
+}
+
+function setProjectScopedValue(baseKey: string, value: string): void {
+  window.localStorage.setItem(
+    getProjectScopedStorageKey(baseKey, PROJECT_ID),
+    value,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.getSystemExecutionOptions).mockResolvedValue(
+    executionOptionsResponse(),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("useThreadCreationOptions", () => {
+  it("uses project-agnostic persisted defaults for new-thread prompt boxes", async () => {
+    window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
+    window.localStorage.setItem("bb.promptbox.model", "global-model");
+    window.localStorage.setItem("bb.promptbox.service-tier", "default");
+    window.localStorage.setItem("bb.promptbox.reasoning", "high");
+    window.localStorage.setItem(
+      "bb.promptbox.permission-mode",
+      "workspace-write",
+    );
+    window.localStorage.setItem(
+      "bb.promptbox.environment",
+      "host:global-host:worktree",
+    );
+
+    setProjectScopedValue("bb.promptbox.provider", PROJECT_PROVIDER_ID);
+    setProjectScopedValue("bb.promptbox.model", "project-model");
+    setProjectScopedValue("bb.promptbox.service-tier", "fast");
+    setProjectScopedValue("bb.promptbox.reasoning", "low");
+    setProjectScopedValue("bb.promptbox.permission-mode", "readonly");
+    setProjectScopedValue("bb.promptbox.environment", "host:project-host:local");
+
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "new-thread",
+          initialProviderId: "initial-provider",
+          initialModel: "initial-model",
+          initialServiceTier: "fast",
+          initialReasoningLevel: "medium",
+          initialPermissionMode: "full",
+          initialEnvironmentSelectionValue: "host:initial-host:local",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(api.getSystemExecutionOptions).toHaveBeenCalledWith({
+        environmentId: undefined,
+        providerId: GLOBAL_PROVIDER_ID,
+      });
+      expect(api.getSystemExecutionOptions).not.toHaveBeenCalledWith({
+        environmentId: undefined,
+        providerId: PROJECT_PROVIDER_ID,
+      });
+      expect(result.current.selectedProviderId).toBe(GLOBAL_PROVIDER_ID);
+      expect(result.current.selectedModel).toBe("global-model");
+      expect(result.current.serviceTier).toBe("default");
+      expect(result.current.reasoningLevel).toBe("high");
+      expect(result.current.permissionMode).toBe("workspace-write");
+      expect(result.current.environmentSelectionValue).toBe(
+        "host:global-host:worktree",
+      );
+    });
+  });
+});

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -24,12 +24,12 @@ import { getProviderIconInfo } from "@/lib/provider-icon";
 import { reconcileReasoningLevel } from "@bb/domain";
 import { useSystemExecutionOptions } from "./queries/system-queries";
 import {
-  usePersistedEnvironmentSelection,
-  usePersistedModelSelection,
-  usePersistedPermissionModeSelection,
-  usePersistedProviderSelection,
-  usePersistedReasoningLevelSelection,
-  usePersistedServiceTierSelection,
+  usePromptBoxEnvironmentPreference,
+  usePromptBoxModelPreference,
+  usePromptBoxPermissionModePreference,
+  usePromptBoxProviderPreference,
+  usePromptBoxReasoningLevelPreference,
+  usePromptBoxServiceTierPreference,
 } from "./thread-creation-options/persisted-selection-fields";
 import {
   buildExecutionInputSources,
@@ -150,24 +150,23 @@ export function useThreadCreationOptions(
     initialPermissionMode,
     initialReasoningLevel,
     initialServiceTier,
-    projectId,
     resetKey,
     scope = "new-thread",
   } = options ?? {};
   const { setValue: setStoredProviderId, value: storedProviderId } =
-    usePersistedProviderSelection(projectId);
+    usePromptBoxProviderPreference();
   const { setValue: setStoredSelectedModel, value: storedSelectedModel } =
-    usePersistedModelSelection(projectId);
+    usePromptBoxModelPreference();
   const { setValue: setStoredServiceTier, value: storedServiceTier } =
-    usePersistedServiceTierSelection(projectId);
+    usePromptBoxServiceTierPreference();
   const { setValue: setStoredReasoningLevel, value: storedReasoningLevel } =
-    usePersistedReasoningLevelSelection(projectId);
+    usePromptBoxReasoningLevelPreference();
   const { setValue: setStoredPermissionMode, value: storedPermissionMode } =
-    usePersistedPermissionModeSelection(projectId);
+    usePromptBoxPermissionModePreference();
   const {
     setValue: setStoredEnvironmentSelectionValue,
     value: storedEnvironmentSelectionValue,
-  } = usePersistedEnvironmentSelection(projectId);
+  } = usePromptBoxEnvironmentPreference();
   // Reuse env values are intentionally NEVER persisted to localStorage —
   // they represent a transient "create one thread in this worktree" intent,
   // not a project default.

--- a/apps/app/src/lib/browser-storage.ts
+++ b/apps/app/src/lib/browser-storage.ts
@@ -1,8 +1,3 @@
-import { atomFamily } from "jotai-family";
-import { atomWithStorage } from "jotai/utils";
-import { getProjectScopedStorageKey } from "./project-scoped-storage";
-
-type ProjectScopedStorageParam = string | null | undefined;
 type StringValueGuard<T extends string> = (value: string) => value is T;
 type StoredValueListener = (storedValue: string | null) => void;
 
@@ -30,12 +25,6 @@ interface SyncStringStorage {
 interface LocalStorageValueCodec<T> {
   parse: (storedValue: string | null, initialValue: T) => T;
   serialize: (value: T) => string;
-}
-
-export interface CreatePersistedEnumAtomArgs<T extends string> {
-  baseKey: string;
-  initialValue: T;
-  isValue: StringValueGuard<T>;
 }
 
 function getLocalStorage(): Storage | null {
@@ -166,31 +155,4 @@ export function createNullableLocalStorageEnumStorage<T extends string>(
         );
       }),
   };
-}
-
-export function createProjectScopedStorageAtomFamily<T>(
-  baseKey: string,
-  initialValue: T,
-  storage: SyncStorage<T>,
-) {
-  return atomFamily((projectId: ProjectScopedStorageParam) =>
-    atomWithStorage<T>(
-      getProjectScopedStorageKey(baseKey, projectId),
-      initialValue,
-      storage,
-      { getOnInit: true },
-    ),
-  );
-}
-
-export function createPersistedEnumAtom<T extends string>({
-  baseKey,
-  initialValue,
-  isValue,
-}: CreatePersistedEnumAtomArgs<T>) {
-  return createProjectScopedStorageAtomFamily(
-    baseKey,
-    initialValue,
-    createLocalStorageEnumStorage(isValue),
-  );
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -241,7 +241,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     useNavigateToThreadAfterCreatePreference();
   const primaryHostId = usePrimaryHost()?.id ?? null;
   const uploadPromptAttachment = useUploadPromptAttachment();
-  const promptDraft = usePromptDraftStorage({ projectId, threadId: null });
+  const promptDraft = usePromptDraftStorage({ kind: "new-thread" });
   const { data: projectPromptHistory = [] } =
     useProjectPromptHistory(projectId);
   const promptMentions = usePromptMentions(
@@ -300,7 +300,6 @@ export function RootComposeView(props: RootComposeViewProps) {
     null;
   const creationOptions = useThreadCreationOptions({
     scope: "new-thread",
-    projectId,
     initialProviderId: projectDefaultExecutionOptions?.providerId,
     initialModel: projectDefaultExecutionOptions?.model,
     initialServiceTier: projectDefaultExecutionOptions?.serviceTier,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -246,6 +246,7 @@ export function ThreadDetailPromptArea({
   const stopThread = useStopThread();
   const uploadPromptAttachment = useUploadPromptAttachment();
   const promptDraft = usePromptDraftStorage({
+    kind: "thread",
     projectId,
     threadId: thread.id,
   });


### PR DESCRIPTION
## Summary
- Use project-agnostic persisted selection keys for new-thread prompt defaults
- Store new-thread prompt contents under a project-agnostic draft key
- Keep existing thread follow-up drafts scoped to the thread
- Add regression tests covering global prompt preferences and global new-thread draft contents

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/usePromptDraftStorage.test.tsx src/hooks/useThreadCreationOptions.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app