### PR TITLE
Fix project row collapse interactions

### DIFF
--- a/apps/app/src/components/project/ProjectActionsMenu.test.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ProjectResponse } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { CompactViewportOverrideProvider } from "@/components/ui/hooks/use-compact-viewport";
+import { ProjectActionsMenu } from "./ProjectActionsMenu";
+
+vi.mock("@/hooks/useLocalPathPicker", () => ({
+  usePathPickerHost: () => ({ hostId: null, hostName: null }),
+}));
+
+vi.mock("./ProjectActionsProvider", () => ({
+  useProjectActions: () => ({
+    requestRename: vi.fn(),
+    requestDelete: vi.fn(),
+    requestAddLocalPath: vi.fn(),
+  }),
+}));
+
+function makeProject(): ProjectResponse {
+  return {
+    id: "proj_test",
+    kind: "standard",
+    name: "Test project",
+    sources: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+describe("ProjectActionsMenu", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("does not bubble archived-thread selection to the project row", async () => {
+    const onProjectRowClick = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={["/projects/proj_test"]}>
+        <CompactViewportOverrideProvider isCompactViewport={true}>
+          <div onClick={onProjectRowClick}>
+            <ProjectActionsMenu project={makeProject()} />
+          </div>
+          <LocationProbe />
+        </CompactViewportOverrideProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Test project actions" }),
+    );
+    fireEvent.click(await screen.findByRole("menuitem", {
+      name: "Archived threads",
+    }));
+
+    expect(onProjectRowClick).not.toHaveBeenCalled();
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/projects/proj_test/archived",
+    );
+  });
+});

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -1,6 +1,6 @@
 import { findLocalPathProjectSourceForHost } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button.js";
 import { Icon } from "@/components/ui/icon.js";
@@ -57,6 +57,10 @@ interface ProjectActionMenuItemProps {
 
 interface ProjectActionMenuSeparatorProps {
   surface: ProjectActionsMenuSurface;
+}
+
+function stopProjectActionsMenuClickPropagation(event: MouseEvent) {
+  event.stopPropagation();
 }
 
 function ProjectActionMenuItem({
@@ -188,7 +192,11 @@ export function ProjectActionsMenu({
           <Icon name="MoreHorizontal" className={COARSE_POINTER_ICON_SIZE_CLASS} />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align={align} className="w-44">
+      <DropdownMenuContent
+        align={align}
+        className="w-44"
+        onClick={stopProjectActionsMenuClickPropagation}
+      >
         <ProjectActionsMenuItems project={project} surface="dropdown" />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -206,6 +214,7 @@ export function ProjectActionsContextMenu({
       <ContextMenuContent
         aria-label={`${project.name} actions`}
         className="w-44"
+        onClick={stopProjectActionsMenuClickPropagation}
       >
         <ProjectActionsMenuItems project={project} surface="context" />
       </ContextMenuContent>

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ProjectResponse } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ProjectRow } from "./ProjectRow";
+
+vi.mock("@/hooks/useLocalPathPicker", () => ({
+  usePathPickerHost: () => ({ hostId: null, hostName: null }),
+}));
+
+vi.mock("@/hooks/usePromptDraftStorage", () => ({
+  usePromptDraftHasInput: () => false,
+}));
+
+vi.mock("@/components/project/ProjectActionsProvider", () => ({
+  useProjectActions: () => ({
+    requestRename: vi.fn(),
+    requestDelete: vi.fn(),
+    requestAddLocalPath: vi.fn(),
+  }),
+}));
+
+function makeProject(): ProjectResponse {
+  return {
+    id: "proj_test",
+    kind: "standard",
+    name: "Test project",
+    sources: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function renderProjectRow(onToggleProjectCollapsed = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <ProjectRow
+        project={makeProject()}
+        threadListState={{ status: "ready", threads: [] }}
+        isActive={false}
+        isCollapsed={false}
+        compareThreads={() => 0}
+        collapsedThreadIds={new Set()}
+        collapsedEnvironmentIds={new Set()}
+        isLocalPathInvalid={false}
+        onToggleProjectCollapsed={onToggleProjectCollapsed}
+        onToggleThreadCollapsed={vi.fn()}
+        onToggleEnvironmentCollapsed={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+  return { onToggleProjectCollapsed };
+}
+
+describe("ProjectRow interactions", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("does not toggle collapse when the project row is clicked", () => {
+    const { onToggleProjectCollapsed } = renderProjectRow();
+
+    fireEvent.click(screen.getByText("Test project"));
+
+    expect(onToggleProjectCollapsed).not.toHaveBeenCalled();
+  });
+
+  it("toggles collapse when the project chevron is clicked", () => {
+    const { onToggleProjectCollapsed } = renderProjectRow();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse Test project" }),
+    );
+
+    expect(onToggleProjectCollapsed).toHaveBeenCalledWith("proj_test");
+  });
+});

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1264,17 +1264,9 @@ function ProjectRowComponent({
                 "select-none",
             )}
             title={project.name}
-            onClick={handleProjectRowToggle}
             {...projectDragBindings?.attributes}
             {...(projectDragBindings?.listeners ?? {})}
           >
-            <button
-              type="button"
-              aria-hidden="true"
-              tabIndex={-1}
-              onClick={handleProjectRowToggle}
-              className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
-            />
             <span
               className={cn(
                 "pointer-events-none relative z-10 flex shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors group-hover/project-row:text-sidebar-foreground",


### PR DESCRIPTION
## Summary
- prevent project actions menu clicks from bubbling into the project row
- stop project row clicks from toggling expand/collapse
- keep explicit chevron expand/collapse behavior covered by regression tests

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ProjectRow.interactions.test.tsx src/components/project/ProjectActionsMenu.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app