### PR TITLE
Hide background command launcher rows

### DIFF
--- a/packages/thread-view/src/background-task-projection.ts
+++ b/packages/thread-view/src/background-task-projection.ts
@@ -12,6 +12,7 @@ import type {
 export interface BackgroundTaskProjectionState {
   messages: EventProjectionMessage[];
   backgroundTasksByItemId: Map<string, EventProjectionWorkflowMessage>;
+  backgroundTaskParentToolCallIds: Set<string>;
 }
 
 interface BackgroundTaskLifecycleEvent {
@@ -102,6 +103,10 @@ export function upsertBackgroundTaskMessage(
     return false;
   }
 
+  if (lifecycle.item.parentToolCallId) {
+    state.backgroundTaskParentToolCallIds.add(lifecycle.item.parentToolCallId);
+  }
+
   const existing = state.backgroundTasksByItemId.get(lifecycle.item.id);
   if (existing) {
     applyBackgroundTaskItem(existing, lifecycle, meta);
@@ -140,4 +145,18 @@ export function upsertBackgroundTaskMessage(
   state.backgroundTasksByItemId.set(lifecycle.item.id, message);
   state.messages.push(message);
   return true;
+}
+
+export function filterBackgroundTaskLauncherMessages(
+  state: BackgroundTaskProjectionState,
+): EventProjectionMessage[] {
+  if (state.backgroundTaskParentToolCallIds.size === 0) {
+    return state.messages;
+  }
+
+  return state.messages.filter(
+    (message) =>
+      message.kind !== "command" ||
+      !state.backgroundTaskParentToolCallIds.has(message.callId),
+  );
 }

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -5,6 +5,7 @@ import {
 } from "@bb/domain";
 import { parseCompactionLifecycleEvent } from "./compaction-lifecycle.js";
 import {
+  filterBackgroundTaskLauncherMessages,
   parseBackgroundTaskLifecycleEvent,
   upsertBackgroundTaskMessage,
 } from "./background-task-projection.js";
@@ -745,7 +746,9 @@ function buildFlatProjectionData(
   }
 
   finalizeProjectionState({ state, options: args.options });
-  const messages = sortEventProjectionMessagesBySource(state.messages);
+  const messages = sortEventProjectionMessagesBySource(
+    filterBackgroundTaskLauncherMessages(state),
+  );
   return {
     activeThinking: args.includeActiveThinking
       ? buildProjectionActiveThinking(state, args.options?.threadStatus)

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -110,6 +110,7 @@ export function createProjectionState(): ProjectionState {
     delegatedTurnLinkCallIds: new Set(),
     toolActivity: createToolActivityState(),
     backgroundTasksByItemId: new Map(),
+    backgroundTaskParentToolCallIds: new Set(),
   };
 }
 

--- a/packages/thread-view/test/background-task-timeline.test.ts
+++ b/packages/thread-view/test/background-task-timeline.test.ts
@@ -65,6 +65,19 @@ function findWorkflowRows(rows: TimelineRow[]): TimelineWorkflowWorkRow[] {
   return found;
 }
 
+function findCommandRows(rows: TimelineRow[]): TimelineRow[] {
+  const found: TimelineRow[] = [];
+  for (const row of rows) {
+    if (row.kind === "work" && row.workKind === "command") {
+      found.push(row);
+    }
+    if (row.kind === "turn" && row.children) {
+      found.push(...findCommandRows(row.children));
+    }
+  }
+  return found;
+}
+
 function taskItem(args: {
   taskStatus: ThreadEventBackgroundTaskItem["taskStatus"];
   status: ThreadEventBackgroundTaskItem["status"];
@@ -442,6 +455,102 @@ describe("background task timeline projection", () => {
         'Background command "Count ticks from 1 to 6 with 1 second delays" completed (exit code 0)',
     });
     expect(row.completedAt).not.toBeNull();
+  });
+
+  it("hides the launcher command when a backgrounded shell command has a parent Bash item", () => {
+    const parentToolCallId = "toolu_bash_1";
+    const rows = buildTimelineRows([
+      turnStarted("turn-1", 1),
+      withMeta(
+        {
+          type: "item/started",
+          threadId: "thread-1",
+          providerThreadId: "provider-1",
+          scope: turnScope("turn-1"),
+          item: {
+            type: "commandExecution",
+            id: parentToolCallId,
+            command: "sleep 10",
+            cwd: "",
+            status: "pending",
+            approvalStatus: null,
+          },
+        },
+        2,
+      ),
+      withMeta(
+        {
+          type: "item/started",
+          threadId: "thread-1",
+          providerThreadId: "provider-1",
+          scope: turnScope("turn-1"),
+          item: {
+            ...bashTaskItem({
+              status: "pending",
+              taskStatus: "running",
+              id: "task:bg-1",
+              description: "Sleep for 10 seconds",
+            }),
+            parentToolCallId,
+          },
+        },
+        3,
+      ),
+      withMeta(
+        {
+          type: "item/completed",
+          threadId: "thread-1",
+          providerThreadId: "provider-1",
+          scope: turnScope("turn-1"),
+          item: {
+            type: "commandExecution",
+            id: parentToolCallId,
+            command: "sleep 10",
+            cwd: "",
+            status: "completed",
+            approvalStatus: null,
+            aggregatedOutput:
+              "Command running in background with ID: bg-1. Output is being written to: /tmp/bg-1.output.",
+            exitCode: 0,
+          },
+        },
+        4,
+      ),
+      turnCompleted("turn-1", 5),
+      withMeta(
+        {
+          type: "item/backgroundTask/completed",
+          threadId: "thread-1",
+          providerThreadId: "provider-1",
+          scope: threadScope(),
+          item: {
+            ...bashTaskItem({
+              status: "completed",
+              taskStatus: "completed",
+              id: "task:bg-1",
+              description: "Sleep for 10 seconds",
+              summary:
+                'Background command "Sleep for 10 seconds" completed (exit code 0)',
+            }),
+            parentToolCallId,
+          },
+        },
+        6,
+      ),
+    ]);
+
+    expect(findCommandRows(rows)).toHaveLength(0);
+    const workflowRows = findWorkflowRows(rows);
+    expect(workflowRows).toHaveLength(1);
+    expect(workflowRows[0]).toMatchObject({
+      itemId: "task:bg-1",
+      taskType: "local_bash",
+      status: "completed",
+      taskStatus: "completed",
+      description: "Sleep for 10 seconds",
+      summary:
+        'Background command "Sleep for 10 seconds" completed (exit code 0)',
+    });
   });
 
   it("keeps backgrounded shell commands out of the active-workflow banner", () => {


### PR DESCRIPTION
## Summary
- Track background task parent tool call IDs during thread-view projection
- Filter the linked commandExecution launcher row so a backgrounded Bash command renders once
- Add a regression test for the real Claude background Bash launcher + task event shape

## Validation
- pnpm exec turbo run test --filter=@bb/thread-view
- pnpm exec turbo run typecheck --filter=@bb/thread-view