### PR TITLE
Handle Claude synthetic no-response turns

### DIFF
--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -1892,6 +1892,124 @@ describe("claude-code provider adapter", () => {
     );
   });
 
+  it("translateEvent completes a pending turn for Claude synthetic no-response messages", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+
+    expect(
+      adapter.translateAcceptedCommand({
+        command: {
+          type: "turn/start",
+          threadId: "bb-thread-1",
+          providerThreadId: "claude-session-1",
+          clientRequestId: "creq_23456789af",
+          input: [promptTextInput({ text: "please do this" })],
+          options: fullProviderExecutionContext,
+        },
+      }),
+    ).toEqual([]);
+
+    const events = adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "No response requested." }],
+          model: "<synthetic>",
+          stop_reason: "stop_sequence",
+          stop_sequence: "",
+          usage: {
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+        session_id: "claude-session-1",
+      },
+      { threadId: "bb-thread-1" },
+    );
+
+    expect(events).toEqual([
+      {
+        type: "turn/started",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+      },
+      {
+        type: "turn/input/accepted",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        clientRequestId: "creq_23456789af",
+      },
+      {
+        type: "turn/completed",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      },
+    ]);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "agentMessage",
+          text: "No response requested.",
+        }),
+      }),
+    );
+  });
+
+  it("translateEvent completes an open turn for Claude synthetic no-response messages", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+
+    adapter.translateEvent(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "Starting" },
+        },
+        session_id: "claude-session-1",
+      },
+      { threadId: "bb-thread-1" },
+    );
+
+    const events = adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "No response requested." }],
+          model: "<synthetic>",
+          stop_reason: "stop_sequence",
+          stop_sequence: "",
+          usage: {
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+        session_id: "claude-session-1",
+      },
+      { threadId: "bb-thread-1" },
+    );
+
+    expect(events).toEqual([
+      {
+        type: "turn/completed",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      },
+    ]);
+  });
+
   it("translateEvent keeps assistant message ids distinct within one turn", () => {
     const adapter = createClaudeCodeProviderAdapter();
 

--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -1962,6 +1962,122 @@ describe("claude-code provider adapter", () => {
     );
   });
 
+  it("translateEvent completes a pending turn for wrapped Claude synthetic no-response messages", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+
+    expect(
+      adapter.translateAcceptedCommand({
+        command: {
+          type: "turn/start",
+          threadId: "bb-thread-1",
+          providerThreadId: "claude-session-1",
+          clientRequestId: "creq_23456789af",
+          input: [promptTextInput({ text: "please do this" })],
+          options: fullProviderExecutionContext,
+        },
+      }),
+    ).toEqual([]);
+
+    const events = adapter.translateEvent(
+      {
+        jsonrpc: "2.0",
+        method: "sdk/message",
+        params: {
+          threadId: "bb-thread-1",
+          message: {
+            type: "assistant",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "No response requested." }],
+              model: "<synthetic>",
+              stop_reason: "stop_sequence",
+              stop_sequence: "",
+              usage: {
+                input_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                output_tokens: 0,
+              },
+            },
+            session_id: "claude-session-1",
+          },
+        },
+      },
+      { threadId: "bb-thread-1" },
+    );
+
+    expect(events).toEqual([
+      {
+        type: "turn/started",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+      },
+      {
+        type: "turn/input/accepted",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        clientRequestId: "creq_23456789af",
+      },
+      {
+        type: "turn/completed",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      },
+    ]);
+  });
+
+  it("translateEvent does not treat Claude synthetic assistant errors as no-response messages", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+
+    const events = adapter.translateEvent(
+      {
+        type: "assistant",
+        error: "rate_limit",
+        isApiErrorMessage: true,
+        apiErrorStatus: 429,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "API Error: Server is temporarily limiting requests.",
+            },
+          ],
+          model: "<synthetic>",
+          stop_reason: "stop_sequence",
+          stop_sequence: "",
+          usage: {
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+        session_id: "claude-session-1",
+      },
+      { threadId: "bb-thread-1" },
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "agentMessage",
+          text: "API Error: Server is temporarily limiting requests.",
+        }),
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+      }),
+    );
+  });
+
   it("translateEvent completes an open turn for Claude synthetic no-response messages", () => {
     const adapter = createClaudeCodeProviderAdapter();
 

--- a/packages/agent-runtime/src/claude-code/translate-message.ts
+++ b/packages/agent-runtime/src/claude-code/translate-message.ts
@@ -5,7 +5,10 @@ import type {
   ThreadEventTokenUsageBreakdown,
 } from "@bb/domain";
 import { threadScope, turnScope } from "@bb/domain";
-import { withParentToolCallId } from "../shared/adapter-utils.js";
+import {
+  toOptionalRecord,
+  withParentToolCallId,
+} from "../shared/adapter-utils.js";
 import type { AcceptedUserMessageState } from "../shared/accepted-user-messages.js";
 import type {
   EnsureProviderTurnStartedArgs,
@@ -29,6 +32,7 @@ import {
   claudeSystemMessageSchema,
   claudeUserMessageSchema,
   type ClaudeApiRetryMessage,
+  type ClaudeAssistantMessage,
   type ClaudeRateLimitEvent,
   type ClaudeResultMessage,
   type ClaudeToolUseResult,
@@ -144,6 +148,22 @@ const claudeResultFallbackErrorDetails: Record<string, string> = {
     "Claude Code exhausted structured output retries.",
   error_max_turns: "Claude Code reached the maximum number of turns.",
 };
+
+const CLAUDE_SYNTHETIC_MODEL = "<synthetic>";
+const CLAUDE_NO_RESPONSE_REQUESTED_TEXT = "No response requested.";
+
+function isClaudeNoResponseRequestedSyntheticMessage(
+  message: ClaudeAssistantMessage,
+): boolean {
+  const nestedMessage = toOptionalRecord(message.message);
+  return (
+    nestedMessage?.model === CLAUDE_SYNTHETIC_MODEL &&
+    nestedMessage.role === "assistant" &&
+    nestedMessage.stop_reason === "stop_sequence" &&
+    nestedMessage.stop_sequence === "" &&
+    extractAssistantText(message) === CLAUDE_NO_RESPONSE_REQUESTED_TEXT
+  );
+}
 
 function buildClaudeProviderErrorEvent(
   args: BuildClaudeProviderErrorEventArgs,
@@ -404,6 +424,29 @@ export function translateClaudeSdkMessage(
         });
       }
       const message = parsedMessage.data;
+      if (isClaudeNoResponseRequestedSyntheticMessage(message)) {
+        const turnId =
+          state.currentTurnId ??
+          (state.pendingAcceptedUserMessages.length > 0
+            ? args.ensureTurnStarted({
+                events,
+                state,
+                threadId,
+              })
+            : undefined);
+        if (!turnId) {
+          return [];
+        }
+        events.push({
+          type: "turn/completed",
+          threadId,
+          providerThreadId: "",
+          scope: turnScope(turnId),
+          status: "completed",
+        });
+        args.turnState.finishTurn({ state, threadId: stateKey });
+        return events;
+      }
       const turnId = args.ensureTurnStarted({
         events,
         state,

--- a/packages/agent-runtime/src/claude-code/translate-message.ts
+++ b/packages/agent-runtime/src/claude-code/translate-message.ts
@@ -151,6 +151,31 @@ const claudeResultFallbackErrorDetails: Record<string, string> = {
 
 const CLAUDE_SYNTHETIC_MODEL = "<synthetic>";
 const CLAUDE_NO_RESPONSE_REQUESTED_TEXT = "No response requested.";
+const CLAUDE_SYNTHETIC_ZERO_USAGE_KEYS = [
+  "input_tokens",
+  "cache_creation_input_tokens",
+  "cache_read_input_tokens",
+  "output_tokens",
+] as const;
+
+function hasClaudeAssistantErrorMarker(
+  message: ClaudeAssistantMessage,
+): boolean {
+  const messageRecord = toOptionalRecord(message);
+  return (
+    messageRecord?.error !== undefined ||
+    messageRecord?.isApiErrorMessage === true ||
+    messageRecord?.apiErrorStatus !== undefined
+  );
+}
+
+function hasClaudeZeroUsage(usage: unknown): boolean {
+  const usageRecord = toOptionalRecord(usage);
+  return (
+    usageRecord !== undefined &&
+    CLAUDE_SYNTHETIC_ZERO_USAGE_KEYS.every((key) => usageRecord[key] === 0)
+  );
+}
 
 function isClaudeNoResponseRequestedSyntheticMessage(
   message: ClaudeAssistantMessage,
@@ -161,6 +186,8 @@ function isClaudeNoResponseRequestedSyntheticMessage(
     nestedMessage.role === "assistant" &&
     nestedMessage.stop_reason === "stop_sequence" &&
     nestedMessage.stop_sequence === "" &&
+    !hasClaudeAssistantErrorMarker(message) &&
+    hasClaudeZeroUsage(nestedMessage.usage) &&
     extractAssistantText(message) === CLAUDE_NO_RESPONSE_REQUESTED_TEXT
   );
 }


### PR DESCRIPTION
## Summary
- Recognize Claude Code synthetic assistant messages with `message.model === "<synthetic>"` and text content `No response requested.`
- Treat that provider-side synthetic no-op as terminal for bb's active/pending turn.
- Suppress the synthetic text from the timeline and emit `turn/completed` so the thread does not stay in Thinking.
- Add regression coverage for both pending first-turn input and already-open turn cases.

## Incident Breadcrumbs
Investigated thread: `thr_mec6x5rwuq`.
Claude Code session observed in `~/.claude/projects/.../16f8a065-1419-4eab-97f8-877b8fde206f.jsonl`.

Timeline from the incident:

1. User sent this prompt to a Claude Code-backed bb thread:
   `can you do a pass and make sure we follow template like this for the new stories http://localhost:61000/?story=thread--timeline--rows--approval--overview&theme=light`
2. bb accepted the user input and sent a provider command shaped as `turn/start`.
3. The Claude bridge queued and consumed the input. The Claude JSONL showed a normal `type: "user"` message for the prompt.
4. Claude Code then produced no normal provider progress for the turn:
   - no `type: "assistant"` with real content
   - no `type: "stream_event"`
   - no `type: "system"` status/error event that completed the turn
   - no `type: "result"`
5. The bb UI stayed in Thinking because the adapter had no terminal provider event to translate into `turn/completed`.
6. Later, after the user sent `hello!!!`, Claude Code wrote a synthetic assistant entry for the previously abandoned prompt immediately before handling the new user input.
7. That synthetic entry had `message.model === "<synthetic>"` and displayed text `No response requested.`.

Important distinction:

- `No response requested.` is the synthetic assistant message text.
- `<synthetic>` is the nested Claude message `model` field.
- Both are emitted by Claude Code internals; they are not generated by bb and are not a normal model response.

## Provider Event Shape
The relevant Claude SDK/JSONL event is an assistant message, not a result message:

```json
{
  "type": "assistant",
  "message": {
    "role": "assistant",
    "content": [
      { "type": "text", "text": "No response requested." }
    ],
    "model": "<synthetic>",
    "stop_reason": "stop_sequence",
    "stop_sequence": "",
    "usage": {
      "input_tokens": 0,
      "cache_creation_input_tokens": 0,
      "cache_read_input_tokens": 0,
      "output_tokens": 0
    }
  },
  "session_id": "claude-session-id"
}
```

The key part of the bug is that no subsequent Claude event arrives with:

```json
{ "type": "result", "subtype": "success" }
```

or any other `type: "result"` that would let bb finish the turn through the normal result path.

## bb Event Translation Before This Change
For a first turn with accepted input but no previous provider output:

1. `translateAcceptedCommand({ command: { type: "turn/start", ... } })`
   - queues the accepted user message
   - returns no `turn/input/accepted` yet because no bb turn id exists until provider output starts
2. Synthetic Claude `type: "assistant"` arrives
3. The adapter treated the text as a normal assistant message and emitted:
   - `turn/started`
   - `turn/input/accepted`
   - `item/completed` with `item.type === "agentMessage"` and text `No response requested.`
4. Because Claude sent no `type: "result"`, the adapter never emitted:
   - `turn/completed`
5. Result: bb could retain an active turn and the UI could remain stuck in Thinking.

For an already-open turn, the same synthetic assistant message could also leave the existing `currentTurnId` open if no provider result followed.

## bb Event Translation After This Change
When the Claude adapter sees the synthetic no-response assistant message:

Required detection fields:

- top-level SDK message `type === "assistant"`
- nested `message.model === "<synthetic>"`
- nested `message.role === "assistant"`
- nested `message.stop_reason === "stop_sequence"`
- nested `message.stop_sequence === ""`
- extracted assistant text is exactly `No response requested.`

For a pending first-turn input, the adapter now emits:

1. `turn/started`
2. `turn/input/accepted`
3. `turn/completed` with `status: "completed"`

It does not emit an `item/completed` `agentMessage` for `No response requested.`.

For an already-open turn, the adapter now emits:

1. `turn/completed` with `status: "completed"`

If there is no open turn and no pending accepted user message, the synthetic event is ignored so bb does not create timeline noise.

## Repro From Adapter Tests
This can be reproduced without the original thread by sending these events through the Claude adapter:

1. Call `translateAcceptedCommand` with `command.type === "turn/start"` for a Claude Code thread.
2. Do not send any normal Claude `assistant`, `stream_event`, `system`, or `result` message.
3. Send the synthetic `type: "assistant"` event shown above.
4. Before this fix, the adapter did not emit `turn/completed`.
5. After this fix, the adapter emits `turn/completed` and suppresses the synthetic `agentMessage`.

Regression tests added in `packages/agent-runtime/src/claude-code/adapter.test.ts`:

- `translateEvent completes a pending turn for Claude synthetic no-response messages`
- `translateEvent completes an open turn for Claude synthetic no-response messages`

## Fix
`packages/agent-runtime/src/claude-code/translate-message.ts` now recognizes this Claude-specific synthetic no-response assistant message before normal assistant text translation.

When recognized, it:

- starts a pending bb turn if there is queued accepted input
- drains the queued `turn/input/accepted` event
- emits `turn/completed` with `status: "completed"`
- calls `turnState.finishTurn(...)`
- returns without emitting an `agentMessage`

This keeps the bb thread state machine moving when Claude Code uses a synthetic message to close an abandoned prompt without sending a normal `result` event.

## Validation
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- claude-code/adapter.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
