### PR TITLE
Expose public bb-app SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This monorepo contains the packaged app plus the runtime services it bundles:
 | [`packages/server-contract`](./packages/server-contract)           | HTTP and WebSocket contract between clients and the server.                           |
 | [`packages/host-daemon-contract`](./packages/host-daemon-contract) | Command/event contract between the server and host daemons.                           |
 
+`bb-app` also exposes a Node scripting SDK:
+`import { BBSdk } from "bb-app"`. See
+[`packages/bb-app`](./packages/bb-app/README.md#scripting-with-the-sdk).
+
 ## Development
 
 Use the development loop when working on bb itself:

--- a/apps/cli/src/commands/thread/helpers.ts
+++ b/apps/cli/src/commands/thread/helpers.ts
@@ -5,18 +5,22 @@ import {
   serviceTierSchema,
   type ServiceTier,
 } from "@bb/domain";
+import {
+  DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS as SDK_DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS,
+  DEFAULT_THREAD_WAIT_TIMEOUT_MS,
+  type ThreadWaitTarget,
+} from "@bb/sdk";
 import { assertNever } from "@bb/core-ui";
 import { joinValues } from "../helpers.js";
-
-export type ThreadWaitTarget =
-  | { kind: "status"; status: ThreadStatus }
-  | { kind: "event"; eventType: string };
 
 export const THREAD_WAIT_EXIT_CODE_TIMEOUT = 2;
 export const THREAD_WAIT_EXIT_CODE_INVALID_REQUEST = 3;
 export const THREAD_WAIT_EXIT_CODE_UNREACHABLE = 4;
-export const DEFAULT_THREAD_WAIT_TIMEOUT_SECONDS = 30;
-export const DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS = 250;
+export const DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS =
+  SDK_DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS;
+export const DEFAULT_THREAD_WAIT_TIMEOUT_SECONDS =
+  DEFAULT_THREAD_WAIT_TIMEOUT_MS / 1000;
+export type { ThreadWaitTarget };
 
 const SERVICE_TIERS: ServiceTier[] = ["fast", "default"];
 export const PERMISSION_MODE_HELP =

--- a/apps/cli/src/commands/thread/wait.ts
+++ b/apps/cli/src/commands/thread/wait.ts
@@ -1,10 +1,6 @@
 import { Command } from "commander";
-import {
-  type ThreadStatus,
-  threadStatusSchema,
-  threadStatusValues,
-} from "@bb/domain";
-import { assertNever } from "@bb/core-ui";
+import { threadStatusSchema, threadStatusValues } from "@bb/domain";
+import { ThreadWaitTimeoutError, ThreadWaitUnreachableError } from "@bb/sdk";
 import { action, CliExitError } from "../../action.js";
 import { createCliBbSdk } from "../../client.js";
 import {
@@ -63,66 +59,43 @@ export function registerWaitCommand(
         const target = parseThreadWaitTarget(opts);
         const timeoutSeconds = parseThreadWaitTimeoutSeconds(opts.timeout);
         const pollIntervalMs = parseThreadWaitPollIntervalMs(opts.pollInterval);
-        const deadline = Date.now() + timeoutSeconds * 1000;
-
-        while (true) {
-          if (target.kind === "status") {
-            const thread = await sdk.threads.get({ threadId });
-            if (thread.status === target.status) {
-              if (outputJson(opts, { threadId, matched: true, target })) return;
-              console.log(
-                `Thread ${threadId} reached status ${target.status}.`,
-              );
-              return;
-            }
-            const unreachableReason = getThreadWaitUnreachableReason(
-              threadId,
-              thread.status,
-              target.status,
+        const waitArgs = {
+          threadId,
+          timeoutMs: timeoutSeconds * 1000,
+          pollIntervalMs,
+          ...(target.kind === "status"
+            ? { status: target.status }
+            : { event: target.eventType }),
+        };
+        let result: Awaited<ReturnType<typeof sdk.threads.wait>>;
+        try {
+          result = await sdk.threads.wait(waitArgs);
+        } catch (error) {
+          if (error instanceof ThreadWaitTimeoutError) {
+            throw new CliExitError(
+              error.message,
+              THREAD_WAIT_EXIT_CODE_TIMEOUT,
             );
-            if (unreachableReason) {
-              throw new CliExitError(
-                unreachableReason,
-                THREAD_WAIT_EXIT_CODE_UNREACHABLE,
-              );
-            }
-
-            if (Date.now() >= deadline) {
-              throw new CliExitError(
-                `Timed out waiting for thread ${threadId} to reach status ${target.status}.`,
-                THREAD_WAIT_EXIT_CODE_TIMEOUT,
-              );
-            }
-
-            await sleep(pollIntervalMs);
-          } else {
-            const remainingMs = Math.max(0, deadline - Date.now());
-            const waitMs = Math.floor(Math.min(remainingMs, 30_000));
-
-            const matched = await sdk.threads.events.wait({
-              threadId,
-              type: target.eventType,
-              waitMs: String(waitMs),
-            });
-
-            if (matched === null) {
-              if (Date.now() >= deadline) {
-                throw new CliExitError(
-                  `Timed out waiting for thread ${threadId} event ${target.eventType}.`,
-                  THREAD_WAIT_EXIT_CODE_TIMEOUT,
-                );
-              }
-              await sleep(pollIntervalMs);
-              continue;
-            }
-
-            if (outputJson(opts, { threadId, matched: true, target })) return;
-            console.log(
-              `Thread ${threadId} observed event ${target.eventType} at seq ${matched.seq}.`,
-            );
-            return;
           }
+          if (error instanceof ThreadWaitUnreachableError) {
+            throw new CliExitError(
+              error.message,
+              THREAD_WAIT_EXIT_CODE_UNREACHABLE,
+            );
+          }
+          throw error;
         }
+
+        if (outputJson(opts, { threadId, matched: true, target })) return;
+        if (!("event" in result)) {
+          console.log(
+            `Thread ${threadId} reached status ${result.target.status}.`,
+          );
+          return;
+        }
+        console.log(
+          `Thread ${threadId} observed event ${result.target.eventType} at seq ${result.event.seq}.`,
+        );
       }),
     );
 }
@@ -155,35 +128,4 @@ function parseThreadWaitTarget(
     kind: "event",
     eventType: opts.event ?? "",
   };
-}
-
-function getThreadWaitUnreachableReason(
-  threadId: string,
-  currentStatus: ThreadStatus,
-  targetStatus: ThreadStatus,
-): string | undefined {
-  if (currentStatus === targetStatus || targetStatus !== "idle") {
-    return undefined;
-  }
-
-  switch (currentStatus) {
-    case "error":
-      return (
-        `Thread ${threadId} is in status error and will not reach idle by waiting alone. ` +
-        `Inspect it with 'bb thread show ${threadId}' and recover by sending a follow-up.`
-      );
-    case "starting":
-    case "idle":
-    case "active":
-    // A stopping thread is winding down toward a settled state; it can still
-    // reach idle by waiting (the stop settles to idle on completion).
-    case "stopping":
-      return undefined;
-    default:
-      return assertNever(currentStatus);
-  }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -70,6 +70,29 @@ the terminal to stop both processes and exit with status `0`.
 From the app, add or open a project, start a thread, and choose the provider
 you want that thread to use.
 
+## Scripting with the SDK
+
+The package also exposes a Node SDK for scripts that drive an already-running
+bb server:
+
+```ts
+import { BBSdk } from "bb-app";
+
+const bb = new BBSdk();
+const thread = await bb.threads.spawn({
+  projectId: "proj_personal",
+  environment: { type: "host", workspace: { type: "personal" } },
+  prompt: "Summarize my active bb work.",
+});
+await bb.threads.wait({ threadId: String(thread.id), status: "idle" });
+console.log(await bb.threads.output({ threadId: String(thread.id) }));
+```
+
+`new BBSdk()` uses the same `BB_SERVER_URL` and bb config resolution as the
+CLI. Pass `new BBSdk({ baseUrl: "http://host:38886" })` for remote or test
+targets. Scripts launched by bb already receive `BB_SERVER_URL` and
+`BB_THREAD_ID` in their environment.
+
 ## Provider Credentials
 
 bb uses whichever providers you have configured. If you need to set one up:

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -21,6 +21,16 @@
     "directory": "packages/bb-app"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/public-sdk.ts",
+      "types": "./dist/index.d.ts",
+      "node": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
   "os": [
     "darwin",
     "linux"
@@ -65,6 +75,7 @@
   },
   "devDependencies": {
     "@bb/config": "workspace:*",
+    "@bb/sdk": "workspace:*",
     "@bb/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.0",

--- a/packages/bb-app/scripts/build.mjs
+++ b/packages/bb-app/scripts/build.mjs
@@ -1,11 +1,15 @@
 import { access } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { cp, rm } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import {
   buildNodeEsmEntry,
   copyDirectory,
 } from "../../../scripts/build-utils.mjs";
 
+const execFileAsync = promisify(execFile);
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptsDir, "..");
 const workspaceRoot = resolve(packageRoot, "..", "..");
@@ -25,6 +29,49 @@ async function copyBuildOutput({ from, label, to }) {
   await copyDirectory({ from, to });
 }
 
+async function buildPublicSdkDeclarations() {
+  const typesDir = resolve(packageRoot, "dist-types");
+  await rm(typesDir, { force: true, recursive: true });
+  await execFileAsync(
+    "tsc",
+    [
+      "--declaration",
+      "--emitDeclarationOnly",
+      "--declarationMap",
+      "false",
+      "--noEmit",
+      "false",
+      "--outDir",
+      typesDir,
+      "--rootDir",
+      "src",
+      "--module",
+      "NodeNext",
+      "--moduleResolution",
+      "NodeNext",
+      "--target",
+      "ES2022",
+      "--strict",
+      "true",
+      "--skipLibCheck",
+      "true",
+      "--esModuleInterop",
+      "true",
+      "--customConditions",
+      "source",
+      "--types",
+      "node",
+      "src/public-sdk.ts",
+    ],
+    { cwd: packageRoot },
+  );
+  await cp(
+    resolve(typesDir, "public-sdk.d.ts"),
+    resolve(packageRoot, "dist", "index.d.ts"),
+  );
+  await rm(typesDir, { force: true, recursive: true });
+}
+
 const entrypoints = [
   ["bb-app", "bb-app.js"],
   ["bb", "bb.js"],
@@ -41,6 +88,14 @@ for (const [sourceName, outputName] of entrypoints) {
     packageRoot,
   });
 }
+
+await buildNodeEsmEntry({
+  cleanDist: false,
+  entryPoint: resolve(packageRoot, "src", "public-sdk.ts"),
+  outfile: resolve(packageRoot, "dist", "index.js"),
+  packageRoot,
+});
+await buildPublicSdkDeclarations();
 
 await copyBuildOutput({
   from: resolve(workspaceRoot, "apps", "app", "dist"),

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -61,9 +61,9 @@ function waitForProcessExit(childProcess) {
   });
 }
 
-async function runCommand({ args, command, env = {}, label }) {
+async function runCommand({ args, command, cwd = tempRoot, env = {}, label }) {
   const childProcess = spawn(command, args, {
-    cwd: tempRoot,
+    cwd,
     env: {
       ...process.env,
       ...env,
@@ -429,7 +429,71 @@ async function smokeConfigCommand(tarballPath) {
   }
 }
 
-async function smokeFullStack(tarballPath) {
+async function smokeSdkPackage(tarballPath) {
+  const sdkDir = join(tempRoot, "sdk-import");
+  await mkdir(sdkDir, { recursive: true });
+  await writeFile(
+    join(sdkDir, "package.json"),
+    JSON.stringify({ type: "module", private: true }, null, 2),
+  );
+  await runCommand({
+    args: [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      tarballPath,
+    ],
+    command: "npm",
+    cwd: sdkDir,
+    label: "install bb-app SDK smoke package",
+  });
+  await runCommand({
+    args: [
+      "--input-type=module",
+      "-e",
+      'import { BBSdk } from "bb-app"; if (typeof BBSdk !== "function") process.exit(1);',
+    ],
+    command: "node",
+    cwd: sdkDir,
+    label: "bb-app SDK JavaScript import",
+  });
+  await writeFile(
+    join(sdkDir, "sdk-smoke.ts"),
+    [
+      'import { BBSdk, BbHttpError } from "bb-app";',
+      "",
+      'const bb = new BBSdk({ baseUrl: "http://127.0.0.1:38886" });',
+      "const error: typeof BbHttpError = BbHttpError;",
+      "void bb.status.get();",
+      "void error;",
+      "",
+    ].join("\n"),
+  );
+  await runCommand({
+    args: [
+      "--yes",
+      "--package",
+      "typescript",
+      "--",
+      "tsc",
+      "--module",
+      "NodeNext",
+      "--moduleResolution",
+      "NodeNext",
+      "--target",
+      "ES2022",
+      "--noEmit",
+      "sdk-smoke.ts",
+    ],
+    command: "npx",
+    cwd: sdkDir,
+    label: "bb-app SDK TypeScript import",
+  });
+  return sdkDir;
+}
+
+async function smokeFullStack(tarballPath, sdkDir) {
   const dataDir = join(tempRoot, "full-stack-data");
   const serverPort = await getFreePort();
   const daemonPort = await getFreePort();
@@ -470,6 +534,23 @@ async function smokeFullStack(tarballPath) {
         BB_SERVER_URL: serverUrl,
       },
       label: "bb cli status",
+    });
+    await runCommand({
+      args: [
+        "--input-type=module",
+        "-e",
+        [
+          'import { BBSdk } from "bb-app";',
+          "const bb = new BBSdk({ baseUrl: process.env.BB_SERVER_URL });",
+          "await bb.status.get();",
+        ].join("\n"),
+      ],
+      command: "node",
+      cwd: sdkDir,
+      env: {
+        BB_SERVER_URL: serverUrl,
+      },
+      label: "bb-app SDK status",
     });
   } finally {
     await stopManagedProcess(stack);
@@ -550,7 +631,8 @@ try {
   await smokeProviderBridgeBundles(tarballPath);
   await smokeHelpCommands(tarballPath);
   await smokeConfigCommand(tarballPath);
-  await smokeFullStack(tarballPath);
+  const sdkDir = await smokeSdkPackage(tarballPath);
+  await smokeFullStack(tarballPath, sdkDir);
   await smokeDaemonJoin(tarballPath);
   process.stdout.write("bb-app tarball smoke passed\n");
 } finally {

--- a/packages/bb-app/src/public-sdk.ts
+++ b/packages/bb-app/src/public-sdk.ts
@@ -1,0 +1,346 @@
+import {
+  BbHttpError as InternalBbHttpError,
+  BbRequestTimeoutError as InternalBbRequestTimeoutError,
+  ThreadWaitTimeoutError as InternalThreadWaitTimeoutError,
+  ThreadWaitUnreachableError as InternalThreadWaitUnreachableError,
+  createNodeBbSdk,
+} from "@bb/sdk/node";
+
+export type JsonValue =
+  | JsonValue[]
+  | boolean
+  | null
+  | number
+  | string
+  | { [key: string]: JsonValue };
+
+export type ThreadStatus =
+  | "idle"
+  | "starting"
+  | "active"
+  | "stopping"
+  | "error";
+
+export type PermissionMode = "full" | "workspace-write" | "readonly";
+export type ReasoningLevel = "low" | "medium" | "high" | "xhigh" | "max";
+export type ServiceTier = "fast" | "default";
+export type ExecutionInputSource = "explicit" | "client-preference";
+
+export interface CreateExecutionInputSources {
+  model?: ExecutionInputSource;
+  permissionMode?: ExecutionInputSource;
+  providerId?: ExecutionInputSource;
+  reasoningLevel?: ExecutionInputSource;
+  serviceTier?: ExecutionInputSource;
+}
+
+export interface ExistingThreadExecutionInputSources {
+  model?: ExecutionInputSource;
+  permissionMode?: ExecutionInputSource;
+  reasoningLevel?: ExecutionInputSource;
+  serviceTier?: ExecutionInputSource;
+}
+
+export interface PromptTextMention {
+  end: number;
+  resource:
+    | {
+        kind: "thread";
+        label: string;
+        projectId?: string;
+        threadId: string;
+      }
+    | {
+        kind: "path";
+        entryKind: "directory" | "file";
+        label: string;
+        path: string;
+        source: "thread-storage" | "workspace";
+      }
+    | {
+        kind: "command";
+        argumentHint: string | null;
+        label: string;
+        name: string;
+        origin: "project" | "user";
+        source: "command" | "skill";
+        trigger: "/";
+      };
+  start: number;
+}
+
+export type PromptInput =
+  | {
+      type: "text";
+      text: string;
+      mentions: PromptTextMention[];
+      visibility?: "agent-only";
+    }
+  | {
+      type: "image";
+      url: string;
+      visibility?: "agent-only";
+    }
+  | {
+      type: "localImage";
+      path: string;
+      visibility?: "agent-only";
+    }
+  | {
+      type: "localFile";
+      path: string;
+      name?: string;
+      sizeBytes?: number;
+      mimeType?: string;
+      visibility?: "agent-only";
+    };
+
+export type BaseBranchSpec =
+  | { kind: "default" }
+  | { kind: "named"; name: string };
+
+export type UnmanagedBranchSpec =
+  | { kind: "existing"; name: string }
+  | { kind: "new"; baseBranch: string };
+
+export type WorkspaceArgs =
+  | {
+      type: "unmanaged";
+      path: string | null;
+      branch?: UnmanagedBranchSpec;
+    }
+  | {
+      type: "managed-worktree";
+      baseBranch: BaseBranchSpec;
+    }
+  | { type: "personal" };
+
+export type EnvironmentArgs =
+  | { type: "reuse"; environmentId: string }
+  | {
+      type: "host";
+      hostId?: string;
+      workspace: WorkspaceArgs;
+    };
+
+export interface BBSdkOptions {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  realtimeUrl?: string;
+  timeoutMs?: number;
+  websocket?: BBSdkRealtimeSocketFactory;
+}
+
+export interface BBSdkRealtimeSocketMessageEvent {
+  data: unknown;
+}
+
+export interface BBSdkRealtimeSocket {
+  close(): void;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: BBSdkRealtimeSocketMessageEvent) => void) | null;
+  onopen: (() => void) | null;
+  readyState: number;
+  send(data: string): void;
+}
+
+export type BBSdkRealtimeSocketFactory = (url: string) => BBSdkRealtimeSocket;
+
+export interface ThreadSpawnBaseArgs {
+  environment: EnvironmentArgs;
+  executionInputSources?: CreateExecutionInputSources;
+  model?: string;
+  parentThreadId?: string;
+  permissionMode?: PermissionMode;
+  projectId: string;
+  providerId?: string;
+  reasoningLevel?: ReasoningLevel;
+  serviceTier?: ServiceTier;
+  sourceSeqEnd?: number;
+  sourceThreadId?: string;
+  title?: string;
+}
+
+export type ThreadSpawnArgs = ThreadSpawnBaseArgs &
+  (
+    | {
+        input: PromptInput[];
+        prompt?: never;
+      }
+    | {
+        input?: never;
+        prompt: string;
+      }
+  );
+
+export interface ThreadSendArgs {
+  executionInputSources?: ExistingThreadExecutionInputSources;
+  input: PromptInput[];
+  mode: "queue-if-active" | "steer-if-active" | "auto" | "start" | "steer";
+  model?: string;
+  permissionMode?: PermissionMode;
+  reasoningLevel?: ReasoningLevel;
+  senderThreadId?: string;
+  serviceTier?: ServiceTier;
+  threadId: string;
+}
+
+export interface ThreadWaitArgs {
+  event?: string;
+  pollIntervalMs?: number;
+  status?: ThreadStatus;
+  threadId: string;
+  timeoutMs?: number;
+}
+
+export interface ThreadListArgs {
+  archived?: boolean;
+  hasParent?: boolean;
+  parentThreadId?: string;
+  projectId?: string;
+}
+
+export interface ThreadGetArgs {
+  include?: string;
+  threadId: string;
+}
+
+export interface ThreadIdArgs {
+  threadId: string;
+}
+
+export interface BBSdkThread {
+  id: string;
+  projectId: string;
+  status: ThreadStatus;
+  title: string | null;
+  [key: string]: unknown;
+}
+
+export interface BBSdkThreadsArea {
+  archive(args: ThreadIdArgs): Promise<{ ok: true }>;
+  get(args: ThreadGetArgs): Promise<BBSdkThread>;
+  list(args?: ThreadListArgs): Promise<BBSdkThread[]>;
+  output(args: ThreadIdArgs): Promise<{ output: string | null }>;
+  send(args: ThreadSendArgs): Promise<{ ok: true }>;
+  spawn(args: ThreadSpawnArgs): Promise<BBSdkThread>;
+  stop(args: ThreadIdArgs): Promise<{ ok: true }>;
+  timeline(
+    args: ThreadIdArgs & Record<string, string | undefined>,
+  ): Promise<unknown>;
+  unarchive(args: ThreadIdArgs): Promise<{ ok: true }>;
+  wait(args: ThreadWaitArgs): Promise<unknown>;
+}
+
+export interface BBSdkStatusArea {
+  get(args?: { projectId?: string; threadId?: string }): Promise<unknown>;
+}
+
+export interface BBSdkRealtimeOnArgs {
+  callback: (event: unknown) => void;
+  event:
+    | "thread:changed"
+    | "project:changed"
+    | "environment:changed"
+    | "host:changed"
+    | "system:changed"
+    | "system:config-changed"
+    | "realtime:connection";
+  environmentId?: string;
+  hostId?: string;
+  projectId?: string;
+  threadId?: string;
+}
+
+export interface BbHttpErrorArgs {
+  code: string | null;
+  message: string;
+  status: number;
+}
+
+export interface BbHttpError extends Error {
+  readonly code: string | null;
+  readonly status: number;
+}
+
+export interface BbHttpErrorConstructor {
+  new (args: BbHttpErrorArgs): BbHttpError;
+  readonly prototype: BbHttpError;
+}
+
+export interface BbRequestTimeoutError extends Error {}
+
+export interface BbRequestTimeoutErrorConstructor {
+  new (timeoutMs: number): BbRequestTimeoutError;
+  readonly prototype: BbRequestTimeoutError;
+}
+
+export interface ThreadWaitTimeoutError extends Error {}
+
+export interface ThreadWaitTimeoutErrorConstructor {
+  readonly prototype: ThreadWaitTimeoutError;
+}
+
+export interface ThreadWaitUnreachableError extends Error {}
+
+export interface ThreadWaitUnreachableErrorConstructor {
+  readonly prototype: ThreadWaitUnreachableError;
+}
+
+export const BbHttpError: BbHttpErrorConstructor = InternalBbHttpError;
+export const BbRequestTimeoutError: BbRequestTimeoutErrorConstructor =
+  InternalBbRequestTimeoutError;
+export const ThreadWaitTimeoutError: ThreadWaitTimeoutErrorConstructor =
+  InternalThreadWaitTimeoutError;
+export const ThreadWaitUnreachableError: ThreadWaitUnreachableErrorConstructor =
+  InternalThreadWaitUnreachableError;
+
+export class BBSdk {
+  #sdk: ReturnType<typeof createNodeBbSdk>;
+
+  readonly automations: object;
+  readonly environments: object;
+  readonly guide: object;
+  readonly hosts: object;
+  readonly projects: object;
+  readonly providers: object;
+  readonly status: BBSdkStatusArea;
+  readonly theme: object;
+  readonly threads: BBSdkThreadsArea;
+
+  constructor(options: BBSdkOptions = {}) {
+    const sdk = createNodeBbSdk(options);
+    this.#sdk = sdk;
+    this.automations = sdk.automations;
+    this.environments = sdk.environments;
+    this.guide = sdk.guide;
+    this.hosts = sdk.hosts;
+    this.projects = sdk.projects;
+    this.providers = sdk.providers;
+    this.status = {
+      get: (args) => sdk.status.get(args),
+    };
+    this.theme = sdk.theme;
+    this.threads = {
+      archive: (args) => sdk.threads.archive(args),
+      get: (args) => sdk.threads.get(args),
+      list: (args) => sdk.threads.list(args),
+      output: (args) => sdk.threads.output(args),
+      send: (args) => sdk.threads.send(args),
+      spawn: (args) => sdk.threads.spawn(args),
+      stop: (args) => sdk.threads.stop(args),
+      timeline: (args) => sdk.threads.timeline(args),
+      unarchive: (args) => sdk.threads.unarchive(args),
+      wait: (args) => sdk.threads.wait(args),
+    };
+  }
+
+  on(args: BBSdkRealtimeOnArgs): () => void {
+    return this.#sdk.on(args);
+  }
+}
+
+export function createBBSdk(options: BBSdkOptions = {}): BBSdk {
+  return new BBSdk(options);
+}

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -1,6 +1,8 @@
 import {
   parseThreadEventRow,
+  type PromptInput,
   type PendingInteractionResolution,
+  type ThreadStatus,
 } from "@bb/domain";
 import type {
   CloseTerminalRequest,
@@ -21,6 +23,9 @@ import type {
   UpdateThreadRequest,
 } from "@bb/server-contract";
 import type { CreateSdkAreaArgs, PublicApiOutput } from "./common.js";
+
+export const DEFAULT_THREAD_WAIT_TIMEOUT_MS = 30_000;
+export const DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS = 250;
 
 export interface ThreadListArgs {
   archived?: boolean;
@@ -78,18 +83,12 @@ export type ThreadTerminalCloseResult = PublicApiOutput<
   "/terminals/:terminalId/close",
   "$post"
 >;
-export type ThreadTerminalCreateResult = PublicApiOutput<
-  "/terminals",
-  "$post"
->;
+export type ThreadTerminalCreateResult = PublicApiOutput<"/terminals", "$post">;
 export type ThreadTerminalInputResult = PublicApiOutput<
   "/terminals/:terminalId/input",
   "$post"
 >;
-export type ThreadTerminalListResult = PublicApiOutput<
-  "/terminals",
-  "$get"
->;
+export type ThreadTerminalListResult = PublicApiOutput<"/terminals", "$get">;
 export type ThreadTerminalOutputResult = PublicApiOutput<
   "/terminals/:terminalId/output",
   "$get"
@@ -107,7 +106,27 @@ export type ThreadUnarchiveResult = PublicApiOutput<
   "$post"
 >;
 
-export interface ThreadSpawnArgs extends CreateThreadRequest {}
+export interface ThreadSpawnBaseArgs extends Omit<
+  CreateThreadRequest,
+  "childOrigin" | "input" | "origin" | "originKind" | "startedOnBehalfOf"
+> {
+  childOrigin?: CreateThreadRequest["childOrigin"];
+  origin?: CreateThreadRequest["origin"];
+  originKind?: CreateThreadRequest["originKind"];
+  startedOnBehalfOf?: CreateThreadRequest["startedOnBehalfOf"];
+}
+
+export type ThreadSpawnArgs = ThreadSpawnBaseArgs &
+  (
+    | {
+        input: CreateThreadRequest["input"];
+        prompt?: never;
+      }
+    | {
+        input?: never;
+        prompt: string;
+      }
+  );
 
 export interface ThreadUpdateArgs extends UpdateThreadRequest {
   threadId: string;
@@ -139,6 +158,7 @@ export interface ThreadEventsListArgs {
 }
 
 export interface ThreadEventWaitArgs {
+  afterSeq?: string;
   threadId: string;
   type: string;
   waitMs: string;
@@ -156,8 +176,10 @@ export interface ThreadTerminalListArgs {
   threadId: string;
 }
 
-export interface ThreadTerminalCreateArgs
-  extends Omit<CreateTerminalRequest, "target"> {
+export interface ThreadTerminalCreateArgs extends Omit<
+  CreateTerminalRequest,
+  "target"
+> {
   threadId: string;
 }
 
@@ -191,6 +213,65 @@ export interface ThreadInteractionGetArgs extends ThreadInteractionListArgs {
 
 export interface ThreadInteractionResolveArgs extends ThreadInteractionGetArgs {
   resolution: PendingInteractionResolution;
+}
+
+export type ThreadWaitTarget =
+  | { kind: "status"; status: ThreadStatus }
+  | { kind: "event"; eventType: string };
+
+export interface ThreadWaitArgs {
+  event?: string;
+  pollIntervalMs?: number;
+  status?: ThreadStatus;
+  threadId: string;
+  timeoutMs?: number;
+}
+
+export type ThreadWaitResult =
+  | {
+      event: NonNullable<ThreadEventWaitResult>;
+      matched: true;
+      target: Extract<ThreadWaitTarget, { kind: "event" }>;
+      threadId: string;
+    }
+  | {
+      matched: true;
+      target: Extract<ThreadWaitTarget, { kind: "status" }>;
+      thread: ThreadGetResult;
+      threadId: string;
+    };
+
+export class ThreadWaitTimeoutError extends Error {
+  readonly target: ThreadWaitTarget;
+  readonly threadId: string;
+
+  constructor(args: { target: ThreadWaitTarget; threadId: string }) {
+    super(formatThreadWaitTimeoutMessage(args));
+    this.name = "ThreadWaitTimeoutError";
+    this.target = args.target;
+    this.threadId = args.threadId;
+  }
+}
+
+export class ThreadWaitUnreachableError extends Error {
+  readonly currentStatus: ThreadStatus;
+  readonly target: Extract<ThreadWaitTarget, { kind: "status" }>;
+  readonly threadId: string;
+
+  constructor(args: {
+    currentStatus: ThreadStatus;
+    target: Extract<ThreadWaitTarget, { kind: "status" }>;
+    threadId: string;
+  }) {
+    super(
+      `Thread ${args.threadId} is in status ${args.currentStatus} and will not reach idle by waiting alone. ` +
+        `Inspect it with 'bb thread show ${args.threadId}' and recover by sending a follow-up.`,
+    );
+    this.name = "ThreadWaitUnreachableError";
+    this.currentStatus = args.currentStatus;
+    this.target = args.target;
+    this.threadId = args.threadId;
+  }
 }
 
 export interface ThreadInteractionsArea {
@@ -234,6 +315,7 @@ export interface ThreadsArea {
   unarchive(args: ThreadStatusArgs): Promise<ThreadUnarchiveResult>;
   unpin(args: ThreadStatusArgs): Promise<ThreadMutationResult>;
   update(args: ThreadUpdateArgs): Promise<ThreadMutationResult>;
+  wait(args: ThreadWaitArgs): Promise<ThreadWaitResult>;
 }
 
 function listQuery(args: ThreadListArgs | undefined): ThreadListQuery {
@@ -269,6 +351,36 @@ function sendJson(args: ThreadSendArgs): SendMessageRequest {
   };
 }
 
+function spawnInput(input: ThreadSpawnArgs): PromptInput[] {
+  if (input.input !== undefined && input.prompt !== undefined) {
+    throw new Error("Provide only one of input or prompt.");
+  }
+  if (input.input !== undefined) {
+    return input.input;
+  }
+  return [{ type: "text", text: input.prompt, mentions: [] }];
+}
+
+function spawnJson(args: ThreadSpawnArgs): CreateThreadRequest {
+  const {
+    childOrigin,
+    input: _input,
+    origin,
+    originKind,
+    prompt: _prompt,
+    startedOnBehalfOf,
+    ...request
+  } = args;
+  return {
+    ...request,
+    input: spawnInput(args),
+    origin: origin ?? "sdk",
+    startedOnBehalfOf: startedOnBehalfOf ?? null,
+    originKind: originKind ?? null,
+    childOrigin: childOrigin ?? null,
+  };
+}
+
 function eventsListQuery(args: ThreadEventsListArgs): ThreadEventsQuery {
   return {
     ...(args.afterSeq !== undefined ? { afterSeq: args.afterSeq } : {}),
@@ -278,6 +390,7 @@ function eventsListQuery(args: ThreadEventsListArgs): ThreadEventsQuery {
 
 function eventWaitQuery(args: ThreadEventWaitArgs): ThreadEventWaitQuery {
   return {
+    ...(args.afterSeq !== undefined ? { afterSeq: args.afterSeq } : {}),
     type: args.type,
     waitMs: args.waitMs,
   };
@@ -313,6 +426,68 @@ function terminalOutputQuery(
       ? { limitChunks: args.limitChunks }
       : {}),
   };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveThreadWaitTarget(args: ThreadWaitArgs): ThreadWaitTarget {
+  const hasStatus = args.status !== undefined;
+  const hasEvent = args.event !== undefined;
+  if (hasStatus && hasEvent) {
+    throw new Error("Provide only one of status or event.");
+  }
+  if (hasEvent) {
+    return { kind: "event", eventType: args.event ?? "" };
+  }
+  return { kind: "status", status: args.status ?? "idle" };
+}
+
+function validateThreadWaitArgs(args: ThreadWaitArgs): {
+  pollIntervalMs: number;
+  target: ThreadWaitTarget;
+  timeoutMs: number;
+} {
+  const timeoutMs = args.timeoutMs ?? DEFAULT_THREAD_WAIT_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    throw new RangeError(
+      "Timeout must be a non-negative number of milliseconds.",
+    );
+  }
+  const pollIntervalMs =
+    args.pollIntervalMs ?? DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS;
+  if (!Number.isInteger(pollIntervalMs) || pollIntervalMs < 1) {
+    throw new RangeError(
+      "Poll interval must be a positive integer number of milliseconds.",
+    );
+  }
+  return {
+    pollIntervalMs,
+    target: resolveThreadWaitTarget(args),
+    timeoutMs,
+  };
+}
+
+function formatThreadWaitTimeoutMessage(args: {
+  target: ThreadWaitTarget;
+  threadId: string;
+}): string {
+  if (args.target.kind === "status") {
+    return `Timed out waiting for thread ${args.threadId} to reach status ${args.target.status}.`;
+  }
+  return `Timed out waiting for thread ${args.threadId} event ${args.target.eventType}.`;
+}
+
+function isThreadWaitTargetUnreachable(
+  currentStatus: ThreadStatus,
+  target: ThreadWaitTarget,
+): target is Extract<ThreadWaitTarget, { kind: "status" }> {
+  return (
+    target.kind === "status" &&
+    target.status === "idle" &&
+    currentStatus === "error"
+  );
 }
 
 export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
@@ -509,7 +684,7 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
     async spawn(input) {
       return transport.readJson(
         transport.api.v1.threads.$post({
-          json: input,
+          json: spawnJson(input),
         }),
       );
     },
@@ -552,6 +727,62 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
           json: updateJson(input),
         }),
       );
+    },
+    async wait(input) {
+      const { pollIntervalMs, target, timeoutMs } =
+        validateThreadWaitArgs(input);
+      const deadline = Date.now() + timeoutMs;
+      while (true) {
+        if (target.kind === "status") {
+          const thread = await getThread({ threadId: input.threadId });
+          if (thread.status === target.status) {
+            return {
+              matched: true,
+              target,
+              thread,
+              threadId: input.threadId,
+            };
+          }
+          if (isThreadWaitTargetUnreachable(thread.status, target)) {
+            throw new ThreadWaitUnreachableError({
+              currentStatus: thread.status,
+              target,
+              threadId: input.threadId,
+            });
+          }
+          if (Date.now() >= deadline) {
+            throw new ThreadWaitTimeoutError({
+              target,
+              threadId: input.threadId,
+            });
+          }
+          await sleep(pollIntervalMs);
+          continue;
+        }
+
+        const remainingMs = Math.max(0, deadline - Date.now());
+        const waitMs = Math.floor(Math.min(remainingMs, 30_000));
+        const event = await events.wait({
+          threadId: input.threadId,
+          type: target.eventType,
+          waitMs: String(waitMs),
+        });
+        if (event !== null) {
+          return {
+            event,
+            matched: true,
+            target,
+            threadId: input.threadId,
+          };
+        }
+        if (Date.now() >= deadline) {
+          throw new ThreadWaitTimeoutError({
+            target,
+            threadId: input.threadId,
+          });
+        }
+        await sleep(pollIntervalMs);
+      }
     },
   };
 }

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -95,6 +95,12 @@ export {
 };
 export { BbHttpError, BbRequestTimeoutError } from "./response.js";
 export { createGuideArea } from "./areas/guide.js";
+export {
+  DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS,
+  DEFAULT_THREAD_WAIT_TIMEOUT_MS,
+  ThreadWaitTimeoutError,
+  ThreadWaitUnreachableError,
+} from "./areas/threads.js";
 export type { BbSdk, BbSdkContext, BbSdkTransport, FetchImplementation };
 export type * from "./realtime.js";
 export type * from "./areas/guide.js";

--- a/packages/sdk/test/sdk.test.ts
+++ b/packages/sdk/test/sdk.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Environment, JsonValue } from "@bb/domain";
 import { createBbSdk } from "../src/core.js";
 import { createHttpTransport } from "../src/transport-http.js";
+import { ThreadWaitTimeoutError } from "../src/areas/threads.js";
 import type { FetchImplementation } from "../src/response.js";
 
 interface CapturedRequest {
@@ -60,7 +61,9 @@ function jsonResponse(args: QueuedJsonResponse): Response {
   });
 }
 
-function createFetchQueue(responses: readonly QueuedJsonResponse[]): FetchQueue {
+function createFetchQueue(
+  responses: readonly QueuedJsonResponse[],
+): FetchQueue {
   const requests: CapturedRequest[] = [];
   const remaining = [...responses];
   const fetchMock: FetchImplementation = async (input, init) => {
@@ -117,9 +120,9 @@ describe("@bb/sdk", () => {
       }),
     });
 
-    await expect(
-      sdk.threads.get({ threadId: "thr_missing" }),
-    ).rejects.toThrow("HTTP 404: Thread not found");
+    await expect(sdk.threads.get({ threadId: "thr_missing" })).rejects.toThrow(
+      "HTTP 404: Thread not found",
+    );
   });
 
   it("updates environment metadata through the HTTP transport", async () => {
@@ -208,6 +211,147 @@ describe("@bb/sdk", () => {
     expect(queue.requests[0]?.method).toBe("POST");
   });
 
+  it("fills thread spawn defaults before sending a request", async () => {
+    const queue = createFetchQueue([{ body: { id: "thr_1" }, status: 201 }]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await sdk.threads.spawn({
+      projectId: "proj_123",
+      environment: {
+        type: "host",
+        hostId: "host_123",
+        workspace: { type: "unmanaged", path: null },
+      },
+      prompt: "Ship it",
+    });
+
+    expect(queue.requests[0]?.bodyText).toBe(
+      JSON.stringify({
+        projectId: "proj_123",
+        environment: {
+          type: "host",
+          hostId: "host_123",
+          workspace: { type: "unmanaged", path: null },
+        },
+        input: [{ type: "text", text: "Ship it", mentions: [] }],
+        origin: "sdk",
+        startedOnBehalfOf: null,
+        originKind: null,
+        childOrigin: null,
+      }),
+    );
+  });
+
+  it("preserves explicit thread spawn origin for CLI callers", async () => {
+    const queue = createFetchQueue([{ body: { id: "thr_1" }, status: 201 }]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await sdk.threads.spawn({
+      projectId: "proj_123",
+      origin: "cli",
+      environment: {
+        type: "host",
+        hostId: "host_123",
+        workspace: { type: "unmanaged", path: null },
+      },
+      input: [{ type: "text", text: "From CLI", mentions: [] }],
+    });
+
+    expect(JSON.parse(queue.requests[0]?.bodyText ?? "{}").origin).toBe("cli");
+  });
+
+  it("rejects thread spawn requests with both prompt and input", async () => {
+    const queue = createFetchQueue([]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.spawn({
+        projectId: "proj_123",
+        environment: {
+          type: "host",
+          hostId: "host_123",
+          workspace: { type: "unmanaged", path: null },
+        },
+        prompt: "Ship it",
+        // @ts-expect-error Runtime guard rejects callers that bypass the union.
+        input: [{ type: "text", text: "Duplicate", mentions: [] }],
+      }),
+    ).rejects.toThrow("Provide only one of input or prompt.");
+    expect(queue.requests).toEqual([]);
+  });
+
+  it("waits for a thread status through the shared SDK loop", async () => {
+    const queue = createFetchQueue([
+      { body: { id: "thr_wait", status: "active" } },
+      { body: { id: "thr_wait", status: "idle" } },
+    ]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.wait({
+        threadId: "thr_wait",
+        status: "idle",
+        timeoutMs: 1_000,
+        pollIntervalMs: 1,
+      }),
+    ).resolves.toMatchObject({
+      matched: true,
+      target: { kind: "status", status: "idle" },
+      threadId: "thr_wait",
+    });
+
+    expect(queue.requests.map((request) => request.url)).toEqual([
+      "http://bb.test/api/v1/threads/thr_wait",
+      "http://bb.test/api/v1/threads/thr_wait",
+    ]);
+  });
+
+  it("throws a typed timeout error from thread wait", async () => {
+    const queue = createFetchQueue([
+      { body: { id: "thr_wait", status: "active" } },
+    ]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.wait({
+        threadId: "thr_wait",
+        status: "idle",
+        timeoutMs: 0,
+        pollIntervalMs: 1,
+      }),
+    ).rejects.toBeInstanceOf(ThreadWaitTimeoutError);
+  });
+
   it("stamps origin agent and createdByThreadId from BB_THREAD_ID on create", async () => {
     const previous = process.env.BB_THREAD_ID;
     process.env.BB_THREAD_ID = "thr_creator";
@@ -251,5 +395,4 @@ describe("@bb/sdk", () => {
       }
     }
   });
-
 });

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -47,7 +47,12 @@ export const sendMessageModeSchema = z.enum([
   "steer",
 ]);
 
-export const threadCreateOriginSchema = z.enum(["app", "cli", "automation"]);
+export const threadCreateOriginSchema = z.enum([
+  "app",
+  "cli",
+  "automation",
+  "sdk",
+]);
 export type ThreadCreateOrigin = z.infer<typeof threadCreateOriginSchema>;
 
 export const executionInputFieldSourceSchema = callerExecutionInputSourceSchema;

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -1104,6 +1104,21 @@ describe("server-contract canonical schemas", () => {
     expect(parsed.childOrigin).toBeNull();
   });
 
+  it("accepts sdk as a thread creation origin", () => {
+    const parsed = createThreadRequestSchema.parse({
+      projectId: "proj_123",
+      providerId: "codex",
+      origin: "sdk",
+      input: [{ type: "text", text: "Scripted start" }],
+      environment: {
+        type: "host",
+        hostId: "host_abc",
+        workspace: { type: "unmanaged", path: null },
+      },
+    });
+    expect(parsed.origin).toBe("sdk");
+  });
+
   it("rejects empty input for a normal thread start", () => {
     expect(() =>
       createThreadRequestSchema.parse({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -791,6 +791,9 @@ importers:
       '@bb/config':
         specifier: workspace:*
         version: link:../config
+      '@bb/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@bb/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig

--- a/turbo.json
+++ b/turbo.json
@@ -69,7 +69,8 @@
         "@bb/app#build",
         "@bb/server#build",
         "@bb/host-daemon#build",
-        "@bb/cli#build"
+        "@bb/cli#build",
+        "@bb/sdk#build"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -80,6 +81,9 @@
         "$TURBO_ROOT$/packages/bb-app/scripts/**",
         "$TURBO_ROOT$/packages/bb-app/src/**",
         "$TURBO_ROOT$/packages/bb-app/tsconfig.json",
+        "$TURBO_ROOT$/packages/sdk/package.json",
+        "$TURBO_ROOT$/packages/sdk/src/**",
+        "$TURBO_ROOT$/packages/sdk/tsconfig.json",
         "$TURBO_ROOT$/packages/tsconfig/*.json",
         "$TURBO_ROOT$/scripts/*.mjs"
       ],


### PR DESCRIPTION
## Summary
- expose a Node scripting SDK from the published `bb-app` package via `import { BBSdk } from "bb-app"`
- move shared thread spawn normalization and wait behavior into `@bb/sdk`, with `bb thread wait` delegating to it
- build and package `dist/index.js` / `dist/index.d.ts`, document the SDK, and add tarball smoke coverage for JS/TS imports plus a live SDK status call

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/sdk --filter=@bb/cli --filter=bb-app --filter=@bb/server-contract`
- `pnpm exec turbo run test --filter=@bb/sdk --force`
- `pnpm exec turbo run test --filter=@bb/server-contract --force`
- `pnpm exec turbo run test --filter=@bb/cli --force`
- `pnpm exec turbo run test --filter=bb-app --force`
- `pnpm exec turbo run build --filter=bb-app --force`
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force`
- `git diff --check`