### PR TITLE
Rename organize option to Manually

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -786,7 +786,7 @@ export function SidebarGroupOptionsMenu({
           }}
         />
         <SidebarGroupMenuOption
-          label="Folders"
+          label="Manually"
           selected={organizationMode === "chronological"}
           onSelect={(event) => {
             event.preventDefault();


### PR DESCRIPTION
Summary:
- Rename the sidebar organize-by manual/folder option label from Folders to Manually.
- Leave internal organization mode names unchanged.

Validation:
- pnpm exec turbo run typecheck --filter=@bb/app