### PR TITLE
Fix Claude subagent output nesting

### DIFF
--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -392,6 +392,29 @@ function consumePendingDelegationTurnLink(
   return undefined;
 }
 
+function shouldUseExplicitEventParentToolCallId({
+  eventTurnId,
+  isAcceptedRootClientTurn,
+  parentToolCallId,
+  state,
+}: {
+  eventTurnId: string | undefined;
+  isAcceptedRootClientTurn: boolean;
+  parentToolCallId: string | undefined;
+  state: ProjectionState;
+}): boolean {
+  if (!parentToolCallId) {
+    return false;
+  }
+  if (!isAcceptedRootClientTurn) {
+    return true;
+  }
+  return (
+    typeof eventTurnId === "string" &&
+    state.delegationTurnIdsByCallId.get(parentToolCallId) === eventTurnId
+  );
+}
+
 function getCompactionTurnFinalization(
   decoded: ThreadEvent,
 ): CompactionTurnFinalization | undefined {
@@ -443,9 +466,16 @@ function buildFlatProjectionData(
     const isAcceptedRootClientTurn =
       typeof eventTurnId === "string" &&
       acceptedRootClientTurnIds.has(eventTurnId);
-    const explicitEventParentToolCallId = isAcceptedRootClientTurn
-      ? undefined
-      : getEventParentToolCallId(decoded);
+    const decodedEventParentToolCallId = getEventParentToolCallId(decoded);
+    const explicitEventParentToolCallId =
+      shouldUseExplicitEventParentToolCallId({
+        eventTurnId,
+        isAcceptedRootClientTurn,
+        parentToolCallId: decodedEventParentToolCallId,
+        state,
+      })
+        ? decodedEventParentToolCallId
+        : undefined;
 
     if (decoded.type === "turn/started") {
       const turnId = requireThreadEventScopeTurnId({
@@ -476,7 +506,7 @@ function buildFlatProjectionData(
     }
 
     const eventParentToolCallId = isAcceptedRootClientTurn
-      ? undefined
+      ? explicitEventParentToolCallId
       : (explicitEventParentToolCallId ??
         (eventTurnId
           ? state.delegationParentToolCallIdsByTurnId.get(eventTurnId)
@@ -628,6 +658,12 @@ function buildFlatProjectionData(
       const toolCallReceiverThreadIds = getToolCallReceiverThreadIds(decoded);
       const toolCallSenderThreadId = getToolCallSenderThreadId(decoded);
       if (toolCallEvent.kind !== "output") {
+        if (toolCallEvent.call.kind === "delegation" && eventTurnId) {
+          state.delegationTurnIdsByCallId.set(
+            toolCallEvent.call.callId,
+            eventTurnId,
+          );
+        }
         if (
           !toolCallEvent.call.parentToolCallId &&
           toolCallName &&

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -83,6 +83,7 @@ export interface ProjectionState
   threadInterruptedAt: number | null;
   delegationParentToolCallIdsByProviderThreadId: Map<string, string>;
   delegationParentToolCallIdsByTurnId: Map<string, string>;
+  delegationTurnIdsByCallId: Map<string, string>;
   pendingDelegationTurnLinksByProviderThreadId: Map<
     string,
     PendingDelegationTurnLink[]
@@ -106,6 +107,7 @@ export function createProjectionState(): ProjectionState {
     ...createReasoningProjectionState(),
     delegationParentToolCallIdsByProviderThreadId: new Map(),
     delegationParentToolCallIdsByTurnId: new Map(),
+    delegationTurnIdsByCallId: new Map(),
     pendingDelegationTurnLinksByProviderThreadId: new Map(),
     delegatedTurnLinkCallIds: new Set(),
     toolActivity: createToolActivityState(),

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1202,6 +1202,90 @@ describe("timeline CLI rendering snapshots", () => {
     });
   });
 
+  it("nests explicit Claude subagent messages inside accepted root turns", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    const startRequest = event.clientTurnRequested({
+      target: { kind: "thread-start" },
+      text: "Run a Claude Code subagent.",
+    });
+    const timeline = renderActiveTimeline([
+      startRequest,
+      event.turnStarted(),
+      event.inputAccepted({
+        clientRequestId: startRequest.data.requestId,
+      }),
+      event.toolCallStarted({
+        itemId: "toolu_agent_1",
+        tool: "Agent",
+        arguments: {
+          prompt: "Reply with FIRST_SUBAGENT_OUTPUT.",
+          subagent_type: "general-purpose",
+        },
+      }),
+      event.toolCallCompleted({
+        itemId: "toolu_agent_1",
+        tool: "Agent",
+        arguments: {
+          prompt: "Reply with FIRST_SUBAGENT_OUTPUT.",
+          subagent_type: "general-purpose",
+        },
+        result: "FIRST_SUBAGENT_OUTPUT",
+      }),
+      event.assistantCompleted({
+        itemId: "subagent-message-1",
+        parentToolCallId: "toolu_agent_1",
+        text: "SECOND_SUBAGENT_OUTPUT",
+      }),
+      event.assistantCompleted({
+        itemId: "main-assistant-1",
+        text: "MAIN_DONE_AFTER_SENDMESSAGE",
+      }),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegation = allRows.find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+    const topLevelSubagentOutput = timeline.rows.find(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "assistant" &&
+        row.text === "SECOND_SUBAGENT_OUTPUT",
+    );
+
+    expect(delegation).toBeDefined();
+    expect(delegation?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          role: "assistant",
+          text: "SECOND_SUBAGENT_OUTPUT",
+          turnId: "turn-1",
+        }),
+      ]),
+    );
+    expect(topLevelSubagentOutput).toBeUndefined();
+    expect(timeline.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          role: "assistant",
+          text: "MAIN_DONE_AFTER_SENDMESSAGE",
+          turnId: "turn-1",
+        }),
+      ]),
+    );
+  });
+
   it("does not attach later human turns to Codex same-provider receiver delegations", () => {
     const event = createTimelineEventFactory({
       providerThreadId: "root-provider",


### PR DESCRIPTION
## Summary
- Preserve explicit subagent parent tool-call ids for Claude Code Agent continuation output inside accepted root turns.
- Track delegation call ids by turn so stale accepted-turn parent ids still stay top-level unless they refer to a delegation from the same turn.
- Add a thread-view regression fixture covering the Agent continuation output case.

## Validation
- pnpm exec turbo run test --filter=@bb/thread-view -- timeline-cli-rendering.snapshots.test.ts
- pnpm exec turbo run test --filter=@bb/thread-view
- pnpm exec turbo run typecheck --filter=@bb/thread-view
- Replayed captured real-provider standalone Claude Code repro events through patched projection; exact subagent output now nests under the Agent delegation.