### PR TITLE
Disable selection menu on coarse pointers

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -12,6 +12,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState, type ComponentProps, type ReactElement } from "react";
 import { MemoryRouter, useNavigate } from "react-router-dom";
+import { COMPACT_VIEWPORT_QUERY } from "@/components/ui/hooks/use-compact-viewport";
+import { POINTER_COARSE_QUERY } from "@/components/ui/hooks/use-pointer-coarse";
 import { conversationRow, turnRow } from "@/test/fixtures/thread-timeline-rows";
 import { ThreadTimelineRows } from "./ThreadTimelineRows";
 
@@ -181,6 +183,27 @@ function mockWindowSelection({ node, text }: { node: Node; text: string }) {
   } as unknown as Selection);
 }
 
+function mockSelectionMenuMedia({
+  isCompactViewport = false,
+  isPointerCoarse = false,
+}: {
+  isCompactViewport?: boolean;
+  isPointerCoarse?: boolean;
+} = {}) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches:
+      (query === COMPACT_VIEWPORT_QUERY && isCompactViewport) ||
+      (query === POINTER_COARSE_QUERY && isPointerCoarse),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -343,6 +366,83 @@ describe("ThreadTimelineRows actions", () => {
       messageText: "this earlier answer",
       sourceSeqEnd: 42,
     });
+  });
+
+  it("does not show the floating selection menu on coarse pointers", async () => {
+    mockSelectionMenuMedia({ isPointerCoarse: true });
+    const onSelectionAddToChat = vi.fn();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(performance.now());
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    renderWithRouter(
+      <ThreadTimelineRows
+        timelineRows={[
+          conversationRow({
+            role: "assistant",
+            text: "Mobile selection should use native controls.",
+          }),
+        ]}
+        threadRuntimeDisplayStatus="idle"
+        onSelectionAddToChat={onSelectionAddToChat}
+        workspaceRootPath={undefined}
+      />,
+    );
+    const textNode = screen.getByText(
+      "Mobile selection should use native controls.",
+    ).firstChild;
+    expect(textNode).not.toBeNull();
+    mockWindowSelection({
+      node: textNode!,
+      text: "native controls",
+    });
+
+    await act(async () => {
+      fireEvent(document, new Event("selectionchange"));
+    });
+
+    expect(screen.queryByRole("button", { name: "Add to chat" })).toBeNull();
+    expect(onSelectionAddToChat).not.toHaveBeenCalled();
+  });
+
+  it("keeps the floating selection menu on compact fine-pointer viewports", async () => {
+    mockSelectionMenuMedia({ isCompactViewport: true });
+    const onSelectionAddToChat = vi.fn();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(performance.now());
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    renderWithRouter(
+      <ThreadTimelineRows
+        timelineRows={[
+          conversationRow({
+            role: "assistant",
+            text: "Compact fine pointer keeps the floating selection menu.",
+          }),
+        ]}
+        threadRuntimeDisplayStatus="idle"
+        onSelectionAddToChat={onSelectionAddToChat}
+        workspaceRootPath={undefined}
+      />,
+    );
+    const textNode = screen.getByText(
+      "Compact fine pointer keeps the floating selection menu.",
+    ).firstChild;
+    expect(textNode).not.toBeNull();
+    mockWindowSelection({
+      node: textNode!,
+      text: "floating selection menu",
+    });
+
+    fireEvent(document, new Event("selectionchange"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Add to chat" })).toBeTruthy(),
+    );
   });
 
   it("ignores sidebar search scroll state for a different thread", () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -84,6 +84,7 @@ import { AutoHeightContainer } from "../../ui/height-transition.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import {
   collectSearchedMessageAncestorRowIds,
   readSearchMessageTarget,
@@ -1794,11 +1795,22 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   // `null` (only emitted by a message that previously had a selection) clears it.
   const onSelectionAddToChat = props.onSelectionAddToChat;
   const onSelectionReplyInSideChat = props.onSelectionReplyInSideChat;
+  const isPointerCoarse = usePointerCoarse();
   const hasSelectionActions =
-    onSelectionAddToChat !== undefined ||
-    onSelectionReplyInSideChat !== undefined;
+    !isPointerCoarse &&
+    (onSelectionAddToChat !== undefined ||
+      onSelectionReplyInSideChat !== undefined);
   const [activeSelection, setActiveSelection] =
     useState<MessageProseSelection | null>(null);
+  useEffect(() => {
+    if (!isPointerCoarse || typeof window === "undefined") return;
+    const frame = window.requestAnimationFrame(() => {
+      setActiveSelection(null);
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [isPointerCoarse]);
   // Only hand a reporter to the messages when an action exists; otherwise the
   // wrapper stays inert and the floating menu never mounts.
   const reportProseSelection = useMemo<

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.stories.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.stories.tsx
@@ -112,13 +112,11 @@ export function Overview() {
 }
 
 export function CompactViewport() {
-  // On a compact viewport the Popover renders as a bottom drawer (see
-  // responsive-overlay). Narrow the Ladle canvas below ~640px to observe it.
   return (
     <StoryCard>
       <StoryRow
-        label="Compact (drawer)"
-        hint="Resize the canvas below ~640px to see the bottom drawer"
+        label="Compact viewport"
+        hint="The selection menu remains anchored instead of becoming a drawer"
       >
         <div className="w-[360px]">
           <AgentMessageWithMenu selected="drop the legacy field" />

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
@@ -2,10 +2,14 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { COMPACT_VIEWPORT_QUERY } from "@/components/ui/hooks/use-compact-viewport";
 import { TimelineSelectionMenu } from "./TimelineSelectionMenu";
 import type { MessageProseSelection } from "./SelectableMessageProse";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 function makeSelection(
   overrides: Partial<MessageProseSelection> = {},
@@ -16,6 +20,19 @@ function makeSelection(
     sourceSeqEnd: 12,
     ...overrides,
   };
+}
+
+function mockCompactViewport() {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: query === COMPACT_VIEWPORT_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
 }
 
 describe("TimelineSelectionMenu", () => {
@@ -73,6 +90,20 @@ describe("TimelineSelectionMenu", () => {
     );
 
     expect(document.body.querySelector('[data-side="bottom"]')).toBeTruthy();
+  });
+
+  it("stays anchored instead of rendering as a compact viewport drawer", () => {
+    mockCompactViewport();
+    render(
+      <TimelineSelectionMenu
+        selection={makeSelection({ anchorSide: "top" })}
+        onAddToChat={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add to chat" })).toBeTruthy();
+    expect(document.body.querySelector('[data-side="top"]')).toBeTruthy();
   });
 
   it("passes the selection branch point to side-chat replies", () => {

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState, type MouseEvent } from "react";
-import { cn } from "@/lib/utils";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { Icon, type IconName } from "../../ui/icon.js";
-import { Popover, PopoverAnchor, PopoverContent } from "../../ui/popover.js";
 import { preventOverlayTriggerSelection } from "../../ui/overlay-trigger.js";
 import type { MessageProseSelection } from "./SelectableMessageProse.js";
 
@@ -10,6 +9,8 @@ import type { MessageProseSelection } from "./SelectableMessageProse.js";
 // affordance, so each action shows its label (matching the approved mock).
 const SELECTION_ACTION_BUTTON_CLASS =
   "inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-xs text-foreground transition-colors hover:bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring select-none";
+const SELECTION_MENU_CONTENT_CLASS =
+  "z-50 flex w-auto items-center gap-0.5 rounded-md border bg-popover p-0.5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95";
 
 interface SelectionAction {
   icon: IconName;
@@ -123,7 +124,7 @@ export function TimelineSelectionMenu({
   const anchorSide = selection.anchorSide ?? "top";
 
   return (
-    <Popover
+    <PopoverPrimitive.Root
       open
       onOpenChange={(next) => {
         if (!next) onDismiss();
@@ -133,7 +134,7 @@ export function TimelineSelectionMenu({
         Zero-size anchor pinned to the pointer release point and gesture side,
         falling back to the selection rect.
       */}
-      <PopoverAnchor asChild>
+      <PopoverPrimitive.Anchor asChild>
         <div
           ref={anchorRef}
           aria-hidden="true"
@@ -145,32 +146,31 @@ export function TimelineSelectionMenu({
             height: 0,
           }}
         />
-      </PopoverAnchor>
-      <PopoverContent
-        side={anchorSide}
-        align="center"
-        sideOffset={6}
-        collisionBoundary={collisionBoundary}
-        collisionPadding={8}
-        mobileTitle="Selection actions"
-        // Tight, horizontal, content-width row — override the default wide
-        // popover padding/width.
-        className={cn(
-          "flex w-auto items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-md",
-        )}
-        mobileClassName="flex items-center justify-center gap-2"
-        onEscapeKeyDown={() => onDismiss()}
-        onOpenAutoFocus={(event) => event.preventDefault()}
-      >
-        {actions.map((action, index) => (
-          <div key={action.label} className="flex items-center">
-            {index > 0 ? (
-              <span aria-hidden="true" className="mx-0.5 h-4 w-px bg-border" />
-            ) : null}
-            <ActionButton action={action} selection={selection} />
-          </div>
-        ))}
-      </PopoverContent>
-    </Popover>
+      </PopoverPrimitive.Anchor>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side={anchorSide}
+          align="center"
+          sideOffset={6}
+          collisionBoundary={collisionBoundary}
+          collisionPadding={8}
+          className={SELECTION_MENU_CONTENT_CLASS}
+          onEscapeKeyDown={() => onDismiss()}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          {actions.map((action, index) => (
+            <div key={action.label} className="flex items-center">
+              {index > 0 ? (
+                <span
+                  aria-hidden="true"
+                  className="mx-0.5 h-4 w-px bg-border"
+                />
+              ) : null}
+              <ActionButton action={action} selection={selection} />
+            </div>
+          ))}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
   );
 }


### PR DESCRIPTION
## Summary
- disable the timeline text-selection action menu whenever the primary pointer is coarse
- keep the selection menu available on compact fine-pointer viewports by rendering it as an anchored Radix popover instead of the shared responsive drawer
- update tests and the selection-menu story for the new behavior

## Tests
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx src/components/thread/timeline/TimelineSelectionMenu.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app