### PR TITLE
Fix OpenCode ACP model discovery and selection

### DIFF
--- a/apps/server/src/services/system/known-acp-agents.ts
+++ b/apps/server/src/services/system/known-acp-agents.ts
@@ -8,6 +8,11 @@ export interface KnownAcpAgent {
   args: string[];
   env: Record<string, string>;
   executableName: string;
+  modelCli?: {
+    listArgs: string[];
+    selectFlag?: string;
+    primaryModels: string[];
+  };
 }
 
 export interface KnownAcpAgentExecutableQuery {

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -289,7 +289,7 @@ describe("acp adapter model cli", () => {
     });
   });
 
-  it("does not use ACP-native selection for CLI-discovered models without a select flag", () => {
+  it("uses ACP-native selection for CLI-discovered models without a select flag", () => {
     const adapter = createAcpProviderAdapter({
       profile: {
         providerId: "acp-custom",
@@ -314,8 +314,11 @@ describe("acp adapter model cli", () => {
       instructionMode: "append",
     });
 
-    const params = (plan as { params: Record<string, unknown> }).params;
-    expect("modelSelection" in params).toBe(false);
+    expect(plan).toMatchObject({
+      params: {
+        modelSelection: { modelId: "custom/strong" },
+      },
+    });
   });
 
   it("omits the reasoning level when the session has none", () => {

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -1170,7 +1170,7 @@ export function createAcpProviderAdapter(
     if (!model || model === ACP_DEFAULT_MODEL_ID) {
       return {};
     }
-    if (!listCommand) {
+    if (!listCommand || !profile.modelCli?.selectFlag) {
       return {
         modelSelection: {
           modelId: model,
@@ -1179,9 +1179,6 @@ export function createAcpProviderAdapter(
             : {}),
         },
       };
-    }
-    if (!profile.modelCli?.selectFlag) {
-      return {};
     }
     // Cursor encodes reasoning in the selected model id and has no ACP
     // `thought_level` option; keep that CLI variant path separate from native

--- a/packages/agent-runtime/src/acp/bridge-protocol.ts
+++ b/packages/agent-runtime/src/acp/bridge-protocol.ts
@@ -53,7 +53,7 @@ const acpBridgeModelListParamsSchema = z.object({
   /**
    * ACP-native model discovery command. Used only when `listCommand` is
    * absent: the bridge starts a throwaway session and reads the model select
-   * from the `session/new` result's `configOptions`.
+   * from the `session/new` result's config state.
    */
   agent: acpBridgeAgentCommandSchema.optional(),
   /**

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -310,6 +310,39 @@ describe("acp bridge", () => {
     });
   });
 
+  it("discovers ACP-native models from session models state", async () => {
+    const modelListId = sendRequest("model/list", {
+      agent: {
+        command: process.execPath,
+        args: [FAKE_AGENT_PATH],
+        envVars: { FAKE_ACP_MODELS_FIELD: "1" },
+      },
+      primaryModels: [],
+    });
+
+    expect((await waitForResponse(modelListId)).result).toMatchObject({
+      models: [
+        {
+          id: "fake/default",
+          model: "fake/default",
+          displayName: "Fake Default",
+          isDefault: true,
+          defaultReasoningEffort: "medium",
+          supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+        },
+        {
+          id: "fake/strong",
+          model: "fake/strong",
+          displayName: "Fake Strong",
+          isDefault: false,
+          defaultReasoningEffort: "medium",
+          supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+        },
+      ],
+      selectedOnlyModels: [],
+    });
+  });
+
   it("keeps ACP-native discovered models when per-model reasoning discovery errors", async () => {
     const modelListId = sendRequest("model/list", {
       agent: {
@@ -528,6 +561,21 @@ describe("acp bridge", () => {
   it("selects ACP-native models with session/set_model before the first prompt", async () => {
     const { providerThreadId } = await startThread({
       envVars: { FAKE_ACP_MODEL_CONFIG: "1" },
+      modelSelection: { modelId: "fake/strong" },
+    });
+
+    sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "echo-selected-model", mentions: [] }],
+    });
+    await waitForTurnCompleted();
+
+    expect(agentMessageTexts()).toContain("selected-model:fake/strong");
+  });
+
+  it("selects ACP-native models from session models state", async () => {
+    const { providerThreadId } = await startThread({
+      envVars: { FAKE_ACP_MODELS_FIELD: "1" },
       modelSelection: { modelId: "fake/strong" },
     });
 

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -56,6 +56,7 @@ import {
   acpRequestPermissionParamsSchema,
   acpSessionNewResultSchema,
   acpSessionNotificationParamsSchema,
+  type AcpSessionModels,
   acpStopReasonSchema,
   acpWriteTextFileParamsSchema,
   type AcpContentBlock,
@@ -70,6 +71,7 @@ import {
   buildAgentModelCatalog,
   buildAcpNativeReasoningSupport,
   buildModelCatalogFromConfigOptions,
+  buildModelCatalogFromSessionModels,
   acpNativeReasoningLevelToValue,
   findAcpModelConfigOption,
   findAcpThoughtLevelConfigOption,
@@ -330,9 +332,19 @@ async function loadSessionDiscoveredModels(
     }
 
     const modelOption = findAcpModelConfigOption(newSession.configOptions);
-    const baseModels = buildModelCatalogFromConfigOptions(modelOption);
-    if (baseModels.length === 0) {
+    const configOptionModels = buildModelCatalogFromConfigOptions(modelOption);
+    const sessionModels = buildModelCatalogFromSessionModels(newSession.models);
+    if (configOptionModels.length === 0 && sessionModels.length === 0) {
       return null;
+    }
+
+    if (configOptionModels.length === 0) {
+      cachedSessionDiscoveredModels = {
+        key,
+        models: sessionModels,
+        fetchedAt: Date.now(),
+      };
+      return sessionModels;
     }
 
     const reasoningByModel = await discoverAcpNativeReasoningByModel({
@@ -342,7 +354,7 @@ async function loadSessionDiscoveredModels(
     });
     const models =
       reasoningByModel === null
-        ? baseModels
+        ? configOptionModels
         : buildModelCatalogFromConfigOptions(modelOption, reasoningByModel);
     cachedSessionDiscoveredModels = {
       key,
@@ -514,6 +526,7 @@ async function selectAcpNativeModel(args: {
   connection: AcpAgentConnection;
   sessionId: string;
   configOptions: readonly AcpConfigOption[] | undefined;
+  models: AcpSessionModels | undefined;
   modelSelection: AcpBridgeThreadStartParams["modelSelection"];
 }): Promise<void> {
   const selection = args.modelSelection;
@@ -522,13 +535,22 @@ async function selectAcpNativeModel(args: {
   }
   let configOptions = args.configOptions;
   const modelOption = findAcpModelConfigOption(args.configOptions);
-  if (modelOption && modelOption.currentValue !== selection.modelId) {
+  const availableSessionModels = args.models?.availableModels ?? [];
+  const sessionModelsIncludeSelection = availableSessionModels.some(
+    (model) => model.modelId === selection.modelId,
+  );
+  const shouldSetModel =
+    (modelOption && modelOption.currentValue !== selection.modelId) ||
+    (!modelOption &&
+      sessionModelsIncludeSelection &&
+      args.models?.currentModelId !== selection.modelId);
+  if (shouldSetModel) {
     const configState = await args.connection.request({
       method: "session/set_model",
       params: { sessionId: args.sessionId, modelId: selection.modelId },
       resultSchema: z.union([acpConfigStateResultSchema, z.null()]),
     });
-    configOptions = configState?.configOptions;
+    configOptions = configState?.configOptions ?? configOptions;
   }
   await selectAcpNativeReasoning({
     connection: args.connection,
@@ -1005,6 +1027,7 @@ async function startAgentSession(
 
     let sessionId: string | undefined;
     let loadedConfigOptions: readonly AcpConfigOption[] | undefined;
+    let loadedModels: AcpSessionModels | undefined;
     if (request.kind === "resume" && supportsLoadSession) {
       session.loading = true;
       try {
@@ -1018,6 +1041,7 @@ async function startAgentSession(
           resultSchema: z.union([acpConfigStateResultSchema, z.null()]),
         });
         loadedConfigOptions = configState?.configOptions;
+        loadedModels = configState?.models;
         sessionId = request.params.providerThreadId;
       } catch {
         sessionId = undefined;
@@ -1037,6 +1061,7 @@ async function startAgentSession(
         connection,
         sessionId,
         configOptions: newSession.configOptions,
+        models: newSession.models,
         modelSelection: params.modelSelection,
       });
       if (request.kind === "resume") {
@@ -1050,6 +1075,7 @@ async function startAgentSession(
         connection,
         sessionId,
         configOptions: loadedConfigOptions,
+        models: loadedModels,
         modelSelection: params.modelSelection,
       });
     }

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -10,6 +10,7 @@
  * Env knobs (passed by tests through thread/start envVars):
  * - FAKE_ACP_LOAD_SESSION=1  → advertise + accept session/load
  * - FAKE_ACP_MODEL_CONFIG=1  → advertise a model configOptions select
+ * - FAKE_ACP_MODELS_FIELD=1  → advertise legacy ACP models state
  * - FAKE_ACP_THOUGHT_LEVEL_CONFIG=1
  *                            → advertise per-model effort configOptions
  * - FAKE_ACP_SET_CONFIG_MODEL_ERROR=1
@@ -24,6 +25,7 @@ import { appendFileSync, writeFileSync } from "node:fs";
 
 const loadSession = process.env.FAKE_ACP_LOAD_SESSION === "1";
 const modelConfig = process.env.FAKE_ACP_MODEL_CONFIG === "1";
+const modelsField = process.env.FAKE_ACP_MODELS_FIELD === "1";
 const thoughtLevelConfig = process.env.FAKE_ACP_THOUGHT_LEVEL_CONFIG === "1";
 const setConfigModelError =
   process.env.FAKE_ACP_SET_CONFIG_MODEL_ERROR === "1";
@@ -122,8 +124,21 @@ function configOptions() {
 }
 
 function configState() {
+  const state = {};
   const options = configOptions();
-  return options === undefined ? {} : { configOptions: options };
+  if (options !== undefined) {
+    state.configOptions = options;
+  }
+  if (modelsField) {
+    state.models = {
+      currentModelId: selectedModel,
+      availableModels: fakeModels.map((model) => ({
+        modelId: model.value,
+        name: model.name,
+      })),
+    };
+  }
+  return state;
 }
 
 function requestClient(method, params) {
@@ -271,7 +286,7 @@ async function handleMessage(message) {
     case "session/set_model": {
       const modelId = message.params?.modelId;
       if (
-        !modelConfig ||
+        (!modelConfig && !modelsField) ||
         typeof modelId !== "string" ||
         !fakeModels.some((model) => model.value === modelId)
       ) {

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.test.ts
@@ -48,6 +48,20 @@ describe("acp model catalog", () => {
     ]);
   });
 
+  it("parses bare model id lines", () => {
+    expect(
+      parseAgentModelLines(
+        "Available models\n\nopenai/gpt-5.3-codex\nopencode/big-pickle\n",
+      ),
+    ).toEqual([
+      {
+        id: "openai/gpt-5.3-codex",
+        displayName: "openai/gpt-5.3-codex",
+      },
+      { id: "opencode/big-pickle", displayName: "opencode/big-pickle" },
+    ]);
+  });
+
   it("groups effort variants into families keyed by the default variant", () => {
     const catalog = catalogFromSample();
     const codex = catalog.models.find((m) => m.id === "gpt-5.3-codex");

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.ts
@@ -1,12 +1,13 @@
 /**
  * Agent CLI model catalog.
  *
- * Cursor's `agent --list-models` prints one `id - Display Name` line per
- * model and encodes reasoning effort in the id: `gpt-5.3-codex-low`, bare
- * `gpt-5.3-codex` for medium, `gpt-5.5-extra-high` as an alternate xhigh
- * spelling, with an optional `-fast` service tail after the effort token
- * (`gpt-5.3-codex-low-fast`). This module groups those raw variants into bb
- * model families so the picker offers one clean entry per family with
+ * Cursor's `agent --list-models` prints one `id - Display Name` line per model,
+ * while OpenCode's `opencode models` prints one bare id per line. These ids
+ * can encode reasoning effort: `gpt-5.3-codex-low`, bare `gpt-5.3-codex` for
+ * medium, `gpt-5.5-extra-high` as an alternate xhigh spelling, with an optional
+ * `-fast` service tail after the effort token (`gpt-5.3-codex-low-fast`). This
+ * module groups those raw variants into bb model families so the picker offers
+ * one clean entry per family with
  * selectable reasoning efforts, and resolves a (family, effort, serviceTier)
  * selection back to the exact raw id at session launch — by table lookup,
  * never string synthesis, because effort spellings vary per family.
@@ -31,7 +32,7 @@
 
 import { reasoningLevelValues } from "@bb/domain";
 import type { AvailableModel, ReasoningLevel, ServiceTier } from "@bb/domain";
-import type { AcpConfigOption } from "../wire.js";
+import type { AcpConfigOption, AcpSessionModels } from "../wire.js";
 
 export interface RawAgentModel {
   id: string;
@@ -63,6 +64,7 @@ interface AgentModelVariant extends RawAgentModel {
 }
 
 const MODEL_LINE_PATTERN = /^(\S+) - (.+)$/;
+const BARE_PROVIDER_MODEL_LINE_PATTERN = /^\S+\/\S+$/;
 
 // Trailing id tokens that mark a reasoning-effort variant, longest first so
 // `extra-high` wins over `high`. `none` maps onto bb's "none" (thinking-off)
@@ -96,12 +98,19 @@ export interface AgentModelCatalog {
   }): string | undefined;
 }
 
-/** Parse `id - Display Name` stdout lines; headers and chatter are skipped. */
+/**
+ * Parse model-list stdout lines. Supports `id - Display Name` and bare
+ * `provider/model`; headers and chatter are skipped.
+ */
 export function parseAgentModelLines(stdout: string): RawAgentModel[] {
   const models: RawAgentModel[] = [];
   for (const line of stdout.split("\n")) {
-    const match = MODEL_LINE_PATTERN.exec(line.trim());
+    const trimmed = line.trim();
+    const match = MODEL_LINE_PATTERN.exec(trimmed);
     if (!match) {
+      if (BARE_PROVIDER_MODEL_LINE_PATTERN.test(trimmed)) {
+        models.push({ id: trimmed, displayName: trimmed });
+      }
       continue;
     }
     const [, id, displayName] = match;
@@ -238,6 +247,36 @@ export function buildModelCatalogFromConfigOptions(
       description: "",
       supportedReasoningEfforts: reasoning.supportedReasoningEfforts,
       defaultReasoningEffort: reasoning.defaultReasoningEffort,
+      isDefault,
+    };
+  });
+  return models.some((model) => model.isDefault)
+    ? models
+    : models.map((model, index) =>
+        index === 0 ? { ...model, isDefault: true } : model,
+      );
+}
+
+export function buildModelCatalogFromSessionModels(
+  sessionModels: AcpSessionModels | undefined,
+): AvailableModel[] {
+  const availableModels = sessionModels?.availableModels ?? [];
+  if (availableModels.length === 0) {
+    return [];
+  }
+  const currentModelId = sessionModels?.currentModelId;
+  const models = availableModels.map((model, index): AvailableModel => {
+    const isDefault =
+      currentModelId !== undefined
+        ? model.modelId === currentModelId
+        : index === 0;
+    return {
+      id: model.modelId,
+      model: model.modelId,
+      displayName: model.name ?? model.modelId,
+      description: model.description ?? "",
+      supportedReasoningEfforts: ACP_NATIVE_REASONING_EFFORTS,
+      defaultReasoningEffort: "medium",
       isDefault,
     };
   });

--- a/packages/agent-runtime/src/acp/wire.ts
+++ b/packages/agent-runtime/src/acp/wire.ts
@@ -227,6 +227,23 @@ export const acpConfigOptionSchema = z
   .passthrough();
 export type AcpConfigOption = z.infer<typeof acpConfigOptionSchema>;
 
+export const acpSessionModelSchema = z
+  .object({
+    modelId: z.string(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough();
+export type AcpSessionModel = z.infer<typeof acpSessionModelSchema>;
+
+export const acpSessionModelsSchema = z
+  .object({
+    currentModelId: z.string().optional(),
+    availableModels: z.array(acpSessionModelSchema).optional(),
+  })
+  .passthrough();
+export type AcpSessionModels = z.infer<typeof acpSessionModelsSchema>;
+
 const acpLooseConfigOptionSchema = z
   .object({
     id: z.string().optional(),
@@ -295,6 +312,7 @@ function parseAcpConfigOptions(
 export const acpSessionNewResultSchema = z
   .object({
     sessionId: z.string(),
+    models: acpSessionModelsSchema.optional(),
     configOptions: z
       .array(z.unknown())
       .optional()
@@ -305,6 +323,7 @@ export type AcpSessionNewResult = z.infer<typeof acpSessionNewResultSchema>;
 
 export const acpConfigStateResultSchema = z
   .object({
+    models: acpSessionModelsSchema.optional(),
     configOptions: z
       .array(z.unknown())
       .optional()


### PR DESCRIPTION
## Summary
- discover OpenCode ACP models from the session `models.availableModels` / `currentModelId` state
- select OpenCode models with ACP-native `session/set_model` instead of launching `opencode --model ... acp`
- keep support for standardized ACP `configOptions` model selectors and custom CLI-style ACP agents
- add regression coverage for session-model discovery and selection

## Validation
- `pnpm exec turbo run test --filter=@bb/agent-runtime`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server`
- `git diff --check`

## Manual verification
- Probed local OpenCode 1.0.79 ACP: `session/new` returns 63 models via `models.availableModels` with `opencode/big-pickle` as current/default.
- Verified `opencode --model <id> acp` exits with help instead of starting ACP.
- Verified `session/set_model` selects `opencode/deepseek-v4-flash-free` and OpenCode logs show inference using `providerID=opencode modelID=deepseek-v4-flash-free`.
- Checked `/api/v1/system/execution-options?providerId=acp-opencode` returns 63 named OpenCode models; warm calls were about 0.9-1.1s locally.