### PR TITLE
Spike: edit script loops from the detail page

### DIFF
--- a/apps/app/src/views/AutomationDetailView.script-edit.test.tsx
+++ b/apps/app/src/views/AutomationDetailView.script-edit.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import type { Automation, UpdateAutomationRequest } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AutomationDetailContent } from "./AutomationDetailView";
+
+afterEach(cleanup);
+
+function scriptAutomation(
+  execOverrides: Partial<Extract<Automation["execution"], { mode: "script" }>> = {},
+): Automation {
+  return {
+    id: "auto_watchdog",
+    projectId: PERSONAL_PROJECT_ID,
+    name: "Disk space watchdog",
+    enabled: true,
+    trigger: {
+      triggerType: "schedule",
+      cron: "*/15 * * * *",
+      timezone: "America/New_York",
+    },
+    execution: {
+      mode: "script",
+      scriptFile: "script.sh",
+      script: "echo old\n",
+      interpreter: "bash",
+      timeoutMs: 30_000,
+      env: { FOO: "bar" },
+      ...execOverrides,
+    },
+    environment: { type: "host", workspace: { type: "personal" } },
+    autoArchive: false,
+    origin: "agent",
+    createdByThreadId: null,
+    nextRunAt: 1_700_003_600_000,
+    lastRunAt: null,
+    runCount: 0,
+    lastRunStatus: null,
+    lastRunThreadId: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 100,
+  };
+}
+
+function renderDetail(
+  automation: Automation,
+  onSave: (patch: UpdateAutomationRequest) => Promise<void>,
+) {
+  return render(
+    <MemoryRouter>
+      <AutomationDetailContent
+        automation={automation}
+        runs={[]}
+        runsLoading={false}
+        runsError={false}
+        onPause={() => {}}
+        onResume={() => {}}
+        onDelete={() => {}}
+        onSave={onSave}
+        savePending={false}
+        actionsPending={false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("AutomationDetailContent script editing", () => {
+  it("pre-fills the script and saves the edited script, interpreter, and timeout", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderDetail(scriptAutomation(), onSave);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const textarea = screen.getByLabelText("Script") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("echo old\n");
+    // The old "delete and recreate" message is gone.
+    expect(screen.queryByText(/delete and recreate/i)).toBeNull();
+
+    fireEvent.change(textarea, { target: { value: "echo new\nexit 0\n" } });
+    fireEvent.change(screen.getByLabelText("Interpreter"), {
+      target: { value: "python3" },
+    });
+    fireEvent.change(screen.getByLabelText("Timeout (seconds)"), {
+      target: { value: "60" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const patch = onSave.mock.calls[0]![0] as UpdateAutomationRequest;
+    expect(patch.execution).toEqual({
+      mode: "script",
+      script: "echo new\nexit 0\n",
+      interpreter: "python3",
+      timeoutMs: 60_000,
+      // env isn't editable here, so it carries through untouched.
+      env: { FOO: "bar" },
+    });
+    expect(patch.name).toBe("Disk space watchdog");
+    expect(patch.trigger).toEqual({
+      triggerType: "schedule",
+      cron: "*/15 * * * *",
+      timezone: "America/New_York",
+    });
+  });
+
+  it("disables Save when the script is cleared", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderDetail(scriptAutomation(), onSave);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText("Script"), {
+      target: { value: "   " },
+    });
+
+    const save = screen.getByRole("button", {
+      name: "Save changes",
+    }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/views/AutomationDetailView.tsx
+++ b/apps/app/src/views/AutomationDetailView.tsx
@@ -1,9 +1,15 @@
 import { useCallback, useState, type ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import type {
-  Automation,
-  AutomationRun,
-  UpdateAutomationRequest,
+import {
+  automationScriptInterpreterValues,
+  type AutomationScriptInterpreter,
+} from "@bb/domain";
+import {
+  AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS,
+  AUTOMATION_SCRIPT_TIMEOUT_MAX_MS,
+  type Automation,
+  type AutomationRun,
+  type UpdateAutomationRequest,
 } from "@bb/server-contract";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -226,6 +232,47 @@ function ConfigLine({ k, v }: { k: string; v: ReactNode }) {
   );
 }
 
+const DEFAULT_INTERPRETER: AutomationScriptInterpreter = "bash";
+const AUTOMATION_SCRIPT_TIMEOUT_MAX_SECONDS = Math.floor(
+  AUTOMATION_SCRIPT_TIMEOUT_MAX_MS / 1000,
+);
+
+function initialScript(automation: Automation): string {
+  return automation.execution.mode === "script"
+    ? (automation.execution.script ?? "")
+    : "";
+}
+
+function initialInterpreter(automation: Automation): AutomationScriptInterpreter {
+  return automation.execution.mode === "script"
+    ? (automation.execution.interpreter ?? DEFAULT_INTERPRETER)
+    : DEFAULT_INTERPRETER;
+}
+
+function initialTimeoutSeconds(automation: Automation): string {
+  const ms =
+    automation.execution.mode === "script"
+      ? automation.execution.timeoutMs
+      : AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS;
+  return String(Math.round(ms / 1000));
+}
+
+/**
+ * Clamp the edited timeout (seconds) to a valid millisecond value, falling back
+ * to the default when the field is blank or non-numeric.
+ */
+function resolveTimeoutMs(timeoutSeconds: string): number {
+  const seconds = Number(timeoutSeconds);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS;
+  }
+  const clamped = Math.min(
+    Math.round(seconds),
+    AUTOMATION_SCRIPT_TIMEOUT_MAX_SECONDS,
+  );
+  return clamped * 1000;
+}
+
 interface AutomationDetailContentProps {
   automation: Automation;
   runs: readonly AutomationRun[];
@@ -269,6 +316,13 @@ export function AutomationDetailContent({
   const [prompt, setPrompt] = useState(
     automation.execution.mode === "agent" ? automation.execution.prompt : "",
   );
+  const [script, setScript] = useState(initialScript(automation));
+  const [interpreter, setInterpreter] = useState<AutomationScriptInterpreter>(
+    initialInterpreter(automation),
+  );
+  const [timeoutSeconds, setTimeoutSeconds] = useState(
+    initialTimeoutSeconds(automation),
+  );
   const [autoArchive, setAutoArchive] = useState(automation.autoArchive);
 
   function startEditing() {
@@ -286,6 +340,9 @@ export function AutomationDetailContent({
     setPrompt(
       automation.execution.mode === "agent" ? automation.execution.prompt : "",
     );
+    setScript(initialScript(automation));
+    setInterpreter(initialInterpreter(automation));
+    setTimeoutSeconds(initialTimeoutSeconds(automation));
     setAutoArchive(automation.autoArchive);
     setEditing(true);
   }
@@ -308,7 +365,20 @@ export function AutomationDetailContent({
                 : {}),
             },
           }
-        : {}),
+        : {
+            // Inline-content path: send `script` (not `scriptFile`) so the server
+            // rewrites the stored file. `env` is not edited here, so carry the
+            // existing value through to avoid silently dropping it.
+            execution: {
+              mode: "script" as const,
+              script,
+              interpreter,
+              timeoutMs: resolveTimeoutMs(timeoutSeconds),
+              ...(automation.execution.env
+                ? { env: automation.execution.env }
+                : {}),
+            },
+          }),
     };
     try {
       await onSave(patch);
@@ -433,10 +503,60 @@ export function AutomationDetailContent({
                     />
                   </div>
                 ) : (
-                  <p className="text-xs text-muted-foreground">
-                    Script edits aren't available here — delete and recreate the
-                    loop to change its script.
-                  </p>
+                  <>
+                    <div>
+                      <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                        Script
+                      </label>
+                      <textarea
+                        value={script}
+                        onChange={(event) => setScript(event.target.value)}
+                        rows={10}
+                        spellCheck={false}
+                        aria-label="Script"
+                        className="block w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs leading-relaxed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                          Interpreter
+                        </label>
+                        <select
+                          value={interpreter}
+                          onChange={(event) =>
+                            setInterpreter(
+                              event.target.value as AutomationScriptInterpreter,
+                            )
+                          }
+                          aria-label="Interpreter"
+                          className="h-8 w-full rounded-md border border-input bg-transparent px-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        >
+                          {automationScriptInterpreterValues.map((value) => (
+                            <option key={value} value={value}>
+                              {value}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                          Timeout (seconds)
+                        </label>
+                        <Input
+                          type="number"
+                          min={1}
+                          max={AUTOMATION_SCRIPT_TIMEOUT_MAX_SECONDS}
+                          value={timeoutSeconds}
+                          onChange={(event) =>
+                            setTimeoutSeconds(event.target.value)
+                          }
+                          className="h-8 font-mono text-sm"
+                          aria-label="Timeout (seconds)"
+                        />
+                      </div>
+                    </div>
+                  </>
                 )}
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-foreground">
@@ -461,7 +581,11 @@ export function AutomationDetailContent({
                   <Button
                     type="button"
                     size="sm"
-                    disabled={savePending}
+                    disabled={
+                      savePending ||
+                      (automation.execution.mode === "script" &&
+                        script.trim().length === 0)
+                    }
                     onClick={handleSave}
                   >
                     Save changes

--- a/apps/server/src/routes/automations.test.ts
+++ b/apps/server/src/routes/automations.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeAutomationRun, createManualRun, listEvents } from "@bb/db";
 import {
@@ -333,6 +335,93 @@ describe("automations routes", () => {
     );
     expect(res.status).toBe(400);
     expect((await res.json()).code).toBe("invalid_request");
+  });
+
+  it("updates a script automation's inline script, interpreter, and timeout", async () => {
+    const createRes = await post(
+      `/projects/${projectId}/automations`,
+      createBody({ name: "Watchdog", execution: agentExecution() }),
+    );
+    const created = await createRes.json();
+    expect(created.execution.mode).toBe("script");
+    const scriptFile = created.execution.scriptFile as string;
+
+    const newScript = "echo 'updated script body'\nexit 0\n";
+    const updateRes = await patch(
+      `/projects/${projectId}/automations/${created.id}`,
+      {
+        execution: {
+          mode: "script",
+          script: newScript,
+          interpreter: "sh",
+          timeoutMs: 45_000,
+        },
+      },
+    );
+    expect(updateRes.status).toBe(200);
+    const updated = await updateRes.json();
+    expect(updated.execution.mode).toBe("script");
+    expect(updated.execution.interpreter).toBe("sh");
+    expect(updated.execution.timeoutMs).toBe(45_000);
+    // PATCH/list responses never carry inline content; only scriptFile.
+    expect(updated.execution.script).toBeUndefined();
+    expect(updated.execution.scriptFile).toBe(scriptFile);
+
+    // The file on disk was rewritten with the new content...
+    const onDisk = await readFile(
+      join(harness.config.dataDir, "automation-scripts", created.id, scriptFile),
+      "utf8",
+    );
+    expect(onDisk).toBe(newScript);
+
+    // ...and the single-automation GET surfaces it so the edit form can pre-fill.
+    const getRes = await harness.app.request(
+      `/api/v1/projects/${projectId}/automations/${created.id}`,
+    );
+    const fetched = await getRes.json();
+    expect(fetched.execution.script).toBe(newScript);
+  });
+
+  it("blocks updating an automation to a script execution when script runs are disabled", async () => {
+    const gatedHarness = await createTestAppHarness({
+      automationsAllowScriptRuns: false,
+    });
+    try {
+      const host = seedHost(gatedHarness);
+      const gatedProjectId = seedProjectWithSource(gatedHarness, {
+        hostId: host.id,
+        name: "Gated",
+        path: "/tmp/bb-automations-gated-patch",
+      }).project.id;
+
+      // Agent create is allowed under the gate.
+      const createRes = await gatedHarness.app.request(
+        `/api/v1/projects/${gatedProjectId}/automations`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(createBody()),
+        },
+      );
+      expect(createRes.status).toBe(201);
+      const created = await createRes.json();
+
+      // Converting it to a script execution must be gated the same as create.
+      const patchRes = await gatedHarness.app.request(
+        `/api/v1/projects/${gatedProjectId}/automations/${created.id}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            execution: { mode: "script", script: "echo hi", interpreter: "bash" },
+          }),
+        },
+      );
+      expect(patchRes.status).toBe(403);
+      expect((await patchRes.json()).code).toBe("invalid_request");
+    } finally {
+      await gatedHarness.cleanup();
+    }
   });
 
   it("blocks creating a script automation when script runs are disabled", async () => {

--- a/apps/server/src/routes/automations.ts
+++ b/apps/server/src/routes/automations.ts
@@ -37,6 +37,7 @@ import {
 } from "../services/scheduling/automation-config.js";
 import {
   deleteAutomationScriptDir,
+  readInlineAutomationScript,
   writeInlineAutomationScript,
 } from "../services/scheduling/automation-scripts.js";
 import { appendAutomationCreatedEvent } from "../services/threads/thread-events.js";
@@ -257,14 +258,42 @@ export function registerAutomationRoutes(app: Hono, deps: AppDeps): void {
     return context.json(toAutomationResponse(created), 201);
   });
 
-  get(routes.get, (context) => {
+  get(routes.get, async (context) => {
     const projectId = context.req.param("id");
     requirePublicProject(deps.db, projectId);
     const automation = requireProjectAutomation(deps, {
       projectId,
       automationId: context.req.param("automationId"),
     });
-    return context.json(toAutomationResponse(automation));
+    const response = toAutomationResponse(automation);
+    // The detail page is the only surface that edits a script, so enrich just
+    // this single-automation GET (not list/overview) with the stored inline
+    // content. The response schema already permits `script`; list/overview stay
+    // lean and avoid a per-row disk read.
+    if (
+      response.execution.mode === "script" &&
+      response.execution.scriptFile !== undefined
+    ) {
+      try {
+        const script = await readInlineAutomationScript({
+          dataDir: deps.config.dataDir,
+          automationId: automation.id,
+          scriptFile: response.execution.scriptFile,
+        });
+        if (script.length > 0) {
+          return context.json({
+            ...response,
+            execution: { ...response.execution, script },
+          });
+        }
+      } catch (error) {
+        deps.logger.warn(
+          { automationId: automation.id, err: error },
+          "Could not read inline script for automation detail",
+        );
+      }
+    }
+    return context.json(response);
   });
 
   patch(routes.update, async (context, payload: UpdateAutomationRequest) => {

--- a/apps/server/src/services/scheduling/automation-scripts.ts
+++ b/apps/server/src/services/scheduling/automation-scripts.ts
@@ -1,4 +1,5 @@
-import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { basename, extname, join, resolve } from "node:path";
 import type { AutomationScriptInterpreter } from "@bb/domain";
 import { resolveContainedPath } from "@bb/process-utils";
@@ -52,6 +53,10 @@ export function resolveInterpreterCommand(
 /**
  * Persist inline script content under `<dataDir>/automation-scripts/<id>/` and
  * return the stored relative file name. Sanitizes the file name and writes 0o700.
+ *
+ * Writes via a temp file + atomic `rename` so an update that rewrites an existing
+ * script (e.g. from the detail page) is atomic w.r.t. a concurrent run: a reader
+ * sees either the complete old or complete new content, never a truncated file.
  */
 export async function writeInlineAutomationScript(args: {
   dataDir: string;
@@ -64,8 +69,30 @@ export async function writeInlineAutomationScript(args: {
   );
   const dir = automationScriptDir(args.dataDir, args.automationId);
   await mkdir(dir, { recursive: true });
-  await writeFile(join(dir, storedName), args.content, { mode: 0o700 });
+  const target = join(dir, storedName);
+  const tmp = join(dir, `.${storedName}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(tmp, args.content, { mode: 0o700 });
+    await rename(tmp, target);
+  } catch (error) {
+    await rm(tmp, { force: true });
+    throw error;
+  }
   return storedName;
+}
+
+/**
+ * Read an automation's stored inline script content, enforcing the same
+ * containment as the run path. Used to surface the current script in the detail
+ * response so the edit form can pre-fill it.
+ */
+export async function readInlineAutomationScript(args: {
+  dataDir: string;
+  automationId: string;
+  scriptFile: string;
+}): Promise<string> {
+  const scriptPath = await resolveAutomationScriptPath(args);
+  return readFile(scriptPath, "utf8");
 }
 
 /**


### PR DESCRIPTION
## What

Make **SCRIPT-mode loops editable end-to-end** from the loop detail page. Previously the inline edit form supported agent loops (name/cron/timezone/prompt/auto-archive) but for script loops showed: _"Script edits aren't available here — delete and recreate the loop to change its script."_ Now a user can change the script (and interpreter/timeout/schedule) right from the page.

## Findings: what the script-update path actually required

The backend was **closer than expected**. The PATCH route and contract (`updateAutomationRequestSchema.execution`) already accepted a script-variant `execution` update — inline `script`, `interpreter`, `timeoutMs` — and `resolveStoredExecution` already wrote the inline script to disk and stored `scriptFile`. The policy gate (`assertScriptRunsAllowed`) was already applied on PATCH. **No daemon involvement**: the server writes the script file directly under `<dataDir>/automation-scripts/<id>/`; the daemon only reads it at run time.

So the real gaps were:

1. **Read path (pre-fill).** GET responses carry only `scriptFile`, never inline content, so the edit form had nothing to populate the textarea with. → Enrich **only the single-automation GET** with the stored script content (the response schema already permits `script`). List/overview stay lean — no per-row disk read.
2. **Atomic write.** `writeInlineAutomationScript` did an in-place `writeFile`, so an update rewriting the existing `script.sh` wasn't atomic against a concurrent run. → Write to a temp file + atomic `rename`. A reader now sees either the complete old or complete new content, never a truncated file. (Mirrors the create path's "never observe a partial state" guarantee.)
3. **Frontend.** The form blocked script edits. → Render an editable font-mono **Script** textarea + **Interpreter** select + **Timeout (seconds)** input, wired into the existing PATCH flow alongside name/cron/timezone. Existing `env` (not surfaced in the form) is carried through untouched so it isn't silently dropped; Save is disabled on an empty script.

## Scope

SCRIPT-editing capability only. Does **not** rework the agent edit flow to use the prompt box (separate effort gated on composer-extraction #283).

## Notes / follow-ups

- Inline edits always normalize the stored file to `script.sh` (the request schema enforces `script` XOR `scriptFile`, so the form can't send a custom filename). The only way to get a non-default `scriptFile` is the "reference a pre-placed file" path; editing such a loop's content via the UI re-homes it to `script.sh` and orphans the old file. Acceptable for the spike; worth a follow-up if custom script filenames need to survive inline edits.

## Validation

- `turbo typecheck` — `@bb/app`, `@bb/server` ✅
- `turbo test @bb/server "automations"` — 16 pass, incl. new **round-trips the new script through disk** and **rejects PATCH→script when script runs are policy-disabled (403)** ✅
- `turbo test @bb/app "AutomationDetail"` — 16 pass, incl. new interactive **edit form → saved patch** test ✅
- **Live smoke** against the dev server: create script loop → GET pre-fills current content → PATCH new script + `python3` + 90s → file on disk rewritten → GET surfaces new content/interpreter/timeout → XOR guard 400 → delete cleans up the script dir ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)