### PR TITLE
Fix mobile drawer handle drag

### DIFF
--- a/apps/app/src/components/ui/drawer.tsx
+++ b/apps/app/src/components/ui/drawer.tsx
@@ -65,7 +65,9 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="mx-auto mt-3 mb-1 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/20" />
+      <DrawerPrimitive.Handle
+        className="mx-auto mt-3 mb-1 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/20"
+      />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>


### PR DESCRIPTION
## Summary
- Render the shared mobile drawer pill as Vaul's `Drawer.Handle` instead of a decorative div
- Preserve `handleOnly` behavior so secondary panel body content does not become a drag target

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app`