### PR TITLE
Fix desktop close cleanup crash

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -729,9 +729,10 @@ function startPopoutConfigSync(serverUrl: string): void {
 }
 
 function registerApplicationWindow(browserWindow: DesktopBrowserWindow): void {
-  applicationWindowWebContentsIds.add(browserWindow.webContents.id);
+  const webContentsId = browserWindow.webContents.id;
+  applicationWindowWebContentsIds.add(webContentsId);
   browserWindow.on("closed", () => {
-    applicationWindowWebContentsIds.delete(browserWindow.webContents.id);
+    applicationWindowWebContentsIds.delete(webContentsId);
   });
 }
 


### PR DESCRIPTION
## Summary
- Capture the application window webContents id before Electron destroys the BrowserWindow
- Use the captured id in the closed handler so shutdown cleanup does not touch destroyed Electron objects

## Test Plan
- pnpm exec turbo run typecheck --filter=@bb/desktop --output-logs=new-only
- pnpm exec turbo run test --filter=@bb/desktop --force --output-logs=new-only
- pnpm exec turbo run build --filter=@bb/desktop --output-logs=new-only