### PR TITLE
Highlight "ultracode" in the prompt box with animated purple sparkles

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -110,6 +110,71 @@
     border-color: var(--pill-surface-selected-border);
   }
 
+  /*
+   * Light up the `ultracode` keyword in the prompt editor with animated purple
+   * sparkles (mirrors Claude Code). The wrapping span is added as a ProseMirror
+   * inline decoration (see prompt-ultracode-highlight-extension.ts); it stays
+   * editable text, so this is paint-only. `background-clip: text` shimmers a
+   * purple gradient through the glyphs, and two pseudo-element glints twinkle at
+   * opposite corners. `prefers-reduced-motion` keeps the purple, drops motion.
+   */
+  .prompt-ultracode-highlight {
+    position: relative;
+    font-weight: 600;
+    background: linear-gradient(
+      90deg,
+      oklch(0.62 0.21 300) 0%,
+      oklch(0.74 0.18 318) 30%,
+      oklch(0.82 0.15 286) 50%,
+      oklch(0.74 0.18 318) 70%,
+      oklch(0.62 0.21 300) 100%
+    );
+    background-size: 200% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: ultracode-shimmer 3s linear infinite;
+  }
+
+  .prompt-ultracode-highlight::before,
+  .prompt-ultracode-highlight::after {
+    content: "✦";
+    position: absolute;
+    font-size: 0.62em;
+    line-height: 1;
+    color: oklch(0.84 0.16 308);
+    /* `-webkit-text-fill-color` is inherited, so the transparent fill above
+     * would hide these glyphs — repaint them solid. */
+    -webkit-text-fill-color: oklch(0.84 0.16 308);
+    pointer-events: none;
+    opacity: 0;
+    animation: ultracode-sparkle 1.8s ease-in-out infinite;
+  }
+
+  .prompt-ultracode-highlight::before {
+    top: -0.32em;
+    right: -0.42em;
+  }
+
+  .prompt-ultracode-highlight::after {
+    bottom: -0.22em;
+    left: -0.42em;
+    animation-delay: 0.9s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prompt-ultracode-highlight {
+      animation: none;
+      background-position: 50% 0%;
+    }
+
+    .prompt-ultracode-highlight::before,
+    .prompt-ultracode-highlight::after {
+      animation: none;
+      opacity: 0.9;
+    }
+  }
+
   [data-promptbox] {
     container: promptbox / inline-size;
   }
@@ -210,5 +275,28 @@
       #000 calc(100% - 1.5rem),
       transparent
     );
+  }
+}
+
+/* Sweep the purple gradient across the `ultracode` glyphs. */
+@keyframes ultracode-shimmer {
+  0% {
+    background-position: 200% 0%;
+  }
+  100% {
+    background-position: -200% 0%;
+  }
+}
+
+/* Twinkle each corner sparkle: fade in, scale up, and spin a quarter turn. */
+@keyframes ultracode-sparkle {
+  0%,
+  100% {
+    opacity: 0;
+    transform: scale(0.4) rotate(0deg);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1) rotate(90deg);
   }
 }

--- a/apps/app/src/components/promptbox/editor/prompt-editor-extensions.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-extensions.ts
@@ -2,6 +2,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import StarterKit from "@tiptap/starter-kit";
 import type { AnyExtension } from "@tiptap/react";
 import { PromptMentionExtension } from "./prompt-mention-extension";
+import { PromptUltracodeHighlightExtension } from "./prompt-ultracode-highlight-extension";
 
 export interface PromptEditorExtensionsOptions {
   /**
@@ -59,5 +60,6 @@ export function promptEditorExtensions({
       placeholder: () => getPlaceholder(),
     }),
     PromptMentionExtension,
+    PromptUltracodeHighlightExtension,
   ];
 }

--- a/apps/app/src/components/promptbox/editor/prompt-ultracode-highlight-extension.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-ultracode-highlight-extension.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { getSchema } from "@tiptap/core";
+import { Node } from "@tiptap/pm/model";
+import { promptEditorExtensions } from "./prompt-editor-extensions";
+import { findUltracodeRanges } from "./prompt-ultracode-highlight-extension";
+
+const schema = getSchema(
+  promptEditorExtensions({ richTextEditing: false, getPlaceholder: () => "" }),
+);
+
+function paragraphDoc(text: string): Node {
+  return Node.fromJSON(schema, {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  });
+}
+
+function highlighted(text: string): string[] {
+  const doc = paragraphDoc(text);
+  return findUltracodeRanges(doc).map(({ from, to }) =>
+    doc.textBetween(from, to),
+  );
+}
+
+describe("findUltracodeRanges", () => {
+  it("highlights a standalone keyword regardless of case", () => {
+    expect(highlighted("run this ultracode now")).toEqual(["ultracode"]);
+    expect(highlighted("UltraCode please")).toEqual(["UltraCode"]);
+  });
+
+  it("highlights every occurrence in the prompt", () => {
+    expect(highlighted("ultracode and ultracode again")).toEqual([
+      "ultracode",
+      "ultracode",
+    ]);
+  });
+
+  it("returns positions that resolve back to the matched word", () => {
+    const doc = paragraphDoc("go ultracode go");
+    const ranges = findUltracodeRanges(doc);
+    expect(ranges).toHaveLength(1);
+    // Paragraph opens at pos 0, so its text starts at 1: "go " is 3 chars.
+    expect(doc.textBetween(ranges[0].from, ranges[0].to)).toBe("ultracode");
+  });
+
+  it("ignores substrings so only the whole keyword lights up", () => {
+    expect(highlighted("ultracodes myultracode supercode")).toEqual([]);
+  });
+
+  it("returns nothing when the keyword is absent", () => {
+    expect(highlighted("just a normal prompt")).toEqual([]);
+  });
+});

--- a/apps/app/src/components/promptbox/editor/prompt-ultracode-highlight-extension.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-ultracode-highlight-extension.ts
@@ -1,0 +1,71 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * Class applied to the inline span wrapping each `ultracode` occurrence. The
+ * animated purple-sparkle paint lives in app.css under this selector.
+ */
+export const ULTRACODE_HIGHLIGHT_CLASS = "prompt-ultracode-highlight";
+
+/**
+ * Matches the standalone word `ultracode`, case-insensitively. Word boundaries
+ * keep it from lighting up substrings (e.g. `ultracodes`, `myultracode`) so the
+ * highlight tracks the actual keyword the user typed.
+ */
+function ultracodePattern(): RegExp {
+  return /\bultracode\b/gi;
+}
+
+/**
+ * Collect the document ranges to highlight. Matching runs per text node, so a
+ * word split across mark boundaries (e.g. partially bold) isn't detected — the
+ * prompt box is plain text by default, so `ultracode` is a single text node in
+ * the common case. Returns absolute `{ from, to }` positions in the doc.
+ */
+export function findUltracodeRanges(
+  doc: ProseMirrorNode,
+): { from: number; to: number }[] {
+  const ranges: { from: number; to: number }[] = [];
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    const pattern = ultracodePattern();
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(node.text)) !== null) {
+      const from = pos + match.index;
+      ranges.push({ from, to: from + match[0].length });
+    }
+  });
+  return ranges;
+}
+
+/**
+ * Decorates every `ultracode` keyword in the prompt editor with the
+ * animated purple-sparkle treatment (matching Claude Code). Decorations are
+ * recomputed from document state on each view update; the prompt is small, so
+ * the full-doc scan is cheap.
+ */
+export const PromptUltracodeHighlightExtension = Extension.create({
+  name: "promptUltracodeHighlight",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          decorations(state) {
+            const ranges = findUltracodeRanges(state.doc);
+            if (ranges.length === 0) return null;
+            return DecorationSet.create(
+              state.doc,
+              ranges.map(({ from, to }) =>
+                Decoration.inline(from, to, {
+                  class: ULTRACODE_HIGHLIGHT_CLASS,
+                }),
+              ),
+            );
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## Summary

Lights up the `ultracode` keyword in the prompt editor with animated purple sparkles, mirroring how Claude Code renders it.

- New TipTap inline-decoration extension (`prompt-ultracode-highlight-extension.ts`) wraps every standalone `ultracode` match (case-insensitive, whole-word) in a styled span. It's paint-only — the underlying text stays editable.
- Registered the extension in `prompt-editor-extensions.ts`, so it applies to every prompt box.
- `app.css`: `.prompt-ultracode-highlight` shimmers a purple gradient through the glyphs via `background-clip: text` and twinkles a `✦` glint at each corner. Includes a `prefers-reduced-motion` fallback that keeps the purple but drops the motion.

Whole-word matching means `ultracode`/`UltraCode` light up but `ultracodes`/`myultracode` don't.

## Tests

- `turbo run typecheck --filter=@bb/app` ✅
- All 50 promptbox editor tests pass, including 5 new tests in `prompt-ultracode-highlight-extension.test.ts` covering case-insensitivity, multiple matches, position resolution, and whole-word boundaries.
- Verified live in the dev app: both `ultracode` and `UltraCode` render with the purple shimmer and alternating corner sparkles; edited text round-trips correctly (decoration doesn't mutate the document).

## Risks

Low — the change is additive and paint-only. With `-webkit-text-fill-color: transparent`, selecting the highlighted word shows slightly muted text under the selection tint; minor and cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)