### PR TITLE
Refresh PR data on focus

### DIFF
--- a/apps/app/src/hooks/queries/environment-queries.test.tsx
+++ b/apps/app/src/hooks/queries/environment-queries.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ThreadPullRequest } from "@bb/domain";
+import type { EnvironmentPullRequestResponse } from "@bb/server-contract";
+import * as api from "@/lib/api";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { environmentPullRequestQueryKey } from "./query-keys";
+import {
+  getEnvironmentPullRequestStaleTime,
+  useEnvironmentPullRequest,
+} from "./environment-queries";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getEnvironmentPullRequest: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useEnvironmentDetailRealtimeSubscription: vi.fn(),
+}));
+
+const ENVIRONMENT_ID = "env-1";
+const ACTIVE_PULL_REQUEST_STALE_MS = 30_000;
+const SETTLED_PULL_REQUEST_STALE_MS = 60 * 60_000;
+
+const pullRequestFixture: ThreadPullRequest = {
+  number: 128,
+  title: "Refresh PR state",
+  state: "open",
+  url: "https://github.com/acme/bb/pull/128",
+  baseRefName: "main",
+  headRefName: "bb/pr-refresh",
+  updatedAt: "2026-06-16T12:30:00Z",
+  checks: {
+    state: "passing",
+    totalCount: 1,
+    passedCount: 1,
+    failedCount: 0,
+    pendingCount: 0,
+  },
+  review: {
+    state: "none",
+    reviewRequestCount: 0,
+  },
+  mergeability: {
+    state: "mergeable",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  },
+  attention: "ready_to_merge",
+};
+
+function pullRequestResponse(
+  pullRequest: ThreadPullRequest | null,
+): EnvironmentPullRequestResponse {
+  return { pullRequest };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  vi.mocked(api.getEnvironmentPullRequest).mockReset();
+});
+
+describe("useEnvironmentPullRequest", () => {
+  it("keeps active and absent pull request data stale after 30 seconds", () => {
+    expect(getEnvironmentPullRequestStaleTime(null)).toBe(
+      ACTIVE_PULL_REQUEST_STALE_MS,
+    );
+    expect(getEnvironmentPullRequestStaleTime(undefined)).toBe(
+      ACTIVE_PULL_REQUEST_STALE_MS,
+    );
+    expect(getEnvironmentPullRequestStaleTime(pullRequestFixture)).toBe(
+      ACTIVE_PULL_REQUEST_STALE_MS,
+    );
+    expect(
+      getEnvironmentPullRequestStaleTime({
+        ...pullRequestFixture,
+        state: "draft",
+      }),
+    ).toBe(ACTIVE_PULL_REQUEST_STALE_MS);
+  });
+
+  it("keeps closed and merged pull request data fresh longer", () => {
+    expect(
+      getEnvironmentPullRequestStaleTime({
+        ...pullRequestFixture,
+        state: "closed",
+      }),
+    ).toBe(SETTLED_PULL_REQUEST_STALE_MS);
+    expect(
+      getEnvironmentPullRequestStaleTime({
+        ...pullRequestFixture,
+        state: "merged",
+      }),
+    ).toBe(SETTLED_PULL_REQUEST_STALE_MS);
+  });
+
+  it("refetches stale pull request data on mount and window focus", async () => {
+    const { wrapper, queryClient } = createQueryClientTestHarness();
+    vi.mocked(api.getEnvironmentPullRequest).mockResolvedValue(
+      pullRequestResponse(pullRequestFixture),
+    );
+
+    renderHook(() => useEnvironmentPullRequest(ENVIRONMENT_ID), { wrapper });
+
+    await waitFor(() => {
+      expect(api.getEnvironmentPullRequest).toHaveBeenCalledTimes(1);
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: environmentPullRequestQueryKey(ENVIRONMENT_ID),
+    });
+
+    expect(query?.options).toEqual(
+      expect.objectContaining({
+        refetchOnMount: true,
+        refetchOnWindowFocus: true,
+        staleTime: expect.any(Function),
+      }),
+    );
+  });
+});

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -1,5 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import type { Environment, WorkspaceDiffTarget } from "@bb/domain";
+import type {
+  Environment,
+  ThreadPullRequest,
+  WorkspaceDiffTarget,
+} from "@bb/domain";
 import type {
   EnvironmentDiffBranchesResponse,
   EnvironmentDiffFilesResponse,
@@ -47,6 +51,7 @@ interface UseEnvironmentDiffFilesOptions extends QueryOptions {
 }
 
 const ENVIRONMENT_PULL_REQUEST_STALE_MS = 30_000;
+const ENVIRONMENT_SETTLED_PULL_REQUEST_STALE_MS = 60 * 60_000;
 const MERGE_BASE_BRANCHES_STALE_MS = 30_000;
 const MERGE_BASE_BRANCHES_LIMIT = 50;
 /** Staleness window for the environment diff TOC query. */
@@ -119,6 +124,14 @@ export function useEnvironmentWorkStatus(
   });
 }
 
+export function getEnvironmentPullRequestStaleTime(
+  pullRequest: ThreadPullRequest | null | undefined,
+): number {
+  return pullRequest?.state === "closed" || pullRequest?.state === "merged"
+    ? ENVIRONMENT_SETTLED_PULL_REQUEST_STALE_MS
+    : ENVIRONMENT_PULL_REQUEST_STALE_MS;
+}
+
 export function useEnvironmentPullRequest(
   environmentId: string | null | undefined,
   options?: QueryOptions,
@@ -134,8 +147,10 @@ export function useEnvironmentPullRequest(
         signal,
       ),
     enabled,
-    refetchOnWindowFocus: false,
-    staleTime: ENVIRONMENT_PULL_REQUEST_STALE_MS,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    staleTime: (query) =>
+      getEnvironmentPullRequestStaleTime(query.state.data?.pullRequest),
   });
 }
 

--- a/packages/db/test/data/terminal-sessions.test.ts
+++ b/packages/db/test/data/terminal-sessions.test.ts
@@ -284,11 +284,16 @@ describe("terminal sessions", () => {
 
     expect(
       listVisibleTerminalSessionsByThread(fixture.db, fixture.thread.id),
-    ).toEqual([
-      expect.objectContaining({ id: starting.id }),
-      expect.objectContaining({ id: running.id }),
-      expect.objectContaining({ id: disconnected.id }),
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: starting.id }),
+        expect.objectContaining({ id: running.id }),
+        expect.objectContaining({ id: disconnected.id }),
+      ]),
+    );
+    expect(
+      listVisibleTerminalSessionsByThread(fixture.db, fixture.thread.id),
+    ).toHaveLength(3);
     expect(
       listVisibleTerminalSessionsByThread(fixture.db, fixture.thread.id),
     ).not.toEqual(


### PR DESCRIPTION
## Summary
- refetch environment PR data on window focus and stale mount
- keep active/no-PR data stale after 30s
- keep closed/merged PR data fresh for 1 hour
- add focused hook coverage for the PR stale-time policy and query options
- stabilize a terminal-session visibility test that assumed creation order when timestamps tie

Follow-up to #208, which merged before this change was pushed.

## Validation
- pnpm exec turbo run test --filter=@bb/app -- environment-queries.test.tsx
- pnpm exec turbo run test --filter=@bb/app -- ThreadPromptContextBanner.test.tsx
- pnpm exec turbo run test --filter=@bb/server -- pull-request.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run test --filter=@bb/db -- terminal-sessions.test.ts
- pnpm exec turbo run typecheck --filter=@bb/db