### PR TITLE
Optimistically update queued messages

### DIFF
--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
@@ -13,6 +13,7 @@ import {
   applyQueuedMessageCreateResult,
   beginCreateQueuedMessageTransaction,
   beginRemoveQueuedMessageTransaction,
+  beginSendQueuedMessageTransaction,
   beginSendThreadMessageTransaction,
   rollbackCreateQueuedMessageTransaction,
   rollbackRemoveQueuedMessageTransaction,
@@ -285,5 +286,61 @@ describe("thread runtime cache owner", () => {
     expect(
       queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
     ).toEqual(previousQueue);
+  });
+
+  it("optimistically projects sent queued messages into the timeline", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const previousQueue = [makeQueuedMessage({ id: "qmsg-1" })];
+    queryClient.setQueryData(
+      threadQueuedMessagesQueryKey("thread-1"),
+      previousQueue,
+    );
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeTimelineResponse(),
+    );
+
+    const transaction = await beginSendQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        mode: "auto",
+        queuedMessageId: "qmsg-1",
+      },
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([]);
+    const timeline = queryClient.getQueryData<ThreadTimelineResponse>(
+      threadTimelineQueryKey("thread-1"),
+    );
+    expect(timeline?.rows).toHaveLength(1);
+    expect(timeline?.rows[0]).toMatchObject({
+      kind: "conversation",
+      role: "user",
+      text: "Queued message",
+    });
+
+    rollbackRemoveQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        queuedMessageId: "qmsg-1",
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual(previousQueue);
+    expect(
+      queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey("thread-1"),
+      )?.rows,
+    ).toEqual([]);
   });
 });

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
@@ -1,8 +1,23 @@
+import type { ThreadQueuedMessage } from "@bb/domain";
 import type { ThreadTimelineResponse } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import { createAppQueryClient } from "@/lib/query-client";
-import { threadTimelineQueryKey } from "../queries/query-keys";
-import { beginSendThreadMessageTransaction } from "./thread-runtime-cache-owner";
+import {
+  threadPromptHistoryQueryKey,
+  threadQueryKey,
+  threadQueuedMessagesQueryKey,
+  threadTimelineQueryKey,
+} from "../queries/query-keys";
+import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default-execution-options-query";
+import {
+  applyQueuedMessageCreateResult,
+  beginCreateQueuedMessageTransaction,
+  beginRemoveQueuedMessageTransaction,
+  beginSendThreadMessageTransaction,
+  rollbackCreateQueuedMessageTransaction,
+  rollbackRemoveQueuedMessageTransaction,
+  rollbackSendThreadMessageTransaction,
+} from "./thread-runtime-cache-owner";
 
 function makeTimelineResponse(): ThreadTimelineResponse {
   return {
@@ -18,6 +33,22 @@ function makeTimelineResponse(): ThreadTimelineResponse {
       hasOlderRows: false,
       olderCursor: null,
     },
+  };
+}
+
+function makeQueuedMessage(
+  message: Partial<ThreadQueuedMessage> = {},
+): ThreadQueuedMessage {
+  return {
+    id: "qmsg-1",
+    content: [{ type: "text", text: "Queued message", mentions: [] }],
+    model: "codex-test",
+    reasoningLevel: "medium",
+    permissionMode: "readonly",
+    serviceTier: "default",
+    createdAt: 1,
+    updatedAt: 1,
+    ...message,
   };
 }
 
@@ -62,5 +93,197 @@ describe("thread runtime cache owner", () => {
       role: "user",
       text: "Visible question",
     });
+  });
+
+  it("optimistically appends queued messages and replaces them with the server row", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), [
+      makeQueuedMessage({ id: "qmsg-existing" }),
+    ]);
+    queryClient.setQueryData(
+      threadDefaultExecutionOptionsQueryKey("thread-1"),
+      {
+        model: "codex-default",
+        reasoningLevel: "high",
+        permissionMode: "workspace-write",
+        serviceTier: "fast",
+      },
+    );
+    queryClient.setQueryData(threadPromptHistoryQueryKey("thread-1"), []);
+
+    const transaction = await beginCreateQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        input: [{ type: "text", text: "Queue this", mentions: [] }],
+      },
+    });
+
+    const optimisticQueue = queryClient.getQueryData<ThreadQueuedMessage[]>(
+      threadQueuedMessagesQueryKey("thread-1"),
+    );
+    expect(optimisticQueue).toHaveLength(2);
+    expect(optimisticQueue?.[1]).toMatchObject({
+      id: expect.stringMatching(/^optimistic-queued-/u),
+      content: [{ type: "text", text: "Queue this", mentions: [] }],
+      model: "codex-default",
+      reasoningLevel: "high",
+      permissionMode: "workspace-write",
+      serviceTier: "fast",
+    });
+
+    const serverQueuedMessage = makeQueuedMessage({
+      id: "qmsg-server",
+      content: [{ type: "text", text: "Queue this", mentions: [] }],
+      createdAt: 10,
+      updatedAt: 10,
+    });
+    applyQueuedMessageCreateResult({
+      queryClient,
+      queuedMessage: serverQueuedMessage,
+      threadId: "thread-1",
+      transaction,
+    });
+
+    expect(
+      queryClient
+        .getQueryData<
+          ThreadQueuedMessage[]
+        >(threadQueuedMessagesQueryKey("thread-1"))
+        ?.map((queuedMessage) => queuedMessage.id),
+    ).toEqual(["qmsg-existing", "qmsg-server"]);
+    expect(
+      queryClient.getQueryData(threadPromptHistoryQueryKey("thread-1")),
+    ).toEqual([
+      {
+        id: "queued-message:qmsg-server",
+        createdAt: 10,
+        input: [{ type: "text", text: "Queue this", mentions: [] }],
+      },
+    ]);
+  });
+
+  it("rolls back optimistic queued message creation", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const previousQueue = [makeQueuedMessage({ id: "qmsg-existing" })];
+    queryClient.setQueryData(
+      threadQueuedMessagesQueryKey("thread-1"),
+      previousQueue,
+    );
+
+    const transaction = await beginCreateQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        input: [{ type: "text", text: "Queue this", mentions: [] }],
+      },
+    });
+    rollbackCreateQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        input: [{ type: "text", text: "Queue this", mentions: [] }],
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual(previousQueue);
+  });
+
+  it("optimistically queues queue-if-active sends", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    queryClient.setQueryData(threadQueryKey("thread-1"), {
+      status: "active",
+    });
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), []);
+
+    const transaction = await beginSendThreadMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        mode: "queue-if-active",
+        input: [{ type: "text", text: "Queue through send", mentions: [] }],
+      },
+    });
+
+    expect(transaction.kind).toBe("queued-message");
+    expect(
+      queryClient.getQueryData<ThreadQueuedMessage[]>(
+        threadQueuedMessagesQueryKey("thread-1"),
+      ),
+    ).toMatchObject([
+      {
+        id: expect.stringMatching(/^optimistic-queued-/u),
+        content: [{ type: "text", text: "Queue through send", mentions: [] }],
+      },
+    ]);
+
+    rollbackSendThreadMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        mode: "queue-if-active",
+        input: [{ type: "text", text: "Queue through send", mentions: [] }],
+      },
+      transaction,
+    });
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([]);
+  });
+
+  it("optimistically removes queued messages and rolls back on failure", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const previousQueue = [
+      makeQueuedMessage({ id: "qmsg-1" }),
+      makeQueuedMessage({ id: "qmsg-2" }),
+    ];
+    queryClient.setQueryData(
+      threadQueuedMessagesQueryKey("thread-1"),
+      previousQueue,
+    );
+
+    const transaction = await beginRemoveQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        queuedMessageId: "qmsg-1",
+      },
+    });
+
+    expect(
+      queryClient
+        .getQueryData<
+          ThreadQueuedMessage[]
+        >(threadQueuedMessagesQueryKey("thread-1"))
+        ?.map((queuedMessage) => queuedMessage.id),
+    ).toEqual(["qmsg-2"]);
+
+    rollbackRemoveQueuedMessageTransaction({
+      queryClient,
+      request: {
+        id: "thread-1",
+        queuedMessageId: "qmsg-1",
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual(previousQueue);
   });
 });

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -2,10 +2,12 @@ import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { nanoid } from "nanoid";
 import type {
   PromptHistoryEntry,
+  ResolvedThreadExecutionOptions,
   ThreadQueuedMessage,
   ThreadWithRuntime,
 } from "@bb/domain";
 import type {
+  CreateQueuedMessageRequest,
   PromptHistoryResponse,
   ThreadQueuedMessageListResponse,
   ThreadResponse,
@@ -41,6 +43,7 @@ import {
   threadTimelineQueryKeyPrefix,
   threadTimelineTurnSummaryDetailsQueryKeyPrefix,
 } from "../queries/query-keys";
+import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default-execution-options-query";
 import {
   invalidateProjectPromptHistoryQueries,
   invalidateThreadAcceptedMessageQueries,
@@ -71,10 +74,41 @@ interface SendThreadMessageTransactionArgs {
   request: SendThreadMessageMutationRequest;
 }
 
+interface CreateQueuedMessageRequestWithThreadId extends CreateQueuedMessageRequest {
+  id: string;
+}
+
+interface CreateQueuedMessageTransactionArgs {
+  queryClient: QueryClient;
+  request: CreateQueuedMessageRequestWithThreadId;
+}
+
+interface RemoveQueuedMessageRequest {
+  id: string;
+  queuedMessageId: string;
+}
+
+interface RemoveQueuedMessageTransactionArgs {
+  queryClient: QueryClient;
+  request: RemoveQueuedMessageRequest;
+}
+
 interface RollbackSendThreadMessageTransactionArgs {
   queryClient: QueryClient;
   request: SendThreadMessageMutationRequest;
   transaction: SendThreadMessageTransaction | undefined;
+}
+
+interface RollbackCreateQueuedMessageTransactionArgs {
+  queryClient: QueryClient;
+  request: CreateQueuedMessageRequestWithThreadId;
+  transaction: CreateQueuedMessageTransaction | undefined;
+}
+
+interface RollbackRemoveQueuedMessageTransactionArgs {
+  queryClient: QueryClient;
+  request: RemoveQueuedMessageRequest;
+  transaction: RemoveQueuedMessageTransaction | undefined;
 }
 
 interface ApplySendThreadMessageSuccessArgs {
@@ -88,6 +122,7 @@ interface QueuedMessageSuccessArgs {
   queryClient: QueryClient;
   queuedMessage: ThreadQueuedMessage;
   threadId: string;
+  transaction: CreateQueuedMessageTransaction | undefined;
 }
 
 interface ReorderQueuedMessageRequest extends QueuedMessageReorderRequest {
@@ -141,6 +176,12 @@ interface BuildOptimisticUserMessageRowParams {
   threadStatus: ThreadWithRuntime["status"] | null;
 }
 
+interface BuildOptimisticQueuedMessageParams {
+  createdAt: number;
+  queryClient: QueryClient;
+  request: CreateQueuedMessageRequestWithThreadId;
+}
+
 type OptimisticTurnRequestKind = "message" | "steer";
 
 interface OptimisticTurnRequestKindArgs {
@@ -157,6 +198,8 @@ export interface SendThreadMessageAcceptedTurnTransaction {
 
 export interface SendThreadMessageQueuedTransaction {
   kind: "queued-message";
+  optimisticQueuedMessageId: string;
+  previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
 }
 
 export type SendThreadMessageTransaction =
@@ -164,6 +207,15 @@ export type SendThreadMessageTransaction =
   | SendThreadMessageQueuedTransaction;
 
 export interface ReorderQueuedMessageTransaction {
+  previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
+}
+
+export interface CreateQueuedMessageTransaction {
+  optimisticQueuedMessageId: string;
+  previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
+}
+
+export interface RemoveQueuedMessageTransaction {
   previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
 }
 
@@ -191,6 +243,105 @@ function buildQueuedPromptHistoryEntry(
     createdAt: queuedMessage.createdAt,
     input: queuedMessage.content,
   };
+}
+
+function getCachedDefaultExecutionOptions(
+  queryClient: QueryClient,
+  threadId: string,
+): ResolvedThreadExecutionOptions | null | undefined {
+  return queryClient.getQueryData<ResolvedThreadExecutionOptions | null>(
+    threadDefaultExecutionOptionsQueryKey(threadId),
+  );
+}
+
+function buildOptimisticQueuedMessage({
+  createdAt,
+  queryClient,
+  request,
+}: BuildOptimisticQueuedMessageParams): ThreadQueuedMessage {
+  const defaultExecutionOptions = getCachedDefaultExecutionOptions(
+    queryClient,
+    request.id,
+  );
+
+  return {
+    id: `optimistic-queued-${nanoid()}`,
+    content: request.input,
+    model: request.model ?? defaultExecutionOptions?.model ?? "pending",
+    reasoningLevel:
+      request.reasoningLevel ??
+      defaultExecutionOptions?.reasoningLevel ??
+      "medium",
+    permissionMode:
+      request.permissionMode ??
+      defaultExecutionOptions?.permissionMode ??
+      "readonly",
+    serviceTier:
+      request.serviceTier ?? defaultExecutionOptions?.serviceTier ?? "default",
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function insertOptimisticQueuedMessage({
+  queryClient,
+  request,
+}: CreateQueuedMessageTransactionArgs): CreateQueuedMessageTransaction {
+  const queryKey = threadQueuedMessagesQueryKey(request.id);
+  const previousQueuedMessages =
+    queryClient.getQueryData<ThreadQueuedMessageListResponse>(queryKey);
+  const optimisticQueuedMessage = buildOptimisticQueuedMessage({
+    createdAt: Date.now(),
+    queryClient,
+    request,
+  });
+
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    queryKey,
+    (currentQueuedMessages) => [
+      ...(currentQueuedMessages ?? []),
+      optimisticQueuedMessage,
+    ],
+  );
+
+  return {
+    optimisticQueuedMessageId: optimisticQueuedMessage.id,
+    previousQueuedMessages,
+  };
+}
+
+function restoreQueuedMessageSnapshot({
+  previousQueuedMessages,
+  queryClient,
+  threadId,
+}: {
+  previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
+  queryClient: QueryClient;
+  threadId: string;
+}): void {
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    threadQueuedMessagesQueryKey(threadId),
+    previousQueuedMessages ?? [],
+  );
+}
+
+function removeCachedQueuedMessage({
+  queryClient,
+  request,
+}: RemoveQueuedMessageTransactionArgs): RemoveQueuedMessageTransaction {
+  const queryKey = threadQueuedMessagesQueryKey(request.id);
+  const previousQueuedMessages =
+    queryClient.getQueryData<ThreadQueuedMessageListResponse>(queryKey);
+
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    queryKey,
+    (currentQueuedMessages) =>
+      currentQueuedMessages?.filter(
+        (queuedMessage) => queuedMessage.id !== request.queuedMessageId,
+      ) ?? currentQueuedMessages,
+  );
+
+  return { previousQueuedMessages };
 }
 
 function prependProjectPromptHistory(
@@ -346,10 +497,7 @@ export function applyCreateThreadResult({
   request,
   thread,
 }: CreateThreadSuccessArgs): void {
-  queryClient.setQueryData<ThreadResponse>(
-    threadQueryKey(thread.id),
-    thread,
-  );
+  queryClient.setQueryData<ThreadResponse>(threadQueryKey(thread.id), thread);
   optimisticallyInsertThread(queryClient, thread);
   prependProjectPromptHistory(
     queryClient,
@@ -381,10 +529,18 @@ export async function beginSendThreadMessageTransaction({
     threadQueryKey(request.id),
   );
   if (requestWillQueueForActiveThread(request, previousThread)) {
+    const queryKey = threadQueuedMessagesQueryKey(request.id);
     await queryClient.cancelQueries({
-      queryKey: threadQueuedMessagesQueryKey(request.id),
+      queryKey,
     });
-    return { kind: "queued-message" };
+    const transaction = insertOptimisticQueuedMessage({
+      queryClient,
+      request,
+    });
+    return {
+      kind: "queued-message",
+      ...transaction,
+    };
   }
 
   await Promise.all([
@@ -436,6 +592,14 @@ export function rollbackSendThreadMessageTransaction({
   request,
   transaction,
 }: RollbackSendThreadMessageTransactionArgs): void {
+  if (transaction?.kind === "queued-message") {
+    restoreQueuedMessageSnapshot({
+      previousQueuedMessages: transaction.previousQueuedMessages,
+      queryClient,
+      threadId: request.id,
+    });
+    return;
+  }
   if (transaction?.kind !== "accepted-turn") {
     return;
   }
@@ -484,17 +648,100 @@ export function applySendThreadMessageSuccess({
   });
 }
 
+export async function beginCreateQueuedMessageTransaction({
+  queryClient,
+  request,
+}: CreateQueuedMessageTransactionArgs): Promise<CreateQueuedMessageTransaction> {
+  await queryClient.cancelQueries({
+    queryKey: threadQueuedMessagesQueryKey(request.id),
+  });
+  return insertOptimisticQueuedMessage({ queryClient, request });
+}
+
+export function rollbackCreateQueuedMessageTransaction({
+  queryClient,
+  request,
+  transaction,
+}: RollbackCreateQueuedMessageTransactionArgs): void {
+  if (!transaction) {
+    return;
+  }
+  restoreQueuedMessageSnapshot({
+    previousQueuedMessages: transaction.previousQueuedMessages,
+    queryClient,
+    threadId: request.id,
+  });
+}
+
 export function applyQueuedMessageCreateResult({
   queryClient,
   queuedMessage,
   threadId,
+  transaction,
 }: QueuedMessageSuccessArgs): void {
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    threadQueuedMessagesQueryKey(threadId),
+    (currentQueuedMessages) => {
+      if (!currentQueuedMessages) {
+        return [queuedMessage];
+      }
+      if (
+        currentQueuedMessages.some(
+          (currentQueuedMessage) =>
+            currentQueuedMessage.id === queuedMessage.id,
+        )
+      ) {
+        return currentQueuedMessages;
+      }
+
+      const optimisticQueuedMessageId =
+        transaction?.optimisticQueuedMessageId ?? null;
+      if (optimisticQueuedMessageId !== null) {
+        const optimisticIndex = currentQueuedMessages.findIndex(
+          (currentQueuedMessage) =>
+            currentQueuedMessage.id === optimisticQueuedMessageId,
+        );
+        if (optimisticIndex !== -1) {
+          const nextQueuedMessages = [...currentQueuedMessages];
+          nextQueuedMessages[optimisticIndex] = queuedMessage;
+          return nextQueuedMessages;
+        }
+      }
+
+      return [...currentQueuedMessages, queuedMessage];
+    },
+  );
   prependThreadPromptHistory(
     queryClient,
     threadId,
     buildQueuedPromptHistoryEntry(queuedMessage),
   );
   invalidateThreadQueueQueries({ queryClient, threadId });
+}
+
+export async function beginRemoveQueuedMessageTransaction({
+  queryClient,
+  request,
+}: RemoveQueuedMessageTransactionArgs): Promise<RemoveQueuedMessageTransaction> {
+  await queryClient.cancelQueries({
+    queryKey: threadQueuedMessagesQueryKey(request.id),
+  });
+  return removeCachedQueuedMessage({ queryClient, request });
+}
+
+export function rollbackRemoveQueuedMessageTransaction({
+  queryClient,
+  request,
+  transaction,
+}: RollbackRemoveQueuedMessageTransactionArgs): void {
+  if (!transaction) {
+    return;
+  }
+  restoreQueuedMessageSnapshot({
+    previousQueuedMessages: transaction.previousQueuedMessages,
+    queryClient,
+    threadId: request.id,
+  });
 }
 
 export function applyQueuedMessageSendResult({

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   CreateQueuedMessageRequest,
   PromptHistoryResponse,
+  SendQueuedMessageMode,
   ThreadQueuedMessageListResponse,
   ThreadResponse,
   TimelineConversationAttachments,
@@ -88,9 +89,18 @@ interface RemoveQueuedMessageRequest {
   queuedMessageId: string;
 }
 
+interface SendQueuedMessageRequest extends RemoveQueuedMessageRequest {
+  mode: SendQueuedMessageMode;
+}
+
 interface RemoveQueuedMessageTransactionArgs {
   queryClient: QueryClient;
   request: RemoveQueuedMessageRequest;
+}
+
+interface SendQueuedMessageTransactionArgs {
+  queryClient: QueryClient;
+  request: SendQueuedMessageRequest;
 }
 
 interface RollbackSendThreadMessageTransactionArgs {
@@ -216,7 +226,9 @@ export interface CreateQueuedMessageTransaction {
 }
 
 export interface RemoveQueuedMessageTransaction {
+  optimisticRowId: string | null;
   previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
+  previousThread: ThreadResponse | undefined;
 }
 
 export interface StopThreadTransaction {
@@ -341,7 +353,11 @@ function removeCachedQueuedMessage({
       ) ?? currentQueuedMessages,
   );
 
-  return { previousQueuedMessages };
+  return {
+    optimisticRowId: null,
+    previousQueuedMessages,
+    previousThread: undefined,
+  };
 }
 
 function prependProjectPromptHistory(
@@ -458,6 +474,33 @@ function buildOptimisticUserMessageRow({
   };
 }
 
+function applyOptimisticAcceptedTurnThreadState({
+  createdAt,
+  queryClient,
+  threadId,
+}: {
+  createdAt: number;
+  queryClient: QueryClient;
+  threadId: string;
+}): void {
+  updateCachedThread(queryClient, threadId, (thread) => ({
+    ...thread,
+    status: "active",
+    updatedAt: Math.max(thread.updatedAt, createdAt),
+    runtime: {
+      ...thread.runtime,
+      // Flip displayStatus so the working indicator mounts with the optimistic
+      // user-message row. Preserve host blockers because promoting them to
+      // "active" would misrepresent host readiness.
+      displayStatus:
+        thread.runtime.displayStatus === "host-reconnecting" ||
+        thread.runtime.displayStatus === "waiting-for-host"
+          ? thread.runtime.displayStatus
+          : "active",
+    },
+  }));
+}
+
 function applyOptimisticStopRequest({
   queryClient,
   requestedAt,
@@ -553,22 +596,11 @@ export async function beginSendThreadMessageTransaction({
   ]);
   const optimisticCreatedAt = Date.now();
 
-  updateCachedThread(queryClient, request.id, (thread) => ({
-    ...thread,
-    status: "active",
-    updatedAt: Math.max(thread.updatedAt, optimisticCreatedAt),
-    runtime: {
-      ...thread.runtime,
-      // Flip displayStatus so the working indicator mounts with the optimistic
-      // user-message row. Preserve host blockers because promoting them to
-      // "active" would misrepresent host readiness.
-      displayStatus:
-        thread.runtime.displayStatus === "host-reconnecting" ||
-        thread.runtime.displayStatus === "waiting-for-host"
-          ? thread.runtime.displayStatus
-          : "active",
-    },
-  }));
+  applyOptimisticAcceptedTurnThreadState({
+    createdAt: optimisticCreatedAt,
+    queryClient,
+    threadId: request.id,
+  });
 
   const optimisticRow = buildOptimisticUserMessageRow({
     createdAt: optimisticCreatedAt,
@@ -729,6 +761,74 @@ export async function beginRemoveQueuedMessageTransaction({
   return removeCachedQueuedMessage({ queryClient, request });
 }
 
+export async function beginSendQueuedMessageTransaction({
+  queryClient,
+  request,
+}: SendQueuedMessageTransactionArgs): Promise<RemoveQueuedMessageTransaction> {
+  await Promise.all([
+    queryClient.cancelQueries({
+      queryKey: threadQueuedMessagesQueryKey(request.id),
+    }),
+    queryClient.cancelQueries({ queryKey: threadQueryKey(request.id) }),
+    queryClient.cancelQueries({
+      queryKey: threadTimelineQueryKeyPrefix(request.id),
+    }),
+    queryClient.cancelQueries({
+      queryKey: threadTimelineTurnSummaryDetailsQueryKeyPrefix(request.id),
+    }),
+  ]);
+
+  const previousQueuedMessages =
+    queryClient.getQueryData<ThreadQueuedMessageListResponse>(
+      threadQueuedMessagesQueryKey(request.id),
+    );
+  const queuedMessage = previousQueuedMessages?.find(
+    (currentQueuedMessage) =>
+      currentQueuedMessage.id === request.queuedMessageId,
+  );
+  const previousThread = queryClient.getQueryData<ThreadResponse>(
+    threadQueryKey(request.id),
+  );
+
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    threadQueuedMessagesQueryKey(request.id),
+    (currentQueuedMessages) =>
+      currentQueuedMessages?.filter(
+        (currentQueuedMessage) =>
+          currentQueuedMessage.id !== request.queuedMessageId,
+      ) ?? currentQueuedMessages,
+  );
+
+  if (!queuedMessage) {
+    return {
+      optimisticRowId: null,
+      previousQueuedMessages,
+      previousThread,
+    };
+  }
+
+  const optimisticCreatedAt = Date.now();
+  applyOptimisticAcceptedTurnThreadState({
+    createdAt: optimisticCreatedAt,
+    queryClient,
+    threadId: request.id,
+  });
+  const optimisticRow = buildOptimisticUserMessageRow({
+    createdAt: optimisticCreatedAt,
+    input: queuedMessage.content,
+    mode: request.mode,
+    threadId: request.id,
+    threadStatus: previousThread?.status ?? null,
+  });
+  insertOptimisticTimelineRow(queryClient, request.id, optimisticRow);
+
+  return {
+    optimisticRowId: optimisticRow.id,
+    previousQueuedMessages,
+    previousThread,
+  };
+}
+
 export function rollbackRemoveQueuedMessageTransaction({
   queryClient,
   request,
@@ -736,6 +836,19 @@ export function rollbackRemoveQueuedMessageTransaction({
 }: RollbackRemoveQueuedMessageTransactionArgs): void {
   if (!transaction) {
     return;
+  }
+  if (transaction.optimisticRowId !== null) {
+    removeOptimisticTimelineRow(
+      queryClient,
+      request.id,
+      transaction.optimisticRowId,
+    );
+  }
+  if (transaction.previousThread) {
+    queryClient.setQueryData<ThreadResponse>(
+      threadQueryKey(request.id),
+      transaction.previousThread,
+    );
   }
   restoreQueuedMessageSnapshot({
     previousQueuedMessages: transaction.previousQueuedMessages,

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ThreadQueuedMessage } from "@bb/domain";
+import type { ExistingThreadExecutionInputSources } from "@bb/server-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/api";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  useCreateThreadQueuedMessage,
+  useSendThreadMessage,
+} from "./thread-runtime-mutations";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    createThreadQueuedMessage: vi.fn(),
+    sendThreadMessage: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/ws", () => ({
+  wsManager: {
+    getConnectionState: vi.fn(() => "connected"),
+  },
+}));
+
+function makeQueuedMessage(
+  message: Partial<ThreadQueuedMessage> = {},
+): ThreadQueuedMessage {
+  return {
+    id: "qmsg-1",
+    content: [{ type: "text", text: "Queued message", mentions: [] }],
+    model: "codex-test",
+    reasoningLevel: "medium",
+    permissionMode: "readonly",
+    serviceTier: "default",
+    createdAt: 1,
+    updatedAt: 1,
+    ...message,
+  };
+}
+
+const executionInputSources = {
+  model: "explicit",
+  serviceTier: "client-preference",
+  reasoningLevel: "explicit",
+  permissionMode: "client-preference",
+} satisfies ExistingThreadExecutionInputSources;
+
+beforeEach(() => {
+  vi.mocked(api.sendThreadMessage).mockResolvedValue(undefined);
+  vi.mocked(api.createThreadQueuedMessage).mockResolvedValue(
+    makeQueuedMessage(),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("thread runtime mutations", () => {
+  it("forwards execution input sources when sending a thread message", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(() => useSendThreadMessage(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "thread-1",
+        mode: "auto",
+        input: [{ type: "text", text: "Run this", mentions: [] }],
+        executionInputSources,
+      });
+    });
+
+    expect(api.sendThreadMessage).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        executionInputSources,
+      }),
+    );
+  });
+
+  it("forwards execution input sources and sender thread when queueing a message", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(() => useCreateThreadQueuedMessage(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "thread-1",
+        input: [{ type: "text", text: "Queue this", mentions: [] }],
+        senderThreadId: "thread-source",
+        executionInputSources,
+      });
+    });
+
+    expect(api.createThreadQueuedMessage).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        executionInputSources,
+        senderThreadId: "thread-source",
+      }),
+    );
+  });
+});

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -18,14 +18,20 @@ import {
   applyQueuedMessageReorderResult,
   applyQueuedMessageSendResult,
   applySendThreadMessageSuccess,
+  beginCreateQueuedMessageTransaction,
   beginCreateThreadTransaction,
+  beginRemoveQueuedMessageTransaction,
   beginReorderQueuedMessageTransaction,
   beginSendThreadMessageTransaction,
   beginStopThreadTransaction,
+  rollbackCreateQueuedMessageTransaction,
+  rollbackRemoveQueuedMessageTransaction,
   rollbackReorderQueuedMessageTransaction,
   rollbackSendThreadMessageTransaction,
   rollbackStopThreadTransaction,
   settleStopThreadTransaction,
+  type CreateQueuedMessageTransaction,
+  type RemoveQueuedMessageTransaction,
   type ReorderQueuedMessageTransaction,
   type SendThreadMessageTransaction,
   type StopThreadTransaction,
@@ -88,6 +94,7 @@ export function useSendThreadMessage() {
       permissionMode,
       mode,
       senderThreadId,
+      executionInputSources,
     }: SendThreadMessageMutationRequest) =>
       api.sendThreadMessage(id, {
         input,
@@ -95,6 +102,7 @@ export function useSendThreadMessage() {
         serviceTier,
         reasoningLevel,
         permissionMode,
+        executionInputSources,
         mode,
         // Non-null only for cross-thread sends (e.g. a side chat handing a
         // result back); the target renders it as "Message from {sender}".
@@ -139,6 +147,8 @@ export function useCreateThreadQueuedMessage() {
       serviceTier,
       reasoningLevel,
       permissionMode,
+      senderThreadId,
+      executionInputSources,
     }: CreateThreadQueuedMessageMutationRequest): Promise<ThreadQueuedMessage> =>
       api.createThreadQueuedMessage(id, {
         input,
@@ -146,12 +156,27 @@ export function useCreateThreadQueuedMessage() {
         serviceTier,
         reasoningLevel,
         permissionMode,
+        executionInputSources,
+        ...(senderThreadId !== undefined ? { senderThreadId } : {}),
       }),
-    onSuccess: (queuedMessage, variables) => {
+    onMutate: async (variables): Promise<CreateQueuedMessageTransaction> =>
+      beginCreateQueuedMessageTransaction({
+        queryClient,
+        request: variables,
+      }),
+    onError: (_error, variables, context) => {
+      rollbackCreateQueuedMessageTransaction({
+        queryClient,
+        request: variables,
+        transaction: context,
+      });
+    },
+    onSuccess: (queuedMessage, variables, context) => {
       applyQueuedMessageCreateResult({
         queryClient,
         queuedMessage,
         threadId: variables.id,
+        transaction: context,
       });
     },
   });
@@ -172,6 +197,18 @@ export function useSendThreadQueuedMessage() {
       queuedMessageId,
     }: SendThreadQueuedMessageMutationRequest): Promise<SendQueuedMessageResponse> =>
       api.sendThreadQueuedMessage(id, queuedMessageId, { mode }),
+    onMutate: async (variables): Promise<RemoveQueuedMessageTransaction> =>
+      beginRemoveQueuedMessageTransaction({
+        queryClient,
+        request: variables,
+      }),
+    onError: (_error, variables, context) => {
+      rollbackRemoveQueuedMessageTransaction({
+        queryClient,
+        request: variables,
+        transaction: context,
+      });
+    },
     onSuccess: (_data, variables) => {
       applyQueuedMessageSendResult({
         queryClient,
@@ -235,6 +272,18 @@ export function useDeleteThreadQueuedMessage() {
       queuedMessageId,
     }: DeleteThreadQueuedMessageMutationRequest) =>
       api.deleteThreadQueuedMessage(id, queuedMessageId),
+    onMutate: async (variables): Promise<RemoveQueuedMessageTransaction> =>
+      beginRemoveQueuedMessageTransaction({
+        queryClient,
+        request: variables,
+      }),
+    onError: (_error, variables, context) => {
+      rollbackRemoveQueuedMessageTransaction({
+        queryClient,
+        request: variables,
+        transaction: context,
+      });
+    },
     onSuccess: (_data, variables) => {
       applyQueuedMessageDeleteResult({
         queryClient,

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -22,6 +22,7 @@ import {
   beginCreateThreadTransaction,
   beginRemoveQueuedMessageTransaction,
   beginReorderQueuedMessageTransaction,
+  beginSendQueuedMessageTransaction,
   beginSendThreadMessageTransaction,
   beginStopThreadTransaction,
   rollbackCreateQueuedMessageTransaction,
@@ -198,7 +199,7 @@ export function useSendThreadQueuedMessage() {
     }: SendThreadQueuedMessageMutationRequest): Promise<SendQueuedMessageResponse> =>
       api.sendThreadQueuedMessage(id, queuedMessageId, { mode }),
     onMutate: async (variables): Promise<RemoveQueuedMessageTransaction> =>
-      beginRemoveQueuedMessageTransaction({
+      beginSendQueuedMessageTransaction({
         queryClient,
         request: variables,
       }),


### PR DESCRIPTION
## Summary
- optimistically insert queued-message rows for queue create and queue-if-active sends
- optimistically remove queued rows for send/delete with rollback on failure
- optimistically project sent queued messages into the timeline using the same user-message row shape as regular follow-ups
- forward executionInputSources and queued senderThreadId through runtime mutations

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/cache-owners/thread-runtime-cache-owner.test.ts src/hooks/mutations/thread-runtime-mutations.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
