### PR TITLE
Fix side-chat unread favicon badge

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -27,7 +27,6 @@ import {
 } from "@/hooks/queries/thread-queries";
 import { useRouteState } from "@/hooks/useRouteState";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
-import { isThreadRead } from "@/lib/thread-read-state";
 import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
 import { cn } from "@/lib/utils";
 import { ProjectPathDialog } from "@/components/dialogs/ProjectPathDialog";
@@ -56,6 +55,7 @@ import { useSetRootComposeProjectId } from "@/lib/root-compose-selection";
 import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
 import { useFaviconBadge } from "@/lib/favicon-color-preference";
+import { getFaviconUnreadCount } from "./faviconUnreadCount";
 
 const SIDEBAR_WIDTH_KEY = "bb.sidebar.width";
 const SIDEBAR_OPEN_KEY = "bb.sidebar.open";
@@ -504,11 +504,11 @@ export function AppLayout({ children }: AppLayoutProps) {
     const routeTitle = routeTitles[location.pathname]?.title;
     return routeTitle && routeTitle.length > 0 ? routeTitle : "BB";
   })();
-  const unreadCount = isThreadView
-    ? thread && !isThreadRead(thread)
-      ? 1
-      : 0
-    : sidebarThreads.filter((candidate) => !isThreadRead(candidate)).length;
+  const unreadCount = getFaviconUnreadCount({
+    isThreadView,
+    sidebarThreads,
+    thread,
+  });
   const faviconBadge = unreadCount > 0 ? "unread" : "none";
   useFaviconBadge(faviconBadge);
 

--- a/apps/app/src/components/layout/faviconUnreadCount.test.ts
+++ b/apps/app/src/components/layout/faviconUnreadCount.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getFaviconUnreadCount } from "./faviconUnreadCount";
+
+type FaviconSidebarThread = Parameters<
+  typeof getFaviconUnreadCount
+>[0]["sidebarThreads"][number];
+
+function makeSidebarThread(
+  overrides: Partial<FaviconSidebarThread> = {},
+): FaviconSidebarThread {
+  return {
+    originKind: null,
+    childOrigin: null,
+    lastReadAt: 10,
+    latestAttentionAt: 20,
+    ...overrides,
+  };
+}
+
+describe("getFaviconUnreadCount", () => {
+  it("ignores unread side-chat threads hidden from the sidebar", () => {
+    expect(
+      getFaviconUnreadCount({
+        isThreadView: false,
+        thread: null,
+        sidebarThreads: [
+          makeSidebarThread({ originKind: "side-chat" }),
+          makeSidebarThread({ childOrigin: "side-chat" }),
+        ],
+      }),
+    ).toBe(0);
+  });
+
+  it("counts visible unread sidebar threads", () => {
+    expect(
+      getFaviconUnreadCount({
+        isThreadView: false,
+        thread: null,
+        sidebarThreads: [
+          makeSidebarThread(),
+          makeSidebarThread({ lastReadAt: 30 }),
+          makeSidebarThread({ originKind: "side-chat" }),
+        ],
+      }),
+    ).toBe(1);
+  });
+
+  it("uses only the current thread while viewing a thread", () => {
+    expect(
+      getFaviconUnreadCount({
+        isThreadView: true,
+        thread: { lastReadAt: 10, latestAttentionAt: 20 },
+        sidebarThreads: [],
+      }),
+    ).toBe(1);
+  });
+});

--- a/apps/app/src/components/layout/faviconUnreadCount.ts
+++ b/apps/app/src/components/layout/faviconUnreadCount.ts
@@ -1,0 +1,31 @@
+import type { ThreadListEntry } from "@bb/domain";
+import { isSidebarProjectThread } from "@/components/sidebar/projectThreadGroups";
+import {
+  isThreadRead,
+  type ThreadReadState,
+} from "@/lib/thread-read-state";
+
+type FaviconSidebarThread = ThreadReadState &
+  Pick<ThreadListEntry, "originKind" | "childOrigin">;
+
+interface GetFaviconUnreadCountArgs {
+  isThreadView: boolean;
+  sidebarThreads: readonly FaviconSidebarThread[];
+  thread: ThreadReadState | null | undefined;
+}
+
+function isUnreadSidebarThread(thread: FaviconSidebarThread): boolean {
+  return isSidebarProjectThread(thread) && !isThreadRead(thread);
+}
+
+export function getFaviconUnreadCount({
+  isThreadView,
+  sidebarThreads,
+  thread,
+}: GetFaviconUnreadCountArgs): number {
+  if (isThreadView) {
+    return thread && !isThreadRead(thread) ? 1 : 0;
+  }
+
+  return sidebarThreads.filter(isUnreadSidebarThread).length;
+}

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -40,6 +40,10 @@ export type ProjectThreadItem =
   | { kind: "environment"; group: EnvironmentThreadGroup };
 
 type WorktreeDisplayKind = "managed-worktree" | "unmanaged-worktree";
+type SidebarProjectThreadShape = Pick<
+  ThreadListEntry,
+  "originKind" | "childOrigin"
+>;
 
 interface BuildThreadNodeArgs {
   ancestorThreadIds: ReadonlySet<string>;
@@ -228,9 +232,7 @@ function isRootThread(
 export function buildProjectThreadGroups(
   allProjectThreads: readonly ThreadListEntry[],
 ): ProjectThreadItem[] {
-  const projectThreads = allProjectThreads.filter(
-    (thread) => (thread.originKind ?? thread.childOrigin) !== "side-chat",
-  );
+  const projectThreads = allProjectThreads.filter(isSidebarProjectThread);
   const projectThreadIds = new Set(projectThreads.map((thread) => thread.id));
   const childrenByParentId = new Map<string, ThreadListEntry[]>();
 
@@ -281,6 +283,12 @@ export function buildProjectThreadGroups(
   }
 
   return buildSortedItems(rootNodes);
+}
+
+export function isSidebarProjectThread(
+  thread: SidebarProjectThreadShape,
+): boolean {
+  return (thread.originKind ?? thread.childOrigin) !== "side-chat";
 }
 
 // Bucket nodes by shared worktree environmentId. A bucket only becomes a group

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -163,9 +163,14 @@ function buildProjectsWithThreadsResponse(
   );
 }
 
+interface BuildProjectsWithThreadsResponseOptions {
+  includeSideChats?: boolean;
+}
+
 function buildProjectsWithThreadsResponseFromRows(
   deps: AppDeps,
   projectRows: ProjectResponseRow[],
+  options: BuildProjectsWithThreadsResponseOptions = {},
 ): ProjectWithThreadsResponse[] {
   const projects = buildProjectResponsesFromRows(deps, projectRows);
   const projectIds = projects.map((project) => project.id);
@@ -173,6 +178,9 @@ function buildProjectsWithThreadsResponseFromRows(
     deps.db,
     {
       archived: false,
+      ...(options.includeSideChats === false
+        ? { excludeOriginKind: "side-chat" as const }
+        : {}),
       projectIds,
     },
   );
@@ -217,6 +225,7 @@ function buildSidebarBootstrapResponse(deps: AppDeps) {
   const personalProjectResponse = buildProjectsWithThreadsResponseFromRows(
     deps,
     [personalProject],
+    { includeSideChats: false },
   )[0];
   if (!personalProjectResponse) {
     throw new ApiError(
@@ -226,7 +235,11 @@ function buildSidebarBootstrapResponse(deps: AppDeps) {
     );
   }
   return {
-    projects: buildProjectsWithThreadsResponse(deps),
+    projects: buildProjectsWithThreadsResponseFromRows(
+      deps,
+      listPublicProjects(deps.db),
+      { includeSideChats: false },
+    ),
     personalProject: personalProjectResponse,
   };
 }

--- a/apps/server/test/public/public-threads.defaults.test.ts
+++ b/apps/server/test/public/public-threads.defaults.test.ts
@@ -498,4 +498,40 @@ describe("public thread default routes", () => {
       ).toBeNull();
     });
   });
+
+  it("excludes side-chat threads from sidebar bootstrap", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/thread-defaults-sidebar-side-chat",
+      });
+      const parentThread = seedThread(harness.deps, {
+        projectId: project.id,
+        title: "Parent",
+      });
+      const sideChatThread = seedThread(harness.deps, {
+        projectId: project.id,
+        sourceThreadId: parentThread.id,
+        originKind: "side-chat",
+        title: "Side chat",
+      });
+
+      const response = await harness.app.request("/api/v1/sidebar-bootstrap");
+
+      expect(response.status).toBe(200);
+      const bootstrap = sidebarBootstrapResponseSchema.parse(
+        await readJson(response),
+      );
+      const sidebarProject = bootstrap.projects.find(
+        (candidate) => candidate.id === project.id,
+      );
+      expect(sidebarProject?.threads.map((thread) => thread.id)).toContain(
+        parentThread.id,
+      );
+      expect(sidebarProject?.threads.map((thread) => thread.id)).not.toContain(
+        sideChatThread.id,
+      );
+    });
+  });
 });

--- a/packages/db/src/data/threads.ts
+++ b/packages/db/src/data/threads.ts
@@ -9,6 +9,7 @@ import {
   isNotNull,
   isNull,
   ne,
+  or,
   sql,
 } from "drizzle-orm";
 import type {
@@ -326,6 +327,7 @@ type ThreadRow = typeof threads.$inferSelect;
 export interface ListThreadsForProjectsOptions {
   projectIds: readonly string[];
   archived?: boolean;
+  excludeOriginKind?: ThreadOriginKind;
 }
 
 export interface PinThreadArgs {
@@ -635,6 +637,18 @@ function buildListThreadsForProjectsFilters(
   return [
     inArray(threads.projectId, [...options.projectIds]),
     isNull(threads.deletedAt),
+    options.excludeOriginKind
+      ? and(
+          or(
+            isNull(threads.originKind),
+            ne(threads.originKind, options.excludeOriginKind),
+          ),
+          or(
+            isNull(threads.childOrigin),
+            ne(threads.childOrigin, options.excludeOriginKind),
+          ),
+        )
+      : undefined,
     options.archived === true
       ? isNotNull(threads.archivedAt)
       : options.archived === false


### PR DESCRIPTION
## Summary
- exclude side-chat threads from sidebar-bootstrap project thread payloads
- reuse the sidebar visibility predicate when calculating the favicon unread badge
- add regression coverage for hidden side-chat unread state

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/layout/faviconUnreadCount.test.ts src/components/sidebar/projectThreadGroups.test.ts
- pnpm exec turbo run test --filter=@bb/server -- test/public/public-threads.defaults.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app --force
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run typecheck --filter=@bb/db