### PR TITLE
[codex] Hide wrapped turn message actions

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -94,8 +94,7 @@ type AssistantMessageRowIdentity = Pick<
 >;
 
 export interface ConversationMessageContentAssistantProps
-  extends ConversationMessageContentBaseProps,
-    AssistantMessageRowIdentity {
+  extends ConversationMessageContentBaseProps, AssistantMessageRowIdentity {
   role: "assistant";
   // Assistant content renders through MarkdownPreview, which is the only
   // surface with clickable links. User messages render as plain text
@@ -128,6 +127,8 @@ export interface ConversationMessageContentAssistantProps
    * menu. Omitted when no controller is wired in (e.g. delegation output).
    */
   onSelectProse?: (selection: MessageProseSelection | null) => void;
+  /** Shows the hover-revealed copy/fork/side-chat action footer. */
+  showActions: boolean;
   turnRequest: null;
   workspaceRootPath?: string;
 }
@@ -172,6 +173,7 @@ interface AssistantConversationMessageProps extends AssistantMessageRowIdentity 
   onOpenLink?: ThreadTimelineLinkHandler;
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   projectId?: string;
+  showActions: boolean;
   text: string;
   workspaceRootPath?: string;
 }
@@ -424,6 +426,7 @@ function AssistantConversationMessage({
   onOpenLink,
   onOpenLocalFileLink,
   projectId,
+  showActions,
   text,
   workspaceRootPath,
 }: AssistantConversationMessageProps) {
@@ -469,25 +472,27 @@ function AssistantConversationMessage({
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
       />
-      {/*
-        Copy + fork (S3) + side chat (S4) actions. Each button is dropped
-        entirely (not rendered disabled) when its handler is absent — e.g. fork
-        is omitted for a personal-only source with no host to base a worktree
-        fork on. `disabled` greys both fork and side chat together when the
-        thread is at the spawn-depth cap (both spawn a child thread, one guard).
-      */}
-      <div className="relative h-5">
-        <div className="absolute left-0 top-1">
-          <MessageActionBar
-            messageText={text}
-            alignment="start"
-            onFork={onFork}
-            onSideChat={onSideChat}
-            onSendToMain={onSendToMain}
-            disabled={forkDisabled}
-          />
+      {showActions ? (
+        /*
+          Copy + fork (S3) + side chat (S4) actions. Each button is dropped
+          entirely (not rendered disabled) when its handler is absent — e.g. fork
+          is omitted for a personal-only source with no host to base a worktree
+          fork on. `disabled` greys both fork and side chat together when the
+          thread is at the spawn-depth cap (both spawn a child thread, one guard).
+        */
+        <div className="relative h-5">
+          <div className="absolute left-0 top-1">
+            <MessageActionBar
+              messageText={text}
+              alignment="start"
+              onFork={onFork}
+              onSideChat={onSideChat}
+              onSendToMain={onSendToMain}
+              disabled={forkDisabled}
+            />
+          </div>
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }
@@ -547,6 +552,7 @@ export function ConversationMessageContent(
       onOpenLink={props.onOpenLink}
       onOpenLocalFileLink={onOpenLocalFileLink}
       projectId={projectId}
+      showActions={props.showActions}
       sourceSeqEnd={props.sourceSeqEnd}
       sourceSeqStart={props.sourceSeqStart}
       text={text}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { conversationRow } from "@/test/fixtures/thread-timeline-rows";
+import { conversationRow, turnRow } from "@/test/fixtures/thread-timeline-rows";
 import { ThreadTimelineRows } from "./ThreadTimelineRows";
 
 function mockWindowSelection({ node, text }: { node: Node; text: string }) {
@@ -55,6 +55,62 @@ describe("ThreadTimelineRows actions", () => {
     );
 
     expect(markup).toContain('aria-label="Send to main thread"');
+  });
+
+  it("hides assistant message actions inside completed turn summaries", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadTimelineRows
+        initialExpanded={new Set(["turn_completed"])}
+        timelineRows={[
+          turnRow({
+            id: "turn_completed",
+            status: "completed",
+            durationMs: 1_000,
+            children: [
+              conversationRow({
+                id: "agent_completed",
+                role: "assistant",
+                text: "Archived assistant response.",
+              }),
+            ],
+          }),
+        ]}
+        threadRuntimeDisplayStatus="idle"
+        workspaceRootPath={undefined}
+      />,
+    );
+
+    expect(markup).toContain("Worked for");
+    expect(markup).toContain("Archived assistant response.");
+    expect(markup).not.toContain('aria-label="Copy message"');
+  });
+
+  it("keeps assistant message actions visible inside pending turn rows", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadTimelineRows
+        initialExpanded={new Set(["turn_pending"])}
+        timelineRows={[
+          turnRow({
+            id: "turn_pending",
+            status: "pending",
+            durationMs: null,
+            children: [
+              conversationRow({
+                id: "agent_pending",
+                role: "assistant",
+                text: "Streaming assistant response.",
+              }),
+            ],
+          }),
+        ]}
+        threadRuntimeDisplayStatus="active"
+        workspaceRootPath={undefined}
+      />,
+    );
+
+    expect(markup).toContain("Working");
+    expect(markup).toContain("Streaming assistant response.");
+    expect(markup).toContain('aria-label="Copy message"');
   });
 
   it("passes the selected assistant row branch point to side-chat replies", async () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -235,6 +235,7 @@ interface TimelineRowsListProps {
   compactActivityIntents: boolean;
   rows: readonly ThreadTimelineViewRow[];
   scopeActive: boolean;
+  showAssistantMessageActions: boolean;
   spacing: TimelineRowsListSpacing;
   className?: string;
   unreadDividerAutoScroll: boolean;
@@ -250,6 +251,7 @@ interface TimelineRowViewProps {
   compactActivityIntents: boolean;
   row: ThreadTimelineViewRow;
   scopeActive: boolean;
+  showAssistantMessageActions: boolean;
   spacing: TimelineRowsListSpacing;
 }
 
@@ -257,6 +259,7 @@ interface TimelineExpandableRowViewProps {
   activeLatestBundleId: string | null;
   compactActivityIntents: boolean;
   scopeActive: boolean;
+  showAssistantMessageActions: boolean;
   title: TimelineTitle;
   horizontalPadding: TimelineRowHorizontalPadding;
   row: Exclude<ThreadTimelineViewRow, { kind: "conversation" }>;
@@ -272,11 +275,13 @@ interface TimelineExpandableBodyProps {
   activeLatestBundleId: string | null;
   compactActivityIntents: boolean;
   row: ThreadTimelineViewRow;
+  showAssistantMessageActions: boolean;
 }
 
 interface TurnRowBodyProps {
   compactActivityIntents: boolean;
   row: TimelineViewTurnRow;
+  showAssistantMessageActions: boolean;
 }
 
 type LazyTurnRowBodyProps = TurnRowBodyProps;
@@ -365,6 +370,7 @@ type TimelineRowsListItem =
 
 interface ConversationRowProps {
   row: TimelineConversationViewRow;
+  showAssistantMessageActions: boolean;
 }
 
 const TimelineRendererStaticContext =
@@ -459,6 +465,7 @@ function areTimelineRowViewPropsEqual(
   return (
     previous.compactActivityIntents === next.compactActivityIntents &&
     previous.scopeActive === next.scopeActive &&
+    previous.showAssistantMessageActions === next.showAssistantMessageActions &&
     previous.spacing === next.spacing &&
     previous.activeLatestBundleId === next.activeLatestBundleId &&
     // The view-row cache keys by the raw rows array, so unchanged query data
@@ -477,6 +484,7 @@ function areTimelineExpandableRowViewPropsEqual(
     previous.activeLatestBundleId === next.activeLatestBundleId &&
     previous.compactActivityIntents === next.compactActivityIntents &&
     previous.scopeActive === next.scopeActive &&
+    previous.showAssistantMessageActions === next.showAssistantMessageActions &&
     previous.title === next.title &&
     previous.horizontalPadding === next.horizontalPadding &&
     // The view-row cache keys by the raw rows array, so unchanged query data
@@ -765,7 +773,10 @@ function isForkSeedAnchorRow(row: TimelineConversationViewRow): boolean {
   );
 }
 
-function ConversationRow({ row }: ConversationRowProps) {
+function ConversationRow({
+  row,
+  showAssistantMessageActions,
+}: ConversationRowProps) {
   const {
     canSpawnChild,
     onForkMessage,
@@ -861,6 +872,7 @@ function ConversationRow({ row }: ConversationRowProps) {
       projectId={projectId}
       resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
       role="assistant"
+      showActions={showAssistantMessageActions}
       sourceSeqEnd={row.sourceSeqEnd}
       sourceSeqStart={row.sourceSeqStart}
       text={row.text}
@@ -940,6 +952,7 @@ function TimelineExpandableBody({
   activeLatestBundleId,
   compactActivityIntents,
   row,
+  showAssistantMessageActions,
 }: TimelineExpandableBodyProps) {
   const {
     onOpenLink,
@@ -958,6 +971,7 @@ function TimelineExpandableBody({
         <TimelineRowsList
           rows={row.children}
           scopeActive={false}
+          showAssistantMessageActions={showAssistantMessageActions}
           compactActivityIntents={true}
           spacing="bundle"
           unreadDividerAutoScroll={false}
@@ -997,6 +1011,11 @@ function TimelineExpandableBody({
         <TurnRowBody
           row={row}
           compactActivityIntents={compactActivityIntents}
+          // Completed turn details live under "Worked for..." as archival
+          // context; pending "Working" rows keep the streaming affordance.
+          showAssistantMessageActions={
+            showAssistantMessageActions && row.status === "pending"
+          }
         />
       );
     case "work":
@@ -1014,6 +1033,7 @@ function TimelineExpandableBody({
                 <TimelineRowsList
                   rows={row.childRows}
                   scopeActive={delegationActive}
+                  showAssistantMessageActions={showAssistantMessageActions}
                   compactActivityIntents={false}
                   spacing="nested"
                   unreadDividerAutoScroll={false}
@@ -1029,6 +1049,7 @@ function TimelineExpandableBody({
                   projectId={projectId}
                   resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
                   role="assistant"
+                  showActions={showAssistantMessageActions}
                   sourceSeqEnd={row.sourceSeqEnd}
                   sourceSeqStart={row.sourceSeqStart}
                   text={row.output}
@@ -1064,12 +1085,17 @@ function TimelineExpandableBody({
   }
 }
 
-function TurnRowBody({ compactActivityIntents, row }: TurnRowBodyProps) {
+function TurnRowBody({
+  compactActivityIntents,
+  row,
+  showAssistantMessageActions,
+}: TurnRowBodyProps) {
   if (row.children === null) {
     return (
       <LazyTurnRowBody
         compactActivityIntents={compactActivityIntents}
         row={row}
+        showAssistantMessageActions={showAssistantMessageActions}
       />
     );
   }
@@ -1078,6 +1104,7 @@ function TurnRowBody({ compactActivityIntents, row }: TurnRowBodyProps) {
     <TimelineRowsList
       rows={row.children}
       scopeActive={false}
+      showAssistantMessageActions={showAssistantMessageActions}
       compactActivityIntents={compactActivityIntents}
       spacing="nested"
       className={NESTED_TIMELINE_GROUP_LINE_CLASS_NAME}
@@ -1090,6 +1117,7 @@ function TurnRowBody({ compactActivityIntents, row }: TurnRowBodyProps) {
 function LazyTurnRowBody({
   compactActivityIntents,
   row,
+  showAssistantMessageActions,
 }: LazyTurnRowBodyProps) {
   const { getViewRows, threadId } = useTimelineRendererStaticContext();
   const {
@@ -1146,6 +1174,7 @@ function LazyTurnRowBody({
       <TimelineRowsList
         rows={rows}
         scopeActive={false}
+        showAssistantMessageActions={showAssistantMessageActions}
         compactActivityIntents={compactActivityIntents}
         spacing="nested"
         className={NESTED_TIMELINE_GROUP_LINE_CLASS_NAME}
@@ -1364,6 +1393,7 @@ function TimelineRowView({
   compactActivityIntents,
   row,
   scopeActive,
+  showAssistantMessageActions,
   spacing,
 }: TimelineRowViewProps) {
   const horizontalPadding = timelineRowHorizontalPadding(spacing);
@@ -1378,7 +1408,12 @@ function TimelineRowView({
   });
 
   if (row.kind === "conversation") {
-    return <ConversationRow row={row} />;
+    return (
+      <ConversationRow
+        row={row}
+        showAssistantMessageActions={showAssistantMessageActions}
+      />
+    );
   }
 
   if (titleState.kind === "compact-activity-intents") {
@@ -1446,6 +1481,7 @@ function TimelineRowView({
       activeLatestBundleId={activeLatestBundleId}
       row={row}
       scopeActive={scopeActive}
+      showAssistantMessageActions={showAssistantMessageActions}
       title={titleState.title}
       horizontalPadding={horizontalPadding}
       compactActivityIntents={compactActivityIntents}
@@ -1462,6 +1498,7 @@ function TimelineExpandableRowView({
   activeLatestBundleId,
   compactActivityIntents,
   scopeActive,
+  showAssistantMessageActions,
   title,
   horizontalPadding,
   row,
@@ -1479,9 +1516,15 @@ function TimelineExpandableRowView({
         activeLatestBundleId={activeLatestBundleId}
         row={row}
         compactActivityIntents={compactActivityIntents}
+        showAssistantMessageActions={showAssistantMessageActions}
       />
     ),
-    [activeLatestBundleId, compactActivityIntents, row],
+    [
+      activeLatestBundleId,
+      compactActivityIntents,
+      row,
+      showAssistantMessageActions,
+    ],
   );
 
   const leadingIcon = leadingIconForRow(row);
@@ -1582,6 +1625,7 @@ function TimelineRowsList({
   compactActivityIntents,
   rows,
   scopeActive,
+  showAssistantMessageActions,
   spacing,
   className,
   unreadDividerAutoScroll,
@@ -1620,6 +1664,7 @@ function TimelineRowsList({
               activeLatestBundleId={activeLatestBundleId}
               row={item.row}
               scopeActive={scopeActive}
+              showAssistantMessageActions={showAssistantMessageActions}
               spacing={spacing}
               compactActivityIntents={compactActivityIntents}
             />
@@ -1780,6 +1825,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
           <TimelineRowsList
             rows={rows}
             scopeActive={scopeActive}
+            showAssistantMessageActions={true}
             compactActivityIntents={false}
             spacing="top-level"
             unreadDividerAutoScroll={props.unreadDividerAutoScroll ?? true}

--- a/apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx
@@ -167,6 +167,7 @@ export function Overview() {
             text={shortMessage}
             attachments={null}
             turnRequest={null}
+            showActions={true}
           />
         </TimelineStage>
       </StoryRow>
@@ -185,6 +186,7 @@ export function Overview() {
             text={longMessage}
             attachments={null}
             turnRequest={null}
+            showActions={true}
           />
         </TimelineStage>
       </StoryRow>


### PR DESCRIPTION
## Summary

- Hide assistant message floating action buttons inside completed `Worked for...` turn-summary details.
- Keep the same action buttons visible in pending `Working` turn bodies so the streaming affordance remains available.
- Add regression coverage for completed versus pending turn bodies and update the assistant-message Ladle story props.

## Why

Completed turn details are archival context after a turn has wrapped up, but they reused the same assistant message renderer as live streaming rows. That made hover-revealed copy/fork/side-chat buttons appear under agent messages inside the `Worked for...` section even though those controls should only show while streaming.

## Validation

- `pnpm exec prettier --check apps/app/src/components/thread/timeline/ConversationMessageContent.tsx apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Attempted: `pnpm exec turbo run test --filter=@bb/app -- ThreadTimelineRows.actions.test.tsx`
  - Blocked before tests loaded because this checkout cannot resolve `jsdom` for Vitest: `Cannot find package 'jsdom'`. A frozen install did not change tracked files or resolve the missing peer.

## Ladle

Launched locally during QA at `http://localhost:61001/` and checked the relevant story surfaces:

- `thread--timeline--rows--turn--overview`
- `thread--timeline--streaming--rows`
- `thread--timeline--streaming--row-details`
- `thread--timeline--rows--assistant-message--overview`
- `thread--timeline--message-action-bar--overview`
