### PR TITLE
[codex] Fix packaged provider bridge startup

### DIFF
--- a/packages/agent-runtime/src/claude-code/adapter.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.ts
@@ -995,13 +995,14 @@ export function createClaudeCodeProviderAdapter(
     displayName: providerInfo.displayName,
     capabilities,
     process: {
-      command: "node",
+      command: opts?.bridgeNodeExecutablePath ?? "node",
       args: resolveBridgeProcessArgs({
         bridgeBundleDir: opts?.bridgeBundleDir,
         bundleFileName: "bb-claude-code-bridge.mjs",
         importMetaUrl: import.meta.url,
         bridgeRelativePath: "bridge/bridge.js",
       }),
+      ...(opts?.bridgeNodeEnv !== undefined ? { env: opts.bridgeNodeEnv } : {}),
     },
 
     // -- Unified command builder -------------------------------------------

--- a/packages/agent-runtime/src/pi/adapter.ts
+++ b/packages/agent-runtime/src/pi/adapter.ts
@@ -652,6 +652,10 @@ function createPiModelContextWindowResolver(): PiModelContextWindowResolver {
 export interface CreatePiProviderAdapterOptions {
   /** Override the directory containing bundled bridge files. */
   bridgeBundleDir?: string;
+  /** Optional environment values needed by the Node runtime that launches the bridge. */
+  bridgeNodeEnv?: Record<string, string>;
+  /** Optional executable used to run the Node bridge process. */
+  bridgeNodeExecutablePath?: string;
   /** Override context-window resolution. Used by unit tests to avoid real catalogs. */
   resolveModelContextWindow?: PiModelContextWindowResolver;
   /** Prefix for bb-owned turn ids emitted by this adapter instance. */
@@ -1213,13 +1217,14 @@ export function createPiProviderAdapter(
     displayName: providerInfo.displayName,
     capabilities,
     process: {
-      command: "node",
+      command: opts?.bridgeNodeExecutablePath ?? "node",
       args: resolveBridgeProcessArgs({
         bridgeBundleDir: opts?.bridgeBundleDir,
         bundleFileName: "bb-pi-bridge.mjs",
         importMetaUrl: import.meta.url,
         bridgeRelativePath: "bridge/bridge.js",
       }),
+      ...(opts?.bridgeNodeEnv !== undefined ? { env: opts.bridgeNodeEnv } : {}),
     },
 
     // -- Unified command builder -------------------------------------------

--- a/packages/agent-runtime/src/provider-adapter.ts
+++ b/packages/agent-runtime/src/provider-adapter.ts
@@ -32,6 +32,8 @@ export interface ProviderAcceptedCommandTranslationArgs {
 export interface ProviderAdapterFactoryOptions {
   additionalWorkspaceWriteRoots: readonly string[];
   bridgeBundleDir?: string;
+  bridgeNodeEnv?: Record<string, string>;
+  bridgeNodeExecutablePath?: string;
   turnIdPrefix?: string;
 }
 
@@ -219,7 +221,7 @@ export interface ProviderAdapter {
   id: string;
   displayName: string;
   capabilities: ProviderCapabilities;
-  process: { command: string; args: string[] };
+  process: { command: string; args: string[]; env?: Record<string, string> };
 
   buildCommandPlan(command: AdapterCommand): ProviderCommandPlan;
   /**

--- a/packages/agent-runtime/src/provider-registry.test.ts
+++ b/packages/agent-runtime/src/provider-registry.test.ts
@@ -45,6 +45,29 @@ describe("provider registry", () => {
     expect(piProvider.process.args[0]).toBe("/tmp/bb-pi-bridge.mjs");
   });
 
+  it("passes the configured bridge node runtime to bundled providers", () => {
+    const bridgeNodeEnv = { ELECTRON_RUN_AS_NODE: "1" };
+    const claudeProvider = createProviderForId("claude-code", {
+      additionalWorkspaceWriteRoots: [],
+      bridgeNodeEnv,
+      bridgeNodeExecutablePath: "/Applications/bb.app/Contents/MacOS/bb",
+    });
+    const piProvider = createProviderForId("pi", {
+      additionalWorkspaceWriteRoots: [],
+      bridgeNodeEnv,
+      bridgeNodeExecutablePath: "/Applications/bb.app/Contents/MacOS/bb",
+    });
+
+    expect(claudeProvider.process.command).toBe(
+      "/Applications/bb.app/Contents/MacOS/bb",
+    );
+    expect(claudeProvider.process.env).toEqual(bridgeNodeEnv);
+    expect(piProvider.process.command).toBe(
+      "/Applications/bb.app/Contents/MacOS/bb",
+    );
+    expect(piProvider.process.env).toEqual(bridgeNodeEnv);
+  });
+
   it("passes the configured turn id prefix to bundled providers", () => {
     const claudeProvider = createProviderForId("claude-code", {
       additionalWorkspaceWriteRoots: [],

--- a/packages/agent-runtime/src/provider-registry.ts
+++ b/packages/agent-runtime/src/provider-registry.ts
@@ -86,6 +86,12 @@ export function createProviderForId(
     ...(options?.bridgeBundleDir !== undefined
       ? { bridgeBundleDir: options.bridgeBundleDir }
       : {}),
+    ...(options?.bridgeNodeEnv !== undefined
+      ? { bridgeNodeEnv: options.bridgeNodeEnv }
+      : {}),
+    ...(options?.bridgeNodeExecutablePath !== undefined
+      ? { bridgeNodeExecutablePath: options.bridgeNodeExecutablePath }
+      : {}),
     ...(options?.turnIdPrefix !== undefined
       ? { turnIdPrefix: options.turnIdPrefix }
       : {}),

--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -44,6 +44,8 @@ export interface RuntimeProviderProcessManagerArgs {
   additionalWorkspaceWriteRoots: readonly string[];
   adapterFactory?: ProviderAdapterFactory;
   bridgeBundleDir: string | undefined;
+  bridgeNodeEnv?: Record<string, string>;
+  bridgeNodeExecutablePath?: string;
   /**
    * Snapshots a thread's turn/provider state for the process-exit
    * notification. Invoked before `onProviderThreadDetached` clears the
@@ -296,6 +298,12 @@ export class RuntimeProviderProcessManager {
     const adapterOptions = {
       additionalWorkspaceWriteRoots: this.args.additionalWorkspaceWriteRoots,
       bridgeBundleDir: this.args.bridgeBundleDir,
+      ...(this.args.bridgeNodeEnv !== undefined
+        ? { bridgeNodeEnv: this.args.bridgeNodeEnv }
+        : {}),
+      ...(this.args.bridgeNodeExecutablePath !== undefined
+        ? { bridgeNodeExecutablePath: this.args.bridgeNodeExecutablePath }
+        : {}),
       turnIdPrefix: createAdapterTurnIdPrefix(),
     };
 
@@ -306,11 +314,12 @@ export class RuntimeProviderProcessManager {
   }
 
   private spawnProvider(args: SpawnProviderArgs): RuntimeProviderProcess {
+    const processConfig = args.adapter.process;
     const env: NodeJS.ProcessEnv = {
       ...sanitizeInheritedChildProcessEnv({ env: process.env }),
       ...this.args.env,
+      ...processConfig.env,
     };
-    const processConfig = args.adapter.process;
 
     const child = spawnPortablePipedProcess({
       command: processConfig.command,

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -25,6 +25,7 @@ import type { AgentRuntimeOptions } from "./types.js";
 import type { ProviderRuntimeEvent } from "./runtime-json-rpc.js";
 
 interface CreateProviderProcessManagerArgs {
+  adapterProcessEnv?: Record<string, string>;
   env?: Record<string, string>;
   onStderr?: NonNullable<AgentRuntimeOptions["onStderr"]>;
   onProcessExit: NonNullable<AgentRuntimeOptions["onProcessExit"]>;
@@ -64,7 +65,8 @@ describe("createAgentRuntime process lifecycle", () => {
     let nextRequestId = 1;
     return new RuntimeProviderProcessManager({
       additionalWorkspaceWriteRoots: [],
-      adapterFactory: () => createNoopInitializeAdapter(args.scriptPath),
+      adapterFactory: () =>
+        createNoopInitializeAdapter(args.scriptPath, args.adapterProcessEnv),
       bridgeBundleDir: undefined,
       captureThreadExitState: (threadId) => ({
         activeTurnId: null,
@@ -90,10 +92,17 @@ describe("createAgentRuntime process lifecycle", () => {
     });
   }
 
-  function createNoopInitializeAdapter(scriptPath: string): ProviderAdapter {
+  function createNoopInitializeAdapter(
+    scriptPath: string,
+    processEnv?: Record<string, string>,
+  ): ProviderAdapter {
     const adapter = createFakeAdapter(scriptPath);
     return {
       ...adapter,
+      process: {
+        ...adapter.process,
+        ...(processEnv !== undefined ? { env: processEnv } : {}),
+      },
       buildCommandPlan(command) {
         if (command.type === "initialize") {
           return { kind: "noop", reason: "initialized by process spawn" };
@@ -1056,6 +1065,86 @@ rl.on("line", (line) => {
       expect(stderrLines[0]).toBe(
         "missing|missing|missing|external-secret|thr_explicit",
       );
+    } finally {
+      await manager.shutdown();
+    }
+  });
+
+  it("passes the current executable to runtime-managed provider adapters", async () => {
+    const adapterOptions: Array<{
+      bridgeNodeEnv?: Record<string, string>;
+      bridgeNodeExecutablePath?: string;
+    }> = [];
+    const runtime = createAgentRuntimeWithAdapters({
+      workspacePath: tmpDir,
+      onEvent: () => {},
+      onToolCall: async () => ({
+        contentItems: [{ type: "inputText", text: "ok" }],
+        success: true,
+      }),
+      adapterFactory: (_providerId, options) => {
+        adapterOptions.push({
+          ...(options.bridgeNodeEnv !== undefined
+            ? { bridgeNodeEnv: options.bridgeNodeEnv }
+            : {}),
+          ...(options.bridgeNodeExecutablePath !== undefined
+            ? { bridgeNodeExecutablePath: options.bridgeNodeExecutablePath }
+            : {}),
+        });
+        return createFakeAdapter(scriptPath);
+      },
+    });
+
+    try {
+      await runtime.ensureProvider({ providerId: "fake" });
+
+      expect(adapterOptions[0]).toMatchObject({
+        bridgeNodeExecutablePath: process.execPath,
+      });
+    } finally {
+      await runtime.shutdown();
+    }
+  });
+
+  it("overlays adapter process env after inherited and runtime env", async () => {
+    vi.stubEnv("ELECTRON_RUN_AS_NODE", "0");
+    const envScript = join(tmpDir, "bridge-env-provider.cjs");
+    writeFileSync(
+      envScript,
+      `const values = [
+        process.env.ELECTRON_RUN_AS_NODE ?? "missing",
+        process.env.BRIDGE_ONLY ?? "missing",
+        process.env.BB_THREAD_ID ?? "missing"
+      ];
+      process.stderr.write(values.join("|") + "\\n");
+      setInterval(() => {}, 1000);`,
+    );
+    const stderrLines: string[] = [];
+    const manager = createProviderProcessManager({
+      adapterProcessEnv: {
+        BRIDGE_ONLY: "bridge",
+        ELECTRON_RUN_AS_NODE: "1",
+      },
+      env: {
+        BB_THREAD_ID: "thr_explicit",
+        ELECTRON_RUN_AS_NODE: "runtime",
+      },
+      onProcessExit: vi.fn(),
+      onStderr: (line) => {
+        stderrLines.push(line);
+      },
+      scriptPath: envScript,
+      workspacePath: tmpDir,
+    });
+
+    try {
+      await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+      await waitForRuntimeState({
+        label: "provider bridge env stderr",
+        predicate: () => stderrLines.length > 0,
+      });
+
+      expect(stderrLines[0]).toBe("1|bridge|thr_explicit");
     } finally {
       await manager.shutdown();
     }

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -122,6 +122,13 @@ interface ResolveThreadStoragePathArgs {
   threadId: string;
 }
 
+function defaultBridgeNodeEnv(): Record<string, string> | undefined {
+  if (process.versions.electron === undefined) {
+    return undefined;
+  }
+  return { ELECTRON_RUN_AS_NODE: "1" };
+}
+
 // ---------------------------------------------------------------------------
 // Runtime implementation
 // ---------------------------------------------------------------------------
@@ -219,11 +226,15 @@ function createAgentRuntimeInternal(
   const threadOperationCounts = new Map<string, number>();
   const turnState = new RuntimeTurnState();
   const turnReplayFilter = new RuntimeTurnReplayFilter();
+  const bridgeNodeEnv = options.bridgeNodeEnv ?? defaultBridgeNodeEnv();
 
   const providerProcesses = new RuntimeProviderProcessManager({
     additionalWorkspaceWriteRoots,
     adapterFactory: options.adapterFactory,
     bridgeBundleDir: options.bridgeBundleDir,
+    ...(bridgeNodeEnv !== undefined ? { bridgeNodeEnv } : {}),
+    bridgeNodeExecutablePath:
+      options.bridgeNodeExecutablePath ?? process.execPath,
     captureThreadExitState: (threadId) => ({
       activeTurnId: turnState.getActiveTurnId(threadId),
       providerThreadId:

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -83,6 +83,12 @@ export interface AgentRuntimeOptions {
   /** Optional directory containing bundled provider bridges. */
   bridgeBundleDir?: string;
 
+  /** Optional executable used to run Node-based provider bridges. */
+  bridgeNodeExecutablePath?: string;
+
+  /** Optional env values needed by the executable used for Node-based bridges. */
+  bridgeNodeEnv?: Record<string, string>;
+
   /** Optional caller-provided skill roots to expose to provider sessions. */
   skillRoots?: readonly AgentRuntimeSkillRoot[];
 


### PR DESCRIPTION
## Summary

Fix packaged provider bridge startup so Claude Code and Pi bridges do not depend on `node` being visible on the GUI app PATH after sleep, crash, or macOS app restore.

## Root Cause

Runtime-managed Node bridge providers were created with `process.command: "node"`. In the packaged desktop app, the host daemon can be restored or cold-started by macOS without the user's shell/NVM PATH, so provider startup could fail with `spawn node ENOENT` after the machine died or the app had to reconstruct provider state.

## Changes

- Added bridge-specific Node executable/env options to the agent runtime adapter contract.
- Runtime-managed providers now pass `process.execPath` to Node bridge adapters by default.
- When the runtime is running under Electron, bridge processes receive `ELECTRON_RUN_AS_NODE=1` so the packaged app binary can run the bridge scripts as Node.
- Claude Code and Pi bridge adapters consume the configured bridge runtime while preserving `node` as the direct-adapter default.
- Added regression coverage for configured bridge runtime propagation and adapter process env overlay.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/agent-runtime`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --force`
