### PR TITLE
Refresh README package overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ bb is an agentic IDE that can control itself. You can seamlessly
 orchestrate all of your favorite coding agents together and have them
 programmatically use bb too.
 
-Every surface — the web app, CLI, and HTTP API — is a first-class way to
-drive bb. Work runs in threads you can follow live, steer at any point,
+Every surface — the desktop app, web app, CLI, and HTTP API — is a first-class
+way to drive bb. Work runs in threads you can follow live, steer at any point,
 or hand off to another agent.
 
 > [!NOTE]
@@ -67,16 +67,21 @@ runs never send. Opt out any run with `BB_TELEMETRY=false`. See
 
 This monorepo contains the packaged app plus the runtime services it bundles:
 
-| Package or app                                                     | Role                                                                                  |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| [`packages/bb-app`](./packages/bb-app)                             | Published npm package and `npx bb-app@latest` launcher.                               |
-| [`apps/app`](./apps/app)                                           | Web UI for inspecting projects, threads, environments, and running work.              |
-| [`apps/server`](./apps/server)                                     | HTTP API, WebSocket notifications, state management, and server-owned product policy. |
-| [`apps/host-daemon`](./apps/host-daemon)                           | Host-local runtime that provisions workspaces and runs provider processes.            |
-| [`apps/cli`](./apps/cli)                                           | Scriptable `bb` CLI for users and agents.                                             |
-| [`apps/landing`](./apps/landing)                                   | Static marketing landing page (TanStack Start, prerendered).                          |
-| [`packages/server-contract`](./packages/server-contract)           | HTTP and WebSocket contract between clients and the server.                           |
-| [`packages/host-daemon-contract`](./packages/host-daemon-contract) | Command/event contract between the server and host daemons.                           |
+| Package or app                                                     | Role                                                                                                |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| [`packages/bb-app`](./packages/bb-app)                             | Published npm package, `npx bb-app@latest` launcher, bundled `bb` CLI entry, and public SDK export. |
+| [`apps/desktop`](./apps/desktop)                                   | macOS Electron shell that supervises the packaged runtime and loads the bb web UI.                  |
+| [`apps/app`](./apps/app)                                           | Web UI for inspecting projects, threads, environments, and running work.                            |
+| [`apps/server`](./apps/server)                                     | HTTP API, WebSocket notifications, state management, and server-owned product policy.               |
+| [`apps/host-daemon`](./apps/host-daemon)                           | Host-local runtime that provisions workspaces and runs provider processes.                          |
+| [`apps/cli`](./apps/cli)                                           | Scriptable `bb` CLI for users and agents.                                                           |
+| [`apps/landing`](./apps/landing)                                   | Static marketing landing page (TanStack Start, prerendered).                                        |
+| [`packages/sdk`](./packages/sdk)                                   | TypeScript SDK used by the CLI, package SDK export, and programmatic clients.                       |
+| [`packages/agent-runtime`](./packages/agent-runtime)               | Provider runtime adapters and bridges for Codex, Claude Code, Pi, and ACP agents.                   |
+| [`packages/config`](./packages/config)                             | Config parsing, defaults, managed package config schema, and environment variable definitions.      |
+| [`packages/db`](./packages/db)                                     | SQLite schema, migrations, and data access helpers.                                                 |
+| [`packages/server-contract`](./packages/server-contract)           | HTTP and WebSocket contract between clients and the server.                                         |
+| [`packages/host-daemon-contract`](./packages/host-daemon-contract) | Command/event contract between the server and host daemons.                                         |
 
 `bb-app` also exposes a Node scripting SDK:
 `import { BBSdk } from "bb-app"`. See
@@ -170,12 +175,12 @@ These reset commands prompt for confirmation before deleting anything.
 
 ### The runtime pieces
 
-| Component       | Role                                                                                                                                                                                                                                                                                                    |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Server**      | Central hub. Stores all state in a SQLite database, exposes an HTTP API, and pushes change notifications over WebSocket. Stateless itself — the DB is the source of truth. Routes work to hosts by queuing commands.                                                                                    |
+| Component       | Role                                                                                                                                                                                                                                                                           |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Server**      | Central hub. Stores all state in a SQLite database, exposes an HTTP API, and pushes change notifications over WebSocket. Stateless itself — the DB is the source of truth. Routes work to hosts by queuing commands.                                                           |
 | **Host daemon** | Runs on the local machine. Connects to the server, picks up commands, provisions workspaces, runs agent provider processes, and streams events back. Exposes a local HTTP API for the app and CLI to do machine-local things (open editor, pick folders, check daemon status). |
-| **App**         | Web UI for inspecting projects and threads, following progress, and steering work.                                                                                                                                                                                                                      |
-| **CLI** (`bb`)  | First-class interface for both users and agents. Same capabilities as the app, scriptable.                                                                                                                                                                                                              |
+| **App**         | Web UI for inspecting projects and threads, following progress, and steering work.                                                                                                                                                                                             |
+| **CLI** (`bb`)  | First-class interface for both users and agents. Same capabilities as the app, scriptable.                                                                                                                                                                                     |
 
 ### Data model
 

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -107,17 +107,16 @@ targets. Scripts launched by bb already receive `BB_SERVER_URL` and
 
 bb uses whichever providers you have configured. Common providers:
 
-| Provider         | Notes        |
-| ---------------- | ------------ |
-| `codex`          | Codex CLI    |
-| `claude-code`    | Claude Code  |
-| `cursor`[^acp]   | Cursor agent |
-| `pi`             | Pi agent     |
-| `opencode`[^acp] | opencode     |
+| Provider      | Setup                                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `codex`       | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                  |
+| `claude-code` | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                   |
+| `acp-cursor`  | Install Cursor's agent CLI (`agent`) and authenticate per Cursor's docs.                                                                               |
+| `pi`          | See the [Pi coding agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup. |
 
-[^acp]:
-    Cursor, opencode, and other ACP-compatible agents run through bb's ACP
-    provider support.
+Known ACP agents such as `opencode` can appear automatically when their
+executable is on `PATH`. Custom ACP agents are configured through
+`customAcpAgents` in `~/.bb/config.json`.
 
 ## Configuration
 

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -111,12 +111,12 @@ bb uses whichever providers you have configured. Common providers:
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `codex`       | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                  |
 | `claude-code` | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                   |
-| `acp-cursor`  | Install Cursor's agent CLI (`agent`) and authenticate per Cursor's docs.                                                                               |
+| `cursor`      | Install Cursor's agent CLI (`agent`) and authenticate per Cursor's docs.                                                                               |
 | `pi`          | See the [Pi coding agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup. |
+| `opencode`    | Install opencode and authenticate per its docs.                                                                                                        |
 
-Known ACP agents such as `opencode` can appear automatically when their
-executable is on `PATH`. Custom ACP agents are configured through
-`customAcpAgents` in `~/.bb/config.json`.
+Custom ACP agents can be configured through `customAcpAgents` in
+`~/.bb/config.json`.
 
 ## Configuration
 

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -107,13 +107,13 @@ targets. Scripts launched by bb already receive `BB_SERVER_URL` and
 
 bb uses whichever providers you have configured. Common providers:
 
-| Provider         |
-| ---------------- |
-| `codex`          |
-| `claude-code`    |
-| `cursor`[^acp]   |
-| `pi`             |
-| `opencode`[^acp] |
+| Provider         | Notes        |
+| ---------------- | ------------ |
+| `codex`          | Codex CLI    |
+| `claude-code`    | Claude Code  |
+| `cursor`[^acp]   | Cursor agent |
+| `pi`             | Pi agent     |
+| `opencode`[^acp] | opencode     |
 
 [^acp]:
     Cursor, opencode, and other ACP-compatible agents run through bb's ACP

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -111,9 +111,9 @@ bb uses whichever providers you have configured. Common providers:
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `codex`       | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                  |
 | `claude-code` | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                   |
-| `cursor`      | Install Cursor's agent CLI (`agent`) and authenticate per Cursor's docs.                                                                               |
+| `cursor`      | Install [Cursor's agent CLI](https://cursor.com/cli) (`agent`) and authenticate per Cursor's docs.                                                     |
 | `pi`          | See the [Pi coding agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup. |
-| `opencode`    | Install opencode and authenticate per its docs.                                                                                                        |
+| `opencode`    | Install [opencode](https://opencode.ai/) and authenticate per its docs.                                                                                |
 
 Custom ACP agents can be configured through `customAcpAgents` in
 `~/.bb/config.json`.

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -105,18 +105,19 @@ targets. Scripts launched by bb already receive `BB_SERVER_URL` and
 
 ## Provider Credentials
 
-bb uses whichever providers you have configured. If you need to set one up:
+bb uses whichever providers you have configured. Common providers:
 
-| Provider      | Setup                                                                                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `codex`       | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                  |
-| `claude-code` | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                   |
-| `acp-cursor`  | Install Cursor's agent CLI (`agent`) and authenticate per Cursor's docs.                                                                               |
-| `pi`          | See the [Pi coding agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup. |
+| Provider         |
+| ---------------- |
+| `codex`          |
+| `claude-code`    |
+| `cursor`[^acp]   |
+| `pi`             |
+| `opencode`[^acp] |
 
-Known ACP agents such as `opencode` can appear automatically when their
-executable is on `PATH`. Custom ACP agents are configured through
-`customAcpAgents` in `~/.bb/config.json`.
+[^acp]:
+    Cursor, opencode, and other ACP-compatible agents run through bb's ACP
+    provider support.
 
 ## Configuration
 

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -14,10 +14,10 @@ bb is an agentic IDE that can control itself. You can seamlessly
 orchestrate all of your favorite coding agents together and have them
 programmatically use bb too.
 
-This package provides the `npx bb-app` launcher. Every surface — the web
-app, CLI, and HTTP API — is a first-class way to drive bb. Work runs in
-threads you can follow live, steer at any point, or hand off to another
-agent.
+This package provides the `npx bb-app` launcher, bundled `bb` CLI entry, and
+Node SDK export. Every surface — the web app, CLI, and HTTP API — is a
+first-class way to drive bb. Work runs in threads you can follow live, steer at
+any point, or hand off to another agent.
 
 > Note: bb is in active development. Workflows and surfaces are still evolving.
 
@@ -27,12 +27,12 @@ bb runs from npm and orchestrates coding agents you already have installed.
 
 ### Prerequisites
 
-- Node.js `22.12.0` or newer. Node `20.19.x` also works.
+- Node.js 22 LTS or newer. Node `20.19.x` is best-effort only.
 - Git.
-- At least one supported agent provider: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://developers.openai.com/codex/cli), or [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent).
+- At least one supported agent provider: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://developers.openai.com/codex/cli), Cursor via ACP, [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent), or another ACP-compatible agent.
 
 If you already use one of these providers, bb will pick up your existing
-credentials. If you use all three, you can mix and match per task.
+credentials. If you use multiple providers, you can mix and match per task.
 
 ### Supported host environments
 
@@ -70,6 +70,16 @@ the terminal to stop both processes and exit with status `0`.
 From the app, add or open a project, start a thread, and choose the provider
 you want that thread to use.
 
+## CLI
+
+The package also exposes the `bb` CLI for an already-running bb server:
+
+```bash
+npx --package bb-app bb --help
+```
+
+The CLI uses the same `BB_SERVER_URL` and bb config resolution as the SDK.
+
 ## Scripting with the SDK
 
 The package also exposes a Node SDK for scripts that drive an already-running
@@ -101,7 +111,12 @@ bb uses whichever providers you have configured. If you need to set one up:
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `codex`       | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                  |
 | `claude-code` | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                   |
+| `acp-cursor`  | Install Cursor's agent CLI (`agent`) and authenticate per Cursor's docs.                                                                               |
 | `pi`          | See the [Pi coding agent docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup. |
+
+Known ACP agents such as `opencode` can appear automatically when their
+executable is on `PATH`. Custom ACP agents are configured through
+`customAcpAgents` in `~/.bb/config.json`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- mention the desktop app as a first-class bb surface in the top-level README
- expand the top-level repository overview with desktop, SDK, runtime, config, and DB packages
- refresh the bb-app package README for bundled CLI/SDK, current provider support, and Node support wording

## Validation
- pnpm exec prettier README.md packages/bb-app/README.md --check