### PR TITLE
Fix child turn completions settling active threads

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -197,6 +197,12 @@ type EventEffectFollowUp =
   | ParentTurnNotificationFollowUp
   | QueuedMessageAutoSendFollowUp;
 
+function isRootTurnStartedEvent(
+  event: Extract<HostDaemonEventEnvelope["event"], { type: "turn/started" }>,
+): boolean {
+  return !event.parentToolCallId;
+}
+
 function resolveProviderIdentifiers(event: HostDaemonEventEnvelope["event"]): {
   providerThreadId: string | null;
 } {
@@ -350,6 +356,9 @@ async function applyEventEffects(
         if (hasThreadAlreadyStartedRun(deps, entry.threadId)) {
           continue;
         }
+        if (!isRootTurnStartedEvent(event)) {
+          continue;
+        }
         applyLoggedThreadLifecycleEvent(deps, {
           event: { type: "run.started" },
           threadId: entry.threadId,
@@ -377,6 +386,7 @@ async function applyEventEffects(
         });
         if (
           turnCompleted.thread &&
+          turnCompleted.isRootTurnCompletion &&
           // Forks / side chats are user-initiated branches, not agent-delegated
           // sub-tasks, so a completed turn must not post a "child finished"
           // notification back into their parent thread.

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -399,7 +399,10 @@ async function applyEventEffects(
             });
           }
         }
-        if (event.status === "completed") {
+        if (
+          event.status === "completed" &&
+          turnCompleted.nextStatus === "idle"
+        ) {
           followUps.push({
             kind: "queued-message-auto-send",
             threadId: entry.threadId,

--- a/apps/server/src/internal/turn-completed-events.ts
+++ b/apps/server/src/internal/turn-completed-events.ts
@@ -18,6 +18,7 @@ import {
 import { applyLoggedThreadLifecycleEvent } from "../services/threads/lifecycle-outcome.js";
 
 interface ApplyTurnCompletedEventResult {
+  isRootTurnCompletion: boolean;
   nextStatus: ThreadStatus | null;
   thread: ReturnType<typeof getThread>;
 }
@@ -40,20 +41,19 @@ export function applyTurnCompletedEvent(
 ): ApplyTurnCompletedEventResult {
   const thread = getThread(deps.db, payload.threadId);
   if (!thread) {
-    return { nextStatus: null, thread: null };
+    return { isRootTurnCompletion: false, nextStatus: null, thread: null };
   }
 
   const turnId = requireThreadEventScopeTurnId({
     type: payload.type,
     scope: payload.scope,
   });
-  if (
-    !hasRootStoredTurnStarted(deps.db, {
-      threadId: payload.threadId,
-      turnId,
-    })
-  ) {
-    return { nextStatus: null, thread };
+  const isRootTurnCompletion = hasRootStoredTurnStarted(deps.db, {
+    threadId: payload.threadId,
+    turnId,
+  });
+  if (!isRootTurnCompletion) {
+    return { isRootTurnCompletion, nextStatus: null, thread };
   }
 
   const outcome = applyLoggedThreadLifecycleEvent(deps, {
@@ -77,7 +77,7 @@ export function applyTurnCompletedEvent(
     closeAutomationRunForSettledThread(deps, payload);
   }
 
-  return { nextStatus, thread };
+  return { isRootTurnCompletion, nextStatus, thread };
 }
 
 /**

--- a/apps/server/src/internal/turn-completed-events.ts
+++ b/apps/server/src/internal/turn-completed-events.ts
@@ -2,11 +2,13 @@ import {
   closeAutomationRun,
   getRunningAutomationRunByThread,
   getThread,
+  hasRootStoredTurnStarted,
 } from "@bb/db";
-import type {
-  ThreadEvent,
-  ThreadLifecycleEvent,
-  ThreadStatus,
+import {
+  requireThreadEventScopeTurnId,
+  type ThreadEvent,
+  type ThreadLifecycleEvent,
+  type ThreadStatus,
 } from "@bb/domain";
 import type { AppDeps } from "../types.js";
 import {
@@ -39,6 +41,19 @@ export function applyTurnCompletedEvent(
   const thread = getThread(deps.db, payload.threadId);
   if (!thread) {
     return { nextStatus: null, thread: null };
+  }
+
+  const turnId = requireThreadEventScopeTurnId({
+    type: payload.type,
+    scope: payload.scope,
+  });
+  if (
+    !hasRootStoredTurnStarted(deps.db, {
+      threadId: payload.threadId,
+      turnId,
+    })
+  ) {
+    return { nextStatus: null, thread };
   }
 
   const outcome = applyLoggedThreadLifecycleEvent(deps, {

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -5,6 +5,7 @@ import {
   getEnvironment,
   getThread,
   listEnvironments,
+  listQueuedThreadMessages,
   threads,
 } from "@bb/db";
 import { threadScope, turnScope } from "@bb/domain";
@@ -311,6 +312,113 @@ describe("internal event and tool-call routes", () => {
         harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
           ?.status,
       ).toBe("idle");
+    });
+  });
+
+  it("keeps active root turns queueable when a delegated child turn completes", async () => {
+    await withTestHarness(async (harness) => {
+      const { session } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: session.hostId,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: session.hostId,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "codex",
+        status: "active",
+      });
+
+      const eventResponse = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          {
+            threadId: thread.id,
+            event: {
+              type: "turn/started",
+              threadId: thread.id,
+              providerThreadId: "provider-thread-main",
+              scope: turnScope("root-turn"),
+            },
+          },
+          {
+            threadId: thread.id,
+            event: {
+              type: "turn/started",
+              threadId: thread.id,
+              providerThreadId: "provider-thread-main",
+              scope: turnScope("delegated-child-turn"),
+              parentToolCallId: "call-delegate-agent",
+            },
+          },
+          {
+            threadId: thread.id,
+            event: {
+              type: "turn/completed",
+              threadId: thread.id,
+              providerThreadId: "provider-thread-main",
+              scope: turnScope("delegated-child-turn"),
+              status: "completed",
+            },
+          },
+        ],
+      });
+
+      expect(eventResponse.status).toBe(200);
+      await expect(readJson(eventResponse)).resolves.toMatchObject({
+        acceptedEvents: [
+          { eventIndex: 0, threadId: thread.id },
+          { eventIndex: 1, threadId: thread.id },
+          { eventIndex: 2, threadId: thread.id },
+        ],
+        rejectedEvents: [],
+      });
+      expect(
+        harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
+          ?.status,
+      ).toBe("active");
+
+      const sendResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/send`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            input: [{ type: "text", text: "Follow up after child turn" }],
+            mode: "queue-if-active",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          }),
+        },
+      );
+
+      expect(sendResponse.status).toBe(200);
+      await expect(readJson(sendResponse)).resolves.toEqual({ ok: true });
+      const queuedRows = listQueuedThreadMessages(harness.db, thread.id);
+      expect(queuedRows).toHaveLength(1);
+      expect(JSON.parse(queuedRows[0]?.content ?? "null")).toEqual([
+        {
+          mentions: [],
+          text: "Follow up after child turn",
+          type: "text",
+        },
+      ]);
+      expect(
+        harness.db
+          .select()
+          .from(events)
+          .where(eq(events.threadId, thread.id))
+          .all()
+          .filter((row) => row.type === "client/turn/requested"),
+      ).toEqual([]);
     });
   });
 

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import { eq } from "drizzle-orm";
 import {
   closeSession,
@@ -67,6 +68,11 @@ async function postToolCall(args: {
       arguments: args.arguments,
     }),
   });
+}
+
+async function flushDeferredChildThreadNotifications(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await sleep(2_100);
 }
 
 describe("internal event and tool-call routes", () => {
@@ -419,6 +425,150 @@ describe("internal event and tool-call routes", () => {
           .all()
           .filter((row) => row.type === "client/turn/requested"),
       ).toEqual([]);
+    });
+  });
+
+  it("does not activate an idle thread for a delegated child turn", async () => {
+    await withTestHarness(async (harness) => {
+      const { session } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: session.hostId,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: session.hostId,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "codex",
+        status: "idle",
+      });
+
+      const response = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          {
+            threadId: thread.id,
+            event: {
+              type: "turn/started",
+              threadId: thread.id,
+              providerThreadId: "provider-thread",
+              scope: turnScope("delegated-child-turn"),
+              parentToolCallId: "call-delegate-agent",
+            },
+          },
+          {
+            threadId: thread.id,
+            event: {
+              type: "turn/completed",
+              threadId: thread.id,
+              providerThreadId: "provider-thread",
+              scope: turnScope("delegated-child-turn"),
+              status: "completed",
+            },
+          },
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      expect(
+        harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
+          ?.status,
+      ).toBe("idle");
+    });
+  });
+
+  it("does not notify a parent when a child thread nested turn completes", async () => {
+    await withTestHarness(async (harness) => {
+      const { session } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: session.hostId,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: session.hostId,
+        projectId: project.id,
+      });
+      const parentThread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "codex",
+        status: "active",
+      });
+      seedEvent(harness.deps, {
+        threadId: parentThread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-parent-thread",
+        sequence: 1,
+        type: "turn/started",
+        scope: turnScope("parent-root-turn"),
+        data: {
+          providerThreadId: "provider-parent-thread",
+        },
+      });
+      const childThread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        parentThreadId: parentThread.id,
+        providerId: "codex",
+        status: "active",
+      });
+
+      const response = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          {
+            threadId: childThread.id,
+            event: {
+              type: "turn/started",
+              threadId: childThread.id,
+              providerThreadId: "provider-child-thread",
+              scope: turnScope("child-root-turn"),
+            },
+          },
+          {
+            threadId: childThread.id,
+            event: {
+              type: "turn/started",
+              threadId: childThread.id,
+              providerThreadId: "provider-child-thread",
+              scope: turnScope("child-nested-turn"),
+              parentToolCallId: "call-nested-agent",
+            },
+          },
+          {
+            threadId: childThread.id,
+            event: {
+              type: "turn/completed",
+              threadId: childThread.id,
+              providerThreadId: "provider-child-thread",
+              scope: turnScope("child-nested-turn"),
+              status: "completed",
+            },
+          },
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      await flushDeferredChildThreadNotifications();
+
+      expect(
+        harness.db
+          .select()
+          .from(threads)
+          .where(eq(threads.id, childThread.id))
+          .get()?.status,
+      ).toBe("active");
+      expect(
+        harness.db
+          .select()
+          .from(events)
+          .where(eq(events.threadId, parentThread.id))
+          .all()
+          .map((row) => row.type),
+      ).toEqual(["turn/started"]);
     });
   });
 

--- a/apps/server/test/system/event-pruning.test.ts
+++ b/apps/server/test/system/event-pruning.test.ts
@@ -292,16 +292,27 @@ describe("thread event pruning", () => {
         threadId: thread.id,
         endingSequence: 305,
       });
+      seedStoredEvent(harness.deps, {
+        threadId: thread.id,
+        scope: turnScope("turn-1"),
+        sequence: 306,
+        type: "turn/started",
+        itemId: null,
+        itemKind: null,
+        data: {
+          providerThreadId: "provider-thread-1",
+        },
+      });
       seedResolvedAssistantMessage(harness, {
         threadId: thread.id,
         itemId: "msg-1",
-        deltaSequences: [306, 307],
-        completedSequence: 308,
+        deltaSequences: [307, 308],
+        completedSequence: 309,
       });
       seedStoredEvent(harness.deps, {
         threadId: thread.id,
         scope: turnScope("turn-1"),
-        sequence: 309,
+        sequence: 310,
         type: "turn/completed",
         itemId: null,
         itemKind: null,
@@ -324,13 +335,13 @@ describe("thread event pruning", () => {
           threadId: thread.id,
           type: "thread/tokenUsage/updated",
         }).at(0),
-      ).toBe(10);
+      ).toBe(11);
       expect(
         listEventSequencesForType(harness, {
           threadId: thread.id,
           type: "item/agentMessage/delta",
         }),
-      ).toEqual([306]);
+      ).toEqual([307]);
     });
   });
 

--- a/apps/server/test/system/event-pruning.test.ts
+++ b/apps/server/test/system/event-pruning.test.ts
@@ -345,6 +345,58 @@ describe("thread event pruning", () => {
     });
   });
 
+  it("identifies root completions even when the thread is already settled", async () => {
+    await withTestHarness(async (harness) => {
+      const host = seedHost(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        status: "idle",
+      });
+      seedStoredEvent(harness.deps, {
+        threadId: thread.id,
+        scope: turnScope("turn-1"),
+        sequence: 1,
+        type: "turn/started",
+        itemId: null,
+        itemKind: null,
+        data: {
+          providerThreadId: "provider-thread-1",
+        },
+      });
+      seedStoredEvent(harness.deps, {
+        threadId: thread.id,
+        scope: turnScope("turn-1"),
+        sequence: 2,
+        type: "turn/completed",
+        itemId: null,
+        itemKind: null,
+        data: {
+          status: "completed",
+        },
+      });
+
+      const result = applyTurnCompletedEvent(harness.deps, {
+        type: "turn/completed",
+        threadId: thread.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      });
+
+      expect(result.isRootTurnCompletion).toBe(true);
+      expect(result.nextStatus).toBeNull();
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+    });
+  });
+
   it("prunes thread history on archive with the archived retention window", async () => {
     await withTestHarness(async (harness) => {
       const host = seedHost(harness.deps);

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -1379,6 +1379,27 @@ export function hasStoredTurnStarted(
   return row !== undefined;
 }
 
+export function hasRootStoredTurnStarted(
+  db: DbQueryConnection,
+  args: HasStoredTurnStartedArgs,
+): boolean {
+  const row = db
+    .select({ sequence: events.sequence })
+    .from(events)
+    .where(
+      and(
+        eq(events.threadId, args.threadId),
+        eq(events.type, "turn/started"),
+        eq(events.turnId, args.turnId),
+        isRootTurnStartedEventData,
+      ),
+    )
+    .limit(1)
+    .get();
+
+  return row !== undefined;
+}
+
 export function listRecentStoredEventRows(
   db: DbConnection,
   args: ListRecentStoredEventRowsArgs,

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -243,6 +243,7 @@ export {
   findStoredClientTurnRequestSequenceByRequestId,
   findStoredEventRow,
   getActiveStoredTurnId,
+  hasRootStoredTurnStarted,
   hasStoredTurnStarted,
   getLastStoredProviderThreadId,
   getStoredProviderThreadIdAtOrBeforeSequence,


### PR DESCRIPTION
## Summary

Fixes a thread lifecycle race where a delegated child turn completion could settle the whole thread from `active` to `idle` while the root turn was still running.

The fix scopes lifecycle settlement to root turns only:

- add `hasRootStoredTurnStarted()` so the server can distinguish root turns from delegated child turns using the existing `parentToolCallId` convention on stored `turn/started` rows
- ignore lifecycle settlement for child `turn/completed` events while still preserving their event storage/projection behavior
- only request queued-message auto-send when a completion actually transitions the thread to `idle`
- add a regression test for the observed failure: child turn completes, root thread remains active, `mode: "queue-if-active"` creates a queued message rather than a pending `new-turn`

## Observed thread context

Original local thread: `http://localhost:11034/projects/proj_atc2gb38gw/threads/thr_jmjz2ja9t7`

Relevant observed state:

- provider: `codex`
- provider thread id: `019ef91c-3856-7ca1-97aa-bc9ac9c56649`
- root turn still producing events: `019efb36-7452-7e10-b6f0-590a7c65778d`
- delegated/child turn completed first: `019efb3a-1490-7520-a28a-dd400a9b3ed1`
- event `70526`: child `turn/completed`, status `completed`
- event `70527`: next user message persisted as `client/turn/requested` with `target.kind = "new-turn"` and `turnRequest.status = "pending"`, not as a queued message
- later event `75518` showed the same pending normal-message shape
- event `75547` / `75548` was a steer and was accepted, which is why the thread continued working despite the normal follow-up not queueing

The important detail is that root work continued after the child completion, so the thread row should have stayed `active`.

## Reliable repro steps

These steps reproduce the bug using the new regression test while temporarily restoring the old source behavior. They do not require the original local DB.

1. Fetch and check out this PR branch:

```bash
git fetch origin bb/diagnose-thread-regression-thr_zjf8w69que
git checkout bb/diagnose-thread-regression-thr_zjf8w69que
```

2. Temporarily restore only the pre-fix source files while keeping the new regression test:

```bash
git checkout HEAD^ -- \
  apps/server/src/internal/events.ts \
  apps/server/src/internal/turn-completed-events.ts \
  packages/db/src/data/events.ts \
  packages/db/src/data/index.ts
```

3. Run the server test package:

```bash
pnpm exec turbo run test --filter=@bb/server
```

4. Expected pre-fix failure: `keeps active root turns queueable when a delegated child turn completes` fails because the child `turn/completed` moves the thread to `idle`; the follow-up no longer queues as active work.

5. Restore the fixed source files:

```bash
git checkout HEAD -- \
  apps/server/src/internal/events.ts \
  apps/server/src/internal/turn-completed-events.ts \
  packages/db/src/data/events.ts \
  packages/db/src/data/index.ts
```

6. Re-run the same test command:

```bash
pnpm exec turbo run test --filter=@bb/server
```

7. Expected fixed behavior: the server test package passes. The regression test posts this deterministic provider sequence:

| Step | Provider thread | Turn | Context |
| --- | --- | --- | --- |
| root start | `provider-thread-main` | `root-turn` | no `parentToolCallId` |
| child start | `provider-thread-main` | `delegated-child-turn` | `parentToolCallId = call-delegate-agent` |
| child complete | `provider-thread-main` | `delegated-child-turn` | status `completed` |
| user follow-up | n/a | n/a | `mode = queue-if-active`, model `gpt-5`, reasoning `medium`, permission `full` |

The fixed result is `threads.status = active`, one queued message row, and no `client/turn/requested` `new-turn` event for the follow-up.

## Why this is the fix

`turn/completed` events do not carry `parentToolCallId`, but the corresponding stored `turn/started` rows do. The lifecycle code was previously treating every completion as the current run completing. That is wrong for delegated child turns inside a still-running root turn.

By looking up the stored `turn/started` and only applying lifecycle settlement for root turns, the thread row remains aligned with the actual root run. This preserves child turn events for timeline/projection behavior without letting them incorrectly make the thread idle or trigger queued-message auto-send.

## Validation

```bash
pnpm exec turbo run test --filter=@bb/server
pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server
pnpm exec turbo run test --filter=@bb/db
git diff --check
```

Local results:

- `@bb/server` tests: 98 files, 769 tests passed
- `@bb/db` tests: 27 files, 337 tests passed
- `@bb/db` + `@bb/server` typecheck passed
- `git diff --check` passed
