### PR TITLE
Hide ACP session info updates

### DIFF
--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -812,6 +812,15 @@ describe("acp adapter event translation", () => {
     ).toEqual([]);
     expect(
       adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "session_info_update",
+          title: "Tool Tester",
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([]);
+    expect(
+      adapter.translateEvent(
         updateNotification({ sessionUpdate: "totally_new_update" }),
         THREAD_CONTEXT,
       ),

--- a/packages/agent-runtime/src/acp/visibility.ts
+++ b/packages/agent-runtime/src/acp/visibility.ts
@@ -34,12 +34,13 @@ const NORMALIZED_ACP_UPDATE_KINDS = new Set<string>([
 ]);
 
 // Update kinds the agent may legitimately send but BB intentionally does not
-// render: replayed history, agent-side mode/command/config bookkeeping.
+// render: replayed history, agent-side mode/command/config/session metadata.
 const NOISE_ACP_UPDATE_KINDS = new Set<string>([
   "user_message_chunk",
   "available_commands_update",
   "current_mode_update",
   "config_option_update",
+  "session_info_update",
   "usage_update",
 ]);
 


### PR DESCRIPTION
## Summary
- classify ACP `session_info_update` events as noise so title/session metadata does not render as raw unhandled chat rows
- add regression coverage for dropping this update kind

## Validation
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- src/acp/adapter.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`