### PR TITLE
Nest sidebar children when grouping is disabled

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -983,14 +983,16 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
     ],
   );
   const showChildren = !isCollapsed && hasChildren;
+  const rowProjectId =
+    variant === "section" ? node.thread.projectId : projectId;
   const hasComposerDraft = usePromptDraftHasInput({
     kind: "thread",
-    projectId,
+    projectId: rowProjectId,
     threadId: node.thread.id,
   });
   const row = (
     <ThreadRow
-      projectId={projectId}
+      projectId={rowProjectId}
       thread={node.thread}
       isActive={selectedThreadId === node.thread.id}
       hasComposerDraft={hasComposerDraft}
@@ -1126,11 +1128,10 @@ function getChronologicalItemProjectId(item: ProjectThreadItem): string {
     : item.group.nodes[0].thread.projectId;
 }
 
-// Flat "All Threads" bucket for chronological mode: one top-level row per
-// non-pinned thread across all projects, globally ordered by the chosen
-// comparator (no parent/child nesting or worktree grouping, so nothing hides
-// behind a collapsed parent). Derives projectId per row from its own thread so
-// cross-project rows still route correctly.
+// "All Threads" bucket for chronological mode: root threads across projects
+// are ordered by the chosen comparator, descendants stay under their parents,
+// and worktree grouping stays off. Section rows derive projectId from each
+// thread so cross-project rows still route correctly.
 export const ChronologicalThreadTree = memo(function ChronologicalThreadTree({
   threadListState,
   compareThreads,

--- a/apps/app/src/components/sidebar/projectThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.test.ts
@@ -384,7 +384,7 @@ describe("buildProjectThreadGroups", () => {
   });
 
   describe("buildChronologicalThreadList", () => {
-    it("flattens parent/child threads into globally sorted top-level rows", () => {
+    it("nests parent/child threads under globally sorted roots", () => {
       const items = buildChronologicalThreadList(
         [
           createThread({ id: "parent", createdAt: 10, latestAttentionAt: 10 }),
@@ -399,9 +399,42 @@ describe("buildProjectThreadGroups", () => {
         compareByCreatedAtDescending,
       );
 
-      // No nesting: the child is its own top-level row, ordered globally by
-      // createdAt desc rather than nested under its parent.
-      expect(summarizeItems(items)).toEqual(["child", "other", "parent"]);
+      expect(summarizeItems(items)).toEqual([
+        "other",
+        { id: "parent", children: ["child"] },
+      ]);
+    });
+
+    it("keeps worktree siblings as thread rows", () => {
+      const items = buildChronologicalThreadList(
+        [
+          createThread({ id: "parent", createdAt: 100 }),
+          createThread({
+            id: "worktree-a",
+            parentThreadId: "parent",
+            environmentId: "env_shared",
+            environmentWorkspaceDisplayKind: "managed-worktree",
+            createdAt: 10,
+            latestAttentionAt: 100,
+          }),
+          createThread({
+            id: "worktree-b",
+            parentThreadId: "parent",
+            environmentId: "env_shared",
+            environmentWorkspaceDisplayKind: "managed-worktree",
+            createdAt: 20,
+            latestAttentionAt: 200,
+          }),
+        ],
+        compareByCreatedAtDescending,
+      );
+
+      expect(summarizeItems(items)).toEqual([
+        {
+          id: "parent",
+          children: ["worktree-b", "worktree-a"],
+        },
+      ]);
     });
 
     it("excludes side chats", () => {

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -58,6 +58,7 @@ interface BuildThreadNodeArgs {
   childrenByParentId: ReadonlyMap<string, readonly ThreadListEntry[]>;
   compareThreads: ThreadComparator;
   depth: number;
+  groupEnvironmentThreads: boolean;
   thread: ThreadListEntry;
   visitedThreadIds: Set<string>;
 }
@@ -185,7 +186,13 @@ function buildEnvironmentItem(
 function buildSortedItems(
   nodes: ProjectThreadNode[],
   compareThreads: ThreadComparator,
+  groupEnvironmentThreads: boolean,
 ): ProjectThreadItem[] {
+  if (!groupEnvironmentThreads) {
+    nodes.sort((left, right) => compareThreads(left.thread, right.thread));
+    return nodes.map(buildThreadItem);
+  }
+
   const { environmentThreadGroups, looseNodes } =
     bucketWorktreeEnvironmentGroups(nodes, compareThreads);
   const items = [
@@ -203,6 +210,7 @@ function buildThreadNode({
   childrenByParentId,
   compareThreads,
   depth,
+  groupEnvironmentThreads,
   thread,
   visitedThreadIds,
 }: BuildThreadNodeArgs): ProjectThreadNode {
@@ -221,13 +229,18 @@ function buildThreadNode({
         childrenByParentId,
         compareThreads,
         depth: depth + 1,
+        groupEnvironmentThreads,
         thread: childThread,
         visitedThreadIds,
       }),
     );
   }
 
-  const children = buildSortedItems(childNodes, compareThreads);
+  const children = buildSortedItems(
+    childNodes,
+    compareThreads,
+    groupEnvironmentThreads,
+  );
   return {
     thread,
     children,
@@ -250,7 +263,15 @@ export function buildProjectThreadGroups(
   allProjectThreads: readonly ThreadListEntry[],
   compareThreads: ThreadComparator = compareStandardThreads,
 ): ProjectThreadItem[] {
-  const projectThreads = allProjectThreads.filter(isSidebarProjectThread);
+  return buildThreadTreeItems(allProjectThreads, compareThreads, true);
+}
+
+function buildThreadTreeItems(
+  allThreads: readonly ThreadListEntry[],
+  compareThreads: ThreadComparator,
+  groupEnvironmentThreads: boolean,
+): ProjectThreadItem[] {
+  const projectThreads = allThreads.filter(isSidebarProjectThread);
   const projectThreadIds = new Set(projectThreads.map((thread) => thread.id));
   const childrenByParentId = new Map<string, ThreadListEntry[]>();
 
@@ -279,6 +300,7 @@ export function buildProjectThreadGroups(
         childrenByParentId,
         compareThreads,
         depth: 0,
+        groupEnvironmentThreads,
         thread,
         visitedThreadIds,
       }),
@@ -296,39 +318,24 @@ export function buildProjectThreadGroups(
         childrenByParentId,
         compareThreads,
         depth: 0,
+        groupEnvironmentThreads,
         thread,
         visitedThreadIds,
       }),
     );
   }
 
-  return buildSortedItems(rootNodes, compareThreads);
+  return buildSortedItems(rootNodes, compareThreads, groupEnvironmentThreads);
 }
 
-// Flat ordering for the chronological "All Threads" bucket: one top-level row
-// per thread, globally ordered by the chosen comparator. Unlike
-// buildProjectThreadGroups this intentionally drops parent/child nesting and
-// worktree grouping so every thread is visible (none hidden behind a collapsed
-// parent) and the sort is global rather than per-sibling. Side chats are
-// excluded to match buildProjectThreadGroups.
+// Chronological "All Threads" bucket: parent/child links still form a tree,
+// but worktree grouping stays off so Group by None does not add synthetic group
+// rows. Side chats are excluded to match buildProjectThreadGroups.
 export function buildChronologicalThreadList(
   allThreads: readonly ThreadListEntry[],
   compareThreads: ThreadComparator = compareStandardThreads,
 ): ProjectThreadItem[] {
-  return allThreads
-    .filter(isSidebarProjectThread)
-    .sort(compareThreads)
-    .map(
-      (thread): ProjectThreadItem => ({
-        kind: "thread",
-        node: {
-          thread,
-          children: [],
-          depth: 0,
-          stats: buildStatsForHiddenThreads([]),
-        },
-      }),
-    );
+  return buildThreadTreeItems(allThreads, compareThreads, false);
 }
 
 export function isSidebarProjectThread(


### PR DESCRIPTION
## Summary
- Reuse the sidebar thread tree builder for Group by None so child threads stay nested under parents.
- Keep worktree grouping disabled in chronological mode.
- Use each thread's own project id for section-mode sidebar rows.

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/projectThreadGroups.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app