### PR TITLE
Stabilize desktop dev and macOS chrome alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ checkout path. The checkout instance id is the sanitized path to the checkout,
 relative to your home directory, plus a short hash suffix. Separate worktrees
 can run alongside each other and the packaged `npx bb-app@latest` instance.
 
+To run that same source dev server with the Electron desktop shell:
+
+```bash
+pnpm dev:desktop
+```
+
+This uses `scripts/bb-dev-app current --desktop`, which stops stale launcher
+sessions, checks dependencies and native modules, starts the source dev server,
+then opens the desktop shell against that dev app.
+
 To use the dev app from another machine, for example over Tailscale, run:
 
 ```bash

--- a/apps/app/src/components/ui/coarse-pointer-sizing.ts
+++ b/apps/app/src/components/ui/coarse-pointer-sizing.ts
@@ -26,7 +26,7 @@ export const COARSE_POINTER_CHECK_SLOT_CLASS =
   "h-3.5 w-3.5 max-md:pointer-coarse:h-5 max-md:pointer-coarse:w-5";
 
 export const COARSE_POINTER_HEADER_ICON_BUTTON_CLASS =
-  "h-7 w-7 rounded-md p-0 [&_svg]:size-4 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";
+  "h-[28px] w-[28px] rounded-md p-0 [&_svg]:size-[16px] max-md:pointer-coarse:h-[36px] max-md:pointer-coarse:w-[36px] max-md:pointer-coarse:[&_svg]:size-[20px]";
 
 export const COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS =
   "h-7 w-7 rounded-md p-0 [&_svg]:size-3.5 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -6,39 +6,40 @@ import type {
 
 // The macOS traffic-light cluster sits in a fixed strip on the left of the
 // frameless window. In-flow chrome clears it with left padding; the pinned
-// sidebar trigger clears it with a matching left offset. Keep the `pl-*` and
-// `left-*` steps in sync so the trigger lands just right of the lights.
+// sidebar trigger clears it with a matching left offset. These are fixed px
+// geometry values because they are paired with Electron/macOS window-control
+// coordinates, not app typography.
 //
 // Two reserve steps, one target — the leading content lands just right of the
-// pinned sidebar trigger (`left-20`), not merely past the lights:
-//  - RESERVE (`pl-20`): the full reserve, applied directly by a surface whose
+// pinned sidebar trigger (`left: 80px`), not merely past the lights:
+//  - RESERVE (`padding-left: 80px`): the full reserve, applied directly by a surface whose
 //    left padding replaces its base inset. The secondary-panel header uses it —
 //    it sits right of the 36px conversation rail, so the trigger overhangs the
 //    header's left edge and the leading tab has to clear the trigger, not just
 //    the lights.
-//  - COLLAPSED_HEADER_RESERVE (`pl-25` = 100px): the page header folds the
-//    whole pinned-trigger footprint into a single left padding: the `pl-20`
+//  - COLLAPSED_HEADER_RESERVE (`padding-left: 100px`): the page header folds the
+//    whole pinned-trigger footprint into a single left padding: the 80px
 //    clear-the-lights step less the header's own `px-4` (80 − 16 = 64) lands at
-//    the trigger's left edge, plus the trigger's own width (`w-7`, 28px) and the
+//    the trigger's left edge, plus the trigger's own width (28px) and the
 //    `gap-2` after it (8px) = 100px, so the leading content sits just right of
 //    the trigger. It is one padding rather than padding + a spacer element so it
 //    can transition in lockstep with the sidebar slide — otherwise it snaps on
 //    and off instantly while the inset animates and the header jumps on toggle.
-export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-20";
-export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-20";
-export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-25";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[80px]";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[80px]";
+export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-[100px]";
 
 // Browser-chrome analogs of the macOS reserve above. The web build has no
 // traffic lights, so it pins the sidebar toggle flush at the app's top-left with
 // a small inset (see AppLayout's SidebarTriggerOverlay), and the collapsed page
 // header reserves that footprint as left padding so its content clears the
 // pinned toggle — the same trick as macOS, just smaller. Keep the inset and the
-// reserve in sync: `pl-8` (32px) on top of the header's own `px-4` (16px) sums to
+// reserve in sync: `padding-left: 32px` on top of the header's own `px-4` (16px) sums to
 // 48px, which clears the 12px inset + the 28px trigger + an 8px gap;
-// `max-md:pointer-coarse:pl-10` (40px) covers the larger 36px touch trigger.
-export const BROWSER_SIDEBAR_TRIGGER_INSET_CLASS = "pl-3";
+// `max-md:pointer-coarse:pl-[40px]` covers the larger 36px touch trigger.
+export const BROWSER_SIDEBAR_TRIGGER_INSET_CLASS = "pl-[12px]";
 export const BROWSER_COLLAPSED_HEADER_RESERVE_CLASS =
-  "pl-8 max-md:pointer-coarse:pl-10";
+  "pl-[32px] max-md:pointer-coarse:pl-[40px]";
 export const MACOS_WINDOW_DRAG_CLASS =
   "select-none [app-region:drag] [-webkit-app-region:drag]";
 export const MACOS_APP_REGION_NO_DRAG_CLASS =
@@ -53,7 +54,7 @@ export const MACOS_WINDOW_NO_DRAG_CLASS = `relative z-50 ${MACOS_APP_REGION_NO_D
 // sidebar icon column's left rail. Electron main and the renderer are separate
 // bundles, so they cannot share one runtime value — keep this height and that
 // inset in sync as a paired geometry contract.
-export const CHROME_ROW_HEIGHT_CLASS = "h-12";
+export const CHROME_ROW_HEIGHT_CLASS = "h-[48px]";
 // Base layout for an in-flow chrome row: the shared height, laid out as a flex
 // row and vertically centered so its contents share the titlebar axis.
 export const CHROME_ROW_CLASS = `flex ${CHROME_ROW_HEIGHT_CLASS} items-center`;

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -59,17 +59,15 @@ export const CHROME_ROW_HEIGHT_CLASS = "h-[48px]";
 // row and vertically centered so its contents share the titlebar axis.
 export const CHROME_ROW_CLASS = `flex ${CHROME_ROW_HEIGHT_CLASS} items-center`;
 
-// macOS renders the traffic-light cluster ~2 CSS px BELOW the chrome row's
-// geometric center: a native window screenshot (Retina 2x) measures the light
-// centers at y≈51.5 device px (≈25.8 CSS) while the renderer chrome box-centers
-// at 24. Box-centering alone (CDP y=24) therefore looks ~2 px high next to the
-// native lights. This nudges the top-of-window chrome down onto the lights'
-// axis. It is the single knob for the collapse trigger, the route-history
-// arrows, and the page/thread header content, and is applied ONLY under macOS
-// desktop chrome — the web build has no traffic lights and stays row-centered.
-// 2 CSS px = 4 device px at 2x, so the shift stays crisp (no sub-pixel blur).
+// macOS native traffic lights and Chromium-rendered chrome land on slightly
+// different visual axes. A Retina screenshot of the desktop titlebar measures
+// the light centers and the sidebar trigger about 2 device px apart with a 2px
+// nudge, so use the smaller crisp shift here: 1 CSS px = 2 device px at 2x.
+// This is the single knob for the collapse trigger, the route-history arrows,
+// and the page/thread header content, and is applied only under macOS desktop
+// chrome. The web build has no traffic lights and stays row-centered.
 export const MACOS_CHROME_TRAFFIC_LIGHT_AXIS_NUDGE_CLASS =
-  "[transform:translateY(2px)]";
+  "[transform:translateY(1px)]";
 
 export type BbDesktopInfoResult = BbDesktopApi | null;
 

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -11,23 +11,23 @@ import type {
 // coordinates, not app typography.
 //
 // Two reserve steps, one target — the leading content lands just right of the
-// pinned sidebar trigger (`left: 82px`), not merely past the lights:
-//  - RESERVE (`padding-left: 82px`): the full reserve, applied directly by a surface whose
+// pinned sidebar trigger (`left: 84px`), not merely past the lights:
+//  - RESERVE (`padding-left: 84px`): the full reserve, applied directly by a surface whose
 //    left padding replaces its base inset. The secondary-panel header uses it —
 //    it sits right of the 36px conversation rail, so the trigger overhangs the
 //    header's left edge and the leading tab has to clear the trigger, not just
 //    the lights.
-//  - COLLAPSED_HEADER_RESERVE (`padding-left: 102px`): the page header folds the
-//    whole pinned-trigger footprint into a single left padding: the 82px
-//    clear-the-lights step less the header's own `px-4` (82 − 16 = 66) lands at
+//  - COLLAPSED_HEADER_RESERVE (`padding-left: 104px`): the page header folds the
+//    whole pinned-trigger footprint into a single left padding: the 84px
+//    clear-the-lights step less the header's own `px-4` (84 − 16 = 68) lands at
 //    the trigger's left edge, plus the trigger's own width (28px) and the
-//    `gap-2` after it (8px) = 102px, so the leading content sits just right of
+//    `gap-2` after it (8px) = 104px, so the leading content sits just right of
 //    the trigger. It is one padding rather than padding + a spacer element so it
 //    can transition in lockstep with the sidebar slide — otherwise it snaps on
 //    and off instantly while the inset animates and the header jumps on toggle.
-export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[82px]";
-export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[82px]";
-export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-[102px]";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[84px]";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[84px]";
+export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-[104px]";
 
 // Browser-chrome analogs of the macOS reserve above. The web build has no
 // traffic lights, so it pins the sidebar toggle flush at the app's top-left with

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -11,23 +11,23 @@ import type {
 // coordinates, not app typography.
 //
 // Two reserve steps, one target — the leading content lands just right of the
-// pinned sidebar trigger (`left: 80px`), not merely past the lights:
-//  - RESERVE (`padding-left: 80px`): the full reserve, applied directly by a surface whose
+// pinned sidebar trigger (`left: 82px`), not merely past the lights:
+//  - RESERVE (`padding-left: 82px`): the full reserve, applied directly by a surface whose
 //    left padding replaces its base inset. The secondary-panel header uses it —
 //    it sits right of the 36px conversation rail, so the trigger overhangs the
 //    header's left edge and the leading tab has to clear the trigger, not just
 //    the lights.
-//  - COLLAPSED_HEADER_RESERVE (`padding-left: 100px`): the page header folds the
-//    whole pinned-trigger footprint into a single left padding: the 80px
-//    clear-the-lights step less the header's own `px-4` (80 − 16 = 64) lands at
+//  - COLLAPSED_HEADER_RESERVE (`padding-left: 102px`): the page header folds the
+//    whole pinned-trigger footprint into a single left padding: the 82px
+//    clear-the-lights step less the header's own `px-4` (82 − 16 = 66) lands at
 //    the trigger's left edge, plus the trigger's own width (28px) and the
-//    `gap-2` after it (8px) = 100px, so the leading content sits just right of
+//    `gap-2` after it (8px) = 102px, so the leading content sits just right of
 //    the trigger. It is one padding rather than padding + a spacer element so it
 //    can transition in lockstep with the sidebar slide — otherwise it snaps on
 //    and off instantly while the inset animates and the header jumps on toggle.
-export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[80px]";
-export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[80px]";
-export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-[100px]";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[82px]";
+export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[82px]";
+export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-[102px]";
 
 // Browser-chrome analogs of the macOS reserve above. The web build has no
 // traffic lights, so it pins the sidebar toggle flush at the app's top-left with

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -5,6 +5,15 @@ uses the packaged `bb-app` launcher for server and host-daemon lifecycle.
 
 ## Development
 
+From the repo root, the full source dev loop is:
+
+```bash
+pnpm dev:desktop
+```
+
+That starts the source dev server and the Electron shell through
+`scripts/bb-dev-app`. To run only the desktop package task directly:
+
 ```bash
 pnpm exec turbo run dev --filter=@bb/desktop
 ```

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -149,8 +149,8 @@ codesign --verify --deep --strict --verbose=2 /path/to/bb.app
 
 ## Debugging
 
-The Turbo dev task opens DevTools automatically. For a packaged app, run the
-binary with `BB_DESKTOP_OPEN_DEVTOOLS=1`:
+Use the View menu to toggle DevTools. To open them automatically on launch, set
+`BB_DESKTOP_OPEN_DEVTOOLS=1`:
 
 ```bash
 BB_DESKTOP_OPEN_DEVTOOLS=1 apps/desktop/release/mac-arm64/bb.app/Contents/MacOS/bb

--- a/apps/desktop/src/desktop-window-factory.ts
+++ b/apps/desktop/src/desktop-window-factory.ts
@@ -22,7 +22,7 @@ export type DesktopWindowIcon = BrowserWindowConstructorOptions["icon"];
 // left edges so they sit on a 45° diagonal from the top-left corner. The shared
 // value vertically centers the lights within the 48px chrome row and brings them
 // onto the sidebar icon column's left rail. This is the native half of a paired
-// geometry contract: the renderer half is `CHROME_ROW_HEIGHT_CLASS` (h-12) and
+// geometry contract: the renderer half is `CHROME_ROW_HEIGHT_CLASS` (48px) and
 // the traffic-light reserve tokens in apps/app/src/lib/bb-desktop.ts. The two
 // bundles can't share a runtime value, so keep this inset in sync with them.
 const MACOS_TRAFFIC_LIGHT_DIAGONAL_INSET = 18;
@@ -52,6 +52,7 @@ export interface DesktopWindowWebContents {
   openDevTools(options: DesktopWindowOpenDevToolsOptions): void;
   send(channel: string, payload: unknown): void;
   setWindowOpenHandler(handler: DesktopWindowOpenHandler): void;
+  setZoomFactor(factor: number): void;
 }
 
 export interface DesktopBrowserWindow extends StatefulBrowserWindow {
@@ -182,6 +183,10 @@ function createWindowOptions(
 }
 
 async function loadUrlIntoWindow(args: LoadUrlIntoWindowArgs): Promise<void> {
+  // Native macOS traffic lights do not scale with Chromium page zoom, so reset
+  // app-window zoom before loading the renderer chrome that visually aligns to
+  // them. This also clears stale per-origin zoom persisted by Electron sessions.
+  args.browserWindow.webContents.setZoomFactor(1);
   try {
     await args.browserWindow.loadURL(args.url);
   } catch (error) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1004,7 +1004,7 @@ async function loadBbApp(serverUrl: string): Promise<void> {
 }
 
 function shouldOpenDevTools(): boolean {
-  return !app.isPackaged || process.env.BB_DESKTOP_OPEN_DEVTOOLS === "1";
+  return process.env.BB_DESKTOP_OPEN_DEVTOOLS === "1";
 }
 
 async function createApplicationWindow(

--- a/apps/desktop/test/desktop-window-factory.test.ts
+++ b/apps/desktop/test/desktop-window-factory.test.ts
@@ -51,6 +51,7 @@ class FakeDesktopWindowWebContents implements DesktopWindowWebContents {
   public readonly sentMessages: Array<{ channel: string; payload: unknown }> =
     [];
   public windowOpenHandler: DesktopWindowOpenHandler | null = null;
+  public readonly zoomFactors: number[] = [];
 
   constructor(id: number) {
     this.id = id;
@@ -68,6 +69,10 @@ class FakeDesktopWindowWebContents implements DesktopWindowWebContents {
 
   setWindowOpenHandler(handler: DesktopWindowOpenHandler): void {
     this.windowOpenHandler = handler;
+  }
+
+  setZoomFactor(factor: number): void {
+    this.zoomFactors.push(factor);
   }
 }
 
@@ -232,6 +237,8 @@ describe("desktop window factory", () => {
     });
     expect(createdWindows[0]?.loadedUrls).toEqual(["http://127.0.0.1:38886"]);
     expect(createdWindows[1]?.loadedUrls).toEqual(["http://127.0.0.1:38886"]);
+    expect(createdWindows[0]?.webContents.zoomFactors).toEqual([1]);
+    expect(createdWindows[1]?.webContents.zoomFactors).toEqual([1]);
     expect(runtimeSupervisorInvocations).toBe(1);
 
     await factory.persistOpenWindows();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "scripts:prepare": "pnpm exec turbo run build --filter=@bb/scripts --output-logs=none --log-prefix=none --summarize=false",
     "cli:prepare": "pnpm exec turbo run build --filter=@bb/scripts --filter=@bb/cli --output-logs=none --log-prefix=none --summarize=false",
-    "dev": "cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts",
+    "dev": "node scripts/ensure-native-modules.mjs && cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts",
+    "dev:desktop": "scripts/bb-dev-app current --desktop",
     "dev:restart": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts both",
     "dev:restart-server": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts server",
     "dev:restart-host-daemon": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts host-daemon",

--- a/packages/scripts/test/ensure-native-modules.test.mjs
+++ b/packages/scripts/test/ensure-native-modules.test.mjs
@@ -97,6 +97,26 @@ describe("ensure-native-modules", () => {
     expect(fake.state.constructorCalls).toBe(2);
   });
 
+  it("rebuilds better-sqlite3 when the native binding is missing", () => {
+    const missingBindingError = new Error(
+      "Could not locate the bindings file. Tried: build/Release/better_sqlite3.node",
+    );
+    const fake = createBetterSqliteRequire(missingBindingError);
+    const execSync = vi.fn(() => {
+      fake.clearConstructorError();
+    });
+
+    expect(() =>
+      ensureNativeModules(createEnsureOptions(fake.requireModule, execSync)),
+    ).not.toThrow();
+
+    expect(execSync).toHaveBeenCalledWith("npx --yes node-gyp rebuild", {
+      cwd: "/tmp/fake-node-modules/better-sqlite3",
+      stdio: "inherit",
+    });
+    expect(fake.state.constructorCalls).toBe(2);
+  });
+
   it("exits non-zero when the post-rebuild instantiation still fails", () => {
     const result = spawnSync(
       process.execPath,

--- a/scripts/bb-dev-app
+++ b/scripts/bb-dev-app
@@ -4,8 +4,62 @@ set -euo pipefail
 script_dir="${0:A:h}"
 REPO_ROOT="${BB_DEV_REPO_ROOT:-${script_dir:h}}"
 
-if [[ -n "${BB_DEV_NODE_BIN_DIR:-}" ]]; then
-  PATH="${BB_DEV_NODE_BIN_DIR}:${HOME}/.local/bin:${PATH}"
+resolve_dev_node_bin_dir() {
+  if [[ -n "${BB_DEV_NODE_BIN_DIR:-}" ]]; then
+    print -r -- "${BB_DEV_NODE_BIN_DIR}"
+    return
+  fi
+
+  local current_major
+  current_major="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || true)"
+  if [[ "${current_major}" == "22" ]]; then
+    return
+  fi
+
+  local node_versions_dir="${NVM_DIR:-${HOME}/.nvm}/versions/node"
+  [[ -d "${node_versions_dir}" ]] || return 0
+
+  node - "${node_versions_dir}" <<'NODE' || true
+const fs = require("node:fs");
+const path = require("node:path");
+
+const nodeVersionsDir = process.argv[2];
+const candidates = fs
+  .readdirSync(nodeVersionsDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => {
+    const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(entry.name);
+    if (match === null) {
+      return null;
+    }
+    return {
+      name: entry.name,
+      major: Number(match[1]),
+      minor: Number(match[2]),
+      patch: Number(match[3]),
+    };
+  })
+  .filter(
+    (version) =>
+      version !== null &&
+      version.major === 22 &&
+      (version.minor > 12 || (version.minor === 12 && version.patch >= 0)),
+  )
+  .sort((left, right) => {
+    if (left.minor !== right.minor) return left.minor - right.minor;
+    return left.patch - right.patch;
+  });
+
+const selected = candidates.at(-1);
+if (selected !== undefined) {
+  console.log(path.join(nodeVersionsDir, selected.name, "bin"));
+}
+NODE
+}
+
+dev_node_bin_dir="$(resolve_dev_node_bin_dir)"
+if [[ -n "${dev_node_bin_dir}" ]]; then
+  PATH="${dev_node_bin_dir}:${HOME}/.local/bin:${PATH}"
 else
   PATH="${HOME}/.local/bin:${PATH}"
 fi
@@ -78,6 +132,21 @@ die() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+assert_desktop_node_runtime() {
+  local major version exec_path
+  major="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || true)"
+  version="$(node -p "process.version" 2>/dev/null || echo "unknown")"
+  exec_path="$(command -v node || echo "unknown")"
+
+  if [[ ! "${major}" == <-> ]]; then
+    die "Could not determine Node version for desktop dev"
+  fi
+
+  if (( major > 22 )); then
+    die "Desktop dev requires Node 20 or 22 because Electron's postinstall runtime is not reliable on Node ${major}. Current node is ${version} at ${exec_path}. Install/use Node 22 or set BB_DEV_NODE_BIN_DIR to a Node 22 bin directory."
+  fi
 }
 
 ensure_repo() {
@@ -299,6 +368,7 @@ open_app_url() {
 start_current() {
   local open_after_start="$1"
   local start_desktop_app="$2"
+  [[ "${start_desktop_app}" == "1" ]] && assert_desktop_node_runtime
   stop_dev_app
   ensure_dependencies
   load_config

--- a/scripts/ensure-native-modules.mjs
+++ b/scripts/ensure-native-modules.mjs
@@ -23,6 +23,12 @@ export function verifyNativeModule(name, requireModule) {
   db.close();
 }
 
+function shouldRebuildNativeModule(errorMessage) {
+  return /NODE_MODULE_VERSION|Could not locate the bindings file/.test(
+    errorMessage,
+  );
+}
+
 export function ensureNativeModules({
   repoRoot = defaultRepoRoot,
   modules = nativeModules,
@@ -36,7 +42,7 @@ export function ensureNativeModules({
       verifyNativeModule(name, requireModule);
     } catch (err) {
       const message = formatThrownValue(err);
-      if (!/NODE_MODULE_VERSION/.test(message)) throw err;
+      if (!shouldRebuildNativeModule(message)) throw err;
 
       const pkgDir = dirname(requireModule.resolve(`${name}/package.json`));
       log(


### PR DESCRIPTION
## Summary
- add a top-level `pnpm dev:desktop` launcher path and make desktop dev prefer a working Node 22 runtime
- rebuild missing/mismatched native modules and repair missing Electron installs during dev startup
- stabilize macOS traffic-light/sidebar-trigger alignment with fixed px chrome metrics, zoom reset, and tuned offsets
- keep desktop DevTools closed by default while preserving `BB_DESKTOP_OPEN_DEVTOOLS=1` and the View menu toggle

## Tests
- `pnpm exec turbo run test --filter=@bb/scripts -- --run test/ensure-native-modules.test.mjs`
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/desktop`
- `pnpm exec turbo run test --filter=@bb/desktop -- --run test/desktop-window-factory.test.ts`
- `pnpm exec turbo run build --filter=@bb/app --filter=@bb/desktop`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run build --filter=@bb/app`