### PR TITLE
Fix optimistic thread read state

### DIFF
--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
@@ -1,0 +1,155 @@
+import type { ThreadListEntry, ThreadWithRuntime } from "@bb/domain";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  sidebarNavigationQueryKey,
+  threadListQueryKey,
+  threadQueryKey,
+} from "../queries/query-keys";
+import {
+  beginThreadReadStateTransaction,
+  rollbackThreadListMutationTransaction,
+} from "./thread-state-cache-owner";
+
+function makeThreadWithRuntime(
+  thread: Partial<ThreadWithRuntime> = {},
+): ThreadWithRuntime {
+  return {
+    id: "thread-1",
+    projectId: "project-1",
+    environmentId: "env-1",
+    providerId: "codex",
+    title: null,
+    titleFallback: null,
+    status: "active",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    childOrigin: null,
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 50,
+    createdAt: 1,
+    updatedAt: 1,
+    runtime: {
+      displayStatus: "waiting-for-host",
+      hostReconnectGraceExpiresAt: null,
+    },
+    ...thread,
+  };
+}
+
+function makeThreadListEntry(
+  thread: Partial<ThreadListEntry> = {},
+): ThreadListEntry {
+  return {
+    ...makeThreadWithRuntime(thread),
+    pinSortKey: null,
+    hasPendingInteraction: false,
+    environmentHostId: "host-1",
+    environmentName: "Environment",
+    environmentBranchName: "main",
+    environmentWorkspaceDisplayKind: "managed-worktree",
+    ...thread,
+  };
+}
+
+function makeSidebarNavigation(
+  threads: ThreadListEntry[],
+): SidebarBootstrapResponse {
+  return {
+    projects: [
+      {
+        id: "project-1",
+        kind: "standard",
+        name: "Project",
+        createdAt: 1,
+        updatedAt: 1,
+        sources: [],
+        threads,
+        defaultExecutionOptions: null,
+      },
+    ],
+    personalProject: {
+      id: "proj_personal",
+      kind: "personal",
+      name: "Personal",
+      createdAt: 1,
+      updatedAt: 1,
+      sources: [],
+      threads: [],
+      defaultExecutionOptions: null,
+    },
+  };
+}
+
+describe("thread state cache owner", () => {
+  it("optimistically marks read state in thread, list, and sidebar caches", async () => {
+    const { queryClient } = createQueryClientTestHarness();
+    const threadId = "thread-1";
+    const unreadThread = makeThreadWithRuntime({
+      id: threadId,
+      lastReadAt: 10,
+      latestAttentionAt: 50,
+    });
+    const unreadListEntry = makeThreadListEntry({
+      id: threadId,
+      lastReadAt: 10,
+      latestAttentionAt: 50,
+    });
+    const threadListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+
+    queryClient.setQueryData(threadQueryKey(threadId), unreadThread);
+    queryClient.setQueryData(threadListKey, [unreadListEntry]);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([unreadListEntry]),
+    );
+
+    const transaction = await beginThreadReadStateTransaction({
+      lastReadAt: 20,
+      queryClient,
+      threadId,
+    });
+
+    expect(
+      queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId))
+        ?.lastReadAt,
+    ).toBe(50);
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0]
+        ?.lastReadAt,
+    ).toBe(50);
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads[0]?.lastReadAt,
+    ).toBe(50);
+
+    rollbackThreadListMutationTransaction({
+      queryClient,
+      threadId,
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId))
+        ?.lastReadAt,
+    ).toBe(10);
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0]
+        ?.lastReadAt,
+    ).toBe(10);
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads[0]?.lastReadAt,
+    ).toBe(10);
+  });
+});

--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
@@ -57,6 +57,10 @@ interface BeginThreadPinTransactionArgs extends ThreadIdCacheArgs {
   pinnedAt: number;
 }
 
+interface BeginThreadReadStateTransactionArgs extends ThreadIdCacheArgs {
+  lastReadAt: number | null;
+}
+
 interface ReorderPinnedThreadTransactionRequest extends ReorderPinnedThreadRequest {
   id: string;
 }
@@ -168,6 +172,16 @@ function updateThreadPinStateInLists({
   );
 }
 
+function getOptimisticLastReadAt(
+  thread: Pick<ThreadWithRuntime, "latestAttentionAt">,
+  lastReadAt: number | null,
+): number | null {
+  if (lastReadAt === null) {
+    return null;
+  }
+  return Math.max(lastReadAt, thread.latestAttentionAt);
+}
+
 function applyPinnedRootResponseToLists({
   orderedRoots,
   queryClient,
@@ -226,13 +240,15 @@ export function applyThreadUpdateResult({
 }
 
 interface OptimisticThreadFieldTransactionArgs extends ThreadIdCacheArgs {
-  patch: Partial<ThreadWithRuntime>;
+  patch?: Partial<ThreadWithRuntime>;
+  patchThread?: (thread: ThreadWithRuntime) => ThreadWithRuntime;
   applyToLists: (queryClient: QueryClient, threadId: string) => void;
 }
 
 async function runOptimisticThreadFieldTransaction({
   applyToLists,
   patch,
+  patchThread,
   queryClient,
   threadId,
 }: OptimisticThreadFieldTransactionArgs): Promise<ThreadListMutationTransaction> {
@@ -256,9 +272,13 @@ async function runOptimisticThreadFieldTransaction({
         return thread;
       }
 
+      if (patchThread) {
+        return patchThread(thread);
+      }
+
       return {
         ...thread,
-        ...patch,
+        ...(patch ?? {}),
       };
     },
   );
@@ -305,6 +325,32 @@ export function beginUnpinThreadTransaction({
         ),
       ),
     patch: { pinnedAt: null },
+    queryClient,
+    threadId,
+  });
+}
+
+export function beginThreadReadStateTransaction({
+  lastReadAt,
+  queryClient,
+  threadId,
+}: BeginThreadReadStateTransactionArgs): Promise<ThreadListMutationTransaction> {
+  return runOptimisticThreadFieldTransaction({
+    applyToLists: (queryClient, threadId) =>
+      applyToCachedThreadListsAndSidebarNavigation(queryClient, (list) =>
+        list.map((thread) =>
+          thread.id === threadId
+            ? {
+                ...thread,
+                lastReadAt: getOptimisticLastReadAt(thread, lastReadAt),
+              }
+            : thread,
+        ),
+      ),
+    patchThread: (thread) => ({
+      ...thread,
+      lastReadAt: getOptimisticLastReadAt(thread, lastReadAt),
+    }),
     queryClient,
     threadId,
   });

--- a/apps/app/src/hooks/mutations/thread-state-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-state-mutations.ts
@@ -15,6 +15,7 @@ import {
   beginArchiveThreadTransaction,
   beginDeleteThreadTransaction,
   beginPinThreadTransaction,
+  beginThreadReadStateTransaction,
   beginReorderPinnedThreadTransaction,
   beginUnarchiveThreadTransaction,
   beginUnpinThreadTransaction,
@@ -260,10 +261,7 @@ export function useDeleteThread() {
     meta: {
       errorMessage: "Failed to delete thread.",
     },
-    mutationFn: ({
-      childThreadsConfirmed,
-      id,
-    }: DeleteThreadMutationRequest) =>
+    mutationFn: ({ childThreadsConfirmed, id }: DeleteThreadMutationRequest) =>
       api.deleteThread(id, { childThreadsConfirmed }),
     onMutate: async ({ id }): Promise<DeleteThreadTransaction> =>
       beginDeleteThreadTransaction({ queryClient, threadId: id }),
@@ -293,6 +291,19 @@ export function useMarkThreadRead() {
       showErrorToast: false,
     },
     mutationFn: (threadId: string) => api.markThreadRead(threadId),
+    onMutate: (threadId): Promise<ThreadListMutationTransaction> =>
+      beginThreadReadStateTransaction({
+        lastReadAt: Date.now(),
+        queryClient,
+        threadId,
+      }),
+    onError: (_error, threadId, context) => {
+      rollbackThreadListMutationTransaction({
+        queryClient,
+        threadId,
+        transaction: context,
+      });
+    },
     onSuccess: (thread) => {
       applyThreadReadStateResult({ queryClient, thread });
     },
@@ -308,6 +319,19 @@ export function useMarkThreadUnread() {
       showErrorToast: false,
     },
     mutationFn: (threadId: string) => api.markThreadUnread(threadId),
+    onMutate: (threadId): Promise<ThreadListMutationTransaction> =>
+      beginThreadReadStateTransaction({
+        lastReadAt: null,
+        queryClient,
+        threadId,
+      }),
+    onError: (_error, threadId, context) => {
+      rollbackThreadListMutationTransaction({
+        queryClient,
+        threadId,
+        transaction: context,
+      });
+    },
     onSuccess: (thread) => {
       applyThreadReadStateResult({ queryClient, thread });
     },


### PR DESCRIPTION
## Summary
- optimistically update thread read state across detail, list, and sidebar navigation caches
- roll back optimistic read/unread updates on mutation failure
- add a regression test covering the cache update and rollback path

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/cache-owners/thread-state-cache-owner.test.ts
- pnpm exec turbo run lint --filter=@bb/app
- git diff --check