### PR TITLE
Timeline performance: incremental delta updates + response caching

### DIFF
--- a/apps/app/src/hooks/cache-owners/cache-invalidation-groups.ts
+++ b/apps/app/src/hooks/cache-owners/cache-invalidation-groups.ts
@@ -113,6 +113,24 @@ export function getThreadTimelineInvalidationQueryKeys({
       ];
 }
 
+/**
+ * Timeline-window-only invalidation for realtime `events-appended` /
+ * `thread-created` / `thread-deleted`. Deliberately excludes the
+ * turn-summary-details prefix: a completed turn's expanded detail is a fixed
+ * `sourceSeqStart..sourceSeqEnd` range and never changes once the turn is done,
+ * so re-fetching every open detail panel on every appended-event batch is pure
+ * waste during streaming. Mutations that can rewrite history (fork/retry/edit)
+ * still use {@link getThreadTimelineInvalidationQueryKeys}, which invalidates
+ * both prefixes.
+ */
+export function getThreadTimelineWindowInvalidationQueryKeys({
+  threadId,
+}: ThreadScopedInvalidationArgs): QueryKey[] {
+  return threadId
+    ? [threadTimelineQueryKeyPrefix(threadId)]
+    : [allThreadTimelineQueryKeyPrefix()];
+}
+
 export function getThreadQueueContentInvalidationQueryKeys({
   threadId,
 }: ThreadScopedInvalidationArgs): QueryKey[] {

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -94,7 +94,7 @@ import {
   getThreadPendingInteractionInvalidationQueryKeys,
   getThreadPromptHistoryInvalidationQueryKeys,
   getThreadQueueContentInvalidationQueryKeys,
-  getThreadTimelineInvalidationQueryKeys,
+  getThreadTimelineWindowInvalidationQueryKeys,
 } from "./cache-invalidation-groups";
 
 interface CollectCachedThreadIdsForEnvironmentArgs {
@@ -498,7 +498,9 @@ function dirtyThreadSearchQueries(): QueryKey[] {
 function dirtyThreadTimelineQueries({
   threadId,
 }: ThreadRealtimeDirtyContext): QueryKey[] {
-  return getThreadTimelineInvalidationQueryKeys({ threadId });
+  // Window only: completed turn-summary-details are immutable, so realtime
+  // event batches must not refetch open detail panels (see helper docs).
+  return getThreadTimelineWindowInvalidationQueryKeys({ threadId });
 }
 
 function dirtyThreadQueueContentQueries({

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
@@ -27,6 +27,7 @@ function makeTimelineResponse(): ThreadTimelineResponse {
     activeWorkflow: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -153,6 +153,7 @@ function makeThreadTimelineResponse(
     activeWorkflow: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     rows,
     timelinePage: {
       kind: "latest",

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -24,6 +24,7 @@ import type {
   ThreadTimelineResponse,
   TimelineTurnSummaryDetailsResponse,
 } from "@bb/server-contract";
+import { applyTimelineDelta } from "@bb/server-contract";
 import type { ThreadListFilters, FilePreview } from "@/lib/api";
 import type { PathListOptions } from "@/lib/path-list-options";
 import type { ThreadStorageFileListOptions } from "@/lib/thread-storage-files";
@@ -481,7 +482,9 @@ export function useThread(id: string, options?: QueryOptions) {
     refetchOnMount: options?.refetchOnMount ?? true,
     placeholderData: (previousData, previousQuery) =>
       resolveThreadPlaceholder(previousData, previousQuery?.queryKey, id) ??
-      liftThreadListPlaceholder(getCachedThreadListPlaceholder(queryClient, id)),
+      liftThreadListPlaceholder(
+        getCachedThreadListPlaceholder(queryClient, id),
+      ),
   });
 }
 
@@ -701,20 +704,59 @@ export function useThreadHostFilePreview(
   });
 }
 
+/**
+ * Resolve a timeline response into the full window to cache. A `delta` response
+ * is applied to the window we already hold (preserving unchanged row identity);
+ * a full response is returned as-is. Falls back to a full fetch if the delta's
+ * base is stale (should not happen, since the server only sends a delta when it
+ * can reconstruct our exact window).
+ */
+async function mergeThreadTimelineDelta(
+  previous: ThreadTimelineResponse | undefined,
+  response: ThreadTimelineResponse,
+  fetchFull: () => Promise<ThreadTimelineResponse>,
+): Promise<ThreadTimelineResponse> {
+  if (response.delta === undefined) {
+    return response;
+  }
+  const merged = previous
+    ? applyTimelineDelta(previous.rows, response.delta)
+    : null;
+  if (merged !== null) {
+    return { ...response, rows: merged, delta: undefined };
+  }
+  return fetchFull();
+}
+
 export function useThreadTimeline(
   id: string,
   options?: ThreadTimelineQueryOptions,
 ) {
+  const queryClient = useQueryClient();
   const enabled = (options?.enabled ?? true) && Boolean(id);
   useThreadDetailRealtimeSubscription(id, { enabled });
 
   return useQuery<ThreadTimelineResponse>({
     queryKey: threadTimelineQueryKey(id),
-    queryFn: ({ signal }) =>
-      api.getThreadTimeline({
-        id: requireThreadId(id, "useThreadTimeline"),
+    queryFn: async ({ signal }) => {
+      const threadId = requireThreadId(id, "useThreadTimeline");
+      // Ask for a delta against the window we already hold. The server only
+      // honors it when it can still reconstruct exactly what we have; otherwise
+      // it returns the full window.
+      const previous = queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey(id),
+      );
+      const response = await api.getThreadTimeline({
+        id: threadId,
         signal,
-      }),
+        ...(previous?.maxSeq !== undefined
+          ? { afterSequence: previous.maxSeq }
+          : {}),
+      });
+      return mergeThreadTimelineDelta(previous, response, () =>
+        api.getThreadTimeline({ id: threadId, signal }),
+      );
+    },
     enabled,
     refetchOnMount: options?.refetchOnMount ?? true,
     ...(options?.staleTime === undefined

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -27,6 +27,7 @@ import {
   threadTerminalsQueryKey,
   threadStorageFilePreviewQueryKey,
   threadTimelineQueryKey,
+  threadTimelineTurnSummaryDetailsQueryKey,
 } from "./queries/query-keys";
 import { createRealtimeCacheEffects } from "./realtime-cache-effects";
 import {
@@ -793,8 +794,17 @@ describe("createRealtimeCacheEffects", () => {
     const threadKey = threadQueryKey("thr_1");
     const timelineKey = threadTimelineQueryKey("thr_1");
     const promptHistoryKey = threadPromptHistoryQueryKey("thr_1");
+    // A completed turn's expanded detail panel is immutable; events-appended
+    // must not refetch it (W2).
+    const turnDetailsKey = threadTimelineTurnSummaryDetailsQueryKey({
+      threadId: "thr_1",
+      turnId: "turn_1",
+      sourceSeqStart: 1,
+      sourceSeqEnd: 5,
+    });
     queryClient.setQueryData(threadKey, { id: "thr_1" });
     queryClient.setQueryData(promptHistoryKey, []);
+    queryClient.setQueryData(turnDetailsKey, { rows: [] });
     queryClient.setQueryData(timelineKey, {
       rows: [],
       timelinePage: {
@@ -818,6 +828,9 @@ describe("createRealtimeCacheEffects", () => {
     expect(queryClient.getQueryState(timelineKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(threadKey)?.isInvalidated).not.toBe(true);
     expect(queryClient.getQueryState(promptHistoryKey)?.isInvalidated).not.toBe(
+      true,
+    );
+    expect(queryClient.getQueryState(turnDetailsKey)?.isInvalidated).not.toBe(
       true,
     );
 

--- a/apps/app/src/lib/api.test.ts
+++ b/apps/app/src/lib/api.test.ts
@@ -26,6 +26,7 @@ function makeTimelineResponse(): ThreadTimelineResponse {
     activeWorkflow: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -906,10 +906,7 @@ export async function getThread(
   signal?: AbortSignal,
 ): Promise<ThreadResponse> {
   return request<ThreadResponse>(
-    apiClient.threads[":id"].$get(
-      { param: { id } },
-      requestOptions(signal),
-    ),
+    apiClient.threads[":id"].$get({ param: { id } }, requestOptions(signal)),
   );
 }
 

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -96,6 +96,7 @@ import type { PathListOptions } from "./path-list-options";
 export type { FilePreview } from "./file-preview";
 
 interface GetThreadTimelineArgs {
+  afterSequence?: number;
   beforeCursor?: TimelinePaginationCursor;
   id: string;
   includeNestedRows?: boolean;
@@ -1378,6 +1379,7 @@ export async function archiveEnvironmentThreads(
 }
 
 export async function getThreadTimeline({
+  afterSequence,
   beforeCursor,
   id,
   includeNestedRows = false,
@@ -1392,6 +1394,9 @@ export async function getThreadTimeline({
           ...(includeNestedRows ? { includeNestedRows: "true" } : {}),
           ...(segmentLimit !== undefined
             ? { segmentLimit: String(segmentLimit) }
+            : {}),
+          ...(afterSequence !== undefined
+            ? { afterSequence: String(afterSequence) }
             : {}),
           ...(beforeCursor
             ? {

--- a/apps/app/src/views/thread-detail/useThreadTimelinePages.test.ts
+++ b/apps/app/src/views/thread-detail/useThreadTimelinePages.test.ts
@@ -100,6 +100,7 @@ function makeTimelineResponse(
     activeWorkflow: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,

--- a/apps/app/src/views/thread-detail/useThreadTimelinePages.ts
+++ b/apps/app/src/views/thread-detail/useThreadTimelinePages.ts
@@ -159,10 +159,7 @@ function preserveTimelineRowIdentity({
   const previousRowsById = buildTimelineRowIdentityMap(previousRows);
   return nextRows.map((row) => {
     const previous = previousRowsById.get(row.id);
-    if (
-      previous &&
-      previous.signature === timelineRowIdentitySignature(row)
-    ) {
+    if (previous && previous.signature === timelineRowIdentitySignature(row)) {
       return previous.row;
     }
     return row;
@@ -303,9 +300,15 @@ export function isStaleTimelinePaginationCursorError(error: Error): boolean {
 export function useThreadTimelinePages({
   threadId,
 }: UseThreadTimelinePagesArgs): UseThreadTimelinePagesResult {
+  // No `staleTime: Infinity` here: it silently defeats `refetchOnMount` (data
+  // is never stale, so a remount/refocus never refreshes), so a thread revisited
+  // after events arrived while it was unmounted shows a frozen, stale timeline
+  // until the next live event. It also didn't reduce streaming rerenders — those
+  // are invalidation-driven and refetch regardless of staleTime. Inheriting the
+  // app-wide 2s staleTime is correct and cheap now that live updates fetch a
+  // row-patch delta (or a cached/no-op response) instead of the full window.
   const latestTimelineQuery = useThreadTimeline(threadId, {
     refetchOnMount: true,
-    staleTime: Infinity,
   });
   const surfaceKey = buildSurfaceKey({ threadId });
   const [loadedTimeline, setLoadedTimeline] = useState<LoadedTimelineState>(

--- a/apps/cli/src/__tests__/helpers/command-output-fixtures.ts
+++ b/apps/cli/src/__tests__/helpers/command-output-fixtures.ts
@@ -69,6 +69,7 @@ export function makeTimelineResponse(
     activeWorkflow: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,

--- a/apps/cli/src/commands/thread/pending-todos.test.ts
+++ b/apps/cli/src/commands/thread/pending-todos.test.ts
@@ -110,6 +110,7 @@ describe("fetchThreadPendingTodos", () => {
       pendingTodos,
       goal: null,
       rows: [],
+      maxSeq: 0,
       timelinePage: {
         kind: "latest",
         segmentLimit: 20,

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -45,6 +45,7 @@ import {
   buildThreadTimelineCacheKey,
   createThreadTimelineCache,
 } from "../../services/threads/timeline-cache.js";
+import { truncateTimelineResponseOutputs } from "../../services/threads/timeline-output-truncation.js";
 import {
   findThreadEvent,
   getLastThreadOutput,
@@ -335,12 +336,14 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     });
     return context.json(
       timelineCache.getOrBuild(cacheKey, () =>
-        buildThreadTimeline(deps.db, thread, {
-          isDevelopment: deps.config.isDevelopment,
-          includeNestedRows,
-          page,
-          summaryOnly,
-        }),
+        truncateTimelineResponseOutputs(
+          buildThreadTimeline(deps.db, thread, {
+            isDevelopment: deps.config.isDevelopment,
+            includeNestedRows,
+            page,
+            summaryOnly,
+          }),
+        ),
       ),
     );
   });

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -43,9 +43,12 @@ import {
 } from "../../services/threads/timeline.js";
 import {
   buildThreadTimelineCacheKey,
+  buildThreadTimelineParamsKey,
   createThreadTimelineCache,
 } from "../../services/threads/timeline-cache.js";
+import { createTimelineLatestRowsCache } from "../../services/threads/timeline-latest-rows-cache.js";
 import { truncateTimelineResponseOutputs } from "../../services/threads/timeline-output-truncation.js";
+import { computeTimelineRowDelta } from "@bb/server-contract";
 import {
   findThreadEvent,
   getLastThreadOutput,
@@ -315,36 +318,63 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
   });
   const routes = publicApiRoutes.threads;
-  // Lives for the server lifetime: registerThreadDataRoutes is called once at
-  // startup. Idle/warm-repeat hits skip the dominant build cost.
+  // Both caches live for the server lifetime: registerThreadDataRoutes is
+  // called once at startup. The response cache skips the dominant build cost on
+  // warm/idle hits; the latest-rows cache lets a client that supplies
+  // `afterSequence` receive only the rows that changed (delta) instead of the
+  // whole window — the big streaming win.
   const timelineCache = createThreadTimelineCache();
+  const timelineLatestRowsCache = createTimelineLatestRowsCache();
 
   get(routes.timeline, (context, query) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
     const page = parseThreadTimelinePage(query);
     const includeNestedRows = query.includeNestedRows === "true";
     const summaryOnly = query.summaryOnly === "true";
-    const cacheKey = buildThreadTimelineCacheKey({
+    const maxSeq = getLatestThreadSequence(deps.db, { threadId: thread.id });
+    const keyArgs = {
       threadId: thread.id,
-      maxSeq: getLatestThreadSequence(deps.db, { threadId: thread.id }),
       status: thread.status,
       environmentId: thread.environmentId,
       page,
       includeNestedRows,
       summaryOnly,
       isDevelopment: deps.config.isDevelopment,
-    });
-    return context.json(
-      timelineCache.getOrBuild(cacheKey, () =>
+    };
+    const full = timelineCache.getOrBuild(
+      buildThreadTimelineCacheKey({ ...keyArgs, maxSeq }),
+      () =>
         truncateTimelineResponseOutputs(
           buildThreadTimeline(deps.db, thread, {
             isDevelopment: deps.config.isDevelopment,
             includeNestedRows,
+            maxSeq,
             page,
             summaryOnly,
           }),
         ),
-      ),
+    );
+
+    // Delta: when the client tells us the revision it currently holds and our
+    // last-sent snapshot still matches it exactly, return only the changed rows.
+    // Reprojecting the full window first keeps every collapse/eviction/finalize
+    // case correct by construction; the diff is the cheap part.
+    const afterSequence = parseOptionalInteger(
+      query.afterSequence,
+      "afterSequence",
+    );
+    const paramsKey = buildThreadTimelineParamsKey(keyArgs);
+    const previous = timelineLatestRowsCache.get(paramsKey);
+    const delta =
+      afterSequence !== undefined &&
+      previous !== undefined &&
+      previous.maxSeq === afterSequence
+        ? computeTimelineRowDelta(previous.rows, full.rows)
+        : undefined;
+    timelineLatestRowsCache.set(paramsKey, { maxSeq, rows: full.rows });
+
+    return context.json(
+      delta === undefined ? full : { ...full, rows: [], delta },
     );
   });
 

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { listQueuedThreadMessages } from "@bb/db";
+import { getLatestThreadSequence, listQueuedThreadMessages } from "@bb/db";
 import type { Hono } from "hono";
 import { PROMPT_HISTORY_ENTRY_LIMIT, threadEventTypeSchema } from "@bb/domain";
 import {
@@ -41,6 +41,10 @@ import {
   type ThreadTimelinePageKind,
   type ThreadTimelinePageRequest,
 } from "../../services/threads/timeline.js";
+import {
+  buildThreadTimelineCacheKey,
+  createThreadTimelineCache,
+} from "../../services/threads/timeline-cache.js";
 import {
   findThreadEvent,
   getLastThreadOutput,
@@ -310,16 +314,34 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
   });
   const routes = publicApiRoutes.threads;
+  // Lives for the server lifetime: registerThreadDataRoutes is called once at
+  // startup. Idle/warm-repeat hits skip the dominant build cost.
+  const timelineCache = createThreadTimelineCache();
 
   get(routes.timeline, (context, query) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
+    const page = parseThreadTimelinePage(query);
+    const includeNestedRows = query.includeNestedRows === "true";
+    const summaryOnly = query.summaryOnly === "true";
+    const cacheKey = buildThreadTimelineCacheKey({
+      threadId: thread.id,
+      maxSeq: getLatestThreadSequence(deps.db, { threadId: thread.id }),
+      status: thread.status,
+      environmentId: thread.environmentId,
+      page,
+      includeNestedRows,
+      summaryOnly,
+      isDevelopment: deps.config.isDevelopment,
+    });
     return context.json(
-      buildThreadTimeline(deps.db, thread, {
-        isDevelopment: deps.config.isDevelopment,
-        includeNestedRows: query.includeNestedRows === "true",
-        page: parseThreadTimelinePage(query),
-        summaryOnly: query.summaryOnly === "true",
-      }),
+      timelineCache.getOrBuild(cacheKey, () =>
+        buildThreadTimeline(deps.db, thread, {
+          isDevelopment: deps.config.isDevelopment,
+          includeNestedRows,
+          page,
+          summaryOnly,
+        }),
+      ),
     );
   });
 

--- a/apps/server/src/services/threads/timeline-cache.ts
+++ b/apps/server/src/services/threads/timeline-cache.ts
@@ -101,12 +101,16 @@ function pageKeyPart(page: ThreadTimelinePageRequest): string {
     : `latest:${page.segmentLimit}`;
 }
 
-export function buildThreadTimelineCacheKey(
-  args: ThreadTimelineCacheKeyArgs,
+/**
+ * The cache identity *excluding* `maxSeq` — i.e. everything that selects which
+ * window is being requested, but not which revision of it. Used to track the
+ * latest-sent rows per request shape for delta computation.
+ */
+export function buildThreadTimelineParamsKey(
+  args: Omit<ThreadTimelineCacheKeyArgs, "maxSeq">,
 ): string {
   return [
     args.threadId,
-    args.maxSeq,
     args.status,
     args.environmentId ?? "-",
     pageKeyPart(args.page),
@@ -114,4 +118,10 @@ export function buildThreadTimelineCacheKey(
     args.summaryOnly ? "1" : "0",
     args.isDevelopment ? "1" : "0",
   ].join("|");
+}
+
+export function buildThreadTimelineCacheKey(
+  args: ThreadTimelineCacheKeyArgs,
+): string {
+  return `${args.maxSeq}|${buildThreadTimelineParamsKey(args)}`;
 }

--- a/apps/server/src/services/threads/timeline-cache.ts
+++ b/apps/server/src/services/threads/timeline-cache.ts
@@ -1,0 +1,117 @@
+import type { ThreadTimelineResponse } from "@bb/server-contract";
+import type { ThreadStatus } from "@bb/domain";
+import type { ThreadTimelinePageRequest } from "./timeline-pagination.js";
+
+/**
+ * Idle/warm-repeat cache for built timeline responses.
+ *
+ * `buildThreadTimeline` is a pure, deterministic projection of a thread's
+ * events. The build (event JSON-decode + projection) is the dominant cost of a
+ * timeline request (~130-260ms on large threads) and is recomputed from scratch
+ * on every request — there is no other caching. The same window is rebuilt
+ * verbatim whenever a thread is refetched without new events: double-mounts
+ * (detail view + side-chat tabs), debounced realtime invalidations that fire
+ * after the tail already settled, and re-opening a thread.
+ *
+ * Keying on the thread high-water `maxSeq` makes invalidation implicit: any
+ * appended event bumps `maxSeq`, producing a new key and a cold rebuild. The
+ * key MUST also include every other input the projection depends on:
+ * `thread.status` (interrupt flips earlier rows), `environmentId` (workspace
+ * root relativizes file paths), and the row-shape request flags. Event pruning
+ * (`pruneResolvedItemDeltas`, background-task progress) is output-preserving and
+ * never lowers `maxSeq`, so it cannot stale a cached entry.
+ *
+ * Entries with many rows are not cached: an expanded active turn (the streaming
+ * case) produces hundreds of rows AND a `maxSeq` that changes on every event,
+ * so caching it only thrashes the LRU and pins large objects for no reuse. Idle
+ * windows collapse completed turns to a handful of rows regardless of thread
+ * size, so the cap excludes exactly the entries that would never be reused.
+ */
+
+const DEFAULT_MAX_ENTRIES = 128;
+const DEFAULT_MAX_CACHEABLE_ROWS = 200;
+
+export interface ThreadTimelineCacheOptions {
+  maxEntries?: number;
+  /** Responses with more rows than this are returned but not stored. */
+  maxCacheableRows?: number;
+}
+
+export interface ThreadTimelineCache {
+  getOrBuild(
+    key: string,
+    build: () => ThreadTimelineResponse,
+  ): ThreadTimelineResponse;
+  /** Number of currently cached entries (for tests/metrics). */
+  readonly size: number;
+}
+
+export function createThreadTimelineCache(
+  options: ThreadTimelineCacheOptions = {},
+): ThreadTimelineCache {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const maxCacheableRows =
+    options.maxCacheableRows ?? DEFAULT_MAX_CACHEABLE_ROWS;
+  const entries = new Map<string, ThreadTimelineResponse>();
+
+  return {
+    getOrBuild(key, build) {
+      const cached = entries.get(key);
+      if (cached !== undefined) {
+        // Re-insert to mark most-recently-used.
+        entries.delete(key);
+        entries.set(key, cached);
+        return cached;
+      }
+
+      const value = build();
+      if (value.rows.length <= maxCacheableRows) {
+        entries.set(key, value);
+        while (entries.size > maxEntries) {
+          const oldest = entries.keys().next().value;
+          if (oldest === undefined) {
+            break;
+          }
+          entries.delete(oldest);
+        }
+      }
+      return value;
+    },
+    get size() {
+      return entries.size;
+    },
+  };
+}
+
+export interface ThreadTimelineCacheKeyArgs {
+  threadId: string;
+  /** Thread high-water event sequence; bumps on every appended event. */
+  maxSeq: number;
+  status: ThreadStatus;
+  environmentId: string | null;
+  page: ThreadTimelinePageRequest;
+  includeNestedRows: boolean;
+  summaryOnly: boolean;
+  isDevelopment: boolean;
+}
+
+function pageKeyPart(page: ThreadTimelinePageRequest): string {
+  return page.kind === "older"
+    ? `older:${page.segmentLimit}:${page.beforeCursor.anchorSeq}:${page.beforeCursor.anchorId}`
+    : `latest:${page.segmentLimit}`;
+}
+
+export function buildThreadTimelineCacheKey(
+  args: ThreadTimelineCacheKeyArgs,
+): string {
+  return [
+    args.threadId,
+    args.maxSeq,
+    args.status,
+    args.environmentId ?? "-",
+    pageKeyPart(args.page),
+    args.includeNestedRows ? "1" : "0",
+    args.summaryOnly ? "1" : "0",
+    args.isDevelopment ? "1" : "0",
+  ].join("|");
+}

--- a/apps/server/src/services/threads/timeline-latest-rows-cache.ts
+++ b/apps/server/src/services/threads/timeline-latest-rows-cache.ts
@@ -1,0 +1,59 @@
+import type { TimelineRow } from "@bb/server-contract";
+
+/**
+ * Tracks the most recent full window rows the server sent for a given request
+ * shape (params key — everything except `maxSeq`). A delta request supplies the
+ * `maxSeq` it last received; when this cache still holds exactly that revision,
+ * the server diffs the current window against it to produce a row patch. When
+ * the cache has moved on (another client advanced it, or it was evicted) the
+ * server falls back to a full response, so this is purely an optimization and
+ * never affects correctness.
+ *
+ * Bounded by entry count. Entries can be large (an expanded active turn is
+ * hundreds of rows), so the bound is small — only actively-viewed threads need
+ * a live entry.
+ */
+const DEFAULT_MAX_ENTRIES = 64;
+
+export interface TimelineLatestRows {
+  maxSeq: number;
+  rows: readonly TimelineRow[];
+}
+
+export interface TimelineLatestRowsCache {
+  get(paramsKey: string): TimelineLatestRows | undefined;
+  set(paramsKey: string, value: TimelineLatestRows): void;
+  readonly size: number;
+}
+
+export function createTimelineLatestRowsCache(
+  options: { maxEntries?: number } = {},
+): TimelineLatestRowsCache {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const entries = new Map<string, TimelineLatestRows>();
+
+  return {
+    get(paramsKey) {
+      const value = entries.get(paramsKey);
+      if (value !== undefined) {
+        entries.delete(paramsKey);
+        entries.set(paramsKey, value);
+      }
+      return value;
+    },
+    set(paramsKey, value) {
+      entries.delete(paramsKey);
+      entries.set(paramsKey, value);
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) {
+          break;
+        }
+        entries.delete(oldest);
+      }
+    },
+    get size() {
+      return entries.size;
+    },
+  };
+}

--- a/apps/server/src/services/threads/timeline-output-truncation.ts
+++ b/apps/server/src/services/threads/timeline-output-truncation.ts
@@ -1,0 +1,96 @@
+import type { ThreadTimelineResponse, TimelineRow } from "@bb/server-contract";
+
+/**
+ * Caps the largest inline strings in a timeline window. A handful of tool/
+ * command outputs and diffs are enormous (observed up to ~1 MB) and dominate
+ * both payload bytes and client parse/render cost. The window only needs a
+ * readable preview; the full content stays available on demand via the
+ * (un-truncated) `timeline/turn-summary-details` route once the turn completes.
+ *
+ * Conservative by design: the threshold is far above a normal output, so only
+ * true outliers are touched. Conversation/message text is never truncated.
+ * Rows are rebuilt only when something actually changes, so unchanged rows keep
+ * their identity (cheap, and stable for delta diffing).
+ */
+export const DEFAULT_MAX_INLINE_OUTPUT_CHARS = 32_000;
+
+function truncateString(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  const dropped = value.length - max;
+  return `${value.slice(0, max)}\n…[${dropped.toLocaleString()} more characters truncated — open the turn to view the full output]`;
+}
+
+function truncateRow(row: TimelineRow, max: number): TimelineRow {
+  if (row.kind === "turn") {
+    if (!row.children) {
+      return row;
+    }
+    const children = truncateRows(row.children, max);
+    return children === row.children ? row : { ...row, children };
+  }
+
+  if (row.kind !== "work") {
+    return row;
+  }
+
+  switch (row.workKind) {
+    case "command":
+    case "tool": {
+      const output = truncateString(row.output, max);
+      return output === row.output ? row : { ...row, output };
+    }
+    case "file-change": {
+      const diff =
+        row.change.diff === null ? null : truncateString(row.change.diff, max);
+      const stdout =
+        row.stdout === null ? null : truncateString(row.stdout, max);
+      const stderr =
+        row.stderr === null ? null : truncateString(row.stderr, max);
+      if (
+        diff === row.change.diff &&
+        stdout === row.stdout &&
+        stderr === row.stderr
+      ) {
+        return row;
+      }
+      return {
+        ...row,
+        change: diff === row.change.diff ? row.change : { ...row.change, diff },
+        stdout,
+        stderr,
+      };
+    }
+    case "delegation": {
+      const output = truncateString(row.output, max);
+      const childRows = truncateRows(row.childRows, max);
+      if (output === row.output && childRows === row.childRows) {
+        return row;
+      }
+      return { ...row, output, childRows };
+    }
+    default:
+      return row;
+  }
+}
+
+function truncateRows(rows: TimelineRow[], max: number): TimelineRow[] {
+  let changed = false;
+  const next = rows.map((row) => {
+    const truncated = truncateRow(row, max);
+    if (truncated !== row) {
+      changed = true;
+    }
+    return truncated;
+  });
+  return changed ? next : rows;
+}
+
+export function truncateTimelineResponseOutputs(
+  response: ThreadTimelineResponse,
+  max: number = DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+): ThreadTimelineResponse {
+  const rows = truncateRows(response.rows, max);
+  return rows === response.rows ? response : { ...response, rows };
+}

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -93,6 +93,8 @@ interface ResolveTurnSummaryDetailsSourceRangeArgs {
 interface BuildThreadTimelineOptions {
   isDevelopment: boolean;
   includeNestedRows?: boolean;
+  /** Thread high-water event sequence this window reflects (echoed to clients). */
+  maxSeq: number;
   page: ThreadTimelinePageRequest;
   /**
    * When true, the response is built without rows (rows: []). The tail-only
@@ -864,6 +866,7 @@ function buildThreadTimelineInternal(
   }
 
   const response: ThreadTimelineResponse = {
+    maxSeq: options.maxSeq,
     rows: options.summaryOnly ? [] : paginatedTimeline.rows,
     activeThinking:
       options.page.kind === "latest" ? timeline.activeThinking : null,

--- a/apps/server/test/public/public-thread-timeline-delta.test.ts
+++ b/apps/server/test/public/public-thread-timeline-delta.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { threadScope, turnScope } from "@bb/domain";
+import {
+  applyTimelineDelta,
+  threadTimelineResponseSchema,
+  type ThreadTimelineResponse,
+} from "@bb/server-contract";
+import { readJson } from "../helpers/json.js";
+import { seedEvent, seedThreadFixture } from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+import type { TestAppHarness } from "../helpers/test-app.js";
+
+async function getTimeline(
+  harness: TestAppHarness,
+  threadId: string,
+  afterSequence?: number,
+): Promise<ThreadTimelineResponse> {
+  const url =
+    afterSequence === undefined
+      ? `/api/v1/threads/${threadId}/timeline`
+      : `/api/v1/threads/${threadId}/timeline?afterSequence=${afterSequence}`;
+  const response = await harness.app.request(url);
+  if (response.status !== 200) {
+    throw new Error(
+      `timeline ${url} -> ${response.status}: ${await response.text()}`,
+    );
+  }
+  return threadTimelineResponseSchema.parse(await readJson(response));
+}
+
+describe("GET /threads/:id/timeline?afterSequence (row-patch delta)", () => {
+  it("a full fetch carries no delta and echoes maxSeq", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        sequence: 1,
+        type: "system/manager/user_message",
+        scope: threadScope(),
+        data: { text: "hello" },
+      });
+
+      const full = await getTimeline(harness, thread.id);
+      expect(full.delta).toBeUndefined();
+      expect(full.rows.length).toBeGreaterThan(0);
+      expect(full.maxSeq).toBe(1);
+    });
+  });
+
+  it("delta + merge reproduces a fresh full window when rows are appended", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "p1",
+        scope: turnScope("turn-1"),
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "p1",
+        scope: turnScope("turn-1"),
+        sequence: 2,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "tool-1",
+            tool: "exec_command",
+            arguments: { cmd: "pnpm test" },
+            status: "completed",
+          },
+        },
+      });
+
+      const before = await getTimeline(harness, thread.id);
+
+      // Append another item to the active turn.
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "p1",
+        scope: turnScope("turn-1"),
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: { type: "agentMessage", id: "assistant-1", text: "Done." },
+        },
+      });
+
+      const delta = await getTimeline(harness, thread.id, before.maxSeq);
+      expect(delta.delta).toBeDefined();
+      expect(delta.rows).toHaveLength(0);
+      expect(delta.maxSeq).toBe(3);
+      expect(delta.delta!.upsertRows.length).toBeGreaterThan(0);
+
+      const merged = applyTimelineDelta(before.rows, delta.delta!);
+      const fresh = await getTimeline(harness, thread.id);
+      expect(merged).toEqual(fresh.rows);
+    });
+  });
+
+  it("delta + merge reproduces a fresh full window when a turn completes (collapse)", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const turn = {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "p1",
+        scope: turnScope("turn-1"),
+      } as const;
+      seedEvent(harness.deps, {
+        ...turn,
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        ...turn,
+        sequence: 2,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "tool-1",
+            tool: "exec_command",
+            arguments: { cmd: "ls" },
+            status: "completed",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        ...turn,
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: { type: "agentMessage", id: "assistant-1", text: "First." },
+        },
+      });
+
+      // Active turn: rows are expanded.
+      const before = await getTimeline(harness, thread.id);
+
+      // Complete the turn -> the projection collapses the turn's rows.
+      seedEvent(harness.deps, {
+        ...turn,
+        sequence: 4,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+
+      const delta = await getTimeline(harness, thread.id, before.maxSeq);
+      expect(delta.delta).toBeDefined();
+
+      const merged = applyTimelineDelta(before.rows, delta.delta!);
+      const fresh = await getTimeline(harness, thread.id);
+      expect(merged).not.toBeNull();
+      expect(merged).toEqual(fresh.rows);
+      // The collapse genuinely changed the window (different row ids/content),
+      // and a row the client held was dropped — i.e. the delta exercised removal,
+      // not just upsert. Otherwise the test proves nothing.
+      expect(fresh.rows).not.toEqual(before.rows);
+      const beforeIds = new Set(before.rows.map((row) => row.id));
+      const freshIds = new Set(fresh.rows.map((row) => row.id));
+      expect([...beforeIds].some((id) => !freshIds.has(id))).toBe(true);
+    });
+  });
+
+  it("a no-op delta (no new events) returns an empty patch and merges to the same rows", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        sequence: 1,
+        type: "system/manager/user_message",
+        scope: threadScope(),
+        data: { text: "hello" },
+      });
+
+      const before = await getTimeline(harness, thread.id);
+      const delta = await getTimeline(harness, thread.id, before.maxSeq);
+      expect(delta.delta).toBeDefined();
+      expect(delta.delta!.upsertRows).toHaveLength(0);
+      expect(applyTimelineDelta(before.rows, delta.delta!)).toEqual(
+        before.rows,
+      );
+    });
+  });
+});

--- a/apps/server/test/services/threads/timeline-cache.test.ts
+++ b/apps/server/test/services/threads/timeline-cache.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadTimelineResponse } from "@bb/server-contract";
+import type { ThreadTimelinePageRequest } from "../../../src/services/threads/timeline-pagination.js";
+import {
+  buildThreadTimelineCacheKey,
+  createThreadTimelineCache,
+  type ThreadTimelineCacheKeyArgs,
+} from "../../../src/services/threads/timeline-cache.js";
+
+function makeResponse(rowCount: number): ThreadTimelineResponse {
+  return {
+    rows: Array.from({ length: rowCount }, (_, index) => ({
+      id: `row-${index}`,
+      kind: "system",
+      threadId: "thr_x",
+      turnId: null,
+      sourceSeqStart: index,
+      sourceSeqEnd: index,
+      startedAt: 0,
+      createdAt: 0,
+      systemKind: "debug",
+      title: "t",
+      detail: null,
+      status: null,
+    })),
+    activeThinking: null,
+    pendingTodos: null,
+    goal: null,
+    timelinePage: {
+      kind: "latest",
+      segmentLimit: 20,
+      returnedSegmentCount: 0,
+      hasOlderRows: false,
+      olderCursor: null,
+    },
+  };
+}
+
+const latestPage: ThreadTimelinePageRequest = {
+  kind: "latest",
+  segmentLimit: 20,
+};
+
+const baseKeyArgs: ThreadTimelineCacheKeyArgs = {
+  threadId: "thr_x",
+  maxSeq: 10,
+  status: "idle",
+  environmentId: null,
+  page: latestPage,
+  includeNestedRows: false,
+  summaryOnly: false,
+  isDevelopment: false,
+};
+
+describe("createThreadTimelineCache", () => {
+  it("builds once for the same key and serves cached on repeat", () => {
+    const cache = createThreadTimelineCache();
+    const build = vi.fn(() => makeResponse(3));
+
+    const first = cache.getOrBuild("k", build);
+    const second = cache.getOrBuild("k", build);
+
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(cache.size).toBe(1);
+  });
+
+  it("rebuilds when the key changes (e.g. new maxSeq)", () => {
+    const cache = createThreadTimelineCache();
+    const build = vi.fn(() => makeResponse(3));
+
+    cache.getOrBuild("k1", build);
+    cache.getOrBuild("k2", build);
+
+    expect(build).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache responses above the row cap (streaming expanded turns)", () => {
+    const cache = createThreadTimelineCache({ maxCacheableRows: 5 });
+    const build = vi.fn(() => makeResponse(50));
+
+    cache.getOrBuild("k", build);
+    cache.getOrBuild("k", build);
+
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(cache.size).toBe(0);
+  });
+
+  it("evicts least-recently-used entries beyond maxEntries", () => {
+    const cache = createThreadTimelineCache({ maxEntries: 2 });
+    const build = vi.fn(() => makeResponse(1));
+
+    cache.getOrBuild("a", build); // [a]
+    cache.getOrBuild("b", build); // [a,b]
+    cache.getOrBuild("a", build); // touch a -> [b,a]
+    cache.getOrBuild("c", build); // evict b -> [a,c]
+
+    expect(cache.size).toBe(2);
+    const buildAgain = vi.fn(() => makeResponse(1));
+    cache.getOrBuild("a", buildAgain); // still cached
+    cache.getOrBuild("b", buildAgain); // evicted -> rebuild
+    expect(buildAgain).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildThreadTimelineCacheKey", () => {
+  it("is stable for identical inputs", () => {
+    expect(buildThreadTimelineCacheKey(baseKeyArgs)).toBe(
+      buildThreadTimelineCacheKey({ ...baseKeyArgs }),
+    );
+  });
+
+  it("differs when any projection input differs", () => {
+    const base = buildThreadTimelineCacheKey(baseKeyArgs);
+    const variants: ThreadTimelineCacheKeyArgs[] = [
+      { ...baseKeyArgs, maxSeq: 11 },
+      { ...baseKeyArgs, status: "active" },
+      { ...baseKeyArgs, environmentId: "env_1" },
+      { ...baseKeyArgs, includeNestedRows: true },
+      { ...baseKeyArgs, summaryOnly: true },
+      { ...baseKeyArgs, isDevelopment: true },
+      {
+        ...baseKeyArgs,
+        page: {
+          kind: "older",
+          segmentLimit: 20,
+          beforeCursor: { anchorSeq: 5, anchorId: "a5" },
+        },
+      },
+    ];
+    for (const variant of variants) {
+      expect(buildThreadTimelineCacheKey(variant)).not.toBe(base);
+    }
+  });
+
+  it("distinguishes older-page cursors", () => {
+    const cursorA = buildThreadTimelineCacheKey({
+      ...baseKeyArgs,
+      page: {
+        kind: "older",
+        segmentLimit: 20,
+        beforeCursor: { anchorSeq: 5, anchorId: "a5" },
+      },
+    });
+    const cursorB = buildThreadTimelineCacheKey({
+      ...baseKeyArgs,
+      page: {
+        kind: "older",
+        segmentLimit: 20,
+        beforeCursor: { anchorSeq: 6, anchorId: "a6" },
+      },
+    });
+    expect(cursorA).not.toBe(cursorB);
+  });
+});

--- a/apps/server/test/services/threads/timeline-cache.test.ts
+++ b/apps/server/test/services/threads/timeline-cache.test.ts
@@ -24,6 +24,7 @@ function makeResponse(rowCount: number): ThreadTimelineResponse {
       status: null,
     })),
     activeThinking: null,
+    activeWorkflow: null,
     pendingTodos: null,
     goal: null,
     maxSeq: 0,

--- a/apps/server/test/services/threads/timeline-cache.test.ts
+++ b/apps/server/test/services/threads/timeline-cache.test.ts
@@ -26,6 +26,7 @@ function makeResponse(rowCount: number): ThreadTimelineResponse {
     activeThinking: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,

--- a/apps/server/test/services/threads/timeline-output-truncation.test.ts
+++ b/apps/server/test/services/threads/timeline-output-truncation.test.ts
@@ -19,6 +19,7 @@ function response(rows: TimelineRow[]): ThreadTimelineResponse {
   return {
     rows,
     activeThinking: null,
+    activeWorkflow: null,
     pendingTodos: null,
     goal: null,
     maxSeq: 0,

--- a/apps/server/test/services/threads/timeline-output-truncation.test.ts
+++ b/apps/server/test/services/threads/timeline-output-truncation.test.ts
@@ -21,6 +21,7 @@ function response(rows: TimelineRow[]): ThreadTimelineResponse {
     activeThinking: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,

--- a/apps/server/test/services/threads/timeline-output-truncation.test.ts
+++ b/apps/server/test/services/threads/timeline-output-truncation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadTimelineResponse, TimelineRow } from "@bb/server-contract";
+import {
+  DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+  truncateTimelineResponseOutputs,
+} from "../../../src/services/threads/timeline-output-truncation.js";
+
+const base = {
+  id: "row",
+  threadId: "thr_x",
+  turnId: "turn_1",
+  sourceSeqStart: 1,
+  sourceSeqEnd: 2,
+  startedAt: 0,
+  createdAt: 0,
+};
+
+function response(rows: TimelineRow[]): ThreadTimelineResponse {
+  return {
+    rows,
+    activeThinking: null,
+    pendingTodos: null,
+    goal: null,
+    timelinePage: {
+      kind: "latest",
+      segmentLimit: 20,
+      returnedSegmentCount: 0,
+      hasOlderRows: false,
+      olderCursor: null,
+    },
+  };
+}
+
+function commandRow(output: string): TimelineRow {
+  return {
+    ...base,
+    kind: "work",
+    status: "completed",
+    workKind: "command",
+    callId: "c1",
+    command: "echo",
+    cwd: null,
+    source: null,
+    output,
+    exitCode: 0,
+    completedAt: 1,
+    approvalStatus: null,
+    activityIntents: [],
+  };
+}
+
+describe("truncateTimelineResponseOutputs", () => {
+  it("truncates a command output above the cap and keeps a marker", () => {
+    const big = "x".repeat(DEFAULT_MAX_INLINE_OUTPUT_CHARS + 5_000);
+    const out = truncateTimelineResponseOutputs(response([commandRow(big)]));
+    const row = out.rows[0] as Extract<
+      TimelineRow,
+      { kind: "work"; workKind: "command" }
+    >;
+    expect(row.output.length).toBeLessThan(big.length);
+    expect(row.output).toContain("more characters truncated");
+    expect(
+      row.output.startsWith("x".repeat(DEFAULT_MAX_INLINE_OUTPUT_CHARS)),
+    ).toBe(true);
+  });
+
+  it("leaves small outputs and their row identity untouched", () => {
+    const input = response([commandRow("ok")]);
+    const out = truncateTimelineResponseOutputs(input);
+    expect(out).toBe(input);
+    expect(out.rows[0]).toBe(input.rows[0]);
+  });
+
+  it("recurses into turn children", () => {
+    const big = "y".repeat(DEFAULT_MAX_INLINE_OUTPUT_CHARS + 1_000);
+    const turn: TimelineRow = {
+      ...base,
+      kind: "turn",
+      turnId: "turn_1",
+      status: "completed",
+      summaryCount: 1,
+      completedAt: 1,
+      children: [commandRow(big)],
+    };
+    const out = truncateTimelineResponseOutputs(response([turn]));
+    const turnOut = out.rows[0] as Extract<TimelineRow, { kind: "turn" }>;
+    const child = turnOut.children![0] as Extract<
+      TimelineRow,
+      { kind: "work"; workKind: "command" }
+    >;
+    expect(child.output).toContain("more characters truncated");
+  });
+});

--- a/apps/server/test/system/event-pruning.test.ts
+++ b/apps/server/test/system/event-pruning.test.ts
@@ -250,6 +250,7 @@ describe("thread event pruning", () => {
       });
       const timeline = buildThreadTimeline(harness.db, thread, {
         isDevelopment: true,
+        maxSeq: 0,
         page: {
           kind: "latest",
           segmentLimit: Number.MAX_SAFE_INTEGER,

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -22,6 +22,7 @@ import {
 } from "@bb/domain";
 import type { CallerExecutionInputSource } from "@bb/domain";
 import {
+  timelineDeltaSchema,
   timelineRowSchema,
   timelineWorkflowWorkRowSchema,
 } from "../thread-timeline.js";
@@ -420,6 +421,13 @@ export const threadTimelineQuerySchema = z
      * semantics.
      */
     summaryOnly: z.enum(["true", "false"]),
+    /**
+     * The `maxSeq` the client last received for this window. When provided and
+     * the server can still reconstruct what the client holds, the response is a
+     * `delta` (changed rows only) instead of the full `rows`; otherwise the
+     * server returns the full window and the client replaces.
+     */
+    afterSequence: z.string().regex(/^\d+$/),
   })
   .partial()
   .superRefine((query, context) => {
@@ -525,6 +533,14 @@ export const threadTimelineResponseSchema = z.object({
   goal: threadTimelineGoalSchema.nullable(),
   contextWindowUsage: threadContextWindowUsageSchema.optional(),
   timelinePage: timelinePageMetadataSchema,
+  /** Thread high-water event sequence this window reflects; bumps on append. */
+  maxSeq: z.number().int().nonnegative(),
+  /**
+   * Present only when the request supplied a usable `afterSequence`: the
+   * changed rows + ordering to apply to the client's previous window. When
+   * present, `rows` is empty and the client merges via `applyTimelineDelta`.
+   */
+  delta: timelineDeltaSchema.optional(),
 });
 export type ThreadTimelineResponse = z.infer<
   typeof threadTimelineResponseSchema

--- a/packages/server-contract/src/thread-timeline.ts
+++ b/packages/server-contract/src/thread-timeline.ts
@@ -178,9 +178,7 @@ export const timelineParentChangeSchema = z.object({
   nextParentThreadId: z.string().nullable(),
   nextParentThreadTitle: z.string().nullable(),
 });
-export type TimelineParentChange = z.infer<
-  typeof timelineParentChangeSchema
->;
+export type TimelineParentChange = z.infer<typeof timelineParentChangeSchema>;
 
 const timelineSystemRowBaseSchema = timelineRowBaseSchema.extend({
   kind: z.literal("system"),
@@ -513,3 +511,72 @@ export const timelineRowSchema: z.ZodType<TimelineRow> = z.lazy(() =>
 );
 
 export type TimelineToolArgs = JsonObject | null;
+
+/**
+ * Incremental update to a previously-fetched timeline window. The server
+ * computes it by reprojecting the full window (correct by construction — all
+ * turn-collapse / window-eviction / finalize / background-task-fold semantics
+ * are preserved) and diffing it against the rows the client last received.
+ *
+ * `upsertRows` carries the full body of every row that was added or changed.
+ * `rowOrder` is the complete, ordered id list of the current window, so the
+ * client reconstructs the exact row order and membership without guessing —
+ * any id present in `rowOrder` but absent from `upsertRows` is an unchanged row
+ * the client already holds. See {@link applyTimelineDelta}.
+ */
+export const timelineDeltaSchema = z.object({
+  upsertRows: z.array(timelineRowSchema),
+  rowOrder: z.array(z.string()),
+});
+export type TimelineDelta = z.infer<typeof timelineDeltaSchema>;
+
+/**
+ * Diff a freshly-projected window against the rows the client last held. Pure;
+ * used by the server to build a {@link TimelineDelta}.
+ */
+export function computeTimelineRowDelta(
+  prevRows: readonly TimelineRow[],
+  currentRows: readonly TimelineRow[],
+): TimelineDelta {
+  const prevById = new Map<string, string>();
+  for (const row of prevRows) {
+    prevById.set(row.id, JSON.stringify(row));
+  }
+  const upsertRows: TimelineRow[] = [];
+  const rowOrder: string[] = [];
+  for (const row of currentRows) {
+    rowOrder.push(row.id);
+    if (prevById.get(row.id) !== JSON.stringify(row)) {
+      upsertRows.push(row);
+    }
+  }
+  return { upsertRows, rowOrder };
+}
+
+/**
+ * Apply a {@link TimelineDelta} to the rows the client currently holds,
+ * yielding the new full window. Returns `null` when the delta references a row
+ * the client neither holds nor was sent (a stale/mismatched base) — the caller
+ * should fall back to a full fetch.
+ */
+export function applyTimelineDelta(
+  prevRows: readonly TimelineRow[],
+  delta: TimelineDelta,
+): TimelineRow[] | null {
+  const byId = new Map<string, TimelineRow>();
+  for (const row of prevRows) {
+    byId.set(row.id, row);
+  }
+  for (const row of delta.upsertRows) {
+    byId.set(row.id, row);
+  }
+  const result: TimelineRow[] = [];
+  for (const id of delta.rowOrder) {
+    const row = byId.get(id);
+    if (row === undefined) {
+      return null;
+    }
+    result.push(row);
+  }
+  return result;
+}

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -199,12 +199,18 @@ const OPTIONAL_SERVER_FIELD_GROUPS: readonly OptionalServerFieldGroup[] = [
       "threadTimelineQuerySchema.beforeAnchorSeq",
       "threadTimelineQuerySchema.beforeAnchorId",
       "threadTimelineQuerySchema.summaryOnly",
+      "threadTimelineQuerySchema.afterSequence",
     ],
   },
   {
     reason:
       "Timeline responses omit context-window usage when the provider did not report it.",
     fields: ["threadTimelineResponseSchema.contextWindowUsage"],
+  },
+  {
+    reason:
+      "Timeline responses carry a row-patch delta only when the request supplied a usable afterSequence; a full window omits it.",
+    fields: ["threadTimelineResponseSchema.delta"],
   },
   {
     reason:

--- a/packages/server-contract/test/thread-timeline-delta.test.ts
+++ b/packages/server-contract/test/thread-timeline-delta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTimelineDelta,
+  computeTimelineRowDelta,
+  type TimelineRow,
+} from "../src/thread-timeline.js";
+
+function row(id: string, sourceSeqStart: number, title = "t"): TimelineRow {
+  return {
+    id,
+    kind: "system",
+    threadId: "thr_x",
+    turnId: null,
+    sourceSeqStart,
+    sourceSeqEnd: sourceSeqStart,
+    startedAt: 0,
+    createdAt: 0,
+    systemKind: "debug",
+    title,
+    detail: null,
+    status: null,
+  };
+}
+
+describe("timeline delta", () => {
+  it("round-trips an upsert + insert (compute then apply equals current)", () => {
+    const prev = [row("a", 1), row("b", 2)];
+    const current = [row("a", 1), row("b", 2, "changed"), row("c", 3)];
+    const delta = computeTimelineRowDelta(prev, current);
+    expect(delta.upsertRows.map((r) => r.id)).toEqual(["b", "c"]);
+    expect(applyTimelineDelta(prev, delta)).toEqual(current);
+  });
+
+  it("round-trips a removal (collapse/eviction)", () => {
+    const prev = [row("a", 1), row("b", 2), row("c", 3)];
+    const current = [row("a", 1), row("c", 3)];
+    const delta = computeTimelineRowDelta(prev, current);
+    expect(delta.upsertRows).toHaveLength(0);
+    expect(applyTimelineDelta(prev, delta)).toEqual(current);
+  });
+
+  it("preserves unchanged row identity (no needless re-render)", () => {
+    const a = row("a", 1);
+    const prev = [a, row("b", 2)];
+    const current = [a, row("b", 2, "changed")];
+    const merged = applyTimelineDelta(
+      prev,
+      computeTimelineRowDelta(prev, current),
+    );
+    expect(merged?.[0]).toBe(a);
+  });
+
+  it("returns null when the base is stale (id neither held nor sent)", () => {
+    expect(
+      applyTimelineDelta([row("a", 1)], {
+        upsertRows: [],
+        rowOrder: ["a", "z"],
+      }),
+    ).toBeNull();
+  });
+});

--- a/plans/timeline-rendering-performance.md
+++ b/plans/timeline-rendering-performance.md
@@ -373,6 +373,13 @@ Implemented W2–W5 this PR (no WS-message change needed — the client carries
 `maxSeq` from the response, so the delta works over the existing fetch path).
 W1 remains, tracked in §13.
 
+Drive-by fix in the same PR: removed a `staleTime: Infinity` on the live timeline
+query (added by `cb78596611`) that silently defeated `refetchOnMount`, leaving a
+revisited thread frozen on stale rows until the next live event. It also never
+reduced streaming rerenders (those are invalidation-driven). The query now
+inherits the app-wide 2s `staleTime`; safe to do now that a revisit/focus refetch
+is a cheap delta (W4) or cached/no-op response (W3) rather than a full rebuild.
+
 ---
 
 ## 10. Before / after (concrete numbers)

--- a/plans/timeline-rendering-performance.md
+++ b/plans/timeline-rendering-performance.md
@@ -1,0 +1,519 @@
+# Timeline Rendering Performance
+
+Status: **in progress.** W3 (server route cache) implemented + tested in this
+PR; W1/W2/W4/W5 remain (sequenced in §9). Investigation complete; design
+validated by adversarial review.
+Branch: `bb/timeline-rendering-performance-plan-*`.
+
+Grounded in measurements against the live packaged server (`http://127.0.0.1:38886`)
+over the local dev DB `/root/.bb/bb.db` (104,490 events / 124 threads), plus an
+in-process profiling probe and an adversarial correctness review of the
+incremental-update design. Concrete before/after numbers are in
+[§10](#10-before--after--concrete-numbers); re-run everything via
+[§12 Validation](#12-validation).
+
+---
+
+## 1. Problem
+
+The thread timeline is slow and wasteful during streaming and on large threads.
+Three reported symptoms, all confirmed and quantified:
+
+1. **Large payload** — the whole visible window is re-sent on every update, and
+   during streaming that window is **huge** (see §3: up to ~950 KB).
+2. **Repeated refetches for incremental updates** — one appended event → a full
+   server rebuild + full window refetch + full client re-merge.
+3. **Thundering herd during streaming** — invalidations land together and each
+   triggers a full from-scratch rebuild, across **every mounted timeline**.
+
+Scenarios we care about: **initial load**, **streaming**, **active turns**,
+**idle threads**.
+
+---
+
+## 2. How it works today (verified against code)
+
+**Fetch (client).** `useThreadTimeline` (`apps/app/src/hooks/queries/thread-queries.ts:632`)
+is a single `useQuery` keyed by `[THREAD_TIMELINE_QUERY_KEY, threadId]`. It calls
+`api.getThreadTimeline({ id })` (`apps/app/src/lib/api.ts:1213`) with **no**
+cursor/segmentLimit/afterSequence → always the server-default latest window
+(`THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT = 20`). "Load older" rows live in
+component-local `useState` in `useThreadTimelinePages.ts` (not a second cached
+query); live updates re-run the single latest-window query and re-merge.
+
+**Invalidation (client).** Realtime transport is a **WebSocket**
+(`apps/app/src/lib/ws.ts`, `useRealtimeSubscription.ts`). `events-appended`
+→ `dirtyThreadTimelineQueries` (`realtime-cache-registry.ts:120`) →
+`getThreadTimelineInvalidationQueryKeys` invalidates **two** prefixes: the
+timeline window **and** the turn-summary-details prefix
+(`cache-invalidation-groups.ts:93`) → `invalidateQueries` = **full refetch**.
+Batched at `INVALIDATION_DEBOUNCE_MS = 50` / `INVALIDATION_MAX_WAIT_MS = 200`
+(`realtime-cache-effects.ts:29`). There is **no incremental/`setQueryData` merge**
+for server-appended events (the only timeline `setQueryData` is optimistic local
+user messages, `thread-runtime-cache-owner.ts:422`).
+
+**The WS `changed` message carries no sequence** — only `{ entity, id, changes,
+metadata:{ eventTypes, hasPendingInteraction, projectId } }` (`change-kinds.ts:166`
+`threadChangeMetadataSchema` is `z.strict()`). So the client cannot know _what_
+or _how many_ events arrived → full refetch is its only correctness-safe option.
+
+**Mounted-timeline fan-out.** Side-chat tabs stay **mounted** when inactive
+(`display:none`, not unmounted — `SideChatTabDeck.tsx:53`); each
+`SideChatTabContent` runs `useThreadTimeline` for its main thread **and** its
+child (`:180`, `:412`). Every mounted timeline is an independent active query
+that refetches its full window on its thread's `events-appended`. **The herd is
+across mounted timelines, not across pages of one thread.**
+
+**Server build (no cache).** `routes/threads/data.ts:314` → `buildThreadTimeline`
+(`services/threads/timeline.ts:894`): segment-anchor window selection →
+JSON-decode events (`parseStoredEvent`) → `compactThreadTimelineSummaryEvents` →
+`buildThreadTimelineFromEvents` (`packages/thread-view/src/build-thread-timeline.ts:1071`)
+→ paginate. **No ETag / Cache-Control / in-memory cache** — every request
+rebuilds from scratch (warm repeats are not faster).
+
+**Projection shape.** A **pure, deterministic, whole-list** projection of the
+ordered event array. Completed turns collapse to a single `:turn` summary row;
+the **active (not-yet-completed) turn renders expanded** as many top-level rows.
+The state machine **mutates earlier row objects in place** as later events
+arrive (tool/exec calls upserted by `callId`, streaming assistant text,
+background tasks). See §6 — this is why naive incremental append is wrong.
+
+**Render.** `ThreadTimelineRows.tsx` (1727 lines). Rows are `memo`'d with a
+custom equality that compares `row` by reference then falls back to a
+**structural deep-equal** (`:461`, `:489`). **No list virtualization** (only an
+`IntersectionObserver` for scroll chrome). A refetch returns a new array, so the
+client deep-equals **every** row and re-renders the changed ones; first mount of
+a big window mounts all rows.
+
+---
+
+## 3. Measured baselines (evidence)
+
+### 3a. Idle window (latest turn collapsed) — modest
+
+| thread                     | events | turns | payload | latency | warm repeat    |
+| -------------------------- | ------ | ----- | ------- | ------- | -------------- |
+| `thr_axgftfi23h` (typical) | 414    | 2     | 14.3 KB | 27 ms   | ~27 ms         |
+| `thr_9ua98izdjf` (large)   | 2,986  | 24    | 40.5 KB | 95 ms   | ~95 ms         |
+| `thr_kg5cffwyw2` (huge)    | 12,206 | 60    | 60.1 KB | 172 ms  | **130–173 ms** |
+
+Warm repeats are not faster → **no server caching**. `summaryOnly=true` (huge) =
+130 ms → cost is event-query + projection, **not serialization**.
+
+### 3b. Streaming window (active turn expanded) — the real problem
+
+Same huge thread, same 942-event turn, built as the **latest** turn, collapsed
+vs active (= what the client refetches on every appended event while streaming):
+
+| latest-turn state      | rows | **payload** | build  |
+| ---------------------- | ---- | ----------- | ------ |
+| collapsed (completed)  | 61   | **65 KB**   | 245 ms |
+| **active / streaming** | 353  | **951 KB**  | 264 ms |
+
+→ **~15× larger payload** when the latest turn is active. And it **grows
+monotonically through the turn** (re-sent in full on every event):
+
+| through the active turn | rows | payload |
+| ----------------------- | ---- | ------- |
+| 25%                     | 131  | 382 KB  |
+| 50%                     | 206  | 550 KB  |
+| 75%                     | 307  | 876 KB  |
+| 100%                    | 353  | 951 KB  |
+
+With the 200 ms debounce capping refetches at ~5/s, a single active big-turn
+thread re-ships on the order of **~3–5 MB/s** of mostly-unchanged rows, each
+triggering a ~250 ms server rebuild and a full client deep-equal + re-render of
+hundreds of rows. (My earlier 60 KB figure was an idle thread and understated
+streaming by ~15×.)
+
+### 3c. Build-cost attribution (in-process probe; windowed build cross-checks live, huge 183 ms ≈ live 172 ms)
+
+| stage (full event set)               | typical | large  | huge       |
+| ------------------------------------ | ------- | ------ | ---------- |
+| event query (DB)                     | 5 ms    | 28 ms  | 76 ms      |
+| **JSON decode** (`parseStoredEvent`) | 33 ms   | 80 ms  | **186 ms** |
+| compaction                           | 1 ms    | 1 ms   | 12 ms      |
+| **projection**                       | 28 ms   | 77 ms  | **280 ms** |
+| serialize rows                       | 0.1 ms  | 0.3 ms | 1 ms       |
+
+→ Per-build CPU is dominated by **event decode + projection, both O(events),
+recomputed from scratch on every refetch**. Serialization is negligible.
+
+### 3d. Event composition / cadence
+
+- `item/completed` = 43,296 rows = **~84% of all event bytes**; **p50 459 B,
+  p90 6.6 KB, avg 4 KB, max 1.09 MB** — a few giant tool outputs/diffs dominate.
+- Streaming bursts reach **13 events/s (one thread), up to 50/thread-s
+  fleet-wide**; with the debounce → ~5 full rebuilds/s per mounted timeline.
+
+---
+
+## 4. Root causes (symptom × scenario)
+
+| RC  | Root cause                                                                                                                                                                                   | Symptoms                 | Worst scenario                    |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------------- |
+| RC1 | **Active turn renders expanded** → the latest window is ~950 KB during a big turn and is **re-sent + rebuilt in full on every appended event**                                               | payload, refetches, herd | streaming / active-turn           |
+| RC2 | Client always full-refetches on `events-appended`; no delta; WS message has no sequence so it _can't_ do better                                                                              | refetches, payload       | streaming                         |
+| RC3 | **Every mounted timeline refetches** — incl. kept-mounted side-chat tabs (main + child)                                                                                                      | herd                     | many threads / side-chat open     |
+| RC4 | Server rebuilds from scratch every request (no cache); cost O(events) decode + projection (~130–264 ms)                                                                                      | herd, refetches          | streaming on big threads          |
+| RC5 | `events-appended` also invalidates **immutable** completed turn-summary-detail panels                                                                                                        | refetches                | active-turn with expanded details |
+| RC6 | Timeline list is **not virtualized**; full deep-equal + mount of hundreds of rows (W4 cuts per-commit re-render; first-mount render cost is **deferred** — virtualization out of scope, §13) | render                   | initial load / active big turn    |
+| RC7 | Giant `item/completed` outputs/diffs (≤1 MB) shipped + parsed + rendered inline                                                                                                              | payload, render          | tool calls with big output        |
+
+---
+
+## 5. Proposed improvements (smallest correct change first)
+
+Honors AGENTS.md "Simplicity First": incremental, independently shippable. The
+adversarial review (§6) **refuted** the tempting "send rows whose source events
+have seq > N and append" design and a resumable in-memory incremental projector
+(too risky vs the batch finalize/interrupt machinery). The validated approach is
+to **keep reprojecting the bounded window server-side (correct by construction)
+and diff it** — plus cheap herd/cache wins.
+
+### W1 (S) — Visibility-gate hidden side-chat timelines → RC3
+
+Pass `enabled: false` to `useThreadTimeline` for inactive (`display:none`)
+side-chat tabs (`SideChatTabContent.tsx:180,412`; thread the active-tab flag from
+`SideChatTabDeck.tsx:53`). `useThreadDetailRealtimeSubscription` is gated by the
+same `enabled` flag, so this cleanly stops both the subscription and the refetch;
+`refetchOnMount` refreshes on show. No contract change. Collapses N mounted
+timelines to ~1 visible. _Product check:_ confirm which live badges (activity /
+thinking) must stay on hidden tabs; if any, keep only the lightweight status
+query active.
+
+### W2 (S) — Don't invalidate turn-summary-details on every batch → RC5
+
+Remove `threadTimelineTurnSummaryDetailsQueryKeyPrefix` from the
+`events-appended` grouping in `getThreadTimelineInvalidationQueryKeys`
+(`cache-invalidation-groups.ts:93`). A completed turn's detail is a fixed
+`sourceSeqStart..sourceSeqEnd` range and is immutable; only the open turn could
+change, and it is not expandable-as-collapsed-detail while streaming. No contract
+change. (Scope to the open turn's key if a turn can be expanded mid-stream.)
+
+### W3 (S–M) — Server idle/warm-repeat route cache → RC4 (idle/warm), double-mount **[IMPLEMENTED — this PR]**
+
+Bounded LRU in `registerThreadDataRoutes` keyed on the **true projection
+inputs**: `(threadId, segmentLimit, includeNestedRows, summaryOnly,
+isDevelopment, maxSeq, thread.status, environmentId)`. `maxSeq` via
+`getLatestThreadSequence` (`packages/db/src/data/events.ts`, indexed). Server-only;
+no WS change. **Key includes `status`** (interrupt flips earlier rows),
+`environmentId` (workspace root relativizes paths), and row-shape flags; `maxSeq`
+alone is insufficient. Expanded active-turn windows (rows > 200) are intentionally
+**not** cached — their `maxSeq` changes every event so they'd only thrash the LRU.
+Eliminates warm-repeat and double-mount cost, and makes idle refetches free.
+Implemented in `apps/server/src/services/threads/timeline-cache.ts` (+ unit test);
+wired in `apps/server/src/routes/threads/data.ts`. (ETag/`304` deferred.)
+
+### W4 (L) — Server-computed row-patch delta → RC1, RC2 (the streaming win)
+
+The big lever. Correct _by construction_ because the server still reprojects the
+full bounded window (all eviction/collapse/finalize/backfill semantics
+preserved), then **diffs**:
+
+1. Add optional `afterSequence` to `threadTimelineQuerySchema`
+   (`packages/server-contract/src/api/threads.ts:342`); thread through
+   `parseThreadTimelinePage` → `buildThreadTimeline`.
+2. Server reprojects the latest window, then returns
+   `{ upsertRows, removedRowIds, windowSequenceStart, olderCursor, maxSeq }`.
+   - `upsertRows` = rows whose `sourceSeqEnd >= afterSequence` ∪ any keyed
+     bg-task/lifecycle/tool row touched by an event `seq > afterSequence` (even
+     if its range is pinned below) ∪ rows flipped by finalize/interrupt.
+   - `removedRowIds` = ids in the prior window's id set absent from the new
+     projection (covers **turn-collapse** and **window eviction**).
+     Computed by diffing the new projection against a small **per-thread last-sent
+     window snapshot** (or recomputed conservatively from the union above).
+3. Add `maxSeq` to the WS `changed` message (`threadChangeMetadataSchema`,
+   `notifier`, hub publisher) so the client knows the new `N`.
+4. Client applies replace-by-id + delete `removedRowIds` + re-sort by
+   `sourceSeqStart`, then runs the existing merge against `windowSequenceStart`.
+   **Falls back to a full window fetch** when `afterSequence` is omitted/stale.
+
+Cuts streaming payload from ~950 KB to the few changed rows (target ≤ 8 KB/batch)
+and makes the client re-render only changed rows. **Note:** W4 does _not_ reduce
+the ~130–264 ms server projection CPU (the server still reprojects); W1 + W3
+are what bound server CPU. Pair W4 with the §8 patch-diff-fidelity spike.
+
+### W5 (M) — Truncate giant inline outputs/diffs → RC7
+
+For `item/completed` outputs/diffs above a threshold, ship a truncated preview
+with a "load full" affordance (the `turn-summary-details` endpoint already serves
+on-demand detail). Targets the ≤1 MB outliers without touching typical rows.
+
+**Out of scope (follow-up), see §13:**
+
+- **List virtualization** (render only visible rows). The lever for huge-thread
+  _initial-load render_ and per-commit deep-equal cost — **deferred at request.**
+  Without it, W4 still cuts per-commit re-renders to the changed rows, but the
+  first mount of a big window still mounts all rows.
+- A resumable in-memory incremental _projector_ that reduces per-build CPU. The
+  adversarial review rates it XL / high-risk against the finalize/interrupt batch
+  machinery; revisit only if probes show server CPU still saturates after
+  W1/W3/W4.
+
+---
+
+## 6. Correctness constraints (why W4 must diff a full reprojection)
+
+All three adversarial skeptics independently **refuted** "fetch rows with
+seq > N and append/replace." Concrete failure modes any delta scheme must handle
+— all are handled by diffing a full reprojection, none by an event-tail:
+
+- **Turn collapse:** on `turn/completed` (summary mode), N streamed message rows
+  (`sourceSeqStart < N`) are **deleted** and replaced by one collapsed `:turn`
+  row (`build-thread-timeline.ts:912`). Naive upsert-by-id leaves N stale
+  duplicates → requires explicit `removedRowIds`.
+- **In-place mutation of earlier rows:** tool/exec calls are upserted by `callId`
+  (`tool-activity-projection.ts:502`); a late `item/completed` rewrites a row
+  whose `sourceSeqStart ≪ N` (output, exit code, status). Streaming assistant
+  text mutates one message object across deltas. A `seq > N` filter misses these
+  → stale "running" rows.
+- **Background tasks outliving their turn:** `item/backgroundTask/progress|completed`
+  are thread-scoped and fold into a row with `sourceSeqEnd` **pinned** to the
+  spawning turn's anchor (`background-task-projection.ts:78`). A range filter
+  excludes them → task pinned "running" forever.
+- **Finalize / interrupt:** flips pending→interrupted across **all** earlier
+  messages (`event-projection-state.ts:259`, `tool-activity-projection.ts:832`).
+- **Window eviction:** a 21st user turn slides the window lower bound; evicted
+  rows must be removed from raw consumers (`SideChatTabContent`).
+- **Append-text-fragment is wrong:** deltas get pruned and `item/completed`
+  **replaces** the streamed text; concatenated fragments ≠ final text. Patches
+  must be **whole-row** replace/insert/delete; the server stays the text source
+  of truth.
+
+W3's cache key has matching constraints: it **must** include `thread.status` and
+the row-shape flags, not just `maxSeq`.
+
+---
+
+## 7. Probes (must pass with each change)
+
+Each probe: method, baseline, target, pass/fail. Harnesses in §12.
+
+### Probe A — Initial load (cold) → W5
+
+- Method: dev-browser (`--connect`, React Profiler + `performance` via
+  `page.evaluate`) loads the huge thread; measure first-rows paint, main-thread
+  blocking, payload (curl). Flag threads whose window contains a >256 KB output.
+- Baseline: 60 KB / 172 ms (idle); giant-output threads spike toward the ≤1 MB
+  outliers.
+- **Exit:** no cold-load regression (p50 within 10% of baseline) for
+  typical/large/huge; with W5, window payload for giant-output threads ↓ and
+  parse/first-paint improves correspondingly. (Huge-thread initial-load _render_
+  remains bounded by the deferred virtualization — §13.)
+
+### Probe B — Streaming payload + refetch volume → W4
+
+- Method: replay a real big turn's events into a scratch DB at the measured
+  cadence; for each `events-appended`, measure bytes the client receives (full
+  window today vs W4 patch). Optionally drive the real client via dev-browser and
+  count GETs.
+- Baseline: up to ~950 KB re-sent per refetch (§3b), ~5×/s.
+- Target: per-batch payload ≤ 8 KB (open-turn patch only), ≥ 85% reduction.
+- **Exit:** streaming bytes/30 s for the huge thread ↓ ≥ 80% **AND** the rendered
+  timeline is byte-identical to a full-refetch render (no stale/dup/missing rows).
+
+### Probe C — Active-turn correctness + render churn → W4 (gate)
+
+- Method: golden test. Replaying events one batch at a time, assert
+  `applyPatch(prev, delta) == fullRebuild` row-for-row across fixtures including
+  every §6 case (turn collapse, late tool completion, background task, interrupt,
+  window eviction). Plus React Profiler committed-row count per batch.
+- **Exit:** patch == full-rebuild for every fixture (a deliberately-broken diff
+  must fail); median rendered-component count per streaming commit on the huge
+  thread ↓ ≥ 70% with no visible stale tool/background-task rows.
+
+### Probe D — Idle threads / herd → W1, W3
+
+- Method: dev-browser opens a thread with side-chat tabs + background threads
+  while another thread streams; count `/timeline` GETs on unfocused threads over
+  30 s (instrument QueryCache / `realtime-cache-effects`). Plus warm-repeat
+  latency on an idle thread.
+- Baseline: every mounted timeline refetches per batch; warm repeat ~150 ms.
+- **Exit:** hidden side-chat tabs issue **0** `/timeline` GETs during a 30 s
+  main-thread stream (W1); warm-repeat p50 on an idle huge thread ↓ ≥ 90% via
+  cache hit / 304 (W3); focusing a tab shows fresh data within one fetch.
+
+---
+
+## 8. Prototypes (throwaway spikes to de-risk before committing)
+
+- **Spike 1 — patch-diff fidelity (keystone for W4):** in a branch, compute the
+  row patch by diffing two full window reprojections (before/after a batch) and
+  assert `applyPatch(prevRows, patch) == fullRebuild` across the §6 fixtures
+  (turn collapse, late tool completion, background-task fold, interrupt, window
+  eviction). If this holds, W4 is safe. **Do this before any client/protocol work.**
+- **Spike 2 — visibility-gate herd:** flip hidden side-chat tabs to
+  `enabled:false`; confirm Probe D (0 GETs) and that re-show refetches cleanly,
+  and audit which live badges break.
+- **Spike 3 — route cache:** add the W3 LRU keyed on the true inputs; measure
+  warm-hit latency; verify invalidation on interrupt/prune via Probe C fixtures.
+
+---
+
+## 9. Sequencing
+
+Each step is independently shippable and reversible.
+
+1. Land the **probe harnesses** + Probe C golden-test infra (gates everything).
+2. **W1** visibility-gate side-chat (S, no contract) — immediate herd collapse;
+   gate on Probe D + Spike 2.
+3. **W2** drop turn-summary-details invalidation (S, no contract).
+4. **W3** server route cache (S–M, server-only) — kills warm-repeat / idle /
+   double-mount; gate on Probe D + Spike 3. **← done in this PR.**
+5. **Spike 1**, then **W4** row-patch delta (L; WS contract change) — the
+   streaming payload win; gate on Probe B + C.
+6. **W5** truncation of giant outputs (gate on Probe A).
+
+---
+
+## 10. Before / after (concrete numbers)
+
+All "before" numbers are measured (live server / in-process probe over
+`/root/.bb/bb.db`). "After" numbers are measured where the mechanism is directly
+simulable (streaming delta, warm cache), else the target the change must hit
+(re-verify with the §7 probes during implementation). Representative threads:
+**typical** 414 events, **large** 2,986, **huge** 12,206.
+
+### Scenario 1 — Open an idle thread (initial load, cold)
+
+|                              | typical         | large           | huge                                             |
+| ---------------------------- | --------------- | --------------- | ------------------------------------------------ |
+| **Before** payload / latency | 14.3 KB / 27 ms | 40.5 KB / 95 ms | 60.1 KB / 172 ms                                 |
+| **After**                    | ≈ unchanged     | ≈ unchanged     | ≈ unchanged (W5 trims only giant-output threads) |
+
+Cold first load is not the bottleneck and is left unchanged (the render lever,
+virtualization, is deferred — §13). W5 reduces payload only for threads whose
+window holds a >256 KB output (the ≤1 MB outliers).
+
+### Scenario 2 — Revisit / second-mount an idle thread (warm) → W3
+
+| huge thread, repeat fetch | before               | after                          |
+| ------------------------- | -------------------- | ------------------------------ |
+| server work               | full rebuild ~150 ms | cache hit ~1 ms (or `304`)     |
+| bytes                     | 60 KB                | 0 (`304`) or served from cache |
+
+Server CPU for redundant/idle refetches: **−~99%**.
+
+### Scenario 3 — Streaming an active turn (the common, expensive case) → W4
+
+Measured by reprojecting the huge thread's 942-event turn as the active turn and
+diffing consecutive states (one refetch per appended item, **415 refetches**):
+
+| per refetch      | **before** (full window)           | **after** (W4 row-patch)                                        |
+| ---------------- | ---------------------------------- | --------------------------------------------------------------- |
+| bytes sent       | median **495 KB**, peak **889 KB** | median **686 B**, p90 6.2 KB, max 64 KB                         |
+| rows re-rendered | all ~350 (deep-equal every row)    | **~0.74** changed rows                                          |
+| server build     | ~250 ms reproject                  | ~250 ms reproject (unchanged; W4 fixes payload+render, not CPU) |
+
+| whole turn (cumulative wire) | before     | after                   |
+| ---------------------------- | ---------- | ----------------------- |
+| bytes transferred            | **214 MB** | **0.9 MB** (**−99.6%**) |
+
+This is the headline: streaming one big turn currently re-ships ~214 MB of
+mostly-unchanged rows; W4 cuts it to ~0.9 MB and shrinks each refetch from
+hundreds of KB to **< 1 KB median**. (W4 does **not** cut the ~250 ms per-build
+server CPU — that needs the deferred projector, §13; W1/W3 reduce how often the
+build runs.)
+
+### Scenario 4 — Idle threads / herd while another thread streams → W1
+
+|                                                                               | before                                                                        | after        |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------ |
+| `/timeline` GETs from hidden side-chat tabs (main + child) over a 30 s stream | one full-window refetch per tab per batch (~150 refetches over 30 s × N tabs) | **0**        |
+| concurrent full rebuilds triggered                                            | N mounted timelines × ~5/s                                                    | ~1 (focused) |
+
+### Net effect by symptom
+
+| reported symptom          | before                                   | after                                    |
+| ------------------------- | ---------------------------------------- | ---------------------------------------- |
+| large payload (streaming) | up to ~950 KB/refetch                    | < 1 KB median, ≤ 64 KB worst (W4 + W5)   |
+| repeated refetches        | full rebuild + full window every batch   | delta patch; idle/warm served from cache |
+| thundering herd           | N mounted timelines × ~5 full rebuilds/s | ~1 focused timeline; hidden tabs silent  |
+
+---
+
+## 11. Overall exit criteria
+
+- Streaming on the huge thread: bytes-on-wire ↓ ≥ 80% and per-commit rendered
+  rows ↓ ≥ 70% (Probe B/C), with patch output **proven equal** to full rebuild
+  across all §6 cases (Probe C). (Probe baseline target: ~214 MB → < 2 MB per
+  big turn; median refetch ~495 KB → < 8 KB.)
+- Idle: hidden side-chat tabs issue 0 `/timeline` GETs while another thread
+  streams; warm-repeat ↓ ≥ 90% (Probe D).
+- Initial load: no cold-load regression; giant-output threads ship a smaller
+  window via W5 (Probe A). (Faster huge-thread _render_ needs the deferred
+  virtualization — §13.)
+- No regressions in `@bb/thread-view` + timeline contract tests.
+
+---
+
+## 12. Validation (re-run these)
+
+Representative threads / distribution:
+
+```bash
+sqlite3 "file:/root/.bb/bb.db?immutable=1" \
+  "WITH c AS (SELECT thread_id, count(*) n, sum(length(data)) b FROM events GROUP BY thread_id) \
+   SELECT thread_id,n,b FROM c ORDER BY n DESC LIMIT 5;"
+```
+
+Live-server payload + latency (idle window):
+
+```bash
+for id in thr_axgftfi23h thr_9ua98izdjf thr_kg5cffwyw2; do
+  curl -s -o /dev/null -w "$id %{size_download}B %{time_total}s\n" \
+    "http://127.0.0.1:38886/api/v1/threads/$id/timeline"; done
+```
+
+**Streaming payload (active turn expanded) — the key probe.** Copy the DB
+(`cp /root/.bb/bb.db /tmp/scratch.db`; `sqlite3 /tmp/scratch.db "PRAGMA
+wal_checkpoint(TRUNCATE);"`; never write the live DB). Truncate the huge thread
+just before a big turn's `turn/completed` (and delete that `turn/completed`) so
+the big turn is the active/latest turn, then build the latest window in-process
+(`node --conditions=source --import tsx`, importing `createConnection`/`getThread`
+from `@bb/db` and `buildThreadTimeline` from
+`apps/server/src/services/threads/timeline.ts`) and compare JSON bytes vs the
+collapsed (keep `turn/completed`) variant. Measured: 65 KB → **951 KB**.
+
+**Row-patch delta (§10 Scenario 3 "after") — the key after-number.** Reproject
+the active big turn at consecutive event prefixes (one item per step), diff rows
+by stable id (changed/new row JSON bytes + removed ids) to get the per-refetch
+patch size, and sum over the turn vs the per-refetch full-window bytes. Measured:
+median patch **686 B** (vs full-window median 495 KB); cumulative **214 MB →
+0.9 MB** over the turn. (`buildThreadTimelineFromEvents` with
+`threadStatus: "active"` to keep the turn expanded.)
+
+Build-cost attribution: same tsx approach timing each stage with
+`performance.now()` (event query, `parseStoredEvent` decode,
+`compactThreadTimelineSummaryEvents`, `buildThreadTimelineFromEvents`,
+`JSON.stringify`).
+
+Browser probes: `npm i -g dev-browser && dev-browser install`; `dev-browser
+--connect`, `page.goto("http://<dev-frontend-url>/...")`, `page.evaluate(...)`
+for React Profiler / `performance`, `page.screenshot()`. Get the dev frontend URL
+from `pnpm dev` (don't assume ports).
+
+Typecheck/test (AGENTS.md / Turbo):
+`pnpm exec turbo run typecheck --filter=@bb/thread-view --filter=@bb/server --filter=@bb/app`
+plus the thread-view + server-contract suites.
+
+---
+
+## 13. Out of scope / follow-ups
+
+- **List virtualization** (render only visible rows) — deferred at request. The
+  lever for huge-thread initial-load render and per-commit deep-equal cost. W4
+  already cuts per-commit re-renders to the changed rows; without virtualization,
+  the first mount of a big window still mounts all rows. Revisit if Probe A shows
+  initial-load render is the bottleneck after W4/W5.
+- Resumable in-memory incremental **projector** (cuts per-build CPU) — XL /
+  high-risk per adversarial review; revisit only if server CPU still saturates
+  after W1/W3/W4.
+- Pushing timeline rows over the WebSocket instead of fetch-on-invalidate (larger
+  protocol change; revisit if Probe B shows the round-trip dominates).
+- Compressing event `data` at rest / on the wire.
+
+---
+
+_Delete this file once the work ships or is superseded (AGENTS.md planning workflow)._

--- a/plans/timeline-rendering-performance.md
+++ b/plans/timeline-rendering-performance.md
@@ -1,8 +1,10 @@
 # Timeline Rendering Performance
 
-Status: **in progress.** W3 (server route cache) implemented + tested in this
-PR; W1/W2/W4/W5 remain (sequenced in §9). Investigation complete; design
-validated by adversarial review.
+Status: **W2, W3, W4, W5 implemented + tested in this PR.** W1 (visibility-gate
+side-chat) is **deferred** — gating its timeline query couples to a side-chat
+delete-safety check and risks deleting a side-chat with real content; W4's deltas
+already make hidden-tab refetches cheap, so the herd impact is largely mitigated.
+Investigation complete; design validated by adversarial review.
 Branch: `bb/timeline-rendering-performance-plan-*`.
 
 Grounded in measurements against the live packaged server (`http://127.0.0.1:38886`)
@@ -171,18 +173,21 @@ have seq > N and append" design and a resumable in-memory incremental projector
 to **keep reprojecting the bounded window server-side (correct by construction)
 and diff it** — plus cheap herd/cache wins.
 
-### W1 (S) — Visibility-gate hidden side-chat timelines → RC3
+### W1 (S) — Visibility-gate hidden side-chat timelines → RC3 **[DEFERRED]**
 
-Pass `enabled: false` to `useThreadTimeline` for inactive (`display:none`)
-side-chat tabs (`SideChatTabContent.tsx:180,412`; thread the active-tab flag from
-`SideChatTabDeck.tsx:53`). `useThreadDetailRealtimeSubscription` is gated by the
-same `enabled` flag, so this cleanly stops both the subscription and the refetch;
-`refetchOnMount` refreshes on show. No contract change. Collapses N mounted
-timelines to ~1 visible. _Product check:_ confirm which live badges (activity /
-thinking) must stay on hidden tabs; if any, keep only the lightweight status
-query active.
+The intent: pass `enabled: false` to `useThreadTimeline` for inactive
+(`display:none`) side-chat tabs. **Deferred after investigation:** the child
+timeline query (`SideChatTabContent.tsx:412`) and the conversation query (`:180`)
+share a query key, so both observers must be gated to actually stop the fetch —
+but `childHasUserMessage` (derived from that query) gates `deleteSideChatIfUnused`
+(`:443`). Gating it could make a reopened side-chat that already holds messages
+look "unused" and **delete it (data loss)** when its hidden tab is cleaned up.
+Doing W1 safely needs `childHasUserMessage` decoupled from the gated query (or a
+product call on hidden-tab live state). W4 already shrinks every hidden-tab
+refetch to a cheap delta, so the herd cost W1 targeted is largely mitigated; W1
+is tracked as a follow-up in §13.
 
-### W2 (S) — Don't invalidate turn-summary-details on every batch → RC5
+### W2 (S) — Don't invalidate turn-summary-details on every batch → RC5 **[IMPLEMENTED — this PR]**
 
 Remove `threadTimelineTurnSummaryDetailsQueryKeyPrefix` from the
 `events-appended` grouping in `getThreadTimelineInvalidationQueryKeys`
@@ -205,7 +210,7 @@ Eliminates warm-repeat and double-mount cost, and makes idle refetches free.
 Implemented in `apps/server/src/services/threads/timeline-cache.ts` (+ unit test);
 wired in `apps/server/src/routes/threads/data.ts`. (ETag/`304` deferred.)
 
-### W4 (L) — Server-computed row-patch delta → RC1, RC2 (the streaming win)
+### W4 (L) — Server-computed row-patch delta → RC1, RC2 (the streaming win) **[IMPLEMENTED — this PR]**
 
 The big lever. Correct _by construction_ because the server still reprojects the
 full bounded window (all eviction/collapse/finalize/backfill semantics
@@ -234,7 +239,7 @@ and makes the client re-render only changed rows. **Note:** W4 does _not_ reduce
 the ~130–264 ms server projection CPU (the server still reprojects); W1 + W3
 are what bound server CPU. Pair W4 with the §8 patch-diff-fidelity spike.
 
-### W5 (M) — Truncate giant inline outputs/diffs → RC7
+### W5 (M) — Truncate giant inline outputs/diffs → RC7 **[IMPLEMENTED — this PR]**
 
 For `item/completed` outputs/diffs above a threshold, ship a truncated preview
 with a "load full" affordance (the `turn-summary-details` endpoint already serves
@@ -356,14 +361,17 @@ Each probe: method, baseline, target, pass/fail. Harnesses in §12.
 Each step is independently shippable and reversible.
 
 1. Land the **probe harnesses** + Probe C golden-test infra (gates everything).
-2. **W1** visibility-gate side-chat (S, no contract) — immediate herd collapse;
-   gate on Probe D + Spike 2.
-3. **W2** drop turn-summary-details invalidation (S, no contract).
+2. **W1** visibility-gate side-chat — **deferred** (data-loss coupling; §13).
+3. **W2** drop turn-summary-details invalidation (S, no contract). **← done.**
 4. **W3** server route cache (S–M, server-only) — kills warm-repeat / idle /
-   double-mount; gate on Probe D + Spike 3. **← done in this PR.**
-5. **Spike 1**, then **W4** row-patch delta (L; WS contract change) — the
-   streaming payload win; gate on Probe B + C.
-6. **W5** truncation of giant outputs (gate on Probe A).
+   double-mount. **← done.**
+5. **W4** row-patch delta (`afterSequence` + diff; client merge) — the streaming
+   payload win; golden test in place of the separate Spike 1. **← done.**
+6. **W5** truncation of giant outputs. **← done.**
+
+Implemented W2–W5 this PR (no WS-message change needed — the client carries
+`maxSeq` from the response, so the delta works over the existing fetch path).
+W1 remains, tracked in §13.
 
 ---
 
@@ -397,22 +405,28 @@ Server CPU for redundant/idle refetches: **−~99%**.
 
 ### Scenario 3 — Streaming an active turn (the common, expensive case) → W4
 
-Measured by reprojecting the huge thread's 942-event turn as the active turn and
-diffing consecutive states (one refetch per appended item, **415 refetches**):
+Measured with the **shipped `computeTimelineRowDelta`** by reprojecting the huge
+thread's 942-event turn as the active turn and diffing consecutive states (one
+refetch per appended item, **415 refetches**):
 
 | per refetch      | **before** (full window)           | **after** (W4 row-patch)                                        |
 | ---------------- | ---------------------------------- | --------------------------------------------------------------- |
-| bytes sent       | median **495 KB**, peak **889 KB** | median **686 B**, p90 6.2 KB, max 64 KB                         |
-| rows re-rendered | all ~350 (deep-equal every row)    | **~0.74** changed rows                                          |
+| bytes sent       | median **495 KB**, peak **889 KB** | median **16 KB**, p90 **26 KB**                                 |
+| rows re-rendered | all ~350 (deep-equal every row)    | only changed rows (unchanged keep identity)                     |
 | server build     | ~250 ms reproject                  | ~250 ms reproject (unchanged; W4 fixes payload+render, not CPU) |
 
 | whole turn (cumulative wire) | before     | after                   |
 | ---------------------------- | ---------- | ----------------------- |
-| bytes transferred            | **214 MB** | **0.9 MB** (**−99.6%**) |
+| bytes transferred            | **214 MB** | **6.8 MB** (**−96.8%**) |
+
+The delta's floor is the `rowOrder` id list (every current row id, so the client
+can reorder exactly) — ~16 KB for a hundreds-of-rows active turn even when one
+row changed. Still a 31× per-refetch reduction; sending order only when it
+changes (follow-up) would push the median toward ~1 KB.
 
 This is the headline: streaming one big turn currently re-ships ~214 MB of
-mostly-unchanged rows; W4 cuts it to ~0.9 MB and shrinks each refetch from
-hundreds of KB to **< 1 KB median**. (W4 does **not** cut the ~250 ms per-build
+mostly-unchanged rows; W4 cuts it to ~6.8 MB and shrinks each refetch from
+hundreds of KB to **~16 KB median**. (W4 does **not** cut the ~250 ms per-build
 server CPU — that needs the deferred projector, §13; W1/W3 reduce how often the
 build runs.)
 
@@ -425,11 +439,11 @@ build runs.)
 
 ### Net effect by symptom
 
-| reported symptom          | before                                   | after                                    |
-| ------------------------- | ---------------------------------------- | ---------------------------------------- |
-| large payload (streaming) | up to ~950 KB/refetch                    | < 1 KB median, ≤ 64 KB worst (W4 + W5)   |
-| repeated refetches        | full rebuild + full window every batch   | delta patch; idle/warm served from cache |
-| thundering herd           | N mounted timelines × ~5 full rebuilds/s | ~1 focused timeline; hidden tabs silent  |
+| reported symptom          | before                                   | after                                         |
+| ------------------------- | ---------------------------------------- | --------------------------------------------- |
+| large payload (streaming) | up to ~950 KB/refetch                    | ~16 KB median (W4); giant outputs capped (W5) |
+| repeated refetches        | full rebuild + full window every batch   | delta patch; idle/warm served from cache      |
+| thundering herd           | N mounted timelines × ~5 full rebuilds/s | ~1 focused timeline; hidden tabs silent       |
 
 ---
 
@@ -437,8 +451,8 @@ build runs.)
 
 - Streaming on the huge thread: bytes-on-wire ↓ ≥ 80% and per-commit rendered
   rows ↓ ≥ 70% (Probe B/C), with patch output **proven equal** to full rebuild
-  across all §6 cases (Probe C). (Probe baseline target: ~214 MB → < 2 MB per
-  big turn; median refetch ~495 KB → < 8 KB.)
+  across all §6 cases (Probe C). (Measured: ~214 MB → 6.8 MB per big turn;
+  median refetch ~495 KB → ~16 KB.)
 - Idle: hidden side-chat tabs issue 0 `/timeline` GETs while another thread
   streams; warm-repeat ↓ ≥ 90% (Probe D).
 - Initial load: no cold-load regression; giant-output threads ship a smaller
@@ -480,8 +494,8 @@ collapsed (keep `turn/completed`) variant. Measured: 65 KB → **951 KB**.
 the active big turn at consecutive event prefixes (one item per step), diff rows
 by stable id (changed/new row JSON bytes + removed ids) to get the per-refetch
 patch size, and sum over the turn vs the per-refetch full-window bytes. Measured:
-median patch **686 B** (vs full-window median 495 KB); cumulative **214 MB →
-0.9 MB** over the turn. (`buildThreadTimelineFromEvents` with
+median patch **~16 KB** (vs full-window median 495 KB); cumulative **214 MB →
+6.8 MB** over the turn. (`buildThreadTimelineFromEvents` with
 `threadStatus: "active"` to keep the turn expanded.)
 
 Build-cost attribution: same tsx approach timing each stage with
@@ -502,6 +516,14 @@ plus the thread-view + server-contract suites.
 
 ## 13. Out of scope / follow-ups
 
+- **W1 — visibility-gate hidden side-chat timelines.** Deferred: gating couples to
+  `deleteSideChatIfUnused` via `childHasUserMessage`, risking deletion of a
+  side-chat with real content. Decouple that signal from the gated query (or get
+  a product call), then gate. Lower priority now that W4 makes hidden-tab
+  refetches cheap.
+- **Leaner W4 delta.** The `rowOrder` id list is the ~16 KB/refetch floor. Send
+  order only when membership/order changes (else just `upsertRows`) to push the
+  median toward ~1 KB.
 - **List virtualization** (render only visible rows) — deferred at request. The
   lever for huge-thread initial-load render and per-commit deep-equal cost. W4
   already cuts per-commit re-renders to the changed rows; without virtualization,

--- a/tests/integration/fake/smoke/timeline-response.test.ts
+++ b/tests/integration/fake/smoke/timeline-response.test.ts
@@ -49,6 +49,7 @@ function makeTimelineResponse(
     activeWorkflow: null,
     pendingTodos: null,
     goal: null,
+    maxSeq: 0,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,


### PR DESCRIPTION
## Summary

The thread timeline was slow and wasteful during streaming and on large threads. On every appended event the client refetched and the server rebuilt the **entire** visible window from scratch — and while a turn is streaming that window is rendered expanded (up to **~950 KB**), re-sent ~5×/second. Over one long turn that's **~214 MB** of mostly-unchanged data across the wire, plus a full deep-compare + re-render each time, repeated for every mounted timeline.

This PR makes live updates **incremental** and adds **server-side caching**, cutting streaming traffic ~97% with no change to what the user sees. Each item below is a separate commit.

## What's in here

1. **Incremental "row-patch" updates for live timelines** _(the main change)._ The client tells the server which revision it already holds (`afterSequence`); the server reprojects the window — so the tricky cases (turn collapse, window eviction, interrupts, background tasks that finish later) stay correct **by construction** — diffs it against what the client has, and returns **only the changed rows**. The client merges them in place, so React re-renders just the rows that changed. Falls back to a full window whenever a delta can't be safely computed.

2. **Server-side response cache.** The timeline endpoint rebuilt from scratch on every request (no caching at all). Added a small bounded cache keyed on the thread's high-water sequence + render options, so idle / repeat / duplicate-mount fetches return instantly instead of repaying the ~130–260 ms build.

3. **Stop refetching immutable turn details.** Appended events were invalidating expanded turn-detail panels, which can't change once a turn is finished. They're now left alone.

4. **Truncate giant inline outputs/diffs.** A few tool outputs are enormous (up to ~1 MB) and dominate payload + render. The window now caps them with a marker; the full content is still available when you expand the turn.

5. **Fix a stale-timeline bug.** An earlier perf change set `staleTime: Infinity` on the timeline query, which silently defeated refetch-on-mount — a thread revisited after events arrived while it was off-screen could stay frozen on stale rows until the next live event. Removed it; revisits refresh again (cheaply now, thanks to 1 & 2).

## Before / after (measured on the dev DB)

**Streaming a long turn** (huge thread, 942-event turn):

| | before (full window every event) | after (row-patch) |
|---|---|---|
| bytes per update | median **495 KB**, peak **889 KB** | median **16 KB** |
| total over the turn | **214 MB** | **6.8 MB** (−96.8%) |
| rows re-rendered | all ~350 | only the ones that changed |

**Re-opening / background-mounted threads:**

| build | before (cold) | after (cache hit) |
|---|---|---|
| typical thread | 64 ms | ~0 ms |
| large thread | 172 ms | ~0 ms |
| huge thread | 239 ms | ~0 ms |

## Correctness & tests

- **Golden test** for the incremental path: `applyDelta(previous)` is asserted byte-for-byte equal to a fresh full window across appends, turn-completion collapse (rows removed + reordered), and no-op updates — exercised through the real route + projection.
- Unit tests for the diff/merge logic and its stale-base fallback; plus tests for the cache, the truncation, and the turn-details invalidation change.
- Green: server-contract 29, server 619, affected app 54, cli 123; typecheck + lint clean across all packages.

## Backward compatibility

Fully compatible in both directions. The new request field (`afterSequence`) is optional and old servers ignore it; the new response fields are additive and clients don't runtime-validate the response, so an old client against a new server behaves exactly as before, and a new client against an old server just never engages the delta path (graceful full fetches). The WebSocket protocol is unchanged.

## Not in this PR

- **Gating hidden side-chat timelines** is intentionally deferred: doing it naively can make a side-chat that still has content look "unused" and delete it (it's coupled to a delete-safety check). Tracked as a follow-up. The incremental updates above already make those background refetches cheap.
- Optional polish noted in the plan: enable HTTP response compression, and shrink the delta further (its floor today is the row-order list).

Full design, investigation, and measurements: `plans/timeline-rendering-performance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
