### PR TITLE
Outdent prompt "+" button to align with text

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button.js";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -117,7 +118,12 @@ export function PromptBoxActionsMenu({
           variant="ghost"
           title="Prompt actions"
           aria-label="Prompt actions"
-          className={COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS}
+          className={cn(
+            COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS,
+            // Outdent so the "+" glyph lines up with the placeholder/text
+            // (toolbar px-3.5 + button px-2 sits 6px right of the editor's px-4).
+            "-ml-1.5",
+          )}
         >
           <Icon name="Plus" className="size-4" />
         </Button>


### PR DESCRIPTION
## Summary

The prompt actions **"+"** button sat ~6px to the right of where the editor text begins, which read as misaligned. The editor text starts at `px-4` (16px), but the toolbar row's `px-3.5` (14px) plus the button's own `px-2` (8px) internal padding placed the plus glyph at 22px.

This adds a `-ml-1.5` (−6px) left margin to the actions button so its icon box lines up with the placeholder/text. The change is scoped to this one button so the right-side paperclip / mic / stop buttons keep their existing right-edge alignment (they share the same sizing constant).

## Before / After

The plus icon box now shares the exact left edge (x=533 in dev) as the placeholder text — verified via DOM measurement and a guide-line screenshot in the dev app.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/app` — passes.
- Manually verified alignment in the dev app (DOM bounding boxes: text left = plus icon-box left = 533px).

## Risks

Low — a single CSS margin on one button, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)