### PR TITLE
Fix Codex same-provider delegation follow-up nesting

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -3535,6 +3535,172 @@ describe("codex provider adapter", () => {
     },
   );
 
+  it("does not inherit a same-provider delegation link onto a later human turn", () => {
+    const adapter = createCodexProviderAdapter();
+    const providerThreadId = "root-provider-thread";
+    const parentToolCallId = "call_MV1jTrxEd9bsYdEXQo1PhVOs";
+
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: providerThreadId,
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("item/started", {
+        threadId: providerThreadId,
+        turnId: "parent-turn",
+        startedAtMs: 0,
+        item: {
+          type: "collabAgentToolCall",
+          id: parentToolCallId,
+          tool: "spawnAgent",
+          status: "inProgress",
+          senderThreadId: providerThreadId,
+          receiverThreadIds: [providerThreadId],
+          prompt: "Run the child command",
+          model: null,
+          reasoningEffort: null,
+          agentsStates: {},
+        },
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: providerThreadId,
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: providerThreadId,
+          turn: codexTurn({
+            id: "child-turn",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        parentToolCallId,
+        scope: turnScope("child-turn"),
+      }),
+    );
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("item/started", {
+          threadId: providerThreadId,
+          turnId: "child-turn",
+          startedAtMs: 0,
+          item: {
+            type: "commandExecution",
+            id: "child-command",
+            command:
+              "/bin/zsh -lc 'sleep 20; echo CHILD_REAL_PROVIDER_DONE'",
+            cwd: "/tmp",
+            processId: null,
+            source: "agent",
+            status: "inProgress",
+            commandActions: [],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null,
+          },
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({
+          type: "commandExecution",
+          id: "child-command",
+          parentToolCallId,
+        }),
+      }),
+    );
+
+    const followUpTurnEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: providerThreadId,
+        turn: codexTurn({
+          id: "follow-up-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    const followUpTurnStarted = followUpTurnEvents.find(
+      (event) => event.type === "turn/started",
+    );
+    expect(followUpTurnStarted).toEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("follow-up-turn"),
+      }),
+    );
+    expect(followUpTurnStarted).not.toHaveProperty("parentToolCallId");
+
+    const followUpAssistantEvents = adapter.translateEvent(
+      codexEvent("item/completed", {
+        threadId: providerThreadId,
+        turnId: "follow-up-turn",
+        completedAtMs: 0,
+        item: {
+          type: "agentMessage",
+          id: "follow-up-assistant",
+          text: "follow-up done",
+          phase: null,
+          memoryCitation: null,
+        },
+      }),
+    );
+    const followUpAssistant = followUpAssistantEvents.find(
+      (event) =>
+        event.type === "item/completed" &&
+        event.item.type === "agentMessage",
+    );
+    expect(followUpAssistant).toEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "agentMessage",
+          id: "follow-up-assistant",
+        }),
+      }),
+    );
+    expect(followUpAssistant).not.toHaveProperty("item.parentToolCallId");
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("item/commandExecution/outputDelta", {
+          threadId: providerThreadId,
+          turnId: "child-turn",
+          itemId: "child-command",
+          delta: "CHILD_REAL_PROVIDER_DONE\n",
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "item/commandExecution/outputDelta",
+        parentToolCallId,
+        scope: turnScope("child-turn"),
+      }),
+    );
+  });
+
   it.each(["spawnAgent", "resumeAgent"] as const)(
     "stamps explicit receiver-thread child events under the %s call",
     (tool) => {

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -792,6 +792,7 @@ interface CodexRawCommandOutputState {
 interface CodexDelegationToolCall {
   callId: string;
   receiverThreadIds: string[];
+  senderThreadId?: string;
 }
 
 interface CodexPendingDelegationTurnLink {
@@ -824,6 +825,11 @@ function getCodexDelegationToolCall(
     receiverThreadIds: collectStringArray(
       event.item.arguments?.receiverThreadIds,
     ),
+    senderThreadId:
+      typeof event.item.arguments?.senderThreadId === "string" &&
+      event.item.arguments.senderThreadId.length > 0
+        ? event.item.arguments.senderThreadId
+        : undefined,
   };
 }
 
@@ -1426,6 +1432,17 @@ export function createCodexProviderAdapter(
 
     const providerThreadId = getCodexEventProviderThreadId(event);
     for (const receiverThreadId of delegationToolCall.receiverThreadIds) {
+      if (
+        receiverThreadId === providerThreadId ||
+        receiverThreadId === delegationToolCall.senderThreadId
+      ) {
+        enqueuePendingDelegationTurnLink({
+          callId: delegationToolCall.callId,
+          parentTurnId: getThreadEventScopeTurnId(event.scope),
+          providerThreadId,
+        });
+        continue;
+      }
       delegationParentToolCallIdsByProviderThreadId.set(
         receiverThreadId,
         delegationToolCall.callId,

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -288,6 +288,20 @@ function getToolCallReceiverThreadIds(decoded: ThreadEvent): string[] {
   );
 }
 
+function getToolCallSenderThreadId(decoded: ThreadEvent): string | undefined {
+  if (
+    (decoded.type !== "item/started" && decoded.type !== "item/completed") ||
+    decoded.item.type !== "toolCall"
+  ) {
+    return undefined;
+  }
+
+  const senderThreadId = decoded.item.arguments?.senderThreadId;
+  return typeof senderThreadId === "string" && senderThreadId.length > 0
+    ? senderThreadId
+    : undefined;
+}
+
 function enqueuePendingDelegationTurnLink(
   state: ProjectionState,
   providerThreadId: string | undefined,
@@ -573,6 +587,7 @@ function buildFlatProjectionData(
     if (toolCallEvent) {
       const toolCallName = getToolCallName(decoded);
       const toolCallReceiverThreadIds = getToolCallReceiverThreadIds(decoded);
+      const toolCallSenderThreadId = getToolCallSenderThreadId(decoded);
       if (toolCallEvent.kind !== "output") {
         if (
           !toolCallEvent.call.parentToolCallId &&
@@ -610,6 +625,18 @@ function buildFlatProjectionData(
             );
           }
           for (const receiverThreadId of toolCallReceiverThreadIds) {
+            if (
+              receiverThreadId === eventProviderThreadId ||
+              receiverThreadId === toolCallSenderThreadId
+            ) {
+              enqueuePendingDelegationTurnLink(
+                state,
+                eventProviderThreadId,
+                eventTurnId,
+                toolCallEvent.call.callId,
+              );
+              continue;
+            }
             state.delegationParentToolCallIdsByProviderThreadId.set(
               receiverThreadId,
               toolCallEvent.call.callId,

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1202,6 +1202,85 @@ describe("timeline CLI rendering snapshots", () => {
     });
   });
 
+  it("does not attach later human turns to Codex same-provider receiver delegations", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "parent-turn",
+    });
+    const parentToolCallId = "call_MV1jTrxEd9bsYdEXQo1PhVOs";
+    const timeline = renderActiveTimeline([
+      event.turnStarted(),
+      event.toolCallStarted({
+        itemId: parentToolCallId,
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Run the child command",
+          senderThreadId: "root-provider",
+          receiverThreadIds: ["root-provider"],
+        },
+      }),
+      event.turnCompleted(),
+      event.turnStarted({
+        turnId: "child-turn",
+        parentToolCallId,
+      }),
+      event.commandStarted({
+        itemId: "child-command",
+        turnId: "child-turn",
+        command: "/bin/zsh -lc 'sleep 20; echo CHILD_REAL_PROVIDER_DONE'",
+      }),
+      event.turnStarted({ turnId: "follow-up-turn" }),
+      event.assistantCompleted({
+        itemId: "follow-up-assistant",
+        turnId: "follow-up-turn",
+        text: "follow-up done",
+      }),
+      event.commandCompleted({
+        itemId: "child-command",
+        turnId: "child-turn",
+        command: "/bin/zsh -lc 'sleep 20; echo CHILD_REAL_PROVIDER_DONE'",
+        aggregatedOutput: "CHILD_REAL_PROVIDER_DONE\n",
+      }),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegation = allRows.find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+    const rootFollowUp = timeline.rows.find(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "assistant" &&
+        row.turnId === "follow-up-turn",
+    );
+
+    expect(delegation).toBeDefined();
+    expect(delegation?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "work",
+          workKind: "command",
+          turnId: "child-turn",
+        }),
+      ]),
+    );
+    expect(
+      delegation?.childRows.some((row) => row.turnId === "follow-up-turn"),
+    ).toBe(false);
+    expect(rootFollowUp).toMatchObject({
+      kind: "conversation",
+      role: "assistant",
+      text: "follow-up done",
+      turnId: "follow-up-turn",
+    });
+  });
+
   it("keeps streaming Codex same-provider child turns out of top-level rows", () => {
     const event = createTimelineEventFactory({
       providerThreadId: "root-provider",


### PR DESCRIPTION
## Summary
- Treat Codex same-provider delegation receiver ids as one-turn pending child links instead of provider-thread-wide parent links.
- Mirror the same guard in thread-view projection so rebuilt timelines do not re-nest later human turns.
- Add adapter and timeline regressions for the real-provider repro shape.

## Validation
- pnpm exec turbo run test --filter=@bb/agent-runtime -- src/codex/adapter.test.ts -t "does not inherit a same-provider delegation link"
- pnpm exec turbo run test --filter=@bb/thread-view -- test/timeline-cli-rendering.snapshots.test.ts -t "does not attach later human turns to Codex same-provider receiver delegations"
- pnpm exec turbo run typecheck --filter=@bb/agent-runtime
- pnpm exec turbo run typecheck --filter=@bb/thread-view
- pnpm exec turbo run test --filter=@bb/agent-runtime
- pnpm exec turbo run test --filter=@bb/thread-view