### PR TITLE
Restore mobile prompt shell compaction

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -208,11 +208,9 @@
     }
   }
 
-  @container promptbox-shell (max-width: 22rem) {
+  @container promptbox-shell (max-width: 34rem) {
     [data-promptbox-shell] [data-promptbox-full-label],
-    [data-promptbox-shell] [data-promptbox-hide-compact],
-    [data-promptbox-shell] [data-promptbox-hide-branch-compact],
-    [data-promptbox-shell] [data-promptbox-hide-tiny] {
+    [data-promptbox-shell] [data-promptbox-hide-compact] {
       display: none !important;
     }
 
@@ -228,6 +226,13 @@
     [data-promptbox-shell] [data-promptbox-project-control] {
       flex-shrink: 0;
       max-inline-size: 10rem;
+    }
+  }
+
+  @container promptbox-shell (max-width: 22rem) {
+    [data-promptbox-shell] [data-promptbox-hide-branch-compact],
+    [data-promptbox-shell] [data-promptbox-hide-tiny] {
+      display: none !important;
     }
   }
 


### PR DESCRIPTION
## Summary
- restore the prompt shell compact breakpoint for normal labels to 34rem
- keep branch/tiny prompt shell details hidden only at the narrower 22rem breakpoint

## Testing
- git diff --check

No behavior tests run; CSS-only breakpoint change.