### PR TITLE
Speed up execution options loading

### DIFF
--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -212,4 +212,25 @@ describe("useThreadCreationOptions", () => {
       ]);
     });
   });
+
+  it("loads the product default provider before any persisted selection exists", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+
+    renderHook(() => useThreadCreationOptions(), { wrapper });
+
+    await waitFor(() => {
+      expect(api.getSystemExecutionOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: undefined,
+          providerId: "codex",
+        }),
+      );
+      expect(api.getSystemExecutionOptions).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: undefined,
+          providerId: undefined,
+        }),
+      );
+    });
+  });
 });

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -53,6 +53,7 @@ export { formatModelLabel, resolvePermissionModeSelection };
 const EMPTY_PROVIDERS: ProviderInfo[] = [];
 const EMPTY_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
 
+const PRODUCT_DEFAULT_PROVIDER_ID = "codex";
 
 const PERMISSION_MODE_OPTIONS: PickerOption<PermissionMode>[] = [
   {
@@ -257,7 +258,7 @@ export function useThreadCreationOptions(
       ? environmentId
       : undefined;
   const executionOptionsProviderId = executionOptionsQueryEnabled
-    ? rawSelectedProviderId || undefined
+    ? rawSelectedProviderId || PRODUCT_DEFAULT_PROVIDER_ID
     : undefined;
   const executionOptionsQuery = useSystemExecutionOptions({
     enabled: executionOptionsQueryEnabled,

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -454,6 +454,96 @@ describe("createHostDaemonApp", () => {
         }),
       );
       expect(listModels).toHaveBeenCalledWith({ providerId: "cursor" });
+
+      await expect(
+        app.router.handleOnlineRpcRequest({
+          type: "host-rpc.request",
+          requestId: "provider-models-app-test-again",
+          command: {
+            type: "provider.list_models",
+            providerId: "cursor",
+          },
+        }),
+      ).resolves.toMatchObject({
+        ok: true,
+      });
+      expect(resolveRuntimeShellEnv).toHaveBeenCalledTimes(1);
+      expect(listModels).toHaveBeenCalledTimes(2);
+    } finally {
+      await app.daemon.shutdown("test");
+    }
+  });
+
+  it("reuses freshly resolved startup shell env for immediate model listing", async () => {
+    const dataDir = await makeTempDir("bb-host-daemon-app-startup-env-");
+    const fetchRecorder = createFetchRecorder();
+    const logger = createLogger();
+    const runtimeOptions: RuntimeOptionsRef = { current: null };
+    const model = {
+      id: "codex-model",
+      model: "codex-model",
+      displayName: "Codex Model",
+      description: "Test model",
+      supportedReasoningEfforts: [],
+      defaultReasoningEffort: "medium" as const,
+      isDefault: true,
+    };
+    const listModels = vi.fn<AgentRuntime["listModels"]>(async () => ({
+      models: [model],
+      selectedOnlyModels: [],
+    }));
+    const resolveRuntimeShellEnv = vi.fn(async () => ({
+      PATH: "/slow-shell/bin:/usr/bin",
+      BB_SERVER_URL: "http://127.0.0.1:3334",
+    }));
+    const app = await createHostDaemonApp({
+      dataDir,
+      serverUrl: "http://127.0.0.1:3334",
+      hostKey: "host-key-app-test",
+      hostType: "persistent",
+      hostId: "host-app-test",
+      hostName: "App Test Host",
+      instanceId: "instance-app-test",
+      logger,
+      releaseLock: async () => undefined,
+      localApiConfig: null,
+      runtimeShellEnv: {
+        PATH: "/startup/bin:/usr/bin",
+        BB_SERVER_URL: "http://127.0.0.1:3334",
+      },
+      runtimeShellEnvResolvedAtMs: 1_000,
+      resolveRuntimeShellEnv,
+      nowMs: () => 1_500,
+      createRuntime: (options) => {
+        runtimeOptions.current = options;
+        return createFakeRuntimeWithModelList(listModels);
+      },
+      fetchFn: fetchRecorder.fetchFn,
+      createWebSocket: createOpeningWebSocket(),
+    });
+
+    try {
+      await expect(
+        app.router.handleOnlineRpcRequest({
+          type: "host-rpc.request",
+          requestId: "provider-models-startup-env-test",
+          command: {
+            type: "provider.list_models",
+            providerId: "codex",
+          },
+        }),
+      ).resolves.toMatchObject({
+        ok: true,
+      });
+
+      expect(resolveRuntimeShellEnv).not.toHaveBeenCalled();
+      expect(runtimeOptions.current).toEqual(
+        expect.objectContaining({
+          env: {
+            PATH: "/startup/bin:/usr/bin",
+          },
+        }),
+      );
     } finally {
       await app.daemon.shutdown("test");
     }

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -62,6 +62,14 @@ interface SessionState {
 const INTERACTIVE_INTERRUPT_RETRY_DELAY_MS = 1_000;
 const IDLE_PROVIDER_SESSION_REAP_AFTER_MS = 30 * 60 * 1000;
 const IDLE_PROVIDER_SESSION_REAP_INTERVAL_MS = 5 * 60 * 1000;
+const RUNTIME_SHELL_ENV_REFRESH_TTL_MS = 10_000;
+
+type RuntimeShellEnv = NonNullable<AgentRuntimeOptions["shellEnv"]>;
+
+interface RuntimeShellEnvRefreshEntry {
+  expiresAtMs: number;
+  promise: Promise<RuntimeShellEnv>;
+}
 
 interface IdleProviderSessionReaperTimer {
   clear(): void;
@@ -106,9 +114,11 @@ export interface CreateHostDaemonAppOptions {
   localApiConfig: HostDaemonLocalApiConfig | null;
   createRuntime?: RuntimeManagerOptions["createRuntime"];
   runtimeShellEnv?: AgentRuntimeOptions["shellEnv"];
+  runtimeShellEnvResolvedAtMs?: number;
   resolveRuntimeShellEnv?: () => Promise<
     NonNullable<AgentRuntimeOptions["shellEnv"]>
   >;
+  nowMs?: () => number;
   threadStorageRootPath?: string;
   hostWatcher?: HostWatcher;
   onToolCall?: (request: ToolCallRequest) => Promise<ToolCallResponse>;
@@ -608,13 +618,49 @@ export async function createHostDaemonApp(
     },
     threadStorageRootPath,
   });
+  const nowMs = options.nowMs ?? Date.now;
+  let runtimeShellEnvRefreshEntry: RuntimeShellEnvRefreshEntry | null =
+    options.runtimeShellEnvResolvedAtMs === undefined
+      ? null
+      : {
+          expiresAtMs:
+            options.runtimeShellEnvResolvedAtMs +
+            RUNTIME_SHELL_ENV_REFRESH_TTL_MS,
+          promise: Promise.resolve(runtimeManager.getShellEnv()),
+        };
   const refreshRuntimeShellEnv = async () => {
     if (!options.resolveRuntimeShellEnv) {
       return runtimeManager.getShellEnv();
     }
-    const shellEnv = await options.resolveRuntimeShellEnv();
-    await runtimeManager.replaceBaseShellEnv(shellEnv);
-    return runtimeManager.getShellEnv();
+    const now = nowMs();
+    if (
+      runtimeShellEnvRefreshEntry &&
+      runtimeShellEnvRefreshEntry.expiresAtMs > now
+    ) {
+      return runtimeShellEnvRefreshEntry.promise;
+    }
+
+    const promise = (async () => {
+      const shellEnv = await options.resolveRuntimeShellEnv?.();
+      if (shellEnv === undefined) {
+        return runtimeManager.getShellEnv();
+      }
+      await runtimeManager.replaceBaseShellEnv(shellEnv);
+      return runtimeManager.getShellEnv();
+    })();
+    const entry = {
+      expiresAtMs: now + RUNTIME_SHELL_ENV_REFRESH_TTL_MS,
+      promise,
+    };
+    runtimeShellEnvRefreshEntry = entry;
+    try {
+      return await promise;
+    } catch (error) {
+      if (runtimeShellEnvRefreshEntry === entry) {
+        runtimeShellEnvRefreshEntry = null;
+      }
+      throw error;
+    }
   };
   const getProviderCliEnv = async () =>
     providerCliEnvFromShellEnv(await refreshRuntimeShellEnv());

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -663,7 +663,7 @@ export async function createHostDaemonApp(
     }
   };
   const getProviderCliEnv = async () =>
-    providerCliEnvFromShellEnv(await refreshRuntimeShellEnv());
+    providerCliEnvFromShellEnv(runtimeManager.getShellEnv());
 
   const idleProviderSessionReaper = startIdleProviderSessionReaper({
     logger: options.logger,

--- a/apps/host-daemon/src/provider-cli-health.test.ts
+++ b/apps/host-daemon/src/provider-cli-health.test.ts
@@ -528,16 +528,10 @@ describe("provider CLI health", () => {
     expect(runner.commandLines()).not.toContain("npm view cursor version");
   });
 
-  it("reports known ACP agent executables with the shared resolution logic", async () => {
+  it("reports known ACP agent executables from PATH without version checks", async () => {
     const runner = new FakeProviderCliCommandRunner();
     runner.setSuccess("which", ["opencode"], "/opt/homebrew/bin/opencode\n");
-    runner.setSuccess("opencode", ["--version"], "opencode 1.0.0\n");
     runner.setExit("which", ["missing-acp"], 1, "missing-acp not found");
-    runner.setSpawnError(
-      "missing-acp",
-      ["--version"],
-      "spawn missing-acp ENOENT",
-    );
 
     const status = await getKnownAcpAgentsStatus({
       runner,
@@ -563,6 +557,10 @@ describe("provider CLI health", () => {
         },
       ],
     });
+    expect(runner.commandLines()).toEqual([
+      "which opencode",
+      "which missing-acp",
+    ]);
   });
 
   it("streams failed npm installs without hiding the exit status", async () => {

--- a/apps/host-daemon/src/provider-cli-health.ts
+++ b/apps/host-daemon/src/provider-cli-health.ts
@@ -471,6 +471,19 @@ function resolveExecutableInstallStatus(
   };
 }
 
+function resolveExecutablePathStatus(whichResult: ProviderCliCommandResult): {
+  installed: boolean;
+  executablePath: string | null;
+} {
+  const executablePath = isSuccessfulCommand(whichResult)
+    ? firstOutputLine(whichResult.stdout)
+    : null;
+  return {
+    executablePath,
+    installed: executablePath !== null,
+  };
+}
+
 function buildInstallAction({
   definition,
   installed,
@@ -749,20 +762,13 @@ export async function inspectExecutableInstallStatus({
   installed: boolean;
   executablePath: string | null;
 }> {
-  const [whichResult, versionResult] = await Promise.all([
-    runner.run({
-      command: "which",
-      args: [executableName],
-      timeoutMs: COMMAND_CHECK_TIMEOUT_MS,
-    }),
-    runner.run({
-      command: executableName,
-      args: ["--version"],
-      timeoutMs: COMMAND_CHECK_TIMEOUT_MS,
-    }),
-  ]);
+  const whichResult = await runner.run({
+    command: "which",
+    args: [executableName],
+    timeoutMs: COMMAND_CHECK_TIMEOUT_MS,
+  });
 
-  return resolveExecutableInstallStatus(whichResult, versionResult);
+  return resolveExecutablePathStatus(whichResult);
 }
 
 export async function getKnownAcpAgentsStatus({

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -194,6 +194,7 @@ export async function startHostDaemon(
         serverUrl,
       });
     const runtimeShellEnv = await resolveRuntimeShellEnv();
+    const runtimeShellEnvResolvedAtMs = Date.now();
     app = await createHostDaemonApp({
       dataDir,
       serverUrl,
@@ -213,6 +214,7 @@ export async function startHostDaemon(
       localApiConfig,
       createRuntime: options.createRuntime,
       runtimeShellEnv,
+      runtimeShellEnvResolvedAtMs,
       resolveRuntimeShellEnv,
       hostWatcher,
       onToolCall: options.onToolCall,

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -70,6 +70,19 @@ interface ListSystemProviderInfosResult {
   providers: ProviderInfo[];
 }
 
+interface ResolveSystemProviderInfosPlanResult
+  extends Omit<ListSystemProviderInfosResult, "providers"> {
+  providersPromise: Promise<ProviderInfo[]>;
+}
+
+interface KnownAcpAgentCacheEntry {
+  expiresAtMs: number;
+  promise: Promise<KnownAcpAgent[]>;
+}
+
+const KNOWN_ACP_AGENT_STATUS_CACHE_TTL_MS = 10_000;
+const knownAcpAgentStatusCache = new Map<string, KnownAcpAgentCacheEntry>();
+
 function buildCustomAcpProviderInfo(agent: CustomAcpAgent): ProviderInfo {
   return buildAcpProviderInfo({
     id: formatCustomAcpAgentProviderId(agent.id),
@@ -102,22 +115,20 @@ function canOmitKnownAcpAgentsForError(error: unknown): error is ApiError {
   );
 }
 
-async function listInstalledKnownAcpAgents(
+function knownAcpAgentStatusCacheKey(
+  hostId: string,
+  knownAgents: ReturnType<typeof listKnownAcpAgentExecutableQueries>,
+): string {
+  return `${hostId}:${knownAgents
+    .map((agent) => `${agent.id}:${agent.executableName}`)
+    .join(",")}`;
+}
+
+async function listInstalledKnownAcpAgentsUncached(
   deps: AppDeps,
   hostId: string,
+  knownAgents: ReturnType<typeof listKnownAcpAgentExecutableQueries>,
 ): Promise<KnownAcpAgent[]> {
-  const customProviderIds = new Set(
-    deps.config.customAcpAgents.map((agent) =>
-      formatCustomAcpAgentProviderId(agent.id),
-    ),
-  );
-  const knownAgents = listKnownAcpAgentExecutableQueries().filter(
-    (agent) => !customProviderIds.has(agent.id),
-  );
-  if (knownAgents.length === 0) {
-    return [];
-  }
-
   try {
     const status = await callHostRetryableOnlineRpc(deps, {
       hostId,
@@ -151,6 +162,46 @@ async function listInstalledKnownAcpAgents(
   }
 }
 
+async function listInstalledKnownAcpAgents(
+  deps: AppDeps,
+  hostId: string,
+): Promise<KnownAcpAgent[]> {
+  const customProviderIds = new Set(
+    deps.config.customAcpAgents.map((agent) =>
+      formatCustomAcpAgentProviderId(agent.id),
+    ),
+  );
+  const knownAgents = listKnownAcpAgentExecutableQueries().filter(
+    (agent) => !customProviderIds.has(agent.id),
+  );
+  if (knownAgents.length === 0) {
+    return [];
+  }
+
+  const cacheKey = knownAcpAgentStatusCacheKey(hostId, knownAgents);
+  const nowMs = Date.now();
+  const cached = knownAcpAgentStatusCache.get(cacheKey);
+  if (cached && cached.expiresAtMs > nowMs) {
+    return cached.promise;
+  }
+
+  const promise = listInstalledKnownAcpAgentsUncached(deps, hostId, knownAgents);
+  const entry = {
+    expiresAtMs: nowMs + KNOWN_ACP_AGENT_STATUS_CACHE_TTL_MS,
+    promise,
+  };
+  knownAcpAgentStatusCache.set(cacheKey, entry);
+
+  try {
+    return await promise;
+  } catch (error) {
+    if (knownAcpAgentStatusCache.get(cacheKey) === entry) {
+      knownAcpAgentStatusCache.delete(cacheKey);
+    }
+    throw error;
+  }
+}
+
 async function listSystemProviderInfosForHost(
   deps: AppDeps,
   hostId: string,
@@ -161,16 +212,16 @@ async function listSystemProviderInfosForHost(
   );
 }
 
-async function resolveSystemProviderInfos(
+function resolveSystemProviderInfosPlan(
   deps: AppDeps,
   query: ListSystemProviderInfosRequest = {},
-): Promise<ListSystemProviderInfosResult> {
+): ResolveSystemProviderInfosPlanResult {
   try {
     const hostId = resolveSystemLookupHostId(deps, query);
     return {
       hostId,
       hostLookupError: null,
-      providers: await listSystemProviderInfosForHost(deps, hostId),
+      providersPromise: listSystemProviderInfosForHost(deps, hostId),
     };
   } catch (error) {
     if (!canOmitKnownAcpAgentsForError(error)) {
@@ -183,12 +234,24 @@ async function resolveSystemProviderInfos(
     return {
       hostId: null,
       hostLookupError: error,
-      providers: listConfiguredSystemProviderInfos(
-        deps.config.customAcpAgents,
-        [],
+      providersPromise: Promise.resolve(
+        listConfiguredSystemProviderInfos(deps.config.customAcpAgents, []),
       ),
     };
   }
+}
+
+async function resolveSystemProviderInfos(
+  deps: AppDeps,
+  query: ListSystemProviderInfosRequest = {},
+): Promise<ListSystemProviderInfosResult> {
+  const { hostId, hostLookupError, providersPromise } =
+    resolveSystemProviderInfosPlan(deps, query);
+  return {
+    hostId,
+    hostLookupError,
+    providers: await providersPromise,
+  };
 }
 
 export async function listSystemProviderInfos(
@@ -281,12 +344,34 @@ export async function resolveSystemExecutionOptions(
   deps: AppDeps,
   query: SystemExecutionOptionsRequest,
 ): Promise<SystemExecutionOptionsResponse> {
-  const { hostId, hostLookupError, providers } =
-    await resolveSystemProviderInfos(deps, query);
+  const { hostId, hostLookupError, providersPromise } =
+    resolveSystemProviderInfosPlan(deps, query);
+  const configuredRequestedProvider = query.providerId
+    ? listConfiguredSystemProviderInfos(deps.config.customAcpAgents, []).find(
+        (provider) => provider.id === query.providerId,
+      )
+    : undefined;
+  const earlyModelResultPromise =
+    hostId !== null && configuredRequestedProvider
+      ? loadSystemProviderModels(deps, {
+          hostId,
+          provider: configuredRequestedProvider,
+        })
+      : null;
+  let providers: ProviderInfo[];
+  try {
+    providers = await providersPromise;
+  } catch (error) {
+    await earlyModelResultPromise?.catch(() => undefined);
+    throw error;
+  }
   const requestedProvider = query.providerId
     ? providers.find((provider) => provider.id === query.providerId)
     : undefined;
-  const modelsProvider = requestedProvider ?? providers[0];
+  const modelsProvider =
+    earlyModelResultPromise !== null
+      ? configuredRequestedProvider
+      : (requestedProvider ?? providers[0]);
 
   if (!modelsProvider) {
     return {
@@ -318,15 +403,47 @@ export async function resolveSystemExecutionOptions(
     };
   }
 
+  const modelResult =
+    earlyModelResultPromise !== null
+      ? await earlyModelResultPromise
+      : await loadSystemProviderModels(deps, {
+          hostId,
+          provider: modelsProvider,
+        });
+
+  const { models, selectedOnlyModels } = appendCustomModels({
+    customModels: deps.config.customModels,
+    models: modelResult.models,
+    providerId: modelsProvider.id,
+    selectedOnlyModels: modelResult.selectedOnlyModels,
+  });
+
+  return {
+    providers,
+    models,
+    selectedOnlyModels,
+    modelLoadError: modelResult.modelLoadError,
+  };
+}
+
+async function loadSystemProviderModels(
+  deps: AppDeps,
+  {
+    hostId,
+    provider,
+  }: {
+    hostId: string;
+    provider: ProviderInfo;
+  },
+): Promise<ModelListResult> {
   const customAcpAgent = findCustomAcpAgentForProviderId(
     deps.config.customAcpAgents,
-    modelsProvider.id,
+    provider.id,
   );
   const knownAcpAgent =
     customAcpAgent === undefined
-      ? findKnownAcpAgentForProviderId(modelsProvider.id)
+      ? findKnownAcpAgentForProviderId(provider.id)
       : undefined;
-  let modelResult: ModelListResult;
   try {
     const { models, selectedOnlyModels } = await callHostRetryableOnlineRpc(
       deps,
@@ -335,7 +452,7 @@ export async function resolveSystemExecutionOptions(
         timeoutMs: COMMAND_TIMEOUT_MS,
         command: {
           type: "provider.list_models",
-          providerId: modelsProvider.id,
+          providerId: provider.id,
           ...(customAcpAgent !== undefined
             ? { acpLaunchSpec: buildAcpLaunchSpec(customAcpAgent) }
             : knownAcpAgent !== undefined
@@ -344,7 +461,7 @@ export async function resolveSystemExecutionOptions(
         },
       },
     );
-    modelResult = {
+    return {
       models,
       selectedOnlyModels,
       modelLoadError: null,
@@ -360,33 +477,19 @@ export async function resolveSystemExecutionOptions(
       {
         err: error,
         hostId,
-        providerId: modelsProvider.id,
+        providerId: provider.id,
       },
       "Failed to resolve provider models",
     );
-    modelResult = {
+    return {
       models: [],
       selectedOnlyModels: [],
       modelLoadError: buildModelLoadError({
         error,
-        provider: modelsProvider,
+        provider,
       }),
     };
   }
-
-  const { models, selectedOnlyModels } = appendCustomModels({
-    customModels: deps.config.customModels,
-    models: modelResult.models,
-    providerId: modelsProvider.id,
-    selectedOnlyModels: modelResult.selectedOnlyModels,
-  });
-
-  return {
-    providers,
-    models,
-    selectedOnlyModels,
-    modelLoadError: modelResult.modelLoadError,
-  };
 }
 
 function buildModelLoadError({

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -75,14 +75,6 @@ interface ResolveSystemProviderInfosPlanResult
   providersPromise: Promise<ProviderInfo[]>;
 }
 
-interface KnownAcpAgentCacheEntry {
-  expiresAtMs: number;
-  promise: Promise<KnownAcpAgent[]>;
-}
-
-const KNOWN_ACP_AGENT_STATUS_CACHE_TTL_MS = 10_000;
-const knownAcpAgentStatusCache = new Map<string, KnownAcpAgentCacheEntry>();
-
 function buildCustomAcpProviderInfo(agent: CustomAcpAgent): ProviderInfo {
   return buildAcpProviderInfo({
     id: formatCustomAcpAgentProviderId(agent.id),
@@ -115,20 +107,22 @@ function canOmitKnownAcpAgentsForError(error: unknown): error is ApiError {
   );
 }
 
-function knownAcpAgentStatusCacheKey(
-  hostId: string,
-  knownAgents: ReturnType<typeof listKnownAcpAgentExecutableQueries>,
-): string {
-  return `${hostId}:${knownAgents
-    .map((agent) => `${agent.id}:${agent.executableName}`)
-    .join(",")}`;
-}
-
-async function listInstalledKnownAcpAgentsUncached(
+async function listInstalledKnownAcpAgents(
   deps: AppDeps,
   hostId: string,
-  knownAgents: ReturnType<typeof listKnownAcpAgentExecutableQueries>,
 ): Promise<KnownAcpAgent[]> {
+  const customProviderIds = new Set(
+    deps.config.customAcpAgents.map((agent) =>
+      formatCustomAcpAgentProviderId(agent.id),
+    ),
+  );
+  const knownAgents = listKnownAcpAgentExecutableQueries().filter(
+    (agent) => !customProviderIds.has(agent.id),
+  );
+  if (knownAgents.length === 0) {
+    return [];
+  }
+
   try {
     const status = await callHostRetryableOnlineRpc(deps, {
       hostId,
@@ -159,46 +153,6 @@ async function listInstalledKnownAcpAgentsUncached(
       "Failed to resolve known ACP agent status",
     );
     return [];
-  }
-}
-
-async function listInstalledKnownAcpAgents(
-  deps: AppDeps,
-  hostId: string,
-): Promise<KnownAcpAgent[]> {
-  const customProviderIds = new Set(
-    deps.config.customAcpAgents.map((agent) =>
-      formatCustomAcpAgentProviderId(agent.id),
-    ),
-  );
-  const knownAgents = listKnownAcpAgentExecutableQueries().filter(
-    (agent) => !customProviderIds.has(agent.id),
-  );
-  if (knownAgents.length === 0) {
-    return [];
-  }
-
-  const cacheKey = knownAcpAgentStatusCacheKey(hostId, knownAgents);
-  const nowMs = Date.now();
-  const cached = knownAcpAgentStatusCache.get(cacheKey);
-  if (cached && cached.expiresAtMs > nowMs) {
-    return cached.promise;
-  }
-
-  const promise = listInstalledKnownAcpAgentsUncached(deps, hostId, knownAgents);
-  const entry = {
-    expiresAtMs: nowMs + KNOWN_ACP_AGENT_STATUS_CACHE_TTL_MS,
-    promise,
-  };
-  knownAcpAgentStatusCache.set(cacheKey, entry);
-
-  try {
-    return await promise;
-  } catch (error) {
-    if (knownAcpAgentStatusCache.get(cacheKey) === entry) {
-      knownAcpAgentStatusCache.delete(cacheKey);
-    }
-    throw error;
   }
 }
 

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -287,6 +287,42 @@ describe("resolveSystemExecutionOptions", () => {
     });
   });
 
+  it("reuses known ACP agent status during burst provider discovery", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-execution-options-known-acp-cache",
+      });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (request.command.type !== "known_acp_agents.status") {
+            throw new Error(`Unexpected RPC command ${request.command.type}`);
+          }
+          return {
+            ok: true,
+            result: {
+              agents: request.command.agents.map((agent) => ({
+                ...agent,
+                installed: false,
+                executablePath: null,
+              })),
+            },
+          };
+        },
+      });
+
+      await Promise.all([
+        listSystemProviderInfos(harness.deps, { hostId: host.id }),
+        listSystemProviderInfos(harness.deps, { hostId: host.id }),
+      ]);
+
+      expect(responder.requests.map((request) => request.command.type)).toEqual(
+        ["known_acp_agents.status"],
+      );
+    });
+  });
+
   it.each([
     {
       name: "status returns 502",

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -287,42 +287,6 @@ describe("resolveSystemExecutionOptions", () => {
     });
   });
 
-  it("reuses known ACP agent status during burst provider discovery", async () => {
-    await withTestHarness({}, async (harness) => {
-      const { host, session } = seedHostSession(harness.deps, {
-        id: "host-execution-options-known-acp-cache",
-      });
-      const responder = registerHostRpcResponder(harness, {
-        hostId: host.id,
-        sessionId: session.id,
-        handle: (request) => {
-          if (request.command.type !== "known_acp_agents.status") {
-            throw new Error(`Unexpected RPC command ${request.command.type}`);
-          }
-          return {
-            ok: true,
-            result: {
-              agents: request.command.agents.map((agent) => ({
-                ...agent,
-                installed: false,
-                executablePath: null,
-              })),
-            },
-          };
-        },
-      });
-
-      await Promise.all([
-        listSystemProviderInfos(harness.deps, { hostId: host.id }),
-        listSystemProviderInfos(harness.deps, { hostId: host.id }),
-      ]);
-
-      expect(responder.requests.map((request) => request.command.type)).toEqual(
-        ["known_acp_agents.status"],
-      );
-    });
-  });
-
   it.each([
     {
       name: "status returns 502",


### PR DESCRIPTION
## Summary
- make known ACP discovery path-only (`which opencode`) instead of running provider version checks
- start explicit configured-provider model loading in parallel with provider discovery, which avoids blocking Codex model loading on known ACP discovery
- keep login-shell env refreshes on provider model listing, seeded/cached briefly from startup shell resolution
- stop `/provider-clis/status` and install env resolution from triggering fresh login-shell probes
- default thread creation execution-options loading to Codex so the initial no-provider request is skipped

## Validation
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run typecheck --filter=@bb/host-daemon
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/server -- --run test/system/execution-options.test.ts
- pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/app.test.ts
- pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/provider-cli-health.test.ts
- pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/useThreadCreationOptions.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/host-daemon --force
- pnpm exec turbo run test --filter=@bb/host-daemon --force -- --run src/app.test.ts
- pnpm exec turbo run test --filter=@bb/host-daemon --force -- --run src/provider-cli-health.test.ts
- pnpm exec turbo run typecheck --filter=@bb/server --force
- pnpm exec turbo run test --filter=@bb/server --force -- --run test/system/execution-options.test.ts

## Manual QA
- Captured the home page with dev-browser before and after the change. The attached HAR previously showed `/api/v1/system/execution-options?providerId=codex` around 1367ms plus aborted no-provider execution-options requests. After this change, the home load goes straight to `providerId=codex`; the no-provider execution-options request is gone, and the warmed startup-window Codex execution-options request was about 22ms.
- Direct curls after the 10s runtime-shell cache TTL still perform real first-request work for model listing, then immediate repeats drop to about 10ms, which matches the brief shell-env cache behavior.
- ACP provider discovery now avoids the expensive `opencode --version` check. Local timing showed `which opencode` around 2ms, versus `opencode --version` around 318-520ms.
- `/provider-clis/status` still performs CLI status checks, but it no longer refreshes the login-shell env; login-shell probing is kept on provider model listing.