### PR TITLE
Hide sidebar child chevrons until hover

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -696,7 +696,7 @@ function EnvironmentThreadGroupHeader({
           expandTitle="Expand worktree threads"
           collapseTitle="Collapse worktree threads"
           onToggle={() => onToggleCollapsed(environmentId)}
-          revealOnHover={!isCollapsed}
+          revealOnHover
         />
       </span>
       <span
@@ -1200,7 +1200,7 @@ function ProjectRowComponent({
                 expandTitle="Expand project threads"
                 collapseTitle="Collapse project threads"
                 onToggle={handleProjectRowToggle}
-                revealOnHover={!isCollapsed}
+                revealOnHover
               />
             </span>
             {isLocalPathInvalid ? (

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -338,7 +338,7 @@ function ThreadRowComponent({
             expandTitle="Expand child threads"
             collapseTitle="Collapse child threads"
             onToggle={() => parentOptions.onToggleCollapsed(thread.id)}
-            revealOnHover={!isParentCollapsed}
+            revealOnHover
           />
         ) : null}
         {hasComposerDraft ? <ThreadDraftIndicator /> : null}


### PR DESCRIPTION
## Summary
- Make project, worktree, and parent-thread expand/collapse chevrons use hover reveal in both collapsed and expanded states.
- Keep using the existing `revealOnHover` sidebar chevron behavior from `main`.

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app`