### PR TITLE
Sidebar chronological mode + project chip in composer footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,13 @@
 Use `scripts/bb-dev-app` when validating changes in the desktop dev app or helping QA from this checkout:
 
 - `scripts/bb-dev-app status` prints the active branch, dev URLs, data dir, and logs.
-- `scripts/bb-dev-app current` restarts dev server and desktop on the current branch.
-- `scripts/bb-dev-app main` fetches `origin/main`, fast-forwards `main`, and launches dev server and desktop from this checkout.
-- `scripts/bb-dev-app branch <branch>` switches to a local branch, or creates it from `origin/<branch>`, then launches dev server and desktop.
+- `scripts/bb-dev-app current` restarts the dev server on the current branch.
+- `scripts/bb-dev-app main` fetches `origin/main`, fast-forwards `main`, and launches the dev server from this checkout.
+- `scripts/bb-dev-app branch <branch>` switches to a local branch, or creates it from `origin/<branch>`, then launches the dev server.
 - `scripts/bb-dev-app stop` stops the launcher-managed dev server and desktop.
 - `scripts/bb-dev-app logs dev` and `scripts/bb-dev-app logs desktop` follow logs.
+
+By default the launcher starts only the dev server (web frontend, server, host daemon). Pass `--desktop` (e.g. `scripts/bb-dev-app current --desktop`) to also launch the Electron desktop shell — only do this when the user is testing a desktop-only change.
 
 Branch switches intentionally keep dirty work in this checkout; git will stop if a local file would be overwritten. Set `BB_DEV_APP_STASH_DIRTY=1` for a one-off launch that stashes first.
 

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -18,4 +18,31 @@ describe("ThreadEnvironmentSummary", () => {
     expect(markup).not.toContain(">Working locally</span>");
     expect(markup).toContain('data-icon="Laptop"');
   });
+
+  it("renders the project chip when a project name is provided", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadEnvironmentSummary
+        projectName="Acme"
+        environmentLabel="Working locally"
+        environmentCompactLabel="Local"
+        environmentIcon="Laptop"
+      />,
+    );
+
+    expect(markup).toContain('title="Project: Acme"');
+    expect(markup).toContain('data-icon="Folder"');
+  });
+
+  it("omits the project chip when no project name is provided", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadEnvironmentSummary
+        environmentLabel="Working locally"
+        environmentCompactLabel="Local"
+        environmentIcon="Laptop"
+      />,
+    );
+
+    expect(markup).not.toContain("Project:");
+    expect(markup).not.toContain('data-icon="Folder"');
+  });
 });

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -9,6 +9,8 @@ const CHECKOUT_CHIP_BASE_CLASS_NAME =
 const CHECKOUT_CHIP_BUTTON_CLASS_NAME = `${CHECKOUT_CHIP_BASE_CLASS_NAME} transition-colors hover:bg-state-hover hover:text-foreground`;
 
 export interface ThreadEnvironmentSummaryProps {
+  /** Display name of the thread's project, shown alongside the environment. */
+  projectName?: string;
   /** Full mode label used for the title (e.g. "Working locally" / "Worktree"). */
   environmentLabel?: string;
   /** Visible label used in the promptbox footer. */
@@ -36,6 +38,7 @@ export interface ThreadEnvironmentSummaryProps {
  *   within its available space above that breakpoint.
  */
 export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
+  projectName,
   environmentLabel,
   environmentCompactLabel,
   environmentIcon,
@@ -51,6 +54,17 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
 
   return (
     <div className="flex min-w-0 max-w-full items-center gap-2 pr-1.5">
+      {projectName ? (
+        <OptionDisplay
+          label="Project"
+          value={projectName}
+          compactValue={projectName}
+          leading={<Icon name="Folder" className="size-4 shrink-0" />}
+          className="h-6 max-w-[10rem] shrink-0"
+          title={`Project: ${projectName}`}
+          muted
+        />
+      ) : null}
       <OptionDisplay
         label="Environment"
         value={visibleEnvironmentLabel}

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -60,9 +60,14 @@ import {
   COARSE_POINTER_ROW_HEIGHT_CLASS,
   COARSE_POINTER_TEXT_SM_CLASS,
 } from "@/components/ui/coarse-pointer-sizing.js";
-import { ProjectThreadTree } from "./ProjectRow";
+import { ChronologicalThreadTree, ProjectThreadTree } from "./ProjectRow";
 import { SidebarThreadSearchPanel } from "./SidebarThreadSearchPanel";
 import type { ProjectThreadListState } from "./ProjectRow";
+import {
+  compareByCreatedAtDescending,
+  compareStandardThreads,
+  type ThreadComparator,
+} from "./projectThreadGroups";
 import {
   ProjectListProjects,
   type ProjectListReorderBindings,
@@ -79,10 +84,25 @@ import {
   collapsedProjectIdsAtom,
   collapsedSidebarSectionIdsAtom,
   DEFAULT_SIDEBAR_SECTION_ORDER,
+  sidebarChronologicalSortAtom,
+  sidebarOrganizationModeAtom,
   sidebarSectionOrderAtom,
   type CollapsibleSidebarSectionId,
+  type SidebarChronologicalSort,
+  type SidebarOrganizationMode,
   type SidebarSectionId,
 } from "./sidebarCollapsedAtoms";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
@@ -406,6 +426,101 @@ function ProjectListThreadsSectionActions({
   );
 }
 
+function isOrganizationMode(value: string): value is SidebarOrganizationMode {
+  return value === "project" || value === "chronological";
+}
+
+function isChronologicalSort(value: string): value is SidebarChronologicalSort {
+  return value === "updated" || value === "created";
+}
+
+// Shared "Organize sidebar" menu rendered on both the Projects and Threads
+// section headers. The organization mode is global, so either header's menu
+// drives the whole sidebar.
+function SidebarOrganizeMenu() {
+  const [organizationMode, setOrganizationMode] = useAtom(
+    sidebarOrganizationModeAtom,
+  );
+  const [chronologicalSort, setChronologicalSort] = useAtom(
+    sidebarChronologicalSortAtom,
+  );
+  const handleModeChange = useCallback(
+    (value: string) => {
+      if (isOrganizationMode(value)) {
+        setOrganizationMode(value);
+      }
+    },
+    [setOrganizationMode],
+  );
+  const handleSortChange = useCallback(
+    (value: string) => {
+      if (isChronologicalSort(value)) {
+        setChronologicalSort(value);
+      }
+    },
+    [setChronologicalSort],
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Organize sidebar"
+          title="Organize sidebar"
+          className={cn(
+            "rounded-md p-0 text-muted-foreground",
+            COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+          )}
+        >
+          <Icon name="MoreHorizontal" className={COARSE_POINTER_ICON_SIZE_CLASS} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>Organize sidebar</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuRadioGroup
+              value={organizationMode}
+              onValueChange={handleModeChange}
+            >
+              <DropdownMenuRadioItem value="project">
+                By project
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="chronological">
+                Chronological list
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        {organizationMode === "chronological" ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Sort by</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuRadioGroup
+                  value={chronologicalSort}
+                  onValueChange={handleSortChange}
+                >
+                  <DropdownMenuRadioItem value="updated">
+                    Updated at
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="created">
+                    Created at
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function ProjectListNavigationLoadingState() {
   return (
     <div
@@ -516,10 +631,12 @@ function TopLevelSidebarSection({
         <span
           className={cn(
             "relative z-10 flex min-w-0 flex-1 items-center gap-1 text-left",
-            actions && "pr-14",
+            actions && "pr-14 max-md:pointer-coarse:pr-[4.5rem]",
           )}
         >
           <span className="min-w-0 truncate">{label}</span>
+          {/* pr-14 reserves room for two action buttons (organize + new) on
+              fine pointers; coarse pointers need a little more. */}
           {collapseControl ? (
             <button
               type="button"
@@ -892,6 +1009,15 @@ function ProjectListComponent({
   const [sidebarSectionOrderList, setSidebarSectionOrderList] = useAtom(
     sidebarSectionOrderAtom,
   );
+  const [organizationMode] = useAtom(sidebarOrganizationModeAtom);
+  const [chronologicalSort] = useAtom(sidebarChronologicalSortAtom);
+  const chronologicalComparator = useMemo<ThreadComparator>(
+    () =>
+      chronologicalSort === "created"
+        ? compareByCreatedAtDescending
+        : compareStandardThreads,
+    [chronologicalSort],
+  );
   const collapsedProjectIds = useMemo(
     () => new Set(collapsedProjectIdList),
     [collapsedProjectIdList],
@@ -1173,6 +1299,22 @@ function ProjectListComponent({
     threads: threadsByProject.get(PERSONAL_PROJECT_ID),
   });
 
+  // Chronological mode flattens every non-pinned thread (across all projects)
+  // into a single bucket. Pinned threads and their descendants stay in the
+  // Pinned section, matching how project mode excludes them.
+  const nonPinnedThreads = useMemo(
+    () =>
+      threads.filter(
+        (thread) =>
+          !pinnedSidebarState.effectivePinnedThreadIds.has(thread.id),
+      ),
+    [pinnedSidebarState.effectivePinnedThreadIds, threads],
+  );
+  const allThreadsListState = getProjectThreadListState({
+    status: projectsState.status,
+    threads: nonPinnedThreads,
+  });
+
   const pinnedSectionContent = (
     <PinnedThreadTree
       rootNodes={pinnedSidebarState.rootNodes}
@@ -1215,18 +1357,38 @@ function ProjectListComponent({
       onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
     />
   );
-  const projectsSectionActions = onNewProject ? (
-    <ProjectListProjectsSectionActions
-      onNewProject={onNewProject}
-      isCreatingProject={isCreatingProject}
+  const allThreadsSectionContent = (
+    <ChronologicalThreadTree
+      threadListState={allThreadsListState}
+      compareThreads={chronologicalComparator}
+      selectedThreadId={selectedThreadId}
+      collapsedThreadIds={collapsedThreadIds}
+      collapsedEnvironmentIds={collapsedEnvironmentIds}
+      onProjectSelect={onProjectSelect}
+      onToggleThreadCollapsed={toggleThreadCollapsed}
+      onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
     />
-  ) : undefined;
+  );
+  const projectsSectionActions = (
+    <>
+      <SidebarOrganizeMenu />
+      {onNewProject ? (
+        <ProjectListProjectsSectionActions
+          onNewProject={onNewProject}
+          isCreatingProject={isCreatingProject}
+        />
+      ) : null}
+    </>
+  );
   const projectsSectionActionsAlwaysVisible =
     projectsState.status === "ready" && renderedProjects.length === 0;
   const threadsSectionActions = (
-    <ProjectListThreadsSectionActions
-      onNewThread={handleCreateProjectlessThread}
-    />
+    <>
+      <SidebarOrganizeMenu />
+      <ProjectListThreadsSectionActions
+        onNewThread={handleCreateProjectlessThread}
+      />
+    </>
   );
 
   if (threadSearch?.isActive) {
@@ -1250,6 +1412,31 @@ function ProjectListComponent({
     return (
       <ProjectListShell>
         <ProjectListNavigationLoadingState />
+      </ProjectListShell>
+    );
+  }
+
+  if (organizationMode === "chronological") {
+    return (
+      <ProjectListShell>
+        <div className="space-y-4">
+          {hasPinnedSection ? (
+            <TopLevelSidebarSection label="Pinned">
+              {pinnedSectionContent}
+            </TopLevelSidebarSection>
+          ) : null}
+          <TopLevelSidebarSection
+            label="All Threads"
+            actions={threadsSectionActions}
+            actionsMobileAlways
+            collapseControl={{
+              isCollapsed: collapsedSidebarSectionIds.has("threads"),
+              onToggleCollapsed: () => toggleSidebarSectionCollapsed("threads"),
+            }}
+          >
+            {allThreadsSectionContent}
+          </TopLevelSidebarSection>
+        </div>
       </ProjectListShell>
     );
   }

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -64,6 +64,7 @@ import {
   type ThreadRowOptions,
 } from "./ThreadRow";
 import {
+  buildChronologicalThreadList,
   buildProjectThreadGroups,
   type EnvironmentThreadGroup,
   type ProjectThreadItem,
@@ -1131,10 +1132,11 @@ function getChronologicalItemProjectId(item: ProjectThreadItem): string {
     : item.group.nodes[0].thread.projectId;
 }
 
-// Flat "All Threads" bucket for chronological mode: every non-pinned thread
-// across all projects, ordered by the chosen comparator. Reuses the section
-// thread-tree rows but derives projectId per top-level item from its own
-// thread so cross-project rows still route correctly.
+// Flat "All Threads" bucket for chronological mode: one top-level row per
+// non-pinned thread across all projects, globally ordered by the chosen
+// comparator (no parent/child nesting or worktree grouping, so nothing hides
+// behind a collapsed parent). Derives projectId per row from its own thread so
+// cross-project rows still route correctly.
 export const ChronologicalThreadTree = memo(function ChronologicalThreadTree({
   threadListState,
   compareThreads,
@@ -1150,7 +1152,7 @@ export const ChronologicalThreadTree = memo(function ChronologicalThreadTree({
       ? threadListState.threads
       : EMPTY_PROJECT_THREADS;
   const rootItems = useMemo(
-    () => buildProjectThreadGroups(threads, compareThreads),
+    () => buildChronologicalThreadList(threads, compareThreads),
     [threads, compareThreads],
   );
 

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -68,6 +68,7 @@ import {
   type EnvironmentThreadGroup,
   type ProjectThreadItem,
   type ProjectThreadNode,
+  type ThreadComparator,
 } from "./projectThreadGroups";
 import {
   SIDEBAR_PROJECT_GROUP_LINE_CLASS,
@@ -125,6 +126,17 @@ export interface ProjectThreadTreeProps {
   collapsedThreadIds: Set<string>;
   collapsedEnvironmentIds: Set<string>;
   variant: ProjectThreadTreeVariant;
+  onProjectSelect?: () => void;
+  onToggleThreadCollapsed: (threadId: string) => void;
+  onToggleEnvironmentCollapsed: (environmentId: string) => void;
+}
+
+export interface ChronologicalThreadTreeProps {
+  threadListState: ProjectThreadListState;
+  compareThreads: ThreadComparator;
+  selectedThreadId?: string;
+  collapsedThreadIds: Set<string>;
+  collapsedEnvironmentIds: Set<string>;
   onProjectSelect?: () => void;
   onToggleThreadCollapsed: (threadId: string) => void;
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
@@ -1104,6 +1116,86 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
           collapsedThreadIds={collapsedThreadIds}
           collapsedEnvironmentIds={collapsedEnvironmentIds}
           variant={variant}
+          onProjectSelect={onProjectSelect}
+          onToggleThreadCollapsed={onToggleThreadCollapsed}
+          onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+        />
+      ))}
+    </ProjectThreadTreeGroup>
+  );
+});
+
+function getChronologicalItemProjectId(item: ProjectThreadItem): string {
+  return item.kind === "thread"
+    ? item.node.thread.projectId
+    : item.group.nodes[0].thread.projectId;
+}
+
+// Flat "All Threads" bucket for chronological mode: every non-pinned thread
+// across all projects, ordered by the chosen comparator. Reuses the section
+// thread-tree rows but derives projectId per top-level item from its own
+// thread so cross-project rows still route correctly.
+export const ChronologicalThreadTree = memo(function ChronologicalThreadTree({
+  threadListState,
+  compareThreads,
+  selectedThreadId,
+  collapsedThreadIds,
+  collapsedEnvironmentIds,
+  onProjectSelect,
+  onToggleThreadCollapsed,
+  onToggleEnvironmentCollapsed,
+}: ChronologicalThreadTreeProps) {
+  const threads =
+    threadListState.status === "ready"
+      ? threadListState.threads
+      : EMPTY_PROJECT_THREADS;
+  const rootItems = useMemo(
+    () => buildProjectThreadGroups(threads, compareThreads),
+    [threads, compareThreads],
+  );
+
+  if (threadListState.status === "loading") {
+    return (
+      <div className="group-data-[collapsible=icon]:hidden">
+        <SidebarMenuSkeleton />
+      </div>
+    );
+  }
+
+  if (threads.length === 0) {
+    return (
+      <EmptyState
+        message={
+          threadListState.status === "unavailable"
+            ? "Threads unavailable"
+            : "No threads"
+        }
+        icon={getProjectThreadTreeEmptyStateIcon("section")}
+        className={getProjectThreadTreeEmptyStateClassName("section")}
+        iconClassName="size-3.5"
+        messageClassName={getProjectThreadTreeEmptyStateMessageClassName(
+          "section",
+        )}
+      />
+    );
+  }
+
+  return (
+    <ProjectThreadTreeGroup variant="section">
+      {rootItems.map((item) => (
+        <ThreadTreeItemRow
+          key={
+            item.kind === "thread"
+              ? `thread:${item.node.thread.id}`
+              : `env:${item.group.environmentId}`
+          }
+          projectId={getChronologicalItemProjectId(item)}
+          item={item}
+          depthOffset={0}
+          selectedThreadId={selectedThreadId}
+          collapsedThreadIds={collapsedThreadIds}
+          collapsedEnvironmentIds={collapsedEnvironmentIds}
+          variant="section"
           onProjectSelect={onProjectSelect}
           onToggleThreadCollapsed={onToggleThreadCollapsed}
           onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}

--- a/apps/app/src/components/sidebar/projectThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.test.ts
@@ -1,6 +1,7 @@
 import type { ThreadListEntry } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
+  buildChronologicalThreadList,
   buildProjectThreadGroups,
   compareByCreatedAtDescending,
   type ProjectThreadItem,
@@ -375,6 +376,42 @@ describe("buildProjectThreadGroups", () => {
         buildProjectThreadGroups(threads, compareByCreatedAtDescending),
       ),
     ).toEqual(["idle-new", "active-old"]);
+  });
+
+  describe("buildChronologicalThreadList", () => {
+    it("flattens parent/child threads into globally sorted top-level rows", () => {
+      const items = buildChronologicalThreadList(
+        [
+          createThread({ id: "parent", createdAt: 10, latestAttentionAt: 10 }),
+          createThread({
+            id: "child",
+            parentThreadId: "parent",
+            createdAt: 30,
+            latestAttentionAt: 30,
+          }),
+          createThread({ id: "other", createdAt: 20, latestAttentionAt: 20 }),
+        ],
+        compareByCreatedAtDescending,
+      );
+
+      // No nesting: the child is its own top-level row, ordered globally by
+      // createdAt desc rather than nested under its parent.
+      expect(summarizeItems(items)).toEqual(["child", "other", "parent"]);
+    });
+
+    it("excludes side chats", () => {
+      const items = buildChronologicalThreadList([
+        createThread({ id: "root", createdAt: 10 }),
+        createThread({
+          id: "side",
+          parentThreadId: "root",
+          originKind: "side-chat",
+          createdAt: 20,
+        }),
+      ]);
+
+      expect(summarizeItems(items)).toEqual(["root"]);
+    });
   });
 
   it("sorts top-level manager roots with the regular root ordering", () => {

--- a/apps/app/src/components/sidebar/projectThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.test.ts
@@ -2,6 +2,7 @@ import type { ThreadListEntry } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
   buildProjectThreadGroups,
+  compareByCreatedAtDescending,
   type ProjectThreadItem,
   type ProjectThreadNode,
 } from "./projectThreadGroups";
@@ -340,6 +341,40 @@ describe("buildProjectThreadGroups", () => {
       },
       childCount: 2,
     });
+  });
+
+  it("orders roots by literal createdAt when given the created comparator", () => {
+    const threads = [
+      createThread({
+        id: "active-old",
+        status: "active",
+        createdAt: 10,
+        latestAttentionAt: 5,
+        runtime: {
+          displayStatus: "active",
+          hostReconnectGraceExpiresAt: null,
+        },
+      }),
+      createThread({
+        id: "idle-new",
+        status: "idle",
+        createdAt: 50,
+        latestAttentionAt: 5,
+      }),
+    ];
+
+    // Default heuristic pins active rows ahead of idle ones.
+    expect(summarizeItems(buildProjectThreadGroups(threads))).toEqual([
+      "active-old",
+      "idle-new",
+    ]);
+
+    // The created comparator ignores status and sorts purely by createdAt desc.
+    expect(
+      summarizeItems(
+        buildProjectThreadGroups(threads, compareByCreatedAtDescending),
+      ),
+    ).toEqual(["idle-new", "active-old"]);
   });
 
   it("sorts top-level manager roots with the regular root ordering", () => {

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -39,6 +39,14 @@ export type ProjectThreadItem =
   | { kind: "thread"; node: ProjectThreadNode }
   | { kind: "environment"; group: EnvironmentThreadGroup };
 
+// Orders sibling threads. The default keeps active rows pinned to createdAt and
+// inactive rows on attention recency; chronological mode can swap in a literal
+// createdAt comparator instead.
+export type ThreadComparator = (
+  left: ThreadListEntry,
+  right: ThreadListEntry,
+) => number;
+
 type WorktreeDisplayKind = "managed-worktree" | "unmanaged-worktree";
 type SidebarProjectThreadShape = Pick<
   ThreadListEntry,
@@ -48,6 +56,7 @@ type SidebarProjectThreadShape = Pick<
 interface BuildThreadNodeArgs {
   ancestorThreadIds: ReadonlySet<string>;
   childrenByParentId: ReadonlyMap<string, readonly ThreadListEntry[]>;
+  compareThreads: ThreadComparator;
   depth: number;
   thread: ThreadListEntry;
   visitedThreadIds: Set<string>;
@@ -64,7 +73,7 @@ function isWorktreeDisplayKind(
   return kind === "managed-worktree" || kind === "unmanaged-worktree";
 }
 
-function compareByCreatedAtDescending(
+export function compareByCreatedAtDescending(
   left: ThreadListEntry,
   right: ThreadListEntry,
 ): number {
@@ -89,7 +98,7 @@ function compareByLatestAttentionAtDescending(
   return compareByCreatedAtDescending(left, right);
 }
 
-function compareStandardThreads(
+export function compareStandardThreads(
   left: ThreadListEntry,
   right: ThreadListEntry,
 ): number {
@@ -118,8 +127,9 @@ function representativeThread(item: ProjectThreadItem): ThreadListEntry {
 function compareProjectThreadItems(
   left: ProjectThreadItem,
   right: ProjectThreadItem,
+  compareThreads: ThreadComparator,
 ): number {
-  return compareStandardThreads(
+  return compareThreads(
     representativeThread(left),
     representativeThread(right),
   );
@@ -172,20 +182,26 @@ function buildEnvironmentItem(
   return { kind: "environment", group };
 }
 
-function buildSortedItems(nodes: ProjectThreadNode[]): ProjectThreadItem[] {
+function buildSortedItems(
+  nodes: ProjectThreadNode[],
+  compareThreads: ThreadComparator,
+): ProjectThreadItem[] {
   const { environmentThreadGroups, looseNodes } =
-    bucketWorktreeEnvironmentGroups(nodes);
+    bucketWorktreeEnvironmentGroups(nodes, compareThreads);
   const items = [
     ...looseNodes.map(buildThreadItem),
     ...environmentThreadGroups.map(buildEnvironmentItem),
   ];
-  items.sort(compareProjectThreadItems);
+  items.sort((left, right) =>
+    compareProjectThreadItems(left, right, compareThreads),
+  );
   return items;
 }
 
 function buildThreadNode({
   ancestorThreadIds,
   childrenByParentId,
+  compareThreads,
   depth,
   thread,
   visitedThreadIds,
@@ -203,6 +219,7 @@ function buildThreadNode({
       buildThreadNode({
         ancestorThreadIds: nextAncestorThreadIds,
         childrenByParentId,
+        compareThreads,
         depth: depth + 1,
         thread: childThread,
         visitedThreadIds,
@@ -210,7 +227,7 @@ function buildThreadNode({
     );
   }
 
-  const children = buildSortedItems(childNodes);
+  const children = buildSortedItems(childNodes, compareThreads);
   return {
     thread,
     children,
@@ -231,6 +248,7 @@ function isRootThread(
 
 export function buildProjectThreadGroups(
   allProjectThreads: readonly ThreadListEntry[],
+  compareThreads: ThreadComparator = compareStandardThreads,
 ): ProjectThreadItem[] {
   const projectThreads = allProjectThreads.filter(isSidebarProjectThread);
   const projectThreadIds = new Set(projectThreads.map((thread) => thread.id));
@@ -259,6 +277,7 @@ export function buildProjectThreadGroups(
       buildThreadNode({
         ancestorThreadIds: new Set(),
         childrenByParentId,
+        compareThreads,
         depth: 0,
         thread,
         visitedThreadIds,
@@ -275,6 +294,7 @@ export function buildProjectThreadGroups(
       buildThreadNode({
         ancestorThreadIds: new Set(),
         childrenByParentId,
+        compareThreads,
         depth: 0,
         thread,
         visitedThreadIds,
@@ -282,7 +302,7 @@ export function buildProjectThreadGroups(
     );
   }
 
-  return buildSortedItems(rootNodes);
+  return buildSortedItems(rootNodes, compareThreads);
 }
 
 export function isSidebarProjectThread(
@@ -296,6 +316,7 @@ export function isSidebarProjectThread(
 // don't render degenerate 1-thread groups.
 function bucketWorktreeEnvironmentGroups(
   nodes: ProjectThreadNode[],
+  compareThreads: ThreadComparator,
 ): BucketWorktreeEnvironmentGroupsResult {
   const nodesByEnvironmentId = new Map<string, ProjectThreadNode[]>();
   for (const node of nodes) {
@@ -316,7 +337,7 @@ function bucketWorktreeEnvironmentGroups(
   for (const [environmentId, bucket] of nodesByEnvironmentId) {
     if (!hasAtLeastTwoThreadNodes(bucket)) continue;
     bucket.sort((left, right) =>
-      compareStandardThreads(left.thread, right.thread),
+      compareThreads(left.thread, right.thread),
     );
     groupedEnvironmentIds.add(environmentId);
     environmentThreadGroups.push(
@@ -330,7 +351,7 @@ function bucketWorktreeEnvironmentGroups(
       !groupedEnvironmentIds.has(node.thread.environmentId),
   );
   looseNodes.sort((left, right) =>
-    compareStandardThreads(left.thread, right.thread),
+    compareThreads(left.thread, right.thread),
   );
 
   return { environmentThreadGroups, looseNodes };

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -305,6 +305,32 @@ export function buildProjectThreadGroups(
   return buildSortedItems(rootNodes, compareThreads);
 }
 
+// Flat ordering for the chronological "All Threads" bucket: one top-level row
+// per thread, globally ordered by the chosen comparator. Unlike
+// buildProjectThreadGroups this intentionally drops parent/child nesting and
+// worktree grouping so every thread is visible (none hidden behind a collapsed
+// parent) and the sort is global rather than per-sibling. Side chats are
+// excluded to match buildProjectThreadGroups.
+export function buildChronologicalThreadList(
+  allThreads: readonly ThreadListEntry[],
+  compareThreads: ThreadComparator = compareStandardThreads,
+): ProjectThreadItem[] {
+  return allThreads
+    .filter(isSidebarProjectThread)
+    .sort(compareThreads)
+    .map(
+      (thread): ProjectThreadItem => ({
+        kind: "thread",
+        node: {
+          thread,
+          children: [],
+          depth: 0,
+          stats: buildStatsForHiddenThreads([]),
+        },
+      }),
+    );
+}
+
 export function isSidebarProjectThread(
   thread: SidebarProjectThreadShape,
 ): boolean {

--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -6,6 +6,8 @@ const COLLAPSED_THREADS_STORAGE_KEY = "bb.sidebar.collapsedThreads";
 const COLLAPSED_ENVIRONMENTS_STORAGE_KEY = "bb.sidebar.collapsedEnvironments";
 const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "bb.sidebar.collapsedSections";
 const SIDEBAR_SECTION_ORDER_STORAGE_KEY = "bb.sidebar.sectionOrder";
+const ORGANIZATION_MODE_STORAGE_KEY = "bb.sidebar.organizationMode";
+const CHRONOLOGICAL_SORT_STORAGE_KEY = "bb.sidebar.chronologicalSort";
 
 export type SidebarSectionId =
   | "pinned"
@@ -14,6 +16,13 @@ export type SidebarSectionId =
 export type CollapsibleSidebarSectionId =
   | "projects"
   | "threads";
+
+// "project" keeps the per-project grouping; "chronological" flattens every
+// non-pinned thread into a single All Threads bucket.
+export type SidebarOrganizationMode = "project" | "chronological";
+// Only meaningful in chronological mode. "updated" reuses the status-aware
+// activity heuristic; "created" sorts by the literal createdAt field.
+export type SidebarChronologicalSort = "updated" | "created";
 
 export const DEFAULT_SIDEBAR_SECTION_ORDER: readonly SidebarSectionId[] = [
   "pinned",
@@ -57,3 +66,19 @@ export const sidebarSectionOrderAtom = atomWithStorage<SidebarSectionId[]>(
   createJsonLocalStorage<SidebarSectionId[]>(),
   { getOnInit: true },
 );
+
+export const sidebarOrganizationModeAtom =
+  atomWithStorage<SidebarOrganizationMode>(
+    ORGANIZATION_MODE_STORAGE_KEY,
+    "project",
+    createJsonLocalStorage<SidebarOrganizationMode>(),
+    { getOnInit: true },
+  );
+
+export const sidebarChronologicalSortAtom =
+  atomWithStorage<SidebarChronologicalSort>(
+    CHRONOLOGICAL_SORT_STORAGE_KEY,
+    "updated",
+    createJsonLocalStorage<SidebarChronologicalSort>(),
+    { getOnInit: true },
+  );

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -61,6 +61,9 @@ export function useProjectDisplayName(
     queryKey: sidebarNavigationQueryKey(),
     queryFn: ({ signal }) => fetchSidebarNavigation(signal),
     staleTime: Infinity,
+    // Nothing to resolve without a project id (e.g. personal threads), so don't
+    // trigger the bootstrap fetch from this read-only selector.
+    enabled: Boolean(projectId),
   });
   if (!data || !projectId) {
     return undefined;

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { apiClient } from "@/lib/api-server";
 import { request, requestOptions } from "@/lib/api";
@@ -44,4 +45,28 @@ export function useSidebarNavigation(options?: QueryOptions) {
     enabled,
     staleTime: Infinity,
   });
+}
+
+/**
+ * Read the active project's display name from the shared sidebar-navigation
+ * cache. The sidebar owns the realtime subscriptions and initial load; this only
+ * reads the cached projects (no extra subscriptions) so surfaces like the
+ * follow-up composer footer can label the current project. Returns undefined
+ * until the cache is populated or when the project is unknown.
+ */
+export function useProjectDisplayName(
+  projectId: string | undefined,
+): string | undefined {
+  const { data } = useQuery<SidebarBootstrapResponse>({
+    queryKey: sidebarNavigationQueryKey(),
+    queryFn: ({ signal }) => fetchSidebarNavigation(signal),
+    staleTime: Infinity,
+  });
+  if (!data || !projectId) {
+    return undefined;
+  }
+  if (projectId === PERSONAL_PROJECT_ID) {
+    return data.personalProject.name;
+  }
+  return data.projects.find((project) => project.id === projectId)?.name;
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { IconName } from "@/components/ui/icon.js";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { getFollowUpPromptPlaceholder } from "@/components/promptbox/follow-up-placeholder";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type {
   EnvironmentStatus,
   PendingInteraction,
@@ -44,6 +45,7 @@ import { usePromptMentions } from "@/hooks/usePromptMentions";
 import { useCommandSuggestions } from "@/hooks/useCommandSuggestions";
 import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
 import { useUploadPromptAttachment } from "@/hooks/mutations/project-mutations";
+import { useProjectDisplayName } from "@/hooks/queries/sidebar-navigation-query";
 import {
   useCreateThreadQueuedMessage,
   useDeleteThreadQueuedMessage,
@@ -267,6 +269,10 @@ export function ThreadDetailPromptArea({
   const stopThread = useStopThread();
   const unarchiveThread = useUnarchiveThread();
   const uploadPromptAttachment = useUploadPromptAttachment();
+  // The personal project isn't a meaningful label in the footer, so skip it.
+  const projectName = useProjectDisplayName(
+    thread.projectId === PERSONAL_PROJECT_ID ? undefined : thread.projectId,
+  );
   const promptDraft = usePromptDraftStorage({
     kind: "thread",
     projectId,
@@ -920,6 +926,7 @@ export function ThreadDetailPromptArea({
     () =>
       environmentLabel ? (
         <ThreadEnvironmentSummary
+          projectName={projectName}
           environmentLabel={environmentLabel}
           environmentCompactLabel={environmentCompactLabel}
           environmentIcon={environmentIcon}
@@ -933,6 +940,7 @@ export function ThreadDetailPromptArea({
       environmentIcon,
       environmentLabel,
       onCreateNewThreadInWorktree,
+      projectName,
     ],
   );
   const promptStack = useMemo(

--- a/scripts/bb-dev-app
+++ b/scripts/bb-dev-app
@@ -36,16 +36,20 @@ LAUNCHER_LOG="${LOG_ROOT}/launcher.log"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/bb-dev-app main [--no-open]
+  By default these start only the source dev server (web frontend, server, host
+  daemon). Pass --desktop to also launch the Electron desktop shell.
+
+  scripts/bb-dev-app main [--no-open] [--desktop]
       Fetch origin/main, switch this checkout to main, fast-forward, then start
-      the source dev server and desktop shell.
+      the source dev server (and the desktop shell with --desktop).
 
-  scripts/bb-dev-app branch <branch> [--no-open]
+  scripts/bb-dev-app branch <branch> [--no-open] [--desktop]
       Switch this checkout to a local branch, or create it from origin/<branch>,
-      then start the source dev server and desktop shell.
+      then start the source dev server (and the desktop shell with --desktop).
 
-  scripts/bb-dev-app current [--no-open]
-      Start the source dev server and desktop shell for the current branch.
+  scripts/bb-dev-app current [--no-open] [--desktop]
+      Start the source dev server for the current branch (and the desktop shell
+      with --desktop).
 
   scripts/bb-dev-app stop
       Stop the launcher-managed dev server and desktop shell.
@@ -294,11 +298,12 @@ open_app_url() {
 
 start_current() {
   local open_after_start="$1"
+  local start_desktop_app="$2"
   stop_dev_app
   ensure_dependencies
   load_config
   start_dev_server
-  start_desktop
+  [[ "${start_desktop_app}" == "1" ]] && start_desktop
   [[ "${open_after_start}" == "1" ]] && open_app_url
   status
 }
@@ -356,25 +361,30 @@ main() {
   mkdir -p "${LOG_ROOT}"
 
   local command="${1:-}"
+  (( $# > 0 )) && shift
   local open_after_start="1"
-  case "${2:-}" in
-    --no-open) open_after_start="0" ;;
-  esac
-  case "${3:-}" in
-    --no-open) open_after_start="0" ;;
-  esac
+  local start_desktop_app="0"
+  local positional=()
+  local arg
+  for arg in "$@"; do
+    case "${arg}" in
+      --no-open) open_after_start="0" ;;
+      --desktop) start_desktop_app="1" ;;
+      *) positional+=("${arg}") ;;
+    esac
+  done
 
   case "${command}" in
     main)
       switch_to_main
-      start_current "${open_after_start}"
+      start_current "${open_after_start}" "${start_desktop_app}"
       ;;
     branch)
-      switch_to_branch "${2:-}"
-      start_current "${open_after_start}"
+      switch_to_branch "${positional[1]:-}"
+      start_current "${open_after_start}" "${start_desktop_app}"
       ;;
     current)
-      start_current "${open_after_start}"
+      start_current "${open_after_start}" "${start_desktop_app}"
       ;;
     stop)
       stop_dev_app
@@ -386,7 +396,7 @@ main() {
       print_env
       ;;
     logs)
-      follow_logs "${2:-dev}"
+      follow_logs "${positional[1]:-dev}"
       ;;
     help|-h|--help|"")
       usage


### PR DESCRIPTION
## Summary

Three related sidebar/composer UX changes plus a dev-launcher tweak.

### 1. Chronological organization mode for the sidebar
Adds an **Organize sidebar** menu (`…`) to the **Projects** and **Threads** section headers. It's a global, localStorage-persisted setting:
- **By project** (default) — today's grouping.
- **Chronological list** — collapses everything non-pinned into a single **All Threads** bucket across all projects. The **Sort by** submenu (shown only in this mode) chooses **Updated at** (the existing status-aware activity heuristic) or **Created at** (literal `createdAt` desc). The Pinned section is preserved.

Implementation: the sibling comparator is now threaded through `buildProjectThreadGroups` (default unchanged) instead of hardcoding `compareStandardThreads`. The flat bucket renders via a new `ChronologicalThreadTree` that derives `projectId` per top-level item so cross-project rows still route correctly.

### 2. Current project in the composer footer
Adds a read-only **project chip** (folder icon + name) to the follow-up composer footer, next to the environment/branch chips. Resolved from the shared sidebar-navigation cache via a new `useProjectDisplayName` selector (no extra subscriptions/refetch). Hidden for the personal project. The new-thread page already has an editable `ProjectSelector`, so this only covers the existing-thread footer where the project is fixed.

### 3. `bb-dev-app`: desktop only with `--desktop`
The launcher started the Electron desktop app on every `current`/`main`/`branch` run. Now it starts **only the dev server by default**; the desktop shell is gated behind a new `--desktop` flag (parsed in any position). AGENTS.md updated.

## Testing
- `pnpm exec turbo run typecheck --filter=@bb/app` ✅
- `pnpm exec turbo run test --filter=@bb/app` for `projectThreadGroups` and `ThreadEnvironmentSummary` ✅ (added regression tests: comparator swap reorders independently of status; project chip shows/hides on `projectName`).
- `zsh -n scripts/bb-dev-app` ✅; verified `current` (no flag) leaves the desktop session stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
