### PR TITLE
Use slash trigger for provider skills

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.stories.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.stories.tsx
@@ -357,7 +357,7 @@ const mixedPromptPillsFixture = buildPromptPillsFixture(
   [
     "Use @apps/app/src/components/promptbox/PromptBoxInternal.tsx with",
     "@apps/app/src/components/promptbox/mentions/ and @thread-storage:notes/status.md;",
-    "then ask @thread:thr_prompt_pills before running $github:gh-fix-ci or /frontend:component.",
+    "then ask @thread:thr_prompt_pills before running /github:gh-fix-ci or /frontend:component.",
   ].join(" "),
   [
     {
@@ -400,10 +400,10 @@ const mixedPromptPillsFixture = buildPromptPillsFixture(
       },
     },
     {
-      token: "$github:gh-fix-ci",
+      token: "/github:gh-fix-ci",
       resource: {
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "github:gh-fix-ci",
         source: "skill",
         origin: "user",
@@ -490,13 +490,13 @@ const threadPromptPillsFixture = buildPromptPillsFixture(
 );
 
 const commandPromptPillsFixture = buildPromptPillsFixture(
-  "Try $github:gh-fix-ci $browser:control-in-app-browser /frontend:component and $review.",
+  "Try /github:gh-fix-ci /browser:control-in-app-browser /frontend:component and /review.",
   [
     {
-      token: "$github:gh-fix-ci",
+      token: "/github:gh-fix-ci",
       resource: {
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "github:gh-fix-ci",
         source: "skill",
         origin: "user",
@@ -505,10 +505,10 @@ const commandPromptPillsFixture = buildPromptPillsFixture(
       },
     },
     {
-      token: "$browser:control-in-app-browser",
+      token: "/browser:control-in-app-browser",
       resource: {
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "browser:control-in-app-browser",
         source: "skill",
         origin: "user",
@@ -529,10 +529,10 @@ const commandPromptPillsFixture = buildPromptPillsFixture(
       },
     },
     {
-      token: "$review",
+      token: "/review",
       resource: {
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "review",
         source: "command",
         origin: "user",
@@ -544,13 +544,13 @@ const commandPromptPillsFixture = buildPromptPillsFixture(
 );
 
 const skillArgumentHintFixture = buildPromptPillsFixture(
-  "$moss-hardening-review ",
+  "/moss-hardening-review ",
   [
     {
-      token: "$moss-hardening-review",
+      token: "/moss-hardening-review",
       resource: {
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "moss-hardening-review",
         source: "skill",
         origin: "user",
@@ -690,14 +690,14 @@ function WithMentionsRow() {
 
 function WithSkillPillRow() {
   const argumentHint = "[branch | staged] [base=<ref>]";
-  const initialValue = "$moss-hardening-review ";
+  const initialValue = "/moss-hardening-review ";
   const { value, mentionRanges, onChange } = useControlledValue(initialValue, [
     storyMention({
       text: initialValue,
-      token: "$moss-hardening-review",
+      token: "/moss-hardening-review",
       resource: {
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "moss-hardening-review",
         source: "skill",
         origin: "user",
@@ -734,11 +734,11 @@ function WithLiveSkillsRow() {
       mentionRanges={mentionRanges}
       onChange={onChange}
       onSubmit={noop}
-      placeholder="Type $ to insert a skill or command"
+      placeholder="Type / to insert a skill or command"
       typeahead={makeTypeahead(
         {},
         {
-          trigger: "$",
+          trigger: "/",
           suggestions,
           isLoading: false,
           isError: false,
@@ -893,7 +893,7 @@ export function AllPromptPills() {
       </StoryRow>
       <StoryRow
         label="command pills"
-        hint="skill commands, project commands, user commands, and both trigger styles"
+        hint="skill commands, project commands, and user commands"
       >
         <PromptBoxStoryInstance fixture={commandPromptPillsFixture} />
       </StoryRow>

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -174,16 +174,16 @@ export interface TypeaheadMentionConfig {
 
 /**
  * The command-typeahead half of {@link TypeaheadConfig}. `trigger` is the
- * provider's command char (`/` for Claude Code, `$` for Codex) or `null` when
- * the provider has no command surface — in which case the composer never
- * activates a command trigger and the rest of this config is inert.
+ * provider's command char (`/`) or `null` when the provider has no command
+ * surface — in which case the composer never activates a command trigger and
+ * the rest of this config is inert.
  *
  * Hosts wire `suggestions` / `isLoading` / `isError` from
  * `useCommandSuggestions`; `onQueryChange` feeds that hook the text typed
  * after the trigger (`null` when no command trigger is active).
  */
 export interface TypeaheadCommandConfig {
-  trigger: "/" | "$" | null;
+  trigger: "/" | null;
   suggestions: readonly ProviderCommandSuggestion[];
   isLoading: boolean;
   isError: boolean;
@@ -1294,7 +1294,7 @@ export function PromptBoxInternal({
     (item: ProviderCommandSuggestion) => {
       const currentEditor = editorRef.current;
       if (!currentEditor || activeTrigger === null) return;
-      if (activeTrigger.char !== "/" && activeTrigger.char !== "$") return;
+      if (activeTrigger.char !== "/") return;
 
       const serializedText = `${activeTrigger.char}${item.name}`;
       const resource = promptCommandResourceFromSuggestion({

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
@@ -113,7 +113,7 @@ describe("prompt editor serialization", () => {
   it("builds command mention resources from provider command suggestions", () => {
     expect(
       promptCommandResourceFromSuggestion({
-        trigger: "$",
+        trigger: "/",
         suggestion: {
           kind: "command",
           name: "review",
@@ -125,7 +125,7 @@ describe("prompt editor serialization", () => {
       }),
     ).toEqual({
       kind: "command",
-      trigger: "$",
+      trigger: "/",
       name: "review",
       source: "skill",
       origin: "user",
@@ -135,14 +135,14 @@ describe("prompt editor serialization", () => {
   });
 
   it("serializes a selected skill as a pill without materializing argument hint text", () => {
-    const text = "$review ";
+    const text = "/review ";
     const mentions: PromptTextMention[] = [
       {
         start: 0,
-        end: "$review".length,
+        end: "/review".length,
         resource: {
           kind: "command",
-          trigger: "$",
+          trigger: "/",
           name: "review",
           source: "skill",
           origin: "user",
@@ -157,7 +157,7 @@ describe("prompt editor serialization", () => {
         type: "mention",
         attrs: {
           resource: mentions[0].resource,
-          serializedText: "$review",
+          serializedText: "/review",
         },
       },
       { type: "text", text: " " },
@@ -168,7 +168,7 @@ describe("prompt editor serialization", () => {
     expect(
       promptMentionArgumentHintPlaceholder({
         kind: "command",
-        trigger: "$",
+        trigger: "/",
         name: "review",
         source: "skill",
         origin: "user",

--- a/apps/app/src/components/promptbox/mentions/command-trigger.test.ts
+++ b/apps/app/src/components/promptbox/mentions/command-trigger.test.ts
@@ -9,8 +9,12 @@ describe("commandTriggerForProvider", () => {
     expect(commandTriggerForProvider("claude-code")).toBe("/");
   });
 
-  it("maps codex to the dollar trigger", () => {
-    expect(commandTriggerForProvider("codex")).toBe("$");
+  it("maps codex to the slash trigger", () => {
+    expect(commandTriggerForProvider("codex")).toBe("/");
+  });
+
+  it("does not expose the legacy dollar trigger for codex", () => {
+    expect(commandTriggerForProvider("codex")).not.toBe("$");
   });
 
   it("returns null for providers with no command surface", () => {

--- a/apps/app/src/components/promptbox/mentions/command-trigger.ts
+++ b/apps/app/src/components/promptbox/mentions/command-trigger.ts
@@ -3,7 +3,7 @@
  * composer, or `null` when the provider has no command surface.
  *
  * - `claude-code` → `/` (skills + legacy `.claude/commands`)
- * - `codex` → `$` (Codex skills; `/<skill>` is unrecognized by Codex)
+ * - `codex` → `/` (Codex skills)
  * - anything else (e.g. `pi`) → `null` (the command typeahead is inert)
  *
  * Takes a plain `string` because callers receive the provider id from thread
@@ -11,12 +11,11 @@
  */
 export function commandTriggerForProvider(
   providerId: string,
-): "/" | "$" | null {
+): "/" | null {
   switch (providerId) {
     case "claude-code":
-      return "/";
     case "codex":
-      return "$";
+      return "/";
     default:
       return null;
   }
@@ -25,8 +24,7 @@ export function commandTriggerForProvider(
 /**
  * A selected command is a one-position mention atom in the editor doc. The
  * dismissed range is based on that rendered node width plus any space inserted
- * after it, not on the serialized provider token length (`/review`, `$test`,
- * etc.).
+ * after it, not on the serialized provider token length (`/review`, etc.).
  */
 export function commandPillDismissedRangeEnd({
   triggerPosition,

--- a/apps/app/src/components/promptbox/mentions/find-active-trigger.test.ts
+++ b/apps/app/src/components/promptbox/mentions/find-active-trigger.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { findActiveTrigger } from "./find-active-trigger";
+
+function editorWithText(
+  text: string,
+  options: { caret?: number; empty?: boolean } = {},
+): Parameters<typeof findActiveTrigger>[0] {
+  const caret = options.caret ?? text.length;
+  return {
+    state: {
+      selection: {
+        empty: options.empty ?? true,
+        from: caret,
+      },
+      doc: {
+        textBetween(from: number, to: number) {
+          return text.slice(from, to);
+        },
+      },
+    },
+  };
+}
+
+describe("findActiveTrigger", () => {
+  it("detects a slash command trigger with a skill query", () => {
+    expect(
+      findActiveTrigger(editorWithText("Run /openai-docs"), [
+        { char: "@", kind: "mention" },
+        { char: "/", kind: "command" },
+      ]),
+    ).toEqual({
+      char: "/",
+      kind: "command",
+      query: "openai-docs",
+      from: 4,
+      to: "Run /openai-docs".length,
+    });
+  });
+
+  it("captures namespaced slash command queries", () => {
+    expect(
+      findActiveTrigger(editorWithText("/frontend:component"), [
+        { char: "@", kind: "mention" },
+        { char: "/", kind: "command" },
+      ]),
+    ).toMatchObject({
+      char: "/",
+      kind: "command",
+      query: "frontend:component",
+    });
+  });
+
+  it("does not treat the legacy dollar prefix as an active command trigger", () => {
+    expect(
+      findActiveTrigger(editorWithText("$openai-docs"), [
+        { char: "@", kind: "mention" },
+        { char: "/", kind: "command" },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/components/promptbox/mentions/find-active-trigger.ts
+++ b/apps/app/src/components/promptbox/mentions/find-active-trigger.ts
@@ -4,6 +4,23 @@ import type {
   TypeaheadTrigger,
 } from "@/components/promptbox/mentions/types";
 
+interface ActiveTriggerEditor {
+  state: {
+    selection: {
+      empty: boolean;
+      from: number;
+    };
+    doc: {
+      textBetween(
+        from: number,
+        to: number,
+        blockSeparator?: string,
+        leafText?: string,
+      ): string;
+    };
+  };
+}
+
 /**
  * Builds the word-boundary detection regex for a trigger char. A trigger only
  * fires at the start of input or after whitespace / an opening bracket, so a
@@ -11,15 +28,12 @@ import type {
  *
  * - `@` (mention) keeps its self-exclusion query class `[^\s@]*`, so a second
  *   `@` ends the current query rather than extending it.
- * - command triggers (`/`, `$`) capture the whole token up to whitespace
+ * - command triggers (`/`) capture the whole token up to whitespace
  *   (`\S*`), so a namespaced name like `frontend:component` is captured whole.
- *
- * `$` is escaped because it is a regex metacharacter.
  */
 function triggerPattern(char: TypeaheadTrigger["char"]): RegExp {
-  const escapedChar = char === "$" ? "\\$" : char;
   const queryClass = char === "@" ? "[^\\s@]*" : "\\S*";
-  return new RegExp(`(^|[\\s([{])${escapedChar}(${queryClass})$`, "u");
+  return new RegExp(`(^|[\\s([{])${char}(${queryClass})$`, "u");
 }
 
 /**
@@ -34,7 +48,7 @@ function triggerPattern(char: TypeaheadTrigger["char"]): RegExp {
  * trigger matches.
  */
 export function findActiveTrigger(
-  editor: Editor,
+  editor: ActiveTriggerEditor | Editor,
   triggers: readonly TypeaheadTrigger[],
 ): ActiveTrigger | null {
   const selection = editor.state.selection;

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -38,7 +38,7 @@ export type PromptMentionSuggestion =
  * returned by `GET /projects/:id/commands`. The `kind: "command"` discriminant
  * lets it join the same menu union as {@link PromptMentionSuggestion} while the
  * composer's apply path inserts a prompt pill that serializes back to the
- * provider-native token (`/<name>` for Claude Code, `$<name>` for Codex).
+ * slash command token (`/<name>`).
  */
 export interface ProviderCommandSuggestion {
   kind: "command";
@@ -68,12 +68,12 @@ export function toProviderCommandSuggestion(
 }
 
 /**
- * A typeahead trigger the composer watches for. `@` opens the mention menu;
- * `/` (Claude Code) and `$` (Codex) open the command menu. A thread is bound to
- * one provider, so at most one command trigger is ever active in a composer.
+ * A typeahead trigger the composer watches for. `@` opens the mention menu and
+ * `/` opens the provider command menu. A thread is bound to one provider, so at
+ * most one command trigger is ever active in a composer.
  */
 export interface TypeaheadTrigger {
-  char: "@" | "/" | "$";
+  char: "@" | "/";
   kind: "mention" | "command";
 }
 

--- a/apps/app/src/components/secondary-panel/SideChatTabContent.test.tsx
+++ b/apps/app/src/components/secondary-panel/SideChatTabContent.test.tsx
@@ -210,7 +210,7 @@ vi.mock("@/hooks/useCommandSuggestions", () => ({
   useCommandSuggestions: (args: unknown) => {
     mocks.commandSuggestionArgs.push(args);
     return {
-      trigger: "$",
+      trigger: "/",
       suggestions: [],
       isLoading: false,
       isError: false,
@@ -459,7 +459,7 @@ describe("SideChatTabContent", () => {
       environmentId: null,
       query: null,
     });
-    expect(screen.getByTestId("command-trigger").textContent).toBe("$");
+    expect(screen.getByTestId("command-trigger").textContent).toBe("/");
 
     fireEvent.click(screen.getByRole("button", { name: "Mention query" }));
     expect(mocks.promptMentionSetQuery).toHaveBeenCalledWith("readme");

--- a/apps/app/src/components/ui/markdown-preview.stories.tsx
+++ b/apps/app/src/components/ui/markdown-preview.stories.tsx
@@ -51,8 +51,8 @@ tags: spec, command-menu, ui
 
 # Prompt Plus Menu
 
-The **prompt-plus menu** opens when you type \`/\` for Claude or \`$\` for Codex
-in the promptbox, offering inline command completions.`;
+The **prompt-plus menu** opens when you type \`/\` in the promptbox, offering
+inline skill and command completions.`;
 
 const LISTS_MARKDOWN = `Unordered:
 

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -192,7 +192,7 @@ export function useProjectPathSuggestions(args: UseProjectPathSuggestionsArgs) {
  * resolution, debounce, and mapping to menu rows, and serves both the
  * existing-thread follow-up composer and the new-thread composer. Unlike
  * mentions, the command list is enabled even with an empty query (commands show
- * the full list on `/`/`$`); the caller gates fetching via `options.enabled`.
+ * the full list on `/`); the caller gates fetching via `options.enabled`.
  */
 export function useProjectCommands(
   args: UseProjectCommandsArgs,

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -25,7 +25,7 @@ export interface UseCommandSuggestionsArgs {
 
 export interface UseCommandSuggestionsResult {
   /** The provider's command trigger char, or `null` when the feature is inert. */
-  trigger: "/" | "$" | null;
+  trigger: "/" | null;
   suggestions: ProviderCommandSuggestion[];
   /**
    * `true` only before the first result lands (and not yet placeholder-backed).
@@ -47,7 +47,7 @@ export interface UseCommandSuggestionsResult {
  * new-thread composer. The hook is inert — never fetches, returns an empty list
  * — when there is no project, no command trigger for the provider, or no active
  * command query. Unlike mentions, it is enabled even when `query` is empty —
- * `/`/`$` show the full available list.
+ * `/` shows the full available list.
  */
 export function useCommandSuggestions(
   args: UseCommandSuggestionsArgs,

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -740,9 +740,9 @@ interface ListProjectCommandsArgs {
 
 /**
  * List the provider skills/slash-commands discoverable for a project, scoped by
- * provider + environment, for the in-composer command typeahead (`/` Claude
- * Code, `$` Codex). Serves both the existing-thread follow-up composer and the
- * new-thread composer. Mirrors {@link searchProjectPaths}: the typed Hono
+ * provider + environment, for the in-composer command typeahead (`/`). Serves
+ * both the existing-thread follow-up composer and the new-thread composer.
+ * Mirrors {@link searchProjectPaths}: the typed Hono
  * client resolves the route from `@bb/server-contract`'s public-api schema, so
  * this types against the committed `CommandListResponse` contract with no cast,
  * and encodes a null `environmentId` as the empty string on the wire.

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -123,7 +123,7 @@ export type PromptMentionPathEntryKind = z.infer<
   typeof promptMentionPathEntryKindSchema
 >;
 
-export const promptMentionCommandTriggerValues = ["/", "$"] as const;
+export const promptMentionCommandTriggerValues = ["/"] as const;
 export const promptMentionCommandTriggerSchema = z.enum(
   promptMentionCommandTriggerValues,
 );

--- a/packages/domain/test/shared-types.test.ts
+++ b/packages/domain/test/shared-types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  promptMentionCommandTriggerSchema,
+  promptMentionCommandTriggerValues,
+  promptMentionResourceSchema,
+} from "../src/shared-types.js";
+
+describe("prompt mention command triggers", () => {
+  it("accepts slash as the only command trigger", () => {
+    expect(promptMentionCommandTriggerValues).toEqual(["/"]);
+    expect(promptMentionCommandTriggerSchema.safeParse("/").success).toBe(true);
+    expect(promptMentionCommandTriggerSchema.safeParse("$").success).toBe(
+      false,
+    );
+  });
+
+  it("rejects legacy dollar command mention resources", () => {
+    expect(
+      promptMentionResourceSchema.safeParse({
+        kind: "command",
+        trigger: "$",
+        name: "review",
+        source: "skill",
+        origin: "user",
+        label: "review",
+        argumentHint: null,
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- use `/` as the command/skill trigger for both Codex and Claude Code composers
- remove the Codex `$` typeahead/dispatch path and make command mention resources slash-only
- update prompt fixtures, docs-like story text, and focused regression coverage

## Validation
- pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/app --force
- pnpm exec turbo run test --filter=@bb/domain --filter=@bb/app --force
- pnpm exec turbo run lint --filter=@bb/app --force
- git diff --check