### PR TITLE
Fetch remote base before creating worktree

### DIFF
--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -232,6 +232,94 @@ function throwIfProvisionAborted(signal: AbortSignal | undefined): void {
   }
 }
 
+async function resolveRemoteBaseBranch(
+  sourcePath: string,
+  baseBranch: string,
+  signal: AbortSignal | undefined,
+): Promise<{ remote: string; branch: string } | null> {
+  if (!baseBranch.includes("/")) {
+    return null;
+  }
+
+  const remotes = (
+    await runGit(["remote"], { cwd: sourcePath, signal })
+  ).stdout
+    .split("\n")
+    .map((remote) => remote.trim())
+    .filter(Boolean);
+  const matchingRemotes = remotes
+    .filter(
+      (remote) =>
+        baseBranch.startsWith(`${remote}/`) &&
+        baseBranch.length > remote.length + 1,
+    )
+    .sort((left, right) => right.length - left.length);
+  const remote = matchingRemotes[0];
+  if (!remote) {
+    return null;
+  }
+
+  return {
+    remote,
+    branch: baseBranch.slice(remote.length + 1),
+  };
+}
+
+async function fetchRemoteBaseBranch(args: {
+  sourcePath: string;
+  baseBranch: string;
+  onProgress: ProgressCallback | undefined;
+  signal: AbortSignal | undefined;
+}): Promise<void> {
+  const remoteBase = await resolveRemoteBaseBranch(
+    args.sourcePath,
+    args.baseBranch,
+    args.signal,
+  );
+  if (!remoteBase) {
+    return;
+  }
+
+  const startedAt = Date.now();
+  emitStep({
+    onProgress: args.onProgress,
+    key: "git-fetch-started",
+    text: `Fetching ${args.baseBranch}`,
+    status: "started",
+    startedAt,
+  });
+
+  const refspec = `+refs/heads/${remoteBase.branch}:refs/remotes/${remoteBase.remote}/${remoteBase.branch}`;
+  try {
+    await runGit(["fetch", "--quiet", remoteBase.remote, refspec], {
+      cwd: args.sourcePath,
+      signal: args.signal,
+    });
+    emitStep({
+      onProgress: args.onProgress,
+      key: "git-fetch-completed",
+      text: `Fetched ${args.baseBranch}`,
+      status: "completed",
+      startedAt,
+      metadata: {
+        durationMs: Date.now() - startedAt,
+      },
+    });
+  } catch (error) {
+    emitStep({
+      onProgress: args.onProgress,
+      key: "git-fetch-failed",
+      text: `Failed to fetch ${args.baseBranch}`,
+      status: "failed",
+      startedAt,
+      metadata: {
+        durationMs: Date.now() - startedAt,
+      },
+    });
+    throw error;
+  }
+}
+
 export async function createWorktree(
   args: CreateWorkspaceArgs,
 ): Promise<{ path: string }> {
@@ -252,6 +340,14 @@ export async function createWorktree(
       `Cannot resolve default branch for source: ${args.sourcePath}`,
     );
   }
+  throwIfProvisionAborted(args.signal);
+  await fetchRemoteBaseBranch({
+    sourcePath: args.sourcePath,
+    baseBranch,
+    onProgress: args.onProgress,
+    signal: args.signal,
+  });
+
   const gitArgs = [
     "worktree",
     "add",

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -42,6 +42,37 @@ async function initRepoWithOptionalSetup(
   return repoPath;
 }
 
+async function initRemoteBackedRepo(): Promise<{
+  remotePath: string;
+  repoPath: string;
+}> {
+  const repoPath = await initRepoWithOptionalSetup();
+  const remotePath = await makeTempDir("bb-provisioning-remote-");
+  await runGit(["init", "--bare"], { cwd: remotePath });
+  await runGit(["remote", "add", "origin", remotePath], { cwd: repoPath });
+  await runGit(["push", "-u", "origin", "main"], { cwd: repoPath });
+  await runGit(["fetch", "origin"], { cwd: repoPath });
+  return { remotePath, repoPath };
+}
+
+async function pushRemoteMainCommit(remotePath: string): Promise<string> {
+  const cloneParent = await makeTempDir("bb-provisioning-remote-clone-");
+  const clonePath = path.join(cloneParent, "repo");
+  await runGit(["clone", "--branch", "main", remotePath, clonePath], {
+    cwd: cloneParent,
+  });
+  await runGit(["config", "user.name", "BB Tests"], { cwd: clonePath });
+  await runGit(["config", "user.email", "bb@example.com"], {
+    cwd: clonePath,
+  });
+  await fs.writeFile(path.join(clonePath, "remote.txt"), "remote\n", "utf8");
+  await runGit(["add", "."], { cwd: clonePath });
+  await runGit(["commit", "-m", "Remote edit"], { cwd: clonePath });
+  const head = await runGit(["rev-parse", "HEAD"], { cwd: clonePath });
+  await runGit(["push", "origin", "main"], { cwd: clonePath });
+  return head.stdout.trim();
+}
+
 class AbortAtSetupListenerSignal extends EventTarget implements AbortSignal {
   onabort: ((this: AbortSignal, event: Event) => void) | null = null;
   readonly reason = new Error("test abort");
@@ -92,6 +123,34 @@ describe("workspace provisioning", () => {
     expect(first.path).toBe(targetPath);
     expect(second.path).toBe(targetPath);
     expect(await new Workspace(targetPath).currentBranch).toBe("feature");
+  });
+
+  it("fetches remote base branches before creating worktrees", async () => {
+    const { remotePath, repoPath } = await initRemoteBackedRepo();
+    const parentDir = await makeTempDir("bb-worktree-remote-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    const remoteHead = await pushRemoteMainCommit(remotePath);
+
+    const staleOriginMain = await runGit(["rev-parse", "origin/main"], {
+      cwd: repoPath,
+    });
+    expect(staleOriginMain.stdout.trim()).not.toBe(remoteHead);
+
+    await createWorktree({
+      sourcePath: repoPath,
+      targetPath,
+      branchName: "feature",
+      baseBranch: "origin/main",
+      timeoutMs: 900000,
+    });
+
+    await expect(
+      fs.readFile(path.join(targetPath, "remote.txt"), "utf8"),
+    ).resolves.toBe("remote\n");
+    const worktreeHead = await runGit(["rev-parse", "HEAD"], {
+      cwd: targetPath,
+    });
+    expect(worktreeHead.stdout.trim()).toBe(remoteHead);
   });
 
   it("rolls back failed worktree setup scripts", async () => {


### PR DESCRIPTION
## Summary
- fetch remote-tracking base refs like origin/main before creating managed worktrees
- use an explicit refspec so the local refs/remotes/<remote>/<branch> is refreshed before git worktree add
- add a regression test that provisions from a stale origin/main and verifies the worktree starts from the latest remote commit

## Tests
- pnpm exec turbo run test --filter=@bb/host-workspace
- pnpm exec turbo run typecheck --filter=@bb/host-workspace