### PR TITLE
Make clipped generated agent messages expandable

### DIFF
--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.stories.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.stories.tsx
@@ -229,6 +229,35 @@ export function Overview() {
   );
 }
 
+export function ClippedAgentMessage() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="agent message"
+        hint="long single-line handoff from another thread; expand to read the full text"
+      >
+        <div className="w-full max-w-[560px]">
+          <ConversationMessageContent
+            role="user"
+            initiator="agent"
+            childOrigin={null}
+            senderThreadId="thr_host_hermes"
+            senderThreadTitle="Host Hermes on Flue"
+            senderChildOrigin={null}
+            resolveSegmentLinkHref={resolveThreadLink}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text="TEST RESULT refines the diagnosis — RULE OUT eviction. A fire-and-forget direct POST with no wait parameter and no client-held stream should still render the complete report after expansion, including the exact follow-up checks the other agent already ran."
+            attachments={null}
+            mentions={[]}
+            projectId="proj_demo"
+            turnRequest={acceptedMessage}
+          />
+        </div>
+      </StoryRow>
+    </StoryCard>
+  );
+}
 
 // Markdown bodies, rendered EXPANDED so the formatting is visible without a
 // click. System-message bodies (sourceKind "system") render through

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -66,6 +66,7 @@ function renderChildCompleted() {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 const TWO_LINE_BODY = "first report line\nsecond report line";
@@ -110,8 +111,27 @@ function renderChildCompletedBody(
 const AGENT_BODY = "# notes\nedited path:src/app.ts here";
 const AGENT_PATH_TOKEN = "path:src/app.ts";
 const AGENT_PATH_START = AGENT_BODY.indexOf(AGENT_PATH_TOKEN);
+const OVERFLOWING_ONE_LINE_AGENT_BODY =
+  "TEST RESULT refines the diagnosis — RULE OUT eviction. A fire-and-forget direct POST with no wait parameter and no client-held stream should still render the complete report after expansion.";
 
-function renderAgentMessage() {
+function renderAgentMessage(text = AGENT_BODY) {
+  const mentions =
+    text === AGENT_BODY
+      ? [
+          {
+            start: AGENT_PATH_START,
+            end: AGENT_PATH_START + AGENT_PATH_TOKEN.length,
+            resource: {
+              kind: "path" as const,
+              source: "workspace" as const,
+              entryKind: "file" as const,
+              path: "src/app.ts",
+              label: "src/app.ts",
+            },
+          },
+        ]
+      : [];
+
   return render(
     <MemoryRouter>
       <RouteNavigationProvider>
@@ -126,25 +146,24 @@ function renderAgentMessage() {
           systemMessageKind="unlabeled"
           systemMessageSubject={null}
           attachments={null}
-          mentions={[
-            {
-              start: AGENT_PATH_START,
-              end: AGENT_PATH_START + AGENT_PATH_TOKEN.length,
-              resource: {
-                kind: "path",
-                source: "workspace",
-                entryKind: "file",
-                path: "src/app.ts",
-                label: "src/app.ts",
-              },
-            },
-          ]}
-          text={AGENT_BODY}
+          mentions={mentions}
+          text={text}
           turnRequest={{ kind: "message", status: "accepted" }}
           projectId="proj_demo"
         />
       </RouteNavigationProvider>
     </MemoryRouter>,
+  );
+}
+
+function mockInnerPreviewTextOverflow(text: string): void {
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(20);
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(20);
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(100);
+  vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(
+    function scrollWidth(this: HTMLElement) {
+      return this.tagName === "SPAN" && this.textContent === text ? 240 : 100;
+    },
   );
 }
 
@@ -177,6 +196,22 @@ describe("GeneratedConversationMessage markdown body", () => {
     // The offset-based `path` mention is preserved (would regress to plain text
     // under the markdown path, which only understands `@thread:<id>` tokens).
     expect(screen.getByText("src/app.ts")).toBeTruthy();
+  });
+
+  it("expands a one-line agent message when its preview text overflows", () => {
+    mockInnerPreviewTextOverflow(OVERFLOWING_ONE_LINE_AGENT_BODY);
+    const { container } = renderAgentMessage(OVERFLOWING_ONE_LINE_AGENT_BODY);
+
+    const toggle = screen.getByRole("button", { name: /Message from Worker/u });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("...")).toBeNull();
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector("p.whitespace-pre-wrap")?.textContent).toBe(
+      OVERFLOWING_ONE_LINE_AGENT_BODY,
+    );
   });
 });
 

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -345,7 +345,6 @@ function systemMessageIsTitleOnly(
 // inline so the row stays one truncated line while still showing inline
 // formatting (bold, code, links) and @thread pills.
 const COLLAPSED_MARKDOWN_PREVIEW_CLASS = cn(
-  "min-w-0 truncate",
   "[&_p]:!m-0 [&_p]:inline",
   "[&_ul]:!m-0 [&_ol]:!m-0 [&_ul]:!pl-0 [&_ol]:!pl-0 [&_li]:!m-0 [&_li]:inline",
   "[&_h1]:!m-0 [&_h2]:!m-0 [&_h3]:!m-0 [&_h4]:!m-0",
@@ -426,7 +425,13 @@ export const GeneratedConversationMessage = memo(
     const collapsedPreviewLine = messageText.split(/\r\n|\r|\n/u, 1)[0] ?? "";
     const hasAdditionalBodyLines =
       collapsedPreviewLine.length < messageText.length;
-    const collapsedPreviewTextRef = useRef<HTMLDivElement>(null);
+    const collapsedPreviewTextRef = useRef<HTMLElement | null>(null);
+    const setCollapsedPreviewTextRef = useCallback(
+      (element: HTMLElement | null) => {
+        collapsedPreviewTextRef.current = element;
+      },
+      [],
+    );
     const collapsedPreviewOverflowMeasurement = useOverflowMeasurement({
       elementRef: collapsedPreviewTextRef,
       enabled: !titleOnly && messageText.length > 0,
@@ -437,6 +442,8 @@ export const GeneratedConversationMessage = memo(
       (hasExpandedOnlyContent ||
         hasAdditionalBodyLines ||
         collapsedPreviewOverflowMeasurement === "overflowing");
+    const showManualContinuation =
+      expandable && collapsedPreviewOverflowMeasurement !== "overflowing";
     const collapsedPreviewBody = clipMentionTextToVisibleRange({
       mentions: messageMentions,
       rangeStart: 0,
@@ -446,31 +453,33 @@ export const GeneratedConversationMessage = memo(
       <div
         className={`${NESTED_TIMELINE_GROUP_LINE_CLASS_NAME} max-w-full min-w-0`}
       >
-        <div
-          ref={collapsedPreviewTextRef}
-          className="flex min-w-0 items-baseline truncate pl-2 text-sm leading-relaxed text-foreground"
-        >
+        <div className="flex min-w-0 items-baseline truncate pl-2 text-sm leading-relaxed text-foreground">
           {sourceKind === "system" ? (
             // Render the collapsed first line as markdown too (inline
             // formatting + @thread pills), clamped to a single line, so a
             // not-yet-expanded system message shows formatted text rather than
             // raw markdown. Block nodes are flattened to inline via
             // COLLAPSED_MARKDOWN_PREVIEW_CLASS.
-            <MarkdownPreview
-              content={collapsedPreviewLine}
-              linkRouting={linkRouting}
-              threadMentions={
-                resolveSegmentLinkHref
-                  ? {
-                      mentions: collapsedPreviewBody.mentions,
-                      resolveLinkHref: resolveSegmentLinkHref,
-                    }
-                  : undefined
-              }
-              className={COLLAPSED_MARKDOWN_PREVIEW_CLASS}
-            />
+            <div
+              ref={setCollapsedPreviewTextRef}
+              className="min-w-0 truncate"
+            >
+              <MarkdownPreview
+                content={collapsedPreviewLine}
+                linkRouting={linkRouting}
+                threadMentions={
+                  resolveSegmentLinkHref
+                    ? {
+                        mentions: collapsedPreviewBody.mentions,
+                        resolveLinkHref: resolveSegmentLinkHref,
+                      }
+                    : undefined
+                }
+                className={COLLAPSED_MARKDOWN_PREVIEW_CLASS}
+              />
+            </div>
           ) : (
-            <span className="min-w-0 truncate">
+            <span ref={setCollapsedPreviewTextRef} className="min-w-0 truncate">
               {renderMentionTextSegments({
                 mentions: collapsedPreviewBody.mentions,
                 resolveMentionLink,
@@ -478,7 +487,7 @@ export const GeneratedConversationMessage = memo(
               })}
             </span>
           )}
-          {expandable ? (
+          {showManualContinuation ? (
             <span className="shrink-0 text-muted-foreground">...</span>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- measure the actual truncated preview text for generated conversation rows
- make clipped one-line agent handoffs expandable without rendering a duplicate ellipsis
- add a focused regression test and Ladle story for the clipped agent-message case

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/thread/timeline/GeneratedConversationMessage.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check