### PR TITLE
Fix stale workflow status in turn details

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -1004,9 +1004,14 @@ export function buildTimelineTurnSummaryDetails(
     },
     useExactEventRowBounds: exactEventRowsForRequestedTurn.removedRows,
   });
+  const eventRowsWithBackgroundTaskState =
+    ensureTimelineWindowBackgroundTaskStateRows(db, {
+      threadId: thread.id,
+      rows: eventRows,
+    });
   const children = buildThreadTimelineTurnDetailsFromEvents({
-    events: [...turnStartedRows, ...eventRows].map((row) =>
-      toThreadEventWithMeta(row),
+    events: [...turnStartedRows, ...eventRowsWithBackgroundTaskState].map(
+      (row) => toThreadEventWithMeta(row),
     ),
     options: {
       includeProviderUnhandledOperations,

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -481,6 +481,124 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("hydrates turn-summary workflow details with late background task completion", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const taskData = (
+        status: "pending" | "completed",
+        taskStatus: "running" | "completed",
+      ) => ({
+        item: {
+          type: "backgroundTask" as const,
+          id: "task:wf-1",
+          taskType: "local_workflow",
+          description: "fixture workflow",
+          status,
+          taskStatus,
+          skipTranscript: false,
+          workflowName: "fixture-mini",
+          ...(status === "completed" ? { summary: "done" } : {}),
+        },
+      });
+
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("turn-1"),
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("turn-1"),
+        sequence: 2,
+        type: "item/started",
+        data: taskData("pending", "running"),
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("turn-1"),
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "agentMessage",
+            id: "assistant-1",
+            text: "Workflow launched.",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("turn-1"),
+        sequence: 4,
+        type: "turn/completed",
+        data: {
+          status: "completed",
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: threadScope(),
+        sequence: 5,
+        type: "item/backgroundTask/completed",
+        data: taskData("completed", "completed"),
+      });
+
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+      expect(timelineResponse.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(timelineResponse),
+      );
+      const turnRow = timeline.rows.find(
+        (row): row is TimelineTurnRow => row.kind === "turn",
+      );
+      expect(turnRow).toBeDefined();
+      if (!turnRow) {
+        throw new Error("Expected a turn row");
+      }
+
+      const detailsResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=${turnRow.turnId}&sourceSeqStart=${turnRow.sourceSeqStart}&sourceSeqEnd=${turnRow.sourceSeqEnd}`,
+      );
+      expect(detailsResponse.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(detailsResponse),
+      );
+      const workflowRow = details.rows.find(
+        (row) =>
+          row.kind === "work" &&
+          row.workKind === "workflow" &&
+          row.itemId === "task:wf-1",
+      );
+      expect(workflowRow).toBeDefined();
+      if (
+        !workflowRow ||
+        workflowRow.kind !== "work" ||
+        workflowRow.workKind !== "workflow"
+      ) {
+        throw new Error("Expected a workflow detail row");
+      }
+
+      expect(workflowRow.status).toBe("completed");
+      expect(workflowRow.taskStatus).toBe("completed");
+      expect(workflowRow.summary).toBe("done");
+      expect(workflowRow.completedAt).not.toBeNull();
+    });
+  });
+
   it("hydrates turn-summary details when the range overlaps another turn", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedThreadFixture(harness);


### PR DESCRIPTION
## Summary
- Backfill latest background task state when hydrating completed turn summary details
- Prevent expanded workflow details from showing stale running status after a late completion event
- Add a regression test for workflow completion arriving after the spawning turn range

## Validation
- pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-thread-data.test.ts
- pnpm exec turbo run typecheck --filter=@bb/server