### PR TITLE
Add interactive remote file browser for project path selection

### DIFF
--- a/apps/app/src/components/dialogs/ProjectPathDialog.stories.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.stories.tsx
@@ -42,6 +42,7 @@ export function Overview() {
             target={createTarget}
             pending={false}
             platform="darwin"
+            hostId={null}
             hostName="Sawyer's MacBook"
             onSubmit={noop}
           />
@@ -56,6 +57,7 @@ export function Overview() {
             target={updateTarget}
             pending={false}
             platform="darwin"
+            hostId={null}
             hostName="Sawyer's MacBook"
             onSubmit={noop}
           />
@@ -70,6 +72,7 @@ export function Overview() {
             target={addSourceTarget}
             pending={false}
             platform="darwin"
+            hostId={null}
             hostName="Sawyer's MacBook"
             onSubmit={noop}
           />
@@ -84,6 +87,7 @@ export function Overview() {
             target={createTarget}
             pending={false}
             platform="wsl"
+            hostId={null}
             hostName="Sawyer's MacBook"
             onSubmit={noop}
           />
@@ -98,6 +102,7 @@ export function Overview() {
             target={createTarget}
             pending={false}
             platform={null}
+            hostId={null}
             hostName={null}
             onSubmit={noop}
           />
@@ -109,6 +114,7 @@ export function Overview() {
             target={updateTarget}
             pending
             platform="darwin"
+            hostId={null}
             hostName="Sawyer's MacBook"
             onSubmit={noop}
           />

--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -6,8 +6,16 @@ import {
 } from "@bb/domain";
 import type { HostPlatform } from "@bb/host-daemon-contract";
 import { Button } from "@/components/ui/button.js";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
 import { Input } from "@/components/ui/input.js";
+import { RemotePathBrowser } from "@/components/dialogs/RemotePathBrowser";
 
 export type ProjectPathDialogTarget =
   | {
@@ -34,6 +42,7 @@ interface ProjectPathDialogProps {
   target: ProjectPathDialogTarget | null;
   pending?: boolean;
   platform: HostPlatform | null;
+  hostId: string | null;
   hostName: string | null;
   onOpenChange: (open: boolean) => void;
   onSubmit: ProjectPathDialogSubmitHandler;
@@ -43,6 +52,7 @@ export function ProjectPathDialog({
   target,
   pending = false,
   platform,
+  hostId,
   hostName,
   onOpenChange,
   onSubmit,
@@ -56,6 +66,7 @@ export function ProjectPathDialog({
             target={target}
             pending={pending}
             platform={platform}
+            hostId={hostId}
             hostName={hostName}
             onSubmit={onSubmit}
           />
@@ -69,6 +80,7 @@ export interface ProjectPathDialogContentProps {
   target: ProjectPathDialogTarget;
   pending: boolean;
   platform: HostPlatform | null;
+  hostId: string | null;
   hostName: string | null;
   onSubmit: ProjectPathDialogSubmitHandler;
 }
@@ -124,32 +136,48 @@ export function ProjectPathDialogContent({
   target,
   pending,
   platform,
+  hostId,
   hostName,
   onSubmit,
 }: ProjectPathDialogContentProps) {
   const inputId = useId();
-  const [pathValue, setPathValue] = useState(
+  // No-host fallback only: the browser owns the path when a host is present.
+  const [manualPath, setManualPath] = useState(
     target.kind === "update" ? target.currentPath : "",
+  );
+  const [browserDirectory, setBrowserDirectory] = useState<string | null>(
+    target.kind === "update" ? target.currentPath : null,
   );
   const [validationMessage, setValidationMessage] = useState<string | null>(
     null,
   );
-  const derivedProjectName = deriveProjectNameFromPath(pathValue);
   const copy = getPlatformCopy(platform, hostName);
   const placeholder =
     target.kind === "update"
       ? target.currentPath || copy.placeholder
       : copy.placeholder;
 
+  const selectedPath = hostId
+    ? browserDirectory
+    : normalizeProjectPathInput(manualPath) || null;
+  const derivedProjectName = selectedPath
+    ? deriveProjectNameFromPath(selectedPath)
+    : "";
+
   useEffect(() => {
     setValidationMessage(null);
-  }, [pathValue]);
+  }, [selectedPath]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (pending) return;
 
-    const normalizedPath = normalizeProjectPathInput(pathValue);
+    if (!selectedPath) {
+      setValidationMessage("Choose a project folder.");
+      return;
+    }
+
+    const normalizedPath = normalizeProjectPathInput(selectedPath);
     const pathValidationMessage =
       getProjectPathValidationMessage(normalizedPath);
     if (pathValidationMessage) {
@@ -172,35 +200,53 @@ export function ProjectPathDialogContent({
     <>
       <DialogHeader>
         <DialogTitle>{getDialogTitle(target.kind)}</DialogTitle>
-        <DialogDescription>{copy.description}</DialogDescription>
+        <DialogDescription>
+          {hostId
+            ? `Browse to the project folder${
+                hostName ? ` on ${hostName}` : ""
+              }, or edit the path directly.`
+            : copy.description}
+        </DialogDescription>
       </DialogHeader>
       <form className="space-y-4" onSubmit={handleSubmit}>
-        <div className="space-y-2">
+        {hostId ? (
+          <RemotePathBrowser
+            hostId={hostId}
+            initialPath={target.kind === "update" ? target.currentPath : null}
+            onDirectoryChange={setBrowserDirectory}
+            disabled={pending}
+          />
+        ) : (
           <Input
             id={inputId}
             aria-label="Project path"
-            value={pathValue}
+            value={manualPath}
             autoFocus
             disabled={pending}
             placeholder={placeholder}
             onChange={(event) => {
-              setPathValue(event.target.value);
+              setManualPath(event.target.value);
             }}
           />
-          {target.kind === "create" && derivedProjectName ? (
-            <p className="text-sm text-muted-foreground">
-              Project name:{" "}
-              <span className="font-medium text-foreground">
-                {derivedProjectName}
-              </span>
-            </p>
-          ) : null}
-          {validationMessage ? (
-            <p className="text-sm text-destructive">{validationMessage}</p>
-          ) : null}
-        </div>
+        )}
+        {(derivedProjectName && target.kind === "create") ||
+        validationMessage ? (
+          <div className="space-y-1">
+            {target.kind === "create" && derivedProjectName ? (
+              <p className="text-sm text-muted-foreground">
+                Project name:{" "}
+                <span className="font-medium text-foreground">
+                  {derivedProjectName}
+                </span>
+              </p>
+            ) : null}
+            {validationMessage ? (
+              <p className="text-sm text-destructive">{validationMessage}</p>
+            ) : null}
+          </div>
+        ) : null}
         <DialogFooter>
-          <Button type="submit" disabled={pending}>
+          <Button type="submit" disabled={pending || !selectedPath}>
             {getDialogSubmitLabel(target.kind)}
           </Button>
         </DialogFooter>

--- a/apps/app/src/components/dialogs/RemotePathBrowser.breadcrumb.test.ts
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.breadcrumb.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { toBreadcrumb } from "./RemotePathBrowser";
+
+describe("toBreadcrumb", () => {
+  it("splits a POSIX path into navigable ancestors rooted at /", () => {
+    expect(toBreadcrumb("/home/me/project")).toEqual([
+      { label: "/", path: "/" },
+      { label: "home", path: "/home" },
+      { label: "me", path: "/home/me" },
+      { label: "project", path: "/home/me/project" },
+    ]);
+  });
+
+  it("returns just the root for /", () => {
+    expect(toBreadcrumb("/")).toEqual([{ label: "/", path: "/" }]);
+  });
+
+  it("splits a Windows path rooted at the drive", () => {
+    expect(toBreadcrumb("C:\\Users\\me")).toEqual([
+      { label: "C:", path: "C:\\" },
+      { label: "Users", path: "C:\\Users" },
+      { label: "me", path: "C:\\Users\\me" },
+    ]);
+  });
+});

--- a/apps/app/src/components/dialogs/RemotePathBrowser.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { normalizeProjectPathInput } from "@bb/domain";
+import { Button } from "@/components/ui/button.js";
+import { EmptyState } from "@/components/ui/empty-state.js";
+import { Icon } from "@/components/ui/icon.js";
+import { Input } from "@/components/ui/input.js";
+import { useHostDirectory } from "@/hooks/queries/host-queries";
+import { getMutationErrorMessage } from "@/lib/mutation-errors";
+import { cn } from "@/lib/utils";
+
+interface Crumb {
+  label: string;
+  path: string;
+}
+
+/**
+ * Splits an absolute directory into navigable ancestor crumbs. The host's
+ * separator is inferred from the path string (the client can't know a remote
+ * host's platform), so this handles both POSIX and Windows roots.
+ */
+export function toBreadcrumb(directory: string): Crumb[] {
+  const isWindows = /^[A-Za-z]:/.test(directory);
+  if (!isWindows) {
+    const crumbs: Crumb[] = [{ label: "/", path: "/" }];
+    let accumulated = "";
+    for (const segment of directory.split("/").filter(Boolean)) {
+      accumulated = `${accumulated}/${segment}`;
+      crumbs.push({ label: segment, path: accumulated });
+    }
+    return crumbs;
+  }
+
+  const segments = directory.replace(/\//g, "\\").split("\\").filter(Boolean);
+  const drive = segments[0] ?? "";
+  const crumbs: Crumb[] = [{ label: drive, path: `${drive}\\` }];
+  let accumulated = drive;
+  for (const segment of segments.slice(1)) {
+    accumulated = `${accumulated}\\${segment}`;
+    crumbs.push({ label: segment, path: accumulated });
+  }
+  return crumbs;
+}
+
+interface RemotePathBrowserProps {
+  hostId: string;
+  /** Directory to open at; null starts at the host's home directory. */
+  initialPath?: string | null;
+  /**
+   * Reports the resolved directory currently shown (the folder that would be
+   * picked). Null while the first listing loads or a manual path fails to read.
+   */
+  onDirectoryChange: (directory: string | null) => void;
+  disabled?: boolean;
+}
+
+export function RemotePathBrowser({
+  hostId,
+  initialPath = null,
+  onDirectoryChange,
+  disabled = false,
+}: RemotePathBrowserProps) {
+  const [currentPath, setCurrentPath] = useState<string | null>(initialPath);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const { data, isError, error, isPlaceholderData } = useHostDirectory(
+    hostId,
+    currentPath,
+  );
+
+  const directory = data?.directory ?? null;
+  const crumbs = directory ? toBreadcrumb(directory) : [];
+
+  // Keep the dialog's pick target in sync with the resolved directory.
+  useEffect(() => {
+    onDirectoryChange(directory);
+  }, [directory, onDirectoryChange]);
+
+  useEffect(() => {
+    if (isEditing) editInputRef.current?.focus();
+  }, [isEditing]);
+
+  const openEditor = () => {
+    setEditValue(directory ?? "");
+    setIsEditing(true);
+  };
+
+  const commitEditor = () => {
+    const normalized = normalizeProjectPathInput(editValue);
+    setIsEditing(false);
+    if (normalized) setCurrentPath(normalized);
+  };
+
+  let body: ReactNode;
+  if (isError) {
+    body = (
+      <EmptyState
+        icon="AlertCircle"
+        message={getMutationErrorMessage({
+          error,
+          fallbackMessage: "Couldn't read this folder.",
+        })}
+        messageClassName="text-destructive"
+        className="px-2 py-3"
+      />
+    );
+  } else if (!data) {
+    body = (
+      <EmptyState
+        icon="Spinner"
+        iconClassName="animate-spin"
+        message="Loading…"
+        className="px-2 py-3"
+      />
+    );
+  } else if (data.entries.length === 0) {
+    body = <EmptyState message="This folder is empty." className="px-2 py-3" />;
+  } else {
+    body = (
+      <ul className="flex flex-col">
+        {data.entries.map((entry) => {
+          if (entry.kind === "file") {
+            return (
+              <li
+                key={entry.path}
+                className="flex items-center gap-2 px-2 py-1 text-sm text-muted-foreground"
+              >
+                <Icon name="File" className="size-4 shrink-0" />
+                <span className="truncate">{entry.name}</span>
+              </li>
+            );
+          }
+          return (
+            <li key={entry.path}>
+              <button
+                type="button"
+                disabled={disabled}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-sm hover:bg-muted disabled:pointer-events-none"
+                onClick={() => setCurrentPath(entry.path)}
+              >
+                <Icon
+                  name="Folder"
+                  className="size-4 shrink-0 text-muted-foreground"
+                />
+                <span className="truncate">{entry.name}</span>
+                <Icon
+                  name="ChevronRight"
+                  className="ml-auto size-4 shrink-0 text-muted-foreground"
+                />
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <div className="flex flex-col rounded-md border">
+      <div className="flex items-center gap-1 border-b px-1.5 py-1">
+        {isEditing ? (
+          <>
+            <Input
+              ref={editInputRef}
+              aria-label="Project path"
+              className="h-7 flex-1 text-xs"
+              value={editValue}
+              disabled={disabled}
+              placeholder="/path/to/project"
+              onChange={(event) => setEditValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  commitEditor();
+                } else if (event.key === "Escape") {
+                  event.preventDefault();
+                  setIsEditing(false);
+                }
+              }}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0"
+              aria-label="Go to path"
+              disabled={disabled}
+              onClick={commitEditor}
+            >
+              <Icon name="Check" />
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0"
+              aria-label="Go to parent folder"
+              disabled={disabled || !data?.parent}
+              onClick={() => {
+                if (data?.parent) setCurrentPath(data.parent);
+              }}
+            >
+              <Icon name="ArrowUp" />
+            </Button>
+            <div className="flex min-w-0 flex-1 items-center overflow-x-auto whitespace-nowrap text-xs text-muted-foreground">
+              {crumbs.map((crumb, index) => (
+                <span key={crumb.path} className="flex items-center">
+                  {index > 0 ? (
+                    <Icon
+                      name="ChevronRight"
+                      className="size-3 shrink-0 opacity-50"
+                    />
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={disabled}
+                    className={cn(
+                      "rounded px-1 py-0.5 hover:bg-muted hover:text-foreground",
+                      index === crumbs.length - 1 &&
+                        "font-medium text-foreground",
+                    )}
+                    onClick={() => setCurrentPath(crumb.path)}
+                  >
+                    {crumb.label}
+                  </button>
+                </span>
+              ))}
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0"
+              aria-label="Edit path"
+              disabled={disabled}
+              onClick={openEditor}
+            >
+              <Icon name="Edit" />
+            </Button>
+          </>
+        )}
+      </div>
+
+      <div
+        className={cn(
+          "h-56 min-h-0 overflow-y-auto px-1.5 py-1",
+          isPlaceholderData && "opacity-60",
+        )}
+      >
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -661,6 +661,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           target={quickCreateProject.projectPathDialog.target}
           pending={quickCreateProject.isCreating}
           platform={quickCreateProject.platform}
+          hostId={quickCreateProject.hostId}
           hostName={quickCreateProject.hostName}
           onOpenChange={quickCreateProject.projectPathDialog.onOpenChange}
           onSubmit={quickCreateProject.submitProjectPath}

--- a/apps/app/src/components/project/ProjectActionsProvider.tsx
+++ b/apps/app/src/components/project/ProjectActionsProvider.tsx
@@ -181,6 +181,7 @@ export function ProjectActionsProvider({
         target={addLocalSourcePicker.projectPathDialog.target}
         pending={addLocalSource.isPending}
         platform={addLocalSourcePicker.platform}
+        hostId={addLocalSourcePicker.hostId}
         hostName={addLocalSourcePicker.hostName}
         onOpenChange={addLocalSourcePicker.projectPathDialog.onOpenChange}
         onSubmit={addLocalSourcePicker.submitProjectPath}

--- a/apps/app/src/hooks/queries/host-queries.ts
+++ b/apps/app/src/hooks/queries/host-queries.ts
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { Host } from "@bb/domain";
+import type { HostDirectoryListing } from "@bb/server-contract";
 import * as api from "@/lib/api";
 import { useHostListRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
-import { hostsQueryKey } from "./query-keys";
+import { hostDirectoryQueryKey, hostsQueryKey } from "./query-keys";
 
 interface QueryOptions {
   enabled?: boolean;
@@ -37,4 +38,24 @@ export function usePrimaryHost(options?: QueryOptions): Host | null {
     if (!hosts || hosts.length === 0) return null;
     return hosts.find((host) => host.status === "connected") ?? hosts[0];
   }, [hosts]);
+}
+
+/**
+ * Single-level directory listing on a host, for the interactive path browser.
+ * A null `path` lists the host's home directory. Keeps the previous listing
+ * visible while navigating so the list doesn't blank out between folders.
+ */
+export function useHostDirectory(hostId: string | null, path: string | null) {
+  return useQuery<HostDirectoryListing>({
+    queryKey: hostDirectoryQueryKey(hostId, path),
+    queryFn: ({ signal }) =>
+      api.browseHostDirectory({
+        hostId: hostId as string,
+        ...(path ? { path } : {}),
+        signal,
+      }),
+    enabled: hostId != null,
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
 }

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -12,6 +12,7 @@ import {
 
 export const HOSTS_QUERY_KEY = "hosts";
 export const HOST_QUERY_KEY = "host";
+export const HOST_DIRECTORY_QUERY_KEY = "hostDirectory";
 export const PROJECTS_QUERY_KEY = "projects";
 export const PROJECT_PATHS_QUERY_KEY = "projectPaths";
 export const PROJECT_FILE_PREVIEW_QUERY_KEY = "projectFilePreview";
@@ -92,6 +93,11 @@ export type HostsQueryKey = readonly [typeof HOSTS_QUERY_KEY];
 export type HostQueryId = string | null | undefined;
 export type HostQueryKey = readonly [typeof HOST_QUERY_KEY, HostQueryId];
 export type AllHostQueryKeyPrefix = readonly [typeof HOST_QUERY_KEY];
+export type HostDirectoryQueryKey = readonly [
+  typeof HOST_DIRECTORY_QUERY_KEY,
+  HostQueryId,
+  string | null,
+];
 export type ProjectsQueryKey = readonly [typeof PROJECTS_QUERY_KEY];
 export type AllProjectPathsQueryKeyPrefix = readonly [
   typeof PROJECT_PATHS_QUERY_KEY,
@@ -455,6 +461,13 @@ export function hostQueryKey(hostId: HostQueryId): HostQueryKey {
 
 export function allHostQueryKeyPrefix(): AllHostQueryKeyPrefix {
   return [HOST_QUERY_KEY];
+}
+
+export function hostDirectoryQueryKey(
+  hostId: HostQueryId,
+  path: string | null,
+): HostDirectoryQueryKey {
+  return [HOST_DIRECTORY_QUERY_KEY, hostId, path];
 }
 
 export function projectsQueryKey(): ProjectsQueryKey {

--- a/apps/app/src/hooks/useQuickCreateProject.tsx
+++ b/apps/app/src/hooks/useQuickCreateProject.tsx
@@ -34,6 +34,7 @@ export interface QuickCreateProjectController {
   isCreating: boolean;
   openCreateDialog: () => void;
   platform: HostPlatform | null;
+  hostId: string | null;
   hostName: string | null;
   projectPathDialog: QuickCreateProjectDialogState;
   submitProjectPath: ProjectPathDialogSubmitHandler;
@@ -89,6 +90,7 @@ export function useQuickCreateProject(): QuickCreateProjectController {
       isCreating: isPending,
       openCreateDialog,
       platform: controller.platform,
+      hostId: controller.hostId,
       hostName: controller.hostName,
       projectPathDialog: controller.projectPathDialog,
       submitProjectPath: controller.submitProjectPath,

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   EnvironmentDiffFileResponse,
   EnvironmentStatusResponse,
   EnvironmentPullRequestResponse,
+  HostDirectoryListing,
   TerminalListResponse,
   CreateThreadRequest,
   CreateTerminalRequest,
@@ -1362,6 +1363,32 @@ export async function markThreadUnread(id: string): Promise<ThreadResponse> {
 export async function getHost(id: string, signal?: AbortSignal): Promise<Host> {
   return request<Host>(
     apiClient.hosts[":id"].$get({ param: { id } }, requestOptions(signal)),
+  );
+}
+
+interface BrowseHostDirectoryArgs {
+  hostId: string;
+  /** Absolute directory to list; omit to list the host's home directory. */
+  path?: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Single-level directory listing for the interactive path browser. Used when
+ * picking a project path on a host whose native folder picker is unavailable
+ * (e.g. a remote device). Each navigation step is one shallow read.
+ */
+export async function browseHostDirectory(
+  args: BrowseHostDirectoryArgs,
+): Promise<HostDirectoryListing> {
+  return request<HostDirectoryListing>(
+    apiClient.hosts[":id"].directory.$get(
+      {
+        param: { id: args.hostId },
+        query: args.path ? { path: args.path } : {},
+      },
+      requestOptions(args.signal),
+    ),
   );
 }
 

--- a/apps/app/src/views/ProjectSettingsView.tsx
+++ b/apps/app/src/views/ProjectSettingsView.tsx
@@ -188,6 +188,7 @@ export function ProjectSettingsView() {
         target={localSourcePicker.projectPathDialog.target}
         pending={localSourcePickerPending}
         platform={localSourcePicker.platform}
+        hostId={localSourcePicker.hostId}
         hostName={localSourcePicker.hostName}
         onOpenChange={localSourcePicker.projectPathDialog.onOpenChange}
         onSubmit={localSourcePicker.submitProjectPath}

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -19,6 +19,7 @@ import {
 import { listHostBranches } from "./command-handlers/host-branches.js";
 import { listHostCommands } from "./command-handlers/list-commands.js";
 import {
+  browseHostDirectory,
   listHostFiles,
   listHostPaths,
   readHostFile,
@@ -223,6 +224,7 @@ const commandHandlers: CommandHandlerMap = {
 const onlineRpcHandlers: OnlineRpcHandlerMap = {
   "host.list_files": listHostFiles,
   "host.list_paths": listHostPaths,
+  "host.browse_directory": browseHostDirectory,
   "host.list_commands": listHostCommands,
   "host.list_branches": listHostBranches,
   "host.file_metadata": readHostFileMetadata,

--- a/apps/host-daemon/src/command-handlers/host-files.test.ts
+++ b/apps/host-daemon/src/command-handlers/host-files.test.ts
@@ -10,6 +10,7 @@ import {
   isExpectedCommandDispatchError,
 } from "../command-dispatch-support.js";
 import {
+  browseHostDirectory,
   readHostFile,
   readHostFileMetadata,
   readHostRelativeFile,
@@ -234,6 +235,77 @@ describe("readHostFileMetadata", () => {
     ).rejects.toMatchObject({
       code: "invalid_path",
       message: expect.stringContaining("escapes read root"),
+    });
+  });
+});
+
+describe("browseHostDirectory", () => {
+  it("lists immediate children sorted directories-first, hiding noise", async () => {
+    const root = await makeTempDir("bb-browse-");
+    await fs.mkdir(path.join(root, "beta"));
+    await fs.mkdir(path.join(root, "alpha"));
+    await fs.mkdir(path.join(root, ".hidden"));
+    await fs.mkdir(path.join(root, "node_modules"));
+    await fs.writeFile(path.join(root, "readme.md"), "hi", "utf8");
+    // A nested file must not surface — listing is single-level.
+    await fs.writeFile(path.join(root, "alpha", "deep.txt"), "x", "utf8");
+    await fs.symlink(path.join(root, "alpha"), path.join(root, "link"));
+
+    const realRoot = await fs.realpath(root);
+    const result = await browseHostDirectory({
+      type: "host.browse_directory",
+      path: root,
+    });
+
+    expect(result.directory).toBe(realRoot);
+    expect(result.parent).toBe(path.dirname(realRoot));
+    expect(result.entries).toEqual([
+      {
+        kind: "directory",
+        name: "alpha",
+        path: path.join(realRoot, "alpha"),
+      },
+      { kind: "directory", name: "beta", path: path.join(realRoot, "beta") },
+      // Symlink to a directory is classified as a navigable directory.
+      { kind: "directory", name: "link", path: path.join(realRoot, "link") },
+      {
+        kind: "file",
+        name: "readme.md",
+        path: path.join(realRoot, "readme.md"),
+      },
+    ]);
+  });
+
+  it("defaults to the host home directory when no path is given", async () => {
+    const result = await browseHostDirectory({
+      type: "host.browse_directory",
+    });
+
+    expect(result.directory).toBe(await fs.realpath(os.homedir()));
+  });
+
+  it("rejects a relative path", async () => {
+    await expect(
+      browseHostDirectory({
+        type: "host.browse_directory",
+        path: "relative/dir",
+      }),
+    ).rejects.toBeInstanceOf(CommandDispatchError);
+  });
+
+  it("rejects a path that is not a directory", async () => {
+    const root = await makeTempDir("bb-browse-file-");
+    const filePath = path.join(root, "file.txt");
+    await fs.writeFile(filePath, "x", "utf8");
+
+    await expect(
+      browseHostDirectory({
+        type: "host.browse_directory",
+        path: filePath,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_path",
+      message: expect.stringContaining("is not a directory"),
     });
   });
 });

--- a/apps/host-daemon/src/command-handlers/host-files.ts
+++ b/apps/host-daemon/src/command-handlers/host-files.ts
@@ -1,5 +1,11 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
+import type {
+  DirectoryEntry,
+  HostDaemonOnlineRpcResult,
+  HostPathEntryKind,
+} from "@bb/host-daemon-contract";
 import { CommandDispatchError } from "../command-dispatch-support.js";
 import type { CommandOf } from "../command-dispatch-support.js";
 import { isFsErrorWithCode } from "../fs-errors.js";
@@ -110,6 +116,71 @@ export async function listHostPaths(
     }
     throw error;
   }
+}
+
+const DIRECTORY_BROWSE_SKIP_NAMES = new Set(["node_modules"]);
+
+function compareDirectoryEntries(a: DirectoryEntry, b: DirectoryEntry): number {
+  if (a.kind !== b.kind) {
+    return a.kind === "directory" ? -1 : 1;
+  }
+  return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
+
+export async function browseHostDirectory(
+  command: CommandOf<"host.browse_directory">,
+): Promise<HostDaemonOnlineRpcResult<"host.browse_directory">> {
+  const requestedPath = command.path ?? os.homedir();
+  if (!path.isAbsolute(requestedPath)) {
+    throw new CommandDispatchError("invalid_path", "Path must be absolute");
+  }
+
+  // Follow a symlinked base directory: single-level browsing has no recursion
+  // loop risk (unlike the recursive lister), and users legitimately navigate
+  // through symlinked folders.
+  const stat = await fs.stat(requestedPath);
+  if (!stat.isDirectory()) {
+    throw new CommandDispatchError(
+      "invalid_path",
+      `Path "${requestedPath}" is not a directory`,
+    );
+  }
+  const directory = await fs.realpath(requestedPath);
+
+  const dirents = await fs.readdir(directory, { withFileTypes: true });
+  const entries: DirectoryEntry[] = [];
+  for (const dirent of dirents) {
+    if (dirent.name.startsWith(".")) continue;
+    if (DIRECTORY_BROWSE_SKIP_NAMES.has(dirent.name)) continue;
+
+    const fullPath = path.join(directory, dirent.name);
+    let kind: HostPathEntryKind;
+    if (dirent.isSymbolicLink()) {
+      // Classify by the symlink target; skip broken links.
+      try {
+        kind = (await fs.stat(fullPath)).isDirectory() ? "directory" : "file";
+      } catch {
+        continue;
+      }
+    } else if (dirent.isDirectory()) {
+      kind = "directory";
+    } else if (dirent.isFile()) {
+      kind = "file";
+    } else {
+      continue; // sockets, fifos, devices — not browsable
+    }
+
+    entries.push({ kind, name: dirent.name, path: fullPath });
+  }
+
+  entries.sort(compareDirectoryEntries);
+
+  const parent = path.dirname(directory);
+  return {
+    directory,
+    parent: parent === directory ? null : parent,
+    entries,
+  };
 }
 
 export async function readHostFile(

--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -5,11 +5,13 @@ import {
 } from "@bb/server-contract";
 import type { Hono } from "hono";
 import type { AppDeps } from "../types.js";
+import { COMMAND_TIMEOUT_MS } from "../constants.js";
 import { ApiError } from "../errors.js";
 import {
   listPublicHostsWithStatus,
   requireNonDestroyedHostWithStatus,
 } from "../services/lib/entity-lookup.js";
+import { callHostRetryableOnlineRpc } from "../services/hosts/online-rpc.js";
 
 export function registerHostRoutes(app: Hono, deps: AppDeps): void {
   const { get } = typedRoutes<PublicApiSchema>(app, {
@@ -27,4 +29,20 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
       requireNonDestroyedHostWithStatus(deps.db, context.req.param("id")),
     ),
   );
+
+  // Single-level directory listing for the interactive path browser. Omitting
+  // `path` lists the host's home directory (resolved on the host).
+  get(routes.directory, async (context, query) => {
+    const hostId = context.req.param("id");
+    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    const result = await callHostRetryableOnlineRpc(deps, {
+      hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command: {
+        type: "host.browse_directory",
+        ...(query.path ? { path: query.path } : {}),
+      },
+    });
+    return context.json(result);
+  });
 }

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -424,6 +424,33 @@ const hostListPathsCommandSchema = z
     message: "At least one path kind must be included",
   });
 
+// Single-level directory listing for the interactive path browser. Unlike
+// `host.list_paths` (a recursive fuzzy-search walk over relative paths), this
+// reads exactly one directory and returns absolute child paths so the UI can
+// navigate step by step.
+const hostBrowseDirectoryCommandSchema = z.object({
+  type: z.literal("host.browse_directory"),
+  // Absolute directory to list. Omitted means the host's home directory, which
+  // the daemon resolves — a remote caller has no way to know the host's home.
+  path: z.string().min(1).optional(),
+});
+
+export const directoryEntrySchema = z.object({
+  kind: hostPathEntryKindSchema,
+  name: z.string(),
+  path: z.string(),
+});
+export type DirectoryEntry = z.infer<typeof directoryEntrySchema>;
+
+export const directoryListingSchema = z.object({
+  // Resolved absolute directory that was listed (symlinks already followed).
+  directory: z.string(),
+  // Absolute parent directory, or null at the filesystem root.
+  parent: z.string().nullable(),
+  entries: z.array(directoryEntrySchema),
+});
+export type DirectoryListing = z.infer<typeof directoryListingSchema>;
+
 export const hostCommandSourceSchema = z.enum(["skill", "command"]);
 export type HostCommandSource = z.infer<typeof hostCommandSourceSchema>;
 
@@ -1135,6 +1162,15 @@ export const hostDaemonCommandRegistry = {
     type: "host.list_paths",
     schema: hostListPathsCommandSchema,
     resultSchema: pathListResultSchema,
+    transport: "onlineRpc",
+    retryable: true,
+    flushEventsBeforeResult: false,
+    envLane: null,
+  }),
+  "host.browse_directory": defineHostDaemonCommandDescriptor({
+    type: "host.browse_directory",
+    schema: hostBrowseDirectoryCommandSchema,
+    resultSchema: directoryListingSchema,
     transport: "onlineRpc",
     retryable: true,
     flushEventsBeforeResult: false,

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -299,6 +299,7 @@ const hostDaemonOnlineRpcResponseSuccessSchema = z.discriminatedUnion(
   [
     onlineRpcResponseSuccessSchemaFor("host.list_files"),
     onlineRpcResponseSuccessSchemaFor("host.list_paths"),
+    onlineRpcResponseSuccessSchemaFor("host.browse_directory"),
     onlineRpcResponseSuccessSchemaFor("host.list_commands"),
     onlineRpcResponseSuccessSchemaFor("host.file_metadata"),
     onlineRpcResponseSuccessSchemaFor("host.list_branches"),

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -170,6 +170,14 @@ const ONLINE_RPC_RESPONSE_RESULT_FIXTURES: OnlineRpcResponseResultFixtures = {
     ],
     truncated: false,
   },
+  "host.browse_directory": {
+    directory: "/home/me/project",
+    parent: "/home/me",
+    entries: [
+      { kind: "directory", name: "src", path: "/home/me/project/src" },
+      { kind: "file", name: "README.md", path: "/home/me/project/README.md" },
+    ],
+  },
   "host.list_commands": {
     commands: [
       {
@@ -503,6 +511,8 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
     "dynamic ACP model selection omits selectFlag when the agent cannot pin a model at launch.",
   "hostDaemonOnlineRpcCommandSchema.query":
     "host.list_files may omit a search string to list files without filtering.",
+  "hostDaemonOnlineRpcCommandSchema.path":
+    "host.browse_directory may omit path to list the host's home directory, which a remote caller cannot resolve.",
   "hostDaemonOnlineRpcCommandSchema.ref":
     "host.read_file may omit ref to read from disk; setting ref switches to git history at that ref.",
   "hostDaemonOnlineRpcCommandSchema.rootPath":

--- a/packages/server-contract/src/api-types.ts
+++ b/packages/server-contract/src/api-types.ts
@@ -2,6 +2,7 @@ export * from "./api/shared.js";
 export * from "./api/automations.js";
 export * from "./api/projects.js";
 export * from "./api/environments.js";
+export * from "./api/hosts.js";
 export * from "./api/system.js";
 export * from "./api/terminals.js";
 export * from "./api/threads.js";

--- a/packages/server-contract/src/api/hosts.ts
+++ b/packages/server-contract/src/api/hosts.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+/**
+ * Query for `GET /hosts/:id/directory`, the interactive path browser's
+ * single-level directory read. `path` is an absolute directory on the host;
+ * omitting it lists the host's home directory (the daemon resolves it, since a
+ * remote caller cannot know the host's home).
+ */
+export const hostDirectoryQuerySchema = z.object({
+  path: z.string().min(1).optional(),
+});
+export type HostDirectoryQuery = z.infer<typeof hostDirectoryQuerySchema>;
+
+export const hostDirectoryEntrySchema = z.object({
+  kind: z.enum(["file", "directory"]),
+  name: z.string(),
+  path: z.string(),
+});
+export type HostDirectoryEntry = z.infer<typeof hostDirectoryEntrySchema>;
+
+export const hostDirectoryListingSchema = z.object({
+  // Resolved absolute directory that was listed (symlinks already followed).
+  directory: z.string(),
+  // Absolute parent directory, or null at the filesystem root.
+  parent: z.string().nullable(),
+  entries: z.array(hostDirectoryEntrySchema),
+});
+export type HostDirectoryListing = z.infer<typeof hostDirectoryListingSchema>;

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -71,6 +71,8 @@ import type {
   EnvironmentPullRequestResponse,
   EnvironmentStatusQuery,
   EnvironmentStatusResponse,
+  HostDirectoryListing,
+  HostDirectoryQuery,
   ProjectAttachmentContentQuery,
   ProjectAttachmentUploadForm,
   ProjectBranchesQuery,
@@ -170,6 +172,7 @@ import {
   environmentDiffQuerySchema,
   environmentPathsQuerySchema,
   environmentStatusQuerySchema,
+  hostDirectoryQuerySchema,
   projectAttachmentContentQuerySchema,
   projectBranchesQuerySchema,
   projectCommandsQuerySchema,
@@ -378,6 +381,14 @@ export const publicApiRoutes = {
       method: "get",
       request: noRequest<PathId>(),
       response: jsonResponse<Host>(),
+    }),
+    directory: defineRoute({
+      path: "/hosts/:id/directory",
+      method: "get",
+      request: queryRequest<PathId, HostDirectoryQuery>(
+        hostDirectoryQuerySchema,
+      ),
+      response: jsonResponse<HostDirectoryListing>(),
     }),
   },
 


### PR DESCRIPTION
## Summary

When picking a project path on a host without a native OS folder picker (e.g. a remote device on the tailnet), the "Add project" dialog previously offered only a free-text absolute-path input. This adds an interactive, single-pane folder browser as the primary surface, with the text input kept as a fallback when no host is available.

The browser navigates one directory at a time (lazy, single-level reads) rather than materializing a tree — a better fit than the existing recursive `host.list_paths` (built for fuzzy search) and than `@pierre/trees` (which has no async child-loading).

## Changes

- **daemon** — new `host.browse_directory` command/handler: a shallow, single-level directory read returning absolute child paths sorted directories-first, hiding dotfiles/`node_modules`, following symlinked directories, and defaulting to the host's home directory when no path is given.
- **server** — host-scoped `GET /hosts/:id/directory` route so the create-project flow can browse before any project exists (it has a `hostId` but no project).
- **app** — `RemotePathBrowser`: a breadcrumb that doubles as an editable path field (✎ to type/paste a path), folder navigation, and parent/home controls. Wired into `ProjectPathDialog`; "Add project" submits the folder currently in view. The plain-text input remains as the no-host fallback.

Selection model: the folder currently in view is what gets added (navigate in to pick a subfolder). The native OS picker is unchanged on local — the browser is the remote/no-native-picker path only.

## Tests

- daemon handler: listing, dirs-first sort, dotfile/`node_modules` filtering, symlinked-dir classification, home-directory default, rejects relative/non-directory paths.
- breadcrumb path-splitting helper (POSIX + Windows roots).
- contract response round-trip + optional-field allowlist for the new command.
- Typecheck + targeted suites green; rebased onto latest `main` (no file overlap).

## Risk

Read-only directory listing scoped to an existing connected host; no writes. Symlinked directories are navigable for single-level browsing (no recursion loop risk), unlike the recursive lister which skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)