### PR TITLE
Host daemon: watcher observability + bounded worktree-watch retries

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -10,6 +10,7 @@ import {
   InteractiveRequestRegistryError,
 } from "./interactive-request-registry.js";
 import { startEventLoopStallMonitor } from "./event-loop-stall-monitor.js";
+import { startHostDaemonHealthMonitor } from "./host-daemon-health-monitor.js";
 import {
   defaultListModels,
   shutdownDefaultListModelsRuntimes,
@@ -222,7 +223,9 @@ export async function createHostDaemonApp(
     _args: HandleServerSessionInvalidatedArgs,
   ): void => undefined;
 
-  function maybeInvalidateServerSession(args: MaybeInvalidateSessionArgs): void {
+  function maybeInvalidateServerSession(
+    args: MaybeInvalidateSessionArgs,
+  ): void {
     if (
       args.observedSessionId === null ||
       !(args.error instanceof ServerResponseError) ||
@@ -407,10 +410,11 @@ export async function createHostDaemonApp(
     onThreadStorageWatchError: ({ error }) => {
       options.logger.warn(
         {
+          watchSource: "thread-storage",
           rootPath: error.rootPath,
           watchError: error.message,
         },
-        "Thread storage watch unavailable; retrying in background",
+        "Host filesystem watch error (live updates for this path may be stale until it recovers)",
       );
     },
     onWorkspaceStatusChanged: ({ environmentId, changeKinds }) => {
@@ -425,11 +429,12 @@ export async function createHostDaemonApp(
     onWorkspaceStatusWatchError: ({ error }) => {
       options.logger.warn(
         {
+          watchSource: "workspace-status",
           environmentId: error.environmentId,
           rootPath: error.rootPath,
           watchError: error.message,
         },
-        "Workspace status watch unavailable; retrying in background",
+        "Host filesystem watch error (live updates for this path may be stale until it recovers)",
       );
     },
   });
@@ -474,10 +479,11 @@ export async function createHostDaemonApp(
     onDataDirSkillsWatchError: ({ error }) => {
       options.logger.warn(
         {
+          watchSource: "data-dir-skills",
           rootPath: error.rootPath,
           watchError: error.message,
         },
-        "Data-dir skills watch unavailable",
+        "Host filesystem watch error (live updates for this path may be stale until it recovers)",
       );
     },
     onWorkspaceStatusChanged: ({ environmentId, changeKinds }) => {
@@ -722,6 +728,13 @@ export async function createHostDaemonApp(
   const eventLoopStallMonitor = startEventLoopStallMonitor({
     logger: options.logger,
   });
+  const hostDaemonHealthMonitor = startHostDaemonHealthMonitor({
+    logger: options.logger,
+    getWatchCounts: () => ({
+      workspaceWatches: watchManager.workspaceWatchCount(),
+      threadStorageTargets: watchManager.threadStorageWatchTargetCount(),
+    }),
+  });
 
   const daemon = createDaemon({
     identity: {
@@ -737,6 +750,7 @@ export async function createHostDaemonApp(
     shutdownRuntimes: async () => {
       idleProviderSessionReaper.stop();
       eventLoopStallMonitor.stop();
+      hostDaemonHealthMonitor.stop();
       await localApi?.close();
       await watchManager.shutdown();
       await terminalManager.shutdownAll();

--- a/apps/host-daemon/src/event-loop-stall-monitor.ts
+++ b/apps/host-daemon/src/event-loop-stall-monitor.ts
@@ -2,7 +2,7 @@ import { monitorEventLoopDelay } from "node:perf_hooks";
 import type { HostDaemonLogger } from "./logger.js";
 
 interface EventLoopStallMonitorOptions {
-  logger: Pick<HostDaemonLogger, "debug">;
+  logger: Pick<HostDaemonLogger, "warn">;
 }
 
 interface EventLoopStallMonitor {
@@ -34,7 +34,7 @@ export function startEventLoopStallMonitor(
   const timer = setInterval(() => {
     const maxDelayMs = nanosecondsToMilliseconds(histogram.max);
     if (maxDelayMs >= thresholdMs) {
-      options.logger.debug(
+      options.logger.warn(
         {
           intervalMs,
           maxDelayMs: roundDurationMs(maxDelayMs),

--- a/apps/host-daemon/src/host-daemon-health-monitor.test.ts
+++ b/apps/host-daemon/src/host-daemon-health-monitor.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  startHostDaemonHealthMonitor,
+  type HostDaemonResourceUsage,
+} from "./host-daemon-health-monitor.js";
+
+interface CapturedTimer {
+  callback: () => void;
+  cleared: boolean;
+  unrefed: boolean;
+}
+
+function createMonitorHarness(
+  usage: HostDaemonResourceUsage,
+  options: { inotifyInstanceWarnThreshold?: number } = {},
+) {
+  const info = vi.fn();
+  const warn = vi.fn();
+  const timer: CapturedTimer = {
+    callback: () => undefined,
+    cleared: false,
+    unrefed: false,
+  };
+  const monitor = startHostDaemonHealthMonitor({
+    logger: { info, warn },
+    getWatchCounts: () => ({ workspaceWatches: 3, threadStorageTargets: 5 }),
+    readResourceUsage: () => usage,
+    inotifyInstanceWarnThreshold: options.inotifyInstanceWarnThreshold,
+    setIntervalFn: (callback) => {
+      timer.callback = callback;
+      return {
+        clear: () => {
+          timer.cleared = true;
+        },
+        unref: () => {
+          timer.unrefed = true;
+        },
+      };
+    },
+  });
+  return { info, warn, timer, monitor };
+}
+
+describe("startHostDaemonHealthMonitor", () => {
+  it("logs resource and watch metrics on each tick", () => {
+    const { info, timer } = createMonitorHarness({
+      rssBytes: 123,
+      openFds: 42,
+      inotifyInstances: 1,
+      threads: 11,
+    });
+
+    timer.callback();
+
+    expect(info).toHaveBeenCalledWith(
+      {
+        rssBytes: 123,
+        openFds: 42,
+        inotifyInstances: 1,
+        threads: 11,
+        workspaceWatches: 3,
+        threadStorageTargets: 5,
+      },
+      "Host daemon health",
+    );
+  });
+
+  it("warns when the inotify instance count indicates leaked watchers", () => {
+    const { warn, timer } = createMonitorHarness(
+      { rssBytes: 1, openFds: 200, inotifyInstances: 17, threads: 40 },
+      { inotifyInstanceWarnThreshold: 8 },
+    );
+
+    timer.callback();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatchObject({
+      inotifyInstances: 17,
+      warnThreshold: 8,
+    });
+  });
+
+  it("does not warn when the inotify count is healthy or unavailable", () => {
+    const healthy = createMonitorHarness(
+      { rssBytes: 1, openFds: 30, inotifyInstances: 2, threads: 11 },
+      { inotifyInstanceWarnThreshold: 8 },
+    );
+    healthy.timer.callback();
+    expect(healthy.warn).not.toHaveBeenCalled();
+
+    const unavailable = createMonitorHarness({
+      rssBytes: 1,
+      openFds: null,
+      inotifyInstances: null,
+      threads: null,
+    });
+    unavailable.timer.callback();
+    expect(unavailable.warn).not.toHaveBeenCalled();
+    expect(unavailable.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the interval timer on stop()", () => {
+    const { monitor, timer } = createMonitorHarness({
+      rssBytes: 1,
+      openFds: 1,
+      inotifyInstances: 1,
+      threads: 1,
+    });
+    expect(timer.unrefed).toBe(true);
+    monitor.stop();
+    expect(timer.cleared).toBe(true);
+  });
+});

--- a/apps/host-daemon/src/host-daemon-health-monitor.ts
+++ b/apps/host-daemon/src/host-daemon-health-monitor.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import type { HostDaemonLogger } from "./logger.js";
+
+/**
+ * Periodically logs host-daemon resource and watch metrics so a leak or wedge
+ * is visible in the logs after the fact instead of needing a live post-mortem.
+ *
+ * The headline signal is the inotify instance count. `@parcel/watcher` shares a
+ * single inotify backend across every watched path, so a healthy daemon needs
+ * roughly one instance no matter how many paths it watches. A count that climbs
+ * with uptime means dead, leaked watcher backends (each one a thread parked
+ * forever in the native teardown after a `poll()` interruption), which both
+ * leaks resources and means filesystem-driven updates have silently stopped.
+ */
+
+interface HostDaemonHealthMonitorTimer {
+  clear(): void;
+  unref(): void;
+}
+
+type HostDaemonHealthMonitorIntervalFn = (
+  callback: () => void,
+  intervalMs: number,
+) => HostDaemonHealthMonitorTimer;
+
+export interface HostDaemonWatchCounts {
+  workspaceWatches: number;
+  threadStorageTargets: number;
+}
+
+export interface HostDaemonResourceUsage {
+  rssBytes: number;
+  /** Open file descriptors, or null when unavailable (e.g. no /proc). */
+  openFds: number | null;
+  /** Live inotify instances, or null when unavailable. */
+  inotifyInstances: number | null;
+  /** OS thread count, or null when unavailable. */
+  threads: number | null;
+}
+
+interface HostDaemonHealthMonitorOptions {
+  logger: Pick<HostDaemonLogger, "info" | "warn">;
+  getWatchCounts: () => HostDaemonWatchCounts;
+  readResourceUsage?: () => HostDaemonResourceUsage;
+  setIntervalFn?: HostDaemonHealthMonitorIntervalFn;
+  intervalMs?: number;
+  inotifyInstanceWarnThreshold?: number;
+}
+
+interface HostDaemonHealthMonitor {
+  stop(): void;
+}
+
+const DEFAULT_HEALTH_MONITOR_INTERVAL_MS = 60_000;
+// Headroom above the ~1 shared backend a healthy daemon needs, so brief
+// overlaps during watch-set churn do not warn but a real leak does.
+const DEFAULT_INOTIFY_INSTANCE_WARN_THRESHOLD = 8;
+
+function countInotifyInstances(fds: string[]): number {
+  let count = 0;
+  for (const fd of fds) {
+    try {
+      if (fs.readlinkSync(`/proc/self/fd/${fd}`).includes("inotify")) {
+        count += 1;
+      }
+    } catch {
+      // The fd may close between listing and reading; ignore it.
+    }
+  }
+  return count;
+}
+
+export function defaultReadResourceUsage(): HostDaemonResourceUsage {
+  const rssBytes = process.memoryUsage().rss;
+  let openFds: number | null = null;
+  let inotifyInstances: number | null = null;
+  let threads: number | null = null;
+  try {
+    const fds = fs.readdirSync("/proc/self/fd");
+    openFds = fds.length;
+    inotifyInstances = countInotifyInstances(fds);
+  } catch {
+    // /proc is unavailable (non-Linux); leave fd metrics null.
+  }
+  try {
+    threads = fs.readdirSync("/proc/self/task").length;
+  } catch {
+    // /proc is unavailable; leave thread count null.
+  }
+  return { rssBytes, openFds, inotifyInstances, threads };
+}
+
+export function startHostDaemonHealthMonitor(
+  options: HostDaemonHealthMonitorOptions,
+): HostDaemonHealthMonitor {
+  const intervalMs = options.intervalMs ?? DEFAULT_HEALTH_MONITOR_INTERVAL_MS;
+  const inotifyInstanceWarnThreshold =
+    options.inotifyInstanceWarnThreshold ??
+    DEFAULT_INOTIFY_INSTANCE_WARN_THRESHOLD;
+  const readResourceUsage =
+    options.readResourceUsage ?? defaultReadResourceUsage;
+  const setIntervalFn: HostDaemonHealthMonitorIntervalFn =
+    options.setIntervalFn ??
+    ((callback, ms) => {
+      const timer = setInterval(callback, ms);
+      return {
+        clear: () => clearInterval(timer),
+        unref: () => timer.unref(),
+      };
+    });
+
+  const timer = setIntervalFn(() => {
+    const usage = readResourceUsage();
+    const watchCounts = options.getWatchCounts();
+    const fields = {
+      rssBytes: usage.rssBytes,
+      openFds: usage.openFds,
+      inotifyInstances: usage.inotifyInstances,
+      threads: usage.threads,
+      workspaceWatches: watchCounts.workspaceWatches,
+      threadStorageTargets: watchCounts.threadStorageTargets,
+    };
+    options.logger.info(fields, "Host daemon health");
+    if (
+      usage.inotifyInstances !== null &&
+      usage.inotifyInstances > inotifyInstanceWarnThreshold
+    ) {
+      options.logger.warn(
+        {
+          inotifyInstances: usage.inotifyInstances,
+          threads: usage.threads,
+          warnThreshold: inotifyInstanceWarnThreshold,
+        },
+        "Host daemon inotify instance count is high; filesystem watchers are likely leaking (dead backends after poll interruptions)",
+      );
+    }
+  }, intervalMs);
+  timer.unref();
+
+  return {
+    stop() {
+      timer.clear();
+    },
+  };
+}

--- a/packages/host-watcher/src/workspace-status-watcher.ts
+++ b/packages/host-watcher/src/workspace-status-watcher.ts
@@ -24,6 +24,11 @@ const WORKSPACE_STATUS_WATCH_DEBOUNCE_MS = 75;
 const WORKSPACE_STATUS_WATCH_MAX_WAIT_MS = 500;
 const WORKSPACE_STATUS_WATCH_RETRY_DELAY_MS = 250;
 const WORKSPACE_STATUS_WATCH_MAX_RETRY_DELAY_MS = 30_000;
+// Setup runs `git` (ignore discovery, metadata resolution). When a worktree is
+// deleted out from under us, that git command fails every time, so without a
+// cap we re-spawn git forever. Give up after a bounded number of attempts; the
+// server recreates this watch (resetting the count) when the watch set changes.
+const WORKSPACE_STATUS_WATCH_MAX_SETUP_RETRY_ATTEMPTS = 10;
 const WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS = [".git"];
 const WORKSPACE_ROOT_IGNORE_STATUS_TIMEOUT_MS = 5_000;
 const WORKSPACE_ROOT_IGNORE_STATUS_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -245,6 +250,16 @@ export class WorkspaceStatusWatcher {
     if (this.disposed || this.workspaceRootStartRetryTimer !== null) {
       return;
     }
+    if (
+      this.workspaceRootRetryAttempt >=
+      WORKSPACE_STATUS_WATCH_MAX_SETUP_RETRY_ATTEMPTS
+    ) {
+      this.args.onWatchError({
+        message: `Workspace root watch setup failed ${this.workspaceRootRetryAttempt} times (the worktree may have been deleted); giving up until the watch is reconfigured`,
+        rootPath,
+      });
+      return;
+    }
     this.workspaceRootRetryAttempt += 1;
     this.workspaceRootStartRetryTimer = setTimeout(
       () => {
@@ -346,6 +361,16 @@ export class WorkspaceStatusWatcher {
 
   private scheduleMetadataWatchRetry(): void {
     if (this.disposed || this.metadataStartRetryTimer !== null) {
+      return;
+    }
+    if (
+      this.metadataRetryAttempt >=
+      WORKSPACE_STATUS_WATCH_MAX_SETUP_RETRY_ATTEMPTS
+    ) {
+      this.args.onWatchError({
+        message: `Workspace metadata watch setup failed ${this.metadataRetryAttempt} times (the worktree may have been deleted); giving up until the watch is reconfigured`,
+        rootPath: this.args.cwd,
+      });
       return;
     }
     this.metadataRetryAttempt += 1;


### PR DESCRIPTION
## Why

While investigating host-daemon filesystem-watcher failures, we found that on Linux `@parcel/watcher`'s inotify backend throws `Unable to poll: Interrupted system call` (EINTR) instead of retrying, which kills the watch and leaks a deadlocked native backend (thread + fds). The watches were dying with no recovery and **no usable signal in the logs** — the daemon even logged `"retrying in background"` when nothing retried.

This PR does **not** fix the underlying parcel leak (that needs an upstream `poll()`-retry patch). It lands the diagnostics that make the failure visible next time, plus two bounded known-issue fixes.

## What

- **Health monitor** (`host-daemon-health-monitor.ts`, new): every 60s logs `rssBytes` / `openFds` / `inotifyInstances` / `threads` / watch counts, and **warns when the inotify instance count is high**. Parcel shares one inotify backend across all watches, so a healthy daemon needs ~1 instance regardless of how many paths it watches — a growing count means leaked dead backends. The 60s heartbeat also makes a daemon wedge visible as a gap in the logs.
- **Event-loop stall monitor made visible**: it already measured loop delay but logged at `debug`, which the daemon doesn't emit in production, so stalls never showed up. Now logs at `warn`.
- **Honest watch-error logs** (`app.ts`): dropped the false `"...retrying in background"` message; log `"Host filesystem watch error..."` with a greppable `watchSource` field.
- **Bounded deleted-worktree retries** (`workspace-status-watcher.ts`): a deleted/broken worktree made workspace-root and metadata setup re-run `git status` forever (every ~30s). Capped at 10 attempts with a clear "giving up; worktree may have been deleted" log. Resets on success; the server recreates the watch on the next watch-set change.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/host-watcher`
- `pnpm exec turbo run test --filter=@bb/host-daemon --filter=@bb/host-watcher` — 338 host-daemon (incl. 4 new health-monitor tests) + 28 host-watcher pass
- prettier clean

Note: no behavior test for the worktree retry cap — hitting it takes ~2 min of real exponential backoff and the delays are module constants not injectable through the public API, so a fast unit test isn't practical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)