### PR TITLE
Improve promptbox context banner previews

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -13,14 +13,33 @@ export default {
 
 const noop = () => {};
 
+type StageSize = "desktop" | "mobile";
+
 interface PromptStageProps {
   children: ReactNode;
+  size: StageSize;
 }
 
-// Production max width matches PageShell's footer cap (760px). Without it the
-// queued list stretches the full row width, which doesn't reflect prod.
-function PromptStage({ children }: PromptStageProps) {
-  return <div className="w-full max-w-[760px]">{children}</div>;
+function PromptStage({ children, size }: PromptStageProps) {
+  return (
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResponsivePromptStage({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <PromptStage size="desktop">{children}</PromptStage>
+      <PromptStage size="mobile">{children}</PromptStage>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -201,62 +220,62 @@ export function Blockquotes() {
         label="mixed: quoted + plain"
         hint="quoted and plain rows both render as one truncated line"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={mixedMessages} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="plain messages (no quotes)"
         hint="single-line preview, leading icon centered — for comparison"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={multipleMessages} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="quote + reply"
         hint="a single `> ` block above the typed reply"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={quoteSingle} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="multi-line quote"
         hint="every quoted line is prefixed and styled as one blockquote"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={quoteMultiline} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="two quote→reply blocks"
         hint="stacked quote/reply sections in one queued message"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={quoteTwoBlocks} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow label="quote only" hint="quoted selection with no reply yet">
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={quoteOnly} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="long quote (truncated)"
         hint="single-line preview fades at the right edge"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={quoteTruncated} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="quote + attachment"
         hint="attachment count still shows under the quoted block"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={quoteWithAttachment} />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
     </StoryCard>
   );
@@ -293,7 +312,7 @@ export function Overview() {
   return (
     <StoryCard>
       <StoryRow label="single message" hint="one queued message">
-        <PromptStage>
+        <ResponsivePromptStage>
           <QueuedMessagesList
             queuedMessages={oneMessage}
             sendDisabled={false}
@@ -305,18 +324,18 @@ export function Overview() {
             onEdit={noop}
             onDelete={noop}
           />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow label="multiple messages" hint="drag the row icon to reorder">
-        <PromptStage>
+        <ResponsivePromptStage>
           <ReorderableQueuedMessagesList />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="overflowing queue"
         hint="height-capped list shows top/bottom fades while scrolling"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <QueuedMessagesList
             queuedMessages={manyMessages}
             sendDisabled={false}
@@ -328,13 +347,13 @@ export function Overview() {
             onEdit={noop}
             onDelete={noop}
           />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="with attachments"
         hint="attachment counts shown alongside text"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <QueuedMessagesList
             queuedMessages={withAttachments}
             sendDisabled={false}
@@ -346,13 +365,13 @@ export function Overview() {
             onEdit={noop}
             onDelete={noop}
           />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="long message"
         hint="single line fades at the right edge; title attribute carries full text"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <QueuedMessagesList
             queuedMessages={longMessage}
             sendDisabled={false}
@@ -364,13 +383,13 @@ export function Overview() {
             onEdit={noop}
             onDelete={noop}
           />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="processing one"
         hint="middle row is being sent immediately; its actions disable"
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <QueuedMessagesList
             queuedMessages={multipleMessages}
             sendDisabled={false}
@@ -382,13 +401,13 @@ export function Overview() {
             onEdit={noop}
             onDelete={noop}
           />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
       <StoryRow
         label="send disabled"
         hint='runtime busy — cannot "Send now" but edit/delete still work'
       >
-        <PromptStage>
+        <ResponsivePromptStage>
           <QueuedMessagesList
             queuedMessages={multipleMessages}
             sendDisabled
@@ -400,7 +419,7 @@ export function Overview() {
             onEdit={noop}
             onDelete={noop}
           />
-        </PromptStage>
+        </ResponsivePromptStage>
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.stories.tsx
@@ -8,8 +8,34 @@ export default {
   title: "promptbox/banner/Background Commands Card",
 };
 
-function Stage({ children }: { children: React.ReactNode }) {
-  return <div className="w-full max-w-[760px]">{children}</div>;
+type StageSize = "desktop" | "mobile";
+
+function Stage({
+  children,
+  size,
+}: {
+  children: React.ReactNode;
+  size: StageSize;
+}) {
+  return (
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResponsiveStage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <Stage size="desktop">{children}</Stage>
+      <Stage size="mobile">{children}</Stage>
+    </div>
+  );
 }
 
 function FauxComposer() {
@@ -90,25 +116,25 @@ export function Overview() {
         label="single"
         hint="one running command: non-expandable single line with live time"
       >
-        <Stage>
+        <ResponsiveStage>
           <ExpandableCard commands={single} />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow
         label="multiple (collapsed)"
         hint='most recent command + "+N more"; click to expand'
       >
-        <Stage>
+        <ResponsiveStage>
           <ExpandableCard commands={many} />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow
         label="multiple (expanded)"
         hint="expanded: the other running commands listed below the primary"
       >
-        <Stage>
+        <ResponsiveStage>
           <ExpandableCard commands={many} startExpanded />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadGoalCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadGoalCard.stories.tsx
@@ -7,8 +7,34 @@ export default {
   title: "promptbox/banner/Goal Card",
 };
 
-function Stage({ children }: { children: React.ReactNode }) {
-  return <div className="w-full max-w-[760px]">{children}</div>;
+type StageSize = "desktop" | "mobile";
+
+function Stage({
+  children,
+  size,
+}: {
+  children: React.ReactNode;
+  size: StageSize;
+}) {
+  return (
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResponsiveStage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <Stage size="desktop">{children}</Stage>
+      <Stage size="mobile">{children}</Stage>
+    </div>
+  );
 }
 
 const activeGoal: ThreadTimelineGoal = {
@@ -71,25 +97,25 @@ export function Overview() {
         label="prompt stack"
         hint="goal card above the composer; click to expand"
       >
-        <Stage>
+        <ResponsiveStage>
           <div className="flex flex-col gap-2">
             <ToggleableGoalCard goal={activeGoal} />
             <FauxComposer />
           </div>
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow
         label="expanded"
         hint="full objective with token budget and elapsed time"
       >
-        <Stage>
+        <ResponsiveStage>
           <ToggleableGoalCard goal={activeGoal} initiallyExpanded />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow label="no token budget" hint="unbounded goal usage summary">
-        <Stage>
+        <ResponsiveStage>
           <ToggleableGoalCard goal={unboundedGoal} initiallyExpanded />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import type {
   ThreadPullRequest,
   WorkspaceFileStatus,
@@ -25,20 +25,25 @@ export default {
 
 const noop = () => {};
 
-// Production max width matches PageShell's footer cap (760px). The promptbox
-// shell attribute enables the same container-query compaction used in the
-// follow-up composer as the story viewport narrows.
-function PromptStage({ children }: { children: React.ReactNode }) {
-  return (
-    <div data-promptbox-shell="" className="w-full min-w-0 max-w-[760px]">
-      {children}
-    </div>
-  );
-}
+type PromptStageSize = "desktop" | "mobile";
 
-function NarrowPromptStage({ children }: { children: React.ReactNode }) {
+// The shell attribute enables the same container-query compaction used in the
+// follow-up composer. Story rows render both breakpoints together: desktop
+// grows into the remaining row width, while mobile stays fixed.
+function PromptStage({
+  children,
+  size,
+}: {
+  children: ReactNode;
+  size: PromptStageSize;
+}) {
   return (
-    <div data-promptbox-shell="" className="w-[5.5rem] min-w-0">
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
       {children}
     </div>
   );
@@ -568,7 +573,7 @@ interface RowConfig {
   initiallyExpandedSection?: ThreadPromptContextBannerExpandedSection | null;
 }
 
-function Row({
+function ContextBannerPreview({
   section,
   mergeBase = featureBranchMergeBase,
   archived = null,
@@ -578,13 +583,14 @@ function Row({
   pullRequest = null,
   pullRequestActions = false,
   initiallyExpandedSection = null,
-}: RowConfig) {
+  size,
+}: RowConfig & { size: PromptStageSize }) {
   const [expandedSection, setExpandedSection] =
     useState<ThreadPromptContextBannerExpandedSection | null>(
       initiallyExpandedSection,
     );
   return (
-    <PromptStage>
+    <PromptStage size={size}>
       <ThreadPromptContextBanner
         gitSection={
           section
@@ -624,41 +630,12 @@ function Row({
   );
 }
 
-function NarrowPullRequestAndGitRow() {
-  const [expandedSection, setExpandedSection] =
-    useState<ThreadPromptContextBannerExpandedSection | null>(null);
+function Row(props: RowConfig) {
   return (
-    <NarrowPromptStage>
-      <ThreadPromptContextBanner
-        gitSection={{
-          changedFiles: committedSection,
-          mergeBase: null,
-          onPromptBannerFileClick: noop,
-        }}
-        gitSectionPending={false}
-        archivedSection={null}
-        environmentGoneSection={null}
-        parentThreadSection={null}
-        childThreadsSection={null}
-        pullRequestSection={{
-          pullRequest: buildPullRequestFixture({
-            number: 260,
-            checks: {
-              state: "passing",
-              totalCount: 6,
-              passedCount: 6,
-              failedCount: 0,
-              pendingCount: 0,
-            },
-            attention: "ready_to_merge",
-          }),
-        }}
-        expandedSection={expandedSection}
-        onToggleSection={(next) =>
-          setExpandedSection((previous) => (previous === next ? null : next))
-        }
-      />
-    </NarrowPromptStage>
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <ContextBannerPreview {...props} size="desktop" />
+      <ContextBannerPreview {...props} size="mobile" />
+    </div>
   );
 }
 
@@ -813,12 +790,6 @@ export function Overview() {
         <Row pullRequest={pullRequestFixture} section={committedSection} />
       </StoryRow>
       <StoryRow
-        label="pull request + committed (narrow)"
-        hint="stress case for compact banner icons below normal chat thread width"
-      >
-        <NarrowPullRequestAndGitRow />
-      </StoryRow>
-      <StoryRow
         label="uncommitted (collapsed)"
         hint="working tree has 5 modified/added files; chevron toggles WorkspaceChangesList"
       >
@@ -847,19 +818,6 @@ export function Overview() {
         hint="mergeBase=null hides the picker (no comparison to make)"
       >
         <Row section={uncommittedSection} mergeBase={null} />
-      </StoryRow>
-    </StoryCard>
-  );
-}
-
-export function NarrowPullRequestAndGit() {
-  return (
-    <StoryCard>
-      <StoryRow
-        label="pull request + committed (narrow)"
-        hint="stress case for compact banner icons below normal chat thread width"
-      >
-        <NarrowPullRequestAndGitRow />
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
 import type { ThreadPullRequest } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
@@ -98,12 +99,55 @@ describe("ThreadPromptContextBanner", () => {
       />,
     );
 
-    expect(markup).toContain("Environment is no longer available");
+    expect(markup).toContain("Environment is unavailable");
     expect(markup).toContain("This thread can&#x27;t run any more work.");
     expect(markup).toContain('role="status"');
     expect(markup).not.toContain("<button");
     expect(markup).not.toContain("Provision");
   });
+
+  it.each([
+    {
+      label: "archived",
+      archivedSection: { archivedAt: 1_731_456_000_000 },
+      environmentGoneSection: null,
+      expectedLabel: "Thread is archived",
+    },
+    {
+      label: "environment gone",
+      archivedSection: null,
+      environmentGoneSection: { status: "destroyed" as const },
+      expectedLabel: "Environment is unavailable",
+    },
+  ])(
+    "keeps the $label read-only status label visible in compact mode",
+    ({ archivedSection, environmentGoneSection, expectedLabel }) => {
+      const markup = renderToStaticMarkup(
+        <MemoryRouter>
+          <ThreadPromptContextBanner
+            gitSection={null}
+            gitSectionPending={false}
+            archivedSection={archivedSection}
+            environmentGoneSection={environmentGoneSection}
+            parentThreadSection={{
+              parentThreadTitle: "Parent thread",
+              href: "/threads/thr_parent",
+              relationship: "parent",
+            }}
+            childThreadsSection={null}
+            pullRequestSection={null}
+            expandedSection={null}
+            onToggleSection={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(markup).toContain(expectedLabel);
+      expect(markup).not.toContain(
+        `data-promptbox-hide-compact="">${expectedLabel}`,
+      );
+    },
+  );
 
   it("labels a standalone pull request without non-actionable attention text", () => {
     const markup = renderToStaticMarkup(
@@ -149,6 +193,8 @@ describe("ThreadPromptContextBanner", () => {
 
     expect(markup).toContain("Squash merge");
     expect(markup).not.toContain('data-icon="GitMerge"');
+    expect(markup).not.toContain("data-promptbox-hide-compact");
+    expect(markup).toContain("data-promptbox-hide-tiny");
   });
 
   it("does not label standalone pending checks", () => {
@@ -260,6 +306,59 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).not.toContain("· Ready to merge");
     expect(markup).toContain("Uncommitted");
     expect(markup).toContain("1 file");
+    expect(markup).not.toContain('data-promptbox-hide-compact="">Uncommitted');
+    expect(markup).not.toContain('data-promptbox-compact-label="">1 file');
+  });
+
+  it("does not force fixed minimum widths on compact segments", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={makeGitSection("uncommitted")}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={{
+            parentThreadTitle: "Parent thread",
+            href: "/threads/thr_parent",
+            relationship: "parent",
+          }}
+          childThreadsSection={null}
+          pullRequestSection={{ pullRequest: pullRequestFixture }}
+          expandedSection={null}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).not.toContain("min-w-12");
+    expect(markup).not.toContain("min-w-11");
+  });
+
+  it("compacts the git status label when more than two segments are visible", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={makeGitSection("uncommitted")}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={{
+            parentThreadTitle: "Parent thread",
+            href: "/threads/thr_parent",
+            relationship: "parent",
+          }}
+          childThreadsSection={null}
+          pullRequestSection={{ pullRequest: pullRequestFixture }}
+          expandedSection={null}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("Uncommitted");
+    expect(markup).toContain('data-promptbox-hide-compact="">Uncommitted');
+    expect(markup).toContain('data-promptbox-compact-label="">1 file');
   });
 
   it("keeps the pull request action visible beside other context segments", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -182,9 +182,9 @@ const KIND_PREFIX: Record<WorkspaceChangedFilesSection["kind"], string> = {
 };
 
 const ARCHIVED_THREAD_STATUS_LABEL = "Thread is archived";
-const ENVIRONMENT_GONE_STATUS_LABEL = "Environment is no longer available";
+const ENVIRONMENT_GONE_STATUS_LABEL = "Environment is unavailable";
 const ENVIRONMENT_GONE_ARIA_LABEL =
-  "Environment is no longer available. This thread can't run any more work.";
+  "Environment is unavailable. This thread can't run any more work.";
 
 // Stable ids for aria-controls / aria-labelledby pairing between each
 // section's toggle button and its expanded body region.
@@ -203,8 +203,7 @@ const SECTION_IDS = {
   },
 } as const;
 
-const SEGMENT_COMPACT_ICON_FOOTPRINT_CLASS = "min-w-12 overflow-hidden";
-const PULL_REQUEST_COMPACT_ICON_FOOTPRINT_CLASS = "min-w-11 overflow-hidden";
+const SEGMENT_SHRINK_CLASS = "min-w-0 overflow-hidden";
 
 function ChildThreadIcon({ className }: { className?: string }) {
   return (
@@ -222,6 +221,7 @@ interface SectionToggleButtonProps {
   ariaLabel?: string;
   icon: ReactNode;
   label: ReactNode;
+  compactLabel?: ReactNode;
   hideLabelInCompact?: boolean;
   isExpanded: boolean;
   onToggle: () => void;
@@ -233,6 +233,7 @@ function SectionToggleButton({
   ariaLabel,
   icon,
   label,
+  compactLabel,
   hideLabelInCompact = true,
   isExpanded,
   onToggle,
@@ -247,7 +248,7 @@ function SectionToggleButton({
       onClick={onToggle}
       className={cn(
         "flex items-center rounded px-1 py-0.5 text-xs transition-colors hover:bg-state-hover",
-        SEGMENT_COMPACT_ICON_FOOTPRINT_CLASS,
+        SEGMENT_SHRINK_CLASS,
         // When a label sits between the icon and the chevron we space the row
         // for legibility (6px). With no label the chevron sits right after the
         // icon — the icons' own internal padding provides enough separation,
@@ -263,6 +264,13 @@ function SectionToggleButton({
           data-promptbox-hide-compact={hideLabelInCompact ? "" : undefined}
         >
           {label}
+        </span>
+      ) : null}
+      {hideLabelInCompact &&
+      compactLabel !== null &&
+      compactLabel !== undefined ? (
+        <span className="min-w-0 truncate" data-promptbox-compact-label="">
+          {compactLabel}
         </span>
       ) : null}
       <Icon
@@ -377,7 +385,7 @@ function BannerActionSlot({ children }: { children: ReactNode }) {
   return (
     <div
       className="ml-auto flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
-      data-promptbox-hide-compact=""
+      data-promptbox-hide-tiny=""
     >
       {children}
     </div>
@@ -525,7 +533,7 @@ function PullRequestBannerLink({
       aria-label={`Pull request ${pullRequest.number}: ${attentionDisplay.label}`}
       className={cn(
         "flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-muted-foreground no-underline transition-colors hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        PULL_REQUEST_COMPACT_ICON_FOOTPRINT_CLASS,
+        SEGMENT_SHRINK_CLASS,
       )}
     >
       <PullRequestStatusPill pullRequest={pullRequest} />
@@ -638,7 +646,6 @@ function ReadOnlyContextBanner({
           />
           <span
             className="min-w-0 truncate"
-            data-promptbox-hide-compact={hasMultipleSegments ? "" : undefined}
             aria-hidden="true"
           >
             {statusLabel}
@@ -795,6 +802,8 @@ export function ThreadPromptContextBanner({
     showParentThread && !showGit && !showChildThreads && !showPullRequest;
 
   const pullRequest = pullRequestSection?.pullRequest ?? null;
+  const showPullRequestLabel =
+    hasSingleVisibleSegment || isPullRequestAndGitOnly;
   const pullRequestActions = pullRequestSection?.actions;
   const pullRequestAction =
     pullRequest && pullRequestActions ? (
@@ -891,7 +900,7 @@ export function ThreadPromptContextBanner({
           <PullRequestBannerLink
             pullRequest={pullRequest}
             hideLabelInCompact={!hasSingleVisibleSegment}
-            showLabel={hasSingleVisibleSegment || isPullRequestAndGitOnly}
+            showLabel={showPullRequestLabel}
             showStateLabel={hasSingleVisibleSegment}
           />
         ) : null}
@@ -907,7 +916,8 @@ export function ThreadPromptContextBanner({
               />
             }
             label={gitSummary}
-            hideLabelInCompact={!hasSingleVisibleSegment}
+            compactLabel={gitTally ? renderChangeSummary(gitTally) : null}
+            hideLabelInCompact={visibleSegmentCount > 2}
             ariaLabel={`Changed files: ${gitSummaryPrefix}, ${gitSummaryText}`}
             isExpanded={isGitExpanded}
             onToggle={() => onToggleSection("git")}

--- a/apps/app/src/components/promptbox/banner/ThreadPromptModeCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptModeCard.stories.tsx
@@ -7,8 +7,34 @@ export default {
   title: "promptbox/banner/Prompt Mode Card",
 };
 
-function Stage({ children }: { children: React.ReactNode }) {
-  return <div className="w-full max-w-[760px]">{children}</div>;
+type StageSize = "desktop" | "mobile";
+
+function Stage({
+  children,
+  size,
+}: {
+  children: React.ReactNode;
+  size: StageSize;
+}) {
+  return (
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResponsiveStage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <Stage size="desktop">{children}</Stage>
+      <Stage size="mobile">{children}</Stage>
+    </div>
+  );
 }
 
 function FauxComposer() {
@@ -53,7 +79,7 @@ export function Overview() {
         label="collapsed"
         hint="active Claude Code plan mode indicator; prompt stays hidden"
       >
-        <Stage>
+        <ResponsiveStage>
           <div className="flex flex-col gap-2">
             <ToggleablePromptModeCard
               activePromptMode={{
@@ -65,10 +91,10 @@ export function Overview() {
             />
             <FauxComposer />
           </div>
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow label="expanded" hint="unfurled body shows full cleaned prompt">
-        <Stage>
+        <ResponsiveStage>
           <ToggleablePromptModeCard
             activePromptMode={{
               mode: "plan",
@@ -79,10 +105,10 @@ export function Overview() {
             initiallyExpanded
             onExitPlanMode={() => {}}
           />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow label="codex" hint="same banner for Codex plan mode">
-        <Stage>
+        <ResponsiveStage>
           <ToggleablePromptModeCard
             activePromptMode={{
               mode: "plan",
@@ -90,16 +116,16 @@ export function Overview() {
               prompt: "review the merge conflicts and propose a fix plan",
             }}
           />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow label="inactive" hint="renders nothing without active mode">
-        <Stage>
+        <ResponsiveStage>
           <ThreadPromptModeCard
             activePromptMode={null}
             isExpanded={false}
             onToggle={() => {}}
           />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadTodoCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadTodoCard.stories.tsx
@@ -7,8 +7,34 @@ export default {
   title: "promptbox/banner/Todo Card",
 };
 
-function Stage({ children }: { children: React.ReactNode }) {
-  return <div className="w-full max-w-[760px]">{children}</div>;
+type StageSize = "desktop" | "mobile";
+
+function Stage({
+  children,
+  size,
+}: {
+  children: React.ReactNode;
+  size: StageSize;
+}) {
+  return (
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResponsiveStage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <Stage size="desktop">{children}</Stage>
+      <Stage size="mobile">{children}</Stage>
+    </div>
+  );
 }
 
 const mixedTodos: ThreadTimelinePendingTodos = {
@@ -99,28 +125,28 @@ export function Overview() {
         label="prompt stack"
         hint="collapsed header shows compact N/M progress; click to expand"
       >
-        <Stage>
+        <ResponsiveStage>
           <div className="flex flex-col gap-2">
             <ToggleableTodoCard pendingTodos={mixedTodos} />
             <FauxComposer />
           </div>
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow
         label="expanded"
         hint="in-progress, pending, and completed items sorted by status"
       >
-        <Stage>
+        <ResponsiveStage>
           <ToggleableTodoCard pendingTodos={mixedTodos} initiallyExpanded />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
       <StoryRow label="pending only" hint="summary starts at 0/N complete">
-        <Stage>
+        <ResponsiveStage>
           <ToggleableTodoCard
             pendingTodos={pendingOnlyTodos}
             initiallyExpanded
           />
-        </Stage>
+        </ResponsiveStage>
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.stories.tsx
@@ -13,8 +13,34 @@ export default {
   title: "promptbox/banner/Workflow Card",
 };
 
-function Stage({ children }: { children: React.ReactNode }) {
-  return <div className="w-full max-w-[760px]">{children}</div>;
+type StageSize = "desktop" | "mobile";
+
+function Stage({
+  children,
+  size,
+}: {
+  children: React.ReactNode;
+  size: StageSize;
+}) {
+  return (
+    <div
+      data-promptbox-shell=""
+      className={
+        size === "desktop" ? "min-w-0 flex-1" : "w-[20rem] shrink-0"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResponsiveStage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-full min-w-0 items-start gap-3 overflow-x-auto">
+      <Stage size="desktop">{children}</Stage>
+      <Stage size="mobile">{children}</Stage>
+    </div>
+  );
 }
 
 // Mirrors the mockup: a six-agent Investigate phase (all done) plus a
@@ -204,56 +230,18 @@ function ToggleableCard({
   );
 }
 
-export function Overview() {
+function CollapsedWorkflowPreview() {
   const [collapsed, setCollapsed] = useState(false);
   return (
-    <StoryCard>
-      <StoryRow
-        label="prompt stack"
-        hint="floats above the composer while the workflow runs (click to toggle)"
-      >
-        <Stage>
-          <div className="flex flex-col gap-2">
-            <ToggleableCard workflow={runningWorkflow} />
-            <FauxComposer />
-          </div>
-        </Stage>
-      </StoryRow>
-      <StoryRow
-        label="collapsed"
-        hint="single-line glance: name, agent count, live time"
-      >
-        <Stage>
-          <ThreadWorkflowCard
-            workflow={runningWorkflow}
-            isExpanded={collapsed}
-            onToggle={() => setCollapsed((value) => !value)}
-          />
-        </Stage>
-      </StoryRow>
-    </StoryCard>
+    <ThreadWorkflowCard
+      workflow={runningWorkflow}
+      isExpanded={collapsed}
+      onToggle={() => setCollapsed((value) => !value)}
+    />
   );
 }
 
-export function ManyPhases() {
-  return (
-    <StoryCard>
-      <StoryRow
-        label="40 phases"
-        hint="caps at a max height and scrolls; each phase is its own toggle and only the active phase is expanded by default"
-      >
-        <Stage>
-          <div className="flex flex-col gap-2">
-            <ToggleableCard workflow={manyPhasesWorkflow} />
-            <FauxComposer />
-          </div>
-        </Stage>
-      </StoryRow>
-    </StoryCard>
-  );
-}
-
-export function AutoAdvance() {
+function AutoAdvancePreview() {
   const [activePhase, setActivePhase] = useState(3);
   const [expanded, setExpanded] = useState(true);
   const workflow = useMemo(
@@ -266,33 +254,87 @@ export function AutoAdvance() {
         description: "Audit the entire repository across forty phases",
         startedAt: Date.now() - 1_472_000,
         workflow: buildManyPhasesSnapshot(40, activePhase),
-        usage: { totalTokens: 4_210_000, toolUses: 1_284, durationMs: 1_472_000 },
+        usage: {
+          totalTokens: 4_210_000,
+          toolUses: 1_284,
+          durationMs: 1_472_000,
+        },
       }),
     [activePhase],
   );
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={() => setActivePhase((p) => Math.min(40, p + 1))}
+        className="self-start rounded-md border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-state-hover"
+      >
+        Advance to phase {Math.min(40, activePhase + 1)}
+      </button>
+      <ThreadWorkflowCard
+        workflow={workflow}
+        isExpanded={expanded}
+        onToggle={() => setExpanded((value) => !value)}
+      />
+      <FauxComposer />
+    </div>
+  );
+}
+
+export function Overview() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="prompt stack"
+        hint="floats above the composer while the workflow runs (click to toggle)"
+      >
+        <ResponsiveStage>
+          <div className="flex flex-col gap-2">
+            <ToggleableCard workflow={runningWorkflow} />
+            <FauxComposer />
+          </div>
+        </ResponsiveStage>
+      </StoryRow>
+      <StoryRow
+        label="collapsed"
+        hint="single-line glance: name, agent count, live time"
+      >
+        <ResponsiveStage>
+          <CollapsedWorkflowPreview />
+        </ResponsiveStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function ManyPhases() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="40 phases"
+        hint="caps at a max height and scrolls; each phase is its own toggle and only the active phase is expanded by default"
+      >
+        <ResponsiveStage>
+          <div className="flex flex-col gap-2">
+            <ToggleableCard workflow={manyPhasesWorkflow} />
+            <FauxComposer />
+          </div>
+        </ResponsiveStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function AutoAdvance() {
   return (
     <StoryCard>
       <StoryRow
         label="auto-advance"
         hint="advancing the run moves the open phase forward and scrolls it into view; phases you toggle yourself stay as you left them"
       >
-        <Stage>
-          <div className="flex flex-col gap-2">
-            <button
-              type="button"
-              onClick={() => setActivePhase((p) => Math.min(40, p + 1))}
-              className="self-start rounded-md border border-border px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-state-hover"
-            >
-              Advance to phase {Math.min(40, activePhase + 1)}
-            </button>
-            <ThreadWorkflowCard
-              workflow={workflow}
-              isExpanded={expanded}
-              onToggle={() => setExpanded((value) => !value)}
-            />
-            <FauxComposer />
-          </div>
-        </Stage>
+        <ResponsiveStage>
+          <AutoAdvancePreview />
+        </ResponsiveStage>
       </StoryRow>
     </StoryCard>
   );


### PR DESCRIPTION
## Summary
- show desktop and mobile promptbox banner previews side by side in stories, and remove the obsolete narrow PR/git story
- remove fixed compact segment minimum widths and keep read-only status labels visible in compact layouts
- tune context banner compact behavior: action buttons hide at the tiny breakpoint, environment copy is shortened, and git status compacts only when more than two segments are visible while preserving diff stats

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm --filter @bb/app storybook:build