### PR TITLE
Sidebar row UX cleanups: cursors, hover affordances, and click-to-toggle

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -469,6 +469,18 @@ function TopLevelSidebarSection({
     },
     [collapseControl],
   );
+  const handleSectionLabelClick = useCallback<MouseEventHandler<HTMLDivElement>>(
+    () => {
+      collapseControl?.onToggleCollapsed();
+    },
+    [collapseControl],
+  );
+  const stopActionsClick = useCallback<MouseEventHandler<HTMLSpanElement>>(
+    (event) => {
+      event.stopPropagation();
+    },
+    [],
+  );
   const stopCollapseControlPointerDown = useCallback<
     PointerEventHandler<HTMLButtonElement>
   >((event) => {
@@ -497,6 +509,7 @@ function TopLevelSidebarSection({
           dragBindings && !dragBindings.disabled && "select-none",
         )}
         title={label}
+        onClick={collapseControl ? handleSectionLabelClick : undefined}
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
       >
@@ -523,7 +536,7 @@ function TopLevelSidebarSection({
               }
               className={cn(
                 !collapseControl.isCollapsed && SIDEBAR_HOVER_ACTIONS_CLASS,
-                "relative z-20 inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2",
+                "relative z-20 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:text-sidebar-foreground focus-visible:ring-2",
               )}
               onClick={handleCollapseControlClick}
               onPointerDown={stopCollapseControlPointerDown}
@@ -541,7 +554,10 @@ function TopLevelSidebarSection({
           ) : null}
         </span>
         {actions ? (
-          <span className="absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center">
+          <span
+            className="absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center"
+            onClick={stopActionsClick}
+          >
             <span
               data-sidebar-hover-actions-mobile={
                 actionsMobileAlways

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -494,9 +494,7 @@ function TopLevelSidebarSection({
           SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
           CHROME_SECTION_LABEL_CLASS,
           "rounded-md pr-1 transition-colors",
-          dragBindings &&
-            !dragBindings.disabled &&
-            "select-none cursor-grab active:cursor-grabbing",
+          dragBindings && !dragBindings.disabled && "select-none",
         )}
         title={label}
         {...dragBindings?.attributes}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1242,7 +1242,7 @@ function ProjectRowComponent({
                 project={project}
                 onOpenChange={setIsDropdownActionsOpen}
                 triggerClassName={cn(
-                  "relative z-10 text-muted-foreground",
+                  "relative z-10 text-muted-foreground hover:bg-transparent",
                   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
                 )}
               />
@@ -1258,7 +1258,7 @@ function ProjectRowComponent({
                   handleCreateThread();
                 }}
                 className={cn(
-                  "rounded-md p-0 text-muted-foreground",
+                  "rounded-md p-0 text-muted-foreground hover:bg-transparent",
                   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
                 )}
               >

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1242,7 +1242,7 @@ function ProjectRowComponent({
                 project={project}
                 onOpenChange={setIsDropdownActionsOpen}
                 triggerClassName={cn(
-                  "relative z-10 text-muted-foreground hover:bg-transparent",
+                  "relative z-10 text-subtle-foreground hover:bg-transparent hover:text-foreground",
                   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
                 )}
               />
@@ -1258,7 +1258,7 @@ function ProjectRowComponent({
                   handleCreateThread();
                 }}
                 className={cn(
-                  "rounded-md p-0 text-muted-foreground hover:bg-transparent",
+                  "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground",
                   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
                 )}
               >

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1175,7 +1175,7 @@ function ProjectRowComponent({
                 : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
               projectDragBindings &&
                 !projectDragBindings.disabled &&
-                "select-none cursor-grab active:cursor-grabbing",
+                "select-none",
             )}
             title={project.name}
             {...projectDragBindings?.attributes}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1178,6 +1178,7 @@ function ProjectRowComponent({
                 "select-none",
             )}
             title={project.name}
+            onClick={handleProjectRowToggle}
             {...projectDragBindings?.attributes}
             {...(projectDragBindings?.listeners ?? {})}
           >

--- a/apps/app/src/components/sidebar/SidebarChildToggleChevron.tsx
+++ b/apps/app/src/components/sidebar/SidebarChildToggleChevron.tsx
@@ -36,7 +36,7 @@ export function SidebarChildToggleChevron({
       }}
       className={cn(
         revealOnHover ? SIDEBAR_HOVER_ACTIONS_CLASS : "pointer-events-auto",
-        "relative z-10 inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-state-hover hover:text-foreground focus-visible:ring-2",
+        "relative z-10 inline-flex size-5 shrink-0 items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:text-foreground focus-visible:ring-2",
       )}
     >
       <Icon

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -313,9 +313,7 @@ function ThreadRowComponent({
     showActive
       ? SIDEBAR_ROW_SELECTED_STATE_CLASS
       : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-    parentDragBindings &&
-      !parentDragBindings.disabled &&
-      "select-none cursor-grab active:cursor-grabbing",
+    parentDragBindings && !parentDragBindings.disabled && "select-none",
   );
   const rowStyle = getThreadRowStyle(options.depth);
   const isActionsOpen = isDropdownActionsOpen || isContextActionsOpen;

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -424,7 +424,7 @@ function ThreadRowComponent({
             <ThreadActionsMenu
               thread={thread}
               triggerClassName={cn(
-                "text-muted-foreground hover:bg-transparent",
+                "text-subtle-foreground hover:bg-transparent hover:text-foreground",
                 COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
               )}
               onOpenChange={setIsDropdownActionsOpen}

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -424,7 +424,7 @@ function ThreadRowComponent({
             <ThreadActionsMenu
               thread={thread}
               triggerClassName={cn(
-                "text-muted-foreground",
+                "text-muted-foreground hover:bg-transparent",
                 COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
               )}
               onOpenChange={setIsDropdownActionsOpen}


### PR DESCRIPTION
## Summary
A series of small UX cleanups to the sidebar rows (projects, threads, and section headers). The theme: a row's children/affordances shouldn't render their own redundant hover/cursor treatments when the whole row is already interactive.

## Changes
- **Chevrons** (`SidebarChildToggleChevron`): removed the pointer cursor and `hover:bg-state-hover` background; the chevron still brightens its text on hover.
- **Grab cursors**: removed `cursor-grab` / `active:cursor-grabbing` from drag-enabled sidebar rows — project rows, thread rows, and section labels — so hovering/dragging no longer shows the open-hand/grabbing cursor.
- **Click-to-toggle**:
  - Clicking anywhere on a **project row** expands/collapses its threads.
  - Clicking anywhere on a **section header** (Projects / Threads) expands/collapses that section.
  - In both cases the chevron/caret and the row action buttons stop propagation so they don't double-toggle, and the existing post-drag click suppression still prevents a toggle after a drag.
- **Row action buttons** (`…` menu, `+` new thread): removed the `ghost` hover background. The icons now rest at `subtle-foreground` and intensify to full `foreground` on hover instead. The open-menu active state is preserved.
- **Section caret** (Projects / Threads headers): removed its `hover:bg-sidebar-accent` background and pointer cursor, keeping only the text brightening — consistent with the row chevrons.

## Notes
The chevron and action-menu components are shared by project and thread rows, so these changes apply consistently to both. Thread rows are intentionally left click-to-navigate (clicking opens the thread), so only their child-toggle chevron collapses sub-threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)