### PR TITLE
Customizable app theme (built-in palettes + CLI custom stylesheet)

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -6,6 +6,7 @@ import { RootComposeRoute } from "./views/RootComposeView";
 import { QuickCreateProjectProvider } from "./hooks/useQuickCreateProject";
 import { ProviderCliHealthToasts } from "./components/provider-cli/ProviderCliHealthToasts";
 import { RouteNavigationProvider } from "./components/ui/app-route-anchor";
+import { useAppTheme } from "./hooks/useAppTheme";
 import { useDesktopThemeSync } from "./hooks/useDesktopThemeSync";
 import {
   useDesktopUpdateAvailableToast,
@@ -151,6 +152,8 @@ export function App() {
   // Keep the Electron window chrome (traffic lights, inactive title bar)
   // in sync with bb's resolved theme.
   useDesktopThemeSync();
+  // Apply the server-stored app palette (built-in or custom CSS) app-wide.
+  useAppTheme();
 
   return (
     <QuickCreateProjectProvider>

--- a/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
+++ b/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
@@ -23,16 +23,16 @@ export type GithubCheckStatus = "success" | "failure" | "pending";
 
 const PR_STATUS_COLOR: Record<PullRequestState, { textClassName: string }> = {
   open: {
-    textClassName: "text-[#238636]",
+    textClassName: "text-success",
   },
   closed: {
-    textClassName: "text-[#da3633]",
+    textClassName: "text-destructive",
   },
   merged: {
-    textClassName: "text-[#8957e5]",
+    textClassName: "text-pr-merged",
   },
   draft: {
-    textClassName: "text-[#656c76]",
+    textClassName: "text-muted-foreground",
   },
 };
 

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -4,6 +4,7 @@ import type { ITheme, Terminal as XTermTerminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { TerminalServerMessage, TerminalSession } from "@bb/server-contract";
 import { terminalServerMessageSchema } from "@bb/server-contract";
+import { useAppThemeEpoch } from "@/hooks/useAppTheme";
 import { usePreferredTheme } from "@/hooks/useTheme";
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { buildTerminalWebSocketUrl } from "./terminal-websocket-url";
@@ -300,6 +301,9 @@ export function ThreadTerminalView({
   const lastStatusNoticeRef = useRef<TerminalSessionStatusNotice | null>(null);
   const scheduleFitRef = useRef<TerminalFitScheduler | null>(null);
   const preferredTheme = usePreferredTheme();
+  // The xterm canvas bakes its palette, so re-apply the theme on app-palette
+  // changes too, not just light/dark toggles.
+  const appThemeEpoch = useAppThemeEpoch();
   const openUrlByPreference = useOpenUrlByPreference();
   const handleOpenLinkByPreference =
     useCallback<MarkdownPreviewLinkHandler>(
@@ -535,7 +539,7 @@ export function ThreadTerminalView({
       return;
     }
     terminal.options.theme = buildTerminalTheme();
-  }, [preferredTheme]);
+  }, [preferredTheme, appThemeEpoch]);
 
   return (
     <div className="h-full min-h-0 w-full overflow-hidden bg-background p-2">

--- a/apps/app/src/components/ui/markdown-mermaid-diagram.tsx
+++ b/apps/app/src/components/ui/markdown-mermaid-diagram.tsx
@@ -20,6 +20,7 @@ import { Button } from "./button.js";
 import { CopyButton } from "./copy-button.js";
 import { Icon } from "./icon.js";
 import { loadMermaid } from "./markdown-mermaid-loader.js";
+import { useAppThemeEpoch } from "@/hooks/useAppTheme";
 import type { Theme } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
 
@@ -222,74 +223,99 @@ const MERMAID_WHEEL_MIN_ZOOM_FACTOR = 0.82;
 const MERMAID_WHEEL_MAX_ZOOM_FACTOR = 1.22;
 const MERMAID_DIAGRAM_CENTER_POINT: MermaidDiagramPoint = { x: 0, y: 0 };
 
-const MERMAID_LIGHT_PALETTE: MermaidThemePalette = {
-  actorBkg: "#f1f1f1",
-  actorBorder: "#dedede",
-  actorTextColor: "#333333",
-  background: "#f7f7f7",
-  clusterBkg: "#f9f9f9",
-  clusterBorder: "#dedede",
-  edgeLabelBackground: "#f1f1f1",
-  labelBoxBkgColor: "#f1f1f1",
-  labelBoxBorderColor: "#dedede",
-  labelTextColor: "#333333",
-  lineColor: "#4075aa",
-  loopTextColor: "#333333",
-  mainBkg: "#f1f1f1",
-  nodeBorder: "#cfcfcf",
-  noteBkgColor: "#f9f9f9",
-  noteBorderColor: "#cfcfcf",
-  noteTextColor: "#333333",
-  primaryBorderColor: "#cfcfcf",
-  primaryColor: "#f1f1f1",
-  primaryTextColor: "#333333",
-  secondaryBorderColor: "#dedede",
-  secondaryColor: "#f9f9f9",
-  secondaryTextColor: "#333333",
-  signalColor: "#4075aa",
-  signalTextColor: "#333333",
-  tertiaryBorderColor: "#cfcfcf",
-  tertiaryColor: "#edf4fb",
-  tertiaryTextColor: "#333333",
-  textColor: "#333333",
-};
+// Mermaid bakes concrete colors into the rendered SVG and does its own
+// lighten/darken math, so it can't consume `var(--token)` directly. Resolve the
+// app's theme tokens to concrete rgb() strings at render time — mirroring
+// buildTerminalTheme in ThreadTerminalView — so diagrams track the active
+// palette (built-in or custom), not just light/dark mode. Each mermaid slot maps
+// to the closest semantic token; the neutral fills/borders/text follow the
+// canvas/ink anchors and the line color follows the accent.
+const MERMAID_TOKEN = {
+  nodeFill: "--secondary",
+  altFill: "--muted",
+  tertiaryFill: "--accent",
+  border: "--border",
+  text: "--foreground",
+  line: "--primary",
+  background: "--background",
+} as const;
 
-const MERMAID_DARK_PALETTE: MermaidThemePalette = {
-  actorBkg: "#1f1f1f",
-  actorBorder: "#303030",
-  actorTextColor: "#c1c1c1",
-  background: "#151515",
-  clusterBkg: "#1a1a1a",
-  clusterBorder: "#303030",
-  edgeLabelBackground: "#151515",
-  labelBoxBkgColor: "#1f1f1f",
-  labelBoxBorderColor: "#303030",
-  labelTextColor: "#c1c1c1",
-  lineColor: "#79a9db",
-  loopTextColor: "#c1c1c1",
-  mainBkg: "#1f1f1f",
-  nodeBorder: "#3b3b3b",
-  noteBkgColor: "#1a1a1a",
-  noteBorderColor: "#3b3b3b",
-  noteTextColor: "#c1c1c1",
-  primaryBorderColor: "#3b3b3b",
-  primaryColor: "#1f1f1f",
-  primaryTextColor: "#c1c1c1",
-  secondaryBorderColor: "#303030",
-  secondaryColor: "#1a1a1a",
-  secondaryTextColor: "#c1c1c1",
-  signalColor: "#79a9db",
-  signalTextColor: "#c1c1c1",
-  tertiaryBorderColor: "#3b3b3b",
-  tertiaryColor: "#172334",
-  tertiaryTextColor: "#c1c1c1",
-  textColor: "#c1c1c1",
-};
+let srgbCanvasContext: CanvasRenderingContext2D | null | undefined;
 
-function getMermaidThemePalette(preferredTheme: Theme): MermaidThemePalette {
-  return preferredTheme === "dark"
-    ? MERMAID_DARK_PALETTE
-    : MERMAID_LIGHT_PALETTE;
+// Normalize any CSS color (including the oklch()/color-mix() values
+// getComputedStyle preserves) to an sRGB rgb()/rgba() string. Mermaid's color
+// math (khroma) only understands sRGB, so feeding it raw oklch() breaks shading.
+// fillStyle alone preserves the color space, so rasterize a pixel and read the
+// sRGB backing store back.
+function toSrgbColor(color: string): string {
+  if (srgbCanvasContext === undefined) {
+    srgbCanvasContext =
+      document.createElement("canvas").getContext("2d", {
+        willReadFrequently: true,
+      }) ?? null;
+  }
+  const ctx = srgbCanvasContext;
+  if (!ctx) return color;
+  ctx.clearRect(0, 0, 1, 1);
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, 1, 1);
+  const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+  return a === 255
+    ? `rgb(${r}, ${g}, ${b})`
+    : `rgba(${r}, ${g}, ${b}, ${(a / 255).toFixed(3)})`;
+}
+
+function resolveThemeColor(probe: HTMLElement, varName: string): string {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+  // Assigning the (possibly color-mix/var) token to a real color property forces
+  // the browser to compute a concrete color. "currentColor" is a themed fallback
+  // if a token is ever missing.
+  probe.style.color = raw || "currentColor";
+  return toSrgbColor(getComputedStyle(probe).color);
+}
+
+function resolveMermaidThemePalette(): MermaidThemePalette {
+  const probe = document.createElement("span");
+  probe.style.position = "absolute";
+  probe.style.visibility = "hidden";
+  probe.style.pointerEvents = "none";
+  document.body.appendChild(probe);
+  const get = (name: string) => resolveThemeColor(probe, name);
+  const palette: MermaidThemePalette = {
+    actorBkg: get(MERMAID_TOKEN.nodeFill),
+    actorBorder: get(MERMAID_TOKEN.border),
+    actorTextColor: get(MERMAID_TOKEN.text),
+    background: get(MERMAID_TOKEN.background),
+    clusterBkg: get(MERMAID_TOKEN.altFill),
+    clusterBorder: get(MERMAID_TOKEN.border),
+    edgeLabelBackground: get(MERMAID_TOKEN.background),
+    labelBoxBkgColor: get(MERMAID_TOKEN.nodeFill),
+    labelBoxBorderColor: get(MERMAID_TOKEN.border),
+    labelTextColor: get(MERMAID_TOKEN.text),
+    lineColor: get(MERMAID_TOKEN.line),
+    loopTextColor: get(MERMAID_TOKEN.text),
+    mainBkg: get(MERMAID_TOKEN.nodeFill),
+    nodeBorder: get(MERMAID_TOKEN.border),
+    noteBkgColor: get(MERMAID_TOKEN.altFill),
+    noteBorderColor: get(MERMAID_TOKEN.border),
+    noteTextColor: get(MERMAID_TOKEN.text),
+    primaryBorderColor: get(MERMAID_TOKEN.border),
+    primaryColor: get(MERMAID_TOKEN.nodeFill),
+    primaryTextColor: get(MERMAID_TOKEN.text),
+    secondaryBorderColor: get(MERMAID_TOKEN.border),
+    secondaryColor: get(MERMAID_TOKEN.altFill),
+    secondaryTextColor: get(MERMAID_TOKEN.text),
+    signalColor: get(MERMAID_TOKEN.line),
+    signalTextColor: get(MERMAID_TOKEN.text),
+    tertiaryBorderColor: get(MERMAID_TOKEN.border),
+    tertiaryColor: get(MERMAID_TOKEN.tertiaryFill),
+    tertiaryTextColor: get(MERMAID_TOKEN.text),
+    textColor: get(MERMAID_TOKEN.text),
+  };
+  probe.remove();
+  return palette;
 }
 
 function buildMermaidConfig(preferredTheme: Theme): MermaidConfig {
@@ -300,7 +326,7 @@ function buildMermaidConfig(preferredTheme: Theme): MermaidConfig {
     startOnLoad: false,
     suppressErrorRendering: true,
     theme: MERMAID_THEME,
-    themeVariables: getMermaidThemePalette(preferredTheme),
+    themeVariables: resolveMermaidThemePalette(),
   };
 }
 
@@ -952,6 +978,9 @@ export function MarkdownMermaidDiagram({
   const reactId = useId();
   const diagramElementRef = useRef<HTMLDivElement>(null);
   const renderId = useMemo(() => buildMermaidRenderId(reactId), [reactId]);
+  // Re-render the SVG (which has baked-in colors) when the app palette changes,
+  // not just on light/dark mode toggles.
+  const appThemeEpoch = useAppThemeEpoch();
   const [renderState, setRenderState] = useState<MermaidRenderState>({
     kind: "loading",
   });
@@ -993,7 +1022,7 @@ export function MarkdownMermaidDiagram({
     return () => {
       isCurrentRender = false;
     };
-  }, [preferredTheme, renderId, source]);
+  }, [preferredTheme, renderId, source, appThemeEpoch]);
 
   useEffect(() => {
     if (renderState.kind !== "rendered" || displayMode !== "preview") {

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -379,7 +379,7 @@
    * faint lift, both translucent so they read on card or page alike. */
   --surface-recessed: color-mix(in oklch, var(--ink) 6%, transparent);
   --surface-raised: color-mix(in oklch, var(--ink) 2.5%, transparent);
-  --surface-scrim: color-mix(in oklch, oklch(1 0 0) 92%, transparent);
+  --surface-scrim: color-mix(in oklch, var(--canvas) 92%, transparent);
   --surface-destructive: color-mix(
     in oklch,
     var(--destructive) 6%,
@@ -547,7 +547,7 @@
   /* Same model as light; ink is light here, so these lift the dark canvas. */
   --surface-recessed: color-mix(in oklch, var(--ink) 6%, transparent);
   --surface-raised: color-mix(in oklch, var(--ink) 2.5%, transparent);
-  --surface-scrim: color-mix(in oklch, oklch(0.195 0 0) 92%, transparent);
+  --surface-scrim: color-mix(in oklch, var(--canvas) 92%, transparent);
   --surface-destructive: color-mix(
     in oklch,
     var(--destructive) 8%,

--- a/apps/app/src/hooks/mutations/settings-mutations.ts
+++ b/apps/app/src/hooks/mutations/settings-mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { Experiments } from "@bb/domain";
+import type { AppTheme, Experiments } from "@bb/domain";
 import * as api from "@/lib/api";
 import { invalidateSystemConfig } from "../cache-owners/system-cache-effects";
 
@@ -17,6 +17,24 @@ export function useUpdateExperiments() {
     },
     mutationFn: (experiments: Experiments) =>
       api.updateExperiments(experiments),
+    onSuccess: () => {
+      invalidateSystemConfig({ queryClient });
+    },
+  });
+}
+
+/**
+ * Set the app-wide color palette. Like experiments, the server broadcasts
+ * `config-changed` for other windows; the local invalidation refreshes this one.
+ */
+export function useUpdateAppearance() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    meta: {
+      errorMessage: "Failed to update appearance.",
+    },
+    mutationFn: (appearance: AppTheme) => api.updateAppearance(appearance),
     onSuccess: () => {
       invalidateSystemConfig({ queryClient });
     },

--- a/apps/app/src/hooks/useAppTheme.ts
+++ b/apps/app/src/hooks/useAppTheme.ts
@@ -1,0 +1,42 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
+import { refreshThemeColorMeta } from "@/hooks/useTheme";
+import {
+  applyAppThemeCss,
+  getAppThemeEpoch,
+  resolveAppThemeCss,
+  subscribeAppThemeChange,
+} from "@/lib/themes";
+
+/**
+ * Applies the server-stored app palette (built-in id or custom CSS) by injecting
+ * a trailing <style> in <head>. Re-runs whenever /system/config changes (the CLI
+ * or another window switched palettes), which the systemConfig query already
+ * refetches on the `config-changed` broadcast.
+ */
+export function useAppTheme(): void {
+  const { data } = useSystemConfig();
+  const css = data?.appearance ? resolveAppThemeCss(data.appearance) : null;
+
+  useEffect(() => {
+    if (css === null) return;
+    applyAppThemeCss(css);
+    // A palette change can move the page background without a light/dark mode
+    // change, so re-sync the PWA chrome color to match.
+    refreshThemeColorMeta();
+  }, [css]);
+}
+
+/**
+ * A counter that increments whenever the active palette CSS changes. Surfaces
+ * that bake colors instead of consuming `var(--token)` (mermaid SVGs, the xterm
+ * canvas) depend on this to re-resolve their colors after a palette swap that
+ * doesn't toggle light/dark mode.
+ */
+export function useAppThemeEpoch(): number {
+  return useSyncExternalStore(
+    subscribeAppThemeChange,
+    getAppThemeEpoch,
+    getAppThemeEpoch,
+  );
+}

--- a/apps/app/src/hooks/useTheme.ts
+++ b/apps/app/src/hooks/useTheme.ts
@@ -49,6 +49,15 @@ function syncThemeColorMeta(): void {
   meta.content = background;
 }
 
+/**
+ * Re-sync the PWA chrome color from the current page background. Exposed so the
+ * app palette (useAppTheme) can refresh it after a palette change that doesn't
+ * toggle light/dark mode.
+ */
+export function refreshThemeColorMeta(): void {
+  syncThemeColorMeta();
+}
+
 function getSystemTheme(): Theme {
   if (typeof window === "undefined") return "light";
   if (typeof window.matchMedia !== "function") return "light";

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { extractErrorMessage, toRecord } from "@bb/core-ui";
 import type {
+  AppTheme,
   Environment,
   Experiments,
   Host,
@@ -1623,6 +1624,12 @@ export async function updateExperiments(
 ): Promise<Experiments> {
   return request<Experiments>(
     apiClient.settings.experiments.$put({ json: experiments }),
+  );
+}
+
+export async function updateAppearance(appearance: AppTheme): Promise<AppTheme> {
+  return request<AppTheme>(
+    apiClient.settings.appearance.$put({ json: appearance }),
   );
 }
 

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -13,6 +13,7 @@ const unavailableSystemConfig: SystemConfigResponse = {
     popoutChat: false,
     popoutChatHotkey: "Alt+Space",
   },
+  appearance: { themeId: "default", customCss: null },
   featureFlags: { placeholder: false },
   hostDaemonPort: null,
   voiceTranscriptionEnabled: false,

--- a/apps/app/src/lib/themes/dracula.ts
+++ b/apps/app/src/lib/themes/dracula.ts
@@ -1,0 +1,76 @@
+/**
+ * Dracula palette (https://draculatheme.com). Dracula is dark-first; the light
+ * variant ("Alucard"-style) keeps the same hues at darker lightness so it stays
+ * legible on a pale canvas. See nord.ts for how the minimal override set
+ * cascades to the rest of the tokens.
+ */
+export const draculaThemeCss = `
+:root, .light {
+  --canvas: #f8f8f2;
+  --ink: #282a36;
+  --primary: #7d5bbe;
+  --primary-foreground: #ffffff;
+  --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+  --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+  --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+  --file-accent: #1f6f8b;
+  --destructive: #c4314b;
+  --destructive-text: #b3243d;
+  --warning: #b8762e;
+  --warning-text: #8f5a22;
+  --attention: #9a7d00;
+  --success: #2c7a4b;
+  --diff-added: #2c7a4b;
+  --diff-removed: #c4314b;
+  --pr-merged: #7d5bbe;
+  --ansi-0: #21222c;
+  --ansi-1: #ff5555;
+  --ansi-2: #50fa7b;
+  --ansi-3: #f1fa8c;
+  --ansi-4: #bd93f9;
+  --ansi-5: #ff79c6;
+  --ansi-6: #8be9fd;
+  --ansi-7: #f8f8f2;
+  --ansi-8: #6272a4;
+  --ansi-9: #ff6e6e;
+  --ansi-10: #69ff94;
+  --ansi-11: #ffffa5;
+  --ansi-12: #d6acff;
+  --ansi-13: #ff92df;
+  --ansi-14: #a4ffff;
+  --ansi-15: #ffffff;
+  /* Readable text drawn on each ANSI background (black/white by contrast). */
+  --ansi-bg-fg-0: #ffffff;
+  --ansi-bg-fg-1: #000000;
+  --ansi-bg-fg-2: #000000;
+  --ansi-bg-fg-3: #000000;
+  --ansi-bg-fg-4: #000000;
+  --ansi-bg-fg-5: #000000;
+  --ansi-bg-fg-6: #000000;
+  --ansi-bg-fg-7: #000000;
+  --ansi-bg-fg-8: #ffffff;
+  --ansi-bg-fg-9: #000000;
+  --ansi-bg-fg-10: #000000;
+  --ansi-bg-fg-11: #000000;
+  --ansi-bg-fg-12: #000000;
+  --ansi-bg-fg-13: #000000;
+  --ansi-bg-fg-14: #000000;
+  --ansi-bg-fg-15: #000000;
+}
+.dark {
+  --canvas: #282a36;
+  --ink: #f8f8f2;
+  --primary: #bd93f9;
+  --primary-foreground: #282a36;
+  --file-accent: #8be9fd;
+  --destructive: #ff5555;
+  --destructive-text: #ff7b7b;
+  --warning: #ffb86c;
+  --warning-text: #ffb86c;
+  --attention: #f1fa8c;
+  --success: #50fa7b;
+  --diff-added: #50fa7b;
+  --diff-removed: #ff5555;
+  --pr-merged: #bd93f9;
+}
+`;

--- a/apps/app/src/lib/themes/gruvbox.ts
+++ b/apps/app/src/lib/themes/gruvbox.ts
@@ -1,0 +1,76 @@
+/**
+ * Gruvbox palette (https://github.com/morhetz/gruvbox). Warm retro earth tones;
+ * light mode uses the "faded" accent set for contrast on the cream canvas, dark
+ * mode uses the "bright" set. See nord.ts for how the minimal override set
+ * cascades to the rest of the tokens.
+ */
+export const gruvboxThemeCss = `
+:root, .light {
+  --canvas: #fbf1c7;
+  --ink: #3c3836;
+  --primary: #076678;
+  --primary-foreground: #fbf1c7;
+  --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+  --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+  --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+  --file-accent: #076678;
+  --destructive: #cc241d;
+  --destructive-text: #9d0006;
+  --warning: #d65d0e;
+  --warning-text: #af3a03;
+  --attention: #b57614;
+  --success: #79740e;
+  --diff-added: #79740e;
+  --diff-removed: #9d0006;
+  --pr-merged: #8f3f71;
+  --ansi-0: #3c3836;
+  --ansi-1: #cc241d;
+  --ansi-2: #98971a;
+  --ansi-3: #d79921;
+  --ansi-4: #458588;
+  --ansi-5: #b16286;
+  --ansi-6: #689d6a;
+  --ansi-7: #ebdbb2;
+  --ansi-8: #928374;
+  --ansi-9: #fb4934;
+  --ansi-10: #b8bb26;
+  --ansi-11: #fabd2f;
+  --ansi-12: #83a598;
+  --ansi-13: #d3869b;
+  --ansi-14: #8ec07c;
+  --ansi-15: #fbf1c7;
+  /* Readable text drawn on each ANSI background (black/white by contrast). */
+  --ansi-bg-fg-0: #ffffff;
+  --ansi-bg-fg-1: #ffffff;
+  --ansi-bg-fg-2: #000000;
+  --ansi-bg-fg-3: #000000;
+  --ansi-bg-fg-4: #000000;
+  --ansi-bg-fg-5: #000000;
+  --ansi-bg-fg-6: #000000;
+  --ansi-bg-fg-7: #000000;
+  --ansi-bg-fg-8: #000000;
+  --ansi-bg-fg-9: #000000;
+  --ansi-bg-fg-10: #000000;
+  --ansi-bg-fg-11: #000000;
+  --ansi-bg-fg-12: #000000;
+  --ansi-bg-fg-13: #000000;
+  --ansi-bg-fg-14: #000000;
+  --ansi-bg-fg-15: #000000;
+}
+.dark {
+  --canvas: #282828;
+  --ink: #ebdbb2;
+  --primary: #83a598;
+  --primary-foreground: #282828;
+  --file-accent: #83a598;
+  --destructive: #fb4934;
+  --destructive-text: #fb4934;
+  --warning: #fe8019;
+  --warning-text: #fe8019;
+  --attention: #fabd2f;
+  --success: #b8bb26;
+  --diff-added: #b8bb26;
+  --diff-removed: #fb4934;
+  --pr-merged: #d3869b;
+}
+`;

--- a/apps/app/src/lib/themes/index.ts
+++ b/apps/app/src/lib/themes/index.ts
@@ -1,0 +1,93 @@
+import type { AppTheme, AppThemeId } from "@bb/domain";
+import { draculaThemeCss } from "./dracula";
+import { gruvboxThemeCss } from "./gruvbox";
+import { nordThemeCss } from "./nord";
+import { solarizedThemeCss } from "./solarized";
+
+const APP_THEME_STYLE_ELEMENT_ID = "bb-app-theme";
+export const APP_THEME_CSS_STORAGE_KEY = "bb.appThemeCss";
+
+/**
+ * CSS overrides per built-in palette. "default" is empty so the base theme.css
+ * tokens show through. The "custom" palette is supplied at runtime (server),
+ * not from this registry.
+ */
+const builtInThemeCss: Record<Exclude<AppThemeId, "custom">, string> = {
+  default: "",
+  nord: nordThemeCss,
+  dracula: draculaThemeCss,
+  solarized: solarizedThemeCss,
+  gruvbox: gruvboxThemeCss,
+};
+
+export function resolveAppThemeCss(appearance: AppTheme): string {
+  if (appearance.themeId === "custom") return appearance.customCss ?? "";
+  return builtInThemeCss[appearance.themeId] ?? "";
+}
+
+function getOrCreateStyleElement(): HTMLStyleElement | null {
+  if (typeof document === "undefined") return null;
+  const existing = document.getElementById(APP_THEME_STYLE_ELEMENT_ID);
+  if (existing instanceof HTMLStyleElement) return existing;
+  const style = document.createElement("style");
+  style.id = APP_THEME_STYLE_ELEMENT_ID;
+  // Appended last in <head> so its :root/.dark token overrides win over
+  // theme.css by source order, regardless of the active light/dark mode.
+  document.head.appendChild(style);
+  return style;
+}
+
+// Surfaces that bake the palette into output once (mermaid SVGs, the xterm
+// canvas) can't consume live `var(--token)`; they re-resolve computed colors
+// when the palette changes. The epoch bumps AFTER the new CSS is applied to the
+// DOM, so a subscriber re-resolving against it always sees the new values.
+let appThemeEpoch = 0;
+const appThemeSubscribers = new Set<() => void>();
+
+export function subscribeAppThemeChange(callback: () => void): () => void {
+  appThemeSubscribers.add(callback);
+  return () => {
+    appThemeSubscribers.delete(callback);
+  };
+}
+
+export function getAppThemeEpoch(): number {
+  return appThemeEpoch;
+}
+
+/**
+ * Inject the resolved palette CSS as the trailing <style> in <head> and cache
+ * it so the next load can apply it before the server config arrives (no flash).
+ * Empty CSS (the default palette) clears both the element and the cache.
+ */
+export function applyAppThemeCss(css: string): void {
+  const style = getOrCreateStyleElement();
+  if (!style) return;
+  if (style.textContent !== css) {
+    style.textContent = css;
+    appThemeEpoch += 1;
+    appThemeSubscribers.forEach((callback) => callback());
+  }
+  try {
+    if (css) localStorage.setItem(APP_THEME_CSS_STORAGE_KEY, css);
+    else localStorage.removeItem(APP_THEME_CSS_STORAGE_KEY);
+  } catch {
+    // Best-effort cache; ignore private-mode / quota failures.
+  }
+}
+
+/**
+ * Apply the palette cached from the previous load. Called once at startup
+ * before the server's /system/config (and thus the authoritative appearance)
+ * has loaded, so a non-default palette doesn't flash the default first.
+ */
+export function applyCachedAppThemeCss(): void {
+  if (typeof document === "undefined") return;
+  let cached: string | null = null;
+  try {
+    cached = localStorage.getItem(APP_THEME_CSS_STORAGE_KEY);
+  } catch {
+    cached = null;
+  }
+  if (cached) applyAppThemeCss(cached);
+}

--- a/apps/app/src/lib/themes/nord.ts
+++ b/apps/app/src/lib/themes/nord.ts
@@ -1,0 +1,78 @@
+/**
+ * Nord palette (https://www.nordtheme.com). Overrides only the two anchors
+ * (--canvas/--ink), the accent, the secondary text tiers, the semantic colors,
+ * and the ANSI palette — every neutral surface (cards, borders, sidebar, hover,
+ * selection, ring) derives from the anchors and accent in theme.css, so it
+ * follows automatically. The ANSI block lives in the light selector and applies
+ * in both modes (terminal colors are mode-independent).
+ */
+export const nordThemeCss = `
+:root, .light {
+  --canvas: #eceff4;
+  --ink: #2e3440;
+  --primary: #5e81ac;
+  --primary-foreground: #eceff4;
+  --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+  --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+  --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+  --file-accent: #5e81ac;
+  --destructive: #bf616a;
+  --destructive-text: #a1343d;
+  --warning: #d08770;
+  --warning-text: #99543a;
+  --attention: #ebcb8b;
+  --success: #6f9655;
+  --diff-added: #5e8a52;
+  --diff-removed: #bf616a;
+  --pr-merged: #9d7cb8;
+  --ansi-0: #3b4252;
+  --ansi-1: #bf616a;
+  --ansi-2: #a3be8c;
+  --ansi-3: #ebcb8b;
+  --ansi-4: #81a1c1;
+  --ansi-5: #b48ead;
+  --ansi-6: #88c0d0;
+  --ansi-7: #e5e9f0;
+  --ansi-8: #4c566a;
+  --ansi-9: #bf616a;
+  --ansi-10: #a3be8c;
+  --ansi-11: #ebcb8b;
+  --ansi-12: #81a1c1;
+  --ansi-13: #b48ead;
+  --ansi-14: #8fbcbb;
+  --ansi-15: #eceff4;
+  /* Readable text drawn on each ANSI background (black/white by contrast). */
+  --ansi-bg-fg-0: #ffffff;
+  --ansi-bg-fg-1: #000000;
+  --ansi-bg-fg-2: #000000;
+  --ansi-bg-fg-3: #000000;
+  --ansi-bg-fg-4: #000000;
+  --ansi-bg-fg-5: #000000;
+  --ansi-bg-fg-6: #000000;
+  --ansi-bg-fg-7: #000000;
+  --ansi-bg-fg-8: #ffffff;
+  --ansi-bg-fg-9: #000000;
+  --ansi-bg-fg-10: #000000;
+  --ansi-bg-fg-11: #000000;
+  --ansi-bg-fg-12: #000000;
+  --ansi-bg-fg-13: #000000;
+  --ansi-bg-fg-14: #000000;
+  --ansi-bg-fg-15: #000000;
+}
+.dark {
+  --canvas: #2e3440;
+  --ink: #d8dee9;
+  --primary: #88c0d0;
+  --primary-foreground: #2e3440;
+  --file-accent: #88c0d0;
+  --destructive: #bf616a;
+  --destructive-text: #d6868d;
+  --warning: #d08770;
+  --warning-text: #e0a48f;
+  --attention: #ebcb8b;
+  --success: #a3be8c;
+  --diff-added: #a3be8c;
+  --diff-removed: #bf616a;
+  --pr-merged: #b48ead;
+}
+`;

--- a/apps/app/src/lib/themes/solarized.ts
+++ b/apps/app/src/lib/themes/solarized.ts
@@ -1,0 +1,75 @@
+/**
+ * Solarized palette (Ethan Schoonover). Uses the canonical base3/base03 canvases
+ * with darkened accents in light mode so text/fills clear contrast on the warm
+ * paper background. See nord.ts for how the minimal override set cascades.
+ */
+export const solarizedThemeCss = `
+:root, .light {
+  --canvas: #fdf6e3;
+  --ink: #073642;
+  --primary: #268bd2;
+  --primary-foreground: #fdf6e3;
+  --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+  --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+  --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+  --file-accent: #268bd2;
+  --destructive: #dc322f;
+  --destructive-text: #c12321;
+  --warning: #cb4b16;
+  --warning-text: #a53c12;
+  --attention: #b58900;
+  --success: #718c00;
+  --diff-added: #718c00;
+  --diff-removed: #dc322f;
+  --pr-merged: #6c71c4;
+  --ansi-0: #073642;
+  --ansi-1: #dc322f;
+  --ansi-2: #859900;
+  --ansi-3: #b58900;
+  --ansi-4: #268bd2;
+  --ansi-5: #d33682;
+  --ansi-6: #2aa198;
+  --ansi-7: #eee8d5;
+  --ansi-8: #586e75;
+  --ansi-9: #cb4b16;
+  --ansi-10: #93a1a1;
+  --ansi-11: #839496;
+  --ansi-12: #657b83;
+  --ansi-13: #6c71c4;
+  --ansi-14: #2aa198;
+  --ansi-15: #fdf6e3;
+  /* Readable text drawn on each ANSI background (black/white by contrast). */
+  --ansi-bg-fg-0: #ffffff;
+  --ansi-bg-fg-1: #ffffff;
+  --ansi-bg-fg-2: #000000;
+  --ansi-bg-fg-3: #000000;
+  --ansi-bg-fg-4: #000000;
+  --ansi-bg-fg-5: #000000;
+  --ansi-bg-fg-6: #000000;
+  --ansi-bg-fg-7: #000000;
+  --ansi-bg-fg-8: #ffffff;
+  --ansi-bg-fg-9: #ffffff;
+  --ansi-bg-fg-10: #000000;
+  --ansi-bg-fg-11: #000000;
+  --ansi-bg-fg-12: #000000;
+  --ansi-bg-fg-13: #000000;
+  --ansi-bg-fg-14: #000000;
+  --ansi-bg-fg-15: #000000;
+}
+.dark {
+  --canvas: #002b36;
+  --ink: #93a1a1;
+  --primary: #268bd2;
+  --primary-foreground: #002b36;
+  --file-accent: #2aa198;
+  --destructive: #dc322f;
+  --destructive-text: #e8645f;
+  --warning: #cb4b16;
+  --warning-text: #e07a4e;
+  --attention: #b58900;
+  --success: #859900;
+  --diff-added: #859900;
+  --diff-removed: #dc322f;
+  --pr-merged: #6c71c4;
+}
+`;

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -8,11 +8,16 @@ import { initializePreferredTheme } from "./hooks/useTheme";
 import { initializeFavicon } from "./lib/favicon-color-preference";
 import { createAppQueryClient } from "./lib/query-client";
 import { takeOverPanelResizeCursor } from "./lib/resizeCursor";
+import { applyCachedAppThemeCss } from "./lib/themes";
 import "./app.css";
 
 const queryClient = createAppQueryClient();
 
 initializePreferredTheme();
+// Apply the palette cached from the last load before React renders, so a
+// non-default theme doesn't flash the default. useAppTheme reconciles it with
+// the server's authoritative appearance once /system/config loads.
+applyCachedAppThemeCss();
 initializeFavicon();
 takeOverPanelResizeCursor();
 

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -1,5 +1,12 @@
 import { useMemo, useState, type KeyboardEvent } from "react";
-import { defaultExperiments, isValidElectronAccelerator } from "@bb/domain";
+import {
+  builtInThemes,
+  defaultAppTheme,
+  defaultExperiments,
+  isValidElectronAccelerator,
+  type AppTheme,
+  type AppThemeId,
+} from "@bb/domain";
 import type {
   WorkspaceOpenTarget,
   WorkspaceOpenTargetId,
@@ -27,7 +34,10 @@ import {
 } from "@/hooks/useTheme";
 import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSettingsSection";
-import { useUpdateExperiments } from "@/hooks/mutations/settings-mutations";
+import {
+  useUpdateAppearance,
+  useUpdateExperiments,
+} from "@/hooks/mutations/settings-mutations";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
 import { useWorkspaceOpenTargets } from "@/hooks/useWorkspaceOpenTargets";
 import { getBbDesktopInfo, isDesktopBrowserAvailable } from "@/lib/bb-desktop";
@@ -110,9 +120,12 @@ export interface FaviconColorSettingsControlProps {
 }
 
 export interface GeneralSettingsSectionProps {
+  appearance: AppTheme;
+  appearanceDisabled: boolean;
   desktopBrowserAvailable: boolean;
   faviconColor: FaviconColorPreference;
   navigateToThreadAfterCreate: boolean;
+  onAppearanceThemeChange: (themeId: AppThemeId) => void;
   onFaviconColorChange: (faviconColor: FaviconColorPreference) => void;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
   onOpenLinksInAppBrowserChange: (enabled: boolean) => void;
@@ -123,6 +136,12 @@ export interface GeneralSettingsSectionProps {
   rewriteLocalhostLinks: boolean;
   richTextEditing: boolean;
   themePreference: ThemePreference;
+}
+
+function appPaletteLabel(appearance: AppTheme): string {
+  if (appearance.themeId === "custom") return "Custom";
+  const meta = builtInThemes.find((entry) => entry.id === appearance.themeId);
+  return meta?.name ?? appearance.themeId;
 }
 
 export interface ExperimentsSettingsSectionProps {
@@ -459,9 +478,12 @@ export function RichTextEditingSettingsControl({
 }
 
 export function GeneralSettingsSection({
+  appearance,
+  appearanceDisabled,
   desktopBrowserAvailable,
   faviconColor,
   navigateToThreadAfterCreate,
+  onAppearanceThemeChange,
   onFaviconColorChange,
   onNavigateToThreadAfterCreateChange,
   onOpenLinksInAppBrowserChange,
@@ -509,6 +531,63 @@ export function GeneralSettingsSection({
                   />
                 </DropdownMenuItem>
               ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SettingsWithControl>
+
+        <SettingsWithControl
+          label="Palette"
+          description="Applies to the whole app. Load a custom stylesheet with the bb theme CLI."
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-between border-border/60 bg-card sm:w-48"
+                aria-label="Palette"
+                disabled={appearanceDisabled}
+              >
+                {appPaletteLabel(appearance)}
+                <Icon
+                  name="ChevronDown"
+                  className="size-3.5 text-muted-foreground"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              {builtInThemes.map((entry) => (
+                <DropdownMenuItem
+                  key={entry.id}
+                  onSelect={() => onAppearanceThemeChange(entry.id)}
+                >
+                  {entry.name}
+                  <Icon
+                    name="Check"
+                    className={cn(
+                      "ml-auto",
+                      appearance.themeId !== entry.id && "opacity-0",
+                      COARSE_POINTER_ICON_SIZE_CLASS,
+                    )}
+                  />
+                </DropdownMenuItem>
+              ))}
+              {appearance.customCss !== null ? (
+                <DropdownMenuItem
+                  key="custom"
+                  onSelect={() => onAppearanceThemeChange("custom")}
+                >
+                  Custom
+                  <Icon
+                    name="Check"
+                    className={cn(
+                      "ml-auto",
+                      appearance.themeId !== "custom" && "opacity-0",
+                      COARSE_POINTER_ICON_SIZE_CLASS,
+                    )}
+                  />
+                </DropdownMenuItem>
+              ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
         </SettingsWithControl>
@@ -815,11 +894,18 @@ export function SettingsView() {
   const [desktopShellAvailable] = useState(() => getBbDesktopInfo() !== null);
   const experiments = systemConfigQuery.data?.experiments ?? defaultExperiments;
   const updateExperimentsMutation = useUpdateExperiments();
+  const appearance = systemConfigQuery.data?.appearance ?? defaultAppTheme;
+  const updateAppearanceMutation = useUpdateAppearance();
 
   return (
     <PageShell contentClassName="pt-4 md:pt-5">
       <div className="mx-auto w-full max-w-3xl space-y-6">
         <GeneralSettingsSection
+          appearance={appearance}
+          appearanceDisabled={
+            systemConfigQuery.data === undefined ||
+            updateAppearanceMutation.isPending
+          }
           desktopBrowserAvailable={desktopBrowserAvailable}
           faviconColor={faviconColor}
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
@@ -827,6 +913,12 @@ export function SettingsView() {
           rewriteLocalhostLinks={rewriteLocalhostLinks}
           richTextEditing={richTextEditing}
           themePreference={themePreference}
+          onAppearanceThemeChange={(themeId) =>
+            updateAppearanceMutation.mutate({
+              themeId,
+              customCss: appearance.customCss,
+            })
+          }
           onFaviconColorChange={setFaviconColor}
           onNavigateToThreadAfterCreateChange={setNavigateToThreadAfterCreate}
           onOpenLinksInAppBrowserChange={setOpenLinksInAppBrowser}

--- a/apps/cli/src/commands/theme.ts
+++ b/apps/cli/src/commands/theme.ts
@@ -1,0 +1,146 @@
+import { readFile } from "node:fs/promises";
+import { Command } from "commander";
+import {
+  BUILTIN_THEME_IDS,
+  builtInThemes,
+  defaultAppTheme,
+  type AppTheme,
+  type AppThemeId,
+} from "@bb/domain";
+import { action } from "../action.js";
+import { createCliBbSdk } from "../client.js";
+import { outputJson, type JsonOutputOptions } from "./helpers.js";
+
+interface ThemeSetCustomCommandOptions extends JsonOutputOptions {
+  file: string;
+}
+
+interface ThemeShowCommandOptions extends JsonOutputOptions {
+  css?: boolean;
+}
+
+function describeActive(theme: AppTheme): string {
+  if (theme.themeId === "custom") {
+    const bytes = theme.customCss?.length ?? 0;
+    return `Custom stylesheet (${bytes} bytes)`;
+  }
+  const meta = builtInThemes.find((entry) => entry.id === theme.themeId);
+  return meta ? `${meta.name} (${meta.id})` : theme.themeId;
+}
+
+export function registerThemeCommands(
+  program: Command,
+  getUrl: () => string,
+): void {
+  const theme = program
+    .command("theme")
+    .description("Manage the app color palette (built-in themes or custom CSS)");
+
+  theme
+    .command("list")
+    .description("List built-in themes and the active palette")
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (opts: JsonOutputOptions) => {
+        const sdk = createCliBbSdk(getUrl());
+        const active = await sdk.theme.get();
+        if (
+          outputJson(opts, {
+            active,
+            builtInThemes,
+            customLoaded: active.customCss !== null,
+          })
+        ) {
+          return;
+        }
+        console.log("");
+        for (const entry of builtInThemes) {
+          const marker = active.themeId === entry.id ? "*" : " ";
+          console.log(`${marker} ${entry.id.padEnd(10)} ${entry.description}`);
+        }
+        const customMarker = active.themeId === "custom" ? "*" : " ";
+        const customState =
+          active.customCss !== null ? "loaded" : "not set — use set-custom";
+        console.log(`${customMarker} ${"custom".padEnd(10)} ${customState}`);
+        console.log("");
+        console.log(`Active: ${describeActive(active)}`);
+      }),
+    );
+
+  theme
+    .command("set <id>")
+    .description(`Switch to a built-in theme (${BUILTIN_THEME_IDS.join(", ")})`)
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (id: string, opts: JsonOutputOptions) => {
+        if (!(BUILTIN_THEME_IDS as readonly string[]).includes(id)) {
+          throw new Error(
+            `Unknown theme '${id}'. Expected one of: ${BUILTIN_THEME_IDS.join(", ")}.`,
+          );
+        }
+        const sdk = createCliBbSdk(getUrl());
+        // Preserve any previously loaded custom CSS so it can be re-selected.
+        const current = await sdk.theme.get();
+        const updated = await sdk.theme.set({
+          themeId: id as AppThemeId,
+          customCss: current.customCss,
+        });
+        if (outputJson(opts, updated)) return;
+        console.log(`Theme set to ${describeActive(updated)}`);
+      }),
+    );
+
+  theme
+    .command("set-custom")
+    .description("Load a custom stylesheet from a file and activate it")
+    .requiredOption("--file <path>", "Path to a CSS file")
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (opts: ThemeSetCustomCommandOptions) => {
+        const customCss = await readFile(opts.file, "utf8");
+        const sdk = createCliBbSdk(getUrl());
+        const updated = await sdk.theme.set({ themeId: "custom", customCss });
+        if (outputJson(opts, updated)) return;
+        console.log(
+          `Custom stylesheet loaded (${customCss.length} bytes) and activated`,
+        );
+      }),
+    );
+
+  theme
+    .command("show")
+    .description("Show the active palette")
+    .option("--css", "Print the active custom CSS (custom theme only)")
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (opts: ThemeShowCommandOptions) => {
+        const sdk = createCliBbSdk(getUrl());
+        const active = await sdk.theme.get();
+        if (outputJson(opts, active)) return;
+        if (opts.css) {
+          if (active.themeId === "custom" && active.customCss !== null) {
+            console.log(active.customCss);
+          } else {
+            console.log(
+              "// Built-in theme CSS is bundled in the app, not stored server-side.",
+            );
+          }
+          return;
+        }
+        console.log(`Active: ${describeActive(active)}`);
+      }),
+    );
+
+  theme
+    .command("reset")
+    .description("Reset to the Default theme and clear any custom stylesheet")
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (opts: JsonOutputOptions) => {
+        const sdk = createCliBbSdk(getUrl());
+        const updated = await sdk.theme.set(defaultAppTheme);
+        if (outputJson(opts, updated)) return;
+        console.log(`Theme reset to ${describeActive(updated)}`);
+      }),
+    );
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,7 @@ import { registerManagerCommands } from "./commands/manager.js";
 import { registerProjectCommands } from "./commands/project.js";
 import { registerProviderCommands } from "./commands/provider.js";
 import { registerStatusCommand } from "./commands/status.js";
+import { registerThemeCommands } from "./commands/theme.js";
 import { registerThreadCommands } from "./commands/thread/index.js";
 import {
   createCliRuntimeContext,
@@ -66,6 +67,7 @@ registerManagerCommands(program, getUrl);
 registerThreadCommands(program, getUrl);
 registerEnvironmentCommands(program, getUrl);
 registerAutomationCommands(program, getUrl);
+registerThemeCommands(program, getUrl);
 registerGuideCommand(program);
 
 program.parseAsync(process.argv).catch((err) => {

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,4 +1,9 @@
-import { getExperiments, setExperiments } from "@bb/db";
+import {
+  getAppTheme,
+  getExperiments,
+  setAppTheme,
+  setExperiments,
+} from "@bb/db";
 import { listBuiltInAgentProviderInfos } from "@bb/agent-providers";
 import {
   publicApiRoutes,
@@ -24,6 +29,7 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
   function buildSystemConfigResponse() {
     return {
       experiments: getExperiments(deps.db),
+      appearance: getAppTheme(deps.db),
       featureFlags: deps.config.featureFlags,
       hostDaemonPort: deps.config.hostDaemonPort,
       voiceTranscriptionEnabled: resolveVoiceTranscriptionEnabled(deps),
@@ -38,6 +44,14 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
     // /system/config and re-gates its experiment-flagged surfaces.
     deps.hub.notifySystem(["config-changed"]);
     return context.json(getExperiments(deps.db));
+  });
+
+  put(routes.appearance, (context, payload) => {
+    setAppTheme(deps.db, payload);
+    // Broadcast like experiments: every window re-reads /system/config and
+    // re-applies the active palette.
+    deps.hub.notifySystem(["config-changed"]);
+    return context.json(getAppTheme(deps.db));
   });
 
   post(routes.reloadConfig, async (context) => {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -138,3 +138,33 @@ For review or fix pipelines, get the environment ID from
   `bb automation run <id>` to trigger now, and `bb automation delete <id> --yes`
   to remove.
 - Run `bb guide automations` for the full command reference.
+
+## Theming
+
+- `bb theme` controls the **app-wide color palette** — a set of CSS-variable
+  overrides persisted server-side and applied live to every open window. This is
+  the *palette* only; light/dark *mode* is a separate per-client setting that the
+  palette layers on top of.
+- Commands:
+  - `bb theme list` — built-in themes and which palette is active.
+  - `bb theme set <id>` — switch to a built-in: `default`, `nord`, `dracula`,
+    `solarized`, `gruvbox`.
+  - `bb theme set-custom --file <path.css>` — load a custom stylesheet and
+    activate it. This is the only way to set custom CSS (Settings only switches
+    between built-ins).
+  - `bb theme show [--css]` — print the active palette; `--css` dumps the custom CSS.
+  - `bb theme reset` — back to `default`, clearing the custom stylesheet.
+
+### Authoring a theme
+
+To write a built-in theme or a custom stylesheet, **read `references/theming.md`
+(in this skill's directory) first.** It is the full design-token reference — what
+every CSS variable drives, which tokens to set vs. which auto-derive — plus the
+two-block light/dark structure, how to set colors and fonts, and a worked example.
+
+The short version: a custom theme is a plain CSS file that overrides CSS custom
+properties. Set the two anchors `--canvas`/`--ink` (most of the UI derives from
+them by mixing ink into canvas), the `--primary` accent, the secondary text tiers
+(`--muted-foreground` etc.), and the semantic colors (`--destructive`,
+`--success`, …). Ship one file with a `:root, .light` block and a `.dark` block,
+then load it with `bb theme set-custom --file <path.css>`.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/theming.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/theming.md
@@ -1,0 +1,237 @@
+# bb theme authoring reference
+
+How to write a good bb app theme: the design model, the full design-token
+reference (what every CSS variable drives), and how to set colors and fonts.
+Read this before authoring or editing a built-in theme or a custom stylesheet.
+
+The *palette* is global and server-stored; light/dark *mode* is a separate
+per-client setting that the palette layers on top of. You ship one stylesheet
+that handles both modes.
+
+## Contents
+
+- [Model](#model)
+- [Stylesheet structure](#stylesheet-structure)
+- [What to set (quick start)](#what-to-set-quick-start)
+- [Token reference — what each variable drives](#token-reference)
+- [Changing fonts](#changing-fonts)
+- [Worked example](#worked-example)
+- [Applying a theme](#applying-a-theme)
+
+## Model
+
+The app's colors flow through CSS custom properties. The whole **neutral ramp**
+(backgrounds, cards, borders, sidebar, hover/active states, inset surfaces) is
+**derived from two anchors** — `--canvas` (the base surface) and `--ink` (the
+base text color) — by mixing `--ink` into `--canvas` at increasing percentages
+(higher % = more contrast / further from the surface). Accent-tinted surfaces
+(focus ring, selection, destructive surfaces) derive from `--primary` /
+`--destructive`. So you mostly set the **anchors + accent + text tiers +
+semantic** tokens, and everything else follows automatically.
+
+A custom theme is a plain CSS file that overrides these tokens. It is injected as
+the last stylesheet, so its rules win.
+
+## Stylesheet structure
+
+Provide two blocks using these exact selectors — `:root, .light` for light mode
+and `.dark` for dark:
+
+```css
+:root, .light { /* light overrides */ }
+.dark { /* dark overrides */ }
+```
+
+`:root` matches in both modes, so anything you put only in `:root, .light`
+applies to dark too. Use that for mode-independent things (the `color-mix` text
+tiers, the ANSI palette, fonts): the `.dark` block then only needs to re-set the
+anchors, accent, and semantic colors.
+
+The stylesheet is capped at ~256 KB.
+
+## What to set (quick start)
+
+Set tokens in this order:
+
+1. **The two anchors — `--canvas` and `--ink`.** Nearly everything derives from
+   them. Keep them high-contrast — aim for ≥ 4.5:1 between `--ink` and
+   `--canvas`.
+2. **The accent — `--primary` and `--primary-foreground`** (text/icons drawn on
+   the accent). The focus ring, selection highlight, and sidebar ring derive from
+   `--primary`.
+3. **The secondary text tiers — `--muted-foreground`, `--subtle-foreground`,
+   `--readback-foreground`.** These do NOT derive by default; derive them from the
+   anchors so contrast tracks the theme:
+   ```css
+   --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+   --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+   --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+   ```
+4. **Semantic + accent colors** (also not derived): `--destructive`,
+   `--destructive-text` (a text-legible variant), `--warning`, `--warning-text`,
+   `--attention`, `--success`, `--diff-added`, `--diff-removed`, `--pr-merged`,
+   and `--file-accent` (file-path tint).
+5. **Terminal palette (optional): `--ansi-0` … `--ansi-15`.** If you remap these,
+   also set `--ansi-bg-fg-0` … `--ansi-bg-fg-15` — the readable text color
+   (usually black or white) drawn on top of each ANSI color when used as a
+   background.
+
+## Token reference
+
+What each variable drives. You mainly set the **anchors + accent + text tiers +
+semantic** tokens; the rest derive.
+
+**Anchors — set first; everything below keys off them:**
+
+| token | drives |
+|---|---|
+| `--canvas` | base surface: page/content background, cards, popovers, sidebar, and (via mixes) every neutral fill, border, and chrome surface |
+| `--ink` | base text/foreground color, and the strength of every neutral fill/border (ink mixed into canvas) |
+
+**Surfaces & chrome — auto-derive from `--canvas`/`--ink`; leave alone unless you want one element to differ:**
+
+| token | drives | derives |
+|---|---|---|
+| `--background` | main content-area background | `= --canvas` |
+| `--card`, `--popover` | card surfaces; dropdown/menu/popover/tooltip surfaces | `= --canvas` |
+| `--secondary`, `--accent` | subtle fills: secondary buttons, hovered list rows, highlights | ink 8% |
+| `--muted` | muted fill: badges, chips, inset blocks | ink 11% |
+| `--border` | default component borders (cards, dividers) | ink 14% |
+| `--border-hairline` | the finest 1px separators | ink ~15% |
+| `--border-seam` | app-shell **horizontal** seam: top nav bar, panel/browser top bars | ink ~10% |
+| `--border-seam-vertical` | app-shell **vertical** seam: sidebar↔content and resizable-panel splits | ink ~12% |
+| `--input` | input/control field borders | ink ~30% |
+| `--surface-recessed` | sunken inset wells (code/diagram backgrounds) | translucent ink |
+| `--surface-raised` | faintly lifted panels | translucent ink |
+| `--surface-scrim` | **frosted top bars** — the thread/page header (`bg-surface-scrim`, blurred) | canvas 92% |
+| `--state-hover`, `--state-active` | translucent hover / pressed overlays on rows & buttons | translucent ink |
+| `--sidebar`, `--sidebar-foreground`, `--sidebar-accent`, `--sidebar-border` | left sidebar surface, its text, hovered items, borders | canvas/ink mixes |
+
+**Accent — set `--primary` (+ foreground); these follow it:**
+
+| token | drives | derives |
+|---|---|---|
+| `--primary` | primary buttons, active/accent states, links, focus ring, selection | set |
+| `--primary-foreground` | text/icons drawn on a `--primary` fill | set |
+| `--ring`, `--sidebar-ring` | keyboard focus outline | `= --primary` |
+| `--surface-selected`, `--surface-selected-border` | selected-row tint and its outline | primary 16% / 35% |
+| `--file-accent` | file-path titles in the timeline (the one tint in otherwise-neutral text) | set |
+
+**Text tiers — set these (they do NOT auto-derive; use the `color-mix` recipe so contrast tracks the anchors):**
+
+| token | drives |
+|---|---|
+| `--foreground` | primary body text (auto `= --ink`; usually leave it) |
+| `--muted-foreground` | secondary text: metadata, timestamps, labels (highest-contrast secondary tier) |
+| `--subtle-foreground` | low-emphasis text: captions, hints, placeholders |
+| `--readback-foreground` | settled/closed-turn machinery text (recede tier between muted and subtle) |
+
+**Semantic / status — set each to a recognizable hue (these carry meaning; don't flatten them to neutral):**
+
+| token | drives |
+|---|---|
+| `--destructive` | destructive buttons/fills (delete; failing/closed PR) |
+| `--destructive-foreground` | text/icons on a `--destructive` fill |
+| `--destructive-text` | text-only destructive (must clear ~4.5:1 on the canvas — give dark mode a lighter value) |
+| `--surface-destructive`, `--surface-destructive-border` | destructive-tinted surfaces/outlines (auto-derive from `--destructive`) |
+| `--warning`, `--warning-text` | warning fills / warning text |
+| `--attention` | attention indicator (amber dot) |
+| `--success` | success states: passing checks, open PR |
+| `--diff-added`, `--diff-removed` | added/removed line colors in diffs |
+| `--pr-merged` | merged-PR purple (the universal merged color) |
+
+**Terminal — set only if remapping:** `--ansi-0` … `--ansi-15` (the 16 ANSI
+colors) and `--ansi-bg-fg-0` … `--ansi-bg-fg-15` (the readable text drawn on each
+ANSI color when used as a background).
+
+**Non-color (optional):** `--radius` (corner rounding) and `--shadow-*`
+(elevation); fonts are below. Decorative `--pill-*` (prompt mention chips) are
+fixed literals — override only if needed.
+
+## Changing fonts
+
+Three font tokens, overridden the same way as colors. Fonts are mode-independent,
+so set them in the `:root, .light` block only. Always end the stack with a
+generic family (`sans-serif` / `monospace` / `serif`) as a fallback.
+
+| token | drives |
+|---|---|
+| `--font-sans` | the entire app UI / body text (`body` uses it) |
+| `--font-mono` | code blocks, diffs, file paths and previews, terminal-style text |
+| `--font-serif` | serif prose (rarely used in the UI) |
+
+The browser must be able to load the family. Three ways:
+
+1. **A system or already-bundled font** — just name it. Inter is bundled (always
+   available); common OS fonts like `Menlo`, `"SF Mono"`, `Consolas`, `Georgia`
+   work by name:
+   ```css
+   :root, .light {
+     --font-sans: "Helvetica Neue", system-ui, sans-serif;
+     --font-mono: "SF Mono", Menlo, monospace;
+   }
+   ```
+2. **A web font via `@import`** — the `@import` must be the VERY FIRST statement
+   in the file (an `@import` after any other rule is ignored), then reference it:
+   ```css
+   @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono&family=Sora&display=swap");
+   :root, .light {
+     --font-sans: "Sora", sans-serif;
+     --font-mono: "JetBrains Mono", monospace;
+   }
+   ```
+3. **A self-hosted font via `@font-face`**:
+   ```css
+   @font-face {
+     font-family: "My Font";
+     src: url("https://example.com/myfont.woff2") format("woff2");
+     font-display: swap;
+   }
+   :root, .light { --font-sans: "My Font", sans-serif; }
+   ```
+
+Options 2–3 fetch the font over the network when the theme applies, so keep the
+generic fallback in the stack so text still renders if the font is slow or fails.
+
+## Worked example
+
+A complete Nord-like theme. Note the text tiers in `:root, .light` recompute from
+whichever anchors are active, so the `.dark` block only re-sets anchors, accent,
+and semantics:
+
+```css
+:root, .light {
+  --canvas: #eceff4;
+  --ink: #2e3440;
+  --primary: #5e81ac;
+  --primary-foreground: #eceff4;
+  --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+  --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+  --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+  --destructive: #bf616a;
+  --destructive-text: #a1343d;
+  --success: #6f9655;
+  --file-accent: #5e81ac;
+}
+.dark {
+  --canvas: #2e3440;
+  --ink: #d8dee9;
+  --primary: #88c0d0;
+  --primary-foreground: #2e3440;
+  --destructive: #bf616a;
+  --destructive-text: #d6868d;
+  --success: #a3be8c;
+  --file-accent: #88c0d0;
+}
+```
+
+## Applying a theme
+
+- `bb theme set-custom --file ./my-theme.css` — load and activate a custom
+  stylesheet (the only way to set custom CSS).
+- `bb theme set <id>` — switch to a built-in (`default`, `nord`, `dracula`,
+  `solarized`, `gruvbox`).
+- `bb theme show --css` — dump the active custom CSS; `bb theme list` shows the
+  active palette; `bb theme reset` returns to `default`.
+
+Changes apply live to every open window — no reload needed.

--- a/apps/server/test/system/appearance.test.ts
+++ b/apps/server/test/system/appearance.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { getAppTheme } from "@bb/db";
+import { appThemeSchema } from "@bb/domain";
+import { systemConfigResponseSchema } from "@bb/server-contract";
+import { readJson } from "../helpers/json.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+describe("appearance settings", () => {
+  it("defaults appearance to the default palette in /system/config", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/system/config");
+      expect(response.status).toBe(200);
+      const body = systemConfigResponseSchema.parse(await readJson(response));
+      expect(body.appearance).toEqual({ themeId: "default", customCss: null });
+    });
+  });
+
+  it("persists a built-in theme and reflects it in /system/config", async () => {
+    await withTestHarness(async (harness) => {
+      const put = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "nord", customCss: null }),
+      });
+      expect(put.status).toBe(200);
+      expect(appThemeSchema.parse(await readJson(put))).toEqual({
+        themeId: "nord",
+        customCss: null,
+      });
+      expect(getAppTheme(harness.db)).toEqual({
+        themeId: "nord",
+        customCss: null,
+      });
+
+      const config = await harness.app.request("/api/v1/system/config");
+      expect(
+        systemConfigResponseSchema.parse(await readJson(config)).appearance,
+      ).toEqual({ themeId: "nord", customCss: null });
+    });
+  });
+
+  it("persists a custom stylesheet", async () => {
+    await withTestHarness(async (harness) => {
+      const customCss = ":root { --primary: #ff00ff; }";
+      const put = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "custom", customCss }),
+      });
+      expect(put.status).toBe(200);
+      expect(getAppTheme(harness.db)).toEqual({ themeId: "custom", customCss });
+    });
+  });
+
+  it("rejects an unknown theme id", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "neon", customCss: null }),
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  it("rejects a custom theme without customCss", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "custom", customCss: null }),
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/packages/db/drizzle/0042_careful_iron_monger.sql
+++ b/packages/db/drizzle/0042_careful_iron_monger.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `app_theme` (
+	`id` text PRIMARY KEY NOT NULL,
+	`theme_id` text NOT NULL,
+	`custom_css` text,
+	`updated_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0042_snapshot.json
+++ b/packages/db/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,2763 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a5784c47-0c24-46c1-8646-9017f4272195",
+  "prevId": "2932d6d3-e6e4-41b4-ac3f-2091e2cc7bed",
+  "tables": {
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_runs": {
+      "name": "automation_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_started_idx": {
+          "name": "automation_runs_automation_started_idx",
+          "columns": [
+            "automation_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "automation_runs_thread_idx": {
+          "name": "automation_runs_thread_idx",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_runs_thread_id_threads_id_fk": {
+          "name": "automation_runs_thread_id_threads_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_thread_id": {
+          "name": "target_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution": {
+          "name": "execution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_archive": {
+          "name": "auto_archive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_thread_id": {
+          "name": "created_by_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_thread_id": {
+          "name": "last_run_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automations_project_idx": {
+          "name": "automations_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            "enabled",
+            "trigger_type",
+            "next_run_at"
+          ],
+          "isUnique": false
+        },
+        "automations_target_thread_idx": {
+          "name": "automations_target_thread_idx",
+          "columns": [
+            "target_thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_project_id_projects_id_fk": {
+          "name": "automations_project_id_projects_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automations_target_thread_id_threads_id_fk": {
+          "name": "automations_target_thread_id_threads_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "target_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destroy_attempt_id": {
+          "name": "destroy_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provision_type": {
+          "name": "workspace_provision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_host_path_idx": {
+          "name": "environments_host_path_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_type": {
+          "name": "host_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claude_code_mock_cli_traffic": {
+          "name": "claude_code_mock_cli_traffic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "popout_chat": {
+          "name": "popout_chat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "popout_chat_hotkey": {
+          "name": "popout_chat_hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_idx": {
+          "name": "thread_search_segments_thread_idx",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "child_origin": {
+          "name": "child_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1781660000003,
       "tag": "0041_add_automations",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1781917615702,
+      "tag": "0042_careful_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/app-theme.ts
+++ b/packages/db/src/data/app-theme.ts
@@ -1,0 +1,45 @@
+import { eq } from "drizzle-orm";
+import { defaultAppTheme, type AppTheme } from "@bb/domain";
+import type { DbConnection } from "../connection.js";
+import { appTheme } from "../schema.js";
+
+const APP_THEME_ROW_ID = "current";
+
+export function getAppTheme(db: DbConnection): AppTheme {
+  const row = db
+    .select({
+      themeId: appTheme.themeId,
+      customCss: appTheme.customCss,
+    })
+    .from(appTheme)
+    .where(eq(appTheme.id, APP_THEME_ROW_ID))
+    .get();
+
+  if (!row) return defaultAppTheme;
+  // themeId is stored as free text; writes always go through setAppTheme with a
+  // validated AppTheme, so narrowing back to the union at this boundary is safe.
+  return {
+    themeId: row.themeId as AppTheme["themeId"],
+    customCss: row.customCss,
+  };
+}
+
+export function setAppTheme(db: DbConnection, theme: AppTheme): void {
+  const updatedAt = Date.now();
+  db.insert(appTheme)
+    .values({
+      id: APP_THEME_ROW_ID,
+      themeId: theme.themeId,
+      customCss: theme.customCss,
+      updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: appTheme.id,
+      set: {
+        themeId: theme.themeId,
+        customCss: theme.customCss,
+        updatedAt,
+      },
+    })
+    .run();
+}

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -170,6 +170,8 @@ export type {
 
 export { getExperiments, setExperiments } from "./experiments.js";
 
+export { getAppTheme, setAppTheme } from "./app-theme.js";
+
 export {
   getThreadDynamicContextFileState,
   upsertThreadDynamicContextFileState,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -152,6 +152,15 @@ export const systemExperiments = sqliteTable("system_experiments", {
   updatedAt: integer("updated_at").notNull(),
 });
 
+// Single-row table (id = "current") holding the app-wide color palette: the
+// active built-in theme id (or "custom") plus the custom stylesheet text.
+export const appTheme = sqliteTable("app_theme", {
+  id: text("id").primaryKey(),
+  themeId: text("theme_id").notNull(),
+  customCss: text("custom_css"),
+  updatedAt: integer("updated_at").notNull(),
+});
+
 export const projectSources = sqliteTable(
   "project_sources",
   {

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -200,12 +200,14 @@ const latestMigrationWhen = Math.max(
   ).entries.map((entry) => entry.when),
 );
 
-function dropAutomationsSchema(db: DbConnection): void {
+function dropRewindAddedTables(db: DbConnection): void {
   // Several tests migrate to head, rewind the schema to a legacy state, then
-  // re-apply forward. The automations tables (added by 0039) must be dropped as
-  // part of that rewind so the forward re-migrate can re-create them.
+  // re-apply forward. Tables added by recent migrations must be dropped as part
+  // of that rewind so the forward re-migrate can re-create them: the automations
+  // tables (added by 0039/0041) and app_theme (added by 0042).
   db.$client.prepare("DROP TABLE IF EXISTS automation_runs").run();
   db.$client.prepare("DROP TABLE IF EXISTS automations").run();
+  db.$client.prepare("DROP TABLE IF EXISTS app_theme").run();
 }
 
 function requirePublishedMigrationWhen(tag: string): number {
@@ -290,7 +292,7 @@ function closeConnection(db: DbConnection): void {
 // real upgrade, where thread-search is repaired before later migrations apply.
 // NOTE: when adding a migration after thread-search, drop its schema here too.
 function resetMigrationsAfterThreadSearch(db: DbConnection): void {
-  dropAutomationsSchema(db);
+  dropRewindAddedTables(db);
   db.$client
     .prepare<[number]>("DELETE FROM __drizzle_migrations WHERE created_at > ?")
     .run(threadSearchRowidFtsMigrationWhen);
@@ -1197,7 +1199,7 @@ describe("migrate", () => {
 
     try {
       migrate(db);
-      dropAutomationsSchema(db);
+      dropRewindAddedTables(db);
       restorePre0022ThreadTypeSchema(db);
       db.$client.exec(`
         INSERT INTO projects (id, name, created_at, updated_at)
@@ -1387,7 +1389,7 @@ describe("migrate", () => {
           `,
         )
         .run(threadSourceOriginMigrationWhen);
-      dropAutomationsSchema(db);
+      dropRewindAddedTables(db);
       db.$client.exec(`
         DROP TRIGGER IF EXISTS thread_search_segments_after_text_update;
         DROP TRIGGER IF EXISTS thread_search_segments_after_delete;
@@ -2192,7 +2194,7 @@ describe("migrate", () => {
 
     try {
       migrate(db);
-      dropAutomationsSchema(db);
+      dropRewindAddedTables(db);
       restorePre0022ThreadTypeSchema(db);
       addPre0017TerminalRuntimeColumns(db);
 
@@ -2818,7 +2820,7 @@ describe("migrate", () => {
 
     try {
       migrate(db);
-      dropAutomationsSchema(db);
+      dropRewindAddedTables(db);
       restorePre0022ThreadTypeSchema(db);
       seedPre0017TerminalSessionMigration({ db });
       db.$client
@@ -2910,7 +2912,7 @@ describe("migrate", () => {
 
     try {
       migrate(db);
-      dropAutomationsSchema(db);
+      dropRewindAddedTables(db);
       seedEventLargeValueBackfillThread(db);
       const values = seedEventLargeValueBackfillEvents(db);
 
@@ -2964,7 +2966,7 @@ describe("migrate", () => {
 
     try {
       migrate(db);
-      dropAutomationsSchema(db);
+      dropRewindAddedTables(db);
       seedEventLargeValueBackfillThread(db);
       const values = seedEventLargeValueBackfillEvents(db);
 

--- a/packages/domain/src/app-theme.ts
+++ b/packages/domain/src/app-theme.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+/**
+ * App color palette ("theme"), distinct from light/dark *mode* (which stays a
+ * per-client localStorage preference). The palette is a set of CSS
+ * custom-property overrides applied app-wide, persisted server-side so the CLI
+ * and Settings can both set it and every open window stays in sync.
+ *
+ * `themeId` is either a built-in palette or "custom"; built-in CSS lives in the
+ * frontend registry, so only the active id and the custom CSS text are stored.
+ */
+export const appThemeIdSchema = z.enum([
+  "default",
+  "nord",
+  "dracula",
+  "solarized",
+  "gruvbox",
+  "custom",
+]);
+export type AppThemeId = z.infer<typeof appThemeIdSchema>;
+
+export interface BuiltInThemeMeta {
+  id: Exclude<AppThemeId, "custom">;
+  name: string;
+  description: string;
+}
+
+/**
+ * Built-in palette metadata, shared by the CLI (`bb theme list`) and the
+ * Settings picker. The actual CSS strings live in the frontend registry; this
+ * is just the id/name/description list the server validates against.
+ */
+export const builtInThemes: readonly BuiltInThemeMeta[] = [
+  { id: "default", name: "Default", description: "The standard bb look" },
+  { id: "nord", name: "Nord", description: "Cool, muted arctic blues" },
+  {
+    id: "dracula",
+    name: "Dracula",
+    description: "Dark, high-contrast purple and pink",
+  },
+  {
+    id: "solarized",
+    name: "Solarized",
+    description: "Balanced light and dark (Schoonover palette)",
+  },
+  { id: "gruvbox", name: "Gruvbox", description: "Warm retro earth tones" },
+];
+
+/** Built-in palette ids (everything except "custom"). */
+export const BUILTIN_THEME_IDS = builtInThemes.map((theme) => theme.id);
+
+/** Max size of a user-supplied custom stylesheet; keeps the persisted and
+ * broadcast config payload bounded. */
+export const CUSTOM_THEME_CSS_MAX_LENGTH = 256_000;
+
+export const appThemeSchema = z
+  .object({
+    themeId: appThemeIdSchema,
+    /** Raw CSS for the "custom" palette; null for built-ins. */
+    customCss: z.string().max(CUSTOM_THEME_CSS_MAX_LENGTH).nullable(),
+  })
+  .refine((value) => value.themeId !== "custom" || value.customCss !== null, {
+    message: 'customCss is required when themeId is "custom"',
+    path: ["customCss"],
+  });
+export type AppTheme = z.infer<typeof appThemeSchema>;
+
+export const defaultAppTheme: AppTheme = { themeId: "default", customCss: null };

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -3,6 +3,7 @@
 // thread.ts re-exports its public names; starring it here would collide with
 // "./thread.js".
 export * from "./active-thinking.js";
+export * from "./app-theme.js";
 export * from "./automation.js";
 export * from "./background-task.js";
 export * from "./change-kinds.js";

--- a/packages/sdk/src/areas/theme.ts
+++ b/packages/sdk/src/areas/theme.ts
@@ -1,0 +1,26 @@
+import type { AppTheme } from "@bb/domain";
+import type { CreateSdkAreaArgs } from "./common.js";
+
+export interface ThemeArea {
+  /** The active app palette (built-in id or custom CSS). */
+  get(): Promise<AppTheme>;
+  /** Set the active app palette; broadcasts to all open windows. */
+  set(input: AppTheme): Promise<AppTheme>;
+}
+
+export function createThemeArea(args: CreateSdkAreaArgs): ThemeArea {
+  const { transport } = args;
+  return {
+    async get() {
+      const config = await transport.readJson(
+        transport.api.v1.system.config.$get(),
+      );
+      return config.appearance;
+    },
+    async set(input) {
+      return transport.readJson(
+        transport.api.v1.settings.appearance.$put({ json: input }),
+      );
+    },
+  };
+}

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -8,6 +8,7 @@ import { createProvidersArea } from "./areas/providers.js";
 import { createBbRealtimeClient } from "./realtime-client.js";
 import type { BbRealtime } from "./realtime-types.js";
 import { createStatusArea } from "./areas/status.js";
+import { createThemeArea } from "./areas/theme.js";
 import { createThreadsArea } from "./areas/threads.js";
 
 export interface CreateBbSdkArgs {
@@ -23,6 +24,7 @@ export interface BbSdk extends BbRealtime {
   projects: ReturnType<typeof createProjectsArea>;
   providers: ReturnType<typeof createProvidersArea>;
   status: ReturnType<typeof createStatusArea>;
+  theme: ReturnType<typeof createThemeArea>;
   threads: ReturnType<typeof createThreadsArea>;
 }
 
@@ -43,6 +45,7 @@ export function createBbSdk(args: CreateBbSdkArgs): BbSdk {
     projects: createProjectsArea(sdkContext),
     providers: createProvidersArea(sdkContext),
     status: createStatusArea(sdkContext),
+    theme: createThemeArea(sdkContext),
     threads: createThreadsArea(sdkContext),
   };
 }

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  appThemeSchema,
   availableModelSchema,
   experimentsSchema,
   featureFlagsSchema,
@@ -75,6 +76,8 @@ export type SystemVoiceTranscriptionResponse = z.infer<
 export const systemConfigResponseSchema = z.object({
   /** User-opt-in experiments (Settings → Experiments), persisted server-side. */
   experiments: experimentsSchema,
+  /** App-wide color palette (built-in id or custom CSS), persisted server-side. */
+  appearance: appThemeSchema,
   featureFlags: featureFlagsSchema,
   hostDaemonPort: z.number().nullable(),
   voiceTranscriptionEnabled: z.boolean(),

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono";
 import { hc } from "hono/client";
 import type {
+  AppTheme,
   Environment,
   Experiments,
   Host,
@@ -11,7 +12,7 @@ import type {
   ThreadEventRow,
   ThreadQueuedMessage,
 } from "@bb/domain";
-import { experimentsSchema } from "@bb/domain";
+import { appThemeSchema, experimentsSchema } from "@bb/domain";
 import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
 import {
   binaryResponse,
@@ -837,6 +838,12 @@ export const publicApiRoutes = {
       method: "put",
       request: jsonRequest<EmptyInput, Experiments>(experimentsSchema),
       response: jsonResponse<Experiments>(),
+    }),
+    appearance: defineRoute({
+      path: "/settings/appearance",
+      method: "put",
+      request: jsonRequest<EmptyInput, AppTheme>(appThemeSchema),
+      response: jsonResponse<AppTheme>(),
     }),
     reloadConfig: defineRoute({
       path: "/system/config/reload",


### PR DESCRIPTION
## Summary

Makes the app's color **palette** customizable — server-stored and applied live to every open window, orthogonal to the per-client light/dark **mode**.

- **Backend:** single-row `app_theme` table + `appThemeSchema`; surfaced on `GET /system/config` and a new `PUT /settings/appearance`; broadcast via `config-changed` (migration `0042`).
- **CLI:** `bb theme list | set <id> | set-custom --file <css> | show [--css] | reset` (new `@bb/sdk` theme area).
- **Frontend:** built-in palettes (`nord`, `dracula`, `solarized`, `gruvbox`) as a CSS-string registry; `useAppTheme` injects a trailing `<style>` (wins the cascade); pre-paint cache avoids a flash; Settings → Appearance palette picker.

### Make existing chrome follow the tokens
- `--surface-scrim` derives from `--canvas`, so the frosted **header bar** tracks the palette (was hardcoded white).
- `PullRequestStatusPill`: GitHub status hexes → `text-success`/`-destructive`/`-pr-merged`/`-muted-foreground`.
- **Mermaid** diagrams resolve their palette from live CSS vars (probe + canvas rasterize to sRGB) and re-render on palette change via a new `useAppThemeEpoch`; the **terminal** re-themes on the same signal.
- Built-in themes set `--ansi-bg-fg-*` contrast colors.

### Docs
- `bb-cli` skill gains `references/theming.md` (token model, what each variable drives, colors, fonts), pointed to from `SKILL.md`.

## Tests
- New `apps/server/test/system/appearance.test.ts` (default, set built-in, set custom, reject unknown id, reject custom-without-css).
- `migrate.test.ts` rewind helper updated to drop `app_theme`.
- Local: typecheck 7/7 touched packages; server (17), db migrate (22), app theme (16) tests pass.
- Verified live in the dev app: all 5 built-ins in light + dark (headers coordinate, text contrast AA+); Mermaid re-renders live on theme switch.

## Risks / notes
- Custom CSS is injected raw (capped 256 KB), no sanitizer — acceptable for a local single-user tool.
- Solarized dark is intentionally low-contrast (still AA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)