### PR TITLE
Delete outdated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-- Removed the legacy STATUS system; use the built-in `status` app and `apps/status/data/state.json` for manager status.


### PR DESCRIPTION
## Summary
- Delete the obsolete root CHANGELOG.md file.

## Testing
- Not run; docs-file deletion only.