### PR TITLE
Suppress redundant thread start lifecycle logs

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -347,6 +347,9 @@ async function applyEventEffects(
         ) {
           continue;
         }
+        if (hasThreadAlreadyStartedRun(deps, entry.threadId)) {
+          continue;
+        }
         applyLoggedThreadLifecycleEvent(deps, {
           event: { type: "run.started" },
           threadId: entry.threadId,
@@ -587,6 +590,18 @@ function hasThreadStopBeforeTurnStarted(
       )
       .limit(1)
       .get() !== undefined
+  );
+}
+
+function hasThreadAlreadyStartedRun(
+  deps: Pick<AppDeps, "db">,
+  threadId: string,
+): boolean {
+  const thread = getThread(deps.db, threadId);
+  return (
+    thread?.status === "active" &&
+    thread.archivedAt === null &&
+    thread.deletedAt === null
   );
 }
 

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -103,6 +103,53 @@ describe("internal event and tool-call routes", () => {
     });
   });
 
+  it("does not log redundant run-start no-ops for already-active threads", async () => {
+    await withTestHarness(async (harness) => {
+      const info = vi.fn();
+      harness.deps.logger.info = info;
+      const { session } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: session.hostId,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: session.hostId,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        status: "active",
+      });
+
+      const response = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          {
+            threadId: thread.id,
+            event: {
+              type: "turn/started",
+              threadId: thread.id,
+              providerThreadId: "provider-thread",
+              scope: turnScope("turn-1"),
+            },
+          },
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      expect(
+        harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
+          ?.status,
+      ).toBe("active");
+      expect(
+        info.mock.calls.filter(
+          ([, message]) => message === "Thread lifecycle event not applied",
+        ),
+      ).toEqual([]);
+    });
+  });
+
   it("logs inactive session details when daemon event posting uses a closed session", async () => {
     await withTestHarness(async (harness) => {
       const info = vi.fn();


### PR DESCRIPTION
## Summary
- skip redundant daemon `turn/started` lifecycle activation when the thread is already cleanly active
- keep stale stop/interruption handling intact
- add regression coverage that already-active turn starts do not emit lifecycle no-op logs

## Test plan
- `pnpm exec turbo run test --filter=@bb/server -- --run test/internal/internal-events-tool-calls.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server`