### PR TITLE
Poll settling pull request state

### DIFF
--- a/apps/app/src/hooks/queries/environment-queries.test.tsx
+++ b/apps/app/src/hooks/queries/environment-queries.test.tsx
@@ -8,6 +8,7 @@ import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { environmentPullRequestQueryKey } from "./query-keys";
 import {
+  getEnvironmentPullRequestRefetchInterval,
   getEnvironmentPullRequestStaleTime,
   useEnvironmentPullRequest,
 } from "./environment-queries";
@@ -27,6 +28,7 @@ vi.mock("@/hooks/useRealtimeSubscription", () => ({
 const ENVIRONMENT_ID = "env-1";
 const ACTIVE_PULL_REQUEST_STALE_MS = 30_000;
 const SETTLED_PULL_REQUEST_STALE_MS = 60 * 60_000;
+const ACTIVE_PULL_REQUEST_REFETCH_MS = 5_000;
 
 const pullRequestFixture: ThreadPullRequest = {
   number: 128,
@@ -104,6 +106,65 @@ describe("useEnvironmentPullRequest", () => {
     ).toBe(SETTLED_PULL_REQUEST_STALE_MS);
   });
 
+  it("polls open pull requests while checks or mergeability are still settling", () => {
+    expect(getEnvironmentPullRequestRefetchInterval(null)).toBe(false);
+    expect(getEnvironmentPullRequestRefetchInterval(undefined)).toBe(false);
+    expect(getEnvironmentPullRequestRefetchInterval(pullRequestFixture)).toBe(
+      false,
+    );
+    expect(
+      getEnvironmentPullRequestRefetchInterval({
+        ...pullRequestFixture,
+        checks: {
+          ...pullRequestFixture.checks,
+          state: "pending",
+          pendingCount: 1,
+        },
+        attention: "checks_pending",
+      }),
+    ).toBe(ACTIVE_PULL_REQUEST_REFETCH_MS);
+    expect(
+      getEnvironmentPullRequestRefetchInterval({
+        ...pullRequestFixture,
+        mergeability: {
+          state: "unknown",
+          mergeStateStatus: "UNKNOWN",
+          mergeable: "UNKNOWN",
+        },
+        attention: "none",
+      }),
+    ).toBe(ACTIVE_PULL_REQUEST_REFETCH_MS);
+  });
+
+  it("does not poll draft or settled pull requests", () => {
+    expect(
+      getEnvironmentPullRequestRefetchInterval({
+        ...pullRequestFixture,
+        state: "draft",
+        mergeability: {
+          state: "draft",
+          mergeStateStatus: "DRAFT",
+          mergeable: "UNKNOWN",
+        },
+        attention: "draft",
+      }),
+    ).toBe(false);
+    expect(
+      getEnvironmentPullRequestRefetchInterval({
+        ...pullRequestFixture,
+        state: "closed",
+        attention: "closed",
+      }),
+    ).toBe(false);
+    expect(
+      getEnvironmentPullRequestRefetchInterval({
+        ...pullRequestFixture,
+        state: "merged",
+        attention: "merged",
+      }),
+    ).toBe(false);
+  });
+
   it("refetches stale pull request data on mount and always refetches on window focus", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
     vi.mocked(api.getEnvironmentPullRequest).mockResolvedValue(
@@ -124,6 +185,7 @@ describe("useEnvironmentPullRequest", () => {
       expect.objectContaining({
         refetchOnMount: true,
         refetchOnWindowFocus: "always",
+        refetchInterval: expect.any(Function),
         staleTime: expect.any(Function),
       }),
     );

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -52,6 +52,7 @@ interface UseEnvironmentDiffFilesOptions extends QueryOptions {
 
 const ENVIRONMENT_PULL_REQUEST_STALE_MS = 30_000;
 const ENVIRONMENT_SETTLED_PULL_REQUEST_STALE_MS = 60 * 60_000;
+const ENVIRONMENT_ACTIVE_PULL_REQUEST_REFETCH_MS = 5_000;
 const MERGE_BASE_BRANCHES_STALE_MS = 30_000;
 const MERGE_BASE_BRANCHES_LIMIT = 50;
 /** Staleness window for the environment diff TOC query. */
@@ -132,6 +133,21 @@ export function getEnvironmentPullRequestStaleTime(
     : ENVIRONMENT_PULL_REQUEST_STALE_MS;
 }
 
+export function getEnvironmentPullRequestRefetchInterval(
+  pullRequest: ThreadPullRequest | null | undefined,
+): number | false {
+  if (!pullRequest || pullRequest.state !== "open") {
+    return false;
+  }
+  if (
+    pullRequest.checks.state === "pending" ||
+    pullRequest.mergeability.state === "unknown"
+  ) {
+    return ENVIRONMENT_ACTIVE_PULL_REQUEST_REFETCH_MS;
+  }
+  return false;
+}
+
 export function useEnvironmentPullRequest(
   environmentId: string | null | undefined,
   options?: QueryOptions,
@@ -149,6 +165,8 @@ export function useEnvironmentPullRequest(
     enabled,
     refetchOnMount: true,
     refetchOnWindowFocus: "always",
+    refetchInterval: (query) =>
+      getEnvironmentPullRequestRefetchInterval(query.state.data?.pullRequest),
     staleTime: (query) =>
       getEnvironmentPullRequestStaleTime(query.state.data?.pullRequest),
   });


### PR DESCRIPTION
## Summary
- poll open pull request data every 5s while checks are pending or mergeability is unknown
- stop polling once the PR is resolved, draft, closed, or merged
- cover polling and non-polling states in the environment query tests

## Validation
- pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/queries/environment-queries.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app