### PR TITLE
Landing: fix mobile hero — fixed-height demo + soft dot-grid/wash

### DIFF
--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -2194,6 +2194,36 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 }
 
 @media (max-width: 720px) {
+  /* Same fixed-px problem as the dots below: the desktop wash uses a 640px
+     radial that can't fade within the narrow mobile hero, leaving a tinted
+     rectangle with hard side edges/corners. Re-size it relative to the hero
+     so the wash fades on all sides. */
+  .hero::before {
+    background: radial-gradient(
+      78% 55% at 50% 6%,
+      color-mix(in oklch, var(--ink) 4.5%, transparent),
+      transparent 70%
+    );
+  }
+
+  /* The desktop dot-grid mask is sized in fixed px for the wide hero; on the
+     narrow mobile hero those values stretch past the edges, leaving a hard
+     full-width band of dots instead of a fading patch. Use a relative-sized
+     ellipse (narrower than the hero) so the field fades on all sides as
+     ambient texture. -webkit- prefix included for iOS Safari. */
+  .hero::after {
+    -webkit-mask-image: radial-gradient(
+      85% 48% at 50% 26%,
+      rgb(0 0 0 / 60%),
+      transparent 80%
+    );
+    mask-image: radial-gradient(
+      85% 48% at 50% 26%,
+      rgb(0 0 0 / 60%),
+      transparent 80%
+    );
+  }
+
   /* Keep a fixed height (sidebar is an overlay drawer here, so it adds no
      in-flow height). A running thread streams rows in endlessly; without a
      bounded body the feed — and the whole card — would grow without limit. */

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -2194,9 +2194,18 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 }
 
 @media (max-width: 720px) {
+  /* Keep a fixed height (sidebar is an overlay drawer here, so it adds no
+     in-flow height). A running thread streams rows in endlessly; without a
+     bounded body the feed — and the whole card — would grow without limit. */
   .mock-body {
     flex-direction: column;
-    height: auto;
+  }
+
+  /* In this column layout .main is on the main axis, so it needs min-height:0
+     to stay within the fixed body instead of growing with the feed's content.
+     This lets .feed clip and anchor newest rows to the bottom (.feed-live). */
+  .main {
+    min-height: 0;
   }
 
   .diff-panel {
@@ -2274,11 +2283,6 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
     padding: 0;
     background: color-mix(in oklch, var(--ink) 34%, transparent);
     cursor: pointer;
-  }
-
-  .feed {
-    overflow: visible;
-    min-height: 200px;
   }
 
   .ctx-branch {


### PR DESCRIPTION
## Summary

Fixes three mobile-only issues on the landing page hero, all reported from a phone:

1. **Demo card grew without bound.** The mock BB app ("Triage the Sentry spike") streams rows in endlessly, and on mobile the card kept growing taller as messages arrived, pushing the page down. The ≤720px media query had dropped the desktop's bounded-and-clipping behavior (`.mock-body` → `height:auto`, `.feed` → `overflow:visible`). Restored a fixed height and added `min-height:0` to `.main` (needed because mobile stacks the body as a column flex) so the feed clips and anchors newest rows to the bottom, matching desktop.

2. **Dot-grid bunched into a hard band.** `.hero::after`'s mask is a fixed-px (`540px`) radial tuned for the wide desktop hero; on the narrow mobile hero it couldn't fade within the box, leaving a full-width band of dots with a hard edge near the headline. Re-sized with a relative `%` ellipse so it fades on all sides as ambient texture.

3. **Neutral wash had hard corners.** `.hero::before`'s background wash had the same fixed-px (`640px`) problem — a faint gray rectangle with hard side edges/corners behind the nav. Re-sized relative to the hero so it fades on all sides too.

All changes are scoped to `@media (max-width: 720px)`; desktop is unchanged. The mask override includes the `-webkit-` prefix for iOS Safari.

## Files changed
- `apps/landing/src/styles.css`

## Testing
- `pnpm exec turbo run typecheck build --filter=@bb/landing` ✓
- `pnpm --filter @bb/landing lint` ✓
- Verified in a 390px mobile viewport (and 360/414px) via headless browser:
  - Demo card height stays fixed (574px) across 18s+ of streaming; newest message visible at bottom, oldest clipped at top.
  - Dot-grid and wash both fade on all sides with no hard band/edges/corners.
  - No horizontal overflow at any tested width.
  - Desktop (1280px) hero + demo unchanged.

## Risks
Low — CSS-only, mobile-scoped. No behavior/logic changes.