### PR TITLE
Allow cross-project sender attribution for thread messages

### DIFF
--- a/apps/server/src/services/lib/lifecycle-api-errors.ts
+++ b/apps/server/src/services/lib/lifecycle-api-errors.ts
@@ -187,10 +187,7 @@ export function throwParentThreadInvalid(
 }
 
 export function throwSenderThreadInvalid(
-  reason: Extract<
-    ParentThreadInvalidReason,
-    "deleted" | "not_found" | "wrong_project"
-  >,
+  reason: Extract<ParentThreadInvalidReason, "deleted" | "not_found">,
 ): never {
   throw new ApiError(
     400,

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -234,14 +234,11 @@ export function resolveMessageSenderThreadId(
   if (senderThread.deletedAt !== null) {
     throwSenderThreadInvalid("deleted");
   }
-  // The cross-thread message template instructs the receiving agent to reply
-  // via `bb thread tell {{senderThreadId}}`, so a sender from another project
-  // would become a cross-project write primitive. Mirror the create-path guard
-  // (assertValidParentThread) here so both the immediate-send and queued
-  // paths, which share this resolver, reject project mismatches.
-  if (senderThread.projectId !== args.targetThread.projectId) {
-    throwSenderThreadInvalid("wrong_project");
-  }
+  // Sender attribution is allowed across projects: the cross-thread message
+  // template tells the receiving agent to reply via
+  // `bb thread tell {{senderThreadId}}`, which is how coordinator/worker
+  // threads in different projects message each other. Existence and not-deleted
+  // are still required so the reply target is a live thread.
 
   return senderThread.id;
 }

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -1382,7 +1382,7 @@ describe("public thread data routes", () => {
     });
   });
 
-  it("rejects send requests whose senderThreadId is in another project", async () => {
+  it("queues send requests whose senderThreadId is in another project", async () => {
     await withTestHarness(async (harness) => {
       const { thread } = seedThreadFixture(harness, {
         thread: {
@@ -1418,20 +1418,16 @@ describe("public thread data routes", () => {
         },
       );
 
-      expect(response.status).toBe(400);
-      expect(JSON.stringify(await readJson(response))).toContain(
-        "wrong_project",
-      );
-      // The forged cross-project send must take no effect: no queued message
-      // and no turn-request event recorded on the target thread.
-      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
-      expect(
-        harness.db
-          .select({ id: events.id })
-          .from(events)
-          .where(eq(events.threadId, thread.id))
-          .all(),
-      ).toHaveLength(0);
+      // Sender attribution is allowed across projects, so the message queues
+      // with the cross-project sender preserved for the reply affordance.
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toEqual({ ok: true });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
+        {
+          senderThreadId: crossProjectSender.id,
+          threadId: thread.id,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

`bb thread tell <target>` auto-attaches the caller's `BB_THREAD_ID` as `senderThreadId`. The shared send/queue resolver (`resolveMessageSenderThreadId`) rejected any sender whose project differed from the target's, so a worker thread in one project could not message a coordinator thread in another — it returned `HTTP 400: Sender thread is invalid` and forced an `env -u BB_THREAD_ID` workaround that dropped attribution entirely (losing the reply-back affordance).

This drops the cross-project guard so any thread can message any other thread with attribution preserved.

## Changes

- **`thread-send.ts`** — `resolveMessageSenderThreadId` no longer rejects cross-project senders (covers both the immediate-send and queued paths, which share this resolver). Existence and not-deleted checks remain so the reply target is a live thread.
- **`lifecycle-api-errors.ts`** — narrowed `throwSenderThreadInvalid`'s reason type to `"deleted" | "not_found"` since `wrong_project` is no longer a sender outcome.
- **`public-thread-data.test.ts`** — flipped the regression test: a cross-project `senderThreadId` now queues the message (200) with the sender preserved, instead of returning 400.

The create/fork hierarchy guard (`assertValidParentThread`) is **intentionally left project-scoped** — that governs parent/fork structure (sidebar grouping, depth caps), not peer-to-peer messaging. The round-trip reply via `bb thread tell {{senderThreadId}}` now works bidirectionally across projects.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/server` — passes
- `pnpm exec turbo run test --filter=@bb/server -- public-thread-data` — 59 passed

## Risks

Low. Single-user local tool with no cross-tenant boundary; cross-project messaging is a deliberate workflow (coordinator/worker dispatcher pattern). Behavior change only takes effect once the updated server is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)