### PR TITLE
Restore git diff context expansion

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCard.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.tsx
@@ -68,10 +68,11 @@ export interface GitDiffCardProps {
   showStuckHeaderEdge?: boolean;
   /**
    * When provided, the card lazy-fetches `oldFile`/`newFile` the first time
-   * it scrolls into view. Text results are forwarded to `<DiffView>`, which
-   * unlocks `@pierre/diffs`'s built-in expand-context buttons in the gaps
-   * between hunks; image results render as an inline preview instead of the
-   * text diff. Without this prop the card renders the hunk-only view.
+   * it scrolls into view. When `patchText` is also available to the shared body,
+   * text results reparse the patch with complete file contents, which unlocks
+   * `@pierre/diffs`'s built-in expand-context buttons in the gaps between
+   * hunks; image results render as an inline preview instead of the text diff.
+   * Without this prop the card renders the hunk-only view.
    *
    * The callback should resolve to `null` for binary files the card can't
    * preview (the diff renderer needs a UTF-8 string) so the card can leave

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -18,6 +18,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton.js";
 import {
   formatGitDiffFileLabel,
+  enrichGitDiffFileForContext,
   isImageGitDiffFile,
   normalizeGitDiffPath,
   type GitDiffFileChangeKind,
@@ -61,19 +62,6 @@ const GIT_DIFF_CARD_BODY_STYLE: CSSProperties = {
   containIntrinsicSize: "0 600px",
 };
 
-// `parseDiffFromFile` in @pierre/diffs splits file contents on this exact regex
-// (positive lookbehind on \n) and tags the resulting arrays onto the parsed
-// file as `oldLines` / `newLines`. The hunks renderer reads those arrays to know
-// what's "expandable" between hunks. We do the same tagging directly on our
-// parsed fileDiff once contents load — no need to make the library re-parse from
-// scratch.
-const SPLIT_WITH_NEWLINES = /(?<=\n)/u;
-
-interface EnrichedFileDiff extends ParsedGitDiffFile {
-  oldLines: string[];
-  newLines: string[];
-}
-
 type DiffFileContentSource =
   | { kind: "empty"; path: string }
   | { kind: "request"; path: string; side: "old" | "new" };
@@ -87,7 +75,7 @@ interface DiffFileContentPlan {
 type DiffFileEnrichmentState =
   | { status: "idle" }
   | { status: "loading" }
-  | { status: "ready"; oldLines: string[]; newLines: string[] }
+  | { status: "ready"; fileDiff: ParsedGitDiffFile }
   | {
       status: "ready-image";
       oldImageUrl: string | null;
@@ -101,6 +89,7 @@ type DiffFileEnrichmentState =
 function buildDiffFileContentPlan(
   fileDiff: ParsedGitDiffFile,
   changeKind: GitDiffFileChangeKind,
+  patchText: string | undefined,
 ): DiffFileContentPlan {
   const currentPath = normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
   const previousPath = normalizeGitDiffPath(fileDiff.prevName) ?? currentPath;
@@ -130,6 +119,9 @@ function buildDiffFileContentPlan(
       describeDiffFileContentSource(oldSource),
       describeDiffFileContentSource(newSource),
       hunkIdentity,
+      patchText ?? "",
+      fileDiff.deletionLines.join(""),
+      fileDiff.additionLines.join(""),
     ].join(":"),
     old: oldSource,
     new: newSource,
@@ -153,11 +145,6 @@ function resolveDiffFileContentSource(
     });
   }
   return fetcher(source.path, source.side);
-}
-
-function splitFileContentsForDiffContext(file: FileContents): string[] {
-  if (file.contents.length === 0) return [];
-  return file.contents.split(SPLIT_WITH_NEWLINES);
 }
 
 /**
@@ -197,12 +184,14 @@ export interface UseGitDiffCardBodyArgs {
   /** When true, holds the body at a skeleton (queued render slots). */
   isRendering: boolean;
   onRequestFileContents: RequestDiffFileContents | undefined;
+  /** Raw per-file patch text, used to reparse with full old/new contents. */
+  patchText?: string;
 }
 
 export interface GitDiffCardBodyState {
   bodySentinelRef: RefCallback<HTMLDivElement>;
   enrichment: DiffFileEnrichmentState;
-  enrichedFileDiff: EnrichedFileDiff | ParsedGitDiffFile;
+  enrichedFileDiff: ParsedGitDiffFile;
   fileDiffLabel: string;
   isImageCard: boolean;
   shouldGateDeletedDiff: boolean;
@@ -225,6 +214,7 @@ export function useGitDiffCardBody({
   changeKind,
   isRendering,
   onRequestFileContents,
+  patchText,
 }: UseGitDiffCardBodyArgs): GitDiffCardBodyState {
   const isDeletedFile = changeKind === "deleted";
   const isImageCard = isImagePreviewCard(fileDiff, onRequestFileContents);
@@ -233,8 +223,8 @@ export function useGitDiffCardBody({
     [fileDiff],
   );
   const fileContentPlan = useMemo(
-    () => buildDiffFileContentPlan(fileDiff, changeKind),
-    [fileDiff, changeKind],
+    () => buildDiffFileContentPlan(fileDiff, changeKind, patchText),
+    [fileDiff, changeKind, patchText],
   );
   const { ref: bodySentinelRef, isIntersecting: isBodyVisible } =
     useIntersectionObserver({
@@ -317,8 +307,12 @@ export function useGitDiffCardBody({
         enrichmentStatusRef.current = "ready";
         setEnrichment({
           status: "ready",
-          oldLines: splitFileContentsForDiffContext(oldResult.file),
-          newLines: splitFileContentsForDiffContext(newResult.file),
+          fileDiff: enrichGitDiffFileForContext({
+            fileDiff,
+            oldFile: oldResult.file,
+            newFile: newResult.file,
+            patchText,
+          }),
         });
       })
       .catch(() => {
@@ -333,15 +327,11 @@ export function useGitDiffCardBody({
         enrichmentStatusRef.current = "idle";
       }
     };
-  }, [fileContentPlan, shouldRenderDiffView]);
+  }, [fileContentPlan, fileDiff, patchText, shouldRenderDiffView]);
 
-  const enrichedFileDiff = useMemo<EnrichedFileDiff | ParsedGitDiffFile>(() => {
+  const enrichedFileDiff = useMemo<ParsedGitDiffFile>(() => {
     if (enrichment.status !== "ready") return fileDiff;
-    return {
-      ...fileDiff,
-      oldLines: enrichment.oldLines,
-      newLines: enrichment.newLines,
-    };
+    return enrichment.fileDiff;
   }, [fileDiff, enrichment]);
 
   const loadDeletedDiff = useCallback(() => {

--- a/apps/app/src/components/git-diff/git-diff-parsing.test.ts
+++ b/apps/app/src/components/git-diff/git-diff-parsing.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import {
+  enrichGitDiffFileForContext,
   formatGitDiffFileLabel,
   getGitDiffFileChangeKind,
   getOpenableGitDiffPath,
@@ -64,6 +65,31 @@ const RENAME_ONLY_DIFF = [
   "",
 ].join("\n");
 
+const OLD_CONTEXT_CONTENT = Array.from(
+  { length: 10 },
+  (_, index) => `line ${index + 1}`,
+).join("\n");
+
+const NEW_CONTEXT_CONTENT = Array.from({ length: 10 }, (_, index) => {
+  if (index === 1) return "line two";
+  if (index === 7) return "line eight";
+  return `line ${index + 1}`;
+}).join("\n");
+
+const MULTI_HUNK_DIFF = [
+  "diff --git a/src/context.ts b/src/context.ts",
+  "index 1111111..2222222 100644",
+  "--- a/src/context.ts",
+  "+++ b/src/context.ts",
+  "@@ -2 +2 @@",
+  "-line 2",
+  "+line two",
+  "@@ -8 +8 @@",
+  "-line 8",
+  "+line eight",
+  "",
+].join("\n");
+
 describe("threadDetailGitDiff", () => {
   it("normalizes the openable path and label from a renamed file's sides", () => {
     const [file] = parseGitDiffFiles(SAMPLE_DIFF);
@@ -119,4 +145,45 @@ describe("threadDetailGitDiff", () => {
     );
   });
 
+  it("reparses a patch with full file contents so diff context can expand", () => {
+    const [file] = parseGitDiffFiles(MULTI_HUNK_DIFF);
+    expect(file).toBeDefined();
+    if (!file) throw new Error("expected parsed file");
+
+    expect(file.isPartial).toBe(true);
+    expect(file.additionLines).toEqual(["line two\n", "line eight\n"]);
+
+    const enrichedFile = enrichGitDiffFileForContext({
+      fileDiff: file,
+      oldFile: {
+        name: "src/context.ts",
+        contents: `${OLD_CONTEXT_CONTENT}\n`,
+      },
+      newFile: {
+        name: "src/context.ts",
+        contents: `${NEW_CONTEXT_CONTENT}\n`,
+      },
+      patchText: MULTI_HUNK_DIFF,
+    });
+
+    expect(enrichedFile.isPartial).toBe(false);
+    expect(enrichedFile.deletionLines).toHaveLength(10);
+    expect(enrichedFile.additionLines).toHaveLength(10);
+    expect(enrichedFile.deletionLines[7]).toBe("line 8\n");
+    expect(enrichedFile.additionLines[7]).toBe("line eight\n");
+
+    const firstHunk = enrichedFile.hunks[0];
+    const secondHunk = enrichedFile.hunks[1];
+    expect(firstHunk).toBeDefined();
+    expect(secondHunk).toBeDefined();
+    if (!firstHunk || !secondHunk) {
+      throw new Error("expected two hunks");
+    }
+
+    expect(firstHunk.additionLineIndex).toBe(1);
+    expect(firstHunk.deletionLineIndex).toBe(1);
+    expect(secondHunk.additionLineIndex).toBe(7);
+    expect(secondHunk.deletionLineIndex).toBe(7);
+    expect(secondHunk.collapsedBefore).toBe(5);
+  });
 });

--- a/apps/app/src/components/git-diff/git-diff-parsing.ts
+++ b/apps/app/src/components/git-diff/git-diff-parsing.ts
@@ -1,4 +1,8 @@
-import { parsePatchFiles } from "@pierre/diffs";
+import {
+  parsePatchFiles,
+  processFile,
+  type FileContents,
+} from "@pierre/diffs";
 import type { GitDiffFileChangeKind } from "@bb/server-contract";
 
 export type ParsedGitDiffFile = ReturnType<
@@ -22,6 +26,38 @@ export function parseGitDiffFiles(
   } catch {
     return [];
   }
+}
+
+export interface GitDiffContextEnrichmentInput {
+  fileDiff: ParsedGitDiffFile;
+  oldFile: FileContents;
+  newFile: FileContents;
+  patchText?: string;
+}
+
+/**
+ * Reparses a card's raw file patch with both full file sides attached. The
+ * diff renderer only exposes expand-context controls when `isPartial` is false
+ * and `additionLines` / `deletionLines` contain complete file contents.
+ */
+export function enrichGitDiffFileForContext({
+  fileDiff,
+  oldFile,
+  newFile,
+  patchText,
+}: GitDiffContextEnrichmentInput): ParsedGitDiffFile {
+  if (!patchText) return fileDiff;
+
+  return (
+    processFile(patchText, {
+      oldFile,
+      newFile,
+      cacheKey:
+        fileDiff.cacheKey === undefined
+          ? undefined
+          : `${fileDiff.cacheKey}:context`,
+    }) ?? fileDiff
+  );
 }
 
 export function summarizeGitDiff(

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -326,6 +326,7 @@ function DiffFileCardBody({
     <DiffFileCardRenderedBody
       entry={entry}
       parsedFile={parsedFile}
+      patchText={patchState.truncated ? undefined : patchState.patch}
       diffViewOptions={diffViewOptions}
       truncated={patchState.truncated ?? false}
       onOpenFilePreview={onOpenFilePreview}
@@ -337,6 +338,7 @@ function DiffFileCardBody({
 interface DiffFileCardRenderedBodyProps {
   entry: DiffFileEntry;
   parsedFile: ParsedGitDiffFile;
+  patchText?: string;
   diffViewOptions: Record<string, string | boolean | number>;
   truncated: boolean;
   onOpenFilePreview?: (path: string) => void;
@@ -353,6 +355,7 @@ interface DiffFileCardRenderedBodyProps {
 function DiffFileCardRenderedBody({
   entry,
   parsedFile,
+  patchText,
   diffViewOptions,
   truncated,
   onOpenFilePreview,
@@ -363,6 +366,7 @@ function DiffFileCardRenderedBody({
     changeKind: entry.changeKind,
     isRendering: false,
     onRequestFileContents,
+    patchText,
   });
   return (
     <>

--- a/packages/server-contract/src/api/environments.ts
+++ b/packages/server-contract/src/api/environments.ts
@@ -102,7 +102,7 @@ const mergeBaseRefQuerySchema = z.string().regex(/^[0-9a-f]{4,40}$/iu);
 
 /**
  * Query for fetching a single file's contents at one side of a diff target.
- * Used by the diff card to populate `<FileDiff>`'s `oldFile`/`newFile` props
+ * Used by the diff card to reparse the card's patch with full old/new contents
  * so `@pierre/diffs` can render expand-context buttons between hunks.
  *
  * For `branch_committed` / `all`, callers pass the resolved merge-base SHA


### PR DESCRIPTION
## Summary
- Reparse loaded git diff card patches with full old/new file contents so @pierre/diffs sees complete addition/deletion lines and enables context expansion again.
- Pass raw per-file patch text through diff panel cards, while leaving truncated patches hunk-only.
- Add a regression test for enriched multi-hunk diffs.

## Tests
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/git-diff/git-diff-parsing.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check