### PR TITLE
Show goal objective preview in prompt-stack Goal card

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadGoalCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadGoalCard.tsx
@@ -52,6 +52,8 @@ export function ThreadGoalCard({
   if (!goal || goal.status !== "active") {
     return null;
   }
+  const objective = goal.objective.trim();
+  const hasObjective = objective.length > 0;
   return (
     <PromptStackCard
       ariaLabel="Goal"
@@ -73,9 +75,21 @@ export function ThreadGoalCard({
             className="size-3.5 shrink-0 text-muted-foreground"
             aria-hidden="true"
           />
-          <span className="min-w-0 flex-1 truncate text-left font-medium opacity-70">
-            Goal
-          </span>
+          {hasObjective ? (
+            <span className="flex min-w-0 flex-1 items-center gap-1 text-left">
+              <span className="shrink-0 text-muted-foreground">Goal:</span>
+              <span
+                className="min-w-0 truncate font-medium text-foreground opacity-70"
+                title={objective}
+              >
+                {objective}
+              </span>
+            </span>
+          ) : (
+            <span className="min-w-0 flex-1 truncate text-left font-medium opacity-70">
+              Goal
+            </span>
+          )}
           <Icon
             name="ChevronDown"
             className={cn(


### PR DESCRIPTION
## Summary

The **Goal** card was the only active-activity banner above the prompt box that showed no preview of its content — it rendered a static `Goal` label, while its siblings show their content inline (`Running workflow: <name>`, `Running background command: <desc>`, `Uncommitted · +86 -0`, `3/5 complete`).

This surfaces the objective inline using that same `muted descriptor: emphasized value` pattern the Workflow / Background-commands cards use:

- Collapsed now reads `🎯 Goal: <objective>` — muted `Goal:` + the objective in `font-medium text-foreground opacity-70`, truncated with a `title` for full text on hover.
- Falls back to the bare `Goal` label if the objective is ever empty.
- Expanded view is unchanged (full objective + token/time usage).

This also reconciles the implementation with the component's own doc comment, which already documented *"Collapsed: objective."*

All prompt-stack banners share the `PromptStackCard` chrome (rounded border, recessed surface, 32px row height, `size-3.5` muted icon, subtle chevron), so this brings the Goal card's content treatment in line with the rest of the set.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/app` ✅
- Rendered the Ladle stories (`promptbox/banner/*`) and visually compared the Goal card against the Workflow, Background-commands, Todo, and Context banners — chrome and collapsed-row treatment now match.

## Risks

Low — presentational change to a single collapsed-row label, guarded against an empty objective. No behavior or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)