### PR TITLE
[codex] optimize provisioning metadata and output

### DIFF
--- a/apps/app/src/components/thread/timeline/Streaming.stories.tsx
+++ b/apps/app/src/components/thread/timeline/Streaming.stories.tsx
@@ -85,13 +85,11 @@ function useStreamingTick(
 
 const PROVISIONING_LINES: readonly string[] = [
   "Creating worktree (305ms)",
-  "git worktree add -B bb/investigate-thread-timeline-load /Users/michael/.bb-dev/worktrees/env_etyr7f84cg/bb",
   "HEAD is now at 37eeec85 Refactor timeline row titles",
   "Preparing worktree (new branch 'bb/investigate-thread-timeline-load')",
   "Created worktree (305ms)",
   "Using workspace: /Users/michael/.bb-dev/worktrees/env_etyr7f84cg/bb",
   "Running .bb-env-setup.sh",
-  "env bash .bb-env-setup.sh",
   "[bb-env-setup] Running: pnpm install",
   "Scope: all 35 workspace projects",
   "Lockfile is up to date, resolution step is skipped",
@@ -463,8 +461,8 @@ export function RowDetails() {
       <StoryRow
         label={
           <StreamingLabel
-            title="provisioning"
-            hint="system row detail streams in line-by-line, status flips on completion"
+            title="provisioning, cleaned transcript"
+            hint="command echo lines are omitted; real git and setup output still streams"
             onRestart={() => setProvisioningKey((k) => k + 1)}
           />
         }

--- a/apps/app/src/components/thread/timeline/rows/System.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/System.stories.tsx
@@ -42,13 +42,11 @@ const provisioningPending: TimelineRow = systemRow({
   title: "Provisioning thread",
   detail:
     "Creating worktree (305ms)\n" +
-    "git worktree add -B bb/investigate-thread-timeline-load-thr_sjgc9pafri /Users/michael/.bb-dev/worktrees/env_etyr7f84cg/bb\n" +
     "HEAD is now at 37eeec85 Refactor timeline row titles\n" +
     "Preparing worktree (new branch 'bb/investigate-thread-timeline-load-thr_sjgc9pafri')\n" +
     "Created worktree (305ms)\n" +
     "Using workspace: /Users/michael/.bb-dev/worktrees/env_etyr7f84cg/bb\n" +
     "Running .bb-env-setup.sh\n" +
-    "env bash .bb-env-setup.sh\n" +
     "[bb-env-setup] Running: pnpm install\n" +
     "Scope: all 35 workspace projects\n" +
     "Lockfile is up to date, resolution step is skipped\n" +
@@ -372,8 +370,8 @@ export function Operations() {
   return (
     <StoryCard>
       <StoryRow
-        label="thread-provisioning — pending"
-        hint="long initial setup, status=pending, transcript still streaming"
+        label="thread-provisioning — pending, cleaned"
+        hint="status=pending; no git/env command echo lines in the transcript"
       >
         <TimelineStage>
           <ThreadTimelineRows
@@ -385,7 +383,7 @@ export function Operations() {
       </StoryRow>
       <StoryRow
         label="thread-provisioning — completed"
-        hint="status=completed, transcript + terminal duration line"
+        hint="status=completed; already matched the cleaned transcript shape"
       >
         <TimelineStage>
           <ThreadTimelineRows

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -132,6 +132,7 @@ function createWorkspace(): HostWorkspace {
     managed: false,
     isGitRepo: false,
     isWorktree: false,
+    getDefaultBranch: unexpectedWorkspaceCall,
     getCurrentBranch: unexpectedWorkspaceCall,
     getHeadSha: unexpectedWorkspaceCall,
     getLocalStateFingerprint: unexpectedWorkspaceCall,

--- a/apps/host-daemon/src/command-handlers/environment.ts
+++ b/apps/host-daemon/src/command-handlers/environment.ts
@@ -50,10 +50,15 @@ export async function provisionEnvironment(
       ),
     });
 
+    const [branchName, resolvedDefaultBranch] = await Promise.all([
+      entry.workspace.getCurrentBranch(),
+      entry.workspace.isGitRepo
+        ? entry.workspace.getDefaultBranch()
+        : Promise.resolve(null),
+    ]);
     const defaultBranch = entry.workspace.isGitRepo
-      ? (await entry.workspace.getStatus()).branch.defaultBranch || null
+      ? (resolvedDefaultBranch ?? branchName)
       : null;
-    const branchName = await entry.workspace.getCurrentBranch();
 
     // For fresh provisions, emit cwd (for unmanaged) and branch/SHA entries.
     if (!alreadyExists) {

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -167,6 +167,7 @@ function createFakeWorkspace(path: string) {
     managed: false,
     isGitRepo: true,
     isWorktree: false,
+    getDefaultBranch: vi.fn(async () => "main"),
     getCurrentBranch: vi.fn(async (..._args: GetCurrentBranchArgs) => "main"),
     getHeadSha: vi.fn(async () => "commit-1"),
     getLocalStateFingerprint: vi.fn(async () => {

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -235,6 +235,7 @@ function createFakeWorkspace(path: string): HostWorkspace {
     managed: false,
     isGitRepo: true,
     isWorktree: false,
+    getDefaultBranch: vi.fn(async () => "main"),
     getCurrentBranch: vi.fn(async () => "main"),
     getHeadSha: vi.fn(async () => "commit-1"),
     getLocalStateFingerprint: vi.fn(async () => "local-1"),

--- a/apps/host-daemon/src/watch-manager.test.ts
+++ b/apps/host-daemon/src/watch-manager.test.ts
@@ -47,6 +47,7 @@ function createFakeWorkspace(path: string) {
     managed: false,
     isGitRepo: true,
     isWorktree: false,
+    getDefaultBranch: vi.fn(async () => "main"),
     getCurrentBranch: vi.fn(async () => "main"),
     getHeadSha: vi.fn(async () => "commit-1"),
     getLocalStateFingerprint: vi.fn(async () => {

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -123,6 +123,9 @@ export function createFakeWorkspace(pathname: string) {
     managed: false,
     isGitRepo: true,
     isWorktree: false,
+    async getDefaultBranch() {
+      return "main";
+    },
     async getCurrentBranch() {
       return "main";
     },

--- a/apps/host-daemon/test/command/environment-dispatch.test.ts
+++ b/apps/host-daemon/test/command/environment-dispatch.test.ts
@@ -174,6 +174,7 @@ describe("environment command dispatch", () => {
       branchName: "main",
       defaultBranch: "main",
     });
+    expect(harness.workspaceState.statusReads).toBe(0);
     expect(result.transcript).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/host-workspace/src/provision.ts
+++ b/packages/host-workspace/src/provision.ts
@@ -32,6 +32,7 @@ import {
   hasUncommittedChanges,
   listBranches,
   pathExists,
+  readDefaultBranch,
   runGit,
   WorkspaceError,
 } from "./git.js";
@@ -127,6 +128,8 @@ export interface ValidatePersonalWorkspaceTargetPathArgs {
 // HostWorkspace interface
 // ---------------------------------------------------------------------------
 
+const WORKSPACE_BRANCH_GIT_TIMEOUT_MS = 15_000;
+
 export interface HostWorkspace {
   /** Absolute path to the workspace directory */
   readonly path: string;
@@ -138,6 +141,7 @@ export interface HostWorkspace {
   readonly isWorktree: boolean;
 
   // Git queries
+  getDefaultBranch(): Promise<string | null>;
   getCurrentBranch(): Promise<string | null>;
   getHeadSha(): Promise<string | null>;
   getLocalStateFingerprint(): Promise<string>;
@@ -208,6 +212,17 @@ class ProvisionedHostWorkspace implements HostWorkspace {
 
   async getCurrentBranch(): Promise<string | null> {
     return (await this.ws.currentBranch) ?? null;
+  }
+
+  async getDefaultBranch(): Promise<string | null> {
+    if (!this.isGitRepo) {
+      return null;
+    }
+    return (
+      (await readDefaultBranch(this.path, {
+        timeoutMs: WORKSPACE_BRANCH_GIT_TIMEOUT_MS,
+      })) ?? null
+    );
   }
 
   getHeadSha(): Promise<string | null> {

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -260,8 +260,6 @@ export async function createWorktree(
     args.targetPath,
     baseBranch,
   ];
-  const commandText = `git ${gitArgs.join(" ")}`;
-
   const worktreeStartedAt = Date.now();
   emitStep({
     onProgress: args.onProgress,
@@ -270,7 +268,6 @@ export async function createWorktree(
     status: "started",
     startedAt: worktreeStartedAt,
   });
-  emitOutput(args.onProgress, "git-worktree-command", commandText);
   let worktreeCreated = false;
   try {
     const result = await runGitWithWorktreeMetadataLock(gitArgs, {
@@ -333,7 +330,6 @@ export async function runSetupScript(
     platform: process.platform,
     scriptPath,
   });
-  const commandText = command.text;
   const startedAt = Date.now();
   emitStep({
     onProgress: args.onProgress,
@@ -342,7 +338,6 @@ export async function runSetupScript(
     status: "started",
     startedAt,
   });
-  emitOutput(args.onProgress, "setup-command", commandText);
 
   const { timeoutMs } = args;
   const child = spawnPortableOutputProcess({


### PR DESCRIPTION
## Summary

This PR trims avoidable work and noisy transcript entries from environment provisioning.

- Adds a narrow `HostWorkspace.getDefaultBranch()` path so provisioning no longer calls full workspace status just to return default branch metadata.
- Reads current/default branch metadata in parallel after provisioning completes.
- Stops emitting synthetic `git worktree add ...` and `env bash .bb-env-setup.sh` command echo lines into provisioning transcripts while preserving real git/setup output and status steps.
- Updates host-daemon fakes, branch-metadata regression coverage, and Ladle provisioning stories to match the cleaned transcript shape.

## Why

Provisioning command result assembly used `getStatus()` only to read `branch.defaultBranch`. That status path scans working-tree state and can be unnecessarily expensive on large or dirty repositories. The transcript also repeated command invocations that did not add much diagnostic value next to the surrounding status and real process output.

## Impact

Locally, the branch metadata step dropped from about 248ms to 101ms on this checkout. End-to-end provisioning improvement depends on setup-script cost, but this avoids a full status scan on the hot path and makes the provisioning row easier to read.

In the dev bb app managed-worktree smoke, full provisioning took about 14.8s. The setup script reported `pnpm install` taking 13.3s, so most of that smoke timing was dependency setup rather than branch metadata/result assembly.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-daemon --filter=@bb/app --output-logs=new-only`
- `pnpm exec turbo run test --filter=@bb/host-workspace --filter=@bb/host-daemon --output-logs=new-only`
- `pnpm exec turbo run test --filter=@bb/host-workspace --force --output-logs=new-only` after trimming the over-specific transcript absence test
- `pnpm exec turbo run typecheck --filter=@bb/app --output-logs=new-only`
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force --output-logs=new-only`
- Dev bb app personal workspace smoke: `thr_5crsarstpk` returned `ok`
- Dev bb app managed worktree smoke: `thr_3qshhskv95` returned `ok`, created ready env `env_ks64ct45xf`, and DB event inspection found no `git-worktree-command` / `setup-command` entries or synthetic command echo text
- GitHub CI checks: passed on cleaned head
- `git diff --check`
