### PR TITLE
Landing: show scaled desktop app mock on mobile

### DIFF
--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -181,6 +181,46 @@ function useConstructMock() {
   }, []);
 }
 
+/** Scale the desktop app mock for narrow viewports. Below the mobile breakpoint
+ *  the mock keeps its full desktop layout and is shrunk with `zoom` so a fixed
+ *  left slice of the app (`--mock-visible-width`) fills the available width; the
+ *  rest bleeds off the right edge, clipped by `.mockup-wrap`'s overflow. This
+ *  stays legible instead of shrinking the whole app to fit. `--mock-visible-width`
+ *  is defined only inside that breakpoint, so above it the variable is unset and
+ *  the mock renders unscaled at its natural width. */
+function useFitMock() {
+  useEffect(() => {
+    const mock = document.querySelector<HTMLElement>(".mock");
+    const wrap = mock?.parentElement;
+    if (!mock || !wrap) {
+      return;
+    }
+    const fit = () => {
+      const wrapStyle = getComputedStyle(wrap);
+      const visibleWidth = Number.parseFloat(
+        getComputedStyle(mock).getPropertyValue("--mock-visible-width"),
+      );
+      if (!visibleWidth) {
+        // Desktop layout (variable unset above the breakpoint): no scaling.
+        mock.style.removeProperty("--mock-scale");
+        return;
+      }
+      // The card is inset by the wrap's side padding (its left gutter holds the
+      // drop shadow), so its on-screen width is the content box — clientWidth
+      // minus the padding — not clientWidth itself.
+      const slice =
+        wrap.clientWidth -
+        Number.parseFloat(wrapStyle.paddingLeft) -
+        Number.parseFloat(wrapStyle.paddingRight);
+      mock.style.setProperty("--mock-scale", String(slice / visibleWidth));
+    };
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(wrap);
+    return () => observer.disconnect();
+  }, []);
+}
+
 /* ── Shared bits ──────────────────────────────────────────────────── */
 
 function ProviderChips() {
@@ -838,9 +878,6 @@ function HeroAppMock() {
   const [activeId, setActiveId] = useState(HERO_THREADS[0].id);
   const [view, setView] = useState<"thread" | "new">("thread");
   const [diffOpen, setDiffOpen] = useState(false);
-  // Mobile sidebar drawer (mirrors the app's openMobile nav). Inert on desktop,
-  // where the sidebar is always in-flow.
-  const [navOpen, setNavOpen] = useState(false);
   // Subagents a running thread spawns, keyed by parent id. They persist once
   // spawned and render as nested child rows in the sidebar.
   const [spawned, setSpawned] = useState<Record<string, MockThread[]>>({});
@@ -856,7 +893,6 @@ function HeroAppMock() {
   const openThread = (id: string) => {
     setActiveId(id);
     setView("thread");
-    setNavOpen(false);
   };
 
   const handleSpawn = useCallback((parentId: string, child: MockThread) => {
@@ -883,15 +919,9 @@ function HeroAppMock() {
               <i />
               <i />
             </span>
-            <button
-              type="button"
-              className="bar-menu"
-              aria-label="Toggle sidebar"
-              aria-expanded={navOpen}
-              onClick={() => setNavOpen((open) => !open)}
-            >
+            <span className="bar-menu" aria-hidden>
               <PanelIcon className="ri bar-ic" />
-            </button>
+            </span>
             <span className="bar-nav" aria-hidden>
               <ChevronLeft className="ri" />
               <ChevronRight className="ri" />
@@ -925,25 +955,14 @@ function HeroAppMock() {
           </div>
         </div>
         <div className="mock-body">
-          {navOpen ? (
-            <button
-              type="button"
-              className="nav-backdrop"
-              aria-label="Close sidebar"
-              onClick={() => setNavOpen(false)}
-            />
-          ) : null}
-          <aside className={navOpen ? "side nav-open" : "side"}>
+          <aside className="side">
             <button
               type="button"
               className={
                 view === "new" ? "side-act active-act" : "side-act"
               }
               aria-pressed={view === "new"}
-              onClick={() => {
-                setView("new");
-                setNavOpen(false);
-              }}
+              onClick={() => setView("new")}
             >
               <NewThreadIcon className="sa-ic" />
               New thread
@@ -1304,6 +1323,7 @@ function ProviderTree() {
 function LandingPage() {
   useScrollReveal();
   useConstructMock();
+  useFitMock();
   return (
     <div className="wrap">
       <nav className="nav">
@@ -1394,11 +1414,6 @@ function LandingPage() {
           tools, and UI, and deploy your own build across your whole
           organization. It still runs local-first on your machines, on the
           provider subscriptions you already pay for.
-        </p>
-        <p className="facts">
-          <span>MIT licensed</span>
-          <span>Fork and customize</span>
-          <span>Self-host in your org</span>
         </p>
         <div className="cta-row">
           <GitHubLink placement="local" className="btn btn-ghost">

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -717,21 +717,12 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   height: 520px;
 }
 
-/* Header sidebar trigger (hamburger). Opens the drawer on mobile. */
+/* Sidebar-toggle glyph in the title bar — decorative window chrome. */
 .bar-menu {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 0;
-  background: none;
-  padding: 0;
   color: inherit;
-  cursor: pointer;
-}
-
-/* Drawer backdrop — only shown on mobile when the sidebar is open. */
-.nav-backdrop {
-  display: none;
 }
 
 /* sidebar */
@@ -2123,22 +2114,6 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   margin: 16px auto 0;
 }
 
-.facts {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px 16px;
-  margin-top: 22px;
-  color: var(--subtle);
-  font-size: 13px;
-}
-
-.facts span:not(:first-child)::before {
-  content: "·";
-  margin-right: 16px;
-  color: var(--border);
-}
-
 /* ── Section titles, closer, footer ─────────────────────────────── */
 
 .sec-title {
@@ -2224,105 +2199,43 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
     );
   }
 
-  /* Keep a fixed height (sidebar is an overlay drawer here, so it adds no
-     in-flow height). A running thread streams rows in endlessly; without a
-     bounded body the feed — and the whole card — would grow without limit. */
-  .mock-body {
-    flex-direction: column;
+  /* Mobile shows the desktop layout at a legible scale, anchored left, so only
+     its left portion is on screen — the rest bleeds off the right edge.
+     Full-bleed the card across the viewport: pull both edges out to cancel
+     .wrap's 28px side padding, then re-inset the card with padding-left so it
+     still lines up with the page content. overflow-x clips the card's right
+     bleed, but because the clip box now reaches the left screen edge too, the
+     card's drop shadow fades into the left gutter instead of being shaved off
+     at the card's own edge. overflow-y stays visible so the bottom shadow and
+     the scroll-in entrance still show. */
+  .mockup-wrap {
+    margin-left: -28px;
+    margin-right: -28px;
+    padding-left: 28px;
+    overflow-x: clip;
   }
 
-  /* In this column layout .main is on the main axis, so it needs min-height:0
-     to stay within the fixed body instead of growing with the feed's content.
-     This lets .feed clip and anchor newest rows to the bottom (.feed-live). */
-  .main {
-    min-height: 0;
+  /* The mock keeps its full desktop width and is shrunk with `zoom` (which
+     reflows, so the card occupies its scaled size and the page below flows
+     normally). JS sets `--mock-scale` so a fixed slice of the app
+     (`--mock-visible-width`) fills the available width. Both vars are defined
+     only here, so the mock is unscaled above this breakpoint; the fallback
+     scale covers the pre-hydration/no-JS paint. */
+  .mock {
+    --mock-desktop-width: 980px;
+    --mock-visible-width: 560px;
+    width: var(--mock-desktop-width);
+    zoom: var(--mock-scale, 0.62);
   }
 
-  .diff-panel {
-    display: none;
+  /* Left-align the centered statement on mobile so it reads like the bands
+     above it instead of centered multi-line text on a narrow screen. */
+  .statement {
+    text-align: left;
   }
 
-  /* Native mobile-app chrome: drop the desktop window furniture (traffic
-     lights, browser back/forward, editor/commit/panel toolbar) and present a
-     simple app header — menu · title · ⋯. */
-  .mock-bar {
-    height: 52px;
-  }
-
-  .bar-left {
-    width: auto;
-    border-right: none;
-    padding-right: 6px;
-  }
-
-  .mock-dots,
-  .bar-nav,
-  .bar-actions {
-    display: none;
-  }
-
-  .bar-ic {
-    width: 20px;
-    height: 20px;
-  }
-
-  .bar-main {
-    padding: 0 14px;
-  }
-
-  .bar-title {
-    flex: 1;
-    min-width: 0;
-    font-size: 15px;
-  }
-
-  .bar-kebab {
-    margin-left: auto;
-  }
-
-  /* The sidebar becomes a slide-in drawer (mirrors the app's mobile nav),
-     toggled by the header hamburger — not a tab strip. */
-  .side {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 30;
-    width: min(78%, 270px);
-    padding: 8px 8px 10px;
-    /* Collapsed: keep the card edge clean — the off-screen drawer must not cast
-       a border/shadow onto the left edge. Both appear only once expanded. */
-    border-right: none;
-    overflow-y: auto;
-    transform: translateX(-100%);
-    transition: transform 0.22s ease;
-  }
-
-  .side.nav-open {
-    transform: translateX(0);
-    border-right: 1px solid var(--border-soft);
-    box-shadow: 8px 0 28px -12px color-mix(in oklch, var(--ink) 45%, transparent);
-  }
-
-  .nav-backdrop {
-    display: block;
-    position: absolute;
-    inset: 0;
-    z-index: 20;
-    border: 0;
-    padding: 0;
-    background: color-mix(in oklch, var(--ink) 34%, transparent);
-    cursor: pointer;
-  }
-
-  .ctx-branch {
-    max-width: 150px;
-  }
-
-  /* Keep the run card compact under the CTA, not an oversized widget. */
-  .runcard {
-    max-width: 100%;
-    padding: 14px 16px 15px;
+  .statement .cta-row {
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary

On the mobile landing page, the hero app mock previously reflowed into a separate mobile layout (sidebar → slide-in drawer, hidden diff panel, native app chrome). This replaces that with the **full desktop layout shrunk to a legible scale**, showing only its left portion — the rest bleeds off the right edge, similar to the Conductor landing page.

- The mock is pinned to a fixed desktop width and scaled with `zoom`; `useFitMock` sets `--mock-scale` from the available width (via `ResizeObserver`) so a fixed left slice (`--mock-visible-width: 560px`) always fills the screen.
- `.mockup-wrap` full-bleeds across the viewport and clips the right overrun with `overflow-x: clip` — no horizontal scroll, and the card's drop shadow fades into the left gutter instead of being shaved off at the card's edge.
- Desktop is unchanged: the scaling custom properties are defined only inside the `@media (max-width: 720px)` block, so above it the mock renders unscaled at its natural width.

Also in this change:
- Removed the now-dead mobile-drawer code (`navOpen` state, hamburger toggle button, backdrop) and its CSS.
- Left-aligned the "Fork it. Make it your own." statement section on mobile so it reads like the bands above it.
- Removed the unused "facts" chips (MIT licensed / Fork and customize / Self-host in your org) and their CSS.

## Tuning

`--mock-visible-width` (in `styles.css`, mobile block) is the single knob for how much of the desktop app shows — lower it to zoom in / show less, raise it to show more.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/landing` passes.
- Manually verified at 320 / 360 / 390px and on desktop (1280px) via headless browser: legible scaled mock, soft left/bottom shadow, diff-panel toggle works, no horizontal scroll (`scrollLeft` pinned at 0, `scrollWidth` == viewport), desktop unaffected (`zoom: 1`).

## Risks

Low — scoped to `apps/landing`, behind the mobile breakpoint. `zoom` is used for scaling (well-supported in current browsers; the no-JS/pre-hydration paint falls back to a fixed `zoom: 0.62`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)