### PR TITLE
Align expanded background-command icons with the header icon

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -148,7 +148,9 @@ export function ThreadBackgroundCommandsCard({
               {others.map((row) => (
                 <div
                   key={row.id}
-                  className="flex min-w-0 items-center gap-1.5 px-2 py-0.5 text-xs"
+                  // px-3 (not px-2) so the icon lines up under the header icon,
+                  // which is offset by the toggle button's own px-1 padding.
+                  className="flex min-w-0 items-center gap-1.5 px-3 py-0.5 text-xs"
                 >
                   <Icon
                     name="Terminal"


### PR DESCRIPTION
## Summary

In the expanded background-commands card, the child-row terminal icons didn't line up under the header row's icon. The header icon sits inside the toggle `<button>`, which adds its own `px-1` (4px) on top of the container's `px-2` (8px), so the header icon starts 12px from the card edge — while the child rows only had `px-2` (8px). That 4px gap is the misalignment.

This bumps the child rows to `px-3` (12px) so:
- the child terminal icons sit directly under the header terminal icon, and
- the trailing duration aligns under the header's chevron (also at 12px).

One-line change in `apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx`.

## Before / After

Before: header icon 12px from edge, child icons 8px → 4px off.
After: all icons 12px → aligned. Verified in the `promptbox/banner/Background Commands Card` Ladle story (the "multiple (expanded)" variant).

## Tests

No automated test covers this purely-presentational className change; verified visually via the existing Ladle story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)