### PR TITLE
Fix thread timeline horizontal overflow

### DIFF
--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -170,6 +170,19 @@ afterEach(() => {
 });
 
 describe("BottomAnchoredScrollBody scroll preservation", () => {
+  it("clips horizontal overflow at the timeline scroll boundary", () => {
+    const { scrollArea } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a"],
+    });
+    const scrollContent = requireHTMLElement(scrollArea.firstElementChild);
+    const contentColumn = requireHTMLElement(scrollContent.firstElementChild);
+
+    expect(scrollArea.classList.contains("overflow-x-hidden")).toBe(true);
+    expect(scrollContent.classList.contains("min-w-0")).toBe(true);
+    expect(contentColumn.classList.contains("min-w-0")).toBe(true);
+  });
+
   it("captures the top-most visible row when scrolled mid-timeline", () => {
     const { scrollArea, rowElements } = renderTimeline({
       threadId: "thread-a",

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -729,20 +729,20 @@ export function BottomAnchoredScrollBody({
         <div
           ref={scrollAreaRef}
           className={cn(
-            "@container/page min-h-0 flex-1 overflow-y-auto",
+            "@container/page min-h-0 flex-1 overflow-x-hidden overflow-y-auto",
             scrollAreaClassName,
           )}
         >
           <div
             ref={scrollContentRef}
             className={cn(
-              "flex min-h-full flex-col",
+              "flex min-h-full min-w-0 flex-col",
               isAtBottom && "scroll-bottom-anchor-content",
             )}
           >
             <div
               className={cn(
-                "mx-auto flex w-full flex-1 flex-col px-4 pb-4 pt-2",
+                "mx-auto flex w-full min-w-0 flex-1 flex-col px-4 pb-4 pt-2",
                 maxWidthClassName,
                 contentClassName,
               )}

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -67,6 +67,24 @@ describe("MarkdownPreview", () => {
     expect(onOpenLink).toHaveBeenCalledWith({ href });
   });
 
+  it("lets long local file link labels wrap without making the anchor flex", () => {
+    const href =
+      "file:///Users/brsbl/Moss/Notes/Agent%20Workspaces/Claude%20Workspace/Release%20Readiness%20Inventory%20%E2%80%94%20Next%20Release/Release%20Readiness%20Inventory%20%E2%80%94%20Next%20Release.md";
+
+    render(
+      <MarkdownPreview
+        content={`[${href}](${href})`}
+        linkRouting={workspaceLinkRouting}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: href });
+
+    expect(link.classList.contains("[overflow-wrap:anywhere]")).toBe(true);
+    expect(link.classList.contains("inline-flex")).toBe(false);
+    expect(link.querySelector('[data-icon="ExternalLink"]')).not.toBeNull();
+  });
+
   it("rewrites localhost link hrefs without changing the visible text", () => {
     const displayedText = "http://127.0.0.1:5173";
 

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -485,8 +485,7 @@ function MarkdownAnchor({
       {...anchorProps}
       href={anchorHref}
       className={cn(
-        "break-words underline underline-offset-2",
-        localFileLink && "inline-flex items-baseline gap-1",
+        "break-words [overflow-wrap:anywhere] underline underline-offset-2",
       )}
       target="_blank"
       rel="noopener noreferrer"
@@ -497,7 +496,7 @@ function MarkdownAnchor({
         <Icon
           name="ExternalLink"
           aria-hidden
-          className="size-3 shrink-0 self-center text-subtle-foreground"
+          className="ml-1 inline size-3 align-[-0.125em] text-subtle-foreground"
         />
       ) : null}
     </RouteAnchor>


### PR DESCRIPTION
## Summary
- prevent the bottom-anchored thread timeline scrollport from panning horizontally
- allow long markdown link labels, including local file links with icons, to wrap within the timeline
- add regressions for the scroll boundary and the long file:// markdown link case

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/ui/markdown-preview.test.tsx
- pnpm exec turbo run test --filter=@bb/app -- src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check