### PR TITLE
[codex] Fix ACP composer bootstrap fallback

### DIFF
--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -101,6 +101,22 @@ function listConfiguredSystemProviderInfos(
   return providers;
 }
 
+function includeRequestedKnownAcpProvider(
+  providers: ProviderInfo[],
+  providerId: string | undefined,
+): ProviderInfo[] {
+  if (
+    providerId === undefined ||
+    providers.some((provider) => provider.id === providerId)
+  ) {
+    return providers;
+  }
+  const knownAgent = findKnownAcpAgentForProviderId(providerId);
+  return knownAgent === undefined
+    ? providers
+    : [...providers, buildKnownAcpProviderInfo(knownAgent)];
+}
+
 function canOmitKnownAcpAgentsForError(error: unknown): error is ApiError {
   return (
     error instanceof ApiError && (error.status === 502 || error.status === 504)
@@ -319,6 +335,7 @@ export async function resolveSystemExecutionOptions(
     await earlyModelResultPromise?.catch(() => undefined);
     throw error;
   }
+  providers = includeRequestedKnownAcpProvider(providers, query.providerId);
   const requestedProvider = query.providerId
     ? providers.find((provider) => provider.id === query.providerId)
     : undefined;

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -2562,6 +2562,96 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("keeps ACP thread composer defaults when provider discovery is degraded", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-composer-acp-degraded",
+      });
+      seedPrimaryHost(harness.deps, host.id);
+      const providerResponder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (
+            request.command.type === "known_acp_agents.status" ||
+            request.command.type === "provider.list_models"
+          ) {
+            return {
+              ok: false,
+              errorCode: "command_failed",
+              errorMessage: "Runtime shutting down",
+            };
+          }
+          throw new Error(`Unexpected RPC command ${request.command.type}`);
+        },
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      upsertProjectExecutionDefaults(harness.deps.db, {
+        projectId: project.id,
+        providerId: "acp-cursor",
+        model: "composer-2.5",
+        reasoningLevel: "medium",
+        permissionMode: "readonly",
+        serviceTier: "default",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "acp-opencode",
+      });
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        inputText: "New review comments on the PR",
+        model: "zai-coding-plan/glm-5.2",
+        permissionMode: "workspace-write",
+        providerThreadId: "ses_opencode",
+        reasoningLevel: "medium",
+        threadId: thread.id,
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/composer-bootstrap`,
+      );
+
+      expect(response.status).toBe(200);
+      const bootstrap = threadComposerBootstrapResponseSchema.parse(
+        await readJson(response),
+      );
+      expect(bootstrap.defaultExecutionOptions).toMatchObject({
+        model: "zai-coding-plan/glm-5.2",
+        permissionMode: "workspace-write",
+        reasoningLevel: "medium",
+      });
+      const { executionOptions } = bootstrap;
+      if (executionOptions === null) {
+        throw new Error(
+          "expected degraded executionOptions for an environment-backed ACP thread",
+        );
+      }
+      expect(
+        executionOptions.providers.some(
+          (provider) => provider.id === "acp-opencode",
+        ),
+      ).toBe(true);
+      expect(executionOptions.modelLoadError).toMatchObject({
+        providerId: "acp-opencode",
+      });
+      expect(
+        providerResponder.requests.map((request) => request.command.type),
+      ).toEqual(["known_acp_agents.status", "provider.list_models"]);
+      expect(providerResponder.requests[1]?.command).toMatchObject({
+        type: "provider.list_models",
+        providerId: "acp-opencode",
+      });
+    });
+  });
+
   it("returns null composer defaults for stale project execution defaults", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {


### PR DESCRIPTION
## Summary

Fixes composer bootstrap for ACP-backed threads when known-agent discovery is degraded. If `known_acp_agents.status` fails, the requested known ACP provider is now preserved in the provider list so existing ACP threads can keep resolving their provider/model state instead of falling back to another project default provider.

Closes #365.

## Root Cause

`resolveSystemExecutionOptions()` intentionally tolerated host/provider discovery failures by omitting known ACP agents. That is fine for generic provider lists, but it breaks thread-specific composer bootstrap when the thread provider itself is a known ACP provider such as `acp-opencode`. The requested provider disappeared from `executionOptions.providers`, so the composer could not reliably display or continue with the thread's historical execution model.

## Changes

- Include the requested known ACP provider in execution options even when the installed-known-agent probe is unavailable.
- Keep model loading degraded through the existing `modelLoadError` path.
- Add a regression test covering an `acp-opencode` thread with last-turn model state, stale project defaults for `acp-cursor`, and failing known-agent/model-list RPCs.

## Validation

- `pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-thread-data.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `git diff --check`
