### PR TITLE
Avoid passive input autofocus on coarse pointers

### DIFF
--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog.js";
 import { Input } from "@/components/ui/input.js";
 import { RemotePathBrowser } from "@/components/dialogs/RemotePathBrowser";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 
 export type ProjectPathDialogTarget =
   | {
@@ -141,6 +142,7 @@ export function ProjectPathDialogContent({
   onSubmit,
 }: ProjectPathDialogContentProps) {
   const inputId = useId();
+  const isPointerCoarse = usePointerCoarse();
   // No-host fallback only: the browser owns the path when a host is present.
   const [manualPath, setManualPath] = useState(
     target.kind === "update" ? target.currentPath : "",
@@ -221,7 +223,7 @@ export function ProjectPathDialogContent({
             id={inputId}
             aria-label="Project path"
             value={manualPath}
-            autoFocus
+            autoFocus={!isPointerCoarse}
             disabled={pending}
             placeholder={placeholder}
             onChange={(event) => {

--- a/apps/app/src/components/dialogs/RemotePathBrowser.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.tsx
@@ -3,6 +3,7 @@ import { normalizeProjectPathInput } from "@bb/domain";
 import { Button } from "@/components/ui/button.js";
 import { EmptyState } from "@/components/ui/empty-state.js";
 import { Icon } from "@/components/ui/icon.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { Input } from "@/components/ui/input.js";
 import { useHostDirectory } from "@/hooks/queries/host-queries";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
@@ -63,6 +64,7 @@ export function RemotePathBrowser({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState("");
   const editInputRef = useRef<HTMLInputElement>(null);
+  const isPointerCoarse = usePointerCoarse();
   const { data, isError, error, isPlaceholderData } = useHostDirectory(
     hostId,
     currentPath,
@@ -77,8 +79,8 @@ export function RemotePathBrowser({
   }, [directory, onDirectoryChange]);
 
   useEffect(() => {
-    if (isEditing) editInputRef.current?.focus();
-  }, [isEditing]);
+    if (isEditing && !isPointerCoarse) editInputRef.current?.focus();
+  }, [isEditing, isPointerCoarse]);
 
   const openEditor = () => {
     setEditValue(directory ?? "");

--- a/apps/app/src/components/dialogs/useRenameDialogAutoFocus.ts
+++ b/apps/app/src/components/dialogs/useRenameDialogAutoFocus.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 
 export interface RenameDialogAutoFocus {
   /** Attach to the rename `Input`. */
@@ -14,13 +15,19 @@ export interface RenameDialogAutoFocus {
  */
 export function useRenameDialogAutoFocus(): RenameDialogAutoFocus {
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const handleOpenAutoFocus = useCallback((event: Event) => {
-    event.preventDefault();
-    const input = inputRef.current;
-    if (input) {
-      input.focus();
-      input.select();
-    }
-  }, []);
+  const isPointerCoarse = usePointerCoarse();
+  const handleOpenAutoFocus = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      if (isPointerCoarse) return;
+
+      const input = inputRef.current;
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    },
+    [isPointerCoarse],
+  );
   return { inputRef, handleOpenAutoFocus };
 }

--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -15,6 +15,7 @@ import {
   COARSE_POINTER_ICON_SIZE_SHRINK_CLASS,
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { useIsCompactViewport } from "@/components/ui/hooks/use-compact-viewport.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { Input } from "@/components/ui/input.js";
 import { blurActiveKeyboardInputWithin } from "@/components/ui/overlay-trigger.js";
 import {
@@ -730,6 +731,7 @@ export function BranchPicker({
   const [open, setOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
   const isCompactViewport = useIsCompactViewport();
+  const isPointerCoarse = usePointerCoarse();
   const selectedCheckoutIntent = resolveCheckoutIntent({
     isCreatingNew,
     value,
@@ -924,7 +926,7 @@ export function BranchPicker({
   }, [debouncedNormalizedQuery, normalizedQuery, onSearchQueryChange, open]);
 
   useEffect(() => {
-    if (!open || !showOptionsSearch || isCompactViewport) {
+    if (!open || !showOptionsSearch || isCompactViewport || isPointerCoarse) {
       return;
     }
 
@@ -935,7 +937,7 @@ export function BranchPicker({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [isCompactViewport, open, showOptionsSearch]);
+  }, [isCompactViewport, isPointerCoarse, open, showOptionsSearch]);
 
   return (
     <Popover modal={modal} open={open} onOpenChange={updateOpen}>

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POINTER_COARSE_QUERY } from "@/components/ui/hooks/use-pointer-coarse";
+import { NewTabFileSearch } from "./NewTabFileSearch";
+
+vi.mock("@/hooks/useFileSearchSuggestions", () => ({
+  useFileSearchSuggestions: () => ({
+    suggestions: [],
+    isLoading: false,
+    fileSearchError: false,
+    isDebouncing: false,
+    isUnavailable: false,
+  }),
+}));
+
+vi.mock("./threadRecentItems", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./threadRecentItems")>();
+  return {
+    ...actual,
+    useThreadRecentItems: () => [],
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function mockPointerCoarse(matches: boolean) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: query === POINTER_COARSE_QUERY && matches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+function renderFileSearch() {
+  render(
+    <NewTabFileSearch
+      projectId="proj_1"
+      environmentId="env_1"
+      currentThreadId="thr_1"
+      focusRequest={0}
+      idleActions={null}
+      onSelect={() => {}}
+    />,
+  );
+}
+
+describe("NewTabFileSearch", () => {
+  it("does not autofocus the search input on coarse pointers", () => {
+    mockPointerCoarse(true);
+    const focusSpy = vi
+      .spyOn(HTMLInputElement.prototype, "focus")
+      .mockImplementation(() => {});
+
+    renderFileSearch();
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it("autofocuses the search input on fine pointers", () => {
+    mockPointerCoarse(false);
+    const focusSpy = vi
+      .spyOn(HTMLInputElement.prototype, "focus")
+      .mockImplementation(() => {});
+
+    renderFileSearch();
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { Input } from "@/components/ui/input.js";
 import { TruncateStart } from "@/components/ui/truncate-start.js";
 import {
@@ -484,6 +485,7 @@ export function NewTabFileSearch({
 }: NewTabFileSearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
+  const isPointerCoarse = usePointerCoarse();
   const [query, setQuery] = useState(initialQuery);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [isRecentExpanded, setIsRecentExpanded] = useState(false);
@@ -550,6 +552,8 @@ export function NewTabFileSearch({
   );
 
   useEffect(() => {
+    if (isPointerCoarse) return;
+
     // Focus synchronously, then again on the next frame to win the focus race
     // against the panel/tab content mounting in the same commit, which can
     // otherwise pull focus away from the input.
@@ -558,7 +562,7 @@ export function NewTabFileSearch({
       inputRef.current?.focus();
     });
     return () => cancelAnimationFrame(frame);
-  }, [focusRequest]);
+  }, [focusRequest, isPointerCoarse]);
 
   useEffect(() => {
     setActiveIndex(navigableEntries.length > 0 ? 0 : -1);

--- a/apps/app/src/components/secondary-panel/ThreadStorageBrowser.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageBrowser.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { EmptyState } from "@/components/ui/empty-state.js";
 import { Icon } from "@/components/ui/icon.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { Input } from "@/components/ui/input.js";
 import { usePreferredTheme } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
@@ -90,12 +91,13 @@ export function ThreadStorageBrowser({
   } = controller;
   const preferredTheme = usePreferredTheme();
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const isPointerCoarse = usePointerCoarse();
 
   useEffect(() => {
-    if (isSearchOpen) {
+    if (isSearchOpen && !isPointerCoarse) {
       searchInputRef.current?.focus();
     }
-  }, [isSearchOpen]);
+  }, [isPointerCoarse, isSearchOpen]);
 
   const fileTreeHostStyle = useMemo<FileTreeHostStyle>(
     () => ({

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { Link, useNavigate } from "react-router-dom";
 import { Icon } from "@/components/ui/icon.js";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { OverflowFade } from "@/components/ui/overflow-fade.js";
 import {
   Sidebar,
@@ -85,15 +86,18 @@ export function AppSidebar({
   const [threadSearchNavigationItems, setThreadSearchNavigationItems] =
     useState<readonly SidebarThreadSearchNavigationItem[]>([]);
   const threadSearchInputRef = useRef<HTMLInputElement | null>(null);
+  const isPointerCoarse = usePointerCoarse();
   const threadSearchActiveDescendantId =
     threadSearchNavigationItems[threadSearchActiveIndex]?.optionId;
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
 
   const focusThreadSearchInput = useCallback(() => {
+    if (isPointerCoarse) return;
+
     window.requestAnimationFrame(() => {
       threadSearchInputRef.current?.focus();
     });
-  }, []);
+  }, [isPointerCoarse]);
 
   const handleThreadSearchActivate = useCallback(() => {
     setIsThreadSearchActive(true);

--- a/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
+++ b/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@bb/domain";
 import { Button } from "@/components/ui/button.js";
 import { Icon } from "@/components/ui/icon.js";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { TabPill } from "@/components/ui/tab-pill.js";
 import { useAutoGrow } from "@/hooks/useAutoGrow";
 import { useResolveThreadPendingInteraction } from "@/hooks/mutations/thread-interaction-mutations";
@@ -156,6 +157,7 @@ function QuestionInputBlock({
   onShortcutSubmit,
 }: QuestionInputBlockProps) {
   const freeTextRef = useRef<HTMLTextAreaElement>(null);
+  const isPointerCoarse = usePointerCoarse();
   const resizeFreeTextArea = useAutoGrow(freeTextRef, {
     minHeight: USER_QUESTION_FREE_TEXT_MIN_HEIGHT,
     maxHeight: USER_QUESTION_FREE_TEXT_MAX_HEIGHT,
@@ -220,7 +222,7 @@ function QuestionInputBlock({
           aria-label={freeTextLabel}
           value={state.otherText}
           rows={1}
-          autoFocus
+          autoFocus={!isPointerCoarse}
           autoComplete="off"
           onChange={(event) => {
             onFreeTextChange(event.target.value);

--- a/apps/app/src/components/ui/responsive-overlay.test.tsx
+++ b/apps/app/src/components/ui/responsive-overlay.test.tsx
@@ -7,6 +7,7 @@ import type {
 } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { POINTER_COARSE_QUERY } from "./hooks/use-pointer-coarse";
 import { ResponsiveDrawerShell } from "./responsive-overlay";
 
 type CapturedAnimationEnd = (args: {
@@ -16,6 +17,7 @@ type CapturedAnimationEnd = (args: {
 
 const drawerContentState = vi.hoisted(() => ({
   fireAnimationEnd: undefined as CapturedAnimationEnd | undefined,
+  fireOpenAutoFocus: undefined as ((event: Event) => void) | undefined,
 }));
 
 vi.mock("./drawer.js", async () => {
@@ -24,23 +26,27 @@ vi.mock("./drawer.js", async () => {
   const Drawer = ({ children }: { children: ReactNode }) =>
     React.createElement("div", { "data-testid": "drawer" }, children);
 
-  const DrawerContent = React.forwardRef<
-    HTMLDivElement,
-    HTMLAttributes<HTMLDivElement>
-  >(({ children, onAnimationEnd, ...props }, ref) => {
-    drawerContentState.fireAnimationEnd = ({ currentTarget, target }) => {
-      onAnimationEnd?.({
-        currentTarget,
-        target,
-      } as ReactAnimationEvent<HTMLDivElement>);
-    };
+  interface MockDrawerContentProps extends HTMLAttributes<HTMLDivElement> {
+    onOpenAutoFocus?: (event: Event) => void;
+  }
 
-    return React.createElement(
-      "div",
-      { ...props, ref, "data-testid": "drawer-content" },
-      children,
-    );
-  });
+  const DrawerContent = React.forwardRef<HTMLDivElement, MockDrawerContentProps>(
+    ({ children, onAnimationEnd, onOpenAutoFocus, ...props }, ref) => {
+      drawerContentState.fireAnimationEnd = ({ currentTarget, target }) => {
+        onAnimationEnd?.({
+          currentTarget,
+          target,
+        } as ReactAnimationEvent<HTMLDivElement>);
+      };
+      drawerContentState.fireOpenAutoFocus = onOpenAutoFocus;
+
+      return React.createElement(
+        "div",
+        { ...props, ref, "data-testid": "drawer-content" },
+        children,
+      );
+    },
+  );
   DrawerContent.displayName = "MockDrawerContent";
 
   const DrawerTitle = ({
@@ -56,6 +62,7 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   drawerContentState.fireAnimationEnd = undefined;
+  drawerContentState.fireOpenAutoFocus = undefined;
 });
 
 function fireDrawerContentAnimationEnd(target: EventTarget) {
@@ -67,6 +74,29 @@ function fireDrawerContentAnimationEnd(target: EventTarget) {
     currentTarget: screen.getByTestId("drawer-content"),
     target,
   });
+}
+
+function mockPointerCoarse(matches: boolean) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: query === POINTER_COARSE_QUERY && matches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+function fireDrawerOpenAutoFocus(): Event {
+  const fireOpenAutoFocus = drawerContentState.fireOpenAutoFocus;
+  if (fireOpenAutoFocus === undefined) {
+    throw new Error("DrawerContent did not receive an autofocus handler");
+  }
+  const event = new Event("openAutoFocus", { cancelable: true });
+  fireOpenAutoFocus(event);
+  return event;
 }
 
 describe("ResponsiveDrawerShell", () => {
@@ -107,5 +137,29 @@ describe("ResponsiveDrawerShell", () => {
     fireDrawerContentAnimationEnd(screen.getByTestId("drawer-content"));
     expect(onContentAnimationEnd).toHaveBeenCalledTimes(1);
     expect(onContentAnimationEnd).toHaveBeenCalledWith(false);
+  });
+
+  it("prevents drawer open autofocus on coarse pointers", () => {
+    mockPointerCoarse(true);
+
+    render(
+      <ResponsiveDrawerShell open={true} onOpenChange={() => {}}>
+        <input aria-label="Search" />
+      </ResponsiveDrawerShell>,
+    );
+
+    expect(fireDrawerOpenAutoFocus().defaultPrevented).toBe(true);
+  });
+
+  it("allows drawer open autofocus on fine pointers", () => {
+    mockPointerCoarse(false);
+
+    render(
+      <ResponsiveDrawerShell open={true} onOpenChange={() => {}}>
+        <input aria-label="Search" />
+      </ResponsiveDrawerShell>,
+    );
+
+    expect(fireDrawerOpenAutoFocus().defaultPrevented).toBe(false);
   });
 });

--- a/apps/app/src/components/ui/responsive-overlay.tsx
+++ b/apps/app/src/components/ui/responsive-overlay.tsx
@@ -10,6 +10,7 @@ import {
   preventOverlayTriggerSelection,
 } from "./overlay-trigger.js";
 import { useIsCompactViewport } from "./hooks/use-compact-viewport.js";
+import { usePointerCoarse } from "./hooks/use-pointer-coarse.js";
 
 // ---------------------------------------------------------------------------
 // Shared context value for responsive overlays (dropdown menus, popovers)
@@ -240,6 +241,7 @@ export function ResponsiveDrawerShell({
 }: ResponsiveDrawerShellProps) {
   const parentDrawerDepth = React.useContext(ResponsiveDrawerDepthContext);
   const drawerContentRef = React.useRef<HTMLDivElement>(null);
+  const isPointerCoarse = usePointerCoarse();
   const isNestedDrawer = parentDrawerDepth > 0;
   const shouldRepositionInputs = repositionInputs ?? !isNestedDrawer;
   const resetClosingKeyboardState = React.useCallback(() => {
@@ -265,6 +267,14 @@ export function ResponsiveDrawerShell({
       },
       [onContentAnimationEnd, open],
     );
+  const handleOpenAutoFocus = React.useCallback(
+    (event: Event) => {
+      if (isPointerCoarse) {
+        event.preventDefault();
+      }
+    },
+    [isPointerCoarse],
+  );
   const previousOpenRef = React.useRef(open);
 
   React.useLayoutEffect(() => {
@@ -286,6 +296,7 @@ export function ResponsiveDrawerShell({
         ref={drawerContentRef}
         className={contentClassName}
         onAnimationEnd={handleContentAnimationEnd}
+        onOpenAutoFocus={handleOpenAutoFocus}
       >
         <ResponsiveDrawerDepthContext.Provider value={parentDrawerDepth + 1}>
           {srLabel !== undefined ? (


### PR DESCRIPTION
## Summary
- prevent mobile drawer open autofocus on coarse-pointer devices
- gate passive input focus in right-panel search, storage search, dialogs, sidebar search, branch picker, and user-question free text
- add regressions for drawer autofocus suppression and right-panel search autofocus behavior

## Tests
- `pnpm exec turbo run test --filter=@bb/app -- responsive-overlay.test.tsx NewTabFileSearch.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
