### PR TITLE
Gate Codex thread starts on supported CLI

### DIFF
--- a/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
@@ -14,7 +14,10 @@ import type {
   PromptBoxAction,
 } from "@/components/promptbox/PromptBoxInternal";
 import { CREATE_LOOP_PROMPT } from "@/components/promptbox/PromptBoxActionsMenu";
+import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
 import type { PickerOption } from "@/components/pickers/OptionPicker";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon.js";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import { ModelPickerStoryQueryProvider } from "../../../.ladle/model-picker-query-provider";
 import {
@@ -150,6 +153,33 @@ function PromptStage({ children }: PromptStageProps) {
   return <div className="mx-auto w-full max-w-[760px]">{children}</div>;
 }
 
+function UnsupportedCodexCliBanner() {
+  return (
+    <PromptStackCard ariaLabel="Codex update needed" className="overflow-hidden">
+      <div className="flex min-h-8 max-w-full items-center gap-2 px-2.5 py-1 text-xs text-muted-foreground">
+        <Icon
+          name="Info"
+          className="size-3.5 shrink-0 text-subtle-foreground"
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1 truncate">
+          Update Codex to start this thread. Installed 0.135.0; required 0.136.0
+          or newer.
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-6 shrink-0 px-2 text-xs"
+          onClick={noop}
+        >
+          Update
+        </Button>
+      </div>
+    </PromptStackCard>
+  );
+}
+
 function DefaultRow() {
   const { value, mentionRanges, onChange } = useControlledValue("");
   return (
@@ -268,6 +298,36 @@ function ModelLoadFailedRow() {
             loadError: codexModelLoadError,
           },
         }}
+      />
+    </PromptStage>
+  );
+}
+
+function UnsupportedCodexCliRow() {
+  const { value, mentionRanges, onChange } = useControlledValue(
+    "Create a loop that checks the release until CI passes.",
+  );
+  return (
+    <PromptStage>
+      <NewThreadPromptBoxUI
+        id="story-new-thread-unsupported-codex-cli"
+        value={value}
+        mentionRanges={mentionRanges}
+        onChange={onChange}
+        onSubmit={noop}
+        isSubmitting={false}
+        disabled
+        zenModeStorageKey="bb.story.new-thread.unsupported-codex-cli"
+        history={baseHistory}
+        typeahead={makeTypeahead()}
+        attachments={makeAttachments()}
+        promptActions={promptActions}
+        modeConfig={{
+          ...baseModeConfig,
+          banner: <UnsupportedCodexCliBanner />,
+        }}
+        project={baseProject}
+        execution={baseExecution}
       />
     </PromptStage>
   );
@@ -552,6 +612,12 @@ export function Overview() {
           <ModelLoadFailedRow />
         </StoryRow>
         <StoryRow
+          label="unsupported Codex CLI"
+          hint="thread creation blocked; banner exposes Update action"
+        >
+          <UnsupportedCodexCliRow />
+        </StoryRow>
+        <StoryRow
           label="missing Codex CLI"
           hint="provider-specific install help; picker menu keeps provider tabs"
         >
@@ -586,6 +652,21 @@ export function Overview() {
           hint="host picker replaces environment picker"
         >
           <ProjectlessThreadRow />
+        </StoryRow>
+      </StoryCard>
+    </ModelPickerStoryQueryProvider>
+  );
+}
+
+export function UnsupportedCodexCli() {
+  return (
+    <ModelPickerStoryQueryProvider>
+      <StoryCard>
+        <StoryRow
+          label="unsupported Codex CLI"
+          hint="Codex is installed but below bb's minimum supported version"
+        >
+          <UnsupportedCodexCliRow />
         </StoryRow>
       </StoryCard>
     </ModelPickerStoryQueryProvider>

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -123,6 +123,8 @@ export interface NewThreadModeConfig {
   branch: NewThreadBranchConfig;
   worktree: NewThreadWorktreeConfig;
   permission: ExecutionPermissionConfig;
+  /** Slot rendered above the prompt box card, matching the follow-up banner stack. */
+  banner?: ReactNode;
   /** Slot rendered inside the prompt box card, above the text area.
    * Used by RootComposeView to surface contextual creation state. */
   header?: ReactNode;
@@ -235,6 +237,9 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
       : "Submit (Enter)";
   return (
     <div data-promptbox-shell="" className="w-full">
+      {modeConfig.banner ? (
+        <div className="mb-2">{modeConfig.banner}</div>
+      ) : null}
       <PromptBoxInternal
         id={id}
         promptBoxRef={promptBoxRef}
@@ -414,6 +419,7 @@ export interface NewThreadConnectedModeConfig {
   branch: NewThreadConnectedBranchConfig;
   worktree: NewThreadWorktreeConfig;
   permission: ExecutionPermissionConfig;
+  banner?: ReactNode;
   header?: ReactNode;
 }
 
@@ -505,6 +511,7 @@ function ConnectedThreadModeBranch({
         branch: uiBranch,
         worktree: threadConfig.worktree,
         permission: threadConfig.permission,
+        banner: threadConfig.banner,
         header: threadConfig.header,
       }}
     />

--- a/apps/app/src/components/provider-cli/ProviderCliHealthToasts.tsx
+++ b/apps/app/src/components/provider-cli/ProviderCliHealthToasts.tsx
@@ -1,97 +1,21 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { appToast } from "@/components/ui/app-toast";
-import { AppToastCommandDescription } from "@/components/ui/app-toast-descriptions";
-import type {
-  ProviderCliInstallEvent,
-  ProviderCliInstallAction,
-  ProviderCliInstallActionKind,
-  ProviderCliKey,
-  ProviderCliStatus,
-  ProviderCliStatusResponse,
-} from "@bb/host-daemon-contract";
-import { providerCliKeyValues } from "@bb/host-daemon-contract";
-import { installProviderCli } from "@/lib/api-host-daemon";
+import type { ProviderCliIssue } from "./provider-cli-install";
+import {
+  buildProviderCliIssue,
+  hasProviderCliAction,
+  isProviderCliIssue,
+  providerCliEntries,
+  useProviderCliInstallRunner,
+} from "./provider-cli-install";
 import {
   useLocalProviderCliStatus,
   useSystemConfig,
 } from "@/hooks/queries/system-queries";
 import { isLoopbackOrigin } from "@/lib/system-config-atoms";
-import {
-  ProviderCliInstallLogDialog,
-  type ProviderCliInstallLogDialogState,
-} from "@/components/dialogs/ProviderCliInstallLogDialog";
-
-type ProviderCliInstallCompletedEvent = Extract<
-  ProviderCliInstallEvent,
-  { type: "completed" }
->;
-
-interface ProviderCliStatusEntry {
-  provider: ProviderCliKey;
-  status: ProviderCliStatus;
-}
-
-interface ProviderCliToastIssue {
-  provider: ProviderCliKey;
-  status: ProviderCliStatus;
-  action: ProviderCliStatus["installAction"];
-  title: string;
-  description: string;
-  fingerprint: string;
-  toastId: string;
-}
-
-interface ProviderCliActionableToastIssue extends ProviderCliToastIssue {
-  action: ProviderCliInstallAction;
-}
-
-interface ShowProviderCliInstallFailureToastParams {
-  issue: ProviderCliActionableToastIssue;
-  log: string;
-  message: string;
-  onViewLog: ViewProviderCliInstallLog;
-  toastId: string;
-}
-
-type ViewProviderCliInstallLog = (
-  state: ProviderCliInstallLogDialogState,
-) => void;
-
-type ProviderCliTitlePhase = "progress" | "success" | "failure" | "log";
-
-type ProviderCliTitleTemplate = (displayName: string) => string;
-
-type StartProviderCliInstall = (issue: ProviderCliActionableToastIssue) => void;
-
-interface GetProviderCliTitleParams {
-  issue: ProviderCliActionableToastIssue;
-  phase: ProviderCliTitlePhase;
-}
 
 const PROVIDER_CLI_TOAST_DISMISSED_STORAGE_KEY_PREFIX =
   "bb:provider-cli-toast:dismissed-v2:";
-
-const PROVIDER_CLI_TITLE_TEMPLATES = {
-  progress: {
-    install: (displayName) => `Installing ${displayName}`,
-    update: (displayName) => `Updating ${displayName}`,
-  },
-  success: {
-    install: (displayName) => `${displayName} installed`,
-    update: (displayName) => `${displayName} is up to date`,
-  },
-  failure: {
-    install: (displayName) => `${displayName} install failed`,
-    update: (displayName) => `${displayName} update failed`,
-  },
-  log: {
-    install: (displayName) => `${displayName} install log`,
-    update: (displayName) => `${displayName} update log`,
-  },
-} satisfies Record<
-  ProviderCliTitlePhase,
-  Record<ProviderCliInstallActionKind, ProviderCliTitleTemplate>
->;
 
 function getLocalStorage(): Storage | null {
   if (typeof window === "undefined") {
@@ -144,115 +68,6 @@ function clearDismissedForFingerprint(fingerprint: string): void {
   }
 }
 
-function providerCliEntries(
-  status: ProviderCliStatusResponse,
-): ProviderCliStatusEntry[] {
-  return providerCliKeyValues.map((provider) => ({
-    provider,
-    status: status[provider],
-  }));
-}
-
-function buildProviderCliIssue(
-  entry: ProviderCliStatusEntry,
-): ProviderCliToastIssue | null {
-  const { provider, status } = entry;
-  const toastId = `provider-cli-health:${provider}`;
-  if (!status.installed) {
-    return {
-      provider,
-      status,
-      action: status.installAction,
-      title: `${status.displayName} CLI not installed`,
-      description: `Install ${status.displayName} so bb can start ${status.displayName} sessions.`,
-      fingerprint: `${provider}:missing:${status.latestVersion ?? "latest"}`,
-      toastId,
-    };
-  }
-
-  if (status.needsUpdate) {
-    if (status.installAction === null) {
-      return null;
-    }
-    const description = `${status.currentVersion ?? "Installed version unknown"} -> ${status.latestVersion ?? "latest"}`;
-    const fingerprint = [
-      provider,
-      "outdated",
-      status.installSource,
-      status.currentVersion ?? "unknown",
-      status.latestVersion ?? "unknown",
-      status.executablePath ?? status.executableName,
-    ].join(":");
-    return {
-      provider,
-      status,
-      action: status.installAction,
-      title: `${status.displayName} update available`,
-      description,
-      fingerprint,
-      toastId,
-    };
-  }
-
-  return null;
-}
-
-function isProviderCliToastIssue(
-  issue: ProviderCliToastIssue | null,
-): issue is ProviderCliToastIssue {
-  return issue !== null;
-}
-
-function hasProviderCliAction(
-  issue: ProviderCliToastIssue,
-): issue is ProviderCliActionableToastIssue {
-  return issue.action !== null;
-}
-
-function exitDescription(event: ProviderCliInstallCompletedEvent): string {
-  if (event.exitCode !== null) {
-    return `Command exited with code ${event.exitCode}`;
-  }
-  return `Command exited after signal ${event.signal ?? "unknown"}`;
-}
-
-function getProviderCliRunToastId(provider: ProviderCliKey): string {
-  return `provider-cli-health-run:${provider}`;
-}
-
-function getProviderCliTitle({
-  issue,
-  phase,
-}: GetProviderCliTitleParams): string {
-  return PROVIDER_CLI_TITLE_TEMPLATES[phase][issue.action.kind](
-    issue.status.displayName,
-  );
-}
-
-function showProviderCliInstallFailureToast({
-  issue,
-  log,
-  message,
-  onViewLog,
-  toastId,
-}: ShowProviderCliInstallFailureToastParams): void {
-  const logDialogState: ProviderCliInstallLogDialogState = {
-    displayName: issue.status.displayName,
-    log,
-    message,
-    title: getProviderCliTitle({ issue, phase: "log" }),
-  };
-
-  appToast.error(getProviderCliTitle({ issue, phase: "failure" }), {
-    id: toastId,
-    description: message,
-    action: {
-      label: "View log",
-      onClick: () => onViewLog(logDialogState),
-    },
-  });
-}
-
 export function ProviderCliHealthToasts() {
   const systemConfig = useSystemConfig();
   // Only probe the loopback-bound daemon when the page is itself a loopback
@@ -265,142 +80,32 @@ export function ProviderCliHealthToasts() {
     enabled: daemonPort !== null,
   });
   const refetchProviderCliStatus = providerCliStatus.refetch;
+  const { installLogDialog, startInstall } = useProviderCliInstallRunner({
+    daemonPort,
+    onStatusUpdated: () => {
+      void refetchProviderCliStatus();
+    },
+  });
   const dismissedFingerprintsRef = useRef<Set<string>>(new Set());
   const shownFingerprintsRef = useRef<Set<string>>(new Set());
-  const activeIssuesRef = useRef<Map<string, ProviderCliToastIssue>>(new Map());
-  const runningProviderRef = useRef<ProviderCliKey | null>(null);
-  const [logDialogState, setLogDialogState] =
-    useState<ProviderCliInstallLogDialogState | null>(null);
+  const activeIssuesRef = useRef<Map<string, ProviderCliIssue>>(new Map());
 
-  const markIssueDismissed = useCallback((issue: ProviderCliToastIssue) => {
+  const markIssueDismissed = useCallback((issue: ProviderCliIssue) => {
     dismissedFingerprintsRef.current.add(issue.fingerprint);
     markDismissedForFingerprint(issue.fingerprint);
   }, []);
 
-  const clearIssueDismissal = useCallback((issue: ProviderCliToastIssue) => {
+  const clearIssueDismissal = useCallback((issue: ProviderCliIssue) => {
     dismissedFingerprintsRef.current.delete(issue.fingerprint);
     clearDismissedForFingerprint(issue.fingerprint);
   }, []);
 
   const dismissIssue = useCallback(
-    (issue: ProviderCliToastIssue) => {
+    (issue: ProviderCliIssue) => {
       markIssueDismissed(issue);
       appToast.dismiss(issue.toastId);
     },
     [markIssueDismissed],
-  );
-
-  const handleCloseProviderCliInstallLog = useCallback(() => {
-    setLogDialogState(null);
-  }, []);
-
-  const startInstall = useCallback<StartProviderCliInstall>(
-    (issue) => {
-      const action = issue.action;
-      if (daemonPort === null) {
-        appToast.error("Host daemon unavailable", {
-          description: "Start bb again and retry the provider CLI setup.",
-        });
-        return;
-      }
-      if (runningProviderRef.current !== null) {
-        appToast.warning("Provider CLI setup already running", {
-          description: "Wait for the current install or update to finish.",
-        });
-        return;
-      }
-
-      runningProviderRef.current = issue.provider;
-      appToast.dismiss(issue.toastId);
-      const runToastId = getProviderCliRunToastId(issue.provider);
-      let installLogChunks = [`$ ${action.command}\n`];
-      let completedEvent: ProviderCliInstallCompletedEvent | null = null;
-      let errorMessage: string | null = null;
-
-      appToast.loading(getProviderCliTitle({ issue, phase: "progress" }), {
-        id: runToastId,
-        description: <AppToastCommandDescription command={action.command} />,
-      });
-
-      void installProviderCli({
-        port: daemonPort,
-        request: {
-          provider: issue.provider,
-          actionKind: action.kind,
-        },
-        onEvent: (event) => {
-          if (event.provider !== issue.provider) {
-            return;
-          }
-          switch (event.type) {
-            case "started":
-              installLogChunks = [`$ ${event.command}\n`];
-              appToast.loading(
-                getProviderCliTitle({ issue, phase: "progress" }),
-                {
-                  id: runToastId,
-                  description: (
-                    <AppToastCommandDescription command={event.command} />
-                  ),
-                },
-              );
-              break;
-            case "output":
-              if (event.text.length > 0) {
-                installLogChunks.push(event.text);
-              }
-              break;
-            case "completed":
-              completedEvent = event;
-              break;
-            case "error":
-              errorMessage = event.message;
-              installLogChunks.push(`\n${event.message}\n`);
-              break;
-          }
-        },
-      })
-        .then(() => {
-          if (completedEvent?.success) {
-            appToast.success(getProviderCliTitle({ issue, phase: "success" }), {
-              id: runToastId,
-            });
-            void refetchProviderCliStatus();
-            return;
-          }
-
-          const failureMessage =
-            errorMessage ??
-            (completedEvent
-              ? exitDescription(completedEvent)
-              : "Command finished without reporting success.");
-          showProviderCliInstallFailureToast({
-            issue,
-            log: installLogChunks.join(""),
-            message: failureMessage,
-            onViewLog: setLogDialogState,
-            toastId: runToastId,
-          });
-        })
-        .catch((error) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          installLogChunks.push(`\n${message}\n`);
-          showProviderCliInstallFailureToast({
-            issue,
-            log: installLogChunks.join(""),
-            message,
-            onViewLog: setLogDialogState,
-            toastId: runToastId,
-          });
-        })
-        .finally(() => {
-          if (runningProviderRef.current === issue.provider) {
-            runningProviderRef.current = null;
-          }
-        });
-    },
-    [daemonPort, refetchProviderCliStatus],
   );
 
   useEffect(() => {
@@ -411,8 +116,8 @@ export function ProviderCliHealthToasts() {
 
     const currentIssues = providerCliEntries(data)
       .map(buildProviderCliIssue)
-      .filter(isProviderCliToastIssue);
-    const currentIssuesByFingerprint = new Map<string, ProviderCliToastIssue>();
+      .filter(isProviderCliIssue);
+    const currentIssuesByFingerprint = new Map<string, ProviderCliIssue>();
 
     for (const issue of currentIssues) {
       currentIssuesByFingerprint.set(issue.fingerprint, issue);
@@ -473,10 +178,5 @@ export function ProviderCliHealthToasts() {
     }
   }, [clearIssueDismissal, dismissIssue, providerCliStatus.data, startInstall]);
 
-  return (
-    <ProviderCliInstallLogDialog
-      state={logDialogState}
-      onClose={handleCloseProviderCliInstallLog}
-    />
-  );
+  return installLogDialog;
 }

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useRef, useState } from "react";
+import type {
+  ProviderCliInstallAction,
+  ProviderCliInstallActionKind,
+  ProviderCliInstallEvent,
+  ProviderCliKey,
+  ProviderCliStatus,
+  ProviderCliStatusResponse,
+} from "@bb/host-daemon-contract";
+import { providerCliKeyValues } from "@bb/host-daemon-contract";
+import { ProviderCliInstallLogDialog } from "@/components/dialogs/ProviderCliInstallLogDialog";
+import type { ProviderCliInstallLogDialogState } from "@/components/dialogs/ProviderCliInstallLogDialog";
+import { appToast } from "@/components/ui/app-toast";
+import { AppToastCommandDescription } from "@/components/ui/app-toast-descriptions";
+import { installProviderCli } from "@/lib/api-host-daemon";
+
+type ProviderCliInstallCompletedEvent = Extract<
+  ProviderCliInstallEvent,
+  { type: "completed" }
+>;
+
+export interface ProviderCliStatusEntry {
+  provider: ProviderCliKey;
+  status: ProviderCliStatus;
+}
+
+export interface ProviderCliIssue {
+  provider: ProviderCliKey;
+  status: ProviderCliStatus;
+  action: ProviderCliStatus["installAction"];
+  title: string;
+  description: string;
+  fingerprint: string;
+  toastId: string;
+}
+
+export interface ProviderCliActionableIssue extends ProviderCliIssue {
+  action: ProviderCliInstallAction;
+}
+
+type ProviderCliTitlePhase = "progress" | "success" | "failure" | "log";
+type ProviderCliTitleTemplate = (displayName: string) => string;
+
+interface GetProviderCliTitleParams {
+  issue: ProviderCliActionableIssue;
+  phase: ProviderCliTitlePhase;
+}
+
+interface UseProviderCliInstallRunnerArgs {
+  daemonPort: number | null;
+  onStatusUpdated?: () => void;
+}
+
+interface ShowProviderCliInstallFailureToastParams {
+  issue: ProviderCliActionableIssue;
+  log: string;
+  message: string;
+  onViewLog: (state: ProviderCliInstallLogDialogState) => void;
+  toastId: string;
+}
+
+const PROVIDER_CLI_TITLE_TEMPLATES = {
+  progress: {
+    install: (displayName) => `Installing ${displayName}`,
+    update: (displayName) => `Updating ${displayName}`,
+  },
+  success: {
+    install: (displayName) => `${displayName} installed`,
+    update: (displayName) => `${displayName} is up to date`,
+  },
+  failure: {
+    install: (displayName) => `${displayName} install failed`,
+    update: (displayName) => `${displayName} update failed`,
+  },
+  log: {
+    install: (displayName) => `${displayName} install log`,
+    update: (displayName) => `${displayName} update log`,
+  },
+} satisfies Record<
+  ProviderCliTitlePhase,
+  Record<ProviderCliInstallActionKind, ProviderCliTitleTemplate>
+>;
+
+export function providerCliEntries(
+  status: ProviderCliStatusResponse,
+): ProviderCliStatusEntry[] {
+  return providerCliKeyValues.map((provider) => ({
+    provider,
+    status: status[provider],
+  }));
+}
+
+export function buildProviderCliIssue(
+  entry: ProviderCliStatusEntry,
+): ProviderCliIssue | null {
+  const { provider, status } = entry;
+  const toastId = `provider-cli-health:${provider}`;
+  if (!status.installed) {
+    return {
+      provider,
+      status,
+      action: status.installAction,
+      title: `${status.displayName} CLI not installed`,
+      description: `Install ${status.displayName} so bb can start ${status.displayName} sessions.`,
+      fingerprint: `${provider}:missing:${status.latestVersion ?? "latest"}`,
+      toastId,
+    };
+  }
+
+  if (status.versionUnsupported) {
+    const currentVersion = status.currentVersion ?? "Installed version unknown";
+    const minimumVersion = status.minimumSupportedVersion ?? "a newer version";
+    const requiredDescription = status.minimumSupportedVersion
+      ? `required ${status.minimumSupportedVersion}+`
+      : "requires a newer version";
+    return {
+      provider,
+      status,
+      action: status.installAction,
+      title: `${status.displayName} update needed`,
+      description: `${currentVersion}; ${requiredDescription}`,
+      fingerprint: [
+        provider,
+        "unsupported",
+        status.installSource,
+        status.currentVersion ?? "unknown",
+        minimumVersion,
+        status.executablePath ?? status.executableName,
+      ].join(":"),
+      toastId,
+    };
+  }
+
+  if (status.needsUpdate) {
+    if (status.installAction === null) {
+      return null;
+    }
+    const description = `${status.currentVersion ?? "Installed version unknown"} -> ${status.latestVersion ?? "latest"}`;
+    const fingerprint = [
+      provider,
+      "outdated",
+      status.installSource,
+      status.currentVersion ?? "unknown",
+      status.latestVersion ?? "unknown",
+      status.executablePath ?? status.executableName,
+    ].join(":");
+    return {
+      provider,
+      status,
+      action: status.installAction,
+      title: `${status.displayName} update available`,
+      description,
+      fingerprint,
+      toastId,
+    };
+  }
+
+  return null;
+}
+
+export function isProviderCliIssue(
+  issue: ProviderCliIssue | null,
+): issue is ProviderCliIssue {
+  return issue !== null;
+}
+
+export function hasProviderCliAction(
+  issue: ProviderCliIssue,
+): issue is ProviderCliActionableIssue {
+  return issue.action !== null;
+}
+
+function exitDescription(event: ProviderCliInstallCompletedEvent): string {
+  if (event.exitCode !== null) {
+    return `Command exited with code ${event.exitCode}`;
+  }
+  return `Command exited after signal ${event.signal ?? "unknown"}`;
+}
+
+function getProviderCliRunToastId(provider: ProviderCliKey): string {
+  return `provider-cli-health-run:${provider}`;
+}
+
+function getProviderCliTitle({
+  issue,
+  phase,
+}: GetProviderCliTitleParams): string {
+  return PROVIDER_CLI_TITLE_TEMPLATES[phase][issue.action.kind](
+    issue.status.displayName,
+  );
+}
+
+function showProviderCliInstallFailureToast({
+  issue,
+  log,
+  message,
+  onViewLog,
+  toastId,
+}: ShowProviderCliInstallFailureToastParams): void {
+  const logDialogState: ProviderCliInstallLogDialogState = {
+    displayName: issue.status.displayName,
+    log,
+    message,
+    title: getProviderCliTitle({ issue, phase: "log" }),
+  };
+
+  appToast.error(getProviderCliTitle({ issue, phase: "failure" }), {
+    id: toastId,
+    description: message,
+    action: {
+      label: "View log",
+      onClick: () => onViewLog(logDialogState),
+    },
+  });
+}
+
+export function useProviderCliInstallRunner({
+  daemonPort,
+  onStatusUpdated,
+}: UseProviderCliInstallRunnerArgs) {
+  const runningProviderRef = useRef<ProviderCliKey | null>(null);
+  const [runningProvider, setRunningProvider] = useState<ProviderCliKey | null>(
+    null,
+  );
+  const [logDialogState, setLogDialogState] =
+    useState<ProviderCliInstallLogDialogState | null>(null);
+
+  const handleCloseProviderCliInstallLog = useCallback(() => {
+    setLogDialogState(null);
+  }, []);
+
+  const startInstall = useCallback(
+    (issue: ProviderCliActionableIssue) => {
+      const action = issue.action;
+      if (daemonPort === null) {
+        appToast.error("Host daemon unavailable", {
+          description: "Start bb again and retry the provider CLI setup.",
+        });
+        return;
+      }
+      if (runningProviderRef.current !== null) {
+        appToast.warning("Provider CLI setup already running", {
+          description: "Wait for the current install or update to finish.",
+        });
+        return;
+      }
+
+      runningProviderRef.current = issue.provider;
+      setRunningProvider(issue.provider);
+      appToast.dismiss(issue.toastId);
+      const runToastId = getProviderCliRunToastId(issue.provider);
+      let installLogChunks = [`$ ${action.command}\n`];
+      let completedEvent: ProviderCliInstallCompletedEvent | null = null;
+      let errorMessage: string | null = null;
+
+      appToast.loading(getProviderCliTitle({ issue, phase: "progress" }), {
+        id: runToastId,
+        description: <AppToastCommandDescription command={action.command} />,
+      });
+
+      void installProviderCli({
+        port: daemonPort,
+        request: {
+          provider: issue.provider,
+          actionKind: action.kind,
+        },
+        onEvent: (event) => {
+          if (event.provider !== issue.provider) {
+            return;
+          }
+          switch (event.type) {
+            case "started":
+              installLogChunks = [`$ ${event.command}\n`];
+              appToast.loading(
+                getProviderCliTitle({ issue, phase: "progress" }),
+                {
+                  id: runToastId,
+                  description: (
+                    <AppToastCommandDescription command={event.command} />
+                  ),
+                },
+              );
+              break;
+            case "output":
+              if (event.text.length > 0) {
+                installLogChunks.push(event.text);
+              }
+              break;
+            case "completed":
+              completedEvent = event;
+              break;
+            case "error":
+              errorMessage = event.message;
+              installLogChunks.push(`\n${event.message}\n`);
+              break;
+          }
+        },
+      })
+        .then(() => {
+          if (completedEvent?.success) {
+            appToast.success(getProviderCliTitle({ issue, phase: "success" }), {
+              id: runToastId,
+            });
+            onStatusUpdated?.();
+            return;
+          }
+
+          const failureMessage =
+            errorMessage ??
+            (completedEvent
+              ? exitDescription(completedEvent)
+              : "Command finished without reporting success.");
+          showProviderCliInstallFailureToast({
+            issue,
+            log: installLogChunks.join(""),
+            message: failureMessage,
+            onViewLog: setLogDialogState,
+            toastId: runToastId,
+          });
+        })
+        .catch((error) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          installLogChunks.push(`\n${message}\n`);
+          showProviderCliInstallFailureToast({
+            issue,
+            log: installLogChunks.join(""),
+            message,
+            onViewLog: setLogDialogState,
+            toastId: runToastId,
+          });
+        })
+        .finally(() => {
+          if (runningProviderRef.current === issue.provider) {
+            runningProviderRef.current = null;
+            setRunningProvider(null);
+          }
+        });
+    },
+    [daemonPort, onStatusUpdated],
+  );
+
+  return {
+    installLogDialog: (
+      <ProviderCliInstallLogDialog
+        state={logDialogState}
+        onClose={handleCloseProviderCliInstallLog}
+      />
+    ),
+    runningProvider,
+    startInstall,
+  };
+}

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -27,6 +27,13 @@ import {
   NewThreadPromptBox,
   type NewThreadProjectConfig,
 } from "@/components/promptbox/NewThreadPromptBox";
+import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
+import {
+  buildProviderCliIssue,
+  hasProviderCliAction,
+  useProviderCliInstallRunner,
+  type ProviderCliActionableIssue,
+} from "@/components/provider-cli/provider-cli-install";
 import { withLoopPromptAction } from "@/components/promptbox/PromptBoxActionsMenu";
 import { buildProviderPromptActionProps } from "@/components/promptbox/mentions/command-trigger";
 import { type PromptBoxHandle } from "@/components/promptbox/PromptBoxInternal";
@@ -72,6 +79,10 @@ import {
 } from "@/hooks/queries/project-queries";
 import { useEnvironment } from "@/hooks/queries/environment-queries";
 import { useProjectDefaultExecutionOptions } from "@/hooks/queries/project-default-execution-options-query";
+import {
+  useLocalProviderCliStatus,
+  useSystemConfig,
+} from "@/hooks/queries/system-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useThreads } from "@/hooks/queries/thread-queries";
 import { useCommandSuggestions } from "@/hooks/useCommandSuggestions";
@@ -134,6 +145,7 @@ import {
   useRootComposeProjectId,
   useSetRootComposeProjectId,
 } from "@/lib/root-compose-selection";
+import { isLoopbackOrigin } from "@/lib/system-config-atoms";
 import { RootComposeSecondaryContent } from "./RootComposeSecondaryContent";
 import {
   buildRootComposeBranchUiState,
@@ -630,6 +642,56 @@ function LegacyProjectComposeRedirect({
   );
 }
 
+interface CodexCliVersionBannerProps {
+  currentVersion: string | null;
+  minimumSupportedVersion: string | null;
+  issue: ProviderCliActionableIssue | null;
+  updating: boolean;
+  onUpdate: () => void;
+}
+
+function CodexCliVersionBanner({
+  currentVersion,
+  minimumSupportedVersion,
+  issue,
+  updating,
+  onUpdate,
+}: CodexCliVersionBannerProps) {
+  const minimumVersion = minimumSupportedVersion ?? "a newer version";
+  const versionCopy = currentVersion
+    ? `Installed ${currentVersion}; required ${minimumVersion} or newer.`
+    : `Required ${minimumVersion} or newer.`;
+  return (
+    <PromptStackCard
+      ariaLabel="Codex update needed"
+      className="overflow-hidden"
+    >
+      <div className="flex min-h-8 max-w-full items-center gap-2 px-2.5 py-1 text-xs text-muted-foreground">
+        <Icon
+          name="Info"
+          className="size-3.5 shrink-0 text-subtle-foreground"
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1 truncate">
+          Update Codex to start this thread. {versionCopy}
+        </span>
+        {issue ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-6 shrink-0 px-2 text-xs"
+            disabled={updating}
+            onClick={onUpdate}
+          >
+            {updating ? "Updating" : issue.action.label}
+          </Button>
+        ) : null}
+      </div>
+    </PromptStackCard>
+  );
+}
+
 export function RootComposeRoute() {
   const { projectId } = useParams<{ projectId: string }>();
 
@@ -784,6 +846,45 @@ export function RootComposeView(props: RootComposeViewProps) {
     serviceTierSupportByProvider,
   } = creationOptions;
   const executionInputSources = creationOptions.executionInputSources;
+  const providerCliSystemConfig = useSystemConfig();
+  const providerCliDaemonPort = isLoopbackOrigin()
+    ? (providerCliSystemConfig.data?.hostDaemonPort ?? null)
+    : null;
+  const providerCliStatus = useLocalProviderCliStatus({
+    daemonPort: providerCliDaemonPort,
+    enabled: providerCliDaemonPort !== null,
+  });
+  const refetchProviderCliStatus = providerCliStatus.refetch;
+  const {
+    installLogDialog: providerCliInstallLogDialog,
+    runningProvider,
+    startInstall,
+  } = useProviderCliInstallRunner({
+    daemonPort: providerCliDaemonPort,
+    onStatusUpdated: () => {
+      void refetchProviderCliStatus();
+    },
+  });
+  const codexCliStatus = providerCliStatus.data?.codex ?? null;
+  const isCodexCliVersionBlocked =
+    selectedProviderId === "codex" &&
+    codexCliStatus?.versionUnsupported === true;
+  const codexCliIssue = useMemo(() => {
+    if (!isCodexCliVersionBlocked || codexCliStatus === null) {
+      return null;
+    }
+    const issue = buildProviderCliIssue({
+      provider: "codex",
+      status: codexCliStatus,
+    });
+    return issue && hasProviderCliAction(issue) ? issue : null;
+  }, [codexCliStatus, isCodexCliVersionBlocked]);
+  const handleUpdateCodexCli = useCallback(() => {
+    if (codexCliIssue === null) {
+      return;
+    }
+    startInstall(codexCliIssue);
+  }, [codexCliIssue, startInstall]);
 
   // Seed transient picker state from navigation state: `reuseEnvironmentId`
   // (the "+" affordance on a worktree) seeds the env picker into reuse mode for
@@ -1114,6 +1215,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     if (
       submittedInput.length === 0 ||
       createThread.isPending ||
+      isCodexCliVersionBlocked ||
       (forkSeed === null && !selectedEnvironment)
     ) {
       return;
@@ -1180,6 +1282,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     createThread,
     executionInputSources,
     forkSeed,
+    isCodexCliVersionBlocked,
     navigate,
     navigateToThreadAfterCreate,
     permissionMode,
@@ -1200,6 +1303,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     isLoadingModels ||
     modelLoadError?.code === "missing_executable" ||
     modelLoadError?.code === "auth_required" ||
+    isCodexCliVersionBlocked ||
     !selectedThreadModel ||
     createThread.isPending ||
     promptInput.length === 0 ||
@@ -2491,7 +2595,9 @@ export function RootComposeView(props: RootComposeViewProps) {
   }, []);
 
   const promptHeader = useMemo(() => {
-    if (forkSeed === null) return null;
+    if (forkSeed === null) {
+      return null;
+    }
     return (
       <div className="flex">
         {/* `-ml-1.5` shifts the pill 6px left so its icon column lines up
@@ -2518,6 +2624,27 @@ export function RootComposeView(props: RootComposeViewProps) {
       </div>
     );
   }, [forkSeed, handleCancelForkDraft]);
+
+  const promptBanner = useMemo(() => {
+    if (!isCodexCliVersionBlocked || codexCliStatus === null) {
+      return null;
+    }
+    return (
+      <CodexCliVersionBanner
+        currentVersion={codexCliStatus.currentVersion}
+        minimumSupportedVersion={codexCliStatus.minimumSupportedVersion}
+        issue={codexCliIssue}
+        updating={runningProvider === "codex"}
+        onUpdate={handleUpdateCodexCli}
+      />
+    );
+  }, [
+    codexCliIssue,
+    codexCliStatus,
+    handleUpdateCodexCli,
+    isCodexCliVersionBlocked,
+    runningProvider,
+  ]);
 
   if (!hasSidebarNavigationSettled) {
     return (
@@ -2558,6 +2685,7 @@ export function RootComposeView(props: RootComposeViewProps) {
         branch: branchConfig,
         worktree: worktreeConfig,
         permission: permissionConfig,
+        banner: promptBanner,
         header: promptHeader,
       }}
       project={{
@@ -2578,11 +2706,17 @@ export function RootComposeView(props: RootComposeViewProps) {
   );
 
   if (props.surface === "popout") {
-    return <div className="w-full">{promptBox}</div>;
+    return (
+      <>
+        <div className="w-full">{promptBox}</div>
+        {providerCliInstallLogDialog}
+      </>
+    );
   }
 
   return (
     <>
+      {providerCliInstallLogDialog}
       {rootPanelToggle}
       <RootComposeSecondaryContent
         contentClassName={

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -11,6 +11,7 @@ import type {
   HostDaemonAcpLaunchSpec,
   HostDaemonInjectedSkillSource,
   HostDaemonOnlineRpcCommand,
+  ProviderCliStatus,
   WorkspaceContext,
 } from "@bb/host-daemon-contract";
 import { getPersonalWorkspaceRoot } from "@bb/host-workspace";
@@ -49,6 +50,9 @@ export interface CommandDispatchOptions {
     models: AvailableModel[];
     selectedOnlyModels: AvailableModel[];
   }>;
+  getProviderCliStatusForProvider?: (
+    providerId: string,
+  ) => Promise<ProviderCliStatus | null>;
   resolveInteractiveRequest?: (
     request: InteractiveResolveCommandInput,
   ) => Promise<void>;

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentRuntime } from "@bb/agent-runtime";
-import type { HostDaemonInjectedSkillSource } from "@bb/host-daemon-contract";
+import type {
+  HostDaemonInjectedSkillSource,
+  ProviderCliStatus,
+} from "@bb/host-daemon-contract";
 import type { HostWorkspace } from "@bb/host-workspace";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import { dispatchCommand } from "./command-dispatch.js";
@@ -281,6 +284,134 @@ describe("dispatchCommand", () => {
 
     expect(result).toEqual({});
     expect(runtime.renameThread).not.toHaveBeenCalled();
+  });
+
+  it("blocks codex thread.start when the CLI is below the minimum version", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    const command: CommandOf<"thread.start"> = {
+      type: "thread.start",
+      environmentId: "env-1",
+      threadId: "thread-1",
+      workspaceContext: {
+        workspacePath: WORKSPACE_PATH,
+        workspaceProvisionType: "unmanaged",
+      },
+      projectId: "proj_1",
+      providerId: "codex",
+      requestId: "creq_unsupported_codex",
+      input: [{ type: "text", text: "hello", mentions: [] }],
+      options: {
+        model: "gpt-5",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        workflowsEnabled: false,
+        permissionMode: "full",
+        permissionEscalation: null,
+      },
+      instructions: "Be concise.",
+      dynamicTools: [],
+      injectedSkillSources: [],
+      instructionMode: "append",
+    };
+
+    const unsupportedCodexStatus: ProviderCliStatus = {
+      displayName: "Codex",
+      executableName: "codex",
+      executablePath: "/usr/local/bin/codex",
+      installed: true,
+      installSource: "npmGlobal",
+      currentVersion: "0.135.0",
+      latestVersion: null,
+      minimumSupportedVersion: "0.136.0",
+      npmPackageName: "@openai/codex",
+      npmGlobalPackageVersion: "0.135.0",
+      installAction: {
+        kind: "update",
+        label: "Update",
+        commandKind: "exec",
+        command: "codex update",
+      },
+      needsUpdate: false,
+      versionUnsupported: true,
+    };
+
+    await expect(
+      dispatchCommand(command, {
+        dataDir: "/tmp/bb-data",
+        eventSink: {
+          emit: vi.fn(),
+          flush: vi.fn(async () => undefined),
+        },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        getProviderCliStatusForProvider: async () => unsupportedCodexStatus,
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      }),
+    ).rejects.toMatchObject({
+      code: "provider_cli_unsupported_version",
+    });
+
+    expect(runtime.startThread).not.toHaveBeenCalled();
+  });
+
+  it("does not check Codex CLI status for non-Codex thread.start", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    const command: CommandOf<"thread.start"> = {
+      type: "thread.start",
+      environmentId: "env-1",
+      threadId: "thread-1",
+      workspaceContext: {
+        workspacePath: WORKSPACE_PATH,
+        workspaceProvisionType: "unmanaged",
+      },
+      projectId: "proj_1",
+      providerId: "claude-code",
+      requestId: "creq_non_codex",
+      input: [{ type: "text", text: "hello", mentions: [] }],
+      options: {
+        model: "claude-sonnet-4-6",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        workflowsEnabled: false,
+        permissionMode: "full",
+        permissionEscalation: null,
+      },
+      instructions: "Be concise.",
+      dynamicTools: [],
+      injectedSkillSources: [],
+      instructionMode: "append",
+    };
+    const getProviderCliStatusForProvider = vi.fn(async () => {
+      throw new Error("Codex CLI status should not be checked");
+    });
+
+    const result = await dispatchCommand(command, {
+      dataDir: "/tmp/bb-data",
+      eventSink: {
+        emit: vi.fn(),
+        flush: vi.fn(async () => undefined),
+      },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      getProviderCliStatusForProvider,
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    });
+
+    expect(result).toEqual({ providerThreadId: "provider-thread-1" });
+    expect(getProviderCliStatusForProvider).not.toHaveBeenCalled();
+    expect(runtime.startThread).toHaveBeenCalledOnce();
   });
 
   // Regression: a thread.start whose freshly staged skill catalog differed

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -5,6 +5,7 @@ import { resolveContainedPath } from "@bb/process-utils";
 import type { RuntimeEntry } from "../runtime-manager.js";
 import {
   CommandDispatchError,
+  ExpectedCommandDispatchError,
   type CommandDispatchOptions,
   type CommandOf,
 } from "../command-dispatch-support.js";
@@ -13,6 +14,7 @@ import {
   stagePromptAttachments,
 } from "./prompt-attachments.js";
 import { requireResolvedWorkspaceForCommand } from "../workspace-resolution.js";
+import { getProviderCliStatusForProvider } from "../provider-cli-health.js";
 
 type TurnSubmitCommand = CommandOf<"turn.submit">;
 
@@ -35,6 +37,11 @@ interface StagedThreadCommandInput {
   cleanup: () => Promise<void>;
   input: TurnSubmitCommand["input"];
   inputGroups?: TurnSubmitCommand["inputGroups"];
+}
+
+interface RequireSupportedProviderCliArgs {
+  command: CommandOf<"thread.start">;
+  options: CommandDispatchOptions;
 }
 
 function requireConfinedPath(rootPath: string, candidatePath: string): string {
@@ -74,6 +81,33 @@ function groupedInputForRuntime(
     index === 0
       ? input
       : [{ type: "text" as const, text: "\n\n", mentions: [] }, ...input],
+  );
+}
+
+async function requireSupportedProviderCliForThreadStart({
+  command,
+  options,
+}: RequireSupportedProviderCliArgs): Promise<void> {
+  if (command.providerId !== "codex") {
+    return;
+  }
+
+  const status =
+    (await options.getProviderCliStatusForProvider?.(command.providerId)) ??
+    (await getProviderCliStatusForProvider("codex", {
+      env: options.runtimeManager.getShellEnv(),
+    }));
+  if (!status.versionUnsupported) {
+    return;
+  }
+
+  const currentVersion = status.currentVersion
+    ? ` ${status.currentVersion}`
+    : "";
+  const minimumVersion = status.minimumSupportedVersion ?? "a newer version";
+  throw new ExpectedCommandDispatchError(
+    "provider_cli_unsupported_version",
+    `Codex${currentVersion} is too old for this bb version. Update Codex to ${minimumVersion} or newer.`,
   );
 }
 
@@ -150,6 +184,7 @@ export async function startThread(
   command: CommandOf<"thread.start">,
   options: CommandDispatchOptions,
 ): Promise<HostDaemonCommandResult<"thread.start">> {
+  await requireSupportedProviderCliForThreadStart({ command, options });
   if (command.threadStoragePath) {
     const confined = requireConfinedPath(
       options.threadStorageRootPath,

--- a/apps/host-daemon/src/provider-cli-health.test.ts
+++ b/apps/host-daemon/src/provider-cli-health.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
+  CODEX_MINIMUM_SUPPORTED_VERSION,
   getKnownAcpAgentsStatus,
   getProviderCliStatus,
   inspectProviderCli,
@@ -181,6 +182,7 @@ const CODEX_DEFINITION: ProviderCliDefinition = {
   displayName: "Codex",
   executableName: "codex",
   npmPackageName: "@openai/codex",
+  minimumSupportedVersion: CODEX_MINIMUM_SUPPORTED_VERSION,
   installCommand: {
     kind: "npmGlobal",
   },
@@ -197,6 +199,7 @@ const CLAUDE_CODE_DEFINITION: ProviderCliDefinition = {
   displayName: "Claude Code",
   executableName: "claude",
   npmPackageName: "@anthropic-ai/claude-code",
+  minimumSupportedVersion: null,
   installCommand: {
     kind: "downloadedShellScript",
     scriptUrl: CLAUDE_INSTALL_SCRIPT_URL,
@@ -214,6 +217,7 @@ const CURSOR_DEFINITION: ProviderCliDefinition = {
   displayName: "Cursor",
   executableName: "agent",
   npmPackageName: null,
+  minimumSupportedVersion: null,
   installCommand: {
     kind: "downloadedShellScript",
     scriptUrl: CURSOR_INSTALL_SCRIPT_URL,
@@ -287,6 +291,15 @@ function installOutdatedNpmCodexCommands(
   runner.setSuccess("codex", ["--version"], "codex 0.132.0\n");
   runner.setSuccess("npm", ["view", "@openai/codex", "version"], "0.133.0\n");
   installNpmStateCommands(runner, CODEX_DEFINITION, "/usr/local", "0.132.0");
+}
+
+function installUnsupportedCodexWithoutLatestCommands(
+  runner: FakeProviderCliCommandRunner,
+): void {
+  runner.setSuccess("which", ["codex"], "/usr/local/bin/codex\n");
+  runner.setSuccess("codex", ["--version"], "codex 0.135.0\n");
+  runner.setExit("npm", ["view", "@openai/codex", "version"], 1, "offline");
+  installNpmStateCommands(runner, CODEX_DEFINITION, "/usr/local", "0.135.0");
 }
 
 function installOutdatedExternalClaudeCommands(
@@ -382,6 +395,7 @@ describe("provider CLI health", () => {
       installSource: "notInstalled",
       currentVersion: null,
       latestVersion: "0.133.0",
+      minimumSupportedVersion: CODEX_MINIMUM_SUPPORTED_VERSION,
       npmPackageName: "@openai/codex",
       npmGlobalPackageVersion: null,
       installAction: {
@@ -391,6 +405,7 @@ describe("provider CLI health", () => {
         command: "npm install -g @openai/codex@latest",
       },
       needsUpdate: false,
+      versionUnsupported: false,
     });
   });
 
@@ -432,6 +447,7 @@ describe("provider CLI health", () => {
       installSource: "notInstalled",
       currentVersion: null,
       latestVersion: null,
+      minimumSupportedVersion: null,
       npmPackageName: null,
       npmGlobalPackageVersion: null,
       installAction: {
@@ -441,6 +457,7 @@ describe("provider CLI health", () => {
         command: CURSOR_INSTALL_COMMAND,
       },
       needsUpdate: false,
+      versionUnsupported: false,
     });
   });
 
@@ -459,6 +476,32 @@ describe("provider CLI health", () => {
     expect(status.currentVersion).toBe("0.132.0");
     expect(status.latestVersion).toBe("0.133.0");
     expect(status.needsUpdate).toBe(true);
+    expect(status.versionUnsupported).toBe(true);
+    expect(status.minimumSupportedVersion).toBe(
+      CODEX_MINIMUM_SUPPORTED_VERSION,
+    );
+    expect(status.installAction).toEqual({
+      kind: "update",
+      label: "Update",
+      commandKind: "exec",
+      command: "codex update",
+    });
+  });
+
+  it("offers a self-update action when Codex is below the minimum version", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    installUnsupportedCodexWithoutLatestCommands(runner);
+
+    const status = await inspectProviderCli({
+      definition: CODEX_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status.currentVersion).toBe("0.135.0");
+    expect(status.latestVersion).toBeNull();
+    expect(status.needsUpdate).toBe(false);
+    expect(status.versionUnsupported).toBe(true);
     expect(status.installAction).toEqual({
       kind: "update",
       label: "Update",

--- a/apps/host-daemon/src/provider-cli-health.ts
+++ b/apps/host-daemon/src/provider-cli-health.ts
@@ -22,6 +22,7 @@ const NPM_VIEW_TIMEOUT_MS = 15_000;
 const NPM_INSTALL_STATE_TIMEOUT_MS = 5_000;
 const CLAUDE_CODE_INSTALL_SCRIPT_URL = "https://claude.ai/install.sh";
 const CURSOR_INSTALL_SCRIPT_URL = "https://cursor.com/install";
+export const CODEX_MINIMUM_SUPPORTED_VERSION = "0.136.0";
 const providerCliNodePtyLogger: HostDaemonLogger = {
   debug() {},
   info() {},
@@ -48,6 +49,7 @@ export interface ProviderCliDefinition {
   displayName: string;
   executableName: string;
   npmPackageName: string | null;
+  minimumSupportedVersion: string | null;
   installCommand: ProviderCliInstallCommandDefinition;
   updateCommand: ProviderCliActionCommand;
 }
@@ -79,6 +81,12 @@ interface InspectProviderCliArgs {
 }
 
 interface GetProviderCliStatusArgs {
+  env?: NodeJS.ProcessEnv;
+  runner?: ProviderCliCommandRunner;
+  nodePlatform?: NodeJS.Platform;
+}
+
+interface GetProviderCliStatusForProviderArgs {
   env?: NodeJS.ProcessEnv;
   runner?: ProviderCliCommandRunner;
   nodePlatform?: NodeJS.Platform;
@@ -150,6 +158,12 @@ interface NeedsProviderCliUpdateArgs {
   latestVersion: string | null;
 }
 
+interface IsProviderCliVersionUnsupportedArgs {
+  installed: boolean;
+  currentVersion: string | null;
+  minimumSupportedVersion: string | null;
+}
+
 interface ResolveProviderCliInstallSourceArgs {
   installed: boolean;
   executablePath: string | null;
@@ -161,6 +175,7 @@ interface BuildInstallActionArgs {
   definition: ProviderCliDefinition;
   installed: boolean;
   needsUpdate: boolean;
+  versionUnsupported: boolean;
   nodePlatform: NodeJS.Platform;
 }
 
@@ -241,6 +256,7 @@ const PROVIDER_CLI_DEFINITIONS = {
     displayName: "Codex",
     executableName: "codex",
     npmPackageName: "@openai/codex",
+    minimumSupportedVersion: CODEX_MINIMUM_SUPPORTED_VERSION,
     installCommand: {
       kind: "npmGlobal",
     },
@@ -256,6 +272,7 @@ const PROVIDER_CLI_DEFINITIONS = {
     displayName: "Claude Code",
     executableName: "claude",
     npmPackageName: "@anthropic-ai/claude-code",
+    minimumSupportedVersion: null,
     installCommand: {
       kind: "downloadedShellScript",
       scriptUrl: CLAUDE_CODE_INSTALL_SCRIPT_URL,
@@ -272,6 +289,7 @@ const PROVIDER_CLI_DEFINITIONS = {
     displayName: "Cursor",
     executableName: "agent",
     npmPackageName: null,
+    minimumSupportedVersion: null,
     installCommand: {
       kind: "downloadedShellScript",
       scriptUrl: CURSOR_INSTALL_SCRIPT_URL,
@@ -357,6 +375,17 @@ function needsProviderCliUpdate(args: NeedsProviderCliUpdateArgs): boolean {
     return false;
   }
   return semver.gt(args.latestVersion, args.currentVersion);
+}
+
+function isProviderCliVersionUnsupported({
+  installed,
+  currentVersion,
+  minimumSupportedVersion,
+}: IsProviderCliVersionUnsupportedArgs): boolean {
+  if (!installed || !currentVersion || !minimumSupportedVersion) {
+    return false;
+  }
+  return semver.lt(currentVersion, minimumSupportedVersion);
 }
 
 function npmInstallCommandArgs(definition: ProviderCliDefinition): string[] {
@@ -488,6 +517,7 @@ function buildInstallAction({
   definition,
   installed,
   needsUpdate,
+  versionUnsupported,
   nodePlatform,
 }: BuildInstallActionArgs): ProviderCliInstallAction | null {
   if (!installed) {
@@ -500,6 +530,15 @@ function buildInstallAction({
     };
   }
   if (needsUpdate) {
+    const command = definition.updateCommand;
+    return {
+      kind: "update",
+      label: "Update",
+      commandKind: command.commandKind,
+      command: command.displayCommand,
+    };
+  }
+  if (versionUnsupported) {
     const command = definition.updateCommand;
     return {
       kind: "update",
@@ -707,10 +746,16 @@ export async function inspectProviderCli({
     currentVersion,
     latestVersion,
   });
+  const versionUnsupported = isProviderCliVersionUnsupported({
+    installed,
+    currentVersion,
+    minimumSupportedVersion: definition.minimumSupportedVersion,
+  });
   const installAction = buildInstallAction({
     definition,
     installed,
     needsUpdate,
+    versionUnsupported,
     nodePlatform,
   });
 
@@ -722,10 +767,12 @@ export async function inspectProviderCli({
     installSource,
     currentVersion,
     latestVersion,
+    minimumSupportedVersion: definition.minimumSupportedVersion,
     npmPackageName,
     npmGlobalPackageVersion,
     installAction,
     needsUpdate,
+    versionUnsupported,
   };
 }
 
@@ -753,6 +800,19 @@ export async function getProviderCliStatus(
   ]);
 
   return { codex, claudeCode, cursor };
+}
+
+export async function getProviderCliStatusForProvider(
+  provider: ProviderCliKey,
+  args: GetProviderCliStatusForProviderArgs = {},
+): Promise<ProviderCliStatus> {
+  const runner = args.runner ?? createSpawnProviderCliCommandRunner(args.env);
+  const nodePlatform = args.nodePlatform ?? process.platform;
+  return await inspectProviderCli({
+    definition: getProviderCliDefinition(provider),
+    runner,
+    nodePlatform,
+  });
 }
 
 export async function inspectExecutableInstallStatus({

--- a/packages/host-daemon-contract/src/local.ts
+++ b/packages/host-daemon-contract/src/local.ts
@@ -158,10 +158,12 @@ export const providerCliStatusSchema = z.object({
   installSource: providerCliInstallSourceSchema,
   currentVersion: z.string().min(1).nullable(),
   latestVersion: z.string().min(1).nullable(),
+  minimumSupportedVersion: z.string().min(1).nullable(),
   npmPackageName: z.string().min(1).nullable(),
   npmGlobalPackageVersion: z.string().min(1).nullable(),
   installAction: providerCliInstallActionSchema.nullable(),
   needsUpdate: z.boolean(),
+  versionUnsupported: z.boolean(),
 });
 export type ProviderCliStatus = z.infer<typeof providerCliStatusSchema>;
 

--- a/packages/host-daemon-contract/test/local.test.ts
+++ b/packages/host-daemon-contract/test/local.test.ts
@@ -104,6 +104,7 @@ describe("provider CLI schemas", () => {
           installSource: "notInstalled",
           currentVersion: null,
           latestVersion: "0.133.0",
+          minimumSupportedVersion: "0.136.0",
           npmPackageName: "@openai/codex",
           npmGlobalPackageVersion: null,
           installAction: {
@@ -113,6 +114,7 @@ describe("provider CLI schemas", () => {
             command: "npm install -g @openai/codex@latest",
           },
           needsUpdate: false,
+          versionUnsupported: false,
         },
         claudeCode: {
           displayName: "Claude Code",
@@ -122,6 +124,7 @@ describe("provider CLI schemas", () => {
           installSource: "npmGlobal",
           currentVersion: "2.1.147",
           latestVersion: "2.1.148",
+          minimumSupportedVersion: null,
           npmPackageName: "@anthropic-ai/claude-code",
           npmGlobalPackageVersion: "2.1.147",
           installAction: {
@@ -131,6 +134,7 @@ describe("provider CLI schemas", () => {
             command: "claude update",
           },
           needsUpdate: true,
+          versionUnsupported: false,
         },
         cursor: {
           displayName: "Cursor",
@@ -140,6 +144,7 @@ describe("provider CLI schemas", () => {
           installSource: "notInstalled",
           currentVersion: null,
           latestVersion: null,
+          minimumSupportedVersion: null,
           npmPackageName: null,
           npmGlobalPackageVersion: null,
           installAction: {
@@ -150,6 +155,7 @@ describe("provider CLI schemas", () => {
               'tmp=$(mktemp "${TMPDIR:-/tmp}/provider-cli-install.XXXXXX") && trap \'rm -f "$tmp"\' EXIT && curl -fsSL https://cursor.com/install -o "$tmp" && bash "$tmp"',
           },
           needsUpdate: false,
+          versionUnsupported: false,
         },
       }).claudeCode.needsUpdate,
     ).toBe(true);
@@ -164,10 +170,17 @@ describe("provider CLI schemas", () => {
           installSource: "npmGlobal",
           currentVersion: "0.133.0",
           latestVersion: "0.133.0",
+          minimumSupportedVersion: "0.136.0",
           npmPackageName: "@openai/codex",
           npmGlobalPackageVersion: "0.133.0",
-          installAction: null,
+          installAction: {
+            kind: "update",
+            label: "Update",
+            commandKind: "exec",
+            command: "codex update",
+          },
           needsUpdate: false,
+          versionUnsupported: true,
         },
         claudeCode: {
           displayName: "Claude Code",
@@ -177,6 +190,7 @@ describe("provider CLI schemas", () => {
           installSource: "notInstalled",
           currentVersion: null,
           latestVersion: "2.1.148",
+          minimumSupportedVersion: null,
           npmPackageName: "@anthropic-ai/claude-code",
           npmGlobalPackageVersion: null,
           installAction: {
@@ -187,6 +201,7 @@ describe("provider CLI schemas", () => {
               'tmp=$(mktemp "${TMPDIR:-/tmp}/provider-cli-install.XXXXXX") && trap \'rm -f "$tmp"\' EXIT && curl -fsSL https://claude.ai/install.sh -o "$tmp" && bash "$tmp"',
           },
           needsUpdate: false,
+          versionUnsupported: false,
         },
         cursor: {
           displayName: "Cursor",
@@ -196,10 +211,12 @@ describe("provider CLI schemas", () => {
           installSource: "external",
           currentVersion: null,
           latestVersion: null,
+          minimumSupportedVersion: null,
           npmPackageName: null,
           npmGlobalPackageVersion: null,
           installAction: null,
           needsUpdate: false,
+          versionUnsupported: false,
         },
       }).claudeCode.installAction,
     ).toMatchObject({ commandKind: "shell" });


### PR DESCRIPTION
## Summary
- require Codex 0.136.0+ before starting Codex threads, with daemon-side enforcement
- surface a neutral promptbox banner with the existing Codex update action when the local CLI is unsupported
- share provider CLI update UI wiring between health toasts and promptbox, plus story coverage for the blocked state

## Tests
- pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/provider-cli-health.test.ts src/command-dispatch.test.ts
- pnpm exec turbo run test --filter=@bb/host-daemon-contract -- --run test/local.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/host-daemon
- pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract
- git diff --check