### PR TITLE
[codex] Fix sidebar new thread empty welcome

### DIFF
--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -20,6 +20,7 @@ import {
   readInitialPromptFromLocationState,
   resolveRootComposeEffectiveEnvironmentValue,
   resolveRootComposePanelThreadId,
+  shouldStartComposingFromLocationState,
   shouldNavigateAfterThreadCreate,
 } from "./RootComposeView";
 
@@ -252,6 +253,22 @@ describe("hasSingleUseRootComposeTargetState", () => {
 
   it("ignores non-target state", () => {
     expect(hasSingleUseRootComposeTargetState(null)).toBe(false);
+  });
+});
+
+describe("shouldStartComposingFromLocationState", () => {
+  it("treats sidebar new-thread focus navigation as a compose request", () => {
+    expect(shouldStartComposingFromLocationState({ focusPrompt: true })).toBe(
+      true,
+    );
+  });
+
+  it("ignores non-focus navigation state", () => {
+    expect(shouldStartComposingFromLocationState(null)).toBe(false);
+    expect(shouldStartComposingFromLocationState({})).toBe(false);
+    expect(
+      shouldStartComposingFromLocationState({ focusPrompt: false }),
+    ).toBe(false);
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -245,6 +245,13 @@ export function readRootComposeFolderTargetFromLocationState(
   return null;
 }
 
+export function shouldStartComposingFromLocationState(state: unknown): boolean {
+  if (typeof state !== "object" || state === null) {
+    return false;
+  }
+  return "focusPrompt" in state && state.focusPrompt === true;
+}
+
 type RootComposeViewProps =
   | {
       surface: "page";
@@ -749,7 +756,9 @@ export function RootComposeView(props: RootComposeViewProps) {
   );
   // The no-projects welcome replaces the composer until the user opts in; once
   // they pick "New thread" we reveal the composer for the rest of the session.
-  const [startedComposing, setStartedComposing] = useState(false);
+  const [startedComposing, setStartedComposing] = useState(() =>
+    shouldStartComposingFromLocationState(location.state),
+  );
   const [navigateToThreadAfterCreate] =
     useNavigateToThreadAfterCreatePreference();
   const [forkSeed, setForkSeed] = useState<ForkThreadCreateSeed | null>(() =>
@@ -903,6 +912,9 @@ export function RootComposeView(props: RootComposeViewProps) {
     );
     if (!hasSingleUseRootComposeTargetState(location.state)) {
       return;
+    }
+    if (shouldStartComposingFromLocationState(location.state)) {
+      setStartedComposing(true);
     }
     if (folderTarget?.kind === "set") {
       setRootComposeFolderId(folderTarget.folderId);


### PR DESCRIPTION
## Summary

- Treat root-compose navigation state with `focusPrompt: true` as an explicit request to reveal the new-thread composer.
- Preserve the no-projects welcome as the default root empty state unless the user invokes New Thread.
- Add a regression unit test for the focus navigation state used by the sidebar New Thread actions.

## Root Cause

The sidebar New Thread action navigated to root compose with `focusPrompt: true`, but root compose only used that state to focus the prompt after it existed. When the no-projects welcome was showing, the prompt never mounted, so the action appeared to no-op on the onboarding interstitial.

## Verification

- `pnpm exec turbo run test --filter=@bb/app -- RootComposeView.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run build --filter=@bb/app`