### PR TITLE
Derive prompt-mention pill tokens from theme anchors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 - Use existing shared primitives when they already fit. Do not create a new shared primitive from a single use.
 - Avoid adding a second rendering path for the same concept. Remove an old path only when the current change directly replaces it.
 - Prefer sanctioned typography tokens over arbitrary `text-[Npx]` classes.
+- Derive theme color tokens from the `--canvas`/`--ink` anchors (`color-mix(in oklch, var(--ink) N%, var(--canvas))`) or from another derived token — never hand-set an `oklch(L 0 0)` literal. Achromatic literals don't follow custom palettes (Nord, Dracula, …), which re-anchor only `--canvas`/`--ink`, so a hardcoded token strands a neutral-gray element in an otherwise tinted UI. Mix opaque steps `in oklch`; mix translucent steps (a `transparent` pole) `in oklab` so the hue survives. `apps/app/src/components/ui/theme.css` is the source of truth and `theme.test.ts` guards it.
 
 ## Build And Typecheck
 

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -400,24 +400,30 @@
     var(--primary) 35%,
     transparent
   );
-  /* Prompt mention pills (light): a near-flat off-white chip with a quiet
-   * top-down surface step, soft border, and light shadow. The icon is a simple
-   * near-black outline glyph (near-white in dark mode). */
+  /* Prompt mention pills (light): a near-flat chip with a quiet top-down surface
+   * step, soft border, and light shadow. Every face/line derives from the
+   * --canvas/--ink anchors (label and icon are the ink itself) so a custom
+   * palette tints the pill along with the rest of the UI instead of stranding a
+   * neutral-gray chip — the shadow stays a faint neutral drop. */
   --pill-surface: linear-gradient(
     to bottom,
-    oklch(0.97 0 0),
-    oklch(0.968 0 0)
+    color-mix(in oklch, var(--ink) 4.4%, var(--canvas)),
+    color-mix(in oklch, var(--ink) 4.7%, var(--canvas))
   );
   --pill-surface-border: var(--border);
-  --pill-foreground: oklch(0.28 0 0);
-  --pill-icon: oklch(0.2 0 0);
+  --pill-foreground: var(--ink);
+  --pill-icon: var(--ink);
   --pill-shadow: 0 1px 1px 0 oklch(0.2 0 0 / 0.02);
   --pill-surface-selected: linear-gradient(
     to bottom,
-    oklch(0.92 0 0),
-    oklch(0.912 0 0)
+    color-mix(in oklch, var(--ink) 11.8%, var(--canvas)),
+    color-mix(in oklch, var(--ink) 13%, var(--canvas))
   );
-  --pill-surface-selected-border: oklch(0.87 0 0);
+  --pill-surface-selected-border: color-mix(
+    in oklch,
+    var(--ink) 19.2%,
+    var(--canvas)
+  );
   --sidebar: color-mix(in oklch, var(--ink) 2.2%, var(--canvas));
   --sidebar-foreground: var(--ink);
   --sidebar-accent: color-mix(in oklch, var(--ink) 8%, var(--canvas));
@@ -584,23 +590,29 @@
     transparent
   );
   /* Prompt mention pills (dark): a raised graphite chip a few steps lighter than
-   * the canvas with a light label and a near-white icon glyph. Mirrors the light
-   * block's token set so the pill is fully theme-dependent. */
+   * the canvas with a light label and icon glyph. Mirrors the light block:
+   * every face/line derives from the --canvas/--ink anchors (label and icon are
+   * the ink itself) so a custom palette tints the pill instead of stranding a
+   * neutral-gray chip — the shadow stays a faint neutral drop. */
   --pill-surface: linear-gradient(
     to bottom,
-    oklch(0.275 0 0),
-    oklch(0.268 0 0)
+    color-mix(in oklch, var(--ink) 13%, var(--canvas)),
+    color-mix(in oklch, var(--ink) 11.9%, var(--canvas))
   );
   --pill-surface-border: var(--border);
-  --pill-foreground: oklch(0.86 0 0);
-  --pill-icon: oklch(0.88 0 0);
+  --pill-foreground: var(--ink);
+  --pill-icon: var(--ink);
   --pill-shadow: 0 1px 1px 0 oklch(0 0 0 / 0.08);
   --pill-surface-selected: linear-gradient(
     to bottom,
-    oklch(0.322 0 0),
-    oklch(0.31 0 0)
+    color-mix(in oklch, var(--ink) 20.7%, var(--canvas)),
+    color-mix(in oklch, var(--ink) 18.7%, var(--canvas))
   );
-  --pill-surface-selected-border: oklch(0.35 0 0);
+  --pill-surface-selected-border: color-mix(
+    in oklch,
+    var(--ink) 25.2%,
+    var(--canvas)
+  );
   --sidebar: color-mix(in oklch, var(--ink) 4.3%, var(--canvas));
   --sidebar-foreground: var(--ink);
   --sidebar-accent: color-mix(in oklch, var(--ink) 12%, var(--canvas));


### PR DESCRIPTION
## Problem

The skill pill's lightning-bolt icon looked **yellow** under custom palettes (Nord, Dracula). Root cause: the `--pill-*` tokens in `theme.css` were the one token group hand-set as achromatic `oklch(L 0 0)` literals (chroma 0, hue removed). Every *other* surface derives from the `--canvas`/`--ink` anchors via `color-mix`, so it follows a palette's hue — but custom palettes only re-anchor `--canvas`/`--ink` and never touch the pill tokens. The neutral-gray pill was stranded in an otherwise cool-tinted UI and read warm/yellow by simultaneous contrast.

## Fix

Derive every pill face/line from the anchors:
- `--pill-surface`, `--pill-surface-selected`, `--pill-surface-selected-border` → `color-mix(in oklch, var(--ink) N%, var(--canvas))`, percentages tuned so the **default theme renders unchanged**.
- `--pill-foreground` / `--pill-icon` → `var(--ink)` so the label/icon follow the palette.
- Shadow left as a faint neutral drop.

The dark `--pill-surface-selected-border` now also falls under the existing `theme.test.ts` ramp guard (present in both modes).

Added an `AGENTS.md` UI rule so theme tokens can't reintroduce hardcoded achromatic literals that ignore custom palettes.

## Testing

- `pnpm exec turbo run test --filter=@bb/app -- theme.test.ts` → 17/17 pass.
- Rendered the real cascade (default / Nord / Dracula, dark) in a browser and sampled computed colors: the icon now resolves to each theme's own `ink` (Nord `rgb(216,222,233)`, Dracula `rgb(248,248,242)`) and the pill border carries real chroma (hue ~264–277) — no more neutral-gray island, no yellow.

## Risk

CSS-token only; no TS/behavior changes. Default theme is visually unchanged. Minor: in the default theme the pill label/icon shift from a slightly-extra-contrast gray to the body `ink` value (cosmetically near-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)