### PR TITLE
Redesign landing hero install CTA and fix oklch color drift

### DIFF
--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import {
+  AppleIcon,
   ArrowDown01Icon,
   ArrowExpand01Icon,
   ArrowLeft01Icon,
@@ -76,7 +77,10 @@ function GitHubLink({ placement, className, children }: CtaLinkProps) {
   );
 }
 
-function InstallCommand({ placement }: { placement: CtaPlacement }) {
+// The browser install path, rendered as an outline button whose body is the
+// run command. Clicking anywhere copies it (there's no hosted URL to open —
+// the command starts bb locally and opens it in the browser).
+function RunCommandButton({ placement }: { placement: CtaPlacement }) {
   const [copied, setCopied] = useState(false);
   const copy = () => {
     // Track and show feedback first; the clipboard write can reject (no user
@@ -90,16 +94,52 @@ function InstallCommand({ placement }: { placement: CtaPlacement }) {
     navigator.clipboard.writeText(CLI_COMMAND).catch(() => {});
   };
   return (
-    <div className="install mono">
-      <span className="dollar">$</span>
-      <span>{CLI_COMMAND}</span>
-      <button
-        type="button"
-        className={copied ? "copied" : undefined}
-        onClick={copy}
+    <button
+      type="button"
+      className={
+        copied
+          ? "btn btn-ghost btn-install cmd-btn copied"
+          : "btn btn-ghost btn-install cmd-btn"
+      }
+      onClick={copy}
+      aria-label={`Copy browser install command: ${CLI_COMMAND}`}
+    >
+      <span className="cmd-dollar">$</span>
+      <span className="cmd-text">{CLI_COMMAND}</span>
+      <span className="cmd-copy">Copy</span>
+      {/* Toast floats above the button (absolute) so confirming the copy never
+          reflows the centered CTA row — the label stays a fixed width. */}
+      <span
+        className={copied ? "cmd-toast show" : "cmd-toast"}
+        aria-hidden="true"
       >
-        {copied ? "✓ Copied" : "Copy"}
-      </button>
+        Copied to clipboard
+      </span>
+    </button>
+  );
+}
+
+function InstallOptions({ placement }: { placement: CtaPlacement }) {
+  return (
+    <div className="install-options">
+      <div className="install-actions">
+        <span className="install-choice">
+          <DownloadLink
+            placement={placement}
+            className="btn btn-primary btn-install"
+          >
+            <HugeiconsIcon icon={AppleIcon} className="btn-ic" />
+            Download for macOS
+          </DownloadLink>
+          <span className="install-note">One-click, no terminal</span>
+        </span>
+        <span className="install-choice">
+          <RunCommandButton placement={placement} />
+          <span className="install-note">
+            Windows, Linux &amp; remote machines
+          </span>
+        </span>
+      </div>
     </div>
   );
 }
@@ -1420,16 +1460,7 @@ function LandingPage() {
           and automations drive it for you.
         </p>
 
-        <div className="cta-row">
-          <DownloadLink placement="hero" className="btn btn-primary">
-            Download for macOS
-          </DownloadLink>
-          <GitHubLink placement="hero" className="btn btn-ghost">
-            Star on GitHub
-          </GitHubLink>
-        </div>
-
-        <InstallCommand placement="hero" />
+        <InstallOptions placement="hero" />
 
         <div className="providers">
           <span className="label">Works with</span>
@@ -1497,10 +1528,8 @@ function LandingPage() {
       <section className="closer" data-reveal>
         <h2 className="sec-title">Start your first loop.</h2>
         <p>Free, open source, and local-first. Install in under a minute.</p>
-        <div className="cta-row">
-          <DownloadLink placement="closer" className="btn btn-primary">
-            Download for macOS
-          </DownloadLink>
+        <InstallOptions placement="closer" />
+        <div className="cta-row cta-row-secondary">
           <GitHubLink placement="closer" className="btn btn-ghost">
             View on GitHub
           </GitHubLink>

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -1,7 +1,10 @@
 /* bb landing — editorial light, themed to match the bb app.
-   Tokens mirror apps/app/src/components/ui/theme.css: neutral zero-chroma
-   oklch grays, inverted-neutral primary button, a single restrained blue
-   accent, Inter Variable. */
+   Tokens mirror apps/app/src/components/ui/theme.css: a neutral zero-chroma
+   ink-over-canvas ramp, inverted-neutral primary button, and the app's own
+   chromatic tokens (file-accent, success, diff-added/removed, warning-text).
+   All color-mix() interpolation is done `in oklab` (rectangular), never
+   `in oklch` (polar) — mixing a chromatic accent toward white in oklch
+   interpolates the hue through pink; oklab keeps the hue put. */
 
 /* Metric-adjusted fallback (Arial sized to Inter) shown until Inter loads, so
    text — the large hero title especially — doesn't reflow/snap when the web
@@ -20,19 +23,17 @@
   --ink: oklch(0.3211 0 0);
   --dim: oklch(0.44 0 0);
   --subtle: oklch(0.5 0 0);
-  --border: color-mix(in oklch, var(--ink) 14%, var(--bg));
-  --border-soft: color-mix(in oklch, var(--ink) 8%, var(--bg));
-  --surface: color-mix(in oklch, var(--ink) 3.5%, var(--bg));
-  --surface-recessed: color-mix(in oklch, var(--ink) 6%, var(--bg));
-  --state-hover: color-mix(in oklch, var(--ink) 5.9%, var(--bg));
-  --accent: oklch(0.55 0.1 250);
-  --ok: oklch(0.6 0.13 150);
-  --warn: oklch(0.64 0.13 65);
-  --add: oklch(0.55 0.14 150);
-  --del: oklch(0.55 0.19 25);
-  --spark: oklch(0.64 0.17 45);
-  --code-green: oklch(0.52 0.13 150);
-  --code-str: oklch(0.52 0.1 50);
+  --border: color-mix(in oklab, var(--ink) 14%, var(--bg));
+  --border-soft: color-mix(in oklab, var(--ink) 8%, var(--bg));
+  --surface: color-mix(in oklab, var(--ink) 3.5%, var(--bg));
+  --surface-recessed: color-mix(in oklab, var(--ink) 6%, var(--bg));
+  --state-hover: color-mix(in oklab, var(--ink) 5.9%, var(--bg));
+  /* Chromatic tokens pulled straight from the app's light theme. */
+  --accent: oklch(0.55 0.1 250); /* --file-accent (paper blue) */
+  --ok: oklch(0.7 0.15 155); /* --success */
+  --add: oklch(0.4 0.13 163); /* --diff-added */
+  --del: oklch(0.4 0.17 28); /* --diff-removed */
+  --spark: oklch(0.55 0.14 50); /* --warning-text */
   --radius: 0.5rem;
   --font-sans:
     "Inter Variable", "Inter Fallback", Inter, -apple-system,
@@ -154,8 +155,8 @@ code,
 }
 
 .btn-primary:hover {
-  background: color-mix(in oklch, var(--ink) 90%, var(--bg));
-  box-shadow: 0 4px 14px color-mix(in oklch, var(--ink) 18%, transparent);
+  background: color-mix(in oklab, var(--ink) 90%, var(--bg));
+  box-shadow: 0 4px 14px color-mix(in oklab, var(--ink) 18%, transparent);
 }
 
 .btn-ghost {
@@ -179,6 +180,130 @@ code,
   flex-wrap: wrap;
 }
 
+.cta-row-secondary {
+  margin-top: 18px;
+}
+
+/* Two equal-height CTAs — solid "Download for macOS" and an outline button
+   whose body is the copyable run command — over one centered caption. */
+.install-options {
+  margin: 38px auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 13px;
+}
+
+.install-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* Hero-sized CTA: a touch larger than the base button. An explicit line-height
+   keeps the <a> (inherits the body's 1.6) and the <button> (UA resets it to
+   `normal`) the same height, so their captions sit on one baseline. */
+.btn-install {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 22px;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.btn-ic {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+/* The browser path: an outline button that copies the install command.
+   Explicit background because a bare <button> otherwise shows the UA
+   `buttonface` grey (the anchor-based ghost buttons stay transparent). */
+.cmd-btn {
+  position: relative;
+  background: var(--bg);
+  font-family: var(--font-mono);
+}
+
+.cmd-dollar {
+  color: var(--accent);
+}
+
+.cmd-copy {
+  margin-left: 3px;
+  padding-left: 11px;
+  border-left: 1px solid var(--border);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  color: var(--subtle);
+}
+
+.cmd-btn:hover .cmd-copy {
+  color: var(--ink);
+}
+
+.cmd-btn.copied .cmd-copy {
+  color: var(--accent);
+}
+
+/* Copy confirmation toast — anchored above the button, out of flow so it
+   never shifts the centered CTA row. */
+.cmd-toast {
+  position: absolute;
+  bottom: calc(100% + 9px);
+  left: 50%;
+  z-index: 2;
+  padding: 6px 11px;
+  border-radius: 7px;
+  background: var(--ink);
+  color: var(--bg);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(4px);
+  box-shadow: 0 8px 22px -8px color-mix(in oklab, var(--ink) 50%, transparent);
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+
+.cmd-toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* little pointer notch under the toast */
+.cmd-toast::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--ink);
+}
+
+/* Each button carries its own caption, directly beneath it, so the platform
+   note clearly targets its option rather than the pair. */
+.install-choice {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.install-note {
+  font-size: 12.5px;
+  color: var(--subtle);
+  text-align: center;
+}
+
 /* ── Hero ───────────────────────────────────────────────────────── */
 
 .hero {
@@ -197,7 +322,7 @@ code,
   z-index: -1;
   background: radial-gradient(
     640px 300px at 50% 12%,
-    color-mix(in oklch, var(--ink) 4.5%, transparent),
+    color-mix(in oklab, var(--ink) 4.5%, transparent),
     transparent 70%
   );
 }
@@ -210,7 +335,7 @@ code,
   z-index: -1;
   background-image: radial-gradient(
     circle,
-    color-mix(in oklch, var(--ink) 16%, transparent) 1px,
+    color-mix(in oklab, var(--ink) 16%, transparent) 1px,
     transparent 1px
   );
   background-size: 24px 24px;
@@ -238,7 +363,7 @@ code,
 
 .uline path {
   fill: none;
-  stroke: color-mix(in oklch, var(--accent) 75%, transparent);
+  stroke: color-mix(in oklab, var(--accent) 75%, transparent);
   stroke-width: 6;
   stroke-linecap: round;
   stroke-dasharray: 210;
@@ -332,51 +457,6 @@ code,
   text-wrap: balance;
 }
 
-.install {
-  margin: 26px auto 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 14px;
-  background: var(--surface);
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius);
-  padding: 11px 18px;
-  font-size: 14px;
-}
-
-.install .dollar {
-  color: var(--accent);
-  user-select: none;
-}
-
-.install button {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  color: var(--dim);
-  border-radius: calc(var(--radius) - 2px);
-  padding: 3px 11px;
-  font-size: 12.5px;
-  cursor: pointer;
-  font-family: var(--font-sans);
-}
-
-.install button:hover {
-  background: var(--state-hover);
-  color: var(--ink);
-}
-
-.install button.copied {
-  color: var(--accent);
-  border-color: color-mix(in oklch, var(--accent) 45%, var(--bg));
-  animation: copy-pop 0.25s ease;
-}
-
-@keyframes copy-pop {
-  40% {
-    transform: scale(1.12);
-  }
-}
-
 .fine {
   margin-top: 14px;
   color: var(--subtle);
@@ -431,8 +511,8 @@ code,
   background: var(--bg);
   overflow: hidden;
   box-shadow:
-    0 1px 0 color-mix(in oklch, var(--ink) 4%, transparent),
-    0 30px 70px -32px color-mix(in oklch, var(--ink) 34%, transparent);
+    0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent),
+    0 30px 70px -32px color-mix(in oklab, var(--ink) 34%, transparent);
 }
 
 /* ── Self-constructing mock ───────────────────────────────────────────
@@ -745,7 +825,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 }
 
 .active-act {
-  background: color-mix(in oklch, var(--ink) 7%, var(--bg));
+  background: color-mix(in oklab, var(--ink) 7%, var(--bg));
   color: var(--ink);
 }
 
@@ -802,7 +882,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 }
 
 .trow.active {
-  background: color-mix(in oklch, var(--ink) 7%, var(--bg));
+  background: color-mix(in oklab, var(--ink) 7%, var(--bg));
   color: var(--ink);
 }
 
@@ -1021,7 +1101,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 }
 
 .askq-opt.on {
-  background: color-mix(in oklch, var(--accent) 8%, var(--bg));
+  background: color-mix(in oklab, var(--accent) 8%, var(--bg));
 }
 
 .askq-radio {
@@ -1430,21 +1510,21 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 }
 
 .dl-add {
-  background: color-mix(in oklch, var(--add) 13%, transparent);
+  background: color-mix(in oklab, var(--add) 13%, transparent);
 }
 
 .dl-add .dl-sign,
 .dl-add .dl-text {
-  color: color-mix(in oklch, var(--add) 62%, var(--ink));
+  color: color-mix(in oklab, var(--add) 62%, var(--ink));
 }
 
 .dl-del {
-  background: color-mix(in oklch, var(--del) 13%, transparent);
+  background: color-mix(in oklab, var(--del) 13%, transparent);
 }
 
 .dl-del .dl-sign,
 .dl-del .dl-text {
-  color: color-mix(in oklch, var(--del) 62%, var(--ink));
+  color: color-mix(in oklab, var(--del) 62%, var(--ink));
 }
 
 /* ── Bands ──────────────────────────────────────────────────────── */
@@ -1511,7 +1591,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   border-radius: 18px;
   overflow: hidden;
   background: var(--bg);
-  box-shadow: 0 18px 50px -26px color-mix(in oklch, var(--ink) 32%, transparent);
+  box-shadow: 0 18px 50px -26px color-mix(in oklab, var(--ink) 32%, transparent);
 }
 
 /* contact bar */
@@ -1579,7 +1659,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   background-color: oklch(0.95 0.025 150);
   background-image:
     radial-gradient(
-      color-mix(in oklch, oklch(0.45 0.06 150) 9%, transparent) 1px,
+      color-mix(in oklab, oklch(0.45 0.06 150) 9%, transparent) 1px,
       transparent 1.5px
     ),
     linear-gradient(165deg, oklch(0.96 0.02 155), oklch(0.92 0.035 140));
@@ -1833,7 +1913,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--bg);
-  box-shadow: 0 14px 36px -22px color-mix(in oklch, var(--ink) 32%, transparent);
+  box-shadow: 0 14px 36px -22px color-mix(in oklab, var(--ink) 32%, transparent);
   text-align: left;
 }
 
@@ -2065,8 +2145,8 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 
 .sb-parent {
   background: var(--bg);
-  border-color: color-mix(in oklch, var(--accent) 32%, var(--bg));
-  box-shadow: 0 1px 10px color-mix(in oklch, var(--accent) 10%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 32%, var(--bg));
+  box-shadow: 0 1px 10px color-mix(in oklab, var(--accent) 10%, transparent);
 }
 
 .sb-prov {
@@ -2274,7 +2354,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   .hero::before {
     background: radial-gradient(
       78% 55% at 50% 6%,
-      color-mix(in oklch, var(--ink) 4.5%, transparent),
+      color-mix(in oklab, var(--ink) 4.5%, transparent),
       transparent 70%
     );
   }
@@ -2334,6 +2414,18 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 
   .statement .cta-row {
     justify-content: flex-start;
+  }
+
+  /* Stack the two CTAs full-width so neither wraps awkwardly. */
+  .install-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-install {
+    width: 100%;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## What

Reworks the install CTA on the landing hero (and closer) and fixes a color-interpolation bug that produced pink artifacts.

### Install CTA
- Replaces the single Download button + bare CLI line (and the interim grey two-column card) with **two equal-height CTAs**: a solid **Download for macOS** and an outline button whose body is the copyable `npx bb-app@latest` command (clicking anywhere copies it).
- Each button carries **its own caption** ("One-click, no terminal" / "Windows, Linux & remote machines") so the platform note clearly targets the browser path instead of floating ambiguously between both.
- Copy confirmation is an **out-of-flow toast** above the button, so confirming a copy no longer reflows the centered row (the label stays a fixed width).
- Removes the hero **Star on GitHub** button (GitHub stays in the nav, closer, and footer).
- Equal button heights via an explicit `line-height` on `.btn-install` — the `<a>` inherited the body's `1.6` while the `<button>` got the UA `normal`, leaving the captions off by 6px.

### Color fix
- Pulls the chromatic tokens straight from `apps/app/src/components/ui/theme.css` (`file-accent`, `success`, `diff-added`/`diff-removed`, `warning-text`).
- Switches **every `color-mix()` from `in oklch` to `in oklab`**. Mixing the blue accent toward white in oklch (a polar space) interpolated the hue through pink — the selected AskQuestion option rendered with a pink wash. oklab (rectangular) keeps the hue put; neutral mixes are unchanged.
- Removes three unused tokens (`--warn`, `--code-green`, `--code-str`) and the now-orphaned `.install` chip styles.

## Tests
- `turbo run typecheck lint build --filter=@bb/landing` — all pass (build includes prerender).
- Verified in-browser at desktop + mobile widths: dual CTAs aligned, copy toast (no reflow), AskQuestion option now blue not pink, diff panel / status colors match the app palette.

## Risk
Landing-page-only, no runtime/server/daemon changes. The `--success` green (L 0.70) is a touch lighter than the old status green on small "done/running" labels — faithful to the app, flagged in case stronger text contrast is preferred.