### PR TITLE
docs: clarify Windows requires WSL2 in README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ The recommended way to start using bb is the desktop app:
 
 **[Download the latest desktop app](https://github.com/ymichael/bb/releases/tag/desktop-latest)**
 
-The desktop build is currently macOS Apple Silicon (arm64) only. Intel Mac,
-Linux, and Windows users should run bb with `npx` instead.
+The desktop build is currently macOS Apple Silicon (arm64) only. Intel Mac and
+Linux users should run bb with `npx` instead. On Windows, run bb inside
+[WSL2 (Windows Subsystem for Linux)](https://learn.microsoft.com/windows/wsl/install):
+install WSL2 first, then run the same `npx` command below from your WSL2 (Linux)
+shell. Native Windows PowerShell and CMD are not supported.
 
 ### Or run it anywhere with npx
 

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -157,7 +157,7 @@ function InstallOptions({ placement }: { placement: CtaPlacement }) {
         <span className="install-choice">
           <RunCommandButton placement={placement} />
           <span className="install-note">
-            Windows, Linux &amp; remote machines
+            Windows (via WSL), Linux &amp; remote machines
           </span>
         </span>
       </div>


### PR DESCRIPTION
## Summary

Windows support runs the Linux stack inside WSL2 (per `docs/platform-support.md` and `packages/bb-app/README.md`), not native PowerShell/CMD. The two public-facing surfaces — the top-level README and the marketing landing page — still implied plain Windows worked. This makes the WSL2 requirement explicit on both, with focused copy edits.

### Changes
- **`README.md`**: The desktop-download section previously grouped "Intel Mac, Linux, and Windows" together under "run bb with `npx`". Now Windows gets its own concise instruction: install [WSL2](https://learn.microsoft.com/windows/wsl/install) first, then run the same `npx` command from a WSL2 (Linux) shell, and notes that native PowerShell/CMD are not supported.
- **`apps/landing/src/routes/index.tsx`**: The npx install-note caption now reads "Windows (via WSL), Linux & remote machines" (was "Windows, Linux & remote machines"). Short and polished to match the surrounding copy.

No native Windows cmd/PowerShell support is implied. Diff kept tight — only these two strings changed; no refactors.

## Validation
Run from the repo root via Turbo (scoped to the affected package):

| Command | Result |
| --- | --- |
| `pnpm exec turbo run typecheck lint --filter=@bb/landing` | ✅ 2 successful, 2 total |
| `pnpm exec turbo run build --filter=@bb/landing` | ✅ prerendered `/` successfully |
| `grep -ro "Windows (via WSL), Linux" apps/landing/dist` | ✅ present in both server and client bundles |

README change is markdown-only (no build step). The landing build prerenders the page and the updated copy appears in the compiled output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)