### PR TITLE
Stop sidebar success glyph cycling on load

### DIFF
--- a/apps/app/src/components/sidebar/SidebarStatusNotifications.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarStatusNotifications.stories.tsx
@@ -29,6 +29,7 @@ const noop = () => {};
 
 const THREAD_SUCCESS_CHECK_DELAY_MS = 1200;
 const ANIMATION_SETTLED_MS = 650;
+const ANIMATION_WORKING_MS = 650;
 const ANIMATION_SUCCESS_MS =
   THREAD_SUCCESS_CHECK_DELAY_MS + ANIMATION_SETTLED_MS;
 
@@ -357,19 +358,24 @@ function ParentRollupPreview({ combo }: { combo: readonly RollupSignal[] }) {
 }
 
 function AnimatedUnreadDoneThreadRow() {
-  const [cycleKey, setCycleKey] = useState(0);
-  const thread = makeSignalThread("unreadDone", "thr_animation_success");
+  const [isUnreadDone, setIsUnreadDone] = useState(false);
+  const thread = isUnreadDone
+    ? makeSignalThread("unreadDone", "thr_animation_success")
+    : makeSignalThread("working", "thr_animation_success");
 
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setCycleKey((current) => current + 1);
-    }, ANIMATION_SUCCESS_MS);
+    const timeoutId = window.setTimeout(
+      () => {
+        setIsUnreadDone((current) => !current);
+      },
+      isUnreadDone ? ANIMATION_SUCCESS_MS : ANIMATION_WORKING_MS,
+    );
     return () => window.clearTimeout(timeoutId);
-  }, [cycleKey]);
+  }, [isUnreadDone]);
 
   return (
     <ThreadRowStage>
-      <StoryThreadRow key={cycleKey} thread={thread} />
+      <StoryThreadRow thread={thread} />
     </ThreadRowStage>
   );
 }
@@ -379,7 +385,7 @@ export function ProductionStates() {
     <StoryCard labelWidth="210px">
       <StoryRow
         label="leaf rows"
-        hint="Real ThreadRow states: idle, working, input needed, unread success, failed. Unread success shows a check before settling to a dot."
+        hint="Real ThreadRow states: idle, working, input needed, unread success, failed. Existing unread success shows the settled dot."
       >
         <ThreadRowStage>
           <StoryThreadRow thread={statusThreads.idle} />
@@ -454,7 +460,7 @@ export function UnreadDoneAnimation() {
     <StoryCard labelWidth="210px">
       <StoryRow
         label="unread success -> done"
-        hint="Loops only the done states: 1200ms CircleCheck, then 650ms settled dot."
+        hint="Loops through a live completion transition: working, 1200ms CircleCheck, then settled dot."
       >
         <AnimatedUnreadDoneThreadRow />
       </StoryRow>

--- a/apps/app/src/components/sidebar/ThreadRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.stories.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useState, type ComponentProps, type ReactNode } from "react";
+import {
+  useEffect,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import { makeThreadListEntry } from "../../../.ladle/story-fixtures";
 import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar.js";
@@ -16,6 +21,7 @@ const childActivity = (
 
 const THREAD_SUCCESS_CHECK_DELAY_MS = 1200;
 const UNREAD_DONE_SETTLED_DOT_MS = 650;
+const UNREAD_DONE_WORKING_MS = 650;
 
 export default {
   title: "sidebar/Threads",
@@ -57,24 +63,37 @@ function StoryThreadRow({
 }
 
 function UnreadDoneThreadRowCycle() {
-  const [cycleKey, setCycleKey] = useState(0);
+  const [isUnreadDone, setIsUnreadDone] = useState(false);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(
-      () => setCycleKey((current) => current + 1),
-      THREAD_SUCCESS_CHECK_DELAY_MS + UNREAD_DONE_SETTLED_DOT_MS,
+      () => setIsUnreadDone((current) => !current),
+      isUnreadDone
+        ? THREAD_SUCCESS_CHECK_DELAY_MS + UNREAD_DONE_SETTLED_DOT_MS
+        : UNREAD_DONE_WORKING_MS,
     );
     return () => window.clearTimeout(timeoutId);
-  }, [cycleKey]);
+  }, [isUnreadDone]);
 
   return (
     <StoryThreadRow
-      key={cycleKey}
       projectId="proj_demo"
-      thread={makeThread({
-        lastReadAt: 50,
-        latestAttentionAt: 200,
-      })}
+      thread={
+        isUnreadDone
+          ? makeThread({
+              lastReadAt: 50,
+              latestAttentionAt: 200,
+            })
+          : makeThread({
+              status: "active",
+              lastReadAt: 200,
+              latestAttentionAt: 200,
+              runtime: {
+                displayStatus: "active",
+                hostReconnectGraceExpiresAt: null,
+              },
+            })
+      }
       isActive={false}
       options={defaultOption}
     />
@@ -225,7 +244,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="unread done"
-        hint="cycles the unread-success states only: CircleCheck for 1200ms, then the settled done dot"
+        hint="live completion transition: working spinner, CircleCheck for 1200ms, then the settled done dot"
       >
         <SidebarStage>
           <UnreadDoneThreadRowCycle />

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { ReactNode } from "react";
 import type { ThreadListEntry } from "@bb/domain";
@@ -57,6 +57,28 @@ const DEFAULT_OPTIONS: ThreadRowOptions = {
   isCompact: false,
 };
 
+function ThreadRowTestHarness({
+  isActive = false,
+  options = DEFAULT_OPTIONS,
+  thread,
+}: {
+  isActive?: boolean;
+  options?: ThreadRowOptions;
+  thread: ThreadListEntry;
+}) {
+  return (
+    <MemoryRouter>
+      <ThreadRow
+        projectId={thread.projectId}
+        thread={thread}
+        isActive={isActive}
+        hasComposerDraft={false}
+        options={options}
+      />
+    </MemoryRouter>
+  );
+}
+
 function renderThreadRow({
   isActive = false,
   options = DEFAULT_OPTIONS,
@@ -66,17 +88,25 @@ function renderThreadRow({
   options?: ThreadRowOptions;
   thread?: ThreadListEntry;
 }) {
-  render(
-    <MemoryRouter>
-      <ThreadRow
-        projectId={thread.projectId}
-        thread={thread}
-        isActive={isActive}
-        hasComposerDraft={false}
-        options={options}
-      />
-    </MemoryRouter>,
+  const result = render(
+    <ThreadRowTestHarness
+      isActive={isActive}
+      options={options}
+      thread={thread}
+    />,
   );
+  return {
+    ...result,
+    rerenderThreadRow(nextThread: ThreadListEntry) {
+      result.rerender(
+        <ThreadRowTestHarness
+          isActive={isActive}
+          options={options}
+          thread={nextThread}
+        />,
+      );
+    },
+  };
 }
 
 afterEach(cleanup);
@@ -109,5 +139,59 @@ describe("ThreadRow", () => {
 
     expect(screen.getByLabelText("Thread working")).not.toBeNull();
     expect(screen.queryByLabelText("Workflow running")).toBeNull();
+  });
+
+  it("renders an already-unread successful thread as a settled dot on initial load", () => {
+    const { container } = renderThreadRow({
+      thread: createThread({
+        status: "idle",
+        lastReadAt: 1_000,
+        latestAttentionAt: 2_000,
+      }),
+    });
+
+    expect(screen.getByLabelText("Unread thread succeeded")).not.toBeNull();
+    expect(container.querySelector('[data-icon="CircleCheck"]')).toBeNull();
+  });
+
+  it("shows the success checkmark when a mounted row becomes unread after finishing", async () => {
+    vi.useFakeTimers();
+    try {
+      const thread = createThread({
+        status: "active",
+        lastReadAt: 1_000,
+        latestAttentionAt: 1_000,
+        runtime: {
+          displayStatus: "active",
+          hostReconnectGraceExpiresAt: null,
+        },
+      });
+      const { container, rerenderThreadRow } = renderThreadRow({ thread });
+
+      expect(screen.getByLabelText("Thread working")).not.toBeNull();
+
+      rerenderThreadRow({
+        ...thread,
+        status: "idle",
+        latestAttentionAt: 2_000,
+        runtime: {
+          displayStatus: "idle",
+          hostReconnectGraceExpiresAt: null,
+        },
+      });
+
+      expect(
+        container.querySelector('[data-icon="CircleCheck"]'),
+      ).not.toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_200);
+      });
+
+      expect(container.querySelector('[data-icon="CircleCheck"]')).toBeNull();
+      expect(screen.getByLabelText("Unread thread succeeded")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -2,6 +2,8 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
+  useRef,
   useState,
   type CSSProperties,
   type MouseEventHandler,
@@ -152,6 +154,7 @@ interface ThreadStatusGlyphProps {
   isBusy: boolean;
   isWorkflowActive: boolean;
   showUnreadBadge: boolean;
+  successAnimationKey?: number | null;
   unreadBadgeTone: SidebarUnreadDotTone;
 }
 
@@ -161,16 +164,28 @@ interface ThreadUnreadBadgeLabelArgs {
 
 const THREAD_SUCCESS_CHECK_DELAY_MS = 1200;
 
-function ThreadSuccessStatusGlyph({ label }: { label: string }) {
-  const [showCheck, setShowCheck] = useState(true);
+function ThreadSuccessStatusGlyph({
+  animate,
+  label,
+}: {
+  animate: boolean;
+  label: string;
+}) {
+  const [showCheck, setShowCheck] = useState(animate);
 
   useEffect(() => {
+    if (!animate) {
+      setShowCheck(false);
+      return;
+    }
+
+    setShowCheck(true);
     const timeoutId = window.setTimeout(
       () => setShowCheck(false),
       THREAD_SUCCESS_CHECK_DELAY_MS,
     );
     return () => window.clearTimeout(timeoutId);
-  }, []);
+  }, [animate]);
 
   if (showCheck) {
     return (
@@ -199,6 +214,7 @@ export function ThreadStatusGlyph({
   isBusy,
   isWorkflowActive,
   showUnreadBadge,
+  successAnimationKey = null,
   unreadBadgeTone,
 }: ThreadStatusGlyphProps) {
   if (showUnreadBadge && unreadBadgeTone === "error") {
@@ -229,10 +245,7 @@ export function ThreadStatusGlyph({
     return (
       <Icon
         name="Workflow"
-        className={cn(
-          "text-muted-foreground",
-          COARSE_POINTER_ICON_SIZE_CLASS,
-        )}
+        className={cn("text-muted-foreground", COARSE_POINTER_ICON_SIZE_CLASS)}
         aria-label="Workflow running"
       />
     );
@@ -240,7 +253,13 @@ export function ThreadStatusGlyph({
 
   if (showUnreadBadge) {
     const label = getThreadUnreadBadgeLabel({ tone: unreadBadgeTone });
-    return <ThreadSuccessStatusGlyph label={label} />;
+    return (
+      <ThreadSuccessStatusGlyph
+        key={successAnimationKey ?? "settled"}
+        animate={successAnimationKey !== null}
+        label={label}
+      />
+    );
   }
 
   if (isBusy) {
@@ -268,11 +287,35 @@ function getThreadUnreadBadgeLabel({
 
 type ThreadTrailingIndicatorProps = ThreadStatusGlyphProps;
 
+function useUnreadSuccessAnimationKey(
+  showUnreadSuccess: boolean,
+): number | null {
+  const previousShowUnreadSuccessRef = useRef(showUnreadSuccess);
+  const [animationKey, setAnimationKey] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const previousShowUnreadSuccess = previousShowUnreadSuccessRef.current;
+    previousShowUnreadSuccessRef.current = showUnreadSuccess;
+
+    if (showUnreadSuccess && !previousShowUnreadSuccess) {
+      setAnimationKey((current) => (current ?? 0) + 1);
+      return;
+    }
+
+    if (!showUnreadSuccess && animationKey !== null) {
+      setAnimationKey(null);
+    }
+  }, [animationKey, showUnreadSuccess]);
+
+  return showUnreadSuccess ? animationKey : null;
+}
+
 function ThreadTrailingIndicator({
   hasPendingInteraction,
   isBusy,
   isWorkflowActive,
   showUnreadBadge,
+  successAnimationKey,
   unreadBadgeTone,
 }: ThreadTrailingIndicatorProps) {
   const showStatusGlyph =
@@ -294,6 +337,7 @@ function ThreadTrailingIndicator({
         isBusy={isBusy}
         isWorkflowActive={isWorkflowActive}
         showUnreadBadge={showUnreadBadge}
+        successAnimationKey={successAnimationKey}
         unreadBadgeTone={unreadBadgeTone}
       />
     </span>
@@ -363,6 +407,9 @@ function ThreadRowComponent({
     : showUnreadBadge;
   const trailingUnreadBadgeTone: SidebarUnreadDotTone =
     hasHiddenChildren && childActivity.unreadError ? "error" : unreadBadgeTone;
+  const unreadSuccessAnimationKey = useUnreadSuccessAnimationKey(
+    trailingShowUnreadBadge && trailingUnreadBadgeTone === "default",
+  );
   const linkLabel = hasComposerDraft
     ? `Open ${threadTitle} (unsubmitted draft)`
     : `Open ${threadTitle}`;
@@ -447,6 +494,7 @@ function ThreadRowComponent({
               isBusy={trailingIsBusy}
               isWorkflowActive={trailingIsWorkflowActive}
               showUnreadBadge={trailingShowUnreadBadge}
+              successAnimationKey={unreadSuccessAnimationKey}
               unreadBadgeTone={trailingUnreadBadgeTone}
             />
           </span>


### PR DESCRIPTION
## Summary
- render already-unread successful thread rows as the settled dot on initial mount
- animate the success check only after a mounted row transitions into unread success
- update sidebar stories to demonstrate the live completion transition

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app