### PR TITLE
Default to opening created threads

### DIFF
--- a/apps/app/src/lib/root-compose-create-preference.ts
+++ b/apps/app/src/lib/root-compose-create-preference.ts
@@ -5,7 +5,7 @@ import { createJsonLocalStorage } from "./browser-storage";
 export const NAVIGATE_TO_THREAD_AFTER_CREATE_STORAGE_KEY =
   "bb.root-compose.navigate-after-create";
 
-export const NAVIGATE_TO_THREAD_AFTER_CREATE_DEFAULT = false;
+export const NAVIGATE_TO_THREAD_AFTER_CREATE_DEFAULT = true;
 
 const navigateToThreadAfterCreateStorage = createJsonLocalStorage<boolean>();
 


### PR DESCRIPTION
## Summary
- Default the root compose “Navigate to threads on creation” preference to enabled
- Keeps the existing settings toggle as the per-user override

## Verification
- pnpm exec turbo run typecheck --filter=@bb/app
