### PR TITLE
Keep accepted root turns out of stale delegation projections

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -3561,11 +3561,35 @@ describe("codex provider adapter", () => {
           tool: "spawnAgent",
           status: "inProgress",
           senderThreadId: providerThreadId,
-          receiverThreadIds: [providerThreadId],
+          receiverThreadIds: [],
           prompt: "Run the child command",
           model: null,
           reasoningEffort: null,
           agentsStates: {},
+        },
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("item/completed", {
+        threadId: providerThreadId,
+        turnId: "parent-turn",
+        completedAtMs: 0,
+        item: {
+          type: "collabAgentToolCall",
+          id: parentToolCallId,
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: providerThreadId,
+          receiverThreadIds: ["child-provider-thread"],
+          prompt: "Run the child command",
+          model: "gpt-5.5",
+          reasoningEffort: "medium",
+          agentsStates: {
+            "child-provider-thread": {
+              status: "pendingInit",
+              message: null,
+            },
+          },
         },
       }),
     );
@@ -3631,6 +3655,15 @@ describe("codex provider adapter", () => {
         }),
       }),
     );
+
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId,
+      clientRequestId: "creq_followup",
+      input: [promptTextInput({ text: "follow-up" })],
+      options: fullProviderExecutionContext,
+    });
 
     const followUpTurnEvents = adapter.translateEvent(
       codexEvent("turn/started", {

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -221,6 +221,32 @@ function buildSelectedStartedTurnIds(
   return turnIds;
 }
 
+function buildAcceptedRootClientTurnIds(
+  events: ThreadEventWithMeta[],
+  clientRequestById: ReadonlyMap<string, ClientTurnRequestedWithMeta>,
+): ReadonlySet<string> {
+  const turnIds = new Set<string>();
+  for (const { event } of events) {
+    if (event.type !== "turn/input/accepted") {
+      continue;
+    }
+    const request = clientRequestById.get(event.clientRequestId);
+    if (
+      request?.event.target.kind !== "new-turn" &&
+      request?.event.target.kind !== "thread-start"
+    ) {
+      continue;
+    }
+    turnIds.add(
+      requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      }),
+    );
+  }
+  return turnIds;
+}
+
 function canUseAcceptedClientRequestForVisibleProjection(
   acceptedClientRequest: AcceptedClientRequest,
   decoded: ClientTurnRequestedEvent,
@@ -409,46 +435,60 @@ function buildFlatProjectionData(
   });
   const clientRequestById = buildClientTurnRequestById(orderedEvents);
   const selectedStartedTurnIds = buildSelectedStartedTurnIds(orderedEvents);
+  const acceptedRootClientTurnIds = buildAcceptedRootClientTurnIds(
+    orderedEvents,
+    clientRequestById,
+  );
   for (const { event: decoded, meta } of orderedEvents) {
     const eventType = decoded.type;
     const eventTurnId = getEventTurnId(decoded);
     const eventProviderThreadId = getEventProviderThreadId(decoded);
-    const explicitEventParentToolCallId = getEventParentToolCallId(decoded);
+    const isAcceptedRootClientTurn =
+      typeof eventTurnId === "string" &&
+      acceptedRootClientTurnIds.has(eventTurnId);
+    const explicitEventParentToolCallId = isAcceptedRootClientTurn
+      ? undefined
+      : getEventParentToolCallId(decoded);
 
     if (decoded.type === "turn/started") {
       const turnId = requireThreadEventScopeTurnId({
         type: decoded.type,
         scope: decoded.scope,
       });
-      const pendingParentToolCallId = consumePendingDelegationTurnLink(
-        state,
-        eventProviderThreadId,
-        turnId,
-      );
-      if (explicitEventParentToolCallId) {
-        state.delegationParentToolCallIdsByTurnId.set(
+      if (isAcceptedRootClientTurn) {
+        state.delegationParentToolCallIdsByTurnId.delete(turnId);
+      } else {
+        const pendingParentToolCallId = consumePendingDelegationTurnLink(
+          state,
+          eventProviderThreadId,
           turnId,
-          explicitEventParentToolCallId,
         );
-      } else if (pendingParentToolCallId) {
-        state.delegationParentToolCallIdsByTurnId.set(
-          turnId,
-          pendingParentToolCallId,
-        );
+        if (explicitEventParentToolCallId) {
+          state.delegationParentToolCallIdsByTurnId.set(
+            turnId,
+            explicitEventParentToolCallId,
+          );
+        } else if (pendingParentToolCallId) {
+          state.delegationParentToolCallIdsByTurnId.set(
+            turnId,
+            pendingParentToolCallId,
+          );
+        }
       }
       onTurnStarted(state, turnId);
     }
 
-    const eventParentToolCallId =
-      explicitEventParentToolCallId ??
-      (eventTurnId
-        ? state.delegationParentToolCallIdsByTurnId.get(eventTurnId)
-        : undefined) ??
-      (eventProviderThreadId
-        ? state.delegationParentToolCallIdsByProviderThreadId.get(
-            eventProviderThreadId,
-          )
-        : undefined);
+    const eventParentToolCallId = isAcceptedRootClientTurn
+      ? undefined
+      : (explicitEventParentToolCallId ??
+        (eventTurnId
+          ? state.delegationParentToolCallIdsByTurnId.get(eventTurnId)
+          : undefined) ??
+        (eventProviderThreadId
+          ? state.delegationParentToolCallIdsByProviderThreadId.get(
+              eventProviderThreadId,
+            )
+          : undefined));
 
     const compactionTurnFinalization = getCompactionTurnFinalization(decoded);
     if (compactionTurnFinalization) {

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1281,6 +1281,115 @@ describe("timeline CLI rendering snapshots", () => {
     });
   });
 
+  it("keeps accepted human turns top-level when persisted Codex child links are stale", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "parent-turn",
+    });
+    const parentToolCallId = "call_XLYYu5d3CKM9X51TRxrIJauc";
+    const followUpRequest = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Queued follow-up during delegated child work.",
+    });
+    const timeline = renderActiveTimeline([
+      event.turnStarted(),
+      event.toolCallStarted({
+        itemId: parentToolCallId,
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Run the child command",
+          senderThreadId: "root-provider",
+          receiverThreadIds: [],
+        },
+      }),
+      event.toolCallCompleted({
+        itemId: parentToolCallId,
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Run the child command",
+          senderThreadId: "root-provider",
+          receiverThreadIds: ["child-provider-thread"],
+        },
+        result: {
+          "child-provider-thread": {
+            status: "pendingInit",
+            message: null,
+          },
+        },
+      }),
+      event.turnStarted({
+        turnId: "child-turn",
+        parentToolCallId,
+      }),
+      event.commandStarted({
+        itemId: "child-command",
+        turnId: "child-turn",
+        command: "/bin/zsh -lc 'sleep 20; echo CHILD_REAL_PROVIDER_DONE'",
+        parentToolCallId,
+      }),
+      event.turnCompleted({ turnId: "parent-turn" }),
+      followUpRequest,
+      event.turnStarted({
+        turnId: "follow-up-turn",
+        parentToolCallId,
+      }),
+      event.inputAccepted({
+        clientRequestId: followUpRequest.data.requestId,
+        turnId: "follow-up-turn",
+      }),
+      event.assistantCompleted({
+        itemId: "follow-up-assistant",
+        turnId: "follow-up-turn",
+        text: "follow-up done",
+        parentToolCallId,
+      }),
+      event.commandCompleted({
+        itemId: "child-command",
+        turnId: "child-turn",
+        command: "/bin/zsh -lc 'sleep 20; echo CHILD_REAL_PROVIDER_DONE'",
+        aggregatedOutput: "CHILD_REAL_PROVIDER_DONE\n",
+        parentToolCallId,
+      }),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegation = allRows.find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+    const rootFollowUp = timeline.rows.find(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "assistant" &&
+        row.turnId === "follow-up-turn",
+    );
+
+    expect(delegation).toBeDefined();
+    expect(delegation?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "work",
+          workKind: "command",
+          turnId: "child-turn",
+        }),
+      ]),
+    );
+    expect(
+      delegation?.childRows.some((row) => row.turnId === "follow-up-turn"),
+    ).toBe(false);
+    expect(rootFollowUp).toMatchObject({
+      kind: "conversation",
+      role: "assistant",
+      text: "follow-up done",
+      turnId: "follow-up-turn",
+    });
+  });
+
   it("keeps streaming Codex same-provider child turns out of top-level rows", () => {
     const event = createTimelineEventFactory({
       providerThreadId: "root-provider",


### PR DESCRIPTION
## Summary
- Keep accepted root client turns (`new-turn` / `thread-start`) out of stale delegation parent inference during timeline rebuilds.
- Add a regression for the real Codex shape where a same-provider delegated child is still running, a later human new-turn is accepted, and persisted events still carry stale `parentToolCallId` values.
- Tighten the Codex adapter regression to match the live `spawnAgent` lifecycle shape: empty receivers on start, receiver populated on completion, then a later prepared root turn.

## Real repro
In isolated dev app on current main after #315, `thr_s8z4i7iau5` showed:
- child command started under `call_XLYYu5d3CKM9X51TRxrIJauc`
- later user follow-up was accepted while child work continued
- persisted follow-up turn/assistant carried stale `parentToolCallId`
- timeline nested `queued done` under the earlier subagent

After this change, the same stored real-provider thread renders `queued done` as a top-level assistant response after the follow-up user message, while the actual child command/`child done` stay nested under the subagent.

## Validation
- `pnpm exec turbo run test --filter=@bb/thread-view -- test/timeline-cli-rendering.snapshots.test.ts -t "keeps accepted human turns top-level"`
- `pnpm exec turbo run test --filter=@bb/thread-view -- test/timeline-cli-rendering.snapshots.test.ts -t "Codex same-provider|accepted human turns|persisted child turns|pending same-provider"`
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- `pnpm exec turbo run test --filter=@bb/thread-view`
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- src/codex/adapter.test.ts -t "does not inherit a same-provider delegation link"`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
