### PR TITLE
Flip bb-dev-app browser open flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Use `scripts/bb-dev-app` when validating changes in the desktop dev app or helpi
 - `scripts/bb-dev-app stop` stops the launcher-managed dev server and desktop.
 - `scripts/bb-dev-app logs dev` and `scripts/bb-dev-app logs desktop` follow logs.
 
-By default the launcher starts only the dev server (web frontend, server, host daemon). Pass `--desktop` (e.g. `scripts/bb-dev-app current --desktop`) to also launch the Electron desktop shell — only do this when the user is testing a desktop-only change.
+By default the launcher starts only the dev server (web frontend, server, host daemon) and prints the URL without opening a browser. Pass `--open` to open the browser after startup. Pass `--desktop` (e.g. `scripts/bb-dev-app current --desktop`) to also launch the Electron desktop shell — only do this when the user is testing a desktop-only change.
 
 Branch switches intentionally keep dirty work in this checkout; git will stop if a local file would be overwritten. Set `BB_DEV_APP_STASH_DIRTY=1` for a one-off launch that stashes first.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ pnpm dev:desktop
 
 This uses `scripts/bb-dev-app current --desktop`, which stops stale launcher
 sessions, checks dependencies and native modules, starts the source dev server,
-then opens the desktop shell against that dev app.
+then opens the desktop shell against that dev app. The launcher prints the web
+URL but does not open a browser unless you pass `--open`.
 
 To use the dev app from another machine, for example over Tailscale, run:
 

--- a/scripts/bb-dev-app
+++ b/scripts/bb-dev-app
@@ -91,17 +91,18 @@ usage() {
   cat <<'EOF'
 Usage:
   By default these start only the source dev server (web frontend, server, host
-  daemon). Pass --desktop to also launch the Electron desktop shell.
+  daemon) and print the URL without opening a browser. Pass --open to open the
+  browser after startup. Pass --desktop to also launch the Electron desktop shell.
 
-  scripts/bb-dev-app main [--no-open] [--desktop]
+  scripts/bb-dev-app main [--open] [--desktop]
       Fetch origin/main, switch this checkout to main, fast-forward, then start
       the source dev server (and the desktop shell with --desktop).
 
-  scripts/bb-dev-app branch <branch> [--no-open] [--desktop]
+  scripts/bb-dev-app branch <branch> [--open] [--desktop]
       Switch this checkout to a local branch, or create it from origin/<branch>,
       then start the source dev server (and the desktop shell with --desktop).
 
-  scripts/bb-dev-app current [--no-open] [--desktop]
+  scripts/bb-dev-app current [--open] [--desktop]
       Start the source dev server for the current branch (and the desktop shell
       with --desktop).
 
@@ -288,7 +289,7 @@ switch_to_main() {
 switch_to_branch() {
   local branch="$1"
   [[ -n "${branch}" ]] || die "Branch name is required"
-  [[ "${branch}" != "--no-open" ]] || die "Branch name is required"
+  [[ "${branch}" != "--open" ]] || die "Branch name is required"
 
   stop_dev_app
   handle_dirty_work_before_branch_switch
@@ -432,13 +433,13 @@ main() {
 
   local command="${1:-}"
   (( $# > 0 )) && shift
-  local open_after_start="1"
+  local open_after_start="0"
   local start_desktop_app="0"
   local positional=()
   local arg
   for arg in "$@"; do
     case "${arg}" in
-      --no-open) open_after_start="0" ;;
+      --open) open_after_start="1" ;;
       --desktop) start_desktop_app="1" ;;
       *) positional+=("${arg}") ;;
     esac


### PR DESCRIPTION
## Summary
- Make `scripts/bb-dev-app` print the app URL without opening the default browser by default
- Replace the documented startup flag from `--no-open` to opt-in `--open`
- Update README and AGENTS launcher docs for the new default

## Validation
- `zsh -n scripts/bb-dev-app`
- `scripts/bb-dev-app help | sed -n '1,32p'`\n- `rg -n -- "--no-open" .`\n- `git diff --check`