### PR TITLE
Skip legacy event large value migration round trip

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -125,6 +125,10 @@ interface ExistingMigrationRow {
   createdAt: number;
 }
 
+interface LatestAppliedMigrationRow {
+  createdAt: number | null;
+}
+
 interface ExistingTableRow {
   name: string;
 }
@@ -491,6 +495,23 @@ function readAppliedMigrationCreatedAts(db: DbConnection): Set<number> {
   return new Set(rows.map((row) => row.createdAt));
 }
 
+function readLatestAppliedMigrationCreatedAt(db: DbConnection): number | null {
+  if (!tableExists(db, "__drizzle_migrations")) {
+    return null;
+  }
+
+  const row = db.$client
+    .prepare<[], LatestAppliedMigrationRow>(
+      `
+        SELECT MAX(created_at) AS createdAt
+        FROM __drizzle_migrations
+      `,
+    )
+    .get();
+
+  return row?.createdAt ?? null;
+}
+
 function requireExpectedAppliedMigration(
   migrations: ExpectedAppliedMigration[],
   tag: string,
@@ -528,6 +549,20 @@ function markMigrationApplied(
       `,
     )
     .run(migration.hash, migration.createdAt);
+}
+
+function applyMigrationStatements(
+  db: DbConnection,
+  migration: ExpectedAppliedMigration,
+): void {
+  const apply = db.$client.transaction(() => {
+    for (const statement of migration.sql) {
+      db.$client.exec(statement);
+    }
+    markMigrationApplied(db, migration);
+  });
+
+  apply();
 }
 
 function hasPublishedTimestampFallback(
@@ -1054,6 +1089,65 @@ function applyReorderedCleanupMigrations(
   }
 }
 
+// 0031 externalized large event JSON and 0032 restored it inline, leaving no
+// persistent schema change. If neither migration started, current event rows
+// already match the final state, so only the migration ledger needs repair.
+function skipEventLargeValuesRoundTripForInlineEvents(
+  db: DbConnection,
+  migrationsFolder: string,
+): void {
+  if (
+    !tableExists(db, "__drizzle_migrations") ||
+    !tableExists(db, "events") ||
+    tableExists(db, "event_large_values")
+  ) {
+    return;
+  }
+
+  const expectedMigrations = readExpectedAppliedMigrations(migrationsFolder);
+  const appliedCreatedAts = readAppliedMigrationCreatedAts(db);
+  const largeValuesMigration = requireExpectedAppliedMigration(
+    expectedMigrations,
+    "0031_mysterious_zaran",
+  );
+  const restoreMigration = requireExpectedAppliedMigration(
+    expectedMigrations,
+    "0032_restore_event_large_values",
+  );
+  if (
+    appliedCreatedAts.has(largeValuesMigration.createdAt) ||
+    appliedCreatedAts.has(restoreMigration.createdAt)
+  ) {
+    return;
+  }
+
+  const popoutChatMigration = requireExpectedAppliedMigration(
+    expectedMigrations,
+    "0030_popout_chat_experiments",
+  );
+  const dropWorkflowTablesMigration = requireExpectedAppliedMigration(
+    expectedMigrations,
+    "0029_drop_workflow_tables",
+  );
+  const latestAppliedMigrationCreatedAt = readLatestAppliedMigrationCreatedAt(db);
+  if (latestAppliedMigrationCreatedAt === null) {
+    return;
+  }
+
+  if (!appliedCreatedAts.has(popoutChatMigration.createdAt)) {
+    if (
+      latestAppliedMigrationCreatedAt !== dropWorkflowTablesMigration.createdAt
+    ) {
+      return;
+    }
+
+    applyMigrationStatements(db, popoutChatMigration);
+  }
+
+  markMigrationApplied(db, largeValuesMigration);
+  markMigrationApplied(db, restoreMigration);
+}
+
 function repairBranchLocalThreadSearchMigrations(db: DbConnection): void {
   if (!tableExists(db, "__drizzle_migrations")) {
     return;
@@ -1211,6 +1305,7 @@ export function migrate(db: DbConnection, options: MigrateOptions = {}): void {
       applyDeferredDestructiveLegacyCleanup(db, migrationsFolder);
     }
     repairBranchLocalThreadSearchMigrations(db);
+    skipEventLargeValuesRoundTripForInlineEvents(db, migrationsFolder);
     drizzleMigrate(db, { migrationsFolder });
     applyReorderedCleanupMigrations(db, migrationsFolder);
   } finally {

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -181,6 +181,15 @@ interface SeedEventLargeValueBackfillEventArgs {
   type?: string;
 }
 
+interface SeededLargeValueBackfillValues {
+  commandOutput: string;
+  firstDiff: string;
+  secondDiff: string;
+  toolResult: { body: string };
+  webFetchResult: string;
+  webSearchResult: string;
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const latestMigrationWhen = Math.max(
@@ -229,7 +238,9 @@ const branchLocalThreadSearchMigrationWhen = 1781403656070;
 const branchLocalThreadSearchRowidFtsMigrationWhen = 1781403656071;
 const rowidThreadSearchMigrationHash =
   "025358fe89253aec7f5bd970dc3eb88d0e834f0d58fb9d75329a5d39899340f4";
+const popoutChatExperimentsMigrationWhen = 1781299832942;
 const eventLargeValuesMigrationWhen = 1781403656069;
+const eventLargeValuesRestoreMigrationWhen = 1781557200000;
 const cleanupModeDropMigrationWhen = 1781557300000;
 const stopRequestedAtDropMigrationWhen = 1781557400000;
 const cleanupRequestedAtDropMigrationWhen = 1781557500000;
@@ -259,6 +270,12 @@ const pendingInteractionSchemaHonestyMigrationPath = resolve(
   "..",
   "drizzle",
   "0019_pending_interactions_schema_honesty.sql",
+);
+const eventLargeValuesMigrationPath = resolve(
+  __dirname,
+  "..",
+  "drizzle",
+  "0031_mysterious_zaran.sql",
 );
 function closeConnection(db: DbConnection): void {
   db.$client.close();
@@ -565,6 +582,96 @@ function seedEventLargeValueBackfillEvent(
     );
 }
 
+function seedEventLargeValueBackfillEvents(
+  db: DbConnection,
+): SeededLargeValueBackfillValues {
+  const values: SeededLargeValueBackfillValues = {
+    commandOutput: "command output ".repeat(48),
+    toolResult: { body: "tool result ".repeat(48) },
+    webFetchResult: "web fetch result ".repeat(40),
+    webSearchResult: "web search result ".repeat(40),
+    firstDiff: "first diff ".repeat(60),
+    secondDiff: "second diff ".repeat(60),
+  };
+
+  seedEventLargeValueBackfillEvent(db, {
+    id: "evt_large_command_output",
+    itemId: "cmd_large",
+    itemKind: "commandExecution",
+    sequence: 1,
+    createdAt: 2001,
+    data: JSON.stringify({
+      item: {
+        id: "cmd_large",
+        type: "commandExecution",
+        aggregatedOutput: values.commandOutput,
+      },
+    }),
+  });
+  seedEventLargeValueBackfillEvent(db, {
+    id: "evt_large_tool_result",
+    itemId: "tool_large",
+    itemKind: "toolCall",
+    sequence: 2,
+    createdAt: 2002,
+    data: JSON.stringify({
+      item: {
+        id: "tool_large",
+        type: "toolCall",
+        result: values.toolResult,
+      },
+    }),
+  });
+  seedEventLargeValueBackfillEvent(db, {
+    id: "evt_large_web_fetch",
+    itemId: "web_fetch_large",
+    itemKind: "webFetch",
+    sequence: 3,
+    createdAt: 2003,
+    data: JSON.stringify({
+      item: {
+        id: "web_fetch_large",
+        type: "webFetch",
+        resultText: values.webFetchResult,
+      },
+    }),
+  });
+  seedEventLargeValueBackfillEvent(db, {
+    id: "evt_large_web_search",
+    itemId: "web_search_large",
+    itemKind: "webSearch",
+    sequence: 4,
+    createdAt: 2004,
+    data: JSON.stringify({
+      item: {
+        id: "web_search_large",
+        type: "webSearch",
+        resultText: values.webSearchResult,
+      },
+    }),
+  });
+  seedEventLargeValueBackfillEvent(db, {
+    id: "evt_large_file_diffs",
+    itemId: "file_large",
+    itemKind: "fileChange",
+    sequence: 5,
+    createdAt: 2005,
+    data: JSON.stringify({
+      item: {
+        id: "file_large",
+        type: "fileChange",
+        changes: [
+          { path: "a.ts", diff: values.firstDiff },
+          { path: "b.ts", diff: "small diff" },
+          { path: "c.ts", diff: values.secondDiff },
+        ],
+      },
+    }),
+  });
+
+  return values;
+}
+
 function readMigratedEventData(db: DbConnection, eventId: string): string {
   const row = db.$client
     .prepare<[string], MigratedEventDataRow>(
@@ -579,6 +686,42 @@ function readMigratedEventData(db: DbConnection, eventId: string): string {
     throw new Error(`Expected migrated event ${eventId}`);
   }
   return row.data;
+}
+
+function expectEventLargeValuesInline(
+  db: DbConnection,
+  values: SeededLargeValueBackfillValues,
+): void {
+  const commandData = JSON.parse(
+    readMigratedEventData(db, "evt_large_command_output"),
+  );
+  expect(commandData.item.aggregatedOutput).toBe(values.commandOutput);
+  expect(commandData.item.truncation).toBeUndefined();
+
+  const toolData = JSON.parse(
+    readMigratedEventData(db, "evt_large_tool_result"),
+  );
+  expect(toolData.item.result).toEqual(values.toolResult);
+  expect(toolData.item.truncation).toBeUndefined();
+
+  const webFetchData = JSON.parse(
+    readMigratedEventData(db, "evt_large_web_fetch"),
+  );
+  expect(webFetchData.item.resultText).toBe(values.webFetchResult);
+  expect(webFetchData.item.truncation).toBeUndefined();
+
+  const webSearchData = JSON.parse(
+    readMigratedEventData(db, "evt_large_web_search"),
+  );
+  expect(webSearchData.item.resultText).toBe(values.webSearchResult);
+  expect(webSearchData.item.truncation).toBeUndefined();
+
+  const fileData = JSON.parse(readMigratedEventData(db, "evt_large_file_diffs"));
+  expect(fileData.item.changes).toEqual([
+    { path: "a.ts", diff: values.firstDiff },
+    { path: "b.ts", diff: "small diff" },
+    { path: "c.ts", diff: values.secondDiff },
+  ]);
 }
 
 function seedPre0017TerminalSessionMigration(
@@ -2762,6 +2905,60 @@ describe("migrate", () => {
     }
   });
 
+  it("skips legacy large event value round trip when values are already inline", () => {
+    const db = createConnection(":memory:");
+
+    try {
+      migrate(db);
+      dropAutomationsSchema(db);
+      seedEventLargeValueBackfillThread(db);
+      const values = seedEventLargeValueBackfillEvents(db);
+
+      markEventLargeValuesMigrationUnapplied(db);
+      db.$client
+        .prepare<DeleteMigrationParameters>(
+          `
+            DELETE FROM __drizzle_migrations
+            WHERE created_at = ?
+          `,
+        )
+        .run(popoutChatExperimentsMigrationWhen);
+
+      migrate(db);
+
+      // The skipped round-trip and every migration after it re-apply, so the
+      // latest applied migration is the most recent in the journal (0041).
+      expect(readLatestAppliedMigrationCreatedAt(db)).toBe(latestMigrationWhen);
+      expect(readTableNames(db)).not.toContain("event_large_values");
+      expect(
+        db.$client
+          .prepare<[number], MigrationCountRow>(
+            `
+              SELECT COUNT(*) AS count
+              FROM __drizzle_migrations
+              WHERE created_at = ?
+            `,
+          )
+          .get(eventLargeValuesMigrationWhen),
+      ).toEqual({ count: 1 });
+      expect(
+        db.$client
+          .prepare<[number], MigrationCountRow>(
+            `
+              SELECT COUNT(*) AS count
+              FROM __drizzle_migrations
+              WHERE created_at = ?
+            `,
+          )
+          .get(eventLargeValuesRestoreMigrationWhen),
+      ).toEqual({ count: 1 });
+
+      expectEventLargeValuesInline(db, values);
+    } finally {
+      closeConnection(db);
+    }
+  });
+
   it("restores legacy large event values to inline payloads", () => {
     const db = createConnection(":memory:");
 
@@ -2769,129 +2966,21 @@ describe("migrate", () => {
       migrate(db);
       dropAutomationsSchema(db);
       seedEventLargeValueBackfillThread(db);
-
-      const commandOutput = "command output ".repeat(48);
-      const toolResult = { body: "tool result ".repeat(48) };
-      const webFetchResult = "web fetch result ".repeat(40);
-      const webSearchResult = "web search result ".repeat(40);
-      const firstDiff = "first diff ".repeat(60);
-      const secondDiff = "second diff ".repeat(60);
-
-      seedEventLargeValueBackfillEvent(db, {
-        id: "evt_large_command_output",
-        itemId: "cmd_large",
-        itemKind: "commandExecution",
-        sequence: 1,
-        createdAt: 2001,
-        data: JSON.stringify({
-          item: {
-            id: "cmd_large",
-            type: "commandExecution",
-            aggregatedOutput: commandOutput,
-          },
-        }),
-      });
-      seedEventLargeValueBackfillEvent(db, {
-        id: "evt_large_tool_result",
-        itemId: "tool_large",
-        itemKind: "toolCall",
-        sequence: 2,
-        createdAt: 2002,
-        data: JSON.stringify({
-          item: {
-            id: "tool_large",
-            type: "toolCall",
-            result: toolResult,
-          },
-        }),
-      });
-      seedEventLargeValueBackfillEvent(db, {
-        id: "evt_large_web_fetch",
-        itemId: "web_fetch_large",
-        itemKind: "webFetch",
-        sequence: 3,
-        createdAt: 2003,
-        data: JSON.stringify({
-          item: {
-            id: "web_fetch_large",
-            type: "webFetch",
-            resultText: webFetchResult,
-          },
-        }),
-      });
-      seedEventLargeValueBackfillEvent(db, {
-        id: "evt_large_web_search",
-        itemId: "web_search_large",
-        itemKind: "webSearch",
-        sequence: 4,
-        createdAt: 2004,
-        data: JSON.stringify({
-          item: {
-            id: "web_search_large",
-            type: "webSearch",
-            resultText: webSearchResult,
-          },
-        }),
-      });
-      seedEventLargeValueBackfillEvent(db, {
-        id: "evt_large_file_diffs",
-        itemId: "file_large",
-        itemKind: "fileChange",
-        sequence: 5,
-        createdAt: 2005,
-        data: JSON.stringify({
-          item: {
-            id: "file_large",
-            type: "fileChange",
-            changes: [
-              { path: "a.ts", diff: firstDiff },
-              { path: "b.ts", diff: "small diff" },
-              { path: "c.ts", diff: secondDiff },
-            ],
-          },
-        }),
-      });
+      const values = seedEventLargeValueBackfillEvents(db);
 
       markEventLargeValuesMigrationUnapplied(db);
+      runMigrationFile({ db, migrationPath: eventLargeValuesMigrationPath });
+      replaceAppliedMigrationHash({
+        db,
+        createdAt: eventLargeValuesMigrationWhen,
+        hash: eventLargeValuesPreOptimizationHash,
+      });
+
       migrate(db);
 
-      // The restore migration and every migration after it re-apply, so the
-      // latest applied migration is the most recent in the journal (0041).
       expect(readLatestAppliedMigrationCreatedAt(db)).toBe(latestMigrationWhen);
       expect(readTableNames(db)).not.toContain("event_large_values");
-
-      const commandData = JSON.parse(
-        readMigratedEventData(db, "evt_large_command_output"),
-      );
-      expect(commandData.item.aggregatedOutput).toBe(commandOutput);
-      expect(commandData.item.truncation).toBeUndefined();
-
-      const toolData = JSON.parse(
-        readMigratedEventData(db, "evt_large_tool_result"),
-      );
-      expect(toolData.item.result).toEqual(toolResult);
-      expect(toolData.item.truncation).toBeUndefined();
-
-      const webFetchData = JSON.parse(
-        readMigratedEventData(db, "evt_large_web_fetch"),
-      );
-      expect(webFetchData.item.resultText).toBe(webFetchResult);
-      expect(webFetchData.item.truncation).toBeUndefined();
-
-      const webSearchData = JSON.parse(
-        readMigratedEventData(db, "evt_large_web_search"),
-      );
-      expect(webSearchData.item.resultText).toBe(webSearchResult);
-      expect(webSearchData.item.truncation).toBeUndefined();
-
-      const fileData = JSON.parse(
-        readMigratedEventData(db, "evt_large_file_diffs"),
-      );
-      expect(fileData.item.changes).toEqual([
-        { path: "a.ts", diff: firstDiff },
-        { path: "b.ts", diff: "small diff" },
-        { path: "c.ts", diff: secondDiff },
-      ]);
+      expectEventLargeValuesInline(db, values);
     } finally {
       closeConnection(db);
     }


### PR DESCRIPTION
## Summary
- skip the 0031/0032 event_large_values round trip when event payloads are already inline and the temporary table does not exist
- apply 0030 first for databases upgrading from 0029 so Drizzle can continue from 0033
- add migration regression coverage for the skipped path and preserve coverage for the restore path when 0031 already completed

## Validation
- pnpm exec turbo run test --filter=@bb/db -- --run test/migrate.test.ts
- pnpm exec turbo run typecheck --filter=@bb/db