### PR TITLE
[codex] Fix animated logo edge highlight

### DIFF
--- a/apps/app/src/views/RootComposeEmptyWelcome.tsx
+++ b/apps/app/src/views/RootComposeEmptyWelcome.tsx
@@ -79,7 +79,8 @@ export function RootComposeEmptyWelcome({
           map, and feSpecularLighting lit by a moving point light produces a
           glint that follows the surface curvature (and travels) the way light
           actually reflects — far less "stuck-on" than a flat sweeping band. The
-          highlight is clipped to the glyph and added over it. */}
+          highlight is clipped just inside the glyph and added over it so the
+          light does not brighten antialiased outer-edge pixels. */}
       <svg aria-hidden className="absolute h-0 w-0" focusable="false">
         <defs>
           <filter
@@ -117,9 +118,15 @@ export function RootComposeEmptyWelcome({
                 )}
               </fePointLight>
             </feSpecularLighting>
+            <feMorphology
+              in="SourceAlpha"
+              operator="erode"
+              radius="0.75"
+              result="innerAlpha"
+            />
             <feComposite
               in="spec"
-              in2="SourceAlpha"
+              in2="innerAlpha"
               operator="in"
               result="specClip"
             />


### PR DESCRIPTION
## Summary

Fixes the animated root onboarding bb logo highlight so the specular layer is clipped slightly inside the glyph instead of being painted onto the glyph's antialiased outer edge.

## Root Cause

The moving `feSpecularLighting` result was composited using the raw `SourceAlpha` as its clip. When the point light reaches the side of the logo, the bright specular layer can hit fractional outer-edge pixels and make the edge look jagged on high-density displays.

## Validation

- Reproduced the visible lit-edge fringe in a same-origin Chromium fixture using the real `bb-mark.svg` mask and the existing SVG filter at `devicePixelRatio = 2`.
- Compared the current filter with the inner-alpha clip variant; the new variant keeps the gloss while pulling the highlight off the outer antialiased edge.
- `pnpm exec turbo run typecheck --filter=@bb/app`
