### PR TITLE
Show reachable Storybook network URLs

### DIFF
--- a/apps/app/.ladle/config.mjs
+++ b/apps/app/.ladle/config.mjs
@@ -1,3 +1,42 @@
+import { networkInterfaces } from "node:os";
+
+function formatNetworkUrls(serverUrl) {
+  const parsedUrl = new URL(serverUrl);
+  const path = `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+  const interfaces = networkInterfaces();
+  const addresses = [];
+  const seenAddresses = new Set();
+
+  for (const [name, entries] of Object.entries(interfaces)) {
+    for (const entry of entries ?? []) {
+      if (
+        entry.family !== "IPv4" ||
+        entry.internal ||
+        seenAddresses.has(entry.address)
+      ) {
+        continue;
+      }
+
+      seenAddresses.add(entry.address);
+      addresses.push({ address: entry.address, name });
+    }
+  }
+
+  addresses.sort((left, right) => {
+    const leftIsTailscale = left.name.startsWith("tailscale") ? 0 : 1;
+    const rightIsTailscale = right.name.startsWith("tailscale") ? 0 : 1;
+    return leftIsTailscale - rightIsTailscale;
+  });
+
+  return [
+    `[storybook] Local:   ${parsedUrl.protocol}//localhost:${parsedUrl.port}${path}`,
+    ...addresses.map(
+      (entry) =>
+        `[storybook] Network: ${parsedUrl.protocol}//${entry.address}:${parsedUrl.port}${path} (${entry.name})`,
+    ),
+  ];
+}
+
 /** @type {import("@ladle/react").UserConfig} */
 export default {
   stories: ["src/**/*.stories.tsx"],
@@ -12,5 +51,12 @@ export default {
     theme: {
       defaultState: "dark",
     },
+  },
+  onDevServerStart(serverUrl) {
+    if (new URL(serverUrl).hostname !== "0.0.0.0") {
+      return;
+    }
+
+    process.stdout.write(`${formatNetworkUrls(serverUrl).join("\n")}\n`);
   },
 };


### PR DESCRIPTION
## Summary
- print usable Storybook URLs after Ladle starts when it binds to `0.0.0.0`
- include detected IPv4 interface names and list Tailscale addresses first
- keep the existing wildcard bind and HMR behavior unchanged

## Validation
- `pnpm storybook`
- `node --check apps/app/.ladle/config.mjs`
- `pnpm exec turbo run typecheck --filter=@bb/app`
