### PR TITLE
Warn that UI forking is unstable

### DIFF
--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -874,7 +874,7 @@ export function ExperimentsSettingsSection({
 
         <SettingsWithControl
           label={UI_FORKING_EXPERIMENT_LABEL}
-          description="Let the bb CLI (bb ui) fork, edit, and live-reload the app's own frontend. Off keeps the shipped UI."
+          description="Let the bb CLI (bb ui) fork, edit, and live-reload the app's own frontend. This feature is unstable, and your forks will probably break in the future. Off keeps the shipped UI."
         >
           <Switch
             checked={uiForkingEnabled}


### PR DESCRIPTION
## Summary
- Update the UI forking experiment copy to warn that the feature is unstable
- Tell users their UI forks will probably break in the future while preserving the shipped UI fallback note

## Tests
- git diff --check