### PR TITLE
Simplify staged attachment paths

### DIFF
--- a/apps/host-daemon/src/command-handlers/prompt-attachments.ts
+++ b/apps/host-daemon/src/command-handlers/prompt-attachments.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, rmdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ClientTurnRequestId, PromptInput } from "@bb/domain";
 import { resolveContainedPath } from "@bb/process-utils";
@@ -27,8 +27,7 @@ interface StagePromptAttachmentsArgs {
 
 interface StageAttachmentArgs extends StagePromptAttachmentsArgs {
   attachment: AttachmentPromptInput;
-  index: number;
-  stagingDir: string;
+  stagedPath: string;
 }
 
 interface StagedPromptAttachments {
@@ -136,15 +135,48 @@ function resolveStagingDir(args: StagePromptAttachmentsArgs): string {
   );
   return requireContainedPath(
     args.threadStorageRootPath,
-    path.join(threadDir, "runtime-attachments", args.requestId),
+    path.join(threadDir, "Attachments"),
   );
 }
 
-async function stageAttachment(args: StageAttachmentArgs): Promise<string> {
-  const stagedPath = path.join(
-    args.stagingDir,
-    `${String(args.index).padStart(3, "0")}-${attachmentFilename(args.attachment)}`,
+function appendFilenameSuffix(filename: string, suffix: string): string {
+  const extension = path.extname(filename);
+  if (!extension) {
+    return `${filename}${suffix}`;
+  }
+  return `${filename.slice(0, -extension.length)}${suffix}${extension}`;
+}
+
+function uniqueStagedPath(
+  stagingDir: string,
+  filename: string,
+  stagedPaths: readonly string[],
+): string {
+  let candidate = path.join(stagingDir, filename);
+  let suffix = 2;
+  while (stagedPaths.includes(candidate)) {
+    candidate = path.join(
+      stagingDir,
+      appendFilenameSuffix(filename, `-${suffix}`),
+    );
+    suffix += 1;
+  }
+  return candidate;
+}
+
+async function cleanupStagedAttachments(
+  stagingDir: string,
+  stagedPaths: readonly string[],
+): Promise<void> {
+  await Promise.all(
+    stagedPaths.map((stagedPath) =>
+      rm(stagedPath, { force: true, recursive: false }),
+    ),
   );
+  await rmdir(stagingDir).catch(() => undefined);
+}
+
+async function stageAttachment(args: StageAttachmentArgs): Promise<string> {
   validateExpectedAttachmentSize(args);
 
   let bytes: Uint8Array;
@@ -165,8 +197,8 @@ async function stageAttachment(args: StageAttachmentArgs): Promise<string> {
   }
 
   validateFetchedAttachmentSize(args.attachment, bytes);
-  await writeFile(stagedPath, bytes, { mode: STAGED_ATTACHMENT_MODE });
-  return stagedPath;
+  await writeFile(args.stagedPath, bytes, { mode: STAGED_ATTACHMENT_MODE });
+  return args.stagedPath;
 }
 
 export async function stagePromptAttachments(
@@ -180,33 +212,38 @@ export async function stagePromptAttachments(
   }
 
   const stagingDir = resolveStagingDir(args);
-  await rm(stagingDir, { force: true, recursive: true });
   await mkdir(stagingDir, { recursive: true });
 
   const stagedInput: PromptInput[] = [];
+  const stagedPaths: string[] = [];
   try {
-    for (const [index, input] of args.input.entries()) {
+    for (const input of args.input) {
       if (!shouldStageAttachment(input)) {
         stagedInput.push(input);
         continue;
       }
+      const stagedPath = uniqueStagedPath(
+        stagingDir,
+        attachmentFilename(input),
+        stagedPaths,
+      );
       stagedInput.push({
         ...input,
         path: await stageAttachment({
           ...args,
           attachment: input,
-          index,
-          stagingDir,
+          stagedPath,
         }),
       });
+      stagedPaths.push(stagedPath);
     }
   } catch (error) {
-    await rm(stagingDir, { force: true, recursive: true });
+    await cleanupStagedAttachments(stagingDir, stagedPaths);
     throw error;
   }
 
   return {
-    cleanup: () => rm(stagingDir, { force: true, recursive: true }),
+    cleanup: () => cleanupStagedAttachments(stagingDir, stagedPaths),
     input: stagedInput,
   };
 }

--- a/apps/host-daemon/test/command/thread-dispatch.test.ts
+++ b/apps/host-daemon/test/command/thread-dispatch.test.ts
@@ -240,11 +240,12 @@ describe("thread command dispatch", () => {
     const stagingDir = path.join(
       threadStorageRootPath,
       "thread-attachments",
-      "runtime-attachments",
-      requestId,
+      "Attachments",
     );
     expect(stagedFile.path.startsWith(`${stagingDir}${path.sep}`)).toBe(true);
     expect(stagedImage.path.startsWith(`${stagingDir}${path.sep}`)).toBe(true);
+    expect(path.basename(stagedFile.path)).toBe("notes.txt");
+    expect(path.basename(stagedImage.path)).toBe("screenshot-uploaded.png");
     expect(existingFile.path).toBe("/tmp/already-readable.txt");
     await expect(fs.readFile(stagedFile.path, "utf8")).resolves.toBe(
       uploadedNotesContent,
@@ -327,10 +328,10 @@ describe("thread command dispatch", () => {
     const stagingDir = path.join(
       threadStorageRootPath,
       "thread-submit-attachments",
-      "runtime-attachments",
-      requestId,
+      "Attachments",
     );
     expect(stagedFile.path.startsWith(`${stagingDir}${path.sep}`)).toBe(true);
+    expect(path.basename(stagedFile.path)).toBe("follow-up-uploaded.har");
     await expect(fs.readFile(stagedFile.path, "utf8")).resolves.toBe(
       "content:follow-up-uploaded.har",
     );
@@ -460,19 +461,18 @@ describe("thread command dispatch", () => {
     ).rejects.toThrow();
   });
 
-  it("removes stale files before restaging attachments for the same request", async () => {
+  it("stages prompt attachments in a readable flat attachments directory", async () => {
     const threadStorageRootPath = await makeTempDir("bb-restage-attachments-");
     const harness = createHarness();
     const requestId = nextClientRequestId();
     const stagingDir = path.join(
       threadStorageRootPath,
       "thread-restage-attachments",
-      "runtime-attachments",
-      requestId,
+      "Attachments",
     );
-    const stalePath = path.join(stagingDir, "999-stale.txt");
+    const restagedPath = path.join(stagingDir, "fresh-uploaded.txt");
     await fs.mkdir(stagingDir, { recursive: true });
-    await fs.writeFile(stalePath, "stale");
+    await fs.writeFile(restagedPath, "stale");
     const fetchProjectAttachment = vi.fn<FetchProjectAttachment>(async () => ({
       bytes: Buffer.from("fresh"),
     }));
@@ -489,7 +489,10 @@ describe("thread command dispatch", () => {
         projectId: "project-restage-attachments",
         providerId: "fake",
         requestId,
-        input: [{ type: "localFile", path: "fresh-uploaded.txt" }],
+        input: [
+          { type: "localFile", path: "fresh-uploaded.txt" },
+          { type: "localFile", path: "fresh-uploaded.txt" },
+        ],
         options: {
           model: "gpt-5",
           serviceTier: "default",
@@ -509,9 +512,10 @@ describe("thread command dispatch", () => {
       },
     );
 
-    await expect(fs.stat(stalePath)).rejects.toThrow();
+    await expect(fs.readFile(restagedPath, "utf8")).resolves.toBe("fresh");
     await expect(fs.readdir(stagingDir)).resolves.toEqual([
-      "000-fresh-uploaded.txt",
+      "fresh-uploaded-2.txt",
+      "fresh-uploaded.txt",
     ]);
   });
 
@@ -582,8 +586,8 @@ describe("thread command dispatch", () => {
         path.join(
           threadStorageRootPath,
           "thread-failed-stage-attachments",
-          "runtime-attachments",
-          requestId,
+          "Attachments",
+          "first-uploaded.txt",
         ),
       ),
     ).rejects.toThrow();
@@ -644,8 +648,8 @@ describe("thread command dispatch", () => {
         path.join(
           threadStorageRootPath,
           "thread-oversized-stage-attachments",
-          "runtime-attachments",
-          requestId,
+          "Attachments",
+          "oversized-uploaded.txt",
         ),
       ),
     ).rejects.toThrow();
@@ -702,8 +706,8 @@ describe("thread command dispatch", () => {
         path.join(
           threadStorageRootPath,
           "thread-runtime-failed-start-attachments",
-          "runtime-attachments",
-          requestId,
+          "Attachments",
+          "runtime-failed-uploaded.txt",
         ),
       ),
     ).rejects.toThrow();
@@ -764,8 +768,8 @@ describe("thread command dispatch", () => {
         path.join(
           threadStorageRootPath,
           "thread-runtime-failed-turn-attachments",
-          "runtime-attachments",
-          requestId,
+          "Attachments",
+          "runtime-turn-uploaded.txt",
         ),
       ),
     ).rejects.toThrow();


### PR DESCRIPTION
## Summary
- stage prompt attachments under a flat `Attachments/` thread-storage directory
- preserve readable attachment filenames without daemon numeric prefixes
- keep failure cleanup scoped to files staged by the failed attempt

## Validation
- `pnpm exec turbo run test --filter=@bb/host-daemon`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`