### PR TITLE
[codex] Remove self-thread labels from system rows

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -1277,10 +1277,10 @@ function leadingIconForWorkRow(
 }
 
 /**
- * Per-action leading glyph for Family-A system operation rows, keyed by
- * `operationKind` (and the parent-change action) so each lifecycle event reads
- * at a glance. Warning / deprecation / provider-unhandled / generic and
- * non-operation system rows keep no leading glyph.
+ * Per-action leading glyph for system operation rows, keyed by `operationKind`
+ * (and the parent-change action) so each lifecycle event reads at a glance.
+ * Warning / deprecation / provider-unhandled / generic and non-operation system
+ * rows keep no leading glyph.
  */
 // Pure operation-kind → leading-icon mapping (exported for exhaustive testing).
 // Warning / deprecation / provider-unhandled / generic keep no leading glyph.

--- a/apps/app/src/components/thread/timeline/rows/System.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/System.stories.tsx
@@ -39,7 +39,7 @@ const provisioningPending: TimelineRow = systemRow({
   createdAt: Date.now(),
   systemKind: "operation",
   operationKind: "thread-provisioning",
-  title: "Provisioning Fix auth bug",
+  title: "Provisioning thread",
   detail:
     "Creating worktree (305ms)\n" +
     "HEAD is now at 37eeec85 Refactor timeline row titles\n" +
@@ -67,7 +67,7 @@ const provisioningCompleted: TimelineRow = systemRow({
   createdAt: 1778027670469,
   systemKind: "operation",
   operationKind: "thread-provisioning",
-  title: "Fix auth bug provisioned",
+  title: "Provisioned thread",
   detail:
     "Created worktree (305ms)\n" +
     "Using workspace: /Users/michael/.bb-dev/worktrees/env_etyr7f84cg/bb\n" +
@@ -132,7 +132,7 @@ const threadInterruptedManualStop: TimelineRow = systemRow({
   createdAt: 1776810312000,
   systemKind: "operation",
   operationKind: "thread-interrupted",
-  title: "Investigate timeline stopped manually",
+  title: "Stopped manually",
   detail: null,
   status: "interrupted",
   completedAt: 1776810312000,

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -71,8 +71,8 @@ interface ThreadTimelineFromEventsBaseOptions {
   isLatestPage: boolean;
   threadStatus: Thread["status"];
   /**
-   * Display name of the thread, interpolated into Family-A operation-row titles
-   * (e.g. "Fix auth bug provisioned"). Empty string when the thread is unnamed.
+   * Display name of the thread, used by operation rows that describe a
+   * relationship to another thread. Empty string when the thread is unnamed.
    */
   threadName: string;
   /**

--- a/packages/thread-view/src/event-projection-message.ts
+++ b/packages/thread-view/src/event-projection-message.ts
@@ -419,9 +419,9 @@ export interface BuildEventProjectionMessagesOptions {
   includeProviderUnhandledOperations?: boolean;
   threadStatus?: Thread["status"];
   /**
-   * Display name of the thread these messages belong to. Family-A operation-row
-   * titles interpolate it (e.g. "Fix auth bug provisioned"). Empty string when
-   * the thread has no name; the title builders fall back to a bare verb.
+   * Display name of the thread these messages belong to. Used by operation rows
+   * that describe a relationship to another thread. Empty string when the thread
+   * has no name; the title builders fall back to a bare verb.
    */
   threadName: string;
 }

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -191,7 +191,6 @@ function getMessageTurnFinalization(
 function finalizePendingMessageForInterruptedTurn(
   message: EventProjectionMessage,
   finalization: TurnPendingFinalization,
-  threadName: string,
 ): void {
   if (finalization.status !== "interrupted") {
     return;
@@ -210,7 +209,7 @@ function finalizePendingMessageForInterruptedTurn(
       }
       return;
     case "operation":
-      interruptOperationMessage(message, threadName);
+      interruptOperationMessage(message);
       return;
     case "permission-grant-lifecycle":
       if (message.status === "pending") {
@@ -233,10 +232,7 @@ function finalizePendingMessageForInterruptedTurn(
   }
 }
 
-function finalizeInterruptedTurnPendingMessages(
-  state: ProjectionState,
-  threadName: string,
-): void {
+function finalizeInterruptedTurnPendingMessages(state: ProjectionState): void {
   if (state.pendingFinalizationByTurnId.size === 0) {
     return;
   }
@@ -256,16 +252,13 @@ function finalizeInterruptedTurnPendingMessages(
     if (!finalization) {
       continue;
     }
-    finalizePendingMessageForInterruptedTurn(message, finalization, threadName);
+    finalizePendingMessageForInterruptedTurn(message, finalization);
   }
 }
 
 export function finalizeProjectionState(
   args: FinalizeProjectionMessagesArgs,
 ): void {
-  finalizeInterruptedTurnPendingMessages(
-    args.state,
-    args.options?.threadName ?? "",
-  );
+  finalizeInterruptedTurnPendingMessages(args.state);
   finalizePendingMessages(args);
 }

--- a/packages/thread-view/src/family-a-verbs.ts
+++ b/packages/thread-view/src/family-a-verbs.ts
@@ -1,36 +1,4 @@
 /**
- * Family-A operation-row verb affixes — the single source of truth shared by the
- * flat-title builders (`parse-operation-message.ts`) and the App-side title
- * splitter (`timeline-row-title.ts`). Operation-row `title` stays a flat string
- * on the wire; the App re-splits it around these affixes to compose the linked
- * thread-name segment. Keeping the literals here means a verb copy-edit lands in
- * both the builder and the splitter at once — the two can't desync and silently
- * drop the thread name from the title.
- */
-
-/** Leading verb for the active provisioning row: `"{verb} {thread}"`. */
-export const PROVISIONING_LEADING_VERB = "Provisioning";
-
-/**
- * Suffix verbs for the terminal/post-active provisioning rows:
- * `"{thread} {verb}"`. Includes the post-hoc-override verb
- * (`provisioning interrupted`) that `interruptOperationMessage` writes.
- */
-export const PROVISIONING_SUFFIX_VERBS = [
-  "provisioned",
-  "failed to provision",
-  "provisioning stopped",
-  "provisioning interrupted",
-] as const;
-
-/** Suffix verbs for `thread-interrupted` rows: `"{thread} {verb}"`. */
-export const THREAD_INTERRUPTED_SUFFIX_VERBS = [
-  "stopped manually",
-  "stopped — host daemon restarted",
-  "stopped — provider turn stopped responding",
-] as const;
-
-/**
  * Ownership-change (parent-change) verbs by action. The flat title reads
  * `"{thread} {verb} {parent}"`; the splitter slices on `" {verb} "` to recover
  * the thread name (the parent comes from the row's `parentChange` ids/titles).

--- a/packages/thread-view/src/parse-operation-message.ts
+++ b/packages/thread-view/src/parse-operation-message.ts
@@ -6,14 +6,14 @@ import type {
 import { ownershipChangeOperationMetadataSchema } from "@bb/domain";
 import { assertNever } from "./assert-never.js";
 import { getCompactionKey } from "./compaction-lifecycle.js";
-import {
-  OWNERSHIP_CHANGE_VERBS,
-  PROVISIONING_LEADING_VERB,
-} from "./family-a-verbs.js";
+import { OWNERSHIP_CHANGE_VERBS } from "./family-a-verbs.js";
 import type { EventMeta } from "./event-decode.js";
 import { capitalize, messageId } from "./format-helpers.js";
 import { buildProviderUnhandledDetail } from "./provider-unhandled-detail.js";
-import { readProvisioningTranscript } from "./provisioning-helpers.js";
+import {
+  provisioningTitleForStatus,
+  readProvisioningTranscript,
+} from "./provisioning-helpers.js";
 import type {
   BuildEventProjectionMessagesOptions,
   EventProjectionPermissionGrantGrantScope,
@@ -35,22 +35,13 @@ type ParseOperationMessageOptions = Pick<
 
 /**
  * Prefix a thread name onto a bare action verb, e.g. ("Fix auth bug",
- * "provisioned") → "Fix auth bug provisioned". Falls back to capitalizing the
- * verb when the thread has no name so the title is never an orphaned fragment.
+ * "assigned to parent") → "Fix auth bug assigned to parent". Falls back to
+ * capitalizing the verb when the thread has no name so the title is never an
+ * orphaned fragment.
  */
 function withThreadName(threadName: string, verb: string): string {
   const name = threadName.trim();
   return name.length > 0 ? `${name} ${verb}` : capitalize(verb);
-}
-
-/**
- * Prefix a leading verb onto a thread name, e.g. ("Provisioning", "Fix auth
- * bug") → "Provisioning Fix auth bug". Falls back to "{verb} thread" when the
- * thread has no name.
- */
-function leadingVerbWithThreadName(verb: string, threadName: string): string {
-  const name = threadName.trim();
-  return name.length > 0 ? `${verb} ${name}` : `${verb} thread`;
 }
 
 type PermissionGrantLifecycleEvent = Extract<
@@ -130,19 +121,15 @@ function createThreadOperationMetadata(
 
 function threadInterruptedTitle(
   reason: SystemThreadInterruptedReason,
-  threadName: string,
 ): string {
   switch (reason) {
     case "manual-stop":
-      return withThreadName(threadName, "stopped manually");
+      return "Stopped manually";
     case "host-daemon-restarted":
-      return withThreadName(threadName, "stopped — host daemon restarted");
+      return "Stopped — host daemon restarted";
     // Legacy persisted watchdog interruption; no current producer.
     case "provider-turn-idle":
-      return withThreadName(
-        threadName,
-        "stopped — provider turn stopped responding",
-      );
+      return "Stopped — provider turn stopped responding";
     default:
       return assertNever(reason);
   }
@@ -485,7 +472,7 @@ export function parseOperationMessage(
   if (decoded.type === "system/thread/interrupted") {
     return op(decoded, meta, "thread-interrupted", {
       opType: "thread-interrupted",
-      title: threadInterruptedTitle(decoded.reason, threadName),
+      title: threadInterruptedTitle(decoded.reason),
       status: "interrupted",
     });
   }
@@ -508,30 +495,11 @@ export function parseOperationMessage(
       return null;
     }
     const transcript = readProvisioningTranscript(decoded.entries);
-    const title = (() => {
-      switch (status) {
-        case "active":
-          return leadingVerbWithThreadName(
-            PROVISIONING_LEADING_VERB,
-            threadName,
-          );
-        case "completed":
-          return withThreadName(threadName, "provisioned");
-        case "failed":
-          return withThreadName(threadName, "failed to provision");
-        case "cancelled":
-          return withThreadName(threadName, "provisioning stopped");
-        default:
-          return leadingVerbWithThreadName(
-            PROVISIONING_LEADING_VERB,
-            threadName,
-          );
-      }
-    })();
+    const operationStatus = provisioningOperationStatus(status);
     return op(decoded, meta, "thread-provisioning", {
       opType: "thread-provisioning",
-      title,
-      status: provisioningOperationStatus(status),
+      title: provisioningTitleForStatus(operationStatus),
+      status: operationStatus,
       provisioning: {
         environmentId,
         provisioningId,
@@ -597,7 +565,6 @@ export function parseOperationMessage(
 
 export function interruptOperationMessage(
   message: EventProjectionOperationMessage,
-  threadName: string,
 ): void {
   if (message.status !== "pending") return;
   message.status = "interrupted";
@@ -605,16 +572,13 @@ export function interruptOperationMessage(
 
   switch (message.opType) {
     case "operation":
-      message.title = withThreadName(threadName, "operation interrupted");
+      message.title = "Operation interrupted";
       return;
     case "thread-provisioning":
-      message.title = withThreadName(threadName, "provisioning interrupted");
+      message.title = provisioningTitleForStatus("interrupted");
       return;
     case "compaction":
-      message.title = withThreadName(
-        threadName,
-        "context compaction interrupted",
-      );
+      message.title = "Context compaction interrupted";
       return;
     default:
       return;
@@ -626,13 +590,12 @@ export function finalizeOperationMessage(
   options: BuildEventProjectionMessagesOptions | undefined,
 ): void {
   if (message.status !== "pending") return;
-  const threadName = options?.threadName ?? "";
 
   if (options?.threadStatus === "error") {
     switch (message.opType) {
       case "thread-provisioning":
         message.status = "error";
-        message.title = withThreadName(threadName, "failed to provision");
+        message.title = provisioningTitleForStatus("error");
         message.completedAt = message.createdAt;
         return;
       default:
@@ -640,5 +603,5 @@ export function finalizeOperationMessage(
     }
   }
 
-  interruptOperationMessage(message, threadName);
+  interruptOperationMessage(message);
 }

--- a/packages/thread-view/src/timeline-row-title.ts
+++ b/packages/thread-view/src/timeline-row-title.ts
@@ -13,12 +13,7 @@ import type {
   TimelineWebSearchWorkRow,
 } from "@bb/server-contract";
 import { assertNever } from "./assert-never.js";
-import {
-  OWNERSHIP_CHANGE_VERBS,
-  PROVISIONING_LEADING_VERB,
-  PROVISIONING_SUFFIX_VERBS,
-  THREAD_INTERRUPTED_SUFFIX_VERBS,
-} from "./family-a-verbs.js";
+import { OWNERSHIP_CHANGE_VERBS } from "./family-a-verbs.js";
 import {
   formatFileChangePath,
   getFileChangeAction,
@@ -1222,9 +1217,8 @@ function mapTurnTitle(row: TimelineViewTurnRow): TimelineTitle {
 
 /**
  * The thread (not parent) segment for a parent-change row: emphasized, linked to
- * `row.threadId`, matching `threadNamedSystemTitleSegments` and the agent
- * "Message from [thread]" title. Rendered unlinked (plain emphasized) when the
- * row carries no thread id.
+ * `row.threadId`. Rendered unlinked (plain emphasized) when the row carries no
+ * thread id.
  */
 function parentChangeThreadSegment(
   row: TimelineParentChangeSystemRow,
@@ -1338,70 +1332,6 @@ function mapParentChangeSystemTitle(
   });
 }
 
-/**
- * Compose the thread-name portion of a Family-A operation title as an
- * emphasized, linked segment (the same treatment the agent "Message from
- * [thread]" title uses), with the surrounding action verb left muted. The row
- * carries a flat interpolated `title` plus its `threadId`; this splits the
- * title around the thread name using the fixed template affixes the projection
- * builds (see `parse-operation-message.ts`). Returns `null` when the title has
- * no extractable thread name (unnamed thread → bare verb), so the caller falls
- * back to a single neutral segment.
- */
-function threadNamedSystemTitleSegments(
-  row: TimelineSystemViewRow,
-  shimmer: boolean,
-): TimelineTitleSegment[] | null {
-  if (row.systemKind !== "operation") return null;
-
-  const nameSegment = (name: string): TimelineTitleSegment =>
-    segment(name, {
-      em: true,
-      truncate: true,
-      shimmer,
-      ...(row.threadId.length > 0
-        ? { link: { kind: "thread", threadId: row.threadId } }
-        : {}),
-    });
-
-  // Leading-verb form: "Provisioning {name}". A thread with no id has no name to
-  // link, so the active-provisioning fallback title is "Provisioning thread";
-  // gating on an empty `row.threadId` (rather than the literal "Provisioning
-  // thread") lets a thread literally named "thread" still link correctly.
-  const provisioningPrefix = `${PROVISIONING_LEADING_VERB} `;
-  if (
-    row.operationKind === "thread-provisioning" &&
-    row.threadId.length > 0 &&
-    row.title.startsWith(provisioningPrefix)
-  ) {
-    const name = row.title.slice(provisioningPrefix.length);
-    return [segment(PROVISIONING_LEADING_VERB, { shimmer }), nameSegment(name)];
-  }
-
-  // Suffix form: "{name} {verb...}". The verbs are the fixed strings the
-  // projection emits (shared via family-a-verbs). Matching the LONGEST candidate
-  // affix first keeps the split unambiguous when one verb is a prefix of another
-  // or a thread name itself contains one of these words.
-  const suffixVerbs =
-    row.operationKind === "thread-provisioning"
-      ? PROVISIONING_SUFFIX_VERBS
-      : row.operationKind === "thread-interrupted"
-        ? THREAD_INTERRUPTED_SUFFIX_VERBS
-        : [];
-  const verbsByLengthDesc = [...suffixVerbs].sort(
-    (a, b) => b.length - a.length,
-  );
-  for (const verb of verbsByLengthDesc) {
-    const suffix = ` ${verb}`;
-    if (row.title.endsWith(suffix) && row.title.length > suffix.length) {
-      const name = row.title.slice(0, row.title.length - suffix.length);
-      return [nameSegment(name), segment(verb, { shimmer })];
-    }
-  }
-
-  return null;
-}
-
 function mapSystemTitle(row: TimelineSystemViewRow): TimelineTitle {
   const hasError = row.systemKind === "error" || row.status === "error";
   if (row.systemKind === "operation" && row.operationKind === "parent-change") {
@@ -1425,12 +1355,6 @@ function mapSystemTitle(row: TimelineSystemViewRow): TimelineTitle {
   // status; error rows are terminal and reconnect rows carry no status, so this
   // uniform rule leaves both static.
   const shimmer = row.status === "pending";
-  // Provisioning and thread-interrupted rows link the thread name they concern;
-  // every other system row renders its flat title as a single neutral segment.
-  const threadNamedSegments = threadNamedSystemTitleSegments(row, shimmer);
-  if (threadNamedSegments !== null) {
-    return makeTitle({ segments: threadNamedSegments, decorations });
-  }
   return makeTitle({
     segments: [segment(titleText, { shimmer, truncate: true })],
     decorations,

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -740,7 +740,7 @@ describe("buildThreadTimelineFromEvents", () => {
     expect(
       collectSystemRows(rows).filter(
         (row) =>
-          row.systemKind === "operation" && row.title === "Provisioned",
+          row.systemKind === "operation" && row.title === "Provisioned thread",
       ),
     ).toHaveLength(1);
   });

--- a/packages/thread-view/test/parse-operation-message.test.ts
+++ b/packages/thread-view/test/parse-operation-message.test.ts
@@ -71,36 +71,36 @@ function ownershipTitle(
   return operationTitleFor(row, threadName);
 }
 
-describe("parseOperationMessage Family-A thread-named titles", () => {
+describe("parseOperationMessage operation titles", () => {
   describe("thread-provisioning", () => {
-    it("interpolates the thread name across all lifecycle states", () => {
+    it("keeps self-scoped lifecycle titles free of the current thread name", () => {
       expect(provisioningTitle("active", THREAD_NAME)).toBe(
-        "Provisioning Fix auth bug",
+        "Provisioning thread",
       );
       expect(provisioningTitle("completed", THREAD_NAME)).toBe(
-        "Fix auth bug provisioned",
+        "Provisioned thread",
       );
       expect(provisioningTitle("failed", THREAD_NAME)).toBe(
-        "Fix auth bug failed to provision",
+        "Provisioning thread failed",
       );
       expect(provisioningTitle("cancelled", THREAD_NAME)).toBe(
-        "Fix auth bug provisioning stopped",
+        "Provisioning thread interrupted",
       );
     });
 
-    it("falls back to a bare verb when the thread is unnamed", () => {
+    it("does not depend on whether the thread is named", () => {
       expect(provisioningTitle("active", "")).toBe("Provisioning thread");
-      expect(provisioningTitle("completed", "")).toBe("Provisioned");
+      expect(provisioningTitle("completed", "")).toBe("Provisioned thread");
     });
   });
 
   describe("thread-interrupted", () => {
-    it("names the thread for manual-stop and host-daemon-restarted", () => {
+    it("does not name or link back to the current thread", () => {
       expect(interruptedTitle("manual-stop", THREAD_NAME)).toBe(
-        "Fix auth bug stopped manually",
+        "Stopped manually",
       );
       expect(interruptedTitle("host-daemon-restarted", THREAD_NAME)).toBe(
-        "Fix auth bug stopped — host daemon restarted",
+        "Stopped — host daemon restarted",
       );
     });
   });
@@ -144,7 +144,7 @@ describe("parseOperationMessage Family-A thread-named titles", () => {
     });
   });
 
-  describe("post-hoc overrides keep the thread name", () => {
+  describe("post-hoc overrides stay scoped to the current thread", () => {
     function pendingProvisioning(): EventProjectionOperationMessage {
       const row = factory().threadProvisioning({
         status: "active",
@@ -160,19 +160,19 @@ describe("parseOperationMessage Family-A thread-named titles", () => {
       return message;
     }
 
-    it("interruptOperationMessage re-interpolates the name", () => {
+    it("interruptOperationMessage does not add the current thread name", () => {
       const message = pendingProvisioning();
-      interruptOperationMessage(message, THREAD_NAME);
-      expect(message.title).toBe("Fix auth bug provisioning interrupted");
+      interruptOperationMessage(message);
+      expect(message.title).toBe("Provisioning thread interrupted");
     });
 
-    it("finalizeOperationMessage on error re-interpolates the name", () => {
+    it("finalizeOperationMessage on error does not add the current thread name", () => {
       const message = pendingProvisioning();
       finalizeOperationMessage(message, {
         threadStatus: "error",
         threadName: THREAD_NAME,
       });
-      expect(message.title).toBe("Fix auth bug failed to provision");
+      expect(message.title).toBe("Provisioning thread failed");
     });
   });
 });

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -40,7 +40,7 @@ export interface RenderTimelineFixtureArgs {
   events: ThreadEventRow[];
   includeNestedRows?: boolean;
   // `threadName` defaults to "" so existing fixtures need not supply it; pass a
-  // name to exercise Family-A thread-named operation-row titles.
+  // name to exercise operation rows that describe relationships to other threads.
   projectionOptions: Omit<BuildEventProjectionOptions, "threadName"> & {
     threadName?: string;
   };


### PR DESCRIPTION
## Summary

- Remove redundant current-thread titles/links from self-scoped system operation rows such as provisioning and manual interruption notices.
- Keep relationship-oriented parent-change rows naming/linking the affected thread and parent thread.
- Update timeline stories and regression tests for the new generic self-scoped titles.

## Why

Self-scoped system rows are shown inside the thread they describe. Including the same thread name as a linked subject makes the title repeat context the user is already viewing and links back to the same page.

## Validation

- `pnpm exec turbo run test --filter=@bb/thread-view`
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- `pnpm exec turbo run typecheck --filter=@bb/app`

## Ladle

- `http://localhost:62002/?story=thread--timeline--rows--system--operations`
