### PR TITLE
Fill the macOS download CTA apple icon

### DIFF
--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -1,5 +1,4 @@
 import {
-  AppleIcon,
   ArrowDown01Icon,
   ArrowExpand01Icon,
   ArrowLeft01Icon,
@@ -26,7 +25,7 @@ import {
   Tick02Icon,
   ZapIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
@@ -42,6 +41,28 @@ import { CLI_COMMAND, GITHUB_URL, downloadMacosHref } from "../site";
 export const Route = createFileRoute("/")({
   component: LandingPage,
 });
+
+// Filled (solid) variant of the Hugeicons apple — same silhouette as their
+// stroke AppleIcon, but rendered as a fill so the macOS CTA reads as a solid
+// glyph (the free icon set ships outline variants only).
+const AppleSolidIcon: IconSvgElement = [
+  [
+    "path",
+    {
+      d: "M12 5.75C12 3.75 13.5 1.75 15.5 1.75C15.5 3.75 14 5.75 12 5.75Z",
+      fill: "currentColor",
+      key: "0",
+    },
+  ],
+  [
+    "path",
+    {
+      d: "M12.5 8.09001C11.9851 8.09001 11.5867 7.92646 11.1414 7.74368C10.5776 7.51225 9.93875 7.25 8.89334 7.25C7.02235 7.25 4 8.74945 4 12.7495C4 17.4016 7.10471 22.25 9.10471 22.25C9.77426 22.25 10.3775 21.9871 10.954 21.7359C11.4815 21.5059 11.9868 21.2857 12.5 21.2857C13.0132 21.2857 13.5185 21.5059 14.046 21.7359C14.6225 21.9871 15.2257 22.25 15.8953 22.25C17.2879 22.25 18.9573 19.8992 20 16.9008C18.3793 16.2202 17.338 14.618 17.338 12.75C17.338 11.121 18.2036 10.0398 19.5 9.25C18.5 7.75 17.0134 7.25 15.9447 7.25C14.8993 7.25 14.2604 7.51225 13.6966 7.74368C13.2514 7.92646 13.0149 8.09001 12.5 8.09001Z",
+      fill: "currentColor",
+      key: "1",
+    },
+  ],
+];
 
 /* ── CTAs ─────────────────────────────────────────────────────────── */
 
@@ -128,7 +149,7 @@ function InstallOptions({ placement }: { placement: CtaPlacement }) {
             placement={placement}
             className="btn btn-primary btn-install"
           >
-            <HugeiconsIcon icon={AppleIcon} className="btn-ic" />
+            <HugeiconsIcon icon={AppleSolidIcon} className="btn-ic" />
             Download for macOS
           </DownloadLink>
           <span className="install-note">One-click, no terminal</span>


### PR DESCRIPTION
## Summary

The "Download for macOS" CTA on the landing page rendered a thin **outline** apple, because the free Hugeicons set ships only stroke variants. This swaps it for a solid (filled) version of the same silhouette so the glyph reads as a proper Apple mark.

- Added a local `AppleSolidIcon` (`IconSvgElement`) reusing the existing Hugeicons apple paths but rendered with `fill="currentColor"` instead of `stroke`.
- Pointed the macOS install button at the filled variant and dropped the now-unused `AppleIcon` import.

Kept local to `apps/landing/src/routes/index.tsx` since the icon has a single call site — no new shared primitive.

| Before | After |
| --- | --- |
| Outline apple | Solid filled apple |

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/landing` ✅
- Rendered the filled SVG locally to confirm it produces a clean solid Apple glyph.

## Risks

Cosmetic, single icon swap. No behavior or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)