### PR TITLE
Hide thread TOC until 3+ user messages

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -15,18 +15,18 @@ class ResizeObserverMock implements ResizeObserver {
   disconnect: ResizeObserver["disconnect"] = vi.fn();
 }
 
-function userConversationRow(): TimelineRow {
+function userConversationRow(index = 1): TimelineRow {
   return {
-    id: "row_user_1",
+    id: `row_user_${index}`,
     threadId: "thr_toc_test",
-    turnId: "turn_1",
-    sourceSeqStart: 1,
-    sourceSeqEnd: 1,
-    startedAt: 1,
-    createdAt: 1,
+    turnId: `turn_${index}`,
+    sourceSeqStart: index,
+    sourceSeqEnd: index,
+    startedAt: index,
+    createdAt: index,
     kind: "conversation",
     role: "user",
-    text: "Loaded after client-side navigation",
+    text: `Loaded after client-side navigation ${index}`,
     attachments: null,
     initiator: "user",
     senderThreadId: null,
@@ -142,12 +142,42 @@ describe("ThreadTableOfContents", () => {
 
     expect(screen.queryByText("Your messages")).toBeNull();
 
-    view.rerender(<TocHost timelineRows={[userConversationRow()]} />);
+    view.rerender(
+      <TocHost
+        timelineRows={[
+          userConversationRow(1),
+          userConversationRow(2),
+          userConversationRow(3),
+        ]}
+      />,
+    );
 
     expect(await screen.findByText("Your messages")).not.toBeNull();
     expect(
-      screen.getByText("Loaded after client-side navigation"),
+      screen.getByText("Loaded after client-side navigation 1"),
     ).not.toBeNull();
+  });
+
+  it("stays hidden until there are at least three user messages", () => {
+    const view = render(
+      <TocHost
+        timelineRows={[userConversationRow(1), userConversationRow(2)]}
+      />,
+    );
+
+    expect(screen.queryByText("Your messages")).toBeNull();
+
+    view.rerender(
+      <TocHost
+        timelineRows={[
+          userConversationRow(1),
+          userConversationRow(2),
+          userConversationRow(3),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Your messages")).not.toBeNull();
   });
 
   it("tracks the conversation item nearest the viewport top away from bottom", () => {

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -32,6 +32,8 @@ interface ThreadTableOfContentsProps {
 
 const TOC_MIN_VISIBLE_WIDTH_PX = 56 * 16;
 const TOC_BOTTOM_ACTIVE_THRESHOLD_PX = 4;
+// Only worth showing once the conversation has enough user turns to navigate.
+const TOC_MIN_USER_MESSAGES = 3;
 
 function toPreviewLabel(text: string): string {
   return text.replace(/\s+/g, " ").trim();
@@ -350,7 +352,7 @@ export function ThreadTableOfContents({
     [bottomAnchor],
   );
 
-  if (userItems.length === 0 && agentItems.length === 0) return null;
+  if (userItems.length < TOC_MIN_USER_MESSAGES) return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary

The thread Table of Contents only earns its place once a conversation has enough user turns to navigate. This gates its rendering behind a `TOC_MIN_USER_MESSAGES` threshold (3), so short threads stay uncluttered.

- `ThreadTableOfContents` now returns `null` when there are fewer than 3 **user** messages (agent messages alone don't surface it).
- Threshold lives in a named constant for clarity.

## Tests

- `@bb/app` TOC component tests: 6 passed. Updated the "shows after rows arrive" test to use 3 user messages and added a regression test that the TOC stays hidden at 2 and appears at 3.
- `@bb/app` typecheck: clean.

## Risks

Low. Pure client-side rendering gate; no data/contract changes. Threshold is hardcoded (not configurable) by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)