### PR TITLE
Mark active side-chat panel threads read

### DIFF
--- a/apps/app/src/components/secondary-panel/SideChatTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/SideChatTabContent.tsx
@@ -64,7 +64,11 @@ import {
   useSendThreadQueuedMessage,
   useSendThreadMessage,
 } from "@/hooks/mutations/thread-runtime-mutations";
-import { useDeleteThread } from "@/hooks/mutations/thread-state-mutations";
+import {
+  useDeleteThread,
+  useMarkThreadRead,
+} from "@/hooks/mutations/thread-state-mutations";
+import { useThreadReadTracking } from "@/hooks/useThreadReadTracking";
 import {
   SIDE_CHAT_PERMISSION_MODE,
   buildSideChatMessageInput,
@@ -112,6 +116,8 @@ export interface SetSideChatThreadId {
 }
 
 export interface SideChatTabContentProps {
+  /** Only the active side-chat tab is visible; inactive tabs stay mounted. */
+  isActive: boolean;
   tab: SideChatFixedPanelTab;
   /** The main thread the side chat is anchored to (lineage + provider source). */
   sourceThread: Thread;
@@ -298,6 +304,7 @@ function SideChatConversation({
  * cross-thread send transport (`senderThreadId`).
  */
 export function SideChatTabContent({
+  isActive,
   tab,
   sourceThread,
   sourceEnvironment,
@@ -309,6 +316,7 @@ export function SideChatTabContent({
   const createQueuedMessage = useCreateThreadQueuedMessage();
   const deleteQueuedMessage = useDeleteThreadQueuedMessage();
   const deleteThread = useDeleteThread();
+  const markThreadRead = useMarkThreadRead();
   const reorderQueuedMessage = useReorderThreadQueuedMessage();
   const sendQueuedMessage = useSendThreadQueuedMessage();
   const sendThreadMessage = useSendThreadMessage();
@@ -318,6 +326,10 @@ export function SideChatTabContent({
   );
   const childThreadQuery = useThread(childThreadId ?? "", {
     enabled: childThreadId !== null,
+  });
+  useThreadReadTracking({
+    markThreadRead,
+    thread: isActive ? childThreadQuery.data : undefined,
   });
   // Build the SAME execution + permission configs the main thread builds (see
   // ThreadDetailPromptArea), seeded from the parent thread's resolved options

--- a/apps/app/src/components/secondary-panel/SideChatTabDeck.tsx
+++ b/apps/app/src/components/secondary-panel/SideChatTabDeck.tsx
@@ -58,6 +58,7 @@ export function SideChatTabDeck({
             className={cn(isActive ? "flex min-h-0 flex-1 flex-col" : "hidden")}
           >
             <SideChatTabContent
+              isActive={isActive}
               tab={tab}
               sourceThread={sourceThread}
               sourceEnvironment={sourceEnvironment}

--- a/apps/app/src/hooks/useThreadReadTracking.test.tsx
+++ b/apps/app/src/hooks/useThreadReadTracking.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useThreadReadTracking } from "./useThreadReadTracking";
+
+type MarkThreadReadMutation = Parameters<
+  typeof useThreadReadTracking
+>[0]["markThreadRead"];
+type MutateOptions = Parameters<MarkThreadReadMutation["mutate"]>[1];
+
+function makeMarkThreadRead() {
+  return {
+    mutate: vi.fn<MarkThreadReadMutation["mutate"]>(),
+  } satisfies MarkThreadReadMutation;
+}
+
+describe("useThreadReadTracking", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not mark read without a visible thread", () => {
+    const markThreadRead = makeMarkThreadRead();
+
+    renderHook(() =>
+      useThreadReadTracking({
+        markThreadRead,
+        thread: undefined,
+      }),
+    );
+
+    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+  });
+
+  it("marks an unread thread once per attention timestamp", () => {
+    const markThreadRead = makeMarkThreadRead();
+    const { rerender } = renderHook(
+      ({ latestAttentionAt }: { latestAttentionAt: number }) =>
+        useThreadReadTracking({
+          markThreadRead,
+          thread: {
+            id: "thr_side_chat",
+            lastReadAt: 10,
+            latestAttentionAt,
+          },
+        }),
+      { initialProps: { latestAttentionAt: 20 } },
+    );
+
+    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
+      "thr_side_chat",
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+
+    rerender({ latestAttentionAt: 20 });
+    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
+
+    rerender({ latestAttentionAt: 30 });
+    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows retrying a failed read marker", () => {
+    const markThreadRead = makeMarkThreadRead();
+    const { rerender } = renderHook(() =>
+      useThreadReadTracking({
+        markThreadRead,
+        thread: {
+          id: "thr_side_chat",
+          lastReadAt: 10,
+          latestAttentionAt: 20,
+        },
+      }),
+    );
+    const options: MutateOptions | undefined =
+      markThreadRead.mutate.mock.calls[0]?.[1];
+
+    options?.onError?.();
+    rerender();
+
+    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/app/src/hooks/useThreadReadTracking.ts
+++ b/apps/app/src/hooks/useThreadReadTracking.ts
@@ -1,11 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import type { Thread } from "@bb/domain";
-import { isThreadRead } from "@/lib/thread-read-state";
-import { useMarkThreadRead } from "../../hooks/mutations/thread-state-mutations";
+import {
+  isThreadRead,
+  type ThreadReadState,
+} from "@/lib/thread-read-state";
+
+type ThreadReadTrackingState = ThreadReadState & Pick<Thread, "id">;
+
+interface MarkThreadReadMutation {
+  mutate: (threadId: string, options?: { onError?: () => void }) => void;
+}
 
 interface UseThreadReadTrackingParams {
-  markThreadRead: ReturnType<typeof useMarkThreadRead>;
-  thread?: Thread;
+  markThreadRead: MarkThreadReadMutation;
+  thread?: ThreadReadTrackingState;
 }
 
 function isDocumentVisible(): boolean {

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -134,7 +134,7 @@ import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/pr
 import type { SecondaryPanelFileTab } from "@/components/secondary-panel/ThreadSecondaryPanel";
 import { useEnvironmentMergeBase } from "@/components/secondary-panel/git-diff/useEnvironmentMergeBase";
 import { useThreadGitActions } from "./useThreadGitActions";
-import { useThreadReadTracking } from "./useThreadReadTracking";
+import { useThreadReadTracking } from "@/hooks/useThreadReadTracking";
 import { useThreadUnreadDividerState } from "./useThreadUnreadDividerState";
 import { useThreadTimelinePages } from "./useThreadTimelinePages";
 import {


### PR DESCRIPTION
## Summary
- move thread read tracking into a shared hook
- mark a side-chat child thread read when its side-chat tab is the active visible tab
- keep inactive mounted side-chat tabs from being marked read

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/useThreadReadTracking.test.tsx src/components/layout/faviconUnreadCount.test.ts src/components/sidebar/projectThreadGroups.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app --force