### PR TITLE
Make workflow banner phases collapsible and scrollable

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.stories.tsx
@@ -1,5 +1,10 @@
-import { useState } from "react";
-import type { WorkflowProgressSnapshot } from "@bb/domain";
+import { useMemo, useState } from "react";
+import type {
+  WorkflowAgentSnapshot,
+  WorkflowAgentState,
+  WorkflowPhaseSnapshot,
+  WorkflowProgressSnapshot,
+} from "@bb/domain";
 import { ThreadWorkflowCard } from "./ThreadWorkflowCard";
 import { workflowRow } from "@/test/fixtures/thread-timeline-rows";
 import { StoryCard, StoryRow } from "../../../../.ladle/story-card";
@@ -71,6 +76,104 @@ const runningWorkflow = workflowRow({
   usage: { totalTokens: 633_400, toolUses: 261, durationMs: 326_000 },
 });
 
+// A long workflow (~40 phases) so the banner's max-height/scroll and per-phase
+// collapse are exercised. Phases before the active one are done, the active one
+// has a running agent, and the rest are queued.
+const PHASE_VERBS = [
+  "Scan",
+  "Map",
+  "Audit",
+  "Refactor",
+  "Verify",
+  "Synthesize",
+  "Index",
+  "Trace",
+  "Validate",
+  "Summarize",
+];
+const PHASE_TARGETS = [
+  "data model",
+  "server routes",
+  "CLI surface",
+  "UI components",
+  "auth flow",
+  "migrations",
+  "telemetry",
+  "fixtures",
+  "docs",
+  "tests",
+];
+
+function phaseTitle(i: number): string {
+  const verb = PHASE_VERBS[i % PHASE_VERBS.length];
+  const target = PHASE_TARGETS[(i * 3) % PHASE_TARGETS.length];
+  return `${verb} ${target}`;
+}
+
+function slug(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+function buildManyPhasesSnapshot(
+  phaseCount: number,
+  activePhase: number,
+): WorkflowProgressSnapshot {
+  const phases: WorkflowPhaseSnapshot[] = [];
+  const agents: WorkflowAgentSnapshot[] = [];
+  const progressAt = 1780540129098;
+  let agentIndex = 1;
+  for (let p = 1; p <= phaseCount; p++) {
+    const title = phaseTitle(p - 1);
+    phases.push({ index: p, title });
+    const agentCount = ((p - 1) % 3) + 1; // 1..3 agents per phase
+    for (let a = 0; a < agentCount; a++) {
+      const done = p < activePhase;
+      const running = p === activePhase && a === 0;
+      const state: WorkflowAgentState = done
+        ? "done"
+        : running
+          ? "running"
+          : "queued";
+      const agent: WorkflowAgentSnapshot = {
+        index: agentIndex++,
+        label: `${slug(title)}-${a + 1}`,
+        state,
+        model: a % 2 === 0 ? "opus" : "haiku",
+        attempt: 1,
+        cached: false,
+        lastProgressAt: progressAt,
+        phaseIndex: p,
+        phaseTitle: title,
+        queuedAt: progressAt - 2_000,
+      };
+      if (state !== "queued") {
+        agent.startedAt = progressAt - 1_000;
+      }
+      if (done) {
+        agent.tokens = 42_000 + ((p * 7 + a * 13) % 90) * 1_000;
+        agent.toolCalls = 18 + ((p * 5 + a * 7) % 40);
+        agent.durationMs = 150_000 + ((p * 11 + a * 17) % 130) * 1_000;
+      } else if (running) {
+        agent.tokens = 28_400;
+        agent.toolCalls = 9;
+      }
+      agents.push(agent);
+    }
+  }
+  return { phases, agents };
+}
+
+const manyPhasesWorkflow = workflowRow({
+  id: "thr_fixture:workflow:many-phases:running",
+  status: "pending",
+  taskStatus: "running",
+  workflowName: "bb-repo-wide-audit",
+  description: "Audit the entire repository across forty phases",
+  startedAt: Date.now() - 1_472_000,
+  workflow: buildManyPhasesSnapshot(40, 12),
+  usage: { totalTokens: 4_210_000, toolUses: 1_284, durationMs: 1_472_000 },
+});
+
 function FauxComposer() {
   return (
     <div className="rounded-lg border border-border bg-popover p-3">
@@ -86,11 +189,15 @@ function FauxComposer() {
   );
 }
 
-function ToggleableCard() {
+function ToggleableCard({
+  workflow,
+}: {
+  workflow: typeof runningWorkflow;
+}) {
   const [expanded, setExpanded] = useState(true);
   return (
     <ThreadWorkflowCard
-      workflow={runningWorkflow}
+      workflow={workflow}
       isExpanded={expanded}
       onToggle={() => setExpanded((value) => !value)}
     />
@@ -107,7 +214,7 @@ export function Overview() {
       >
         <Stage>
           <div className="flex flex-col gap-2">
-            <ToggleableCard />
+            <ToggleableCard workflow={runningWorkflow} />
             <FauxComposer />
           </div>
         </Stage>
@@ -122,6 +229,69 @@ export function Overview() {
             isExpanded={collapsed}
             onToggle={() => setCollapsed((value) => !value)}
           />
+        </Stage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function ManyPhases() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="40 phases"
+        hint="caps at a max height and scrolls; each phase is its own toggle and only the active phase is expanded by default"
+      >
+        <Stage>
+          <div className="flex flex-col gap-2">
+            <ToggleableCard workflow={manyPhasesWorkflow} />
+            <FauxComposer />
+          </div>
+        </Stage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function AutoAdvance() {
+  const [activePhase, setActivePhase] = useState(3);
+  const [expanded, setExpanded] = useState(true);
+  const workflow = useMemo(
+    () =>
+      workflowRow({
+        id: "thr_fixture:workflow:auto-advance:running",
+        status: "pending",
+        taskStatus: "running",
+        workflowName: "bb-repo-wide-audit",
+        description: "Audit the entire repository across forty phases",
+        startedAt: Date.now() - 1_472_000,
+        workflow: buildManyPhasesSnapshot(40, activePhase),
+        usage: { totalTokens: 4_210_000, toolUses: 1_284, durationMs: 1_472_000 },
+      }),
+    [activePhase],
+  );
+  return (
+    <StoryCard>
+      <StoryRow
+        label="auto-advance"
+        hint="advancing the run moves the open phase forward and scrolls it into view; phases you toggle yourself stay as you left them"
+      >
+        <Stage>
+          <div className="flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={() => setActivePhase((p) => Math.min(40, p + 1))}
+              className="self-start rounded-md border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-state-hover"
+            >
+              Advance to phase {Math.min(40, activePhase + 1)}
+            </button>
+            <ThreadWorkflowCard
+              workflow={workflow}
+              isExpanded={expanded}
+              onToggle={() => setExpanded((value) => !value)}
+            />
+            <FauxComposer />
+          </div>
         </Stage>
       </StoryRow>
     </StoryCard>

--- a/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.tsx
@@ -52,10 +52,12 @@ export interface ThreadWorkflowCardProps {
  * Collapsible workflow card for the prompt stack above the composer. Surfaces a
  * running Workflow tool run the same way ThreadGoalCard surfaces the active
  * goal: collapsed shows the workflow name, agent progress, and live elapsed
- * time; expanded reveals the full phase/agent tree (reusing WorkflowWorkRowBody
- * so there is a single rendering path). Only rendered while
- * the workflow is running — once it settles it drops out of the prompt stack
- * and its timeline row carries the terminal state.
+ * time; expanded reveals the phase/agent tree (reusing WorkflowWorkRowBody so
+ * there is a single rendering path). In the banner the tree caps at a max
+ * height and scrolls, and each phase is its own collapse toggle whose expansion
+ * follows the active phase as the run advances, so a long run stays glanceable.
+ * Only rendered while the workflow is running — once it settles it drops out of
+ * the prompt stack and its timeline row carries the terminal state.
  */
 export function ThreadWorkflowCard({
   workflow,
@@ -128,7 +130,7 @@ export function ThreadWorkflowCard({
         )}
       >
         <div className="overflow-hidden bg-popover">
-          <WorkflowWorkRowBody row={workflow} />
+          <WorkflowWorkRowBody row={workflow} size="base" collapsiblePhases />
         </div>
       </section>
     </PromptStackCard>

--- a/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.tsx
+++ b/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { isSettledWorkflowAgentState } from "@bb/domain";
 import type {
   WorkflowAgentSnapshot,
@@ -5,6 +6,7 @@ import type {
 } from "@bb/domain";
 import type { TimelineViewWorkflowWorkRow } from "@bb/thread-view";
 import { Icon } from "../../ui/icon.js";
+import type { DetailScrollSize } from "../../ui/detail-scroll-size.js";
 import { TimelineDetailScroll } from "./TimelineDetailScroll.js";
 import { cn } from "@/lib/utils";
 
@@ -216,10 +218,227 @@ function phaseProgressLabel(agents: readonly WorkflowAgentSnapshot[]): string {
   return `${settled}/${agents.length}`;
 }
 
+function groupKey(group: WorkflowPhaseGroup): string {
+  return group.phase ? `phase-${group.phase.index}` : "unphased";
+}
+
+/**
+ * The phase that should be expanded by default in collapsible mode: the one
+ * with a running agent, else the first phase still in flight, else the last
+ * phase that ever produced an agent. Returns null when there is nothing to
+ * surface (no agents at all).
+ */
+function activePhaseKey(groups: readonly WorkflowPhaseGroup[]): string | null {
+  const running = groups.find((group) =>
+    group.agents.some((agent) => agent.state === "running"),
+  );
+  if (running) {
+    return groupKey(running);
+  }
+  const inFlight = groups.find(
+    (group) =>
+      group.agents.length > 0 &&
+      !group.agents.every((agent) => isSettledWorkflowAgentState(agent.state)),
+  );
+  if (inFlight) {
+    return groupKey(inFlight);
+  }
+  for (let i = groups.length - 1; i >= 0; i--) {
+    if (groups[i].agents.length > 0) {
+      return groupKey(groups[i]);
+    }
+  }
+  return null;
+}
+
+function StaticPhaseGroup({
+  group,
+  workflowSettled,
+}: {
+  group: WorkflowPhaseGroup;
+  workflowSettled: boolean;
+}) {
+  const agentLines = group.agents.map((agent) => (
+    <WorkflowAgentLine
+      key={agent.index}
+      agent={agent}
+      workflowSettled={workflowSettled}
+    />
+  ));
+  // Phase-less trailing agents have no header.
+  if (!group.phase) {
+    return <div>{agentLines}</div>;
+  }
+  return (
+    <div>
+      <div className="flex items-baseline gap-2 px-2 py-0.5">
+        <span className="text-xs font-medium text-foreground">
+          {group.phase.title}
+        </span>
+        <span className="text-xs text-subtle-foreground">
+          {phaseProgressLabel(group.agents)}
+        </span>
+      </div>
+      {agentLines}
+    </div>
+  );
+}
+
+// Leaves a small gap above the active phase when it scrolls into view so its
+// header clears the container's top fade instead of sitting flush against it.
+const ACTIVE_PHASE_SCROLL_OFFSET = 12;
+
+function CollapsiblePhaseSection({
+  group,
+  expanded,
+  isActive,
+  onToggle,
+  workflowSettled,
+}: {
+  group: WorkflowPhaseGroup;
+  expanded: boolean;
+  /**
+   * Whether this is the workflow's active phase. When a phase becomes active it
+   * scrolls itself to the top of the container so the view follows the run
+   * forward instead of leaving the user parked on a finished phase.
+   */
+  isActive: boolean;
+  onToggle: () => void;
+  workflowSettled: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const scroller = el.closest("[data-detail-scroll-area]");
+    if (scroller instanceof HTMLElement) {
+      scroller.scrollTop +=
+        el.getBoundingClientRect().top -
+        scroller.getBoundingClientRect().top -
+        ACTIVE_PHASE_SCROLL_OFFSET;
+    }
+  }, [isActive]);
+
+  const agentLines = group.agents.map((agent) => (
+    <WorkflowAgentLine
+      key={agent.index}
+      agent={agent}
+      workflowSettled={workflowSettled}
+    />
+  ));
+
+  // Phase-less trailing agents have no header to collapse under.
+  if (!group.phase) {
+    return <div ref={ref}>{agentLines}</div>;
+  }
+
+  const progress = phaseProgressLabel(group.agents);
+  // A declared-but-empty phase has nothing to reveal, so it isn't a toggle.
+  if (group.agents.length === 0) {
+    return (
+      <div ref={ref} className="flex items-center gap-1.5 px-2 py-0.5">
+        <span className="size-3 shrink-0" aria-hidden="true" />
+        <span className="text-xs font-medium text-foreground">
+          {group.phase.title}
+        </span>
+        <span className="text-xs text-subtle-foreground">{progress}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={onToggle}
+        className="flex w-full items-center gap-1.5 rounded px-2 py-0.5 text-left transition-colors hover:bg-state-hover"
+      >
+        <Icon
+          name="ChevronDown"
+          className={cn(
+            "size-3 shrink-0 text-subtle-foreground transition-transform duration-200",
+            !expanded && "-rotate-90",
+          )}
+          aria-hidden="true"
+        />
+        <span className="text-xs font-medium text-foreground">
+          {group.phase.title}
+        </span>
+        <span className="text-xs text-subtle-foreground">{progress}</span>
+      </button>
+      {expanded ? agentLines : null}
+    </div>
+  );
+}
+
+/**
+ * Collapsible phase tree for the prompt-stack banner. Expansion is derived from
+ * the active phase so it auto-advances as the run progresses — the live phase is
+ * open and the rest collapse, with no extra render to keep state in sync. A
+ * click records an override that sticks across active changes, so a phase the
+ * user explicitly opened (or closed) stays that way.
+ */
+function CollapsiblePhaseGroups({
+  groups,
+  workflowSettled,
+}: {
+  groups: readonly WorkflowPhaseGroup[];
+  workflowSettled: boolean;
+}) {
+  const activeKey = activePhaseKey(groups);
+  const [overrides, setOverrides] = useState<ReadonlyMap<string, boolean>>(
+    () => new Map(),
+  );
+  const isExpanded = (key: string): boolean =>
+    overrides.get(key) ?? key === activeKey;
+  const toggle = (key: string) =>
+    setOverrides((current) => {
+      const wasExpanded = current.get(key) ?? key === activeKey;
+      const next = new Map(current);
+      next.set(key, !wasExpanded);
+      return next;
+    });
+
+  return (
+    <>
+      {groups.map((group) => {
+        const key = groupKey(group);
+        return (
+          <CollapsiblePhaseSection
+            key={key}
+            group={group}
+            expanded={isExpanded(key)}
+            isActive={key === activeKey}
+            onToggle={() => toggle(key)}
+            workflowSettled={workflowSettled}
+          />
+        );
+      })}
+    </>
+  );
+}
+
 export function WorkflowWorkRowBody({
   row,
+  size = "delegation",
+  collapsiblePhases = false,
 }: {
   row: TimelineViewWorkflowWorkRow;
+  /** Max-height tier for the scroll container. */
+  size?: DetailScrollSize;
+  /**
+   * When true, each phase is an independent collapse toggle and expansion
+   * follows the active phase as the run advances. Used by the prompt-stack
+   * banner where a long workflow needs to stay glanceable; the timeline keeps
+   * phases fully open.
+   */
+  collapsiblePhases?: boolean;
 }) {
   const workflowSettled = row.status !== "pending";
 
@@ -243,32 +462,28 @@ export function WorkflowWorkRowBody({
 
   return (
     <TimelineDetailScroll
-      size="delegation"
-      streaming={row.status === "pending"}
+      size={size}
+      // Collapsible mode lets the active phase pull itself into view instead of
+      // chasing the bottom, which in a long run would only show empty queued
+      // phases.
+      streaming={collapsiblePhases ? false : row.status === "pending"}
       contentKey={contentKey}
     >
       <div className="flex flex-col gap-1 py-1">
-        {groups.map((group) => (
-          <div key={group.phase?.index ?? "unphased"}>
-            {group.phase ? (
-              <div className="flex items-baseline gap-2 px-2 py-0.5">
-                <span className="text-xs font-medium text-foreground">
-                  {group.phase.title}
-                </span>
-                <span className="text-xs text-subtle-foreground">
-                  {phaseProgressLabel(group.agents)}
-                </span>
-              </div>
-            ) : null}
-            {group.agents.map((agent) => (
-              <WorkflowAgentLine
-                key={agent.index}
-                agent={agent}
-                workflowSettled={workflowSettled}
-              />
-            ))}
-          </div>
-        ))}
+        {collapsiblePhases ? (
+          <CollapsiblePhaseGroups
+            groups={groups}
+            workflowSettled={workflowSettled}
+          />
+        ) : (
+          groups.map((group) => (
+            <StaticPhaseGroup
+              key={groupKey(group)}
+              group={group}
+              workflowSettled={workflowSettled}
+            />
+          ))
+        )}
         {row.error ? (
           <div className="px-2 py-0.5 text-xs text-destructive/80">
             {row.error}


### PR DESCRIPTION
## Summary
The prompt-stack workflow banner (`ThreadWorkflowCard`) now stays glanceable for long runs:

- **Max height + scroll** — the expanded body caps at a max height (`size="base"`) and scrolls instead of growing unbounded.
- **Collapsible phases** — each phase is its own collapse toggle. Expansion is *derived* from the active phase, so it **auto-advances** as the run progresses: the live phase opens, the others collapse, and the active phase scrolls itself into view with a small top gap so it clears the top fade. Explicit user toggles override and persist across active-phase changes.

`WorkflowWorkRowBody` gains two opt-in props (`size`, `collapsiblePhases`); the timeline keeps its existing fully-expanded rendering path byte-for-byte unchanged (defaults off). Internally the combined phase component was split into `StaticPhaseGroup` (timeline) and `CollapsiblePhaseGroups`/`CollapsiblePhaseSection` (banner).

Stories added to exercise the behavior with a ~40-phase fixture: `ManyPhases` (scroll + collapse) and `AutoAdvance` (button steps the run; the open phase follows).

## Tests
- `turbo run typecheck --filter=@bb/app` — clean
- `turbo run lint --filter=@bb/app` — clean
- `vitest run timeline-auto-expand.test.ts` — 17 passed
- Manual: verified in Ladle — body caps at 288px and scrolls (scrollHeight 1025 > 288), 40 collapsible toggles with only the active phase open, advancing the run moves the open phase forward + scrolls it into view, prior active auto-collapses, and a user-opened phase persists across advances. Confirmed the timeline workflow row still renders fully-expanded phase headers.

## Risks
- Low. Behavior change is gated behind `collapsiblePhases` (banner only); timeline path unchanged.
- A user toggle override is permanent for that phase (it no longer auto-collapses once set) — intentional, matches "stay as I left them".