### PR TITLE
Add usage limits section to settings for Codex and Claude Code

### DIFF
--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
@@ -1,0 +1,222 @@
+import type {
+  ProviderUsage,
+  ProviderUsageWindow,
+} from "@bb/host-daemon-contract";
+import { Button } from "@/components/ui/button";
+import { SettingsSection } from "@/components/ui/settings-section";
+import { useSystemUsageLimits } from "@/hooks/queries/system-queries";
+import { cn } from "@/lib/utils";
+
+interface ProviderConfig {
+  key: "codex" | "claudeCode";
+  name: string;
+  signInHint: string;
+  expiredHint: string;
+}
+
+const PROVIDERS: ProviderConfig[] = [
+  {
+    key: "codex",
+    name: "Codex",
+    signInHint: "Run `codex` to sign in and see your usage.",
+    expiredHint: "Your Codex session expired. Run `codex`, then refresh.",
+  },
+  {
+    key: "claudeCode",
+    name: "Claude Code",
+    signInHint: "Run `claude` to sign in and see your usage.",
+    expiredHint: "Your Claude session expired. Run `claude`, then refresh.",
+  },
+];
+
+function barColorClass(usedPercent: number): string {
+  if (usedPercent >= 95) {
+    return "bg-destructive";
+  }
+  if (usedPercent >= 80) {
+    return "bg-warning";
+  }
+  return "bg-primary";
+}
+
+function formatReset(resetsAt: string | null): string | null {
+  if (!resetsAt) {
+    return null;
+  }
+  const reset = new Date(resetsAt);
+  if (Number.isNaN(reset.getTime())) {
+    return null;
+  }
+  const diffMs = reset.getTime() - Date.now();
+  if (diffMs <= 0) {
+    return "Resetting now";
+  }
+
+  const diffMinutes = Math.round(diffMs / 60_000);
+  if (diffMinutes < 60) {
+    return `Resets in ${diffMinutes} min`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    const minutes = diffMinutes % 60;
+    return minutes > 0
+      ? `Resets in ${diffHours} hr ${minutes} min`
+      : `Resets in ${diffHours} hr`;
+  }
+
+  const withinWeek = diffMs < 7 * 24 * 60 * 60_000;
+  const formatted = reset.toLocaleString(undefined, {
+    weekday: withinWeek ? "short" : undefined,
+    month: withinWeek ? undefined : "short",
+    day: withinWeek ? undefined : "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `Resets ${formatted}`;
+}
+
+function UsageWindowRow({ window }: { window: ProviderUsageWindow }) {
+  const reset = formatReset(window.resetsAt);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium">{window.label}</span>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {window.usedPercent}% used
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full",
+            barColorClass(window.usedPercent),
+          )}
+          style={{ width: `${Math.max(window.usedPercent, 2)}%` }}
+        />
+      </div>
+      {reset ? <p className="text-xs text-muted-foreground">{reset}</p> : null}
+    </div>
+  );
+}
+
+interface ProviderUsageBlockProps {
+  config: ProviderConfig;
+  usage: ProviderUsage | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+function ProviderUsageBlock({
+  config,
+  usage,
+  isLoading,
+  isError,
+}: ProviderUsageBlockProps) {
+  const planLabel = usage?.status === "ok" ? usage.planLabel : null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">{config.name}</h3>
+        {planLabel ? (
+          <span className="text-xs text-muted-foreground">{planLabel}</span>
+        ) : null}
+      </div>
+      <ProviderUsageBody
+        config={config}
+        usage={usage}
+        isLoading={isLoading}
+        isError={isError}
+      />
+    </div>
+  );
+}
+
+function ProviderUsageBody({
+  config,
+  usage,
+  isLoading,
+  isError,
+}: ProviderUsageBlockProps) {
+  if (isError) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Couldn&apos;t load usage right now. Make sure bb&apos;s host is
+        connected, then refresh.
+      </p>
+    );
+  }
+  if (!usage) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {isLoading ? "Loading usage…" : "Usage unavailable."}
+      </p>
+    );
+  }
+  switch (usage.status) {
+    case "ok":
+      if (usage.windows.length === 0) {
+        return (
+          <p className="text-xs text-muted-foreground">
+            No usage limits reported for this plan.
+          </p>
+        );
+      }
+      return (
+        <div className="space-y-3">
+          {usage.windows.map((window) => (
+            <UsageWindowRow key={window.label} window={window} />
+          ))}
+        </div>
+      );
+    case "unauthenticated":
+      return (
+        <p className="text-xs text-muted-foreground">{config.signInHint}</p>
+      );
+    case "expired":
+      return (
+        <p className="text-xs text-muted-foreground">{config.expiredHint}</p>
+      );
+    case "error":
+      return <p className="text-xs text-muted-foreground">{usage.message}</p>;
+    default:
+      return null;
+  }
+}
+
+export function UsageLimitsSettingsSection() {
+  const usageQuery = useSystemUsageLimits();
+
+  return (
+    <SettingsSection
+      title="Usage limits"
+      description="Your Codex and Claude Code subscription usage."
+      action={
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={usageQuery.isFetching}
+          onClick={() => {
+            void usageQuery.refetch();
+          }}
+        >
+          {usageQuery.isFetching ? "Refreshing…" : "Refresh"}
+        </Button>
+      }
+    >
+      <div className="divide-y divide-border">
+        {PROVIDERS.map((config) => (
+          <div key={config.key} className="py-3 first:pt-0 last:pb-0">
+            <ProviderUsageBlock
+              config={config}
+              usage={usageQuery.data?.[config.key]}
+              isLoading={usageQuery.isLoading}
+              isError={usageQuery.isError}
+            />
+          </div>
+        ))}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -56,6 +56,7 @@ export const SYSTEM_CONFIG_QUERY_KEY = "systemConfig";
 export const SYSTEM_EXECUTION_OPTIONS_QUERY_KEY = "systemExecutionOptions";
 export const SYSTEM_VERSION_QUERY_KEY = "systemVersion";
 export const LOCAL_PROVIDER_CLI_STATUS_QUERY_KEY = "localProviderCliStatus";
+export const SYSTEM_USAGE_LIMITS_QUERY_KEY = "systemUsageLimits";
 export const LOCAL_PATH_EXISTENCE_QUERY_KEY = "localPathExistence";
 export const AUTOMATIONS_QUERY_KEY = "automations";
 export const AUTOMATION_DETAIL_QUERY_KEY = "automationDetail";
@@ -397,6 +398,9 @@ export type SystemVersionQueryKey = readonly [typeof SYSTEM_VERSION_QUERY_KEY];
 export type LocalProviderCliStatusQueryKey = readonly [
   typeof LOCAL_PROVIDER_CLI_STATUS_QUERY_KEY,
   number | null,
+];
+export type SystemUsageLimitsQueryKey = readonly [
+  typeof SYSTEM_USAGE_LIMITS_QUERY_KEY,
 ];
 export type SystemExecutionOptionsQueryKey = readonly [
   typeof SYSTEM_EXECUTION_OPTIONS_QUERY_KEY,
@@ -977,6 +981,10 @@ export function localProviderCliStatusQueryKey(
   daemonPort: number | null,
 ): LocalProviderCliStatusQueryKey {
   return [LOCAL_PROVIDER_CLI_STATUS_QUERY_KEY, daemonPort];
+}
+
+export function systemUsageLimitsQueryKey(): SystemUsageLimitsQueryKey {
+  return [SYSTEM_USAGE_LIMITS_QUERY_KEY];
 }
 
 export interface SystemExecutionOptionsQueryKeyArgs {

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -5,6 +5,7 @@ import type {
   SystemVersionResponse,
 } from "@bb/server-contract";
 import type { ProviderCliStatusResponse } from "@bb/host-daemon-contract";
+import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
 import * as api from "@/lib/api";
 import { fetchProviderCliStatus } from "@/lib/api-host-daemon";
 import { useSystemRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
@@ -12,6 +13,7 @@ import {
   localProviderCliStatusQueryKey,
   systemConfigQueryKey,
   systemExecutionOptionsQueryKey,
+  systemUsageLimitsQueryKey,
   systemVersionQueryKey,
 } from "./query-keys";
 import { requireEnabledQueryArg } from "./query-helpers";
@@ -97,5 +99,18 @@ export function useLocalProviderCliStatus({
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     staleTime: Infinity,
+  });
+}
+
+const PROVIDER_USAGE_STALE_TIME_MS = 30_000;
+
+export function useSystemUsageLimits(options?: QueryOptions) {
+  return useQuery<ProviderUsageResponse>({
+    queryKey: systemUsageLimitsQueryKey(),
+    queryFn: ({ signal }) => api.getSystemUsageLimits(signal),
+    enabled: options?.enabled ?? true,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: PROVIDER_USAGE_STALE_TIME_MS,
   });
 }

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -79,6 +79,7 @@ import type {
   ThreadStoragePathListResponse,
   WorkspacePathListResponse,
 } from "@bb/server-contract";
+import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
 import { apiClient, toRelativeUrl } from "./api-server";
 import {
   buildFilePreview,
@@ -1606,6 +1607,14 @@ export async function getSystemConfig(
 ): Promise<SystemConfigResponse> {
   return request<SystemConfigResponse>(
     apiClient.system.config.$get({}, requestOptions(signal)),
+  );
+}
+
+export async function getSystemUsageLimits(
+  signal?: AbortSignal,
+): Promise<ProviderUsageResponse> {
+  return request<ProviderUsageResponse>(
+    apiClient.system["usage-limits"].$get({}, requestOptions(signal)),
   );
 }
 

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -26,6 +26,7 @@ import {
   type ThemePreference,
 } from "@/hooks/useTheme";
 import { useHostDaemon } from "@/hooks/useHostDaemon";
+import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSettingsSection";
 import { useUpdateExperiments } from "@/hooks/mutations/settings-mutations";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
 import { useWorkspaceOpenTargets } from "@/hooks/useWorkspaceOpenTargets";
@@ -385,7 +386,8 @@ const IN_APP_BROWSER_LINK_SETTING_LABEL = "Open links in the in-app browser";
 const REWRITE_LOCALHOST_LINKS_SETTING_LABEL = "Rewrite localhost links";
 const NAVIGATE_TO_THREAD_AFTER_CREATE_SETTING_LABEL =
   "Navigate to threads on creation";
-const RICH_TEXT_EDITING_SETTING_LABEL = "Rich text formatting in the prompt box";
+const RICH_TEXT_EDITING_SETTING_LABEL =
+  "Rich text formatting in the prompt box";
 
 export function RootComposeBehaviorSettingsControl({
   navigateToThreadAfterCreate,
@@ -833,6 +835,8 @@ export function SettingsView() {
           onThemePreferenceChange={setPreferredTheme}
         />
 
+        <UsageLimitsSettingsSection />
+
         <LocalOpenTargetSettingsSection
           directoryTargetId={directoryTargetId}
           fileTargetId={fileTargetId}
@@ -843,9 +847,7 @@ export function SettingsView() {
         />
 
         <ExperimentsSettingsSection
-          claudeCodeMockCliTrafficEnabled={
-            experiments.claudeCodeMockCliTraffic
-          }
+          claudeCodeMockCliTrafficEnabled={experiments.claudeCodeMockCliTraffic}
           desktopShellAvailable={desktopShellAvailable}
           disabled={
             systemConfigQuery.data === undefined ||

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -31,6 +31,7 @@ import {
   completeCodexInference,
   transcribeCodexVoice,
 } from "./codex-chatgpt-client.js";
+import { getProviderUsage } from "./provider-usage.js";
 import {
   ensureThreadRuntime,
   startThread,
@@ -230,6 +231,7 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
     (options.listModels ?? defaultListModels)({
       providerId: command.providerId,
     }),
+  "provider.usage": async () => getProviderUsage(),
   "workspace.status": async (command, options) => {
     const resolution = await resolveWorkspaceForCommand({
       dataDir: options.dataDir,

--- a/apps/host-daemon/src/provider-usage.test.ts
+++ b/apps/host-daemon/src/provider-usage.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./provider-usage.js";
+
+const {
+  normalizeCodexUsage,
+  normalizeClaudeUsage,
+  codexPlanLabel,
+  claudePlanLabel,
+} = __testing;
+
+describe("normalizeCodexUsage", () => {
+  it("maps primary/secondary windows and plan to the unified shape", () => {
+    const primaryReset = 1_780_000_000;
+    const secondaryReset = 1_780_500_000;
+    const result = normalizeCodexUsage({
+      plan_type: "pro",
+      rate_limit: {
+        primary_window: {
+          used_percent: 12,
+          reset_at: primaryReset,
+          limit_window_seconds: 18_000,
+        },
+        secondary_window: {
+          used_percent: 18,
+          reset_at: secondaryReset,
+          limit_window_seconds: 604_800,
+        },
+      },
+      // Unknown sibling fields must be ignored, not fatal.
+      credits: { has_credits: false, unlimited: false, balance: null },
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      planLabel: "Pro",
+      windows: [
+        {
+          label: "Current session",
+          usedPercent: 12,
+          resetsAt: new Date(primaryReset * 1000).toISOString(),
+        },
+        {
+          label: "Weekly limit",
+          usedPercent: 18,
+          resetsAt: new Date(secondaryReset * 1000).toISOString(),
+        },
+      ],
+    });
+  });
+
+  it("clamps and rounds percentages and tolerates a missing reset", () => {
+    const result = normalizeCodexUsage({
+      plan_type: "team",
+      rate_limit: {
+        primary_window: { used_percent: 150.6 },
+        secondary_window: { used_percent: -5 },
+      },
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      planLabel: "Team",
+      windows: [
+        { label: "Current session", usedPercent: 100, resetsAt: null },
+        { label: "Weekly limit", usedPercent: 0, resetsAt: null },
+      ],
+    });
+  });
+
+  it("returns ok with no windows when rate limits are absent", () => {
+    expect(normalizeCodexUsage({ plan_type: "plus" })).toEqual({
+      status: "ok",
+      planLabel: "Plus",
+      windows: [],
+    });
+  });
+
+  it("flags a malformed payload instead of inventing numbers", () => {
+    const result = normalizeCodexUsage({
+      rate_limit: { primary_window: { used_percent: "lots" } },
+    });
+    expect(result.status).toBe("error");
+  });
+});
+
+describe("normalizeClaudeUsage", () => {
+  const credentials = {
+    accessToken: "token",
+    rateLimitTier: "default_claude_max_20x",
+    subscriptionType: "max",
+  };
+
+  it("maps the session and weekly windows and derives the plan label", () => {
+    const result = normalizeClaudeUsage(
+      {
+        five_hour: { utilization: 0, resets_at: "2026-06-19T22:00:00.000Z" },
+        seven_day: { utilization: 18.4, resets_at: "2026-06-24T14:23:00.000Z" },
+        // Model-specific sub-limits are intentionally ignored.
+        seven_day_sonnet: { utilization: 0, resets_at: null },
+      },
+      credentials,
+    );
+
+    expect(result).toEqual({
+      status: "ok",
+      planLabel: "Max (20x)",
+      windows: [
+        {
+          label: "Current session",
+          usedPercent: 0,
+          resetsAt: "2026-06-19T22:00:00.000Z",
+        },
+        {
+          label: "Weekly limit",
+          usedPercent: 18,
+          resetsAt: "2026-06-24T14:23:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("drops windows the API omits or leaves without a utilization", () => {
+    const result = normalizeClaudeUsage(
+      {
+        five_hour: { utilization: 7, resets_at: null },
+        seven_day: { resets_at: "2026-06-24T14:23:00.000Z" },
+      },
+      { accessToken: "token" },
+    );
+
+    expect(result).toEqual({
+      status: "ok",
+      planLabel: null,
+      windows: [{ label: "Current session", usedPercent: 7, resetsAt: null }],
+    });
+  });
+});
+
+describe("plan labels", () => {
+  it("derives codex plan labels", () => {
+    expect(codexPlanLabel("pro")).toBe("Pro");
+    expect(codexPlanLabel("free_workspace")).toBe("Free_workspace");
+    expect(codexPlanLabel(null)).toBeNull();
+  });
+
+  it("derives claude plan labels from the rate-limit tier first", () => {
+    expect(claudePlanLabel({ accessToken: "t", rateLimitTier: "max_5x" })).toBe(
+      "Max (5x)",
+    );
+    expect(claudePlanLabel({ accessToken: "t", subscriptionType: "pro" })).toBe(
+      "Pro",
+    );
+    expect(claudePlanLabel({ accessToken: "t" })).toBeNull();
+  });
+});

--- a/apps/host-daemon/src/provider-usage.ts
+++ b/apps/host-daemon/src/provider-usage.ts
@@ -1,0 +1,422 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type {
+  ProviderUsage,
+  ProviderUsageResponse,
+  ProviderUsageWindow,
+} from "@bb/host-daemon-contract";
+import { z } from "zod";
+import {
+  getChatGptCloudflareCookieHeader,
+  storeChatGptCloudflareCookies,
+} from "./chatgpt-cloudflare-cookies.js";
+import { readCodexAuthCredentials } from "./codex-auth.js";
+import { ExpectedCommandDispatchError } from "./command-dispatch-support.js";
+
+const USAGE_FETCH_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function epochSecondsToIso(seconds: number | null | undefined): string | null {
+  if (seconds == null || !Number.isFinite(seconds)) {
+    return null;
+  }
+  return new Date(seconds * 1000).toISOString();
+}
+
+function normalizeIsoTimestamp(
+  value: string | null | undefined,
+): string | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Codex (ChatGPT subscription) usage
+// ---------------------------------------------------------------------------
+
+const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+
+const codexUsageWindowSchema = z.object({
+  used_percent: z.number(),
+  reset_at: z.number().nullish(),
+  limit_window_seconds: z.number().nullish(),
+});
+
+const codexUsageResponseSchema = z.object({
+  plan_type: z.string().nullish(),
+  rate_limit: z
+    .object({
+      primary_window: codexUsageWindowSchema.nullish(),
+      secondary_window: codexUsageWindowSchema.nullish(),
+    })
+    .nullish(),
+});
+
+const CODEX_PLAN_LABELS: Record<string, string> = {
+  free: "Free",
+  go: "Go",
+  plus: "Plus",
+  pro: "Pro",
+  team: "Team",
+  business: "Business",
+  education: "Education",
+  edu: "Education",
+  enterprise: "Enterprise",
+};
+
+function codexPlanLabel(planType: string | null | undefined): string | null {
+  if (!planType) {
+    return null;
+  }
+  return (
+    CODEX_PLAN_LABELS[planType] ??
+    planType.charAt(0).toUpperCase() + planType.slice(1)
+  );
+}
+
+function codexWindow(
+  window: z.infer<typeof codexUsageWindowSchema> | null | undefined,
+  label: string,
+): ProviderUsageWindow | null {
+  if (!window) {
+    return null;
+  }
+  return {
+    label,
+    usedPercent: clampPercent(window.used_percent),
+    resetsAt: epochSecondsToIso(window.reset_at),
+  };
+}
+
+async function fetchChatGptUsage(headers: Headers): Promise<Response> {
+  const doFetch = async (): Promise<Response> => {
+    const requestHeaders = new Headers(headers);
+    const cookie = getChatGptCloudflareCookieHeader(CODEX_USAGE_URL);
+    if (cookie) {
+      requestHeaders.set("Cookie", cookie);
+    }
+    const response = await fetch(CODEX_USAGE_URL, {
+      method: "GET",
+      headers: requestHeaders,
+      signal: AbortSignal.timeout(USAGE_FETCH_TIMEOUT_MS),
+    });
+    storeChatGptCloudflareCookies(CODEX_USAGE_URL, response.headers);
+    return response;
+  };
+
+  const response = await doFetch();
+  if (
+    response.status === 403 &&
+    response.headers.get("cf-mitigated")?.toLowerCase() === "challenge"
+  ) {
+    // Cloudflare handed us a fresh clearance cookie; retry once with it.
+    return doFetch();
+  }
+  return response;
+}
+
+function normalizeCodexUsage(raw: unknown): ProviderUsage {
+  const parsed = codexUsageResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { status: "error", message: "Codex usage response was malformed." };
+  }
+
+  const windows = [
+    codexWindow(parsed.data.rate_limit?.primary_window, "Current session"),
+    codexWindow(parsed.data.rate_limit?.secondary_window, "Weekly limit"),
+  ].filter((window): window is ProviderUsageWindow => window !== null);
+
+  return {
+    status: "ok",
+    planLabel: codexPlanLabel(parsed.data.plan_type),
+    windows,
+  };
+}
+
+async function fetchCodexUsage(): Promise<ProviderUsage> {
+  let credentials;
+  try {
+    credentials = await readCodexAuthCredentials();
+  } catch (error) {
+    // Missing file (never logged in) and invalid/empty credentials (logged out,
+    // or tokens cleared) both mean "sign in to Codex" rather than a hard error.
+    if (
+      error instanceof ExpectedCommandDispatchError &&
+      (error.code === "codex_auth_missing" ||
+        error.code === "codex_auth_invalid")
+    ) {
+      return { status: "unauthenticated" };
+    }
+    return { status: "error", message: errorMessage(error) };
+  }
+
+  if (credentials.type === "apiKey") {
+    return {
+      status: "error",
+      message:
+        "Codex is authenticated with an API key, which has no subscription usage limits.",
+    };
+  }
+
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${credentials.accessToken}`);
+  headers.set("chatgpt-account-id", credentials.accountId);
+  headers.set("originator", "bb");
+  headers.set("User-Agent", "bb-host-daemon");
+  headers.set("Accept", "application/json");
+  if (credentials.isFedrampAccount) {
+    headers.set("X-OpenAI-Fedramp", "true");
+  }
+
+  const response = await fetchChatGptUsage(headers);
+  if (response.status === 401) {
+    return { status: "expired" };
+  }
+  if (!response.ok) {
+    return {
+      status: "error",
+      message: `Codex usage request failed (HTTP ${response.status}).`,
+    };
+  }
+
+  return normalizeCodexUsage(await response.json());
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code (Anthropic OAuth) usage
+// ---------------------------------------------------------------------------
+
+const execFileAsync = promisify(execFile);
+
+const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
+const CLAUDE_OAUTH_BETA_HEADER = "oauth-2025-04-20";
+const CLAUDE_USER_AGENT = "claude-code/2.1.0";
+
+const claudeCredentialsSchema = z.object({
+  claudeAiOauth: z.object({
+    accessToken: z.string().min(1),
+    expiresAt: z.number().nullish(),
+    subscriptionType: z.string().nullish(),
+    rateLimitTier: z.string().nullish(),
+  }),
+});
+type ClaudeCredentials = z.infer<
+  typeof claudeCredentialsSchema
+>["claudeAiOauth"];
+
+const claudeUsageWindowSchema = z.object({
+  utilization: z.number().nullish(),
+  resets_at: z.string().nullish(),
+});
+
+const claudeUsageResponseSchema = z
+  .object({
+    five_hour: claudeUsageWindowSchema.nullish(),
+    seven_day: claudeUsageWindowSchema.nullish(),
+  })
+  .passthrough();
+
+async function readClaudeKeychainCredentials(): Promise<string | null> {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const argumentSets = [
+    [
+      "find-generic-password",
+      "-s",
+      CLAUDE_KEYCHAIN_SERVICE,
+      "-a",
+      os.userInfo().username,
+      "-w",
+    ],
+    ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"],
+  ];
+  for (const args of argumentSets) {
+    try {
+      const { stdout } = await execFileAsync("security", args, {
+        timeout: 10_000,
+      });
+      const trimmed = stdout.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    } catch {
+      // Try the next lookup, then fall back to the credentials file.
+    }
+  }
+  return null;
+}
+
+async function readClaudeFileCredentials(): Promise<string | null> {
+  try {
+    return await fs.readFile(
+      path.join(os.homedir(), ".claude", ".credentials.json"),
+      "utf8",
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function readClaudeCredentials(): Promise<ClaudeCredentials | null> {
+  const raw =
+    (await readClaudeKeychainCredentials()) ??
+    (await readClaudeFileCredentials());
+  if (!raw) {
+    return null;
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const parsed = claudeCredentialsSchema.safeParse(json);
+  return parsed.success ? parsed.data.claudeAiOauth : null;
+}
+
+function claudePlanLabel(credentials: ClaudeCredentials): string | null {
+  const tier = credentials.rateLimitTier ?? "";
+  const maxMatch = tier.match(/max_(\d+)x/u);
+  if (maxMatch) {
+    return `Max (${maxMatch[1]}x)`;
+  }
+  const subscription = credentials.subscriptionType;
+  if (subscription) {
+    return subscription.charAt(0).toUpperCase() + subscription.slice(1);
+  }
+  return null;
+}
+
+function claudeWindow(
+  window: z.infer<typeof claudeUsageWindowSchema> | null | undefined,
+  label: string,
+): ProviderUsageWindow | null {
+  if (!window || window.utilization == null) {
+    return null;
+  }
+  return {
+    label,
+    usedPercent: clampPercent(window.utilization),
+    resetsAt: normalizeIsoTimestamp(window.resets_at),
+  };
+}
+
+function normalizeClaudeUsage(
+  raw: unknown,
+  credentials: ClaudeCredentials,
+): ProviderUsage {
+  const parsed = claudeUsageResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { status: "error", message: "Claude usage response was malformed." };
+  }
+
+  const windows = [
+    claudeWindow(parsed.data.five_hour, "Current session"),
+    claudeWindow(parsed.data.seven_day, "Weekly limit"),
+  ].filter((window): window is ProviderUsageWindow => window !== null);
+
+  return {
+    status: "ok",
+    planLabel: claudePlanLabel(credentials),
+    windows,
+  };
+}
+
+async function fetchClaudeUsage(): Promise<ProviderUsage> {
+  const credentials = await readClaudeCredentials();
+  if (!credentials) {
+    return { status: "unauthenticated" };
+  }
+  if (credentials.expiresAt != null && Date.now() >= credentials.expiresAt) {
+    // The Claude CLI owns these tokens and refreshes them on its own next run;
+    // refreshing here risks rotating its refresh token out from under it.
+    return { status: "expired" };
+  }
+
+  const response = await fetch(CLAUDE_USAGE_URL, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${credentials.accessToken}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "anthropic-beta": CLAUDE_OAUTH_BETA_HEADER,
+      "User-Agent": CLAUDE_USER_AGENT,
+    },
+    signal: AbortSignal.timeout(USAGE_FETCH_TIMEOUT_MS),
+  });
+
+  if (response.status === 401) {
+    return { status: "expired" };
+  }
+  if (response.status === 429) {
+    return {
+      status: "error",
+      message: "Claude usage is rate limited right now. Try again shortly.",
+    };
+  }
+  if (!response.ok) {
+    return {
+      status: "error",
+      message: `Claude usage request failed (HTTP ${response.status}).`,
+    };
+  }
+
+  return normalizeClaudeUsage(await response.json(), credentials);
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads live usage/rate-limit snapshots for the local Codex and Claude Code
+ * subscriptions. Each provider resolves independently so one failing never
+ * blanks the other. Tokens are read from the providers' own credential stores
+ * and used as-is — we never refresh another tool's tokens.
+ */
+export async function getProviderUsage(): Promise<ProviderUsageResponse> {
+  const [codex, claudeCode] = await Promise.all([
+    fetchCodexUsage().catch(
+      (error): ProviderUsage => ({
+        status: "error",
+        message: errorMessage(error),
+      }),
+    ),
+    fetchClaudeUsage().catch(
+      (error): ProviderUsage => ({
+        status: "error",
+        message: errorMessage(error),
+      }),
+    ),
+  ]);
+  return { codex, claudeCode };
+}
+
+export const __testing = {
+  normalizeCodexUsage,
+  normalizeClaudeUsage,
+  codexPlanLabel,
+  claudePlanLabel,
+};

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -13,6 +13,7 @@ import {
   transcribeVoiceInput,
 } from "../services/ai/voice-transcription.js";
 import { resolveSystemExecutionOptions } from "../services/system/execution-options.js";
+import { getProviderUsageLimits } from "../services/system/usage-limits.js";
 
 export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
   const { get, post, put } = typedRoutes<PublicApiSchema>(app, {
@@ -51,6 +52,10 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
 
   get(routes.providers, (context) =>
     context.json(listBuiltInAgentProviderInfos()),
+  );
+
+  get(routes.usageLimits, async (context) =>
+    context.json(await getProviderUsageLimits(deps)),
   );
 
   get(routes.executionOptions, async (context, query) =>

--- a/apps/server/src/services/system/usage-limits.ts
+++ b/apps/server/src/services/system/usage-limits.ts
@@ -1,0 +1,22 @@
+import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
+import type { AppDeps } from "../../types.js";
+import { COMMAND_TIMEOUT_MS } from "../../constants.js";
+import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
+import { requireConnectedPrimaryHostId } from "../hosts/primary-host.js";
+
+/**
+ * Reads live Codex/Claude Code subscription usage from the connected primary
+ * host's daemon. The daemon owns the credentials and provider HTTP calls; the
+ * server only routes the request so the browser never needs to reach the
+ * loopback-bound daemon directly (which fails for non-localhost app origins).
+ */
+export async function getProviderUsageLimits(
+  deps: AppDeps,
+): Promise<ProviderUsageResponse> {
+  const hostId = requireConnectedPrimaryHostId(deps);
+  return callHostRetryableOnlineRpc(deps, {
+    hostId,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+    command: { type: "provider.usage" },
+  });
+}

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -24,7 +24,7 @@ import {
 } from "@bb/domain";
 import { z } from "zod";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 41 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 42 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,
@@ -788,6 +788,55 @@ const hostRunScriptResultSchema = z
   })
   .strict();
 
+// ---------------------------------------------------------------------------
+// Provider usage limits (live read from the host's provider credentials)
+// ---------------------------------------------------------------------------
+
+/**
+ * One usage window for a provider subscription, e.g. the rolling 5h session
+ * limit or the weekly limit. `usedPercent` is normalized to 0-100 and
+ * `resetsAt` is an ISO-8601 timestamp (or null when the provider omits it).
+ */
+export const providerUsageWindowSchema = z.object({
+  label: z.string().min(1),
+  usedPercent: z.number().min(0).max(100),
+  resetsAt: z.string().min(1).nullable(),
+});
+export type ProviderUsageWindow = z.infer<typeof providerUsageWindowSchema>;
+
+/**
+ * Live usage snapshot for a single provider. Discriminated on `status` so the
+ * UI can render the windows, prompt the user to sign in, or surface an error
+ * without inventing placeholder numbers.
+ *
+ * - `ok` — usage was read; `windows` may be empty if the plan exposes none.
+ * - `unauthenticated` — no local credentials (the CLI is not logged in).
+ * - `expired` — credentials exist but the token expired; the CLI must refresh
+ *   it (we never refresh another tool's tokens here).
+ * - `error` — network/HTTP/parse failure; `message` is user-facing.
+ */
+export const providerUsageSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("ok"),
+    planLabel: z.string().min(1).nullable(),
+    windows: z.array(providerUsageWindowSchema),
+  }),
+  z.object({ status: z.literal("unauthenticated") }),
+  z.object({ status: z.literal("expired") }),
+  z.object({ status: z.literal("error"), message: z.string().min(1) }),
+]);
+export type ProviderUsage = z.infer<typeof providerUsageSchema>;
+
+export const providerUsageResponseSchema = z.object({
+  codex: providerUsageSchema,
+  claudeCode: providerUsageSchema,
+});
+export type ProviderUsageResponse = z.infer<typeof providerUsageResponseSchema>;
+
+const providerUsageCommandSchema = z
+  .object({ type: z.literal("provider.usage") })
+  .strict();
+
 type HostDaemonCommandTransport = "settled" | "onlineRpc";
 export type HostDaemonCommandEnvironmentLane = "read" | "write";
 type HostDaemonFlushEventsBeforeResult = boolean | "when-initiated";
@@ -1044,6 +1093,15 @@ export const hostDaemonCommandRegistry = {
     type: "provider.list_models",
     schema: providerListModelsCommandSchema,
     resultSchema: providerListModelsResultSchema,
+    transport: "onlineRpc",
+    retryable: true,
+    flushEventsBeforeResult: false,
+    envLane: null,
+  }),
+  "provider.usage": defineHostDaemonCommandDescriptor({
+    type: "provider.usage",
+    schema: providerUsageCommandSchema,
+    resultSchema: providerUsageResponseSchema,
     transport: "onlineRpc",
     retryable: true,
     flushEventsBeforeResult: false,

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -305,6 +305,7 @@ const hostDaemonOnlineRpcResponseSuccessSchema = z.discriminatedUnion(
     onlineRpcResponseSuccessSchemaFor("host.read_file"),
     onlineRpcResponseSuccessSchemaFor("host.read_file_relative"),
     onlineRpcResponseSuccessSchemaFor("provider.list_models"),
+    onlineRpcResponseSuccessSchemaFor("provider.usage"),
     onlineRpcResponseSuccessSchemaFor("workspace.status"),
     onlineRpcResponseSuccessSchemaFor("workspace.diff"),
     onlineRpcResponseSuccessSchemaFor("workspace.diffFiles"),

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -226,6 +226,20 @@ const ONLINE_RPC_RESPONSE_RESULT_FIXTURES: OnlineRpcResponseResultFixtures = {
     ],
     selectedOnlyModels: [],
   },
+  "provider.usage": {
+    codex: {
+      status: "ok",
+      planLabel: "Pro",
+      windows: [
+        {
+          label: "Current session",
+          usedPercent: 6,
+          resetsAt: "2026-06-20T05:28:16.000Z",
+        },
+      ],
+    },
+    claudeCode: { status: "unauthenticated" },
+  },
   "workspace.status": WORKSPACE_UNAVAILABLE_RESULT,
   "workspace.diff": WORKSPACE_UNAVAILABLE_RESULT,
   "workspace.diffFiles": WORKSPACE_UNAVAILABLE_RESULT,
@@ -1895,7 +1909,7 @@ describe("host-daemon command schemas", () => {
 
 describe("host-daemon session schemas", () => {
   it("documents the current protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(41);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(42);
   });
 
   it("parses valid session open and event batch payloads", () => {

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -12,6 +12,7 @@ import type {
   ThreadQueuedMessage,
 } from "@bb/domain";
 import { experimentsSchema } from "@bb/domain";
+import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
 import {
   binaryResponse,
   defineRoute,
@@ -856,6 +857,12 @@ export const publicApiRoutes = {
       method: "get",
       request: noRequest(),
       response: jsonResponse<SystemProviderInfo[]>(),
+    }),
+    usageLimits: defineRoute({
+      path: "/system/usage-limits",
+      method: "get",
+      request: noRequest(),
+      response: jsonResponse<ProviderUsageResponse>(),
     }),
     voiceTranscription: defineRoute({
       path: "/system/voice-transcription",


### PR DESCRIPTION
## What

Adds a **Usage limits** section to Settings showing live Codex and Claude Code subscription usage — plan label, a 5h "Current session" window and a "Weekly limit" window per provider, each with a % bar and reset time — in one consistent style.

## How

- **Daemon reads creds + provider APIs directly** (`apps/host-daemon/src/provider-usage.ts`): Codex from `~/.codex/auth.json` → `chatgpt.com/backend-api/wham/usage` (reusing the existing ChatGPT token + Cloudflare-cookie handling); Claude from the macOS Keychain (`Claude Code-credentials`, fallback `~/.claude/.credentials.json`) → `api.anthropic.com/api/oauth/usage`. Both normalized into one `ProviderUsageResponse` shape.
- **Tokens are used as-is, never refreshed** — the CLIs own them, so refreshing could rotate their refresh token out from under them. Missing/expired creds surface `unauthenticated`/`expired` states instead of errors (matches how codexbar treats CLI-owned creds).
- **Routed through the server, not the browser→daemon loopback API.** A host-daemon online-RPC command `provider.usage` is exposed via `GET /api/v1/system/usage-limits` (resolves the connected primary host + `callHostRetryableOnlineRpc`). The browser only talks to the server, so it works over non-loopback origins (e.g. Tailscale) where the daemon's local API is unreachable. Bumped `HOST_DAEMON_PROTOCOL_VERSION` 41→42.

## Graceful states
Each provider resolves independently. Not signed in → "Run `codex`/`claude` to sign in"; token expired → "session expired, run … then refresh"; no host connected → "couldn't load usage"; network/parse error → per-provider message. A brand-new user sees the section with sign-in prompts, no errors.

## Tests
- New unit tests for the daemon normalization (codex/claude parsing, clamping, plan labels, malformed payloads).
- Updated host-daemon-contract fixtures + protocol-version assertion for the new command.
- `typecheck` + `test` green across host-daemon-contract, host-daemon, server-contract, server, app; lint + prettier clean.
- Verified end-to-end against live accounts via the server route and the rendered Settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)