### PR TITLE
Link Codex delegated child turns to parent tool calls

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -3453,6 +3453,167 @@ describe("codex provider adapter", () => {
     );
   });
 
+  it.each(["spawnAgent", "resumeAgent"] as const)(
+    "stamps pending same-provider child turn events for %s",
+    (tool) => {
+      const adapter = createCodexProviderAdapter();
+
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "parent-turn",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      );
+      adapter.translateEvent(
+        codexEvent("item/started", {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          startedAtMs: 0,
+          item: {
+            type: "collabAgentToolCall",
+            id: "delegation-1",
+            tool,
+            status: "inProgress",
+            senderThreadId: "root-provider-thread",
+            receiverThreadIds: [],
+            prompt: "Inspect the repo",
+            model: null,
+            reasoningEffort: null,
+            agentsStates: {},
+          },
+        }),
+      );
+
+      expect(
+        adapter.translateEvent(
+          codexEvent("turn/started", {
+            threadId: "root-provider-thread",
+            turn: codexTurn({
+              id: "child-turn",
+              status: "inProgress",
+              error: null,
+            }),
+          }),
+        ),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "turn/started",
+          parentToolCallId: "delegation-1",
+          scope: turnScope("child-turn"),
+        }),
+      );
+
+      expect(
+        adapter.translateEvent(
+          codexEvent("item/completed", {
+            threadId: "root-provider-thread",
+            turnId: "child-turn",
+            completedAtMs: 0,
+            item: {
+              type: "agentMessage",
+              id: "child-assistant-1",
+              text: "Child done.",
+              phase: null,
+              memoryCitation: null,
+            },
+          }),
+        ),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "item/completed",
+          item: expect.objectContaining({
+            type: "agentMessage",
+            id: "child-assistant-1",
+            parentToolCallId: "delegation-1",
+          }),
+        }),
+      );
+    },
+  );
+
+  it.each(["spawnAgent", "resumeAgent"] as const)(
+    "stamps explicit receiver-thread child events under the %s call",
+    (tool) => {
+      const adapter = createCodexProviderAdapter();
+
+      adapter.translateEvent(
+        codexEvent("item/completed", {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          completedAtMs: 0,
+          item: {
+            type: "collabAgentToolCall",
+            id: "delegation-1",
+            tool,
+            status: "completed",
+            senderThreadId: "root-provider-thread",
+            receiverThreadIds: ["child-provider-thread"],
+            prompt: "Inspect the docs",
+            model: null,
+            reasoningEffort: null,
+            agentsStates: {
+              "child-provider-thread": {
+                status: "completed",
+                message: "done",
+              },
+            },
+          },
+        }),
+      );
+
+      expect(
+        adapter.translateEvent(
+          codexEvent("turn/started", {
+            threadId: "child-provider-thread",
+            turn: codexTurn({
+              id: "child-turn",
+              status: "inProgress",
+              error: null,
+            }),
+          }),
+        ),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "turn/started",
+          parentToolCallId: "delegation-1",
+          providerThreadId: "child-provider-thread",
+          scope: turnScope("child-turn"),
+        }),
+      );
+
+      expect(
+        adapter.translateEvent(
+          codexEvent("item/completed", {
+            threadId: "child-provider-thread",
+            turnId: "child-turn",
+            completedAtMs: 0,
+            item: {
+              type: "agentMessage",
+              id: "child-assistant-1",
+              text: "Child done.",
+              phase: null,
+              memoryCitation: null,
+            },
+          }),
+        ),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "item/completed",
+          providerThreadId: "child-provider-thread",
+          item: expect.objectContaining({
+            type: "agentMessage",
+            id: "child-assistant-1",
+            parentToolCallId: "delegation-1",
+          }),
+        }),
+      );
+    },
+  );
+
   it("translateEvent item/completed with search maps to webSearch", () => {
     const adapter = createCodexProviderAdapter();
     const events = adapter.translateEvent(

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getBuiltInAgentProviderInfo } from "@bb/agent-providers";
 import {
+  getThreadEventScopeTurnId,
   jsonValueSchema,
   requireThreadEventScopeTurnId,
   turnScope,
@@ -750,6 +751,7 @@ function toCodexDynamicTools(
 // 2. The later normalized `item/completed` commandExecution consumes that
 //    stored state to repair the authoritative final output.
 const CODEX_SHELL_TOOL_NAMES = new Set(["exec_command", "Bash", "bash"]);
+const CODEX_DELEGATION_TOOL_NAMES = new Set(["spawnAgent", "resumeAgent"]);
 const TOOL_OUTPUT_MARKER_LINE = "Output:";
 const TOOL_OUTPUT_METADATA_PREFIXES = [
   "Chunk ID:",
@@ -785,6 +787,111 @@ type CodexParsedCommandOutput =
 interface CodexRawCommandOutputState {
   capturedCommandOutputByCallId: Map<string, CodexCapturedCommandOutput>;
   shellToolCallIds: Set<string>;
+}
+
+interface CodexDelegationToolCall {
+  callId: string;
+  receiverThreadIds: string[];
+}
+
+interface CodexPendingDelegationTurnLink {
+  callId: string;
+  parentTurnId: string;
+}
+
+function collectStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0,
+  );
+}
+
+function getCodexDelegationToolCall(
+  event: ThreadEvent,
+): CodexDelegationToolCall | null {
+  if (
+    (event.type !== "item/started" && event.type !== "item/completed") ||
+    event.item.type !== "toolCall" ||
+    !CODEX_DELEGATION_TOOL_NAMES.has(event.item.tool)
+  ) {
+    return null;
+  }
+
+  return {
+    callId: event.item.id,
+    receiverThreadIds: collectStringArray(
+      event.item.arguments?.receiverThreadIds,
+    ),
+  };
+}
+
+function getCodexEventProviderThreadId(
+  event: ThreadEvent,
+): string | undefined {
+  if (
+    "providerThreadId" in event &&
+    typeof event.providerThreadId === "string" &&
+    event.providerThreadId.length > 0
+  ) {
+    return event.providerThreadId;
+  }
+  return undefined;
+}
+
+function getCodexEventParentToolCallId(
+  event: ThreadEvent,
+): string | undefined {
+  switch (event.type) {
+    case "item/started":
+    case "item/completed":
+      return event.item.parentToolCallId;
+    case "turn/started":
+    case "item/agentMessage/delta":
+    case "item/commandExecution/outputDelta":
+    case "item/fileChange/outputDelta":
+    case "item/reasoning/summaryTextDelta":
+    case "item/reasoning/textDelta":
+    case "item/plan/delta":
+    case "item/mcpToolCall/progress":
+    case "item/toolCall/progress":
+    case "provider/unhandled":
+      return event.parentToolCallId;
+    default:
+      return undefined;
+  }
+}
+
+function withCodexParentToolCallId(
+  event: ThreadEvent,
+  parentToolCallId: string,
+): ThreadEvent {
+  if (getCodexEventParentToolCallId(event)) {
+    return event;
+  }
+
+  switch (event.type) {
+    case "turn/started":
+    case "item/agentMessage/delta":
+    case "item/commandExecution/outputDelta":
+    case "item/fileChange/outputDelta":
+    case "item/reasoning/summaryTextDelta":
+    case "item/reasoning/textDelta":
+    case "item/plan/delta":
+    case "item/mcpToolCall/progress":
+    case "item/toolCall/progress":
+    case "provider/unhandled":
+      return { ...event, parentToolCallId };
+    case "item/started":
+    case "item/completed":
+      return {
+        ...event,
+        item: { ...event.item, parentToolCallId },
+      };
+    default:
+      return event;
+  }
 }
 
 function toCodexRawNotification(
@@ -935,6 +1042,16 @@ export function createCodexProviderAdapter(
     string,
     CodexRawCommandOutputState
   >();
+  const delegationParentToolCallIdsByProviderThreadId = new Map<
+    string,
+    string
+  >();
+  const delegationParentToolCallIdsByTurnId = new Map<string, string>();
+  const pendingDelegationTurnLinksByProviderThreadId = new Map<
+    string,
+    CodexPendingDelegationTurnLink[]
+  >();
+  const pendingDelegationCallIds = new Set<string>();
 
   function stageThreadGitWritableRoots(
     args: RecordThreadGitWritableRootsArgs,
@@ -1057,9 +1174,15 @@ export function createCodexProviderAdapter(
       return;
     }
     rawCommandOutputStateByProviderThreadId.delete(paramsResult.data.threadId);
+    clearCodexDelegationParentState(paramsResult.data.threadId);
     clearGitWritableRootsByProviderThreadId({
       providerThreadId: paramsResult.data.threadId,
     });
+  }
+
+  function clearCodexDelegationParentState(providerThreadId: string): void {
+    delegationParentToolCallIdsByProviderThreadId.delete(providerThreadId);
+    pendingDelegationTurnLinksByProviderThreadId.delete(providerThreadId);
   }
 
   function queueNativeTurnStartClientRequestId(args: {
@@ -1184,6 +1307,148 @@ export function createCodexProviderAdapter(
     }
 
     return [];
+  }
+
+  function enqueuePendingDelegationTurnLink(args: {
+    callId: string;
+    parentTurnId: string | undefined;
+    providerThreadId: string | undefined;
+  }): void {
+    if (!args.providerThreadId || !args.parentTurnId) {
+      return;
+    }
+    if (pendingDelegationCallIds.has(args.callId)) {
+      return;
+    }
+
+    const pendingLinks =
+      pendingDelegationTurnLinksByProviderThreadId.get(args.providerThreadId) ??
+      [];
+    pendingLinks.push({
+      callId: args.callId,
+      parentTurnId: args.parentTurnId,
+    });
+    pendingDelegationTurnLinksByProviderThreadId.set(
+      args.providerThreadId,
+      pendingLinks,
+    );
+    pendingDelegationCallIds.add(args.callId);
+  }
+
+  function consumePendingDelegationTurnLink(args: {
+    providerThreadId: string | undefined;
+    turnId: string;
+  }): string | undefined {
+    if (!args.providerThreadId) {
+      return undefined;
+    }
+    if (delegationParentToolCallIdsByTurnId.has(args.turnId)) {
+      return delegationParentToolCallIdsByTurnId.get(args.turnId);
+    }
+
+    const pendingLinks = pendingDelegationTurnLinksByProviderThreadId.get(
+      args.providerThreadId,
+    );
+    if (!pendingLinks || pendingLinks.length === 0) {
+      return undefined;
+    }
+
+    while (pendingLinks.length > 0) {
+      const pendingLink = pendingLinks.shift();
+      if (!pendingLink || pendingLink.parentTurnId === args.turnId) {
+        continue;
+      }
+      if (pendingLinks.length === 0) {
+        pendingDelegationTurnLinksByProviderThreadId.delete(
+          args.providerThreadId,
+        );
+      }
+      delegationParentToolCallIdsByTurnId.set(
+        args.turnId,
+        pendingLink.callId,
+      );
+      return pendingLink.callId;
+    }
+
+    pendingDelegationTurnLinksByProviderThreadId.delete(
+      args.providerThreadId,
+    );
+    return undefined;
+  }
+
+  function attachCodexDelegationParentLink(event: ThreadEvent): ThreadEvent {
+    const providerThreadId = getCodexEventProviderThreadId(event);
+    const turnId = getThreadEventScopeTurnId(event.scope);
+    let parentToolCallId =
+      getCodexEventParentToolCallId(event) ??
+      (turnId ? delegationParentToolCallIdsByTurnId.get(turnId) : undefined);
+
+    if (!parentToolCallId && event.type === "turn/started") {
+      const startedTurnId = requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      });
+      parentToolCallId =
+        (providerThreadId
+          ? delegationParentToolCallIdsByProviderThreadId.get(providerThreadId)
+          : undefined) ??
+        consumePendingDelegationTurnLink({
+          providerThreadId,
+          turnId: startedTurnId,
+        });
+    }
+
+    if (!parentToolCallId && providerThreadId) {
+      parentToolCallId =
+        delegationParentToolCallIdsByProviderThreadId.get(providerThreadId);
+    }
+
+    if (event.type === "turn/started" && parentToolCallId) {
+      delegationParentToolCallIdsByTurnId.set(
+        requireThreadEventScopeTurnId({
+          type: event.type,
+          scope: event.scope,
+        }),
+        parentToolCallId,
+      );
+    }
+
+    return parentToolCallId
+      ? withCodexParentToolCallId(event, parentToolCallId)
+      : event;
+  }
+
+  function observeCodexDelegationToolCall(event: ThreadEvent): void {
+    const delegationToolCall = getCodexDelegationToolCall(event);
+    if (!delegationToolCall) {
+      return;
+    }
+
+    const providerThreadId = getCodexEventProviderThreadId(event);
+    for (const receiverThreadId of delegationToolCall.receiverThreadIds) {
+      delegationParentToolCallIdsByProviderThreadId.set(
+        receiverThreadId,
+        delegationToolCall.callId,
+      );
+    }
+
+    if (delegationToolCall.receiverThreadIds.length === 0) {
+      enqueuePendingDelegationTurnLink({
+        callId: delegationToolCall.callId,
+        parentTurnId: getThreadEventScopeTurnId(event.scope),
+        providerThreadId,
+      });
+    }
+  }
+
+  function attachCodexDelegationParentLinks(
+    events: ThreadEvent[],
+  ): ThreadEvent[] {
+    return events.map((event) => {
+      const parentLinkedEvent = attachCodexDelegationParentLink(event);
+      observeCodexDelegationToolCall(parentLinkedEvent);
+      return parentLinkedEvent;
+    });
   }
 
   function consumeCodexRawResponseItem(event: ProviderRuntimeEvent): boolean {
@@ -1549,8 +1814,10 @@ export function createCodexProviderAdapter(
       const translatedEvents = translateCodexEvent(event).flatMap(
         attachAcceptedUserMessageCorrelation,
       );
-      reconcileRawCommandOutputLifecycle(translatedEvents);
-      return applyRecoveredCommandOutput(translatedEvents);
+      const parentLinkedEvents =
+        attachCodexDelegationParentLinks(translatedEvents);
+      reconcileRawCommandOutputLifecycle(parentLinkedEvents);
+      return applyRecoveredCommandOutput(parentLinkedEvents);
     },
 
     translateAcceptedCommand({ command, providerThreadId }) {

--- a/packages/agent-runtime/src/runtime-turn-state.test.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.test.ts
@@ -4,11 +4,17 @@ import { turnScope } from "@bb/domain";
 import { RuntimeTurnReplayFilter } from "./runtime-turn-replay-filter.js";
 import { RuntimeTurnState } from "./runtime-turn-state.js";
 
-function turnStarted(turnId: string): ThreadEvent {
+function turnStarted(
+  turnId: string,
+  options: { parentToolCallId?: string } = {},
+): ThreadEvent {
   return {
     type: "turn/started",
     threadId: "t1",
     providerThreadId: "p1",
+    ...(options.parentToolCallId
+      ? { parentToolCallId: options.parentToolCallId }
+      : {}),
     scope: turnScope(turnId),
   };
 }
@@ -38,6 +44,27 @@ describe("RuntimeTurnState", () => {
     state.observe(turnCompleted("turn-1"));
     expect(state.getActiveTurnId("t1")).toBeNull();
     expect(state.getActiveThreadIds()).toEqual([]);
+  });
+
+  it("ignores delegated child turn starts for active foreground state", async () => {
+    vi.useFakeTimers();
+    const state = new RuntimeTurnState();
+
+    const waiter = state.waitForActiveTurn({
+      threadId: "t1",
+      timeoutMs: 100,
+    });
+    state.observe(turnStarted("child-turn", { parentToolCallId: "tool-1" }));
+    vi.advanceTimersByTime(100);
+
+    await expect(waiter).resolves.toBeNull();
+    expect(state.getActiveTurnId("t1")).toBeNull();
+
+    state.observe(turnStarted("root-turn"));
+    state.observe(turnStarted("child-turn", { parentToolCallId: "tool-1" }));
+
+    expect(state.getActiveTurnId("t1")).toBe("root-turn");
+    expect(state.getActiveThreadIds()).toEqual(["t1"]);
   });
 
   it("resolves waitForActiveTurn immediately when a turn is active", async () => {

--- a/packages/agent-runtime/src/runtime-turn-state.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.ts
@@ -72,6 +72,9 @@ export class RuntimeTurnState {
 
   observe(event: ThreadEvent): void {
     if (event.type === "turn/started") {
+      if (event.parentToolCallId) {
+        return;
+      }
       const turnId = requireThreadEventScopeTurnId({
         type: event.type,
         scope: event.scope,

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -50,6 +50,8 @@ import {
 
 const STORED_EVENT_SEQUENCE_LOOKUP_CHUNK_SIZE = 250;
 
+const isRootTurnStartedEventData = sql`COALESCE(json_extract(${events.data}, '$.parentToolCallId'), '') = ''`;
+
 export interface InsertEventInput {
   threadId: string;
   environmentId?: string | null;
@@ -1600,6 +1602,7 @@ export function getActiveStoredTurnId(
         eq(events.threadId, threadId),
         eq(events.type, "turn/started"),
         isNotNull(events.turnId),
+        isRootTurnStartedEventData,
       ),
     )
     .orderBy(desc(events.sequence))
@@ -1695,12 +1698,14 @@ export function listThreadTurnInterruptionEventStates(
         inArray(events.threadId, threadIds),
         eq(events.type, "turn/started"),
         isNotNull(events.turnId),
+        isRootTurnStartedEventData,
         sql`${events.sequence} = (
           SELECT MAX(latest.sequence)
           FROM events AS latest
           WHERE latest.thread_id = ${events.threadId}
             AND latest.type = 'turn/started'
             AND latest.turn_id IS NOT NULL
+            AND COALESCE(json_extract(latest.data, '$.parentToolCallId'), '') = ''
         )`,
         sql`NOT EXISTS (
           SELECT 1

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1344,6 +1344,45 @@ describe("events", () => {
     expect(getActiveStoredTurnId(db, thread.id)).toBeNull();
   });
 
+  it("ignores delegated child turn starts when reconstructing the active stored turn", () => {
+    const { db, thread } = setup();
+
+    appendStoredThreadEvent(db, noopNotifier, {
+      threadId: thread.id,
+      scope: turnScope("root_turn"),
+      providerThreadId: "provider_thr_1",
+      type: "turn/started",
+      data: {
+        providerThreadId: "provider_thr_1",
+      },
+    });
+    appendStoredThreadEvent(db, noopNotifier, {
+      threadId: thread.id,
+      scope: turnScope("child_turn"),
+      providerThreadId: "provider_thr_1",
+      type: "turn/started",
+      data: {
+        providerThreadId: "provider_thr_1",
+        parentToolCallId: "delegation-1",
+      },
+    });
+
+    expect(getActiveStoredTurnId(db, thread.id)).toBe("root_turn");
+
+    appendStoredThreadEvent(db, noopNotifier, {
+      threadId: thread.id,
+      scope: turnScope("root_turn"),
+      providerThreadId: "provider_thr_1",
+      type: "turn/completed",
+      data: {
+        providerThreadId: "provider_thr_1",
+        status: "completed",
+      },
+    });
+
+    expect(getActiveStoredTurnId(db, thread.id)).toBeNull();
+  });
+
   it("appends stored thread events in one transaction with per-thread sequences", () => {
     const { db, project, thread } = setup();
     const otherThread = createThread(db, noopNotifier, {
@@ -1540,6 +1579,52 @@ describe("events", () => {
         activeTurnId: null,
         latestProviderThreadId: null,
         threadId: noEventThread.id,
+      },
+    ]);
+  });
+
+  it("ignores delegated child turn starts for thread interruption active-turn lookup", () => {
+    const { db, thread } = setup();
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        scope: turnScope("root_turn"),
+        providerThreadId: "provider_thr_1",
+        type: "turn/started",
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({
+          providerThreadId: "provider_thr_1",
+          turnId: "root_turn",
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        scope: turnScope("child_turn"),
+        providerThreadId: "provider_thr_1",
+        type: "turn/started",
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({
+          providerThreadId: "provider_thr_1",
+          turnId: "child_turn",
+          parentToolCallId: "delegation-1",
+        }),
+      },
+    ]);
+
+    expect(
+      listThreadTurnInterruptionEventStates(db, {
+        threadIds: [thread.id],
+      }),
+    ).toEqual([
+      {
+        activeTurnId: "root_turn",
+        latestProviderThreadId: "provider_thr_1",
+        threadId: thread.id,
       },
     ]);
   });

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -360,6 +360,7 @@ const unscopedProviderEventSchema = z.discriminatedUnion("type", [
     type: z.literal("turn/started"),
     threadId: z.string(),
     providerThreadId: z.string(),
+    parentToolCallId: z.string().optional(),
   }),
   z.object({
     type: z.literal("turn/completed"),

--- a/packages/domain/test/provider-event.test.ts
+++ b/packages/domain/test/provider-event.test.ts
@@ -63,4 +63,18 @@ describe("provider event schema", () => {
       }),
     ).toThrow();
   });
+
+  it("allows provider turn starts to carry parent tool call ids", () => {
+    expect(
+      threadEventSchema.parse({
+        type: "turn/started",
+        threadId: "thr_child",
+        providerThreadId: "provider-thread-123",
+        parentToolCallId: "tool-call-123",
+        scope: turnScope("turn_child"),
+      }),
+    ).toMatchObject({
+      parentToolCallId: "tool-call-123",
+    });
+  });
 });

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -406,16 +406,20 @@ function buildFlatProjectionData(
         type: decoded.type,
         scope: decoded.scope,
       });
+      const pendingParentToolCallId = consumePendingDelegationTurnLink(
+        state,
+        eventProviderThreadId,
+        turnId,
+      );
       if (explicitEventParentToolCallId) {
         state.delegationParentToolCallIdsByTurnId.set(
           turnId,
           explicitEventParentToolCallId,
         );
-      } else {
-        consumePendingDelegationTurnLink(
-          state,
-          eventProviderThreadId,
+      } else if (pendingParentToolCallId) {
+        state.delegationParentToolCallIdsByTurnId.set(
           turnId,
+          pendingParentToolCallId,
         );
       }
       onTurnStarted(state, turnId);

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -406,11 +406,18 @@ function buildFlatProjectionData(
         type: decoded.type,
         scope: decoded.scope,
       });
-      consumePendingDelegationTurnLink(
-        state,
-        eventProviderThreadId,
-        turnId,
-      );
+      if (explicitEventParentToolCallId) {
+        state.delegationParentToolCallIdsByTurnId.set(
+          turnId,
+          explicitEventParentToolCallId,
+        );
+      } else {
+        consumePendingDelegationTurnLink(
+          state,
+          eventProviderThreadId,
+          turnId,
+        );
+      }
       onTurnStarted(state, turnId);
     }
 

--- a/packages/thread-view/src/event-decode.ts
+++ b/packages/thread-view/src/event-decode.ts
@@ -76,10 +76,10 @@ export function getEventParentToolCallId(
     case "item/mcpToolCall/progress":
     case "item/toolCall/progress":
     case "provider/unhandled":
+    case "turn/started":
       return decoded.parentToolCallId;
     case "thread/started":
     case "thread/identity":
-    case "turn/started":
     case "turn/completed":
     case "turn/input/accepted":
     case "thread/name/updated":

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1264,6 +1264,61 @@ describe("timeline CLI rendering snapshots", () => {
     );
   });
 
+  it("nests persisted child turns from turn started parent ids", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const timeline = renderIdleTimeline([
+      event.turnStarted(),
+      event.toolCallStarted({
+        itemId: "delegation-1",
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Review the branch",
+          receiverThreadIds: ["child-provider"],
+        },
+      }),
+      event.turnStarted({
+        turnId: "child-turn-1",
+        parentToolCallId: "delegation-1",
+      }),
+      event.assistantCompleted({
+        itemId: "child-assistant-1",
+        turnId: "child-turn-1",
+        text: "Child done.",
+      }),
+      event.turnCompleted({ turnId: "child-turn-1" }),
+      event.turnCompleted(),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegation = allRows.find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+    const topLevelChildRows = timeline.rows.filter(
+      (row) => row.turnId === "child-turn-1",
+    );
+
+    expect(topLevelChildRows).toHaveLength(0);
+    expect(delegation?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          role: "assistant",
+          text: "Child done.",
+          turnId: "child-turn-1",
+        }),
+      ]),
+    );
+  });
+
   it("renders pending delegation children as flat rows even with mixed statuses", () => {
     // Regression: a pending delegation whose subagent stream contains a mix
     // of pending, errored, and completed messages must NOT synthesize a

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1319,6 +1319,78 @@ describe("timeline CLI rendering snapshots", () => {
     );
   });
 
+  it("drains pending same-provider links when child turns have explicit parent ids", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const timeline = renderActiveTimeline([
+      event.turnStarted(),
+      event.toolCallStarted({
+        itemId: "delegation-1",
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Review the branch",
+          receiverThreadIds: [],
+        },
+      }),
+      event.turnStarted({
+        turnId: "child-turn-1",
+        parentToolCallId: "delegation-1",
+      }),
+      event.assistantCompleted({
+        itemId: "child-assistant-1",
+        turnId: "child-turn-1",
+        text: "Child done.",
+      }),
+      event.turnCompleted({ turnId: "child-turn-1" }),
+      event.turnCompleted(),
+      event.turnStarted({ turnId: "turn-2" }),
+      event.assistantCompleted({
+        itemId: "root-assistant-2",
+        turnId: "turn-2",
+        text: "Root follow-up is separate.",
+      }),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegation = allRows.find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+    const rootFollowUp = timeline.rows.find(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "assistant" &&
+        row.turnId === "turn-2",
+    );
+
+    expect(delegation?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          role: "assistant",
+          text: "Child done.",
+          turnId: "child-turn-1",
+        }),
+      ]),
+    );
+    expect(
+      delegation?.childRows.some((row) => row.turnId === "turn-2"),
+    ).toBe(false);
+    expect(rootFollowUp).toMatchObject({
+      kind: "conversation",
+      role: "assistant",
+      text: "Root follow-up is separate.",
+      turnId: "turn-2",
+    });
+  });
+
   it("renders pending delegation children as flat rows even with mixed statuses", () => {
     // Regression: a pending delegation whose subagent stream contains a mix
     // of pending, errored, and completed messages must NOT synthesize a

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -70,6 +70,7 @@ export interface EventFactoryRowOptions {
 }
 
 interface ProviderTurnEventOptions extends EventFactoryRowOptions {
+  parentToolCallId?: string;
   providerThreadId?: string;
   turnId?: string;
 }
@@ -924,7 +925,12 @@ export function createTimelineEventFactory(
       return {
         ...base,
         type: "turn/started",
-        data: providerFields(args),
+        data: {
+          ...providerFields(args),
+          ...(args?.parentToolCallId
+            ? { parentToolCallId: args.parentToolCallId }
+            : {}),
+        },
       };
     },
     providerUserMessage(args) {


### PR DESCRIPTION
## Summary
- allow provider `turn/started` events to carry `parentToolCallId`
- track Codex `spawnAgent`/`resumeAgent` calls and stamp explicit receiver-thread and pending same-provider child turns/events with the parent call id
- teach thread-view projection to use `turn/started.parentToolCallId` when nesting persisted child turn messages
- include delegated-child active-turn handling: runtime and DB active-turn reconstruction/interruption lookup ignore child `turn/started` rows with `parentToolCallId`

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/domain`
- `pnpm exec turbo run typecheck --filter=@bb/server-contract`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- `pnpm exec turbo run typecheck --filter=@bb/db`
- `pnpm exec turbo run test --filter=@bb/domain -- test/provider-event.test.ts`
- `pnpm exec turbo run test --filter=@bb/server-contract`
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- src/codex/adapter.test.ts`
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- src/runtime-turn-state.test.ts`
- `pnpm exec turbo run test --filter=@bb/thread-view -- test/timeline-cli-rendering.snapshots.test.ts`
- `pnpm exec turbo run test --filter=@bb/db -- test/data/events.test.ts`