### PR TITLE
Fix automations page header and stories

### DIFF
--- a/apps/app/src/views/AutomationDetailView.stories.tsx
+++ b/apps/app/src/views/AutomationDetailView.stories.tsx
@@ -1,4 +1,3 @@
-import { MemoryRouter } from "react-router-dom";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type { Automation, AutomationRun } from "@bb/server-contract";
 import { PROJECT_IDS } from "../../.ladle/story-fixtures";
@@ -115,21 +114,19 @@ const agentRuns: AutomationRun[] = [
 
 function Story(props: Partial<Parameters<typeof AutomationDetailContent>[0]>) {
   return (
-    <MemoryRouter>
-      <main className="flex h-screen min-w-0 flex-col p-4 md:p-5">
-        <AutomationDetailContent
-          automation={props.automation ?? makeAutomation()}
-          runs={props.runs ?? scriptRuns}
-          runsLoading={props.runsLoading ?? false}
-          runsError={props.runsError ?? false}
-          onPause={NOOP}
-          onResume={NOOP}
-          onRun={NOOP}
-          onDelete={NOOP}
-          actionsPending={props.actionsPending ?? false}
-        />
-      </main>
-    </MemoryRouter>
+    <main className="flex h-screen min-w-0 flex-col p-4 md:p-5">
+      <AutomationDetailContent
+        automation={props.automation ?? makeAutomation()}
+        runs={props.runs ?? scriptRuns}
+        runsLoading={props.runsLoading ?? false}
+        runsError={props.runsError ?? false}
+        onPause={NOOP}
+        onResume={NOOP}
+        onRun={NOOP}
+        onDelete={NOOP}
+        actionsPending={props.actionsPending ?? false}
+      />
+    </main>
   );
 }
 

--- a/apps/app/src/views/AutomationsView.stories.tsx
+++ b/apps/app/src/views/AutomationsView.stories.tsx
@@ -1,4 +1,3 @@
-import { MemoryRouter } from "react-router-dom";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type { Automation } from "@bb/server-contract";
 import { PROJECT_IDS, PROJECT_NAMES } from "../../.ladle/story-fixtures";
@@ -110,17 +109,15 @@ const NOOP_ACTIONS: AutomationRowActions = {
 
 function Story(props: Partial<AutomationsOverviewProps>) {
   return (
-    <MemoryRouter>
-      <main className="flex h-screen min-w-0 flex-col p-4 md:p-5">
-        <AutomationsOverview
-          entries={props.entries ?? sampleEntries}
-          isLoading={props.isLoading ?? false}
-          hasInitialLoadError={props.hasInitialLoadError ?? false}
-          actions={props.actions ?? NOOP_ACTIONS}
-          onCreateAutomation={NOOP}
-        />
-      </main>
-    </MemoryRouter>
+    <main className="flex h-screen min-w-0 flex-col p-4 md:p-5">
+      <AutomationsOverview
+        entries={props.entries ?? sampleEntries}
+        isLoading={props.isLoading ?? false}
+        hasInitialLoadError={props.hasInitialLoadError ?? false}
+        actions={props.actions ?? NOOP_ACTIONS}
+        onCreateAutomation={NOOP}
+      />
+    </main>
   );
 }
 

--- a/apps/app/src/views/AutomationsView.test.tsx
+++ b/apps/app/src/views/AutomationsView.test.tsx
@@ -88,6 +88,11 @@ function renderOverview(
 
 
 describe("AutomationsOverview", () => {
+  it("leaves the page title to the app chrome", () => {
+    const markup = renderOverview({ entries: [] });
+    expect(markup).not.toContain(">Automations<");
+  });
+
   it("groups automations by status into Active and Paused sections", () => {
     const markup = renderOverview({
       entries: [

--- a/apps/app/src/views/AutomationsView.tsx
+++ b/apps/app/src/views/AutomationsView.tsx
@@ -263,8 +263,7 @@ export function AutomationsOverview({
   return (
     <PageShell contentClassName="pt-4 md:pt-5">
       <div className="mx-auto w-full max-w-3xl space-y-6">
-        <div className="flex items-center justify-between gap-2">
-          <h1 className="text-sm font-semibold">Automations</h1>
+        <div className="flex items-center justify-end">
           <Button
             type="button"
             variant="default"


### PR DESCRIPTION
## Summary
- remove the duplicate in-page Automations title so the app chrome owns the page header
- add a regression test for the Automations overview title behavior
- remove redundant MemoryRouter wrappers from automation stories because Ladle already provides one globally

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- src/views/AutomationsView.test.tsx

Note: `pnpm exec turbo run storybook:build --filter=@bb/app` was attempted, but Turbo has no configured `storybook:build` task for @bb/app.