### PR TITLE
Fix Cursor CLI availability checks

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -463,7 +463,9 @@ export function ModelReasoningPicker({
               "max-h-[min(250px,var(--radix-popover-content-available-height,250px)-80px)]",
           )}
         >
-          <MenuSectionLabel>Model</MenuSectionLabel>
+          {isShowingModelError ? null : (
+            <MenuSectionLabel>Model</MenuSectionLabel>
+          )}
           {activeModelIsLoading ? (
             <div
               className={cn(

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -511,7 +511,7 @@ export function ModelReasoningPicker({
             <div
               className={cn(
                 "px-2 text-xs leading-relaxed text-muted-foreground",
-                isCompactViewport ? "pb-3 pt-1" : "pb-2 pt-0.5",
+                isCompactViewport ? "pb-3 pt-2" : "pb-2 pt-1.5",
               )}
               title={activeModelLoadErrorMessage ?? undefined}
             >

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -277,7 +277,10 @@ export function ModelReasoningPicker({
   const showSelectedFastMode =
     hasSelectedModel && fastModeEnabled && modelOptions.length > 0;
   const showReasoningSection =
-    hasSelectedModel && !modelIsLoading && !selectedModelLoadFailed;
+    hasSelectedModel &&
+    !modelIsLoading &&
+    !selectedModelLoadFailed &&
+    !isShowingModelError;
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -460,9 +463,7 @@ export function ModelReasoningPicker({
               "max-h-[min(250px,var(--radix-popover-content-available-height,250px)-80px)]",
           )}
         >
-          {isShowingModelError ? null : (
-            <MenuSectionLabel>Model</MenuSectionLabel>
-          )}
+          <MenuSectionLabel>Model</MenuSectionLabel>
           {activeModelIsLoading ? (
             <div
               className={cn(
@@ -507,8 +508,8 @@ export function ModelReasoningPicker({
           ) : (
             <div
               className={cn(
-                "px-2 text-xs text-muted-foreground",
-                isCompactViewport ? "py-2" : "py-[0.3125rem]",
+                "px-2 text-xs leading-relaxed text-muted-foreground",
+                isCompactViewport ? "pb-3 pt-1" : "pb-2 pt-0.5",
               )}
               title={activeModelLoadErrorMessage ?? undefined}
             >

--- a/apps/app/src/components/pickers/model-load-error-message.tsx
+++ b/apps/app/src/components/pickers/model-load-error-message.tsx
@@ -46,7 +46,7 @@ export function formatModelLoadErrorText({
   }
 
   if (error.code === "auth_required") {
-    return `Could not load models for ${providerLabel}. Cursor agent is installed but not authenticated. Run agent login or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.`;
+    return `Could not load models for ${providerLabel}. Cursor agent is not authenticated.`;
   }
 
   return `Could not load models for ${providerLabel}.`;
@@ -80,9 +80,8 @@ export function ModelLoadErrorMessage({
   if (error.code === "auth_required") {
     return (
       <>
-        Could not load models for {providerLabel}. Cursor agent is installed but
-        not authenticated. Run <code>agent login</code> or set{" "}
-        <code>CURSOR_API_KEY</code>/<code>CURSOR_AUTH_TOKEN</code>.
+        Could not load models for {providerLabel}. Cursor agent is not
+        authenticated.
       </>
     );
   }

--- a/apps/app/src/components/pickers/model-load-error-message.tsx
+++ b/apps/app/src/components/pickers/model-load-error-message.tsx
@@ -45,6 +45,10 @@ export function formatModelLoadErrorText({
     return `Could not load models for ${providerLabel}. Please make sure the ${providerCliLabel({ error, providerLabel })} is installed.`;
   }
 
+  if (error.code === "auth_required") {
+    return `Could not load models for ${providerLabel}. Cursor agent is installed but not authenticated. Run agent login or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.`;
+  }
+
   return `Could not load models for ${providerLabel}.`;
 }
 
@@ -69,6 +73,16 @@ export function ModelLoadErrorMessage({
           {helpLink.label}
         </a>{" "}
         is installed.
+      </>
+    );
+  }
+
+  if (error.code === "auth_required") {
+    return (
+      <>
+        Could not load models for {providerLabel}. Cursor agent is installed but
+        not authenticated. Run <code>agent login</code> or set{" "}
+        <code>CURSOR_API_KEY</code>/<code>CURSOR_AUTH_TOKEN</code>.
       </>
     );
   }

--- a/apps/app/src/components/pickers/model-load-error-message.tsx
+++ b/apps/app/src/components/pickers/model-load-error-message.tsx
@@ -11,10 +11,27 @@ interface FormatModelLoadErrorTextArgs {
   providerLabel: string;
 }
 
-const CODEX_CLI_HELP_LINK = {
-  label: "Codex CLI",
-  url: "https://developers.openai.com/codex/cli",
+const PROVIDER_CLI_HELP_LINKS: Partial<
+  Record<string, { label: string; url: string }>
+> = {
+  codex: {
+    label: "Codex CLI",
+    url: "https://developers.openai.com/codex/cli",
+  },
+  "acp-cursor": {
+    label: "Cursor CLI",
+    url: "https://cursor.com/docs/cli/installation",
+  },
 };
+
+function providerCliLabel({
+  error,
+  providerLabel,
+}: FormatModelLoadErrorTextArgs): string {
+  return (
+    PROVIDER_CLI_HELP_LINKS[error.providerId]?.label ?? `${providerLabel} CLI`
+  );
+}
 
 export function formatModelLoadErrorText({
   error,
@@ -24,8 +41,8 @@ export function formatModelLoadErrorText({
     return `Timed out loading models for ${providerLabel}.`;
   }
 
-  if (error.code === "missing_executable" && error.providerId === "codex") {
-    return `Could not load models for ${providerLabel}. Please make sure the ${CODEX_CLI_HELP_LINK.label} is installed.`;
+  if (error.code === "missing_executable") {
+    return `Could not load models for ${providerLabel}. Please make sure the ${providerCliLabel({ error, providerLabel })} is installed.`;
   }
 
   return `Could not load models for ${providerLabel}.`;
@@ -35,17 +52,21 @@ export function ModelLoadErrorMessage({
   error,
   providerLabel,
 }: ModelLoadErrorMessageProps): ReactNode {
-  if (error.code === "missing_executable" && error.providerId === "codex") {
+  if (error.code === "missing_executable") {
+    const helpLink = PROVIDER_CLI_HELP_LINKS[error.providerId];
+    if (!helpLink) {
+      return formatModelLoadErrorText({ error, providerLabel });
+    }
     return (
       <>
         Could not load models for {providerLabel}. Please make sure the{" "}
         <a
-          href={CODEX_CLI_HELP_LINK.url}
+          href={helpLink.url}
           target="_blank"
           rel="noreferrer"
           className="underline underline-offset-2 hover:text-foreground"
         >
-          {CODEX_CLI_HELP_LINK.label}
+          {helpLink.label}
         </a>{" "}
         is installed.
       </>

--- a/apps/app/src/components/provider-cli/ProviderCliHealthToasts.tsx
+++ b/apps/app/src/components/provider-cli/ProviderCliHealthToasts.tsx
@@ -9,6 +9,7 @@ import type {
   ProviderCliStatus,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
+import { providerCliKeyValues } from "@bb/host-daemon-contract";
 import { installProviderCli } from "@/lib/api-host-daemon";
 import {
   useLocalProviderCliStatus,
@@ -146,10 +147,10 @@ function clearDismissedForFingerprint(fingerprint: string): void {
 function providerCliEntries(
   status: ProviderCliStatusResponse,
 ): ProviderCliStatusEntry[] {
-  return [
-    { provider: "codex", status: status.codex },
-    { provider: "claudeCode", status: status.claudeCode },
-  ];
+  return providerCliKeyValues.map((provider) => ({
+    provider,
+    status: status[provider],
+  }));
 }
 
 function buildProviderCliIssue(

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -878,6 +878,7 @@ export function RootComposeView(props: RootComposeViewProps) {
   const isSubmitDisabled =
     !selectedProviderId ||
     isLoadingModels ||
+    modelLoadError?.code === "missing_executable" ||
     !selectedThreadModel ||
     createThread.isPending ||
     promptInput.length === 0 ||

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -879,6 +879,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     !selectedProviderId ||
     isLoadingModels ||
     modelLoadError?.code === "missing_executable" ||
+    modelLoadError?.code === "auth_required" ||
     !selectedThreadModel ||
     createThread.isPending ||
     promptInput.length === 0 ||

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -281,6 +281,15 @@ function createFakeRuntime(): AgentRuntime {
   };
 }
 
+function createFakeRuntimeWithModelList(
+  listModels: AgentRuntime["listModels"],
+): AgentRuntime {
+  return {
+    ...createFakeRuntime(),
+    listModels,
+  };
+}
+
 function createCommandApprovalRequest(): PendingInteractionCreate {
   return {
     threadId: "thr_app_interactive",
@@ -369,6 +378,86 @@ async function createAppFixture(
 }
 
 describe("createHostDaemonApp", () => {
+  it("refreshes runtime shell env before provider model listing", async () => {
+    const dataDir = await makeTempDir("bb-host-daemon-app-models-");
+    const fetchRecorder = createFetchRecorder();
+    const logger = createLogger();
+    const runtimeOptions: RuntimeOptionsRef = { current: null };
+    const model = {
+      id: "cursor-model",
+      model: "cursor-model",
+      displayName: "Cursor Model",
+      description: "Test model",
+      supportedReasoningEfforts: [],
+      defaultReasoningEffort: "medium" as const,
+      isDefault: true,
+    };
+    const listModels = vi.fn<AgentRuntime["listModels"]>(async () => ({
+      models: [model],
+      selectedOnlyModels: [],
+    }));
+    const resolveRuntimeShellEnv = vi.fn(async () => ({
+      PATH: "/shell/bin:/usr/bin",
+      BB_SERVER_URL: "http://127.0.0.1:3334",
+    }));
+    const app = await createHostDaemonApp({
+      dataDir,
+      serverUrl: "http://127.0.0.1:3334",
+      hostKey: "host-key-app-test",
+      hostType: "persistent",
+      hostId: "host-app-test",
+      hostName: "App Test Host",
+      instanceId: "instance-app-test",
+      logger,
+      releaseLock: async () => undefined,
+      localApiConfig: null,
+      runtimeShellEnv: {
+        PATH: "/old/bin:/usr/bin",
+      },
+      resolveRuntimeShellEnv,
+      createRuntime: (options) => {
+        runtimeOptions.current = options;
+        return createFakeRuntimeWithModelList(listModels);
+      },
+      fetchFn: fetchRecorder.fetchFn,
+      createWebSocket: createOpeningWebSocket(),
+    });
+
+    try {
+      const response = await app.router.handleOnlineRpcRequest({
+        type: "host-rpc.request",
+        requestId: "provider-models-app-test",
+        command: {
+          type: "provider.list_models",
+          providerId: "cursor",
+        },
+      });
+
+      expect(response).toMatchObject({
+        ok: true,
+        result: {
+          models: [model],
+          selectedOnlyModels: [],
+        },
+      });
+      expect(resolveRuntimeShellEnv).toHaveBeenCalledTimes(1);
+      expect(runtimeOptions.current).toEqual(
+        expect.objectContaining({
+          env: {
+            PATH: "/shell/bin:/usr/bin",
+          },
+          shellEnv: {
+            PATH: "/shell/bin:/usr/bin",
+            BB_SERVER_URL: "http://127.0.0.1:3334",
+          },
+        }),
+      );
+      expect(listModels).toHaveBeenCalledWith({ providerId: "cursor" });
+    } finally {
+      await app.daemon.shutdown("test");
+    }
+  });
+
   it("runs the idle provider session reaper on a non-overlapping interval", async () => {
     const logger = createLogger();
     const firstReap =

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -11,10 +11,7 @@ import {
 } from "./interactive-request-registry.js";
 import { startEventLoopStallMonitor } from "./event-loop-stall-monitor.js";
 import { startHostDaemonHealthMonitor } from "./host-daemon-health-monitor.js";
-import {
-  defaultListModels,
-  shutdownDefaultListModelsRuntimes,
-} from "./command-dispatch-support.js";
+import { shutdownDefaultListModelsRuntimes } from "./command-dispatch-support.js";
 import { startLocalApiServer, type LocalApiServer } from "./local-api.js";
 import type { HostDaemonLocalApiConfig } from "./local-api-config.js";
 import type { HostDaemonLogger } from "./logger.js";
@@ -102,6 +99,9 @@ export interface CreateHostDaemonAppOptions {
   localApiConfig: HostDaemonLocalApiConfig | null;
   createRuntime?: RuntimeManagerOptions["createRuntime"];
   runtimeShellEnv?: AgentRuntimeOptions["shellEnv"];
+  resolveRuntimeShellEnv?: () => Promise<
+    NonNullable<AgentRuntimeOptions["shellEnv"]>
+  >;
   threadStorageRootPath?: string;
   hostWatcher?: HostWatcher;
   onToolCall?: (request: ToolCallRequest) => Promise<ToolCallResponse>;
@@ -176,6 +176,12 @@ export function startIdleProviderSessionReaper(
       timer.clear();
     },
   };
+}
+
+function providerCliEnvFromShellEnv(
+  shellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]>,
+): NodeJS.ProcessEnv {
+  return shellEnv.PATH ? { ...process.env, PATH: shellEnv.PATH } : process.env;
 }
 
 interface SessionRequestArgs<TResult> {
@@ -595,6 +601,17 @@ export async function createHostDaemonApp(
     },
     threadStorageRootPath,
   });
+  const refreshRuntimeShellEnv = async () => {
+    if (!options.resolveRuntimeShellEnv) {
+      return runtimeManager.getShellEnv();
+    }
+    const shellEnv = await options.resolveRuntimeShellEnv();
+    await runtimeManager.replaceBaseShellEnv(shellEnv);
+    return runtimeManager.getShellEnv();
+  };
+  const getProviderCliEnv = async () =>
+    providerCliEnvFromShellEnv(await refreshRuntimeShellEnv());
+
   const idleProviderSessionReaper = startIdleProviderSessionReaper({
     logger: options.logger,
     nowMs: Date.now,
@@ -629,10 +646,13 @@ export async function createHostDaemonApp(
       }),
     runtimeManager,
     terminalManager,
-    listModels: (args) =>
-      defaultListModels(args, {
-        bridgeBundleDir: options.bridgeBundleDir,
-      }),
+    listModels: async (args) => {
+      await refreshRuntimeShellEnv();
+      const runtime = await runtimeManager.ensureProviderMaintenanceRuntime({
+        dataDir: options.dataDir,
+      });
+      return runtime.listModels(args);
+    },
     resolveInteractiveRequest: async (request) => {
       interactiveRequestRegistry.resolve(request);
     },
@@ -721,6 +741,7 @@ export async function createHostDaemonApp(
         serverPort: Number(new URL(options.serverUrl).port) || 0,
         devAppPort: options.devAppPort,
         appUrl: options.appUrl,
+        getProviderCliEnv,
         getConnected: () => connection.sessionId != null,
         pickFolder: options.pickFolder,
       })

--- a/apps/host-daemon/src/command-dispatch-support.test.ts
+++ b/apps/host-daemon/src/command-dispatch-support.test.ts
@@ -99,8 +99,13 @@ describe("command dispatch support", () => {
   it("classifies Cursor model-list authentication errors", () => {
     expect(
       getErrorCode(
+        new Error("Cursor agent is not authenticated."),
+      ),
+    ).toBe("auth_required");
+    expect(
+      getErrorCode(
         new Error(
-          "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
+          "Error: Authentication required. Run 'agent login', pass --api-key/--auth-token, or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
         ),
       ),
     ).toBe("auth_required");

--- a/apps/host-daemon/src/command-dispatch-support.test.ts
+++ b/apps/host-daemon/src/command-dispatch-support.test.ts
@@ -19,6 +19,7 @@ vi.mock("@bb/agent-runtime", async (importOriginal) => {
 
 import {
   defaultListModels,
+  getErrorCode,
   shutdownDefaultListModelsRuntimes,
 } from "./command-dispatch-support.js";
 
@@ -93,6 +94,16 @@ describe("command dispatch support", () => {
 
   beforeEach(() => {
     createAgentRuntimeMock.mockReset();
+  });
+
+  it("classifies Cursor model-list authentication errors", () => {
+    expect(
+      getErrorCode(
+        new Error(
+          "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
+        ),
+      ),
+    ).toBe("auth_required");
   });
 
   it("reuses the default model list runtime until shutdown", async () => {

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -84,6 +84,8 @@ export function isExpectedOnlineRpcFailureError(error: unknown): boolean {
 
 const MISSING_EXECUTABLE_PATTERN = /\bENOENT\b/;
 const SPAWN_PATTERN = /\bspawn\b/;
+const CURSOR_AUTH_REQUIRED_PATTERN =
+  /Cursor agent is installed but not authenticated|Authentication required.*(?:agent login|CURSOR_API_KEY|CURSOR_AUTH_TOKEN)/is;
 
 const defaultModelListRuntimes = new Map<string, AgentRuntime>();
 
@@ -144,6 +146,9 @@ export function getErrorCode(error: unknown): string {
   if (isMessageOnlySpawnMissingExecutableError(error)) {
     return "missing_executable";
   }
+  if (isMessageOnlyCursorAuthRequiredError(error)) {
+    return "auth_required";
+  }
   return "command_failed";
 }
 
@@ -169,6 +174,12 @@ function isMessageOnlySpawnMissingExecutableError(error: unknown): boolean {
   return (
     MISSING_EXECUTABLE_PATTERN.test(error.message) &&
     SPAWN_PATTERN.test(error.message)
+  );
+}
+
+function isMessageOnlyCursorAuthRequiredError(error: unknown): boolean {
+  return (
+    error instanceof Error && CURSOR_AUTH_REQUIRED_PATTERN.test(error.message)
   );
 }
 

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -85,7 +85,7 @@ export function isExpectedOnlineRpcFailureError(error: unknown): boolean {
 const MISSING_EXECUTABLE_PATTERN = /\bENOENT\b/;
 const SPAWN_PATTERN = /\bspawn\b/;
 const CURSOR_AUTH_REQUIRED_PATTERN =
-  /Cursor agent is installed but not authenticated|Authentication required.*(?:agent login|CURSOR_API_KEY|CURSOR_AUTH_TOKEN)/is;
+  /Cursor agent is (?:installed but )?not authenticated|Authentication required.*(?:agent login|CURSOR_API_KEY|CURSOR_AUTH_TOKEN)/is;
 
 const defaultModelListRuntimes = new Map<string, AgentRuntime>();
 

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -57,6 +57,7 @@ export interface StartLocalApiServerOptions {
   /** Optional public app origin (e.g. `https://app.example.com`); allowed
    * origin for CORS when the frontend is served from a non-localhost domain. */
   appUrl?: string;
+  getProviderCliEnv?: () => Promise<NodeJS.ProcessEnv>;
   getConnected: () => boolean;
   listWorkspaceOpenTargets?: WorkspaceOpenTargetListHandler;
   openInTarget?: OpenInTargetHandler;
@@ -158,9 +159,14 @@ export async function startLocalApiServer(
     }),
   );
 
-  get("/provider-clis/status", async (c) =>
-    c.json(providerCliStatusResponseSchema.parse(await getProviderCliStatus())),
-  );
+  get("/provider-clis/status", async (c) => {
+    const env = await options.getProviderCliEnv?.();
+    return c.json(
+      providerCliStatusResponseSchema.parse(
+        await getProviderCliStatus(env ? { env } : {}),
+      ),
+    );
+  });
 
   app.post("/provider-clis/install", async (c) => {
     const parsed = providerCliInstallRequestSchema.safeParse(
@@ -174,10 +180,12 @@ export async function startLocalApiServer(
     }
 
     try {
+      const env = await options.getProviderCliEnv?.();
       return new Response(
         streamProviderCliInstall({
           provider: parsed.data.provider,
           actionKind: parsed.data.actionKind,
+          ...(env ? { env } : {}),
         }),
         {
           headers: {

--- a/apps/host-daemon/src/provider-cli-health.test.ts
+++ b/apps/host-daemon/src/provider-cli-health.test.ts
@@ -27,6 +27,13 @@ const CLAUDE_INSTALL_COMMAND = [
   `curl -fsSL ${CLAUDE_INSTALL_SCRIPT_URL} -o "$tmp"`,
   'bash "$tmp"',
 ].join(" && ");
+const CURSOR_INSTALL_SCRIPT_URL = "https://cursor.com/install";
+const CURSOR_INSTALL_COMMAND = [
+  'tmp=$(mktemp "${TMPDIR:-/tmp}/provider-cli-install.XXXXXX")',
+  "trap 'rm -f \"$tmp\"' EXIT",
+  `curl -fsSL ${CURSOR_INSTALL_SCRIPT_URL} -o "$tmp"`,
+  'bash "$tmp"',
+].join(" && ");
 
 interface FakeCommandBehavior {
   stdout: string;
@@ -201,21 +208,42 @@ const CLAUDE_CODE_DEFINITION: ProviderCliDefinition = {
   },
 };
 
+const CURSOR_DEFINITION: ProviderCliDefinition = {
+  key: "cursor",
+  displayName: "Cursor",
+  executableName: "agent",
+  npmPackageName: null,
+  installCommand: {
+    kind: "downloadedShellScript",
+    scriptUrl: CURSOR_INSTALL_SCRIPT_URL,
+  },
+  updateCommand: {
+    commandKind: "exec",
+    displayCommand: "agent update",
+    command: "agent",
+    args: ["update"],
+  },
+};
+
 function installNpmStateCommands(
   runner: FakeProviderCliCommandRunner,
   definition: ProviderCliDefinition,
   prefix: string,
   packageVersion: string | null,
 ): void {
+  const packageName = definition.npmPackageName;
+  if (packageName === null) {
+    throw new Error(`${definition.displayName} has no npm package`);
+  }
   runner.setSuccess("npm", ["prefix", "-g"], `${prefix}\n`);
   runner.setSuccess(
     "npm",
-    ["list", "-g", definition.npmPackageName, "--depth=0", "--json"],
+    ["list", "-g", packageName, "--depth=0", "--json"],
     packageVersion === null
       ? JSON.stringify({ dependencies: {} })
       : JSON.stringify({
           dependencies: {
-            [definition.npmPackageName]: { version: packageVersion },
+            [packageName]: { version: packageVersion },
           },
         }),
   );
@@ -241,6 +269,14 @@ function installMissingClaudeCommands(
     "2.1.148\n",
   );
   installNpmStateCommands(runner, CLAUDE_CODE_DEFINITION, "/usr/local", null);
+}
+
+function installMissingCursorCommands(
+  runner: FakeProviderCliCommandRunner,
+): void {
+  runner.setExit("which", ["agent"], 1, "agent not found");
+  runner.setSpawnError("agent", ["--version"], "spawn agent ENOENT");
+  runner.setSuccess("npm", ["prefix", "-g"], "/usr/local\n");
 }
 
 function installOutdatedNpmCodexCommands(
@@ -286,6 +322,14 @@ function installCurrentClaudeCommands(
     "/opt/homebrew",
     "2.1.148",
   );
+}
+
+function installCurrentCursorCommands(
+  runner: FakeProviderCliCommandRunner,
+): void {
+  runner.setSuccess("which", ["agent"], "/Users/me/.local/bin/agent\n");
+  runner.setSuccess("agent", ["--version"], "agent 1.2.3\n");
+  runner.setSuccess("npm", ["prefix", "-g"], "/usr/local\n");
 }
 
 async function collectInstallEvents(
@@ -369,6 +413,36 @@ describe("provider CLI health", () => {
     });
   });
 
+  it("reports a missing Cursor agent CLI with the downloaded shell installer action", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    installMissingCursorCommands(runner);
+
+    const status = await inspectProviderCli({
+      definition: CURSOR_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status).toEqual({
+      displayName: "Cursor",
+      executableName: "agent",
+      executablePath: null,
+      installed: false,
+      installSource: "notInstalled",
+      currentVersion: null,
+      latestVersion: null,
+      npmPackageName: null,
+      npmGlobalPackageVersion: null,
+      installAction: {
+        kind: "install",
+        label: "Install",
+        commandKind: "shell",
+        command: CURSOR_INSTALL_COMMAND,
+      },
+      needsUpdate: false,
+    });
+  });
+
   it("offers a self-update action when the active executable is npm-global", async () => {
     const runner = new FakeProviderCliCommandRunner();
     installOutdatedNpmCodexCommands(runner);
@@ -431,10 +505,11 @@ describe("provider CLI health", () => {
     expect(status.installAction).toBeNull();
   });
 
-  it("returns both provider keys and queries the confirmed npm packages", async () => {
+  it("returns all provider keys and queries the confirmed npm packages", async () => {
     const runner = new FakeProviderCliCommandRunner();
     installOutdatedNpmCodexCommands(runner);
     installCurrentClaudeCommands(runner);
+    installCurrentCursorCommands(runner);
 
     const status = await getProviderCliStatus({
       runner,
@@ -443,10 +518,13 @@ describe("provider CLI health", () => {
 
     expect(status.codex.needsUpdate).toBe(true);
     expect(status.claudeCode.needsUpdate).toBe(false);
+    expect(status.cursor.installed).toBe(true);
     expect(runner.commandLines()).toContain("npm view @openai/codex version");
     expect(runner.commandLines()).toContain(
       "npm view @anthropic-ai/claude-code version",
     );
+    expect(runner.commandLines()).toContain("which agent");
+    expect(runner.commandLines()).not.toContain("npm view cursor version");
   });
 
   it("streams failed npm installs without hiding the exit status", async () => {
@@ -531,6 +609,49 @@ describe("provider CLI health", () => {
     ]);
     expect(CLAUDE_INSTALL_COMMAND).not.toContain("| bash");
     expect(CLAUDE_INSTALL_COMMAND).toContain('bash "$tmp"');
+  });
+
+  it("streams Cursor installs from a downloaded script file", async () => {
+    const spawner = new FakeProviderCliInstallProcessSpawner();
+    const stream = streamProviderCliInstall({
+      provider: "cursor",
+      actionKind: "install",
+      nodePlatform: "darwin",
+      installProcessSpawner: spawner,
+    });
+    const eventsPromise = collectInstallEvents(stream);
+
+    spawner.lastProcess().stdout.write("installing cursor\n");
+    spawner.lastProcess().emitClose(0, null);
+
+    await expect(eventsPromise).resolves.toEqual([
+      {
+        type: "started",
+        provider: "cursor",
+        command: CURSOR_INSTALL_COMMAND,
+      },
+      {
+        type: "output",
+        provider: "cursor",
+        stream: "stdout",
+        text: "installing cursor\n",
+      },
+      {
+        type: "completed",
+        provider: "cursor",
+        exitCode: 0,
+        signal: null,
+        success: true,
+      },
+    ]);
+    expect(spawner.spawnRequests).toEqual([
+      {
+        command: "sh",
+        args: ["-c", CURSOR_INSTALL_COMMAND],
+      },
+    ]);
+    expect(CURSOR_INSTALL_COMMAND).not.toContain("| bash");
+    expect(CURSOR_INSTALL_COMMAND).toContain('bash "$tmp"');
   });
 
   it("streams provider self-updates with the visible update command", async () => {

--- a/apps/host-daemon/src/provider-cli-health.ts
+++ b/apps/host-daemon/src/provider-cli-health.ts
@@ -21,6 +21,7 @@ const COMMAND_CHECK_TIMEOUT_MS = 5_000;
 const NPM_VIEW_TIMEOUT_MS = 15_000;
 const NPM_INSTALL_STATE_TIMEOUT_MS = 5_000;
 const CLAUDE_CODE_INSTALL_SCRIPT_URL = "https://claude.ai/install.sh";
+const CURSOR_INSTALL_SCRIPT_URL = "https://cursor.com/install";
 const providerCliNodePtyLogger: HostDaemonLogger = {
   debug() {},
   info() {},
@@ -46,7 +47,7 @@ export interface ProviderCliDefinition {
   key: ProviderCliKey;
   displayName: string;
   executableName: string;
-  npmPackageName: string;
+  npmPackageName: string | null;
   installCommand: ProviderCliInstallCommandDefinition;
   updateCommand: ProviderCliActionCommand;
 }
@@ -208,44 +209,60 @@ export class ProviderCliInstallInProgressError extends Error {
   }
 }
 
+const PROVIDER_CLI_DEFINITIONS = {
+  codex: {
+    key: "codex",
+    displayName: "Codex",
+    executableName: "codex",
+    npmPackageName: "@openai/codex",
+    installCommand: {
+      kind: "npmGlobal",
+    },
+    updateCommand: {
+      commandKind: "exec",
+      displayCommand: "codex update",
+      command: "codex",
+      args: ["update"],
+    },
+  },
+  claudeCode: {
+    key: "claudeCode",
+    displayName: "Claude Code",
+    executableName: "claude",
+    npmPackageName: "@anthropic-ai/claude-code",
+    installCommand: {
+      kind: "downloadedShellScript",
+      scriptUrl: CLAUDE_CODE_INSTALL_SCRIPT_URL,
+    },
+    updateCommand: {
+      commandKind: "exec",
+      displayCommand: "claude update",
+      command: "claude",
+      args: ["update"],
+    },
+  },
+  cursor: {
+    key: "cursor",
+    displayName: "Cursor",
+    executableName: "agent",
+    npmPackageName: null,
+    installCommand: {
+      kind: "downloadedShellScript",
+      scriptUrl: CURSOR_INSTALL_SCRIPT_URL,
+    },
+    updateCommand: {
+      commandKind: "exec",
+      displayCommand: "agent update",
+      command: "agent",
+      args: ["update"],
+    },
+  },
+} satisfies Record<ProviderCliKey, ProviderCliDefinition>;
+
 function getProviderCliDefinition(
   provider: ProviderCliKey,
 ): ProviderCliDefinition {
-  switch (provider) {
-    case "codex":
-      return {
-        key: "codex",
-        displayName: "Codex",
-        executableName: "codex",
-        npmPackageName: "@openai/codex",
-        installCommand: {
-          kind: "npmGlobal",
-        },
-        updateCommand: {
-          commandKind: "exec",
-          displayCommand: "codex update",
-          command: "codex",
-          args: ["update"],
-        },
-      };
-    case "claudeCode":
-      return {
-        key: "claudeCode",
-        displayName: "Claude Code",
-        executableName: "claude",
-        npmPackageName: "@anthropic-ai/claude-code",
-        installCommand: {
-          kind: "downloadedShellScript",
-          scriptUrl: CLAUDE_CODE_INSTALL_SCRIPT_URL,
-        },
-        updateCommand: {
-          commandKind: "exec",
-          displayCommand: "claude update",
-          command: "claude",
-          args: ["update"],
-        },
-      };
-  }
+  return PROVIDER_CLI_DEFINITIONS[provider];
 }
 
 function npmExecutableName(nodePlatform: NodeJS.Platform): string {
@@ -317,6 +334,11 @@ function needsProviderCliUpdate(args: NeedsProviderCliUpdateArgs): boolean {
 }
 
 function npmInstallCommandArgs(definition: ProviderCliDefinition): string[] {
+  if (definition.npmPackageName === null) {
+    throw new Error(
+      `${definition.displayName} CLI does not define an npm package installer.`,
+    );
+  }
   return ["install", "-g", `${definition.npmPackageName}@latest`];
 }
 
@@ -556,6 +578,7 @@ export async function inspectProviderCli({
   nodePlatform,
 }: InspectProviderCliArgs): Promise<ProviderCliStatus> {
   const npmCommand = npmExecutableName(nodePlatform);
+  const npmPackageName = definition.npmPackageName;
   const [
     whichResult,
     versionResult,
@@ -573,21 +596,25 @@ export async function inspectProviderCli({
       args: ["--version"],
       timeoutMs: COMMAND_CHECK_TIMEOUT_MS,
     }),
-    runner.run({
-      command: npmCommand,
-      args: ["view", definition.npmPackageName, "version"],
-      timeoutMs: NPM_VIEW_TIMEOUT_MS,
-    }),
+    npmPackageName === null
+      ? Promise.resolve(null)
+      : runner.run({
+          command: npmCommand,
+          args: ["view", npmPackageName, "version"],
+          timeoutMs: NPM_VIEW_TIMEOUT_MS,
+        }),
     runner.run({
       command: npmCommand,
       args: ["prefix", "-g"],
       timeoutMs: NPM_INSTALL_STATE_TIMEOUT_MS,
     }),
-    runner.run({
-      command: npmCommand,
-      args: ["list", "-g", definition.npmPackageName, "--depth=0", "--json"],
-      timeoutMs: NPM_INSTALL_STATE_TIMEOUT_MS,
-    }),
+    npmPackageName === null
+      ? Promise.resolve(null)
+      : runner.run({
+          command: npmCommand,
+          args: ["list", "-g", npmPackageName, "--depth=0", "--json"],
+          timeoutMs: NPM_INSTALL_STATE_TIMEOUT_MS,
+        }),
   ]);
 
   const executablePath = isSuccessfulCommand(whichResult)
@@ -598,16 +625,20 @@ export async function inspectProviderCli({
   const currentVersion = isSuccessfulCommand(versionResult)
     ? extractVersion(`${versionResult.stdout}\n${versionResult.stderr}`)
     : null;
-  const latestVersion = isSuccessfulCommand(latestResult)
-    ? extractVersion(`${latestResult.stdout}\n${latestResult.stderr}`)
-    : null;
+  const latestVersion =
+    latestResult !== null && isSuccessfulCommand(latestResult)
+      ? extractVersion(`${latestResult.stdout}\n${latestResult.stderr}`)
+      : null;
   const npmGlobalPrefix = isSuccessfulCommand(npmPrefixResult)
     ? firstOutputLine(npmPrefixResult.stdout)
     : null;
-  const npmGlobalPackageVersion = parseNpmGlobalPackageVersion(
-    `${npmListResult.stdout}\n${npmListResult.stderr}`,
-    definition.npmPackageName,
-  );
+  const npmGlobalPackageVersion =
+    npmListResult !== null && npmPackageName !== null
+      ? parseNpmGlobalPackageVersion(
+          `${npmListResult.stdout}\n${npmListResult.stderr}`,
+          npmPackageName,
+        )
+      : null;
   const installSource = resolveProviderCliInstallSource({
     installed,
     executablePath,
@@ -634,7 +665,7 @@ export async function inspectProviderCli({
     installSource,
     currentVersion,
     latestVersion,
-    npmPackageName: definition.npmPackageName,
+    npmPackageName,
     npmGlobalPackageVersion,
     installAction,
     needsUpdate,
@@ -646,7 +677,7 @@ export async function getProviderCliStatus(
 ): Promise<ProviderCliStatusResponse> {
   const runner = args.runner ?? createSpawnProviderCliCommandRunner();
   const nodePlatform = args.nodePlatform ?? process.platform;
-  const [codex, claudeCode] = await Promise.all([
+  const [codex, claudeCode, cursor] = await Promise.all([
     inspectProviderCli({
       definition: getProviderCliDefinition("codex"),
       runner,
@@ -657,12 +688,14 @@ export async function getProviderCliStatus(
       runner,
       nodePlatform,
     }),
+    inspectProviderCli({
+      definition: getProviderCliDefinition("cursor"),
+      runner,
+      nodePlatform,
+    }),
   ]);
 
-  return {
-    codex,
-    claudeCode,
-  };
+  return { codex, claudeCode, cursor };
 }
 
 function providerCliPtyShellCommand(

--- a/apps/host-daemon/src/provider-cli-health.ts
+++ b/apps/host-daemon/src/provider-cli-health.ts
@@ -79,6 +79,7 @@ interface InspectProviderCliArgs {
 }
 
 interface GetProviderCliStatusArgs {
+  env?: NodeJS.ProcessEnv;
   runner?: ProviderCliCommandRunner;
   nodePlatform?: NodeJS.Platform;
 }
@@ -86,6 +87,7 @@ interface GetProviderCliStatusArgs {
 export interface SpawnProviderCliInstallProcessArgs {
   command: string;
   args: string[];
+  env?: NodeJS.ProcessEnv;
 }
 
 export type ProviderCliInstallProcessErrorListener = (error: Error) => void;
@@ -109,6 +111,7 @@ export interface ProviderCliInstallProcessSpawner {
 interface StreamProviderCliInstallArgs {
   provider: ProviderCliKey;
   actionKind: ProviderCliInstallActionKind;
+  env?: NodeJS.ProcessEnv;
   nodePlatform?: NodeJS.Platform;
   installProcessSpawner?: ProviderCliInstallProcessSpawner;
 }
@@ -483,14 +486,17 @@ function createCommandResult(
   };
 }
 
-export function createSpawnProviderCliCommandRunner(): ProviderCliCommandRunner {
+export function createSpawnProviderCliCommandRunner(
+  env: NodeJS.ProcessEnv = process.env,
+): ProviderCliCommandRunner {
   return {
-    run: runProviderCliCommand,
+    run: (args) => runProviderCliCommand(args, env),
   };
 }
 
 export async function runProviderCliCommand(
   args: RunProviderCliCommandArgs,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<ProviderCliCommandResult> {
   return await new Promise<ProviderCliCommandResult>((resolve) => {
     let child;
@@ -498,7 +504,7 @@ export async function runProviderCliCommand(
       child = spawnPortableOutputProcess({
         command: args.command,
         args: [...args.args],
-        env: process.env,
+        env,
       });
     } catch (error) {
       resolve(
@@ -675,7 +681,7 @@ export async function inspectProviderCli({
 export async function getProviderCliStatus(
   args: GetProviderCliStatusArgs = {},
 ): Promise<ProviderCliStatusResponse> {
-  const runner = args.runner ?? createSpawnProviderCliCommandRunner();
+  const runner = args.runner ?? createSpawnProviderCliCommandRunner(args.env);
   const nodePlatform = args.nodePlatform ?? process.platform;
   const [codex, claudeCode, cursor] = await Promise.all([
     inspectProviderCli({
@@ -724,7 +730,7 @@ export function createPtyProviderCliInstallProcessSpawner(): ProviderCliInstallP
       const pty = spawnPty(ptyCommand.command, ptyCommand.args, {
         cols: 120,
         cwd: process.cwd(),
-        env: process.env,
+        env: args.env ?? process.env,
         name: "xterm-256color",
         rows: 30,
       });
@@ -815,6 +821,7 @@ function closeInstallStream({
 export function streamProviderCliInstall({
   provider,
   actionKind,
+  env,
   nodePlatform = process.platform,
   installProcessSpawner = createPtyProviderCliInstallProcessSpawner(),
 }: StreamProviderCliInstallArgs): ReadableStream<Uint8Array> {
@@ -852,6 +859,7 @@ export function streamProviderCliInstall({
         state.childProcess = installProcessSpawner.spawn({
           command,
           args: commandArgs,
+          ...(env ? { env } : {}),
         });
       } catch (error) {
         writeInstallEvent({

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -57,6 +57,13 @@ interface RuntimeOptionsRef {
   current: AgentRuntimeOptions | null;
 }
 
+interface RuntimeManagerProviderMaintenanceInternals {
+  createProviderMaintenanceRuntime: (args: {
+    dataDir: string;
+  }) => Promise<AgentRuntime>;
+  providerMaintenanceRuntime: AgentRuntime | null;
+}
+
 const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
 
@@ -1104,6 +1111,47 @@ describe("RuntimeManager", () => {
         },
       }),
     );
+  });
+
+  it("does not let stale provider maintenance creation replace a newer runtime", async () => {
+    const dataDir = await makeTempDir("bb-provider-maintenance-race-");
+    const staleRuntime = createFakeRuntime();
+    const currentRuntime = createFakeRuntime();
+    const staleCreation = createDeferred<AgentRuntime>();
+    const manager = new RuntimeManager({
+      shellEnv: {
+        PATH: "/old/bin:/usr/bin",
+      },
+    });
+    const managerInternals =
+      manager as unknown as RuntimeManagerProviderMaintenanceInternals;
+    vi.spyOn(
+      managerInternals,
+      "createProviderMaintenanceRuntime",
+    )
+      .mockImplementationOnce(() => staleCreation.promise)
+      .mockImplementationOnce(async () => currentRuntime);
+
+    const staleRuntimePromise = manager.ensureProviderMaintenanceRuntime({
+      dataDir,
+    });
+    const replaceShellEnvPromise = manager.replaceBaseShellEnv({
+      PATH: "/new/bin:/usr/bin",
+    });
+    const currentRuntimePromise = manager.ensureProviderMaintenanceRuntime({
+      dataDir,
+    });
+
+    await expect(currentRuntimePromise).resolves.toBe(currentRuntime);
+    expect(managerInternals.providerMaintenanceRuntime).toBe(currentRuntime);
+
+    staleCreation.resolve(staleRuntime);
+    await expect(staleRuntimePromise).resolves.toBe(staleRuntime);
+    await replaceShellEnvPromise;
+
+    expect(managerInternals.providerMaintenanceRuntime).toBe(currentRuntime);
+    expect(staleRuntime.shutdown).toHaveBeenCalledTimes(1);
+    expect(currentRuntime.shutdown).not.toHaveBeenCalled();
   });
 
   it("evicts idle environment runtimes after base shell env changes", async () => {

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -996,6 +996,38 @@ describe("RuntimeManager", () => {
     );
   });
 
+  it("passes shell PATH through to provider process env", async () => {
+    const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
+    const createRuntime = vi.fn(() => createFakeRuntime());
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      createRuntime,
+      shellEnv: {
+        PATH: "/tmp/bb-bin:/home/me/.local/bin:/usr/bin",
+        BB_SERVER_URL: "http://127.0.0.1:3334",
+        OPENAI_API_KEY: "test-openai-key",
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+
+    expect(createRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {
+          PATH: "/tmp/bb-bin:/home/me/.local/bin:/usr/bin",
+        },
+        shellEnv: {
+          PATH: "/tmp/bb-bin:/home/me/.local/bin:/usr/bin",
+          BB_SERVER_URL: "http://127.0.0.1:3334",
+          OPENAI_API_KEY: "test-openai-key",
+        },
+      }),
+    );
+  });
+
   it("merges managed shell env into future runtime creation", async () => {
     const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
     const createRuntime = vi.fn(() => createFakeRuntime());
@@ -1031,6 +1063,93 @@ describe("RuntimeManager", () => {
         },
       }),
     );
+  });
+
+  it("recreates the provider maintenance runtime after base shell env changes", async () => {
+    const dataDir = await makeTempDir("bb-provider-maintenance-");
+    const firstRuntime = createFakeRuntime();
+    const secondRuntime = createFakeRuntime();
+    const createRuntime = vi
+      .fn()
+      .mockReturnValueOnce(firstRuntime)
+      .mockReturnValueOnce(secondRuntime);
+    const manager = new RuntimeManager({
+      createRuntime,
+      shellEnv: {
+        PATH: "/old/bin:/usr/bin",
+      },
+    });
+
+    await expect(
+      manager.ensureProviderMaintenanceRuntime({ dataDir }),
+    ).resolves.toBe(firstRuntime);
+    await manager.replaceBaseShellEnv({
+      PATH: "/new/bin:/usr/bin",
+      BB_SERVER_URL: "http://127.0.0.1:3334",
+    });
+    await expect(
+      manager.ensureProviderMaintenanceRuntime({ dataDir }),
+    ).resolves.toBe(secondRuntime);
+
+    expect(firstRuntime.shutdown).toHaveBeenCalledTimes(1);
+    expect(createRuntime).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        env: {
+          PATH: "/new/bin:/usr/bin",
+        },
+        shellEnv: {
+          PATH: "/new/bin:/usr/bin",
+          BB_SERVER_URL: "http://127.0.0.1:3334",
+        },
+      }),
+    );
+  });
+
+  it("evicts idle environment runtimes after base shell env changes", async () => {
+    const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
+    const firstRuntime = createFakeRuntime();
+    const secondRuntime = createFakeRuntime();
+    const createRuntime = vi
+      .fn()
+      .mockReturnValueOnce(firstRuntime)
+      .mockReturnValueOnce(secondRuntime);
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      createRuntime,
+      shellEnv: {
+        PATH: "/old/bin:/usr/bin",
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+    await manager.replaceBaseShellEnv({
+      PATH: "/new/bin:/usr/bin",
+    });
+
+    expect(manager.get("env-1")).toBeUndefined();
+    expect(firstRuntime.shutdown).toHaveBeenCalledTimes(1);
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+
+    expect(createRuntime).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        env: {
+          PATH: "/new/bin:/usr/bin",
+        },
+        shellEnv: {
+          PATH: "/new/bin:/usr/bin",
+        },
+      }),
+    );
+    expect(secondRuntime.shutdown).not.toHaveBeenCalled();
   });
 
   it("reuses the existing runtime for subsequent requests", async () => {

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -235,11 +235,29 @@ interface RunCancellableEnvironmentProvisionArgs {
   work: (signal: AbortSignal) => Promise<void>;
 }
 
+function shellEnvEquals(
+  left: NonNullable<AgentRuntimeOptions["shellEnv"]>,
+  right: NonNullable<AgentRuntimeOptions["shellEnv"]>,
+): boolean {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  if (leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  return leftEntries.every(([key, value]) => right[key] === value);
+}
+
+function providerProcessEnvFromShellEnv(
+  shellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]>,
+): Record<string, string> | null {
+  return shellEnv.PATH ? { PATH: shellEnv.PATH } : null;
+}
+
 export class RuntimeManager {
   private readonly createRuntime;
   private readonly hostWatcher;
   private readonly provisionWorkspace;
-  private readonly baseShellEnv;
+  private baseShellEnv;
   private readonly entries = new Map<string, RuntimeEntry>();
   private readonly pendingEntries = new Map<string, Promise<RuntimeEntry>>();
   private readonly pendingEnvironmentProvisions = new Map<
@@ -338,6 +356,18 @@ export class RuntimeManager {
       ...this.baseShellEnv,
       ...this.managedShellEnv,
     };
+  }
+
+  async replaceBaseShellEnv(
+    shellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]>,
+  ): Promise<void> {
+    if (shellEnvEquals(this.baseShellEnv, shellEnv)) {
+      return;
+    }
+
+    this.baseShellEnv = { ...shellEnv };
+    await this.shutdownProviderMaintenanceRuntime();
+    await this.evictIdleRuntimeEntries();
   }
 
   private getInjectedSkillsLogger(): InjectedSkillsLogger | undefined {
@@ -481,6 +511,42 @@ export class RuntimeManager {
     shellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]>,
   ): void {
     this.managedShellEnv = { ...shellEnv };
+  }
+
+  private async shutdownProviderMaintenanceRuntime(): Promise<void> {
+    const existingRuntime = this.providerMaintenanceRuntime;
+    const pendingRuntime = this.pendingProviderMaintenanceRuntime;
+    this.providerMaintenanceRuntime = null;
+    this.pendingProviderMaintenanceRuntime = null;
+
+    const resolvedPendingRuntime = pendingRuntime
+      ? await pendingRuntime.catch(() => null)
+      : null;
+    if (
+      resolvedPendingRuntime &&
+      this.providerMaintenanceRuntime === resolvedPendingRuntime
+    ) {
+      this.providerMaintenanceRuntime = null;
+    }
+
+    const runtimes = [...new Set([existingRuntime, resolvedPendingRuntime])];
+    await Promise.all(
+      runtimes.map((runtime) => runtime?.shutdown() ?? Promise.resolve()),
+    );
+  }
+
+  private async evictIdleRuntimeEntries(): Promise<void> {
+    const idleEntries = [...this.entries.values()].filter(
+      (entry) => !this.entryHasActiveRuntimeWork(entry),
+    );
+
+    for (const entry of idleEntries) {
+      await this.stopWatchingStatus(entry);
+      this.entries.delete(entry.environmentId);
+    }
+
+    await Promise.all(idleEntries.map((entry) => entry.runtime.shutdown()));
+    await this.cleanupUnusedInjectedSkillStagingDirs([]);
   }
 
   async openWorkspace(path: string): Promise<HostWorkspace> {
@@ -818,10 +884,13 @@ export class RuntimeManager {
     await mkdir(workspacePath, { recursive: true });
 
     let runtime: AgentRuntime | null = null;
+    const shellEnv = this.getShellEnv();
+    const providerProcessEnv = providerProcessEnvFromShellEnv(shellEnv);
     runtime = this.createRuntime({
       workspacePath,
       additionalWorkspaceWriteRoots: [],
-      shellEnv: this.getShellEnv(),
+      ...(providerProcessEnv ? { env: providerProcessEnv } : {}),
+      shellEnv,
       threadStorageRootPath: this.options.threadStorageRootPath ?? undefined,
       bridgeBundleDir: this.options.bridgeBundleDir,
       onEvent: (event) => {
@@ -883,11 +952,14 @@ export class RuntimeManager {
       workspaceRoots: workspaceWriteRoots,
     });
     let runtime: AgentRuntime | null = null;
+    const shellEnv = this.getShellEnv();
+    const providerProcessEnv = providerProcessEnvFromShellEnv(shellEnv);
     runtime = this.createRuntime({
       workspacePath: workspace.path,
       additionalWorkspaceWriteRoots,
       ...(args.skillConfig ? { skillRoots: args.skillConfig.skillRoots } : {}),
-      shellEnv: this.getShellEnv(),
+      ...(providerProcessEnv ? { env: providerProcessEnv } : {}),
+      shellEnv,
       threadStorageRootPath: this.options.threadStorageRootPath ?? undefined,
       bridgeBundleDir: this.options.bridgeBundleDir,
       onEvent: (event) => {

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -230,6 +230,11 @@ interface PendingEnvironmentProvision {
   done: Promise<unknown>;
 }
 
+interface PendingProviderMaintenanceRuntime {
+  generation: number;
+  promise: Promise<AgentRuntime>;
+}
+
 interface RunCancellableEnvironmentProvisionArgs {
   environmentId: string;
   work: (signal: AbortSignal) => Promise<void>;
@@ -265,8 +270,9 @@ export class RuntimeManager {
     PendingEnvironmentProvision
   >();
   private providerMaintenanceRuntime: AgentRuntime | null = null;
-  private pendingProviderMaintenanceRuntime: Promise<AgentRuntime> | null =
+  private pendingProviderMaintenanceRuntime: PendingProviderMaintenanceRuntime | null =
     null;
+  private providerMaintenanceRuntimeGeneration = 0;
   private managedShellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]> = {};
   private stopWatchingDataDirSkillsRoot: StopWatching = STOP_WATCHING;
 
@@ -516,11 +522,14 @@ export class RuntimeManager {
   private async shutdownProviderMaintenanceRuntime(): Promise<void> {
     const existingRuntime = this.providerMaintenanceRuntime;
     const pendingRuntime = this.pendingProviderMaintenanceRuntime;
+    this.providerMaintenanceRuntimeGeneration += 1;
     this.providerMaintenanceRuntime = null;
-    this.pendingProviderMaintenanceRuntime = null;
+    if (this.pendingProviderMaintenanceRuntime === pendingRuntime) {
+      this.pendingProviderMaintenanceRuntime = null;
+    }
 
     const resolvedPendingRuntime = pendingRuntime
-      ? await pendingRuntime.catch(() => null)
+      ? await pendingRuntime.promise.catch(() => null)
       : null;
     if (
       resolvedPendingRuntime &&
@@ -563,19 +572,33 @@ export class RuntimeManager {
       return this.providerMaintenanceRuntime;
     }
     if (this.pendingProviderMaintenanceRuntime) {
-      return this.pendingProviderMaintenanceRuntime;
+      return this.pendingProviderMaintenanceRuntime.promise;
     }
 
-    const creation = this.createProviderMaintenanceRuntime(args).then(
-      (runtime) => {
-        this.providerMaintenanceRuntime = runtime;
+    const generation = this.providerMaintenanceRuntimeGeneration;
+    let pendingRuntime!: PendingProviderMaintenanceRuntime;
+    const promise = Promise.resolve()
+      .then(() => this.createProviderMaintenanceRuntime(args))
+      .then((runtime) => {
+        if (
+          this.pendingProviderMaintenanceRuntime === pendingRuntime &&
+          this.providerMaintenanceRuntimeGeneration === generation
+        ) {
+          this.providerMaintenanceRuntime = runtime;
+        }
         return runtime;
-      },
-    );
-    this.pendingProviderMaintenanceRuntime = creation.finally(() => {
-      this.pendingProviderMaintenanceRuntime = null;
-    });
-    return this.pendingProviderMaintenanceRuntime;
+      })
+      .finally(() => {
+        if (this.pendingProviderMaintenanceRuntime === pendingRuntime) {
+          this.pendingProviderMaintenanceRuntime = null;
+        }
+      });
+    pendingRuntime = {
+      generation,
+      promise,
+    };
+    this.pendingProviderMaintenanceRuntime = pendingRuntime;
+    return promise;
   }
 
   async ensureEnvironment(args: EnsureEnvironmentArgs): Promise<RuntimeEntry> {
@@ -819,16 +842,7 @@ export class RuntimeManager {
       // lifecycle via explicit environment.destroy commands. Daemon shutdown
       // should only release in-memory state and stop provider processes.
     }
-    const providerMaintenanceRuntime =
-      this.providerMaintenanceRuntime ??
-      (this.pendingProviderMaintenanceRuntime
-        ? await this.pendingProviderMaintenanceRuntime.catch(() => null)
-        : null);
-    this.providerMaintenanceRuntime = null;
-    this.pendingProviderMaintenanceRuntime = null;
-    if (providerMaintenanceRuntime) {
-      await providerMaintenanceRuntime.shutdown();
-    }
+    await this.shutdownProviderMaintenanceRuntime();
     await this.stopWatchingDataDirSkillsRoot();
     this.stopWatchingDataDirSkillsRoot = STOP_WATCHING;
     await this.cleanupUnusedInjectedSkillStagingDirs([]);

--- a/apps/host-daemon/src/runtime-shell-env.test.ts
+++ b/apps/host-daemon/src/runtime-shell-env.test.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   prepareRuntimeShellEnv,
   resolveLocalBbExecutableDirectory,
+  resolveUserShellPath,
+  type SpawnUserShellEnv,
+  type SpawnUserShellEnvArgs,
+  type UserShellEnvSpawnResult,
 } from "./runtime-shell-env.js";
 
 const tempDirs: string[] = [];
@@ -23,6 +27,23 @@ interface FakeCliPackageOptions {
 
 interface FakeCliPackage {
   cliEntryPath: string;
+}
+
+interface FakeShellEnvSpawn {
+  calls: SpawnUserShellEnvArgs[];
+  spawn: SpawnUserShellEnv;
+}
+
+interface CreateShellEnvSpawnResultArgs {
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+  status?: number | null;
+  stderr?: string;
+  stdout?: string;
+}
+
+interface CreateFakeShellEnvSpawnArgs {
+  results: UserShellEnvSpawnResult[];
 }
 
 async function withPlatform<T>(
@@ -68,6 +89,47 @@ async function createFakeCliPackage(
 
   return {
     cliEntryPath,
+  };
+}
+
+function createShellEnvSpawnResult(
+  args: CreateShellEnvSpawnResultArgs,
+): UserShellEnvSpawnResult {
+  return {
+    ...(args.error === undefined ? {} : { error: args.error }),
+    signal: args.signal ?? null,
+    status: args.status ?? 0,
+    stderr: args.stderr ?? "",
+    stdout: args.stdout ?? "",
+  };
+}
+
+function createMarkedShellEnvOutput(pathValue: string): string {
+  return [
+    "shell startup noise",
+    "__BB_SHELL_ENV_START__",
+    "USER=test-user",
+    `PATH=${pathValue}`,
+    "__BB_SHELL_ENV_END__",
+    "shell shutdown noise",
+  ].join("\n");
+}
+
+function createFakeShellEnvSpawn(
+  args: CreateFakeShellEnvSpawnArgs,
+): FakeShellEnvSpawn {
+  const calls: SpawnUserShellEnvArgs[] = [];
+  const results = [...args.results];
+  return {
+    calls,
+    async spawn(spawnArgs) {
+      calls.push(spawnArgs);
+      const result = results.shift();
+      if (!result) {
+        throw new Error("Unexpected shell env spawn");
+      }
+      return result;
+    },
   };
 }
 
@@ -135,6 +197,130 @@ describe("resolveLocalBbExecutableDirectory", () => {
         }),
       ),
     ).resolves.toBe(path.dirname(cliEntryPath));
+  });
+});
+
+describe("resolveUserShellPath", () => {
+  it("loads PATH from the configured interactive login shell", async () => {
+    const shellPath = "/root/.local/bin:/usr/local/bin:/usr/bin";
+    const fakeSpawn = createFakeShellEnvSpawn({
+      results: [
+        createShellEnvSpawnResult({
+          stdout: createMarkedShellEnvOutput(shellPath),
+        }),
+      ],
+    });
+
+    await expect(
+      resolveUserShellPath({
+        env: { SHELL: "/usr/bin/bash", PATH: "/usr/bin" },
+        platform: "linux",
+        spawnUserShellEnv: fakeSpawn.spawn,
+        timeoutMs: 1234,
+      }),
+    ).resolves.toBe(shellPath);
+
+    expect(fakeSpawn.calls).toEqual([
+      {
+        command: "/usr/bin/bash",
+        args: [
+          "-ilc",
+          "printf '%s\\n' __BB_SHELL_ENV_START__; env; printf '%s\\n' __BB_SHELL_ENV_END__",
+        ],
+        env: { SHELL: "/usr/bin/bash", PATH: "/usr/bin" },
+        timeoutMs: 1234,
+      },
+    ]);
+  });
+
+  it("falls back to a non-interactive login shell when the interactive probe fails", async () => {
+    const shellPath = "/home/me/.local/bin:/usr/bin";
+    const fakeSpawn = createFakeShellEnvSpawn({
+      results: [
+        createShellEnvSpawnResult({
+          status: 1,
+          stderr: "interactive shell failed",
+        }),
+        createShellEnvSpawnResult({
+          stdout: createMarkedShellEnvOutput(shellPath),
+        }),
+      ],
+    });
+
+    await expect(
+      resolveUserShellPath({
+        env: { SHELL: "/bin/zsh", PATH: "/usr/bin" },
+        platform: "linux",
+        spawnUserShellEnv: fakeSpawn.spawn,
+      }),
+    ).resolves.toBe(shellPath);
+
+    expect(fakeSpawn.calls.map((call) => call.args[0])).toEqual([
+      "-ilc",
+      "-lc",
+    ]);
+  });
+
+  it("uses plain login mode for sh-compatible fallback shells", async () => {
+    const fakeSpawn = createFakeShellEnvSpawn({
+      results: [
+        createShellEnvSpawnResult({
+          stdout: createMarkedShellEnvOutput("/usr/bin:/bin"),
+        }),
+      ],
+    });
+
+    await expect(
+      resolveUserShellPath({
+        env: { PATH: "/usr/bin" },
+        platform: "linux",
+        spawnUserShellEnv: fakeSpawn.spawn,
+      }),
+    ).resolves.toBe("/usr/bin:/bin");
+
+    expect(fakeSpawn.calls[0]?.command).toBe("/bin/sh");
+    expect(fakeSpawn.calls[0]?.args[0]).toBe("-lc");
+  });
+
+  it("uses zsh as the macOS fallback shell when SHELL is unset", async () => {
+    const fakeSpawn = createFakeShellEnvSpawn({
+      results: [
+        createShellEnvSpawnResult({
+          stdout: createMarkedShellEnvOutput("/opt/homebrew/bin:/usr/bin"),
+        }),
+      ],
+    });
+
+    await expect(
+      resolveUserShellPath({
+        env: { PATH: "/usr/bin" },
+        platform: "darwin",
+        spawnUserShellEnv: fakeSpawn.spawn,
+      }),
+    ).resolves.toBe("/opt/homebrew/bin:/usr/bin");
+
+    expect(fakeSpawn.calls[0]?.command).toBe("/bin/zsh");
+    expect(fakeSpawn.calls[0]?.args[0]).toBe("-ilc");
+  });
+
+  it("skips shell probing on Windows", async () => {
+    const fakeSpawn = createFakeShellEnvSpawn({
+      results: [
+        createShellEnvSpawnResult({
+          stdout: createMarkedShellEnvOutput("C:\\Windows"),
+        }),
+      ],
+    });
+
+    await expect(
+      resolveUserShellPath({
+        env: { SHELL: "/bin/bash", PATH: "C:\\Windows" },
+        platform: "win32",
+        spawnUserShellEnv: fakeSpawn.spawn,
+      }),
+    ).resolves.toBeNull();
+
+    expect(fakeSpawn.calls).toEqual([]);
   });
 });
 

--- a/apps/host-daemon/src/runtime-shell-env.test.ts
+++ b/apps/host-daemon/src/runtime-shell-env.test.ts
@@ -201,6 +201,33 @@ describe("resolveLocalBbExecutableDirectory", () => {
 });
 
 describe("resolveUserShellPath", () => {
+  it("settles when the shell env probe times out even if the shell ignores SIGTERM", async () => {
+    const shellDir = await makeTempDir("bb-shell-timeout-");
+    const shellPath = path.join(shellDir, "ignore-term-shell");
+    await fs.writeFile(
+      shellPath,
+      [
+        "#!/usr/bin/env node",
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    await fs.chmod(shellPath, 0o755);
+
+    const startedAt = Date.now();
+
+    await expect(
+      resolveUserShellPath({
+        env: { SHELL: shellPath, PATH: "/usr/bin" },
+        platform: "linux",
+        timeoutMs: 25,
+      }),
+    ).resolves.toBeNull();
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
   it("loads PATH from the configured interactive login shell", async () => {
     const shellPath = "/root/.local/bin:/usr/local/bin:/usr/bin";
     const fakeSpawn = createFakeShellEnvSpawn({

--- a/apps/host-daemon/src/runtime-shell-env.ts
+++ b/apps/host-daemon/src/runtime-shell-env.ts
@@ -51,6 +51,7 @@ const SHELL_ENV_COMMAND = [
   `printf '%s\\n' ${SHELL_ENV_END_MARKER}`,
 ].join("; ");
 const USER_SHELL_ENV_TIMEOUT_MS = 3_000;
+const USER_SHELL_ENV_FORCE_KILL_AFTER_MS = 1_000;
 
 function getDefaultCliExecutablePath(): string {
   return fileURLToPath(new URL("../../cli/bin/bb", import.meta.url));
@@ -117,17 +118,45 @@ function defaultSpawnUserShellEnv(
     let stderr = "";
     let settled = false;
     let timeout: NodeJS.Timeout | undefined;
+    let forceKillTimeout: NodeJS.Timeout | undefined;
     let child: ReturnType<typeof spawn>;
 
-    function settle(result: UserShellEnvSpawnResult): void {
+    function clearTimeouts(args?: { keepForceKillTimeout?: boolean }): void {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+      if (!args?.keepForceKillTimeout && forceKillTimeout) {
+        clearTimeout(forceKillTimeout);
+        forceKillTimeout = undefined;
+      }
+    }
+
+    function settle(
+      result: UserShellEnvSpawnResult,
+      args?: { keepForceKillTimeout?: boolean },
+    ): void {
       if (settled) {
         return;
       }
       settled = true;
-      if (timeout) {
-        clearTimeout(timeout);
-      }
+      clearTimeouts(args);
       resolveSpawn(result);
+    }
+
+    function forceKillChildAfterDelay(): void {
+      if (forceKillTimeout) {
+        return;
+      }
+      forceKillTimeout = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, USER_SHELL_ENV_FORCE_KILL_AFTER_MS);
+      forceKillTimeout.unref();
+    }
+
+    function terminateChild(): void {
+      child.kill("SIGTERM");
+      forceKillChildAfterDelay();
     }
 
     try {
@@ -147,18 +176,34 @@ function defaultSpawnUserShellEnv(
     }
 
     timeout = setTimeout(() => {
-      child.kill("SIGTERM");
+      terminateChild();
+      settle(
+        {
+          error: new Error(
+            `Shell env probe timed out after ${args.timeoutMs}ms`,
+          ),
+          signal: "SIGTERM",
+          status: null,
+          stderr,
+          stdout,
+        },
+        { keepForceKillTimeout: true },
+      );
     }, args.timeoutMs);
+    timeout.unref();
 
     if (!child.stdout || !child.stderr) {
-      child.kill("SIGTERM");
-      settle({
-        error: new Error("Shell env probe did not attach stdout and stderr"),
-        signal: null,
-        status: null,
-        stderr,
-        stdout,
-      });
+      terminateChild();
+      settle(
+        {
+          error: new Error("Shell env probe did not attach stdout and stderr"),
+          signal: null,
+          status: null,
+          stderr,
+          stdout,
+        },
+        { keepForceKillTimeout: true },
+      );
       return;
     }
 
@@ -171,6 +216,10 @@ function defaultSpawnUserShellEnv(
       stderr += chunk;
     });
     child.on("error", (error) => {
+      if (settled) {
+        clearTimeouts();
+        return;
+      }
       settle({
         error,
         signal: null,
@@ -180,6 +229,10 @@ function defaultSpawnUserShellEnv(
       });
     });
     child.on("close", (status, signal) => {
+      if (settled) {
+        clearTimeouts();
+        return;
+      }
       settle({
         signal,
         status,

--- a/apps/host-daemon/src/runtime-shell-env.ts
+++ b/apps/host-daemon/src/runtime-shell-env.ts
@@ -1,6 +1,7 @@
+import { spawn } from "node:child_process";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
-import { delimiter, dirname, resolve } from "node:path";
+import { basename, delimiter, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentRuntimeOptions } from "@bb/agent-runtime";
 import { assignIfDefined } from "@bb/config/objects";
@@ -15,6 +16,41 @@ export interface PrepareRuntimeShellEnvOptions {
   serverUrl: string;
   inheritedPath?: string;
 }
+
+export interface ResolveUserShellPathOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  spawnUserShellEnv?: SpawnUserShellEnv;
+  timeoutMs?: number;
+}
+
+export interface SpawnUserShellEnvArgs {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+}
+
+export interface UserShellEnvSpawnResult {
+  error?: Error;
+  signal: NodeJS.Signals | null;
+  status: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+export type SpawnUserShellEnv = (
+  args: SpawnUserShellEnvArgs,
+) => Promise<UserShellEnvSpawnResult>;
+
+const SHELL_ENV_START_MARKER = "__BB_SHELL_ENV_START__";
+const SHELL_ENV_END_MARKER = "__BB_SHELL_ENV_END__";
+const SHELL_ENV_COMMAND = [
+  `printf '%s\\n' ${SHELL_ENV_START_MARKER}`,
+  "env",
+  `printf '%s\\n' ${SHELL_ENV_END_MARKER}`,
+].join("; ");
+const USER_SHELL_ENV_TIMEOUT_MS = 3_000;
 
 function getDefaultCliExecutablePath(): string {
   return fileURLToPath(new URL("../../cli/bin/bb", import.meta.url));
@@ -71,6 +107,175 @@ function prependPath(
   return inheritedPath
     ? `${executableDirectoryPath}${delimiter}${inheritedPath}`
     : executableDirectoryPath;
+}
+
+function defaultSpawnUserShellEnv(
+  args: SpawnUserShellEnvArgs,
+): Promise<UserShellEnvSpawnResult> {
+  return new Promise<UserShellEnvSpawnResult>((resolveSpawn) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timeout: NodeJS.Timeout | undefined;
+    let child: ReturnType<typeof spawn>;
+
+    function settle(result: UserShellEnvSpawnResult): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolveSpawn(result);
+    }
+
+    try {
+      child = spawn(args.command, args.args, {
+        env: args.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      settle({
+        error: error instanceof Error ? error : new Error(String(error)),
+        signal: null,
+        status: null,
+        stderr,
+        stdout,
+      });
+      return;
+    }
+
+    timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+    }, args.timeoutMs);
+
+    if (!child.stdout || !child.stderr) {
+      child.kill("SIGTERM");
+      settle({
+        error: new Error("Shell env probe did not attach stdout and stderr"),
+        signal: null,
+        status: null,
+        stderr,
+        stdout,
+      });
+      return;
+    }
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      settle({
+        error,
+        signal: null,
+        status: null,
+        stderr,
+        stdout,
+      });
+    });
+    child.on("close", (status, signal) => {
+      settle({
+        signal,
+        status,
+        stderr,
+        stdout,
+      });
+    });
+  });
+}
+
+function resolveUserShellCommand(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string | null {
+  if (platform === "win32") {
+    return null;
+  }
+  const configuredShell = env.SHELL?.trim();
+  if (configuredShell && configuredShell.length > 0) {
+    return configuredShell;
+  }
+  return platform === "darwin" ? "/bin/zsh" : "/bin/sh";
+}
+
+function userShellEnvArgSets(shell: string): string[][] {
+  const shellName = basename(shell);
+  if (shellName === "sh" || shellName === "dash") {
+    return [["-lc", SHELL_ENV_COMMAND]];
+  }
+  return [
+    ["-ilc", SHELL_ENV_COMMAND],
+    ["-lc", SHELL_ENV_COMMAND],
+  ];
+}
+
+function parsePathFromUserShellEnv(stdout: string): string | null {
+  const lines = stdout.split(/\r?\n/u);
+  const startIndex = lines.findIndex(
+    (line) => line.trim() === SHELL_ENV_START_MARKER,
+  );
+  if (startIndex === -1) {
+    return null;
+  }
+  const endIndex = lines.findIndex(
+    (line, index) =>
+      index > startIndex && line.trim() === SHELL_ENV_END_MARKER,
+  );
+  if (endIndex === -1) {
+    return null;
+  }
+
+  for (const line of lines.slice(startIndex + 1, endIndex)) {
+    if (!line.startsWith("PATH=")) {
+      continue;
+    }
+    const pathValue = line.slice("PATH=".length).trim();
+    return pathValue.length > 0 ? pathValue : null;
+  }
+  return null;
+}
+
+export async function resolveUserShellPath(
+  options: ResolveUserShellPathOptions = {},
+): Promise<string | null> {
+  const env = options.env ?? process.env;
+  const shell = resolveUserShellCommand(
+    env,
+    options.platform ?? process.platform,
+  );
+  if (!shell) {
+    return null;
+  }
+
+  const spawnUserShellEnv =
+    options.spawnUserShellEnv ?? defaultSpawnUserShellEnv;
+  for (const shellArgs of userShellEnvArgSets(shell)) {
+    const result = await spawnUserShellEnv({
+      command: shell,
+      args: shellArgs,
+      env,
+      timeoutMs: options.timeoutMs ?? USER_SHELL_ENV_TIMEOUT_MS,
+    });
+    if (
+      result.error !== undefined ||
+      result.signal !== null ||
+      result.status !== 0
+    ) {
+      continue;
+    }
+    const path = parsePathFromUserShellEnv(result.stdout);
+    if (path !== null) {
+      return path;
+    }
+  }
+
+  return null;
 }
 
 export async function resolveLocalBbExecutableDirectory(

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -23,6 +23,7 @@ import {
 import {
   prepareRuntimeShellEnv,
   resolveLocalBbExecutableDirectory,
+  resolveUserShellPath,
 } from "./runtime-shell-env.js";
 import type { HostDaemonLogger } from "./logger.js";
 import type { CreateReconnectingWebSocket } from "./server-connection.js";
@@ -152,12 +153,23 @@ export async function startHostDaemon(
     const bbExecutableDirectory =
       options.bbExecutableDirectory ??
       (await resolveLocalBbExecutableDirectory());
+    const logger =
+      options.logger ??
+      createLogger({
+        component: "host-daemon",
+        base: { serverUrl },
+        dataDir,
+        transportMode: "worker",
+      });
     const hostWatcher = options.hostWatcher ?? (await createHostWatcher());
-    const runtimeShellEnv = prepareRuntimeShellEnv({
-      bbExecutableDirectory,
-      hostDaemonPort: localApiConfig?.port,
-      serverUrl,
-    });
+    const resolveRuntimeShellEnv = async () =>
+      prepareRuntimeShellEnv({
+        bbExecutableDirectory,
+        hostDaemonPort: localApiConfig?.port,
+        inheritedPath: (await resolveUserShellPath()) ?? process.env.PATH,
+        serverUrl,
+      });
+    const runtimeShellEnv = await resolveRuntimeShellEnv();
     app = await createHostDaemonApp({
       dataDir,
       serverUrl,
@@ -172,18 +184,12 @@ export async function startHostDaemon(
           ? undefined
           : hostDaemonConfig?.BB_APP_URL,
       devAppPort: hostDaemonConfig?.BB_DEV_APP_PORT,
-      logger:
-        options.logger ??
-        createLogger({
-          component: "host-daemon",
-          base: { serverUrl },
-          dataDir,
-          transportMode: "worker",
-        }),
+      logger,
       releaseLock,
       localApiConfig,
       createRuntime: options.createRuntime,
       runtimeShellEnv,
+      resolveRuntimeShellEnv,
       hostWatcher,
       onToolCall: options.onToolCall,
       pickFolder: options.pickFolder,

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -211,5 +211,9 @@ function toModelLoadErrorCode(
     return "missing_executable";
   }
 
+  if (error.body.code === "auth_required") {
+    return "auth_required";
+  }
+
   return "failed";
 }

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -221,4 +221,35 @@ describe("resolveSystemExecutionOptions", () => {
       },
     );
   });
+
+  it("surfaces provider auth-required model load failures", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-execution-options-auth-required",
+      });
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelErrorsByProviderId: {
+          "acp-cursor": {
+            errorCode: "auth_required",
+            errorMessage:
+              "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
+          },
+        },
+      });
+
+      const response = await resolveSystemExecutionOptions(harness.deps, {
+        hostId: host.id,
+        providerId: "acp-cursor",
+      });
+
+      expect(response.modelLoadError).toEqual({
+        providerId: "acp-cursor",
+        code: "auth_required",
+      });
+      expect(response.models).toEqual([]);
+      expect(response.selectedOnlyModels).toEqual([]);
+    });
+  });
 });

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -233,8 +233,7 @@ describe("resolveSystemExecutionOptions", () => {
         modelErrorsByProviderId: {
           "acp-cursor": {
             errorCode: "auth_required",
-            errorMessage:
-              "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
+            errorMessage: "Cursor agent is not authenticated.",
           },
         },
       });

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -232,7 +232,7 @@ describe("acp bridge", () => {
     });
   });
 
-  it("falls back to the synthetic model when the list command fails", async () => {
+  it("fails model/list with a clear error when the list command is missing", async () => {
     const failingId = sendRequest("model/list", {
       listCommand: {
         command: "/nonexistent/acp-model-lister",
@@ -240,10 +240,13 @@ describe("acp bridge", () => {
       },
       primaryModels: [],
     });
-    expect((await waitForResponse(failingId)).result).toMatchObject({
-      models: [{ id: "acp-default", isDefault: true }],
-    });
+    const failingResponse = await waitForResponse(failingId);
+    expect(failingResponse.error?.message).toMatch(
+      /spawn \/nonexistent\/acp-model-lister ENOENT/,
+    );
+  });
 
+  it("falls back to the synthetic model when the list command prints no models", async () => {
     const emptyId = sendRequest("model/list", {
       listCommand: {
         command: process.execPath,

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -246,6 +246,27 @@ describe("acp bridge", () => {
     );
   });
 
+  it("fails model/list when the list command reports Cursor auth is required", async () => {
+    const authId = sendRequest("model/list", {
+      listCommand: {
+        command: process.execPath,
+        args: [
+          "-e",
+          [
+            "console.error(\"Error: Authentication required. Run 'agent login', pass --api-key/--auth-token, or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.\");",
+            "process.exit(1);",
+          ].join(""),
+        ],
+      },
+      primaryModels: [],
+    });
+
+    const response = await waitForResponse(authId);
+    expect(response.error?.message).toBe(
+      "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
+    );
+  });
+
   it("falls back to the synthetic model when the list command prints no models", async () => {
     const emptyId = sendRequest("model/list", {
       listCommand: {

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -263,7 +263,7 @@ describe("acp bridge", () => {
 
     const response = await waitForResponse(authId);
     expect(response.error?.message).toBe(
-      "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.",
+      "Cursor agent is not authenticated.",
     );
   });
 

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -195,12 +195,22 @@ let cachedModelCatalog: { key: string; catalog: AgentModelCatalog } | null =
 async function loadAgentModelCatalog(
   listCommand: AcpBridgeAgentCommand,
 ): Promise<AgentModelCatalog | null> {
-  const stdout = await new Promise<string | null>((resolveExec) => {
+  const stdout = await new Promise<string | null>((resolveExec, rejectExec) => {
     execFile(
       listCommand.command,
       listCommand.args,
       { timeout: MODEL_LIST_TIMEOUT_MS },
-      (error, out) => resolveExec(error ? null : out),
+      (error, out) => {
+        if (!error) {
+          resolveExec(out);
+          return;
+        }
+        if (isMissingExecutableError(error)) {
+          rejectExec(error);
+          return;
+        }
+        resolveExec(null);
+      },
     );
   });
   const key = JSON.stringify(listCommand);
@@ -219,6 +229,17 @@ async function loadAgentModelCatalog(
   }
   cachedModelCatalog = { key, catalog };
   return catalog;
+}
+
+function isMissingExecutableError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "ENOENT" &&
+    "syscall" in error &&
+    typeof error.syscall === "string" &&
+    error.syscall.startsWith("spawn")
+  );
 }
 
 /**

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -181,6 +181,8 @@ const ACP_DEFAULT_MODEL: AvailableModel = {
 };
 
 const MODEL_LIST_TIMEOUT_MS = 30_000;
+const AUTH_REQUIRED_MODEL_LIST_ERROR_MESSAGE =
+  "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.";
 
 let cachedModelCatalog: { key: string; catalog: AgentModelCatalog } | null =
   null;
@@ -200,13 +202,17 @@ async function loadAgentModelCatalog(
       listCommand.command,
       listCommand.args,
       { timeout: MODEL_LIST_TIMEOUT_MS },
-      (error, out) => {
+      (error, out, stderr) => {
         if (!error) {
           resolveExec(out);
           return;
         }
         if (isMissingExecutableError(error)) {
           rejectExec(error);
+          return;
+        }
+        if (isAuthRequiredModelListError(error, out, stderr)) {
+          rejectExec(new AcpModelListAuthRequiredError());
           return;
         }
         resolveExec(null);
@@ -239,6 +245,33 @@ function isMissingExecutableError(error: unknown): boolean {
     "syscall" in error &&
     typeof error.syscall === "string" &&
     error.syscall.startsWith("spawn")
+  );
+}
+
+class AcpModelListAuthRequiredError extends Error {
+  readonly code = "auth_required";
+
+  constructor() {
+    super(AUTH_REQUIRED_MODEL_LIST_ERROR_MESSAGE);
+    this.name = "AcpModelListAuthRequiredError";
+  }
+}
+
+function isAuthRequiredModelListError(
+  error: unknown,
+  stdout: string,
+  stderr: string,
+): boolean {
+  const text = [
+    error instanceof Error ? error.message : String(error),
+    stdout,
+    stderr,
+  ].join("\n");
+  return (
+    text.includes("Authentication required") &&
+    (text.includes("agent login") ||
+      text.includes("CURSOR_API_KEY") ||
+      text.includes("CURSOR_AUTH_TOKEN"))
   );
 }
 

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -182,7 +182,7 @@ const ACP_DEFAULT_MODEL: AvailableModel = {
 
 const MODEL_LIST_TIMEOUT_MS = 30_000;
 const AUTH_REQUIRED_MODEL_LIST_ERROR_MESSAGE =
-  "Cursor agent is installed but not authenticated. Run `agent login` or set CURSOR_API_KEY/CURSOR_AUTH_TOKEN.";
+  "Cursor agent is not authenticated.";
 
 let cachedModelCatalog: { key: string; catalog: AgentModelCatalog } | null =
   null;

--- a/packages/host-daemon-contract/src/local.ts
+++ b/packages/host-daemon-contract/src/local.ts
@@ -100,7 +100,7 @@ export type StatusResponse = z.infer<typeof statusResponseSchema>;
 export const healthResponseSchema = z.string().min(1);
 export type HealthResponse = z.infer<typeof healthResponseSchema>;
 
-export const providerCliKeyValues = ["codex", "claudeCode"] as const;
+export const providerCliKeyValues = ["codex", "claudeCode", "cursor"] as const;
 export const providerCliKeySchema = z.enum(providerCliKeyValues);
 export type ProviderCliKey = z.infer<typeof providerCliKeySchema>;
 
@@ -158,17 +158,17 @@ export const providerCliStatusSchema = z.object({
   installSource: providerCliInstallSourceSchema,
   currentVersion: z.string().min(1).nullable(),
   latestVersion: z.string().min(1).nullable(),
-  npmPackageName: z.string().min(1),
+  npmPackageName: z.string().min(1).nullable(),
   npmGlobalPackageVersion: z.string().min(1).nullable(),
   installAction: providerCliInstallActionSchema.nullable(),
   needsUpdate: z.boolean(),
 });
 export type ProviderCliStatus = z.infer<typeof providerCliStatusSchema>;
 
-export const providerCliStatusResponseSchema = z.object({
-  codex: providerCliStatusSchema,
-  claudeCode: providerCliStatusSchema,
-});
+export const providerCliStatusResponseSchema = z.record(
+  providerCliKeySchema,
+  providerCliStatusSchema,
+);
 export type ProviderCliStatusResponse = z.infer<
   typeof providerCliStatusResponseSchema
 >;

--- a/packages/host-daemon-contract/test/local.test.ts
+++ b/packages/host-daemon-contract/test/local.test.ts
@@ -93,7 +93,7 @@ describe("pathsExistResponseSchema", () => {
 });
 
 describe("provider CLI schemas", () => {
-  it("accepts status for Codex and Claude Code", () => {
+  it("accepts status for provider CLIs", () => {
     expect(
       providerCliStatusResponseSchema.parse({
         codex: {
@@ -132,6 +132,25 @@ describe("provider CLI schemas", () => {
           },
           needsUpdate: true,
         },
+        cursor: {
+          displayName: "Cursor",
+          executableName: "agent",
+          executablePath: null,
+          installed: false,
+          installSource: "notInstalled",
+          currentVersion: null,
+          latestVersion: null,
+          npmPackageName: null,
+          npmGlobalPackageVersion: null,
+          installAction: {
+            kind: "install",
+            label: "Install",
+            commandKind: "shell",
+            command:
+              'tmp=$(mktemp "${TMPDIR:-/tmp}/provider-cli-install.XXXXXX") && trap \'rm -f "$tmp"\' EXIT && curl -fsSL https://cursor.com/install -o "$tmp" && bash "$tmp"',
+          },
+          needsUpdate: false,
+        },
       }).claudeCode.needsUpdate,
     ).toBe(true);
 
@@ -167,6 +186,19 @@ describe("provider CLI schemas", () => {
             command:
               'tmp=$(mktemp "${TMPDIR:-/tmp}/provider-cli-install.XXXXXX") && trap \'rm -f "$tmp"\' EXIT && curl -fsSL https://claude.ai/install.sh -o "$tmp" && bash "$tmp"',
           },
+          needsUpdate: false,
+        },
+        cursor: {
+          displayName: "Cursor",
+          executableName: "agent",
+          executablePath: "/Users/me/.local/bin/agent",
+          installed: true,
+          installSource: "external",
+          currentVersion: null,
+          latestVersion: null,
+          npmPackageName: null,
+          npmGlobalPackageVersion: null,
+          installAction: null,
           needsUpdate: false,
         },
       }).claudeCode.installAction,

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -8,6 +8,7 @@ import {
 
 export const systemExecutionOptionsModelLoadErrorCodeSchema = z.enum([
   "missing_executable",
+  "auth_required",
   "timeout",
   "failed",
 ]);


### PR DESCRIPTION
## Summary
- add Cursor to provider CLI health/status and install handling
- make ACP model listing surface missing Cursor `agent` instead of falling back to `acp-default`
- resolve provider CLI PATH from the user shell, refresh it for provider health/model-list requests, and recreate stale idle runtimes when it changes
- harden user-shell PATH probing so timeouts settle immediately and stubborn shells are force-killed
- guard provider maintenance runtime creation so stale pending model-list runtimes cannot replace or clear newer runtimes
- surface Cursor auth-required model-list failures as picker errors instead of silently showing `Agent default`
- show Cursor-specific missing CLI/auth messaging, with concise auth copy in the picker, and block root compose submit on missing executable/auth-required model-load errors
- polish the picker load-error state by hiding reasoning and spacing the error text cleanly

## Validation
- pnpm exec turbo run test --filter=@bb/host-daemon-contract
- pnpm exec turbo run test --filter=@bb/host-daemon
- pnpm exec turbo run test --filter=@bb/agent-runtime
- pnpm exec turbo run test --filter=@bb/server
- pnpm exec turbo run test --filter=@bb/server-contract
- pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/agent-runtime --filter=@bb/server --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/host-daemon
- pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon --filter=@bb/server --filter=@bb/server-contract --filter=@bb/app
- git diff --check
