### PR TITLE
Run native module verifier before Turbo tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "scripts:prepare": "pnpm exec turbo run build --filter=@bb/scripts --output-logs=none --log-prefix=none --summarize=false",
     "cli:prepare": "pnpm exec turbo run build --filter=@bb/scripts --filter=@bb/cli --output-logs=none --log-prefix=none --summarize=false",
+    "ensure-native-modules": "node scripts/ensure-native-modules.mjs",
     "dev": "node scripts/ensure-native-modules.mjs && cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts",
     "dev:desktop": "scripts/bb-dev-app current --desktop",
     "dev:restart": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts both",

--- a/turbo.json
+++ b/turbo.json
@@ -43,6 +43,9 @@
       ]
     },
     "@bb/sdk#test": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/*/package.json",
@@ -215,6 +218,16 @@
         "$TURBO_ROOT$/pnpm-workspace.yaml"
       ]
     },
+    "//#ensure-native-modules": {
+      "cache": false,
+      "inputs": [
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/packages/db/package.json",
+        "$TURBO_ROOT$/pnpm-lock.yaml",
+        "$TURBO_ROOT$/scripts/ensure-native-modules.mjs"
+      ],
+      "outputs": []
+    },
     "typecheck": {},
     "@bb/integration-tests#typecheck": {
       "inputs": [
@@ -229,6 +242,9 @@
       ]
     },
     "test": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/vitest.shared.ts"
@@ -242,6 +258,9 @@
       "outputs": []
     },
     "@bb/integration-tests#test": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/server/package.json",
@@ -254,12 +273,18 @@
       ]
     },
     "test:smoke": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/vitest.shared.ts"
       ]
     },
     "@bb/integration-tests#test:smoke": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/server/package.json",
@@ -272,6 +297,9 @@
       ]
     },
     "test:integration": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/vitest.shared.ts"
@@ -279,6 +307,7 @@
     },
     "@bb/integration-tests#test:integration": {
       "dependsOn": [
+        "//#ensure-native-modules",
         "@bb/agent-runtime#test:integration"
       ],
       "inputs": [
@@ -294,6 +323,10 @@
     },
     "@bb/sdk#typecheck": {},
     "@bb/server#typecheck": {},
-    "@bb/server#test": {}
+    "@bb/server#test": {
+      "dependsOn": [
+        "//#ensure-native-modules"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a root `ensure-native-modules` script for the existing native ABI verifier
- wire Turbo test tasks to run the verifier before unit, smoke, and integration tests
- keep the verifier uncached so cached test tasks still preflight native bindings

## Validation
- `pnpm exec turbo run test --filter=@bb/db --force`
- `pnpm exec turbo run test --filter=@bb/db`
- dry-run checked `@bb/server`, `@bb/integration-tests#test:smoke`, and `@bb/integration-tests#test:integration` dependencies