### PR TITLE
Replace landing provider tree with nested thread sidebar

### DIFF
--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -1288,30 +1288,102 @@ function AutomationRun() {
   );
 }
 
-/* ── Band 5 visual: one agent runs another ────────────────────────── */
+/* ── Band 5 visual: one agent spawns and manages a thread per provider ── */
 
-function ProviderTree() {
+// A bb sidebar mock: a parent Claude thread with three worker threads nested
+// beneath it on a connector rail, one per provider. Each worker's status flips
+// running → done; the parent manages until they all land, then ships. Mirrors
+// the run-receipt pill and reveal timing — the list replays each cycle.
+function SpawnRow({
+  icon,
+  name,
+  task,
+  status,
+  at,
+  doneAt,
+  parent,
+}: {
+  icon: ReactNode;
+  name: string;
+  task: string;
+  status: string;
+  at: number;
+  doneAt: number;
+  parent?: boolean;
+}) {
   return (
-    <div className="ptree" aria-label="One agent spawning workers on other providers">
-      <div className="pnode parent">
-        <ClaudeIcon className="pn-icon" />
-        <span className="pn-name">Claude Code</span>
-        <span className="pn-task">Ship the release</span>
+    <div
+      className={parent ? "sb-thread sb-parent" : "sb-thread"}
+      style={{ animationDelay: `${at}s` }}
+    >
+      <span className="sb-prov" aria-hidden>
+        {icon}
+      </span>
+      <span className="sb-body">
+        <span className="sb-name">{name}</span>
+        <span className="sb-task">{task}</span>
+      </span>
+      <span className="sb-stat" aria-hidden>
+        <span className="sb-run" style={{ animationDelay: `${doneAt}s` }}>
+          <span className="sb-dot" />
+          {status}
+        </span>
+        <span className="sb-done" style={{ animationDelay: `${doneAt}s` }}>
+          <CheckIcon className="sb-check" />
+          done
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function SpawnSidebar() {
+  const { cycle, leaving } = useCycle(5600, 500);
+  return (
+    <div
+      className="spawnbar"
+      aria-label="bb spawns and manages a worker thread for each provider"
+    >
+      <div className="sb-head">
+        <img src={bbIcon} alt="" className="sb-mark" />
+        <span className="sb-title">Threads</span>
+        <span className="sb-active">4 active</span>
       </div>
-      <div className="pbranch" aria-hidden>
-        <span />
-        <span />
-      </div>
-      <div className="pchildren">
-        <div className="pnode">
-          <OpenAiIcon className="pn-icon" />
-          <span className="pn-name">Codex</span>
-          <span className="pn-task">Port module to TS</span>
-        </div>
-        <div className="pnode">
-          <PiIcon className="pn-icon" />
-          <span className="pn-name">Pi</span>
-          <span className="pn-task">Write release notes</span>
+      <div className={leaving ? "sb-list leaving" : "sb-list"} key={cycle}>
+        <SpawnRow
+          parent
+          icon={<ClaudeIcon className="sb-ic" />}
+          name="Claude Code"
+          task="Ship the release"
+          status="managing"
+          at={0.1}
+          doneAt={4}
+        />
+        <div className="sb-kids">
+          <SpawnRow
+            icon={<OpenAiIcon className="sb-ic" />}
+            name="Codex"
+            task="Port module to TS"
+            status="running"
+            at={0.6}
+            doneAt={2.3}
+          />
+          <SpawnRow
+            icon={<CursorIcon className="sb-ic" />}
+            name="Cursor"
+            task="Refactor the auth flow"
+            status="running"
+            at={1}
+            doneAt={3}
+          />
+          <SpawnRow
+            icon={<PiIcon className="sb-ic" />}
+            name="Pi"
+            task="Write release notes"
+            status="running"
+            at={1.4}
+            doneAt={3.7}
+          />
         </div>
       </div>
     </div>
@@ -1391,7 +1463,7 @@ function LandingPage() {
       <Band
         title="The gang's all here"
         flip
-        visual={<ProviderTree />}
+        visual={<SpawnSidebar />}
       >
         <p>
           Claude Code, Codex, Cursor, and Pi all live in bb. Give a task to

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -2003,97 +2003,189 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   }
 }
 
-/* ── Provider tree (Band 5) ─────────────────────────────────────── */
+/* ── Spawn sidebar (Band 5): a worker thread per provider, nested ──── */
 
-.ptree {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+.spawnbar {
   width: 100%;
-}
-
-.pnode {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
   background: var(--bg);
-  padding: 12px 16px;
-  text-align: center;
-  min-width: 150px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-.pnode.parent {
-  border-color: color-mix(in oklch, var(--accent) 40%, var(--bg));
-  box-shadow: 0 1px 10px color-mix(in oklch, var(--accent) 12%, transparent);
+.sb-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 9px 10px;
 }
 
-.pn-icon {
-  width: 20px;
-  height: 20px;
+.sb-mark {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.sb-title {
+  font-size: 12px;
+  font-weight: 600;
   color: var(--ink);
 }
 
-.pn-name {
-  font-size: 13.5px;
-  font-weight: 600;
-}
-
-.pn-task {
-  font-size: 12px;
+.sb-active {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
   color: var(--subtle);
 }
 
-.pbranch {
+.sb-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sb-list.leaving {
+  animation: rc-leave 0.5s ease forwards;
+}
+
+.sb-thread {
   position: relative;
-  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface);
+  animation: rc-step 0.45s ease backwards;
+}
+
+.sb-parent {
+  background: var(--bg);
+  border-color: color-mix(in oklch, var(--accent) 32%, var(--bg));
+  box-shadow: 0 1px 10px color-mix(in oklch, var(--accent) 10%, transparent);
+}
+
+.sb-prov {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
   height: 28px;
+  flex-shrink: 0;
+  border-radius: 7px;
+  background: var(--bg);
+  border: 1px solid var(--border-soft);
 }
 
-.pbranch::before {
-  content: "";
+.sb-parent .sb-prov {
+  background: var(--surface);
+}
+
+.sb-ic {
+  width: 15px;
+  height: 15px;
+  color: var(--ink);
+}
+
+.sb-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+}
+
+.sb-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.sb-task {
+  font-size: 11.5px;
+  color: var(--subtle);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* status: running → done flip, mirroring the run-receipt pill */
+.sb-stat {
+  position: relative;
+  flex-shrink: 0;
+  width: 70px;
+  height: 16px;
+}
+
+.sb-run,
+.sb-done {
   position: absolute;
+  right: 0;
   top: 0;
-  left: 50%;
-  width: 1px;
-  height: 14px;
-  background: var(--border);
-  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
-.pbranch::after {
+.sb-run {
+  color: var(--accent);
+  animation: rc-out 0.4s ease forwards;
+}
+
+.sb-done {
+  opacity: 0;
+  color: var(--ok);
+  animation: rc-in 0.4s ease forwards;
+}
+
+.sb-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: rc-blink 1.1s ease-in-out infinite;
+}
+
+.sb-check {
+  width: 12px;
+  height: 12px;
+}
+
+/* nesting: workers sit under the parent on a connector rail */
+.sb-kids {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+  padding-left: 24px;
+}
+
+.sb-kids::before {
   content: "";
   position: absolute;
-  top: 14px;
-  left: 25%;
-  right: 25%;
+  left: 11px;
+  top: -6px;
+  bottom: 23px;
+  width: 1px;
+  background: var(--border);
+}
+
+.sb-kids .sb-thread::before {
+  content: "";
+  position: absolute;
+  left: -13px;
+  top: 50%;
+  width: 13px;
   height: 1px;
   background: var(--border);
-}
-
-.pbranch span {
-  position: absolute;
-  top: 14px;
-  height: 14px;
-  width: 1px;
-  background: var(--border);
-}
-
-.pbranch span:first-child {
-  left: 25%;
-}
-
-.pbranch span:last-child {
-  right: 25%;
-}
-
-.pchildren {
-  display: flex;
-  gap: 18px;
-  width: 100%;
-  justify-content: center;
 }
 
 /* ── Statement (Band 4) ─────────────────────────────────────────── */
@@ -2165,6 +2257,12 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 
   .band {
     padding: 64px 0;
+  }
+
+  /* The stacked sidebar visual already shows every provider logo, so the
+     chip row under the copy is redundant on narrow screens. */
+  .band-copy .providers {
+    display: none;
   }
 }
 
@@ -2279,6 +2377,22 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   .tg-stat-run,
   .tg-spin {
     animation: none;
+  }
+
+  .sb-thread,
+  .sb-run,
+  .sb-done,
+  .sb-dot {
+    animation: none;
+  }
+
+  /* Static settled sidebar when motion is reduced: every thread done. */
+  .sb-run {
+    opacity: 0;
+  }
+
+  .sb-done {
+    opacity: 1;
   }
 
   /* Static spawned thread when motion is reduced. */


### PR DESCRIPTION
## What

Replaces the static org-chart graphic in the landing page's **"The gang's all here"** band with a bb-style **nested thread sidebar**.

- Parent **Claude Code · Ship the release** thread with three worker threads — **Codex**, **Cursor**, **Pi** — nested beneath it on a connector rail.
- Each worker's status flips **● running → ✓ done** while the parent shows **● managing**, then ships once they land. Reuses the run-receipt pill + reveal timing from `AutomationRun`; the list replays each cycle.
- Adds **Cursor**, which the band copy names but the old graphic omitted.
- Hides the now-redundant provider chip row under the copy on narrow screens (the stacked sidebar already shows every provider logo).
- Honors `prefers-reduced-motion`: the sidebar rests in a static "all done" state.

## Why

The org chart was the only static, diagram-style visual on the page — its neighbors (`AgentChat`, `AutomationRun`) are animated product mocks. The sidebar looks like the real product, literally shows "spawn and manage another, each in its own thread," and fits all four providers.

## Tests

- `turbo run typecheck --filter=@bb/landing` ✓
- `turbo run lint --filter=@bb/landing` ✓
- Manual: verified running, settled (done), and mobile-width states in the browser; confirmed the band chip row is `display: none` at mobile width while the hero "Works with" chips are unaffected.

## Risks

Low — scoped to the landing app; no shared primitives or runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)