### PR TITLE
Fix popout shadow clipping and let the quick-ask box grow

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -26,7 +26,10 @@ import {
   THREAD_DETAIL_ROUTE_PATH,
 } from "./lib/route-paths";
 import { Icon } from "./components/ui/icon";
-import { POPOUT_QUICK_ASK_HEIGHT } from "@bb/desktop-contract";
+import {
+  POPOUT_QUICK_ASK_HEIGHT,
+  POPOUT_SHADOW_MARGIN,
+} from "@bb/desktop-contract";
 
 const ThreadDetailRoute = lazy(
   () => import("./views/thread-detail/ThreadDetailRoute"),
@@ -72,15 +75,14 @@ function PopoutRouteFallback() {
     };
   }, []);
 
-  const style = {
-    height: `${POPOUT_QUICK_ASK_HEIGHT}px`,
-  };
-
   return (
-    <div className="h-screen overflow-visible bg-transparent text-foreground">
+    <div
+      className="flex h-screen flex-col overflow-visible bg-transparent text-foreground"
+      style={{ padding: `${POPOUT_SHADOW_MARGIN}px` }}
+    >
       <div
-        className="flex min-h-0 w-full flex-col items-center justify-center rounded-2xl border border-border bg-background text-sm text-muted-foreground shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.08),0_16px_48px_rgba(0,0,0,0.18)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07),0_2px_8px_rgba(0,0,0,0.4),0_16px_48px_rgba(0,0,0,0.55)]"
-        style={style}
+        className="flex min-h-0 w-full flex-col items-center justify-center rounded-2xl border border-border bg-background text-sm text-muted-foreground shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.08),0_8px_20px_rgba(0,0,0,0.16)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07),0_2px_8px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.5)]"
+        style={{ height: `${POPOUT_QUICK_ASK_HEIGHT}px` }}
       >
         <Icon name="Spinner" className="mb-2 size-4 animate-spin" />
         Loading...

--- a/apps/app/src/views/PopoutChatView.tsx
+++ b/apps/app/src/views/PopoutChatView.tsx
@@ -6,13 +6,11 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type ReactNode,
 } from "react";
 import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
 import {
-  POPOUT_QUICK_ASK_HEIGHT,
-  POPOUT_WINDOW_HEIGHT,
+  POPOUT_SHADOW_MARGIN,
   type BbDesktopPopoutThreadChangedPayload,
 } from "@bb/desktop-contract";
 import type { ThreadRoutePathArgs } from "@/lib/route-paths";
@@ -31,12 +29,9 @@ import {
   useHostListRealtimeSubscription,
   useProjectListRealtimeSubscription,
 } from "@/hooks/useRealtimeSubscription";
-import {
-  HEIGHT_TRANSITION_DURATION_MS,
-  HEIGHT_TRANSITION_EASE_CSS,
-} from "@/components/ui/height-transition";
 import { Icon } from "@/components/ui/icon";
 import { CompactViewportOverrideProvider } from "@/components/ui/hooks/use-compact-viewport";
+import { cn } from "@/lib/utils";
 
 const ThreadDetailRoute = lazy(
   () => import("./thread-detail/ThreadDetailRoute"),
@@ -52,15 +47,9 @@ interface PopoutShellProps {
   isThreadOpen: boolean;
 }
 
-interface PopoutCardStyle extends CSSProperties {
-  "--popout-card-height": string;
-  "--popout-card-transition-duration": string;
-  "--popout-card-transition-ease": string;
-}
-
 function PopoutLoadingCard() {
   return (
-    <div className="flex h-full min-h-0 items-center justify-center text-sm text-muted-foreground">
+    <div className="flex min-h-[120px] flex-1 items-center justify-center text-sm text-muted-foreground">
       <Icon name="Spinner" className="mr-2 size-4 animate-spin" />
       Loading...
     </div>
@@ -181,25 +170,25 @@ function usePopoutMousePassthrough() {
 }
 
 function PopoutShell({ children, isThreadOpen }: PopoutShellProps) {
-  const cardHeight = isThreadOpen
-    ? POPOUT_WINDOW_HEIGHT
-    : POPOUT_QUICK_ASK_HEIGHT;
-  const cardStyle: PopoutCardStyle = {
-    "--popout-card-height": `${cardHeight}px`,
-    "--popout-card-transition-duration": `${HEIGHT_TRANSITION_DURATION_MS}ms`,
-    "--popout-card-transition-ease": HEIGHT_TRANSITION_EASE_CSS,
-  };
-
+  // The window reserves a transparent gutter of POPOUT_SHADOW_MARGIN on every
+  // side (see desktop-contract). Padding the transparent region by that amount
+  // insets the card so its drop shadow has room to render on all four edges
+  // instead of being clipped at the window bounds. A thread fills the card to a
+  // fixed height; the quick-ask composer sizes to its content so the card grows
+  // downward into the gutter as the textarea and attachments expand.
   return (
     <CompactViewportOverrideProvider isCompactViewport={false}>
       <div
-        className="h-screen overflow-visible bg-transparent text-foreground"
+        className="flex h-screen flex-col overflow-visible bg-transparent text-foreground"
         data-bb-popout-transparent-region=""
+        style={{ padding: `${POPOUT_SHADOW_MARGIN}px` }}
       >
         <div
-          className="flex h-[var(--popout-card-height)] min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.08),0_16px_48px_rgba(0,0,0,0.18)] transition-[height] duration-[var(--popout-card-transition-duration)] ease-[var(--popout-card-transition-ease)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07),0_2px_8px_rgba(0,0,0,0.4),0_16px_48px_rgba(0,0,0,0.55)]"
+          className={cn(
+            "flex min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.08),0_8px_20px_rgba(0,0,0,0.16)] dark:shadow-[0_0_0_1px_rgba(255,255,255,0.07),0_2px_8px_rgba(0,0,0,0.4),0_8px_20px_rgba(0,0,0,0.5)]",
+            isThreadOpen && "flex-1",
+          )}
           data-bb-popout-card=""
-          style={cardStyle}
         >
           <Suspense fallback={<PopoutLoadingCard />}>{children}</Suspense>
         </div>

--- a/apps/desktop/test/popout-window.test.ts
+++ b/apps/desktop/test/popout-window.test.ts
@@ -9,6 +9,10 @@ import {
   shouldHandlePopoutToggleSender,
   shouldHandlePopoutWindowSender,
 } from "../src/popout-ipc-authorization.js";
+import {
+  POPOUT_WINDOW_HEIGHT,
+  POPOUT_WINDOW_WIDTH,
+} from "@bb/desktop-contract";
 
 const electronMock = vi.hoisted(() => {
   interface Bounds {
@@ -356,12 +360,12 @@ describe("createPopoutWindowManager", () => {
       backgroundColor: "#00000000",
       frame: false,
       hasShadow: false,
-      height: 620,
+      height: POPOUT_WINDOW_HEIGHT,
       paintWhenInitiallyHidden: true,
       resizable: false,
       skipTaskbar: true,
       transparent: true,
-      width: 480,
+      width: POPOUT_WINDOW_WIDTH,
     });
     expect(browserWindow?.options).not.toHaveProperty("type");
     expect(browserWindow?.options.webPreferences).toMatchObject({

--- a/packages/desktop-contract/src/popout.ts
+++ b/packages/desktop-contract/src/popout.ts
@@ -3,8 +3,19 @@ import { z } from "zod";
 
 export const BB_DESKTOP_POPOUT_ID_MAX_LENGTH = 200;
 export const POPOUT_ROUTE_PATH = "/popout";
-export const POPOUT_WINDOW_WIDTH = 480;
-export const POPOUT_WINDOW_HEIGHT = 620;
+// The visible popout card. Its height when a thread is open; the quick-ask
+// composer instead sizes to its content so it grows as the textarea and
+// attachments expand.
+export const POPOUT_CARD_WIDTH = 480;
+export const POPOUT_THREAD_CARD_HEIGHT = 620;
+// Transparent gutter reserved around the card on every side so its drop shadow
+// renders into the (frameless, transparent) window instead of being clipped at
+// the window edges.
+export const POPOUT_SHADOW_MARGIN = 28;
+export const POPOUT_WINDOW_WIDTH = POPOUT_CARD_WIDTH + POPOUT_SHADOW_MARGIN * 2;
+export const POPOUT_WINDOW_HEIGHT =
+  POPOUT_THREAD_CARD_HEIGHT + POPOUT_SHADOW_MARGIN * 2;
+// Height of the loading placeholder shown before the popout renderer mounts.
 export const POPOUT_QUICK_ASK_HEIGHT = 220;
 
 export const bbDesktopPopoutThreadRefSchema = z


### PR DESCRIPTION
## Summary

The desktop popout window is frameless and transparent (`hasShadow: false`), so its drop shadow is pure CSS on the card. Two problems were visible:

1. **Shadow clipped** on the top/left/right (the card was `w-full` and flush against the window's top edge, and the window was sized exactly to the card — no transparent gutter for the shadow to render into), and abruptly cut off at the **bottom**.
2. **The box didn't grow** as the text area expanded — the quick-ask card was pinned to a fixed `220px` with `overflow-hidden`, so the composer (and attachments) got clipped.

## Changes

- **Shadow gutter:** reserve a `POPOUT_SHADOW_MARGIN` (28px) gutter around the card by growing the window and padding the transparent region, so the shadow renders on all four sides. The visible card keeps its original `480×620` footprint (window is now `536×676`).
- **Growth:** the quick-ask card now sizes to its content and grows downward; an open thread fills the card via `flex-1`.
- **Bottom cutoff:** toned down the shadow's outer layer (`0 16px 48px` → `0 8px 20px`). On macOS a transparent window only composites ~40px beyond the opaque card, so the old 64px-reach shadow was cut off abruptly at the bottom (this is OS compositing, not a CSS clip — it renders fine in a plain browser). The tighter shadow renders fully within that limit, so the bottom now matches the sides.

The 220→620 open-thread height *animation* is gone as a side effect of making the quick-ask card content-sized (CSS can't transition between `auto` and a fixed height) — the route fully swaps content on open, so it now snaps. Easy to revisit if undesired.

## Testing

- `turbo run typecheck` for `@bb/app`, `@bb/desktop`, `@bb/desktop-contract` — pass
- `turbo run test --filter=@bb/desktop` (163 tests, incl. updated `popout-window.test.ts`) — pass
- Rendered the `/popout` route in a browser at the true window size: quick-ask card grows 202px → 580px while keeping the footer visible and the shadow intact on all sides; thread mode fills to 620px with a clean bottom gutter.
- Verified the toned-down shadow against the live macOS desktop app per @kirbyhood's report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)