### PR TITLE
Make running workflow agent indicator a prominent box

### DIFF
--- a/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.tsx
+++ b/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.tsx
@@ -61,7 +61,7 @@ function WorkflowAgentStateIcon({
       return (
         <Icon
           name="Square"
-          className={cn(className, "fill-current text-muted-foreground/30")}
+          className={cn(className, "text-muted-foreground")}
           aria-hidden="true"
         />
       );


### PR DESCRIPTION
## Summary

In the workflow banner (`WorkflowWorkRowBody`), the `running` agent's status icon rendered its `Square` filled at 30% opacity (`fill-current text-muted-foreground/30`), which read as a washed-out grey checkbox. This drops the fill and uses full `text-muted-foreground`, so it renders as a crisp, more prominent box outline.

```diff
  case "running":
    <Icon name="Square"
-     className={cn(className, "fill-current text-muted-foreground/30")} />
+     className={cn(className, "text-muted-foreground")} />
```

`done` (check), `queued`/`interrupted` (faint `/45` box), and `failed`/`skipped` (X) are untouched, so the running box now reads as the most prominent box while staying distinguishable from queued.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app` ✓
- `pnpm exec turbo run lint --filter=@bb/app` ✓ (0 errors)
- Visually verified in the `promptbox--banner--workflow-card` Ladle stories (running box distinct from done/queued).

## Risk

Low — single-line CSS class change to one presentational status icon; no logic or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)