### PR TITLE
Store custom app themes under .bb/theme/<name>/theme.css

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCard.stories.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.stories.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import type { AppThemeId } from "@bb/domain";
+import type { BuiltInThemeId } from "@bb/domain";
 import { builtInThemes } from "@bb/domain";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -65,7 +65,7 @@ const STORY_THEME_STYLE_ID = "story-git-diff-theme";
 
 /** Inject the selected palette's CSS globally (the same string the app applies
  *  at runtime) so the `.light` / `.dark` panes below pick up its tokens. */
-function usePaletteCss(themeId: AppThemeId) {
+function usePaletteCss(themeId: BuiltInThemeId) {
   useEffect(() => {
     let el = document.getElementById(
       STORY_THEME_STYLE_ID,
@@ -121,7 +121,7 @@ function ModePane({ mode }: { mode: "light" | "dark" }) {
 }
 
 export function ThemedDiffPanel() {
-  const [themeId, setThemeId] = useState<AppThemeId>("catppuccin");
+  const [themeId, setThemeId] = useState<BuiltInThemeId>("catppuccin");
   usePaletteCss(themeId);
 
   return (

--- a/apps/app/src/hooks/mutations/settings-mutations.ts
+++ b/apps/app/src/hooks/mutations/settings-mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { AppTheme, Experiments } from "@bb/domain";
+import type { Experiments } from "@bb/domain";
 import * as api from "@/lib/api";
 import { invalidateSystemConfig } from "../cache-owners/system-cache-effects";
 
@@ -24,8 +24,9 @@ export function useUpdateExperiments() {
 }
 
 /**
- * Set the app-wide color palette. Like experiments, the server broadcasts
- * `config-changed` for other windows; the local invalidation refreshes this one.
+ * Set the app-wide color palette by id (built-in id or custom theme name). Like
+ * experiments, the server broadcasts `config-changed` for other windows; the
+ * local invalidation refreshes this one.
  */
 export function useUpdateAppearance() {
   const queryClient = useQueryClient();
@@ -34,7 +35,7 @@ export function useUpdateAppearance() {
     meta: {
       errorMessage: "Failed to update appearance.",
     },
-    mutationFn: (appearance: AppTheme) => api.updateAppearance(appearance),
+    mutationFn: (themeId: string) => api.updateAppearance(themeId),
     onSuccess: () => {
       invalidateSystemConfig({ queryClient });
     },

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -1652,9 +1652,9 @@ export async function updateExperiments(
   );
 }
 
-export async function updateAppearance(appearance: AppTheme): Promise<AppTheme> {
+export async function updateAppearance(themeId: string): Promise<AppTheme> {
   return request<AppTheme>(
-    apiClient.settings.appearance.$put({ json: appearance }),
+    apiClient.settings.appearance.$put({ json: { themeId } }),
   );
 }
 

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -14,6 +14,7 @@ const unavailableSystemConfig: SystemConfigResponse = {
     popoutChatHotkey: "Alt+Space",
   },
   appearance: { themeId: "default", customCss: null },
+  customThemes: [],
   featureFlags: { placeholder: false },
   hostDaemonPort: null,
   voiceTranscriptionEnabled: false,

--- a/apps/app/src/lib/themes/index.ts
+++ b/apps/app/src/lib/themes/index.ts
@@ -1,4 +1,4 @@
-import type { AppTheme, AppThemeId } from "@bb/domain";
+import { isBuiltInThemeId, type AppTheme, type BuiltInThemeId } from "@bb/domain";
 import { catppuccinThemeCss } from "./catppuccin";
 import { draculaThemeCss } from "./dracula";
 import { gruvboxThemeCss } from "./gruvbox";
@@ -10,10 +10,10 @@ export const APP_THEME_CSS_STORAGE_KEY = "bb.appThemeCss";
 
 /**
  * CSS overrides per built-in palette. "default" is empty so the base theme.css
- * tokens show through. The "custom" palette is supplied at runtime (server),
- * not from this registry.
+ * tokens show through. Custom palettes are supplied at runtime (the server reads
+ * their CSS from disk), not from this registry.
  */
-const builtInThemeCss: Record<Exclude<AppThemeId, "custom">, string> = {
+const builtInThemeCss: Record<BuiltInThemeId, string> = {
   default: "",
   nord: nordThemeCss,
   dracula: draculaThemeCss,
@@ -23,8 +23,10 @@ const builtInThemeCss: Record<Exclude<AppThemeId, "custom">, string> = {
 };
 
 export function resolveAppThemeCss(appearance: AppTheme): string {
-  if (appearance.themeId === "custom") return appearance.customCss ?? "";
-  return builtInThemeCss[appearance.themeId] ?? "";
+  if (isBuiltInThemeId(appearance.themeId)) {
+    return builtInThemeCss[appearance.themeId];
+  }
+  return appearance.customCss ?? "";
 }
 
 function getOrCreateStyleElement(): HTMLStyleElement | null {

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -5,7 +5,6 @@ import {
   defaultExperiments,
   isValidElectronAccelerator,
   type AppTheme,
-  type AppThemeId,
 } from "@bb/domain";
 import type {
   WorkspaceOpenTarget,
@@ -122,10 +121,11 @@ export interface FaviconColorSettingsControlProps {
 export interface GeneralSettingsSectionProps {
   appearance: AppTheme;
   appearanceDisabled: boolean;
+  customThemes: readonly string[];
   desktopBrowserAvailable: boolean;
   faviconColor: FaviconColorPreference;
   navigateToThreadAfterCreate: boolean;
-  onAppearanceThemeChange: (themeId: AppThemeId) => void;
+  onAppearanceThemeChange: (themeId: string) => void;
   onFaviconColorChange: (faviconColor: FaviconColorPreference) => void;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
   onOpenLinksInAppBrowserChange: (enabled: boolean) => void;
@@ -139,7 +139,6 @@ export interface GeneralSettingsSectionProps {
 }
 
 function appPaletteLabel(appearance: AppTheme): string {
-  if (appearance.themeId === "custom") return "Custom";
   const meta = builtInThemes.find((entry) => entry.id === appearance.themeId);
   return meta?.name ?? appearance.themeId;
 }
@@ -480,6 +479,7 @@ export function RichTextEditingSettingsControl({
 export function GeneralSettingsSection({
   appearance,
   appearanceDisabled,
+  customThemes,
   desktopBrowserAvailable,
   faviconColor,
   navigateToThreadAfterCreate,
@@ -537,7 +537,7 @@ export function GeneralSettingsSection({
 
         <SettingsWithControl
           label="Palette"
-          description="Applies to the whole app. Load a custom stylesheet with the bb theme CLI."
+          description="Applies to the whole app. Add a custom theme by creating .bb/theme/<name>/theme.css, then pick it here or with the bb theme CLI."
         >
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -572,22 +572,22 @@ export function GeneralSettingsSection({
                   />
                 </DropdownMenuItem>
               ))}
-              {appearance.customCss !== null ? (
+              {customThemes.map((name) => (
                 <DropdownMenuItem
-                  key="custom"
-                  onSelect={() => onAppearanceThemeChange("custom")}
+                  key={`custom:${name}`}
+                  onSelect={() => onAppearanceThemeChange(name)}
                 >
-                  Custom
+                  {name}
                   <Icon
                     name="Check"
                     className={cn(
                       "ml-auto",
-                      appearance.themeId !== "custom" && "opacity-0",
+                      appearance.themeId !== name && "opacity-0",
                       COARSE_POINTER_ICON_SIZE_CLASS,
                     )}
                   />
                 </DropdownMenuItem>
-              ) : null}
+              ))}
             </DropdownMenuContent>
           </DropdownMenu>
         </SettingsWithControl>
@@ -906,6 +906,7 @@ export function SettingsView() {
             systemConfigQuery.data === undefined ||
             updateAppearanceMutation.isPending
           }
+          customThemes={systemConfigQuery.data?.customThemes ?? []}
           desktopBrowserAvailable={desktopBrowserAvailable}
           faviconColor={faviconColor}
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
@@ -914,10 +915,7 @@ export function SettingsView() {
           richTextEditing={richTextEditing}
           themePreference={themePreference}
           onAppearanceThemeChange={(themeId) =>
-            updateAppearanceMutation.mutate({
-              themeId,
-              customCss: appearance.customCss,
-            })
+            updateAppearanceMutation.mutate(themeId)
           }
           onFaviconColorChange={setFaviconColor}
           onNavigateToThreadAfterCreateChange={setNavigateToThreadAfterCreate}

--- a/apps/cli/src/__tests__/command-output/thread-terminals.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-terminals.test.ts
@@ -40,11 +40,11 @@ describe("bb thread terminal command output", () => {
     const list = vi.fn(async () => ({
       sessions: [makeTerminalSession({ title: "pnpm dev" })],
     }));
-    stubServerApi({ "v1.threads.:id.terminals.$get": list });
+    stubServerApi({ "v1.terminals.$get": list });
 
     await runCommand(["thread", "terminal", "list", "thr-1"], register);
 
-    expect(list).toHaveBeenCalledWith({ param: { id: "thr-1" } });
+    expect(list).toHaveBeenCalledWith({ query: { threadId: "thr-1" } });
     expect(collectLogLines(vi.mocked(console.log)).join("\n")).toContain(
       "pnpm dev",
     );
@@ -52,7 +52,7 @@ describe("bb thread terminal command output", () => {
 
   it("bb thread terminal start sends command start requests", async () => {
     const start = vi.fn(async () => makeTerminalSession({ title: "echo hi" }));
-    stubServerApi({ "v1.threads.:id.terminals.$post": start });
+    stubServerApi({ "v1.terminals.$post": start });
 
     await runCommand(
       ["thread", "terminal", "start", "thr-1", "--", "echo", "hi"],
@@ -60,12 +60,12 @@ describe("bb thread terminal command output", () => {
     );
 
     expect(start).toHaveBeenCalledWith({
-      param: { id: "thr-1" },
       json: {
         cols: 80,
         rows: 24,
         title: undefined,
         start: { mode: "command", command: "echo hi" },
+        target: { kind: "thread", threadId: "thr-1" },
       },
     });
     expect(collectLogLines(vi.mocked(console.log))).toContain(
@@ -77,7 +77,7 @@ describe("bb thread terminal command output", () => {
     const start = vi.fn(async () =>
       makeTerminalSession({ title: "python server" }),
     );
-    stubServerApi({ "v1.threads.:id.terminals.$post": start });
+    stubServerApi({ "v1.terminals.$post": start });
 
     await runCommand(
       [
@@ -95,7 +95,6 @@ describe("bb thread terminal command output", () => {
     );
 
     expect(start).toHaveBeenCalledWith({
-      param: { id: "thr-1" },
       json: {
         cols: 80,
         rows: 24,
@@ -104,6 +103,7 @@ describe("bb thread terminal command output", () => {
           mode: "command",
           command: `python3 -u -c 'print("hello world"); print('"'"'quoted'"'"')'`,
         },
+        target: { kind: "thread", threadId: "thr-1" },
       },
     });
   });
@@ -113,7 +113,7 @@ describe("bb thread terminal command output", () => {
     const start = vi.fn(async () =>
       makeTerminalSession({ threadId: "thr-env", title: "echo env" }),
     );
-    stubServerApi({ "v1.threads.:id.terminals.$post": start });
+    stubServerApi({ "v1.terminals.$post": start });
 
     await runCommand(
       ["thread", "terminal", "start", "--command", "echo env"],
@@ -121,12 +121,12 @@ describe("bb thread terminal command output", () => {
     );
 
     expect(start).toHaveBeenCalledWith({
-      param: { id: "thr-env" },
       json: {
         cols: 80,
         rows: 24,
         title: undefined,
         start: { mode: "command", command: "echo env" },
+        target: { kind: "thread", threadId: "thr-env" },
       },
     });
   });
@@ -135,14 +135,14 @@ describe("bb thread terminal command output", () => {
     const list = vi.fn(async () => ({
       sessions: [makeTerminalSession({ id: "term-attach" })],
     }));
-    stubServerApi({ "v1.threads.:id.terminals.$get": list });
+    stubServerApi({ "v1.terminals.$get": list });
 
     await runCommand(
       ["thread", "terminal", "attach", "term-attach", "thr-1", "--json"],
       register,
     );
 
-    expect(list).toHaveBeenCalledWith({ param: { id: "thr-1" } });
+    expect(list).toHaveBeenCalledWith({ query: { threadId: "thr-1" } });
     expect(
       JSON.parse(collectLogPayloads(vi.mocked(console.log))[0] ?? "{}"),
     ).toEqual(makeTerminalSession({ id: "term-attach" }));
@@ -151,7 +151,7 @@ describe("bb thread terminal command output", () => {
   it("bb thread terminal send forwards text input", async () => {
     const send = vi.fn(async () => makeTerminalSession());
     stubServerApi({
-      "v1.threads.:id.terminals.:terminalId.input.$post": send,
+      "v1.terminals.:terminalId.input.$post": send,
     });
 
     await runCommand(
@@ -169,7 +169,7 @@ describe("bb thread terminal command output", () => {
     );
 
     expect(send).toHaveBeenCalledWith({
-      param: { id: "thr-1", terminalId: "term-1" },
+      param: { terminalId: "term-1" },
       json: {
         dataBase64: Buffer.from("echo hi\n", "utf8").toString("base64"),
       },
@@ -191,7 +191,7 @@ describe("bb thread terminal command output", () => {
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
     stubServerApi({
-      "v1.threads.:id.terminals.:terminalId.output.$get": output,
+      "v1.terminals.:terminalId.output.$get": output,
     });
 
     await runCommand(
@@ -200,7 +200,7 @@ describe("bb thread terminal command output", () => {
     );
 
     expect(output).toHaveBeenCalledWith({
-      param: { id: "thr-1", terminalId: "term-1" },
+      param: { terminalId: "term-1" },
       query: {},
     });
     expect(write).toHaveBeenCalledWith(Buffer.from("hello\n", "utf8"));
@@ -213,7 +213,7 @@ describe("bb thread terminal command output", () => {
       truncated: true,
     }));
     stubServerApi({
-      "v1.threads.:id.terminals.:terminalId.output.$get": output,
+      "v1.terminals.:terminalId.output.$get": output,
     });
 
     await runCommand(
@@ -260,7 +260,7 @@ describe("bb thread terminal command output", () => {
       };
     });
     stubServerApi({
-      "v1.threads.:id.terminals.:terminalId.output.$get": output,
+      "v1.terminals.:terminalId.output.$get": output,
     });
 
     await runCommand(
@@ -281,11 +281,11 @@ describe("bb thread terminal command output", () => {
     );
 
     expect(output).toHaveBeenNthCalledWith(1, {
-      param: { id: "thr-1", terminalId: "term-1" },
+      param: { terminalId: "term-1" },
       query: { limitChunks: 1, tailBytes: 1 },
     });
     expect(output).toHaveBeenNthCalledWith(2, {
-      param: { id: "thr-1", terminalId: "term-1" },
+      param: { terminalId: "term-1" },
       query: { sinceSeq: 5 },
     });
     expect(collectLogLines(vi.mocked(console.log))).toContain(
@@ -309,7 +309,7 @@ describe("bb thread terminal command output", () => {
         ),
     );
     stubServerApi({
-      "v1.threads.:id.terminals.:terminalId.output.$get": output,
+      "v1.terminals.:terminalId.output.$get": output,
     });
 
     await expect(

--- a/apps/cli/src/commands/theme.ts
+++ b/apps/cli/src/commands/theme.ts
@@ -1,28 +1,22 @@
-import { readFile } from "node:fs/promises";
 import { Command } from "commander";
 import {
-  BUILTIN_THEME_IDS,
   builtInThemes,
   defaultAppTheme,
+  isBuiltInThemeId,
   type AppTheme,
-  type AppThemeId,
 } from "@bb/domain";
 import { action } from "../action.js";
 import { createCliBbSdk } from "../client.js";
 import { outputJson, type JsonOutputOptions } from "./helpers.js";
-
-interface ThemeSetCustomCommandOptions extends JsonOutputOptions {
-  file: string;
-}
 
 interface ThemeShowCommandOptions extends JsonOutputOptions {
   css?: boolean;
 }
 
 function describeActive(theme: AppTheme): string {
-  if (theme.themeId === "custom") {
+  if (!isBuiltInThemeId(theme.themeId)) {
     const bytes = theme.customCss?.length ?? 0;
-    return `Custom stylesheet (${bytes} bytes)`;
+    return `Custom theme '${theme.themeId}' (${bytes} bytes)`;
   }
   const meta = builtInThemes.find((entry) => entry.id === theme.themeId);
   return meta ? `${meta.name} (${meta.id})` : theme.themeId;
@@ -38,72 +32,70 @@ export function registerThemeCommands(
 
   theme
     .command("list")
-    .description("List built-in themes and the active palette")
+    .description("List built-in and custom themes and the active palette")
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (opts: JsonOutputOptions) => {
         const sdk = createCliBbSdk(getUrl());
-        const active = await sdk.theme.get();
+        const catalog = await sdk.theme.catalog();
         if (
           outputJson(opts, {
-            active,
+            active: catalog.active,
             builtInThemes,
-            customLoaded: active.customCss !== null,
+            custom: catalog.custom,
+            dir: catalog.dir,
           })
         ) {
           return;
         }
+        const active = catalog.active.themeId;
         console.log("");
+        console.log("Built-in:");
         for (const entry of builtInThemes) {
-          const marker = active.themeId === entry.id ? "*" : " ";
-          console.log(`${marker} ${entry.id.padEnd(10)} ${entry.description}`);
+          const marker = active === entry.id ? "*" : " ";
+          console.log(`${marker} ${entry.id.padEnd(12)} ${entry.description}`);
         }
-        const customMarker = active.themeId === "custom" ? "*" : " ";
-        const customState =
-          active.customCss !== null ? "loaded" : "not set — use set-custom";
-        console.log(`${customMarker} ${"custom".padEnd(10)} ${customState}`);
         console.log("");
-        console.log(`Active: ${describeActive(active)}`);
+        console.log(`Custom (${catalog.dir}):`);
+        if (catalog.custom.length === 0) {
+          console.log(`  (none — create <name>/theme.css under that directory)`);
+        } else {
+          for (const name of catalog.custom) {
+            const marker = active === name ? "*" : " ";
+            console.log(`${marker} ${name}`);
+          }
+        }
+        console.log("");
+        console.log(`Active: ${describeActive(catalog.active)}`);
       }),
     );
 
   theme
     .command("set <id>")
-    .description(`Switch to a built-in theme (${BUILTIN_THEME_IDS.join(", ")})`)
+    .description(
+      "Switch to a built-in theme or a custom theme by name " +
+        "(a directory under the theme dir with a theme.css)",
+    )
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (id: string, opts: JsonOutputOptions) => {
-        if (!(BUILTIN_THEME_IDS as readonly string[]).includes(id)) {
-          throw new Error(
-            `Unknown theme '${id}'. Expected one of: ${BUILTIN_THEME_IDS.join(", ")}.`,
-          );
-        }
         const sdk = createCliBbSdk(getUrl());
-        // Preserve any previously loaded custom CSS so it can be re-selected.
-        const current = await sdk.theme.get();
-        const updated = await sdk.theme.set({
-          themeId: id as AppThemeId,
-          customCss: current.customCss,
-        });
+        const updated = await sdk.theme.set(id);
         if (outputJson(opts, updated)) return;
         console.log(`Theme set to ${describeActive(updated)}`);
       }),
     );
 
   theme
-    .command("set-custom")
-    .description("Load a custom stylesheet from a file and activate it")
-    .requiredOption("--file <path>", "Path to a CSS file")
+    .command("dir")
+    .description("Print the directory where custom themes live")
     .option("--json", "Print machine-readable JSON output")
     .action(
-      action(async (opts: ThemeSetCustomCommandOptions) => {
-        const customCss = await readFile(opts.file, "utf8");
+      action(async (opts: JsonOutputOptions) => {
         const sdk = createCliBbSdk(getUrl());
-        const updated = await sdk.theme.set({ themeId: "custom", customCss });
-        if (outputJson(opts, updated)) return;
-        console.log(
-          `Custom stylesheet loaded (${customCss.length} bytes) and activated`,
-        );
+        const catalog = await sdk.theme.catalog();
+        if (outputJson(opts, { dir: catalog.dir })) return;
+        console.log(catalog.dir);
       }),
     );
 
@@ -118,11 +110,11 @@ export function registerThemeCommands(
         const active = await sdk.theme.get();
         if (outputJson(opts, active)) return;
         if (opts.css) {
-          if (active.themeId === "custom" && active.customCss !== null) {
+          if (active.customCss !== null) {
             console.log(active.customCss);
           } else {
             console.log(
-              "// Built-in theme CSS is bundled in the app, not stored server-side.",
+              "// Built-in theme CSS is bundled in the app, not stored on disk.",
             );
           }
           return;
@@ -133,12 +125,12 @@ export function registerThemeCommands(
 
   theme
     .command("reset")
-    .description("Reset to the Default theme and clear any custom stylesheet")
+    .description("Reset to the Default theme")
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (opts: JsonOutputOptions) => {
         const sdk = createCliBbSdk(getUrl());
-        const updated = await sdk.theme.set(defaultAppTheme);
+        const updated = await sdk.theme.set(defaultAppTheme.themeId);
         if (outputJson(opts, updated)) return;
         console.log(`Theme reset to ${describeActive(updated)}`);
       }),

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,9 +1,10 @@
 import {
-  getAppTheme,
   getExperiments,
-  setAppTheme,
+  getStoredThemeId,
   setExperiments,
+  setStoredThemeId,
 } from "@bb/db";
+import { customThemeNameSchema, isBuiltInThemeId } from "@bb/domain";
 import {
   publicApiRoutes,
   typedRoutes,
@@ -21,6 +22,13 @@ import {
   resolveSystemExecutionOptions,
 } from "../services/system/execution-options.js";
 import { getProviderUsageLimits } from "../services/system/usage-limits.js";
+import {
+  listCustomThemeNames,
+  readCustomThemeCss,
+  resolveAppTheme,
+  resolveCustomThemeCssPath,
+  resolveThemeRootPath,
+} from "../services/system/custom-themes.js";
 
 export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
   const { get, post, put } = typedRoutes<PublicApiSchema>(app, {
@@ -28,10 +36,13 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
   });
   const routes = publicApiRoutes.system;
 
+  const themeRoot = resolveThemeRootPath(deps.config.dataDir);
+
   function buildSystemConfigResponse() {
     return {
       experiments: getExperiments(deps.db),
-      appearance: getAppTheme(deps.db),
+      appearance: resolveAppTheme(themeRoot, getStoredThemeId(deps.db)),
+      customThemes: listCustomThemeNames(themeRoot),
       featureFlags: deps.config.featureFlags,
       hostDaemonPort: deps.config.hostDaemonPort,
       voiceTranscriptionEnabled: resolveVoiceTranscriptionEnabled(deps),
@@ -49,12 +60,37 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
   });
 
   put(routes.appearance, (context, payload) => {
-    setAppTheme(deps.db, payload);
+    const { themeId } = payload;
+    if (!isBuiltInThemeId(themeId)) {
+      if (!customThemeNameSchema.safeParse(themeId).success) {
+        throw new ApiError(
+          400,
+          "invalid_request",
+          `Invalid theme id '${themeId}'.`,
+        );
+      }
+      if (readCustomThemeCss(themeRoot, themeId) === null) {
+        throw new ApiError(
+          404,
+          "theme_not_found",
+          `Custom theme '${themeId}' not found. Create ${resolveCustomThemeCssPath(themeRoot, themeId)} first.`,
+        );
+      }
+    }
+    setStoredThemeId(deps.db, themeId);
     // Broadcast like experiments: every window re-reads /system/config and
     // re-applies the active palette.
     deps.hub.notifySystem(["config-changed"]);
-    return context.json(getAppTheme(deps.db));
+    return context.json(resolveAppTheme(themeRoot, themeId));
   });
+
+  get(routes.themes, (context) =>
+    context.json({
+      dir: themeRoot,
+      custom: listCustomThemeNames(themeRoot),
+      active: resolveAppTheme(themeRoot, getStoredThemeId(deps.db)),
+    }),
+  );
 
   post(routes.reloadConfig, async (context) => {
     try {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -170,26 +170,38 @@ For review or fix pipelines, get the environment ID from
   overrides persisted server-side and applied live to every open window. This is
   the _palette_ only; light/dark _mode_ is a separate per-client setting that the
   palette layers on top of.
+- **Custom themes live on disk** under the app data dir, one folder per theme:
+  `<bb-data-dir>/theme/<name>/theme.css` (the packaged app uses `~/.bb/theme/…`).
+  The folder name *is* the theme id. This mirrors how user skills live under
+  `<bb-data-dir>/skills/<name>/`.
 - Commands:
-  - `bb theme list` — built-in themes and which palette is active.
-  - `bb theme set <id>` — switch to a built-in: `default`, `nord`, `dracula`,
-    `solarized`, `gruvbox`, `catppuccin`.
-  - `bb theme set-custom --file <path.css>` — load a custom stylesheet and
-    activate it. This is the only way to set custom CSS (Settings only switches
-    between built-ins).
-  - `bb theme show [--css]` — print the active palette; `--css` dumps the custom CSS.
-  - `bb theme reset` — back to `default`, clearing the custom stylesheet.
+  - `bb theme list` — built-in and custom themes and which palette is active.
+  - `bb theme dir` — print the absolute custom-theme directory (where to create
+    `<name>/theme.css`). Use this instead of guessing the path.
+  - `bb theme set <id>` — activate a built-in (`default`, `nord`, `dracula`,
+    `solarized`, `gruvbox`, `catppuccin`) or a custom theme by its folder name.
+  - `bb theme show [--css]` — print the active palette; `--css` dumps the active
+    theme's CSS.
+  - `bb theme reset` — back to `default`.
 
-### Authoring a theme
+### Creating or editing a custom theme
 
-To write a built-in theme or a custom stylesheet, **read `references/theming.md`
-(in this skill's directory) first.** It is the full design-token reference — what
-every CSS variable drives, which tokens to set vs. which auto-derive — plus the
-two-block light/dark structure, how to set colors and fonts, and a worked example.
+This is the BB habit: custom app-theme work belongs in
+`<bb-data-dir>/theme/<name>/theme.css` — never a stray `.css` file elsewhere.
+
+1. Find the directory: `bb theme dir` (e.g. `~/.bb/theme`).
+2. Write the stylesheet to `<that-dir>/<name>/theme.css` (create the folder). Use
+   a short, lowercase, hyphenated `<name>` (it must not collide with a built-in
+   id). To edit an existing theme, change its `theme.css` in place.
+3. Activate it: `bb theme set <name>`. Changes apply live to every open window.
+
+To author the stylesheet, **read `references/theming.md` (in this skill's
+directory) first.** It is the full design-token reference — what every CSS
+variable drives, which tokens to set vs. which auto-derive — plus the two-block
+light/dark structure, how to set colors and fonts, and a worked example.
 
 The short version: a custom theme is a plain CSS file that overrides CSS custom
 properties. Set the two anchors `--canvas`/`--ink` (most of the UI derives from
 them by mixing ink into canvas), the `--primary` accent, the secondary text tiers
 (`--muted-foreground` etc.), and the semantic colors (`--destructive`,
-`--success`, …). Ship one file with a `:root, .light` block and a `.dark` block,
-then load it with `bb theme set-custom --file <path.css>`.
+`--success`, …). Ship one file with a `:root, .light` block and a `.dark` block.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/theming.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/theming.md
@@ -10,6 +10,7 @@ that handles both modes.
 
 ## Contents
 
+- [Where themes live](#where-themes-live)
 - [Model](#model)
 - [Stylesheet structure](#stylesheet-structure)
 - [What to set (quick start)](#what-to-set-quick-start)
@@ -17,6 +18,15 @@ that handles both modes.
 - [Changing fonts](#changing-fonts)
 - [Worked example](#worked-example)
 - [Applying a theme](#applying-a-theme)
+
+## Where themes live
+
+A custom theme is a folder under the app data dir:
+`<bb-data-dir>/theme/<name>/theme.css` (the packaged app uses `~/.bb/theme/…`).
+The folder name is the theme id. Run `bb theme dir` to print the exact directory
+rather than guessing it. Always put custom app-theme CSS here — not in a stray
+`.css` file elsewhere in a repo. To edit a theme, change its `theme.css` in place
+and re-run `bb theme set <name>` (or just re-select it) to re-apply.
 
 ## Model
 
@@ -227,11 +237,17 @@ and semantics:
 
 ## Applying a theme
 
-- `bb theme set-custom --file ./my-theme.css` — load and activate a custom
-  stylesheet (the only way to set custom CSS).
+1. `bb theme dir` — print the custom-theme directory (e.g. `~/.bb/theme`).
+2. Write your stylesheet to `<that-dir>/<name>/theme.css` (create the folder;
+   `<name>` is the theme id — lowercase/hyphenated, not a built-in id).
+3. `bb theme set <name>` — activate it. To edit later, change the file in place
+   and re-run `bb theme set <name>`.
+
+Other commands:
+
 - `bb theme set <id>` — switch to a built-in (`default`, `nord`, `dracula`,
-  `solarized`, `gruvbox`, `catppuccin`).
-- `bb theme show --css` — dump the active custom CSS; `bb theme list` shows the
-  active palette; `bb theme reset` returns to `default`.
+  `solarized`, `gruvbox`, `catppuccin`) or a custom theme by folder name.
+- `bb theme show --css` — dump the active theme's CSS; `bb theme list` shows the
+  active palette and all discovered themes; `bb theme reset` returns to `default`.
 
 Changes apply live to every open window — no reload needed.

--- a/apps/server/src/services/system/custom-themes.ts
+++ b/apps/server/src/services/system/custom-themes.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CUSTOM_THEME_CSS_MAX_LENGTH,
+  customThemeNameSchema,
+  defaultAppTheme,
+  isBuiltInThemeId,
+  type AppTheme,
+} from "@bb/domain";
+
+const THEME_DIR_NAME = "theme";
+const THEME_CSS_FILE_NAME = "theme.css";
+
+/**
+ * Custom themes live on disk under the app data dir, mirroring how user skills
+ * live under `<data-dir>/skills`. A theme is a directory holding a `theme.css`;
+ * the directory name is the palette id.
+ */
+export function resolveThemeRootPath(dataDir: string): string {
+  return join(dataDir, THEME_DIR_NAME);
+}
+
+/** Absolute path to a custom theme's stylesheet. */
+export function resolveCustomThemeCssPath(
+  themeRoot: string,
+  name: string,
+): string {
+  return join(themeRoot, name, THEME_CSS_FILE_NAME);
+}
+
+/**
+ * Discover custom themes: subdirectories of `<themeRoot>` whose name is a safe
+ * single path segment and that contain a `theme.css`. Sorted for stable
+ * UI/CLI ordering.
+ */
+export function listCustomThemeNames(themeRoot: string): string[] {
+  let entries;
+  try {
+    entries = readdirSync(themeRoot, { withFileTypes: true });
+  } catch {
+    return []; // No theme dir yet (ENOENT) → no custom themes.
+  }
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => customThemeNameSchema.safeParse(name).success)
+    .filter((name) => existsSync(resolveCustomThemeCssPath(themeRoot, name)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Read a custom theme's stylesheet. Returns null when the name is unsafe, the
+ * file is missing, or it exceeds the size cap (kept bounded because the CSS is
+ * broadcast inline in the system config payload).
+ */
+export function readCustomThemeCss(
+  themeRoot: string,
+  name: string,
+): string | null {
+  if (!customThemeNameSchema.safeParse(name).success) return null;
+  let css: string;
+  try {
+    css = readFileSync(resolveCustomThemeCssPath(themeRoot, name), "utf8");
+  } catch {
+    return null;
+  }
+  if (css.length > CUSTOM_THEME_CSS_MAX_LENGTH) return null;
+  return css;
+}
+
+/**
+ * Resolve a stored palette id into the active appearance: built-ins carry no
+ * CSS (the frontend bundles it); a custom theme's CSS is read from disk. A
+ * selection whose theme folder is gone (deleted out from under the app) falls
+ * back to the default palette so the app never renders against missing CSS.
+ */
+export function resolveAppTheme(themeRoot: string, themeId: string): AppTheme {
+  if (isBuiltInThemeId(themeId)) return { themeId, customCss: null };
+  const customCss = readCustomThemeCss(themeRoot, themeId);
+  if (customCss === null) return defaultAppTheme;
+  return { themeId, customCss };
+}

--- a/apps/server/test/system/appearance.test.ts
+++ b/apps/server/test/system/appearance.test.ts
@@ -1,9 +1,25 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { getAppTheme } from "@bb/db";
+import { getStoredThemeId } from "@bb/db";
 import { appThemeSchema } from "@bb/domain";
-import { systemConfigResponseSchema } from "@bb/server-contract";
+import {
+  themeCatalogResponseSchema,
+  systemConfigResponseSchema,
+} from "@bb/server-contract";
 import { readJson } from "../helpers/json.js";
 import { withTestHarness } from "../helpers/test-app.js";
+
+/** Write a custom theme's `theme.css` under `<dataDir>/theme/<name>/`. */
+async function writeCustomTheme(
+  dataDir: string,
+  name: string,
+  css: string,
+): Promise<void> {
+  const dir = join(dataDir, "theme", name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "theme.css"), css, "utf8");
+}
 
 describe("appearance settings", () => {
   it("defaults appearance to the default palette in /system/config", async () => {
@@ -12,6 +28,7 @@ describe("appearance settings", () => {
       expect(response.status).toBe(200);
       const body = systemConfigResponseSchema.parse(await readJson(response));
       expect(body.appearance).toEqual({ themeId: "default", customCss: null });
+      expect(body.customThemes).toEqual([]);
     });
   });
 
@@ -20,17 +37,14 @@ describe("appearance settings", () => {
       const put = await harness.app.request("/api/v1/settings/appearance", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeId: "nord", customCss: null }),
+        body: JSON.stringify({ themeId: "nord" }),
       });
       expect(put.status).toBe(200);
       expect(appThemeSchema.parse(await readJson(put))).toEqual({
         themeId: "nord",
         customCss: null,
       });
-      expect(getAppTheme(harness.db)).toEqual({
-        themeId: "nord",
-        customCss: null,
-      });
+      expect(getStoredThemeId(harness.db)).toBe("nord");
 
       const config = await harness.app.request("/api/v1/system/config");
       expect(
@@ -39,36 +53,92 @@ describe("appearance settings", () => {
     });
   });
 
-  it("persists a custom stylesheet", async () => {
+  it("activates a custom theme discovered on disk", async () => {
     await withTestHarness(async (harness) => {
-      const customCss = ":root { --primary: #ff00ff; }";
+      const css = ":root { --primary: #ff00ff; }";
+      await writeCustomTheme(harness.config.dataDir, "midnight", css);
+
       const put = await harness.app.request("/api/v1/settings/appearance", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeId: "custom", customCss }),
+        body: JSON.stringify({ themeId: "midnight" }),
       });
       expect(put.status).toBe(200);
-      expect(getAppTheme(harness.db)).toEqual({ themeId: "custom", customCss });
-    });
-  });
-
-  it("rejects an unknown theme id", async () => {
-    await withTestHarness(async (harness) => {
-      const response = await harness.app.request("/api/v1/settings/appearance", {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeId: "neon", customCss: null }),
+      expect(appThemeSchema.parse(await readJson(put))).toEqual({
+        themeId: "midnight",
+        customCss: css,
       });
-      expect(response.status).toBe(400);
+      expect(getStoredThemeId(harness.db)).toBe("midnight");
+
+      const config = systemConfigResponseSchema.parse(
+        await readJson(await harness.app.request("/api/v1/system/config")),
+      );
+      expect(config.appearance).toEqual({ themeId: "midnight", customCss: css });
+      expect(config.customThemes).toEqual(["midnight"]);
     });
   });
 
-  it("rejects a custom theme without customCss", async () => {
+  it("lists discovered custom themes in the theme catalog", async () => {
+    await withTestHarness(async (harness) => {
+      await writeCustomTheme(harness.config.dataDir, "zephyr", ":root {}");
+      await writeCustomTheme(harness.config.dataDir, "amber", ":root {}");
+      // A directory without a theme.css is not a theme.
+      await mkdir(join(harness.config.dataDir, "theme", "incomplete"), {
+        recursive: true,
+      });
+
+      const response = await harness.app.request("/api/v1/settings/themes");
+      expect(response.status).toBe(200);
+      const catalog = themeCatalogResponseSchema.parse(
+        await readJson(response),
+      );
+      expect(catalog.dir).toBe(join(harness.config.dataDir, "theme"));
+      expect(catalog.custom).toEqual(["amber", "zephyr"]);
+      expect(catalog.active).toEqual({ themeId: "default", customCss: null });
+    });
+  });
+
+  it("falls back to default when the active custom theme is deleted", async () => {
+    await withTestHarness(async (harness) => {
+      await writeCustomTheme(harness.config.dataDir, "ghost", ":root {}");
+      await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "ghost" }),
+      });
+
+      await rm(join(harness.config.dataDir, "theme", "ghost"), {
+        recursive: true,
+        force: true,
+      });
+
+      const config = systemConfigResponseSchema.parse(
+        await readJson(await harness.app.request("/api/v1/system/config")),
+      );
+      // The selection is still stored, but resolution falls back gracefully.
+      expect(getStoredThemeId(harness.db)).toBe("ghost");
+      expect(config.appearance).toEqual({ themeId: "default", customCss: null });
+      expect(config.customThemes).toEqual([]);
+    });
+  });
+
+  it("rejects selecting a custom theme that does not exist", async () => {
     await withTestHarness(async (harness) => {
       const response = await harness.app.request("/api/v1/settings/appearance", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeId: "custom", customCss: null }),
+        body: JSON.stringify({ themeId: "nonexistent" }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  it("rejects a theme id that is not a safe path segment", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "../evil" }),
       });
       expect(response.status).toBe(400);
     });

--- a/apps/server/test/system/custom-themes.test.ts
+++ b/apps/server/test/system/custom-themes.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CUSTOM_THEME_CSS_MAX_LENGTH } from "@bb/domain";
+import {
+  listCustomThemeNames,
+  readCustomThemeCss,
+  resolveAppTheme,
+  resolveThemeRootPath,
+} from "../../src/services/system/custom-themes.js";
+
+async function writeTheme(root: string, name: string, css: string) {
+  await mkdir(join(root, name), { recursive: true });
+  await writeFile(join(root, name, "theme.css"), css, "utf8");
+}
+
+describe("custom themes service", () => {
+  let dataDir: string;
+  let themeRoot: string;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-theme-test-"));
+    themeRoot = resolveThemeRootPath(dataDir);
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("returns no themes when the theme dir is absent", () => {
+    expect(listCustomThemeNames(themeRoot)).toEqual([]);
+  });
+
+  it("lists only directories with a theme.css, sorted, safe names only", async () => {
+    await writeTheme(themeRoot, "solar", ":root {}");
+    await writeTheme(themeRoot, "aurora", ":root {}");
+    await mkdir(join(themeRoot, "no-css"), { recursive: true });
+    await writeFile(join(themeRoot, "loose.css"), ":root {}", "utf8");
+
+    expect(listCustomThemeNames(themeRoot)).toEqual(["aurora", "solar"]);
+  });
+
+  it("resolves a built-in id without reading disk", () => {
+    expect(resolveAppTheme(themeRoot, "nord")).toEqual({
+      themeId: "nord",
+      customCss: null,
+    });
+  });
+
+  it("resolves a custom theme's CSS from disk", async () => {
+    await writeTheme(themeRoot, "ocean", ":root { --primary: #06f; }");
+    expect(resolveAppTheme(themeRoot, "ocean")).toEqual({
+      themeId: "ocean",
+      customCss: ":root { --primary: #06f; }",
+    });
+  });
+
+  it("falls back to default for a missing or unsafe selection", () => {
+    expect(resolveAppTheme(themeRoot, "missing")).toEqual({
+      themeId: "default",
+      customCss: null,
+    });
+    expect(resolveAppTheme(themeRoot, "../escape")).toEqual({
+      themeId: "default",
+      customCss: null,
+    });
+  });
+
+  it("rejects oversized stylesheets so the broadcast payload stays bounded", async () => {
+    await writeTheme(themeRoot, "huge", "a".repeat(CUSTOM_THEME_CSS_MAX_LENGTH + 1));
+    expect(readCustomThemeCss(themeRoot, "huge")).toBeNull();
+    expect(resolveAppTheme(themeRoot, "huge")).toEqual({
+      themeId: "default",
+      customCss: null,
+    });
+  });
+});

--- a/packages/db/drizzle/0044_flimsy_black_cat.sql
+++ b/packages/db/drizzle/0044_flimsy_black_cat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `app_theme` DROP COLUMN `custom_css`;

--- a/packages/db/drizzle/meta/0044_snapshot.json
+++ b/packages/db/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,2756 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "728d4177-c6bd-48fd-af16-1ca83bdfa34f",
+  "prevId": "37888a75-eb3f-4f33-b430-26928568f390",
+  "tables": {
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_runs": {
+      "name": "automation_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_started_idx": {
+          "name": "automation_runs_automation_started_idx",
+          "columns": [
+            "automation_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "automation_runs_thread_idx": {
+          "name": "automation_runs_thread_idx",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_runs_thread_id_threads_id_fk": {
+          "name": "automation_runs_thread_id_threads_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_thread_id": {
+          "name": "target_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution": {
+          "name": "execution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_archive": {
+          "name": "auto_archive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_thread_id": {
+          "name": "created_by_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_thread_id": {
+          "name": "last_run_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automations_project_idx": {
+          "name": "automations_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            "enabled",
+            "trigger_type",
+            "next_run_at"
+          ],
+          "isUnique": false
+        },
+        "automations_target_thread_idx": {
+          "name": "automations_target_thread_idx",
+          "columns": [
+            "target_thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_project_id_projects_id_fk": {
+          "name": "automations_project_id_projects_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automations_target_thread_id_threads_id_fk": {
+          "name": "automations_target_thread_id_threads_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "target_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destroy_attempt_id": {
+          "name": "destroy_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provision_type": {
+          "name": "workspace_provision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_host_path_idx": {
+          "name": "environments_host_path_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_type": {
+          "name": "host_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claude_code_mock_cli_traffic": {
+          "name": "claude_code_mock_cli_traffic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "popout_chat": {
+          "name": "popout_chat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "popout_chat_hotkey": {
+          "name": "popout_chat_hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_idx": {
+          "name": "thread_search_segments_thread_idx",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "child_origin": {
+          "name": "child_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1782173519934,
       "tag": "0043_threadless_terminal_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "6",
+      "when": 1782249376381,
+      "tag": "0044_flimsy_black_cat",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/app-theme.ts
+++ b/packages/db/src/data/app-theme.ts
@@ -1,45 +1,31 @@
 import { eq } from "drizzle-orm";
-import { defaultAppTheme, type AppTheme } from "@bb/domain";
+import { defaultAppTheme } from "@bb/domain";
 import type { DbConnection } from "../connection.js";
 import { appTheme } from "../schema.js";
 
 const APP_THEME_ROW_ID = "current";
 
-export function getAppTheme(db: DbConnection): AppTheme {
+/**
+ * The persisted active palette id (built-in id or custom theme name). The CSS
+ * for a custom theme is resolved from disk by the server, not stored here.
+ */
+export function getStoredThemeId(db: DbConnection): string {
   const row = db
-    .select({
-      themeId: appTheme.themeId,
-      customCss: appTheme.customCss,
-    })
+    .select({ themeId: appTheme.themeId })
     .from(appTheme)
     .where(eq(appTheme.id, APP_THEME_ROW_ID))
     .get();
 
-  if (!row) return defaultAppTheme;
-  // themeId is stored as free text; writes always go through setAppTheme with a
-  // validated AppTheme, so narrowing back to the union at this boundary is safe.
-  return {
-    themeId: row.themeId as AppTheme["themeId"],
-    customCss: row.customCss,
-  };
+  return row?.themeId ?? defaultAppTheme.themeId;
 }
 
-export function setAppTheme(db: DbConnection, theme: AppTheme): void {
+export function setStoredThemeId(db: DbConnection, themeId: string): void {
   const updatedAt = Date.now();
   db.insert(appTheme)
-    .values({
-      id: APP_THEME_ROW_ID,
-      themeId: theme.themeId,
-      customCss: theme.customCss,
-      updatedAt,
-    })
+    .values({ id: APP_THEME_ROW_ID, themeId, updatedAt })
     .onConflictDoUpdate({
       target: appTheme.id,
-      set: {
-        themeId: theme.themeId,
-        customCss: theme.customCss,
-        updatedAt,
-      },
+      set: { themeId, updatedAt },
     })
     .run();
 }

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -170,7 +170,7 @@ export type {
 
 export { getExperiments, setExperiments } from "./experiments.js";
 
-export { getAppTheme, setAppTheme } from "./app-theme.js";
+export { getStoredThemeId, setStoredThemeId } from "./app-theme.js";
 
 export {
   getThreadDynamicContextFileState,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -153,11 +153,11 @@ export const systemExperiments = sqliteTable("system_experiments", {
 });
 
 // Single-row table (id = "current") holding the app-wide color palette: the
-// active built-in theme id (or "custom") plus the custom stylesheet text.
+// active palette id — a built-in theme id, or a custom theme name whose CSS
+// lives on disk under `<data-dir>/theme/<name>/theme.css`.
 export const appTheme = sqliteTable("app_theme", {
   id: text("id").primaryKey(),
   themeId: text("theme_id").notNull(),
-  customCss: text("custom_css"),
   updatedAt: integer("updated_at").notNull(),
 });
 

--- a/packages/domain/src/app-theme.ts
+++ b/packages/domain/src/app-theme.ts
@@ -6,22 +6,23 @@ import { z } from "zod";
  * custom-property overrides applied app-wide, persisted server-side so the CLI
  * and Settings can both set it and every open window stays in sync.
  *
- * `themeId` is either a built-in palette or "custom"; built-in CSS lives in the
- * frontend registry, so only the active id and the custom CSS text are stored.
+ * A palette is either a built-in id (CSS bundled in the frontend registry) or a
+ * custom theme discovered on disk under `<data-dir>/theme/<name>/theme.css`. For
+ * a custom palette `themeId` is the theme's directory name and the resolved CSS
+ * is read from that file by the server.
  */
-export const appThemeIdSchema = z.enum([
+export const builtInThemeIdSchema = z.enum([
   "default",
   "nord",
   "dracula",
   "solarized",
   "gruvbox",
   "catppuccin",
-  "custom",
 ]);
-export type AppThemeId = z.infer<typeof appThemeIdSchema>;
+export type BuiltInThemeId = z.infer<typeof builtInThemeIdSchema>;
 
 export interface BuiltInThemeMeta {
-  id: Exclude<AppThemeId, "custom">;
+  id: BuiltInThemeId;
   name: string;
   description: string;
 }
@@ -52,23 +53,58 @@ export const builtInThemes: readonly BuiltInThemeMeta[] = [
   },
 ];
 
-/** Built-in palette ids (everything except "custom"). */
-export const BUILTIN_THEME_IDS = builtInThemes.map((theme) => theme.id);
+/** Built-in palette ids. */
+export const BUILTIN_THEME_IDS = builtInThemeIdSchema.options;
+
+/** Whether an id refers to a bundled built-in palette (vs. a custom theme). */
+export function isBuiltInThemeId(id: string): id is BuiltInThemeId {
+  return (BUILTIN_THEME_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * Custom theme name = the directory under `<data-dir>/theme/`. Constrained to a
+ * single safe path segment (no separators or `..`) so it can be used directly as
+ * a filesystem path and a stable id; built-in ids are not allowed (they're
+ * reserved and would shadow the custom theme).
+ */
+export const customThemeNameSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
+    "Custom theme names may use letters, digits, '.', '_', and '-' and cannot start with '.'",
+  )
+  .refine((name) => name !== "." && name !== "..", "Invalid custom theme name")
+  .refine(
+    (name) => !isBuiltInThemeId(name),
+    "Custom theme name collides with a built-in palette id",
+  );
 
 /** Max size of a user-supplied custom stylesheet; keeps the persisted and
  * broadcast config payload bounded. */
 export const CUSTOM_THEME_CSS_MAX_LENGTH = 256_000;
 
-export const appThemeSchema = z
-  .object({
-    themeId: appThemeIdSchema,
-    /** Raw CSS for the "custom" palette; null for built-ins. */
-    customCss: z.string().max(CUSTOM_THEME_CSS_MAX_LENGTH).nullable(),
-  })
-  .refine((value) => value.themeId !== "custom" || value.customCss !== null, {
-    message: 'customCss is required when themeId is "custom"',
-    path: ["customCss"],
-  });
+/**
+ * The active palette as resolved by the server: a palette id (built-in or
+ * custom theme name) plus the resolved custom CSS (null for built-ins, the
+ * `theme.css` contents for a custom theme).
+ */
+export const appThemeSchema = z.object({
+  themeId: z.string().min(1),
+  /** Resolved CSS for a custom palette; null for built-ins. */
+  customCss: z.string().max(CUSTOM_THEME_CSS_MAX_LENGTH).nullable(),
+});
 export type AppTheme = z.infer<typeof appThemeSchema>;
+
+/**
+ * The palette selection a client sends when switching themes: just the id. The
+ * server validates it (built-in id or an existing custom theme) and resolves the
+ * CSS from disk for custom themes.
+ */
+export const appThemeSelectionSchema = z.object({
+  themeId: z.string().min(1),
+});
+export type AppThemeSelection = z.infer<typeof appThemeSelectionSchema>;
 
 export const defaultAppTheme: AppTheme = { themeId: "default", customCss: null };

--- a/packages/sdk/src/areas/theme.ts
+++ b/packages/sdk/src/areas/theme.ts
@@ -1,11 +1,17 @@
 import type { AppTheme } from "@bb/domain";
+import type { ThemeCatalogResponse } from "@bb/server-contract";
 import type { CreateSdkAreaArgs } from "./common.js";
 
 export interface ThemeArea {
-  /** The active app palette (built-in id or custom CSS). */
+  /** The active app palette, resolved server-side (built-in id or custom CSS). */
   get(): Promise<AppTheme>;
-  /** Set the active app palette; broadcasts to all open windows. */
-  set(input: AppTheme): Promise<AppTheme>;
+  /** The custom-theme directory plus discovered themes and the active palette. */
+  catalog(): Promise<ThemeCatalogResponse>;
+  /**
+   * Activate a palette by id — a built-in id or a custom theme name that exists
+   * under `<data-dir>/theme/<name>/theme.css`. Broadcasts to all open windows.
+   */
+  set(themeId: string): Promise<AppTheme>;
 }
 
 export function createThemeArea(args: CreateSdkAreaArgs): ThemeArea {
@@ -17,9 +23,12 @@ export function createThemeArea(args: CreateSdkAreaArgs): ThemeArea {
       );
       return config.appearance;
     },
-    async set(input) {
+    async catalog() {
+      return transport.readJson(transport.api.v1.settings.themes.$get());
+    },
+    async set(themeId) {
       return transport.readJson(
-        transport.api.v1.settings.appearance.$put({ json: input }),
+        transport.api.v1.settings.appearance.$put({ json: { themeId } }),
       );
     },
   };

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -76,13 +76,32 @@ export type SystemVoiceTranscriptionResponse = z.infer<
 export const systemConfigResponseSchema = z.object({
   /** User-opt-in experiments (Settings → Experiments), persisted server-side. */
   experiments: experimentsSchema,
-  /** App-wide color palette (built-in id or custom CSS), persisted server-side. */
+  /** Active app-wide palette (built-in id or custom theme), resolved server-side. */
   appearance: appThemeSchema,
+  /**
+   * Names of custom themes discovered under `<data-dir>/theme/<name>/theme.css`,
+   * so the Settings picker can offer them alongside the built-ins.
+   */
+  customThemes: z.array(z.string()),
   featureFlags: featureFlagsSchema,
   hostDaemonPort: z.number().nullable(),
   voiceTranscriptionEnabled: z.boolean(),
 });
 export type SystemConfigResponse = z.infer<typeof systemConfigResponseSchema>;
+
+/**
+ * Theme catalog: the on-disk custom-theme directory plus the discovered custom
+ * themes and the active palette. Drives `bb theme list` / `bb theme dir`.
+ */
+export const themeCatalogResponseSchema = z.object({
+  /** Absolute path of the custom-theme root: `<data-dir>/theme`. */
+  dir: z.string(),
+  /** Discovered custom theme names (each has a `theme.css`). */
+  custom: z.array(z.string()),
+  /** The active palette, resolved server-side. */
+  active: appThemeSchema,
+});
+export type ThemeCatalogResponse = z.infer<typeof themeCatalogResponseSchema>;
 
 export const systemVersionResponseSchema = z.object({
   /** Version of the running bb-app package, read from package.json. */

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -2,6 +2,7 @@ import type { Hono } from "hono";
 import { hc } from "hono/client";
 import type {
   AppTheme,
+  AppThemeSelection,
   Environment,
   Experiments,
   Host,
@@ -12,7 +13,7 @@ import type {
   ThreadEventRow,
   ThreadQueuedMessage,
 } from "@bb/domain";
-import { appThemeSchema, experimentsSchema } from "@bb/domain";
+import { appThemeSelectionSchema, experimentsSchema } from "@bb/domain";
 import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
 import {
   binaryResponse,
@@ -99,6 +100,7 @@ import type {
   SystemVoiceTranscriptionForm,
   SystemVoiceTranscriptionResponse,
   TerminalListResponse,
+  ThemeCatalogResponse,
   TerminalSession,
   TerminalInputRequest,
   TerminalListQuery,
@@ -859,8 +861,16 @@ export const publicApiRoutes = {
     appearance: defineRoute({
       path: "/settings/appearance",
       method: "put",
-      request: jsonRequest<EmptyInput, AppTheme>(appThemeSchema),
+      request: jsonRequest<EmptyInput, AppThemeSelection>(
+        appThemeSelectionSchema,
+      ),
       response: jsonResponse<AppTheme>(),
+    }),
+    themes: defineRoute({
+      path: "/settings/themes",
+      method: "get",
+      request: noRequest(),
+      response: jsonResponse<ThemeCatalogResponse>(),
     }),
     reloadConfig: defineRoute({
       path: "/system/config/reload",


### PR DESCRIPTION
## Summary

Moves custom app-theme storage out of the database and onto disk, following the BB `.bb` convention: custom themes now live under **`<data-dir>/theme/<name>/theme.css`** (the packaged app uses `~/.bb/theme/…`), mirroring how user skills live under `<data-dir>/skills/`. The folder name is the palette id.

This is a **breaking change** (as requested): the old `bb theme set-custom --file` path and the DB-stored custom CSS blob are removed. Custom themes are now created/edited by writing the file and selected by name.

### Behavior
- **Discovery/loading**: the server scans `<data-dir>/theme/*/theme.css`, resolves the active theme's CSS from disk, and broadcasts it live. A selected theme whose folder is deleted falls back to the default palette.
- **Server**: `appearance` in `/system/config` is resolved server-side; added `customThemes` to the config and a new `GET /settings/themes` catalog (`{dir, custom, active}`). `PUT /settings/appearance` now takes a theme-id selection and validates it (400 for an unsafe id, 404 for a missing custom theme, with the expected path in the message).
- **CLI**: `theme list` enumerates built-ins + discovered custom themes + the dir; `theme set <id>` accepts a custom theme name; new `theme dir`; removed `theme set-custom`.
- **Settings**: the Palette picker lists discovered custom themes alongside built-ins.
- **DB**: dropped the now-unused `app_theme.custom_css` column (migration `0043`); the table stores only the active selection.
- **Docs/skills**: updated the `bb-cli` skill + theming reference to establish the `.bb/theme/<name>/theme.css` habit and the create/edit/select workflow.

## Tests
- `@bb/db` — 307 passed (incl. migration journal/folder checks validating `0043`).
- `@bb/server` theme tests — 13 passed (`appearance` + new `custom-themes` service: discovery, disk resolve, delete-fallback, size cap, 404 missing, 400 unsafe name).
- Typecheck (Turbo): `@bb/domain`, `@bb/db`, `@bb/server-contract`, `@bb/sdk`, `@bb/server`, `@bb/app`, `@bb/desktop` — all clean.
- Manual QA: ran the dev server, verified the catalog endpoint, `customThemes` in config, the picker lists a sample `sunset` theme, and selection applies live.

## Notes / risks
- Custom theme names are reserved against built-in ids and constrained to a safe single path segment (no `..`/separators); CSS is size-capped to keep the broadcast payload bounded.
- Pre-existing unrelated typecheck failure in `apps/cli/.../thread-open.test.ts` (missing `activity` field from #276) — confirmed present on a clean tree, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)