### PR TITLE
Fix desktop popout reveal

### DIFF
--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppToaster } from "./AppToaster";
+
+vi.mock("@/hooks/useTheme", () => ({
+  usePreferredTheme: () => "light",
+}));
+
+vi.mock("@/components/ui/sonner.js", () => ({
+  Toaster: ({ position, theme }: { position?: string; theme?: string }) => (
+    <div
+      data-testid="app-toaster"
+      data-position={position}
+      data-theme={theme}
+    />
+  ),
+}));
+
+function renderToaster(path: string) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppToaster position="bottom-right" />
+    </MemoryRouter>,
+  );
+}
+
+describe("AppToaster", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders on normal app routes", () => {
+    renderToaster("/threads/thr_test");
+
+    expect(screen.getByTestId("app-toaster").getAttribute("data-position")).toBe(
+      "bottom-right",
+    );
+  });
+
+  it.each([
+    "/popout",
+    "/popout/threads/thr_test",
+    "/popout/projects/proj_test/threads/thr_test",
+  ])(
+    "does not render on %s",
+    (path) => {
+      renderToaster(path);
+
+      expect(screen.queryByTestId("app-toaster")).toBeNull();
+    },
+  );
+});

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,8 +1,22 @@
 import { Toaster, type ToasterProps } from "@/components/ui/sonner.js";
 import { usePreferredTheme } from "@/hooks/useTheme";
+import { POPOUT_ROUTE_PATH } from "@/lib/route-paths";
+import { useLocation } from "react-router-dom";
+
+function isPopoutPath(pathname: string): boolean {
+  return (
+    pathname === POPOUT_ROUTE_PATH ||
+    pathname.startsWith(`${POPOUT_ROUTE_PATH}/`)
+  );
+}
 
 export function AppToaster(props: ToasterProps) {
+  const location = useLocation();
   const theme = usePreferredTheme();
+
+  if (isPopoutPath(location.pathname)) {
+    return null;
+  }
 
   return <Toaster theme={theme} {...props} />;
 }

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -30,8 +30,8 @@ createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <App />
+        <AppToaster position="bottom-right" />
       </BrowserRouter>
-      <AppToaster position="bottom-right" />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/desktop/src/popout-window.ts
+++ b/apps/desktop/src/popout-window.ts
@@ -37,20 +37,11 @@ interface ShouldRepositionPopoutWindowArgs {
   hasPositionedWindow: boolean;
 }
 
-interface CreatePopoutWindowReadinessArgs {
-  browserWindow: BrowserWindow;
-}
-
 interface DisplayIdentity {
   height: number;
   width: number;
   x: number;
   y: number;
-}
-
-interface PopoutWindowReadiness {
-  isReadyToReveal(): boolean;
-  readyToRevealPromise: Promise<void>;
 }
 
 export interface PopoutWindowManager {
@@ -204,43 +195,6 @@ function logOpenInMainFailure(error: unknown): void {
   );
 }
 
-function createPopoutWindowReadiness({
-  browserWindow,
-}: CreatePopoutWindowReadinessArgs): PopoutWindowReadiness {
-  let hasFinishedLoad = false;
-  let hasFirstPaint = false;
-  let isReadyToReveal = false;
-  let resolveReadyToReveal: () => void = () => {};
-
-  const readyToRevealPromise = new Promise<void>((resolve) => {
-    resolveReadyToReveal = resolve;
-  });
-
-  function resolveIfReady(): void {
-    if (isReadyToReveal || !hasFinishedLoad || !hasFirstPaint) {
-      return;
-    }
-    isReadyToReveal = true;
-    resolveReadyToReveal();
-  }
-
-  browserWindow.webContents.on("did-finish-load", () => {
-    hasFinishedLoad = true;
-    resolveIfReady();
-  });
-  browserWindow.on("ready-to-show", () => {
-    hasFirstPaint = true;
-    resolveIfReady();
-  });
-
-  return {
-    isReadyToReveal() {
-      return isReadyToReveal;
-    },
-    readyToRevealPromise,
-  };
-}
-
 export function createPopoutWindowManager(
   args: CreatePopoutWindowManagerArgs,
 ): PopoutWindowManager {
@@ -251,8 +205,6 @@ export function createPopoutWindowManager(
   let hasPositionedWindow = false;
   let destroyRequested = false;
   let loadReadyPromise: Promise<void> | null = null;
-  let windowReadiness: PopoutWindowReadiness | null = null;
-  let hasLoggedWarmReadinessWait = false;
 
   function getLiveWindow(): BrowserWindow | null {
     if (popoutWindow === null || popoutWindow.isDestroyed()) {
@@ -272,10 +224,8 @@ export function createPopoutWindowManager(
     lastSentThread = null;
     hasSentThread = false;
     hasPositionedWindow = false;
-    hasLoggedWarmReadinessWait = false;
     const browserWindow = new BrowserWindow(createPopoutWindowOptions(args));
     popoutWindow = browserWindow;
-    windowReadiness = createPopoutWindowReadiness({ browserWindow });
     browserWindow.setVisibleOnAllWorkspaces(true, {
       visibleOnFullScreen: true,
     });
@@ -296,11 +246,9 @@ export function createPopoutWindowManager(
       }
       if (popoutWindow === null) {
         loadReadyPromise = null;
-        windowReadiness = null;
         lastSentThread = null;
         hasSentThread = false;
         hasPositionedWindow = false;
-        hasLoggedWarmReadinessWait = false;
       }
     });
     browserWindow.webContents.on("did-fail-load", () => {
@@ -334,16 +282,7 @@ export function createPopoutWindowManager(
   async function show(): Promise<void> {
     const browserWindow = ensureWindow();
     const loadPromise = loadReadyPromise;
-    const readiness = windowReadiness;
-    if (readiness?.isReadyToReveal() !== true && !hasLoggedWarmReadinessWait) {
-      hasLoggedWarmReadinessWait = true;
-      process.stderr.write(
-        "Popout chat summoned before hidden renderer first paint; waiting for warm readiness.\n",
-      );
-    }
-    if (loadPromise !== null && readiness !== null) {
-      await Promise.all([loadPromise, readiness.readyToRevealPromise]);
-    } else {
+    if (loadPromise !== null) {
       await loadPromise;
     }
     if (browserWindow.isDestroyed()) {
@@ -367,8 +306,6 @@ export function createPopoutWindowManager(
       lastSentThread = null;
       hasSentThread = false;
       hasPositionedWindow = false;
-      windowReadiness = null;
-      hasLoggedWarmReadinessWait = false;
       if (browserWindow !== null) {
         browserWindow.destroy();
       }
@@ -421,13 +358,7 @@ export function createPopoutWindowManager(
     warm(): void {
       ensureWindow();
       const loadPromise = loadReadyPromise;
-      const readiness = windowReadiness;
-      if (loadPromise === null || readiness === null) {
-        return;
-      }
-      void Promise.all([loadPromise, readiness.readyToRevealPromise]).catch(
-        () => undefined,
-      );
+      void loadPromise?.catch(() => undefined);
     },
   };
 }

--- a/apps/desktop/test/popout-window.test.ts
+++ b/apps/desktop/test/popout-window.test.ts
@@ -295,7 +295,7 @@ describe("createPopoutWindowManager", () => {
     expect(browserWindow?.focused).toBe(true);
   });
 
-  it("waits for first paint readiness before showing the first summon", async () => {
+  it("shows a selected thread after load even if ready-to-show does not fire", async () => {
     const manager = createPopoutWindowManager({
       appUrl: "http://127.0.0.1:38886",
       preloadPath: "/tmp/preload.cjs",
@@ -304,19 +304,21 @@ describe("createPopoutWindowManager", () => {
     });
 
     manager.warm();
-    const showPromise = manager.toggle();
+    const showPromise = manager.setThread({
+      projectId: "proj_a",
+      threadId: "thr_a",
+    });
     const browserWindow = electronMock.createdWindows[0];
     browserWindow?.emitDidFinishLoad();
     browserWindow?.resolveLoadUrl();
-    await Promise.resolve();
-
-    expect(browserWindow?.shown).toBe(false);
-
-    browserWindow?.emitReadyToShow();
     await showPromise;
 
     expect(browserWindow?.shown).toBe(true);
     expect(browserWindow?.focused).toBe(true);
+    expect(browserWindow?.webContents.sentMessages).toContainEqual({
+      channel: BB_DESKTOP_POPOUT_THREAD_CHANGED_CHANNEL,
+      payload: { projectId: "proj_a", threadId: "thr_a" },
+    });
   });
 
   it("destroys a warmed popout when the manager is destroyed", () => {


### PR DESCRIPTION
## Summary
- stop gating popout reveal on Electron's `ready-to-show` event so "Send to popout" can show after the popout renderer load completes
- keep app toasts out of popout routes while leaving the normal app toaster intact
- add focused regression coverage for popout reveal and popout route toaster suppression

## Validation
- `pnpm exec turbo run test --filter=@bb/desktop -- test/popout-window.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/desktop`
- `pnpm exec turbo run build --filter=@bb/desktop`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/AppToaster.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run build --filter=@bb/app`
- `git diff --check`

## Manual QA
- Enable the Popout chat experiment in desktop, then use a thread action menu's "Send to popout" entry. The popout should appear for that thread.
- Trigger an action that would normally toast from inside the popout; no toast stack should render in the popout window.