### PR TITLE
Cancel superseded client read requests

### DIFF
--- a/apps/app/src/components/secondary-panel/git-diff/useDiffFileContentsRequester.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useDiffFileContentsRequester.ts
@@ -55,8 +55,8 @@ export function useDiffFileContentsRequester({
           path,
           side,
         ),
-        queryFn: () =>
-          getEnvironmentDiffFile(envId, resolvedTarget, path, side),
+        queryFn: ({ signal }) =>
+          getEnvironmentDiffFile(envId, resolvedTarget, path, side, signal),
         staleTime: 5_000,
       });
       return toDiffFileContentsResult(path, result);

--- a/apps/app/src/hooks/cache-owners/thread-detail-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-detail-cache-owner.ts
@@ -91,9 +91,10 @@ export function ingestThreadDetailBootstrap({
   if (timelinePrefetch) {
     void queryClient.prefetchQuery({
       queryKey: threadTimelineQueryKey(thread.id),
-      queryFn: () =>
+      queryFn: ({ signal }) =>
         api.getThreadTimeline({
           id: thread.id,
+          signal,
         }),
     });
   }
@@ -102,11 +103,12 @@ export function ingestThreadDetailBootstrap({
     const environmentId = thread.environmentId ?? null;
     void queryClient.prefetchQuery({
       queryKey: threadComposerBootstrapQueryKey(thread.id, environmentId),
-      queryFn: () =>
+      queryFn: ({ signal }) =>
         fetchAndHydrateThreadComposerBootstrap({
           environmentId,
           providerId: thread.providerId,
           queryClient,
+          signal,
           threadId: thread.id,
         }),
     });

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -72,8 +72,11 @@ export function useEnvironment(
 
   return useQuery<Environment>({
     queryKey: environmentQueryKey(environmentId),
-    queryFn: () =>
-      api.getEnvironment(requireEnvironmentId(environmentId, "useEnvironment")),
+    queryFn: ({ signal }) =>
+      api.getEnvironment(
+        requireEnvironmentId(environmentId, "useEnvironment"),
+        signal,
+      ),
     enabled,
     staleTime: options?.staleTime,
   });
@@ -93,10 +96,11 @@ export function useEnvironmentWorkStatus(
       environmentId,
       normalizedMergeBaseBranch,
     ),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getEnvironmentWorkStatus(
         requireEnvironmentId(environmentId, "useEnvironmentWorkStatus"),
         mergeBaseBranch,
+        signal,
       ),
     enabled,
     // Subscriptions can be absent while no UI is listening, so remount must
@@ -124,9 +128,10 @@ export function useEnvironmentPullRequest(
 
   return useQuery<EnvironmentPullRequestResponse>({
     queryKey: environmentPullRequestQueryKey(environmentId),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getEnvironmentPullRequest(
         requireEnvironmentId(environmentId, "useEnvironmentPullRequest"),
+        signal,
       ),
     enabled,
     refetchOnWindowFocus: false,
@@ -150,12 +155,16 @@ export function useEnvironmentMergeBaseBranches(
       limit,
       selectedBranch ?? "",
     ),
-    queryFn: () =>
-      api.getEnvironmentDiffBranches(environmentId, {
-        ...(query ? { query } : {}),
-        ...(selectedBranch ? { selectedBranch } : {}),
-        limit,
-      }),
+    queryFn: ({ signal }) =>
+      api.getEnvironmentDiffBranches(
+        environmentId,
+        {
+          ...(query ? { query } : {}),
+          ...(selectedBranch ? { selectedBranch } : {}),
+          limit,
+        },
+        signal,
+      ),
     enabled,
     refetchOnWindowFocus: false,
     staleTime: MERGE_BASE_BRANCHES_STALE_MS,
@@ -242,7 +251,7 @@ export function useEnvironmentPathSuggestions(
       includeFiles,
       includeDirectories,
     ),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.searchEnvironmentPaths({
         environmentId: requireEnvironmentId(
           environmentId,
@@ -252,6 +261,7 @@ export function useEnvironmentPathSuggestions(
         limit,
         includeFiles,
         includeDirectories,
+        signal,
       }),
     enabled,
     staleTime: 15_000,
@@ -281,7 +291,7 @@ export function useEnvironmentDiffFiles(
       target?.type ?? null,
       environmentDiffTargetKey(target),
     ),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getEnvironmentDiffFiles(
         environmentId,
         requireEnabledQueryArg({
@@ -289,6 +299,7 @@ export function useEnvironmentDiffFiles(
           hookName: "useEnvironmentDiffFiles",
           argName: "target",
         }),
+        signal,
       ),
     enabled,
     placeholderData: (previousData, previousQuery) =>

--- a/apps/app/src/hooks/queries/host-path-queries.ts
+++ b/apps/app/src/hooks/queries/host-path-queries.ts
@@ -32,7 +32,7 @@ export function useLocalPathExistence(
   const query = useQuery({
     queryKey: localPathExistenceQueryKey(localDaemonHostId ?? "", sortedPaths),
     queryFn: enabled
-      ? () => checkPathsExist(daemonPort, sortedPaths)
+      ? ({ signal }) => checkPathsExist(daemonPort, sortedPaths, signal)
       : skipToken,
     staleTime: 10_000,
   });

--- a/apps/app/src/hooks/queries/host-queries.ts
+++ b/apps/app/src/hooks/queries/host-queries.ts
@@ -20,7 +20,7 @@ export function useHosts(options?: QueryOptions) {
 
   return useQuery<Host[]>({
     queryKey: hostsQueryKey(),
-    queryFn: () => api.listHosts(),
+    queryFn: ({ signal }) => api.listHosts(signal),
     enabled,
     staleTime: 60_000,
   });

--- a/apps/app/src/hooks/queries/project-default-execution-options-query.ts
+++ b/apps/app/src/hooks/queries/project-default-execution-options-query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { ProjectExecutionDefaults } from "@bb/domain";
 import { apiClient } from "@/lib/api-server";
-import { request } from "@/lib/api";
+import { request, requestOptions } from "@/lib/api";
 import { useProjectDetailRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import { requireEnabledQueryArg } from "./query-helpers";
 
@@ -27,6 +27,7 @@ interface UseProjectDefaultExecutionOptionsArgs {
 
 interface FetchProjectDefaultExecutionOptionsArgs {
   projectId: string;
+  signal?: AbortSignal;
 }
 
 function requireProjectId(
@@ -48,12 +49,16 @@ export function projectDefaultExecutionOptionsQueryKey({
 
 export function fetchProjectDefaultExecutionOptions({
   projectId,
+  signal,
 }: FetchProjectDefaultExecutionOptionsArgs): Promise<ProjectExecutionDefaults | null> {
   return request<ProjectExecutionDefaults | null>(
-    apiClient.projects[":id"]["default-execution-options"].$get({
-      param: { id: projectId },
-      query: {},
-    }),
+    apiClient.projects[":id"]["default-execution-options"].$get(
+      {
+        param: { id: projectId },
+        query: {},
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -69,12 +74,13 @@ export function useProjectDefaultExecutionOptions(
     queryKey: projectDefaultExecutionOptionsQueryKey({
       projectId: projectId ?? "",
     }),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchProjectDefaultExecutionOptions({
         projectId: requireProjectId(
           projectId,
           "useProjectDefaultExecutionOptions",
         ),
+        signal,
       }),
     enabled,
     staleTime: 10_000,

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -101,7 +101,7 @@ export function useProjectSourceBranches(
       limit,
       selectedBranch,
     ),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getProjectSourceBranches(
         requireProjectId(projectId, "useProjectSourceBranches"),
         hostId ?? "",
@@ -110,6 +110,7 @@ export function useProjectSourceBranches(
           ...(selectedBranch ? { selectedBranch } : {}),
           limit,
         },
+        signal,
       ),
     enabled,
     refetchOnReconnect: true,
@@ -168,13 +169,14 @@ export function useProjectPathSuggestions(args: UseProjectPathSuggestionsArgs) {
       includeFiles,
       includeDirectories,
     ),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.searchProjectPaths({
         projectId: projectId ?? "",
         query: trimmedQuery,
         limit,
         includeFiles,
         includeDirectories,
+        signal,
       }),
     enabled,
     staleTime: 15_000,
@@ -211,7 +213,7 @@ export function useProjectCommands(
       args.offset,
       args.limit,
     ),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.listProjectCommands({
         projectId: requireProjectId(args.projectId, "useProjectCommands"),
         providerId: requireProviderId(args.providerId, "useProjectCommands"),
@@ -219,6 +221,7 @@ export function useProjectCommands(
         query: args.query,
         limit: args.limit,
         offset: args.offset,
+        signal,
       }),
     enabled,
     staleTime: 15_000,
@@ -240,7 +243,7 @@ export function useProjectCommandsPages(
       args.query,
       args.limit,
     ),
-    queryFn: ({ pageParam }) =>
+    queryFn: ({ pageParam, signal }) =>
       api.listProjectCommands({
         projectId: requireProjectId(args.projectId, "useProjectCommandsPages"),
         providerId: requireProviderId(
@@ -251,6 +254,7 @@ export function useProjectCommandsPages(
         query: args.query,
         limit: args.limit,
         offset: pageParam,
+        signal,
       }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) =>

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -36,10 +36,11 @@ export function useSystemExecutionOptions(
 
   return useQuery<SystemExecutionOptionsResponse>({
     queryKey: systemExecutionOptionsQueryKey({ environmentId, providerId }),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getSystemExecutionOptions({
         environmentId: args.environmentId,
         providerId: args.providerId,
+        signal,
       }),
     enabled,
     staleTime: 60_000,
@@ -52,7 +53,7 @@ export function useSystemConfig(options?: QueryOptions) {
 
   return useQuery<SystemConfigResponse>({
     queryKey: systemConfigQueryKey(),
-    queryFn: () => api.getSystemConfig(),
+    queryFn: ({ signal }) => api.getSystemConfig(signal),
     enabled,
     staleTime: 60_000,
   });
@@ -63,7 +64,7 @@ const SYSTEM_VERSION_STALE_TIME_MS = 60 * 60 * 1000;
 export function useSystemVersion(options?: QueryOptions) {
   return useQuery<SystemVersionResponse>({
     queryKey: systemVersionQueryKey(),
-    queryFn: () => api.getSystemVersion(),
+    queryFn: ({ signal }) => api.getSystemVersion(signal),
     enabled: options?.enabled ?? true,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
@@ -82,13 +83,14 @@ export function useLocalProviderCliStatus({
 }: UseLocalProviderCliStatusArgs) {
   return useQuery<ProviderCliStatusResponse>({
     queryKey: localProviderCliStatusQueryKey(daemonPort),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchProviderCliStatus(
         requireEnabledQueryArg({
           value: daemonPort,
           hookName: "useLocalProviderCliStatus",
           argName: "daemonPort",
         }),
+        signal,
       ),
     enabled: (enabled ?? true) && daemonPort !== null,
     refetchOnMount: false,

--- a/apps/app/src/hooks/queries/thread-composer-bootstrap-query.ts
+++ b/apps/app/src/hooks/queries/thread-composer-bootstrap-query.ts
@@ -5,7 +5,7 @@ import {
 } from "@tanstack/react-query";
 import type { ThreadComposerBootstrapResponse } from "@bb/server-contract";
 import { apiClient } from "@/lib/api-server";
-import { request } from "@/lib/api";
+import { request, requestOptions } from "@/lib/api";
 import { hydrateThreadComposerBootstrap } from "../cache-owners/composer-cache-owner";
 import { requireEnabledQueryArg } from "./query-helpers";
 
@@ -33,6 +33,7 @@ interface FetchAndHydrateThreadComposerBootstrapArgs {
   environmentId: string | null;
   providerId: string | null;
   queryClient: QueryClient;
+  signal?: AbortSignal;
   threadId: string;
 }
 
@@ -58,11 +59,15 @@ export function threadComposerBootstrapEnvironmentQueryKeyPrefix(
 
 export function fetchThreadComposerBootstrap(
   threadId: string,
+  signal?: AbortSignal,
 ): Promise<ThreadComposerBootstrapResponse> {
   return request<ThreadComposerBootstrapResponse>(
-    apiClient.threads[":id"]["composer-bootstrap"].$get({
-      param: { id: threadId },
-    }),
+    apiClient.threads[":id"]["composer-bootstrap"].$get(
+      {
+        param: { id: threadId },
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -70,9 +75,10 @@ export async function fetchAndHydrateThreadComposerBootstrap({
   environmentId,
   providerId,
   queryClient,
+  signal,
   threadId,
 }: FetchAndHydrateThreadComposerBootstrapArgs): Promise<ThreadComposerBootstrapResponse> {
-  const bootstrap = await fetchThreadComposerBootstrap(threadId);
+  const bootstrap = await fetchThreadComposerBootstrap(threadId, signal);
   hydrateThreadComposerBootstrap({
     bootstrap,
     environmentId,
@@ -93,11 +99,12 @@ export function useThreadComposerBootstrap(
 
   return useQuery<ThreadComposerBootstrapResponse>({
     queryKey: threadComposerBootstrapQueryKey(id, environmentId),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchAndHydrateThreadComposerBootstrap({
         environmentId,
         providerId,
         queryClient,
+        signal,
         threadId: requireThreadId(id, "useThreadComposerBootstrap"),
       }),
     enabled: (options?.enabled ?? true) && Boolean(id),

--- a/apps/app/src/hooks/queries/thread-default-execution-options-query.ts
+++ b/apps/app/src/hooks/queries/thread-default-execution-options-query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { ResolvedThreadExecutionOptions } from "@bb/domain";
 import { apiClient } from "@/lib/api-server";
-import { request } from "@/lib/api";
+import { request, requestOptions } from "@/lib/api";
 import { useThreadDetailRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import { requireEnabledQueryArg } from "./query-helpers";
 
@@ -38,11 +38,15 @@ export function allThreadDefaultExecutionOptionsQueryKeyPrefix(): ThreadDefaultE
 
 export function fetchThreadDefaultExecutionOptions(
   threadId: string,
+  signal?: AbortSignal,
 ): Promise<ResolvedThreadExecutionOptions | null> {
   return request<ResolvedThreadExecutionOptions | null>(
-    apiClient.threads[":id"]["default-execution-options"].$get({
-      param: { id: threadId },
-    }),
+    apiClient.threads[":id"]["default-execution-options"].$get(
+      {
+        param: { id: threadId },
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -55,9 +59,10 @@ export function useThreadDefaultExecutionOptions(
 
   return useQuery<ResolvedThreadExecutionOptions | null>({
     queryKey: threadDefaultExecutionOptionsQueryKey(id),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchThreadDefaultExecutionOptions(
         requireThreadId(id, "useThreadDefaultExecutionOptions"),
+        signal,
       ),
     enabled,
     refetchOnMount: options?.refetchOnMount ?? true,

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -474,7 +474,8 @@ export function useThread(id: string, options?: QueryOptions) {
 
   return useQuery<ThreadResponse>({
     queryKey: threadQueryKey(id),
-    queryFn: () => api.getThread(requireThreadId(id, "useThread")),
+    queryFn: ({ signal }) =>
+      api.getThread(requireThreadId(id, "useThread"), signal),
     enabled,
     staleTime: 5_000,
     refetchOnMount: options?.refetchOnMount ?? true,
@@ -507,9 +508,10 @@ export function useThreadDetailBootstrap(
 
   return useQuery<ThreadWithIncludesResponse>({
     queryKey: threadDetailBootstrapQueryKey(id),
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const thread = await api.getThreadWithEnvironmentHost(
         requireThreadId(id, "useThreadDetailBootstrap"),
+        signal,
       );
       ingestThreadDetailBootstrap({
         composerBootstrapPrefetch: options?.composerBootstrapPrefetch ?? false,
@@ -533,9 +535,10 @@ export function useThreadQueuedMessages(
 
   return useQuery<ThreadQueuedMessageListResponse>({
     queryKey: threadQueuedMessagesQueryKey(id),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.listThreadQueuedMessages(
         requireThreadId(id, "useThreadQueuedMessages"),
+        signal,
       ),
     enabled,
     refetchOnMount: options?.refetchOnMount ?? true,
@@ -570,9 +573,10 @@ export function useThreadDefaultExecutionOptions(
 ) {
   return useQuery<ResolvedThreadExecutionOptions | null>({
     queryKey: threadDefaultExecutionOptionsQueryKey(id),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getThreadDefaultExecutionOptions(
         requireThreadId(id, "useThreadDefaultExecutionOptions"),
+        signal,
       ),
     enabled: (options?.enabled ?? true) && Boolean(id),
     refetchOnMount: options?.refetchOnMount ?? true,
@@ -706,9 +710,10 @@ export function useThreadTimeline(
 
   return useQuery<ThreadTimelineResponse>({
     queryKey: threadTimelineQueryKey(id),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getThreadTimeline({
         id: requireThreadId(id, "useThreadTimeline"),
+        signal,
       }),
     enabled,
     refetchOnMount: options?.refetchOnMount ?? true,
@@ -730,12 +735,13 @@ export function useThreadTimelineTurnSummaryDetails(
 ) {
   return useQuery<TimelineTurnSummaryDetailsResponse>({
     queryKey: threadTimelineTurnSummaryDetailsQueryKey(identity),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       api.getThreadTimelineTurnSummaryDetails({
         id: requireThreadId(
           identity.threadId,
           "useThreadTimelineTurnSummaryDetails",
         ),
+        signal,
         sourceSeqEnd: identity.sourceSeqEnd,
         sourceSeqStart: identity.sourceSeqStart,
         turnId: identity.turnId,

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
@@ -57,6 +57,38 @@ beforeEach(() => {
 });
 
 describe("useEnvironmentDiffPatches", () => {
+  it("aborts in-flight patch fetches when the target changes", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const changedTarget: WorkspaceDiffTarget = {
+      type: "branch_committed",
+      mergeBaseBranch: "main",
+    };
+    const firstFetch = deferred<EnvironmentDiffPatchResponse>();
+    vi.mocked(api.getEnvironmentDiffPatches).mockReturnValue(
+      firstFetch.promise,
+    );
+
+    const { result, rerender } = renderHook(
+      ({ target }) => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target }),
+      { wrapper, initialProps: { target: TARGET as WorkspaceDiffTarget } },
+    );
+
+    act(() => {
+      result.current.requestPaths({ visible: [PATH], overscan: [] });
+    });
+
+    await waitFor(() => {
+      expect(api.getEnvironmentDiffPatches).toHaveBeenCalledTimes(1);
+    });
+    const request = vi.mocked(api.getEnvironmentDiffPatches).mock.calls[0]?.[1];
+    expect(request?.signal?.aborted).toBe(false);
+
+    rerender({ target: changedTarget });
+
+    expect(request?.signal?.aborted).toBe(true);
+    expect(result.current.getPatchState(PATH).status).toBe("idle");
+  });
+
   it("drops a patch fetch that resolves after a mid-flight eviction and re-fetches fresh", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
 

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.ts
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.ts
@@ -196,11 +196,12 @@ export function useEnvironmentDiffPatches(
   }, [targetIdentity]);
 
   useEffect(() => {
+    const abortControllers = abortControllersRef.current;
     return () => {
       if (debounceTimerRef.current !== null) {
         clearTimeout(debounceTimerRef.current);
       }
-      abortPatchRequests(abortControllersRef.current);
+      abortPatchRequests(abortControllers);
     };
   }, []);
 

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.ts
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.ts
@@ -78,6 +78,17 @@ const EMPTY_IN_FLIGHT: InFlightState = {
   errors: new Map(),
 };
 
+function abortPatchRequests(controllers: Set<AbortController>): void {
+  for (const controller of controllers) {
+    controller.abort();
+  }
+  controllers.clear();
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 function dedupeOrderedPaths(args: PendingPaths): string[] {
   const seen = new Set<string>();
   const ordered: string[] = [];
@@ -162,6 +173,7 @@ export function useEnvironmentDiffPatches(
   const targetIdentityRef = useRef(targetIdentity);
   const inFlightRef = useRef(inFlight);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortControllersRef = useRef<Set<AbortController>>(new Set());
 
   // Mirror in-flight state into a ref from an effect — never during render, which
   // is unsafe under concurrent rendering — so the debounced settle tick can dedupe
@@ -179,6 +191,7 @@ export function useEnvironmentDiffPatches(
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
     }
+    abortPatchRequests(abortControllersRef.current);
     setInFlight(EMPTY_IN_FLIGHT);
   }, [targetIdentity]);
 
@@ -187,6 +200,7 @@ export function useEnvironmentDiffPatches(
       if (debounceTimerRef.current !== null) {
         clearTimeout(debounceTimerRef.current);
       }
+      abortPatchRequests(abortControllersRef.current);
     };
   }, []);
 
@@ -203,11 +217,17 @@ export function useEnvironmentDiffPatches(
       // `loading` without caching lets the panel's already-re-fired
       // `requestPaths` dispatch re-fetch them fresh.
       const evictionGeneration = getDiffPatchEvictionGeneration(environmentId);
+      const controller = new AbortController();
+      abortControllersRef.current.add(controller);
       try {
         const response = await api.getEnvironmentDiffPatches(environmentId, {
           target,
           paths,
+          signal: controller.signal,
         });
+        if (controller.signal.aborted) {
+          return;
+        }
         // Drop the response if the target changed while it was in flight.
         if (targetIdentityRef.current !== generationTarget) {
           return;
@@ -238,6 +258,9 @@ export function useEnvironmentDiffPatches(
           );
         }
       } catch (caught) {
+        if (isAbortError(caught) || controller.signal.aborted) {
+          return;
+        }
         if (targetIdentityRef.current !== generationTarget) {
           return;
         }
@@ -254,6 +277,8 @@ export function useEnvironmentDiffPatches(
         setInFlight((previous) =>
           settlePage({ previous, paths, error: message }),
         );
+      } finally {
+        abortControllersRef.current.delete(controller);
       }
     },
     [environmentId, target, identity, queryClient],

--- a/apps/app/src/hooks/useForkThreadFromMessage.ts
+++ b/apps/app/src/hooks/useForkThreadFromMessage.ts
@@ -55,7 +55,8 @@ export function useForkThreadFromMessage({
       // effective execution options (cached if already fetched by the composer).
       const executionOptions = await queryClient.fetchQuery({
         queryKey: threadDefaultExecutionOptionsQueryKey(sourceThread.id),
-        queryFn: () => api.getThreadDefaultExecutionOptions(sourceThread.id),
+        queryFn: ({ signal }) =>
+          api.getThreadDefaultExecutionOptions(sourceThread.id, signal),
       });
       if (executionOptions === null) {
         return;

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -139,14 +139,18 @@ describe("useThreadCreationOptions", () => {
     );
 
     await waitFor(() => {
-      expect(api.getSystemExecutionOptions).toHaveBeenCalledWith({
-        environmentId: undefined,
-        providerId: GLOBAL_PROVIDER_ID,
-      });
-      expect(api.getSystemExecutionOptions).not.toHaveBeenCalledWith({
-        environmentId: undefined,
-        providerId: PROJECT_PROVIDER_ID,
-      });
+      expect(api.getSystemExecutionOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: undefined,
+          providerId: GLOBAL_PROVIDER_ID,
+        }),
+      );
+      expect(api.getSystemExecutionOptions).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: undefined,
+          providerId: PROJECT_PROVIDER_ID,
+        }),
+      );
       expect(result.current.selectedProviderId).toBe(GLOBAL_PROVIDER_ID);
       expect(result.current.selectedModel).toBe("global-model");
       expect(result.current.serviceTier).toBe("default");

--- a/apps/app/src/lib/api-host-daemon.ts
+++ b/apps/app/src/lib/api-host-daemon.ts
@@ -95,9 +95,13 @@ export async function fetchWorkspaceOpenTargets(
 
 export async function fetchProviderCliStatus(
   port: number,
+  signal?: AbortSignal,
 ): Promise<ProviderCliStatusResponse> {
   const daemon = getHostDaemonClient(port);
-  const res = await daemon["provider-clis"].status.$get();
+  const res = await daemon["provider-clis"].status.$get(
+    {},
+    signal ? { init: { signal } } : undefined,
+  );
   if (!res.ok) {
     const status = Number(res.status);
     throw new Error(`Provider CLI status check failed: HTTP ${status}`);
@@ -242,10 +246,14 @@ export async function pickFolder(port: number): Promise<string | null> {
 export async function checkPathsExist(
   port: number,
   paths: string[],
+  signal?: AbortSignal,
 ): Promise<Record<string, boolean>> {
   if (paths.length === 0) return {};
   const daemon = getHostDaemonClient(port);
-  const res = await daemon.paths.exist.$post({ json: { paths } });
+  const res = await daemon.paths.exist.$post(
+    { json: { paths } },
+    signal ? { init: { signal } } : undefined,
+  );
   if (!res.ok) {
     throw new Error(`Path existence check failed: HTTP ${res.status}`);
   }

--- a/apps/app/src/lib/api.test.ts
+++ b/apps/app/src/lib/api.test.ts
@@ -1,0 +1,66 @@
+import type { ThreadTimelineResponse } from "@bb/server-contract";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getThreadTimeline } from "./api";
+
+const mocks = vi.hoisted(() => ({
+  timelineGet: vi.fn(),
+}));
+
+vi.mock("./api-server", () => ({
+  apiClient: {
+    threads: {
+      ":id": {
+        timeline: {
+          $get: mocks.timelineGet,
+        },
+      },
+    },
+  },
+  toRelativeUrl: (url: URL) => `${url.pathname}${url.search}`,
+}));
+
+function makeTimelineResponse(): ThreadTimelineResponse {
+  return {
+    rows: [],
+    activeThinking: null,
+    pendingTodos: null,
+    goal: null,
+    timelinePage: {
+      kind: "latest",
+      segmentLimit: 20,
+      returnedSegmentCount: 0,
+      hasOlderRows: false,
+      olderCursor: null,
+    },
+  };
+}
+
+describe("api timeline requests", () => {
+  beforeEach(() => {
+    mocks.timelineGet.mockReset();
+    mocks.timelineGet.mockResolvedValue(
+      new Response(JSON.stringify(makeTimelineResponse()), { status: 200 }),
+    );
+  });
+
+  it("passes abort signals to the generated client", async () => {
+    const controller = new AbortController();
+
+    await getThreadTimeline({
+      id: "thr_1",
+      signal: controller.signal,
+    });
+
+    expect(mocks.timelineGet).toHaveBeenCalledWith(
+      {
+        param: { id: "thr_1" },
+        query: {},
+      },
+      {
+        init: {
+          signal: controller.signal,
+        },
+      },
+    );
+  });
+});

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -96,10 +96,12 @@ interface GetThreadTimelineArgs {
   id: string;
   includeNestedRows?: boolean;
   segmentLimit?: number;
+  signal?: AbortSignal;
 }
 
 interface GetThreadTimelineTurnSummaryDetailsArgs extends TimelineTurnSummaryDetailsRequest {
   id: string;
+  signal?: AbortSignal;
 }
 
 interface GetEnvironmentFilePreviewArgs {
@@ -549,6 +551,7 @@ interface SearchProjectPathsArgs {
   limit: number;
   includeFiles: boolean;
   includeDirectories: boolean;
+  signal?: AbortSignal;
 }
 
 interface SearchEnvironmentPathsArgs {
@@ -557,6 +560,7 @@ interface SearchEnvironmentPathsArgs {
   limit: number;
   includeFiles: boolean;
   includeDirectories: boolean;
+  signal?: AbortSignal;
 }
 
 function toPathListIncludeQueryValue(
@@ -574,21 +578,24 @@ export async function searchProjectPaths(
   args: SearchProjectPathsArgs,
 ): Promise<WorkspacePathListResponse> {
   return request<WorkspacePathListResponse>(
-    apiClient.projects[":id"].paths.$get({
-      param: { id: args.projectId },
-      query: {
-        query: args.query,
-        limit: String(args.limit),
-        // The project-source listing has no environment to scope to; the shared
-        // query schema still carries the field, so send the empty string (=
-        // null) to select the default source.
-        environmentId: "",
-        includeFiles: toPathListIncludeQueryValue(args.includeFiles),
-        includeDirectories: toPathListIncludeQueryValue(
-          args.includeDirectories,
-        ),
+    apiClient.projects[":id"].paths.$get(
+      {
+        param: { id: args.projectId },
+        query: {
+          query: args.query,
+          limit: String(args.limit),
+          // The project-source listing has no environment to scope to; the shared
+          // query schema still carries the field, so send the empty string (=
+          // null) to select the default source.
+          environmentId: "",
+          includeFiles: toPathListIncludeQueryValue(args.includeFiles),
+          includeDirectories: toPathListIncludeQueryValue(
+            args.includeDirectories,
+          ),
+        },
       },
-    }),
+      requestOptions(args.signal),
+    ),
   );
 }
 
@@ -597,17 +604,20 @@ export async function searchEnvironmentPaths(
   args: SearchEnvironmentPathsArgs,
 ): Promise<WorkspacePathListResponse> {
   return request<WorkspacePathListResponse>(
-    apiClient.environments[":id"].paths.$get({
-      param: { id: args.environmentId },
-      query: {
-        query: args.query,
-        limit: String(args.limit),
-        includeFiles: toPathListIncludeQueryValue(args.includeFiles),
-        includeDirectories: toPathListIncludeQueryValue(
-          args.includeDirectories,
-        ),
+    apiClient.environments[":id"].paths.$get(
+      {
+        param: { id: args.environmentId },
+        query: {
+          query: args.query,
+          limit: String(args.limit),
+          includeFiles: toPathListIncludeQueryValue(args.includeFiles),
+          includeDirectories: toPathListIncludeQueryValue(
+            args.includeDirectories,
+          ),
+        },
       },
-    }),
+      requestOptions(args.signal),
+    ),
   );
 }
 
@@ -618,6 +628,7 @@ interface ListProjectCommandsArgs {
   query: string;
   limit: number;
   offset: number;
+  signal?: AbortSignal;
 }
 
 /**
@@ -633,16 +644,19 @@ export async function listProjectCommands(
   args: ListProjectCommandsArgs,
 ): Promise<CommandListResponse> {
   return request<CommandListResponse>(
-    apiClient.projects[":id"].commands.$get({
-      param: { id: args.projectId },
-      query: {
-        provider: args.providerId,
-        environmentId: args.environmentId ?? "",
-        ...(args.query.length > 0 ? { query: args.query } : {}),
-        limit: String(args.limit),
-        ...(args.offset > 0 ? { offset: String(args.offset) } : {}),
+    apiClient.projects[":id"].commands.$get(
+      {
+        param: { id: args.projectId },
+        query: {
+          provider: args.providerId,
+          environmentId: args.environmentId ?? "",
+          ...(args.query.length > 0 ? { query: args.query } : {}),
+          limit: String(args.limit),
+          ...(args.offset > 0 ? { offset: String(args.offset) } : {}),
+        },
       },
-    }),
+      requestOptions(args.signal),
+    ),
   );
 }
 
@@ -650,12 +664,16 @@ export async function getProjectSourceBranches(
   projectId: string,
   hostId: string,
   args?: ProjectBranchListRequest,
+  signal?: AbortSignal,
 ): Promise<ProjectBranchesResponse> {
   return request<ProjectBranchesResponse>(
-    apiClient.projects[":id"].branches.$get({
-      param: { id: projectId },
-      query: buildProjectBranchesQuery(hostId, args),
-    }),
+    apiClient.projects[":id"].branches.$get(
+      {
+        param: { id: projectId },
+        query: buildProjectBranchesQuery(hostId, args),
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -776,9 +794,15 @@ export async function searchThreads(
   );
 }
 
-export async function getThread(id: string): Promise<ThreadResponse> {
+export async function getThread(
+  id: string,
+  signal?: AbortSignal,
+): Promise<ThreadResponse> {
   return request<ThreadResponse>(
-    apiClient.threads[":id"].$get({ param: { id } }),
+    apiClient.threads[":id"].$get(
+      { param: { id } },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -1010,9 +1034,13 @@ export async function createThreadQueuedMessage(
 
 export async function listThreadQueuedMessages(
   id: string,
+  signal?: AbortSignal,
 ): Promise<ThreadQueuedMessageListResponse> {
   return request<ThreadQueuedMessageListResponse>(
-    apiClient.threads[":id"]["queued-messages"].$get({ param: { id } }),
+    apiClient.threads[":id"]["queued-messages"].$get(
+      { param: { id } },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -1073,11 +1101,15 @@ export async function stopThread(id: string): Promise<void> {
 
 export async function getThreadDefaultExecutionOptions(
   id: string,
+  signal?: AbortSignal,
 ): Promise<ResolvedThreadExecutionOptions | null> {
   return request<ResolvedThreadExecutionOptions | null>(
-    apiClient.threads[":id"]["default-execution-options"].$get({
-      param: { id },
-    }),
+    apiClient.threads[":id"]["default-execution-options"].$get(
+      {
+        param: { id },
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -1207,12 +1239,16 @@ export async function getEnvironmentPullRequest(
 export async function getEnvironmentDiffBranches(
   id: string,
   args?: EnvironmentBranchListRequest,
+  signal?: AbortSignal,
 ): Promise<EnvironmentDiffBranchesResponse> {
   return request<EnvironmentDiffBranchesResponse>(
-    apiClient.environments[":id"].diff.branches.$get({
-      param: { id },
-      query: buildEnvironmentDiffBranchesQuery(args),
-    }),
+    apiClient.environments[":id"].diff.branches.$get(
+      {
+        param: { id },
+        query: buildEnvironmentDiffBranchesQuery(args),
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -1240,41 +1276,49 @@ export async function getThreadTimeline({
   id,
   includeNestedRows = false,
   segmentLimit,
+  signal,
 }: GetThreadTimelineArgs): Promise<ThreadTimelineResponse> {
   return request<ThreadTimelineResponse>(
-    apiClient.threads[":id"].timeline.$get({
-      param: { id },
-      query: {
-        ...(includeNestedRows ? { includeNestedRows: "true" } : {}),
-        ...(segmentLimit !== undefined
-          ? { segmentLimit: String(segmentLimit) }
-          : {}),
-        ...(beforeCursor
-          ? {
-              beforeAnchorSeq: String(beforeCursor.anchorSeq),
-              beforeAnchorId: beforeCursor.anchorId,
-            }
-          : {}),
+    apiClient.threads[":id"].timeline.$get(
+      {
+        param: { id },
+        query: {
+          ...(includeNestedRows ? { includeNestedRows: "true" } : {}),
+          ...(segmentLimit !== undefined
+            ? { segmentLimit: String(segmentLimit) }
+            : {}),
+          ...(beforeCursor
+            ? {
+                beforeAnchorSeq: String(beforeCursor.anchorSeq),
+                beforeAnchorId: beforeCursor.anchorId,
+              }
+            : {}),
+        },
       },
-    }),
+      requestOptions(signal),
+    ),
   );
 }
 
 export async function getThreadTimelineTurnSummaryDetails({
   id,
+  signal,
   turnId,
   sourceSeqStart,
   sourceSeqEnd,
 }: GetThreadTimelineTurnSummaryDetailsArgs): Promise<TimelineTurnSummaryDetailsResponse> {
   return request<TimelineTurnSummaryDetailsResponse>(
-    apiClient.threads[":id"].timeline["turn-summary-details"].$get({
-      param: { id },
-      query: {
-        turnId,
-        sourceSeqStart: String(sourceSeqStart),
-        sourceSeqEnd: String(sourceSeqEnd),
+    apiClient.threads[":id"].timeline["turn-summary-details"].$get(
+      {
+        param: { id },
+        query: {
+          turnId,
+          sourceSeqStart: String(sourceSeqStart),
+          sourceSeqEnd: String(sourceSeqEnd),
+        },
       },
-    }),
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -1300,6 +1344,7 @@ export async function getEnvironmentDiffFile(
   target: DiffFileTarget,
   path: string,
   side: DiffFileSide,
+  signal?: AbortSignal,
 ): Promise<EnvironmentDiffFileResponse> {
   const baseQuery = (() => {
     switch (target.type) {
@@ -1328,10 +1373,13 @@ export async function getEnvironmentDiffFile(
   })();
 
   return request<EnvironmentDiffFileResponse>(
-    apiClient.environments[":id"].diff.file.$get({
-      param: { id },
-      query: { ...baseQuery, path, side },
-    }),
+    apiClient.environments[":id"].diff.file.$get(
+      {
+        param: { id },
+        query: { ...baseQuery, path, side },
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
@@ -1374,18 +1422,23 @@ function buildEnvironmentDiffTargetQuery(
 export async function getEnvironmentDiffFiles(
   id: string,
   target: WorkspaceDiffTarget,
+  signal?: AbortSignal,
 ): Promise<EnvironmentDiffFilesResponse> {
   return request<EnvironmentDiffFilesResponse>(
-    apiClient.environments[":id"].diff.files.$get({
-      param: { id },
-      query: buildEnvironmentDiffTargetQuery(target),
-    }),
+    apiClient.environments[":id"].diff.files.$get(
+      {
+        param: { id },
+        query: buildEnvironmentDiffTargetQuery(target),
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
 interface GetEnvironmentDiffPatchesArgs {
   target: WorkspaceDiffTarget;
   paths: string[];
+  signal?: AbortSignal;
 }
 
 /**
@@ -1395,27 +1448,34 @@ interface GetEnvironmentDiffPatchesArgs {
  */
 export async function getEnvironmentDiffPatches(
   id: string,
-  { target, paths }: GetEnvironmentDiffPatchesArgs,
+  { target, paths, signal }: GetEnvironmentDiffPatchesArgs,
 ): Promise<EnvironmentDiffPatchResponse> {
   return request<EnvironmentDiffPatchResponse>(
-    apiClient.environments[":id"].diff.patch.$post({
-      param: { id },
-      json: { target, paths },
-    }),
+    apiClient.environments[":id"].diff.patch.$post(
+      {
+        param: { id },
+        json: { target, paths },
+      },
+      requestOptions(signal),
+    ),
   );
 }
 
 export async function getSystemExecutionOptions(args: {
   environmentId?: string;
   providerId?: string;
+  signal?: AbortSignal;
 }): Promise<SystemExecutionOptionsResponse> {
   return request<SystemExecutionOptionsResponse>(
-    apiClient.system["execution-options"].$get({
-      query: {
-        ...(args.environmentId ? { environmentId: args.environmentId } : {}),
-        ...(args.providerId ? { providerId: args.providerId } : {}),
+    apiClient.system["execution-options"].$get(
+      {
+        query: {
+          ...(args.environmentId ? { environmentId: args.environmentId } : {}),
+          ...(args.providerId ? { providerId: args.providerId } : {}),
+        },
       },
-    }),
+      requestOptions(args.signal),
+    ),
   );
 }
 
@@ -1425,12 +1485,20 @@ export async function listSystemProviders(): Promise<SystemProviderInfo[]> {
   );
 }
 
-export async function getSystemVersion(): Promise<SystemVersionResponse> {
-  return request<SystemVersionResponse>(apiClient.system.version.$get());
+export async function getSystemVersion(
+  signal?: AbortSignal,
+): Promise<SystemVersionResponse> {
+  return request<SystemVersionResponse>(
+    apiClient.system.version.$get({}, requestOptions(signal)),
+  );
 }
 
-export async function getSystemConfig(): Promise<SystemConfigResponse> {
-  return request<SystemConfigResponse>(apiClient.system.config.$get());
+export async function getSystemConfig(
+  signal?: AbortSignal,
+): Promise<SystemConfigResponse> {
+  return request<SystemConfigResponse>(
+    apiClient.system.config.$get({}, requestOptions(signal)),
+  );
 }
 
 export async function updateExperiments(
@@ -1441,6 +1509,6 @@ export async function updateExperiments(
   );
 }
 
-export async function listHosts(): Promise<Host[]> {
-  return request<Host[]>(apiClient.hosts.$get());
+export async function listHosts(signal?: AbortSignal): Promise<Host[]> {
+  return request<Host[]>(apiClient.hosts.$get({}, requestOptions(signal)));
 }


### PR DESCRIPTION
## Summary
- Thread React Query abort signals through client read helpers so superseded refetches can cancel the underlying browser request.
- Cover high-churn reads including timeline, thread detail/bootstrap, environment/project path and command suggestions, diff reads, system/host reads, and host-daemon read probes.
- Add explicit abort handling for the custom diff patch loader when the diff target changes or the hook unmounts.

## Context
The attached HAR showed `GET /api/v1/threads/thr_a8eyut82sq/timeline` firing 25 times in 36s, transferring 43.4 MB with up to 10 concurrent downloads. The existing query invalidations could supersede old timeline data, but the request itself kept downloading because the query function did not consume React Query's `signal`.

## Validation
- `pnpm exec turbo run test --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`
