### PR TITLE
Fix stale queued message removal

### DIFF
--- a/apps/app/src/hooks/cache-owners/composer-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/composer-cache-owner.test.ts
@@ -1,3 +1,4 @@
+import { QueryObserver } from "@tanstack/react-query";
 import type {
   SystemExecutionOptionsResponse,
   ThreadComposerBootstrapResponse,
@@ -58,6 +59,53 @@ const NULL_EXECUTION_BOOTSTRAP: ThreadComposerBootstrapResponse = {
 };
 
 describe("composer cache owner", () => {
+  it("does not clobber an active queued-message cache from bootstrap hydration", () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          retry: false,
+        },
+      },
+      showMutationErrorToasts: false,
+    });
+    const queuedMessagesKey = threadQueuedMessagesQueryKey("thread-1");
+    queryClient.setQueryData(queuedMessagesKey, []);
+    const observer = new QueryObserver(queryClient, {
+      queryKey: queuedMessagesKey,
+      queryFn: () => Promise.resolve([]),
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    try {
+      hydrateThreadComposerBootstrap({
+        bootstrap: {
+          ...NULL_EXECUTION_BOOTSTRAP,
+          queuedMessages: [
+            {
+              id: "qmsg-stale",
+              content: [{ type: "text", text: "Stale", mentions: [] }],
+              model: "gpt-5.5",
+              reasoningLevel: "medium",
+              permissionMode: "readonly",
+              serviceTier: "default",
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        },
+        environmentId: null,
+        providerId: "codex",
+        queryClient,
+        threadId: "thread-1",
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(queryClient.getQueryData(queuedMessagesKey)).toEqual([]);
+  });
+
   it("does not clobber new-thread system execution options for an environmentless archived bootstrap", () => {
     const queryClient = createAppQueryClient({
       defaultOptions: {

--- a/apps/app/src/hooks/cache-owners/composer-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/composer-cache-owner.ts
@@ -23,13 +23,27 @@ export function hydrateThreadComposerBootstrap({
   queryClient,
   threadId,
 }: ThreadComposerBootstrapHydrationArgs): void {
+  const queuedMessagesQueryKey = threadQueuedMessagesQueryKey(threadId);
+  const queuedMessagesQuery = queryClient
+    .getQueryCache()
+    .find({ queryKey: queuedMessagesQueryKey });
+  const hasActiveQueuedMessagesOwner =
+    queuedMessagesQuery?.isActive() ?? false;
+
   queryClient.setQueryData(
     threadDefaultExecutionOptionsQueryKey(threadId),
     bootstrap.defaultExecutionOptions,
   );
   queryClient.setQueryData(
-    threadQueuedMessagesQueryKey(threadId),
-    bootstrap.queuedMessages,
+    queuedMessagesQueryKey,
+    (
+      currentQueuedMessages:
+        | ThreadComposerBootstrapResponse["queuedMessages"]
+        | undefined,
+    ) =>
+      currentQueuedMessages === undefined || !hasActiveQueuedMessagesOwner
+        ? bootstrap.queuedMessages
+        : currentQueuedMessages,
   );
   queryClient.setQueryData(
     threadPromptHistoryQueryKey(threadId),

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
@@ -6,8 +6,10 @@ import type { ExistingThreadExecutionInputSources } from "@bb/server-contract";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/api";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { threadQueuedMessagesQueryKey } from "../queries/query-keys";
 import {
   useCreateThreadQueuedMessage,
+  useDeleteThreadQueuedMessage,
   useSendThreadMessage,
 } from "./thread-runtime-mutations";
 
@@ -16,6 +18,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
   return {
     ...actual,
     createThreadQueuedMessage: vi.fn(),
+    deleteThreadQueuedMessage: vi.fn(),
     sendThreadMessage: vi.fn(),
   };
 });
@@ -54,6 +57,7 @@ beforeEach(() => {
   vi.mocked(api.createThreadQueuedMessage).mockResolvedValue(
     makeQueuedMessage(),
   );
+  vi.mocked(api.deleteThreadQueuedMessage).mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -105,5 +109,44 @@ describe("thread runtime mutations", () => {
         senderThreadId: "thread-source",
       }),
     );
+  });
+
+  it("keeps an optimistically deleted queued message removed when the server says it is already gone", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), [
+      makeQueuedMessage({ id: "qmsg-1" }),
+      makeQueuedMessage({ id: "qmsg-2" }),
+    ]);
+    vi.mocked(api.deleteThreadQueuedMessage).mockRejectedValue(
+      new api.HttpError({
+        status: 404,
+        code: "invalid_request",
+        message: "Queued message not found",
+        body: {
+          code: "invalid_request",
+          message: "Queued message not found",
+        },
+      }),
+    );
+    const { result } = renderHook(() => useDeleteThreadQueuedMessage(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          id: "thread-1",
+          queuedMessageId: "qmsg-1",
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    expect(
+      queryClient
+        .getQueryData<
+          ThreadQueuedMessage[]
+        >(threadQueuedMessagesQueryKey("thread-1"))
+        ?.map((queuedMessage) => queuedMessage.id),
+    ).toEqual(["qmsg-2"]);
   });
 });

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -57,6 +57,42 @@ interface ReorderThreadQueuedMessageMutationRequest extends QueuedMessageReorder
   id: string;
 }
 
+function getHttpErrorBodyMessage(error: api.HttpError): string | null {
+  const body = error.body;
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("message" in body) ||
+    typeof body.message !== "string"
+  ) {
+    return null;
+  }
+  return body.message;
+}
+
+function isQueuedMessageNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof api.HttpError &&
+    error.status === 404 &&
+    error.code === "invalid_request" &&
+    getHttpErrorBodyMessage(error) === "Queued message not found"
+  );
+}
+
+async function deleteThreadQueuedMessageOrConfirmMissing({
+  id,
+  queuedMessageId,
+}: DeleteThreadQueuedMessageMutationRequest): Promise<void> {
+  try {
+    await api.deleteThreadQueuedMessage(id, queuedMessageId);
+  } catch (error) {
+    if (isQueuedMessageNotFoundError(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
 export function useCreateThread() {
   const queryClient = useQueryClient();
 
@@ -268,11 +304,7 @@ export function useDeleteThreadQueuedMessage() {
       errorMessage: "Failed to delete queued message.",
       showErrorToast: false,
     },
-    mutationFn: ({
-      id,
-      queuedMessageId,
-    }: DeleteThreadQueuedMessageMutationRequest) =>
-      api.deleteThreadQueuedMessage(id, queuedMessageId),
+    mutationFn: deleteThreadQueuedMessageOrConfirmMissing,
     onMutate: async (variables): Promise<RemoveQueuedMessageTransaction> =>
       beginRemoveQueuedMessageTransaction({
         queryClient,


### PR DESCRIPTION
## Summary
- keep active queued-message cache data from being overwritten by late composer bootstrap hydration
- treat delete 404s for already-gone queued messages as successful removal on the client
- add regressions for bootstrap clobbering and delete rollback behavior

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/cache-owners/composer-cache-owner.test.ts src/hooks/mutations/thread-runtime-mutations.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app