### PR TITLE
Fix ACP edit diff stats and completion state

### DIFF
--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -48,6 +48,20 @@ function startTurn(adapter: AcpProviderAdapter) {
   );
 }
 
+function countChangedLines(diff: string | undefined): {
+  added: number;
+  removed: number;
+} {
+  let added = 0;
+  let removed = 0;
+  for (const line of diff?.split("\n") ?? []) {
+    if (line.startsWith("+++ ") || line.startsWith("--- ")) continue;
+    if (line.startsWith("+")) added += 1;
+    if (line.startsWith("-")) removed += 1;
+  }
+  return { added, removed };
+}
+
 describe("acp adapter command plans", () => {
   it("builds thread/start with agent command, policy, and write roots", () => {
     const adapter = createAdapter();
@@ -456,8 +470,8 @@ describe("acp adapter event translation", () => {
           {
             type: "diff",
             path: "/workspace/a.ts",
-            oldText: "old line",
-            newText: "new line",
+            oldText: "same\nold line\nsame\n",
+            newText: "same\nnew line\nsame\n",
           },
         ],
       }),
@@ -473,6 +487,151 @@ describe("acp adapter event translation", () => {
         changes: [{ path: "/workspace/a.ts", kind: "update" }],
       },
     });
+    const change = events[0]?.type === "item/completed" &&
+      events[0].item.type === "fileChange"
+      ? events[0].item.changes[0]
+      : undefined;
+    expect(change?.diff).toContain("-old line");
+    expect(change?.diff).toContain("+new line");
+    expect(change?.diff).not.toContain("-same");
+    expect(change?.diff).not.toContain("+same");
+    expect(countChangedLines(change?.diff)).toEqual({ added: 1, removed: 1 });
+  });
+
+  it("tracks Cursor edit calls as file changes before the final diff arrives", () => {
+    const adapter = createAdapter();
+    startTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call",
+          toolCallId: "call-edit",
+          title: "Edit file",
+          kind: "edit",
+          status: "in_progress",
+          locations: [{ path: "/workspace/a.ts" }],
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "item/started",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        item: {
+          type: "fileChange",
+          id: "call-edit",
+          changes: [{ path: "/workspace/a.ts", kind: "update" }],
+          status: "pending",
+          approvalStatus: null,
+        },
+      },
+    ]);
+
+    const completedEvents = adapter.translateEvent(
+      updateNotification({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-edit",
+        status: "completed",
+        content: [
+          {
+            type: "diff",
+            path: "/workspace/a.ts",
+            oldText: "before\n",
+            newText: "after\n",
+          },
+        ],
+      }),
+      THREAD_CONTEXT,
+    );
+
+    expect(completedEvents).toHaveLength(1);
+    expect(completedEvents[0]).toMatchObject({
+      type: "item/completed",
+      item: {
+        type: "fileChange",
+        id: "call-edit",
+        status: "completed",
+        changes: [{ path: "/workspace/a.ts", kind: "update" }],
+      },
+    });
+    const change =
+      completedEvents[0]?.type === "item/completed" &&
+      completedEvents[0].item.type === "fileChange"
+        ? completedEvents[0].item.changes[0]
+        : undefined;
+    expect(countChangedLines(change?.diff)).toEqual({ added: 1, removed: 1 });
+  });
+
+  it("settles a started generic ACP edit when completion is a file change", () => {
+    const adapter = createAdapter();
+    startTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call",
+          toolCallId: "call-late-diff",
+          title: "Edit file",
+          kind: "edit",
+          status: "in_progress",
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "item/started",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        item: {
+          type: "toolCall",
+          id: "call-late-diff",
+          tool: "Edit file",
+          status: "pending",
+        },
+      },
+    ]);
+
+    const completedEvents = adapter.translateEvent(
+      updateNotification({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-late-diff",
+        status: "completed",
+        content: [
+          {
+            type: "diff",
+            path: "/workspace/a.ts",
+            oldText: "before\n",
+            newText: "after\n",
+          },
+        ],
+      }),
+      THREAD_CONTEXT,
+    );
+
+    expect(completedEvents).toMatchObject([
+      {
+        type: "item/completed",
+        item: {
+          type: "toolCall",
+          id: "call-late-diff",
+          tool: "Edit file",
+          status: "completed",
+        },
+      },
+      {
+        type: "item/completed",
+        item: {
+          type: "fileChange",
+          id: "call-late-diff",
+          status: "completed",
+          changes: [{ path: "/workspace/a.ts", kind: "update" }],
+        },
+      },
+    ]);
   });
 
   it("translates plan updates", () => {

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -16,6 +16,7 @@ import type {
   PendingInteractionApprovalDecision,
   ThreadEvent,
   ThreadEventItem,
+  ThreadEventItemStatus,
   ThreadEventPlanStep,
 } from "@bb/domain";
 import {
@@ -47,6 +48,7 @@ import {
   type AcceptedUserMessageState,
 } from "../shared/accepted-user-messages.js";
 import {
+  buildEditDiff,
   extractResultText,
   toOptionalString,
   withParentToolCallId,
@@ -164,6 +166,13 @@ function mapAcpToolCallStatus(
 const acpRawInputCommandSchema = z
   .object({ command: z.string() })
   .passthrough();
+const acpRawInputPathSchema = z
+  .object({
+    path: z.string().optional(),
+    filePath: z.string().optional(),
+    file_path: z.string().optional(),
+  })
+  .passthrough();
 
 function extractAcpCommand(event: {
   rawInput?: unknown;
@@ -174,6 +183,24 @@ function extractAcpCommand(event: {
     return parsed.data.command;
   }
   return toOptionalString(event.title);
+}
+
+function extractAcpToolCallPath(
+  event: Pick<AcpToolCallUpdateEvent, "locations" | "rawInput">,
+): string | undefined {
+  for (const location of event.locations ?? []) {
+    if (location.path.trim().length > 0) {
+      return location.path;
+    }
+  }
+  const parsed = acpRawInputPathSchema.safeParse(event.rawInput);
+  if (!parsed.success) {
+    return undefined;
+  }
+  return [parsed.data.path, parsed.data.filePath, parsed.data.file_path].find(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0,
+  );
 }
 
 function extractAcpToolCallOutputText(
@@ -209,35 +236,28 @@ function buildAcpFileChangesFromToolCall(
       continue;
     }
     const oldText = entry.oldText ?? undefined;
+    const diff = buildEditDiff(entry.path, oldText, entry.newText);
     changes.push({
       path: entry.path,
       kind: oldText === undefined ? "add" : "update",
-      diff: buildAcpUnifiedDiff(entry.path, oldText, entry.newText),
+      ...(diff ? { diff } : {}),
     });
   }
-  return changes;
-}
+  if (changes.length > 0) {
+    return changes;
+  }
 
-function buildAcpUnifiedDiff(
-  filePath: string,
-  oldText: string | undefined,
-  newText: string,
-): string {
-  const normalizedPath = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
-  const removedLines = (oldText ?? "")
-    .split("\n")
-    .filter(
-      (line, index, lines) => oldText !== undefined || index < lines.length,
-    )
-    .map((line) => `-${line}`);
-  const addedLines = newText.split("\n").map((line) => `+${line}`);
-  const header =
-    oldText === undefined
-      ? ["--- /dev/null", `+++ b/${normalizedPath}`]
-      : [`--- a/${normalizedPath}`, `+++ b/${normalizedPath}`];
-  const body =
-    oldText === undefined ? addedLines : [...removedLines, ...addedLines];
-  return [...header, ...body].join("\n") + "\n";
+  const path = extractAcpToolCallPath(event);
+  if (!path) {
+    return [];
+  }
+  if (event.kind === "edit") {
+    return [{ path, kind: "update" }];
+  }
+  if (event.kind === "delete") {
+    return [{ path, kind: "delete" }];
+  }
+  return [];
 }
 
 function translateAcpToolCallItem(
@@ -293,6 +313,94 @@ function translateAcpToolCallItem(
     },
     parentToolCallId,
   );
+}
+
+function completeAcpStartedToolItem(
+  item: ThreadEventItem,
+  event: AcpToolCallUpdateEvent | undefined,
+  status: ThreadEventItemStatus,
+  parentToolCallId: string | undefined,
+): ThreadEventItem {
+  const resolvedParentToolCallId = parentToolCallId ?? item.parentToolCallId;
+  switch (item.type) {
+    case "commandExecution": {
+      const outputText = event
+        ? extractAcpToolCallOutputText(event)
+        : undefined;
+      return withParentToolCallId(
+        {
+          type: "commandExecution",
+          id: item.id,
+          command: item.command,
+          cwd: item.cwd,
+          status,
+          approvalStatus: item.approvalStatus,
+          ...(outputText === undefined
+            ? {}
+            : { aggregatedOutput: outputText }),
+          ...(status === "completed" || status === "failed"
+            ? { exitCode: status === "failed" ? 1 : 0 }
+            : {}),
+        },
+        resolvedParentToolCallId,
+      );
+    }
+    case "fileChange":
+      return withParentToolCallId(
+        {
+          type: "fileChange",
+          id: item.id,
+          changes: item.changes,
+          status,
+          approvalStatus: item.approvalStatus,
+        },
+        resolvedParentToolCallId,
+      );
+    case "toolCall": {
+      const outputText = event
+        ? extractAcpToolCallOutputText(event)
+        : undefined;
+      return withParentToolCallId(
+        {
+          type: "toolCall",
+          id: item.id,
+          tool: item.tool,
+          ...(item.arguments === undefined
+            ? {}
+            : { arguments: item.arguments }),
+          status,
+          ...(outputText === undefined ? {} : { result: outputText }),
+        },
+        resolvedParentToolCallId,
+      );
+    }
+    default:
+      return item;
+  }
+}
+
+function buildAcpTerminalToolCallItems(args: {
+  completedItem: ThreadEventItem;
+  event: AcpToolCallUpdateEvent;
+  parentToolCallId: string | undefined;
+  startedItem: ThreadEventItem | undefined;
+  status: ThreadEventItemStatus;
+}): ThreadEventItem[] {
+  if (!args.startedItem) {
+    return [args.completedItem];
+  }
+  if (args.startedItem.type === args.completedItem.type) {
+    return [args.completedItem];
+  }
+  return [
+    completeAcpStartedToolItem(
+      args.startedItem,
+      args.event,
+      args.status,
+      args.parentToolCallId,
+    ),
+    args.completedItem,
+  ];
 }
 
 /**
@@ -484,6 +592,56 @@ export function createAcpProviderAdapter(
     });
   }
 
+  function completeOpenToolCallItems(args: {
+    events: ThreadEvent[];
+    parentToolCallId: string | undefined;
+    state: AcpTurnState;
+    status: ThreadEventItemStatus;
+    turnId: string;
+  }): void {
+    for (const [callId, startedItem] of args.state.toolItemsByCallId) {
+      const latestEvent = args.state.toolCallEventsByCallId.get(callId);
+      const latestItem = latestEvent
+        ? translateAcpToolCallItem(latestEvent, args.parentToolCallId)
+        : startedItem;
+      const completedItems =
+        latestItem.type === startedItem.type
+          ? [
+              completeAcpStartedToolItem(
+                latestItem,
+                latestEvent,
+                args.status,
+                args.parentToolCallId,
+              ),
+            ]
+          : [
+              completeAcpStartedToolItem(
+                startedItem,
+                latestEvent,
+                args.status,
+                args.parentToolCallId,
+              ),
+              completeAcpStartedToolItem(
+                latestItem,
+                latestEvent,
+                args.status,
+                args.parentToolCallId,
+              ),
+            ];
+      for (const item of completedItems) {
+        args.events.push({
+          type: "item/completed",
+          threadId: UNSTAMPED_THREAD_ID,
+          providerThreadId: "",
+          scope: turnScope(args.turnId),
+          item,
+        });
+      }
+    }
+    args.state.toolItemsByCallId.clear();
+    args.state.toolCallEventsByCallId.clear();
+  }
+
   function translateAcpUpdate(
     update: AcpSessionUpdate,
     state: AcpTurnState,
@@ -591,6 +749,7 @@ export function createAcpProviderAdapter(
           return events;
         }
         state.toolCallEventsByCallId.set(parsed.data.toolCallId, parsed.data);
+        state.toolItemsByCallId.set(parsed.data.toolCallId, item);
         events.push({
           type: "item/started",
           threadId: UNSTAMPED_THREAD_ID,
@@ -609,6 +768,9 @@ export function createAcpProviderAdapter(
         const startedEvent = state.toolCallEventsByCallId.get(
           parsed.data.toolCallId,
         );
+        const startedItem = state.toolItemsByCallId.get(
+          parsed.data.toolCallId,
+        );
         const mergedEvent = mergeAcpToolCallEvents(startedEvent, parsed.data);
         const mergedItem = translateAcpToolCallItem(
           mergedEvent,
@@ -619,16 +781,29 @@ export function createAcpProviderAdapter(
           mergedEvent.status === "failed"
         ) {
           state.toolCallEventsByCallId.delete(parsed.data.toolCallId);
-          events.push({
-            type: "item/completed",
-            threadId: UNSTAMPED_THREAD_ID,
-            providerThreadId: "",
-            scope: turnScope(state.currentTurnId),
-            item: mergedItem,
-          });
+          state.toolItemsByCallId.delete(parsed.data.toolCallId);
+          const terminalStatus = mapAcpToolCallStatus(mergedEvent.status);
+          for (const item of buildAcpTerminalToolCallItems({
+            completedItem: mergedItem,
+            event: mergedEvent,
+            parentToolCallId,
+            startedItem,
+            status: terminalStatus,
+          })) {
+            events.push({
+              type: "item/completed",
+              threadId: UNSTAMPED_THREAD_ID,
+              providerThreadId: "",
+              scope: turnScope(state.currentTurnId),
+              item,
+            });
+          }
           return events;
         }
         state.toolCallEventsByCallId.set(parsed.data.toolCallId, mergedEvent);
+        if (!startedItem || startedItem.type === mergedItem.type) {
+          state.toolItemsByCallId.set(parsed.data.toolCallId, mergedItem);
+        }
         const progressText = extractAcpToolCallOutputText(parsed.data);
         if (progressText && mergedItem.type === "toolCall") {
           events.push({
@@ -699,6 +874,19 @@ export function createAcpProviderAdapter(
     const events: ThreadEvent[] = [];
     flushOpenThoughtItem(events, state, context?.parentToolCallId);
     flushOpenAgentMessageItem(events, state, context?.parentToolCallId);
+    const openToolCallStatus: ThreadEventItemStatus =
+      stopReason === "end_turn"
+        ? "completed"
+        : stopReason === "cancelled"
+          ? "interrupted"
+          : "failed";
+    completeOpenToolCallItems({
+      events,
+      parentToolCallId: context?.parentToolCallId,
+      state,
+      status: openToolCallStatus,
+      turnId: currentTurnId,
+    });
 
     if (stopReason === "cancelled") {
       events.push({

--- a/packages/agent-runtime/src/shared/adapter-utils.test.ts
+++ b/packages/agent-runtime/src/shared/adapter-utils.test.ts
@@ -7,6 +7,20 @@ import {
 } from "./adapter-utils.js";
 
 describe("adapter-utils", () => {
+  function countChangedLines(diff: string | undefined): {
+    added: number;
+    removed: number;
+  } {
+    let added = 0;
+    let removed = 0;
+    for (const line of diff?.split("\n") ?? []) {
+      if (line.startsWith("+++ ") || line.startsWith("--- ")) continue;
+      if (line.startsWith("+")) added += 1;
+      if (line.startsWith("-")) removed += 1;
+    }
+    return { added, removed };
+  }
+
   it("extractResultText returns an empty string for nullish content", () => {
     expect(extractResultText(null)).toBe("");
     expect(extractResultText(undefined)).toBe("");
@@ -118,6 +132,38 @@ describe("adapter-utils", () => {
     expect(diff).not.toContain("@@");
   });
 
+  it("buildEditDiff avoids reporting unchanged whole-file lines as edits", () => {
+    const diff = buildEditDiff(
+      "src/app.ts",
+      ["alpha", "beta", "gamma", "delta"].join("\n") + "\n",
+      ["alpha", "beta", "GAMMA", "delta"].join("\n") + "\n",
+    );
+
+    expect(diff).toContain("-gamma");
+    expect(diff).toContain("+GAMMA");
+    expect(diff).not.toContain("-alpha");
+    expect(diff).not.toContain("+alpha");
+    expect(countChangedLines(diff)).toEqual({ added: 1, removed: 1 });
+  });
+
+  it("buildEditDiff normalizes CRLF-only differences", () => {
+    expect(
+      buildEditDiff("src/app.ts", "alpha\r\nbeta\r\n", "alpha\nbeta\n"),
+    ).toBeUndefined();
+  });
+
+  it("buildEditDiff counts content changes in CRLF files without inflating every line", () => {
+    const diff = buildEditDiff(
+      "src/app.ts",
+      "alpha\r\nbeta\r\ngamma\r\n",
+      "alpha\nBETA\ngamma\n",
+    );
+
+    expect(diff).toContain("-beta");
+    expect(diff).toContain("+BETA");
+    expect(countChangedLines(diff)).toEqual({ added: 1, removed: 1 });
+  });
+
   it("buildEditDiff renders pure additions against /dev/null", () => {
     const diff = buildEditDiff(
       "src/new-file.ts",
@@ -128,6 +174,7 @@ describe("adapter-utils", () => {
     expect(diff).toContain("--- /dev/null");
     expect(diff).toContain("+++ b/src/new-file.ts");
     expect(diff).toContain("+export const enabled = true;");
+    expect(countChangedLines(diff)).toEqual({ added: 1, removed: 0 });
   });
 
   it("buildEditDiff renders pure deletions to /dev/null", () => {
@@ -140,5 +187,6 @@ describe("adapter-utils", () => {
     expect(diff).toContain("--- a/src/old-file.ts");
     expect(diff).toContain("+++ /dev/null");
     expect(diff).toContain("-export const enabled = false;");
+    expect(countChangedLines(diff)).toEqual({ added: 0, removed: 1 });
   });
 });

--- a/packages/agent-runtime/src/shared/adapter-utils.ts
+++ b/packages/agent-runtime/src/shared/adapter-utils.ts
@@ -34,8 +34,158 @@ const shellEnvironmentVariableKeySchema = z
 // Diff helpers
 // ---------------------------------------------------------------------------
 
+type LineDiffOperation =
+  | { type: "add"; line: string }
+  | { type: "remove"; line: string };
+
+const MAX_EXACT_LINE_DIFF_CELLS = 1_000_000;
+
+function splitComparableLines(text: string): string[] {
+  const normalized = text.replace(/\r\n?/gu, "\n");
+  if (normalized.length === 0) {
+    return [];
+  }
+  const lines = normalized.split("\n");
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function commonPrefixLength(
+  oldLines: readonly string[],
+  newLines: readonly string[],
+): number {
+  const limit = Math.min(oldLines.length, newLines.length);
+  let index = 0;
+  while (index < limit && oldLines[index] === newLines[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function commonSuffixLength(args: {
+  newLines: readonly string[];
+  oldLines: readonly string[];
+  prefixLength: number;
+}): number {
+  let oldIndex = args.oldLines.length - 1;
+  let newIndex = args.newLines.length - 1;
+  let length = 0;
+  while (
+    oldIndex >= args.prefixLength &&
+    newIndex >= args.prefixLength &&
+    args.oldLines[oldIndex] === args.newLines[newIndex]
+  ) {
+    length += 1;
+    oldIndex -= 1;
+    newIndex -= 1;
+  }
+  return length;
+}
+
+function buildReplacementLineDiff(
+  oldLines: readonly string[],
+  newLines: readonly string[],
+): LineDiffOperation[] {
+  return [
+    ...oldLines.map((line) => ({ type: "remove" as const, line })),
+    ...newLines.map((line) => ({ type: "add" as const, line })),
+  ];
+}
+
+function buildExactLineDiff(
+  oldLines: readonly string[],
+  newLines: readonly string[],
+): LineDiffOperation[] {
+  if (oldLines.length === 0) {
+    return newLines.map((line) => ({ type: "add" as const, line }));
+  }
+  if (newLines.length === 0) {
+    return oldLines.map((line) => ({ type: "remove" as const, line }));
+  }
+
+  const columnCount = newLines.length + 1;
+  const cellCount = (oldLines.length + 1) * columnCount;
+  if (cellCount > MAX_EXACT_LINE_DIFF_CELLS) {
+    return buildReplacementLineDiff(oldLines, newLines);
+  }
+
+  const lcs = new Uint32Array(cellCount);
+  for (let oldIndex = oldLines.length - 1; oldIndex >= 0; oldIndex -= 1) {
+    const rowOffset = oldIndex * columnCount;
+    const nextRowOffset = (oldIndex + 1) * columnCount;
+    for (let newIndex = newLines.length - 1; newIndex >= 0; newIndex -= 1) {
+      lcs[rowOffset + newIndex] =
+        oldLines[oldIndex] === newLines[newIndex]
+          ? lcs[nextRowOffset + newIndex + 1] + 1
+          : Math.max(
+              lcs[nextRowOffset + newIndex],
+              lcs[rowOffset + newIndex + 1],
+            );
+    }
+  }
+
+  const operations: LineDiffOperation[] = [];
+  let oldIndex = 0;
+  let newIndex = 0;
+  while (oldIndex < oldLines.length && newIndex < newLines.length) {
+    if (oldLines[oldIndex] === newLines[newIndex]) {
+      oldIndex += 1;
+      newIndex += 1;
+      continue;
+    }
+    const removeScore = lcs[(oldIndex + 1) * columnCount + newIndex];
+    const addScore = lcs[oldIndex * columnCount + newIndex + 1];
+    if (removeScore >= addScore) {
+      operations.push({ type: "remove", line: oldLines[oldIndex] ?? "" });
+      oldIndex += 1;
+    } else {
+      operations.push({ type: "add", line: newLines[newIndex] ?? "" });
+      newIndex += 1;
+    }
+  }
+  while (oldIndex < oldLines.length) {
+    operations.push({ type: "remove", line: oldLines[oldIndex] ?? "" });
+    oldIndex += 1;
+  }
+  while (newIndex < newLines.length) {
+    operations.push({ type: "add", line: newLines[newIndex] ?? "" });
+    newIndex += 1;
+  }
+  return operations;
+}
+
+function buildChangedLineDiff(
+  oldLines: readonly string[],
+  newLines: readonly string[],
+): LineDiffOperation[] {
+  const prefixLength = commonPrefixLength(oldLines, newLines);
+  const suffixLength = commonSuffixLength({
+    oldLines,
+    newLines,
+    prefixLength,
+  });
+  const oldEnd = oldLines.length - suffixLength;
+  const newEnd = newLines.length - suffixLength;
+  return buildExactLineDiff(
+    oldLines.slice(prefixLength, oldEnd),
+    newLines.slice(prefixLength, newEnd),
+  );
+}
+
+function formatLineDiff(args: {
+  headers: readonly string[];
+  operations: readonly LineDiffOperation[];
+}): string {
+  const body = args.operations.map((operation) =>
+    operation.type === "add" ? `+${operation.line}` : `-${operation.line}`,
+  );
+  return [...args.headers, ...body].join("\n") + "\n";
+}
+
 /**
- * Builds a minimal unified-diff string from old/new text pairs.
+ * Builds a compact unified-diff-like string from old/new text pairs.
  * Exported so each adapter can call it with its own arg names.
  */
 export function buildEditDiff(
@@ -45,32 +195,36 @@ export function buildEditDiff(
 ): string | undefined {
   const normalizedPath = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
   if (oldString === undefined && newString !== undefined) {
-    const newLines = newString.split("\n").map((line) => `+${line}`);
-    return (
-      ["--- /dev/null", `+++ b/${normalizedPath}`, ...newLines].join("\n") +
-      "\n"
-    );
+    return formatLineDiff({
+      headers: ["--- /dev/null", `+++ b/${normalizedPath}`],
+      operations: splitComparableLines(newString).map((line) => ({
+        type: "add",
+        line,
+      })),
+    });
   }
 
   if (oldString !== undefined && newString === undefined) {
-    const oldLines = oldString.split("\n").map((line) => `-${line}`);
-    return (
-      [`--- a/${normalizedPath}`, "+++ /dev/null", ...oldLines].join("\n") +
-      "\n"
-    );
+    return formatLineDiff({
+      headers: [`--- a/${normalizedPath}`, "+++ /dev/null"],
+      operations: splitComparableLines(oldString).map((line) => ({
+        type: "remove",
+        line,
+      })),
+    });
   }
 
   if (oldString !== undefined && newString !== undefined) {
-    const oldLines = oldString.split("\n").map((line) => `-${line}`);
-    const newLines = newString.split("\n").map((line) => `+${line}`);
-    return (
-      [
-        `--- a/${normalizedPath}`,
-        `+++ b/${normalizedPath}`,
-        ...oldLines,
-        ...newLines,
-      ].join("\n") + "\n"
-    );
+    const oldLines = splitComparableLines(oldString);
+    const newLines = splitComparableLines(newString);
+    const operations = buildChangedLineDiff(oldLines, newLines);
+    if (operations.length === 0) {
+      return undefined;
+    }
+    return formatLineDiff({
+      headers: [`--- a/${normalizedPath}`, `+++ b/${normalizedPath}`],
+      operations,
+    });
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- Generate compact ACP edit diffs from before/after text instead of reporting whole-file replacements.
- Normalize CRLF/LF-only differences before computing edit stats.
- Track ACP started tool items so Cursor edit tool calls settle to terminal rows even when the final update changes from a generic tool call to a file change.

## Validation
- `pnpm exec turbo run test --filter=@bb/agent-runtime`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/thread-view`
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- `pnpm exec turbo run build --filter=@bb/agent-runtime` (no package build task)
