### PR TITLE
Fix timeline diff sticky header chrome

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCard.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from "react";
 import { useIntersectionObserver } from "usehooks-ts";
+import { cn } from "@/lib/utils";
 import {
   GitDiffCardBody,
   useGitDiffCardBody,
@@ -48,15 +49,23 @@ export interface GitDiffCardProps {
   isCollapsed?: boolean;
   onToggleCollapsed?: () => void;
   /**
-   * When true, the header sticks to the scroll container and grows a top
-   * border when stuck. Used by the secondary panel; timeline rows leave this
-   * off because their scroll container is per-row, not per-panel.
+   * When true, the header sticks to the nearest scroll container. The default
+   * stuck chrome is for panel-level scrolling; timeline row diffs can suppress
+   * that edge when their own scroll area owns the fixed border.
    */
   stickyHeader?: boolean;
+  /** Override the sticky top offset when the scroll container owns surrounding chrome. */
+  stickyHeaderTopClassName?: string;
+  /** Whether crossing the sticky threshold changes header rounding/edge chrome. */
+  applyStuckHeaderChrome?: boolean;
   /** When true, replaces the body with a skeleton (for queued render slots). */
   isRendering?: boolean;
   /** Forwarded to the outer card element — used for IntersectionObserver-based scheduling. */
   cardRef?: (element: HTMLDivElement | null) => void;
+  /** Extra classes for the outer card shell. */
+  cardClassName?: string;
+  /** Whether a stuck sticky header should draw its own replacement top edge. */
+  showStuckHeaderEdge?: boolean;
   /**
    * When provided, the card lazy-fetches `oldFile`/`newFile` the first time
    * it scrolls into view. Text results are forwarded to `<DiffView>`, which
@@ -94,8 +103,12 @@ export const GitDiffCard = memo(function GitDiffCard({
   isCollapsed,
   onToggleCollapsed,
   stickyHeader = false,
+  stickyHeaderTopClassName,
+  applyStuckHeaderChrome = true,
   isRendering = false,
   cardRef,
+  cardClassName,
+  showStuckHeaderEdge = true,
   onRequestFileContents,
 }: GitDiffCardProps) {
   const headerModel = useMemo(
@@ -125,14 +138,20 @@ export const GitDiffCard = memo(function GitDiffCard({
   return (
     <div
       ref={cardRef}
-      className="rounded-lg border border-border bg-background"
+      className={cn(
+        "rounded-lg border border-border bg-background",
+        cardClassName,
+      )}
     >
       {stickyHeader ? <div ref={stickySentinelRef} className="h-0" /> : null}
       <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader,
+          stickyHeaderTopClassName,
           isBodyHidden,
           isStuck: isHeaderStuck,
+          applyStuckHeaderChrome,
+          showStuckHeaderEdge,
         })}
       >
         <GitDiffCardHeader

--- a/apps/app/src/components/git-diff/GitDiffCard.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.tsx
@@ -7,7 +7,6 @@ import {
   type RequestDiffFileContents,
 } from "./GitDiffCardBody";
 import {
-  GIT_DIFF_CARD_STICKY_SENTINEL_CLASS,
   GitDiffCardHeader,
   GitDiffCardImageSizeStat,
   gitDiffCardHeaderWrapperClass,
@@ -144,13 +143,7 @@ export const GitDiffCard = memo(function GitDiffCard({
         cardClassName,
       )}
     >
-      {stickyHeader ? (
-        <div
-          ref={stickySentinelRef}
-          aria-hidden
-          className={GIT_DIFF_CARD_STICKY_SENTINEL_CLASS}
-        />
-      ) : null}
+      {stickyHeader ? <div ref={stickySentinelRef} className="h-0" /> : null}
       <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader,

--- a/apps/app/src/components/git-diff/GitDiffCard.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.tsx
@@ -7,6 +7,7 @@ import {
   type RequestDiffFileContents,
 } from "./GitDiffCardBody";
 import {
+  GIT_DIFF_CARD_STICKY_SENTINEL_CLASS,
   GitDiffCardHeader,
   GitDiffCardImageSizeStat,
   gitDiffCardHeaderWrapperClass,
@@ -143,7 +144,13 @@ export const GitDiffCard = memo(function GitDiffCard({
         cardClassName,
       )}
     >
-      {stickyHeader ? <div ref={stickySentinelRef} className="h-0" /> : null}
+      {stickyHeader ? (
+        <div
+          ref={stickySentinelRef}
+          aria-hidden
+          className={GIT_DIFF_CARD_STICKY_SENTINEL_CLASS}
+        />
+      ) : null}
       <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader,

--- a/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
@@ -248,8 +248,11 @@ const GIT_DIFF_CARD_HEADER_WRAPPER_BASE_CLASS =
 
 export interface GitDiffCardHeaderWrapperClassArgs {
   stickyHeader: boolean;
+  stickyHeaderTopClassName?: string;
   isBodyHidden: boolean;
   isStuck: boolean;
+  applyStuckHeaderChrome?: boolean;
+  showStuckHeaderEdge?: boolean;
 }
 
 /**
@@ -258,16 +261,24 @@ export interface GitDiffCardHeaderWrapperClassArgs {
  */
 export function gitDiffCardHeaderWrapperClass({
   stickyHeader,
+  stickyHeaderTopClassName = "top-0",
   isBodyHidden,
   isStuck,
+  applyStuckHeaderChrome = true,
+  showStuckHeaderEdge = true,
 }: GitDiffCardHeaderWrapperClassArgs): string {
   return cn(
     GIT_DIFF_CARD_HEADER_WRAPPER_BASE_CLASS,
-    stickyHeader && "sticky top-0 z-30",
+    stickyHeader && "sticky z-30",
+    stickyHeader && stickyHeaderTopClassName,
     !isBodyHidden && "rounded-b-none",
-    // When stuck, the card's own rounded top border scrolls out of view; add a
-    // matching top border on the sticky so it still reads as the top edge of the
-    // card instead of a flat-cut slab.
-    isStuck && "rounded-t-none border-t border-border",
+    isStuck && applyStuckHeaderChrome && "rounded-t-none",
+    // When stuck, the card's own rounded top border scrolls out of view. Draw
+    // the replacement top edge as an inset shadow instead of a real border so
+    // the stuck transition does not change layout.
+    isStuck &&
+      applyStuckHeaderChrome &&
+      showStuckHeaderEdge &&
+      "shadow-[inset_0_1px_0_var(--border)]",
   );
 }

--- a/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
@@ -246,9 +246,6 @@ const GIT_DIFF_CARD_HEADER_WRAPPER_BASE_CLASS =
   // chevrons the library renders between hunks below.
   "rounded-lg bg-background py-1.5 pl-2 pr-3 text-xs font-medium text-foreground";
 
-export const GIT_DIFF_CARD_STICKY_SENTINEL_CLASS =
-  "pointer-events-none -mb-px h-px w-full";
-
 export interface GitDiffCardHeaderWrapperClassArgs {
   stickyHeader: boolean;
   stickyHeaderTopClassName?: string;

--- a/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
@@ -246,6 +246,9 @@ const GIT_DIFF_CARD_HEADER_WRAPPER_BASE_CLASS =
   // chevrons the library renders between hunks below.
   "rounded-lg bg-background py-1.5 pl-2 pr-3 text-xs font-medium text-foreground";
 
+export const GIT_DIFF_CARD_STICKY_SENTINEL_CLASS =
+  "pointer-events-none -mb-px h-px w-full";
+
 export interface GitDiffCardHeaderWrapperClassArgs {
   stickyHeader: boolean;
   stickyHeaderTopClassName?: string;

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -7,6 +7,7 @@ import {
   type RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import {
+  GIT_DIFF_CARD_STICKY_SENTINEL_CLASS,
   GitDiffCardHeader,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
@@ -163,7 +164,11 @@ export const DiffFileCard = memo(function DiffFileCard({
     // card's rounded bottom. `clip` (unlike `hidden`) is NOT a scroll container,
     // so it doesn't capture the sticky header — it still pins to the panel.
     <div className="overflow-clip rounded-lg border border-border bg-background">
-      <div ref={stickySentinelRef} className="h-0" />
+      <div
+        ref={stickySentinelRef}
+        aria-hidden
+        className={GIT_DIFF_CARD_STICKY_SENTINEL_CLASS}
+      />
       <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader: true,

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button.js";
 import { FilePathLink } from "@/components/ui/file-path-link.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import type { DiffPatchState } from "@/hooks/queries/use-environment-diff-patches";
+import { cn } from "@/lib/utils";
 
 /**
  * Build the file label for a TOC entry. Renames/copies read as `old -> new`;
@@ -165,11 +166,15 @@ export const DiffFileCard = memo(function DiffFileCard({
     <div className="overflow-clip rounded-lg border border-border bg-background">
       <div ref={stickySentinelRef} className="h-0" />
       <div
-        className={gitDiffCardHeaderWrapperClass({
-          stickyHeader: true,
-          isBodyHidden,
-          isStuck: isHeaderStuck,
-        })}
+        className={cn(
+          gitDiffCardHeaderWrapperClass({
+            stickyHeader: true,
+            isBodyHidden,
+            isStuck: isHeaderStuck,
+            showStuckHeaderEdge: false,
+          }),
+          "-mt-px border-t border-border",
+        )}
       >
         <GitDiffCardHeader
           model={headerModel}

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -7,7 +7,6 @@ import {
   type RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import {
-  GIT_DIFF_CARD_STICKY_SENTINEL_CLASS,
   GitDiffCardHeader,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
@@ -164,11 +163,7 @@ export const DiffFileCard = memo(function DiffFileCard({
     // card's rounded bottom. `clip` (unlike `hidden`) is NOT a scroll container,
     // so it doesn't capture the sticky header — it still pins to the panel.
     <div className="overflow-clip rounded-lg border border-border bg-background">
-      <div
-        ref={stickySentinelRef}
-        aria-hidden
-        className={GIT_DIFF_CARD_STICKY_SENTINEL_CLASS}
-      />
+      <div ref={stickySentinelRef} className="h-0" />
       <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader: true,

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from "react";
+import { useIntersectionObserver } from "usehooks-ts";
 import type { DiffFileEntry } from "@bb/server-contract";
 import {
   GitDiffCardBody,
@@ -6,6 +7,7 @@ import {
   type RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import {
+  GIT_DIFF_CARD_STICKY_SENTINEL_CLASS,
   GitDiffCardHeader,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
@@ -142,6 +144,20 @@ export const DiffFileCard = memo(function DiffFileCard({
   const changedLines = entry.additions + entry.deletions;
   const isBodyHidden = isCollapsed;
 
+  // Detect when this card's sticky header is pinned to the panel top: a
+  // zero-height sentinel sits just above the header, so once it scrolls out of
+  // the scroll container the header is stuck. When stuck we square the header's
+  // top and draw a non-layout top edge — the card's own rounded top has
+  // scrolled off-screen by then, and a rounded header top would otherwise show
+  // the scrolling diff through its corners. (`overflow-clip` below keeps the
+  // bottom rounded; the top can't be fixed by clipping because the rounded
+  // corners are the header's own, over live content.)
+  const { ref: stickySentinelRef, isIntersecting } = useIntersectionObserver({
+    initialIsIntersecting: true,
+    threshold: 1,
+  });
+  const isHeaderStuck = !isIntersecting;
+
   return (
     // `overflow-clip` clips the header/body to the card's rounded shape so a
     // short file's square-bottomed sticky header can't poke its corners past the
@@ -149,12 +165,15 @@ export const DiffFileCard = memo(function DiffFileCard({
     // so it doesn't capture the sticky header — it still pins to the panel.
     <div className="overflow-clip rounded-lg border border-border bg-background">
       <div
+        ref={stickySentinelRef}
+        aria-hidden
+        className={GIT_DIFF_CARD_STICKY_SENTINEL_CLASS}
+      />
+      <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader: true,
           isBodyHidden,
-          isStuck: false,
-          applyStuckHeaderChrome: false,
-          showStuckHeaderEdge: false,
+          isStuck: isHeaderStuck,
         })}
       >
         <GitDiffCardHeader

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -1,5 +1,4 @@
 import { memo, useMemo } from "react";
-import { useIntersectionObserver } from "usehooks-ts";
 import type { DiffFileEntry } from "@bb/server-contract";
 import {
   GitDiffCardBody,
@@ -7,7 +6,6 @@ import {
   type RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import {
-  GIT_DIFF_CARD_STICKY_SENTINEL_CLASS,
   GitDiffCardHeader,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
@@ -144,20 +142,6 @@ export const DiffFileCard = memo(function DiffFileCard({
   const changedLines = entry.additions + entry.deletions;
   const isBodyHidden = isCollapsed;
 
-  // Detect when this card's sticky header is pinned to the panel top: a
-  // zero-height sentinel sits just above the header, so once it scrolls out of
-  // the scroll container the header is stuck. When stuck we square the header's
-  // top and draw a non-layout top edge — the card's own rounded top has
-  // scrolled off-screen by then, and a rounded header top would otherwise show
-  // the scrolling diff through its corners. (`overflow-clip` below keeps the
-  // bottom rounded; the top can't be fixed by clipping because the rounded
-  // corners are the header's own, over live content.)
-  const { ref: stickySentinelRef, isIntersecting } = useIntersectionObserver({
-    initialIsIntersecting: true,
-    threshold: 1,
-  });
-  const isHeaderStuck = !isIntersecting;
-
   return (
     // `overflow-clip` clips the header/body to the card's rounded shape so a
     // short file's square-bottomed sticky header can't poke its corners past the
@@ -165,15 +149,12 @@ export const DiffFileCard = memo(function DiffFileCard({
     // so it doesn't capture the sticky header — it still pins to the panel.
     <div className="overflow-clip rounded-lg border border-border bg-background">
       <div
-        ref={stickySentinelRef}
-        aria-hidden
-        className={GIT_DIFF_CARD_STICKY_SENTINEL_CLASS}
-      />
-      <div
         className={gitDiffCardHeaderWrapperClass({
           stickyHeader: true,
           isBodyHidden,
-          isStuck: isHeaderStuck,
+          isStuck: false,
+          applyStuckHeaderChrome: false,
+          showStuckHeaderEdge: false,
         })}
       >
         <GitDiffCardHeader

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -146,11 +146,11 @@ export const DiffFileCard = memo(function DiffFileCard({
   // Detect when this card's sticky header is pinned to the panel top: a
   // zero-height sentinel sits just above the header, so once it scrolls out of
   // the scroll container the header is stuck. When stuck we square the header's
-  // top (`rounded-t-none border-t`) — the card's own rounded top has scrolled
-  // off-screen by then, and a rounded header top would otherwise show the
-  // scrolling diff through its corners. (`overflow-clip` below keeps the bottom
-  // rounded; the top can't be fixed by clipping because the rounded corners are
-  // the header's own, over live content.)
+  // top and draw a non-layout top edge — the card's own rounded top has
+  // scrolled off-screen by then, and a rounded header top would otherwise show
+  // the scrolling diff through its corners. (`overflow-clip` below keeps the
+  // bottom rounded; the top can't be fixed by clipping because the rounded
+  // corners are the header's own, over live content.)
   const { ref: stickySentinelRef, isIntersecting } = useIntersectionObserver({
     initialIsIntersecting: true,
     threshold: 1,

--- a/apps/app/src/components/thread/timeline/TimelineDetailScroll.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineDetailScroll.tsx
@@ -31,6 +31,7 @@ export interface TimelineDetailScrollProps {
    * only the scroll mechanics (max-height, overflow, fade affordances).
    */
   scrollClassName?: string;
+  showAboveFade?: boolean;
   children: ReactNode;
 }
 
@@ -48,6 +49,7 @@ export function TimelineDetailScroll({
   contentKey,
   className,
   scrollClassName,
+  showAboveFade = true,
   children,
 }: TimelineDetailScrollProps) {
   const sticky = useStickyBottomScroll<HTMLDivElement>({
@@ -92,7 +94,7 @@ export function TimelineDetailScroll({
         <div
           ref={overflow.topSentinelRef}
           aria-hidden
-          className="h-px w-full"
+          className="-mb-px h-px w-full"
         />
         {children}
         <div
@@ -101,7 +103,7 @@ export function TimelineDetailScroll({
           className="h-px w-full"
         />
       </div>
-      {aboveOverflow ? (
+      {showAboveFade && aboveOverflow ? (
         <div
           aria-hidden
           data-detail-scroll-fade="above"

--- a/apps/app/src/components/thread/timeline/TimelineFileDiffBlock.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineFileDiffBlock.tsx
@@ -273,12 +273,16 @@ export const TimelineFileDiffBlock = memo(function TimelineFileDiffBlock({
         size="base"
         contentKey={diffContentKey}
         className="mt-1"
+        scrollClassName="rounded-lg border border-border bg-background"
+        showAboveFade={false}
       >
         <div data-timeline-file-diff="">
           <GitDiffCard
             fileDiff={renderablePatch.fileDiff}
             diffViewOptions={cardDiffViewOptions}
             filePathRoot={workspaceRootPath}
+            cardClassName="rounded-none border-0 bg-transparent"
+            showStuckHeaderEdge={false}
             stickyHeader
           />
         </div>


### PR DESCRIPTION
## Summary
- Let timeline diff scroll areas own the fixed border/background while keeping sticky headers
- Add diff-card controls for sticky header chrome and card shell classes
- Avoid layout-changing stuck borders and suppress the top fade for timeline diff rows

## Testing
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run build --filter=@bb/app

## Notes
- Visual verification is intended in the app for the reported sticky-header artifact.