### PR TITLE
Fix GitHub favicon dark mode

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -83,6 +83,8 @@ import { useUrlAnchorClickHandler } from "@/lib/url-open-routing";
 
 const GITHUB_FAVICON_URL =
   "https://github.githubassets.com/favicons/favicon.png";
+const GITHUB_DARK_FAVICON_URL =
+  "https://github.githubassets.com/favicons/favicon-dark.png";
 
 export interface ParentSelectorRowProps {
   thread: Thread;
@@ -465,12 +467,20 @@ export function PullRequestRow({ pullRequest }: PullRequestRowProps) {
         {showGithubCheckIcon ? (
           <PullRequestGithubCheckIcon pullRequest={pullRequest} />
         ) : (
-          <img
-            src={GITHUB_FAVICON_URL}
-            alt=""
-            className="size-4 shrink-0"
-            aria-hidden="true"
-          />
+          <>
+            <img
+              src={GITHUB_FAVICON_URL}
+              alt=""
+              className="size-4 shrink-0 dark:hidden"
+              aria-hidden="true"
+            />
+            <img
+              src={GITHUB_DARK_FAVICON_URL}
+              alt=""
+              className="hidden size-4 shrink-0 dark:block"
+              aria-hidden="true"
+            />
+          </>
         )}
         <span className="shrink-0 text-muted-foreground">
           #{pullRequest.number}


### PR DESCRIPTION
## Summary
- Use GitHub's dark favicon variant for the info-tab pull request fallback icon in dark mode.
- Keep the existing light favicon in light mode.

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- Tests not added per request.