### PR TITLE
Add sidebar archived threads and display controls

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -20,6 +20,7 @@ import {
   LEGACY_PROJECT_COMPOSE_ROUTE_PATH,
   POPOUT_ROUTE_PATH,
   PROJECT_ARCHIVED_ROUTE_PATH,
+  PROJECTLESS_ARCHIVED_ROUTE_PATH,
   PROJECTLESS_THREAD_DETAIL_ROUTE_PATH,
   PROJECT_SETTINGS_ROUTE_PATH,
   SETTINGS_ROUTE_PATH,
@@ -116,6 +117,10 @@ function AppRoutes() {
           />
           <Route
             path={PROJECT_ARCHIVED_ROUTE_PATH}
+            element={<ProjectArchivedThreadsView />}
+          />
+          <Route
+            path={PROJECTLESS_ARCHIVED_ROUTE_PATH}
             element={<ProjectArchivedThreadsView />}
           />
           <Route

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -49,6 +49,8 @@ import {
   getLegacyProjectComposeRoutePath,
   getProjectArchivedRoutePath,
   getProjectSettingsRoutePath,
+  getRootComposeRoutePath,
+  isProjectlessProjectId,
 } from "@/lib/route-paths";
 import { useQuickCreateProjectController } from "@/hooks/useQuickCreateProject";
 import { useSetRootComposeProjectId } from "@/lib/root-compose-selection";
@@ -309,7 +311,9 @@ function AppHeader({
   ) : null;
 
   const actions =
-    usesProjectChromeStyle && projectId ? (
+    usesProjectChromeStyle &&
+    projectId &&
+    !isProjectlessProjectId(projectId) ? (
       <>
         <Link
           to={getProjectSettingsRoutePath(projectId)}
@@ -455,17 +459,26 @@ export function AppLayout({ children }: AppLayoutProps) {
           ],
         }
       : isArchivedView && projectId
-      ? {
-          title: "",
-          subtitle: undefined,
-          breadcrumbs: [
-            {
-              label: projectLabel ?? projectId,
-              to: getLegacyProjectComposeRoutePath(projectId),
-            },
-            { label: "Archived" },
-          ],
-        }
+        ? isProjectlessProjectId(projectId)
+          ? {
+              title: "",
+              subtitle: undefined,
+              breadcrumbs: [
+                { label: "Threads", to: getRootComposeRoutePath() },
+                { label: "Archived" },
+              ],
+            }
+          : {
+              title: "",
+              subtitle: undefined,
+              breadcrumbs: [
+                {
+                  label: projectLabel ?? projectId,
+                  to: getLegacyProjectComposeRoutePath(projectId),
+                },
+                { label: "Archived" },
+              ],
+            }
       : isSettingsView && projectId
         ? {
             title: "",
@@ -493,6 +506,9 @@ export function AppLayout({ children }: AppLayoutProps) {
       return `${automationName} · Automations`;
     }
     if (isArchivedView && projectId) {
+      if (isProjectlessProjectId(projectId)) {
+        return "Threads · Archived";
+      }
       return `${projectLabel ?? projectId} · Archived`;
     }
     if (isSettingsView && projectId) {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type { SystemExecutionOptionsModelLoadError } from "@bb/server-contract";
 import type { ReasoningLevel } from "@bb/domain";
 import { stripModelBrandPrefix } from "./model-brand-prefix";
@@ -16,7 +16,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover.js";
 import { Switch } from "@/components/ui/switch.js";
-import { CHROME_SECTION_LABEL_CLASS } from "@/components/ui/chromeStyleTokens.js";
 import { cn } from "@/lib/utils";
 import { useSystemExecutionOptions } from "@/hooks/queries/system-queries";
 import { useIsCompactViewport } from "@/components/ui/hooks/use-compact-viewport.js";
@@ -574,19 +573,16 @@ export function ModelReasoningPicker({
   );
 }
 
-// `sticky top-0` keeps "Model" pinned to the top of its scrolling parent
-// (no-op for "Reasoning" — its parent doesn't scroll). `-mx-1 px-3` covers the
-// scroll container gutter while keeping label text aligned with option rows.
-// The top inset lives inside the opaque sticky label, not on the scroll
-// container, so rows can't peek above it while it is pinned. Uses
-// `CHROME_SECTION_LABEL_CLASS` so these read like the sidebar's
-// Projects/Pinned/Threads section labels.
-function MenuSectionLabel({ children }: { children: React.ReactNode }) {
+// Mirrors DropdownMenuLabel spacing/typography while staying sticky in the
+// scrollable model list.
+function MenuSectionLabel({ children }: { children: ReactNode }) {
+  const isCompactViewport = useIsCompactViewport();
+
   return (
     <div
       className={cn(
-        "sticky top-0 z-10 -mx-1 flex h-8 items-center bg-background px-3 pt-1",
-        CHROME_SECTION_LABEL_CLASS,
+        "sticky top-0 z-10 bg-background px-2 text-xs font-medium text-muted-foreground",
+        isCompactViewport ? "pb-1.5 pt-2" : "pb-[0.3125rem] pt-2",
       )}
     >
       {children}

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -177,6 +177,7 @@ export function ProjectActionsMenu({
           className={cn(
             "rounded-md p-0 text-muted-foreground",
             triggerClassName,
+            "data-[state=open]:bg-state-active data-[state=open]:text-foreground",
           )}
           aria-label={`${project.name} actions`}
           title={`${project.name} actions`}

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useState,
   type CSSProperties,
   type KeyboardEventHandler,
   type MouseEventHandler,
@@ -36,7 +37,10 @@ import {
   useLocalPathExistence,
 } from "@/hooks/queries/host-path-queries";
 import { useHostDaemon } from "@/hooks/useHostDaemon";
-import { getRootComposeRoutePath } from "@/lib/route-paths";
+import {
+  getProjectlessArchivedRoutePath,
+  getRootComposeRoutePath,
+} from "@/lib/route-paths";
 import {
   applyNeighborReorder,
   buildNeighborReorderRequest,
@@ -88,6 +92,7 @@ import {
   sidebarOrganizationModeAtom,
   sidebarSectionOrderAtom,
   type CollapsibleSidebarSectionId,
+  type SidebarOrganizationMode,
   type SidebarSectionId,
 } from "./sidebarCollapsedAtoms";
 import {
@@ -100,6 +105,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
+  SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
@@ -159,6 +165,18 @@ interface ProjectListProjectsSectionActionsProps {
 
 interface ProjectListThreadsSectionActionsProps {
   onNewThread: () => void;
+}
+
+interface SidebarViewOptionsMenuProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onOrganizationModeSelect?: (mode: SidebarOrganizationMode) => void;
+}
+
+interface SidebarThreadActionsMenuProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onOpenArchivedThreads?: () => void;
 }
 
 interface ProjectListNavigationLoadingRowProps {
@@ -225,6 +243,7 @@ interface TopLevelSidebarSectionProps {
   actions?: ReactNode;
   actionsAlwaysVisible?: boolean;
   actionsMobileAlways?: boolean;
+  actionsOpen?: boolean;
   collapseControl?: TopLevelSidebarSectionCollapseControl;
   dragBindings?: SidebarSortableDragBindings;
   sectionRef?: (element: HTMLDivElement | null) => void;
@@ -421,9 +440,8 @@ function ProjectListThreadsSectionActions({
   );
 }
 
-
 interface SidebarOrganizeMenuSectionLabelProps {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }
 
@@ -446,7 +464,7 @@ function SidebarOrganizeMenuSectionLabel({
 interface SidebarOrganizeMenuOptionProps {
   label: string;
   selected: boolean;
-  onSelect: () => void;
+  onSelect: (event: Event) => void;
 }
 
 function SidebarOrganizeMenuOption({
@@ -471,10 +489,14 @@ function SidebarOrganizeMenuOption({
   );
 }
 
-// Shared "Organize sidebar" menu rendered on both the Projects and Threads
-// section headers. The organization mode is global, so either header's menu
-// drives the whole sidebar.
-function SidebarOrganizeMenu() {
+// Shared display menu rendered on both the Projects and Threads section
+// headers. The organization mode is global, so either header's menu drives the
+// whole sidebar.
+function SidebarViewOptionsMenu({
+  open,
+  onOpenChange,
+  onOrganizationModeSelect,
+}: SidebarViewOptionsMenuProps) {
   const [organizationMode, setOrganizationMode] = useAtom(
     sidebarOrganizationModeAtom,
   );
@@ -483,54 +505,112 @@ function SidebarOrganizeMenu() {
   );
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
           variant="ghost"
           size="icon"
-          aria-label="Organize sidebar"
-          title="Organize sidebar"
+          aria-label="Sidebar display options"
+          title="Sidebar display options"
           className={cn(
             "rounded-md p-0 text-muted-foreground",
+            "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
             COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
           )}
         >
           <Icon name="Sort" className={COARSE_POINTER_ICON_SIZE_CLASS} />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-52">
+      <DropdownMenuContent
+        align="end"
+        className="w-52"
+        mobileTitle="Sidebar display options"
+      >
         <SidebarOrganizeMenuSectionLabel className="pt-1.5">
-          Organize sidebar
+          Group by
         </SidebarOrganizeMenuSectionLabel>
         <SidebarOrganizeMenuOption
-          label="By project"
+          label="Project"
           selected={organizationMode === "project"}
-          onSelect={() => setOrganizationMode("project")}
+          onSelect={(event) => {
+            event.preventDefault();
+            setOrganizationMode("project");
+            onOrganizationModeSelect?.("project");
+          }}
         />
         <SidebarOrganizeMenuOption
-          label="Chronological list"
+          label="None"
           selected={organizationMode === "chronological"}
-          onSelect={() => setOrganizationMode("chronological")}
+          onSelect={(event) => {
+            event.preventDefault();
+            setOrganizationMode("chronological");
+            onOrganizationModeSelect?.("chronological");
+          }}
         />
-        {organizationMode === "chronological" ? (
-          <>
-            <DropdownMenuSeparator />
-            <SidebarOrganizeMenuSectionLabel className="pt-2">
-              Sort by
-            </SidebarOrganizeMenuSectionLabel>
-            <SidebarOrganizeMenuOption
-              label="Updated at"
-              selected={chronologicalSort === "updated"}
-              onSelect={() => setChronologicalSort("updated")}
-            />
-            <SidebarOrganizeMenuOption
-              label="Created at"
-              selected={chronologicalSort === "created"}
-              onSelect={() => setChronologicalSort("created")}
-            />
-          </>
-        ) : null}
+        <DropdownMenuSeparator />
+        <SidebarOrganizeMenuSectionLabel className="pt-2">
+          Sort by
+        </SidebarOrganizeMenuSectionLabel>
+        <SidebarOrganizeMenuOption
+          label="Updated at"
+          selected={chronologicalSort === "updated"}
+          onSelect={(event) => {
+            event.preventDefault();
+            setChronologicalSort("updated");
+          }}
+        />
+        <SidebarOrganizeMenuOption
+          label="Created at"
+          selected={chronologicalSort === "created"}
+          onSelect={(event) => {
+            event.preventDefault();
+            setChronologicalSort("created");
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function SidebarThreadActionsMenu({
+  open,
+  onOpenChange,
+  onOpenArchivedThreads,
+}: SidebarThreadActionsMenuProps) {
+  if (!onOpenArchivedThreads) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Threads actions"
+          title="Threads actions"
+          className={cn(
+            "rounded-md p-0 text-muted-foreground",
+            "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
+            COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+          )}
+        >
+          <Icon
+            name="MoreHorizontal"
+            className={COARSE_POINTER_ICON_SIZE_CLASS}
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-44"
+        mobileTitle="Threads actions"
+      >
+        <DropdownMenuItem onSelect={onOpenArchivedThreads}>
+          Archived threads
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -573,6 +653,7 @@ function TopLevelSidebarSection({
   actions,
   actionsAlwaysVisible = false,
   actionsMobileAlways = false,
+  actionsOpen = false,
   collapseControl,
   dragBindings,
   sectionRef,
@@ -646,12 +727,12 @@ function TopLevelSidebarSection({
         <span
           className={cn(
             "relative z-10 flex min-w-0 flex-1 items-center gap-1 text-left",
-            actions && "pr-14 max-md:pointer-coarse:pr-[4.5rem]",
+            actions && "pr-[5.75rem] max-md:pointer-coarse:pr-[7.25rem]",
           )}
         >
           <span className="min-w-0 truncate">{label}</span>
-          {/* pr-14 reserves room for two action buttons (organize + new) on
-              fine pointers; coarse pointers need a little more. */}
+          {/* Reserve room for up to three section action buttons on the right;
+              coarse pointers need a little more. */}
           {collapseControl ? (
             <button
               type="button"
@@ -691,6 +772,9 @@ function TopLevelSidebarSection({
             onClick={stopActionsClick}
           >
             <span
+              data-sidebar-hover-actions-open={
+                actionsOpen ? "true" : undefined
+              }
               data-sidebar-hover-actions-mobile={
                 actionsMobileAlways
                   ? SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
@@ -698,6 +782,7 @@ function TopLevelSidebarSection({
               }
               className={cn(
                 "inline-flex shrink-0 items-center",
+                SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
                 !actionsAlwaysVisible && SIDEBAR_HOVER_ACTIONS_CLASS,
               )}
             >
@@ -1010,6 +1095,10 @@ function ProjectListComponent({
   const handleCreateProjectlessThread = useCallback(() => {
     openRootComposeForProject(PERSONAL_PROJECT_ID);
   }, [openRootComposeForProject]);
+  const handleOpenProjectlessArchivedThreads = useCallback(() => {
+    onProjectSelect?.();
+    navigate(getProjectlessArchivedRoutePath());
+  }, [navigate, onProjectSelect]);
   const [collapsedProjectIdList, setCollapsedProjectIdList] = useAtom(
     collapsedProjectIdsAtom,
   );
@@ -1024,9 +1113,52 @@ function ProjectListComponent({
   const [sidebarSectionOrderList, setSidebarSectionOrderList] = useAtom(
     sidebarSectionOrderAtom,
   );
+  const [isProjectsViewOptionsMenuOpen, setIsProjectsViewOptionsMenuOpen] =
+    useState(false);
+  const [isThreadsActionsMenuOpen, setIsThreadsActionsMenuOpen] =
+    useState(false);
+  const [isThreadsViewOptionsMenuOpen, setIsThreadsViewOptionsMenuOpen] =
+    useState(false);
+  const handleProjectsViewOptionsMenuOpenChange = useCallback(
+    (open: boolean) => {
+      setIsProjectsViewOptionsMenuOpen(open);
+      if (open) {
+        setIsThreadsActionsMenuOpen(false);
+        setIsThreadsViewOptionsMenuOpen(false);
+      }
+    },
+    [],
+  );
+  const handleThreadsActionsMenuOpenChange = useCallback((open: boolean) => {
+    setIsThreadsActionsMenuOpen(open);
+    if (open) {
+      setIsProjectsViewOptionsMenuOpen(false);
+      setIsThreadsViewOptionsMenuOpen(false);
+    }
+  }, []);
+  const handleThreadsViewOptionsMenuOpenChange = useCallback(
+    (open: boolean) => {
+      setIsThreadsViewOptionsMenuOpen(open);
+      if (open) {
+        setIsProjectsViewOptionsMenuOpen(false);
+        setIsThreadsActionsMenuOpen(false);
+      }
+    },
+    [],
+  );
+  const handleProjectsViewOptionsOrganizationModeSelect = useCallback(
+    (mode: SidebarOrganizationMode) => {
+      if (mode === "chronological") {
+        setIsProjectsViewOptionsMenuOpen(false);
+        setIsThreadsActionsMenuOpen(false);
+        setIsThreadsViewOptionsMenuOpen(true);
+      }
+    },
+    [],
+  );
   const [organizationMode] = useAtom(sidebarOrganizationModeAtom);
   const [chronologicalSort] = useAtom(sidebarChronologicalSortAtom);
-  const chronologicalComparator = useMemo<ThreadComparator>(
+  const sidebarThreadComparator = useMemo<ThreadComparator>(
     () =>
       chronologicalSort === "created"
         ? compareByCreatedAtDescending
@@ -1351,6 +1483,7 @@ function ProjectListComponent({
       collapsedProjectIds={collapsedProjectIds}
       collapsedThreadIds={collapsedThreadIds}
       collapsedEnvironmentIds={collapsedEnvironmentIds}
+      compareThreads={sidebarThreadComparator}
       onProjectSelect={onProjectSelect}
       onCreateProjectThread={handleCreateProjectThread}
       onToggleProjectCollapsed={toggleProjectCollapsed}
@@ -1366,6 +1499,7 @@ function ProjectListComponent({
       selectedThreadId={selectedThreadId}
       collapsedThreadIds={collapsedThreadIds}
       collapsedEnvironmentIds={collapsedEnvironmentIds}
+      compareThreads={sidebarThreadComparator}
       variant="section"
       onProjectSelect={onProjectSelect}
       onToggleThreadCollapsed={toggleThreadCollapsed}
@@ -1375,7 +1509,7 @@ function ProjectListComponent({
   const allThreadsSectionContent = (
     <ChronologicalThreadTree
       threadListState={allThreadsListState}
-      compareThreads={chronologicalComparator}
+      compareThreads={sidebarThreadComparator}
       selectedThreadId={selectedThreadId}
       collapsedThreadIds={collapsedThreadIds}
       collapsedEnvironmentIds={collapsedEnvironmentIds}
@@ -1386,7 +1520,13 @@ function ProjectListComponent({
   );
   const projectsSectionActions = (
     <>
-      <SidebarOrganizeMenu />
+      <SidebarViewOptionsMenu
+        open={isProjectsViewOptionsMenuOpen}
+        onOpenChange={handleProjectsViewOptionsMenuOpenChange}
+        onOrganizationModeSelect={
+          handleProjectsViewOptionsOrganizationModeSelect
+        }
+      />
       {onNewProject ? (
         <ProjectListProjectsSectionActions
           onNewProject={onNewProject}
@@ -1399,7 +1539,15 @@ function ProjectListComponent({
     projectsState.status === "ready" && renderedProjects.length === 0;
   const threadsSectionActions = (
     <>
-      <SidebarOrganizeMenu />
+      <SidebarThreadActionsMenu
+        open={isThreadsActionsMenuOpen}
+        onOpenChange={handleThreadsActionsMenuOpenChange}
+        onOpenArchivedThreads={handleOpenProjectlessArchivedThreads}
+      />
+      <SidebarViewOptionsMenu
+        open={isThreadsViewOptionsMenuOpen}
+        onOpenChange={handleThreadsViewOptionsMenuOpenChange}
+      />
       <ProjectListThreadsSectionActions
         onNewThread={handleCreateProjectlessThread}
       />
@@ -1443,6 +1591,9 @@ function ProjectListComponent({
           <TopLevelSidebarSection
             label="All Threads"
             actions={threadsSectionActions}
+            actionsOpen={
+              isThreadsActionsMenuOpen || isThreadsViewOptionsMenuOpen
+            }
             actionsMobileAlways
             collapseControl={{
               isCollapsed: collapsedSidebarSectionIds.has("threads"),
@@ -1484,6 +1635,7 @@ function ProjectListComponent({
                   label="Projects"
                   disabled={visibleSidebarSectionOrder.length < 2}
                   actions={projectsSectionActions}
+                  actionsOpen={isProjectsViewOptionsMenuOpen}
                   actionsAlwaysVisible={projectsSectionActionsAlwaysVisible}
                   collapseControl={{
                     isCollapsed: collapsedSidebarSectionIds.has("projects"),
@@ -1503,6 +1655,9 @@ function ProjectListComponent({
                   label="Threads"
                   disabled={visibleSidebarSectionOrder.length < 2}
                   actions={threadsSectionActions}
+                  actionsOpen={
+                    isThreadsActionsMenuOpen || isThreadsViewOptionsMenuOpen
+                  }
                   actionsMobileAlways
                   collapseControl={{
                     isCollapsed: collapsedSidebarSectionIds.has("threads"),

--- a/apps/app/src/components/sidebar/ProjectListProjects.tsx
+++ b/apps/app/src/components/sidebar/ProjectListProjects.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/sidebar.js";
 import { ProjectRow } from "./ProjectRow";
 import type { ProjectRowProps, ProjectThreadListState } from "./ProjectRow";
+import type { ThreadComparator } from "./projectThreadGroups";
 import { useSidebarSortable } from "./sortableMotion";
 import type { SidebarReorderDndContextProps } from "./useSidebarReorderDnd";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
@@ -49,6 +50,7 @@ export interface ProjectListProjectsProps {
   collapsedProjectIds: Set<string>;
   collapsedThreadIds: Set<string>;
   collapsedEnvironmentIds: Set<string>;
+  compareThreads: ThreadComparator;
   onProjectSelect?: () => void;
   onCreateProjectThread?: (projectId: string) => void;
   onToggleProjectCollapsed: (projectId: string) => void;
@@ -96,6 +98,7 @@ export function ProjectListProjects({
   collapsedProjectIds,
   collapsedThreadIds,
   collapsedEnvironmentIds,
+  compareThreads,
   onProjectSelect,
   onCreateProjectThread,
   onToggleProjectCollapsed,
@@ -111,6 +114,7 @@ export function ProjectListProjects({
     isCollapsed: collapsedProjectIds.has(row.project.id),
     collapsedThreadIds,
     collapsedEnvironmentIds,
+    compareThreads,
     isLocalPathInvalid: row.isLocalPathInvalid,
     onProjectSelect,
     onCreateProjectThread,

--- a/apps/app/src/components/sidebar/ProjectRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.stories.tsx
@@ -17,6 +17,7 @@ import {
   ProjectListProjects,
   type ProjectListRowModel,
 } from "./ProjectListProjects";
+import { compareStandardThreads } from "./projectThreadGroups";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 
 export default {
@@ -126,6 +127,7 @@ function InteractiveProjectList({
       collapsedProjectIds={collapsedProjectIds}
       collapsedThreadIds={collapsedThreadIds}
       collapsedEnvironmentIds={collapsedEnvironmentIds}
+      compareThreads={compareStandardThreads}
       onCreateProjectThread={noop}
       onToggleProjectCollapsed={onToggleProjectCollapsed}
       onToggleThreadCollapsed={onToggleThreadCollapsed}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -49,6 +49,7 @@ import {
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+  SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
@@ -106,6 +107,7 @@ export interface ProjectRowProps {
   selectedThreadId?: string;
   isActive: boolean;
   isCollapsed: boolean;
+  compareThreads: ThreadComparator;
   collapsedThreadIds: Set<string>;
   collapsedEnvironmentIds: Set<string>;
   isLocalPathInvalid: boolean;
@@ -123,6 +125,7 @@ export interface ProjectRowProps {
 export interface ProjectThreadTreeProps {
   projectId: string;
   threadListState: ProjectThreadListState;
+  compareThreads: ThreadComparator;
   selectedThreadId?: string;
   collapsedThreadIds: Set<string>;
   collapsedEnvironmentIds: Set<string>;
@@ -585,6 +588,7 @@ function EnvironmentThreadGroupHeaderActions({
             title="Worktree actions"
             className={cn(
               "rounded-md p-0 text-muted-foreground",
+              "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
               COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
             )}
           >
@@ -1048,6 +1052,7 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
 export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
   threadListState,
+  compareThreads,
   selectedThreadId,
   collapsedThreadIds,
   collapsedEnvironmentIds,
@@ -1061,8 +1066,8 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       ? threadListState.threads
       : EMPTY_PROJECT_THREADS;
   const rootItems = useMemo(
-    () => buildProjectThreadGroups(projectThreads),
-    [projectThreads],
+    () => buildProjectThreadGroups(projectThreads, compareThreads),
+    [compareThreads, projectThreads],
   );
 
   if (threadListState.status === "loading") {
@@ -1213,6 +1218,7 @@ function ProjectRowComponent({
   selectedThreadId,
   isActive,
   isCollapsed,
+  compareThreads,
   collapsedThreadIds,
   collapsedEnvironmentIds,
   isLocalPathInvalid,
@@ -1330,6 +1336,7 @@ function ProjectRowComponent({
               className={cn(
                 SIDEBAR_HOVER_ACTIONS_CLASS,
                 "relative z-10 inline-flex shrink-0 items-center",
+                SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
               )}
             >
               <ProjectActionsMenu
@@ -1372,6 +1379,7 @@ function ProjectRowComponent({
             selectedThreadId={selectedThreadId}
             collapsedThreadIds={collapsedThreadIds}
             collapsedEnvironmentIds={collapsedEnvironmentIds}
+            compareThreads={compareThreads}
             variant="project"
             onProjectSelect={onProjectSelect}
             onToggleThreadCollapsed={onToggleThreadCollapsed}
@@ -1463,6 +1471,7 @@ function areProjectRowPropsEqual(
     prev.threadListState !== next.threadListState ||
     prev.isActive !== next.isActive ||
     prev.isCollapsed !== next.isCollapsed ||
+    prev.compareThreads !== next.compareThreads ||
     prev.isLocalPathInvalid !== next.isLocalPathInvalid ||
     prev.onProjectSelect !== next.onProjectSelect ||
     prev.onCreateProjectThread !== next.onCreateProjectThread ||

--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -20,8 +20,9 @@ export type CollapsibleSidebarSectionId =
 // "project" keeps the per-project grouping; "chronological" flattens every
 // non-pinned thread into a single All Threads bucket.
 export type SidebarOrganizationMode = "project" | "chronological";
-// Only meaningful in chronological mode. "updated" reuses the status-aware
-// activity heuristic; "created" sorts by the literal createdAt field.
+// Controls thread ordering in both grouped and ungrouped sidebar views.
+// "updated" reuses the status-aware activity heuristic; "created" sorts by
+// the literal createdAt field.
 export type SidebarChronologicalSort = "updated" | "created";
 
 export const DEFAULT_SIDEBAR_SECTION_ORDER: readonly SidebarSectionId[] = [

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -182,7 +182,11 @@ export function ThreadActionsMenu({
           type="button"
           variant="ghost"
           size="icon"
-          className={cn("rounded-md p-0", triggerClassName)}
+          className={cn(
+            "rounded-md p-0",
+            triggerClassName,
+            "data-[state=open]:bg-state-active data-[state=open]:text-foreground",
+          )}
           aria-label="Thread actions"
           title="Thread actions"
           onClick={(event) => {

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -47,7 +47,7 @@ const ACTION_BUTTON_CLASS =
 const HOVER_REVEAL_CLASS =
   "opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100";
 const MOBILE_OVERFLOW_TRIGGER_CLASS =
-  "hidden size-9 items-center justify-center text-muted-foreground hover:text-foreground max-md:pointer-coarse:inline-flex max-md:pointer-coarse:[&_svg]:size-5";
+  "hidden size-9 items-center justify-center rounded-md text-muted-foreground hover:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground max-md:pointer-coarse:inline-flex max-md:pointer-coarse:[&_svg]:size-5";
 
 export function findMessageActionTooltipCollisionBoundary(
   node: HTMLElement | null,

--- a/apps/app/src/components/ui/sidebar-hover-actions.ts
+++ b/apps/app/src/components/ui/sidebar-hover-actions.ts
@@ -2,6 +2,8 @@ export const SIDEBAR_HOVER_ACTIONS_ROW_CLASS = "bb-sidebar-hover-actions-row";
 
 export const SIDEBAR_HOVER_ACTIONS_CLASS = "bb-sidebar-hover-actions";
 
+export const SIDEBAR_HOVER_ACTIONS_GAP_CLASS = "gap-0.5";
+
 export const SIDEBAR_HOVER_ACTIONS_FADE_CLASS =
   "bb-sidebar-hover-actions-fade";
 

--- a/apps/app/src/hooks/useRouteState.ts
+++ b/apps/app/src/hooks/useRouteState.ts
@@ -8,7 +8,7 @@ export interface RouteState {
   threadId: string | undefined;
   /** On a thread detail URL. */
   isThreadView: boolean;
-  /** On the project's archived threads list. */
+  /** On a project or projectless archived threads list. */
   isArchivedView: boolean;
   /** On the project settings page. */
   isSettingsView: boolean;
@@ -25,7 +25,7 @@ export interface RouteState {
   automationProjectId: string | undefined;
   /** On the root route ("/"). */
   isRootView: boolean;
-  /** On the projectless new-thread surface or canonical projectless thread URL. */
+  /** On a projectless surface: compose, thread detail, or archived threads. */
   isProjectlessView: boolean;
 }
 
@@ -48,6 +48,7 @@ export function useRouteState(): RouteState {
     "/popout/projects/:projectId/threads/:threadId/*",
   );
   const popoutProjectlessThreadMatch = useMatch("/popout/threads/:threadId/*");
+  const projectlessArchivedMatch = useMatch("/archived");
   const projectArchivedMatch = useMatch("/projects/:projectId/archived");
   const projectSettingsMatch = useMatch("/projects/:projectId/settings");
   const automationDetailMatch = useMatch(
@@ -69,7 +70,7 @@ export function useRouteState(): RouteState {
   const projectRouteProjectId =
     projectMatch?.params.projectId ?? popoutProjectThreadMatch?.params.projectId;
   const projectId =
-    projectlessThreadId !== undefined
+    projectlessThreadId !== undefined || Boolean(projectlessArchivedMatch)
       ? PERSONAL_PROJECT_ID
       : isUnsupportedPersonalProjectThread
         ? undefined
@@ -83,7 +84,8 @@ export function useRouteState(): RouteState {
       Boolean(popoutProjectlessThreadMatch) ||
       ((Boolean(projectThreadMatch) || Boolean(popoutProjectThreadMatch)) &&
         !isUnsupportedPersonalProjectThread),
-    isArchivedView: Boolean(projectArchivedMatch),
+    isArchivedView:
+      Boolean(projectArchivedMatch) || Boolean(projectlessArchivedMatch),
     isSettingsView: Boolean(projectSettingsMatch),
     isAutomationsView:
       location.pathname === "/automations" || Boolean(automationDetailMatch),
@@ -91,6 +93,9 @@ export function useRouteState(): RouteState {
     automationId: automationDetailMatch?.params.automationId,
     automationProjectId: automationDetailMatch?.params.projectId,
     isRootView,
-    isProjectlessView: isRootView || projectlessThreadId !== undefined,
+    isProjectlessView:
+      isRootView ||
+      projectlessThreadId !== undefined ||
+      Boolean(projectlessArchivedMatch),
   };
 }

--- a/apps/app/src/lib/route-paths.test.ts
+++ b/apps/app/src/lib/route-paths.test.ts
@@ -5,6 +5,7 @@ import {
   getPopoutRoutePath,
   getPopoutThreadRoutePath,
   getProjectArchivedRoutePath,
+  getProjectlessArchivedRoutePath,
   getProjectSettingsRoutePath,
   getRootComposeRoutePath,
   getSurfaceAwareThreadRoutePath,
@@ -35,6 +36,12 @@ describe("route path helpers", () => {
     expect(getProjectArchivedRoutePath("proj_standard")).toBe(
       "/projects/proj_standard/archived",
     );
+  });
+
+  it("builds and recognizes the canonical projectless archived URL", () => {
+    expect(getProjectlessArchivedRoutePath()).toBe("/archived");
+    expect(getProjectArchivedRoutePath(PERSONAL_PROJECT_ID)).toBe("/archived");
+    expect(isRoutePath({ path: "/archived" })).toBe(true);
   });
 
   it("builds canonical projectless thread detail URLs", () => {

--- a/apps/app/src/lib/route-paths.ts
+++ b/apps/app/src/lib/route-paths.ts
@@ -20,6 +20,7 @@ export const AUTOMATION_DETAIL_ROUTE_PATH =
   "/automations/:projectId/:automationId";
 export const ROOT_COMPOSE_ROUTE_PATH = APP_ROOT_ROUTE_PATH;
 export const LEGACY_PROJECT_COMPOSE_ROUTE_PATH = "/projects/:projectId";
+export const PROJECTLESS_ARCHIVED_ROUTE_PATH = "/archived";
 export const PROJECTLESS_THREAD_DETAIL_ROUTE_PATH = "/threads/:threadId";
 export const PROJECT_SETTINGS_ROUTE_PATH = "/projects/:projectId/settings";
 export const PROJECT_ARCHIVED_ROUTE_PATH = "/projects/:projectId/archived";
@@ -96,7 +97,14 @@ export function getProjectSettingsRoutePath(projectId: string): string {
   return `/projects/${projectId}/settings`;
 }
 
+export function getProjectlessArchivedRoutePath(): string {
+  return PROJECTLESS_ARCHIVED_ROUTE_PATH;
+}
+
 export function getProjectArchivedRoutePath(projectId: string): string {
+  if (isProjectlessProjectId(projectId)) {
+    return getProjectlessArchivedRoutePath();
+  }
   return `/projects/${projectId}/archived`;
 }
 
@@ -124,6 +132,7 @@ const baseRoutePatterns: readonly string[] = [
   AUTOMATIONS_ROUTE_PATH,
   AUTOMATION_DETAIL_ROUTE_PATH,
   LEGACY_PROJECT_COMPOSE_ROUTE_PATH,
+  PROJECTLESS_ARCHIVED_ROUTE_PATH,
   PROJECT_SETTINGS_ROUTE_PATH,
   PROJECT_ARCHIVED_ROUTE_PATH,
   PROJECTLESS_THREAD_DETAIL_ROUTE_PATH,

--- a/apps/app/src/views/AutomationsView.tsx
+++ b/apps/app/src/views/AutomationsView.tsx
@@ -230,7 +230,7 @@ function AutomationRow({ entry, actions }: AutomationRowProps) {
             type="button"
             variant="ghost"
             size="icon"
-            className="size-6 shrink-0 rounded-md p-0 text-muted-foreground"
+            className="size-6 shrink-0 rounded-md p-0 text-muted-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground"
             aria-label={`${automation.name} actions`}
             title={`${automation.name} actions`}
           >

--- a/apps/app/src/views/ProjectArchivedThreadsView.tsx
+++ b/apps/app/src/views/ProjectArchivedThreadsView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 import type { ThreadListEntry } from "@bb/domain";
 import { Button } from "@/components/ui/button.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
@@ -8,6 +8,7 @@ import { Pill } from "@/components/ui/pill.js";
 import { ThreadUnarchiveButton } from "@/components/thread/ThreadUnarchiveButton";
 import { useUnarchiveThread } from "@/hooks/mutations/thread-state-mutations";
 import { useArchivedThreads } from "@/hooks/queries/thread-queries";
+import { useRouteState } from "@/hooks/useRouteState";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getThreadRoutePath } from "@/lib/route-paths";
 
@@ -21,7 +22,7 @@ function getArchivedThreadPillLabel(
 }
 
 export function ProjectArchivedThreadsView() {
-  const { projectId } = useParams<{ projectId: string }>();
+  const { projectId } = useRouteState();
   const archivedThreadsQuery = useArchivedThreads({ projectId });
   const unarchiveThread = useUnarchiveThread();
 

--- a/apps/app/src/views/project-settings/ProjectSourceRow.tsx
+++ b/apps/app/src/views/project-settings/ProjectSourceRow.tsx
@@ -47,7 +47,7 @@ export function ProjectSourceRow({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 shrink-0"
+            className="h-7 w-7 shrink-0 data-[state=open]:bg-state-active data-[state=open]:text-foreground"
             aria-label="Source actions"
           >
             <Icon name="MoreHorizontal" className="size-4" />


### PR DESCRIPTION
## Summary
- add a projectless archived threads route at `/archived` and reuse the archived threads view/header breadcrumbs for it
- add a Threads section three-dot menu with `Archived threads`, separate from the sidebar display-options menu
- update sidebar display options to use upstream menu styling with `Group by` (`Project` / `None`) and `Sort by` (`Updated at` / `Created at`)
- keep display-options menus open while group/sort selections change, and keep sidebar menu triggers highlighted/open-state controlled
- apply sort ordering to both grouped project thread trees and the ungrouped all-threads view
- add spacing between adjacent sidebar row/header action buttons

## Tests
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/lib/route-paths.test.ts`