### PR TITLE
Remove stale CLI thread activity fixture field

### DIFF
--- a/apps/cli/src/__tests__/command-output/thread-open.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-open.test.ts
@@ -36,7 +36,6 @@ function makeThreadEntry(args: ThreadEntryArgs): ThreadListEntry {
     hasPendingInteraction: false,
     activity: {
       activeWorkflowCount: 0,
-      activeBackgroundSubagentCount: 0,
     },
     environmentHostId: args.environmentId ? "host-test-001" : null,
     environmentName: null,


### PR DESCRIPTION
## Summary
- Remove stale activeBackgroundSubagentCount from the CLI thread open test fixture.
- Confirm no remaining activeBackgroundSubagentCount references.

## Validation
- pnpm exec turbo run typecheck --filter=@bb/cli