### PR TITLE
Handle stale disconnected terminal tabs

### DIFF
--- a/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
@@ -73,7 +73,11 @@ export function ThreadTerminalContent({
     );
   }
 
-  if (controller.activeSession.status !== "running") {
+  const shouldRenderTerminalView =
+    controller.activeSession.status === "running" ||
+    controller.shouldRetainActiveTerminalView;
+
+  if (!shouldRenderTerminalView) {
     const inactiveContent = getInactiveTerminalContent({
       canCreateTerminal: controller.canCreateTerminal,
       status: controller.activeSession.status,

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.stories.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.stories.tsx
@@ -62,6 +62,7 @@ interface MakeControllerArgs {
   isPanelOpen: boolean;
   isTerminalQueryLoading: boolean;
   showTerminalPlaceholders: boolean;
+  shouldRetainActiveTerminalView?: boolean;
   terminalBodyMessage: string;
   visibleSessions: readonly TerminalSession[];
 }
@@ -87,6 +88,7 @@ function makeController({
   isPanelOpen,
   isTerminalQueryLoading,
   showTerminalPlaceholders,
+  shouldRetainActiveTerminalView = false,
   terminalBodyMessage,
   visibleSessions,
 }: MakeControllerArgs): ThreadTerminalController {
@@ -107,6 +109,7 @@ function makeController({
     isPanelOpen,
     isTerminalQueryLoading,
     showTerminalPlaceholders,
+    shouldRetainActiveTerminalView,
     terminalBodyMessage,
     threadId: THREAD_ID,
     visibleSessions,

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -90,6 +90,12 @@ interface WriteTerminalStatusArgs {
   text: string;
 }
 
+interface WriteTerminalSessionStatusNoticeArgs {
+  lastNotice: TerminalSessionStatusNoticeRef;
+  session: TerminalSession;
+  terminal: XTermTerminal;
+}
+
 interface TerminalOutputWriteArgs {
   isReplay: boolean;
   replayWriteState: TerminalReplayWriteState;
@@ -106,6 +112,11 @@ interface OpenTerminalWebLinkArgs {
 interface TerminalReplayWriteState {
   suppressedWriteCount: number;
 }
+
+type TerminalSessionStatusNotice = "disconnected" | "exited";
+type TerminalSessionStatusNoticeRef = {
+  current: TerminalSessionStatusNotice | null;
+};
 
 interface HandleTerminalServerMessageArgs {
   message: TerminalServerMessage;
@@ -161,6 +172,39 @@ function hasVisibleTerminalSize({
 
 function writeTerminalStatus({ terminal, text }: WriteTerminalStatusArgs): void {
   terminal.write(`\r\n\x1b[2m${text}\x1b[0m\r\n`);
+}
+
+function writeTerminalSessionStatusNotice({
+  lastNotice,
+  session,
+  terminal,
+}: WriteTerminalSessionStatusNoticeArgs): void {
+  switch (session.status) {
+    case "disconnected":
+      if (lastNotice.current === "disconnected") {
+        return;
+      }
+      lastNotice.current = "disconnected";
+      writeTerminalStatus({ terminal, text: "Terminal disconnected" });
+      return;
+    case "exited":
+      if (lastNotice.current === "exited") {
+        return;
+      }
+      lastNotice.current = "exited";
+      writeTerminalStatus({
+        terminal,
+        text:
+          session.exitCode === null
+            ? "Terminal exited"
+            : `Terminal exited with code ${session.exitCode}`,
+      });
+      return;
+    case "starting":
+    case "running":
+      lastNotice.current = null;
+      return;
+  }
 }
 
 function openTerminalWebLink({
@@ -250,10 +294,15 @@ export function ThreadTerminalView({
   );
   const onUserInputRef = useRef<(() => void) | undefined>(onUserInput);
   const isPanelOpenRef = useRef(isPanelOpen);
+  const sessionStatusRef = useRef<TerminalSession["status"]>(session.status);
+  const sessionRef = useRef(session);
+  const lastStatusNoticeRef = useRef<TerminalSessionStatusNotice | null>(null);
   const scheduleFitRef = useRef<TerminalFitScheduler | null>(null);
   const preferredTheme = usePreferredTheme();
 
   isPanelOpenRef.current = isPanelOpen;
+  sessionStatusRef.current = session.status;
+  sessionRef.current = session;
   onOpenLinkRef.current = onOpenLink;
   onTitleChangeRef.current = onTitleChange;
   onUserInputRef.current = onUserInput;
@@ -311,6 +360,11 @@ export function ThreadTerminalView({
         }),
       );
       terminal.open(containerElement);
+      writeTerminalSessionStatusNotice({
+        lastNotice: lastStatusNoticeRef,
+        session: sessionRef.current,
+        terminal,
+      });
       const fitTerminal = () => {
         if (!fitAddon || !terminal) {
           return;
@@ -392,6 +446,9 @@ export function ThreadTerminalView({
         if (replayWriteState.suppressedWriteCount > 0) {
           return;
         }
+        if (sessionStatusRef.current !== "running") {
+          return;
+        }
         if (activeSocket.readyState !== WebSocket.OPEN) {
           return;
         }
@@ -405,6 +462,9 @@ export function ThreadTerminalView({
       });
       activeTerminal.onTitleChange((title) => {
         if (replayWriteState.suppressedWriteCount > 0) {
+          return;
+        }
+        if (sessionStatusRef.current !== "running") {
           return;
         }
         onTitleChangeRef.current?.(title);
@@ -446,6 +506,18 @@ export function ThreadTerminalView({
     terminalRef.current?.focus();
     scheduleFitRef.current?.();
   }, [isPanelOpen]);
+
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) {
+      return;
+    }
+    writeTerminalSessionStatusNotice({
+      lastNotice: lastStatusNoticeRef,
+      session,
+      terminal,
+    });
+  }, [session]);
 
   useEffect(() => {
     const terminal = terminalRef.current;

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.test.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.test.ts
@@ -1,0 +1,82 @@
+import type { TerminalSession } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import {
+  isVisibleTerminalSession,
+  shouldCloseDisconnectedTerminalSession,
+} from "./useThreadTerminalController";
+
+function terminalSession(
+  overrides: Partial<TerminalSession>,
+): TerminalSession {
+  return {
+    id: "term_1",
+    threadId: "thr_1",
+    environmentId: "env_1",
+    hostId: "host_1",
+    title: "Terminal",
+    initialCwd: "/workspace",
+    cols: 100,
+    rows: 30,
+    status: "running",
+    exitCode: null,
+    closeReason: null,
+    createdAt: 1,
+    updatedAt: 1,
+    lastUserInputAt: null,
+    ...overrides,
+  };
+}
+
+describe("terminal visibility", () => {
+  it("shows disconnected sessions only while retaining a mounted terminal view", () => {
+    const disconnected = terminalSession({
+      id: "term_disconnected",
+      status: "disconnected",
+    });
+
+    expect(
+      isVisibleTerminalSession({
+        retainedTerminalViewId: null,
+        session: disconnected,
+      }),
+    ).toBe(false);
+    expect(
+      isVisibleTerminalSession({
+        retainedTerminalViewId: "term_disconnected",
+        session: disconnected,
+      }),
+    ).toBe(true);
+    expect(
+      isVisibleTerminalSession({
+        retainedTerminalViewId: null,
+        session: terminalSession({ status: "running" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("cleans up only disconnected sessions without a retained terminal view", () => {
+    const disconnected = terminalSession({
+      id: "term_disconnected",
+      status: "disconnected",
+    });
+
+    expect(
+      shouldCloseDisconnectedTerminalSession({
+        retainedTerminalViewId: null,
+        session: disconnected,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCloseDisconnectedTerminalSession({
+        retainedTerminalViewId: "term_disconnected",
+        session: disconnected,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCloseDisconnectedTerminalSession({
+        retainedTerminalViewId: null,
+        session: terminalSession({ status: "running" }),
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TerminalSession } from "@bb/server-contract";
 import { isVisibleTerminalSessionStatus } from "@bb/domain";
 import {
@@ -43,6 +43,7 @@ export interface ThreadTerminalController {
   isPanelOpen: boolean;
   isTerminalQueryLoading: boolean;
   showTerminalPlaceholders: boolean;
+  shouldRetainActiveTerminalView: boolean;
   terminalBodyMessage: string;
   threadId: string;
   visibleSessions: readonly TerminalSession[];
@@ -58,8 +59,33 @@ export type ThreadTerminalIdHandler = (terminalId: string) => void;
 export type ThreadTerminalTitleChangeHandler = (title: string) => void;
 type TerminalTitleRenameTimeout = number;
 
-function isVisibleTerminalSession(session: TerminalSession): boolean {
-  return isVisibleTerminalSessionStatus(session.status);
+export function isVisibleTerminalSession({
+  retainedTerminalViewId,
+  session,
+}: {
+  retainedTerminalViewId: string | null;
+  session: TerminalSession;
+}): boolean {
+  if (!isVisibleTerminalSessionStatus(session.status)) {
+    return false;
+  }
+  return (
+    session.status !== "disconnected" ||
+    session.id === retainedTerminalViewId
+  );
+}
+
+export function shouldCloseDisconnectedTerminalSession({
+  retainedTerminalViewId,
+  session,
+}: {
+  retainedTerminalViewId: string | null;
+  session: TerminalSession;
+}): boolean {
+  return (
+    session.status === "disconnected" &&
+    session.id !== retainedTerminalViewId
+  );
 }
 
 function pickActiveTerminalId(
@@ -101,10 +127,14 @@ export function useThreadTerminalController({
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(threadId);
   const dirtyTerminalIdsRef = useRef<Set<string>>(new Set());
   const closingCleanTerminalIdsRef = useRef<Set<string>>(new Set());
+  const closingDisconnectedTerminalIdsRef = useRef<Set<string>>(new Set());
   const latestRequestedTitleRenameRef =
     useRef<TerminalTitleRenameRequest | null>(null);
   const pendingTitleRenameTimeoutRef =
     useRef<TerminalTitleRenameTimeout | null>(null);
+  const [retainedTerminalViewId, setRetainedTerminalViewId] = useState<
+    string | null
+  >(null);
   const terminalsQuery = useThreadTerminals(threadId, {
     enabled: isRightPanelOpen,
   });
@@ -113,8 +143,11 @@ export function useThreadTerminalController({
   const renameTerminal = useRenameThreadTerminal();
   const sessions = terminalsQuery.data?.sessions ?? EMPTY_TERMINAL_SESSIONS;
   const visibleSessions = useMemo(
-    () => sessions.filter(isVisibleTerminalSession),
-    [sessions],
+    () =>
+      sessions.filter((session) =>
+        isVisibleTerminalSession({ retainedTerminalViewId, session }),
+      ),
+    [retainedTerminalViewId, sessions],
   );
   const activeTerminalId = useMemo(
     () => pickActiveTerminalId(visibleSessions, activeFixedTerminalId),
@@ -122,6 +155,32 @@ export function useThreadTerminalController({
   );
   const activeSession =
     visibleSessions.find((session) => session.id === activeTerminalId) ?? null;
+  const shouldRetainActiveTerminalView =
+    activeSession?.status === "disconnected" &&
+    activeSession.id === retainedTerminalViewId;
+
+  useEffect(() => {
+    if (!isRightPanelOpen) {
+      setRetainedTerminalViewId(null);
+      return;
+    }
+    if (activeSession?.status === "running") {
+      setRetainedTerminalViewId(activeSession.id);
+      return;
+    }
+    if (
+      retainedTerminalViewId !== null &&
+      activeTerminalId !== retainedTerminalViewId
+    ) {
+      setRetainedTerminalViewId(null);
+    }
+  }, [
+    activeSession?.id,
+    activeSession?.status,
+    activeTerminalId,
+    isRightPanelOpen,
+    retainedTerminalViewId,
+  ]);
 
   useEffect(() => {
     if (!isRightPanelOpen || terminalsQuery.isLoading || terminalsQuery.error) {
@@ -138,6 +197,49 @@ export function useThreadTerminalController({
     setActiveFixedTerminal,
     terminalsQuery.error,
     terminalsQuery.isLoading,
+  ]);
+
+  useEffect(() => {
+    if (!isRightPanelOpen || terminalsQuery.isLoading || terminalsQuery.error) {
+      return;
+    }
+    for (const session of sessions) {
+      if (
+        !shouldCloseDisconnectedTerminalSession({
+          retainedTerminalViewId,
+          session,
+        }) ||
+        closingDisconnectedTerminalIdsRef.current.has(session.id)
+      ) {
+        continue;
+      }
+      closingDisconnectedTerminalIdsRef.current.add(session.id);
+      closeTerminal.mutate(
+        { mode: "force", threadId, terminalId: session.id },
+        {
+          onSuccess: (closedSession) => {
+            if (closedSession.status !== "exited") {
+              return;
+            }
+            dirtyTerminalIdsRef.current.delete(closedSession.id);
+            closingCleanTerminalIdsRef.current.delete(closedSession.id);
+            removeFixedTerminalTab(closedSession.id);
+          },
+          onSettled: () => {
+            closingDisconnectedTerminalIdsRef.current.delete(session.id);
+          },
+        },
+      );
+    }
+  }, [
+    closeTerminal,
+    isRightPanelOpen,
+    removeFixedTerminalTab,
+    retainedTerminalViewId,
+    sessions,
+    terminalsQuery.error,
+    terminalsQuery.isLoading,
+    threadId,
   ]);
 
   useEffect(() => {
@@ -373,6 +475,7 @@ export function useThreadTerminalController({
     isPanelOpen: isRightPanelOpen,
     isTerminalQueryLoading: terminalsQuery.isLoading,
     showTerminalPlaceholders,
+    shouldRetainActiveTerminalView,
     terminalBodyMessage,
     threadId,
     visibleSessions,

--- a/apps/server/test/public/public-thread-terminals.test.ts
+++ b/apps/server/test/public/public-thread-terminals.test.ts
@@ -490,6 +490,8 @@ describe("public thread terminal routes", () => {
       threadId: fixture.thread.id,
       title: "Terminal 1",
     });
+    const browserSocket = createFakeBrowserSocket();
+    fixture.harness.hub.registerTerminalClient(stored.id, browserSocket);
 
     fixture.harness.deps.terminalSessions.handleDaemonSessionClosed({
       sessionId: fixture.session.id,
@@ -506,6 +508,15 @@ describe("public thread terminal routes", () => {
         status: "disconnected",
       }),
     ]);
+    expect(readBrowserMessages(browserSocket)).toContainEqual(
+      expect.objectContaining({
+        type: "session-updated",
+        session: expect.objectContaining({
+          id: stored.id,
+          status: "disconnected",
+        }),
+      }),
+    );
   });
 
   it("expires disconnected terminals on daemon reconnect without restoring them in v1", async () => {

--- a/packages/db/test/data/terminal-sessions.test.ts
+++ b/packages/db/test/data/terminal-sessions.test.ts
@@ -5,6 +5,7 @@ import { noopNotifier } from "../../src/notifier.js";
 import {
   createTerminalSession,
   listTerminalSessionsByThread,
+  listVisibleTerminalSessionsByThread,
   markDaemonTerminalSessionsDisconnected,
   markEnvironmentTerminalSessionsExited,
   markTerminalSessionUserInput,
@@ -232,6 +233,67 @@ describe("terminal sessions", () => {
         status: "disconnected",
       }),
     ]);
+  });
+
+  it("lists starting, running, and disconnected terminals as visible", () => {
+    const fixture = setup();
+    const starting = createTerminalSession(fixture.db, {
+      cols: 80,
+      daemonSessionId: fixture.session.id,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/workspace",
+      rows: 24,
+      status: "starting",
+      threadId: fixture.thread.id,
+      title: "Starting terminal",
+    });
+    const running = createTerminalSession(fixture.db, {
+      cols: 80,
+      daemonSessionId: fixture.session.id,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/workspace",
+      rows: 24,
+      status: "running",
+      threadId: fixture.thread.id,
+      title: "Running terminal",
+    });
+    const disconnected = createTerminalSession(fixture.db, {
+      cols: 80,
+      daemonSessionId: null,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/workspace",
+      rows: 24,
+      status: "disconnected",
+      threadId: fixture.thread.id,
+      title: "Disconnected terminal",
+    });
+    const exited = createTerminalSession(fixture.db, {
+      cols: 80,
+      daemonSessionId: null,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/workspace",
+      rows: 24,
+      status: "exited",
+      threadId: fixture.thread.id,
+      title: "Exited terminal",
+    });
+
+    expect(
+      listVisibleTerminalSessionsByThread(fixture.db, fixture.thread.id),
+    ).toEqual([
+      expect.objectContaining({ id: starting.id }),
+      expect.objectContaining({ id: running.id }),
+      expect.objectContaining({ id: disconnected.id }),
+    ]);
+    expect(
+      listVisibleTerminalSessionsByThread(fixture.db, fixture.thread.id),
+    ).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: exited.id })]),
+    );
   });
 
   it("does not mark a starting terminal running for another daemon session", () => {


### PR DESCRIPTION
## Summary
- Retain a mounted terminal view when its session becomes disconnected so scrollback stays visible and a disconnected notice is written into the terminal.
- Clean up disconnected terminal sessions that appear cold on terminal panel mount/refresh, removing stale tabs through the existing close flow.
- Add focused coverage for the client visibility/cleanup predicates and preserve server/db expectations around disconnected terminal state.

## Tests
- `pnpm exec turbo run test --filter=@bb/app -- useThreadTerminalController`
- `pnpm exec turbo run test --filter=@bb/domain -- terminal`
- `pnpm exec turbo run test --filter=@bb/db -- terminal-sessions`
- `pnpm exec turbo run test --filter=@bb/server -- public-thread-terminals`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/domain`
- `pnpm exec turbo run typecheck --filter=@bb/db`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `git diff --check`
