### PR TITLE
Preserve prompt ordered list start numbers

### DIFF
--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
@@ -217,6 +217,28 @@ describe("prompt editor markdown serialization (doc -> markdown text)", () => {
         },
       ]).text,
     ).toBe("1. a\n2. b");
+    expect(
+      serialize([
+        {
+          type: "orderedList",
+          attrs: { start: 3 },
+          content: [
+            {
+              type: "listItem",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: "c" }] },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: "d" }] },
+              ],
+            },
+          ],
+        },
+      ]).text,
+    ).toBe("3. c\n4. d");
   });
 
   it("indents nested lists", () => {
@@ -337,6 +359,43 @@ describe("prompt editor markdown serialization (doc -> markdown text)", () => {
       },
     ]);
     expect(result.text).toBe("- first\n- ping @thr");
+    expect(result.mentions).toHaveLength(1);
+    expect(
+      result.text.slice(result.mentions[0]!.start, result.mentions[0]!.end),
+    ).toBe("@thr");
+  });
+
+  it("keeps a mention's offset correct inside an ordered list with a custom start", () => {
+    const resource = {
+      kind: "thread" as const,
+      threadId: "thr_1",
+      projectId: "proj_1",
+      label: "@thr",
+    };
+    const result = serialize([
+      {
+        type: "orderedList",
+        attrs: { start: 10 },
+        content: [
+          {
+            type: "listItem",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "ping " },
+                  {
+                    type: "mention",
+                    attrs: { resource, serializedText: "@thr" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(result.text).toBe("10. ping @thr");
     expect(result.mentions).toHaveLength(1);
     expect(
       result.text.slice(result.mentions[0]!.start, result.mentions[0]!.end),

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
@@ -374,7 +374,10 @@ export function promptEditorValueFromDoc(
     ordered: boolean,
     depth: number,
   ) => {
-    let itemNumber = 1;
+    let itemNumber =
+      ordered && typeof listNode.attrs.start === "number"
+        ? listNode.attrs.start
+        : 1;
     for (let index = 0; index < listNode.childCount; index += 1) {
       const item = listNode.child(index);
       if (hasSerializedBlock) {


### PR DESCRIPTION
## Summary
- Follow-up to #256 after the post-merge scope/review audit.
- Confirms the #256 squash merge only landed prompt editor markdown files plus the sidebar Ctrl/Cmd+B shortcut removal; unrelated `origin/main` sidebar/status story files were not part of the merge commit.
- Fixes one P1 review finding: prompt markdown serialization ignored `orderedList.attrs.start`, so a list created from `3. item` could be submitted as `1. item`.
- Adds regression coverage for custom ordered-list starts and mention offsets after a multi-digit ordered-list marker.

## Validation
- `git diff --check`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/editor/prompt-editor-list.test.ts src/components/promptbox/editor/prompt-editor-paragraph.test.ts src/components/promptbox/editor/prompt-editor-heading.test.ts src/components/promptbox/editor/prompt-editor-serialization.test.ts`

## Review Notes
- Reviewed actual squash merge `74c2115e^..74c2115e`; file list is limited to the intended prompt markdown rendering surface and sidebar shortcut removal.
- Searched for nearby-device sharing and secondary compose-page leftovers; no landed #256 files contain those surfaces.
