### PR TITLE
Hide side chats from parent and mention pickers

### DIFF
--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -494,6 +494,12 @@ function threadMatchesListFilters(
     return false;
   }
   if (
+    filters?.excludeSideChats &&
+    (thread.originKind ?? thread.childOrigin) === "side-chat"
+  ) {
+    return false;
+  }
+  if (
     filters?.childOrigin !== undefined &&
     (thread.originKind ?? thread.childOrigin) !== filters.childOrigin
   ) {

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -557,4 +557,38 @@ describe("optimisticallyInsertThread", () => {
         ?.map((entry) => entry.id),
     ).toEqual(["fork-1"]);
   });
+
+  it("respects the excludeSideChats filter when inserting source-derived threads", () => {
+    const { queryClient } = createQueryClientTestHarness();
+    const nonSideChatListKey = threadListQueryKey({
+      archived: false,
+      excludeSideChats: true,
+      projectId: "project-1",
+    });
+    queryClient.setQueryData(nonSideChatListKey, []);
+
+    optimisticallyInsertThread(
+      queryClient,
+      makeThreadWithRuntime({
+        id: "side-chat-1",
+        originKind: "side-chat",
+      }),
+    );
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(nonSideChatListKey),
+    ).toEqual([]);
+
+    optimisticallyInsertThread(
+      queryClient,
+      makeThreadWithRuntime({
+        id: "fork-1",
+        originKind: "fork",
+      }),
+    );
+    expect(
+      queryClient
+        .getQueryData<ThreadListEntry[]>(nonSideChatListKey)
+        ?.map((entry) => entry.id),
+    ).toEqual(["fork-1"]);
+  });
 });

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -67,6 +67,7 @@ export interface ThreadListQueryFilters {
   parentThreadId?: string;
   sourceThreadId?: string;
   originKind?: ThreadListFilters["originKind"];
+  excludeSideChats?: ThreadListFilters["excludeSideChats"];
   childOrigin?: ThreadListFilters["childOrigin"];
   archived: boolean;
   limit?: number;

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -113,6 +113,7 @@ export interface UseThreadsFilters extends Omit<
 export interface ProjectThreadSubsetFilters {
   hasParent?: ThreadListFilters["hasParent"];
   parentThreadId?: string;
+  excludeSideChats?: ThreadListFilters["excludeSideChats"];
 }
 
 export interface UseProjectThreadSubsetArgs {
@@ -169,6 +170,7 @@ interface GetThreadMentionCandidatePlaceholderArgs {
 
 const THREAD_MENTION_CANDIDATE_FILTERS = {
   archived: false,
+  excludeSideChats: true,
   limit: THREAD_MENTION_CANDIDATE_LIMIT,
 } satisfies UseThreadsFilters;
 
@@ -193,6 +195,9 @@ function buildThreadSubsetListFilters({
   if (filters.hasParent !== undefined) {
     listFilters.hasParent = filters.hasParent;
   }
+  if (filters.excludeSideChats !== undefined) {
+    listFilters.excludeSideChats = filters.excludeSideChats;
+  }
 
   return listFilters;
 }
@@ -213,6 +218,12 @@ function threadMatchesProjectThreadSubset(
   ) {
     return false;
   }
+  if (
+    filters.excludeSideChats &&
+    (thread.originKind ?? thread.childOrigin) === "side-chat"
+  ) {
+    return false;
+  }
   return true;
 }
 
@@ -230,6 +241,9 @@ function addThreadMentionCandidate(
   thread: ThreadListItem,
 ): void {
   if (thread.archivedAt !== null || thread.deletedAt !== null) {
+    return;
+  }
+  if ((thread.originKind ?? thread.childOrigin) === "side-chat") {
     return;
   }
   if (!candidatesById.has(thread.id)) {
@@ -344,6 +358,7 @@ export function useProjectThreadSubset({
   const enabled = (enabledOption ?? true) && Boolean(projectId);
   useThreadListRealtimeSubscription({ enabled });
   const { hasParent, parentThreadId } = filters;
+  const canDeriveFromActiveProjectThreads = !filters.excludeSideChats;
   const activeProjectThreadListQueryKey =
     enabled && projectId
       ? threadListQueryKey({ archived: false, projectId })
@@ -351,6 +366,7 @@ export function useProjectThreadSubset({
           projectId ? { archived: false, projectId } : { archived: false },
         );
   const activeProjectThreadListIsCached =
+    canDeriveFromActiveProjectThreads &&
     enabled &&
     projectId !== undefined &&
     queryClient.getQueryData<ThreadListResponse>(

--- a/apps/app/src/hooks/threadMentionSuggestions.test.ts
+++ b/apps/app/src/hooks/threadMentionSuggestions.test.ts
@@ -8,6 +8,8 @@ interface ThreadFixtureOptions {
   projectId?: string;
   title: string | null;
   titleFallback?: string | null;
+  originKind?: Thread["originKind"];
+  childOrigin?: Thread["childOrigin"];
 }
 
 interface BuildSuggestionFixtureArgs {
@@ -29,8 +31,8 @@ function makeThread(options: ThreadFixtureOptions): Thread {
     status: "idle",
     parentThreadId: options.parentThreadId ?? null,
     sourceThreadId: null,
-    originKind: null,
-    childOrigin: null,
+    originKind: options.originKind ?? null,
+    childOrigin: options.childOrigin ?? null,
     archivedAt: null,
     pinnedAt: null,
     deletedAt: null,
@@ -121,6 +123,32 @@ describe("buildThreadMentionSuggestions", () => {
         currentThreadId: "thr_current",
       }),
     ).toEqual(["thr_other"]);
+  });
+
+  it("excludes side chats", () => {
+    const threads = [
+      makeThread({
+        id: "thr_parent",
+        title: "Prompt mention improvements",
+      }),
+      makeThread({
+        id: "thr_side_chat",
+        originKind: "side-chat",
+        title: "Prompt mention side chat",
+      }),
+      makeThread({
+        id: "thr_legacy_side_chat",
+        childOrigin: "side-chat",
+        title: "Prompt mention legacy side chat",
+      }),
+    ];
+
+    expect(
+      getSuggestionThreadIds({
+        threads,
+        query: "prompt mention",
+      }),
+    ).toEqual(["thr_parent"]);
   });
 
   it("returns threads with deterministic ties", () => {

--- a/apps/app/src/hooks/threadMentionSuggestions.ts
+++ b/apps/app/src/hooks/threadMentionSuggestions.ts
@@ -55,7 +55,11 @@ function canSuggestThread(
   thread: Thread,
   args: BuildThreadMentionSuggestionsArgs,
 ): boolean {
-  return thread.id !== args.currentThreadId;
+  return thread.id !== args.currentThreadId && !isSideChatThread(thread);
+}
+
+function isSideChatThread(thread: Thread): boolean {
+  return (thread.originKind ?? thread.childOrigin) === "side-chat";
 }
 
 function shouldShowProjectName(

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -833,6 +833,8 @@ export interface ThreadListFilters {
   hasParent?: boolean;
   /** Restrict to threads spawned with this origin (fork or side-chat). */
   originKind?: ThreadChildOrigin;
+  /** Exclude source-derived side-chat threads. */
+  excludeSideChats?: boolean;
   /** @deprecated Use originKind. */
   childOrigin?: ThreadChildOrigin;
   /** App callers must choose active or archived; server omission intentionally means both. */
@@ -869,6 +871,13 @@ export async function listThreads(
             ? { hasParent: toBooleanQueryValue(filters.hasParent) }
             : {}),
           ...(filters.originKind ? { originKind: filters.originKind } : {}),
+          ...(filters.excludeSideChats !== undefined
+            ? {
+                excludeSideChats: toBooleanQueryValue(
+                  filters.excludeSideChats,
+                ),
+              }
+            : {}),
           ...(filters.childOrigin ? { childOrigin: filters.childOrigin } : {}),
           archived: toBooleanQueryValue(filters.archived),
           ...(filters.limit !== undefined

--- a/apps/app/src/lib/lifecycle-errors.test.ts
+++ b/apps/app/src/lib/lifecycle-errors.test.ts
@@ -569,6 +569,22 @@ const descriptionCases: DescriptionCase[] = [
     },
   },
   {
+    name: "parent_thread_invalid side chat",
+    body: {
+      code: "parent_thread_invalid",
+      message: "Parent thread is invalid",
+      details: {
+        reason: "side_chat",
+        subject: "parent",
+      },
+    },
+    expected: {
+      title: "Parent thread unavailable",
+      body: "Choose a parent thread that is not a side chat.",
+      severity: "error",
+    },
+  },
+  {
     name: "parent_thread_invalid sender",
     body: {
       code: "parent_thread_invalid",

--- a/apps/app/src/lib/lifecycle-errors.ts
+++ b/apps/app/src/lib/lifecycle-errors.ts
@@ -405,6 +405,12 @@ function describeParentThreadInvalid({
         title,
         body: "Thread nesting is limited to 4 levels.",
       });
+    case "side_chat":
+      return errorDescription({
+        operation,
+        title,
+        body: "Choose a parent thread that is not a side chat.",
+      });
     default:
       return assertNever(error.details.reason);
   }

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -203,6 +203,9 @@ import { isThreadNewTabKeyboardShortcut } from "./threadDetailNewTabShortcut";
 const EMPTY_PARENT_THREADS: readonly ThreadListEntry[] = [];
 const EMPTY_PROJECT_THREAD_SUBSET_FILTERS =
   {} satisfies ProjectThreadSubsetFilters;
+const PARENT_THREAD_SELECTOR_FILTERS = {
+  excludeSideChats: true,
+} satisfies ProjectThreadSubsetFilters;
 const EMPTY_TERMINAL_SESSIONS: readonly TerminalSession[] = [];
 const DEFAULT_PULL_REQUEST_MERGE_METHOD: PullRequestMergeMethod = "merge";
 const PULL_REQUEST_MERGE_METHOD_STORAGE_KEY =
@@ -662,7 +665,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     threadQueryState.status === "ready" && isThreadRoot;
   const parentThreadSubsetQuery = useProjectThreadSubset({
     enabled: shouldLoadParentThreads,
-    filters: EMPTY_PROJECT_THREAD_SUBSET_FILTERS,
+    filters: PARENT_THREAD_SELECTOR_FILTERS,
     projectId,
   });
   const childThreadSubsetFilters = useMemo<ProjectThreadSubsetFilters>(() => {

--- a/apps/app/src/views/thread-detail/threadParentSelectorOptions.test.ts
+++ b/apps/app/src/views/thread-detail/threadParentSelectorOptions.test.ts
@@ -91,10 +91,37 @@ describe("thread parent selector options", () => {
     ]);
   });
 
+  it("excludes side chats from parent candidates", () => {
+    const options = buildParentSelectorOptions({
+      currentThreadId: "thr_child",
+      parentThreadDisplayName: null,
+      parentThreadId: null,
+      parentThreads: [
+        makeThread({ id: "thr_parent", title: "Parent" }),
+        makeThread({
+          id: "thr_side_chat",
+          originKind: "side-chat",
+          title: "Side chat",
+        }),
+        makeThread({
+          id: "thr_legacy_side_chat",
+          childOrigin: "side-chat",
+          title: "Legacy side chat",
+        }),
+      ],
+    });
+
+    expect(options).toEqual([
+      { value: "none", label: "None" },
+      { value: "thr_parent", label: "Parent" },
+    ]);
+  });
+
   it("only marks root threads as assignable", () => {
     expect(isRootThread(makeThread({ parentThreadId: null }))).toBe(true);
     expect(isRootThread(makeThread({ parentThreadId: "thr_parent" }))).toBe(
       false,
     );
+    expect(isRootThread(makeThread({ originKind: "side-chat" }))).toBe(false);
   });
 });

--- a/apps/app/src/views/thread-detail/threadParentSelectorOptions.ts
+++ b/apps/app/src/views/thread-detail/threadParentSelectorOptions.ts
@@ -8,6 +8,8 @@ export interface ParentSelectorOption {
 interface ThreadAssignmentState {
   id: string;
   parentThreadId: string | null;
+  originKind?: ThreadListEntry["originKind"];
+  childOrigin?: ThreadListEntry["childOrigin"];
 }
 
 interface CollectDescendantThreadIdsArgs {
@@ -25,7 +27,17 @@ export interface BuildParentSelectorOptionsArgs {
 export function isRootThread(
   thread: ThreadAssignmentState | undefined,
 ): boolean {
-  return thread !== undefined && thread.parentThreadId === null;
+  return (
+    thread !== undefined &&
+    thread.parentThreadId === null &&
+    !isSideChatThread(thread)
+  );
+}
+
+function isSideChatThread(
+  thread: Pick<ThreadAssignmentState, "originKind" | "childOrigin">,
+): boolean {
+  return (thread.originKind ?? thread.childOrigin) === "side-chat";
 }
 
 function collectDescendantThreadIds({
@@ -88,6 +100,9 @@ export function buildParentSelectorOptions({
     parentThreadDisplayName ?? "Parent thread",
   );
   for (const parentThread of parentThreads) {
+    if (isSideChatThread(parentThread)) {
+      continue;
+    }
     addOption(
       parentThread.id,
       parentThread.title?.trim() ? parentThread.title : "Parent thread",

--- a/apps/server/src/routes/threads/base.ts
+++ b/apps/server/src/routes/threads/base.ts
@@ -201,6 +201,7 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
       ...(query.parentThreadId ? { parentThreadId: query.parentThreadId } : {}),
       ...(query.sourceThreadId ? { sourceThreadId: query.sourceThreadId } : {}),
       ...(query.originKind ? { originKind: query.originKind } : {}),
+      ...(query.excludeSideChats === "true" ? { excludeSideChats: true } : {}),
       ...(query.childOrigin ? { childOrigin: query.childOrigin } : {}),
       archived:
         query.archived === undefined ? undefined : query.archived === "true",

--- a/apps/server/src/services/threads/thread-parent.ts
+++ b/apps/server/src/services/threads/thread-parent.ts
@@ -24,7 +24,8 @@ export type ParentThread = Pick<
   | "id"
   | "parentThreadId"
   | "projectId"
->;
+> &
+  Partial<Pick<Thread, "originKind" | "childOrigin">>;
 
 export interface IsLiveParentThreadArgs {
   parentThread: ParentThread | null;
@@ -153,6 +154,12 @@ export function assertValidParentThread(
   }
   if (liveParentThread.deletedAt !== null) {
     throwParentThreadInvalid("deleted");
+  }
+  if (
+    (liveParentThread.originKind ?? liveParentThread.childOrigin) ===
+    "side-chat"
+  ) {
+    throwParentThreadInvalid("side_chat");
   }
 
   const parentDepth = resolveParentDepth(deps, {

--- a/apps/server/test/public/public-thread-parenting.test.ts
+++ b/apps/server/test/public/public-thread-parenting.test.ts
@@ -4,6 +4,7 @@ import {
   apiErrorSchema,
   threadArchiveAllResponseSchema,
   threadChildSummaryResponseSchema,
+  threadListResponseSchema,
 } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import { waitForQueuedCommand } from "../helpers/commands.js";
@@ -95,6 +96,45 @@ describe("public thread parenting routes", () => {
       expect(response.status).toBe(200);
       const updatedThread = threadSchema.parse(await readJson(response));
       expect(updatedThread.parentThreadId).toBe(parentThread.id);
+    });
+  });
+
+  it("rejects assigning a side chat as a parent", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const sourceThread = seedThread(harness.deps, {
+        projectId: project.id,
+      });
+      const sideChatThread = seedThread(harness.deps, {
+        originKind: "side-chat",
+        projectId: project.id,
+        sourceThreadId: sourceThread.id,
+      });
+      const childThread = seedThread(harness.deps, {
+        projectId: project.id,
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${childThread.id}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ parentThreadId: sideChatThread.id }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      const error = apiErrorSchema.parse(await readJson(response));
+      expect(error).toMatchObject({
+        code: "parent_thread_invalid",
+        details: {
+          reason: "side_chat",
+          subject: "parent",
+        },
+      });
     });
   });
 
@@ -241,6 +281,46 @@ describe("public thread parenting routes", () => {
       expect(archivedSideChat?.archivedAt).not.toBeNull();
       expect(archivedSideChat?.sourceThreadId).toBe(sourceThread.id);
       expect(archivedSideChat?.parentThreadId).toBeNull();
+    });
+  });
+
+  it("excludes side chats from thread list results when requested", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const sourceThread = seedThread(harness.deps, {
+        projectId: project.id,
+        title: "Source",
+      });
+      const forkThread = seedThread(harness.deps, {
+        originKind: "fork",
+        projectId: project.id,
+        sourceThreadId: sourceThread.id,
+        title: "Fork",
+      });
+      const sideChatThread = seedThread(harness.deps, {
+        originKind: "side-chat",
+        projectId: project.id,
+        sourceThreadId: sourceThread.id,
+        title: "Side chat",
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads?projectId=${project.id}&archived=false&excludeSideChats=true`,
+      );
+
+      expect(response.status).toBe(200);
+      const listedThreads = threadListResponseSchema.parse(
+        await readJson(response),
+      );
+      expect(listedThreads.map((thread) => thread.id).sort()).toEqual(
+        [sourceThread.id, forkThread.id].sort(),
+      );
+      expect(listedThreads.map((thread) => thread.id)).not.toContain(
+        sideChatThread.id,
+      );
     });
   });
 });

--- a/packages/db/src/data/threads.ts
+++ b/packages/db/src/data/threads.ts
@@ -316,6 +316,8 @@ export interface ListThreadsOptions {
   sourceThreadId?: string;
   /** Restrict to threads spawned with this origin (fork or side-chat). */
   originKind?: ThreadOriginKind;
+  /** Exclude source-derived side-chat threads. */
+  excludeSideChats?: boolean;
   /** @deprecated Use originKind. */
   childOrigin?: ThreadChildOrigin;
   limit?: number;
@@ -617,6 +619,18 @@ function buildListThreadsFilters(options: ListThreadsOptions) {
       : undefined,
     originKind
       ? eq(threads.originKind, originKind)
+      : undefined,
+    options.excludeSideChats
+      ? and(
+          or(
+            isNull(threads.originKind),
+            ne(threads.originKind, "side-chat"),
+          ),
+          or(
+            isNull(threads.childOrigin),
+            ne(threads.childOrigin, "side-chat"),
+          ),
+        )
       : undefined,
     options.archived === true
       ? isNotNull(threads.archivedAt)

--- a/packages/db/test/data/threads.test.ts
+++ b/packages/db/test/data/threads.test.ts
@@ -1213,5 +1213,13 @@ describe("thread originKind compatibility", () => {
     expect(all.map((thread) => thread.id).sort()).toEqual(
       [parent.id, fork.id, sideChat.id].sort(),
     );
+
+    const withoutSideChats = listThreads(db, {
+      projectId: project.id,
+      excludeSideChats: true,
+    });
+    expect(withoutSideChats.map((thread) => thread.id).sort()).toEqual(
+      [parent.id, fork.id].sort(),
+    );
   });
 });

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -429,6 +429,8 @@ export const threadListQuerySchema = z.object({
   hasParent: z.enum(["true", "false"]).optional(),
   /** Restrict to threads spawned with this origin (fork or side-chat). */
   originKind: threadOriginKindSchema.optional(),
+  /** Exclude source-derived side-chat threads. */
+  excludeSideChats: z.enum(["true", "false"]).optional(),
   /** @deprecated Use originKind. */
   childOrigin: threadChildOriginSchema.optional(),
   limit: z.string().regex(/^\d+$/).optional(),

--- a/packages/server-contract/src/errors.ts
+++ b/packages/server-contract/src/errors.ts
@@ -126,6 +126,7 @@ export const parentThreadInvalidReasonSchema = z.enum([
   "self",
   "cycle",
   "too_deep",
+  "side_chat",
 ]);
 export type ParentThreadInvalidReason = z.infer<
   typeof parentThreadInvalidReasonSchema

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -182,6 +182,7 @@ const OPTIONAL_SERVER_FIELD_GROUPS: readonly OptionalServerFieldGroup[] = [
     fields: [
       "threadListQuerySchema.archived",
       "threadListQuerySchema.childOrigin",
+      "threadListQuerySchema.excludeSideChats",
       "threadListQuerySchema.limit",
       "threadListQuerySchema.hasParent",
       "threadListQuerySchema.offset",


### PR DESCRIPTION
## Summary
- add a server-side `excludeSideChats` thread-list filter and use it for parent picker and @-mention candidates
- keep side chats out of cached/optimistic picker data and local suggestion helpers
- reject direct attempts to assign a side chat as a parent thread

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/db --filter=@bb/server-contract --force`
- `pnpm exec turbo run test --filter=@bb/app --force -- src/hooks/threadMentionSuggestions.test.ts src/views/thread-detail/threadParentSelectorOptions.test.ts src/hooks/queries/query-helpers.test.ts src/lib/lifecycle-errors.test.ts`
- `pnpm exec turbo run test --filter=@bb/db --force -- test/data/threads.test.ts`
- `pnpm exec turbo run test --filter=@bb/server-contract --force -- test/contract.test.ts`
- `pnpm exec turbo run test --filter=@bb/server --force -- test/public/public-thread-parenting.test.ts`
- `git diff --check`