### PR TITLE
Store favicon color on the server

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -7,6 +7,7 @@ import { QuickCreateProjectProvider } from "./hooks/useQuickCreateProject";
 import { ProviderCliHealthToasts } from "./components/provider-cli/ProviderCliHealthToasts";
 import { RouteNavigationProvider } from "./components/ui/app-route-anchor";
 import { useAppTheme } from "./hooks/useAppTheme";
+import { useFaviconColorSync } from "./lib/favicon-color-preference";
 import { useDesktopThemeSync } from "./hooks/useDesktopThemeSync";
 import {
   useDesktopUpdateAvailableToast,
@@ -154,6 +155,9 @@ export function App() {
   useDesktopThemeSync();
   // Apply the server-stored app palette (built-in or custom CSS) app-wide.
   useAppTheme();
+  // Reconcile the favicon tint with the server-stored appearance (and migrate
+  // any legacy localStorage-only preference on first load).
+  useFaviconColorSync();
 
   return (
     <QuickCreateProjectProvider>

--- a/apps/app/src/components/git-diff/GitDiffCard.stories.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.stories.tsx
@@ -75,7 +75,11 @@ function usePaletteCss(themeId: BuiltInThemeId) {
       el.id = STORY_THEME_STYLE_ID;
       document.head.appendChild(el);
     }
-    el.textContent = resolveAppThemeCss({ themeId, customCss: null });
+    el.textContent = resolveAppThemeCss({
+      themeId,
+      customCss: null,
+      faviconColor: "default",
+    });
   }, [themeId]);
   useEffect(
     () => () => document.getElementById(STORY_THEME_STYLE_ID)?.remove(),

--- a/apps/app/src/hooks/mutations/settings-mutations.ts
+++ b/apps/app/src/hooks/mutations/settings-mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { Experiments } from "@bb/domain";
+import type { AppThemeSelection, Experiments } from "@bb/domain";
 import * as api from "@/lib/api";
 import { invalidateSystemConfig } from "../cache-owners/system-cache-effects";
 
@@ -24,7 +24,8 @@ export function useUpdateExperiments() {
 }
 
 /**
- * Set the app-wide color palette by id (built-in id or custom theme name). Like
+ * Set the app-wide appearance: the palette id (built-in id or custom theme name)
+ * and optionally the favicon tint (omit to leave it unchanged). Like
  * experiments, the server broadcasts `config-changed` for other windows; the
  * local invalidation refreshes this one.
  */
@@ -35,7 +36,8 @@ export function useUpdateAppearance() {
     meta: {
       errorMessage: "Failed to update appearance.",
     },
-    mutationFn: (themeId: string) => api.updateAppearance(themeId),
+    mutationFn: (selection: AppThemeSelection) =>
+      api.updateAppearance(selection),
     onSuccess: () => {
       invalidateSystemConfig({ queryClient });
     },

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { extractErrorMessage, toRecord } from "@bb/core-ui";
 import type {
   AppTheme,
+  AppThemeSelection,
   Environment,
   Experiments,
   Host,
@@ -1652,9 +1653,11 @@ export async function updateExperiments(
   );
 }
 
-export async function updateAppearance(themeId: string): Promise<AppTheme> {
+export async function updateAppearance(
+  selection: AppThemeSelection,
+): Promise<AppTheme> {
   return request<AppTheme>(
-    apiClient.settings.appearance.$put({ json: { themeId } }),
+    apiClient.settings.appearance.$put({ json: selection }),
   );
 }
 

--- a/apps/app/src/lib/favicon-color-preference.ts
+++ b/apps/app/src/lib/favicon-color-preference.ts
@@ -1,23 +1,18 @@
 import { useEffect } from "react";
-import { atom, getDefaultStore, useAtom, useSetAtom } from "jotai";
-import { atomWithStorage } from "jotai/utils";
-import { createLocalStorageEnumStorage } from "./browser-storage";
+import { atom, getDefaultStore, useSetAtom } from "jotai";
+import {
+  defaultFaviconColor,
+  faviconColorPreferenceSchema,
+  type FaviconColor,
+  type FaviconColorPreference,
+} from "@bb/domain";
+import { useUpdateAppearance } from "@/hooks/mutations/settings-mutations";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
 
+// Reused as both the boot cache (apply the last-known tint before /system/config
+// loads, so the tab icon doesn't flash) and the legacy source for the one-time
+// migration off the old localStorage-only preference.
 export const FAVICON_COLOR_STORAGE_KEY = "bb.faviconColor";
-
-export const FAVICON_COLORS = [
-  "red",
-  "orange",
-  "yellow",
-  "green",
-  "teal",
-  "blue",
-  "purple",
-  "pink",
-] as const;
-
-export type FaviconColor = (typeof FAVICON_COLORS)[number];
-export type FaviconColorPreference = FaviconColor | "default";
 
 export const FAVICON_BADGES = ["none", "unread"] as const;
 export type FaviconBadge = (typeof FAVICON_BADGES)[number];
@@ -33,27 +28,71 @@ export const FAVICON_COLOR_VALUES: Record<FaviconColor, string> = {
   pink: "#d6409f",
 };
 
-function isFaviconColorPreference(
-  value: string,
-): value is FaviconColorPreference {
-  return value === "default" || FAVICON_COLORS.some((color) => color === value);
+function readCachedFaviconColor(): FaviconColorPreference {
+  try {
+    const parsed = faviconColorPreferenceSchema.safeParse(
+      localStorage.getItem(FAVICON_COLOR_STORAGE_KEY),
+    );
+    return parsed.success ? parsed.data : defaultFaviconColor;
+  } catch {
+    return defaultFaviconColor;
+  }
 }
 
-const faviconColorPreferenceStorage =
-  createLocalStorageEnumStorage<FaviconColorPreference>(
-    isFaviconColorPreference,
-  );
+function cacheFaviconColor(color: FaviconColorPreference): void {
+  try {
+    if (color === defaultFaviconColor) {
+      localStorage.removeItem(FAVICON_COLOR_STORAGE_KEY);
+    } else {
+      localStorage.setItem(FAVICON_COLOR_STORAGE_KEY, color);
+    }
+  } catch {
+    // Best-effort cache; ignore private-mode / quota failures.
+  }
+}
 
-const faviconColorPreferenceAtom = atomWithStorage<FaviconColorPreference>(
-  FAVICON_COLOR_STORAGE_KEY,
-  "default",
-  faviconColorPreferenceStorage,
-  { getOnInit: true },
-);
+// Seeded from the boot cache so initializeFavicon() can tint immediately, then
+// reconciled with the server's authoritative value by useFaviconColorSync().
+const faviconColorAtom = atom<FaviconColorPreference>(readCachedFaviconColor());
 const faviconBadgeAtom = atom<FaviconBadge>("none");
 
-export function useFaviconColorPreference() {
-  return useAtom(faviconColorPreferenceAtom);
+function setActiveFaviconColor(color: FaviconColorPreference): void {
+  getDefaultStore().set(faviconColorAtom, color);
+  cacheFaviconColor(color);
+}
+
+let legacyFaviconColorMigrated = false;
+
+/**
+ * Reconciles the favicon tint with the server-stored appearance and re-applies
+ * it whenever /system/config changes (another window updated it). Also performs
+ * a one-time migration off the old localStorage-only preference: if this client
+ * still has a non-default cached color and the server has none, adopt it
+ * server-side so the choice survives the move to server storage.
+ */
+export function useFaviconColorSync(): void {
+  const { data } = useSystemConfig();
+  const appearance = data?.appearance;
+  const { mutate: updateAppearance } = useUpdateAppearance();
+
+  useEffect(() => {
+    if (!appearance) return;
+    const legacy = readCachedFaviconColor();
+    const needsMigration =
+      legacy !== defaultFaviconColor &&
+      appearance.faviconColor === defaultFaviconColor;
+    if (needsMigration) {
+      // Keep showing the legacy tint locally until the server adopts it (so it
+      // doesn't flash to default mid-flight), and fire the migration once.
+      setActiveFaviconColor(legacy);
+      if (!legacyFaviconColorMigrated) {
+        legacyFaviconColorMigrated = true;
+        updateAppearance({ themeId: appearance.themeId, faviconColor: legacy });
+      }
+      return;
+    }
+    setActiveFaviconColor(appearance.faviconColor);
+  }, [appearance, updateAppearance]);
 }
 
 export function useFaviconBadge(badge: FaviconBadge): void {
@@ -228,10 +267,10 @@ export function initializeFavicon(): void {
     // index.html bootstrap script already applied.
     void applyFaviconState({
       badge: store.get(faviconBadgeAtom),
-      colorPreference: store.get(faviconColorPreferenceAtom),
+      colorPreference: store.get(faviconColorAtom),
     }).catch(() => {});
   };
-  store.sub(faviconColorPreferenceAtom, apply);
+  store.sub(faviconColorAtom, apply);
   store.sub(faviconBadgeAtom, apply);
   if (typeof window.matchMedia === "function") {
     window

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { defaultAppTheme } from "@bb/domain";
 import type { WorkspaceOpenTarget } from "@bb/host-daemon-contract";
 import type { HostDaemonStatusSnapshot } from "./api-host-daemon";
 import type { SystemConfigResponse } from "@bb/server-contract";
@@ -13,7 +14,7 @@ const unavailableSystemConfig: SystemConfigResponse = {
     popoutChat: false,
     popoutChatHotkey: "Alt+Space",
   },
-  appearance: { themeId: "default", customCss: null },
+  appearance: defaultAppTheme,
   customThemes: [],
   featureFlags: { placeholder: false },
   hostDaemonPort: null,

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -5,6 +5,7 @@ import {
   defaultExperiments,
   isValidElectronAccelerator,
   type AppTheme,
+  type FaviconColorPreference,
 } from "@bb/domain";
 import type {
   WorkspaceOpenTarget,
@@ -43,8 +44,6 @@ import { getBbDesktopInfo, isDesktopBrowserAvailable } from "@/lib/bb-desktop";
 import {
   FAVICON_COLOR_VALUES,
   getFaviconGlyphHref,
-  useFaviconColorPreference,
-  type FaviconColorPreference,
 } from "@/lib/favicon-color-preference";
 import { useOpenLinksInAppBrowserPreference } from "@/lib/in-app-browser-link-preference";
 import { useRewriteLocalhostLinksPreference } from "@/lib/localhost-link-rewrite-preference";
@@ -114,6 +113,7 @@ export interface RichTextEditingSettingsControlProps {
 }
 
 export interface FaviconColorSettingsControlProps {
+  disabled: boolean;
   faviconColor: FaviconColorPreference;
   onFaviconColorChange: (faviconColor: FaviconColorPreference) => void;
 }
@@ -209,6 +209,7 @@ function FaviconColorPreview({ value }: { value: FaviconColorPreference }) {
 }
 
 export function FaviconColorSettingsControl({
+  disabled,
   faviconColor,
   onFaviconColorChange,
 }: FaviconColorSettingsControlProps) {
@@ -224,6 +225,7 @@ export function FaviconColorSettingsControl({
             size="sm"
             className="w-full justify-between border-border/60 bg-card sm:w-48"
             aria-label="Favicon color"
+            disabled={disabled}
           >
             <span className="flex min-w-0 items-center gap-2">
               <FaviconColorPreview value={faviconColor} />
@@ -593,6 +595,7 @@ export function GeneralSettingsSection({
         </SettingsWithControl>
 
         <FaviconColorSettingsControl
+          disabled={appearanceDisabled}
           faviconColor={faviconColor}
           onFaviconColorChange={onFaviconColorChange}
         />
@@ -873,7 +876,6 @@ export function ExperimentsSettingsSection({
 export function SettingsView() {
   const themePreference = useThemePreference();
   const systemConfigQuery = useSystemConfig();
-  const [faviconColor, setFaviconColor] = useFaviconColorPreference();
   const { hasDaemon } = useHostDaemon();
   const { workspaceOpenTargets } = useWorkspaceOpenTargets({
     enabled: hasDaemon,
@@ -908,16 +910,21 @@ export function SettingsView() {
           }
           customThemes={systemConfigQuery.data?.customThemes ?? []}
           desktopBrowserAvailable={desktopBrowserAvailable}
-          faviconColor={faviconColor}
+          faviconColor={appearance.faviconColor}
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
           openLinksInAppBrowser={openLinksInAppBrowser}
           rewriteLocalhostLinks={rewriteLocalhostLinks}
           richTextEditing={richTextEditing}
           themePreference={themePreference}
           onAppearanceThemeChange={(themeId) =>
-            updateAppearanceMutation.mutate(themeId)
+            updateAppearanceMutation.mutate({ themeId })
           }
-          onFaviconColorChange={setFaviconColor}
+          onFaviconColorChange={(faviconColor) =>
+            updateAppearanceMutation.mutate({
+              themeId: appearance.themeId,
+              faviconColor,
+            })
+          }
           onNavigateToThreadAfterCreateChange={setNavigateToThreadAfterCreate}
           onOpenLinksInAppBrowserChange={setOpenLinksInAppBrowser}
           onRewriteLocalhostLinksChange={setRewriteLocalhostLinks}

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -1,8 +1,9 @@
 import {
   getExperiments,
+  getStoredFaviconColor,
   getStoredThemeId,
   setExperiments,
-  setStoredThemeId,
+  setStoredAppearance,
 } from "@bb/db";
 import { customThemeNameSchema, isBuiltInThemeId } from "@bb/domain";
 import {
@@ -41,7 +42,11 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
   function buildSystemConfigResponse() {
     return {
       experiments: getExperiments(deps.db),
-      appearance: resolveAppTheme(themeRoot, getStoredThemeId(deps.db)),
+      appearance: resolveAppTheme(
+        themeRoot,
+        getStoredThemeId(deps.db),
+        getStoredFaviconColor(deps.db),
+      ),
       customThemes: listCustomThemeNames(themeRoot),
       featureFlags: deps.config.featureFlags,
       hostDaemonPort: deps.config.hostDaemonPort,
@@ -77,18 +82,24 @@ export function registerSystemRoutes(app: Hono, deps: ServerAppDeps): void {
         );
       }
     }
-    setStoredThemeId(deps.db, themeId);
+    // Favicon tint is omitted for theme-only changes; keep the current value.
+    const faviconColor = payload.faviconColor ?? getStoredFaviconColor(deps.db);
+    setStoredAppearance(deps.db, { themeId, faviconColor });
     // Broadcast like experiments: every window re-reads /system/config and
     // re-applies the active palette.
     deps.hub.notifySystem(["config-changed"]);
-    return context.json(resolveAppTheme(themeRoot, themeId));
+    return context.json(resolveAppTheme(themeRoot, themeId, faviconColor));
   });
 
   get(routes.themes, (context) =>
     context.json({
       dir: themeRoot,
       custom: listCustomThemeNames(themeRoot),
-      active: resolveAppTheme(themeRoot, getStoredThemeId(deps.db)),
+      active: resolveAppTheme(
+        themeRoot,
+        getStoredThemeId(deps.db),
+        getStoredFaviconColor(deps.db),
+      ),
     }),
   );
 

--- a/apps/server/src/services/system/custom-themes.ts
+++ b/apps/server/src/services/system/custom-themes.ts
@@ -6,6 +6,7 @@ import {
   defaultAppTheme,
   isBuiltInThemeId,
   type AppTheme,
+  type FaviconColorPreference,
 } from "@bb/domain";
 
 const THEME_DIR_NAME = "theme";
@@ -72,11 +73,16 @@ export function readCustomThemeCss(
  * Resolve a stored palette id into the active appearance: built-ins carry no
  * CSS (the frontend bundles it); a custom theme's CSS is read from disk. A
  * selection whose theme folder is gone (deleted out from under the app) falls
- * back to the default palette so the app never renders against missing CSS.
+ * back to the default palette so the app never renders against missing CSS. The
+ * favicon tint is an independent appearance facet, passed through unchanged.
  */
-export function resolveAppTheme(themeRoot: string, themeId: string): AppTheme {
-  if (isBuiltInThemeId(themeId)) return { themeId, customCss: null };
+export function resolveAppTheme(
+  themeRoot: string,
+  themeId: string,
+  faviconColor: FaviconColorPreference,
+): AppTheme {
+  if (isBuiltInThemeId(themeId)) return { themeId, customCss: null, faviconColor };
   const customCss = readCustomThemeCss(themeRoot, themeId);
-  if (customCss === null) return defaultAppTheme;
-  return { themeId, customCss };
+  if (customCss === null) return { ...defaultAppTheme, faviconColor };
+  return { themeId, customCss, faviconColor };
 }

--- a/apps/server/test/system/appearance.test.ts
+++ b/apps/server/test/system/appearance.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { getStoredThemeId } from "@bb/db";
+import { getStoredFaviconColor, getStoredThemeId } from "@bb/db";
 import { appThemeSchema } from "@bb/domain";
 import {
   themeCatalogResponseSchema,
@@ -27,7 +27,11 @@ describe("appearance settings", () => {
       const response = await harness.app.request("/api/v1/system/config");
       expect(response.status).toBe(200);
       const body = systemConfigResponseSchema.parse(await readJson(response));
-      expect(body.appearance).toEqual({ themeId: "default", customCss: null });
+      expect(body.appearance).toEqual({
+        themeId: "default",
+        customCss: null,
+        faviconColor: "default",
+      });
       expect(body.customThemes).toEqual([]);
     });
   });
@@ -43,13 +47,14 @@ describe("appearance settings", () => {
       expect(appThemeSchema.parse(await readJson(put))).toEqual({
         themeId: "nord",
         customCss: null,
+        faviconColor: "default",
       });
       expect(getStoredThemeId(harness.db)).toBe("nord");
 
       const config = await harness.app.request("/api/v1/system/config");
       expect(
         systemConfigResponseSchema.parse(await readJson(config)).appearance,
-      ).toEqual({ themeId: "nord", customCss: null });
+      ).toEqual({ themeId: "nord", customCss: null, faviconColor: "default" });
     });
   });
 
@@ -67,14 +72,74 @@ describe("appearance settings", () => {
       expect(appThemeSchema.parse(await readJson(put))).toEqual({
         themeId: "midnight",
         customCss: css,
+        faviconColor: "default",
       });
       expect(getStoredThemeId(harness.db)).toBe("midnight");
 
       const config = systemConfigResponseSchema.parse(
         await readJson(await harness.app.request("/api/v1/system/config")),
       );
-      expect(config.appearance).toEqual({ themeId: "midnight", customCss: css });
+      expect(config.appearance).toEqual({
+        themeId: "midnight",
+        customCss: css,
+        faviconColor: "default",
+      });
       expect(config.customThemes).toEqual(["midnight"]);
+    });
+  });
+
+  it("persists the favicon color independently of the palette", async () => {
+    await withTestHarness(async (harness) => {
+      const put = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "default", faviconColor: "teal" }),
+      });
+      expect(put.status).toBe(200);
+      expect(getStoredFaviconColor(harness.db)).toBe("teal");
+
+      const config = systemConfigResponseSchema.parse(
+        await readJson(await harness.app.request("/api/v1/system/config")),
+      );
+      expect(config.appearance).toEqual({
+        themeId: "default",
+        customCss: null,
+        faviconColor: "teal",
+      });
+    });
+  });
+
+  it("leaves the favicon color unchanged on a theme-only change", async () => {
+    await withTestHarness(async (harness) => {
+      await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "default", faviconColor: "purple" }),
+      });
+
+      // A theme-only write omits faviconColor and must not reset it.
+      const put = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "nord" }),
+      });
+      expect(appThemeSchema.parse(await readJson(put))).toEqual({
+        themeId: "nord",
+        customCss: null,
+        faviconColor: "purple",
+      });
+      expect(getStoredFaviconColor(harness.db)).toBe("purple");
+    });
+  });
+
+  it("rejects an unknown favicon color", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/settings/appearance", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ themeId: "default", faviconColor: "chartreuse" }),
+      });
+      expect(response.status).toBe(400);
     });
   });
 
@@ -94,7 +159,11 @@ describe("appearance settings", () => {
       );
       expect(catalog.dir).toBe(join(harness.config.dataDir, "theme"));
       expect(catalog.custom).toEqual(["amber", "zephyr"]);
-      expect(catalog.active).toEqual({ themeId: "default", customCss: null });
+      expect(catalog.active).toEqual({
+        themeId: "default",
+        customCss: null,
+        faviconColor: "default",
+      });
     });
   });
 
@@ -117,7 +186,11 @@ describe("appearance settings", () => {
       );
       // The selection is still stored, but resolution falls back gracefully.
       expect(getStoredThemeId(harness.db)).toBe("ghost");
-      expect(config.appearance).toEqual({ themeId: "default", customCss: null });
+      expect(config.appearance).toEqual({
+        themeId: "default",
+        customCss: null,
+        faviconColor: "default",
+      });
       expect(config.customThemes).toEqual([]);
     });
   });

--- a/apps/server/test/system/custom-themes.test.ts
+++ b/apps/server/test/system/custom-themes.test.ts
@@ -42,37 +42,42 @@ describe("custom themes service", () => {
   });
 
   it("resolves a built-in id without reading disk", () => {
-    expect(resolveAppTheme(themeRoot, "nord")).toEqual({
+    expect(resolveAppTheme(themeRoot, "nord", "blue")).toEqual({
       themeId: "nord",
       customCss: null,
+      faviconColor: "blue",
     });
   });
 
   it("resolves a custom theme's CSS from disk", async () => {
     await writeTheme(themeRoot, "ocean", ":root { --primary: #06f; }");
-    expect(resolveAppTheme(themeRoot, "ocean")).toEqual({
+    expect(resolveAppTheme(themeRoot, "ocean", "teal")).toEqual({
       themeId: "ocean",
       customCss: ":root { --primary: #06f; }",
+      faviconColor: "teal",
     });
   });
 
-  it("falls back to default for a missing or unsafe selection", () => {
-    expect(resolveAppTheme(themeRoot, "missing")).toEqual({
+  it("falls back to default palette but keeps the favicon tint for a missing or unsafe selection", () => {
+    expect(resolveAppTheme(themeRoot, "missing", "pink")).toEqual({
       themeId: "default",
       customCss: null,
+      faviconColor: "pink",
     });
-    expect(resolveAppTheme(themeRoot, "../escape")).toEqual({
+    expect(resolveAppTheme(themeRoot, "../escape", "pink")).toEqual({
       themeId: "default",
       customCss: null,
+      faviconColor: "pink",
     });
   });
 
   it("rejects oversized stylesheets so the broadcast payload stays bounded", async () => {
     await writeTheme(themeRoot, "huge", "a".repeat(CUSTOM_THEME_CSS_MAX_LENGTH + 1));
     expect(readCustomThemeCss(themeRoot, "huge")).toBeNull();
-    expect(resolveAppTheme(themeRoot, "huge")).toEqual({
+    expect(resolveAppTheme(themeRoot, "huge", "default")).toEqual({
       themeId: "default",
       customCss: null,
+      faviconColor: "default",
     });
   });
 });

--- a/packages/db/drizzle/0045_unique_monster_badoon.sql
+++ b/packages/db/drizzle/0045_unique_monster_badoon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `app_theme` ADD `favicon_color` text DEFAULT 'default' NOT NULL;

--- a/packages/db/drizzle/meta/0045_snapshot.json
+++ b/packages/db/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,2764 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3ad532d1-168c-4b2c-a7f9-854978aa6d94",
+  "prevId": "728d4177-c6bd-48fd-af16-1ca83bdfa34f",
+  "tables": {
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "favicon_color": {
+          "name": "favicon_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_runs": {
+      "name": "automation_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_started_idx": {
+          "name": "automation_runs_automation_started_idx",
+          "columns": [
+            "automation_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "automation_runs_thread_idx": {
+          "name": "automation_runs_thread_idx",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_automations_id_fk": {
+          "name": "automation_runs_automation_id_automations_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_runs_thread_id_threads_id_fk": {
+          "name": "automation_runs_thread_id_threads_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_thread_id": {
+          "name": "target_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution": {
+          "name": "execution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_archive": {
+          "name": "auto_archive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_thread_id": {
+          "name": "created_by_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_thread_id": {
+          "name": "last_run_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "automations_project_idx": {
+          "name": "automations_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            "enabled",
+            "trigger_type",
+            "next_run_at"
+          ],
+          "isUnique": false
+        },
+        "automations_target_thread_idx": {
+          "name": "automations_target_thread_idx",
+          "columns": [
+            "target_thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_project_id_projects_id_fk": {
+          "name": "automations_project_id_projects_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automations_target_thread_id_threads_id_fk": {
+          "name": "automations_target_thread_id_threads_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "target_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destroy_attempt_id": {
+          "name": "destroy_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provision_type": {
+          "name": "workspace_provision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_host_path_idx": {
+          "name": "environments_host_path_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_type": {
+          "name": "host_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claude_code_mock_cli_traffic": {
+          "name": "claude_code_mock_cli_traffic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "popout_chat": {
+          "name": "popout_chat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "popout_chat_hotkey": {
+          "name": "popout_chat_hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_idx": {
+          "name": "thread_search_segments_thread_idx",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "child_origin": {
+          "name": "child_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1782249376381,
       "tag": "0044_flimsy_black_cat",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "6",
+      "when": 1782251367423,
+      "tag": "0045_unique_monster_badoon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/app-theme.ts
+++ b/packages/db/src/data/app-theme.ts
@@ -1,5 +1,9 @@
 import { eq } from "drizzle-orm";
-import { defaultAppTheme } from "@bb/domain";
+import {
+  defaultAppTheme,
+  defaultFaviconColor,
+  type FaviconColorPreference,
+} from "@bb/domain";
 import type { DbConnection } from "../connection.js";
 import { appTheme } from "../schema.js";
 
@@ -19,13 +23,28 @@ export function getStoredThemeId(db: DbConnection): string {
   return row?.themeId ?? defaultAppTheme.themeId;
 }
 
-export function setStoredThemeId(db: DbConnection, themeId: string): void {
+/** The persisted favicon tint; "default" when unset. */
+export function getStoredFaviconColor(db: DbConnection): FaviconColorPreference {
+  const row = db
+    .select({ faviconColor: appTheme.faviconColor })
+    .from(appTheme)
+    .where(eq(appTheme.id, APP_THEME_ROW_ID))
+    .get();
+
+  return row?.faviconColor ?? defaultFaviconColor;
+}
+
+export function setStoredAppearance(
+  db: DbConnection,
+  appearance: { themeId: string; faviconColor: FaviconColorPreference },
+): void {
   const updatedAt = Date.now();
+  const { themeId, faviconColor } = appearance;
   db.insert(appTheme)
-    .values({ id: APP_THEME_ROW_ID, themeId, updatedAt })
+    .values({ id: APP_THEME_ROW_ID, themeId, faviconColor, updatedAt })
     .onConflictDoUpdate({
       target: appTheme.id,
-      set: { themeId, updatedAt },
+      set: { themeId, faviconColor, updatedAt },
     })
     .run();
 }

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -170,7 +170,11 @@ export type {
 
 export { getExperiments, setExperiments } from "./experiments.js";
 
-export { getStoredThemeId, setStoredThemeId } from "./app-theme.js";
+export {
+  getStoredThemeId,
+  getStoredFaviconColor,
+  setStoredAppearance,
+} from "./app-theme.js";
 
 export {
   getThreadDynamicContextFileState,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -20,6 +20,7 @@ import type {
   AutomationRunTrigger,
   AutomationTriggerType,
   EnvironmentStatus,
+  FaviconColorPreference,
   HostType,
   PendingInteractionStatus,
   PermissionMode,
@@ -152,12 +153,16 @@ export const systemExperiments = sqliteTable("system_experiments", {
   updatedAt: integer("updated_at").notNull(),
 });
 
-// Single-row table (id = "current") holding the app-wide color palette: the
-// active palette id — a built-in theme id, or a custom theme name whose CSS
-// lives on disk under `<data-dir>/theme/<name>/theme.css`.
+// Single-row table (id = "current") holding the app-wide appearance: the active
+// palette id (a built-in theme id, or a custom theme name whose CSS lives on
+// disk under `<data-dir>/theme/<name>/theme.css`) and the browser tab icon tint.
 export const appTheme = sqliteTable("app_theme", {
   id: text("id").primaryKey(),
   themeId: text("theme_id").notNull(),
+  faviconColor: text("favicon_color")
+    .$type<FaviconColorPreference>()
+    .notNull()
+    .default("default"),
   updatedAt: integer("updated_at").notNull(),
 });
 

--- a/packages/domain/src/app-theme.ts
+++ b/packages/domain/src/app-theme.ts
@@ -90,21 +90,55 @@ export const CUSTOM_THEME_CSS_MAX_LENGTH = 256_000;
  * custom theme name) plus the resolved custom CSS (null for built-ins, the
  * `theme.css` contents for a custom theme).
  */
+/**
+ * Selectable favicon tints. The hex values and canvas tinting live in the
+ * frontend; the contract only needs the set of allowed ids so the server can
+ * validate writes. "default" leaves the monochrome glyph untinted.
+ */
+export const FAVICON_COLORS = [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "teal",
+  "blue",
+  "purple",
+  "pink",
+] as const;
+export type FaviconColor = (typeof FAVICON_COLORS)[number];
+
+export const faviconColorPreferenceSchema = z.enum([
+  "default",
+  ...FAVICON_COLORS,
+]);
+export type FaviconColorPreference = z.infer<typeof faviconColorPreferenceSchema>;
+
+export const defaultFaviconColor: FaviconColorPreference = "default";
+
 export const appThemeSchema = z.object({
   themeId: z.string().min(1),
   /** Resolved CSS for a custom palette; null for built-ins. */
   customCss: z.string().max(CUSTOM_THEME_CSS_MAX_LENGTH).nullable(),
+  /** Browser tab icon tint; "default" leaves the glyph untinted. */
+  faviconColor: faviconColorPreferenceSchema,
 });
 export type AppTheme = z.infer<typeof appThemeSchema>;
 
 /**
- * The palette selection a client sends when switching themes: just the id. The
- * server validates it (built-in id or an existing custom theme) and resolves the
- * CSS from disk for custom themes.
+ * The appearance selection a client sends when changing the palette and/or the
+ * favicon tint. The server validates `themeId` (built-in id or an existing
+ * custom theme) and resolves the CSS from disk for custom themes. `faviconColor`
+ * is omitted to leave the current tint unchanged, so a theme-only change (and
+ * the CLI/SDK `theme set`, which only knows the id) never resets the tint.
  */
 export const appThemeSelectionSchema = z.object({
   themeId: z.string().min(1),
+  faviconColor: faviconColorPreferenceSchema.optional(),
 });
 export type AppThemeSelection = z.infer<typeof appThemeSelectionSchema>;
 
-export const defaultAppTheme: AppTheme = { themeId: "default", customCss: null };
+export const defaultAppTheme: AppTheme = {
+  themeId: "default",
+  customCss: null,
+  faviconColor: defaultFaviconColor,
+};


### PR DESCRIPTION
## Summary

Moves the favicon tab-icon tint from per-browser `localStorage` into the server-side `app_theme` / `appearance` setting, so the choice is app-wide and syncs across windows (and survives reinstalls) like the color palette.

Rebased onto the new theme architecture (#305), where appearance writes are id-only (`appThemeSelectionSchema`) and custom CSS is resolved from disk.

- **domain** (`packages/domain/src/app-theme.ts`): add `faviconColor` to `AppTheme` (the resolved read model) and an **optional** `faviconColor` to `appThemeSelectionSchema` (the write). Omitting it leaves the current tint unchanged — so a theme-only change, and the CLI/SDK `theme set` (which only knows the id), never reset the tint.
- **db** (`packages/db/`): add `favicon_color text NOT NULL DEFAULT 'default'` to `app_theme` (migration `0045`, a clean `ADD COLUMN` so existing rows backfill); add `getStoredFaviconColor` and a combined `setStoredAppearance`.
- **server**: `resolveAppTheme` carries the tint through; `PUT /settings/appearance` keeps the current tint when the selection omits it, and broadcasts `config-changed` as before.
- **app**: feed the favicon tint from `/system/config` via a new `useFaviconColorSync()` (replacing the `localStorage` atom). A `localStorage` boot cache applies the last-known tint before config loads (no flash), and a one-time migration adopts any legacy `localStorage` value server-side (kept visible mid-flight, robust under StrictMode). Both pickers write through the appearance mutation.

## Behavior change

Favicon color is now **app-wide** (shared across all windows/browsers hitting the same server), which is the point of moving it server-side. It was previously per-browser-profile.

## Tests

- `apps/server/test/system/appearance.test.ts`: favicon color persists independently of the palette, a theme-only write leaves it unchanged, and an invalid color is rejected; existing assertions updated for the new field.
- `apps/server/test/system/custom-themes.test.ts`: `resolveAppTheme` passes the tint through, including when falling back from a missing custom theme.
- `@bb/db` full suite, `@bb/server` appearance + custom-themes suites (16), and the favicon unread-count test pass. Typecheck green across `@bb/domain`, `@bb/db`, `@bb/server`, `@bb/server-contract`, `@bb/app`, `@bb/cli`, `@bb/sdk`.

## Notes

No CLI/guide/skill/docs changes needed — the CLI/SDK `theme set` is unchanged (it omits `faviconColor`, so the tint is preserved automatically), and favicon color remains an in-app Settings toggle with no existing mention in those surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)