### PR TITLE
Fix VS Code workspace open target

### DIFF
--- a/apps/host-daemon/src/workspace-open-targets.test.ts
+++ b/apps/host-daemon/src/workspace-open-targets.test.ts
@@ -212,6 +212,35 @@ describe("workspace open targets", () => {
     }
   });
 
+  it("uses the VS Code CLI for workspace opens when available", async () => {
+    const workspacePath = await mkdtemp(path.join(tmpdir(), "bb-workspace-"));
+    const calls: ExecFileCall[] = [];
+    const execFile = createAvailableExecFile({
+      availableBundleIdSubstrings: ["com.microsoft.VSCode"],
+      availableExecutables: ["code"],
+      calls,
+    });
+
+    try {
+      await openPathInTargetWithRuntime(
+        {
+          lineNumber: null,
+          path: workspacePath,
+          targetId: "vscode",
+        },
+        createRuntime({ execFile }),
+      );
+
+      expect(calls.find((call) => call.file === "code")).toEqual({
+        file: "code",
+        args: [workspacePath],
+      });
+      expect(calls.some((call) => call.file === "open")).toBe(false);
+    } finally {
+      await rm(workspacePath, { force: true, recursive: true });
+    }
+  });
+
   it("rejects missing paths", async () => {
     await expect(
       openPathInTargetWithRuntime(

--- a/apps/host-daemon/src/workspace-open-targets.ts
+++ b/apps/host-daemon/src/workspace-open-targets.ts
@@ -64,6 +64,7 @@ interface MacApplicationOpenTargetDefinition {
   builtIn: boolean;
   lineOpenCommand?: MacLineOpenCommandDefinition;
   openMode: "application";
+  pathOpenCommand?: MacPathOpenCommandDefinition;
 }
 
 type MacWorkspaceOpenTargetDefinition =
@@ -91,6 +92,11 @@ interface BuildMacLineOpenArgs {
 interface MacLineOpenCommandDefinition {
   executable: string;
   toArgs: (args: BuildMacLineOpenArgs) => string[];
+}
+
+interface MacPathOpenCommandDefinition {
+  executable: string;
+  toArgs: (path: string) => string[];
 }
 
 interface ResolveMacOpenInvocationArgs {
@@ -140,6 +146,10 @@ const WORKSPACE_OPEN_TARGET_DEFINITIONS: WorkspaceOpenTargetDefinition[] = [
       lineOpenCommand: {
         executable: "code",
         toArgs: (args) => ["-g", formatPathWithLineNumber(args)],
+      },
+      pathOpenCommand: {
+        executable: "code",
+        toArgs: (path) => [path],
       },
     },
   },
@@ -526,6 +536,33 @@ async function maybeResolveMacLineOpenInvocation(
   };
 }
 
+async function maybeResolveMacPathOpenInvocation(
+  args: ResolveMacOpenInvocationArgs,
+  runtime: WorkspaceOpenTargetRuntime,
+): Promise<ExecFileInvocation | null> {
+  if (args.definition.macos.openMode === "default-app") {
+    return null;
+  }
+
+  const pathOpenCommand = args.definition.macos.pathOpenCommand;
+  if (!pathOpenCommand) {
+    return null;
+  }
+
+  if (!(await isExecutableAvailable(pathOpenCommand.executable, runtime))) {
+    return null;
+  }
+
+  const openPath = resolveTargetOpenPath({
+    definition: args.definition,
+    existingPath: args.existingPath,
+  });
+  return {
+    file: pathOpenCommand.executable,
+    args: pathOpenCommand.toArgs(openPath),
+  };
+}
+
 async function resolveMacOpenInvocation(
   args: ResolveMacOpenInvocationArgs,
   runtime: WorkspaceOpenTargetRuntime,
@@ -536,6 +573,14 @@ async function resolveMacOpenInvocation(
   );
   if (lineOpenInvocation) {
     return lineOpenInvocation;
+  }
+
+  const pathOpenInvocation = await maybeResolveMacPathOpenInvocation(
+    args,
+    runtime,
+  );
+  if (pathOpenInvocation) {
+    return pathOpenInvocation;
   }
 
   const openPath = resolveTargetOpenPath({


### PR DESCRIPTION
## Summary
- prefer the `code` CLI for VS Code workspace opens when available
- keep the existing macOS `open -a` fallback for machines without the CLI
- add a daemon regression test for VS Code workspace opens

## Validation
- pnpm exec turbo run test --filter=@bb/host-daemon
- pnpm exec turbo run typecheck --filter=@bb/host-daemon