### PR TITLE
Fix user prompt blockquote markdown serialization

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -297,7 +297,7 @@ describe("PromptBoxInternal controlled value sync", () => {
     );
 
     expect(onChange).toHaveBeenLastCalledWith(
-      "> selected text\nreply",
+      "> selected text\n\nreply",
       [],
     );
   });

--- a/apps/app/src/components/promptbox/editor/prompt-editor-blockquote.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-blockquote.test.ts
@@ -67,7 +67,7 @@ describe("createExitTrailingBlockquoteBreakTransaction", () => {
       'doc(blockquote(paragraph("quote")), paragraph)',
     );
     expect(nextState.selection.from).toBe(10);
-    expect(promptEditorValueFromDoc(nextState.doc).text).toBe("> quote\n");
+    expect(promptEditorValueFromDoc(nextState.doc).text).toBe("> quote\n\n");
   });
 
   it("does not exit a blockquote before the first trailing hard break exists", () => {

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
@@ -62,17 +62,23 @@ describe("prompt editor serialization round-trip", () => {
     expect(roundTrip(value)).toEqual(value);
   });
 
-  it("round-trips a quote followed by a reply", () => {
+  it("canonicalizes a quote followed by a reply with a separator blank", () => {
     const value: PromptEditorValue = { text: "> a\nmy reply", mentions: [] };
-    expect(roundTrip(value)).toEqual(value);
+    expect(roundTrip(value)).toEqual({
+      text: "> a\n\nmy reply",
+      mentions: [],
+    });
   });
 
-  it("round-trips two quotes each with a reply", () => {
+  it("canonicalizes two quotes each with a reply", () => {
     const value: PromptEditorValue = {
       text: "> q1\nr1\n> q2\nr2",
       mentions: [],
     };
-    expect(roundTrip(value)).toEqual(value);
+    expect(roundTrip(value)).toEqual({
+      text: "> q1\n\nr1\n> q2\n\nr2",
+      mentions: [],
+    });
   });
 
   it("round-trips a quote with an internal blank line", () => {
@@ -86,8 +92,8 @@ describe("prompt editor serialization round-trip", () => {
   });
 
   it("preserves a mention's offsets in a reply after a quote", () => {
-    // "> a\nhey @thread done" — the mention "@thread" sits in the reply line.
-    const prefix = "> a\nhey ";
+    // "> a\n\nhey @thread done" — the mention "@thread" sits in the reply line.
+    const prefix = "> a\n\nhey ";
     const mentionText = "@thread";
     const text = `${prefix}${mentionText} done`;
     const mention: PromptTextMention = {
@@ -295,6 +301,26 @@ describe("prompt editor markdown serialization (doc -> markdown text)", () => {
         },
       ]).text,
     ).toBe("# H\npara\n- i");
+  });
+
+  it("separates a blockquote from a following paragraph with a blank line", () => {
+    expect(
+      serialize([
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "quoted" }],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "reply" }],
+        },
+      ]).text,
+    ).toBe("> quoted\n\nreply");
   });
 
   it("keeps a mention's offset correct inside a heading", () => {

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
@@ -74,6 +74,10 @@ function isQuoteLine(line: string): boolean {
   return line === ">" || line.startsWith("> ");
 }
 
+function isBlankLine(line: string): boolean {
+  return line.length === 0;
+}
+
 function stripQuotePrefix(line: string): string {
   if (line.startsWith("> ")) return line.slice(2);
   if (line === ">") return "";
@@ -212,6 +216,13 @@ export function promptEditorContentFromValue(
     const groupStarts = lineGlobalStarts.slice(index, end);
     if (quote) {
       blocks.push(blockquoteFromLines(value, groupLines, groupStarts));
+      if (
+        isBlankLine(lines[end] ?? "") &&
+        end + 1 < lines.length &&
+        !isQuoteLine(lines[end + 1]!)
+      ) {
+        end += 1;
+      }
     } else {
       const spanStart = groupStarts[0]!;
       const lastLine = groupLines[groupLines.length - 1]!;
@@ -290,8 +301,17 @@ export function promptEditorValueFromDoc(
   doc: ProseMirrorNode,
 ): PromptEditorValue {
   let text = "";
-  let hasSerializedBlock = false;
+  let previousSerializedBlockWasBlockquote: boolean | null = null;
   const mentions: PromptTextMention[] = [];
+
+  const appendBlockBoundary = (blockIsBlockquote: boolean) => {
+    if (previousSerializedBlockWasBlockquote !== null) {
+      text += previousSerializedBlockWasBlockquote && !blockIsBlockquote
+        ? "\n\n"
+        : "\n";
+    }
+    previousSerializedBlockWasBlockquote = blockIsBlockquote;
+  };
 
   const appendInline = (node: ProseMirrorNode) => {
     if (node.type.name === "text") {
@@ -380,10 +400,11 @@ export function promptEditorValueFromDoc(
         : 1;
     for (let index = 0; index < listNode.childCount; index += 1) {
       const item = listNode.child(index);
-      if (hasSerializedBlock) {
+      if (depth === 0 && index === 0) {
+        appendBlockBoundary(false);
+      } else {
         text += "\n";
       }
-      hasSerializedBlock = true;
       const indent = "  ".repeat(depth);
       const marker = ordered ? `${itemNumber}. ` : "- ";
       text += `${indent}${marker}`;
@@ -414,19 +435,13 @@ export function promptEditorValueFromDoc(
     }
 
     if (node.type.name === "blockquote") {
-      if (hasSerializedBlock) {
-        text += "\n";
-      }
-      hasSerializedBlock = true;
+      appendBlockBoundary(true);
       appendBlockquote(node);
       return;
     }
 
     if (node.type.name === "heading") {
-      if (hasSerializedBlock) {
-        text += "\n";
-      }
-      hasSerializedBlock = true;
+      appendBlockBoundary(false);
       const level = typeof node.attrs.level === "number" ? node.attrs.level : 1;
       const clampedLevel = Math.min(Math.max(level, 1), 6);
       text += `${"#".repeat(clampedLevel)} `;
@@ -440,10 +455,7 @@ export function promptEditorValueFromDoc(
     }
 
     if (node.isBlock && node.type.name !== "doc") {
-      if (hasSerializedBlock) {
-        text += "\n";
-      }
-      hasSerializedBlock = true;
+      appendBlockBoundary(false);
       appendChildren(node);
       return;
     }

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.user.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.user.test.tsx
@@ -124,6 +124,16 @@ describe("ConversationMessageContent user message markdown", () => {
     expect(screen.getByText(/quoted context/u)).toBeTruthy();
   });
 
+  it("renders a legacy unprefixed line after a blockquote as a regular paragraph", () => {
+    const { container } = renderUserMessage({
+      text: "> hat would you like me to wo\nasdf",
+    });
+
+    const quote = container.querySelector("blockquote");
+    expect(quote?.textContent?.trim()).toBe("hat would you like me to wo");
+    expect(screen.getByText("asdf").closest("blockquote")).toBeNull();
+  });
+
   it("wraps the body in a message bubble", () => {
     const { container } = renderUserMessage({ text: "hello there" });
     const bubble = container.querySelector(".bg-surface-recessed");

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -896,6 +896,104 @@ function useMarkdownContentWidthVariable() {
 
 const FRONTMATTER_PATTERN =
   /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+const MARKDOWN_FENCE_START_PATTERN = /^(?: {0,3})(`{3,}|~{3,})/u;
+
+interface MarkdownFence {
+  character: string;
+  length: number;
+}
+
+function trimMarkdownLineCarriageReturn(line: string): string {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function isPromptMarkdownBlankLine(line: string): boolean {
+  return /^[ \t]*$/u.test(trimMarkdownLineCarriageReturn(line));
+}
+
+function isPromptMarkdownBlockquoteLine(line: string): boolean {
+  return /^ {0,3}>/u.test(trimMarkdownLineCarriageReturn(line));
+}
+
+function parseMarkdownFenceStart(line: string): MarkdownFence | null {
+  const match = MARKDOWN_FENCE_START_PATTERN.exec(
+    trimMarkdownLineCarriageReturn(line),
+  );
+  const marker = match?.[1];
+  if (marker === undefined) {
+    return null;
+  }
+  return { character: marker[0]!, length: marker.length };
+}
+
+function isMarkdownFenceClose(line: string, fence: MarkdownFence): boolean {
+  const value = trimMarkdownLineCarriageReturn(line);
+  const leadingSpaces = /^ {0,3}/u.exec(value)?.[0].length ?? 0;
+  let index = leadingSpaces;
+  while (value[index] === fence.character) {
+    index += 1;
+  }
+  return (
+    index - leadingSpaces >= fence.length &&
+    /^[ \t]*$/u.test(value.slice(index))
+  );
+}
+
+/**
+ * Older authored prompt bodies could store a quote immediately followed by an
+ * unprefixed reply line. CommonMark treats that as a lazy blockquote
+ * continuation, so make the legacy block boundary explicit before handing
+ * prompt markdown to `react-markdown`.
+ */
+function normalizePromptBlockquoteBoundaries(markdown: string): string {
+  const lines = markdown.split("\n");
+  if (lines.length < 2) {
+    return markdown;
+  }
+
+  const normalizedLines: string[] = [];
+  let activeFence: MarkdownFence | null = null;
+  let previousNonblankLineWasBlockquote: boolean | null = null;
+
+  for (const line of lines) {
+    if (activeFence !== null) {
+      normalizedLines.push(line);
+      if (isMarkdownFenceClose(line, activeFence)) {
+        activeFence = null;
+      }
+      continue;
+    }
+
+    const lineIsBlank = isPromptMarkdownBlankLine(line);
+    const lineIsBlockquote = isPromptMarkdownBlockquoteLine(line);
+    if (
+      !lineIsBlank &&
+      previousNonblankLineWasBlockquote === true &&
+      !lineIsBlockquote
+    ) {
+      const previousLine = normalizedLines[normalizedLines.length - 1];
+      if (
+        previousLine !== undefined &&
+        !isPromptMarkdownBlankLine(previousLine)
+      ) {
+        normalizedLines.push("");
+      }
+    }
+
+    normalizedLines.push(line);
+
+    if (lineIsBlank) {
+      continue;
+    }
+
+    previousNonblankLineWasBlockquote = lineIsBlockquote;
+    if (!lineIsBlockquote) {
+      activeFence = parseMarkdownFenceStart(line);
+    }
+  }
+
+  return normalizedLines.join("\n");
+}
 
 /**
  * Splits a leading YAML frontmatter block (`---` … `---` at the very start of
@@ -1003,9 +1101,16 @@ function MarkdownPreviewComponent({
         : substitutedContent,
     [substitutedContent, normalizeLocalFileLinks],
   );
+  const promptMarkdownContent = useMemo(
+    () =>
+      promptMentions !== undefined
+        ? normalizePromptBlockquoteBoundaries(markdownContent)
+        : markdownContent,
+    [markdownContent, promptMentions],
+  );
   const { frontmatter, body } = useMemo(
-    () => splitMarkdownFrontmatter(markdownContent),
-    [markdownContent],
+    () => splitMarkdownFrontmatter(promptMarkdownContent),
+    [promptMarkdownContent],
   );
   const markdownComponents = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- serialize prompt-editor blockquotes followed by normal blocks with an explicit blank separator
- parse that separator back into editor structure without adding a leading hard break
- keep a narrow timeline renderer fallback for legacy stored user messages with ambiguous blockquote text

## Testing
- pnpm exec turbo run test --filter=@bb/app -- prompt-editor
- pnpm exec turbo run test --filter=@bb/app -- markdown-preview markdown-prompt-mentions markdown-thread-mentions ConversationMessageContent.user
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app
- git diff --check