### PR TITLE
[codex] Add timeline scroll button pointer cursor

### DIFF
--- a/apps/app/src/components/ui/scroll-to-bottom-button.stories.tsx
+++ b/apps/app/src/components/ui/scroll-to-bottom-button.stories.tsx
@@ -1,3 +1,6 @@
+import type { ReactNode } from "react";
+
+import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import { ScrollToBottomButton } from "./scroll-to-bottom-button";
 
 export default {
@@ -6,28 +9,42 @@ export default {
 
 const noop = () => {};
 
-// In the real timeline the button floats above the composer via a -mt-20 offset
-// and an h-0 container; the padding here just gives the story room to show it.
+function ButtonStage({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-28 w-28 cursor-default items-end justify-center rounded-md border border-dashed border-border bg-surface-recessed">
+      {children}
+    </div>
+  );
+}
+
 export function Overview() {
   return (
-    <div className="flex gap-16 px-8 pb-8 pt-28">
-      <div className="flex flex-col items-center gap-3">
-        <ScrollToBottomButton visible active={false} onClick={noop} />
-        <span className="text-xs text-muted-foreground">Idle — scrolled up</span>
-      </div>
-      <div className="flex flex-col items-center gap-3">
-        <ScrollToBottomButton visible active onClick={noop} />
-        <span className="text-xs text-muted-foreground">
-          Active — shimmering arrow
-        </span>
-      </div>
-      <div className="flex flex-col items-center gap-3">
-        <ScrollToBottomButton visible={false} active onClick={noop} />
-        <span className="text-xs text-muted-foreground">
-          Hidden (at bottom)
-        </span>
-      </div>
-    </div>
+    <StoryCard labelWidth="180px">
+      <StoryRow
+        label="idle"
+        hint="Scrolled up; hover the arrow to verify the pointer cursor."
+      >
+        <ButtonStage>
+          <ScrollToBottomButton visible active={false} onClick={noop} />
+        </ButtonStage>
+      </StoryRow>
+      <StoryRow
+        label="active"
+        hint="Agent running; the arrow keeps the same hover target."
+      >
+        <ButtonStage>
+          <ScrollToBottomButton visible active onClick={noop} />
+        </ButtonStage>
+      </StoryRow>
+      <StoryRow
+        label="hidden"
+        hint="At bottom; the control ignores pointer events."
+      >
+        <ButtonStage>
+          <ScrollToBottomButton visible={false} active onClick={noop} />
+        </ButtonStage>
+      </StoryRow>
+    </StoryCard>
   );
 }
 

--- a/apps/app/src/components/ui/scroll-to-bottom-button.tsx
+++ b/apps/app/src/components/ui/scroll-to-bottom-button.tsx
@@ -21,7 +21,7 @@ export function ScrollToBottomButton({
       <button
         onClick={onClick}
         className={cn(
-          "z-20 -mt-20 flex size-8 items-center justify-center rounded-full border border-border bg-surface-scrim backdrop-blur-md transition-all duration-200 hover:bg-state-hover",
+          "z-20 -mt-20 flex size-8 cursor-pointer items-center justify-center rounded-full border border-border bg-surface-scrim backdrop-blur-md transition-all duration-200 hover:bg-state-hover",
           visible
             ? "translate-y-0 opacity-100"
             : "pointer-events-none translate-y-2 opacity-0",


### PR DESCRIPTION
## Summary

Adds an explicit pointer cursor to the timeline scroll-to-bottom arrow so the floating control reads as clickable when it appears after scrolling up.

Updates the Ladle story for `ScrollToBottomButton` to show the idle, active, and hidden states in the shared story layout. The story now places the button on a default-cursor stage so the arrow hover state can be checked directly.

## Impact

Users get a clearer affordance for the scroll-to-bottom action in timelines. The visual states and hidden pointer-events behavior remain unchanged.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`

Note: `pnpm exec turbo run storybook:build --filter=@bb/app` is not configured as a Turbo task in this repo.
