### PR TITLE
Fix packaged provider bridge runtime startup

### DIFF
--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -113,6 +113,10 @@ export interface CreateAcpProviderAdapterOptions {
   additionalWorkspaceWriteRoots: readonly string[];
   /** Override the directory containing bundled bridge files. */
   bridgeBundleDir?: string;
+  /** Optional environment values needed by the Node runtime that launches the bridge. */
+  bridgeNodeEnv?: Record<string, string>;
+  /** Optional executable used to run the Node bridge process. */
+  bridgeNodeExecutablePath?: string;
   /** Prefix for bb-owned turn ids emitted by this adapter instance. */
   turnIdPrefix?: string;
 }
@@ -1146,13 +1150,14 @@ export function createAcpProviderAdapter(
     displayName: providerInfo.displayName,
     capabilities: providerInfo.capabilities,
     process: {
-      command: "node",
+      command: opts.bridgeNodeExecutablePath ?? "node",
       args: resolveBridgeProcessArgs({
         bridgeBundleDir: opts.bridgeBundleDir,
         bundleFileName: "bb-acp-bridge.mjs",
         importMetaUrl: import.meta.url,
         bridgeRelativePath: "bridge/bridge.js",
       }),
+      ...(opts.bridgeNodeEnv !== undefined ? { env: opts.bridgeNodeEnv } : {}),
     },
 
     // -- Unified command builder -------------------------------------------

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   captureBridgeJsonRpcOutput,
   type BridgeJsonRpcOutputMessage,
@@ -176,6 +176,7 @@ afterEach(async () => {
   for (const providerThreadId of startedProviderThreadIds.splice(0)) {
     await stopThread(providerThreadId);
   }
+  vi.unstubAllEnvs();
   output.restore();
   rmSync(workspaceDir, { recursive: true, force: true });
 });
@@ -313,6 +314,21 @@ describe("acp bridge", () => {
         (text) => text === "argv:--model pinme-extra-high",
       ),
     ).toBe(true);
+  });
+
+  it("does not leak bridge-only Electron env to the spawned agent", async () => {
+    vi.stubEnv("ELECTRON_RUN_AS_NODE", "1");
+    const { providerThreadId } = await startThread();
+
+    sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [
+        { type: "text", text: "echo-electron-run-as-node", mentions: [] },
+      ],
+    });
+    await waitForTurnCompleted();
+
+    expect(agentMessageTexts()).toContain("electron-run-as-node:missing");
   });
 
   it("warns and launches the family id when a reasoning variant is missing", async () => {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -30,6 +30,7 @@ import {
   decodeBridgeJsonRpcResponse,
   jsonRpcEnvelopeSchema,
 } from "../../shared/bridge-tool-calls.js";
+import { withoutBridgeRuntimeEnv } from "../../shared/bridge-runtime-env.js";
 import {
   ACP_DEFAULT_MODEL_ID,
   ACP_FS_WRITE_METHOD,
@@ -201,7 +202,10 @@ async function loadAgentModelCatalog(
     execFile(
       listCommand.command,
       listCommand.args,
-      { timeout: MODEL_LIST_TIMEOUT_MS },
+      {
+        env: withoutBridgeRuntimeEnv(process.env),
+        timeout: MODEL_LIST_TIMEOUT_MS,
+      },
       (error, out, stderr) => {
         if (!error) {
           resolveExec(out);
@@ -681,7 +685,7 @@ async function startAgentSession(
     command: params.agent.command,
     args: launch.args,
     cwd: params.cwd,
-    env: { ...process.env, ...params.envVars },
+    env: { ...withoutBridgeRuntimeEnv(process.env), ...params.envVars },
     onNotification: (method, notificationParams) =>
       handleAgentNotification(session, method, notificationParams),
     onRequest: (method, requestParams, responder) =>

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -119,6 +119,12 @@ async function handlePrompt(message) {
   } else if (text.includes("echo-argv")) {
     // Lets bridge tests assert the launch args (e.g. the --model pin).
     notifyUpdate(messageChunk(`argv:${process.argv.slice(2).join(" ")}`));
+  } else if (text.includes("echo-electron-run-as-node")) {
+    notifyUpdate(
+      messageChunk(
+        `electron-run-as-node:${process.env.ELECTRON_RUN_AS_NODE ?? "missing"}`,
+      ),
+    );
   } else {
     notifyUpdate(messageChunk(`echo:${text}`));
   }

--- a/packages/agent-runtime/src/claude-code/adapter.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.ts
@@ -995,13 +995,14 @@ export function createClaudeCodeProviderAdapter(
     displayName: providerInfo.displayName,
     capabilities,
     process: {
-      command: "node",
+      command: opts?.bridgeNodeExecutablePath ?? "node",
       args: resolveBridgeProcessArgs({
         bridgeBundleDir: opts?.bridgeBundleDir,
         bundleFileName: "bb-claude-code-bridge.mjs",
         importMetaUrl: import.meta.url,
         bridgeRelativePath: "bridge/bridge.js",
       }),
+      ...(opts?.bridgeNodeEnv !== undefined ? { env: opts.bridgeNodeEnv } : {}),
     },
 
     // -- Unified command builder -------------------------------------------

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -37,6 +37,7 @@ import {
   decodeToolCallResponsePayload,
   type BridgeToolCallRequest,
 } from "../../shared/bridge-tool-calls.js";
+import { withoutBridgeRuntimeEnv } from "../../shared/bridge-runtime-env.js";
 import { shouldAutoDenyInteractiveRequest } from "../../shared/permission-policy.js";
 import { SdkSession, type SdkSessionOptions } from "./sdk-session.js";
 import { listClaudeCodeBridgeModels } from "./model-list.js";
@@ -742,7 +743,7 @@ function buildSessionEnv(
   envOverrides: Record<string, string>,
 ): NodeJS.ProcessEnv {
   const sessionEnv: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...withoutBridgeRuntimeEnv(process.env),
     ...envOverrides,
     CLAUDE_CODE_ENTRYPOINT: "cli",
   };

--- a/packages/agent-runtime/src/pi/adapter.ts
+++ b/packages/agent-runtime/src/pi/adapter.ts
@@ -652,6 +652,10 @@ function createPiModelContextWindowResolver(): PiModelContextWindowResolver {
 export interface CreatePiProviderAdapterOptions {
   /** Override the directory containing bundled bridge files. */
   bridgeBundleDir?: string;
+  /** Optional environment values needed by the Node runtime that launches the bridge. */
+  bridgeNodeEnv?: Record<string, string>;
+  /** Optional executable used to run the Node bridge process. */
+  bridgeNodeExecutablePath?: string;
   /** Override context-window resolution. Used by unit tests to avoid real catalogs. */
   resolveModelContextWindow?: PiModelContextWindowResolver;
   /** Prefix for bb-owned turn ids emitted by this adapter instance. */
@@ -1213,13 +1217,14 @@ export function createPiProviderAdapter(
     displayName: providerInfo.displayName,
     capabilities,
     process: {
-      command: "node",
+      command: opts?.bridgeNodeExecutablePath ?? "node",
       args: resolveBridgeProcessArgs({
         bridgeBundleDir: opts?.bridgeBundleDir,
         bundleFileName: "bb-pi-bridge.mjs",
         importMetaUrl: import.meta.url,
         bridgeRelativePath: "bridge/bridge.js",
       }),
+      ...(opts?.bridgeNodeEnv !== undefined ? { env: opts.bridgeNodeEnv } : {}),
     },
 
     // -- Unified command builder -------------------------------------------

--- a/packages/agent-runtime/src/provider-adapter.ts
+++ b/packages/agent-runtime/src/provider-adapter.ts
@@ -32,6 +32,8 @@ export interface ProviderAcceptedCommandTranslationArgs {
 export interface ProviderAdapterFactoryOptions {
   additionalWorkspaceWriteRoots: readonly string[];
   bridgeBundleDir?: string;
+  bridgeNodeEnv?: Record<string, string>;
+  bridgeNodeExecutablePath?: string;
   turnIdPrefix?: string;
 }
 
@@ -219,7 +221,7 @@ export interface ProviderAdapter {
   id: string;
   displayName: string;
   capabilities: ProviderCapabilities;
-  process: { command: string; args: string[] };
+  process: { command: string; args: string[]; env?: Record<string, string> };
 
   buildCommandPlan(command: AdapterCommand): ProviderCommandPlan;
   /**

--- a/packages/agent-runtime/src/provider-registry.test.ts
+++ b/packages/agent-runtime/src/provider-registry.test.ts
@@ -48,6 +48,38 @@ describe("provider registry", () => {
     expect(piProvider.process.args[0]).toBe("/tmp/bb-pi-bridge.mjs");
   });
 
+  it("passes the configured bridge node runtime to bundled providers", () => {
+    const bridgeNodeEnv = { ELECTRON_RUN_AS_NODE: "1" };
+    const claudeProvider = createProviderForId("claude-code", {
+      additionalWorkspaceWriteRoots: [],
+      bridgeNodeEnv,
+      bridgeNodeExecutablePath: "/Applications/bb.app/Contents/MacOS/bb",
+    });
+    const piProvider = createProviderForId("pi", {
+      additionalWorkspaceWriteRoots: [],
+      bridgeNodeEnv,
+      bridgeNodeExecutablePath: "/Applications/bb.app/Contents/MacOS/bb",
+    });
+    const acpProvider = createProviderForId("acp-cursor", {
+      additionalWorkspaceWriteRoots: [],
+      bridgeNodeEnv,
+      bridgeNodeExecutablePath: "/Applications/bb.app/Contents/MacOS/bb",
+    });
+
+    expect(claudeProvider.process.command).toBe(
+      "/Applications/bb.app/Contents/MacOS/bb",
+    );
+    expect(claudeProvider.process.env).toEqual(bridgeNodeEnv);
+    expect(piProvider.process.command).toBe(
+      "/Applications/bb.app/Contents/MacOS/bb",
+    );
+    expect(piProvider.process.env).toEqual(bridgeNodeEnv);
+    expect(acpProvider.process.command).toBe(
+      "/Applications/bb.app/Contents/MacOS/bb",
+    );
+    expect(acpProvider.process.env).toEqual(bridgeNodeEnv);
+  });
+
   it("passes the configured turn id prefix to bundled providers", () => {
     const claudeProvider = createProviderForId("claude-code", {
       additionalWorkspaceWriteRoots: [],

--- a/packages/agent-runtime/src/provider-registry.ts
+++ b/packages/agent-runtime/src/provider-registry.ts
@@ -93,6 +93,12 @@ export function createProviderForId(
     ...(options?.bridgeBundleDir !== undefined
       ? { bridgeBundleDir: options.bridgeBundleDir }
       : {}),
+    ...(options?.bridgeNodeEnv !== undefined
+      ? { bridgeNodeEnv: options.bridgeNodeEnv }
+      : {}),
+    ...(options?.bridgeNodeExecutablePath !== undefined
+      ? { bridgeNodeExecutablePath: options.bridgeNodeExecutablePath }
+      : {}),
     ...(options?.turnIdPrefix !== undefined
       ? { turnIdPrefix: options.turnIdPrefix }
       : {}),

--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -44,6 +44,8 @@ export interface RuntimeProviderProcessManagerArgs {
   additionalWorkspaceWriteRoots: readonly string[];
   adapterFactory?: ProviderAdapterFactory;
   bridgeBundleDir: string | undefined;
+  bridgeNodeEnv?: Record<string, string>;
+  bridgeNodeExecutablePath?: string;
   /**
    * Snapshots a thread's turn/provider state for the process-exit
    * notification. Invoked before `onProviderThreadDetached` clears the
@@ -296,6 +298,12 @@ export class RuntimeProviderProcessManager {
     const adapterOptions = {
       additionalWorkspaceWriteRoots: this.args.additionalWorkspaceWriteRoots,
       bridgeBundleDir: this.args.bridgeBundleDir,
+      ...(this.args.bridgeNodeEnv !== undefined
+        ? { bridgeNodeEnv: this.args.bridgeNodeEnv }
+        : {}),
+      ...(this.args.bridgeNodeExecutablePath !== undefined
+        ? { bridgeNodeExecutablePath: this.args.bridgeNodeExecutablePath }
+        : {}),
       turnIdPrefix: createAdapterTurnIdPrefix(),
     };
 
@@ -306,11 +314,12 @@ export class RuntimeProviderProcessManager {
   }
 
   private spawnProvider(args: SpawnProviderArgs): RuntimeProviderProcess {
+    const processConfig = args.adapter.process;
     const env: NodeJS.ProcessEnv = {
       ...sanitizeInheritedChildProcessEnv({ env: process.env }),
       ...this.args.env,
+      ...processConfig.env,
     };
-    const processConfig = args.adapter.process;
 
     const child = spawnPortablePipedProcess({
       command: processConfig.command,

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -25,6 +25,7 @@ import type { AgentRuntimeOptions } from "./types.js";
 import type { ProviderRuntimeEvent } from "./runtime-json-rpc.js";
 
 interface CreateProviderProcessManagerArgs {
+  adapterProcessEnv?: Record<string, string>;
   env?: Record<string, string>;
   onStderr?: NonNullable<AgentRuntimeOptions["onStderr"]>;
   onProcessExit: NonNullable<AgentRuntimeOptions["onProcessExit"]>;
@@ -64,7 +65,8 @@ describe("createAgentRuntime process lifecycle", () => {
     let nextRequestId = 1;
     return new RuntimeProviderProcessManager({
       additionalWorkspaceWriteRoots: [],
-      adapterFactory: () => createNoopInitializeAdapter(args.scriptPath),
+      adapterFactory: () =>
+        createNoopInitializeAdapter(args.scriptPath, args.adapterProcessEnv),
       bridgeBundleDir: undefined,
       captureThreadExitState: (threadId) => ({
         activeTurnId: null,
@@ -90,10 +92,17 @@ describe("createAgentRuntime process lifecycle", () => {
     });
   }
 
-  function createNoopInitializeAdapter(scriptPath: string): ProviderAdapter {
+  function createNoopInitializeAdapter(
+    scriptPath: string,
+    processEnv?: Record<string, string>,
+  ): ProviderAdapter {
     const adapter = createFakeAdapter(scriptPath);
     return {
       ...adapter,
+      process: {
+        ...adapter.process,
+        ...(processEnv !== undefined ? { env: processEnv } : {}),
+      },
       buildCommandPlan(command) {
         if (command.type === "initialize") {
           return { kind: "noop", reason: "initialized by process spawn" };
@@ -1056,6 +1065,84 @@ rl.on("line", (line) => {
       expect(stderrLines[0]).toBe(
         "missing|missing|missing|external-secret|thr_explicit",
       );
+    } finally {
+      await manager.shutdown();
+    }
+  });
+
+  it("launches runtime-managed node bridges with the current executable when node is absent from PATH", async () => {
+    vi.stubEnv("PATH", "");
+    const idleScript = join(tmpDir, "pathless-node-provider.cjs");
+    writeFileSync(idleScript, `setInterval(() => {}, 1000);`);
+    const adapterCommands: string[] = [];
+    const runtime = createAgentRuntimeWithAdapters({
+      workspacePath: tmpDir,
+      onEvent: () => {},
+      onToolCall: async () => ({
+        contentItems: [{ type: "inputText", text: "ok" }],
+        success: true,
+      }),
+      adapterFactory: (_providerId, options) => {
+        const adapter = createNoopInitializeAdapter(idleScript);
+        const command = options.bridgeNodeExecutablePath ?? "node";
+        adapterCommands.push(command);
+        return {
+          ...adapter,
+          process: {
+            ...adapter.process,
+            command,
+          },
+        };
+      },
+    });
+
+    try {
+      await runtime.ensureProvider({ providerId: "fake" });
+      expect(adapterCommands).toEqual([process.execPath]);
+    } finally {
+      await runtime.shutdown();
+    }
+  });
+
+  it("overlays adapter process env after inherited and runtime env", async () => {
+    vi.stubEnv("ELECTRON_RUN_AS_NODE", "0");
+    const envScript = join(tmpDir, "bridge-env-provider.cjs");
+    writeFileSync(
+      envScript,
+      `const values = [
+        process.env.ELECTRON_RUN_AS_NODE ?? "missing",
+        process.env.BRIDGE_ONLY ?? "missing",
+        process.env.BB_THREAD_ID ?? "missing"
+      ];
+      process.stderr.write(values.join("|") + "\\n");
+      setInterval(() => {}, 1000);`,
+    );
+    const stderrLines: string[] = [];
+    const manager = createProviderProcessManager({
+      adapterProcessEnv: {
+        BRIDGE_ONLY: "bridge",
+        ELECTRON_RUN_AS_NODE: "1",
+      },
+      env: {
+        BB_THREAD_ID: "thr_explicit",
+        ELECTRON_RUN_AS_NODE: "runtime",
+      },
+      onProcessExit: vi.fn(),
+      onStderr: (line) => {
+        stderrLines.push(line);
+      },
+      scriptPath: envScript,
+      workspacePath: tmpDir,
+    });
+
+    try {
+      await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+      await waitForRuntimeState({
+        label: "provider bridge env stderr",
+        predicate: () => stderrLines.length > 0,
+      });
+
+      expect(stderrLines[0]).toBe("1|bridge|thr_explicit");
     } finally {
       await manager.shutdown();
     }

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -122,6 +122,13 @@ interface ResolveThreadStoragePathArgs {
   threadId: string;
 }
 
+function defaultBridgeNodeEnv(): Record<string, string> | undefined {
+  if (process.versions.electron === undefined) {
+    return undefined;
+  }
+  return { ELECTRON_RUN_AS_NODE: "1" };
+}
+
 // ---------------------------------------------------------------------------
 // Runtime implementation
 // ---------------------------------------------------------------------------
@@ -219,11 +226,15 @@ function createAgentRuntimeInternal(
   const threadOperationCounts = new Map<string, number>();
   const turnState = new RuntimeTurnState();
   const turnReplayFilter = new RuntimeTurnReplayFilter();
+  const bridgeNodeEnv = options.bridgeNodeEnv ?? defaultBridgeNodeEnv();
 
   const providerProcesses = new RuntimeProviderProcessManager({
     additionalWorkspaceWriteRoots,
     adapterFactory: options.adapterFactory,
     bridgeBundleDir: options.bridgeBundleDir,
+    ...(bridgeNodeEnv !== undefined ? { bridgeNodeEnv } : {}),
+    bridgeNodeExecutablePath:
+      options.bridgeNodeExecutablePath ?? process.execPath,
     captureThreadExitState: (threadId) => ({
       activeTurnId: turnState.getActiveTurnId(threadId),
       providerThreadId:

--- a/packages/agent-runtime/src/shared/bridge-runtime-env.test.ts
+++ b/packages/agent-runtime/src/shared/bridge-runtime-env.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { withoutBridgeRuntimeEnv } from "./bridge-runtime-env.js";
+
+describe("bridge runtime env", () => {
+  it("removes bridge-only Electron runtime flags from child env", () => {
+    const sourceEnv = {
+      ELECTRON_RUN_AS_NODE: "1",
+      PATH: "/usr/bin",
+      BB_THREAD_ID: "thr_123",
+    };
+
+    expect(withoutBridgeRuntimeEnv(sourceEnv)).toEqual({
+      PATH: "/usr/bin",
+      BB_THREAD_ID: "thr_123",
+    });
+    expect(sourceEnv.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
+});

--- a/packages/agent-runtime/src/shared/bridge-runtime-env.ts
+++ b/packages/agent-runtime/src/shared/bridge-runtime-env.ts
@@ -1,0 +1,7 @@
+export function withoutBridgeRuntimeEnv(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = { ...env };
+  delete childEnv.ELECTRON_RUN_AS_NODE;
+  return childEnv;
+}

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -83,6 +83,12 @@ export interface AgentRuntimeOptions {
   /** Optional directory containing bundled provider bridges. */
   bridgeBundleDir?: string;
 
+  /** Optional executable used to run Node-based provider bridges. */
+  bridgeNodeExecutablePath?: string;
+
+  /** Optional env values needed by the executable used for Node-based bridges. */
+  bridgeNodeEnv?: Record<string, string>;
+
   /** Optional caller-provided skill roots to expose to provider sessions. */
   skillRoots?: readonly AgentRuntimeSkillRoot[];
 


### PR DESCRIPTION
## Summary
- Launch runtime-managed Node bridge providers with an explicit Node runtime instead of relying on `node` on GUI app PATH
- Pass `ELECTRON_RUN_AS_NODE=1` only to Electron-launched bridge processes
- Cover Claude Code, Pi, and ACP bridge adapters on current `main`
- Strip bridge-only Electron runtime env before launching downstream Claude/ACP agent subprocesses

## Repro
- Confirmed `spawn node` fails with `ENOENT` when `PATH` is empty
- Confirmed `process.execPath` still launches successfully with empty `PATH`
- Added a regression test that clears `PATH` and starts a runtime-managed bridge provider

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force`

Replaces #220.