### PR TITLE
Optimistically update thread renames

### DIFF
--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../queries/query-keys";
 import {
   beginThreadReadStateTransaction,
+  beginThreadTitleTransaction,
   rollbackThreadListMutationTransaction,
 } from "./thread-state-cache-owner";
 
@@ -87,6 +88,68 @@ function makeSidebarNavigation(
 }
 
 describe("thread state cache owner", () => {
+  it("optimistically renames thread in thread, list, and sidebar caches", async () => {
+    const { queryClient } = createQueryClientTestHarness();
+    const threadId = "thread-1";
+    const thread = makeThreadWithRuntime({
+      id: threadId,
+      title: "Old title",
+    });
+    const listEntry = makeThreadListEntry({
+      id: threadId,
+      title: "Old title",
+    });
+    const threadListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+
+    queryClient.setQueryData(threadQueryKey(threadId), thread);
+    queryClient.setQueryData(threadListKey, [listEntry]);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([listEntry]),
+    );
+
+    const transaction = await beginThreadTitleTransaction({
+      queryClient,
+      threadId,
+      title: "New title",
+    });
+
+    expect(
+      queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId))
+        ?.title,
+    ).toBe("New title");
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0]?.title,
+    ).toBe("New title");
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads[0]?.title,
+    ).toBe("New title");
+
+    rollbackThreadListMutationTransaction({
+      queryClient,
+      threadId,
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId))
+        ?.title,
+    ).toBe("Old title");
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0]?.title,
+    ).toBe("Old title");
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads[0]?.title,
+    ).toBe("Old title");
+  });
+
   it("optimistically marks read state in thread, list, and sidebar caches", async () => {
     const { queryClient } = createQueryClientTestHarness();
     const threadId = "thread-1";

--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
@@ -61,6 +61,10 @@ interface BeginThreadReadStateTransactionArgs extends ThreadIdCacheArgs {
   lastReadAt: number | null;
 }
 
+interface BeginThreadTitleTransactionArgs extends ThreadIdCacheArgs {
+  title: string | null;
+}
+
 interface ReorderPinnedThreadTransactionRequest extends ReorderPinnedThreadRequest {
   id: string;
 }
@@ -351,6 +355,24 @@ export function beginThreadReadStateTransaction({
       ...thread,
       lastReadAt: getOptimisticLastReadAt(thread, lastReadAt),
     }),
+    queryClient,
+    threadId,
+  });
+}
+
+export function beginThreadTitleTransaction({
+  queryClient,
+  threadId,
+  title,
+}: BeginThreadTitleTransactionArgs): Promise<ThreadListMutationTransaction> {
+  return runOptimisticThreadFieldTransaction({
+    applyToLists: (queryClient, threadId) =>
+      applyToCachedThreadListsAndSidebarNavigation(queryClient, (list) =>
+        list.map((thread) =>
+          thread.id === threadId ? { ...thread, title } : thread,
+        ),
+      ),
+    patch: { title },
     queryClient,
     threadId,
   });

--- a/apps/app/src/hooks/mutations/thread-state-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/thread-state-mutations.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ThreadListEntry, ThreadWithRuntime } from "@bb/domain";
+import type {
+  SidebarBootstrapResponse,
+  ThreadResponse,
+} from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/api";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  sidebarNavigationQueryKey,
+  threadListQueryKey,
+  threadQueryKey,
+} from "../queries/query-keys";
+import { useUpdateThread } from "./thread-state-mutations";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    updateThread: vi.fn(),
+  };
+});
+
+function makeThreadWithRuntime(
+  thread: Partial<ThreadWithRuntime> = {},
+): ThreadWithRuntime {
+  return {
+    id: "thread-1",
+    projectId: "project-1",
+    environmentId: "env-1",
+    providerId: "codex",
+    title: null,
+    titleFallback: null,
+    status: "active",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    childOrigin: null,
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 50,
+    createdAt: 1,
+    updatedAt: 1,
+    runtime: {
+      displayStatus: "waiting-for-host",
+      hostReconnectGraceExpiresAt: null,
+    },
+    ...thread,
+  };
+}
+
+function makeThreadResponse(
+  thread: Partial<ThreadResponse> = {},
+): ThreadResponse {
+  return {
+    ...makeThreadWithRuntime(thread),
+    canSpawnChild: true,
+    ...thread,
+  };
+}
+
+function makeThreadListEntry(
+  thread: Partial<ThreadListEntry> = {},
+): ThreadListEntry {
+  return {
+    ...makeThreadWithRuntime(thread),
+    pinSortKey: null,
+    hasPendingInteraction: false,
+    environmentHostId: "host-1",
+    environmentName: "Environment",
+    environmentBranchName: "main",
+    environmentWorkspaceDisplayKind: "managed-worktree",
+    ...thread,
+  };
+}
+
+function makeSidebarNavigation(
+  threads: ThreadListEntry[],
+): SidebarBootstrapResponse {
+  return {
+    projects: [
+      {
+        id: "project-1",
+        kind: "standard",
+        name: "Project",
+        createdAt: 1,
+        updatedAt: 1,
+        sources: [],
+        threads,
+        defaultExecutionOptions: null,
+      },
+    ],
+    personalProject: {
+      id: "proj_personal",
+      kind: "personal",
+      name: "Personal",
+      createdAt: 1,
+      updatedAt: 1,
+      sources: [],
+      threads: [],
+      defaultExecutionOptions: null,
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("thread state mutations", () => {
+  it("optimistically renames a thread while the update request is pending", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const threadId = "thread-1";
+    const thread = makeThreadWithRuntime({
+      id: threadId,
+      title: "Old title",
+    });
+    const listEntry = makeThreadListEntry({
+      id: threadId,
+      title: "Old title",
+    });
+    const threadListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+    let resolveUpdate: (thread: ThreadResponse) => void = () => {};
+
+    queryClient.setQueryData(threadQueryKey(threadId), thread);
+    queryClient.setQueryData(threadListKey, [listEntry]);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([listEntry]),
+    );
+    vi.mocked(api.updateThread).mockImplementation(
+      () =>
+        new Promise<ThreadResponse>((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useUpdateThread(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: threadId, title: "New title" });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId))
+          ?.title,
+      ).toBe("New title");
+    });
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0]?.title,
+    ).toBe("New title");
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads[0]?.title,
+    ).toBe("New title");
+    expect(api.updateThread).toHaveBeenCalledWith(threadId, {
+      title: "New title",
+    });
+
+    act(() => {
+      resolveUpdate(
+        makeThreadResponse({
+          id: threadId,
+          title: "New title",
+          updatedAt: 2,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});

--- a/apps/app/src/hooks/mutations/thread-state-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-state-mutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type {
   ReorderPinnedThreadRequest,
   ThreadArchiveAllResponse,
+  ThreadResponse,
   UpdateThreadRequest,
 } from "@bb/server-contract";
 import * as api from "@/lib/api";
@@ -16,6 +17,7 @@ import {
   beginDeleteThreadTransaction,
   beginPinThreadTransaction,
   beginThreadReadStateTransaction,
+  beginThreadTitleTransaction,
   beginReorderPinnedThreadTransaction,
   beginUnarchiveThreadTransaction,
   beginUnpinThreadTransaction,
@@ -61,7 +63,12 @@ interface DeleteThreadMutationRequest {
 export function useUpdateThread(options?: UpdateThreadMutationOptions) {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<
+    ThreadResponse,
+    Error,
+    UpdateThreadMutationRequest,
+    ThreadListMutationTransaction | undefined
+  >({
     meta: {
       errorMessage: options?.errorMessage ?? "Failed to update thread.",
       ...(options?.lifecycleOperation
@@ -70,6 +77,27 @@ export function useUpdateThread(options?: UpdateThreadMutationOptions) {
     },
     mutationFn: ({ id, ...request }: UpdateThreadMutationRequest) =>
       api.updateThread(id, request),
+    onMutate: ({
+      id,
+      title,
+    }): Promise<ThreadListMutationTransaction | undefined> | undefined => {
+      if (title === undefined) {
+        return undefined;
+      }
+
+      return beginThreadTitleTransaction({
+        queryClient,
+        threadId: id,
+        title,
+      });
+    },
+    onError: (_error, variables, context) => {
+      rollbackThreadListMutationTransaction({
+        queryClient,
+        threadId: variables.id,
+        transaction: context,
+      });
+    },
     onSuccess: (thread) => {
       applyThreadUpdateResult({ queryClient, thread });
     },


### PR DESCRIPTION
## Summary
- add a title-only optimistic transaction for thread rename updates
- wire `useUpdateThread` to patch thread detail, thread list, and sidebar caches before the request resolves
- add cache-owner and hook-level regression tests for optimistic rename behavior

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/hooks/mutations/thread-state-mutations.test.tsx src/hooks/cache-owners/thread-state-cache-owner.test.ts`