### PR TITLE
Fix flaky timeline scroll-to-bottom restores

### DIFF
--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -3,7 +3,10 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { getDefaultStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BottomAnchoredScrollBody } from "@/components/ui/bottom-anchored-scroll-body";
+import {
+  BottomAnchoredScrollBody,
+  useBottomAnchoredScroll,
+} from "@/components/ui/bottom-anchored-scroll-body";
 import { threadTimelineScrollAnchorAtomFamily } from "@/lib/thread-timeline-scroll-anchor";
 
 // Real externals only: the ResizeObserver/rAF used by the scroll body are
@@ -89,9 +92,23 @@ function requireHTMLElement(element: Element | null) {
 interface RenderArgs {
   threadId: string;
   rowIds: string[];
+  showScrollToBottomControl?: boolean;
 }
 
-function renderTimeline({ threadId, rowIds }: RenderArgs) {
+function ScrollToBottomControl() {
+  const bottomAnchor = useBottomAnchoredScroll();
+  return (
+    <button type="button" onClick={() => bottomAnchor?.scrollToBottom()}>
+      Bottom
+    </button>
+  );
+}
+
+function renderTimeline({
+  threadId,
+  rowIds,
+  showScrollToBottomControl = false,
+}: RenderArgs) {
   const view = render(
     <BottomAnchoredScrollBody
       footer={<div>Footer</div>}
@@ -99,6 +116,7 @@ function renderTimeline({ threadId, rowIds }: RenderArgs) {
       scrollAreaClassName={SCROLL_AREA_CLASS}
       scrollAnchorThreadId={threadId}
     >
+      {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
       {rowIds.map((rowId) => (
         <div key={rowId} data-timeline-row-id={rowId}>
           {rowId}
@@ -120,7 +138,12 @@ function renderTimeline({ threadId, rowIds }: RenderArgs) {
     );
   }
 
-  return { scrollArea, rowElements, unmount: view.unmount };
+  return {
+    getByRole: view.getByRole,
+    scrollArea,
+    rowElements,
+    unmount: view.unmount,
+  };
 }
 
 function readAnchor(threadId: string) {
@@ -294,6 +317,37 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     for (let attempt = 0; attempt < 7; attempt += 1) {
       observer.trigger();
     }
+
+    expect(scrollArea.scrollTop).toBe(300);
+  });
+
+  it("does not let a pending saved-row restore undo an explicit bottom scroll", () => {
+    getDefaultStore().set(threadTimelineScrollAnchorAtomFamily("thread-a"), {
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+
+    const { getByRole, scrollArea, rowElements } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+      showScrollToBottomControl: true,
+    });
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: -100,
+      bottom: 0,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    fireEvent.click(getByRole("button", { name: "Bottom" }));
+    expect(scrollArea.scrollTop).toBe(300);
+
+    getLatestResizeObserver().trigger();
 
     expect(scrollArea.scrollTop).toBe(300);
   });

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -352,6 +352,37 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     expect(scrollArea.scrollTop).toBe(300);
   });
 
+  it("preserves bottom intent when unmounting during transient off-bottom layout", () => {
+    const { scrollArea, rowElements, unmount } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+    });
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
+      top: -20,
+      bottom: 80,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: 80,
+      bottom: 180,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      // Layout/streaming has temporarily left us visibly off the physical bottom,
+      // but no user scroll intent disabled sticky-bottom.
+      scrollTop: 250,
+    });
+
+    unmount();
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "",
+      offsetWithinRow: 0,
+      atBottom: true,
+    });
+  });
+
   it("restores thread A's own anchor after a fast A -> B -> A switch", () => {
     // Leave A mid-timeline at row-b.
     const a1 = renderTimeline({

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -3,10 +3,7 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { getDefaultStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  BottomAnchoredScrollBody,
-  useBottomAnchoredScroll,
-} from "@/components/ui/bottom-anchored-scroll-body";
+import { BottomAnchoredScrollBody } from "@/components/ui/bottom-anchored-scroll-body";
 import { threadTimelineScrollAnchorAtomFamily } from "@/lib/thread-timeline-scroll-anchor";
 
 // Real externals only: the ResizeObserver/rAF used by the scroll body are
@@ -92,23 +89,9 @@ function requireHTMLElement(element: Element | null) {
 interface RenderArgs {
   threadId: string;
   rowIds: string[];
-  showScrollToBottomControl?: boolean;
 }
 
-function ScrollToBottomControl() {
-  const bottomAnchor = useBottomAnchoredScroll();
-  return (
-    <button type="button" onClick={() => bottomAnchor?.scrollToBottom()}>
-      Bottom
-    </button>
-  );
-}
-
-function renderTimeline({
-  threadId,
-  rowIds,
-  showScrollToBottomControl = false,
-}: RenderArgs) {
+function renderTimeline({ threadId, rowIds }: RenderArgs) {
   const view = render(
     <BottomAnchoredScrollBody
       footer={<div>Footer</div>}
@@ -116,7 +99,6 @@ function renderTimeline({
       scrollAreaClassName={SCROLL_AREA_CLASS}
       scrollAnchorThreadId={threadId}
     >
-      {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
       {rowIds.map((rowId) => (
         <div key={rowId} data-timeline-row-id={rowId}>
           {rowId}
@@ -138,12 +120,7 @@ function renderTimeline({
     );
   }
 
-  return {
-    getByRole: view.getByRole,
-    scrollArea,
-    rowElements,
-    unmount: view.unmount,
-  };
+  return { scrollArea, rowElements, unmount: view.unmount };
 }
 
 function readAnchor(threadId: string) {
@@ -319,102 +296,6 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     }
 
     expect(scrollArea.scrollTop).toBe(300);
-  });
-
-  it("does not let a pending saved-row restore undo an explicit bottom scroll", () => {
-    getDefaultStore().set(threadTimelineScrollAnchorAtomFamily("thread-a"), {
-      rowId: "row-b",
-      offsetWithinRow: 20,
-      atBottom: false,
-    });
-
-    const { getByRole, scrollArea, rowElements } = renderTimeline({
-      threadId: "thread-a",
-      rowIds: ["row-a", "row-b", "row-c"],
-      showScrollToBottomControl: true,
-    });
-    mockScrollAreaRect(scrollArea);
-    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
-      top: -100,
-      bottom: 0,
-    });
-    setScrollMetrics(scrollArea, {
-      scrollHeight: 400,
-      clientHeight: 100,
-      scrollTop: 0,
-    });
-
-    fireEvent.click(getByRole("button", { name: "Bottom" }));
-    expect(scrollArea.scrollTop).toBe(300);
-
-    getLatestResizeObserver().trigger();
-
-    expect(scrollArea.scrollTop).toBe(300);
-  });
-
-  it("preserves bottom intent when unmounting during transient off-bottom layout", () => {
-    const { scrollArea, rowElements, unmount } = renderTimeline({
-      threadId: "thread-a",
-      rowIds: ["row-a", "row-b", "row-c"],
-    });
-    mockScrollAreaRect(scrollArea);
-    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
-      top: -20,
-      bottom: 80,
-    });
-    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
-      top: 80,
-      bottom: 180,
-    });
-    setScrollMetrics(scrollArea, {
-      scrollHeight: 400,
-      clientHeight: 100,
-      // Layout/streaming has temporarily left us visibly off the physical bottom,
-      // but no user scroll intent disabled sticky-bottom.
-      scrollTop: 250,
-    });
-
-    unmount();
-
-    expect(readAnchor("thread-a")).toEqual({
-      rowId: "",
-      offsetWithinRow: 0,
-      atBottom: true,
-    });
-  });
-
-  it("preserves a user-scrolled row when unmounting before the scroll event", () => {
-    const { scrollArea, rowElements, unmount } = renderTimeline({
-      threadId: "thread-a",
-      rowIds: ["row-a", "row-b", "row-c"],
-    });
-    mockScrollAreaRect(scrollArea);
-    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
-      top: -120,
-      bottom: -20,
-    });
-    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
-      top: -20,
-      bottom: 80,
-    });
-    mockRowRect(requireHTMLElement(rowElements.get("row-c")!), {
-      top: 80,
-      bottom: 180,
-    });
-    setScrollMetrics(scrollArea, {
-      scrollHeight: 400,
-      clientHeight: 100,
-      scrollTop: 150,
-    });
-
-    fireEvent.wheel(scrollArea);
-    unmount();
-
-    expect(readAnchor("thread-a")).toEqual({
-      rowId: "row-b",
-      offsetWithinRow: 20,
-      atBottom: false,
-    });
   });
 
   it("restores thread A's own anchor after a fast A -> B -> A switch", () => {

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -352,6 +352,81 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     expect(scrollArea.scrollTop).toBe(300);
   });
 
+  it("preserves bottom intent when unmounting during transient off-bottom layout", () => {
+    const { scrollArea, rowElements, unmount } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+    });
+    getDefaultStore().set(threadTimelineScrollAnchorAtomFamily("thread-a"), {
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
+      top: -20,
+      bottom: 80,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: 80,
+      bottom: 180,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      // Layout/streaming has temporarily left us visibly off the physical bottom,
+      // but no user scroll intent disabled sticky-bottom.
+      scrollTop: 250,
+    });
+
+    unmount();
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "",
+      offsetWithinRow: 0,
+      atBottom: true,
+    });
+  });
+
+  it("preserves a user-scrolled row when unmounting before the scroll event", () => {
+    const { scrollArea, rowElements, unmount } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+    });
+    getDefaultStore().set(threadTimelineScrollAnchorAtomFamily("thread-a"), {
+      rowId: "",
+      offsetWithinRow: 0,
+      atBottom: true,
+    });
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
+      top: -120,
+      bottom: -20,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: -20,
+      bottom: 80,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-c")!), {
+      top: 80,
+      bottom: 180,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 150,
+    });
+
+    fireEvent.wheel(scrollArea);
+    unmount();
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+  });
+
   it("restores thread A's own anchor after a fast A -> B -> A switch", () => {
     // Leave A mid-timeline at row-b.
     const a1 = renderTimeline({

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -383,6 +383,40 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     });
   });
 
+  it("preserves a user-scrolled row when unmounting before the scroll event", () => {
+    const { scrollArea, rowElements, unmount } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+    });
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
+      top: -120,
+      bottom: -20,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: -20,
+      bottom: 80,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-c")!), {
+      top: 80,
+      bottom: 180,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 150,
+    });
+
+    fireEvent.wheel(scrollArea);
+    unmount();
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+  });
+
   it("restores thread A's own anchor after a fast A -> B -> A switch", () => {
     // Leave A mid-timeline at row-b.
     const a1 = renderTimeline({

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -401,6 +401,13 @@ export function BottomAnchoredScrollBody({
     pendingPrependAnchorRef.current = null;
   });
 
+  const hasRecentUserScrollIntent = useCallback(() => {
+    return (
+      pointerScrollIntentRef.current ||
+      window.performance.now() <= userScrollIntentUntilRef.current
+    );
+  }, []);
+
   // Persist the current scroll position (top-most visible row + within-row
   // offset + atBottom) into the per-thread atom so returning to this thread
   // restores it. Continuous capture keeps the atom current while mounted; cleanup
@@ -411,7 +418,8 @@ export function BottomAnchoredScrollBody({
     const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
     if (!scrollArea) return;
     const atBottom =
-      shouldStickToBottomRef.current || isScrolledNearBottom(scrollArea);
+      isScrolledNearBottom(scrollArea) ||
+      (shouldStickToBottomRef.current && !hasRecentUserScrollIntent());
     const anchorAtom =
       threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
     if (atBottom) {
@@ -426,7 +434,7 @@ export function BottomAnchoredScrollBody({
       offsetWithinRow: topMostRow.offsetWithinRow,
       atBottom: false,
     });
-  }, [scrollAnchorThreadId, store]);
+  }, [hasRecentUserScrollIntent, scrollAnchorThreadId, store]);
 
   const captureScrollAnchorThrottled = useCallback(() => {
     if (scrollAnchorThreadId === undefined) return;
@@ -516,18 +524,14 @@ export function BottomAnchoredScrollBody({
       return;
     }
 
-    const hasUserScrollIntent =
-      pointerScrollIntentRef.current ||
-      window.performance.now() <= userScrollIntentUntilRef.current;
-
-    if (!hasUserScrollIntent) return;
+    if (!hasRecentUserScrollIntent()) return;
 
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
     cancelQueuedRestore();
     // The user is scrolling on their own; don't yank them back to the anchor.
     pendingScrollRestoreRef.current = null;
-  }, [cancelQueuedRestore]);
+  }, [cancelQueuedRestore, hasRecentUserScrollIntent]);
 
   const handleScroll = useCallback(() => {
     syncBottomStateFromScroll();

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -261,6 +261,10 @@ export function BottomAnchoredScrollBody({
   }>({ lastWriteAt: 0, trailingTimeout: null });
   const [isAtBottom, setIsAtBottom] = useState(true);
 
+  const cancelPendingScrollRestore = useCallback(() => {
+    pendingScrollRestoreRef.current = null;
+  }, []);
+
   const cancelQueuedRestore = useCallback(() => {
     if (restoreFrameRef.current === null) return;
     window.cancelAnimationFrame(restoreFrameRef.current);
@@ -320,6 +324,7 @@ export function BottomAnchoredScrollBody({
 
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
+    cancelPendingScrollRestore();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
     shouldStickToBottomRef.current = true;
@@ -328,7 +333,7 @@ export function BottomAnchoredScrollBody({
       scrollElementToBottom(scrollArea);
     }
     queueBottomRestore();
-  }, [queueBottomRestore]);
+  }, [cancelPendingScrollRestore, queueBottomRestore]);
 
   const scrollElementIntoView = useCallback(
     ({ element, options }: ScrollElementIntoViewArgs) => {

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -786,6 +786,27 @@ export function BottomAnchoredScrollBody({
     ],
   );
 
+  const flushScrollAnchorCapture = useCallback(
+    (source: string, scrollArea: HTMLElement) => {
+      const captureThrottle = scrollAnchorCaptureThrottleRef.current;
+      if (captureThrottle.trailingTimeout !== null) {
+        window.clearTimeout(captureThrottle.trailingTimeout);
+        captureThrottle.trailingTimeout = null;
+      }
+      writeScrollAnchor(source, scrollArea);
+    },
+    [writeScrollAnchor],
+  );
+
+  useLayoutEffect(() => {
+    const scrollArea = scrollAreaRef.current;
+    if (!scrollArea) return;
+
+    return () => {
+      flushScrollAnchorCapture("layout-cleanup", scrollArea);
+    };
+  }, [flushScrollAnchorCapture]);
+
   useEffect(() => {
     const scrollArea = scrollAreaRef.current;
     const scrollContent = scrollContentRef.current;
@@ -822,12 +843,6 @@ export function BottomAnchoredScrollBody({
 
     queueBottomRestore();
 
-    // Capture the (stable) throttle-state object so the cleanup doesn't read a
-    // ref's `.current` directly (react-hooks/exhaustive-deps). The ref is never
-    // reassigned — only its `trailingTimeout` field mutates — so this still
-    // clears the live pending timeout at cleanup time.
-    const captureThrottle = scrollAnchorCaptureThrottleRef.current;
-
     return () => {
       resizeObserver?.disconnect();
       scrollArea.removeEventListener("scroll", handleScroll);
@@ -839,13 +854,6 @@ export function BottomAnchoredScrollBody({
       window.removeEventListener("pointercancel", endPointerScrollIntent);
       window.removeEventListener("keydown", markKeyboardScrollIntent);
       cancelQueuedRestore();
-      // Flush the final resting position before the key={threadId} teardown:
-      // a pending trailing capture would otherwise be dropped on unmount.
-      if (captureThrottle.trailingTimeout !== null) {
-        window.clearTimeout(captureThrottle.trailingTimeout);
-        captureThrottle.trailingTimeout = null;
-      }
-      writeScrollAnchor("unmount", scrollArea);
     };
   }, [
     cancelQueuedRestore,
@@ -858,7 +866,6 @@ export function BottomAnchoredScrollBody({
     markWheelScrollIntent,
     queueBottomRestore,
     startPointerScrollIntent,
-    writeScrollAnchor,
   ]);
 
   return (

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -90,7 +90,6 @@ const SCROLL_ANCHOR_CAPTURE_THROTTLE_MS = 100;
 // observed re-applies so a deleted/never-arriving row can't hang at the top.
 const SCROLL_ANCHOR_RESTORE_MAX_ATTEMPTS = 8;
 const TIMELINE_ROW_ID_SELECTOR = "[data-timeline-row-id]";
-const DEBUG_TIMELINE_SCROLL_ANCHOR = true;
 const SCROLL_INTENT_KEYS = new Set([
   "ArrowDown",
   "ArrowUp",
@@ -111,22 +110,6 @@ export function useBottomAnchoredScroll(): BottomAnchorContextValue | null {
 
 function getMaxScrollOffset(element: HTMLElement) {
   return Math.max(0, element.scrollHeight - element.clientHeight);
-}
-
-function getScrollDebugMetrics(element: HTMLElement) {
-  const maxScrollOffset = getMaxScrollOffset(element);
-  return {
-    scrollTop: element.scrollTop,
-    scrollHeight: element.scrollHeight,
-    clientHeight: element.clientHeight,
-    maxScrollOffset,
-    distanceFromBottom: maxScrollOffset - element.scrollTop,
-  };
-}
-
-function logScrollAnchorDebug(event: string, details: object) {
-  if (!DEBUG_TIMELINE_SCROLL_ANCHOR) return;
-  console.log(`[bb-scroll-anchor] ${event}`, details);
 }
 
 function isScrolledNearBottom(element: HTMLElement) {
@@ -280,14 +263,8 @@ export function BottomAnchoredScrollBody({
   const [isAtBottom, setIsAtBottom] = useState(true);
 
   const cancelPendingScrollRestore = useCallback(() => {
-    if (pendingScrollRestoreRef.current !== null) {
-      logScrollAnchorDebug("cancel-pending-row-restore", {
-        threadId: scrollAnchorThreadId,
-        anchor: pendingScrollRestoreRef.current.anchor,
-      });
-    }
     pendingScrollRestoreRef.current = null;
-  }, [scrollAnchorThreadId]);
+  }, []);
 
   const cancelQueuedRestore = useCallback(() => {
     if (restoreFrameRef.current === null) return;
@@ -311,14 +288,9 @@ export function BottomAnchoredScrollBody({
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea || !shouldStickToBottomRef.current) return false;
     if (isScrolledNearBottom(scrollArea)) return false;
-    logScrollAnchorDebug("restore-bottom-once", {
-      threadId: scrollAnchorThreadId,
-      userDetachedFromBottom: userDetachedFromBottomRef.current,
-      ...getScrollDebugMetrics(scrollArea),
-    });
     scrollElementToBottom(scrollArea);
     return true;
-  }, [scrollAnchorThreadId]);
+  }, []);
 
   const runQueuedRestore = useCallback(() => {
     restoreFrameRef.current = null;
@@ -353,13 +325,6 @@ export function BottomAnchoredScrollBody({
 
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
-    logScrollAnchorDebug("scroll-to-bottom-requested", {
-      threadId: scrollAnchorThreadId,
-      hadPendingRowRestore: pendingScrollRestoreRef.current !== null,
-      shouldStickToBottom: shouldStickToBottomRef.current,
-      userDetachedFromBottom: userDetachedFromBottomRef.current,
-      ...(scrollArea ? getScrollDebugMetrics(scrollArea) : {}),
-    });
     cancelPendingScrollRestore();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
@@ -369,14 +334,8 @@ export function BottomAnchoredScrollBody({
     if (scrollArea) {
       scrollElementToBottom(scrollArea);
     }
-    if (scrollArea) {
-      logScrollAnchorDebug("scroll-to-bottom-applied", {
-        threadId: scrollAnchorThreadId,
-        ...getScrollDebugMetrics(scrollArea),
-      });
-    }
     queueBottomRestore();
-  }, [cancelPendingScrollRestore, queueBottomRestore, scrollAnchorThreadId]);
+  }, [cancelPendingScrollRestore, queueBottomRestore]);
 
   const scrollElementIntoView = useCallback(
     ({ element, options }: ScrollElementIntoViewArgs) => {
@@ -454,32 +413,17 @@ export function BottomAnchoredScrollBody({
   // flushes through the effect-captured scroll area because refs can be nulled
   // during unmount.
   const writeScrollAnchor = useCallback(
-    (source: string, scrollAreaOverride?: HTMLElement) => {
+    (scrollAreaOverride?: HTMLElement) => {
       if (scrollAnchorThreadId === undefined) return;
       const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
-      if (!scrollArea) {
-        logScrollAnchorDebug("save-skip-no-scroll-area", {
-          source,
-          threadId: scrollAnchorThreadId,
-        });
-        return;
-      }
+      if (!scrollArea) return;
       const atBottomByGeometry = isScrolledNearBottom(scrollArea);
       const recentUserIntent = hasRecentUserScrollIntent();
-      const wasUserDetachedFromBottom = userDetachedFromBottomRef.current;
       const anchorAtom =
         threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
       if (atBottomByGeometry) {
         userDetachedFromBottomRef.current = false;
         store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
-        logScrollAnchorDebug("save-bottom-geometry", {
-          source,
-          threadId: scrollAnchorThreadId,
-          shouldStickToBottom: shouldStickToBottomRef.current,
-          wasUserDetachedFromBottom,
-          recentUserIntent,
-          ...getScrollDebugMetrics(scrollArea),
-        });
         return;
       }
       if (recentUserIntent) {
@@ -487,43 +431,15 @@ export function BottomAnchoredScrollBody({
       }
       if (shouldStickToBottomRef.current && !userDetachedFromBottomRef.current) {
         store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
-        logScrollAnchorDebug("save-bottom-sticky-intent", {
-          source,
-          threadId: scrollAnchorThreadId,
-          shouldStickToBottom: shouldStickToBottomRef.current,
-          wasUserDetachedFromBottom,
-          recentUserIntent,
-          ...getScrollDebugMetrics(scrollArea),
-        });
         return;
       }
       const topMostRow = getTopMostVisibleRow(scrollArea);
       // No rows yet: don't clobber a good anchor with an empty one.
-      if (!topMostRow) {
-        logScrollAnchorDebug("save-skip-no-visible-row", {
-          source,
-          threadId: scrollAnchorThreadId,
-          shouldStickToBottom: shouldStickToBottomRef.current,
-          userDetachedFromBottom: userDetachedFromBottomRef.current,
-          recentUserIntent,
-          ...getScrollDebugMetrics(scrollArea),
-        });
-        return;
-      }
+      if (!topMostRow) return;
       store.set(anchorAtom, {
         rowId: topMostRow.rowId,
         offsetWithinRow: topMostRow.offsetWithinRow,
         atBottom: false,
-      });
-      logScrollAnchorDebug("save-row", {
-        source,
-        threadId: scrollAnchorThreadId,
-        rowId: topMostRow.rowId,
-        offsetWithinRow: topMostRow.offsetWithinRow,
-        shouldStickToBottom: shouldStickToBottomRef.current,
-        userDetachedFromBottom: userDetachedFromBottomRef.current,
-        recentUserIntent,
-        ...getScrollDebugMetrics(scrollArea),
       });
     },
     [hasRecentUserScrollIntent, scrollAnchorThreadId, store],
@@ -536,7 +452,7 @@ export function BottomAnchoredScrollBody({
     const elapsed = now - throttle.lastWriteAt;
     if (elapsed >= SCROLL_ANCHOR_CAPTURE_THROTTLE_MS) {
       throttle.lastWriteAt = now;
-      writeScrollAnchor("scroll");
+      writeScrollAnchor();
       return;
     }
     // Trailing write so the final resting position is always recorded even when
@@ -545,7 +461,7 @@ export function BottomAnchoredScrollBody({
     throttle.trailingTimeout = window.setTimeout(() => {
       throttle.trailingTimeout = null;
       throttle.lastWriteAt = window.performance.now();
-      writeScrollAnchor("scroll-trailing");
+      writeScrollAnchor();
     }, SCROLL_ANCHOR_CAPTURE_THROTTLE_MS - elapsed);
   }, [scrollAnchorThreadId, writeScrollAnchor]);
 
@@ -558,13 +474,7 @@ export function BottomAnchoredScrollBody({
       const scrollArea = scrollAreaRef.current;
       if (!scrollArea) return null;
       const rowElement = findTimelineRowElement(scrollArea, anchor.rowId);
-      if (!rowElement) {
-        logScrollAnchorDebug("restore-row-missing", {
-          threadId: scrollAnchorThreadId,
-          anchor,
-        });
-        return null;
-      }
+      if (!rowElement) return null;
       // Suppress stick-to-bottom; this is the same state scrollElementIntoView
       // sets, inlined here so we can add the within-row offset afterward.
       shouldStickToBottomRef.current = false;
@@ -579,52 +489,35 @@ export function BottomAnchoredScrollBody({
         revealOffset + anchor.offsetWithinRow,
       );
       scrollArea.scrollTop = targetScrollTop;
-      logScrollAnchorDebug("restore-row-applied", {
-        threadId: scrollAnchorThreadId,
-        anchor,
-        targetScrollTop,
-        ...getScrollDebugMetrics(scrollArea),
-      });
       return targetScrollTop;
     },
-    [cancelQueuedRestore, scrollAnchorThreadId],
+    [cancelQueuedRestore],
   );
 
-  const markUserScrollIntent = useCallback((source: string) => {
+  const markUserScrollIntent = useCallback(() => {
     userScrollIntentUntilRef.current =
       window.performance.now() + USER_SCROLL_INTENT_MS;
-    logScrollAnchorDebug("user-scroll-intent", {
-      source,
-      threadId: scrollAnchorThreadId,
-      intentUntil: userScrollIntentUntilRef.current,
-    });
-  }, [scrollAnchorThreadId]);
+  }, []);
 
   const markWheelScrollIntent = useCallback(() => {
-    markUserScrollIntent("wheel");
+    markUserScrollIntent();
   }, [markUserScrollIntent]);
 
   const markTouchStartScrollIntent = useCallback(() => {
-    markUserScrollIntent("touchstart");
+    markUserScrollIntent();
   }, [markUserScrollIntent]);
 
   const markTouchMoveScrollIntent = useCallback(() => {
-    markUserScrollIntent("touchmove");
+    markUserScrollIntent();
   }, [markUserScrollIntent]);
 
   const startPointerScrollIntent = useCallback(() => {
     pointerScrollIntentRef.current = true;
-    logScrollAnchorDebug("pointer-scroll-intent-start", {
-      threadId: scrollAnchorThreadId,
-    });
-  }, [scrollAnchorThreadId]);
+  }, []);
 
   const endPointerScrollIntent = useCallback(() => {
     pointerScrollIntentRef.current = false;
-    logScrollAnchorDebug("pointer-scroll-intent-end", {
-      threadId: scrollAnchorThreadId,
-    });
-  }, [scrollAnchorThreadId]);
+  }, []);
 
   const markKeyboardScrollIntent = useCallback(
     (event: KeyboardEvent) => {
@@ -634,7 +527,7 @@ export function BottomAnchoredScrollBody({
       if (isEditableKeyboardTarget(event.target)) return;
       if (!isKeyboardEventFromScrollArea(event, scrollArea)) return;
 
-      markUserScrollIntent("keyboard");
+      markUserScrollIntent();
     },
     [markUserScrollIntent],
   );
@@ -644,12 +537,6 @@ export function BottomAnchoredScrollBody({
     if (!scrollArea) return;
 
     if (isScrolledNearBottom(scrollArea)) {
-      logScrollAnchorDebug("scroll-near-bottom", {
-        threadId: scrollAnchorThreadId,
-        shouldStickToBottom: shouldStickToBottomRef.current,
-        userDetachedFromBottom: userDetachedFromBottomRef.current,
-        ...getScrollDebugMetrics(scrollArea),
-      });
       userDetachedFromBottomRef.current = false;
       shouldStickToBottomRef.current = true;
       setIsAtBottom(true);
@@ -659,21 +546,8 @@ export function BottomAnchoredScrollBody({
       return;
     }
 
-    if (!hasRecentUserScrollIntent()) {
-      logScrollAnchorDebug("scroll-off-bottom-without-user-intent", {
-        threadId: scrollAnchorThreadId,
-        shouldStickToBottom: shouldStickToBottomRef.current,
-        userDetachedFromBottom: userDetachedFromBottomRef.current,
-        ...getScrollDebugMetrics(scrollArea),
-      });
-      return;
-    }
+    if (!hasRecentUserScrollIntent()) return;
 
-    logScrollAnchorDebug("scroll-user-detached-from-bottom", {
-      threadId: scrollAnchorThreadId,
-      shouldStickToBottom: shouldStickToBottomRef.current,
-      ...getScrollDebugMetrics(scrollArea),
-    });
     userDetachedFromBottomRef.current = true;
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
@@ -696,21 +570,10 @@ export function BottomAnchoredScrollBody({
     const pending = pendingScrollRestoreRef.current;
     if (!pending) return false;
     pending.attemptsRemaining -= 1;
-    logScrollAnchorDebug("pending-row-restore-advance", {
-      threadId: scrollAnchorThreadId,
-      anchor: pending.anchor,
-      attemptsRemaining: pending.attemptsRemaining,
-      lastAppliedScrollTop: pending.lastAppliedScrollTop,
-    });
     const appliedScrollTop = applyScrollRestore(pending.anchor);
     if (appliedScrollTop !== null) {
       if (pending.lastAppliedScrollTop === appliedScrollTop) {
         pendingScrollRestoreRef.current = null;
-        logScrollAnchorDebug("pending-row-restore-stable", {
-          threadId: scrollAnchorThreadId,
-          anchor: pending.anchor,
-          appliedScrollTop,
-        });
         return true;
       }
       pending.lastAppliedScrollTop = appliedScrollTop;
@@ -722,10 +585,6 @@ export function BottomAnchoredScrollBody({
       if (appliedScrollTop === null) {
         shouldStickToBottomRef.current = true;
         setIsAtBottom(true);
-        logScrollAnchorDebug("pending-row-restore-fallback-bottom", {
-          threadId: scrollAnchorThreadId,
-          anchor: pending.anchor,
-        });
         // Scroll to the bottom in this same call. We return true below, so the
         // caller (`handleScrollAreaResize`) early-returns and won't run its own
         // `queueBottomRestore()`; without this the view would stay pinned at the
@@ -734,7 +593,7 @@ export function BottomAnchoredScrollBody({
       }
     }
     return true;
-  }, [applyScrollRestore, queueBottomRestore, scrollAnchorThreadId]);
+  }, [applyScrollRestore, queueBottomRestore]);
 
   const handleScrollAreaResize = useCallback(() => {
     // While a restore is pending, the ResizeObserver is the settle signal; the
@@ -755,10 +614,6 @@ export function BottomAnchoredScrollBody({
       threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId),
     );
     if (!anchor || anchor.atBottom) return;
-    logScrollAnchorDebug("mount-restore-row-anchor", {
-      threadId: scrollAnchorThreadId,
-      anchor,
-    });
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
     pendingScrollRestoreRef.current = {
@@ -787,13 +642,13 @@ export function BottomAnchoredScrollBody({
   );
 
   const flushScrollAnchorCapture = useCallback(
-    (source: string, scrollArea: HTMLElement) => {
+    (scrollArea: HTMLElement) => {
       const captureThrottle = scrollAnchorCaptureThrottleRef.current;
       if (captureThrottle.trailingTimeout !== null) {
         window.clearTimeout(captureThrottle.trailingTimeout);
         captureThrottle.trailingTimeout = null;
       }
-      writeScrollAnchor(source, scrollArea);
+      writeScrollAnchor(scrollArea);
     },
     [writeScrollAnchor],
   );
@@ -803,7 +658,7 @@ export function BottomAnchoredScrollBody({
     if (!scrollArea) return;
 
     return () => {
-      flushScrollAnchorCapture("layout-cleanup", scrollArea);
+      flushScrollAnchorCapture(scrollArea);
     };
   }, [flushScrollAnchorCapture]);
 

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -261,11 +261,6 @@ export function BottomAnchoredScrollBody({
   }>({ lastWriteAt: 0, trailingTimeout: null });
   const [isAtBottom, setIsAtBottom] = useState(true);
 
-  const clearPendingScrollRestores = useCallback(() => {
-    pendingPrependAnchorRef.current = null;
-    pendingScrollRestoreRef.current = null;
-  }, []);
-
   const cancelQueuedRestore = useCallback(() => {
     if (restoreFrameRef.current === null) return;
     window.cancelAnimationFrame(restoreFrameRef.current);
@@ -325,7 +320,6 @@ export function BottomAnchoredScrollBody({
 
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
-    clearPendingScrollRestores();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
     shouldStickToBottomRef.current = true;
@@ -334,7 +328,7 @@ export function BottomAnchoredScrollBody({
       scrollElementToBottom(scrollArea);
     }
     queueBottomRestore();
-  }, [clearPendingScrollRestores, queueBottomRestore]);
+  }, [queueBottomRestore]);
 
   const scrollElementIntoView = useCallback(
     ({ element, options }: ScrollElementIntoViewArgs) => {
@@ -345,13 +339,12 @@ export function BottomAnchoredScrollBody({
       ) {
         return;
       }
-      clearPendingScrollRestores();
       shouldStickToBottomRef.current = false;
       setIsAtBottom(false);
       cancelQueuedRestore();
       element.scrollIntoView(options);
     },
-    [cancelQueuedRestore, clearPendingScrollRestores],
+    [cancelQueuedRestore],
   );
 
   const scrollElementIntoViewClampedToMaxScroll = useCallback(
@@ -362,7 +355,6 @@ export function BottomAnchoredScrollBody({
         return;
       }
 
-      clearPendingScrollRestores();
       scrollArea.scrollTop = getRevealScrollOffsetClampedToMax({
         element,
         scrollArea,
@@ -379,7 +371,7 @@ export function BottomAnchoredScrollBody({
 
       cancelQueuedRestore();
     },
-    [cancelQueuedRestore, clearPendingScrollRestores, queueBottomRestore],
+    [cancelQueuedRestore, queueBottomRestore],
   );
 
   const captureScrollAnchor = useCallback(() => {
@@ -401,25 +393,16 @@ export function BottomAnchoredScrollBody({
     pendingPrependAnchorRef.current = null;
   });
 
-  const hasRecentUserScrollIntent = useCallback(() => {
-    return (
-      pointerScrollIntentRef.current ||
-      window.performance.now() <= userScrollIntentUntilRef.current
-    );
-  }, []);
-
   // Persist the current scroll position (top-most visible row + within-row
   // offset + atBottom) into the per-thread atom so returning to this thread
-  // restores it. Continuous capture keeps the atom current while mounted; cleanup
-  // flushes through the effect-captured scroll area because refs can be nulled
-  // during unmount.
-  const writeScrollAnchor = useCallback((scrollAreaOverride?: HTMLElement) => {
+  // restores it. Continuous capture (vs. on unmount) is required: the timeline
+  // subtree is force-remounted via `key={threadId}`, and an unmount-time read
+  // races that teardown.
+  const writeScrollAnchor = useCallback(() => {
     if (scrollAnchorThreadId === undefined) return;
-    const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
+    const scrollArea = scrollAreaRef.current;
     if (!scrollArea) return;
-    const atBottom =
-      isScrolledNearBottom(scrollArea) ||
-      (shouldStickToBottomRef.current && !hasRecentUserScrollIntent());
+    const atBottom = isScrolledNearBottom(scrollArea);
     const anchorAtom =
       threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
     if (atBottom) {
@@ -434,7 +417,7 @@ export function BottomAnchoredScrollBody({
       offsetWithinRow: topMostRow.offsetWithinRow,
       atBottom: false,
     });
-  }, [hasRecentUserScrollIntent, scrollAnchorThreadId, store]);
+  }, [scrollAnchorThreadId, store]);
 
   const captureScrollAnchorThrottled = useCallback(() => {
     if (scrollAnchorThreadId === undefined) return;
@@ -524,14 +507,18 @@ export function BottomAnchoredScrollBody({
       return;
     }
 
-    if (!hasRecentUserScrollIntent()) return;
+    const hasUserScrollIntent =
+      pointerScrollIntentRef.current ||
+      window.performance.now() <= userScrollIntentUntilRef.current;
+
+    if (!hasUserScrollIntent) return;
 
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
     cancelQueuedRestore();
     // The user is scrolling on their own; don't yank them back to the anchor.
     pendingScrollRestoreRef.current = null;
-  }, [cancelQueuedRestore, hasRecentUserScrollIntent]);
+  }, [cancelQueuedRestore]);
 
   const handleScroll = useCallback(() => {
     syncBottomStateFromScroll();
@@ -677,7 +664,7 @@ export function BottomAnchoredScrollBody({
         window.clearTimeout(captureThrottle.trailingTimeout);
         captureThrottle.trailingTimeout = null;
       }
-      writeScrollAnchor(scrollArea);
+      writeScrollAnchor();
     };
   }, [
     cancelQueuedRestore,

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -259,6 +259,7 @@ export function BottomAnchoredScrollBody({
     lastWriteAt: number;
     trailingTimeout: number | null;
   }>({ lastWriteAt: 0, trailingTimeout: null });
+  const userDetachedFromBottomRef = useRef(false);
   const [isAtBottom, setIsAtBottom] = useState(true);
 
   const cancelPendingScrollRestore = useCallback(() => {
@@ -327,6 +328,7 @@ export function BottomAnchoredScrollBody({
     cancelPendingScrollRestore();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
+    userDetachedFromBottomRef.current = false;
     shouldStickToBottomRef.current = true;
     setIsAtBottom(true);
     if (scrollArea) {
@@ -398,19 +400,34 @@ export function BottomAnchoredScrollBody({
     pendingPrependAnchorRef.current = null;
   });
 
+  const hasRecentUserScrollIntent = useCallback(() => {
+    return (
+      pointerScrollIntentRef.current ||
+      window.performance.now() <= userScrollIntentUntilRef.current
+    );
+  }, []);
+
   // Persist the current scroll position (top-most visible row + within-row
   // offset + atBottom) into the per-thread atom so returning to this thread
-  // restores it. Continuous capture (vs. on unmount) is required: the timeline
-  // subtree is force-remounted via `key={threadId}`, and an unmount-time read
-  // races that teardown.
-  const writeScrollAnchor = useCallback(() => {
+  // restores it. Continuous capture keeps the atom current while mounted; cleanup
+  // flushes through the effect-captured scroll area because refs can be nulled
+  // during unmount.
+  const writeScrollAnchor = useCallback((scrollAreaOverride?: HTMLElement) => {
     if (scrollAnchorThreadId === undefined) return;
-    const scrollArea = scrollAreaRef.current;
+    const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
     if (!scrollArea) return;
-    const atBottom = isScrolledNearBottom(scrollArea);
+    const atBottomByGeometry = isScrolledNearBottom(scrollArea);
     const anchorAtom =
       threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
-    if (atBottom) {
+    if (atBottomByGeometry) {
+      userDetachedFromBottomRef.current = false;
+      store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
+      return;
+    }
+    if (hasRecentUserScrollIntent()) {
+      userDetachedFromBottomRef.current = true;
+    }
+    if (shouldStickToBottomRef.current && !userDetachedFromBottomRef.current) {
       store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
       return;
     }
@@ -422,7 +439,7 @@ export function BottomAnchoredScrollBody({
       offsetWithinRow: topMostRow.offsetWithinRow,
       atBottom: false,
     });
-  }, [scrollAnchorThreadId, store]);
+  }, [hasRecentUserScrollIntent, scrollAnchorThreadId, store]);
 
   const captureScrollAnchorThrottled = useCallback(() => {
     if (scrollAnchorThreadId === undefined) return;
@@ -504,6 +521,7 @@ export function BottomAnchoredScrollBody({
     if (!scrollArea) return;
 
     if (isScrolledNearBottom(scrollArea)) {
+      userDetachedFromBottomRef.current = false;
       shouldStickToBottomRef.current = true;
       setIsAtBottom(true);
       // A deliberate scroll to the bottom during the restore settle window means
@@ -512,18 +530,15 @@ export function BottomAnchoredScrollBody({
       return;
     }
 
-    const hasUserScrollIntent =
-      pointerScrollIntentRef.current ||
-      window.performance.now() <= userScrollIntentUntilRef.current;
+    if (!hasRecentUserScrollIntent()) return;
 
-    if (!hasUserScrollIntent) return;
-
+    userDetachedFromBottomRef.current = true;
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
     cancelQueuedRestore();
     // The user is scrolling on their own; don't yank them back to the anchor.
     pendingScrollRestoreRef.current = null;
-  }, [cancelQueuedRestore]);
+  }, [cancelQueuedRestore, hasRecentUserScrollIntent]);
 
   const handleScroll = useCallback(() => {
     syncBottomStateFromScroll();
@@ -669,7 +684,7 @@ export function BottomAnchoredScrollBody({
         window.clearTimeout(captureThrottle.trailingTimeout);
         captureThrottle.trailingTimeout = null;
       }
-      writeScrollAnchor();
+      writeScrollAnchor(scrollArea);
     };
   }, [
     cancelQueuedRestore,

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -261,6 +261,11 @@ export function BottomAnchoredScrollBody({
   }>({ lastWriteAt: 0, trailingTimeout: null });
   const [isAtBottom, setIsAtBottom] = useState(true);
 
+  const clearPendingScrollRestores = useCallback(() => {
+    pendingPrependAnchorRef.current = null;
+    pendingScrollRestoreRef.current = null;
+  }, []);
+
   const cancelQueuedRestore = useCallback(() => {
     if (restoreFrameRef.current === null) return;
     window.cancelAnimationFrame(restoreFrameRef.current);
@@ -320,6 +325,7 @@ export function BottomAnchoredScrollBody({
 
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
+    clearPendingScrollRestores();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
     shouldStickToBottomRef.current = true;
@@ -328,7 +334,7 @@ export function BottomAnchoredScrollBody({
       scrollElementToBottom(scrollArea);
     }
     queueBottomRestore();
-  }, [queueBottomRestore]);
+  }, [clearPendingScrollRestores, queueBottomRestore]);
 
   const scrollElementIntoView = useCallback(
     ({ element, options }: ScrollElementIntoViewArgs) => {
@@ -339,12 +345,13 @@ export function BottomAnchoredScrollBody({
       ) {
         return;
       }
+      clearPendingScrollRestores();
       shouldStickToBottomRef.current = false;
       setIsAtBottom(false);
       cancelQueuedRestore();
       element.scrollIntoView(options);
     },
-    [cancelQueuedRestore],
+    [cancelQueuedRestore, clearPendingScrollRestores],
   );
 
   const scrollElementIntoViewClampedToMaxScroll = useCallback(
@@ -355,6 +362,7 @@ export function BottomAnchoredScrollBody({
         return;
       }
 
+      clearPendingScrollRestores();
       scrollArea.scrollTop = getRevealScrollOffsetClampedToMax({
         element,
         scrollArea,
@@ -371,7 +379,7 @@ export function BottomAnchoredScrollBody({
 
       cancelQueuedRestore();
     },
-    [cancelQueuedRestore, queueBottomRestore],
+    [cancelQueuedRestore, clearPendingScrollRestores, queueBottomRestore],
   );
 
   const captureScrollAnchor = useCallback(() => {

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -90,6 +90,7 @@ const SCROLL_ANCHOR_CAPTURE_THROTTLE_MS = 100;
 // observed re-applies so a deleted/never-arriving row can't hang at the top.
 const SCROLL_ANCHOR_RESTORE_MAX_ATTEMPTS = 8;
 const TIMELINE_ROW_ID_SELECTOR = "[data-timeline-row-id]";
+const DEBUG_TIMELINE_SCROLL_ANCHOR = true;
 const SCROLL_INTENT_KEYS = new Set([
   "ArrowDown",
   "ArrowUp",
@@ -110,6 +111,22 @@ export function useBottomAnchoredScroll(): BottomAnchorContextValue | null {
 
 function getMaxScrollOffset(element: HTMLElement) {
   return Math.max(0, element.scrollHeight - element.clientHeight);
+}
+
+function getScrollDebugMetrics(element: HTMLElement) {
+  const maxScrollOffset = getMaxScrollOffset(element);
+  return {
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    maxScrollOffset,
+    distanceFromBottom: maxScrollOffset - element.scrollTop,
+  };
+}
+
+function logScrollAnchorDebug(event: string, details: object) {
+  if (!DEBUG_TIMELINE_SCROLL_ANCHOR) return;
+  console.log(`[bb-scroll-anchor] ${event}`, details);
 }
 
 function isScrolledNearBottom(element: HTMLElement) {
@@ -263,8 +280,14 @@ export function BottomAnchoredScrollBody({
   const [isAtBottom, setIsAtBottom] = useState(true);
 
   const cancelPendingScrollRestore = useCallback(() => {
+    if (pendingScrollRestoreRef.current !== null) {
+      logScrollAnchorDebug("cancel-pending-row-restore", {
+        threadId: scrollAnchorThreadId,
+        anchor: pendingScrollRestoreRef.current.anchor,
+      });
+    }
     pendingScrollRestoreRef.current = null;
-  }, []);
+  }, [scrollAnchorThreadId]);
 
   const cancelQueuedRestore = useCallback(() => {
     if (restoreFrameRef.current === null) return;
@@ -288,9 +311,14 @@ export function BottomAnchoredScrollBody({
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea || !shouldStickToBottomRef.current) return false;
     if (isScrolledNearBottom(scrollArea)) return false;
+    logScrollAnchorDebug("restore-bottom-once", {
+      threadId: scrollAnchorThreadId,
+      userDetachedFromBottom: userDetachedFromBottomRef.current,
+      ...getScrollDebugMetrics(scrollArea),
+    });
     scrollElementToBottom(scrollArea);
     return true;
-  }, []);
+  }, [scrollAnchorThreadId]);
 
   const runQueuedRestore = useCallback(() => {
     restoreFrameRef.current = null;
@@ -325,6 +353,13 @@ export function BottomAnchoredScrollBody({
 
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
+    logScrollAnchorDebug("scroll-to-bottom-requested", {
+      threadId: scrollAnchorThreadId,
+      hadPendingRowRestore: pendingScrollRestoreRef.current !== null,
+      shouldStickToBottom: shouldStickToBottomRef.current,
+      userDetachedFromBottom: userDetachedFromBottomRef.current,
+      ...(scrollArea ? getScrollDebugMetrics(scrollArea) : {}),
+    });
     cancelPendingScrollRestore();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
@@ -334,8 +369,14 @@ export function BottomAnchoredScrollBody({
     if (scrollArea) {
       scrollElementToBottom(scrollArea);
     }
+    if (scrollArea) {
+      logScrollAnchorDebug("scroll-to-bottom-applied", {
+        threadId: scrollAnchorThreadId,
+        ...getScrollDebugMetrics(scrollArea),
+      });
+    }
     queueBottomRestore();
-  }, [cancelPendingScrollRestore, queueBottomRestore]);
+  }, [cancelPendingScrollRestore, queueBottomRestore, scrollAnchorThreadId]);
 
   const scrollElementIntoView = useCallback(
     ({ element, options }: ScrollElementIntoViewArgs) => {
@@ -412,34 +453,81 @@ export function BottomAnchoredScrollBody({
   // restores it. Continuous capture keeps the atom current while mounted; cleanup
   // flushes through the effect-captured scroll area because refs can be nulled
   // during unmount.
-  const writeScrollAnchor = useCallback((scrollAreaOverride?: HTMLElement) => {
-    if (scrollAnchorThreadId === undefined) return;
-    const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
-    if (!scrollArea) return;
-    const atBottomByGeometry = isScrolledNearBottom(scrollArea);
-    const anchorAtom =
-      threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
-    if (atBottomByGeometry) {
-      userDetachedFromBottomRef.current = false;
-      store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
-      return;
-    }
-    if (hasRecentUserScrollIntent()) {
-      userDetachedFromBottomRef.current = true;
-    }
-    if (shouldStickToBottomRef.current && !userDetachedFromBottomRef.current) {
-      store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
-      return;
-    }
-    const topMostRow = getTopMostVisibleRow(scrollArea);
-    // No rows yet: don't clobber a good anchor with an empty one.
-    if (!topMostRow) return;
-    store.set(anchorAtom, {
-      rowId: topMostRow.rowId,
-      offsetWithinRow: topMostRow.offsetWithinRow,
-      atBottom: false,
-    });
-  }, [hasRecentUserScrollIntent, scrollAnchorThreadId, store]);
+  const writeScrollAnchor = useCallback(
+    (source: string, scrollAreaOverride?: HTMLElement) => {
+      if (scrollAnchorThreadId === undefined) return;
+      const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
+      if (!scrollArea) {
+        logScrollAnchorDebug("save-skip-no-scroll-area", {
+          source,
+          threadId: scrollAnchorThreadId,
+        });
+        return;
+      }
+      const atBottomByGeometry = isScrolledNearBottom(scrollArea);
+      const recentUserIntent = hasRecentUserScrollIntent();
+      const wasUserDetachedFromBottom = userDetachedFromBottomRef.current;
+      const anchorAtom =
+        threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
+      if (atBottomByGeometry) {
+        userDetachedFromBottomRef.current = false;
+        store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
+        logScrollAnchorDebug("save-bottom-geometry", {
+          source,
+          threadId: scrollAnchorThreadId,
+          shouldStickToBottom: shouldStickToBottomRef.current,
+          wasUserDetachedFromBottom,
+          recentUserIntent,
+          ...getScrollDebugMetrics(scrollArea),
+        });
+        return;
+      }
+      if (recentUserIntent) {
+        userDetachedFromBottomRef.current = true;
+      }
+      if (shouldStickToBottomRef.current && !userDetachedFromBottomRef.current) {
+        store.set(anchorAtom, { rowId: "", offsetWithinRow: 0, atBottom: true });
+        logScrollAnchorDebug("save-bottom-sticky-intent", {
+          source,
+          threadId: scrollAnchorThreadId,
+          shouldStickToBottom: shouldStickToBottomRef.current,
+          wasUserDetachedFromBottom,
+          recentUserIntent,
+          ...getScrollDebugMetrics(scrollArea),
+        });
+        return;
+      }
+      const topMostRow = getTopMostVisibleRow(scrollArea);
+      // No rows yet: don't clobber a good anchor with an empty one.
+      if (!topMostRow) {
+        logScrollAnchorDebug("save-skip-no-visible-row", {
+          source,
+          threadId: scrollAnchorThreadId,
+          shouldStickToBottom: shouldStickToBottomRef.current,
+          userDetachedFromBottom: userDetachedFromBottomRef.current,
+          recentUserIntent,
+          ...getScrollDebugMetrics(scrollArea),
+        });
+        return;
+      }
+      store.set(anchorAtom, {
+        rowId: topMostRow.rowId,
+        offsetWithinRow: topMostRow.offsetWithinRow,
+        atBottom: false,
+      });
+      logScrollAnchorDebug("save-row", {
+        source,
+        threadId: scrollAnchorThreadId,
+        rowId: topMostRow.rowId,
+        offsetWithinRow: topMostRow.offsetWithinRow,
+        shouldStickToBottom: shouldStickToBottomRef.current,
+        userDetachedFromBottom: userDetachedFromBottomRef.current,
+        recentUserIntent,
+        ...getScrollDebugMetrics(scrollArea),
+      });
+    },
+    [hasRecentUserScrollIntent, scrollAnchorThreadId, store],
+  );
 
   const captureScrollAnchorThrottled = useCallback(() => {
     if (scrollAnchorThreadId === undefined) return;
@@ -448,7 +536,7 @@ export function BottomAnchoredScrollBody({
     const elapsed = now - throttle.lastWriteAt;
     if (elapsed >= SCROLL_ANCHOR_CAPTURE_THROTTLE_MS) {
       throttle.lastWriteAt = now;
-      writeScrollAnchor();
+      writeScrollAnchor("scroll");
       return;
     }
     // Trailing write so the final resting position is always recorded even when
@@ -457,7 +545,7 @@ export function BottomAnchoredScrollBody({
     throttle.trailingTimeout = window.setTimeout(() => {
       throttle.trailingTimeout = null;
       throttle.lastWriteAt = window.performance.now();
-      writeScrollAnchor();
+      writeScrollAnchor("scroll-trailing");
     }, SCROLL_ANCHOR_CAPTURE_THROTTLE_MS - elapsed);
   }, [scrollAnchorThreadId, writeScrollAnchor]);
 
@@ -470,7 +558,13 @@ export function BottomAnchoredScrollBody({
       const scrollArea = scrollAreaRef.current;
       if (!scrollArea) return null;
       const rowElement = findTimelineRowElement(scrollArea, anchor.rowId);
-      if (!rowElement) return null;
+      if (!rowElement) {
+        logScrollAnchorDebug("restore-row-missing", {
+          threadId: scrollAnchorThreadId,
+          anchor,
+        });
+        return null;
+      }
       // Suppress stick-to-bottom; this is the same state scrollElementIntoView
       // sets, inlined here so we can add the within-row offset afterward.
       shouldStickToBottomRef.current = false;
@@ -485,23 +579,52 @@ export function BottomAnchoredScrollBody({
         revealOffset + anchor.offsetWithinRow,
       );
       scrollArea.scrollTop = targetScrollTop;
+      logScrollAnchorDebug("restore-row-applied", {
+        threadId: scrollAnchorThreadId,
+        anchor,
+        targetScrollTop,
+        ...getScrollDebugMetrics(scrollArea),
+      });
       return targetScrollTop;
     },
-    [cancelQueuedRestore],
+    [cancelQueuedRestore, scrollAnchorThreadId],
   );
 
-  const markUserScrollIntent = useCallback(() => {
+  const markUserScrollIntent = useCallback((source: string) => {
     userScrollIntentUntilRef.current =
       window.performance.now() + USER_SCROLL_INTENT_MS;
-  }, []);
+    logScrollAnchorDebug("user-scroll-intent", {
+      source,
+      threadId: scrollAnchorThreadId,
+      intentUntil: userScrollIntentUntilRef.current,
+    });
+  }, [scrollAnchorThreadId]);
+
+  const markWheelScrollIntent = useCallback(() => {
+    markUserScrollIntent("wheel");
+  }, [markUserScrollIntent]);
+
+  const markTouchStartScrollIntent = useCallback(() => {
+    markUserScrollIntent("touchstart");
+  }, [markUserScrollIntent]);
+
+  const markTouchMoveScrollIntent = useCallback(() => {
+    markUserScrollIntent("touchmove");
+  }, [markUserScrollIntent]);
 
   const startPointerScrollIntent = useCallback(() => {
     pointerScrollIntentRef.current = true;
-  }, []);
+    logScrollAnchorDebug("pointer-scroll-intent-start", {
+      threadId: scrollAnchorThreadId,
+    });
+  }, [scrollAnchorThreadId]);
 
   const endPointerScrollIntent = useCallback(() => {
     pointerScrollIntentRef.current = false;
-  }, []);
+    logScrollAnchorDebug("pointer-scroll-intent-end", {
+      threadId: scrollAnchorThreadId,
+    });
+  }, [scrollAnchorThreadId]);
 
   const markKeyboardScrollIntent = useCallback(
     (event: KeyboardEvent) => {
@@ -511,7 +634,7 @@ export function BottomAnchoredScrollBody({
       if (isEditableKeyboardTarget(event.target)) return;
       if (!isKeyboardEventFromScrollArea(event, scrollArea)) return;
 
-      markUserScrollIntent();
+      markUserScrollIntent("keyboard");
     },
     [markUserScrollIntent],
   );
@@ -521,6 +644,12 @@ export function BottomAnchoredScrollBody({
     if (!scrollArea) return;
 
     if (isScrolledNearBottom(scrollArea)) {
+      logScrollAnchorDebug("scroll-near-bottom", {
+        threadId: scrollAnchorThreadId,
+        shouldStickToBottom: shouldStickToBottomRef.current,
+        userDetachedFromBottom: userDetachedFromBottomRef.current,
+        ...getScrollDebugMetrics(scrollArea),
+      });
       userDetachedFromBottomRef.current = false;
       shouldStickToBottomRef.current = true;
       setIsAtBottom(true);
@@ -530,8 +659,21 @@ export function BottomAnchoredScrollBody({
       return;
     }
 
-    if (!hasRecentUserScrollIntent()) return;
+    if (!hasRecentUserScrollIntent()) {
+      logScrollAnchorDebug("scroll-off-bottom-without-user-intent", {
+        threadId: scrollAnchorThreadId,
+        shouldStickToBottom: shouldStickToBottomRef.current,
+        userDetachedFromBottom: userDetachedFromBottomRef.current,
+        ...getScrollDebugMetrics(scrollArea),
+      });
+      return;
+    }
 
+    logScrollAnchorDebug("scroll-user-detached-from-bottom", {
+      threadId: scrollAnchorThreadId,
+      shouldStickToBottom: shouldStickToBottomRef.current,
+      ...getScrollDebugMetrics(scrollArea),
+    });
     userDetachedFromBottomRef.current = true;
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
@@ -554,10 +696,21 @@ export function BottomAnchoredScrollBody({
     const pending = pendingScrollRestoreRef.current;
     if (!pending) return false;
     pending.attemptsRemaining -= 1;
+    logScrollAnchorDebug("pending-row-restore-advance", {
+      threadId: scrollAnchorThreadId,
+      anchor: pending.anchor,
+      attemptsRemaining: pending.attemptsRemaining,
+      lastAppliedScrollTop: pending.lastAppliedScrollTop,
+    });
     const appliedScrollTop = applyScrollRestore(pending.anchor);
     if (appliedScrollTop !== null) {
       if (pending.lastAppliedScrollTop === appliedScrollTop) {
         pendingScrollRestoreRef.current = null;
+        logScrollAnchorDebug("pending-row-restore-stable", {
+          threadId: scrollAnchorThreadId,
+          anchor: pending.anchor,
+          appliedScrollTop,
+        });
         return true;
       }
       pending.lastAppliedScrollTop = appliedScrollTop;
@@ -569,6 +722,10 @@ export function BottomAnchoredScrollBody({
       if (appliedScrollTop === null) {
         shouldStickToBottomRef.current = true;
         setIsAtBottom(true);
+        logScrollAnchorDebug("pending-row-restore-fallback-bottom", {
+          threadId: scrollAnchorThreadId,
+          anchor: pending.anchor,
+        });
         // Scroll to the bottom in this same call. We return true below, so the
         // caller (`handleScrollAreaResize`) early-returns and won't run its own
         // `queueBottomRestore()`; without this the view would stay pinned at the
@@ -577,7 +734,7 @@ export function BottomAnchoredScrollBody({
       }
     }
     return true;
-  }, [applyScrollRestore, queueBottomRestore]);
+  }, [applyScrollRestore, queueBottomRestore, scrollAnchorThreadId]);
 
   const handleScrollAreaResize = useCallback(() => {
     // While a restore is pending, the ResizeObserver is the settle signal; the
@@ -598,6 +755,10 @@ export function BottomAnchoredScrollBody({
       threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId),
     );
     if (!anchor || anchor.atBottom) return;
+    logScrollAnchorDebug("mount-restore-row-anchor", {
+      threadId: scrollAnchorThreadId,
+      anchor,
+    });
     shouldStickToBottomRef.current = false;
     setIsAtBottom(false);
     pendingScrollRestoreRef.current = {
@@ -640,13 +801,13 @@ export function BottomAnchoredScrollBody({
     scrollArea.addEventListener("scroll", handleScroll, {
       passive: true,
     });
-    scrollArea.addEventListener("wheel", markUserScrollIntent, {
+    scrollArea.addEventListener("wheel", markWheelScrollIntent, {
       passive: true,
     });
-    scrollArea.addEventListener("touchstart", markUserScrollIntent, {
+    scrollArea.addEventListener("touchstart", markTouchStartScrollIntent, {
       passive: true,
     });
-    scrollArea.addEventListener("touchmove", markUserScrollIntent, {
+    scrollArea.addEventListener("touchmove", markTouchMoveScrollIntent, {
       passive: true,
     });
     // Captures scrollbar-thumb drags and other pointer-driven scrolling that
@@ -670,9 +831,9 @@ export function BottomAnchoredScrollBody({
     return () => {
       resizeObserver?.disconnect();
       scrollArea.removeEventListener("scroll", handleScroll);
-      scrollArea.removeEventListener("wheel", markUserScrollIntent);
-      scrollArea.removeEventListener("touchstart", markUserScrollIntent);
-      scrollArea.removeEventListener("touchmove", markUserScrollIntent);
+      scrollArea.removeEventListener("wheel", markWheelScrollIntent);
+      scrollArea.removeEventListener("touchstart", markTouchStartScrollIntent);
+      scrollArea.removeEventListener("touchmove", markTouchMoveScrollIntent);
       scrollArea.removeEventListener("pointerdown", startPointerScrollIntent);
       window.removeEventListener("pointerup", endPointerScrollIntent);
       window.removeEventListener("pointercancel", endPointerScrollIntent);
@@ -684,7 +845,7 @@ export function BottomAnchoredScrollBody({
         window.clearTimeout(captureThrottle.trailingTimeout);
         captureThrottle.trailingTimeout = null;
       }
-      writeScrollAnchor(scrollArea);
+      writeScrollAnchor("unmount", scrollArea);
     };
   }, [
     cancelQueuedRestore,
@@ -692,7 +853,9 @@ export function BottomAnchoredScrollBody({
     handleScroll,
     handleScrollAreaResize,
     markKeyboardScrollIntent,
-    markUserScrollIntent,
+    markTouchMoveScrollIntent,
+    markTouchStartScrollIntent,
+    markWheelScrollIntent,
     queueBottomRestore,
     startPointerScrollIntent,
     writeScrollAnchor,

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -403,14 +403,15 @@ export function BottomAnchoredScrollBody({
 
   // Persist the current scroll position (top-most visible row + within-row
   // offset + atBottom) into the per-thread atom so returning to this thread
-  // restores it. Continuous capture (vs. on unmount) is required: the timeline
-  // subtree is force-remounted via `key={threadId}`, and an unmount-time read
-  // races that teardown.
-  const writeScrollAnchor = useCallback(() => {
+  // restores it. Continuous capture keeps the atom current while mounted; cleanup
+  // flushes through the effect-captured scroll area because refs can be nulled
+  // during unmount.
+  const writeScrollAnchor = useCallback((scrollAreaOverride?: HTMLElement) => {
     if (scrollAnchorThreadId === undefined) return;
-    const scrollArea = scrollAreaRef.current;
+    const scrollArea = scrollAreaOverride ?? scrollAreaRef.current;
     if (!scrollArea) return;
-    const atBottom = isScrolledNearBottom(scrollArea);
+    const atBottom =
+      shouldStickToBottomRef.current || isScrolledNearBottom(scrollArea);
     const anchorAtom =
       threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId);
     if (atBottom) {
@@ -672,7 +673,7 @@ export function BottomAnchoredScrollBody({
         window.clearTimeout(captureThrottle.trailingTimeout);
         captureThrottle.trailingTimeout = null;
       }
-      writeScrollAnchor();
+      writeScrollAnchor(scrollArea);
     };
   }, [
     cancelQueuedRestore,


### PR DESCRIPTION
Summary:
- Cancel a pending saved-row restore when an explicit scroll-to-bottom request happens, so a later ResizeObserver settle pass cannot pull the timeline back up.
- Add a latched user-detached-from-bottom state so streaming/layout drift can save bottom intent, while actual manual scrolls still save the visible row.
- Flush the final scroll anchor from the effect-captured scroll element during unmount, since refs can already be nulled.
- Add regression tests for stale saved-row restore undoing scroll-to-bottom, streaming drift on unmount, and fast unmount after manual wheel scroll.

Validation:
- pnpm exec turbo run test --filter=@bb/app -- src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app