### PR TITLE
Add ACP dynamic tool support

### DIFF
--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { isAcpProviderId } from "@bb/agent-providers";
 import { getProject } from "@bb/db";
 import type {
   DynamicTool,
@@ -92,11 +91,7 @@ function requireWorkspacePath(
   return environment.path;
 }
 
-function resolveDynamicTools(thread: Thread): DynamicTool[] {
-  if (isAcpProviderId(thread.providerId)) {
-    return [];
-  }
-
+function resolveDynamicTools(): DynamicTool[] {
   return [UPDATE_ENVIRONMENT_DIRECTORY_TOOL];
 }
 
@@ -148,7 +143,7 @@ export async function resolveThreadRuntimeCommandConfig(
     deps.logger,
     deps.config.dataDir,
   );
-  const dynamicTools = resolveDynamicTools(args.thread);
+  const dynamicTools = resolveDynamicTools();
   const workspaceAgentInstructions = readWorkspaceAgentInstructions(
     deps.logger,
     workspacePath,

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -175,8 +175,12 @@ describe("thread runtime config", () => {
           thread,
         });
         expect(startCommand.acpLaunchSpec).toEqual(expectedSpec);
-        expect(startCommand.dynamicTools).toEqual([]);
-        expect(startCommand.instructions).not.toContain(
+        expect(startCommand.dynamicTools).toEqual([
+          expect.objectContaining({
+            name: "update_environment_directory",
+          }),
+        ]);
+        expect(startCommand.instructions).toContain(
           "update_environment_directory",
         );
 
@@ -193,8 +197,12 @@ describe("thread runtime config", () => {
         );
         expect(submitCommand.acpLaunchSpec).toEqual(expectedSpec);
         expect(submitCommand.resumeContext.acpLaunchSpec).toEqual(expectedSpec);
-        expect(submitCommand.resumeContext.dynamicTools).toEqual([]);
-        expect(submitCommand.resumeContext.instructions).not.toContain(
+        expect(submitCommand.resumeContext.dynamicTools).toEqual([
+          expect.objectContaining({
+            name: "update_environment_directory",
+          }),
+        ]);
+        expect(submitCommand.resumeContext.instructions).toContain(
           "update_environment_directory",
         );
       },
@@ -251,8 +259,12 @@ describe("thread runtime config", () => {
         thread,
       });
       expect(startCommand.acpLaunchSpec).toEqual(expectedSpec);
-      expect(startCommand.dynamicTools).toEqual([]);
-      expect(startCommand.instructions).not.toContain(
+      expect(startCommand.dynamicTools).toEqual([
+        expect.objectContaining({
+          name: "update_environment_directory",
+        }),
+      ]);
+      expect(startCommand.instructions).toContain(
         "update_environment_directory",
       );
 
@@ -269,8 +281,12 @@ describe("thread runtime config", () => {
       );
       expect(submitCommand.acpLaunchSpec).toEqual(expectedSpec);
       expect(submitCommand.resumeContext.acpLaunchSpec).toEqual(expectedSpec);
-      expect(submitCommand.resumeContext.dynamicTools).toEqual([]);
-      expect(submitCommand.resumeContext.instructions).not.toContain(
+      expect(submitCommand.resumeContext.dynamicTools).toEqual([
+        expect.objectContaining({
+          name: "update_environment_directory",
+        }),
+      ]);
+      expect(submitCommand.resumeContext.instructions).toContain(
         "update_environment_directory",
       );
     });

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -176,20 +176,30 @@ describe("acp adapter command plans", () => {
     ).toBe("noop");
   });
 
-  it("rejects dynamic tools", () => {
+  it("passes dynamic tools to the bridge", () => {
     const adapter = createAdapter();
-    expect(() =>
+    const dynamicTool = {
+      name: "ask",
+      description: "ask",
+      inputSchema: { type: "object" },
+    };
+
+    expect(
       adapter.buildCommandPlan({
         type: "thread/start",
         threadId: "thread-1",
         cwd: "/workspace",
         options: fullProviderExecutionContext,
         instructionMode: "append",
-        dynamicTools: [
-          { name: "ask", description: "ask", inputSchema: { type: "object" } },
-        ],
+        dynamicTools: [dynamicTool],
       }),
-    ).toThrow(/does not support dynamic tools/);
+    ).toMatchObject({
+      kind: "request",
+      method: "thread/start",
+      params: {
+        dynamicTools: [dynamicTool],
+      },
+    });
   });
 });
 

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -1133,11 +1133,6 @@ export function createAcpProviderAdapter(
       { type: "thread/start" | "thread/resume" }
     >,
   ): Record<string, unknown> {
-    if (command.dynamicTools && command.dynamicTools.length > 0) {
-      throw new Error(
-        `Provider "${profile.providerId}" does not support dynamic tools.`,
-      );
-    }
     const instructions = command.options.instructions?.trim();
     const cwd = profile.cwd ?? command.cwd;
     const envVars = {
@@ -1157,6 +1152,9 @@ export function createAcpProviderAdapter(
       workspaceWriteRoots: [cwd, ...additionalWorkspaceWriteRoots],
       ...(Object.keys(envVars).length > 0 ? { envVars } : {}),
       ...(instructions ? { instructions } : {}),
+      ...(command.dynamicTools && command.dynamicTools.length > 0
+        ? { dynamicTools: command.dynamicTools }
+        : {}),
     };
   }
 

--- a/packages/agent-runtime/src/acp/bridge-protocol.ts
+++ b/packages/agent-runtime/src/acp/bridge-protocol.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  dynamicToolSchema,
   permissionEscalationSchema,
   permissionModeSchema,
   promptInputSchema,
@@ -105,6 +106,7 @@ const acpBridgeSessionParamsSchema = z.object({
   envVars: z.record(z.string(), z.string()).optional(),
   /** Server-owned instructions; prepended to the session's first prompt. */
   instructions: z.string().optional(),
+  dynamicTools: z.array(dynamicToolSchema).optional(),
 });
 
 export const acpBridgeThreadStartParamsSchema = acpBridgeSessionParamsSchema;

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -5,16 +5,19 @@ import {
   readFileSync,
   rmSync,
 } from "node:fs";
+import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DynamicTool } from "@bb/domain";
 import {
   captureBridgeJsonRpcOutput,
   type BridgeJsonRpcOutputMessage,
   type CapturedBridgeJsonRpcOutput,
 } from "../../test/bridge-json-rpc-test-helpers.js";
 import { handleLine } from "./bridge.js";
+import { ACP_BRIDGE_MCP_SERVER_NAME } from "./tool-proxy-mcp.js";
 
 const FAKE_AGENT_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -87,6 +90,7 @@ interface StartThreadArgs {
   envVars?: Record<string, string>;
   instructions?: string;
   agent?: { command: string; args: string[] };
+  dynamicTools?: DynamicTool[];
   modelSelection?:
     | {
         listCommand: { command: string; args: string[] };
@@ -119,6 +123,7 @@ async function startThread(args?: StartThreadArgs): Promise<{
     workspaceWriteRoots: [workspaceDir],
     ...(args?.envVars ? { envVars: args.envVars } : {}),
     ...(args?.instructions ? { instructions: args.instructions } : {}),
+    ...(args?.dynamicTools ? { dynamicTools: args.dynamicTools } : {}),
   });
   const response = await waitForResponse(id);
   if (response.error) {
@@ -180,6 +185,67 @@ function agentMessageTexts(): string[] {
       return [];
     }
     return [content.text];
+  });
+}
+
+function callDynamicToolBridge(args: {
+  callId: string;
+  host: string;
+  port: number;
+  threadId: string;
+  token: string;
+  tool: string;
+  toolArguments: Record<string, unknown>;
+}): Promise<unknown> {
+  return new Promise((resolveCall, rejectCall) => {
+    const socket = createConnection({ host: args.host, port: args.port });
+    let buffer = "";
+    let settled = false;
+    const rejectOnce = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      rejectCall(error);
+    };
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(
+        `${JSON.stringify({
+          arguments: args.toolArguments,
+          callId: args.callId,
+          threadId: args.threadId,
+          token: args.token,
+          tool: args.tool,
+        })}\n`,
+      );
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+      const line = buffer.slice(0, newlineIndex);
+      socket.end();
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        resolveCall(JSON.parse(line));
+      } catch (error) {
+        rejectCall(error);
+      }
+    });
+    socket.on("error", rejectOnce);
+    socket.on("end", () => {
+      if (!settled) {
+        rejectOnce(
+          new Error("Dynamic tool bridge socket closed without a response"),
+        );
+      }
+    });
   });
 }
 
@@ -702,6 +768,125 @@ describe("acp bridge", () => {
     });
     expect(notifications("acp/turn/started")).toHaveLength(1);
     expect(agentMessageTexts()).toContain("echo:hello there");
+  });
+
+  it("passes dynamic tools to ACP sessions as an MCP server", async () => {
+    const { providerThreadId } = await startThread({
+      dynamicTools: [
+        {
+          name: "update_environment_directory",
+          description: "Move this thread to another environment directory.",
+          inputSchema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+        },
+      ],
+    });
+
+    const turnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "echo-mcp-servers", mentions: [] }],
+    });
+    await waitForResponse(turnId);
+    await waitForTurnCompleted();
+
+    expect(agentMessageTexts()).toContain(
+      `mcp-servers:${ACP_BRIDGE_MCP_SERVER_NAME}`,
+    );
+  });
+
+  it("forwards ACP dynamic tool calls through the runtime tool-call contract", async () => {
+    const { bbThreadId, providerThreadId } = await startThread({
+      dynamicTools: [
+        {
+          name: "update_environment_directory",
+          description: "Move this thread to another environment directory.",
+          inputSchema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+        },
+      ],
+    });
+
+    const turnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "echo-mcp-server-config", mentions: [] }],
+    });
+    await waitForResponse(turnId);
+    await waitForTurnCompleted();
+
+    const configPrefix = "mcp-server-config:";
+    const configText = agentMessageTexts().find((text) =>
+      text.startsWith(configPrefix),
+    );
+    if (!configText) {
+      throw new Error("Fake ACP agent did not report MCP server config");
+    }
+    const [mcpServerConfig] = JSON.parse(
+      configText.slice(configPrefix.length),
+    ) as { env: { name: string; value: string }[]; name: string }[];
+    if (!mcpServerConfig) {
+      throw new Error("Fake ACP agent reported no MCP server config");
+    }
+    expect(mcpServerConfig?.name).toBe(ACP_BRIDGE_MCP_SERVER_NAME);
+    const env = new Map(
+      mcpServerConfig.env.map(({ name, value }) => [name, value]),
+    );
+    const host = env.get("BB_ACP_DYNAMIC_TOOL_HOST");
+    const port = Number(env.get("BB_ACP_DYNAMIC_TOOL_PORT"));
+    const threadId = env.get("BB_ACP_DYNAMIC_TOOL_THREAD_ID");
+    const token = env.get("BB_ACP_DYNAMIC_TOOL_TOKEN");
+    if (!host || !Number.isInteger(port) || !threadId || !token) {
+      throw new Error("MCP server config is missing dynamic tool bridge env");
+    }
+
+    const bridgeCall = callDynamicToolBridge({
+      callId: "test-dynamic-tool-call",
+      host,
+      port,
+      threadId,
+      token,
+      tool: "update_environment_directory",
+      toolArguments: { path: "/tmp/next-worktree" },
+    });
+    const forwarded = await waitFor(
+      () =>
+        output.messages.find(
+          (message) =>
+            message.method === "item/tool/call" && message.id !== undefined,
+        ),
+      "forwarded dynamic tool call",
+    );
+    expect(forwarded.params).toMatchObject({
+      arguments: { path: "/tmp/next-worktree" },
+      providerThreadId,
+      threadId: bbThreadId,
+      tool: "update_environment_directory",
+      turnId: null,
+    });
+
+    handleLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: forwarded.id,
+        result: {
+          success: true,
+          contentItems: [
+            { type: "inputText", text: "environment directory updated" },
+          ],
+        },
+      }),
+    );
+
+    await expect(bridgeCall).resolves.toEqual({
+      content: "environment directory updated",
+      isError: false,
+      ok: true,
+    });
   });
 
   it("prepends instructions to the first prompt only", async () => {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -12,7 +12,9 @@
  */
 
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { promises as fs, readFileSync, realpathSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
 import {
   dirname,
   extname,
@@ -27,6 +29,8 @@ import { z } from "zod";
 import type { AvailableModel, PromptInput } from "@bb/domain";
 import { buildEditDiff } from "../../shared/adapter-utils.js";
 import {
+  decodeToolCallResponsePayload,
+  type BridgeJsonRpcResponse,
   decodeBridgeJsonRpcResponse,
   jsonRpcEnvelopeSchema,
 } from "../../shared/bridge-tool-calls.js";
@@ -80,6 +84,11 @@ import {
   type AcpNativeReasoningSupport,
   type AgentModelCatalog,
 } from "./model-catalog.js";
+import {
+  buildAcpMcpServerConfig,
+  runAcpDynamicToolMcpServer,
+  type AcpMcpServerConfig,
+} from "./tool-proxy-mcp.js";
 
 // ---------------------------------------------------------------------------
 // Session state
@@ -118,9 +127,10 @@ const sessionsByBbThreadId = new Map<string, AcpThreadSession>();
 const bbThreadIdByProviderThreadId = new Map<string, string>();
 const pendingRuntimeRequests = new Map<
   number,
-  (decision: "allow_once" | "allow_for_session" | "deny" | null) => void
+  (response: BridgeJsonRpcResponse) => void
 >();
 let runtimeRequestIdCounter = 0;
+let dynamicToolBridgePromise: Promise<AcpDynamicToolBridge> | null = null;
 
 // Runtime waits on thread/stop until the agent settles the cancelled prompt or
 // this timeout forces disposal. Stop remains a best-effort success boundary.
@@ -171,6 +181,160 @@ function sendNotification(
   send({ jsonrpc: "2.0", method, params });
 }
 
+function sendRuntimeRequest(
+  method: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  runtimeRequestIdCounter += 1;
+  const requestId = runtimeRequestIdCounter;
+  const responsePromise = new Promise<unknown>(
+    (resolveResponse, rejectResponse) => {
+      pendingRuntimeRequests.set(requestId, (response) => {
+        if ("error" in response) {
+          rejectResponse(
+            new Error(response.error.message ?? "Runtime request failed"),
+          );
+          return;
+        }
+        resolveResponse(response.result);
+      });
+    },
+  );
+  send({
+    jsonrpc: "2.0",
+    id: requestId,
+    method,
+    params,
+  });
+  return responsePromise;
+}
+
+function resolveBridgeProcessArgsForMcpServer(): string[] {
+  const entryPoint = process.argv[1]
+    ? resolve(process.argv[1])
+    : fileURLToPath(import.meta.url);
+  return [...process.execArgv, entryPoint, "--mcp-stdio"];
+}
+
+async function forwardDynamicToolCall(args: {
+  arguments: Record<string, unknown>;
+  callId: string;
+  threadId: string;
+  tool: string;
+}): Promise<
+  | { ok: true; content: string; isError?: boolean }
+  | { ok: false; error: string }
+> {
+  const session = sessionsByBbThreadId.get(args.threadId);
+  if (!session || !session.providerThreadId || session.stopping) {
+    return { ok: false, error: "No active ACP session for dynamic tool call." };
+  }
+
+  try {
+    const result = await sendRuntimeRequest("item/tool/call", {
+      providerThreadId: session.providerThreadId,
+      threadId: session.bbThreadId,
+      turnId: null,
+      callId: args.callId,
+      tool: args.tool,
+      arguments: args.arguments,
+    });
+    return { ok: true, ...decodeToolCallResponsePayload(result) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function handleDynamicToolBridgeSocket(
+  bridge: AcpDynamicToolBridge,
+  socket: Socket,
+): void {
+  let buffer = "";
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk) => {
+    buffer += chunk;
+    const newlineIndex = buffer.indexOf("\n");
+    if (newlineIndex === -1) {
+      return;
+    }
+    const line = buffer.slice(0, newlineIndex);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      socket.end(`${JSON.stringify({ ok: false, error: "Invalid JSON" })}\n`);
+      return;
+    }
+    const request = dynamicToolBridgeRequestSchema.safeParse(parsed);
+    if (!request.success || request.data.token !== bridge.token) {
+      socket.end(
+        `${JSON.stringify({ ok: false, error: "Invalid dynamic tool request" })}\n`,
+      );
+      return;
+    }
+    void forwardDynamicToolCall(request.data).then((response) => {
+      socket.end(`${JSON.stringify(response)}\n`);
+    });
+  });
+}
+
+async function ensureDynamicToolBridge(): Promise<AcpDynamicToolBridge> {
+  if (dynamicToolBridgePromise) {
+    return dynamicToolBridgePromise;
+  }
+
+  dynamicToolBridgePromise = new Promise((resolveBridge, rejectBridge) => {
+    const host = "127.0.0.1";
+    const server = createServer((socket) => {
+      void dynamicToolBridgePromise?.then((bridge) => {
+        handleDynamicToolBridgeSocket(bridge, socket);
+      });
+    });
+    server.once("error", rejectBridge);
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        rejectBridge(
+          new Error("ACP dynamic tool bridge did not bind a TCP port"),
+        );
+        return;
+      }
+      resolveBridge({
+        host,
+        port: address.port,
+        server,
+        token: randomBytes(32).toString("hex"),
+      });
+    });
+  });
+
+  return dynamicToolBridgePromise;
+}
+
+async function buildSessionMcpServers(
+  params: AcpBridgeThreadStartParams,
+): Promise<AcpMcpServerConfig[]> {
+  const dynamicTools = params.dynamicTools ?? [];
+  if (dynamicTools.length === 0) {
+    return [];
+  }
+  const bridge = await ensureDynamicToolBridge();
+  return [
+    buildAcpMcpServerConfig({
+      bridgeArgs: resolveBridgeProcessArgsForMcpServer(),
+      command: process.execPath,
+      dynamicTools,
+      host: bridge.host,
+      port: bridge.port,
+      threadId: params.threadId,
+      token: bridge.token,
+    }),
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Model catalog — parsed from the agent CLI's list command, with the
 // synthetic "Agent default" entry as the resilience fallback
@@ -196,6 +360,21 @@ const ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS = 5_000;
 const ACP_NATIVE_REASONING_DISCOVERY_MODEL_LIMIT = 50;
 const AUTH_REQUIRED_MODEL_LIST_ERROR_MESSAGE =
   "ACP agent is not authenticated.";
+
+interface AcpDynamicToolBridge {
+  host: string;
+  port: number;
+  server: Server;
+  token: string;
+}
+
+const dynamicToolBridgeRequestSchema = z.object({
+  arguments: z.record(z.string(), z.unknown()).default({}),
+  callId: z.string().min(1),
+  threadId: z.string().min(1),
+  token: z.string().min(1),
+  tool: z.string().min(1),
+});
 
 let cachedModelCatalog: { key: string; catalog: AgentModelCatalog } | null =
   null;
@@ -767,43 +946,46 @@ function handlePermissionRequest(
   }
 
   session.pendingPermissions.add(pending);
-  runtimeRequestIdCounter += 1;
-  const requestId = runtimeRequestIdCounter;
-  pendingRuntimeRequests.set(requestId, (decision) => {
-    if (!session.pendingPermissions.delete(pending)) {
-      // Already settled as cancelled (stop/cancel raced the user's decision).
-      return;
-    }
-    respondPermission(pending, decision);
-  });
 
   const toolCall = parsed.data.toolCall;
   const rawInputCommand = acpRawInputCommandSchema.safeParse(
     toolCall?.rawInput,
   );
-  send({
-    jsonrpc: "2.0",
-    id: requestId,
-    method: ACP_PERMISSION_REQUEST_METHOD,
-    params: {
-      threadId: session.bbThreadId,
-      providerThreadId: session.providerThreadId,
-      turnId: null,
-      ...(toolCall?.toolCallId
-        ? {
-            toolCall: {
-              toolCallId: toolCall.toolCallId,
-              ...(toolCall.title ? { title: toolCall.title } : {}),
-              ...(toolCall.kind ? { kind: toolCall.kind } : {}),
-              ...(rawInputCommand.success
-                ? { command: rawInputCommand.data.command }
-                : {}),
-            },
-          }
-        : {}),
-      options: parsed.data.options,
-    },
-  });
+  void sendRuntimeRequest(ACP_PERMISSION_REQUEST_METHOD, {
+    threadId: session.bbThreadId,
+    providerThreadId: session.providerThreadId,
+    turnId: null,
+    ...(toolCall?.toolCallId
+      ? {
+          toolCall: {
+            toolCallId: toolCall.toolCallId,
+            ...(toolCall.title ? { title: toolCall.title } : {}),
+            ...(toolCall.kind ? { kind: toolCall.kind } : {}),
+            ...(rawInputCommand.success
+              ? { command: rawInputCommand.data.command }
+              : {}),
+          },
+        }
+      : {}),
+    options: parsed.data.options,
+  })
+    .then((result) => {
+      if (!session.pendingPermissions.delete(pending)) {
+        // Already settled as cancelled (stop/cancel raced the user's decision).
+        return;
+      }
+      const decision = acpPermissionResponseSchema.safeParse(result);
+      respondPermission(
+        pending,
+        decision.success ? decision.data.decision : null,
+      );
+    })
+    .catch(() => {
+      if (!session.pendingPermissions.delete(pending)) {
+        return;
+      }
+      respondPermission(pending, null);
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -1024,6 +1206,7 @@ async function startAgentSession(
       initializeResult.agentCapabilities?.promptCapabilities?.image ?? false;
     const supportsLoadSession =
       initializeResult.agentCapabilities?.loadSession ?? false;
+    const mcpServers = await buildSessionMcpServers(params);
 
     let sessionId: string | undefined;
     let loadedConfigOptions: readonly AcpConfigOption[] | undefined;
@@ -1036,7 +1219,7 @@ async function startAgentSession(
           params: {
             sessionId: request.params.providerThreadId,
             cwd: params.cwd,
-            mcpServers: [],
+            mcpServers,
           },
           resultSchema: z.union([acpConfigStateResultSchema, z.null()]),
         });
@@ -1053,7 +1236,7 @@ async function startAgentSession(
     if (sessionId === undefined) {
       const newSession = await connection.request({
         method: "session/new",
-        params: { cwd: params.cwd, mcpServers: [] },
+        params: { cwd: params.cwd, mcpServers },
         resultSchema: acpSessionNewResultSchema,
       });
       sessionId = newSession.sessionId;
@@ -1359,12 +1542,7 @@ export function handleLine(line: string): void {
     const pending = pendingRuntimeRequests.get(response.id);
     if (pending) {
       pendingRuntimeRequests.delete(response.id);
-      if ("error" in response) {
-        pending(null);
-      } else {
-        const decision = acpPermissionResponseSchema.safeParse(response.result);
-        pending(decision.success ? decision.data.decision : null);
-      }
+      pending(response);
       return;
     }
   }
@@ -1388,6 +1566,16 @@ async function stopAllSessions(): Promise<void> {
       stopSession(session),
     ),
   );
+  const dynamicToolBridge = dynamicToolBridgePromise
+    ? await dynamicToolBridgePromise.catch(() => null)
+    : null;
+  await new Promise<void>((resolveClose) => {
+    if (!dynamicToolBridge) {
+      resolveClose();
+      return;
+    }
+    dynamicToolBridge.server.close(() => resolveClose());
+  });
 }
 
 function isMainModule(): boolean {
@@ -1406,13 +1594,17 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
-  const rl = createInterface({ input: process.stdin, terminal: false });
-  rl.on("line", handleLine);
-  rl.on("close", () => {
-    // Stdin close is a process shutdown boundary; cancel and reap the agent
-    // subprocesses before the bridge exits so none outlive the daemon.
-    void stopAllSessions().finally(() => {
-      process.exit(0);
+  if (process.argv.includes("--mcp-stdio")) {
+    runAcpDynamicToolMcpServer();
+  } else {
+    const rl = createInterface({ input: process.stdin, terminal: false });
+    rl.on("line", handleLine);
+    rl.on("close", () => {
+      // Stdin close is a process shutdown boundary; cancel and reap the agent
+      // subprocesses before the bridge exits so none outlive the daemon.
+      void stopAllSessions().finally(() => {
+        process.exit(0);
+      });
     });
-  });
+  }
 }

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -27,8 +27,7 @@ const loadSession = process.env.FAKE_ACP_LOAD_SESSION === "1";
 const modelConfig = process.env.FAKE_ACP_MODEL_CONFIG === "1";
 const modelsField = process.env.FAKE_ACP_MODELS_FIELD === "1";
 const thoughtLevelConfig = process.env.FAKE_ACP_THOUGHT_LEVEL_CONFIG === "1";
-const setConfigModelError =
-  process.env.FAKE_ACP_SET_CONFIG_MODEL_ERROR === "1";
+const setConfigModelError = process.env.FAKE_ACP_SET_CONFIG_MODEL_ERROR === "1";
 const hangInitialize = process.env.FAKE_ACP_HANG_INITIALIZE === "1";
 const sessionId = `fake-sess-${process.pid}`;
 const fakeModels = [
@@ -41,6 +40,7 @@ let nextAgentRequestId = 1000;
 let selectedModel = "fake/default";
 let selectedEffort = "none";
 const pendingClientRequests = new Map();
+let currentMcpServers = [];
 
 const effortsByModel = new Map([
   ["fake/strong", ["none", "low", "medium", "high", "xhigh"]],
@@ -161,6 +161,12 @@ function promptText(prompt) {
     .join("\n");
 }
 
+function captureMcpServers(message) {
+  currentMcpServers = Array.isArray(message.params?.mcpServers)
+    ? message.params.mcpServers
+    : [];
+}
+
 async function handlePrompt(message) {
   activePromptId = message.id;
   const text = promptText(message.params?.prompt);
@@ -230,6 +236,16 @@ async function handlePrompt(message) {
         `electron-run-as-node:${process.env.ELECTRON_RUN_AS_NODE ?? "missing"}`,
       ),
     );
+  } else if (text.includes("echo-mcp-servers")) {
+    const names = currentMcpServers
+      .map((server) => server?.name)
+      .filter((name) => typeof name === "string")
+      .join(",");
+    notifyUpdate(messageChunk(`mcp-servers:${names}`));
+  } else if (text.includes("echo-mcp-server-config")) {
+    notifyUpdate(
+      messageChunk(`mcp-server-config:${JSON.stringify(currentMcpServers)}`),
+    );
   } else {
     notifyUpdate(messageChunk(`echo:${text}`));
   }
@@ -263,6 +279,7 @@ async function handleMessage(message) {
       });
       return;
     case "session/new":
+      captureMcpServers(message);
       send({
         jsonrpc: "2.0",
         id: message.id,
@@ -274,6 +291,7 @@ async function handleMessage(message) {
       return;
     case "session/load":
       if (loadSession) {
+        captureMcpServers(message);
         send({ jsonrpc: "2.0", id: message.id, result: configState() });
       } else {
         send({

--- a/packages/agent-runtime/src/acp/bridge/tool-proxy-mcp.ts
+++ b/packages/agent-runtime/src/acp/bridge/tool-proxy-mcp.ts
@@ -1,0 +1,271 @@
+import { createConnection } from "node:net";
+import { createInterface } from "node:readline";
+import { dynamicToolSchema, type DynamicTool } from "@bb/domain";
+import { z } from "zod";
+
+export const ACP_BRIDGE_MCP_SERVER_NAME = "bb-bridge";
+
+const ENV_HOST = "BB_ACP_DYNAMIC_TOOL_HOST";
+const ENV_PORT = "BB_ACP_DYNAMIC_TOOL_PORT";
+const ENV_TOKEN = "BB_ACP_DYNAMIC_TOOL_TOKEN";
+const ENV_THREAD_ID = "BB_ACP_DYNAMIC_TOOL_THREAD_ID";
+const ENV_TOOLS = "BB_ACP_DYNAMIC_TOOLS";
+
+export interface AcpMcpServerConfig {
+  name: string;
+  command: string;
+  args: string[];
+  env: { name: string; value: string }[];
+}
+
+export interface BuildAcpMcpServerConfigArgs {
+  bridgeArgs: string[];
+  command: string;
+  dynamicTools: readonly DynamicTool[];
+  host: string;
+  port: number;
+  threadId: string;
+  token: string;
+}
+
+interface BridgeToolCallRequest {
+  arguments: Record<string, unknown>;
+  callId: string;
+  threadId: string;
+  token: string;
+  tool: string;
+}
+
+type BridgeToolCallResponse =
+  | { ok: true; content: string; isError?: boolean }
+  | { ok: false; error: string };
+
+const bridgeToolCallResponseSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    content: z.string(),
+    isError: z.boolean().optional(),
+  }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+
+interface JsonRpcMessage {
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+}
+
+interface McpServerEnvironment {
+  host: string;
+  port: number;
+  threadId: string;
+  token: string;
+  tools: DynamicTool[];
+}
+
+let nextMcpToolCallId = 0;
+
+export function buildAcpMcpServerConfig(
+  args: BuildAcpMcpServerConfigArgs,
+): AcpMcpServerConfig {
+  return {
+    name: ACP_BRIDGE_MCP_SERVER_NAME,
+    command: args.command,
+    args: args.bridgeArgs,
+    env: [
+      { name: ENV_HOST, value: args.host },
+      { name: ENV_PORT, value: String(args.port) },
+      { name: ENV_TOKEN, value: args.token },
+      { name: ENV_THREAD_ID, value: args.threadId },
+      { name: ENV_TOOLS, value: JSON.stringify(args.dynamicTools) },
+    ],
+  };
+}
+
+function readEnvironment(): McpServerEnvironment {
+  const port = Number(process.env[ENV_PORT]);
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`${ENV_PORT} must be a positive integer`);
+  }
+  const host = process.env[ENV_HOST];
+  const token = process.env[ENV_TOKEN];
+  const threadId = process.env[ENV_THREAD_ID];
+  const toolsJson = process.env[ENV_TOOLS];
+  if (!host || !token || !threadId || !toolsJson) {
+    throw new Error("Missing ACP dynamic tool MCP server environment");
+  }
+  const parsedTools = JSON.parse(toolsJson) as unknown;
+  const tools = dynamicToolSchema.array().parse(parsedTools);
+  return {
+    host,
+    port,
+    threadId,
+    token,
+    tools,
+  };
+}
+
+function writeJson(message: unknown): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function writeResult(id: string | number, result: unknown): void {
+  writeJson({ jsonrpc: "2.0", id, result });
+}
+
+function writeError(id: string | number, code: number, message: string): void {
+  writeJson({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function mcpToolCallId(toolName: string): string {
+  nextMcpToolCallId += 1;
+  return `acp-mcp-${toolName}-${Date.now()}-${nextMcpToolCallId}`;
+}
+
+function callBridge(
+  env: McpServerEnvironment,
+  request: Omit<BridgeToolCallRequest, "threadId" | "token">,
+): Promise<BridgeToolCallResponse> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host: env.host, port: env.port });
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      const payload: BridgeToolCallRequest = {
+        ...request,
+        threadId: env.threadId,
+        token: env.token,
+      };
+      socket.write(`${JSON.stringify(payload)}\n`);
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+      const line = buffer.slice(0, newlineIndex);
+      socket.end();
+      try {
+        resolve(bridgeToolCallResponseSchema.parse(JSON.parse(line)));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    socket.on("error", reject);
+    socket.on("end", () => {
+      if (!buffer.includes("\n")) {
+        reject(new Error("ACP dynamic tool bridge closed without a response"));
+      }
+    });
+  });
+}
+
+function objectParams(params: unknown): Record<string, unknown> {
+  return params && typeof params === "object" && !Array.isArray(params)
+    ? (params as Record<string, unknown>)
+    : {};
+}
+
+async function handleRequest(
+  env: McpServerEnvironment,
+  message: JsonRpcMessage,
+): Promise<void> {
+  if (message.id === undefined || message.method === undefined) {
+    return;
+  }
+
+  switch (message.method) {
+    case "initialize":
+      writeResult(message.id, {
+        protocolVersion:
+          typeof objectParams(message.params).protocolVersion === "string"
+            ? objectParams(message.params).protocolVersion
+            : "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: { name: ACP_BRIDGE_MCP_SERVER_NAME, version: "1.0.0" },
+      });
+      return;
+
+    case "tools/list":
+      writeResult(message.id, {
+        tools: env.tools.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        })),
+      });
+      return;
+
+    case "tools/call": {
+      const params = objectParams(message.params);
+      const name = typeof params.name === "string" ? params.name : "";
+      const tool = env.tools.find((candidate) => candidate.name === name);
+      if (!tool) {
+        writeError(message.id, -32602, `Unknown tool: ${name}`);
+        return;
+      }
+      const rawArguments = params.arguments;
+      const toolArguments =
+        rawArguments &&
+        typeof rawArguments === "object" &&
+        !Array.isArray(rawArguments)
+          ? (rawArguments as Record<string, unknown>)
+          : {};
+      try {
+        const result = await callBridge(env, {
+          arguments: toolArguments,
+          callId: mcpToolCallId(tool.name),
+          tool: tool.name,
+        });
+        if (!result.ok) {
+          writeResult(message.id, {
+            content: [{ type: "text", text: result.error }],
+            isError: true,
+          });
+          return;
+        }
+        writeResult(message.id, {
+          content: [{ type: "text", text: result.content }],
+          ...(result.isError ? { isError: true } : {}),
+        });
+      } catch (error) {
+        writeResult(message.id, {
+          content: [
+            {
+              type: "text",
+              text: error instanceof Error ? error.message : String(error),
+            },
+          ],
+          isError: true,
+        });
+      }
+      return;
+    }
+
+    default:
+      writeError(
+        message.id,
+        -32601,
+        `Unsupported MCP method: ${message.method}`,
+      );
+  }
+}
+
+export function runAcpDynamicToolMcpServer(): void {
+  const env = readEnvironment();
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  rl.on("line", (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(trimmed) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+    void handleRequest(env, message);
+  });
+}


### PR DESCRIPTION
Stacked on #209. This keeps the core dynamic environment work separate from provider-specific ACP support.

## Summary
- Pass bb dynamic tools through ACP session configuration instead of rejecting ACP providers.
- Expose those tools to ACP agents through a lightweight stdio MCP server launched by the ACP bridge.
- Forward MCP `tools/call` requests over a loopback bridge into the existing `item/tool/call` runtime path.
- Include ACP bridge/adapter coverage for tool advertisement and forwarding.

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/db -- test/data/events.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/threads/thread-runtime-config.test.ts test/threads/thread-send-dispatch.test.ts`
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- src/acp/adapter.test.ts src/acp/bridge/bridge.test.ts`

## Manual QA
- Verified against an isolated dev instance with real `acp-opencode`.
- Spawned thread `thr_x8z4af5pha`, called `bb-bridge_update_environment_directory`, confirmed the thread environment moved to `/tmp/bb-acp-env-switch-fixed-1DaiFE`.
- Sent a follow-up prompt that read `QA_MARKER.txt` from the new directory and returned `qa target fixed`.
- Confirmed the follow-up used a new provider session after the environment switch.