### PR TITLE
Clean up Cursor model list: concise names, Fast tier, and a None reasoning level

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type { SystemExecutionOptionsModelLoadError } from "@bb/server-contract";
 import type { ReasoningLevel } from "@bb/domain";
 import { stripModelBrandPrefix } from "./model-brand-prefix";
+import { REASONING_LABELS } from "@/lib/reasoning-labels";
 import { Button } from "@/components/ui/button.js";
 import { Icon } from "@/components/ui/icon.js";
 import {
@@ -230,6 +231,32 @@ export function ModelReasoningPicker({
     previewQuery.data?.selectedOnlyModels,
     formatModelLabel,
   ]);
+  // While previewing, the reasoning levels belong to the previewed provider's
+  // default model (each provider exposes its own set), so the section reflects
+  // the tab on screen rather than the committed model.
+  const previewDefaultModel = useMemo(() => {
+    if (!isPreviewing) return undefined;
+    const models = previewQuery.data?.models;
+    if (!models || models.length === 0) return undefined;
+    return models.find((model) => model.isDefault) ?? models[0];
+  }, [isPreviewing, previewQuery.data?.models]);
+  const previewReasoningOptions = useMemo((): readonly PickerOption<ReasoningLevel>[] => {
+    if (!previewDefaultModel) return [];
+    const seen = new Set<ReasoningLevel>();
+    const options: PickerOption<ReasoningLevel>[] = [];
+    for (const effort of previewDefaultModel.supportedReasoningEfforts) {
+      if (seen.has(effort.reasoningEffort)) continue;
+      seen.add(effort.reasoningEffort);
+      options.push({
+        value: effort.reasoningEffort,
+        label: REASONING_LABELS[effort.reasoningEffort],
+      });
+    }
+    return options;
+  }, [previewDefaultModel]);
+  const activeReasoningOptions = isPreviewing
+    ? previewReasoningOptions
+    : reasoningOptions;
   const activeModelLoadError = isPreviewing
     ? (previewQuery.data?.modelLoadError ?? null)
     : (modelLoadError ?? null);
@@ -277,15 +304,11 @@ export function ModelReasoningPicker({
   const showSelectedFastMode =
     hasSelectedModel && fastModeEnabled && modelOptions.length > 0;
   const showReasoningSection =
-    hasSelectedModel &&
-    !modelIsLoading &&
-    !selectedModelLoadFailed &&
     !isShowingModelError &&
-    // While previewing another provider's models, the reasoning options belong
-    // to the committed model, not the tab on screen — hide them so a level the
-    // previewed provider lacks (e.g. Cursor's "None") doesn't appear under it.
-    // The committed reasoning state is untouched; it returns on commit.
-    !isPreviewing;
+    activeReasoningOptions.length > 0 &&
+    (isPreviewing
+      ? hasActiveModelOptions && !activeModelIsLoading
+      : hasSelectedModel && !modelIsLoading && !selectedModelLoadFailed);
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -312,14 +335,27 @@ export function ModelReasoningPicker({
 
   const handleReasoningSelect = useCallback(
     (level: ReasoningLevel) => {
+      // While previewing, the listed levels are the previewed provider's, so
+      // picking one commits that provider's default model at the chosen level —
+      // symmetric with picking one of its models.
+      if (isPreviewing && previewDefaultModel) {
+        onSelectedProviderChange?.(previewProviderId!);
+        onModelChange(previewDefaultModel.model);
+      }
       onReasoningChange(level);
       // Match the standalone Reasoning OptionPicker's behaviour: picking a
-      // value commits and closes. Provider preview is also discarded since
-      // the user moved their attention to reasoning.
+      // value commits and closes.
       setOpen(false);
       setPreviewProviderId(null);
     },
-    [onReasoningChange],
+    [
+      isPreviewing,
+      previewDefaultModel,
+      previewProviderId,
+      onModelChange,
+      onReasoningChange,
+      onSelectedProviderChange,
+    ],
   );
 
   const TriggerIcon = hasSelectedModel ? ProviderIcon : undefined;
@@ -534,19 +570,19 @@ export function ModelReasoningPicker({
           )}
         </div>
 
-        {/* Reasoning section — the committed model's reasoning options. Hidden
-            while previewing another provider (see showReasoningSection), since
-            they don't apply to the tab on screen. */}
-        {showReasoningSection && reasoningOptions.length > 0 ? (
+        {/* Reasoning section — the committed model's levels, or (while
+            previewing) the previewed provider's default-model levels. Like the
+            model list, nothing is checked during preview until committed. */}
+        {showReasoningSection ? (
           <>
             <div className="border-t border-border" />
             <div className="px-1 pb-1 pt-0">
               <MenuSectionLabel>Reasoning</MenuSectionLabel>
-              {reasoningOptions.map((option) => (
+              {activeReasoningOptions.map((option) => (
                 <MenuRowButton
                   key={option.value}
                   label={option.label}
-                  selected={option.value === reasoningValue}
+                  selected={!isPreviewing && option.value === reasoningValue}
                   onClick={() => handleReasoningSelect(option.value)}
                 />
               ))}

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -280,7 +280,12 @@ export function ModelReasoningPicker({
     hasSelectedModel &&
     !modelIsLoading &&
     !selectedModelLoadFailed &&
-    !isShowingModelError;
+    !isShowingModelError &&
+    // While previewing another provider's models, the reasoning options belong
+    // to the committed model, not the tab on screen — hide them so a level the
+    // previewed provider lacks (e.g. Cursor's "None") doesn't appear under it.
+    // The committed reasoning state is untouched; it returns on commit.
+    !isPreviewing;
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -529,9 +534,9 @@ export function ModelReasoningPicker({
           )}
         </div>
 
-        {/* Reasoning section — only shows for the committed model; previewing
-            other providers doesn't touch reasoning state, so the committed
-            model's reasoning options stay visible. */}
+        {/* Reasoning section — the committed model's reasoning options. Hidden
+            while previewing another provider (see showReasoningSection), since
+            they don't apply to the tab on screen. */}
         {showReasoningSection && reasoningOptions.length > 0 ? (
           <>
             <div className="border-t border-border" />

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -53,6 +53,7 @@ const EMPTY_PROVIDERS: ProviderInfo[] = [];
 const EMPTY_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
 
 const REASONING_LABELS: Record<ReasoningLevel, string> = {
+  none: "None",
   low: "Low",
   medium: "Medium",
   high: "High",

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -22,6 +22,7 @@ import type {
 import { parseEnvironmentValue } from "@/components/pickers/environment-picker-value";
 import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { getProviderIconInfo } from "@/lib/provider-icon";
+import { REASONING_LABELS } from "@/lib/reasoning-labels";
 import { reconcileReasoningLevel } from "@bb/domain";
 import { useSystemExecutionOptions } from "./queries/system-queries";
 import {
@@ -52,15 +53,6 @@ export { formatModelLabel, resolvePermissionModeSelection };
 const EMPTY_PROVIDERS: ProviderInfo[] = [];
 const EMPTY_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
 
-const REASONING_LABELS: Record<ReasoningLevel, string> = {
-  none: "None",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra High",
-  ultracode: "Ultracode",
-  max: "Max",
-};
 
 const PERMISSION_MODE_OPTIONS: PickerOption<PermissionMode>[] = [
   {

--- a/apps/app/src/lib/reasoning-labels.ts
+++ b/apps/app/src/lib/reasoning-labels.ts
@@ -1,0 +1,17 @@
+import type { ReasoningLevel } from "@bb/domain";
+
+/**
+ * Short, user-facing labels for each reasoning level. Shared by the
+ * thread-creation options hook (committed model) and the model/reasoning
+ * picker (previewed provider) so the two never drift — adding a level forces
+ * an entry here once.
+ */
+export const REASONING_LABELS: Record<ReasoningLevel, string> = {
+  none: "None",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  ultracode: "Ultracode",
+  max: "Max",
+};

--- a/packages/agent-providers/src/catalog.ts
+++ b/packages/agent-providers/src/catalog.ts
@@ -129,10 +129,13 @@ const ACP_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
 // its own model selection, tool execution, and session naming, so BB-side
 // capabilities stay minimal. Permission modes are enforced cooperatively by
 // the ACP bridge (permission-request policy + client fs write policy).
+// Cursor exposes a `-fast` service tail per model; the bridge resolves it from
+// the serviceTier (the "Fast mode" toggle), so service tier is supported here
+// rather than fanning fast variants out as separate model-list entries.
 const ACP_CAPABILITIES: ProviderCapabilities = {
   supportsArchive: false,
   supportsRename: false,
-  supportsServiceTier: false,
+  supportsServiceTier: true,
   supportsUserQuestion: false,
   // ACP has no session-fork primitive; the adapter has no thread/fork handler,
   // so forks are blocked at the server boundary rather than failing at runtime.

--- a/packages/agent-providers/test/catalog.test.ts
+++ b/packages/agent-providers/test/catalog.test.ts
@@ -75,7 +75,7 @@ describe("agent provider catalog", () => {
         capabilities: {
           supportsArchive: false,
           supportsRename: false,
-          supportsServiceTier: false,
+          supportsServiceTier: true,
           supportsUserQuestion: false,
           supportsFork: false,
           supportedPermissionModes: ["full", "workspace-write", "readonly"],

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -250,6 +250,42 @@ describe("acp adapter model cli", () => {
     expect("reasoningLevel" in selection).toBe(false);
   });
 
+  it("forwards Fast mode as the model selection service tier", () => {
+    const plan = createAdapter().buildCommandPlan({
+      type: "thread/start",
+      threadId: "thread-1",
+      cwd: "/workspace",
+      options: {
+        ...fullProviderExecutionContext,
+        model: "composer-2.5",
+        serviceTier: "fast",
+      },
+      instructionMode: "append",
+    });
+    expect(plan).toMatchObject({
+      params: {
+        modelSelection: { model: "composer-2.5", serviceTier: "fast" },
+      },
+    });
+  });
+
+  it("omits a default service tier from the model selection", () => {
+    const plan = createAdapter().buildCommandPlan({
+      type: "thread/start",
+      threadId: "thread-1",
+      cwd: "/workspace",
+      options: {
+        ...fullProviderExecutionContext,
+        model: "composer-2.5",
+        serviceTier: "default",
+      },
+      instructionMode: "append",
+    });
+    const params = (plan as { params: Record<string, unknown> }).params;
+    const selection = params.modelSelection as Record<string, unknown>;
+    expect("serviceTier" in selection).toBe(false);
+  });
+
   it("never forwards the synthetic default model id", () => {
     const plan = createAdapter().buildCommandPlan({
       type: "thread/start",

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -1113,9 +1113,9 @@ export function createAcpProviderAdapter(
 
   /**
    * Session-level model pin for the bridge, which resolves (model,
-   * reasoningLevel) to the exact agent model variant via the list command's
-   * catalog. The synthetic "acp-default" id (persisted by threads started
-   * before the bridge listed real models) is never forwarded.
+   * reasoningLevel, serviceTier) to the exact agent model variant via the list
+   * command's catalog. The synthetic "acp-default" id (persisted by threads
+   * started before the bridge listed real models) is never forwarded.
    */
   function buildModelSelectionParam(
     options: ProviderExecutionContext,
@@ -1134,6 +1134,10 @@ export function createAcpProviderAdapter(
         model,
         ...(options.reasoningLevel !== undefined
           ? { reasoningLevel: options.reasoningLevel }
+          : {}),
+        // Only "fast" changes resolution; "default" is the catalog's normal id.
+        ...(options.serviceTier === "fast"
+          ? { serviceTier: options.serviceTier }
           : {}),
       },
     };

--- a/packages/agent-runtime/src/acp/bridge-protocol.ts
+++ b/packages/agent-runtime/src/acp/bridge-protocol.ts
@@ -12,6 +12,7 @@ import {
   permissionModeSchema,
   promptInputSchema,
   reasoningLevelSchema,
+  serviceTierSchema,
 } from "@bb/domain";
 import { z } from "zod";
 import {
@@ -56,17 +57,19 @@ const acpBridgeModelListParamsSchema = z.object({
 });
 
 /**
- * Session-level model pin. The bridge resolves (model, reasoningLevel) to the
- * exact raw agent model id via the catalog parsed from `listCommand`, then
- * launches the agent with `<selectFlag> <resolved-id>` ahead of its args.
- * Absent when the thread has no model preference — the agent uses its own
- * default.
+ * Session-level model pin. The bridge resolves (model, reasoningLevel,
+ * serviceTier) to the exact raw agent model id via the catalog parsed from
+ * `listCommand`, then launches the agent with `<selectFlag> <resolved-id>`
+ * ahead of its args. `serviceTier` "fast" selects the model's `-fast` twin
+ * when it has one. Absent when the thread has no model preference — the agent
+ * uses its own default.
  */
 const acpBridgeModelSelectionSchema = z.object({
   listCommand: acpBridgeAgentCommandSchema,
   selectFlag: z.string().min(1),
   model: z.string().min(1),
   reasoningLevel: reasoningLevelSchema.optional(),
+  serviceTier: serviceTierSchema.optional(),
 });
 export type AcpBridgeModelSelection = z.infer<
   typeof acpBridgeModelSelectionSchema

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -291,7 +291,12 @@ async function resolveAgentLaunchArgs(
   }
   let resolved: string | undefined;
   let warning: string | undefined;
-  if (selection.reasoningLevel !== undefined) {
+  // Resolve whenever the selection narrows the raw id: an explicit reasoning
+  // effort, or Fast mode (which picks the model's `-fast` twin).
+  if (
+    selection.reasoningLevel !== undefined ||
+    selection.serviceTier === "fast"
+  ) {
     // Prefer the catalog cached by the last model/list (the picker the
     // selection came from) over re-running the list command per spawn.
     const key = JSON.stringify(selection.listCommand);
@@ -302,8 +307,9 @@ async function resolveAgentLaunchArgs(
     resolved = catalog?.resolveVariant({
       model: selection.model,
       reasoningLevel: selection.reasoningLevel,
+      serviceTier: selection.serviceTier,
     });
-    if (resolved === undefined) {
+    if (resolved === undefined && selection.reasoningLevel !== undefined) {
       warning = `Model "${selection.model}" has no ${selection.reasoningLevel} reasoning variant; launching it at its default effort.`;
     }
   }

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.test.ts
@@ -56,12 +56,61 @@ describe("acp model catalog", () => {
     ).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
-  it("keeps -fast variants as their own family", () => {
+  it("folds -fast variants into the family as a service tier", () => {
     const catalog = catalogFromSample();
-    const fast = catalog.models.find((m) => m.id === "gpt-5.3-codex-fast");
+    // No standalone `-fast` family is offered in the picker anymore.
+    expect(catalog.models.some((m) => m.id.endsWith("-fast"))).toBe(false);
     expect(
-      fast?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
-    ).toEqual(["low", "medium"]);
+      catalog.models.find((m) => m.id === "gpt-5.3-codex-fast"),
+    ).toBeUndefined();
+    // The family's reasoning ladder comes from the non-fast members.
+    const codex = catalog.models.find((m) => m.id === "gpt-5.3-codex");
+    expect(
+      codex?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
+    ).toEqual(["low", "medium", "high", "xhigh"]);
+    // The fast tail is reachable through serviceTier instead of a new entry.
+    expect(
+      catalog.resolveVariant({
+        model: "gpt-5.3-codex",
+        reasoningLevel: "low",
+        serviceTier: "fast",
+      }),
+    ).toBe("gpt-5.3-codex-low-fast");
+    // The default tier resolves to the normal id.
+    expect(
+      catalog.resolveVariant({
+        model: "gpt-5.3-codex",
+        reasoningLevel: "low",
+        serviceTier: "default",
+      }),
+    ).toBe("gpt-5.3-codex-low");
+    // An effort with no fast twin falls back to the normal id under fast.
+    expect(
+      catalog.resolveVariant({
+        model: "gpt-5.3-codex",
+        reasoningLevel: "high",
+        serviceTier: "fast",
+      }),
+    ).toBe("gpt-5.3-codex-high");
+  });
+
+  it("resolves fast at the default effort when no reasoning level is given", () => {
+    const catalog = buildAgentModelCatalog(
+      parseAgentModelLines(
+        [
+          "composer-2.5 - Composer 2.5",
+          "composer-2.5-fast - Composer 2.5 Fast",
+        ].join("\n"),
+      ),
+    );
+    // composer's `-fast` twin folds in — one family, fast id reachable as a tier.
+    expect(catalog?.models.map((m) => m.id)).toEqual(["composer-2.5"]);
+    expect(
+      catalog?.resolveVariant({ model: "composer-2.5", serviceTier: "fast" }),
+    ).toBe("composer-2.5-fast");
+    expect(catalog?.resolveVariant({ model: "composer-2.5" })).toBe(
+      "composer-2.5",
+    );
   });
 
   it("maps the extra-high spelling onto xhigh and resolves it back exactly", () => {
@@ -88,7 +137,7 @@ describe("acp model catalog", () => {
     ).toBe("gpt-5.1-codex-max-high");
   });
 
-  it("strips the default variant's effort word from the family name", () => {
+  it("strips the effort word and picker noise from the family name", () => {
     const catalog = buildAgentModelCatalog(
       parseAgentModelLines(
         [
@@ -98,14 +147,40 @@ describe("acp model catalog", () => {
         ].join("\n"),
       ),
     );
+    // 1M, the (NO ZDR) marker, and the default variant's effort word are gone;
+    // the load-bearing "Thinking" word stays.
     expect(catalog?.models.map((m) => m.displayName)).toEqual([
-      "Opus 4.8 1M",
-      "Fable 5 1M Thinking (NO ZDR)",
+      "Opus 4.8",
+      "Fable 5 Thinking",
     ]);
     // The raw variant names survive as per-effort descriptions.
     expect(
       catalog?.models[0]?.supportedReasoningEfforts.map((e) => e.description),
     ).toEqual(["Opus 4.8 1M Medium", "Opus 4.8 1M"]);
+  });
+
+  it("strips 1M, NO ZDR, and Cursor's default/current annotations", () => {
+    const catalog = buildAgentModelCatalog(
+      parseAgentModelLines(
+        [
+          "composer-2.5 - Composer 2.5 (current)",
+          "composer-2.5-fast - Composer 2.5 Fast (default)",
+          "gpt-5.5-medium - GPT-5.5 1M",
+          "claude-fable-5-high - Fable 5 1M (NO ZDR)",
+        ].join("\n"),
+      ),
+    );
+    expect(catalog?.models.map((m) => m.displayName)).toEqual([
+      "Composer 2.5",
+      "GPT-5.5",
+      "Fable 5",
+    ]);
+    // The family id stays the non-fast variant; fast is the opt-in tier.
+    expect(catalog?.models.map((m) => m.id)).toEqual([
+      "composer-2.5",
+      "gpt-5.5-medium",
+      "claude-fable-5-high",
+    ]);
   });
 
   it("orders reasoning efforts low → max regardless of listing order", () => {

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.test.ts
@@ -116,9 +116,10 @@ describe("acp model catalog", () => {
   it("maps the extra-high spelling onto xhigh and resolves it back exactly", () => {
     const catalog = catalogFromSample();
     const gpt55 = catalog.models.find((m) => m.id === "gpt-5.5-medium");
+    // The explicit `gpt-5.5-none` id contributes the "none" level.
     expect(
       gpt55?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
-    ).toEqual(["low", "medium", "xhigh"]);
+    ).toEqual(["none", "low", "medium", "xhigh"]);
     expect(
       catalog.resolveVariant({ model: "gpt-5.5-medium", reasoningLevel: "xhigh" }),
     ).toBe("gpt-5.5-extra-high");
@@ -147,11 +148,11 @@ describe("acp model catalog", () => {
         ].join("\n"),
       ),
     );
-    // 1M, the (NO ZDR) marker, and the default variant's effort word are gone;
-    // the load-bearing "Thinking" word stays.
+    // 1M, the (NO ZDR) marker, the "Thinking" marker, and the default
+    // variant's effort word are all stripped.
     expect(catalog?.models.map((m) => m.displayName)).toEqual([
       "Opus 4.8",
-      "Fable 5 Thinking",
+      "Fable 5",
     ]);
     // The raw variant names survive as per-effort descriptions.
     expect(
@@ -183,6 +184,43 @@ describe("acp model catalog", () => {
     ]);
   });
 
+  it("merges infix-thinking variants into one entry with a none level", () => {
+    const catalog = buildAgentModelCatalog(
+      parseAgentModelLines(
+        [
+          "claude-opus-4-8-low - Opus 4.8 1M Low",
+          "claude-opus-4-8-medium - Opus 4.8 1M Medium",
+          "claude-opus-4-8-thinking-low - Opus 4.8 1M Low Thinking",
+          "claude-opus-4-8-thinking-medium - Opus 4.8 1M Medium Thinking",
+        ].join("\n"),
+      ),
+    );
+    // One clean entry, defaulting to the thinking medium, with "none" at the
+    // bottom of the ladder.
+    expect(catalog?.models).toHaveLength(1);
+    const opus = catalog?.models[0];
+    expect(opus?.id).toBe("claude-opus-4-8-thinking-medium");
+    expect(opus?.displayName).toBe("Opus 4.8");
+    expect(opus?.defaultReasoningEffort).toBe("medium");
+    expect(
+      opus?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
+    ).toEqual(["none", "low", "medium"]);
+    // "none" picks the medium-effort non-thinking representative; thinking
+    // efforts resolve to the thinking ids.
+    expect(
+      catalog?.resolveVariant({
+        model: "claude-opus-4-8-thinking-medium",
+        reasoningLevel: "none",
+      }),
+    ).toBe("claude-opus-4-8-medium");
+    expect(
+      catalog?.resolveVariant({
+        model: "claude-opus-4-8-thinking-medium",
+        reasoningLevel: "low",
+      }),
+    ).toBe("claude-opus-4-8-thinking-low");
+  });
+
   it("orders reasoning efforts low → max regardless of listing order", () => {
     const catalog = buildAgentModelCatalog(
       parseAgentModelLines(
@@ -210,34 +248,44 @@ describe("acp model catalog", () => {
     ).toBe("Codex 5.1 Max");
   });
 
-  it("defaults effort-less and unrecognized ids to standalone models", () => {
+  it("folds an explicit -none id into the family's none level", () => {
     const catalog = catalogFromSample();
-    const none = catalog.models.find((m) => m.id === "gpt-5.5-none");
+    // gpt-5.5-none is no longer offered as its own standalone model.
+    expect(catalog.models.find((m) => m.id === "gpt-5.5-none")).toBeUndefined();
     expect(
-      none?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
-    ).toEqual(["medium"]);
-    // `…-high-thinking` does not follow base[-effort][-fast]; stays standalone.
-    const thinking = catalog.models.find(
-      (m) => m.id === "claude-4.6-opus-high-thinking",
-    );
-    expect(
-      thinking?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
-    ).toEqual(["medium"]);
+      catalog.resolveVariant({
+        model: "gpt-5.5-medium",
+        reasoningLevel: "none",
+      }),
+    ).toBe("gpt-5.5-none");
   });
 
-  it("falls back to the first variant when a family has no medium", () => {
+  it("merges thinking with its non-thinking twins, defaulting to a thinking effort when there is no medium", () => {
     const catalog = catalogFromSample();
-    const opus = catalog.models.find((m) => m.id === "claude-4.6-opus-high");
+    // claude-4.6-opus-high / -max (non-thinking) and -high-thinking (suffix
+    // thinking) collapse into one family. With no medium, the default is the
+    // thinking effort, never the bottom "none" rung.
+    const opus = catalog.models.find(
+      (m) => m.id === "claude-4.6-opus-high-thinking",
+    );
     expect(opus).toMatchObject({ defaultReasoningEffort: "high" });
     expect(
       opus?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
-    ).toEqual(["high", "max"]);
+    ).toEqual(["none", "high"]);
+    // The thinking effort resolves to the thinking id; "none" resolves to a
+    // non-thinking twin.
     expect(
       catalog.resolveVariant({
-        model: "claude-4.6-opus-high",
-        reasoningLevel: "max",
+        model: "claude-4.6-opus-high-thinking",
+        reasoningLevel: "high",
       }),
-    ).toBe("claude-4.6-opus-max");
+    ).toBe("claude-4.6-opus-high-thinking");
+    expect(
+      catalog.resolveVariant({
+        model: "claude-4.6-opus-high-thinking",
+        reasoningLevel: "none",
+      }),
+    ).toBe("claude-4.6-opus-high");
   });
 
   it("marks only the first listed family as default", () => {

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.ts
@@ -6,17 +6,25 @@
  * `gpt-5.3-codex` for medium, `gpt-5.5-extra-high` as an alternate xhigh
  * spelling, with an optional `-fast` service tail after the effort token
  * (`gpt-5.3-codex-low-fast`). This module groups those raw variants into bb
- * model families so the picker offers one entry per family with selectable
- * reasoning efforts, and resolves a (family, effort) selection back to the
- * exact raw id at session launch — by table lookup, never string synthesis,
- * because effort spellings vary per family.
+ * model families so the picker offers one clean entry per family with
+ * selectable reasoning efforts, and resolves a (family, effort, serviceTier)
+ * selection back to the exact raw id at session launch — by table lookup,
+ * never string synthesis, because effort spellings vary per family.
+ *
+ * The `-fast` tail is a service tier, not a separate model: both the normal
+ * and fast raw ids for a given effort collapse into one family, and the bb
+ * "Fast mode" toggle (serviceTier) selects between them at launch. Display
+ * names are stripped of noise the picker renders elsewhere or doesn't need —
+ * the per-model effort word (reasoning has its own control), the redundant
+ * `1M` context tag, the `(NO ZDR)` data-retention marker, and Cursor's own
+ * `(default)`/`(current)` annotations.
  *
  * Ids that don't follow the `base[-effort][-fast]` grammar (e.g. the
  * `…-high-thinking` style) stay standalone single-effort models.
  */
 
 import { reasoningLevelValues } from "@bb/domain";
-import type { AvailableModel, ReasoningLevel } from "@bb/domain";
+import type { AvailableModel, ReasoningLevel, ServiceTier } from "@bb/domain";
 
 export interface RawAgentModel {
   id: string;
@@ -25,6 +33,8 @@ export interface RawAgentModel {
 
 interface AgentModelVariant extends RawAgentModel {
   effort: ReasoningLevel;
+  /** Whether this raw id carried the `-fast` service tail. */
+  fast: boolean;
 }
 
 const MODEL_LINE_PATTERN = /^(\S+) - (.+)$/;
@@ -47,12 +57,15 @@ export interface AgentModelCatalog {
   models: AvailableModel[];
   /**
    * Exact raw agent id for the family identified by its default-variant id
-   * (`AvailableModel.id`) at the given effort; undefined when the family has
-   * no such variant.
+   * (`AvailableModel.id`) at the given effort and service tier. Picks the
+   * `-fast` id when `serviceTier` is "fast" and the family has one, otherwise
+   * the normal id. `reasoningLevel` omitted falls back to the family's default
+   * effort. Returns undefined when the family or requested effort is unknown.
    */
   resolveVariant(args: {
     model: string;
-    reasoningLevel: ReasoningLevel;
+    reasoningLevel?: ReasoningLevel;
+    serviceTier?: ServiceTier;
   }): string | undefined;
 }
 
@@ -74,6 +87,7 @@ function splitVariant(id: string): {
   familyKey: string;
   effort: ReasoningLevel;
   effortToken: string | undefined;
+  fast: boolean;
 } {
   let rest = id;
   let fast = false;
@@ -83,16 +97,17 @@ function splitVariant(id: string): {
   }
   for (const [token, effort] of EFFORT_TOKENS) {
     if (rest.endsWith(`-${token}`)) {
-      const base = rest.slice(0, -(token.length + 1));
       return {
-        familyKey: base + (fast ? FAST_TAIL : ""),
+        familyKey: rest.slice(0, -(token.length + 1)),
         effort,
         effortToken: token,
+        fast,
       };
     }
   }
-  // No effort token: the id is its own family and acts as its medium.
-  return { familyKey: id, effort: "medium", effortToken: undefined };
+  // No effort token: the id (minus any `-fast` tail) is its own family and
+  // acts as its medium.
+  return { familyKey: rest, effort: "medium", effortToken: undefined, fast };
 }
 
 // How the agent's display names spell each effort token, for stripping the
@@ -119,20 +134,43 @@ function familyDisplayName(
 ): string {
   const word = effortToken ? EFFORT_DISPLAY_WORDS[effortToken] : undefined;
   if (!word) {
-    return displayName;
+    return cleanDisplayName(displayName);
   }
-  return displayName
-    .replace(new RegExp(`(^|\\s)${word}(?=\\s|$)`), "$1")
+  return cleanDisplayName(
+    displayName.replace(new RegExp(`(^|\\s)${word}(?=\\s|$)`), "$1"),
+  );
+}
+
+/**
+ * Strip picker noise from a Cursor display name so the list reads like the
+ * Claude Code / Codex lists: the `1M` context tag (every big Cursor model is
+ * 1M, so it distinguishes nothing), the `(NO ZDR)` data-retention marker, and
+ * Cursor's own `(default)`/`(current)` annotations. The "Thinking" word is
+ * deliberately kept — it distinguishes two real, separately selectable
+ * families (e.g. `claude-opus-4-8` vs `claude-opus-4-8-thinking`).
+ */
+function cleanDisplayName(name: string): string {
+  return name
+    .replace(/\s*\((?:NO ZDR|default|current)\)/gi, "")
+    .replace(/(^|\s)1M(?=\s|$)/g, "$1")
     .replace(/\s{2,}/g, " ")
     .trim();
 }
 
+/** Normal and fast raw ids for one (family, effort) cell. */
+interface VariantTier {
+  normal?: string;
+  fast?: string;
+}
+
 /**
  * Group raw variants into model families. The family's bb-facing id is the
- * raw id of its default variant (medium when present, else the first listed),
- * so threads persist real agent ids and an effort-less launch needs no
- * translation. Returns null when nothing parsed, so callers can fall back to
- * the synthetic default model.
+ * raw id of its default variant (the non-fast medium when present, else the
+ * first non-fast listed), so threads persist real agent ids, fast stays an
+ * opt-in tier rather than the default, and an effort-less launch needs no
+ * translation. `-fast` ids fold into the same family as their normal twin and
+ * become the family's fast service tier. Returns null when nothing parsed, so
+ * callers can fall back to the synthetic default model.
  */
 export function buildAgentModelCatalog(
   rawModels: readonly RawAgentModel[],
@@ -140,13 +178,14 @@ export function buildAgentModelCatalog(
   const families = new Map<string, AgentModelVariant[]>();
   const effortTokensById = new Map<string, string | undefined>();
   for (const raw of rawModels) {
-    const { familyKey, effort, effortToken } = splitVariant(raw.id);
+    const { familyKey, effort, effortToken, fast } = splitVariant(raw.id);
     effortTokensById.set(raw.id, effortToken);
     const members = families.get(familyKey) ?? [];
-    if (members.some((member) => member.effort === effort)) {
+    // Dedupe per (effort, tier): keep one normal and one fast id per effort.
+    if (members.some((m) => m.effort === effort && m.fast === fast)) {
       continue;
     }
-    members.push({ ...raw, effort });
+    members.push({ ...raw, effort, fast });
     families.set(familyKey, members);
   }
   if (families.size === 0) {
@@ -154,13 +193,23 @@ export function buildAgentModelCatalog(
   }
 
   const models: AvailableModel[] = [];
-  const variantsByFamilyId = new Map<string, Map<ReasoningLevel, string>>();
+  const variantsByFamilyId = new Map<
+    string,
+    Map<ReasoningLevel, VariantTier>
+  >();
+  const defaultEffortByFamilyId = new Map<string, ReasoningLevel>();
   for (const members of families.values()) {
+    // The default variant and the reasoning ladder come from the non-fast
+    // members (fast is a tier overlay, never the default). Fall back to all
+    // members for the rare fast-only family.
+    const baseMembers = members.filter((m) => !m.fast);
+    const ladderMembers = baseMembers.length > 0 ? baseMembers : members;
     const defaultVariant =
-      members.find((member) => member.effort === "medium") ?? members[0];
+      ladderMembers.find((member) => member.effort === "medium") ??
+      ladderMembers[0];
     // Members keep the agent's listing order (it anchors the no-medium
     // default), but the picker's ladder reads low → max.
-    const effortsInLadderOrder = [...members].sort(
+    const effortsInLadderOrder = [...ladderMembers].sort(
       (a, b) =>
         reasoningLevelValues.indexOf(a.effort) -
         reasoningLevelValues.indexOf(b.effort),
@@ -181,16 +230,36 @@ export function buildAgentModelCatalog(
       // The agent lists its default model first.
       isDefault: models.length === 0,
     });
-    variantsByFamilyId.set(
-      defaultVariant.id,
-      new Map(members.map((member) => [member.effort, member.id])),
-    );
+    const byEffort = new Map<ReasoningLevel, VariantTier>();
+    for (const member of members) {
+      const tier = byEffort.get(member.effort) ?? {};
+      if (member.fast) {
+        tier.fast = member.id;
+      } else {
+        tier.normal = member.id;
+      }
+      byEffort.set(member.effort, tier);
+    }
+    variantsByFamilyId.set(defaultVariant.id, byEffort);
+    defaultEffortByFamilyId.set(defaultVariant.id, defaultVariant.effort);
   }
 
   return {
     models,
-    resolveVariant({ model, reasoningLevel }) {
-      return variantsByFamilyId.get(model)?.get(reasoningLevel);
+    resolveVariant({ model, reasoningLevel, serviceTier }) {
+      const byEffort = variantsByFamilyId.get(model);
+      if (!byEffort) {
+        return undefined;
+      }
+      const effort = reasoningLevel ?? defaultEffortByFamilyId.get(model);
+      const tier = effort === undefined ? undefined : byEffort.get(effort);
+      if (!tier) {
+        return undefined;
+      }
+      if (serviceTier === "fast" && tier.fast !== undefined) {
+        return tier.fast;
+      }
+      return tier.normal ?? tier.fast;
     },
   };
 }

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.ts
@@ -13,14 +13,20 @@
  *
  * The `-fast` tail is a service tier, not a separate model: both the normal
  * and fast raw ids for a given effort collapse into one family, and the bb
- * "Fast mode" toggle (serviceTier) selects between them at launch. Display
- * names are stripped of noise the picker renders elsewhere or doesn't need —
- * the per-model effort word (reasoning has its own control), the redundant
- * `1M` context tag, the `(NO ZDR)` data-retention marker, and Cursor's own
- * `(default)`/`(current)` annotations.
+ * "Fast mode" toggle (serviceTier) selects between them at launch.
  *
- * Ids that don't follow the `base[-effort][-fast]` grammar (e.g. the
- * `…-high-thinking` style) stay standalone single-effort models.
+ * Cursor's "thinking" marker (appearing as an infix `…-thinking-medium` or a
+ * suffix `…-medium-thinking` / `…-thinking`) is folded into the reasoning
+ * ladder too: thinking variants keep their effort, and the model's
+ * non-thinking variants collapse onto a single "none" (thinking-off) level at
+ * the bottom of the ladder. So one "Opus 4.8" entry offers None, Low … Max
+ * instead of separate "Opus 4.8" and "Opus 4.8 Thinking" rows. An explicit
+ * `-none` effort id (e.g. `gpt-5.5-none`) is the same "none" level.
+ *
+ * Display names are stripped of noise the picker renders elsewhere or doesn't
+ * need — the per-model effort word and "Thinking" marker (reasoning has its
+ * own control), the redundant `1M` context tag, the `(NO ZDR)` data-retention
+ * marker, and Cursor's own `(default)`/`(current)` annotations.
  */
 
 import { reasoningLevelValues } from "@bb/domain";
@@ -32,16 +38,21 @@ export interface RawAgentModel {
 }
 
 interface AgentModelVariant extends RawAgentModel {
+  /** Raw effort token's level (medium when absent), before the none collapse. */
   effort: ReasoningLevel;
+  /** Matched effort display token, for stripping the family name. */
+  effortToken: string | undefined;
   /** Whether this raw id carried the `-fast` service tail. */
   fast: boolean;
+  /** Whether this raw id carried Cursor's "thinking" marker. */
+  thinking: boolean;
 }
 
 const MODEL_LINE_PATTERN = /^(\S+) - (.+)$/;
 
 // Trailing id tokens that mark a reasoning-effort variant, longest first so
-// `extra-high` wins over `high`. `none` is deliberately absent — bb has no
-// matching level, so `-none` ids stay standalone models.
+// `extra-high` wins over `high`. `none` maps onto bb's "none" (thinking-off)
+// level, used by explicit `-none` ids and by the non-thinking collapse.
 const EFFORT_TOKENS: ReadonlyArray<readonly [string, ReasoningLevel]> = [
   ["extra-high", "xhigh"],
   ["medium", "medium"],
@@ -49,9 +60,11 @@ const EFFORT_TOKENS: ReadonlyArray<readonly [string, ReasoningLevel]> = [
   ["high", "high"],
   ["low", "low"],
   ["max", "max"],
+  ["none", "none"],
 ];
 
 const FAST_TAIL = "-fast";
+const THINKING_TOKEN = "thinking";
 
 export interface AgentModelCatalog {
   models: AvailableModel[];
@@ -88,12 +101,25 @@ function splitVariant(id: string): {
   effort: ReasoningLevel;
   effortToken: string | undefined;
   fast: boolean;
+  thinking: boolean;
 } {
   let rest = id;
   let fast = false;
   if (rest.endsWith(FAST_TAIL)) {
     fast = true;
     rest = rest.slice(0, -FAST_TAIL.length);
+  }
+  // Cursor marks extended thinking either as a suffix (`…-medium-thinking`,
+  // `…-thinking`) or an infix (`…-thinking-medium`). Strip it so the family
+  // key matches the non-thinking twin; its presence is what later keeps the
+  // variant a real effort instead of collapsing it to "none".
+  let thinking = false;
+  if (rest.endsWith(`-${THINKING_TOKEN}`)) {
+    thinking = true;
+    rest = rest.slice(0, -(THINKING_TOKEN.length + 1));
+  } else if (rest.includes(`-${THINKING_TOKEN}-`)) {
+    thinking = true;
+    rest = rest.replace(`-${THINKING_TOKEN}-`, "-");
   }
   for (const [token, effort] of EFFORT_TOKENS) {
     if (rest.endsWith(`-${token}`)) {
@@ -102,12 +128,19 @@ function splitVariant(id: string): {
         effort,
         effortToken: token,
         fast,
+        thinking,
       };
     }
   }
-  // No effort token: the id (minus any `-fast` tail) is its own family and
-  // acts as its medium.
-  return { familyKey: rest, effort: "medium", effortToken: undefined, fast };
+  // No effort token: the id (minus any `-fast`/`-thinking` markers) is its own
+  // family and acts as its medium.
+  return {
+    familyKey: rest,
+    effort: "medium",
+    effortToken: undefined,
+    fast,
+    thinking,
+  };
 }
 
 // How the agent's display names spell each effort token, for stripping the
@@ -119,6 +152,7 @@ const EFFORT_DISPLAY_WORDS: Readonly<Record<string, string>> = {
   high: "High",
   low: "Low",
   max: "Max",
+  none: "None",
 };
 
 /**
@@ -143,16 +177,15 @@ function familyDisplayName(
 
 /**
  * Strip picker noise from a Cursor display name so the list reads like the
- * Claude Code / Codex lists: the `1M` context tag (every big Cursor model is
- * 1M, so it distinguishes nothing), the `(NO ZDR)` data-retention marker, and
- * Cursor's own `(default)`/`(current)` annotations. The "Thinking" word is
- * deliberately kept — it distinguishes two real, separately selectable
- * families (e.g. `claude-opus-4-8` vs `claude-opus-4-8-thinking`).
+ * Claude Code / Codex lists: the "Thinking" marker (now a reasoning level, not
+ * a separate entry), the `1M` context tag (every big Cursor model is 1M, so it
+ * distinguishes nothing), the `(NO ZDR)` data-retention marker, and Cursor's
+ * own `(default)`/`(current)` annotations.
  */
 function cleanDisplayName(name: string): string {
   return name
     .replace(/\s*\((?:NO ZDR|default|current)\)/gi, "")
-    .replace(/(^|\s)1M(?=\s|$)/g, "$1")
+    .replace(/(^|\s)(?:1M|Thinking)(?=\s|$)/g, "$1")
     .replace(/\s{2,}/g, " ")
     .trim();
 }
@@ -164,28 +197,26 @@ interface VariantTier {
 }
 
 /**
- * Group raw variants into model families. The family's bb-facing id is the
- * raw id of its default variant (the non-fast medium when present, else the
- * first non-fast listed), so threads persist real agent ids, fast stays an
- * opt-in tier rather than the default, and an effort-less launch needs no
- * translation. `-fast` ids fold into the same family as their normal twin and
- * become the family's fast service tier. Returns null when nothing parsed, so
- * callers can fall back to the synthetic default model.
+ * Group raw variants into model families. The family's bb-facing id is the raw
+ * id of its default variant — the non-fast, thinking "medium" when present,
+ * else the first non-`none` non-fast variant, else the first listed — so
+ * threads persist real agent ids and the picker preselects a real effort, not
+ * the bottom "none" rung. Within a family: thinking variants keep their
+ * effort, the non-thinking variants collapse onto a single "none" level (a
+ * medium-effort representative), and `-fast` ids fold in as each level's fast
+ * service tier. Returns null when nothing parsed, so callers can fall back to
+ * the synthetic default model.
  */
 export function buildAgentModelCatalog(
   rawModels: readonly RawAgentModel[],
 ): AgentModelCatalog | null {
   const families = new Map<string, AgentModelVariant[]>();
-  const effortTokensById = new Map<string, string | undefined>();
   for (const raw of rawModels) {
-    const { familyKey, effort, effortToken, fast } = splitVariant(raw.id);
-    effortTokensById.set(raw.id, effortToken);
+    const { familyKey, effort, effortToken, fast, thinking } = splitVariant(
+      raw.id,
+    );
     const members = families.get(familyKey) ?? [];
-    // Dedupe per (effort, tier): keep one normal and one fast id per effort.
-    if (members.some((m) => m.effort === effort && m.fast === fast)) {
-      continue;
-    }
-    members.push({ ...raw, effort, fast });
+    members.push({ ...raw, effort, effortToken, fast, thinking });
     families.set(familyKey, members);
   }
   if (families.size === 0) {
@@ -199,60 +230,91 @@ export function buildAgentModelCatalog(
   >();
   const defaultEffortByFamilyId = new Map<string, ReasoningLevel>();
   for (const members of families.values()) {
-    // The default variant and the reasoning ladder come from the non-fast
-    // members (fast is a tier overlay, never the default). Fall back to all
-    // members for the rare fast-only family.
-    const baseMembers = members.filter((m) => !m.fast);
-    const ladderMembers = baseMembers.length > 0 ? baseMembers : members;
-    const defaultVariant =
-      ladderMembers.find((member) => member.effort === "medium") ??
-      ladderMembers[0];
-    // Members keep the agent's listing order (it anchors the no-medium
-    // default), but the picker's ladder reads low → max.
-    const effortsInLadderOrder = [...ladderMembers].sort(
+    // A family with any thinking variant maps its non-thinking variants to the
+    // "none" (thinking-off) level; a family with none keeps each variant's own
+    // effort (so an explicit `-none` id stays the "none" level).
+    const hasThinking = members.some((m) => m.thinking);
+    const leveled = members.map((member) => ({
+      member,
+      level: member.thinking
+        ? member.effort
+        : hasThinking
+          ? ("none" as ReasoningLevel)
+          : member.effort,
+    }));
+
+    // Resolution table: one normal + one fast id per level. Multiple
+    // non-thinking variants collapse onto "none" — keep a medium-effort
+    // representative when present, else the first listed.
+    const byLevel = new Map<ReasoningLevel, VariantTier>();
+    const repEffortByCell = new Map<string, ReasoningLevel>();
+    for (const { member, level } of leveled) {
+      const slot: keyof VariantTier = member.fast ? "fast" : "normal";
+      const tier = byLevel.get(level) ?? {};
+      const cellKey = `${level}:${slot}`;
+      const upgradesNoneRep =
+        level === "none" &&
+        member.effort === "medium" &&
+        repEffortByCell.get(cellKey) !== "medium";
+      if (tier[slot] === undefined || upgradesNoneRep) {
+        tier[slot] = member.id;
+        repEffortByCell.set(cellKey, member.effort);
+        byLevel.set(level, tier);
+      }
+    }
+
+    // Prefer a thinking "medium" default so the picker preselects a real
+    // effort; fall back to the first non-`none`, then to anything listed.
+    const nonFast = leveled.filter((entry) => !entry.member.fast);
+    const pool = nonFast.length > 0 ? nonFast : leveled;
+    const defaultEntry =
+      pool.find((entry) => entry.level === "medium") ??
+      pool.find((entry) => entry.level !== "none") ??
+      pool[0];
+    const defaultVariant = defaultEntry.member;
+
+    // The picker's ladder reads none → max regardless of listing order.
+    const levelsInLadderOrder = [...byLevel.keys()].sort(
       (a, b) =>
-        reasoningLevelValues.indexOf(a.effort) -
-        reasoningLevelValues.indexOf(b.effort),
+        reasoningLevelValues.indexOf(a) - reasoningLevelValues.indexOf(b),
     );
+    // First raw name seen per level, kept as the (non-user-facing) description.
+    const nameByLevel = new Map<ReasoningLevel, string>();
+    for (const { member, level } of leveled) {
+      if (!nameByLevel.has(level)) {
+        nameByLevel.set(level, member.displayName);
+      }
+    }
+
     models.push({
       id: defaultVariant.id,
       model: defaultVariant.id,
       displayName: familyDisplayName(
         defaultVariant.displayName,
-        effortTokensById.get(defaultVariant.id),
+        defaultVariant.effortToken,
       ),
       description: "",
-      supportedReasoningEfforts: effortsInLadderOrder.map((member) => ({
-        reasoningEffort: member.effort,
-        description: member.displayName,
+      supportedReasoningEfforts: levelsInLadderOrder.map((level) => ({
+        reasoningEffort: level,
+        description: nameByLevel.get(level) ?? "",
       })),
-      defaultReasoningEffort: defaultVariant.effort,
+      defaultReasoningEffort: defaultEntry.level,
       // The agent lists its default model first.
       isDefault: models.length === 0,
     });
-    const byEffort = new Map<ReasoningLevel, VariantTier>();
-    for (const member of members) {
-      const tier = byEffort.get(member.effort) ?? {};
-      if (member.fast) {
-        tier.fast = member.id;
-      } else {
-        tier.normal = member.id;
-      }
-      byEffort.set(member.effort, tier);
-    }
-    variantsByFamilyId.set(defaultVariant.id, byEffort);
-    defaultEffortByFamilyId.set(defaultVariant.id, defaultVariant.effort);
+    variantsByFamilyId.set(defaultVariant.id, byLevel);
+    defaultEffortByFamilyId.set(defaultVariant.id, defaultEntry.level);
   }
 
   return {
     models,
     resolveVariant({ model, reasoningLevel, serviceTier }) {
-      const byEffort = variantsByFamilyId.get(model);
-      if (!byEffort) {
+      const byLevel = variantsByFamilyId.get(model);
+      if (!byLevel) {
         return undefined;
       }
-      const effort = reasoningLevel ?? defaultEffortByFamilyId.get(model);
-      const tier = effort === undefined ? undefined : byEffort.get(effort);
+      const level = reasoningLevel ?? defaultEffortByFamilyId.get(model);
+      const tier = level === undefined ? undefined : byLevel.get(level);
       if (!tier) {
         return undefined;
       }

--- a/packages/agent-runtime/src/acp/profiles.ts
+++ b/packages/agent-runtime/src/acp/profiles.ts
@@ -48,8 +48,8 @@ export const ACP_AGENT_PROFILES: readonly AcpAgentProfile[] = [
         "claude-fable-5-thinking-medium",
         "claude-opus-4-8-thinking-medium",
         "gpt-5.5-medium",
-        // Cursor's own default composer is the fast variant.
-        "composer-2.5-fast",
+        // Composer is one family now; its `-fast` twin is the Fast-mode tier.
+        "composer-2.5",
       ],
     },
   },

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -59,7 +59,11 @@ const CLAUDE_CODE_EXECUTABLE_ENV = "BB_CLAUDE_CODE_EXECUTABLE";
 function toSdkEffort(
   reasoningLevel: ReasoningLevel,
 ): Exclude<Options["effort"], undefined> {
-  return reasoningLevel === "ultracode" ? "xhigh" : reasoningLevel;
+  if (reasoningLevel === "ultracode") return "xhigh";
+  // "none" (thinking-off) is a Cursor-only level; Claude Code models never
+  // expose it, so this is a defensive floor that reconciliation never reaches.
+  if (reasoningLevel === "none") return "low";
+  return reasoningLevel;
 }
 
 function buildFlagSettings(

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -667,6 +667,10 @@ function toCodexReasoningEffort(
       return "high";
     case "xhigh":
       return "xhigh";
+    case "none":
+      // "none" (thinking-off) is a Cursor-only level; Codex models never
+      // expose it, so model-switch reconciliation maps it away before here.
+      throw new Error("Codex does not support the none reasoning level.");
     case "ultracode":
       throw new Error("Codex does not support ultracode reasoning level.");
     case "max":

--- a/packages/domain/src/reasoning-efforts.ts
+++ b/packages/domain/src/reasoning-efforts.ts
@@ -1,6 +1,10 @@
 import type { ModelReasoningEffort } from "./provider-types.js";
 import type { ReasoningLevel } from "./shared-types.js";
 
+export const NONE_REASONING_EFFORT: ModelReasoningEffort = {
+  reasoningEffort: "none",
+  description: "No extended thinking",
+};
 export const LOW_REASONING_EFFORT: ModelReasoningEffort = {
   reasoningEffort: "low",
   description: "Low reasoning effort",
@@ -37,6 +41,7 @@ export const ALL_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
 
 const REASONING_EFFORT_BY_LEVEL: Record<ReasoningLevel, ModelReasoningEffort> =
   {
+    none: NONE_REASONING_EFFORT,
     low: LOW_REASONING_EFFORT,
     medium: MEDIUM_REASONING_EFFORT,
     high: HIGH_REASONING_EFFORT,

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -2,11 +2,14 @@ import { z } from "zod";
 
 /**
  * Order is load-bearing: `reasoningRank` (index) drives model-switch
- * reconciliation. "ultracode" sits between "xhigh" and "max" because its
- * underlying effort IS xhigh (plus standing workflow orchestration) — a model
- * without ultracode support should reconcile down to xhigh, not up to max.
+ * reconciliation. "none" (no extended thinking) sits at the bottom — only
+ * providers that expose a thinking-off variant list it (currently Cursor).
+ * "ultracode" sits between "xhigh" and "max" because its underlying effort IS
+ * xhigh (plus standing workflow orchestration) — a model without ultracode
+ * support should reconcile down to xhigh, not up to max.
  */
 export const reasoningLevelValues = [
+  "none",
   "low",
   "medium",
   "high",


### PR DESCRIPTION
Cleans up the Cursor provider's model picker so it reads like the Claude Code / Codex lists, and makes reasoning options consistent across providers.

## What changed

**1. Concise names + Fast-mode service tier** (`a13060365`)
- The `-fast` id tail becomes a **service tier** instead of a separate model family — the normal/fast ids per (model, effort) collapse into one family, and the existing capability-gated **Fast mode** toggle now appears for Cursor (`supportsServiceTier: true`). `resolveVariant` returns the `-fast` id when Fast is on and the family has one, else the normal id.
- Display names strip noise: the redundant `1M` tag, `(NO ZDR)`, and Cursor's own `(default)`/`(current)` annotations.
- `serviceTier` was already plumbed end-to-end; the ACP adapter/bridge now forward and resolve it.

**2. "None" reasoning level — thinking/non-thinking merge** (`a9c35978d`)
- Cursor lists each Claude model twice ("Opus 4.8" vs "Opus 4.8 Thinking"). These merge into one entry whose reasoning ladder gains a **None** (thinking-off) rung at the bottom: None → a non-thinking variant, Low…Max → the thinking variants. Explicit `-none` ids (GPT-5.5 None, etc.) map onto the same level.
- Adds `none` as the lowest reasoning level in `@bb/domain` (rank 0). Only providers exposing a thinking-off variant list it (Cursor); Codex/Claude Code translators handle it defensively (reconciliation maps it away before they receive it).

**3. Picker: reasoning reflects the provider on screen** (`18ad1b5ce`, `dc4839beb`)
- Previewing another provider's tab now shows **that provider's** reasoning levels (from its default model) rather than the committed model's — so each tab only shows what it supports (Codex: Low–Extra High, Claude Code: +Ultracode/Max, Cursor: +None). Picking a level while previewing commits that provider's default model at the chosen level. The level→label map moved to a shared `lib/reasoning-labels` module so the hook and picker can't drift.

No model ids or routing change — only how variants are grouped, labeled, and resolved.

## Result (Cursor picker)
- Primary list: Auto, Fable 5, Opus 4.8, GPT-5.5, Composer 2.5 (one clean entry each).
- "More models" dropped from **48 → 22** rows; all `… Fast` and `… Thinking` duplicates gone.
- Opus 4.8 reasoning: None · Low · Medium · High · Extra High · Max, with a Fast-mode toggle.

## Tests
- `turbo typecheck` across domain, agent-runtime, agent-providers, app, server, host-daemon ✅
- `turbo test` for domain / agent-runtime / agent-providers / app / server ✅ (catalog unit tests updated + added)
- eslint ✅; Dev Browser verified before/after, the None ladder, Fast toggle, and per-provider preview reasoning.

## Risks / notes
- The picker preview behavior is browser-verified rather than unit-tested — there's no existing test harness for `ModelReasoningPicker`.
- Existing Cursor threads pinned to a now-collapsed raw id still launch correctly (the bridge falls back to launching the stored id as-is); they just may not show as "selected" in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)