### PR TITLE
Add a setting to gate prompt-box rich-text formatting (default off)

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1,10 +1,8 @@
 import { atom, useAtom } from "jotai";
 import { RESET, atomWithStorage } from "jotai/utils";
 import type { PromptMentionCommandTrigger, PromptTextMention } from "@bb/domain";
-import Placeholder from "@tiptap/extension-placeholder";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { EditorContent, useEditor, type Editor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
 import {
   useCallback,
   useEffect,
@@ -41,6 +39,7 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { createJsonLocalStorage } from "@/lib/browser-storage";
+import { useRichTextEditingPreference } from "@/lib/rich-text-editing-preference";
 import {
   arePromptDraftStatesEqual,
   isPromptDraftEmpty,
@@ -57,7 +56,7 @@ import {
   PromptMentionLinkContext,
   type PromptMentionLinkResolver,
 } from "./editor/prompt-mention-link";
-import { PromptMentionExtension } from "./editor/prompt-mention-extension";
+import { promptEditorExtensions } from "./editor/prompt-editor-extensions";
 import {
   promptCommandResourceFromSuggestion,
   promptEditorContentFromValue,
@@ -1173,38 +1172,22 @@ export function PromptBoxInternal({
     syncTriggerStateRef.current = syncTriggerState;
   }, [syncTriggerState]);
 
+  // Markdown rich-text formatting (headings/lists/marks + their live input
+  // rules) is opt-in; the default-OFF preference keeps the prompt box plain
+  // text. Toggling rebuilds the editor (see the `[richTextEditing]` deps below)
+  // so the schema and input rules switch immediately.
+  const [richTextEditing] = useRichTextEditingPreference();
+  const editorExtensions = useMemo(
+    () =>
+      promptEditorExtensions({
+        richTextEditing,
+        getPlaceholder: () => placeholderRef.current,
+      }),
+    [richTextEditing],
+  );
+
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        // Markdown formatting: marks (bold/italic/code) + block nodes
-        // (heading/lists/blockquote). Each enabled node/mark has a
-        // markdown text representation in prompt-editor-serialization.ts so the
-        // submitted prompt is plain markdown. StarterKit ships input rules for
-        // these (`# `, `- `, `1. `, `**`, `_`, `` ` ``), so typing applies
-        // formatting live. Code blocks/link/underline stay disabled: code
-        // blocks make multiline prompt editing too sticky; underline isn't
-        // markdown; links need authoring UI we don't provide.
-        blockquote: {},
-        bold: {},
-        bulletList: {},
-        code: {},
-        codeBlock: false,
-        dropcursor: false,
-        gapcursor: false,
-        heading: {},
-        horizontalRule: false,
-        italic: {},
-        link: false,
-        listItem: {},
-        orderedList: {},
-        strike: false,
-        underline: false,
-      }),
-      Placeholder.configure({
-        placeholder: () => placeholderRef.current,
-      }),
-      PromptMentionExtension,
-    ],
+    extensions: editorExtensions,
     content: promptEditorContentFromValue({
       text: value,
       mentions: mentionRanges,
@@ -1304,7 +1287,10 @@ export function PromptBoxInternal({
       syncTriggerStateRef.current(updatedEditor);
       scheduleRevealEditorSelection();
     },
-  });
+    // Rebuild the editor when the rich-text preference toggles so the schema
+    // and input rules switch. The editor is otherwise created once; its
+    // handlers route through refs (above) to stay current without rebuilding.
+  }, [richTextEditing]);
 
   useEffect(() => {
     editorRef.current = editor;

--- a/apps/app/src/components/promptbox/editor/prompt-editor-extensions.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-extensions.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getSchema } from "@tiptap/core";
+import { promptEditorExtensions } from "./prompt-editor-extensions";
+
+function schemaFor(richTextEditing: boolean) {
+  return getSchema(
+    promptEditorExtensions({ richTextEditing, getPlaceholder: () => "" }),
+  );
+}
+
+// Nodes/marks the Markdown rich-text feature added; gated by the preference.
+const GATED_NODES = ["heading", "bulletList", "orderedList", "listItem"];
+const GATED_MARKS = ["bold", "italic", "code"];
+
+describe("promptEditorExtensions", () => {
+  it("enables the Markdown nodes and marks when rich text is on", () => {
+    const schema = schemaFor(true);
+    for (const node of GATED_NODES) {
+      expect(schema.nodes[node]).toBeDefined();
+    }
+    for (const mark of GATED_MARKS) {
+      expect(schema.marks[mark]).toBeDefined();
+    }
+  });
+
+  it("disables the Markdown nodes and marks when rich text is off", () => {
+    const schema = schemaFor(false);
+    for (const node of GATED_NODES) {
+      expect(schema.nodes[node]).toBeUndefined();
+    }
+    for (const mark of GATED_MARKS) {
+      expect(schema.marks[mark]).toBeUndefined();
+    }
+  });
+
+  it("keeps paragraph, blockquote, and mention available in both modes", () => {
+    // blockquote backs the quote-into-prompt flow and must round-trip stored
+    // `> ` drafts regardless of the rich-text preference; paragraph + mention
+    // are always required by the serializer.
+    for (const richTextEditing of [true, false]) {
+      const schema = schemaFor(richTextEditing);
+      expect(schema.nodes.paragraph).toBeDefined();
+      expect(schema.nodes.blockquote).toBeDefined();
+      expect(schema.nodes.mention).toBeDefined();
+    }
+  });
+
+  it("keeps code blocks, links, strike, and underline disabled in both modes", () => {
+    for (const richTextEditing of [true, false]) {
+      const schema = schemaFor(richTextEditing);
+      expect(schema.nodes.codeBlock).toBeUndefined();
+      expect(schema.marks.link).toBeUndefined();
+      expect(schema.marks.strike).toBeUndefined();
+      expect(schema.marks.underline).toBeUndefined();
+    }
+  });
+});

--- a/apps/app/src/components/promptbox/editor/prompt-editor-extensions.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-extensions.ts
@@ -1,0 +1,63 @@
+import Placeholder from "@tiptap/extension-placeholder";
+import StarterKit from "@tiptap/starter-kit";
+import type { AnyExtension } from "@tiptap/react";
+import { PromptMentionExtension } from "./prompt-mention-extension";
+
+export interface PromptEditorExtensionsOptions {
+  /**
+   * When true, the composer enables Markdown rich-text formatting (headings,
+   * lists, bold/italic/inline code) with StarterKit's live input rules. When
+   * false (the default user preference), those nodes/marks — and their input
+   * rules — are disabled, so the prompt box stays plain text.
+   */
+  richTextEditing: boolean;
+  /** Resolves the current placeholder text at render time. */
+  getPlaceholder: () => string;
+}
+
+/**
+ * Build the TipTap extension set for the prompt box.
+ *
+ * Markdown formatting is gated behind `richTextEditing`. Each gated node/mark
+ * has a Markdown text representation in prompt-editor-serialization.ts so the
+ * submitted prompt is plain Markdown regardless of the toggle. StarterKit ships
+ * input rules for these (`# `, `- `, `1. `, `**`, `_`, `` ` ``), so when
+ * enabled, typing applies formatting live; when disabled, the node/mark and its
+ * input rule are removed and the same characters stay literal.
+ *
+ * `blockquote` is intentionally NOT gated: it predates the Markdown feature and
+ * backs the quote-into-prompt flow (appendQuoteToDraftText writes `> ` lines
+ * that the serializer parses back into blockquote nodes). It must stay in the
+ * schema in both modes, or re-parsing a quoted draft would hit an unknown node
+ * type. Code blocks/link/underline stay disabled: code blocks make multiline
+ * prompt editing too sticky; underline isn't Markdown; links need authoring UI
+ * we don't provide.
+ */
+export function promptEditorExtensions({
+  richTextEditing,
+  getPlaceholder,
+}: PromptEditorExtensionsOptions): AnyExtension[] {
+  return [
+    StarterKit.configure({
+      blockquote: {},
+      bold: richTextEditing ? {} : false,
+      bulletList: richTextEditing ? {} : false,
+      code: richTextEditing ? {} : false,
+      codeBlock: false,
+      dropcursor: false,
+      gapcursor: false,
+      heading: richTextEditing ? {} : false,
+      horizontalRule: false,
+      italic: richTextEditing ? {} : false,
+      link: false,
+      listItem: richTextEditing ? {} : false,
+      orderedList: richTextEditing ? {} : false,
+      strike: false,
+      underline: false,
+    }),
+    Placeholder.configure({
+      placeholder: () => getPlaceholder(),
+    }),
+    PromptMentionExtension,
+  ];
+}

--- a/apps/app/src/lib/rich-text-editing-preference.ts
+++ b/apps/app/src/lib/rich-text-editing-preference.ts
@@ -1,0 +1,28 @@
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import { createJsonLocalStorage } from "./browser-storage";
+
+export const RICH_TEXT_EDITING_STORAGE_KEY = "bb.promptbox.rich-text-editing";
+
+/**
+ * Default OFF: the prompt box behaves as a plain-text editor. When ON, typing
+ * Markdown (`# `, `- `, `1. `, `**`, `_`, `` ` ``) live-formats into headings,
+ * lists, bold, italic, and inline code in the composer (see
+ * {@link promptEditorExtensions}). The submitted prompt is plain Markdown text
+ * either way — this only controls the live editing experience. Blockquotes
+ * (`> `, used by the quote-into-prompt feature) are unaffected by this setting.
+ */
+export const RICH_TEXT_EDITING_DEFAULT = false;
+
+const richTextEditingStorage = createJsonLocalStorage<boolean>();
+
+export const richTextEditingPreferenceAtom = atomWithStorage<boolean>(
+  RICH_TEXT_EDITING_STORAGE_KEY,
+  RICH_TEXT_EDITING_DEFAULT,
+  richTextEditingStorage,
+  { getOnInit: true },
+);
+
+export function useRichTextEditingPreference() {
+  return useAtom(richTextEditingPreferenceAtom);
+}

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -37,6 +37,7 @@ import {
   type FaviconColorPreference,
 } from "@/lib/favicon-color-preference";
 import { useOpenLinksInAppBrowserPreference } from "@/lib/in-app-browser-link-preference";
+import { useRichTextEditingPreference } from "@/lib/rich-text-editing-preference";
 import { useNavigateToThreadAfterCreatePreference } from "@/lib/root-compose-create-preference";
 import { cn } from "@/lib/utils";
 import {
@@ -91,6 +92,11 @@ export interface RootComposeBehaviorSettingsControlProps {
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
 }
 
+export interface RichTextEditingSettingsControlProps {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+}
+
 export interface FaviconColorSettingsControlProps {
   faviconColor: FaviconColorPreference;
   onFaviconColorChange: (faviconColor: FaviconColorPreference) => void;
@@ -103,8 +109,10 @@ export interface GeneralSettingsSectionProps {
   onFaviconColorChange: (faviconColor: FaviconColorPreference) => void;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
   onOpenLinksInAppBrowserChange: (enabled: boolean) => void;
+  onRichTextEditingChange: (enabled: boolean) => void;
   onThemePreferenceChange: (themePreference: ThemePreference) => void;
   openLinksInAppBrowser: boolean;
+  richTextEditing: boolean;
   themePreference: ThemePreference;
 }
 
@@ -368,6 +376,7 @@ export function LocalOpenTargetSettingsSection({
 const IN_APP_BROWSER_LINK_SETTING_LABEL = "Open links in the in-app browser";
 const NAVIGATE_TO_THREAD_AFTER_CREATE_SETTING_LABEL =
   "Navigate to threads on creation";
+const RICH_TEXT_EDITING_SETTING_LABEL = "Rich text formatting in the prompt box";
 
 export function RootComposeBehaviorSettingsControl({
   navigateToThreadAfterCreate,
@@ -402,6 +411,24 @@ export function InAppBrowserLinkSettingsControl({
   );
 }
 
+export function RichTextEditingSettingsControl({
+  enabled,
+  onEnabledChange,
+}: RichTextEditingSettingsControlProps) {
+  return (
+    <SettingsWithControl
+      label={RICH_TEXT_EDITING_SETTING_LABEL}
+      description="Format the prompt box with Markdown as you type — headings, lists, bold, italic, and inline code. When off, the prompt box stays plain text."
+    >
+      <Switch
+        checked={enabled}
+        onCheckedChange={onEnabledChange}
+        aria-label={RICH_TEXT_EDITING_SETTING_LABEL}
+      />
+    </SettingsWithControl>
+  );
+}
+
 export function GeneralSettingsSection({
   desktopBrowserAvailable,
   faviconColor,
@@ -409,8 +436,10 @@ export function GeneralSettingsSection({
   onFaviconColorChange,
   onNavigateToThreadAfterCreateChange,
   onOpenLinksInAppBrowserChange,
+  onRichTextEditingChange,
   onThemePreferenceChange,
   openLinksInAppBrowser,
+  richTextEditing,
   themePreference,
 }: GeneralSettingsSectionProps) {
   return (
@@ -463,6 +492,11 @@ export function GeneralSettingsSection({
           onNavigateToThreadAfterCreateChange={
             onNavigateToThreadAfterCreateChange
           }
+        />
+
+        <RichTextEditingSettingsControl
+          enabled={richTextEditing}
+          onEnabledChange={onRichTextEditingChange}
         />
 
         {desktopBrowserAvailable ? (
@@ -736,6 +770,7 @@ export function SettingsView() {
     useOpenLinksInAppBrowserPreference();
   const [navigateToThreadAfterCreate, setNavigateToThreadAfterCreate] =
     useNavigateToThreadAfterCreatePreference();
+  const [richTextEditing, setRichTextEditing] = useRichTextEditingPreference();
   // The in-app browser only exists on desktop; hide the toggle entirely on web,
   // where it would have no effect.
   const [desktopBrowserAvailable] = useState(isDesktopBrowserAvailable);
@@ -751,10 +786,12 @@ export function SettingsView() {
           faviconColor={faviconColor}
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
           openLinksInAppBrowser={openLinksInAppBrowser}
+          richTextEditing={richTextEditing}
           themePreference={themePreference}
           onFaviconColorChange={setFaviconColor}
           onNavigateToThreadAfterCreateChange={setNavigateToThreadAfterCreate}
           onOpenLinksInAppBrowserChange={setOpenLinksInAppBrowser}
+          onRichTextEditingChange={setRichTextEditing}
           onThemePreferenceChange={setPreferredTheme}
         />
 


### PR DESCRIPTION
## Summary

Makes the prompt box's live Markdown rich-text formatting an opt-in user setting, **disabled by default**. With it off, the composer is plain text — typing `# `, `- `, `**`, etc. stays literal. Toggling it on restores today's behavior.

The "rich text editing feature" here is the live formatting added by the "Add markdown rendering to the prompt box" change (commit `74c2115e0`), which flipped 7 StarterKit nodes/marks on. This PR gates exactly those behind a preference.

## What changed

- **New `rich-text-editing-preference`** (`apps/app/src/lib/rich-text-editing-preference.ts`) — localStorage-backed boolean, default `false`, mirroring the existing boolean-preference pattern (`root-compose-create-preference.ts`).
- **Extract `promptEditorExtensions`** (`editor/prompt-editor-extensions.ts`) — builds the TipTap extension set, gating the 7 Markdown nodes/marks (`heading`, `bulletList`, `orderedList`, `listItem`, `bold`, `italic`, `code`) on the preference. Disabling a node also removes its input rule, so the characters stay literal.
- **`PromptBoxInternal`** reads the preference and passes `[richTextEditing]` to `useEditor`'s deps, so the editor rebuilds (schema + input rules switch) immediately on toggle.
- **Settings → General** gets a "Rich text formatting in the prompt box" switch.
- **Unit tests** for the on/off schema gating.

## Deliberate scope: blockquote stays enabled

`blockquote` is **not** gated. It predates the Markdown feature and backs the quote-into-prompt flow (`appendQuoteToDraftText` writes `> ` lines the serializer parses back into blockquote nodes). Keeping it enabled in both modes means stored quoted drafts still round-trip and required **no serializer change** and **no existing test/story changes**.

## Tests

- `tsc --noEmit`: clean
- ESLint on changed files: clean
- `vitest run` (promptbox + editor + settings): **122 passed (20 files)**, including the existing blockquote-dependent `PromptBoxInternal` test, plus 4 new gating tests.

## Risk

Low. Default-off changes the prompt box's out-of-the-box behavior to plain text (intended). Live input-rule formatting has no pre-existing automated coverage; the new schema-gating tests plus the existing `WithBlockquoteRow` story are the guards. Editor rebuild on toggle resets caret/undo, which is acceptable for a rare settings action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
