### PR TITLE
Quiet routine host daemon health logs

### DIFF
--- a/apps/host-daemon/src/host-daemon-health-monitor.test.ts
+++ b/apps/host-daemon/src/host-daemon-health-monitor.test.ts
@@ -14,7 +14,6 @@ function createMonitorHarness(
   usage: HostDaemonResourceUsage,
   options: { inotifyInstanceWarnThreshold?: number } = {},
 ) {
-  const debug = vi.fn();
   const warn = vi.fn();
   const timer: CapturedTimer = {
     callback: () => undefined,
@@ -22,7 +21,7 @@ function createMonitorHarness(
     unrefed: false,
   };
   const monitor = startHostDaemonHealthMonitor({
-    logger: { debug, warn },
+    logger: { warn },
     getWatchCounts: () => ({ workspaceWatches: 3, threadStorageTargets: 5 }),
     readResourceUsage: () => usage,
     inotifyInstanceWarnThreshold: options.inotifyInstanceWarnThreshold,
@@ -38,46 +37,36 @@ function createMonitorHarness(
       };
     },
   });
-  return { debug, warn, timer, monitor };
+  return { warn, timer, monitor };
 }
 
 describe("startHostDaemonHealthMonitor", () => {
-  it("debug-logs resource and watch metrics on each tick", () => {
-    const { debug, timer } = createMonitorHarness({
-      rssBytes: 123,
-      openFds: 42,
-      inotifyInstances: 1,
-      threads: 11,
-    });
-
-    timer.callback();
-
-    expect(debug).toHaveBeenCalledWith(
+  it("warns with resource and watch metrics when inotify count is high", () => {
+    const { warn, timer } = createMonitorHarness(
       {
         rssBytes: 123,
         openFds: 42,
-        inotifyInstances: 1,
+        inotifyInstances: 17,
         threads: 11,
-        workspaceWatches: 3,
-        threadStorageTargets: 5,
       },
-      "Host daemon health",
-    );
-  });
-
-  it("warns when the inotify instance count indicates leaked watchers", () => {
-    const { warn, timer } = createMonitorHarness(
-      { rssBytes: 1, openFds: 200, inotifyInstances: 17, threads: 40 },
       { inotifyInstanceWarnThreshold: 8 },
     );
 
     timer.callback();
 
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toMatchObject({
-      inotifyInstances: 17,
-      warnThreshold: 8,
-    });
+    expect(warn).toHaveBeenCalledWith(
+      {
+        rssBytes: 123,
+        openFds: 42,
+        inotifyInstances: 17,
+        threads: 11,
+        workspaceWatches: 3,
+        threadStorageTargets: 5,
+        warnThreshold: 8,
+      },
+      "Host daemon inotify instance count is high; filesystem watchers are likely leaking (dead backends after poll interruptions)",
+    );
   });
 
   it("does not warn when the inotify count is healthy or unavailable", () => {
@@ -89,14 +78,13 @@ describe("startHostDaemonHealthMonitor", () => {
     expect(healthy.warn).not.toHaveBeenCalled();
 
     const unavailable = createMonitorHarness({
-      rssBytes: 1,
+      rssBytes: 123,
       openFds: null,
       inotifyInstances: null,
       threads: null,
     });
     unavailable.timer.callback();
     expect(unavailable.warn).not.toHaveBeenCalled();
-    expect(unavailable.debug).toHaveBeenCalledTimes(1);
   });
 
   it("stops the interval timer on stop()", () => {

--- a/apps/host-daemon/src/host-daemon-health-monitor.ts
+++ b/apps/host-daemon/src/host-daemon-health-monitor.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import type { HostDaemonLogger } from "./logger.js";
 
 /**
- * Periodically debug-logs host-daemon resource and watch metrics so a leak or wedge
- * is visible in the logs after the fact instead of needing a live post-mortem.
+ * Periodically checks host-daemon resource and watch metrics so a leak or wedge
+ * emits an actionable warning instead of needing a live post-mortem.
  *
  * The headline signal is the inotify instance count. `@parcel/watcher` shares a
  * single inotify backend across every watched path, so a healthy daemon needs
@@ -39,7 +39,7 @@ export interface HostDaemonResourceUsage {
 }
 
 interface HostDaemonHealthMonitorOptions {
-  logger: Pick<HostDaemonLogger, "debug" | "warn">;
+  logger: Pick<HostDaemonLogger, "warn">;
   getWatchCounts: () => HostDaemonWatchCounts;
   readResourceUsage?: () => HostDaemonResourceUsage;
   setIntervalFn?: HostDaemonHealthMonitorIntervalFn;
@@ -111,24 +111,19 @@ export function startHostDaemonHealthMonitor(
 
   const timer = setIntervalFn(() => {
     const usage = readResourceUsage();
-    const watchCounts = options.getWatchCounts();
-    const fields = {
-      rssBytes: usage.rssBytes,
-      openFds: usage.openFds,
-      inotifyInstances: usage.inotifyInstances,
-      threads: usage.threads,
-      workspaceWatches: watchCounts.workspaceWatches,
-      threadStorageTargets: watchCounts.threadStorageTargets,
-    };
-    options.logger.debug(fields, "Host daemon health");
     if (
       usage.inotifyInstances !== null &&
       usage.inotifyInstances > inotifyInstanceWarnThreshold
     ) {
+      const watchCounts = options.getWatchCounts();
       options.logger.warn(
         {
+          rssBytes: usage.rssBytes,
+          openFds: usage.openFds,
           inotifyInstances: usage.inotifyInstances,
           threads: usage.threads,
+          workspaceWatches: watchCounts.workspaceWatches,
+          threadStorageTargets: watchCounts.threadStorageTargets,
           warnThreshold: inotifyInstanceWarnThreshold,
         },
         "Host daemon inotify instance count is high; filesystem watchers are likely leaking (dead backends after poll interruptions)",


### PR DESCRIPTION
## Summary
- stop emitting the routine host-daemon health debug line on every monitor tick
- keep the actionable inotify leak warning and include resource/watch metrics in that warning
- update the health monitor unit test for the new behavior

## Validation
- pnpm exec turbo run typecheck --filter=@bb/host-daemon
- pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/host-daemon-health-monitor.test.ts