### PR TITLE
Fix mobile sidebar manual organize toggle

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -2081,6 +2081,7 @@ function ProjectListComponent({
             projectsDisplayOptionsMenuOpen !== null ||
             allThreadsOverflowMenuOpen
           }
+          actionsMobileAlways
           collapseControl={{
             isCollapsed: collapsedSidebarSectionIds.has("threads"),
             onToggleCollapsed: () => toggleSidebarSectionCollapsed("threads"),

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -138,6 +138,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip.js";
+import { useIsCompactViewport } from "@/components/ui/hooks/use-compact-viewport.js";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
@@ -674,6 +675,7 @@ function SidebarGroupMenuOption({
 
 interface SidebarSortMenuOptionProps {
   direction: SidebarSortDirection;
+  keepOpenOnSelect: boolean;
   label: string;
   selected: boolean;
   sort: SidebarChronologicalSort;
@@ -723,6 +725,7 @@ function SidebarDisplayMenuTrigger({
 
 function SidebarSortMenuOption({
   direction,
+  keepOpenOnSelect,
   label,
   selected,
   sort,
@@ -731,7 +734,9 @@ function SidebarSortMenuOption({
   return (
     <DropdownMenuItem
       onSelect={(event) => {
-        event.preventDefault();
+        if (keepOpenOnSelect) {
+          event.preventDefault();
+        }
         onToggle(sort);
       }}
       className="flex items-center justify-between gap-3"
@@ -758,6 +763,7 @@ export function SidebarGroupOptionsMenu({
   open,
   onOpenChange,
 }: SidebarGroupOptionsMenuProps) {
+  const isCompactViewport = useIsCompactViewport();
   const [organizationMode, setOrganizationMode] = useAtom(
     sidebarOrganizationModeAtom,
   );
@@ -781,7 +787,9 @@ export function SidebarGroupOptionsMenu({
           label="Projects"
           selected={organizationMode === "project"}
           onSelect={(event) => {
-            event.preventDefault();
+            if (!isCompactViewport || organizationMode === "project") {
+              event.preventDefault();
+            }
             setOrganizationMode("project");
           }}
         />
@@ -789,7 +797,9 @@ export function SidebarGroupOptionsMenu({
           label="Manually"
           selected={organizationMode === "chronological"}
           onSelect={(event) => {
-            event.preventDefault();
+            if (!isCompactViewport || organizationMode === "chronological") {
+              event.preventDefault();
+            }
             setOrganizationMode("chronological");
           }}
         />
@@ -802,6 +812,7 @@ export function SidebarSortOptionsMenu({
   open,
   onOpenChange,
 }: SidebarSortOptionsMenuProps) {
+  const isCompactViewport = useIsCompactViewport();
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,
   );
@@ -839,6 +850,7 @@ export function SidebarSortOptionsMenu({
           sort="updated"
           selected={selectedSort === "updated"}
           direction={sortDirection}
+          keepOpenOnSelect={!isCompactViewport}
           onToggle={handleSortToggle}
         />
         <SidebarSortMenuOption
@@ -846,6 +858,7 @@ export function SidebarSortOptionsMenu({
           sort="created"
           selected={selectedSort === "created"}
           direction={sortDirection}
+          keepOpenOnSelect={!isCompactViewport}
           onToggle={handleSortToggle}
         />
         <SidebarSortMenuOption
@@ -853,6 +866,7 @@ export function SidebarSortOptionsMenu({
           sort="alpha"
           selected={selectedSort === "alpha"}
           direction={sortDirection}
+          keepOpenOnSelect={!isCompactViewport}
           onToggle={handleSortToggle}
         />
       </DropdownMenuContent>

--- a/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
@@ -61,4 +61,23 @@ describe("TopLevelSidebarSection", () => {
       ),
     ).not.toBeNull();
   });
+
+  it("can keep section actions visible on mobile", () => {
+    render(
+      <TopLevelSidebarSection
+        label="All Threads"
+        actions={<button type="button">Organize by</button>}
+        actionsMobileAlways
+      >
+        <div>Section body</div>
+      </TopLevelSidebarSection>,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Organize by" })
+        .closest(".bb-sidebar-hover-actions")
+        ?.getAttribute("data-sidebar-hover-actions-mobile"),
+    ).toBe("always");
+  });
 });

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { useState, type ReactNode } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { createStore, Provider as JotaiProvider, useAtomValue } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CompactViewportOverrideProvider } from "@/components/ui/hooks/use-compact-viewport";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { SidebarGroupOptionsMenu, SidebarSortOptionsMenu } from "./ProjectList";
+import {
+  sidebarChronologicalSortAtom,
+  sidebarOrganizationModeAtom,
+  sidebarSortDirectionAtom,
+} from "./sidebarCollapsedAtoms";
+
+function StateProbe() {
+  const organizationMode = useAtomValue(sidebarOrganizationModeAtom);
+  const chronologicalSort = useAtomValue(sidebarChronologicalSortAtom);
+  const sortDirection = useAtomValue(sidebarSortDirectionAtom);
+
+  return (
+    <>
+      <div data-testid="organization-mode">{organizationMode}</div>
+      <div data-testid="chronological-sort">{chronologicalSort}</div>
+      <div data-testid="sort-direction">{sortDirection}</div>
+    </>
+  );
+}
+
+function createSidebarViewStore() {
+  const store = createStore();
+  store.set(sidebarOrganizationModeAtom, "project");
+  store.set(sidebarChronologicalSortAtom, "updated");
+  store.set(sidebarSortDirectionAtom, "desc");
+  return store;
+}
+
+function ControlledGroupOptionsMenu({
+  onOpenChange,
+}: {
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <SidebarGroupOptionsMenu
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        onOpenChange(nextOpen);
+      }}
+    />
+  );
+}
+
+function ControlledSortOptionsMenu({
+  onOpenChange,
+}: {
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <SidebarSortOptionsMenu
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        onOpenChange(nextOpen);
+      }}
+    />
+  );
+}
+
+function renderMobileViewOptions(children: ReactNode) {
+  render(
+    <CompactViewportOverrideProvider isCompactViewport={true}>
+      <JotaiProvider store={createSidebarViewStore()}>
+        <TooltipProvider>
+          {children}
+          <StateProbe />
+        </TooltipProvider>
+      </JotaiProvider>
+    </CompactViewportOverrideProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("sidebar view options menus", () => {
+  it("closes the mobile organize drawer after changing organization", async () => {
+    const onOpenChange = vi.fn();
+
+    renderMobileViewOptions(
+      <ControlledGroupOptionsMenu onOpenChange={onOpenChange} />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Sidebar organize options",
+      hidden: true,
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Manually" }));
+
+    expect(screen.getByTestId("organization-mode").textContent).toBe(
+      "chronological",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("false"),
+    );
+  });
+
+  it("closes the mobile sort drawer after changing sort", async () => {
+    const onOpenChange = vi.fn();
+
+    renderMobileViewOptions(
+      <ControlledSortOptionsMenu onOpenChange={onOpenChange} />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Sidebar sort options",
+      hidden: true,
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Created at" }));
+
+    expect(screen.getByTestId("chronological-sort").textContent).toBe(
+      "created",
+    );
+    expect(screen.getByTestId("sort-direction").textContent).toBe("desc");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("false"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the manual-mode All Threads header actions visible on mobile so users can switch back to Projects organization.
- Close the mobile Organize by and Sort by drawers when a sidebar view selection changes.
- Add regression coverage for mobile-visible sidebar section actions and mobile drawer close behavior.

## Tests
- pnpm exec turbo run test --filter=@bb/app -- ProjectListSectionHeader.test.tsx SidebarViewOptionsMenu.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app