### PR TITLE
Force refetch PR status on window focus

### DIFF
--- a/apps/app/src/hooks/queries/environment-queries.test.tsx
+++ b/apps/app/src/hooks/queries/environment-queries.test.tsx
@@ -104,7 +104,7 @@ describe("useEnvironmentPullRequest", () => {
     ).toBe(SETTLED_PULL_REQUEST_STALE_MS);
   });
 
-  it("refetches stale pull request data on mount and window focus", async () => {
+  it("refetches stale pull request data on mount and always refetches on window focus", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
     vi.mocked(api.getEnvironmentPullRequest).mockResolvedValue(
       pullRequestResponse(pullRequestFixture),
@@ -123,7 +123,7 @@ describe("useEnvironmentPullRequest", () => {
     expect(query?.options).toEqual(
       expect.objectContaining({
         refetchOnMount: true,
-        refetchOnWindowFocus: true,
+        refetchOnWindowFocus: "always",
         staleTime: expect.any(Function),
       }),
     );

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -148,7 +148,7 @@ export function useEnvironmentPullRequest(
       ),
     enabled,
     refetchOnMount: true,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: "always",
     staleTime: (query) =>
       getEnvironmentPullRequestStaleTime(query.state.data?.pullRequest),
   });


### PR DESCRIPTION
## Summary
- Force environment PR status to refetch whenever the app window regains focus
- Update the PR status query test to expect the always-refetch focus policy

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/queries/environment-queries.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app