### PR TITLE
Prevent stale queued-message overflow fades

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadQueuedMessage } from "@bb/domain";
 import { QueuedMessagesList } from "./QueuedMessagesList";
 
@@ -38,6 +44,7 @@ function renderQueuedMessages(queuedMessages: readonly ThreadQueuedMessage[]) {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe("QueuedMessagesList", () => {
@@ -91,5 +98,90 @@ describe("QueuedMessagesList", () => {
         container.querySelector('[data-queued-messages-fade="below"]'),
       ).not.toBeNull();
     });
+  });
+
+  it("does not show a fade when stale observer entries report hidden sentinels without overflow", async () => {
+    interface ObserverControl {
+      targets: Element[];
+      trigger(entries: readonly Partial<IntersectionObserverEntry>[]): void;
+    }
+
+    const observers: ObserverControl[] = [];
+
+    class IntersectionObserverMock implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [0];
+      readonly targets: Element[] = [];
+
+      constructor(private readonly callback: IntersectionObserverCallback) {
+        observers.push(this);
+      }
+
+      disconnect() {}
+
+      observe(target: Element) {
+        this.targets.push(target);
+      }
+
+      takeRecords() {
+        return [];
+      }
+
+      trigger(entries: readonly Partial<IntersectionObserverEntry>[]) {
+        this.callback(entries as IntersectionObserverEntry[], this);
+      }
+
+      unobserve() {}
+    }
+
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
+    vi.stubGlobal("requestAnimationFrame", () => 1);
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+
+    const { container } = renderQueuedMessages([
+      makeQueuedMessage("q_one", "single queued message"),
+    ]);
+    const scroll = container.querySelector<HTMLDivElement>(
+      "[data-queued-messages-scroll]",
+    );
+    expect(scroll).not.toBeNull();
+    if (!scroll) return;
+
+    Object.defineProperty(scroll, "clientHeight", {
+      configurable: true,
+      value: 48,
+    });
+    Object.defineProperty(scroll, "scrollHeight", {
+      configurable: true,
+      value: 48,
+    });
+
+    await waitFor(() => {
+      expect(observers[0]?.targets).toHaveLength(2);
+    });
+
+    const currentObserver = observers[0];
+    expect(currentObserver).toBeDefined();
+    if (!currentObserver) return;
+
+    const [topSentinel, bottomSentinel] = currentObserver.targets;
+    expect(topSentinel).toBeDefined();
+    expect(bottomSentinel).toBeDefined();
+    if (!topSentinel || !bottomSentinel) return;
+
+    act(() => {
+      currentObserver.trigger([
+        { target: topSentinel, isIntersecting: false },
+        { target: bottomSentinel, isIntersecting: false },
+      ]);
+    });
+
+    expect(
+      container.querySelector('[data-queued-messages-fade="above"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-queued-messages-fade="below"]'),
+    ).toBeNull();
   });
 });

--- a/apps/app/src/components/thread/timeline/useScrollOverflowState.ts
+++ b/apps/app/src/components/thread/timeline/useScrollOverflowState.ts
@@ -153,9 +153,10 @@ export function useScrollOverflowState<
             belowVisible = entry.isIntersecting;
           }
         }
+        const hasOverflow = scroll.scrollHeight - scroll.clientHeight > 1;
         applyFlags({
-          above: !aboveVisible,
-          below: !belowVisible,
+          above: hasOverflow && !aboveVisible,
+          below: hasOverflow && !belowVisible,
         });
       },
       { root: scroll, threshold: 0 },


### PR DESCRIPTION
## Summary
- gate scroll-fade state on actual scroll overflow before rendering queued-message/timeline fades
- add a queued-message regression for stale IntersectionObserver entries on a non-overflowing list

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/QueuedMessagesList.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app