### PR TITLE
Improve file preview header actions

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FilePreview } from "./FilePreview";
@@ -72,6 +78,10 @@ const pierreMock = vi.hoisted(() => {
   };
 });
 
+const clipboardMock = vi.hoisted(() => ({
+  copyToClipboardWithToast: vi.fn(async () => true),
+}));
+
 vi.mock("@pierre/diffs/react", async () => {
   const React = await import("react");
 
@@ -97,6 +107,14 @@ vi.mock("@pierre/diffs/react", async () => {
   };
 });
 
+vi.mock("@/lib/clipboard", () => clipboardMock);
+
+async function openFilePreviewActionsMenu() {
+  const trigger = screen.getByRole("button", { name: "File preview actions" });
+  fireEvent.pointerDown(trigger, { button: 0 });
+  return screen.findByRole("menuitem", { name: "Copy raw file" });
+}
+
 describe("FilePreview", () => {
   beforeEach(() => {
     pierreMock.state.cachedFileKeys.clear();
@@ -108,6 +126,7 @@ describe("FilePreview", () => {
     pierreMock.state.unsubscribe.mockClear();
     pierreMock.workerPool.subscribeToStatChanges.mockClear();
     pierreMock.workerPool.getFileResultCache.mockClear();
+    clipboardMock.copyToClipboardWithToast.mockClear();
   });
 
   afterEach(() => {
@@ -226,6 +245,142 @@ describe("FilePreview", () => {
         firstInstanceId + 1,
       );
     });
+  });
+
+  it("renders a compact file preview actions menu in the header", async () => {
+    render(
+      <FilePreview
+        path="apps/app/src/lib/thread-read-state.ts"
+        state={{
+          kind: "ready",
+          file: {
+            name: "thread-read-state.ts",
+            contents: "export const marker = true;",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: false,
+        }}
+      />,
+    );
+
+    const actionsButton = screen.getByRole("button", {
+      name: "File preview actions",
+    });
+
+    expect(actionsButton.className).toContain("h-5");
+    expect(actionsButton.className).toContain("w-5");
+    expect(actionsButton.className).toContain("[&_svg]:size-3");
+
+    await openFilePreviewActionsMenu();
+    expect(
+      screen
+        .getByRole("menuitemcheckbox", { name: "Wrap" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+    expect(
+      screen.getByRole("menuitem", { name: "Copy raw file" }),
+    ).not.toBeNull();
+  });
+
+  it("lets source previews grow to content height so the sticky header stays bounded by the full file", () => {
+    const view = render(
+      <FilePreview
+        path="apps/app/src/lib/thread-read-state.ts"
+        state={{
+          kind: "ready",
+          file: {
+            name: "thread-read-state.ts",
+            contents: "export const marker = true;",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: false,
+        }}
+      />,
+    );
+
+    const previewRoot = view.container.firstElementChild;
+    expect(previewRoot?.classList.contains("min-h-full")).toBe(true);
+    expect(previewRoot?.classList.contains("h-full")).toBe(false);
+    expect(
+      screen
+        .getByTestId("pierre-file")
+        .parentElement?.classList.contains("flex-auto"),
+    ).toBe(true);
+  });
+
+  it("toggles source line wrap from the file preview actions menu", async () => {
+    render(
+      <FilePreview
+        path="apps/app/src/lib/thread-read-state.ts"
+        state={{
+          kind: "ready",
+          file: {
+            name: "thread-read-state.ts",
+            contents: "export const marker = true;",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: false,
+        }}
+      />,
+    );
+
+    await openFilePreviewActionsMenu();
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Wrap" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("menuitemcheckbox", { name: "Wrap" }),
+      ).toBeNull();
+    });
+
+    await openFilePreviewActionsMenu();
+    expect(
+      screen
+        .getByRole("menuitemcheckbox", { name: "Wrap" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("copies loaded raw file contents from the file preview actions menu", async () => {
+    render(
+      <FilePreview
+        path="docs/right-panel/README.md"
+        state={{
+          kind: "ready",
+          file: {
+            name: "README.md",
+            contents: "# Preview\n\nRaw markdown.",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: true,
+        }}
+      />,
+    );
+
+    await openFilePreviewActionsMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy raw file" }));
+
+    await waitFor(() => {
+      expect(clipboardMock.copyToClipboardWithToast).toHaveBeenCalledWith(
+        "# Preview\n\nRaw markdown.",
+        {
+          errorMessage: "Failed to copy",
+          successMessage: null,
+        },
+      );
+    });
+  });
+
+  it("does not show the file preview actions menu for non-text previews", () => {
+    render(
+      <FilePreview
+        path="docs/screenshots/right-panel.png"
+        state={{ kind: "image", url: "/preview/right-panel.png" }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "File preview actions" }),
+    ).toBeNull();
   });
 
   it("passes cache keys for loaded text previews to Pierre", async () => {

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -11,11 +11,17 @@ import type { SelectedLineRange, SupportedLanguages } from "@pierre/diffs";
 import type { UrlTransform } from "react-markdown";
 import { Button } from "@/components/ui/button.js";
 import {
-  COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
   COARSE_POINTER_TEXT_SM_CLASS,
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
 import { CopyButton } from "@/components/ui/copy-button.js";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.js";
 import { Icon } from "@/components/ui/icon.js";
 import { OpenInEditorButton } from "@/components/ui/open-in-editor-button.js";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
@@ -23,13 +29,13 @@ import { MarkdownPreview } from "@/components/ui/markdown-preview.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { TruncateStart } from "@/components/ui/truncate-start.js";
 import { usePreferredTheme } from "@/hooks/useTheme";
+import { copyToClipboardWithToast } from "@/lib/clipboard";
 import type {
   FilePreviewLineRange,
   WorkspaceFilePreviewStatusLabel,
 } from "@/lib/file-preview";
 import {
   DEFAULT_CODE_OVERFLOW_MODE,
-  getNextCodeOverflowMode,
   type CodeOverflowMode,
   type CodeOverflowModeChangeHandler,
 } from "@/lib/code-overflow-mode";
@@ -99,6 +105,7 @@ interface HtmlFilePreviewBodyProps {
 interface FilePreviewHeaderProps {
   path: string;
   copyPath: string | null;
+  rawContents: string | null;
   onOpenInEditor?: (path: string) => void;
   statusLabel: WorkspaceFilePreviewStatusLabel | null;
   toggleKind: FilePreviewToggleKind | null;
@@ -107,6 +114,13 @@ interface FilePreviewHeaderProps {
   onLineOverflowModeChange: CodeOverflowModeChangeHandler;
   viewMode: FilePreviewViewMode;
   onViewModeChange: (mode: FilePreviewViewMode) => void;
+}
+
+interface FilePreviewActionsMenuProps {
+  rawContents: string | null;
+  showLineOverflowToggle: boolean;
+  lineOverflowMode: CodeOverflowMode;
+  onLineOverflowModeChange: CodeOverflowModeChangeHandler;
 }
 
 interface MarkdownFilePreviewProps {
@@ -187,6 +201,8 @@ const HTML_FILE_PREVIEW_IFRAME_STYLE = {
   border: 0,
 } as CSSProperties;
 const IFRAME_LOADING_INDICATOR_DELAY_MS = 160;
+const FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS =
+  "h-5 w-5 rounded-sm p-0 [&_svg]:size-3 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";
 
 function isMarkdownFile(name: string): boolean {
   const extension = name.split(".").pop()?.toLowerCase();
@@ -222,6 +238,13 @@ function getFilePreviewLineRange(
 ): FilePreviewLineRange | null {
   if (state.kind === "html" || state.kind === "ready") {
     return state.lineRange;
+  }
+  return null;
+}
+
+function getRawFilePreviewContents(state: FilePreviewState): string | null {
+  if (state.kind === "html" || state.kind === "ready") {
+    return state.file.contents;
   }
   return null;
 }
@@ -262,6 +285,7 @@ export function FilePreview({
 }: FilePreviewProps) {
   const toggleKind = getFilePreviewToggleKind(state);
   const filePreviewLineRange = getFilePreviewLineRange(state);
+  const rawContents = getRawFilePreviewContents(state);
   const [viewMode, setViewMode] = useState<FilePreviewViewMode>(
     getInitialFilePreviewViewMode({
       lineRange: filePreviewLineRange,
@@ -289,7 +313,6 @@ export function FilePreview({
     toggleKind === null ? "preview" : viewMode;
   const usesCodeLayout = usesCodeViewLayout(state, bodyViewMode);
   const showLineOverflowToggle = usesCodeLayout;
-  const usesFullHeightLayout = usesIframeLayout || usesCodeLayout;
   // The markdown preview renders on a raised "paper" surface that should fill
   // the panel to the bottom even for short documents. `min-h-full` (vs the
   // iframe layout's `h-full min-h-0`) keeps the column growable, so long
@@ -298,17 +321,18 @@ export function FilePreview({
     state.kind === "ready" &&
     isMarkdownFile(state.file.name) &&
     bodyViewMode === "preview";
+  const usesContentHeightLayout = usesCodeLayout || usesMarkdownPreviewLayout;
 
   // Establish a `@container/page` scope so MarkdownPreview's `100cqw`-based
   // table breakout sizes against this panel, not the viewport.
   return (
     <div
       className={
-        usesFullHeightLayout
+        usesIframeLayout
           ? "@container/page flex h-full min-h-0 flex-col"
-          : usesMarkdownPreviewLayout
+          : usesContentHeightLayout
             ? "@container/page flex min-h-full flex-col"
-            : "@container/page"
+            : "@container/page min-h-full"
       }
       style={FILE_PREVIEW_WRAPPER_STYLE}
     >
@@ -316,6 +340,7 @@ export function FilePreview({
         <FilePreviewHeader
           path={path}
           copyPath={copyPath}
+          rawContents={rawContents}
           onOpenInEditor={onOpenInEditor}
           statusLabel={statusLabel}
           toggleKind={toggleKind}
@@ -406,6 +431,7 @@ function FilePreviewBody({
 function FilePreviewHeader({
   path,
   copyPath,
+  rawContents,
   onOpenInEditor,
   statusLabel,
   toggleKind,
@@ -415,6 +441,9 @@ function FilePreviewHeader({
   viewMode,
   onViewModeChange,
 }: FilePreviewHeaderProps) {
+  const showActionsMenu = showLineOverflowToggle || rawContents !== null;
+  const showHeaderControls = showActionsMenu || toggleKind !== null;
+
   return (
     // The wrapper carries an opaque `bg-background` base so the translucent
     // `bg-surface-recessed` tint on the bar composites to a solid tone — without
@@ -456,36 +485,15 @@ function FilePreviewHeader({
             <OpenInEditorButton onClick={() => onOpenInEditor(path)} />
           ) : null}
         </div>
-        {showLineOverflowToggle || toggleKind !== null ? (
+        {showHeaderControls ? (
           <div className="ml-auto flex shrink-0 items-center gap-1">
-            {showLineOverflowToggle ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
-                  "text-muted-foreground",
-                )}
-                onClick={() =>
-                  onLineOverflowModeChange(
-                    getNextCodeOverflowMode(lineOverflowMode),
-                  )
-                }
-                aria-label={
-                  lineOverflowMode === "wrap"
-                    ? "Disable source line wrap"
-                    : "Wrap source lines"
-                }
-                aria-pressed={lineOverflowMode === "wrap"}
-                title={
-                  lineOverflowMode === "wrap"
-                    ? "Disable source line wrap"
-                    : "Wrap source lines"
-                }
-              >
-                <Icon name="TextWrap" />
-              </Button>
+            {showActionsMenu ? (
+              <FilePreviewActionsMenu
+                rawContents={rawContents}
+                showLineOverflowToggle={showLineOverflowToggle}
+                lineOverflowMode={lineOverflowMode}
+                onLineOverflowModeChange={onLineOverflowModeChange}
+              />
             ) : null}
             {toggleKind !== null ? (
               <div
@@ -527,6 +535,62 @@ function FilePreviewHeader({
         ) : null}
       </div>
     </div>
+  );
+}
+
+function FilePreviewActionsMenu({
+  rawContents,
+  showLineOverflowToggle,
+  lineOverflowMode,
+  onLineOverflowModeChange,
+}: FilePreviewActionsMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
+            "text-muted-foreground",
+          )}
+          aria-label="File preview actions"
+          title="File preview actions"
+        >
+          <Icon name="MoreHorizontal" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        mobileTitle="File preview actions"
+        className="w-44"
+      >
+        {showLineOverflowToggle ? (
+          <DropdownMenuCheckboxItem
+            checked={lineOverflowMode === "wrap"}
+            onCheckedChange={(checked) =>
+              onLineOverflowModeChange(checked ? "wrap" : "scroll")
+            }
+            textValue="Wrap"
+          >
+            Wrap
+          </DropdownMenuCheckboxItem>
+        ) : null}
+        {rawContents === null ? null : (
+          <DropdownMenuItem
+            onSelect={() => {
+              void copyToClipboardWithToast(rawContents, {
+                successMessage: null,
+                errorMessage: "Failed to copy",
+              });
+            }}
+          >
+            Copy raw file
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -572,7 +636,7 @@ function MarkdownFilePreview({
     // viewer reads as a distinct surface from the white chat — one tonal step
     // lighter than the recessed header (matching the raised-body / recessed-
     // header pairing used elsewhere in this panel).
-    <div className="flex-1 bg-surface-raised px-4 py-4">
+    <div className="flex-auto bg-surface-raised px-4 py-4">
       <MarkdownPreview
         allowHtml
         content={file.contents}
@@ -837,7 +901,7 @@ function FilePreviewCode({
   return (
     <div
       ref={containerRef}
-      className="min-h-0 flex-1"
+      className="min-h-0 flex-auto"
       style={FILE_PREVIEW_VIEW_STYLE}
       data-file-preview-line-number={targetLineNumber ?? undefined}
     >


### PR DESCRIPTION
## Summary
- replace separate source wrap/copy controls with a compact file preview actions menu
- add Copy raw file for loaded text/html previews
- keep source preview headers sticky by letting source content define the sticky boundary

## Validation
- pnpm exec turbo run test --filter=@bb/app -- FilePreview.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app
- git diff --check