### PR TITLE
Split completed turn summaries at user boundaries

### DIFF
--- a/packages/thread-view/src/apply-turn-message-detail.ts
+++ b/packages/thread-view/src/apply-turn-message-detail.ts
@@ -108,6 +108,7 @@ function applyTurnMessageDetail(
   const includeMessages =
     turn.status === "pending" ||
     turnMessageDetail === "full" ||
+    (turn.externalUserBoundarySeqs?.length ?? 0) > 0 ||
     shouldIncludeSummaryTurnMessages(messages, terminalMessage);
 
   const detailedTurn: EventProjectionTurn = {
@@ -120,6 +121,9 @@ function applyTurnMessageDetail(
     completedAt: turn.completedAt,
     status: turn.status,
     summaryCount,
+    ...(turn.externalUserBoundarySeqs
+      ? { externalUserBoundarySeqs: turn.externalUserBoundarySeqs }
+      : {}),
   };
   if (terminalMessage) {
     detailedTurn.terminalMessage = terminalMessage;

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -1072,6 +1072,65 @@ function hasTurnSummaryRows(rows: TimelineRow[]): boolean {
   return rows.some((row) => row.kind === "turn");
 }
 
+function collectExternalUserBoundarySeqs(
+  projection: EventProjection,
+): number[] {
+  const boundarySeqs = new Set<number>();
+  for (const entry of projection.entries) {
+    if (entry.kind !== "turn") {
+      continue;
+    }
+    for (const seq of entry.turn.externalUserBoundarySeqs ?? []) {
+      boundarySeqs.add(seq);
+    }
+  }
+  return [...boundarySeqs].sort((left, right) => left - right);
+}
+
+function compareTimelineRowsBySource(
+  left: TimelineRow,
+  right: TimelineRow,
+): number {
+  if (left.sourceSeqStart !== right.sourceSeqStart) {
+    return left.sourceSeqStart - right.sourceSeqStart;
+  }
+  if (left.sourceSeqEnd !== right.sourceSeqEnd) {
+    return left.sourceSeqEnd - right.sourceSeqEnd;
+  }
+  return 0;
+}
+
+function orderRowsAfterExternalUserBoundary(
+  rows: TimelineRow[],
+  boundarySeqs: readonly number[],
+): TimelineRow[] {
+  const firstBoundarySeq = boundarySeqs[0];
+  if (firstBoundarySeq === undefined) {
+    return rows;
+  }
+
+  const suffixStartIndex = rows.findIndex(
+    (row) => row.sourceSeqStart >= firstBoundarySeq,
+  );
+  if (suffixStartIndex === -1) {
+    return rows;
+  }
+
+  // Keep pre-boundary rows in their established projection order. A global
+  // source sort moves thread provisioning under initial turn summaries because
+  // those summaries inherit the accepted request's source range.
+  const suffix = rows.slice(suffixStartIndex);
+  const orderedSuffix = suffix
+    .map((row, index) => ({ index, row }))
+    .sort((left, right) => {
+      const sourceOrder = compareTimelineRowsBySource(left.row, right.row);
+      return sourceOrder === 0 ? left.index - right.index : sourceOrder;
+    })
+    .map(({ row }) => row);
+
+  return [...rows.slice(0, suffixStartIndex), ...orderedSuffix];
+}
+
 function buildTimelineRows(
   projection: EventProjection,
   options: BuildTimelineRowsOptions,
@@ -1100,7 +1159,10 @@ function buildTimelineRows(
     }
   }
 
-  return rows;
+  return orderRowsAfterExternalUserBoundary(
+    rows,
+    collectExternalUserBoundarySeqs(projection),
+  );
 }
 
 export function buildThreadTimelineFromEvents(

--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -123,7 +123,11 @@ function groupCompletedTurnSummaryMessages(
   turn: EventProjectionTurn,
   summaryMessages: EventProjectionMessage[],
 ): CompletedTurnSummaryItem[] {
-  if (!summaryMessages.some(isTimelineUngroupableMessage)) {
+  const externalBoundarySeqs = turn.externalUserBoundarySeqs ?? [];
+  if (
+    externalBoundarySeqs.length === 0 &&
+    !summaryMessages.some(isTimelineUngroupableMessage)
+  ) {
     return [
       {
         kind: "summary",
@@ -139,6 +143,7 @@ function groupCompletedTurnSummaryMessages(
   const items: CompletedTurnSummaryItem[] = [];
   let groupedMessages: EventProjectionMessage[] = [];
   let segmentIndex = 0;
+  let externalBoundaryIndex = 0;
 
   function flushGroupedMessages(): void {
     if (groupedMessages.length === 0) {
@@ -159,7 +164,19 @@ function groupCompletedTurnSummaryMessages(
     groupedMessages = [];
   }
 
+  function flushExternalBoundariesBefore(message: EventProjectionMessage): void {
+    while (
+      externalBoundaryIndex < externalBoundarySeqs.length &&
+      (externalBoundarySeqs[externalBoundaryIndex] ?? 0) <
+        message.sourceSeqStart
+    ) {
+      flushGroupedMessages();
+      externalBoundaryIndex += 1;
+    }
+  }
+
   for (const message of summaryMessages) {
+    flushExternalBoundariesBefore(message);
     if (isTimelineUngroupableMessage(message)) {
       flushGroupedMessages();
       items.push({

--- a/packages/thread-view/src/event-projection.ts
+++ b/packages/thread-view/src/event-projection.ts
@@ -76,6 +76,7 @@ export interface EventProjectionTurn {
   completedAt: number | null;
   status: EventProjectionTurnStatus;
   summaryCount: number;
+  externalUserBoundarySeqs?: number[];
   terminalMessage?: EventProjectionMessage;
   messages?: EventProjectionMessage[];
 }

--- a/packages/thread-view/src/group-event-projection-turns.ts
+++ b/packages/thread-view/src/group-event-projection-turns.ts
@@ -156,6 +156,42 @@ function addProjectionTurnMessage(
   });
 }
 
+function isExternalUserBoundaryForTurn(
+  turnId: string,
+  turn: EventProjectionTurn,
+  message: EventProjectionMessage,
+): boolean {
+  if (message.kind !== "user" || message.initiator !== "user") {
+    return false;
+  }
+  if (
+    message.sourceSeqStart <= turn.sourceSeqStart ||
+    message.sourceSeqStart >= turn.sourceSeqEnd
+  ) {
+    return false;
+  }
+  return message.scope.kind !== "turn" || message.scope.turnId !== turnId;
+}
+
+function applyExternalUserBoundaries(
+  turnsById: Map<string, ProjectionTurnDraft>,
+  messages: EventProjectionMessage[],
+): void {
+  for (const [turnId, draft] of turnsById) {
+    const boundarySeqs = new Set<number>();
+    for (const message of messages) {
+      if (isExternalUserBoundaryForTurn(turnId, draft.turn, message)) {
+        boundarySeqs.add(message.sourceSeqStart);
+      }
+    }
+    if (boundarySeqs.size > 0) {
+      draft.turn.externalUserBoundarySeqs = [...boundarySeqs].sort(
+        (left, right) => left - right,
+      );
+    }
+  }
+}
+
 function createEventProjectionEntry(
   draft: ProjectionEntryDraft,
   turnsById: Map<string, ProjectionTurnDraft>,
@@ -289,6 +325,8 @@ export function groupEventProjectionTurns(
 
     addProjectionTurnMessage(turnDraft, message);
   }
+
+  applyExternalUserBoundaries(turnsById, args.messages);
 
   const orderedEntryDrafts = [...entryDrafts].sort((left, right) => {
     if (left.sourceSeqStart !== right.sourceSeqStart) {

--- a/packages/thread-view/test/completed-turn-summary-rendering.test.ts
+++ b/packages/thread-view/test/completed-turn-summary-rendering.test.ts
@@ -256,6 +256,110 @@ describe("completed turn summary rendering", () => {
     ).toEqual([["work:command"], ["work:command"]]);
   });
 
+  it("splits completed turn summaries at external human new-turn boundaries", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const initialRequest = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "start the long turn",
+    });
+    const events: TimelineFixtureEvent[] = [
+      initialRequest,
+      event.turnStarted({ turnId: "long-turn" }),
+      event.inputAccepted({
+        clientRequestId: initialRequest.data.requestId,
+        turnId: "long-turn",
+      }),
+      event.commandCompleted({
+        command: "pnpm test",
+        itemId: "before-user",
+        turnId: "long-turn",
+      }),
+    ];
+    const followUpRequest = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "new turn while the first turn is still emitting",
+    });
+    events.push(
+      followUpRequest,
+      event.commandCompleted({
+        command: "pnpm typecheck",
+        itemId: "after-user",
+        turnId: "long-turn",
+      }),
+      event.assistantCompleted({
+        itemId: "assistant-1",
+        text: "Long turn finished.",
+        turnId: "long-turn",
+      }),
+      event.turnCompleted({ turnId: "long-turn" }),
+    );
+
+    const timeline = renderCompletedTimeline({ events });
+
+    expect(rowSignatures(timeline.rows)).toEqual([
+      "conversation:user",
+      "turn:4-4",
+      "conversation:user",
+      "turn:6-6",
+      "conversation:assistant",
+    ]);
+    expect(
+      turnRows(timeline.rows).map((row) => rowSignatures(row.children ?? [])),
+    ).toEqual([["work:command"], ["work:command"]]);
+  });
+
+  it("keeps provisioning rows before the initial completed turn summary", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "thread-start" },
+      text: "start with provisioning",
+    });
+
+    const timeline = renderCompletedTimeline({
+      events: [
+        request,
+        event.threadProvisioning({
+          status: "active",
+          entries: [
+            {
+              type: "step",
+              key: "workspace",
+              text: "Using workspace",
+              status: "started",
+            },
+          ],
+        }),
+        event.threadProvisioning({
+          status: "completed",
+          entries: [],
+        }),
+        event.turnStarted({ turnId: "turn-1" }),
+        event.inputAccepted({
+          clientRequestId: request.data.requestId,
+          turnId: "turn-1",
+        }),
+        event.commandCompleted({
+          command: "pnpm test",
+          itemId: "tool-1",
+          turnId: "turn-1",
+        }),
+        event.assistantCompleted({
+          itemId: "assistant-1",
+          text: "Done.",
+          turnId: "turn-1",
+        }),
+        event.turnCompleted({ turnId: "turn-1" }),
+      ],
+    });
+
+    expect(rowSignatures(timeline.rows)).toEqual([
+      "conversation:user",
+      "system:operation",
+      "turn:1-8",
+      "conversation:assistant",
+    ]);
+  });
+
   it("does not split completed turn summaries around accepted assistant steers", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const events: TimelineFixtureEvent[] = [


### PR DESCRIPTION
## Summary
- detect external human new-turn boundaries inside completed turn ranges
- split completed turn summary groups at those boundaries so later user rows stay in source order
- constrain source-order sorting to the affected suffix so provisioning rows remain before initial turn summaries

## Validation
- pnpm exec turbo run typecheck --filter=@bb/thread-view
- pnpm exec turbo run test --filter=@bb/thread-view -- test/completed-turn-summary-rendering.test.ts
- pnpm exec turbo run test --filter=@bb/thread-view