### PR TITLE
Fix mobile restore query failures

### DIFF
--- a/apps/app/src/hooks/cache-owners/browser-lifecycle-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/browser-lifecycle-cache-owner.ts
@@ -1,0 +1,10 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export function cancelActiveQueryFetchesForBrowserSuspend(
+  queryClient: QueryClient,
+): void {
+  void queryClient.cancelQueries({
+    fetchStatus: "fetching",
+    type: "active",
+  });
+}

--- a/apps/app/src/hooks/queries/system-queries.test.tsx
+++ b/apps/app/src/hooks/queries/system-queries.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { SystemExecutionOptionsResponse } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/api";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { useSystemExecutionOptions } from "./system-queries";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getSystemExecutionOptions: vi.fn(),
+  };
+});
+
+const EXECUTION_OPTIONS_RESPONSE: SystemExecutionOptionsResponse = {
+  providers: [],
+  models: [],
+  selectedOnlyModels: [],
+  modelLoadError: null,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useSystemExecutionOptions", () => {
+  it("retries one transient failure before surfacing model selector errors", async () => {
+    vi.mocked(api.getSystemExecutionOptions)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(EXECUTION_OPTIONS_RESPONSE);
+
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () => useSystemExecutionOptions({ providerId: "codex" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(EXECUTION_OPTIONS_RESPONSE);
+      expect(api.getSystemExecutionOptions).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not retry intentionally aborted model selector requests", async () => {
+    vi.mocked(api.getSystemExecutionOptions).mockRejectedValue(
+      new DOMException("Aborted", "AbortError"),
+    );
+
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () => useSystemExecutionOptions({ providerId: "codex" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+      expect(api.getSystemExecutionOptions).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { toRecord } from "@bb/core-ui";
 import type {
   SystemConfigResponse,
   SystemExecutionOptionsResponse,
@@ -28,6 +29,34 @@ interface QueryOptions {
   enabled?: boolean;
 }
 
+const SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS = 250;
+const SYSTEM_EXECUTION_OPTIONS_RETRY_COUNT = 1;
+
+function isAbortLikeError(error: unknown): boolean {
+  return toRecord(error)?.name === "AbortError";
+}
+
+function shouldRetrySystemExecutionOptions(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (failureCount >= SYSTEM_EXECUTION_OPTIONS_RETRY_COUNT) {
+    return false;
+  }
+
+  if (isAbortLikeError(error)) {
+    return false;
+  }
+
+  if (error instanceof api.HttpError) {
+    return (
+      error.status === 408 || error.status === 429 || error.status >= 500
+    );
+  }
+
+  return true;
+}
+
 export function useSystemExecutionOptions(
   args: UseSystemExecutionOptionsArgs = {},
 ) {
@@ -46,6 +75,8 @@ export function useSystemExecutionOptions(
       }),
     enabled,
     staleTime: 60_000,
+    retry: shouldRetrySystemExecutionOptions,
+    retryDelay: SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS,
   });
 }
 

--- a/apps/app/src/lib/query-client.test.ts
+++ b/apps/app/src/lib/query-client.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { QueryObserver } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createAppQueryClient,
+  installAppQueryClientBrowserEvents,
+} from "./query-client";
+
+describe("createAppQueryClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refetches active failed queries after a mobile history restore", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+      showMutationErrorToasts: false,
+    });
+    queryClient.mount();
+
+    const queryFn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("mobile page restore interrupted fetch"))
+      .mockResolvedValueOnce("loaded");
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["mobile-restore"],
+      queryFn,
+      refetchOnWindowFocus: true,
+      staleTime: 60_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await vi.waitFor(() => {
+      expect(observer.getCurrentResult().isError).toBe(true);
+    });
+
+    window.dispatchEvent(new Event("pageshow"));
+
+    await vi.waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(2);
+      expect(observer.getCurrentResult().data).toBe("loaded");
+    });
+
+    unsubscribe();
+    queryClient.unmount();
+    queryClient.clear();
+  });
+
+  it("cancels active query fetches before mobile page suspension can fail them", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+      showMutationErrorToasts: false,
+    });
+    const lifecycleEvents = installAppQueryClientBrowserEvents(queryClient);
+    queryClient.mount();
+
+    const signals: AbortSignal[] = [];
+    const resolveFetches: Array<(value: string) => void> = [];
+    const queryFn = vi.fn(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise<string>((resolve, reject) => {
+          signals.push(signal);
+          resolveFetches.push(resolve);
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        }),
+    );
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["mobile-suspend"],
+      queryFn,
+      refetchOnWindowFocus: true,
+      staleTime: 60_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await vi.waitFor(() => {
+      expect(observer.getCurrentResult().fetchStatus).toBe("fetching");
+    });
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    await vi.waitFor(() => {
+      expect(signals[0]?.aborted).toBe(true);
+      expect(observer.getCurrentResult().isError).toBe(false);
+      expect(observer.getCurrentResult().fetchStatus).toBe("idle");
+    });
+
+    window.dispatchEvent(new Event("pageshow"));
+
+    await vi.waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(2);
+    });
+
+    resolveFetches[1]?.("loaded");
+
+    await vi.waitFor(() => {
+      expect(observer.getCurrentResult().data).toBe("loaded");
+    });
+
+    unsubscribe();
+    lifecycleEvents.cleanup();
+    queryClient.unmount();
+    queryClient.clear();
+  });
+});

--- a/apps/app/src/lib/query-client.ts
+++ b/apps/app/src/lib/query-client.ts
@@ -1,4 +1,5 @@
 import {
+  focusManager,
   MutationCache,
   QueryClient,
   type QueryClientConfig,
@@ -7,15 +8,75 @@ import {
   getMutationErrorMeta,
   showMutationErrorToast,
 } from "./mutation-errors";
+import { cancelActiveQueryFetchesForBrowserSuspend } from "@/hooks/cache-owners/browser-lifecycle-cache-owner";
 
 export interface CreateAppQueryClientOptions {
   defaultOptions?: QueryClientConfig["defaultOptions"];
   showMutationErrorToasts?: boolean;
 }
 
+export interface AppQueryClientBrowserEventCleanup {
+  cleanup: () => void;
+}
+
+let appFocusEventsInstalled = false;
+
+function installAppFocusEvents(): void {
+  if (appFocusEventsInstalled) {
+    return;
+  }
+  appFocusEventsInstalled = true;
+
+  focusManager.setEventListener((handleFocus) => {
+    if (typeof window === "undefined" || !window.addEventListener) {
+      return;
+    }
+
+    const listener = () => handleFocus();
+    window.addEventListener("visibilitychange", listener, false);
+    window.addEventListener("pageshow", listener, false);
+
+    return () => {
+      window.removeEventListener("visibilitychange", listener);
+      window.removeEventListener("pageshow", listener);
+    };
+  });
+}
+
+export function installAppQueryClientBrowserEvents(
+  queryClient: QueryClient,
+): AppQueryClientBrowserEventCleanup {
+  installAppFocusEvents();
+
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return { cleanup: () => {} };
+  }
+
+  const handlePageHide = () => {
+    cancelActiveQueryFetchesForBrowserSuspend(queryClient);
+  };
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      cancelActiveQueryFetchesForBrowserSuspend(queryClient);
+    }
+  };
+
+  window.addEventListener("pagehide", handlePageHide, false);
+  document.addEventListener("visibilitychange", handleVisibilityChange, false);
+
+  return {
+    cleanup: () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    },
+  };
+}
+
 export function createAppQueryClient(
   options: CreateAppQueryClientOptions = {},
 ): QueryClient {
+  installAppFocusEvents();
+
   const defaultOptions = options.defaultOptions;
   const showMutationErrorToasts = options.showMutationErrorToasts ?? true;
 

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -6,12 +6,16 @@ import { App } from "./App";
 import { AppToaster } from "./components/AppToaster";
 import { initializePreferredTheme } from "./hooks/useTheme";
 import { initializeFavicon } from "./lib/favicon-color-preference";
-import { createAppQueryClient } from "./lib/query-client";
+import {
+  createAppQueryClient,
+  installAppQueryClientBrowserEvents,
+} from "./lib/query-client";
 import { takeOverPanelResizeCursor } from "./lib/resizeCursor";
 import { applyCachedAppThemeCss } from "./lib/themes";
 import "./app.css";
 
 const queryClient = createAppQueryClient();
+installAppQueryClientBrowserEvents(queryClient);
 
 initializePreferredTheme();
 // Apply the palette cached from the last load before React renders, so a


### PR DESCRIPTION
## Summary
- cancel active React Query fetches when the mobile browser suspends the page
- treat mobile history restores as app focus so failed active queries can recover
- add scoped retry for system execution options so the model selector survives one transient mobile fetch failure

## Tests
- pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/queries/system-queries.test.tsx src/hooks/useThreadCreationOptions.test.tsx src/lib/query-client.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app