### PR TITLE
Fix menus staying open behind dialogs

### DIFF
--- a/apps/app/src/components/project/ProjectActionsMenu.test.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.test.tsx
@@ -1,22 +1,34 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ProjectResponse } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { CompactViewportOverrideProvider } from "@/components/ui/hooks/use-compact-viewport";
 import { ProjectActionsMenu } from "./ProjectActionsMenu";
 
+const mockPathPickerHost = vi.hoisted(() => ({
+  value: { hostId: null as string | null, hostName: null as string | null },
+}));
+
+const mockProjectActions = vi.hoisted(() => ({
+  requestRename: vi.fn(),
+  requestDelete: vi.fn(),
+  requestAddLocalPath: vi.fn(),
+}));
+
 vi.mock("@/hooks/useLocalPathPicker", () => ({
-  usePathPickerHost: () => ({ hostId: null, hostName: null }),
+  usePathPickerHost: () => mockPathPickerHost.value,
 }));
 
 vi.mock("./ProjectActionsProvider", () => ({
-  useProjectActions: () => ({
-    requestRename: vi.fn(),
-    requestDelete: vi.fn(),
-    requestAddLocalPath: vi.fn(),
-  }),
+  useProjectActions: () => mockProjectActions,
 }));
 
 function makeProject(): ProjectResponse {
@@ -39,6 +51,7 @@ describe("ProjectActionsMenu", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    mockPathPickerHost.value = { hostId: null, hostName: null };
   });
 
   it("does not bubble archived-thread selection to the project row", async () => {
@@ -66,5 +79,43 @@ describe("ProjectActionsMenu", () => {
     expect(screen.getByTestId("location").textContent).toBe(
       "/projects/proj_test/archived",
     );
+  });
+
+  it.each([
+    {
+      label: "Rename",
+      action: mockProjectActions.requestRename,
+      hostId: null,
+    },
+    {
+      label: "Add local path",
+      action: mockProjectActions.requestAddLocalPath,
+      hostId: "host_test",
+    },
+    {
+      label: "Remove",
+      action: mockProjectActions.requestDelete,
+      hostId: null,
+    },
+  ])("closes after selecting $label", async ({ label, action, hostId }) => {
+    mockPathPickerHost.value = { hostId, hostName: null };
+    const project = makeProject();
+
+    render(
+      <MemoryRouter>
+        <ProjectActionsMenu project={project} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Test project actions" }),
+      { button: 0 },
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: label }));
+
+    expect(action).toHaveBeenCalledWith(project);
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: label })).toBeNull();
+    });
   });
 });

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -127,10 +127,7 @@ function ProjectActionsMenuItems({
       <ProjectActionMenuSeparator surface={surface} />
       <ProjectActionMenuItem
         surface={surface}
-        onSelect={(event) => {
-          if (surface === "dropdown") {
-            event.preventDefault();
-          }
+        onSelect={() => {
           requestRename(project);
         }}
       >
@@ -139,10 +136,7 @@ function ProjectActionsMenuItems({
       {showAddLocalPath ? (
         <ProjectActionMenuItem
           surface={surface}
-          onSelect={(event) => {
-            if (surface === "dropdown") {
-              event.preventDefault();
-            }
+          onSelect={() => {
             requestAddLocalPath(project);
           }}
         >
@@ -152,10 +146,7 @@ function ProjectActionsMenuItems({
       <ProjectActionMenuItem
         surface={surface}
         className="text-destructive focus:text-destructive"
-        onSelect={(event) => {
-          if (surface === "dropdown") {
-            event.preventDefault();
-          }
+        onSelect={() => {
           requestDelete(project);
         }}
       >

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -1,13 +1,44 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ThreadListEntry } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { ProjectRow } from "./ProjectRow";
+import { ProjectRow, type ProjectThreadListState } from "./ProjectRow";
+
+const mockUpdateEnvironment = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  reset: vi.fn(),
+}));
 
 vi.mock("@/hooks/useLocalPathPicker", () => ({
   usePathPickerHost: () => ({ hostId: null, hostName: null }),
+}));
+
+vi.mock("@/hooks/mutations/environment-mutations", () => ({
+  useArchiveEnvironmentThreads: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    variables: undefined,
+  }),
+  useUpdateEnvironment: () => ({
+    error: null,
+    isPending: false,
+    mutate: mockUpdateEnvironment.mutate,
+    reset: mockUpdateEnvironment.reset,
+    variables: undefined,
+  }),
+}));
+
+vi.mock("@/hooks/useCreateThreadInWorktree", () => ({
+  useCreateThreadInWorktree: () => vi.fn(),
 }));
 
 vi.mock("@/hooks/usePromptDraftStorage", () => ({
@@ -33,12 +64,47 @@ function makeProject(): ProjectResponse {
   };
 }
 
-function renderProjectRow(onToggleProjectCollapsed = vi.fn()) {
+function makeThread(overrides: Partial<ThreadListEntry> = {}): ThreadListEntry {
+  return {
+    id: "thr_test",
+    projectId: "proj_test",
+    environmentId: null,
+    providerId: "codex",
+    title: "Test thread",
+    titleFallback: "Test thread",
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    childOrigin: null,
+    archivedAt: null,
+    pinnedAt: null,
+    pinSortKey: null,
+    deletedAt: null,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    createdAt: 0,
+    updatedAt: 100,
+    activity: { activeWorkflowCount: 0, activeBackgroundSubagentCount: 0 },
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+    ...overrides,
+  };
+}
+
+function renderProjectRow(
+  onToggleProjectCollapsed = vi.fn(),
+  threadListState: ProjectThreadListState = { status: "ready", threads: [] },
+) {
   render(
     <MemoryRouter>
       <ProjectRow
         project={makeProject()}
-        threadListState={{ status: "ready", threads: [] }}
+        threadListState={threadListState}
         isActive={false}
         isCollapsed={false}
         compareThreads={() => 0}
@@ -76,5 +142,41 @@ describe("ProjectRow interactions", () => {
     );
 
     expect(onToggleProjectCollapsed).toHaveBeenCalledWith("proj_test");
+  });
+
+  it("closes the worktree actions menu after selecting rename", async () => {
+    renderProjectRow(vi.fn(), {
+      status: "ready",
+      threads: [
+        makeThread({
+          id: "thr_worktree_a",
+          environmentId: "env_test",
+          environmentName: "Feature workspace",
+          environmentBranchName: "feat/menu-close",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+        }),
+        makeThread({
+          id: "thr_worktree_b",
+          environmentId: "env_test",
+          environmentName: "Feature workspace",
+          environmentBranchName: "feat/menu-close",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+        }),
+      ],
+    });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Worktree actions" }),
+      { button: 0 },
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Rename" }));
+
+    expect(mockUpdateEnvironment.reset).toHaveBeenCalled();
+    expect(
+      await screen.findByRole("dialog", { name: "Rename environment" }),
+    ).not.toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+    });
   });
 });

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -605,8 +605,7 @@ function EnvironmentThreadGroupHeaderActions({
           ) : null}
           {onRenameEnvironment ? (
             <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
+              onSelect={() => {
                 onRenameEnvironment();
               }}
             >

--- a/apps/app/src/views/AutomationsView.interactions.test.tsx
+++ b/apps/app/src/views/AutomationsView.interactions.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import type { Automation } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import {
+  AutomationsOverview,
+  type AutomationRowActions,
+} from "./AutomationsView";
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: "auto_test",
+    projectId: PERSONAL_PROJECT_ID,
+    name: "Daily standup digest",
+    enabled: true,
+    trigger: {
+      triggerType: "schedule",
+      cron: "0 9 * * 1-5",
+      timezone: "America/Los_Angeles",
+    },
+    execution: {
+      mode: "agent",
+      prompt: "Summarize updates.",
+      providerId: "codex",
+      model: "gpt-5",
+      permissionMode: "readonly",
+    },
+    environment: { type: "host", workspace: { type: "personal" } },
+    autoArchive: false,
+    origin: "human",
+    createdByThreadId: null,
+    nextRunAt: 1_700_003_600_000,
+    lastRunAt: null,
+    runCount: 0,
+    lastRunStatus: null,
+    lastRunThreadId: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+describe("AutomationsOverview interactions", () => {
+  afterEach(cleanup);
+
+  it("closes the row actions menu after selecting delete", async () => {
+    const automation = makeAutomation();
+    const actions: AutomationRowActions = {
+      onPause: vi.fn(),
+      onResume: vi.fn(),
+      onRun: vi.fn(),
+      onDelete: vi.fn(),
+    };
+
+    render(
+      <MemoryRouter>
+        <AutomationsOverview
+          entries={[
+            {
+              automation,
+              project: { id: PERSONAL_PROJECT_ID, name: "Personal" },
+            },
+          ]}
+          isLoading={false}
+          hasInitialLoadError={false}
+          actions={actions}
+          onCreateAutomation={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Daily standup digest actions" }),
+      { button: 0 },
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
+
+    expect(actions.onDelete).toHaveBeenCalledWith({
+      automation,
+      project: { id: PERSONAL_PROJECT_ID, name: "Personal" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Delete" })).toBeNull();
+    });
+  });
+});

--- a/apps/app/src/views/AutomationsView.tsx
+++ b/apps/app/src/views/AutomationsView.tsx
@@ -101,8 +101,6 @@ export interface AutomationRowMenuItem {
   key: "pause" | "resume" | "run" | "delete";
   label: string;
   destructive: boolean;
-  /** True when selecting should keep the menu open (the confirm dialog opens). */
-  preventClose: boolean;
   run: () => void;
 }
 
@@ -123,28 +121,24 @@ export function buildAutomationRowMenuItems(
           key: "pause",
           label: "Pause",
           destructive: false,
-          preventClose: false,
           run: () => actions.onPause(entry),
         }
       : {
           key: "resume",
           label: "Resume",
           destructive: false,
-          preventClose: false,
           run: () => actions.onResume(entry),
         },
     {
       key: "run",
       label: "Run now",
       destructive: false,
-      preventClose: false,
       run: () => actions.onRun(entry),
     },
     {
       key: "delete",
       label: "Delete",
       destructive: true,
-      preventClose: true,
       run: () => actions.onDelete(entry),
     },
   ];
@@ -163,10 +157,7 @@ function AutomationRowActionItems({ entry, actions }: AutomationRowProps) {
                 ? "text-destructive focus:text-destructive"
                 : undefined
             }
-            onSelect={(event) => {
-              if (item.preventClose) {
-                event.preventDefault();
-              }
+            onSelect={() => {
               item.run();
             }}
           >

--- a/apps/app/src/views/project-settings/ProjectSourceRow.test.tsx
+++ b/apps/app/src/views/project-settings/ProjectSourceRow.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { LocalPathProjectSource } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProjectSourceRow } from "./ProjectSourceRow";
+
+const source: LocalPathProjectSource = {
+  id: "src_test",
+  projectId: "proj_test",
+  type: "local_path",
+  hostId: "host_test",
+  path: "/tmp/test-project",
+  isDefault: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+describe("ProjectSourceRow", () => {
+  afterEach(cleanup);
+
+  it("closes the actions menu after selecting edit local path", async () => {
+    const onEditLocalPath = vi.fn();
+
+    render(
+      <ProjectSourceRow
+        source={source}
+        canEditLocalPath={true}
+        isLocalPathInvalid={false}
+        isEditPending={false}
+        isOnlySource={false}
+        onEditLocalPath={onEditLocalPath}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Source actions" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Edit local path" }),
+    );
+
+    expect(onEditLocalPath).toHaveBeenCalledWith(source);
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("menuitem", { name: "Edit local path" }),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/app/src/views/project-settings/ProjectSourceRow.tsx
+++ b/apps/app/src/views/project-settings/ProjectSourceRow.tsx
@@ -57,8 +57,7 @@ export function ProjectSourceRow({
           {canEditLocalPath ? (
             <DropdownMenuItem
               disabled={isEditPending}
-              onSelect={(event) => {
-                event.preventDefault();
+              onSelect={() => {
                 onEditLocalPath(source);
               }}
             >


### PR DESCRIPTION
## Summary
- Let dialog-opening dropdown actions close normally instead of canceling Radix menu selection
- Cover project source edit, project actions, automation delete, and worktree rename menus with interaction tests
- Remove automation row metadata whose only purpose was keeping the delete menu open

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/project/ProjectActionsMenu.test.tsx src/components/sidebar/ProjectRow.interactions.test.tsx src/views/AutomationsView.interactions.test.tsx src/views/project-settings/ProjectSourceRow.test.tsx src/views/AutomationsView.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app