### PR TITLE
Fix timeline fetch cancellation churn

### DIFF
--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -103,6 +103,91 @@ interface CollectCachedThreadIdsForEnvironmentArgs {
   queryClient: QueryClient;
 }
 
+interface InvalidateQueryKeysWithoutCancelingActiveFetchesArgs {
+  queryClient: QueryClient;
+  queryKeys: readonly QueryKey[];
+}
+
+interface ScheduleTrailingActiveRefetchArgs {
+  queryClient: QueryClient;
+  queryKey: QueryKey;
+}
+
+const trailingActiveRefetchUnsubscribers = new WeakMap<
+  QueryClient,
+  Map<string, () => void>
+>();
+
+function timelineInvalidationKey(queryKey: QueryKey): string {
+  return JSON.stringify(queryKey);
+}
+
+function hasActiveFetchingQueries(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+): boolean {
+  return queryClient
+    .getQueryCache()
+    .findAll({ queryKey, type: "active" })
+    .some((query) => query.state.fetchStatus !== "idle");
+}
+
+function scheduleTrailingActiveRefetch({
+  queryClient,
+  queryKey,
+}: ScheduleTrailingActiveRefetchArgs): void {
+  const scheduleKey = timelineInvalidationKey(queryKey);
+  let unsubscribers = trailingActiveRefetchUnsubscribers.get(queryClient);
+  if (!unsubscribers) {
+    unsubscribers = new Map();
+    trailingActiveRefetchUnsubscribers.set(queryClient, unsubscribers);
+  }
+  if (unsubscribers.has(scheduleKey)) {
+    return;
+  }
+
+  const unsubscribe = queryClient.getQueryCache().subscribe(() => {
+    if (hasActiveFetchingQueries(queryClient, queryKey)) {
+      return;
+    }
+
+    unsubscribe();
+    unsubscribers.delete(scheduleKey);
+    void queryClient
+      .refetchQueries({ queryKey, type: "active" }, { cancelRefetch: false })
+      .catch(() => {
+        // Individual query state already captures the refetch error.
+      });
+  });
+  unsubscribers.set(scheduleKey, unsubscribe);
+}
+
+function invalidateQueryKeysWithoutCancelingActiveFetches({
+  queryClient,
+  queryKeys,
+}: InvalidateQueryKeysWithoutCancelingActiveFetchesArgs): void {
+  for (const queryKey of queryKeys) {
+    const hadActiveFetch = hasActiveFetchingQueries(queryClient, queryKey);
+    // Avoid aborting the active timeline request on every event batch, but keep
+    // one trailing refetch so an event that raced the in-flight read is not lost.
+    queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false });
+    if (hadActiveFetch) {
+      scheduleTrailingActiveRefetch({ queryClient, queryKey });
+    }
+  }
+}
+
+export function disposeTrailingActiveRefetches(queryClient: QueryClient): void {
+  const unsubscribers = trailingActiveRefetchUnsubscribers.get(queryClient);
+  if (!unsubscribers) {
+    return;
+  }
+  for (const unsubscribe of unsubscribers.values()) {
+    unsubscribe();
+  }
+  trailingActiveRefetchUnsubscribers.delete(queryClient);
+}
+
 export const REALTIME_THREAD_CHANGE_REGISTRY = {
   "thread-created": {
     flush: "debounced",
@@ -497,11 +582,15 @@ function dirtyThreadSearchQueries(): QueryKey[] {
 }
 
 function dirtyThreadTimelineQueries({
+  queryClient,
   threadId,
-}: ThreadRealtimeDirtyContext): QueryKey[] {
+}: ThreadRealtimeDirtyContext): void {
   // Window only: completed turn-summary-details are immutable, so realtime
   // event batches must not refetch open detail panels (see helper docs).
-  return getThreadTimelineWindowInvalidationQueryKeys({ threadId });
+  invalidateQueryKeysWithoutCancelingActiveFetches({
+    queryClient,
+    queryKeys: getThreadTimelineWindowInvalidationQueryKeys({ threadId }),
+  });
 }
 
 function dirtyThreadQueueContentQueries({

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -837,6 +837,76 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
+  it("does not cancel active timeline refetches for repeated event invalidations", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const timelineKey = threadTimelineQueryKey("thr_1");
+    const signals: AbortSignal[] = [];
+    const resolveFetches: Array<(value: unknown) => void> = [];
+    const timelineQueryFn = vi.fn(({ signal }: { signal: AbortSignal }) => {
+      signals.push(signal);
+      return new Promise((resolve) => {
+        resolveFetches.push(resolve);
+      });
+    });
+    const timelineObserver = new QueryObserver(queryClient, {
+      queryKey: timelineKey,
+      queryFn: timelineQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribeTimeline = timelineObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(timelineQueryFn).toHaveBeenCalledTimes(1);
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { eventTypes: ["system/error"], projectId: "project-1" },
+      changes: ["events-appended"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { eventTypes: ["item/completed"], projectId: "project-1" },
+      changes: ["events-appended"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(signals[0]?.aborted).toBe(false);
+    expect(timelineQueryFn).toHaveBeenCalledTimes(1);
+
+    resolveFetches[0]?.({
+      rows: [],
+      timelinePage: {
+        kind: "latest",
+        topLevelLimit: 100,
+        returnedOlderTopLevelRowCount: 0,
+        hasOlderRows: false,
+        olderCursor: null,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(timelineQueryFn).toHaveBeenCalledTimes(2);
+    expect(signals[0]?.aborted).toBe(false);
+    resolveFetches[1]?.({
+      rows: [],
+      timelinePage: {
+        kind: "latest",
+        topLevelLimit: 100,
+        returnedOlderTopLevelRowCount: 0,
+        hasOlderRows: false,
+        olderCursor: null,
+      },
+    });
+
+    unsubscribeTimeline();
+    effects.dispose();
+  });
+
   it("invalidates thread prompt history when a batched appended event includes a turn request", () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();

--- a/apps/app/src/hooks/realtime-cache-effects.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.ts
@@ -15,6 +15,7 @@ import {
 import { createBufferedEnvironmentInvalidator } from "./buffered-environment-invalidator";
 import {
   collectCachedThreadIdsForEnvironment,
+  disposeTrailingActiveRefetches,
   executeRealtimeDirtyHandlers,
   REALTIME_ENVIRONMENT_CHANGE_REGISTRY,
   REALTIME_HOST_CHANGE_REGISTRY,
@@ -241,6 +242,7 @@ export function createRealtimeCacheEffects({
     dispose: () => {
       invalidationScheduler.dispose();
       environmentInvalidator.dispose();
+      disposeTrailingActiveRefetches(queryClient);
       resetThreadChangeState(threadChangeState);
     },
     handleChanged: (message) => {


### PR DESCRIPTION
## Summary
- prevent realtime timeline invalidations from canceling the active timeline fetch repeatedly
- queue one trailing timeline refetch after an in-flight request settles so racing events are still picked up
- dispose queued trailing refetch subscriptions with the realtime cache effects lifecycle

## Tests
- pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/realtime-cache-effects.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app