### PR TITLE
Anchor selection menu to pointer release

### DIFF
--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
@@ -86,6 +86,34 @@ describe("SelectableMessageProse", () => {
     );
   });
 
+  it("includes the pointer release point when a pointer selection starts in the message", async () => {
+    const onSelect = vi.fn();
+    const { getByText } = render(
+      <SelectableMessageProse onSelect={onSelect}>
+        Selectable answer text
+      </SelectableMessageProse>,
+    );
+    const target = getByText("Selectable answer text");
+    const textNode = target.firstChild;
+    expect(textNode).not.toBeNull();
+    mockWindowSelection({
+      node: textNode!,
+      text: "answer text",
+    });
+
+    fireEvent.pointerDown(target);
+    fireEvent.pointerUp(document, { clientX: 42, clientY: 84 });
+
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          anchorPoint: { x: 42, y: 84 },
+          text: "answer text",
+        }),
+      ),
+    );
+  });
+
   it("reports a selection that updates after pointer release", async () => {
     const onSelect = vi.fn();
     const { getByText } = render(

--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
@@ -86,7 +86,7 @@ describe("SelectableMessageProse", () => {
     );
   });
 
-  it("includes the pointer release point when a pointer selection starts in the message", async () => {
+  it("includes the pointer release point and side when a pointer selection starts in the message", async () => {
     const onSelect = vi.fn();
     const { getByText } = render(
       <SelectableMessageProse onSelect={onSelect}>
@@ -101,13 +101,14 @@ describe("SelectableMessageProse", () => {
       text: "answer text",
     });
 
-    fireEvent.pointerDown(target);
+    fireEvent.pointerDown(target, { clientX: 12, clientY: 24 });
     fireEvent.pointerUp(document, { clientX: 42, clientY: 84 });
 
     await waitFor(() =>
       expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           anchorPoint: { x: 42, y: 84 },
+          anchorSide: "bottom",
           text: "answer text",
         }),
       ),

--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
@@ -5,10 +5,18 @@ interface SelectionAnchorPoint {
   y: number;
 }
 
+type SelectionAnchorSide = "top" | "bottom";
+
+interface SelectionAnchor {
+  point: SelectionAnchorPoint;
+  side: SelectionAnchorSide;
+}
+
 export interface MessageProseSelection {
   text: string;
   rect: DOMRect;
   anchorPoint?: SelectionAnchorPoint;
+  anchorSide?: SelectionAnchorSide;
   sourceSeqEnd?: number;
 }
 
@@ -24,6 +32,7 @@ export interface SelectableMessageProseProps {
 }
 
 export const MULTI_CLICK_SELECTION_REPORT_DELAY_MS = 180;
+const SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
 
 /**
  * Pure predicate: does `selection` fall entirely within `node`?
@@ -98,18 +107,19 @@ function isSelectionBoundarySpillWithinNode(
 }
 
 function toMessageProseSelection({
-  anchorPoint,
+  anchor,
   rect,
   text,
 }: {
-  anchorPoint: SelectionAnchorPoint | null;
+  anchor: SelectionAnchor | null;
   rect: DOMRect | null;
   text: string;
 }): MessageProseSelection | null {
   if (text.length === 0 || rect === null) return null;
   const selection: MessageProseSelection = { text, rect };
-  if (anchorPoint !== null) {
-    selection.anchorPoint = anchorPoint;
+  if (anchor !== null) {
+    selection.anchorPoint = anchor.point;
+    selection.anchorSide = anchor.side;
   }
   return selection;
 }
@@ -123,6 +133,25 @@ function anchorPointFromMouseEvent(
   return { x: event.clientX, y: event.clientY };
 }
 
+function selectionAnchorFromPointerRelease(
+  startPoint: SelectionAnchorPoint | null,
+  releaseEvent: Pick<MouseEvent, "clientX" | "clientY">,
+): SelectionAnchor | null {
+  const releasePoint = anchorPointFromMouseEvent(releaseEvent);
+  if (releasePoint === null) {
+    return null;
+  }
+
+  return {
+    point: releasePoint,
+    side:
+      startPoint !== null &&
+      releasePoint.y - startPoint.y > SELECTION_DRAG_DIRECTION_THRESHOLD_PX
+        ? "bottom"
+        : "top",
+  };
+}
+
 function isEventTargetWithinNode(event: Event, node: HTMLElement | null): boolean {
   if (node === null || !(event.target instanceof Node)) return false;
   return node.contains(event.target);
@@ -130,7 +159,7 @@ function isEventTargetWithinNode(event: Event, node: HTMLElement | null): boolea
 
 function readSelectionWithinNode(
   node: HTMLElement | null,
-  anchorPoint: SelectionAnchorPoint | null,
+  anchor: SelectionAnchor | null,
 ): MessageProseSelection | null {
   if (node === null || typeof window === "undefined") return null;
 
@@ -147,13 +176,13 @@ function readSelectionWithinNode(
   if (accepted) {
     const text = selection.toString().trim();
     const rect = firstClientRect(range);
-    return toMessageProseSelection({ anchorPoint, rect, text });
+    return toMessageProseSelection({ anchor, rect, text });
   }
 
   const text = selection.toString().trim();
   if (isSelectionBoundarySpillWithinNode(node, range, text)) {
     const rect = firstClientRect(range);
-    return toMessageProseSelection({ anchorPoint, rect, text });
+    return toMessageProseSelection({ anchor, rect, text });
   }
 
   return null;
@@ -184,14 +213,15 @@ export function SelectableMessageProse({
     let hadSelection = false;
     let pointerIsDown = false;
     let pointerStartedInNode = false;
-    let pendingReportAnchorPoint: SelectionAnchorPoint | null = null;
-    let lastPointerReleaseAnchorPoint: SelectionAnchorPoint | null = null;
+    let pointerStartPoint: SelectionAnchorPoint | null = null;
+    let pendingReportAnchor: SelectionAnchor | null = null;
+    let lastPointerReleaseAnchor: SelectionAnchor | null = null;
     let multiClickTimer: number | null = null;
     const report = () => {
       frame = null;
-      const anchorPoint = pendingReportAnchorPoint;
-      pendingReportAnchorPoint = null;
-      const next = readSelectionWithinNode(nodeRef.current, anchorPoint);
+      const anchor = pendingReportAnchor;
+      pendingReportAnchor = null;
+      const next = readSelectionWithinNode(nodeRef.current, anchor);
       if (next === null && !hadSelection) return;
       hadSelection = next !== null;
       onSelectRef.current?.(next);
@@ -210,27 +240,25 @@ export function SelectableMessageProse({
       if (frame !== null) return;
       frame = window.requestAnimationFrame(report);
     };
-    const scheduleWithAnchorPoint = (
-      anchorPoint: SelectionAnchorPoint | null,
-    ) => {
-      if (anchorPoint !== null) {
-        pendingReportAnchorPoint = anchorPoint;
+    const scheduleWithAnchor = (anchor: SelectionAnchor | null) => {
+      if (anchor !== null) {
+        pendingReportAnchor = anchor;
       }
       schedule();
     };
-    const scheduleFresh = (anchorPoint: SelectionAnchorPoint | null = null) => {
+    const scheduleFresh = (anchor: SelectionAnchor | null = null) => {
       cancelMultiClickTimer();
       cancelFrame();
-      scheduleWithAnchorPoint(anchorPoint);
+      scheduleWithAnchor(anchor);
     };
     const scheduleAfterMultiClickDelay = (
-      anchorPoint: SelectionAnchorPoint | null = null,
+      anchor: SelectionAnchor | null = null,
     ) => {
       cancelFrame();
       cancelMultiClickTimer();
       multiClickTimer = window.setTimeout(() => {
         multiClickTimer = null;
-        scheduleWithAnchorPoint(anchorPoint);
+        scheduleWithAnchor(anchor);
       }, MULTI_CLICK_SELECTION_REPORT_DELAY_MS);
     };
     const handleSelectionChange = () => {
@@ -245,42 +273,47 @@ export function SelectableMessageProse({
     const handlePointerDown = (event: PointerEvent) => {
       cancelMultiClickTimer();
       cancelFrame();
-      pendingReportAnchorPoint = null;
+      pendingReportAnchor = null;
       pointerStartedInNode = isEventTargetWithinNode(event, nodeRef.current);
+      pointerStartPoint = pointerStartedInNode
+        ? anchorPointFromMouseEvent(event)
+        : null;
       pointerIsDown = true;
     };
     const handlePointerRelease = (event: PointerEvent | MouseEvent) => {
-      const anchorPoint = pointerStartedInNode
-        ? anchorPointFromMouseEvent(event)
+      const anchor = pointerStartedInNode
+        ? selectionAnchorFromPointerRelease(pointerStartPoint, event)
         : null;
-      if (anchorPoint !== null) {
-        lastPointerReleaseAnchorPoint = anchorPoint;
+      if (anchor !== null) {
+        lastPointerReleaseAnchor = anchor;
       }
       pointerIsDown = false;
       pointerStartedInNode = false;
-      scheduleWithAnchorPoint(anchorPoint);
+      pointerStartPoint = null;
+      scheduleWithAnchor(anchor);
     };
     const handlePointerCancel = () => {
       pointerIsDown = false;
       pointerStartedInNode = false;
+      pointerStartPoint = null;
       schedule();
     };
     const handleMultiClick = (event: MouseEvent) => {
       if (event.detail < 2) {
         return;
       }
-      const anchorPoint =
-        anchorPointFromMouseEvent(event) ?? lastPointerReleaseAnchorPoint;
+      const clickAnchor =
+        selectionAnchorFromPointerRelease(null, event) ?? lastPointerReleaseAnchor;
       if (event.detail === 2) {
-        scheduleAfterMultiClickDelay(anchorPoint);
+        scheduleAfterMultiClickDelay(clickAnchor);
         return;
       }
       // Multi-click selection can be finalized after pointerup. Replace any
       // stale pointerup read with one explicitly tied to the completed click.
-      scheduleFresh(anchorPoint);
+      scheduleFresh(clickAnchor);
     };
     const handleDoubleClick = () => {
-      scheduleAfterMultiClickDelay(lastPointerReleaseAnchorPoint);
+      scheduleAfterMultiClickDelay(lastPointerReleaseAnchor);
     };
     const node = nodeRef.current;
 

--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, type ReactNode } from "react";
 
+interface SelectionAnchorPoint {
+  x: number;
+  y: number;
+}
+
 export interface MessageProseSelection {
   text: string;
   rect: DOMRect;
+  anchorPoint?: SelectionAnchorPoint;
   sourceSeqEnd?: number;
 }
 
@@ -91,8 +97,40 @@ function isSelectionBoundarySpillWithinNode(
   );
 }
 
+function toMessageProseSelection({
+  anchorPoint,
+  rect,
+  text,
+}: {
+  anchorPoint: SelectionAnchorPoint | null;
+  rect: DOMRect | null;
+  text: string;
+}): MessageProseSelection | null {
+  if (text.length === 0 || rect === null) return null;
+  const selection: MessageProseSelection = { text, rect };
+  if (anchorPoint !== null) {
+    selection.anchorPoint = anchorPoint;
+  }
+  return selection;
+}
+
+function anchorPointFromMouseEvent(
+  event: Pick<MouseEvent, "clientX" | "clientY">,
+): SelectionAnchorPoint | null {
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+    return null;
+  }
+  return { x: event.clientX, y: event.clientY };
+}
+
+function isEventTargetWithinNode(event: Event, node: HTMLElement | null): boolean {
+  if (node === null || !(event.target instanceof Node)) return false;
+  return node.contains(event.target);
+}
+
 function readSelectionWithinNode(
   node: HTMLElement | null,
+  anchorPoint: SelectionAnchorPoint | null,
 ): MessageProseSelection | null {
   if (node === null || typeof window === "undefined") return null;
 
@@ -109,13 +147,13 @@ function readSelectionWithinNode(
   if (accepted) {
     const text = selection.toString().trim();
     const rect = firstClientRect(range);
-    return text.length > 0 && rect !== null ? { text, rect } : null;
+    return toMessageProseSelection({ anchorPoint, rect, text });
   }
 
   const text = selection.toString().trim();
   if (isSelectionBoundarySpillWithinNode(node, range, text)) {
     const rect = firstClientRect(range);
-    return text.length > 0 && rect !== null ? { text, rect } : null;
+    return toMessageProseSelection({ anchorPoint, rect, text });
   }
 
   return null;
@@ -145,10 +183,15 @@ export function SelectableMessageProse({
     // N messages don't thrash a shared controller.
     let hadSelection = false;
     let pointerIsDown = false;
+    let pointerStartedInNode = false;
+    let pendingReportAnchorPoint: SelectionAnchorPoint | null = null;
+    let lastPointerReleaseAnchorPoint: SelectionAnchorPoint | null = null;
     let multiClickTimer: number | null = null;
     const report = () => {
       frame = null;
-      const next = readSelectionWithinNode(nodeRef.current);
+      const anchorPoint = pendingReportAnchorPoint;
+      pendingReportAnchorPoint = null;
+      const next = readSelectionWithinNode(nodeRef.current, anchorPoint);
       if (next === null && !hadSelection) return;
       hadSelection = next !== null;
       onSelectRef.current?.(next);
@@ -167,17 +210,27 @@ export function SelectableMessageProse({
       if (frame !== null) return;
       frame = window.requestAnimationFrame(report);
     };
-    const scheduleFresh = () => {
-      cancelMultiClickTimer();
-      cancelFrame();
+    const scheduleWithAnchorPoint = (
+      anchorPoint: SelectionAnchorPoint | null,
+    ) => {
+      if (anchorPoint !== null) {
+        pendingReportAnchorPoint = anchorPoint;
+      }
       schedule();
     };
-    const scheduleAfterMultiClickDelay = () => {
+    const scheduleFresh = (anchorPoint: SelectionAnchorPoint | null = null) => {
+      cancelMultiClickTimer();
+      cancelFrame();
+      scheduleWithAnchorPoint(anchorPoint);
+    };
+    const scheduleAfterMultiClickDelay = (
+      anchorPoint: SelectionAnchorPoint | null = null,
+    ) => {
       cancelFrame();
       cancelMultiClickTimer();
       multiClickTimer = window.setTimeout(() => {
         multiClickTimer = null;
-        schedule();
+        scheduleWithAnchorPoint(anchorPoint);
       }, MULTI_CLICK_SELECTION_REPORT_DELAY_MS);
     };
     const handleSelectionChange = () => {
@@ -189,36 +242,52 @@ export function SelectableMessageProse({
       }
       schedule();
     };
-    const handlePointerDown = () => {
+    const handlePointerDown = (event: PointerEvent) => {
       cancelMultiClickTimer();
       cancelFrame();
+      pendingReportAnchorPoint = null;
+      pointerStartedInNode = isEventTargetWithinNode(event, nodeRef.current);
       pointerIsDown = true;
     };
-    const handlePointerEnd = () => {
+    const handlePointerRelease = (event: PointerEvent | MouseEvent) => {
+      const anchorPoint = pointerStartedInNode
+        ? anchorPointFromMouseEvent(event)
+        : null;
+      if (anchorPoint !== null) {
+        lastPointerReleaseAnchorPoint = anchorPoint;
+      }
       pointerIsDown = false;
+      pointerStartedInNode = false;
+      scheduleWithAnchorPoint(anchorPoint);
+    };
+    const handlePointerCancel = () => {
+      pointerIsDown = false;
+      pointerStartedInNode = false;
       schedule();
     };
     const handleMultiClick = (event: MouseEvent) => {
       if (event.detail < 2) {
         return;
       }
+      const anchorPoint =
+        anchorPointFromMouseEvent(event) ?? lastPointerReleaseAnchorPoint;
       if (event.detail === 2) {
-        scheduleAfterMultiClickDelay();
+        scheduleAfterMultiClickDelay(anchorPoint);
         return;
       }
       // Multi-click selection can be finalized after pointerup. Replace any
       // stale pointerup read with one explicitly tied to the completed click.
-      scheduleFresh();
+      scheduleFresh(anchorPoint);
     };
     const handleDoubleClick = () => {
-      scheduleAfterMultiClickDelay();
+      scheduleAfterMultiClickDelay(lastPointerReleaseAnchorPoint);
     };
     const node = nodeRef.current;
 
     document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("pointerup", handlePointerEnd);
-    document.addEventListener("pointercancel", handlePointerEnd);
-    document.addEventListener("mouseup", handlePointerEnd);
+    document.addEventListener("pointerup", handlePointerRelease);
+    document.addEventListener("pointercancel", handlePointerCancel);
+    document.addEventListener("mouseup", handlePointerRelease);
     document.addEventListener("selectionchange", handleSelectionChange);
     document.addEventListener("keyup", schedule);
     node?.addEventListener("click", handleMultiClick);
@@ -227,9 +296,9 @@ export function SelectableMessageProse({
       if (frame !== null) window.cancelAnimationFrame(frame);
       cancelMultiClickTimer();
       document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("pointerup", handlePointerEnd);
-      document.removeEventListener("pointercancel", handlePointerEnd);
-      document.removeEventListener("mouseup", handlePointerEnd);
+      document.removeEventListener("pointerup", handlePointerRelease);
+      document.removeEventListener("pointercancel", handlePointerCancel);
+      document.removeEventListener("mouseup", handlePointerRelease);
       document.removeEventListener("selectionchange", handleSelectionChange);
       document.removeEventListener("keyup", schedule);
       node?.removeEventListener("click", handleMultiClick);

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
@@ -60,6 +60,21 @@ describe("TimelineSelectionMenu", () => {
     expect(anchor.style.top).toBe("84px");
   });
 
+  it("uses the selected anchor side when positioning from a pointer release", () => {
+    render(
+      <TimelineSelectionMenu
+        selection={makeSelection({
+          anchorPoint: { x: 42, y: 84 },
+          anchorSide: "bottom",
+        })}
+        onAddToChat={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(document.body.querySelector('[data-side="bottom"]')).toBeTruthy();
+  });
+
   it("passes the selection branch point to side-chat replies", () => {
     const onReplyInSideChat = vi.fn();
     render(

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
@@ -7,11 +7,14 @@ import type { MessageProseSelection } from "./SelectableMessageProse";
 
 afterEach(cleanup);
 
-function makeSelection(): MessageProseSelection {
+function makeSelection(
+  overrides: Partial<MessageProseSelection> = {},
+): MessageProseSelection {
   return {
     text: "selected text",
     rect: new DOMRect(10, 10, 100, 20),
     sourceSeqEnd: 12,
+    ...overrides,
   };
 }
 
@@ -37,6 +40,24 @@ describe("TimelineSelectionMenu", () => {
     );
 
     expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("anchors to the pointer release point when one is available", () => {
+    const { container } = render(
+      <TimelineSelectionMenu
+        selection={makeSelection({ anchorPoint: { x: 42, y: 84 } })}
+        onAddToChat={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    const anchor = container.querySelector('[aria-hidden="true"]');
+    expect(anchor).toBeInstanceOf(HTMLElement);
+    if (!(anchor instanceof HTMLElement)) {
+      throw new Error("Expected selection menu anchor to render");
+    }
+    expect(anchor.style.left).toBe("42px");
+    expect(anchor.style.top).toBe("84px");
   });
 
   it("passes the selection branch point to side-chat replies", () => {

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
@@ -117,7 +117,9 @@ export function TimelineSelectionMenu({
   ];
   if (actions.length === 0) return null;
 
-  const { rect } = selection;
+  const { anchorPoint, rect } = selection;
+  const anchorLeft = anchorPoint?.x ?? rect.left + rect.width / 2;
+  const anchorTop = anchorPoint?.y ?? rect.top;
 
   return (
     <Popover
@@ -126,15 +128,18 @@ export function TimelineSelectionMenu({
         if (!next) onDismiss();
       }}
     >
-      {/* Zero-size anchor pinned to the selection rect (viewport coords). */}
+      {/*
+        Zero-size anchor pinned to the pointer release point, falling back to the
+        selection rect.
+      */}
       <PopoverAnchor asChild>
         <div
           ref={anchorRef}
           aria-hidden="true"
           style={{
             position: "fixed",
-            left: rect.left + rect.width / 2,
-            top: rect.top,
+            left: anchorLeft,
+            top: anchorTop,
             width: 0,
             height: 0,
           }}

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
@@ -56,9 +56,9 @@ function ActionButton({
 }
 
 /**
- * Floating horizontal menu shown above an agent-message text selection. Built
- * as a self-contained component driven by `selection` + callbacks; the
- * timeline controller that supplies them is wired separately.
+ * Floating horizontal menu shown near an agent-message text selection. Built as
+ * a self-contained component driven by `selection` + callbacks; the timeline
+ * controller that supplies them is wired separately.
  */
 export function TimelineSelectionMenu({
   selection,
@@ -120,6 +120,7 @@ export function TimelineSelectionMenu({
   const { anchorPoint, rect } = selection;
   const anchorLeft = anchorPoint?.x ?? rect.left + rect.width / 2;
   const anchorTop = anchorPoint?.y ?? rect.top;
+  const anchorSide = selection.anchorSide ?? "top";
 
   return (
     <Popover
@@ -129,8 +130,8 @@ export function TimelineSelectionMenu({
       }}
     >
       {/*
-        Zero-size anchor pinned to the pointer release point, falling back to the
-        selection rect.
+        Zero-size anchor pinned to the pointer release point and gesture side,
+        falling back to the selection rect.
       */}
       <PopoverAnchor asChild>
         <div
@@ -146,7 +147,7 @@ export function TimelineSelectionMenu({
         />
       </PopoverAnchor>
       <PopoverContent
-        side="top"
+        side={anchorSide}
         align="center"
         sideOffset={6}
         collisionBoundary={collisionBoundary}


### PR DESCRIPTION
## Summary
- Capture the pointer/mouse release point and drag direction for assistant prose selections.
- Prefer anchoring the Add to chat / side-chat selection popover at the release point, below the cursor for downward drags and above otherwise, with Radix collision fallback.
- Add regression coverage for carrying the pointer release anchor, preserving the side preference, and passing that side into popover positioning.

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/thread/timeline/SelectableMessageProse.events.test.tsx src/components/thread/timeline/TimelineSelectionMenu.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app