### PR TITLE
Add localhost link rewrite setting

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -20,6 +20,7 @@ const workspaceLinkRouting = {
 
 afterEach(() => {
   cleanup();
+  window.localStorage.clear();
   vi.clearAllMocks();
 });
 
@@ -64,5 +65,20 @@ describe("MarkdownPreview", () => {
     fireEvent.click(screen.getByRole("link", { name: "local thread" }));
 
     expect(onOpenLink).toHaveBeenCalledWith({ href });
+  });
+
+  it("rewrites localhost link hrefs without changing the visible text", () => {
+    const displayedText = "http://127.0.0.1:5173";
+
+    render(
+      <MarkdownPreview
+        content={`Open [${displayedText}](http://127.0.0.1:5173/demo).`}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: displayedText });
+    expect(link.getAttribute("href")).toBe(
+      `${window.location.protocol}//${window.location.hostname}:5173/demo`,
+    );
   });
 });

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -48,6 +48,10 @@ import { MarkdownMermaidDiagram } from "./markdown-mermaid-diagram.js";
 import type { PromptTextMention } from "@bb/domain";
 import type { TimelineTitleLinkResolver } from "@/components/thread/timeline/TimelineTitleView.js";
 import { usePreferredTheme, type Theme } from "@/hooks/useTheme";
+import {
+  rewriteLocalhostLinkHref,
+  useRewriteLocalhostLinksPreference,
+} from "@/lib/localhost-link-rewrite-preference";
 import { resolveRouteHref } from "@/lib/route-paths";
 import { cn } from "@/lib/utils";
 
@@ -79,6 +83,7 @@ export interface MarkdownThreadMentions {
 interface MarkdownAnchorProps
   extends ComponentPropsWithoutRef<"a">, ExtraProps {
   linkRouting?: MarkdownLinkRouting;
+  rewriteLocalhostLinks?: boolean;
 }
 
 interface IsMarkdownAppRouteHrefArgs {
@@ -88,6 +93,7 @@ interface IsMarkdownAppRouteHrefArgs {
 interface BuildMarkdownComponentsArgs {
   linkRouting?: MarkdownLinkRouting;
   preferredTheme: Theme;
+  rewriteLocalhostLinks: boolean;
   setExpandedImageUrl: ExpandedImageUrlSetter;
   threadMentions?: MarkdownThreadMentions;
 }
@@ -152,6 +158,7 @@ type MarkdownCodeProps = ComponentPropsWithoutRef<"code"> & ExtraProps;
 interface MarkdownCodeRendererProps extends MarkdownCodeProps {
   linkRouting?: MarkdownLinkRouting;
   preferredTheme: Theme;
+  rewriteLocalhostLinks: boolean;
 }
 type MarkdownHeadingProps = ComponentPropsWithoutRef<"h1"> & ExtraProps;
 type MarkdownHrProps = ComponentPropsWithoutRef<"hr"> & ExtraProps;
@@ -378,19 +385,26 @@ function MarkdownAnchor({
   children,
   href,
   linkRouting,
+  rewriteLocalhostLinks,
   ...anchorProps
 }: MarkdownAnchorProps) {
   const localFileRouting = linkRouting?.localFile;
   const onOpenLocalFileLink = localFileRouting?.onOpenLink;
-  const isAppRouteHref = isMarkdownAppRouteHref({ href });
+  const rewrittenHref = rewriteLocalhostLinkHref({
+    currentHostname:
+      typeof window === "undefined" ? undefined : window.location.hostname,
+    enabled: rewriteLocalhostLinks ?? false,
+    href,
+  });
+  const isAppRouteHref = isMarkdownAppRouteHref({ href: rewrittenHref });
   const localFileLink =
     !isAppRouteHref && localFileRouting
       ? parseLocalFileHref({
           absoluteLinks: localFileRouting.absoluteLinks,
-          href,
+          href: rewrittenHref,
         })
       : null;
-  const anchorHref = buildLocalFileAnchorHref(localFileLink, href);
+  const anchorHref = buildLocalFileAnchorHref(localFileLink, rewrittenHref);
   const handleAnchorClick = (event: MarkdownAnchorEvent) => {
     if (localFileLink && onOpenLocalFileLink) {
       if (onOpenLocalFileLink(localFileLink)) {
@@ -402,7 +416,11 @@ function MarkdownAnchor({
     // Let timeline/terminal hosts claim web links first. Absolute app-origin
     // URLs can still be browser destinations even though they resolve to an
     // app route.
-    if (linkRouting?.onOpenLink && href && linkRouting.onOpenLink({ href })) {
+    if (
+      linkRouting?.onOpenLink &&
+      rewrittenHref &&
+      linkRouting.onOpenLink({ href: rewrittenHref })
+    ) {
       event.preventDefault();
       return;
     }
@@ -442,6 +460,7 @@ function MarkdownCode({
   linkRouting,
   node: _node,
   preferredTheme,
+  rewriteLocalhostLinks,
   ...props
 }: MarkdownCodeRendererProps) {
   const codeText = String(children ?? "").replace(/\n$/, "");
@@ -486,7 +505,11 @@ function MarkdownCode({
   });
   if (markdownFileHref !== null) {
     return (
-      <MarkdownAnchor href={markdownFileHref} linkRouting={linkRouting}>
+      <MarkdownAnchor
+        href={markdownFileHref}
+        linkRouting={linkRouting}
+        rewriteLocalhostLinks={rewriteLocalhostLinks}
+      >
         {codeText}
       </MarkdownAnchor>
     );
@@ -680,11 +703,18 @@ function resolveMarkdownSourceMedia({
 function buildMarkdownComponents({
   linkRouting,
   preferredTheme,
+  rewriteLocalhostLinks,
   setExpandedImageUrl,
   threadMentions,
 }: BuildMarkdownComponentsArgs): Components {
   function MarkdownLink(props: MarkdownAnchorProps) {
-    return <MarkdownAnchor {...props} linkRouting={linkRouting} />;
+    return (
+      <MarkdownAnchor
+        {...props}
+        linkRouting={linkRouting}
+        rewriteLocalhostLinks={rewriteLocalhostLinks}
+      />
+    );
   }
 
   function MarkdownCodeRenderer(props: MarkdownCodeProps) {
@@ -693,6 +723,7 @@ function buildMarkdownComponents({
         {...props}
         linkRouting={linkRouting}
         preferredTheme={preferredTheme}
+        rewriteLocalhostLinks={rewriteLocalhostLinks}
       />
     );
   }
@@ -874,6 +905,7 @@ function MarkdownPreviewComponent({
   urlTransform,
 }: MarkdownPreviewProps) {
   const preferredTheme = usePreferredTheme();
+  const [rewriteLocalhostLinks] = useRewriteLocalhostLinksPreference();
   const contentRef = useMarkdownContentWidthVariable();
   const [expandedImageUrl, setExpandedImageUrl] = useState<string | null>(null);
   const localFileRouting = linkRouting?.localFile;
@@ -894,10 +926,11 @@ function MarkdownPreviewComponent({
       buildMarkdownComponents({
         linkRouting,
         preferredTheme,
+        rewriteLocalhostLinks,
         setExpandedImageUrl,
         threadMentions,
       }),
-    [linkRouting, preferredTheme, threadMentions],
+    [linkRouting, preferredTheme, rewriteLocalhostLinks, threadMentions],
   );
   // The thread-mention pipeline only activates when `threadMentions` is set.
   // Assistant content (no mentions) keeps the unchanged `[remarkGfm]` pipeline,

--- a/apps/app/src/lib/localhost-link-rewrite-preference.test.ts
+++ b/apps/app/src/lib/localhost-link-rewrite-preference.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { rewriteLocalhostLinkHref } from "./localhost-link-rewrite-preference";
+
+describe("rewriteLocalhostLinkHref", () => {
+  it("rewrites localhost and 127.0.0.1 http links to the current page hostname", () => {
+    expect(
+      rewriteLocalhostLinkHref({
+        currentHostname: "100.64.158.8",
+        enabled: true,
+        href: "http://localhost:5173/app?debug=1#ready",
+      }),
+    ).toBe("http://100.64.158.8:5173/app?debug=1#ready");
+
+    expect(
+      rewriteLocalhostLinkHref({
+        currentHostname: "100.64.158.8",
+        enabled: true,
+        href: "https://127.0.0.1:8443/",
+      }),
+    ).toBe("https://100.64.158.8:8443/");
+  });
+
+  it("leaves visible hrefs unchanged when disabled or not a localhost http link", () => {
+    expect(
+      rewriteLocalhostLinkHref({
+        currentHostname: "100.64.158.8",
+        enabled: false,
+        href: "http://localhost:5173/",
+      }),
+    ).toBe("http://localhost:5173/");
+
+    for (const href of [
+      "https://example.com/docs",
+      "mailto:hi@example.com",
+      "/projects/proj_123",
+      "file:///workspace/app.ts",
+      "not a url",
+      undefined,
+    ]) {
+      expect(
+        rewriteLocalhostLinkHref({
+          currentHostname: "100.64.158.8",
+          enabled: true,
+          href,
+        }),
+      ).toBe(href);
+    }
+  });
+});

--- a/apps/app/src/lib/localhost-link-rewrite-preference.ts
+++ b/apps/app/src/lib/localhost-link-rewrite-preference.ts
@@ -1,0 +1,60 @@
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import { createJsonLocalStorage } from "./browser-storage";
+
+export const REWRITE_LOCALHOST_LINKS_STORAGE_KEY =
+  "bb.rewriteLocalhostLinks";
+
+export const REWRITE_LOCALHOST_LINKS_DEFAULT = true;
+
+interface RewriteLocalhostLinkHrefArgs {
+  currentHostname: string | undefined;
+  enabled: boolean;
+  href: string | undefined;
+}
+
+const LOOPBACK_LINK_HOSTNAMES = new Set(["127.0.0.1", "localhost"]);
+
+function isRewriteableLoopbackLink(url: URL): boolean {
+  return (
+    (url.protocol === "http:" || url.protocol === "https:") &&
+    LOOPBACK_LINK_HOSTNAMES.has(url.hostname.toLowerCase())
+  );
+}
+
+export function rewriteLocalhostLinkHref({
+  currentHostname,
+  enabled,
+  href,
+}: RewriteLocalhostLinkHrefArgs): string | undefined {
+  if (!enabled || href === undefined || currentHostname === undefined) {
+    return href;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  if (!isRewriteableLoopbackLink(url)) {
+    return href;
+  }
+
+  url.hostname = currentHostname;
+  return url.toString();
+}
+
+const rewriteLocalhostLinksStorage = createJsonLocalStorage<boolean>();
+
+export const rewriteLocalhostLinksPreferenceAtom = atomWithStorage<boolean>(
+  REWRITE_LOCALHOST_LINKS_STORAGE_KEY,
+  REWRITE_LOCALHOST_LINKS_DEFAULT,
+  rewriteLocalhostLinksStorage,
+  { getOnInit: true },
+);
+
+export function useRewriteLocalhostLinksPreference() {
+  return useAtom(rewriteLocalhostLinksPreferenceAtom);
+}

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -37,6 +37,7 @@ import {
   type FaviconColorPreference,
 } from "@/lib/favicon-color-preference";
 import { useOpenLinksInAppBrowserPreference } from "@/lib/in-app-browser-link-preference";
+import { useRewriteLocalhostLinksPreference } from "@/lib/localhost-link-rewrite-preference";
 import { useRichTextEditingPreference } from "@/lib/rich-text-editing-preference";
 import { useNavigateToThreadAfterCreatePreference } from "@/lib/root-compose-create-preference";
 import { cn } from "@/lib/utils";
@@ -87,6 +88,11 @@ export interface InAppBrowserLinkSettingsControlProps {
   onEnabledChange: (enabled: boolean) => void;
 }
 
+export interface RewriteLocalhostLinksSettingsControlProps {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+}
+
 export interface RootComposeBehaviorSettingsControlProps {
   navigateToThreadAfterCreate: boolean;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
@@ -109,9 +115,11 @@ export interface GeneralSettingsSectionProps {
   onFaviconColorChange: (faviconColor: FaviconColorPreference) => void;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
   onOpenLinksInAppBrowserChange: (enabled: boolean) => void;
+  onRewriteLocalhostLinksChange: (enabled: boolean) => void;
   onRichTextEditingChange: (enabled: boolean) => void;
   onThemePreferenceChange: (themePreference: ThemePreference) => void;
   openLinksInAppBrowser: boolean;
+  rewriteLocalhostLinks: boolean;
   richTextEditing: boolean;
   themePreference: ThemePreference;
 }
@@ -374,6 +382,7 @@ export function LocalOpenTargetSettingsSection({
 }
 
 const IN_APP_BROWSER_LINK_SETTING_LABEL = "Open links in the in-app browser";
+const REWRITE_LOCALHOST_LINKS_SETTING_LABEL = "Rewrite localhost links";
 const NAVIGATE_TO_THREAD_AFTER_CREATE_SETTING_LABEL =
   "Navigate to threads on creation";
 const RICH_TEXT_EDITING_SETTING_LABEL = "Rich text formatting in the prompt box";
@@ -411,6 +420,24 @@ export function InAppBrowserLinkSettingsControl({
   );
 }
 
+export function RewriteLocalhostLinksSettingsControl({
+  enabled,
+  onEnabledChange,
+}: RewriteLocalhostLinksSettingsControlProps) {
+  return (
+    <SettingsWithControl
+      label={REWRITE_LOCALHOST_LINKS_SETTING_LABEL}
+      description="When a rendered Markdown link points to localhost or 127.0.0.1, keep the displayed text unchanged but point the link to this page's hostname."
+    >
+      <Switch
+        checked={enabled}
+        onCheckedChange={onEnabledChange}
+        aria-label={REWRITE_LOCALHOST_LINKS_SETTING_LABEL}
+      />
+    </SettingsWithControl>
+  );
+}
+
 export function RichTextEditingSettingsControl({
   enabled,
   onEnabledChange,
@@ -436,9 +463,11 @@ export function GeneralSettingsSection({
   onFaviconColorChange,
   onNavigateToThreadAfterCreateChange,
   onOpenLinksInAppBrowserChange,
+  onRewriteLocalhostLinksChange,
   onRichTextEditingChange,
   onThemePreferenceChange,
   openLinksInAppBrowser,
+  rewriteLocalhostLinks,
   richTextEditing,
   themePreference,
 }: GeneralSettingsSectionProps) {
@@ -505,6 +534,11 @@ export function GeneralSettingsSection({
             onEnabledChange={onOpenLinksInAppBrowserChange}
           />
         ) : null}
+
+        <RewriteLocalhostLinksSettingsControl
+          enabled={rewriteLocalhostLinks}
+          onEnabledChange={onRewriteLocalhostLinksChange}
+        />
       </div>
     </SettingsSection>
   );
@@ -768,6 +802,8 @@ export function SettingsView() {
   const [fileTargetId, setFileTargetId] = useFileOpenTargetPreference();
   const [openLinksInAppBrowser, setOpenLinksInAppBrowser] =
     useOpenLinksInAppBrowserPreference();
+  const [rewriteLocalhostLinks, setRewriteLocalhostLinks] =
+    useRewriteLocalhostLinksPreference();
   const [navigateToThreadAfterCreate, setNavigateToThreadAfterCreate] =
     useNavigateToThreadAfterCreatePreference();
   const [richTextEditing, setRichTextEditing] = useRichTextEditingPreference();
@@ -786,11 +822,13 @@ export function SettingsView() {
           faviconColor={faviconColor}
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
           openLinksInAppBrowser={openLinksInAppBrowser}
+          rewriteLocalhostLinks={rewriteLocalhostLinks}
           richTextEditing={richTextEditing}
           themePreference={themePreference}
           onFaviconColorChange={setFaviconColor}
           onNavigateToThreadAfterCreateChange={setNavigateToThreadAfterCreate}
           onOpenLinksInAppBrowserChange={setOpenLinksInAppBrowser}
+          onRewriteLocalhostLinksChange={setRewriteLocalhostLinks}
           onRichTextEditingChange={setRichTextEditing}
           onThemePreferenceChange={setPreferredTheme}
         />


### PR DESCRIPTION
## Summary
- add a persisted setting to rewrite rendered localhost/127.0.0.1 Markdown link hrefs to the current page hostname
- keep visible link text unchanged while passing rewritten hrefs through link routing
- cover the URL helper and Markdown rendering behavior with regression tests

## Tests
- pnpm exec turbo run test --filter=@bb/app -- markdown-preview localhost-link-rewrite-preference
- pnpm exec turbo run typecheck --filter=@bb/app