### PR TITLE
Fix desktop launch: export bb-app/dist/bb-app.js

### DIFF
--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -28,7 +28,8 @@
       "node": "./dist/index.js",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./dist/bb-app.js": "./dist/bb-app.js"
   },
   "types": "./dist/index.d.ts",
   "os": [


### PR DESCRIPTION
## Problem

The packaged desktop app crashes at startup:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/bb-app.js' is
not defined by "exports" in .../node_modules/bb-app/package.json imported from
.../dist/bb-app-bridge.mjs
```

## Root cause

The desktop bridge (`apps/desktop/src/bb-app-bridge.ts`) boots the app via a
side-effect import of the launcher entry:

```ts
import "bb-app/dist/bb-app.js";
```

Before #343, `bb-app` had no `exports` field, so Node allowed any deep import.
#343 ("Expose public bb-app SDK") added an `exports` map declaring only the
`"."` entry. Once `exports` is present, Node's exports encapsulation rejects
every subpath that isn't listed — breaking the bridge's deep import.

`npx bb-app` is unaffected because it launches through the `bin` field (a direct
file path that bypasses module-exports resolution), which is why only the
desktop app failed.

## Fix

Add the `./dist/bb-app.js` subpath to the `exports` map. Verified with
`import.meta.resolve` that both the deep launcher import and the root SDK entry
resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)