### PR TITLE
Add bb skills to command autocomplete

### DIFF
--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -19,6 +19,8 @@ import {
 
 interface WorkspaceFixture {
   cwd: string;
+  builtinSkillsRootPath: string;
+  dataDir: string;
   homeDir: string;
   codexHome: string;
 }
@@ -35,11 +37,15 @@ async function writeFileEnsuringDir(
 
 async function makeWorkspaceFixture(): Promise<WorkspaceFixture> {
   const cwd = path.join(tempRoot, "workspace");
+  const builtinSkillsRootPath = path.join(tempRoot, "builtin-skills");
+  const dataDir = path.join(tempRoot, "bb-data");
   const homeDir = path.join(tempRoot, "home");
   const codexHome = path.join(homeDir, ".codex");
   await mkdir(cwd, { recursive: true });
+  await mkdir(builtinSkillsRootPath, { recursive: true });
+  await mkdir(dataDir, { recursive: true });
   await mkdir(homeDir, { recursive: true });
-  return { cwd, homeDir, codexHome };
+  return { cwd, builtinSkillsRootPath, dataDir, homeDir, codexHome };
 }
 
 async function discoverClaude(
@@ -50,6 +56,8 @@ async function discoverClaude(
     roots: await resolveProviderCommandScanRoots({
       providerId: "claude-code",
       cwd,
+      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
+      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     }),
@@ -64,6 +72,8 @@ async function discoverCodex(
     roots: await resolveProviderCommandScanRoots({
       providerId: "codex",
       cwd,
+      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
+      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     }),
@@ -86,6 +96,46 @@ afterEach(async () => {
 });
 
 describe("discoverProviderCommands (claude-code)", () => {
+  it("discovers project-local and globally installed bb skills", async () => {
+    const fixture = await makeWorkspaceFixture();
+    await writeFileEnsuringDir(
+      path.join(fixture.cwd, ".bb", "skills", "project-bb", "SKILL.md"),
+      "---\nname: project-bb\ndescription: Project bb skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(fixture.dataDir, "skills", "user-bb", "SKILL.md"),
+      "---\nname: user-bb\ndescription: User bb skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(fixture.builtinSkillsRootPath, "bb-cli", "SKILL.md"),
+      "---\nname: bb-cli\ndescription: Built-in bb CLI skill\n---\n",
+    );
+
+    const commands = await discoverClaude(fixture, fixture.cwd);
+
+    expect(byName(commands, "project-bb")).toEqual({
+      name: "project-bb",
+      source: "skill",
+      origin: "project",
+      description: "Project bb skill",
+      argumentHint: null,
+    });
+    expect(byName(commands, "user-bb")).toEqual({
+      name: "user-bb",
+      source: "skill",
+      origin: "user",
+      description: "User bb skill",
+      argumentHint: null,
+    });
+    expect(byName(commands, "bb-cli")).toEqual({
+      name: "bb-cli",
+      source: "skill",
+      origin: "user",
+      description: "Built-in bb CLI skill",
+      argumentHint: null,
+    });
+  });
+
   it("parses project skills, namespaced commands, and frontmatter", async () => {
     const fixture = await makeWorkspaceFixture();
     await writeFileEnsuringDir(
@@ -770,6 +820,46 @@ describe("discoverProviderCommands (claude-code)", () => {
 });
 
 describe("discoverProviderCommands (codex)", () => {
+  it("discovers project-local and globally installed bb skills", async () => {
+    const fixture = await makeWorkspaceFixture();
+    await writeFileEnsuringDir(
+      path.join(fixture.cwd, ".bb", "skills", "project-bb", "SKILL.md"),
+      "---\nname: project-bb\ndescription: Project bb skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(fixture.dataDir, "skills", "user-bb", "SKILL.md"),
+      "---\nname: user-bb\ndescription: User bb skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(fixture.builtinSkillsRootPath, "bb-cli", "SKILL.md"),
+      "---\nname: bb-cli\ndescription: Built-in bb CLI skill\n---\n",
+    );
+
+    const commands = await discoverCodex(fixture, fixture.cwd);
+
+    expect(byName(commands, "project-bb")).toEqual({
+      name: "project-bb",
+      source: "skill",
+      origin: "project",
+      description: "Project bb skill",
+      argumentHint: null,
+    });
+    expect(byName(commands, "user-bb")).toEqual({
+      name: "user-bb",
+      source: "skill",
+      origin: "user",
+      description: "User bb skill",
+      argumentHint: null,
+    });
+    expect(byName(commands, "bb-cli")).toEqual({
+      name: "bb-cli",
+      source: "skill",
+      origin: "user",
+      description: "Built-in bb CLI skill",
+      argumentHint: null,
+    });
+  });
+
   it("parses project and user codex skills with correct origins", async () => {
     const fixture = await makeWorkspaceFixture();
     await writeFileEnsuringDir(
@@ -1001,6 +1091,8 @@ describe("resolveCommandScanRoots", () => {
     const roots = resolveCommandScanRoots({
       providerId: "pi",
       cwd: fixture.cwd,
+      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
+      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     });

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -2,6 +2,7 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveDataDirSkillsRootPath } from "@bb/config/skill-storage-paths";
 import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
 import { z } from "zod";
 import {
@@ -16,6 +17,10 @@ import {
 export interface CommandRootResolution {
   /** Resolved workspace path, or null for an unprovisioned thread. */
   cwd: string | null;
+  /** Built-in bb skills bundled with the server. */
+  builtinSkillsRootPath: string;
+  /** bb data directory containing user-installed bb skills. */
+  dataDir: string;
   /** Claude user-home base (`os.homedir()`). */
   homeDir: string;
   /** Codex user-home base (`$CODEX_HOME` or `~/.codex`). */
@@ -1064,6 +1069,13 @@ export function resolveCommandScanRoots(
   if (resolution.providerId === "claude-code") {
     if (resolution.cwd !== null) {
       roots.push({
+        rootPath: path.join(resolution.cwd, ".bb", "skills"),
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "project",
+      });
+      roots.push({
         rootPath: path.join(resolution.cwd, ".claude", "skills"),
         shape: "skill",
         namePrefix: "",
@@ -1073,6 +1085,20 @@ export function resolveCommandScanRoots(
     }
     roots.push({
       rootPath: path.join(resolution.homeDir, ".claude", "skills"),
+      shape: "skill",
+      namePrefix: "",
+      source: "skill",
+      origin: "user",
+    });
+    roots.push({
+      rootPath: resolveDataDirSkillsRootPath(resolution.dataDir),
+      shape: "skill",
+      namePrefix: "",
+      source: "skill",
+      origin: "user",
+    });
+    roots.push({
+      rootPath: resolution.builtinSkillsRootPath,
       shape: "skill",
       namePrefix: "",
       source: "skill",
@@ -1100,6 +1126,13 @@ export function resolveCommandScanRoots(
   if (resolution.providerId === "codex") {
     if (resolution.cwd !== null) {
       roots.push({
+        rootPath: path.join(resolution.cwd, ".bb", "skills"),
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "project",
+      });
+      roots.push({
         rootPath: path.join(resolution.cwd, ".codex", "skills"),
         shape: "skill",
         namePrefix: "",
@@ -1109,6 +1142,20 @@ export function resolveCommandScanRoots(
     }
     roots.push({
       rootPath: path.join(resolution.codexHome, "skills"),
+      shape: "skill",
+      namePrefix: "",
+      source: "skill",
+      origin: "user",
+    });
+    roots.push({
+      rootPath: resolveDataDirSkillsRootPath(resolution.dataDir),
+      shape: "skill",
+      namePrefix: "",
+      source: "skill",
+      origin: "user",
+    });
+    roots.push({
+      rootPath: resolution.builtinSkillsRootPath,
       shape: "skill",
       namePrefix: "",
       source: "skill",
@@ -1129,13 +1176,22 @@ export function resolveCommandScanRoots(
 
 export async function listHostCommands(
   command: CommandOf<"host.list_commands">,
+  options: { dataDir: string },
 ): Promise<HostDaemonOnlineRpcResult<"host.list_commands">> {
   if (command.cwd !== null && !path.isAbsolute(command.cwd)) {
     throw new CommandDispatchError("invalid_path", "cwd must be absolute");
   }
+  if (!path.isAbsolute(command.builtinSkillsRootPath)) {
+    throw new CommandDispatchError(
+      "invalid_path",
+      "builtinSkillsRootPath must be absolute",
+    );
+  }
   const homeDir = os.homedir();
   const roots = await resolveProviderCommandScanRoots({
     cwd: command.cwd,
+    builtinSkillsRootPath: command.builtinSkillsRootPath,
+    dataDir: options.dataDir,
     homeDir,
     codexHome: resolveCodexHome(homeDir),
     providerId: command.providerId,

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -593,6 +593,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
         type: "host.list_commands",
         providerId: query.provider,
         cwd: workspace.cwd,
+        builtinSkillsRootPath: deps.config.builtinSkillsRootPath,
       },
     });
     return context.json(

--- a/apps/server/src/services/skills/injected-skills.ts
+++ b/apps/server/src/services/skills/injected-skills.ts
@@ -8,8 +8,7 @@ import { z } from "zod";
 import type { ServerLogger } from "../../types.js";
 
 const SKILL_FILE_NAME = "SKILL.md";
-const SKILL_NAME_PATTERN =
-  /^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/u;
+const SKILL_NAME_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/u;
 const SKILL_FRONTMATTER_DELIMITER = "---";
 
 const skillFrontmatterSchema = z
@@ -33,6 +32,7 @@ const skillFrontmatterSchema = z
 export interface ResolveInjectedSkillSourcesArgs {
   builtinSkillsRootPath: string;
   dataDir: string;
+  projectSkillsRootPath?: string;
 }
 
 interface SkillCandidateSource {
@@ -185,27 +185,13 @@ function readSkillCandidate(
     return null;
   }
 
-  if (args.sourceType === "builtin") {
-    return {
-      sourceType: "builtin",
-      name: frontmatter.data.name,
-      description: frontmatter.data.description,
-      sourceRootPath: args.candidatePath,
-      skillFilePath,
-    };
-  }
-
-  if (args.sourceType === "data-dir") {
-    return {
-      sourceType: "data-dir",
-      name: frontmatter.data.name,
-      description: frontmatter.data.description,
-      sourceRootPath: args.candidatePath,
-      skillFilePath,
-    };
-  }
-
-  throw new Error(`Unsupported injected skill source type: ${args.sourceType}`);
+  return {
+    sourceType: args.sourceType,
+    name: frontmatter.data.name,
+    description: frontmatter.data.description,
+    sourceRootPath: args.candidatePath,
+    skillFilePath,
+  };
 }
 
 function readSkillsRoot(
@@ -242,9 +228,11 @@ function readSkillsRoot(
     return [];
   }
 
-  const entries = fs.readdirSync(args.skillsRootPath, {
-    withFileTypes: true,
-  }).sort(sortDirentsByName);
+  const entries = fs
+    .readdirSync(args.skillsRootPath, {
+      withFileTypes: true,
+    })
+    .sort(sortDirentsByName);
   const sources: HostDaemonInjectedSkillSource[] = [];
 
   for (const entry of entries) {
@@ -354,6 +342,14 @@ export function resolveInjectedSkillSources(
   logger: ServerLogger,
   args: ResolveInjectedSkillSourcesArgs,
 ): HostDaemonInjectedSkillSource[] {
+  const projectSources =
+    args.projectSkillsRootPath !== undefined
+      ? readSkillsRoot({
+          logger,
+          skillsRootPath: args.projectSkillsRootPath,
+          sourceType: "project",
+        })
+      : [];
   const builtinSources = readSkillsRoot({
     logger,
     skillsRootPath: args.builtinSkillsRootPath,
@@ -371,6 +367,19 @@ export function resolveInjectedSkillSources(
     builtinSources,
     userSources,
   });
+  const globalSources = excludeCollisions(logger, [
+    ...activeBuiltinSources,
+    ...userSources,
+  ]);
+  const activeProjectSources = excludeCollisions(logger, projectSources);
+  const projectNames = new Set(
+    activeProjectSources.map((source) => source.name),
+  );
 
-  return excludeCollisions(logger, [...activeBuiltinSources, ...userSources]);
+  return [...activeProjectSources, ...globalSources]
+    .filter(
+      (source) =>
+        source.sourceType === "project" || !projectNames.has(source.name),
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
 }

--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { getProject } from "@bb/db";
 import type {
   DynamicTool,
@@ -122,6 +123,7 @@ export async function resolveThreadRuntimeCommandConfig(
   const injectedSkillSources = resolveInjectedSkillSources(deps.logger, {
     builtinSkillsRootPath: deps.config.builtinSkillsRootPath,
     dataDir: deps.config.dataDir,
+    projectSkillsRootPath: path.join(workspacePath, ".bb", "skills"),
   });
   const threadStoragePath = await requireThreadStoragePath(deps, {
     hostId: args.environment.hostId,

--- a/apps/server/test/public/public-project-commands.test.ts
+++ b/apps/server/test/public/public-project-commands.test.ts
@@ -159,6 +159,7 @@ describe("public project command typeahead route", () => {
           type: "host.list_commands",
           providerId: "claude-code",
           cwd: "/tmp/claude-commands-env",
+          builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
         },
       ]);
     });
@@ -202,6 +203,7 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "codex",
         cwd: "/tmp/codex-commands-env",
+        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
       });
     });
   });
@@ -306,6 +308,7 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: "/tmp/no-env-project",
+        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
       });
     });
   });
@@ -349,6 +352,7 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: "/tmp/provisioning-project",
+        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
       });
     });
   });
@@ -385,6 +389,7 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: null,
+        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
       });
     });
   });
@@ -414,6 +419,7 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "codex",
         cwd: null,
+        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
       });
     });
   });

--- a/apps/server/test/services/threads/provider-command-typeahead.test.ts
+++ b/apps/server/test/services/threads/provider-command-typeahead.test.ts
@@ -2,13 +2,16 @@ import type { HostProviderCommand } from "@bb/host-daemon-contract";
 import { describe, expect, it } from "vitest";
 import { buildCommandListResponse } from "../../../src/services/threads/provider-command-typeahead.js";
 
-function skill(name: string): HostProviderCommand {
+function skill(
+  name: string,
+  overrides: Partial<HostProviderCommand> = {},
+): HostProviderCommand {
   return {
     name,
     source: "skill",
-    origin: "user",
-    description: null,
-    argumentHint: null,
+    origin: overrides.origin ?? "user",
+    description: overrides.description ?? null,
+    argumentHint: overrides.argumentHint ?? null,
   };
 }
 
@@ -29,5 +32,27 @@ describe("buildCommandListResponse", () => {
       "ottonomous:review",
     ]);
     expect(response.truncated).toBe(true);
+  });
+
+  it("keeps the first user-origin skill when global roots provide the same name", () => {
+    const response = buildCommandListResponse({
+      commands: [
+        skill("bb-cli", { description: "Data-dir override" }),
+        skill("bb-cli", { description: "Built-in default" }),
+      ],
+      limit: 10,
+      offset: 0,
+      query: "bb-cli",
+    });
+
+    expect(response.commands).toEqual([
+      {
+        name: "bb-cli",
+        source: "skill",
+        origin: "user",
+        description: "Data-dir override",
+        argumentHint: null,
+      },
+    ]);
   });
 });

--- a/apps/server/test/skills/injected-skills.test.ts
+++ b/apps/server/test/skills/injected-skills.test.ts
@@ -1,10 +1,4 @@
-import {
-  mkdir,
-  mkdtemp,
-  rm,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -252,6 +246,45 @@ describe("injected skill source discovery", () => {
         message: "Built-in injected skill overridden by user skill",
       }),
     ]);
+  });
+
+  it("lets a project skill override global skills with the same name", async () => {
+    const dataDir = await makeTempDir();
+    const workspacePath = await makeTempDir();
+    const builtinSkillsRootPath = path.join(dataDir, "builtin-skills");
+    await writeSkill({
+      rootPath: builtinSkillsRootPath,
+      name: "bb-cli",
+      description: "Built-in copy.",
+    });
+    await writeSkill({
+      rootPath: path.join(dataDir, "skills"),
+      name: "bb-cli",
+      description: "User copy.",
+    });
+    const projectSkillRoot = await writeSkill({
+      rootPath: path.join(workspacePath, ".bb", "skills"),
+      name: "bb-cli",
+      description: "Project copy.",
+    });
+    const { logger, warnings } = createCapturingLogger();
+
+    const sources = await resolveInjectedSkillSources(logger, {
+      builtinSkillsRootPath,
+      dataDir,
+      projectSkillsRootPath: path.join(workspacePath, ".bb", "skills"),
+    });
+
+    expect(sources).toEqual([
+      {
+        sourceType: "project",
+        name: "bb-cli",
+        description: "Project copy.",
+        sourceRootPath: projectSkillRoot,
+        skillFilePath: path.join(projectSkillRoot, "SKILL.md"),
+      },
+    ]);
+    expect(warnings).toEqual([]);
   });
 
   it("resolves the bundled built-in skills root with valid built-in skills", async () => {

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -359,6 +359,14 @@ describe("thread runtime config", () => {
         name: "bb-cli",
         rootPath: harness.config.builtinSkillsRootPath,
       });
+      const workspacePath = path.join(
+        harness.config.dataDir,
+        "runtime-skill-workspace",
+      );
+      const projectSourceRootPath = await writeRuntimeSkill({
+        name: "project-helper",
+        rootPath: path.join(workspacePath, ".bb", "skills"),
+      });
       const { host } = seedHostSession(harness.deps, {
         id: "host-runtime-injected-skills",
       });
@@ -368,6 +376,7 @@ describe("thread runtime config", () => {
       const environment = seedEnvironment(harness.deps, {
         hostId: host.id,
         projectId: project.id,
+        path: workspacePath,
       });
       const thread = seedThread(harness.deps, {
         projectId: project.id,
@@ -402,6 +411,13 @@ describe("thread runtime config", () => {
           description: "Use bb-cli when server runtime tests run.",
           sourceRootPath: builtinSourceRootPath,
           skillFilePath: path.join(builtinSourceRootPath, "SKILL.md"),
+        },
+        {
+          sourceType: "project",
+          name: "project-helper",
+          description: "Use project-helper when server runtime tests run.",
+          sourceRootPath: projectSourceRootPath,
+          skillFilePath: path.join(projectSourceRootPath, "SKILL.md"),
         },
         {
           sourceType: "data-dir",

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -24,7 +24,7 @@ import {
 } from "@bb/domain";
 import { z } from "zod";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 39 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 40 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,
@@ -91,6 +91,11 @@ export const hostDaemonInjectedSkillSourceSchema = z.discriminatedUnion(
     hostDaemonInjectedSkillSourceBaseSchema
       .extend({
         sourceType: z.literal("data-dir"),
+      })
+      .strict(),
+    hostDaemonInjectedSkillSourceBaseSchema
+      .extend({
+        sourceType: z.literal("project"),
       })
       .strict(),
   ],
@@ -386,6 +391,7 @@ const hostListCommandsCommandSchema = z.object({
   type: z.literal("host.list_commands"),
   providerId: z.string().min(1),
   cwd: z.string().min(1).nullable(),
+  builtinSkillsRootPath: z.string().min(1),
 });
 
 /**

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -829,6 +829,20 @@ describe("host-daemon command schemas", () => {
 
     expect(
       hostDaemonOnlineRpcCommandSchema.parse({
+        type: "host.list_commands",
+        providerId: "claude-code",
+        cwd: "/tmp/workspace",
+        builtinSkillsRootPath: "/tmp/builtin-skills",
+      }),
+    ).toMatchObject({
+      type: "host.list_commands",
+      providerId: "claude-code",
+      cwd: "/tmp/workspace",
+      builtinSkillsRootPath: "/tmp/builtin-skills",
+    });
+
+    expect(
+      hostDaemonOnlineRpcCommandSchema.parse({
         type: "host.list_branches",
         path: "/tmp/workspace",
         query: "release",
@@ -1274,6 +1288,12 @@ describe("host-daemon command schemas", () => {
         sourceType: "data-dir",
       }),
     ).toMatchObject({ sourceType: "data-dir" });
+    expect(
+      hostDaemonInjectedSkillSourceSchema.parse({
+        ...base,
+        sourceType: "project",
+      }),
+    ).toMatchObject({ sourceType: "project" });
 
     expect(() =>
       hostDaemonInjectedSkillSourceSchema.parse({
@@ -1873,7 +1893,7 @@ describe("host-daemon command schemas", () => {
 
 describe("host-daemon session schemas", () => {
   it("documents the current protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(39);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(40);
   });
 
   it("parses valid session open and event batch payloads", () => {


### PR DESCRIPTION
## Summary
- include project .bb/skills, data-dir skills, and built-in bb skills in provider command discovery for command typeahead
- pass the built-in skills root through the host list-commands RPC and bump the host daemon protocol
- inject project .bb/skills into runtime skill sources so autocomplete suggestions are dispatchable

## Validation
- pnpm exec turbo run test --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/host-daemon-contract
- pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/host-daemon-contract
- git diff --check