### PR TITLE
Improve PR context banner states

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -620,9 +620,7 @@ export function Overview() {
         label="git — merge-base picker"
         hint="git is the only segment, so the merge-base action is pinned to the far right. It still carries data-promptbox-hide-compact."
       >
-        <div className="w-[40rem] max-w-full overflow-x-auto">
-          <Row section={committedSection} />
-        </div>
+        <Row section={committedSection} />
       </StoryRow>
       <StoryRow
         label="archived thread"
@@ -742,9 +740,15 @@ export function Overview() {
       ))}
       <StoryRow
         label="pull request + uncommitted"
-        hint="PR segment coexists with existing banner sections"
+        hint="PR number and the shared uncommitted diff label stay visible"
       >
         <Row pullRequest={pullRequestFixture} section={uncommittedSection} />
+      </StoryRow>
+      <StoryRow
+        label="pull request + committed"
+        hint="committed branch changes use the same label with or without PR context"
+      >
+        <Row pullRequest={pullRequestFixture} section={committedSection} />
       </StoryRow>
       <StoryRow
         label="uncommitted (collapsed)"

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -1,8 +1,66 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import type { ThreadPullRequest } from "@bb/domain";
 import { describe, expect, it } from "vitest";
-import { ThreadPromptContextBanner } from "./ThreadPromptContextBanner";
+import {
+  ThreadPromptContextBanner,
+  type ThreadPromptGitSection,
+} from "./ThreadPromptContextBanner";
 
 const noop = () => {};
+
+const changedFile = {
+  path: "apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx",
+  status: "M" as const,
+  insertions: 2,
+  deletions: 0,
+};
+
+const pullRequestFixture: ThreadPullRequest = {
+  number: 128,
+  title: "Show pull request status in the prompt context banner",
+  state: "open",
+  url: "https://github.com/acme/bb/pull/128",
+  baseRefName: "main",
+  headRefName: "bb/pr-context-banner",
+  updatedAt: "2026-06-16T12:30:00Z",
+  checks: {
+    state: "passing",
+    totalCount: 1,
+    passedCount: 1,
+    failedCount: 0,
+    pendingCount: 0,
+  },
+  review: {
+    state: "none",
+    reviewRequestCount: 0,
+  },
+  mergeability: {
+    state: "mergeable",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  },
+  attention: "ready_to_merge",
+};
+
+function makeGitSection(
+  kind: ThreadPromptGitSection["changedFiles"]["kind"] = "uncommitted",
+): ThreadPromptGitSection {
+  return {
+    changedFiles: {
+      kind,
+      label: kind === "committed" ? "Committed" : "Uncommitted",
+      files: [changedFile],
+      mergeBaseRef: kind === "committed" ? "abc1234" : null,
+      stats: {
+        insertions: 2,
+        deletions: 0,
+        files: [changedFile],
+      },
+    },
+    mergeBase: null,
+    onPromptBannerFileClick: noop,
+  };
+}
 
 describe("ThreadPromptContextBanner", () => {
   it("renders the archived read-only status without an action", () => {
@@ -45,5 +103,158 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain('role="status"');
     expect(markup).not.toContain("<button");
     expect(markup).not.toContain("Provision");
+  });
+
+  it("labels a standalone pull request without non-actionable attention text", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={null}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{ pullRequest: pullRequestFixture }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("PR #128");
+    expect(markup).not.toContain("PR #128 · Open");
+    expect(markup).not.toContain("· Ready to merge");
+    expect(markup).not.toContain('alt="Checks success"');
+  });
+
+  it("does not label standalone pending checks", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={null}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{
+          pullRequest: {
+            ...pullRequestFixture,
+            checks: {
+              state: "pending",
+              totalCount: 1,
+              passedCount: 0,
+              failedCount: 0,
+              pendingCount: 1,
+            },
+            attention: "checks_pending",
+          },
+        }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("PR #128");
+    expect(markup).not.toContain("PR #128 · Open");
+    expect(markup).not.toContain("· Checks pending");
+    expect(markup).not.toContain('alt="Checks pending"');
+  });
+
+  it("keeps useful standalone terminal pull request state labels", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={null}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{
+          pullRequest: {
+            ...pullRequestFixture,
+            state: "closed",
+            attention: "closed",
+          },
+        }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("PR #128 · Closed");
+  });
+
+  it("labels standalone actionable pull request attention", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={null}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{
+          pullRequest: {
+            ...pullRequestFixture,
+            checks: {
+              state: "failing",
+              totalCount: 1,
+              passedCount: 0,
+              failedCount: 1,
+              pendingCount: 0,
+            },
+            attention: "checks_failed",
+          },
+        }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("PR #128");
+    expect(markup).toContain("· Checks failing");
+    expect(markup).not.toContain("Checks failure");
+  });
+
+  it("shows pull request and diff labels together when only PR and git context are visible", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={makeGitSection("uncommitted")}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{ pullRequest: pullRequestFixture }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("PR #128");
+    expect(markup).not.toContain("Open PR #128");
+    expect(markup).not.toContain("· Ready to merge");
+    expect(markup).toContain("Uncommitted");
+    expect(markup).toContain("1 file");
+    expect(markup).not.toContain("data-promptbox-hide-compact");
+  });
+
+  it("uses the shared committed git label beside pull request context", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={makeGitSection("committed")}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{ pullRequest: pullRequestFixture }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("PR #128");
+    expect(markup).toContain("Committed");
+    expect(markup).toContain("1 file");
   });
 });

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -21,7 +21,10 @@ import {
 } from "@/components/workspace/workspace-change-summary";
 import { cn } from "@/lib/utils";
 import { Icon, type IconName } from "@/components/ui/icon.js";
-import { getPullRequestAttentionDisplay } from "@/lib/pull-request-display";
+import {
+  getPullRequestAttentionDisplay,
+  PULL_REQUEST_STATE_DISPLAY,
+} from "@/lib/pull-request-display";
 import { PullRequestStatusPill } from "@/components/pull-request/PullRequestStatusPill";
 
 export interface ContextBannerMergeBaseConfig {
@@ -292,6 +295,18 @@ function parentSectionAriaLabel(
   return `${PARENT_SECTION_COPY[section.relationship].ariaPrefix} ${section.parentThreadTitle}`;
 }
 
+function shouldShowPullRequestAttentionLabel(
+  pullRequest: ThreadPullRequest,
+): boolean {
+  return (
+    pullRequest.attention === "checks_failed" ||
+    pullRequest.attention === "changes_requested" ||
+    pullRequest.attention === "review_requested" ||
+    pullRequest.attention === "conflicts" ||
+    pullRequest.attention === "blocked"
+  );
+}
+
 function ParentThreadBody({
   parentThreadTitle,
   href,
@@ -370,14 +385,17 @@ function ThreadUnarchiveTextAction({
 
 function PullRequestBannerLink({
   pullRequest,
+  showLabel,
+  showStateLabel,
 }: {
   pullRequest: ThreadPullRequest;
+  showLabel: boolean;
+  showStateLabel: boolean;
 }) {
   const attentionDisplay = getPullRequestAttentionDisplay(pullRequest);
+  const stateDisplay = PULL_REQUEST_STATE_DISPLAY[pullRequest.state];
   const showAttentionLabel =
-    attentionDisplay.className === "text-destructive" &&
-    pullRequest.attention !== "checks_failed" &&
-    pullRequest.attention !== "closed";
+    showLabel && shouldShowPullRequestAttentionLabel(pullRequest);
   return (
     <a
       href={pullRequest.url}
@@ -388,9 +406,17 @@ function PullRequestBannerLink({
       className="flex min-w-0 items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground no-underline transition-colors hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
     >
       <PullRequestStatusPill pullRequest={pullRequest} />
+      {showLabel ? (
+        <span className="shrink-0">
+          PR #{pullRequest.number}
+          {showStateLabel && pullRequest.state !== "open"
+            ? ` · ${stateDisplay.label}`
+            : ""}
+        </span>
+      ) : null}
       {showAttentionLabel ? (
         <span className={cn("min-w-0 truncate", attentionDisplay.className)}>
-          {attentionDisplay.label}
+          · {attentionDisplay.label}
         </span>
       ) : null}
     </a>
@@ -577,6 +603,8 @@ export function ThreadPromptContextBanner({
     Number(showPullRequest) +
     Number(showGit);
   const hasSingleVisibleSegment = visibleSegmentCount === 1;
+  const isPullRequestAndGitOnly =
+    showPullRequest && showGit && visibleSegmentCount === 2;
   // selectWorkspaceChangedFilesSection only emits a section when files exist,
   // so showGit implies a non-empty file list.
   const isGitExpanded = expandedSection === "git" && showGit;
@@ -588,11 +616,13 @@ export function ThreadPromptContextBanner({
     ? toChangeTally(gitSection.changedFiles.stats)
     : null;
   const gitSummaryText = gitTally ? formatChangeSummary(gitTally) : "";
+  const gitSummaryPrefix = showGit
+    ? KIND_PREFIX[gitSection.changedFiles.kind]
+    : "";
   const gitSummary: ReactNode =
     showGit && gitTally ? (
       <>
-        {KIND_PREFIX[gitSection.changedFiles.kind]} ·{" "}
-        {renderChangeSummary(gitTally)}
+        {gitSummaryPrefix} · {renderChangeSummary(gitTally)}
       </>
     ) : null;
 
@@ -709,7 +739,11 @@ export function ThreadPromptContextBanner({
           />
         ) : null}
         {showPullRequest && pullRequest ? (
-          <PullRequestBannerLink pullRequest={pullRequest} />
+          <PullRequestBannerLink
+            pullRequest={pullRequest}
+            showLabel={hasSingleVisibleSegment || isPullRequestAndGitOnly}
+            showStateLabel={hasSingleVisibleSegment}
+          />
         ) : null}
         {showGit && gitSummary ? (
           <SectionToggleButton
@@ -723,8 +757,10 @@ export function ThreadPromptContextBanner({
               />
             }
             label={gitSummary}
-            hideLabelInCompact={!hasSingleVisibleSegment}
-            ariaLabel={`Changed files: ${gitSummaryText}`}
+            hideLabelInCompact={
+              !(hasSingleVisibleSegment || isPullRequestAndGitOnly)
+            }
+            ariaLabel={`Changed files: ${gitSummaryPrefix}, ${gitSummaryText}`}
             isExpanded={isGitExpanded}
             onToggle={() => onToggleSection("git")}
           />

--- a/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
+++ b/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
@@ -119,12 +119,14 @@ export function PullRequestGithubCheckIcon({
         <>
           <img
             src={checksSuccessIcon}
-            alt="Checks success"
+            alt=""
+            aria-hidden="true"
             className={cn(checkStatusClassName, "dark:hidden", className)}
           />
           <img
             src={checksSuccessDarkIcon}
-            alt="Checks success"
+            alt=""
+            aria-hidden="true"
             className={cn(checkStatusClassName, "hidden dark:block", className)}
           />
         </>
@@ -134,12 +136,14 @@ export function PullRequestGithubCheckIcon({
         <>
           <img
             src={checksFailureIcon}
-            alt="Checks failure"
+            alt=""
+            aria-hidden="true"
             className={cn(checkStatusClassName, "dark:hidden", className)}
           />
           <img
             src={checksFailureDarkIcon}
-            alt="Checks failure"
+            alt=""
+            aria-hidden="true"
             className={cn(checkStatusClassName, "hidden dark:block", className)}
           />
         </>
@@ -149,12 +153,14 @@ export function PullRequestGithubCheckIcon({
         <>
           <img
             src={checksPendingIcon}
-            alt="Checks pending"
+            alt=""
+            aria-hidden="true"
             className={cn(checkStatusClassName, "dark:hidden", className)}
           />
           <img
             src={checksPendingDarkIcon}
-            alt="Checks pending"
+            alt=""
+            aria-hidden="true"
             className={cn(checkStatusClassName, "hidden dark:block", className)}
           />
         </>

--- a/apps/server/src/services/environments/pull-request.test.ts
+++ b/apps/server/src/services/environments/pull-request.test.ts
@@ -117,6 +117,39 @@ describe("assembleThreadPullRequest", () => {
     });
   });
 
+  it("treats unstable merge state with pending checks as checks pending", () => {
+    expect(
+      assembleThreadPullRequest(
+        rawPullRequest({
+          mergeStateStatus: "UNSTABLE",
+          mergeable: "MERGEABLE",
+          checks: [
+            {
+              name: "Checks (ubuntu-latest, Node 22.x)",
+              status: "in_progress",
+              conclusion: null,
+              url: "https://github.com/acme/bb/actions/runs/1",
+            },
+          ],
+        }),
+      ),
+    ).toMatchObject({
+      checks: {
+        state: "pending",
+        totalCount: 1,
+        passedCount: 0,
+        failedCount: 0,
+        pendingCount: 1,
+      },
+      mergeability: {
+        state: "mergeable",
+        mergeStateStatus: "UNSTABLE",
+        mergeable: "MERGEABLE",
+      },
+      attention: "checks_pending",
+    });
+  });
+
   it("summarizes review requests and conflicts", () => {
     expect(
       assembleThreadPullRequest(

--- a/apps/server/src/services/environments/pull-request.ts
+++ b/apps/server/src/services/environments/pull-request.ts
@@ -107,8 +107,7 @@ function assembleThreadPullRequestMergeability(
   } else if (
     raw.mergeStateStatus === "BLOCKED" ||
     raw.mergeStateStatus === "BEHIND" ||
-    raw.mergeStateStatus === "HAS_HOOKS" ||
-    raw.mergeStateStatus === "UNSTABLE"
+    raw.mergeStateStatus === "HAS_HOOKS"
   ) {
     state = "blocked";
   } else if (


### PR DESCRIPTION
## Summary
- show useful PR labels in the prompt context banner without non-actionable open/ready/pending text
- keep PR and git diff labels visible together, including committed and uncommitted cases
- fix automations stories nested router usage
- treat GitHub UNSTABLE merge state with pending checks as pending checks instead of blocked

## Validation
- pnpm exec turbo run test --filter=@bb/app -- ThreadPromptContextBanner.test.tsx
- pnpm exec turbo run test --filter=@bb/server -- pull-request.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/server