### PR TITLE
Fix disabling Fast mode from picker

### DIFF
--- a/apps/app/src/components/promptbox/ExecutionControls.test.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.test.tsx
@@ -74,4 +74,25 @@ describe("ExecutionControls", () => {
 
     expect(screen.queryByTitle("Claude Code")).not.toBeNull();
   });
+
+  it("maps disabled fast mode to the explicit default service tier", () => {
+    const onServiceTierChange = vi.fn();
+    renderExecutionControls({
+      ...makeExecutionControlsProps(),
+      serviceTier: {
+        value: "fast",
+        onChange: onServiceTierChange,
+        supported: true,
+      },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+    );
+    fireEvent.click(screen.getByRole("switch", { name: "Fast mode" }));
+
+    expect(onServiceTierChange).toHaveBeenCalledWith("default");
+  });
 });

--- a/apps/app/src/components/promptbox/ExecutionControls.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.tsx
@@ -106,7 +106,7 @@ export const ExecutionControls = memo(function ExecutionControls({
           onReasoningChange={reasoning.onChange}
           fastModeEnabled={serviceTier?.value === "fast"}
           onFastModeChange={(enabled) =>
-            handleServiceTierChange(enabled ? "fast" : undefined)
+            handleServiceTierChange(enabled ? "fast" : "default")
           }
           showFastModeToggle={serviceTier?.supported ?? false}
           serviceTierSupportByProvider={serviceTier?.supportByProvider}


### PR DESCRIPTION
## Summary
- Map the Fast mode switch off-state to explicit `default` service tier instead of clearing the value
- Add regression coverage that disabling Fast mode emits `default`

## Tests
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/ExecutionControls.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`

## Notes
- This fixes projects whose stored defaults already have `service_tier = fast`; clearing the field previously caused the server to inherit fast again.