### PR TITLE
Avoid self-links in thread timeline titles

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.link.test.ts
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.link.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveThreadTimelineSegmentLinkHref } from "./ThreadTimelineRows";
+
+describe("resolveThreadTimelineSegmentLinkHref", () => {
+  it("renders current-thread title segments as plain text", () => {
+    expect(
+      resolveThreadTimelineSegmentLinkHref({
+        currentThreadId: "thr_current",
+        link: { kind: "thread", threadId: "thr_current" },
+        projectId: "proj_demo",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps other-thread title segments navigable", () => {
+    expect(
+      resolveThreadTimelineSegmentLinkHref({
+        currentThreadId: "thr_current",
+        link: { kind: "thread", threadId: "thr_other" },
+        projectId: "proj_demo",
+      }),
+    ).toBe("/projects/proj_demo/threads/thr_other");
+  });
+
+  it("renders links as plain text without project context", () => {
+    expect(
+      resolveThreadTimelineSegmentLinkHref({
+        currentThreadId: "thr_current",
+        link: { kind: "thread", threadId: "thr_other" },
+        projectId: undefined,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -39,6 +39,7 @@ import {
   type ThreadTimelineViewRow,
   type TimelineActivityIntentTitle,
   type TimelineTitle,
+  type TimelineTitleLink,
   type TimelineViewTurnRow,
   type TimelineViewWorkRow,
 } from "@bb/thread-view";
@@ -159,6 +160,25 @@ export interface ThreadTimelineRowsProps {
    * only when the environment hasn't loaded yet.
    */
   workspaceRootPath: string | undefined;
+}
+
+export function resolveThreadTimelineSegmentLinkHref(args: {
+  currentThreadId: string | undefined;
+  link: TimelineTitleLink;
+  projectId: string | undefined;
+}): string | null {
+  if (
+    args.currentThreadId !== undefined &&
+    args.link.threadId === args.currentThreadId
+  ) {
+    return null;
+  }
+  return args.projectId !== undefined
+    ? getThreadRoutePath({
+        projectId: args.projectId,
+        threadId: args.link.threadId,
+      })
+    : null;
 }
 
 /**
@@ -1650,13 +1670,13 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   });
   const resolveSegmentLinkHref = useMemo<TimelineTitleLinkResolver>(() => {
     return (link) => {
-      // Thread routes are project-scoped; without a project context the
-      // segment renders as plain text.
-      return projectId !== undefined
-        ? getThreadRoutePath({ projectId, threadId: link.threadId })
-        : null;
+      return resolveThreadTimelineSegmentLinkHref({
+        currentThreadId: props.threadId,
+        link,
+        projectId,
+      });
     };
-  }, [projectId]);
+  }, [projectId, props.threadId]);
   // One selection controller for the whole timeline: any assistant message that
   // reports a non-null selection replaces it (single open menu), and a report of
   // `null` (only emitted by a message that previously had a selection) clears it.


### PR DESCRIPTION
## Summary
- Render current-thread title segments as plain text instead of linking to the page already open
- Preserve links for other thread title segments
- Add regression coverage for self-link suppression and cross-thread links

## Validation
- pnpm exec turbo run test --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/app