### PR TITLE
Remove dev-only badge from favicon color and rewrite-localhost settings

### DIFF
--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -230,7 +230,6 @@ export function FaviconColorSettingsControl({
   return (
     <SettingsWithControl
       label="Favicon color"
-      labelBadge="dev-only"
       description="Tint browser tabs to tell instances apart."
     >
       <DropdownMenu>
@@ -470,7 +469,6 @@ export function RewriteLocalhostLinksSettingsControl({
   return (
     <SettingsWithControl
       label={REWRITE_LOCALHOST_LINKS_SETTING_LABEL}
-      labelBadge="dev-only"
       description="Point localhost links at this host."
     >
       <Switch


### PR DESCRIPTION
## Summary

The **Favicon color** and **Rewrite localhost links** settings were tagged with a `dev-only` badge in the settings page, but both are generally useful to all users (not just for development). This removes the `labelBadge="dev-only"` from each control.

Both settings already rendered unconditionally — only the visual badge was gated. The unrelated Claude Code mock CLI traffic experiment keeps its `dev-only` badge.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/app` — passes

## Risks

Minimal — UI-only change removing two static badge strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)