### PR TITLE
Fix zen promptbox overflow

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -303,6 +303,46 @@ describe("PromptBoxInternal controlled value sync", () => {
   });
 });
 
+describe("PromptBoxInternal zen mode layout", () => {
+  it("keeps long editor content constrained to the scroll area", async () => {
+    const storageKey = "bb.test.promptbox.zen-layout";
+    window.localStorage.removeItem(storageKey);
+
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          value: Array.from({ length: 40 }, (_, index) => `Line ${index + 1}`)
+            .join("\n"),
+          zenMode: { storageKey },
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Enter zen mode" }));
+
+    await waitFor(() => {
+      const scrollContainer = document.querySelector(
+        "[data-promptbox-editor-scroll]",
+      );
+      if (!(scrollContainer instanceof HTMLElement)) {
+        throw new Error("Prompt editor scroll container was not rendered");
+      }
+
+      expect(scrollContainer.classList.contains("min-h-0")).toBe(true);
+      expect(scrollContainer.parentElement?.classList.contains("min-h-0")).toBe(
+        true,
+      );
+    });
+
+    const footerRow =
+      screen.getByRole("button", { name: "Attach files" }).parentElement
+        ?.parentElement;
+    expect(footerRow?.classList.contains("shrink-0")).toBe(true);
+
+    window.localStorage.removeItem(storageKey);
+  });
+});
+
 describe("PromptBoxInternal prompt actions", () => {
   it("places prompt actions before the right-side action cluster", () => {
     renderPromptBox("");

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2289,7 +2289,9 @@ export function PromptBoxInternal({
         // mode also gets more top room since the card fills the viewport.
         <div className="pl-4 pr-14 pt-3">{header}</div>
       ) : null}
-      <div className={cn("relative", isZenMode && "flex flex-1 flex-col")}>
+      <div
+        className={cn("relative", isZenMode && "min-h-0 flex flex-1 flex-col")}
+      >
         <Button
           type="button"
           size="icon"
@@ -2410,7 +2412,7 @@ export function PromptBoxInternal({
         </div>
       ) : null}
 
-      <div className="flex flex-row items-center gap-3 px-3.5 pt-1.5">
+      <div className="flex shrink-0 flex-row items-center gap-3 px-3.5 pt-1.5">
         <div
           className="flex min-w-0 flex-1 flex-row items-center gap-1"
           aria-live="polite"


### PR DESCRIPTION
## Summary
- keep the zen-mode prompt editor region shrinkable so long content scrolls inside the editor
- keep the promptbox footer controls from shrinking out of the promptbox
- add a regression test for the zen-mode flex constraints

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxInternal.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app