### PR TITLE
Add fake test edit plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 [![npm version](https://img.shields.io/npm/v/bb-app.svg)](https://www.npmjs.com/package/bb-app)
 
+Test edit for draft PR workflow validation.
+
 bb is an agentic IDE that can control itself. You can seamlessly
 orchestrate all of your favorite coding agents together and have them
 programmatically use bb too.

--- a/plans/fake-test-edit-plan.md
+++ b/plans/fake-test-edit-plan.md
@@ -1,0 +1,21 @@
+# Fake Test Edit Plan
+
+## Purpose
+
+Validate that a small repository edit and a plan file can move through the draft PR workflow.
+
+## Steps
+
+1. Add a harmless test edit.
+2. Add this fake plan under `plans/`.
+3. Open a draft PR for review.
+
+## Exit Criteria
+
+- The README contains the test edit.
+- This plan exists in `plans/`.
+- A draft PR is available on GitHub.
+
+## Validation
+
+No behavior validation is required because this is an intentional fake/docs-only workflow test.


### PR DESCRIPTION
## Summary
- add a harmless README test edit
- add a fake plan under plans/ for PR workflow validation

## Testing
- Not run; docs-only fake workflow test.