### PR TITLE
[codex] Fix triple-click agent message selection

### DIFF
--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
@@ -2,33 +2,44 @@
 
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SelectableMessageProse } from "./SelectableMessageProse.js";
+import {
+  MULTI_CLICK_SELECTION_REPORT_DELAY_MS,
+  SelectableMessageProse,
+} from "./SelectableMessageProse.js";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
 function makeWindowSelection({
+  commonAncestorContainer,
+  focusNode,
+  intersectsNode,
   node,
   text,
 }: {
+  commonAncestorContainer?: Node;
+  focusNode?: Node;
+  intersectsNode?: (node: Node) => boolean;
   node: Node;
   text: string;
 }): Selection {
   const rect = new DOMRect(10, 20, 30, 8);
   const range = {
-    commonAncestorContainer: node,
+    commonAncestorContainer: commonAncestorContainer ?? node,
     getBoundingClientRect: () => rect,
     getClientRects: () => ({
       length: 1,
       item: (index: number) => (index === 0 ? rect : null),
     }),
+    intersectsNode: intersectsNode ?? (() => true),
   } as unknown as Range;
   return {
     anchorNode: node,
-    commonAncestorContainer: node,
-    focusNode: node,
+    commonAncestorContainer: commonAncestorContainer ?? node,
+    focusNode: focusNode ?? node,
     getRangeAt: () => range,
     isCollapsed: false,
     rangeCount: 1,
@@ -36,9 +47,9 @@ function makeWindowSelection({
   } as unknown as Selection;
 }
 
-function mockWindowSelection({ node, text }: { node: Node; text: string }) {
+function mockWindowSelection(args: Parameters<typeof makeWindowSelection>[0]) {
   vi.spyOn(window, "getSelection").mockReturnValue(
-    makeWindowSelection({ node, text }),
+    makeWindowSelection(args),
   );
 }
 
@@ -106,7 +117,13 @@ describe("SelectableMessageProse", () => {
   });
 
   it("reports double-click selections from the message click target", async () => {
+    vi.useFakeTimers();
     const onSelect = vi.fn();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(performance.now());
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
     const { getByText } = render(
       <SelectableMessageProse onSelect={onSelect}>
         Double click target paragraph text
@@ -122,12 +139,16 @@ describe("SelectableMessageProse", () => {
     });
     fireEvent.doubleClick(target, { detail: 2 });
 
-    await waitFor(() =>
-      expect(onSelect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          text: "Double click target paragraph text",
-        }),
-      ),
+    await vi.advanceTimersByTimeAsync(
+      MULTI_CLICK_SELECTION_REPORT_DELAY_MS - 1,
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Double click target paragraph text",
+      }),
     );
   });
 
@@ -152,6 +173,87 @@ describe("SelectableMessageProse", () => {
       expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           text: "Triple click selectable paragraph text",
+        }),
+      ),
+    );
+  });
+
+  it("cancels a delayed double-click report when a third click completes", async () => {
+    vi.useFakeTimers();
+    const onSelect = vi.fn();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(performance.now());
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const { getByText } = render(
+      <SelectableMessageProse onSelect={onSelect}>
+        Triple click replaces word selection
+      </SelectableMessageProse>,
+    );
+    const target = getByText("Triple click replaces word selection");
+    const textNode = target.firstChild;
+    expect(textNode).not.toBeNull();
+
+    let currentSelection = makeWindowSelection({
+      node: textNode!,
+      text: "Triple",
+    });
+    vi.spyOn(window, "getSelection").mockImplementation(() => currentSelection);
+
+    fireEvent.doubleClick(target, { detail: 2 });
+    await vi.advanceTimersByTimeAsync(
+      MULTI_CLICK_SELECTION_REPORT_DELAY_MS - 1,
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+
+    currentSelection = makeWindowSelection({
+      node: textNode!,
+      text: "Triple click replaces word selection",
+    });
+    fireEvent.click(target, { detail: 3 });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Triple click replaces word selection",
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts triple-click selections that spill only whitespace past the message", async () => {
+    const onSelect = vi.fn();
+    const { container, getByTestId, getByText } = render(
+      <div>
+        <SelectableMessageProse onSelect={onSelect}>
+          <p>Boundary paragraph in agent message.</p>
+        </SelectableMessageProse>
+        <div data-testid="message-actions">Actions</div>
+      </div>,
+    );
+    const target = getByText("Boundary paragraph in agent message.");
+    const textNode = target.firstChild;
+    const messageNode = container.firstChild;
+    const outsideNode = getByTestId("message-actions");
+    expect(textNode).not.toBeNull();
+    expect(messageNode).not.toBeNull();
+
+    mockWindowSelection({
+      commonAncestorContainer: messageNode!,
+      focusNode: outsideNode,
+      intersectsNode: (node) => node.contains(textNode!),
+      node: textNode!,
+      text: "Boundary paragraph in agent message.\n\n",
+    });
+    fireEvent.click(target, { detail: 3 });
+
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "Boundary paragraph in agent message.",
         }),
       ),
     );

--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
@@ -17,6 +17,8 @@ export interface SelectableMessageProseProps {
   onSelect?: (selection: MessageProseSelection | null) => void;
 }
 
+export const MULTI_CLICK_SELECTION_REPORT_DELAY_MS = 180;
+
 /**
  * Pure predicate: does `selection` fall entirely within `node`?
  *
@@ -61,6 +63,34 @@ function firstClientRect(range: Range): DOMRect | null {
   return rect.width > 0 || rect.height > 0 ? rect : null;
 }
 
+function normalizeSelectionText(text: string): string {
+  return text.replace(/\s+/gu, " ").trim();
+}
+
+function isSelectionBoundarySpillWithinNode(
+  node: HTMLElement,
+  range: Range,
+  selectionText: string,
+): boolean {
+  if (typeof range.intersectsNode !== "function") {
+    return false;
+  }
+  if (!range.intersectsNode(node)) {
+    return false;
+  }
+
+  const normalizedSelectionText = normalizeSelectionText(selectionText);
+  if (normalizedSelectionText.length === 0) {
+    return false;
+  }
+
+  // Triple-clicking a final paragraph can place the focus/common nodes just
+  // outside this wrapper while selecting only this node's text plus newlines.
+  return normalizeSelectionText(node.textContent ?? "").includes(
+    normalizedSelectionText,
+  );
+}
+
 function readSelectionWithinNode(
   node: HTMLElement | null,
 ): MessageProseSelection | null {
@@ -78,6 +108,12 @@ function readSelectionWithinNode(
   });
   if (accepted) {
     const text = selection.toString().trim();
+    const rect = firstClientRect(range);
+    return text.length > 0 && rect !== null ? { text, rect } : null;
+  }
+
+  const text = selection.toString().trim();
+  if (isSelectionBoundarySpillWithinNode(node, range, text)) {
     const rect = firstClientRect(range);
     return text.length > 0 && rect !== null ? { text, rect } : null;
   }
@@ -109,6 +145,7 @@ export function SelectableMessageProse({
     // N messages don't thrash a shared controller.
     let hadSelection = false;
     let pointerIsDown = false;
+    let multiClickTimer: number | null = null;
     const report = () => {
       frame = null;
       const next = readSelectionWithinNode(nodeRef.current);
@@ -121,21 +158,40 @@ export function SelectableMessageProse({
       window.cancelAnimationFrame(frame);
       frame = null;
     };
+    const cancelMultiClickTimer = () => {
+      if (multiClickTimer === null) return;
+      window.clearTimeout(multiClickTimer);
+      multiClickTimer = null;
+    };
     const schedule = () => {
       if (frame !== null) return;
       frame = window.requestAnimationFrame(report);
     };
     const scheduleFresh = () => {
+      cancelMultiClickTimer();
       cancelFrame();
       schedule();
+    };
+    const scheduleAfterMultiClickDelay = () => {
+      cancelFrame();
+      cancelMultiClickTimer();
+      multiClickTimer = window.setTimeout(() => {
+        multiClickTimer = null;
+        schedule();
+      }, MULTI_CLICK_SELECTION_REPORT_DELAY_MS);
     };
     const handleSelectionChange = () => {
       if (pointerIsDown) {
         return;
       }
+      if (multiClickTimer !== null) {
+        return;
+      }
       schedule();
     };
     const handlePointerDown = () => {
+      cancelMultiClickTimer();
+      cancelFrame();
       pointerIsDown = true;
     };
     const handlePointerEnd = () => {
@@ -146,9 +202,16 @@ export function SelectableMessageProse({
       if (event.detail < 2) {
         return;
       }
+      if (event.detail === 2) {
+        scheduleAfterMultiClickDelay();
+        return;
+      }
       // Multi-click selection can be finalized after pointerup. Replace any
       // stale pointerup read with one explicitly tied to the completed click.
       scheduleFresh();
+    };
+    const handleDoubleClick = () => {
+      scheduleAfterMultiClickDelay();
     };
     const node = nodeRef.current;
 
@@ -159,9 +222,10 @@ export function SelectableMessageProse({
     document.addEventListener("selectionchange", handleSelectionChange);
     document.addEventListener("keyup", schedule);
     node?.addEventListener("click", handleMultiClick);
-    node?.addEventListener("dblclick", scheduleFresh);
+    node?.addEventListener("dblclick", handleDoubleClick);
     return () => {
       if (frame !== null) window.cancelAnimationFrame(frame);
+      cancelMultiClickTimer();
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("pointerup", handlePointerEnd);
       document.removeEventListener("pointercancel", handlePointerEnd);
@@ -169,7 +233,7 @@ export function SelectableMessageProse({
       document.removeEventListener("selectionchange", handleSelectionChange);
       document.removeEventListener("keyup", schedule);
       node?.removeEventListener("click", handleMultiClick);
-      node?.removeEventListener("dblclick", scheduleFresh);
+      node?.removeEventListener("dblclick", handleDoubleClick);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes flaky triple-click selection handling in normal agent messages.

Chrome can triple-click a final paragraph and produce a range whose selected text is only the paragraph plus trailing newlines, while the range focus/common ancestor lands just outside the selectable prose wrapper. The selection toolbar rejected that as out-of-bounds. This change accepts that whitespace-only boundary spillover while still rejecting real cross-message selections.

It also delays double-click selection reporting briefly so the toolbar does not flash between click 2 and click 3 when the user is triple-clicking.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/components/thread/timeline/SelectableMessageProse.events.test.tsx src/components/thread/timeline/SelectableMessageProse.test.ts src/components/thread/timeline/TimelineSelectionMenu.test.tsx src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Manual QA passed on the branch dev app for triple-clicking agent messages
