### PR TITLE
Quiet host daemon health heartbeat

### DIFF
--- a/apps/host-daemon/src/host-daemon-health-monitor.test.ts
+++ b/apps/host-daemon/src/host-daemon-health-monitor.test.ts
@@ -14,7 +14,7 @@ function createMonitorHarness(
   usage: HostDaemonResourceUsage,
   options: { inotifyInstanceWarnThreshold?: number } = {},
 ) {
-  const info = vi.fn();
+  const debug = vi.fn();
   const warn = vi.fn();
   const timer: CapturedTimer = {
     callback: () => undefined,
@@ -22,7 +22,7 @@ function createMonitorHarness(
     unrefed: false,
   };
   const monitor = startHostDaemonHealthMonitor({
-    logger: { info, warn },
+    logger: { debug, warn },
     getWatchCounts: () => ({ workspaceWatches: 3, threadStorageTargets: 5 }),
     readResourceUsage: () => usage,
     inotifyInstanceWarnThreshold: options.inotifyInstanceWarnThreshold,
@@ -38,12 +38,12 @@ function createMonitorHarness(
       };
     },
   });
-  return { info, warn, timer, monitor };
+  return { debug, warn, timer, monitor };
 }
 
 describe("startHostDaemonHealthMonitor", () => {
-  it("logs resource and watch metrics on each tick", () => {
-    const { info, timer } = createMonitorHarness({
+  it("debug-logs resource and watch metrics on each tick", () => {
+    const { debug, timer } = createMonitorHarness({
       rssBytes: 123,
       openFds: 42,
       inotifyInstances: 1,
@@ -52,7 +52,7 @@ describe("startHostDaemonHealthMonitor", () => {
 
     timer.callback();
 
-    expect(info).toHaveBeenCalledWith(
+    expect(debug).toHaveBeenCalledWith(
       {
         rssBytes: 123,
         openFds: 42,
@@ -96,7 +96,7 @@ describe("startHostDaemonHealthMonitor", () => {
     });
     unavailable.timer.callback();
     expect(unavailable.warn).not.toHaveBeenCalled();
-    expect(unavailable.info).toHaveBeenCalledTimes(1);
+    expect(unavailable.debug).toHaveBeenCalledTimes(1);
   });
 
   it("stops the interval timer on stop()", () => {

--- a/apps/host-daemon/src/host-daemon-health-monitor.ts
+++ b/apps/host-daemon/src/host-daemon-health-monitor.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import type { HostDaemonLogger } from "./logger.js";
 
 /**
- * Periodically logs host-daemon resource and watch metrics so a leak or wedge
+ * Periodically debug-logs host-daemon resource and watch metrics so a leak or wedge
  * is visible in the logs after the fact instead of needing a live post-mortem.
  *
  * The headline signal is the inotify instance count. `@parcel/watcher` shares a
@@ -39,7 +39,7 @@ export interface HostDaemonResourceUsage {
 }
 
 interface HostDaemonHealthMonitorOptions {
-  logger: Pick<HostDaemonLogger, "info" | "warn">;
+  logger: Pick<HostDaemonLogger, "debug" | "warn">;
   getWatchCounts: () => HostDaemonWatchCounts;
   readResourceUsage?: () => HostDaemonResourceUsage;
   setIntervalFn?: HostDaemonHealthMonitorIntervalFn;
@@ -120,7 +120,7 @@ export function startHostDaemonHealthMonitor(
       workspaceWatches: watchCounts.workspaceWatches,
       threadStorageTargets: watchCounts.threadStorageTargets,
     };
-    options.logger.info(fields, "Host daemon health");
+    options.logger.debug(fields, "Host daemon health");
     if (
       usage.inotifyInstances !== null &&
       usage.inotifyInstances > inotifyInstanceWarnThreshold


### PR DESCRIPTION
## Summary
- move the periodic host daemon health heartbeat from info to debug
- keep high inotify watcher leak warnings visible at warn
- update the focused monitor test to assert debug telemetry

## Tests
- pnpm exec turbo run test --filter=@bb/host-daemon -- host-daemon-health-monitor.test.ts
- pnpm exec turbo run typecheck --filter=@bb/host-daemon