### PR TITLE
Fix Add to chat composer race

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1,7 +1,76 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { suppressPromptEditorAnchorActivation } from "./PromptBoxInternal";
+import { cleanup, render } from "@testing-library/react";
+import {
+  useLayoutEffect,
+  useRef,
+  type ComponentProps,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  INERT_TYPEAHEAD_COMMAND_CONFIG,
+  PromptBoxInternal,
+  suppressPromptEditorAnchorActivation,
+  type PromptBoxHandle,
+} from "./PromptBoxInternal";
+
+type PromptBoxProps = ComponentProps<typeof PromptBoxInternal>;
+
+function createPromptBoxProps(
+  overrides: Partial<PromptBoxProps> = {},
+): PromptBoxProps {
+  return {
+    value: "",
+    mentionRanges: [],
+    onChange: vi.fn(),
+    onSubmit: vi.fn(),
+    mentionMenuPlacement: "bottom",
+    typeahead: {
+      mention: {
+        suggestions: [],
+        isLoading: false,
+        isError: false,
+        onQueryChange: vi.fn(),
+      },
+      command: INERT_TYPEAHEAD_COMMAND_CONFIG,
+    },
+    ...overrides,
+  };
+}
+
+function PromptBoxRaceHarness({
+  onChange,
+  value,
+}: {
+  onChange: PromptBoxProps["onChange"];
+  value: string;
+}) {
+  const promptBoxRef = useRef<PromptBoxHandle | null>(null);
+  const insertedForValueRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (value === "" || insertedForValueRef.current === value) return;
+
+    insertedForValueRef.current = value;
+    promptBoxRef.current?.focusEnd();
+    promptBoxRef.current?.insertTextAtCursor("reply");
+  }, [value]);
+
+  return (
+    <PromptBoxInternal
+      {...createPromptBoxProps({
+        onChange,
+        promptBoxRef,
+        value,
+      })}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 function dispatchThroughEditorTarget({
   eventName,
@@ -72,5 +141,23 @@ describe("suppressPromptEditorAnchorActivation", () => {
     expect(result.suppressed).toBe(false);
     expect(result.event.defaultPrevented).toBe(false);
     expect(result.defaultAllowed).toBe(true);
+  });
+});
+
+describe("PromptBoxInternal controlled value sync", () => {
+  it("applies an added quote before focus-end insertion can edit the old document", () => {
+    const onChange = vi.fn();
+    const view = render(
+      <PromptBoxRaceHarness onChange={onChange} value="" />,
+    );
+
+    view.rerender(
+      <PromptBoxRaceHarness onChange={onChange} value={"> selected text\n"} />,
+    );
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      "> selected text\nreply",
+      [],
+    );
   });
 });

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -982,7 +982,7 @@ export function PromptBoxInternal({
     valueRef.current = value;
   }, [value]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!editor) return;
     const nextValue = {
       text: value,
@@ -1012,11 +1012,9 @@ export function PromptBoxInternal({
 
   // An explicit draft-restore action (e.g. editing a queued message) bumps
   // `focusEndKey` so the caret lands at the END of the restored text. It is a
-  // passive effect defined AFTER the content-sync effect above, so React's
-  // definition-order guarantee runs it once that effect has applied
-  // `setContent` for the new draft in the same commit. (A useLayoutEffect, or
-  // an effect ordered before content-sync, would focus("end") against the
-  // pre-edit content and setContent would then map the caret to the start.)
+  // passive effect defined AFTER the layout content-sync effect above, so the
+  // editor has already applied `setContent` for the new draft in the same
+  // commit.
   // Not gated by the coarse-pointer guard since it follows a deliberate click.
   const lastFocusEndKeyRef = useRef(focusEndKey);
   useEffect(() => {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { IconName } from "@/components/ui/icon.js";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { getFollowUpPromptPlaceholder } from "@/components/promptbox/follow-up-placeholder";
@@ -689,17 +689,9 @@ export function ThreadDetailPromptArea({
   );
 
   const [editFocusNonce, setEditFocusNonce] = useState(0);
-
-  // Focus the composer caret at the end whenever the timeline host appends a
-  // quote ("Add to chat"), so the user can immediately type the reply beneath
-  // the freshly inserted blockquote. Skips the initial mount (nonce starts 0).
-  const previousFocusRequestNonceRef = useRef(composerFocusRequestNonce);
-  useEffect(() => {
-    if (composerFocusRequestNonce !== previousFocusRequestNonceRef.current) {
-      previousFocusRequestNonceRef.current = composerFocusRequestNonce;
-      setEditFocusNonce((nonce) => nonce + 1);
-    }
-  }, [composerFocusRequestNonce]);
+  // Selection quotes and queued-message edits both need the composer caret at
+  // the end of the latest draft; combine their counters into one focus key.
+  const focusEndKey = `${composerFocusRequestNonce}:${editFocusNonce}`;
 
   const handleEditQueuedMessage = useCallback(
     (messageId: string) => {
@@ -1123,7 +1115,7 @@ export function ThreadDetailPromptArea({
       stack={promptStack}
       composer={shouldHideComposer ? null : composerConfig}
       zenModeResetKey={thread.id}
-      focusEndKey={editFocusNonce}
+      focusEndKey={focusEndKey}
       environmentSummary={environmentSummary}
       contextWindowUsage={contextWindowUsage ?? null}
       execution={executionConfig}


### PR DESCRIPTION
## Summary
- sync controlled prompt editor value before browser input can edit a stale TipTap document
- pass selection quote focus requests directly into the composer focus key
- add a regression test for quote insertion followed by immediate typing

## Verification
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxInternal.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app