### PR TITLE
[codex] Add agent loop edit composer

### DIFF
--- a/apps/app/src/hooks/usePromptDraftStorage.test.tsx
+++ b/apps/app/src/hooks/usePromptDraftStorage.test.tsx
@@ -75,6 +75,19 @@ describe("usePromptDraftStorage", () => {
       "bb.promptbox.contents-proj_prompt-thr_followup-3",
     );
   });
+
+  it("keeps automation edit drafts scoped to the automation", () => {
+    const { result } = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "automation-edit",
+        automationId: "auto_watchdog",
+      }),
+    );
+
+    expect(result.current.storageKey).toBe(
+      "bb.promptbox.contents-automation-edit-auto_watchdog-3",
+    );
+  });
 });
 
 describe("usePromptDraftStorage addQuote", () => {

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -18,6 +18,7 @@ const PROMPT_DRAFT_STORAGE_VERSION = "3";
 const PROMPT_DRAFT_PERSIST_DEBOUNCE_MS = 250;
 
 export type PromptDraftScope =
+  | { kind: "automation-edit"; automationId: string }
   | { kind: "new-thread" }
   | { kind: "side-chat"; parentThreadId: string; tabId: string }
   | { kind: "thread"; projectId: string; threadId: string };
@@ -222,6 +223,10 @@ function restorePromptDraftIfEmpty(
 }
 
 function getPromptDraftStorageKey(scope: PromptDraftScope): string | null {
+  if (scope.kind === "automation-edit") {
+    const normalizedAutomationId = normalizeStorageSegment(scope.automationId);
+    return `${PROMPT_DRAFT_STORAGE_PREFIX}-automation-edit-${normalizedAutomationId}-${PROMPT_DRAFT_STORAGE_VERSION}`;
+  }
   if (scope.kind === "new-thread") {
     return `${PROMPT_DRAFT_STORAGE_PREFIX}-draft-${PROMPT_DRAFT_STORAGE_VERSION}`;
   }

--- a/apps/app/src/views/AutomationDetailView.agent-edit.test.tsx
+++ b/apps/app/src/views/AutomationDetailView.agent-edit.test.tsx
@@ -1,0 +1,346 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { PERSONAL_PROJECT_ID, type PermissionMode } from "@bb/domain";
+import type {
+  Automation,
+  SystemExecutionOptionsResponse,
+  UpdateAutomationRequest,
+} from "@bb/server-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/api";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { AutomationDetailContent } from "./AutomationDetailView";
+
+vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
+  PromptBoxInternal: ({
+    attachments,
+    footerStart,
+    onChange,
+    onSubmit,
+    value,
+  }: {
+    attachments: {
+      onAttachFiles?: (files: File[]) => void | Promise<void>;
+    };
+    footerStart: ReactNode;
+    onChange: (value: string, mentions: []) => void;
+    onSubmit: () => void;
+    value: string;
+  }) => (
+    <div>
+      <textarea
+        aria-label="Prompt"
+        value={value}
+        onChange={(event) => onChange(event.target.value, [])}
+      />
+      <div>{footerStart}</div>
+      <button
+        type="button"
+        onClick={() =>
+          void attachments.onAttachFiles?.([
+            new File(["notes"], "notes.md", { type: "text/markdown" }),
+          ])
+        }
+      >
+        Attach
+      </button>
+      <button type="button" onClick={onSubmit}>
+        Prompt box save
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/promptbox/ExecutionControls", () => ({
+  ExecutionControls: ({
+    model,
+    provider,
+  }: {
+    model: {
+      moreOptions: readonly { label: string; value: string }[];
+      onChange: (value: string) => void;
+      options: readonly { label: string; value: string }[];
+      selected: string;
+    };
+    provider: {
+      onChange?: (value: string) => void;
+      options?: readonly { label: string; value: string }[];
+      selectedId?: string;
+    };
+  }) => (
+    <div>
+      <select
+        aria-label="Provider"
+        value={provider.selectedId ?? ""}
+        onChange={(event) => provider.onChange?.(event.target.value)}
+      >
+        {(provider.options ?? []).map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Model"
+        value={model.selected}
+        onChange={(event) => model.onChange(event.target.value)}
+      >
+        {[...model.options, ...model.moreOptions].map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/pickers/PermissionModePicker", () => ({
+  PermissionModePicker: ({
+    onChange,
+    options,
+    value,
+  }: {
+    onChange: (value: PermissionMode) => void;
+    options: readonly { label: string; value: PermissionMode }[];
+    value?: PermissionMode;
+  }) => (
+    <select
+      aria-label="Permission mode"
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value as PermissionMode)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getSystemExecutionOptions: vi.fn(),
+    uploadPromptAttachment: vi.fn(),
+  };
+});
+
+function agentAutomation(): Automation {
+  return {
+    id: "auto_watchdog",
+    projectId: PERSONAL_PROJECT_ID,
+    name: "Daily summary",
+    enabled: true,
+    trigger: {
+      triggerType: "schedule",
+      cron: "0 9 * * *",
+      timezone: "America/New_York",
+    },
+    execution: {
+      mode: "agent",
+      prompt: "Summarize yesterday.",
+      providerId: "codex",
+      model: "gpt-5",
+      permissionMode: "readonly",
+    },
+    environment: { type: "host", workspace: { type: "personal" } },
+    autoArchive: false,
+    origin: "agent",
+    createdByThreadId: null,
+    nextRunAt: 1_700_003_600_000,
+    lastRunAt: null,
+    runCount: 0,
+    lastRunStatus: null,
+    lastRunThreadId: null,
+    lastError: null,
+    createdAt: 0,
+    updatedAt: 100,
+  };
+}
+
+function executionOptionsResponse(
+  providerId?: string,
+): SystemExecutionOptionsResponse {
+  const isClaude = providerId === "claude-code";
+  return {
+    providers: [
+      {
+        id: "codex",
+        displayName: "Codex",
+        available: true,
+        composerActions: [{ kind: "skills", trigger: "/" }],
+        capabilities: {
+          supportsArchive: true,
+          supportsRename: true,
+          supportsServiceTier: false,
+          supportsUserQuestion: true,
+          supportsFork: true,
+          supportedPermissionModes: ["readonly", "workspace-write", "full"],
+        },
+      },
+      {
+        id: "claude-code",
+        displayName: "Claude Code",
+        available: true,
+        composerActions: [{ kind: "skills", trigger: "/" }],
+        capabilities: {
+          supportsArchive: true,
+          supportsRename: true,
+          supportsServiceTier: false,
+          supportsUserQuestion: true,
+          supportsFork: true,
+          supportedPermissionModes: ["readonly", "workspace-write", "full"],
+        },
+      },
+    ],
+    models: isClaude
+      ? [
+          {
+            id: "claude-sonnet",
+            model: "claude-sonnet",
+            displayName: "Claude Sonnet",
+            description: "",
+            supportedReasoningEfforts: [
+              { reasoningEffort: "medium", description: "" },
+            ],
+            defaultReasoningEffort: "medium",
+            isDefault: true,
+          },
+          {
+            id: "claude-opus",
+            model: "claude-opus",
+            displayName: "Claude Opus",
+            description: "",
+            supportedReasoningEfforts: [
+              { reasoningEffort: "medium", description: "" },
+            ],
+            defaultReasoningEffort: "medium",
+            isDefault: false,
+          },
+        ]
+      : [
+          {
+            id: "gpt-5",
+            model: "gpt-5",
+            displayName: "GPT-5",
+            description: "",
+            supportedReasoningEfforts: [
+              { reasoningEffort: "medium", description: "" },
+            ],
+            defaultReasoningEffort: "medium",
+            isDefault: true,
+          },
+        ],
+    selectedOnlyModels: [],
+    modelLoadError: null,
+  };
+}
+
+function renderDetail(
+  automation: Automation,
+  onSave: (patch: UpdateAutomationRequest) => Promise<void>,
+) {
+  const { wrapper } = createQueryClientTestHarness();
+  return render(
+    <MemoryRouter>
+      <AutomationDetailContent
+        automation={automation}
+        runs={[]}
+        runsLoading={false}
+        runsError={false}
+        onPause={() => {}}
+        onResume={() => {}}
+        onDelete={() => {}}
+        onSave={onSave}
+        savePending={false}
+        actionsPending={false}
+      />
+    </MemoryRouter>,
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.getSystemExecutionOptions).mockImplementation(({ providerId }) =>
+    Promise.resolve(executionOptionsResponse(providerId)),
+  );
+  vi.mocked(api.uploadPromptAttachment).mockResolvedValue({
+    type: "localFile",
+    path: "uploads/notes.md",
+    name: "notes.md",
+    mimeType: "text/markdown",
+    sizeBytes: 5,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("AutomationDetailContent agent editing", () => {
+  it("saves the edited prompt, provider, model, and permission", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderDetail(agentAutomation(), onSave);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const prompt = (await screen.findByLabelText(
+      "Prompt",
+    )) as HTMLTextAreaElement;
+    expect(prompt.value).toBe("Summarize yesterday.");
+
+    fireEvent.change(prompt, {
+      target: { value: "Summarize yesterday and flag blockers." },
+    });
+    fireEvent.change(screen.getByLabelText("Provider"), {
+      target: { value: "claude-code" },
+    });
+    await waitFor(() => {
+      expect((screen.getByLabelText("Model") as HTMLSelectElement).value).toBe(
+        "claude-sonnet",
+      );
+    });
+    fireEvent.change(screen.getByLabelText("Model"), {
+      target: { value: "claude-opus" },
+    });
+    fireEvent.change(screen.getByLabelText("Permission mode"), {
+      target: { value: "workspace-write" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    expect(onSave.mock.calls[0]![0]).toEqual({
+      name: "Daily summary",
+      trigger: {
+        triggerType: "schedule",
+        cron: "0 9 * * *",
+        timezone: "America/New_York",
+      },
+      autoArchive: false,
+      execution: {
+        mode: "agent",
+        prompt: "Summarize yesterday and flag blockers.",
+        providerId: "claude-code",
+        model: "claude-opus",
+        permissionMode: "workspace-write",
+      },
+    });
+  });
+});

--- a/apps/app/src/views/AutomationDetailView.tsx
+++ b/apps/app/src/views/AutomationDetailView.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   automationScriptInterpreterValues,
@@ -16,6 +22,15 @@ import {
   ConfirmDeleteDialog,
   ConfirmDeleteDialogContent,
 } from "@/components/dialogs/ConfirmDeleteDialog.js";
+import { ExecutionControls } from "@/components/promptbox/ExecutionControls";
+import { PermissionModePicker } from "@/components/pickers/PermissionModePicker";
+import { PromptBoxInternal } from "@/components/promptbox/PromptBoxInternal";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
+import {
+  permissionDisplayForPromptMode,
+  shouldDisablePermissionPickerForPromptMode,
+} from "@/components/promptbox/effective-prompt-mode";
+import { useComposerArea } from "@/components/promptbox/useComposerArea";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
@@ -302,6 +317,258 @@ function resolveTimeoutMs(timeoutSeconds: string): number {
   return clamped * 1000;
 }
 
+type AgentAutomationExecution = Extract<
+  Automation["execution"],
+  { mode: "agent" }
+>;
+
+interface AgentAutomationEditComposerProps {
+  automation: Automation;
+  execution: AgentAutomationExecution;
+  editSessionKey: number;
+  name: string;
+  cron: string;
+  timezone: string;
+  autoArchive: boolean;
+  onAutoArchiveChange: (value: boolean) => void;
+  onSave: (patch: UpdateAutomationRequest) => Promise<void>;
+  onCancel: () => void;
+  onSaved: () => void;
+  savePending: boolean;
+}
+
+function automationComposerEnvironmentId(automation: Automation): string | null {
+  return automation.environment.type === "reuse"
+    ? automation.environment.environmentId
+    : null;
+}
+
+/**
+ * Form-local composer for editing an agent loop. It reuses the prompt-box
+ * editor internals plus execution controls, but owns a form save payload rather
+ * than thread submission state.
+ */
+function AgentAutomationEditComposer({
+  automation,
+  execution,
+  editSessionKey,
+  name,
+  cron,
+  timezone,
+  autoArchive,
+  onAutoArchiveChange,
+  onSave,
+  onCancel,
+  onSaved,
+  savePending,
+}: AgentAutomationEditComposerProps) {
+  const environmentId = automationComposerEnvironmentId(automation);
+  const resolveMentionLink = useCallback<PromptMentionLinkResolver>(
+    () => null,
+    [],
+  );
+  const composerArea = useComposerArea({
+    creationOptions: {
+      scope: "component-local",
+      environmentId: environmentId ?? undefined,
+      resetKey: editSessionKey,
+      initialProviderId: execution.providerId,
+      initialModel: execution.model,
+      initialPermissionMode: execution.permissionMode,
+    },
+    draftScope: {
+      kind: "automation-edit",
+      automationId: automation.id,
+    },
+    mentionsProjectId: automation.projectId,
+    mentions: {
+      environmentId,
+    },
+    commands: {
+      projectId: automation.projectId,
+      environmentId,
+    },
+    resolveMentionLink,
+    attachments: { projectId: automation.projectId },
+    execution: { providerSwitchable: true },
+    permission: { kind: "editable" },
+  });
+  const {
+    attachmentsConfig,
+    composer,
+    executionConfig,
+    permissionConfig,
+    promptActions,
+    promptDraft,
+    setAttachmentError,
+    threadCreationOptions,
+    typeaheadConfig,
+  } = composerArea;
+
+  const { setDraft } = promptDraft;
+  useLayoutEffect(() => {
+    setDraft({
+      text: execution.prompt,
+      mentions: [],
+      attachments: [],
+    });
+    setAttachmentError(null);
+  }, [editSessionKey, execution.prompt, setAttachmentError, setDraft]);
+
+  const promptModeInput = useMemo(
+    () => ({
+      providerId: executionConfig.provider.selectedId,
+      value: composer.message,
+      mentionRanges: composer.mentionRanges,
+    }),
+    [
+      composer.mentionRanges,
+      composer.message,
+      executionConfig.provider.selectedId,
+    ],
+  );
+  const permissionDisplayOverride = useMemo(
+    () => permissionDisplayForPromptMode(promptModeInput),
+    [promptModeInput],
+  );
+  const permissionPickerDisabledByPlanMode =
+    shouldDisablePermissionPickerForPromptMode(promptModeInput);
+
+  const selectedProviderId =
+    threadCreationOptions.selectedProviderId || execution.providerId;
+  const selectedModel = threadCreationOptions.selectedModel || execution.model;
+  const selectedPermissionMode =
+    threadCreationOptions.permissionMode || execution.permissionMode;
+  const canSave =
+    !threadCreationOptions.isLoadingModels &&
+    composer.message.trim().length > 0 &&
+    selectedProviderId.length > 0 &&
+    selectedModel.length > 0;
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) {
+      return;
+    }
+    const patch: UpdateAutomationRequest = {
+      name,
+      trigger: { triggerType: "schedule", cron, timezone },
+      autoArchive,
+      execution: {
+        mode: "agent",
+        prompt: composer.message,
+        providerId: selectedProviderId,
+        model: selectedModel,
+        permissionMode: selectedPermissionMode,
+        ...(execution.targetThreadId
+          ? { targetThreadId: execution.targetThreadId }
+          : {}),
+      },
+    };
+
+    try {
+      await onSave(patch);
+      promptDraft.clear();
+      onSaved();
+    } catch {
+      // Mutation errors are surfaced by the global error handler; stay in edit
+      // mode so the user can retry without losing their changes.
+    }
+  }, [
+    autoArchive,
+    canSave,
+    composer.message,
+    cron,
+    execution.targetThreadId,
+    name,
+    onSave,
+    onSaved,
+    promptDraft,
+    selectedModel,
+    selectedPermissionMode,
+    selectedProviderId,
+    timezone,
+  ]);
+
+  const handleCancel = useCallback(() => {
+    promptDraft.clear();
+    setAttachmentError(null);
+    onCancel();
+  }, [onCancel, promptDraft, setAttachmentError]);
+
+  return (
+    <>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          Prompt
+        </label>
+        <PromptBoxInternal
+          value={composer.message}
+          mentionRanges={composer.mentionRanges}
+          onChange={composer.onChangeMessage}
+          onSubmit={handleSave}
+          placeholder="Ask anything. @ to mention files or folders"
+          typeahead={typeaheadConfig}
+          mentionMenuPlacement="bottom"
+          attachments={attachmentsConfig}
+          promptActions={promptActions}
+          footerStart={<ExecutionControls {...executionConfig} />}
+          submission={{
+            isSubmitting: savePending,
+            disabled: !canSave || savePending,
+            title: savePending ? "Saving..." : "Save changes (Enter)",
+          }}
+          zenMode={{
+            layout: "thread",
+            storageKey: null,
+            resetKey: editSessionKey,
+          }}
+        />
+        <div className="mt-1 flex min-h-6 justify-end px-3.5">
+          <PermissionModePicker
+            value={permissionConfig.value}
+            options={permissionConfig.options}
+            onChange={permissionConfig.onChange}
+            supported={permissionConfig.supported}
+            disabled={savePending || permissionPickerDisabledByPlanMode}
+            showChevronWhenDisabled={permissionPickerDisabledByPlanMode}
+            displayOverride={permissionDisplayOverride}
+            className="h-6"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-foreground">
+          Auto-archive the thread when it finishes
+        </span>
+        <Switch
+          checked={autoArchive}
+          onCheckedChange={onAutoArchiveChange}
+          aria-label="Auto-archive the thread when it finishes"
+        />
+      </div>
+      <div className="flex justify-end gap-2 pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={savePending}
+          onClick={handleCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          disabled={savePending || !canSave}
+          onClick={handleSave}
+        >
+          Save changes
+        </Button>
+      </div>
+    </>
+  );
+}
+
 interface AutomationDetailContentProps {
   automation: Automation;
   runs: readonly AutomationRun[];
@@ -333,6 +600,7 @@ export function AutomationDetailContent({
   actionsPending,
 }: AutomationDetailContentProps) {
   const [editing, setEditing] = useState(false);
+  const [editSessionKey, setEditSessionKey] = useState(0);
   const [name, setName] = useState(automation.name);
   const [cron, setCron] = useState(
     automation.trigger.triggerType === "schedule" ? automation.trigger.cron : "",
@@ -341,9 +609,6 @@ export function AutomationDetailContent({
     automation.trigger.triggerType === "schedule"
       ? automation.trigger.timezone
       : "",
-  );
-  const [prompt, setPrompt] = useState(
-    automation.execution.mode === "agent" ? automation.execution.prompt : "",
   );
   const [script, setScript] = useState(initialScript(automation));
   const [interpreter, setInterpreter] = useState<AutomationScriptInterpreter>(
@@ -366,13 +631,11 @@ export function AutomationDetailContent({
         ? automation.trigger.timezone
         : "",
     );
-    setPrompt(
-      automation.execution.mode === "agent" ? automation.execution.prompt : "",
-    );
     setScript(initialScript(automation));
     setInterpreter(initialInterpreter(automation));
     setTimeoutSeconds(initialTimeoutSeconds(automation));
     setAutoArchive(automation.autoArchive);
+    setEditSessionKey((key) => key + 1);
     setEditing(true);
   }
 
@@ -381,23 +644,11 @@ export function AutomationDetailContent({
       name,
       trigger: { triggerType: "schedule", cron, timezone },
       autoArchive,
-      ...(automation.execution.mode === "agent"
+      // Inline-content path: send `script` (not `scriptFile`) so the server
+      // rewrites the stored file. `env` is not edited here, so carry the
+      // existing value through to avoid silently dropping it.
+      ...(automation.execution.mode === "script"
         ? {
-            execution: {
-              mode: "agent" as const,
-              prompt,
-              providerId: automation.execution.providerId,
-              model: automation.execution.model,
-              permissionMode: automation.execution.permissionMode,
-              ...(automation.execution.targetThreadId
-                ? { targetThreadId: automation.execution.targetThreadId }
-                : {}),
-            },
-          }
-        : {
-            // Inline-content path: send `script` (not `scriptFile`) so the server
-            // rewrites the stored file. `env` is not edited here, so carry the
-            // existing value through to avoid silently dropping it.
             execution: {
               mode: "script" as const,
               script,
@@ -407,7 +658,8 @@ export function AutomationDetailContent({
                 ? { env: automation.execution.env }
                 : {}),
             },
-          }),
+          }
+        : {}),
     };
     try {
       await onSave(patch);
@@ -519,18 +771,20 @@ export function AutomationDetailContent({
                   {formatCronCadence(cron)}
                 </p>
                 {automation.execution.mode === "agent" ? (
-                  <div>
-                    <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                      Prompt
-                    </label>
-                    <textarea
-                      value={prompt}
-                      onChange={(event) => setPrompt(event.target.value)}
-                      rows={3}
-                      aria-label="Prompt"
-                      className="block w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    />
-                  </div>
+                  <AgentAutomationEditComposer
+                    automation={automation}
+                    execution={automation.execution}
+                    editSessionKey={editSessionKey}
+                    name={name}
+                    cron={cron}
+                    timezone={timezone}
+                    autoArchive={autoArchive}
+                    onAutoArchiveChange={setAutoArchive}
+                    onSave={onSave}
+                    onCancel={() => setEditing(false)}
+                    onSaved={() => setEditing(false)}
+                    savePending={savePending}
+                  />
                 ) : (
                   <>
                     <div>
@@ -585,41 +839,37 @@ export function AutomationDetailContent({
                         />
                       </div>
                     </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-foreground">
+                        Auto-archive the thread when it finishes
+                      </span>
+                      <Switch
+                        checked={autoArchive}
+                        onCheckedChange={setAutoArchive}
+                        aria-label="Auto-archive the thread when it finishes"
+                      />
+                    </div>
+                    <div className="flex justify-end gap-2 pt-1">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={savePending}
+                        onClick={() => setEditing(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={savePending || script.trim().length === 0}
+                        onClick={handleSave}
+                      >
+                        Save changes
+                      </Button>
+                    </div>
                   </>
                 )}
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-foreground">
-                    Auto-archive the thread when it finishes
-                  </span>
-                  <Switch
-                    checked={autoArchive}
-                    onCheckedChange={setAutoArchive}
-                    aria-label="Auto-archive the thread when it finishes"
-                  />
-                </div>
-                <div className="flex justify-end gap-2 pt-1">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={savePending}
-                    onClick={() => setEditing(false)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    disabled={
-                      savePending ||
-                      (automation.execution.mode === "script" &&
-                        script.trim().length === 0)
-                    }
-                    onClick={handleSave}
-                  >
-                    Save changes
-                  </Button>
-                </div>
               </div>
             ) : (
               <>


### PR DESCRIPTION
## Summary

- Replaces the AGENT loop edit textarea with a prompt-box composer built from `useComposerArea` parts.
- Adds an `automation-edit` prompt draft scope and seeds it from the saved loop prompt whenever edit mode opens.
- Keeps SCRIPT loop editing on the existing monospace script/interpreter/timeout form.
- Adds a regression test for saving edited prompt/provider/model/permission into `UpdateAutomationRequest`.

## Save Mapping

On AGENT loop save, the form sends:

- `execution.mode`: `"agent"`
- `execution.prompt`: `composer.message`
- `execution.providerId`: `threadCreationOptions.selectedProviderId`
- `execution.model`: `threadCreationOptions.selectedModel`
- `execution.permissionMode`: `threadCreationOptions.permissionMode`

`name`, `trigger.cron`, `trigger.timezone`, and `autoArchive` continue to come from the existing edit form state.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/views/AutomationDetailView.test.tsx src/views/AutomationDetailView.script-edit.test.tsx src/views/AutomationDetailView.agent-edit.test.tsx src/components/secondary-panel/SideChatTabContent.test.tsx src/views/RootComposeView.test.ts src/views/RootComposeSecondaryContent.test.tsx src/views/RootComposeMobileRecents.test.tsx src/views/root-compose-branch-selection.test.ts src/views/root-compose-branch-ui.test.ts src/views/root-compose-thread-environment.test.ts`
- `pnpm exec turbo run test --filter=@bb/app -- src/hooks/usePromptDraftStorage.test.tsx`