### PR TITLE
Reposition the thread TOC popover to the right side and the scroll overlay

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -387,10 +387,10 @@ export function ThreadTableOfContents({
 
           <div
             className={cn(
-              "absolute left-full top-0 w-[18.25rem] max-w-[calc(100vw-3rem)] pl-1 transition-all duration-150",
+              "absolute right-full top-0 w-[18.25rem] max-w-[calc(100vw-3rem)] pr-1 transition-all duration-150",
               open
                 ? "pointer-events-auto translate-x-0 opacity-100"
-                : "pointer-events-none -translate-x-1 opacity-0",
+                : "pointer-events-none translate-x-1 opacity-0",
             )}
           >
             <div className="rounded-lg border border-border bg-popover p-1 shadow-lg">

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -779,7 +779,7 @@ export function BottomAnchoredScrollBody({
         {scrollOverlay ? (
           <div
             data-scroll-overlay=""
-            className="pointer-events-none z-30 col-start-1 row-start-1 flex min-h-0 min-w-0 items-start justify-start px-3 pt-3"
+            className="pointer-events-none z-30 col-start-1 row-start-1 flex min-h-0 min-w-0 items-center justify-end px-3 py-3"
           >
             <div className="pointer-events-auto">{scrollOverlay}</div>
           </div>


### PR DESCRIPTION
Two small UI positioning tweaks:

- Open the expanded thread table-of-contents popover on the `right-full` side (was `left-full`), with the matching slide-in direction.
- Reposition the scroll overlay to vertically center / `justify-end` (was top / start).

Developed via bb's self-modifying UI (`bb ui`), then upstreamed. (The visibility / active-item logic from the original fork was dropped — #371 already addressed those upstream.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)