### PR TITLE
Hide merge-base banner action when compact

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -657,7 +657,7 @@ export function Overview() {
     <StoryCard>
       <StoryRow
         label="git — merge-base picker"
-        hint="git is the only segment, so the merge-base action is pinned to the far right. It still carries data-promptbox-hide-compact."
+        hint="git is the only segment, so the merge-base action is pinned to the far right on wide rows and hidden at the compact breakpoint."
       >
         <Row section={committedSection} />
       </StoryRow>

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -45,6 +45,7 @@ const pullRequestFixture: ThreadPullRequest = {
 
 function makeGitSection(
   kind: ThreadPromptGitSection["changedFiles"]["kind"] = "uncommitted",
+  mergeBase: ThreadPromptGitSection["mergeBase"] = null,
 ): ThreadPromptGitSection {
   return {
     changedFiles: {
@@ -58,7 +59,7 @@ function makeGitSection(
         files: [changedFile],
       },
     },
-    mergeBase: null,
+    mergeBase,
     onPromptBannerFileClick: noop,
   };
 }
@@ -359,6 +360,30 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("Uncommitted");
     expect(markup).toContain('data-promptbox-hide-compact="">Uncommitted');
     expect(markup).toContain('data-promptbox-compact-label="">1 file');
+  });
+
+  it("hides the standalone merge-base action at the compact breakpoint", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={makeGitSection("committed", {
+          branch: "origin/very-long-feature-base-branch",
+          onChange: noop,
+        })}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={null}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toContain("Merge base");
+    expect(markup).toContain("origin/very-long-feature-base-branch");
+    expect(markup).toContain("data-promptbox-hide-compact");
+    expect(markup).toContain("data-promptbox-hide-tiny");
   });
 
   it("keeps the pull request action visible beside other context segments", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -381,10 +381,17 @@ function ChildThreadsBody({
   );
 }
 
-function BannerActionSlot({ children }: { children: ReactNode }) {
+function BannerActionSlot({
+  children,
+  hideInCompact = false,
+}: {
+  children: ReactNode;
+  hideInCompact?: boolean;
+}) {
   return (
     <div
       className="ml-auto flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
+      data-promptbox-hide-compact={hideInCompact ? "" : undefined}
       data-promptbox-hide-tiny=""
     >
       {children}
@@ -770,7 +777,7 @@ export function ThreadPromptContextBanner({
       : { options: [], remoteOptions: [] };
   const segmentAction =
     hasSingleVisibleSegment && showGit && gitSection.mergeBase ? (
-      <BannerActionSlot>
+      <BannerActionSlot hideInCompact>
         <Icon
           name="GitMerge"
           className="size-3.5 shrink-0"


### PR DESCRIPTION
## Summary
- Hide the standalone merge-base action slot at the promptbox compact breakpoint
- Keep other banner actions visible with their existing behavior
- Add coverage for the compact-hide marker on the merge-base action

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app