### PR TITLE
Track observed environment branches

### DIFF
--- a/apps/server/src/routes/environments.ts
+++ b/apps/server/src/routes/environments.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { updateEnvironmentMetadata } from "@bb/db";
+import { recordEnvironmentCurrentBranch } from "@bb/db/internal-environment-lifecycle";
 import {
   type GitBranchRefClassification,
   resolveEnvironmentWorkspaceDisplayKind,
@@ -270,6 +271,10 @@ function resolveGitDiffWorkspaceTarget(deps: AppDeps, environmentId: string) {
   return requireWorkspaceCommandTarget(environment);
 }
 
+function normalizeObservedDefaultBranch(defaultBranch: string): string | null {
+  return defaultBranch.length > 0 ? defaultBranch : null;
+}
+
 export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
   const { get, patch, post } = typedRoutes<PublicApiSchema>(app, {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
@@ -342,6 +347,12 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
         failure: result.failure,
       });
     }
+    recordEnvironmentCurrentBranch(deps.db, deps.hub, environment.id, {
+      branchName: result.workspaceStatus.branch.currentBranch,
+      defaultBranch: normalizeObservedDefaultBranch(
+        result.workspaceStatus.branch.defaultBranch,
+      ),
+    });
     return context.json({
       outcome: "available",
       workspace: result.workspaceStatus,

--- a/apps/server/src/routes/environments.ts
+++ b/apps/server/src/routes/environments.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { updateEnvironmentMetadata } from "@bb/db";
-import { recordEnvironmentCurrentBranch } from "@bb/db/internal-environment-lifecycle";
 import {
   type GitBranchRefClassification,
   resolveEnvironmentWorkspaceDisplayKind,
@@ -40,6 +39,7 @@ import {
 import { parseFileListLimit } from "./file-list-query.js";
 import { parsePathKindInclusion } from "./path-list-inclusion.js";
 import { requireWorkspaceCommandTarget } from "../services/environments/workspace-command-target.js";
+import { callEnvironmentWorkspaceStatus } from "../services/environments/workspace-status.js";
 import { assembleThreadPullRequest } from "../services/environments/pull-request.js";
 import {
   requireAvailableWorkspaceDiff,
@@ -271,10 +271,6 @@ function resolveGitDiffWorkspaceTarget(deps: AppDeps, environmentId: string) {
   return requireWorkspaceCommandTarget(environment);
 }
 
-function normalizeObservedDefaultBranch(defaultBranch: string): string | null {
-  return defaultBranch.length > 0 ? defaultBranch : null;
-}
-
 export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
   const { get, patch, post } = typedRoutes<PublicApiSchema>(app, {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
@@ -329,17 +325,12 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
       });
     }
     const target = requireWorkspaceCommandTarget(environment);
-    const result = await callHostRetryableOnlineRpc(deps, {
-      hostId: target.hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command: {
-        type: "workspace.status",
-        environmentId: target.environmentId,
-        workspaceContext: target.workspaceContext,
-        ...(query.mergeBaseBranch
-          ? { mergeBaseBranch: query.mergeBaseBranch }
-          : {}),
-      },
+    const result = await callEnvironmentWorkspaceStatus(deps, {
+      environment,
+      target,
+      ...(query.mergeBaseBranch
+        ? { mergeBaseBranch: query.mergeBaseBranch }
+        : {}),
     });
     if (result.outcome === "unavailable") {
       return context.json({
@@ -347,12 +338,6 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
         failure: result.failure,
       });
     }
-    recordEnvironmentCurrentBranch(deps.db, deps.hub, environment.id, {
-      branchName: result.workspaceStatus.branch.currentBranch,
-      defaultBranch: normalizeObservedDefaultBranch(
-        result.workspaceStatus.branch.defaultBranch,
-      ),
-    });
     return context.json({
       outcome: "available",
       workspace: result.workspaceStatus,
@@ -624,14 +609,9 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
         const { workspaceContext } = target;
 
         const [statusResult, diffResult] = await Promise.all([
-          callHostRetryableOnlineRpc(deps, {
-            hostId: target.hostId,
-            timeoutMs: COMMAND_TIMEOUT_MS,
-            command: {
-              type: "workspace.status",
-              environmentId: target.environmentId,
-              workspaceContext,
-            },
+          callEnvironmentWorkspaceStatus(deps, {
+            environment,
+            target,
           }),
           callHostRetryableOnlineRpc(deps, {
             hostId: target.hostId,
@@ -691,14 +671,9 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
         const { workspaceContext } = target;
         const targetBranch = payload.options.mergeBaseBranch;
 
-        const statusResult = await callHostRetryableOnlineRpc(deps, {
-          hostId: target.hostId,
-          timeoutMs: COMMAND_TIMEOUT_MS,
-          command: {
-            type: "workspace.status",
-            environmentId: target.environmentId,
-            workspaceContext,
-          },
+        const statusResult = await callEnvironmentWorkspaceStatus(deps, {
+          environment,
+          target,
         });
         const workspaceStatus = requireAvailableWorkspaceStatus(statusResult);
 

--- a/apps/server/src/services/environments/workspace-command-target.ts
+++ b/apps/server/src/services/environments/workspace-command-target.ts
@@ -15,7 +15,7 @@ interface WorkspaceCommandTargetPath {
   workspaceProvisionType: WorkspaceProvisionType;
 }
 
-interface WorkspaceCommandTarget {
+export interface WorkspaceCommandTarget {
   environmentId: string;
   hostId: string;
   workspaceContext: WorkspaceContext;

--- a/apps/server/src/services/environments/workspace-status.ts
+++ b/apps/server/src/services/environments/workspace-status.ts
@@ -1,0 +1,48 @@
+import { recordEnvironmentCurrentBranch } from "@bb/db/internal-environment-lifecycle";
+import type { Environment } from "@bb/domain";
+import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
+import { COMMAND_TIMEOUT_MS } from "../../constants.js";
+import type { AppDeps } from "../../types.js";
+import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
+import type { WorkspaceCommandTarget } from "./workspace-command-target.js";
+
+type WorkspaceStatusResult = HostDaemonOnlineRpcResult<"workspace.status">;
+
+interface CallEnvironmentWorkspaceStatusArgs {
+  environment: Pick<Environment, "id">;
+  target: WorkspaceCommandTarget;
+  mergeBaseBranch?: string;
+}
+
+function normalizeObservedDefaultBranch(defaultBranch: string): string | null {
+  return defaultBranch.length > 0 ? defaultBranch : null;
+}
+
+export async function callEnvironmentWorkspaceStatus(
+  deps: AppDeps,
+  args: CallEnvironmentWorkspaceStatusArgs,
+): Promise<WorkspaceStatusResult> {
+  const result = await callHostRetryableOnlineRpc(deps, {
+    hostId: args.target.hostId,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+    command: {
+      type: "workspace.status",
+      environmentId: args.target.environmentId,
+      workspaceContext: args.target.workspaceContext,
+      ...(args.mergeBaseBranch
+        ? { mergeBaseBranch: args.mergeBaseBranch }
+        : {}),
+    },
+  });
+
+  if (result.outcome === "available") {
+    recordEnvironmentCurrentBranch(deps.db, deps.hub, args.environment.id, {
+      branchName: result.workspaceStatus.branch.currentBranch,
+      defaultBranch: normalizeObservedDefaultBranch(
+        result.workspaceStatus.branch.defaultBranch,
+      ),
+    });
+  }
+
+  return result;
+}

--- a/apps/server/test/public/public-environment-action-regressions.test.ts
+++ b/apps/server/test/public/public-environment-action-regressions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getEnvironment } from "@bb/db";
 import type { GitHostPullRequest } from "@bb/domain";
 import { readJson } from "../helpers/json.js";
 import {
@@ -83,6 +84,159 @@ describe("public environment action regressions", () => {
       expect(mismatchedResponse.status).toBe(400);
       await expect(readJson(mismatchedResponse)).resolves.toMatchObject({
         code: "invalid_request",
+      });
+    });
+  });
+
+  it("records the daemon-observed branch during commit action status preflight", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-commit-observed-branch",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        branchName: "bb/stale",
+        defaultBranch: "main",
+        path: "/tmp/commit-observed-branch-env",
+      });
+
+      const responsePromise = harness.app.request(
+        `/api/v1/environments/${environment.id}/actions`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "commit" }),
+        },
+      );
+
+      const statusCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, statusCommand, {
+        outcome: "available",
+        workspaceStatus: {
+          workingTree: {
+            insertions: 0,
+            deletions: 0,
+            files: [],
+            hasUncommittedChanges: false,
+            state: "clean",
+          },
+          branch: {
+            currentBranch: "feature/current",
+            defaultBranch: "trunk",
+          },
+          checkout: {
+            kind: "branch",
+            branchName: "feature/current",
+            headSha: null,
+          },
+          mergeBase: null,
+        },
+      });
+
+      const diffCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.diff" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, diffCommand, {
+        outcome: "available",
+        diff: {
+          diff: "",
+          files: "",
+          mergeBaseRef: null,
+          shortstat: "",
+          truncated: false,
+        },
+      });
+
+      const response = await responsePromise;
+      expect(response.status).toBe(409);
+      await expect(readJson(response)).resolves.toMatchObject({
+        code: "no_changes",
+      });
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        branchName: "feature/current",
+        defaultBranch: "trunk",
+      });
+    });
+  });
+
+  it("clears the stored branch during detached squash-merge status preflight", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-squash-detached-branch",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        managed: true,
+        workspaceProvisionType: "managed-worktree",
+        branchName: "bb/stale",
+        defaultBranch: "main",
+        path: "/tmp/squash-detached-branch-env",
+      });
+
+      const responsePromise = harness.app.request(
+        `/api/v1/environments/${environment.id}/actions`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            action: "squash_merge",
+            options: { mergeBaseBranch: "main" },
+          }),
+        },
+      );
+
+      const statusCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, statusCommand, {
+        outcome: "available",
+        workspaceStatus: {
+          workingTree: {
+            insertions: 0,
+            deletions: 0,
+            files: [],
+            hasUncommittedChanges: false,
+            state: "clean",
+          },
+          branch: {
+            currentBranch: null,
+            defaultBranch: "main",
+          },
+          checkout: {
+            kind: "detached",
+            headSha: "0123456789abcdef0123456789abcdef01234567",
+          },
+          mergeBase: null,
+        },
+      });
+
+      const response = await responsePromise;
+      expect(response.status).toBe(409);
+      await expect(readJson(response)).resolves.toMatchObject({
+        code: "invalid_request",
+      });
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        branchName: null,
+        defaultBranch: "main",
       });
     });
   });

--- a/apps/server/test/public/public-environments.test.ts
+++ b/apps/server/test/public/public-environments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getEnvironment } from "@bb/db";
 import {
   reportQueuedCommandSuccess,
   waitForQueuedCommand,
@@ -12,6 +13,130 @@ import {
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("public environments", () => {
+  it("records the daemon-observed current branch after workspace status", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-environment-current-branch",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        branchName: "bb/stale",
+        defaultBranch: "main",
+        path: "/tmp/current-branch-env",
+        workspaceProvisionType: "managed-worktree",
+      });
+
+      const statusPromise = harness.app.request(
+        `/api/v1/environments/${environment.id}/status`,
+      );
+      const statusCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, statusCommand, {
+        outcome: "available",
+        workspaceStatus: {
+          workingTree: {
+            insertions: 0,
+            deletions: 0,
+            files: [],
+            hasUncommittedChanges: false,
+            state: "clean",
+          },
+          branch: {
+            currentBranch: "feature/current",
+            defaultBranch: "trunk",
+          },
+          checkout: {
+            kind: "branch",
+            branchName: "feature/current",
+            headSha: null,
+          },
+          mergeBase: null,
+        },
+      });
+
+      const response = await statusPromise;
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toMatchObject({
+        outcome: "available",
+        workspace: {
+          branch: {
+            currentBranch: "feature/current",
+            defaultBranch: "trunk",
+          },
+        },
+      });
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        branchName: "feature/current",
+        defaultBranch: "trunk",
+      });
+    });
+  });
+
+  it("clears the stored branch after detached workspace status", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-environment-detached-branch",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        branchName: "bb/stale",
+        defaultBranch: "main",
+        path: "/tmp/detached-branch-env",
+        workspaceProvisionType: "managed-worktree",
+      });
+
+      const statusPromise = harness.app.request(
+        `/api/v1/environments/${environment.id}/status`,
+      );
+      const statusCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, statusCommand, {
+        outcome: "available",
+        workspaceStatus: {
+          workingTree: {
+            insertions: 0,
+            deletions: 0,
+            files: [],
+            hasUncommittedChanges: false,
+            state: "clean",
+          },
+          branch: {
+            currentBranch: null,
+            defaultBranch: "main",
+          },
+          checkout: {
+            kind: "detached",
+            headSha: "0123456789abcdef0123456789abcdef01234567",
+          },
+          mergeBase: null,
+        },
+      });
+
+      const response = await statusPromise;
+      expect(response.status).toBe(200);
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        branchName: null,
+        defaultBranch: "main",
+      });
+    });
+  });
+
   it("renames an environment through the public update route", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {

--- a/packages/db/src/data/environments.ts
+++ b/packages/db/src/data/environments.ts
@@ -134,6 +134,11 @@ export interface UpdateEnvironmentMetadataInput {
   name?: string | null;
 }
 
+export interface RecordEnvironmentCurrentBranchInput {
+  branchName: string | null;
+  defaultBranch?: string | null;
+}
+
 export interface ListRetiredLoadedEnvironmentIdsOnHostArgs {
   environmentIds: readonly string[];
   hostId: string;
@@ -239,6 +244,20 @@ export function updateEnvironmentMetadata(
   input: UpdateEnvironmentMetadataInput,
 ) {
   return updateEnvironmentMetadataRecord(db, notifier, id, input);
+}
+
+export function recordEnvironmentCurrentBranch(
+  db: EnvironmentWriteConnection,
+  notifier: DbNotifier,
+  id: string,
+  input: RecordEnvironmentCurrentBranchInput,
+) {
+  return updateEnvironmentMetadataRecord(db, notifier, id, {
+    branchName: input.branchName,
+    ...(input.defaultBranch !== undefined
+      ? { defaultBranch: input.defaultBranch }
+      : {}),
+  });
 }
 
 export interface RecordProvisionedEnvironmentWorkspaceInput extends DiscoveredWorkspaceProperties {

--- a/packages/db/src/internal-environment-lifecycle.ts
+++ b/packages/db/src/internal-environment-lifecycle.ts
@@ -3,6 +3,7 @@ export {
   applyEnvironmentLifecycleEventInTransaction,
   EnvironmentLifecycleEventNotAppliedError,
   listStaleDestroyingManagedEnvironments,
+  recordEnvironmentCurrentBranch,
   recordProvisionedEnvironmentWorkspace,
   requireEnvironmentLifecycleEventApplied,
 } from "./data/environments.js";

--- a/packages/db/test/data/environments.test.ts
+++ b/packages/db/test/data/environments.test.ts
@@ -6,6 +6,7 @@ import type { DbNotifier } from "../../src/notifier.js";
 import {
   createEnvironment,
   listRetiredLoadedEnvironmentIdsOnHost,
+  recordEnvironmentCurrentBranch,
   recordProvisionedEnvironmentWorkspace,
   updateEnvironmentMetadata,
 } from "../../src/data/environments.js";
@@ -143,6 +144,69 @@ describe("environments", () => {
       status: "provisioning",
       isGitRepo: true,
       branchName: "bb/test",
+      defaultBranch: "main",
+    });
+    expect(notifier.notifyEnvironment).toHaveBeenCalledWith(environment.id, [
+      "metadata-changed",
+    ]);
+  });
+
+  it("records the current branch observed for an environment", () => {
+    const { db, host, project } = setup();
+    const environment = createEnvironment(db, noopNotifier, {
+      projectId: project.id,
+      hostId: host.id,
+      workspaceProvisionType: "managed-worktree",
+      branchName: "bb/old",
+      defaultBranch: "main",
+      status: "ready",
+    });
+    const notifier = createNotifierSpy();
+
+    const updated = recordEnvironmentCurrentBranch(
+      db,
+      notifier,
+      environment.id,
+      {
+        branchName: "feature/current",
+        defaultBranch: "trunk",
+      },
+    );
+
+    expect(updated).toMatchObject({
+      branchName: "feature/current",
+      defaultBranch: "trunk",
+      baseBranch: null,
+      mergeBaseBranch: null,
+    });
+    expect(notifier.notifyEnvironment).toHaveBeenCalledWith(environment.id, [
+      "metadata-changed",
+    ]);
+  });
+
+  it("clears the current branch when a detached checkout is observed", () => {
+    const { db, host, project } = setup();
+    const environment = createEnvironment(db, noopNotifier, {
+      projectId: project.id,
+      hostId: host.id,
+      workspaceProvisionType: "managed-worktree",
+      branchName: "bb/old",
+      defaultBranch: "main",
+      status: "ready",
+    });
+    const notifier = createNotifierSpy();
+
+    const updated = recordEnvironmentCurrentBranch(
+      db,
+      notifier,
+      environment.id,
+      {
+        branchName: null,
+      },
+    );
+
+    expect(updated).toMatchObject({
+      branchName: null,
       defaultBranch: "main",
     });
     expect(notifier.notifyEnvironment).toHaveBeenCalledWith(environment.id, [

--- a/plans/detached-new-worktree-default.md
+++ b/plans/detached-new-worktree-default.md
@@ -1,0 +1,432 @@
+# Detached New Worktree Default
+
+## Goal
+
+Add an explicit checkout mode for managed "New worktree" environments:
+
+- Detached HEAD worktrees are the default for "New worktree".
+- A branch-backed worktree remains available as an explicit option for callers
+  that want the current behavior.
+- The selected base ref behavior stays intact: users can still choose which
+  branch/ref the new worktree starts from.
+
+This plan covers the app composer, CLI `--new-environment worktree`, server
+request/provisioning flow, daemon command contract, and host worktree creation.
+
+Out of scope:
+
+- Branch cleanup/deletion.
+- A broader environment identity/display refactor.
+- Changing existing reused worktrees.
+- Adding a DB migration unless implementation discovers one is unavoidable.
+
+## Current Flow
+
+- The app encodes "New worktree" as `host:<hostId>:worktree` in
+  `apps/app/src/components/pickers/environment-picker-value.ts`.
+- `RootComposeView` treats the branch picker as a base-branch picker when the
+  environment mode is `worktree`.
+- `resolveRootComposeThreadEnvironment()` emits:
+
+  ```ts
+  {
+    type: "host",
+    hostId,
+    workspace: {
+      type: "managed-worktree",
+      baseBranch,
+    },
+  }
+  ```
+
+- `packages/server-contract/src/api/shared.ts` requires `baseBranch` for every
+  managed worktree request, but has no checkout mode.
+- `apps/server/src/services/threads/thread-create.ts` resolves the base branch
+  and creates a `direct-managed` provisioning intent.
+- `thread-provisioning-environment.ts` always mints a branch name with
+  `buildManagedBranchName()`.
+- `packages/host-daemon-contract/src/commands.ts` requires `branchName` on
+  every managed worktree provision command.
+- `packages/host-workspace/src/provisioning.ts` creates managed worktrees with:
+
+  ```sh
+  git worktree add -B <branchName> <targetPath> <baseBranch>
+  ```
+
+That means every new managed worktree creates or resets a local branch in the
+source repository.
+
+## Desired Behavior
+
+Default "New worktree" behavior:
+
+- User selects "New worktree".
+- User optionally chooses a base ref using the existing base-branch picker.
+- BB provisions the target with:
+
+  ```sh
+  git worktree add --detach <targetPath> <baseRef>
+  ```
+
+- The provisioned environment records:
+  - `branchName: null`
+  - `baseBranch: <chosen base branch or null for default>`
+  - `defaultBranch` from daemon discovery
+
+Explicit branch-backed behavior:
+
+- User selects "New worktree".
+- User switches checkout mode from "Detached HEAD" to "Create branch".
+- User optionally chooses the base ref.
+- BB provisions the target with the current branch-backed behavior:
+
+  ```sh
+  git worktree add -B <bb-generated-branch> <targetPath> <baseRef>
+  ```
+
+- The provisioned environment records the daemon-observed branch name.
+
+## Data Model
+
+Do not add a DB column in the first implementation.
+
+Use existing fields this way:
+
+- `environments.branchName` remains the actual daemon-observed current branch.
+  Detached worktrees store `null`.
+- `environments.baseBranch` remains the base ref selected for managed worktree
+  provisioning.
+- Reprovisioning a ready managed worktree should not mint a branch when
+  `environment.branchName` is `null`; it should reprovision detached from the
+  stored base branch/default.
+
+This matches the current branch-tracking direction: `branchName` is an
+observation, not a durable desired branch identity.
+
+## Contract Changes
+
+### Server API Contract
+
+Update `managedWorktreeWorkspaceSchema` in
+`packages/server-contract/src/api/shared.ts` to carry an explicit checkout
+mode.
+
+Recommended shape:
+
+```ts
+const managedWorktreeCheckoutSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("detached") }).strict(),
+  z.object({ kind: z.literal("branch") }).strict(),
+]);
+
+const managedWorktreeWorkspaceSchema = z.object({
+  type: z.literal("managed-worktree"),
+  baseBranch: baseBranchSpecSchema,
+  checkout: managedWorktreeCheckoutSchema,
+});
+```
+
+For compatibility, the HTTP boundary may accept omitted `checkout` and normalize
+it once to `{ kind: "detached" }`. After request normalization, internal server
+code should carry an explicit checkout mode.
+
+### Host Daemon Command Contract
+
+Update `packages/host-daemon-contract/src/commands.ts` so managed worktree
+provision commands do not require `branchName` unless branch mode is selected.
+
+Recommended shape:
+
+```ts
+const managedWorktreeCheckoutCommandSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("detached") }).strict(),
+  z.object({
+    kind: z.literal("branch"),
+    branchName: gitBranchNameSchema,
+  }).strict(),
+]);
+```
+
+Then replace the top-level managed `branchName` field with:
+
+```ts
+checkout: managedWorktreeCheckoutCommandSchema
+```
+
+Keep `baseBranch: gitBranchNameSchema.nullable()` as the start ref input.
+
+## App Changes
+
+### Root Compose
+
+Update `apps/app/src/views/root-compose-thread-environment.ts`:
+
+- Add a `worktreeCheckout` argument with `"detached" | "branch"`.
+- For `parsed.mode === "worktree"`, include:
+
+  ```ts
+  checkout: { kind: worktreeCheckout }
+  ```
+
+- Default `worktreeCheckout` to `"detached"` from `RootComposeView`.
+
+Keep the existing base branch resolution logic. The selected branch continues to
+mean "base ref" in worktree mode.
+
+### UI Control
+
+Add a compact worktree checkout mode control that appears only when the
+environment picker is in "New worktree" mode.
+
+Recommended labels:
+
+- `Detached HEAD` - default
+- `Create branch`
+
+The base branch picker remains visible in both modes:
+
+- Detached mode trigger copy: `Detached at: <base>`
+- Branch mode trigger copy: `Branch from: <base>`
+
+Implementation options:
+
+- Extend `BranchPicker`'s `base` mode with an optional checkout-mode section.
+- Or add a small segmented control next to the base picker in
+  `NewThreadPromptBox.tsx`.
+
+Prefer the smaller change once the component boundaries are clear. Do not encode
+the checkout mode into `host:<id>:worktree`; keep it as separate scoped composer
+state so the environment picker still means "new managed worktree".
+
+### App Tests And Stories
+
+Update:
+
+- `apps/app/src/views/root-compose-thread-environment.test.ts`
+- `apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx`
+- `apps/app/src/components/promptbox/NewThreadEnvironmentOptions.stories.tsx`
+  if the story is still the right surface
+- Any BranchPicker story touched by the checkout-mode UI
+
+Required test cases:
+
+- Worktree mode defaults to `{ checkout: { kind: "detached" } }`.
+- Worktree mode with `Create branch` sends `{ checkout: { kind: "branch" } }`.
+- Base branch selection still sends the selected base ref in both modes.
+- Personal project still resolves to a personal workspace.
+
+## CLI Changes
+
+Update `apps/cli/src/commands/thread/spawn.ts`:
+
+- `bb thread spawn --new-environment worktree` should send detached checkout by
+  default.
+- Add an explicit option for branch-backed worktrees, for example:
+
+  ```sh
+  --worktree-checkout <detached|branch>
+  ```
+
+- Keep `--base-branch <branch>` as the base/start ref for both detached and
+  branch-backed worktrees.
+- Reject `--worktree-checkout` unless `--new-environment worktree` is present.
+
+Update:
+
+- `apps/cli/src/__tests__/spawn-helpers.test.ts`
+- `apps/cli/src/__tests__/command-output/thread-spawn.test.ts`
+- `packages/templates/src/templates/bb-guide-threads.md`
+- regenerated templates if this repo requires generated guide updates
+
+## Server Changes
+
+### Request Resolution
+
+Update the server-side managed worktree request path:
+
+- `apps/server/src/services/threads/thread-create.ts`
+- `apps/server/src/services/threads/thread-provisioning-context.ts`
+- `apps/server/src/services/threads/thread-provisioning-environment.ts`
+- `apps/server/src/services/threads/thread-create-helpers.ts`
+
+Carry checkout mode through:
+
+1. Public request/environment args.
+2. Resolved create-thread environment.
+3. Thread provisioning context.
+4. Direct managed environment intent.
+5. Daemon provision command.
+
+Branch mode:
+
+- Mint `buildManagedBranchName()` only when checkout mode is `branch`.
+- Send daemon command checkout `{ kind: "branch", branchName }`.
+
+Detached mode:
+
+- Do not mint a branch name.
+- Send daemon command checkout `{ kind: "detached" }`.
+- Create the environment row with `branchName: null`.
+
+### Default Policy And Child Work
+
+Audit callers that construct managed worktrees without going through root
+compose:
+
+- `resolveCreateThreadEnvironment()` in
+  `apps/server/src/services/threads/thread-default-policy.ts`
+- `resolveChildThreadEnvironment()` in
+  `apps/app/src/lib/child-thread-environment.ts`
+- fork and side-chat builders that use child-thread environment resolution
+- CLI spawn helper
+
+Decision for the first implementation:
+
+- Explicit user "New worktree" surfaces default to detached.
+- Preserve fork/side-chat child-thread behavior unless product explicitly wants
+  those flows to change too. If preserving, have those builders send
+  `{ checkout: { kind: "branch" } }` explicitly.
+
+### Reprovision
+
+Update `dispatchManagedEnvironmentReprovision()` in
+`apps/server/src/services/environments/environment-provisioning-internal.ts`:
+
+- If `environment.branchName` is non-null, reprovision in branch mode using that
+  branch name.
+- If `environment.branchName` is null, reprovision in detached mode.
+- Do not fall back to `buildManagedBranchName()` for null-branch managed
+  worktrees.
+
+This is required because detached worktrees intentionally have no branch name.
+
+## Host Workspace Changes
+
+Update:
+
+- `packages/host-workspace/src/provision.ts`
+- `packages/host-workspace/src/provisioning.ts`
+
+Replace `branchName`-only managed worktree creation with explicit checkout
+mode:
+
+```ts
+type ManagedWorktreeCheckout =
+  | { kind: "detached" }
+  | { kind: "branch"; branchName: string };
+```
+
+Creation behavior:
+
+- Branch mode:
+
+  ```sh
+  git worktree add -B <branchName> <targetPath> <baseRef>
+  ```
+
+- Detached mode:
+
+  ```sh
+  git worktree add --detach <targetPath> <baseRef>
+  ```
+
+Existing target validation:
+
+- Branch mode should keep validating that an existing target is on the expected
+  branch.
+- Detached mode should validate that an existing target is a git repo and not on
+  an unexpected branch. If practical, validate the current HEAD matches the
+  expected start ref; otherwise keep idempotency conservative and fail with a
+  clear error when the existing checkout cannot be proven safe.
+
+Setup scripts, progress streaming, cancellation, and rollback should stay
+unchanged.
+
+Progress copy can remain generic (`Creating worktree`) or become explicit
+(`Creating detached worktree` / `Creating branch worktree`) if tests are updated.
+
+## Environment Metadata And Status
+
+No special branch metadata write is needed beyond the normal provisioning
+result:
+
+- The daemon already reports `branchName` from the created workspace.
+- Detached worktrees should report `branchName: null`.
+- `recordProvisionedEnvironmentWorkspace()` should persist that null value.
+- The status route branch-tracking path should continue to refresh
+  `environments.branchName` from daemon-observed checkout state.
+
+Diff and merge-base behavior should continue to use `baseBranch` /
+`mergeBaseBranch`, not `branchName`, for detached worktrees.
+
+## Risks
+
+- Some code currently treats managed worktree `branchName` as always present
+  after provisioning. Tests should catch the main server/app/CLI paths, but
+  manual review should search for assumptions after implementation.
+- Reprovision is easy to regress because the old fallback minted a branch when
+  `branchName` was null.
+- `git worktree add --detach <baseRef>` starts from the current commit of the
+  base ref. If the base branch advances later, the detached environment remains
+  on the original commit until the user or reprovision changes it.
+- Branch-backed worktrees still have the existing branch collision/reset risk
+  from `git worktree add -B`. This plan does not solve branch hygiene.
+
+## Implementation Steps
+
+1. Add managed worktree checkout mode to `@bb/server-contract`.
+2. Normalize omitted checkout mode to detached at the server request boundary.
+3. Carry checkout mode through thread create, provisioning context, and managed
+   environment plans.
+4. Update daemon command contract to carry managed checkout mode.
+5. Update host workspace provisioner to support detached managed worktrees.
+6. Update root compose state/request building and add the checkout mode UI.
+7. Update CLI `--new-environment worktree` default and add explicit branch mode
+   flag.
+8. Update reprovision so null-branch managed worktrees stay detached.
+9. Update tests and guide text.
+10. Search for stale branch-required assumptions around managed worktrees and
+    fix only the assumptions that break detached worktree creation.
+
+## Exit Criteria
+
+- Creating a new worktree from the app default path provisions a detached HEAD
+  worktree.
+- The same app flow can explicitly request a branch-backed worktree and creates
+  the generated `bb/...` branch as before.
+- `bb thread spawn --new-environment worktree` defaults to detached checkout.
+- The CLI branch-backed flag creates a branch-backed managed worktree.
+- Detached worktree provisioning persists `environments.branchName = null`.
+- Detached worktree reprovision stays detached and does not mint a generated
+  branch.
+- Existing setup-script, cancellation, rollback, and cleanup behavior still
+  works for both checkout modes.
+- Fork/side-chat behavior is either explicitly preserved or intentionally
+  changed with tests documenting the decision.
+
+## Validation
+
+Run targeted checks through Turbo:
+
+```sh
+pnpm exec turbo run typecheck --filter=@bb/server-contract --filter=@bb/host-daemon-contract --filter=@bb/host-workspace --filter=@bb/server --filter=@bb/app --filter=@bb/cli
+pnpm exec turbo run test --filter=@bb/host-workspace --force > /tmp/host-workspace-detached-worktree-test-out.txt 2>&1
+pnpm exec turbo run test --filter=@bb/server --force > /tmp/server-detached-worktree-test-out.txt 2>&1
+pnpm exec turbo run test --filter=@bb/app --force > /tmp/app-detached-worktree-test-out.txt 2>&1
+pnpm exec turbo run test --filter=@bb/cli --force > /tmp/cli-detached-worktree-test-out.txt 2>&1
+```
+
+Manual smoke test:
+
+1. Start the dev app with `scripts/bb-dev-app current`.
+2. Create a project thread with `New worktree` and no checkout-mode changes.
+3. Confirm the workspace is detached:
+
+   ```sh
+   git -C <new-worktree-path> branch --show-current
+   git -C <new-worktree-path> rev-parse --short HEAD
+   ```
+
+4. Confirm the DB row has `branchName` null and the expected `baseBranch`.
+5. Create another `New worktree`, choose `Create branch`, and confirm
+   `git branch --show-current` prints the generated BB branch.


### PR DESCRIPTION
## Summary
- record daemon-observed environment branch/default-branch metadata after successful workspace status checks
- add DB helper coverage for updating and clearing environment branch metadata
- add a scoped plan for making New worktree default to detached HEAD with an explicit branch-backed option

## Tests
- pnpm exec turbo run test --filter=@bb/db --force
- pnpm exec turbo run test --filter=@bb/server --force
- pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server
- git diff --check