### PR TITLE
Fix thread timeline TOC activation

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TimelineRow } from "@bb/server-contract";
+import {
+  findActiveItemIds,
+  ThreadTableOfContents,
+  type TocItem,
+} from "./ThreadTableOfContents";
+
+class ResizeObserverMock implements ResizeObserver {
+  observe: ResizeObserver["observe"] = vi.fn();
+  unobserve: ResizeObserver["unobserve"] = vi.fn();
+  disconnect: ResizeObserver["disconnect"] = vi.fn();
+}
+
+function userConversationRow(): TimelineRow {
+  return {
+    id: "row_user_1",
+    threadId: "thr_toc_test",
+    turnId: "turn_1",
+    sourceSeqStart: 1,
+    sourceSeqEnd: 1,
+    startedAt: 1,
+    createdAt: 1,
+    kind: "conversation",
+    role: "user",
+    text: "Loaded after client-side navigation",
+    attachments: null,
+    initiator: "user",
+    senderThreadId: null,
+    systemMessageKind: "unlabeled",
+    systemMessageSubject: null,
+    turnRequest: {
+      kind: "message",
+      status: "accepted",
+    },
+    mentions: [],
+  };
+}
+
+function TocHost({ timelineRows }: { timelineRows: readonly TimelineRow[] }) {
+  return (
+    <div
+      ref={(node) => {
+        if (!node) return;
+        Object.defineProperty(node, "clientWidth", {
+          configurable: true,
+          value: 1_200,
+        });
+      }}
+      data-scroll-overlay=""
+    >
+      <ThreadTableOfContents timelineRows={timelineRows} />
+    </div>
+  );
+}
+
+function rect({ bottom, top }: { bottom: number; top: number }): DOMRect {
+  return {
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 100,
+    toJSON: () => ({}),
+    top,
+    width: 100,
+    x: 0,
+    y: top,
+  };
+}
+
+function createScrollElement({
+  clientHeight,
+  rows,
+  scrollHeight,
+  scrollTop,
+}: {
+  clientHeight: number;
+  rows: ReadonlyArray<{ id: string; bottom: number; top: number }>;
+  scrollHeight: number;
+  scrollTop: number;
+}): HTMLElement {
+  const scrollElement = document.createElement("div");
+  Object.defineProperty(scrollElement, "clientHeight", {
+    configurable: true,
+    value: clientHeight,
+  });
+  Object.defineProperty(scrollElement, "scrollHeight", {
+    configurable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(scrollElement, "scrollTop", {
+    configurable: true,
+    value: scrollTop,
+  });
+  scrollElement.getBoundingClientRect = () =>
+    rect({ bottom: clientHeight, top: 0 });
+
+  for (const row of rows) {
+    const rowElement = document.createElement("div");
+    rowElement.dataset.timelineRowId = row.id;
+    rowElement.getBoundingClientRect = () =>
+      rect({ bottom: row.bottom, top: row.top });
+    scrollElement.append(rowElement);
+  }
+
+  return scrollElement;
+}
+
+const userItems: TocItem[] = [
+  { id: "user-1", label: "First prompt", role: "user" },
+  { id: "user-2", label: "Second prompt", role: "user" },
+];
+
+const agentItems: TocItem[] = [
+  { id: "agent-1", label: "First response", role: "assistant" },
+  { id: "agent-2", label: "Second response", role: "assistant" },
+];
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }),
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ThreadTableOfContents", () => {
+  it("shows after timeline rows arrive following an empty initial render", async () => {
+    const view = render(<TocHost timelineRows={[]} />);
+
+    expect(screen.queryByText("Your messages")).toBeNull();
+
+    view.rerender(<TocHost timelineRows={[userConversationRow()]} />);
+
+    expect(await screen.findByText("Your messages")).not.toBeNull();
+    expect(
+      screen.getByText("Loaded after client-side navigation"),
+    ).not.toBeNull();
+  });
+
+  it("tracks the conversation item nearest the viewport top away from bottom", () => {
+    const scrollElement = createScrollElement({
+      clientHeight: 100,
+      scrollHeight: 1_000,
+      scrollTop: 400,
+      rows: [
+        { id: "user-1", top: 10, bottom: 30 },
+        { id: "agent-1", top: 35, bottom: 55 },
+        { id: "user-2", top: 80, bottom: 100 },
+        { id: "agent-2", top: 105, bottom: 125 },
+      ],
+    });
+
+    expect(findActiveItemIds({ agentItems, scrollElement, userItems })).toEqual(
+      {
+        agent: "agent-1",
+        user: "user-1",
+      },
+    );
+  });
+
+  it("ignores conversation items above the viewport", () => {
+    const scrollElement = createScrollElement({
+      clientHeight: 100,
+      scrollHeight: 1_000,
+      scrollTop: 400,
+      rows: [
+        { id: "user-1", top: -30, bottom: -10 },
+        { id: "agent-1", top: -8, bottom: -1 },
+        { id: "user-2", top: 30, bottom: 50 },
+        { id: "agent-2", top: 60, bottom: 80 },
+      ],
+    });
+
+    expect(findActiveItemIds({ agentItems, scrollElement, userItems })).toEqual(
+      {
+        agent: "agent-2",
+        user: "user-2",
+      },
+    );
+  });
+
+  it("tracks the latest visible conversation item at the bottom", () => {
+    const scrollElement = createScrollElement({
+      clientHeight: 100,
+      scrollHeight: 1_000,
+      scrollTop: 900,
+      rows: [
+        { id: "user-1", top: 10, bottom: 30 },
+        { id: "agent-1", top: 35, bottom: 55 },
+        { id: "user-2", top: 80, bottom: 100 },
+        { id: "agent-2", top: 90, bottom: 110 },
+      ],
+    });
+
+    expect(findActiveItemIds({ agentItems, scrollElement, userItems })).toEqual(
+      {
+        agent: "agent-2",
+        user: "user-2",
+      },
+    );
+  });
+
+  it("does not mark a role active at the bottom when that role is offscreen", () => {
+    const scrollElement = createScrollElement({
+      clientHeight: 100,
+      scrollHeight: 1_000,
+      scrollTop: 900,
+      rows: [
+        { id: "user-1", top: -120, bottom: -80 },
+        { id: "user-2", top: -60, bottom: -20 },
+        { id: "agent-2", top: 20, bottom: 90 },
+      ],
+    });
+
+    expect(findActiveItemIds({ agentItems, scrollElement, userItems })).toEqual(
+      {
+        agent: "agent-2",
+        user: null,
+      },
+    );
+  });
+});

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -1,5 +1,4 @@
 import {
-  type RefObject,
   useCallback,
   useEffect,
   useMemo,
@@ -14,7 +13,7 @@ import { useScrollOverflowState } from "@/components/thread/timeline/useScrollOv
 import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
 import { cn } from "@/lib/utils";
 
-interface TocItem {
+export interface TocItem {
   id: string;
   label: string;
   role: "user" | "assistant";
@@ -32,6 +31,7 @@ interface ThreadTableOfContentsProps {
 }
 
 const TOC_MIN_VISIBLE_WIDTH_PX = 56 * 16;
+const TOC_BOTTOM_ACTIVE_THRESHOLD_PX = 4;
 
 function toPreviewLabel(text: string): string {
   return text.replace(/\s+/g, " ").trim();
@@ -110,17 +110,20 @@ function useConversationTocItems(timelineRows: readonly TimelineRow[]) {
   }, [timelineRows]);
 }
 
-function useThreadTocVisible(
-  rootRef: RefObject<HTMLDivElement | null>,
-): boolean {
+function useThreadTocVisible(rootElement: HTMLDivElement | null): boolean {
   const [visible, setVisible] = useState(
     () => typeof ResizeObserver === "undefined",
   );
 
   useEffect(() => {
     const host =
-      rootRef.current?.closest<HTMLElement>("[data-scroll-overlay]") ?? null;
-    if (!host || typeof ResizeObserver === "undefined") {
+      rootElement?.closest<HTMLElement>("[data-scroll-overlay]") ?? null;
+    if (typeof ResizeObserver === "undefined") {
+      setVisible(true);
+      return;
+    }
+    if (!host) {
+      setVisible(false);
       return;
     }
 
@@ -141,7 +144,7 @@ function useThreadTocVisible(
       if (frame !== null) window.cancelAnimationFrame(frame);
       resizeObserver.disconnect();
     };
-  }, [rootRef]);
+  }, [rootElement]);
 
   return visible;
 }
@@ -167,7 +170,16 @@ function findTimelineRowElement(
   );
 }
 
-function findActiveItemIds({
+function isScrollElementNearBottom(scrollElement: HTMLElement): boolean {
+  return (
+    scrollElement.scrollHeight -
+      scrollElement.clientHeight -
+      scrollElement.scrollTop <=
+    TOC_BOTTOM_ACTIVE_THRESHOLD_PX
+  );
+}
+
+export function findActiveItemIds({
   agentItems,
   scrollElement,
   userItems,
@@ -182,11 +194,14 @@ function findActiveItemIds({
   const scrollRect = scrollElement.getBoundingClientRect();
   const scrollTop = scrollRect.top;
   const scrollBottom = scrollRect.bottom;
+  const isNearBottom = isScrollElementNearBottom(scrollElement);
   const rolesById = new Map<string, TocTab>();
   for (const item of userItems) rolesById.set(item.id, "user");
   for (const item of agentItems) rolesById.set(item.id, "agent");
   let nearestUser: { id: string; distance: number } | null = null;
   let nearestAgent: { id: string; distance: number } | null = null;
+  let lastVisibleUserId: string | null = null;
+  let lastVisibleAgentId: string | null = null;
 
   for (const row of findTimelineRowElements(scrollElement)) {
     const rowId = row.dataset.timelineRowId;
@@ -194,7 +209,15 @@ function findActiveItemIds({
     const role = rolesById.get(rowId);
     if (!role) continue;
     const rect = row.getBoundingClientRect();
-    if (rect.top >= scrollBottom) continue;
+    if (rect.bottom <= scrollTop || rect.top >= scrollBottom) continue;
+    if (isNearBottom) {
+      if (role === "user") {
+        lastVisibleUserId = rowId;
+      } else {
+        lastVisibleAgentId = rowId;
+      }
+      continue;
+    }
     const distance =
       rect.top <= scrollTop
         ? Math.max(0, scrollTop - rect.bottom)
@@ -209,6 +232,10 @@ function findActiveItemIds({
     }
   }
 
+  if (isNearBottom) {
+    return { agent: lastVisibleAgentId, user: lastVisibleUserId };
+  }
+
   return { agent: nearestAgent?.id ?? null, user: nearestUser?.id ?? null };
 }
 
@@ -217,8 +244,8 @@ export function ThreadTableOfContents({
 }: ThreadTableOfContentsProps) {
   const bottomAnchor = useBottomAnchoredScroll();
   const { agentItems, userItems } = useConversationTocItems(timelineRows);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const tocVisible = useThreadTocVisible(rootRef);
+  const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
+  const tocVisible = useThreadTocVisible(rootElement);
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<TocTab>("user");
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
@@ -327,7 +354,7 @@ export function ThreadTableOfContents({
 
   return (
     <div
-      ref={rootRef}
+      ref={setRootElement}
       data-thread-toc=""
       className="group/toc relative w-8"
       onMouseEnter={() => setOpen(true)}


### PR DESCRIPTION
## Summary
- Re-run TOC visibility measurement when the TOC root appears after timeline rows load
- Limit active TOC items to rows that intersect the scroll viewport
- Make bottom-of-timeline activation choose the latest visible item per role
- Add regression coverage for delayed row loading, offscreen rows, and bottom activation

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/thread/toc/ThreadTableOfContents.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app