### PR TITLE
Fix fork thread naming and navigation

### DIFF
--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -13,6 +13,7 @@ import {
   buildMobileRecentThreads,
   readInitialPromptFromLocationState,
   resolveRootComposeEffectiveEnvironmentValue,
+  shouldNavigateAfterThreadCreate,
 } from "./RootComposeView";
 
 interface MakeThreadArgs {
@@ -162,6 +163,32 @@ describe("readInitialPromptFromLocationState", () => {
     expect(
       readInitialPromptFromLocationState({ initialPrompt: 42 }),
     ).toBeNull();
+  });
+});
+
+describe("shouldNavigateAfterThreadCreate", () => {
+  it("follows the preference for ordinary new threads", () => {
+    expect(
+      shouldNavigateAfterThreadCreate({
+        isForkDraft: false,
+        navigateToThreadAfterCreate: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldNavigateAfterThreadCreate({
+        isForkDraft: false,
+        navigateToThreadAfterCreate: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("always navigates for submitted fork drafts", () => {
+    expect(
+      shouldNavigateAfterThreadCreate({
+        isForkDraft: true,
+        navigateToThreadAfterCreate: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -105,6 +105,11 @@ interface ResolveRootComposeEffectiveEnvironmentValueArgs {
   reuseThreadOptionsLoading: boolean;
 }
 
+interface ShouldNavigateAfterThreadCreateArgs {
+  isForkDraft: boolean;
+  navigateToThreadAfterCreate: boolean;
+}
+
 // react-router's location.state is freeform unknown — narrow it here at the
 // system boundary before reading.
 function readReuseEnvironmentIdFromLocationState(
@@ -115,6 +120,13 @@ function readReuseEnvironmentIdFromLocationState(
     .reuseEnvironmentId;
   if (typeof candidate === "string" && candidate.length > 0) return candidate;
   return null;
+}
+
+export function shouldNavigateAfterThreadCreate({
+  isForkDraft,
+  navigateToThreadAfterCreate,
+}: ShouldNavigateAfterThreadCreateArgs): boolean {
+  return isForkDraft || navigateToThreadAfterCreate;
 }
 
 function readForkThreadCreateSeedFromLocationState(
@@ -809,6 +821,10 @@ export function RootComposeView(props: RootComposeViewProps) {
     }
 
     try {
+      const shouldNavigateToCreatedThread = shouldNavigateAfterThreadCreate({
+        isForkDraft: forkSeed !== null,
+        navigateToThreadAfterCreate,
+      });
       const request =
         forkSeed !== null
           ? buildForkThreadRequest({
@@ -845,7 +861,7 @@ export function RootComposeView(props: RootComposeViewProps) {
           projectId: thread.projectId,
           threadId: thread.id,
         });
-      } else if (navigateToThreadAfterCreate) {
+      } else if (shouldNavigateToCreatedThread) {
         navigate(
           getThreadRoutePath({
             projectId: thread.projectId,

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -7,7 +7,6 @@ import {
   listThreadEnvironmentAssignmentsOnHost,
   MissingStoredTurnStartedError,
   events as storedEvents,
-  updateThread,
 } from "@bb/db";
 import type {
   AcceptedDaemonEvent,
@@ -389,12 +388,6 @@ async function applyEventEffects(
           });
         }
         continue;
-      }
-
-      if (event.type === "thread/name/updated") {
-        updateThread(deps.db, deps.hub, entry.threadId, {
-          title: event.threadName,
-        });
       }
     } catch (error) {
       deps.logger.error(

--- a/apps/server/src/services/threads/thread-create-helpers.ts
+++ b/apps/server/src/services/threads/thread-create-helpers.ts
@@ -10,10 +10,7 @@ import type { BaseBranchSpec } from "@bb/server-contract";
 import type { AppDeps } from "../../types.js";
 import { ApiError } from "../../errors.js";
 import type { ThreadCreateServiceRequest } from "./thread-create-request.js";
-import {
-  deriveTitleFallback,
-  sanitizeGeneratedBranchSlug,
-} from "./title-generation.js";
+import { sanitizeGeneratedBranchSlug } from "./title-generation.js";
 
 /**
  * Convert a {@link BaseBranchSpec} to the stored/wire branch-name shape.
@@ -167,7 +164,7 @@ export function createThreadRecord(
     environmentId: args.environmentId,
     providerId: args.request.providerId,
     title: args.request.title ?? null,
-    titleFallback: deriveTitleFallback(args.request.input),
+    titleFallback: args.request.titleFallback,
     parentThreadId: args.request.parentThreadId ?? null,
     sourceThreadId: args.request.sourceThreadId ?? null,
     originKind: args.request.originKind ?? args.request.childOrigin,

--- a/apps/server/src/services/threads/thread-create-request.ts
+++ b/apps/server/src/services/threads/thread-create-request.ts
@@ -36,4 +36,5 @@ export interface ThreadCreateServiceRequest extends Omit<
   "providerId"
 > {
   providerId: string;
+  titleFallback: string | null;
 }

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -44,6 +44,7 @@ import {
   type ThreadCreateServiceRequestInput,
   type ThreadCreateServiceRequest,
 } from "./thread-create-request.js";
+import { deriveTitleFallback } from "./title-generation.js";
 import {
   advanceThreadProvisioning,
   requestThreadProvision,
@@ -89,6 +90,12 @@ interface ResolveForkDescriptorArgs {
   sourceThread: Thread | null;
 }
 
+interface DeriveThreadCreateTitleFallbackArgs {
+  input: ThreadCreateServiceRequestInput["input"];
+  originKind: ThreadOriginKind | null;
+  sourceThread: Thread | null;
+}
+
 /**
  * Resolve the native-fork descriptor for a source-derived thread, or null when
  * it cannot be provisioned as a fork. Both forks and side chats are native
@@ -99,8 +106,8 @@ interface ResolveForkDescriptorArgs {
  * already has a provider session, and a new workspace on the same host as the
  * source (a cross-host clone of a provider session is not possible).
  * Returns null when the request has no source provenance or the source session
- * cannot be cloned; the consumer treats a null descriptor for an
- * empty-input child as an unforkable error rather than a silent fresh start.
+ * cannot be cloned; the consumer treats a null descriptor for a source-derived
+ * thread as an unforkable error rather than a silent fresh start.
  */
 function resolveForkDescriptor(
   deps: Pick<ThreadCreateDeps, "db">,
@@ -150,6 +157,30 @@ function childHostIdForResolvedEnvironment(
     case "personal":
       return resolvedEnvironment.hostId;
   }
+}
+
+function sourceThreadDisplayTitle(sourceThread: Thread): string {
+  const title = sourceThread.title?.trim();
+  if (title) return title;
+  const titleFallback = sourceThread.titleFallback?.trim();
+  if (titleFallback) return titleFallback;
+  return `Thread ${sourceThread.id.slice(0, 8)}`;
+}
+
+function deriveThreadCreateTitleFallback({
+  input,
+  originKind,
+  sourceThread,
+}: DeriveThreadCreateTitleFallbackArgs): string | null {
+  const inputFallback = deriveTitleFallback(input);
+  if (inputFallback !== null) {
+    return inputFallback;
+  }
+  if (originKind !== "side-chat" || sourceThread === null) {
+    return null;
+  }
+
+  return `Side chat of ${sourceThreadDisplayTitle(sourceThread)}`;
 }
 
 interface EnsureCreateHostOnlineArgs {
@@ -438,6 +469,13 @@ export async function createThreadFromRequest(
     (originKind !== null ? requestInput.parentThreadId : undefined);
   const hierarchyParentThreadId =
     originKind === null ? requestInput.parentThreadId : undefined;
+  if (originKind === "fork" && requestInput.input.length === 0) {
+    throw new ApiError(
+      400,
+      "invalid_request",
+      "fork input must contain at least one entry",
+    );
+  }
   const parentThread = hierarchyParentThreadId
     ? assertValidParentThread(deps, {
         parentThreadId: hierarchyParentThreadId,
@@ -545,6 +583,11 @@ export async function createThreadFromRequest(
       requestedEnvironment: requestInput.environment,
     }),
     providerId,
+    titleFallback: deriveThreadCreateTitleFallback({
+      input: requestInput.input,
+      originKind,
+      sourceThread,
+    }),
   };
   const resolvedEnvironment = resolveStableThreadRequestEnvironment(deps, {
     environment: request.environment,

--- a/apps/server/src/services/threads/thread-provisioning.ts
+++ b/apps/server/src/services/threads/thread-provisioning.ts
@@ -212,10 +212,10 @@ async function startThreadIfEnvironmentReady(
   // short-circuit, we issue the real start carrying the fork descriptor so the
   // child's provider session is cloned from the parent at its branch point now.
   //
-  // The app sends a fork with empty input, and the runtime starts no first turn
-  // when the start input is empty (its no-input-no-turn guard). So the forked
-  // session is established and the thread lands idle with an empty timeline; the
-  // user steers the first executed turn.
+  // When a side-chat preload is created with empty input, the runtime starts no
+  // first turn (its no-input-no-turn guard). The forked provider session is
+  // established and the thread lands idle; the user steers the first executed
+  // turn later. Submitted fork prompts carry their input and run immediately.
   await requestThreadStart(deps, {
     thread: args.thread,
     environment: {

--- a/apps/server/test/internal/internal-event-append-ownership.test.ts
+++ b/apps/server/test/internal/internal-event-append-ownership.test.ts
@@ -413,11 +413,11 @@ describe("internal event append ownership", () => {
           },
         ],
       });
-      expect(getThread(harness.db, thread.id)?.title).toBe(
+      expect(getThread(harness.db, thread.id)?.title).not.toBe(
         "First owned rename",
       );
       expect(getThread(harness.db, secondThread.id)?.title).toBe(
-        "Second owned rename",
+        "Second Thread",
       );
       expect(
         harness.db
@@ -486,7 +486,8 @@ describe("internal event append ownership", () => {
       const parentTurnCommand = await waitForQueuedCommand(
         harness,
         ({ command }) =>
-          command.type === "turn.submit" && command.threadId === parentThread.id,
+          command.type === "turn.submit" &&
+          command.threadId === parentThread.id,
         3_000,
       );
       if (parentTurnCommand.command.type !== "turn.submit") {
@@ -500,9 +501,11 @@ describe("internal event append ownership", () => {
       }
       const threadMention = `@thread:${childThread.id}`;
       expect(input.text).toContain(
-        [`${threadMention} failed.`, "", "Review the thread before deciding next steps."].join(
-          "\n",
-        ),
+        [
+          `${threadMention} failed.`,
+          "",
+          "Review the thread before deciding next steps.",
+        ].join("\n"),
       );
       expect(input.text).not.toContain("No failure output was recorded.");
       expect(input.mentions).toEqual([

--- a/apps/server/test/internal/internal-event-envelope-threadid-regression.test.ts
+++ b/apps/server/test/internal/internal-event-envelope-threadid-regression.test.ts
@@ -1,4 +1,4 @@
-import { getThread } from "@bb/db";
+import { createThread, getThread } from "@bb/db";
 import { threadScope } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
@@ -66,8 +66,57 @@ describe("internal event envelope threadId regression", () => {
       });
 
       expect(response.status).toBe(200);
-      expect(getThread(harness.db, threadA.id)?.title).toBe("hacked");
+      expect(getThread(harness.db, threadA.id)?.title).toBe("Owned thread");
       expect(getThread(harness.db, threadB.id)?.title).toBe("Foreign thread");
+    });
+  });
+
+  it("does not apply provider names to thread titles", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-fork-provider-title",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = createThread(harness.db, harness.hub, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "codex",
+        title: null,
+        titleFallback: "Summarize the work",
+        status: "active",
+      });
+
+      const response = await harness.app.request("/internal/session/events", {
+        method: "POST",
+        headers: internalAuthHeaders(harness, { hostId: host.id }),
+        body: JSON.stringify({
+          sessionId: session.id,
+          events: [
+            createTestDaemonEventEnvelope({
+              threadId: thread.id,
+              event: {
+                type: "thread/name/updated",
+                threadId: thread.id,
+                providerThreadId: "provider-thread",
+                scope: threadScope(),
+                threadName: "Provider supplied name",
+              },
+            }),
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.title).toBeNull();
+      expect(getThread(harness.db, thread.id)?.titleFallback).toBe(
+        "Summarize the work",
+      );
     });
   });
 });

--- a/apps/server/test/threads/generated-branch-names.test.ts
+++ b/apps/server/test/threads/generated-branch-names.test.ts
@@ -23,10 +23,12 @@ import {
   seedHostSession,
   seedProjectWithSource,
   seedThread,
+  seedTurnStarted,
 } from "../helpers/seed.js";
 import { createTestAppHarness, withTestHarness } from "../helpers/test-app.js";
 import { InferenceTimeoutError } from "../../src/services/ai/inference.js";
 import { runEnvironmentProvisioningSweep } from "../../src/services/system/periodic-sweeps.js";
+import { createThreadFromRequest } from "../../src/services/threads/thread-create.js";
 import { requestThreadStopForCurrentState } from "../../src/services/threads/thread-lifecycle.js";
 import {
   advanceThreadProvisioning,
@@ -332,8 +334,9 @@ describe("generated managed branch names", () => {
         .filter((event) => event.type === "system/thread-provisioning")
         .map(
           (event) =>
-            systemThreadProvisioningEventDataSchema.parse(JSON.parse(event.data))
-              .status,
+            systemThreadProvisioningEventDataSchema.parse(
+              JSON.parse(event.data),
+            ).status,
         );
       expect(provisioningStatuses).toContain("cancelled");
       expect(
@@ -611,6 +614,79 @@ describe("generated managed branch names", () => {
         type: "thread.rename",
         threadId: thread.id,
         title: "Generated Rename Title",
+      });
+    });
+  });
+
+  it("generates titles for submitted fork threads", async () => {
+    mockThreadMetadata({ title: "Generated Fork Title" });
+
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-generated-fork-title",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/generated-fork-title-project",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/generated-fork-title-project",
+        status: "ready",
+        workspaceProvisionType: "unmanaged",
+      });
+      const sourceThread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+      });
+      seedTurnStarted(harness.deps, {
+        threadId: sourceThread.id,
+        turnId: "turn-generated-fork-title-source",
+        providerThreadId: "provider-generated-fork-title-source",
+      });
+
+      const input = textInput("Continue this fork and generate a useful title");
+      const fork = await createThreadFromRequest(harness.deps, {
+        environment: { type: "reuse", environmentId: environment.id },
+        input,
+        model: "gpt-5",
+        origin: "app",
+        originKind: "fork",
+        projectId: project.id,
+        providerId: "codex",
+        sourceThreadId: sourceThread.id,
+        startedOnBehalfOf: null,
+      });
+
+      expect(getThread(harness.db, fork.id)?.titleFallback).toBe(
+        "Continue this fork and generate a useful title",
+      );
+
+      const start = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.start" && command.threadId === fork.id,
+      );
+      if (start.command.type !== "thread.start") {
+        throw new Error("Expected a thread.start command");
+      }
+      expect(start.command.input).toEqual(input);
+      expect(start.command.fork).toEqual({
+        sourceProviderThreadId: "provider-generated-fork-title-source",
+      });
+
+      await reportQueuedCommandSuccess(
+        harness,
+        start,
+        { providerThreadId: "provider-generated-fork-title" },
+        { hostId: host.id },
+      );
+
+      await vi.waitFor(() => {
+        expect(getThread(harness.db, fork.id)?.title).toBe(
+          "Generated Fork Title",
+        );
       });
     });
   });

--- a/apps/server/test/threads/thread-create-seed-without-run.test.ts
+++ b/apps/server/test/threads/thread-create-seed-without-run.test.ts
@@ -44,7 +44,7 @@ function threadStartTurnRequest(
 }
 
 describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
-  it("persists an agent fork anchor while cloning the source provider session", async () => {
+  it("persists an agent fork start while cloning the source provider session", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {
         id: "host-seed-without-run",
@@ -71,6 +71,7 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
         providerThreadId: "provider-seed-without-run-source",
       });
 
+      const input = textInput("Continue from the fork point");
       const fork = await createThreadFromRequest(harness.deps, {
         environment: {
           type: "host",
@@ -80,7 +81,7 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
             path: "/tmp/seed-without-run-project",
           },
         },
-        input: [],
+        input,
         origin: "app",
         originKind: "fork",
         projectId: project.id,
@@ -107,20 +108,15 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
       if (queuedStart.command.type !== "thread.start") {
         throw new Error("Expected a thread.start command");
       }
-      expect(queuedStart.command.input).toEqual([]);
+      expect(queuedStart.command.input).toEqual(input);
       expect(queuedStart.command.fork).toEqual({
         sourceProviderThreadId: "provider-seed-without-run-source",
       });
-
-      await reportQueuedCommandSuccess(harness, queuedStart, {
-        providerThreadId: "provider-seed-without-run-fork",
-      });
-
-      expect(getThread(harness.db, fork.id)?.status).toBe("idle");
       const persistedFork = getThread(harness.db, fork.id);
       expect(persistedFork?.originKind).toBe("fork");
       expect(persistedFork?.sourceThreadId).toBe(sourceThread.id);
       expect(persistedFork?.parentThreadId).toBeNull();
+      expect(persistedFork?.titleFallback).toBe("Continue from the fork point");
     });
   });
 
@@ -155,6 +151,7 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
         sequence: 9,
       });
 
+      const forkInput = textInput("Continue from the earlier source sequence");
       const fork = await createThreadFromRequest(harness.deps, {
         environment: {
           type: "host",
@@ -164,7 +161,7 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
             path: "/tmp/source-sequence-fork-project",
           },
         },
-        input: [],
+        input: forkInput,
         origin: "app",
         originKind: "fork",
         projectId: project.id,
@@ -185,6 +182,7 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
       if (queuedStart.command.type !== "thread.start") {
         throw new Error("Expected a thread.start command");
       }
+      expect(queuedStart.command.input).toEqual(forkInput);
       expect(queuedStart.command.fork).toEqual({
         sourceProviderThreadId: "provider-earlier-source",
       });
@@ -536,13 +534,14 @@ describe("thread creation child-thread boundary validation", () => {
         expect(persistedFork?.originKind).toBe("fork");
         expect(persistedFork?.sourceThreadId).toBe(sourceThreadId);
         expect(persistedFork?.parentThreadId).toBeNull();
+        expect(persistedFork?.titleFallback).toBe("Forked anchor");
       },
     );
   });
 
-  it("settles an empty-input native fork to idle after cloning the provider session", async () => {
+  it("rejects an empty-input native fork", async () => {
     await withChildBoundaryHarness(
-      "empty-native-fork-idle",
+      "empty-native-fork",
       async ({ harness, hostId, path, projectId, sourceThreadId }) => {
         seedTurnStarted(harness.deps, {
           threadId: sourceThreadId,
@@ -550,42 +549,30 @@ describe("thread creation child-thread boundary validation", () => {
           providerThreadId: "provider-parent-session",
         });
 
-        const fork = await createThreadFromRequest(harness.deps, {
-          environment: {
-            type: "host",
-            hostId,
-            workspace: { type: "unmanaged", path },
-          },
-          input: [],
-          origin: "app",
-          originKind: "fork",
-          projectId,
-          providerId: "codex",
-          sourceThreadId,
-          startedOnBehalfOf: {
-            initiator: "agent",
-            senderThreadId: sourceThreadId,
-          },
-        });
-
-        const queuedStart = await waitForQueuedCommand(
-          harness,
-          ({ command }) =>
-            command.type === "thread.start" && command.threadId === fork.id,
+        const error = await captureCreateError(() =>
+          createThreadFromRequest(harness.deps, {
+            environment: {
+              type: "host",
+              hostId,
+              workspace: { type: "unmanaged", path },
+            },
+            input: [],
+            origin: "app",
+            originKind: "fork",
+            projectId,
+            providerId: "codex",
+            sourceThreadId,
+            startedOnBehalfOf: {
+              initiator: "agent",
+              senderThreadId: sourceThreadId,
+            },
+          }),
         );
-        if (queuedStart.command.type !== "thread.start") {
-          throw new Error("Expected a thread.start command");
-        }
-        expect(queuedStart.command.input).toEqual([]);
-        expect(queuedStart.command.fork).toEqual({
-          sourceProviderThreadId: "provider-parent-session",
-        });
-
-        await reportQueuedCommandSuccess(harness, queuedStart, {
-          providerThreadId: "provider-fork-session",
-        });
-
-        expect(getThread(harness.db, fork.id)?.status).toBe("idle");
+        expect(error.status).toBe(400);
+        expect(error.body.code).toBe("invalid_request");
+        expect(error.body.message).toBe(
+          "fork input must contain at least one entry",
+        );
       },
     );
   });
@@ -818,10 +805,8 @@ describe("thread creation child-thread boundary validation", () => {
     await withChildBoundaryHarness(
       "fork-no-source-session",
       async ({ harness, hostId, path, projectId, sourceThreadId }) => {
-        // Source has no turn/started ⇒ no provider session to clone. A fork is
-        // sent with empty input, so there is nothing to run a fresh turn with
-        // either. The create must fail rather than dispatch an empty,
-        // session-less start.
+        // Source has no turn/started ⇒ no provider session to clone. The create
+        // must fail rather than silently dispatch a fresh, history-less start.
         const error = await captureCreateError(() =>
           createThreadFromRequest(harness.deps, {
             environment: {
@@ -829,7 +814,7 @@ describe("thread creation child-thread boundary validation", () => {
               hostId,
               workspace: { type: "unmanaged", path },
             },
-            input: [],
+            input: textInput("Fork without a source session"),
             origin: "app",
             originKind: "fork",
             projectId,

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -100,10 +100,10 @@ export const createThreadRequestSchema = z
     providerId: z.string().min(1).optional(),
     origin: threadCreateOriginSchema,
     title: z.string().min(1).optional(),
-    // A source-derived native fork/side chat may establish the cloned provider
-    // session with an empty timeline, so it can carry no input. A normal thread
-    // start requires at least one input, enforced by the refinement below rather
-    // than a blanket `.min(1)`.
+    // A source-derived side-chat preload may establish the cloned provider
+    // session without a first prompt. Normal starts and forks require at least
+    // one input entry, enforced by the refinement below rather than a blanket
+    // `.min(1)`.
     input: z.array(promptInputSchema),
     model: z.string().min(1).optional(),
     serviceTier: serviceTierSchema.optional(),
@@ -125,6 +125,13 @@ export const createThreadRequestSchema = z
       ctx.addIssue({
         code: "custom",
         message: "input must contain at least one entry",
+        path: ["input"],
+      });
+    }
+    if (originKind === "fork" && value.input.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        message: "fork input must contain at least one entry",
         path: ["input"],
       });
     }

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -1075,6 +1075,26 @@ describe("server-contract canonical schemas", () => {
     ).toThrow("input must contain at least one entry");
   });
 
+  it("rejects empty input for a fork", () => {
+    expect(() =>
+      createThreadRequestSchema.parse({
+        projectId: "proj_123",
+        providerId: "codex",
+        origin: "app",
+        input: [],
+        environment: {
+          type: "host",
+          hostId: "host_abc",
+          workspace: { type: "unmanaged", path: null },
+        },
+        originKind: "fork",
+        sourceSeqEnd: 12,
+        sourceThreadId: "thr_source",
+        startedOnBehalfOf: null,
+      }),
+    ).toThrow("fork input must contain at least one entry");
+  });
+
   it("accepts empty input for a source-derived side chat preload", () => {
     const parsed = createThreadRequestSchema.parse({
       projectId: "proj_123",


### PR DESCRIPTION
## Summary
- make fork submits always navigate to the created fork while ordinary new-thread submits keep respecting the user preference
- reject empty fork creates in the public contract and server service path
- keep thread titles owned by bb by ignoring provider `thread/name/updated` events as title mutations, while still storing those events
- normalize create-time title fallbacks so valid fork prompts and side-chat preloads have useful display fallbacks

## Validation
- `pnpm exec turbo run test --filter=@bb/app -- src/views/RootComposeView.test.ts`
- `pnpm exec turbo run test --filter=@bb/server-contract -- test/contract.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/threads/thread-create-seed-without-run.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/internal/internal-event-envelope-threadid-regression.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/internal/internal-event-append-ownership.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/threads/generated-branch-names.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/server-contract`
- `pnpm exec turbo run typecheck --filter=@bb/server`