### PR TITLE
[codex] Preserve prompt drafts across option changes

### DIFF
--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -14,6 +14,8 @@ import {
   buildRootComposeTerminalSessions,
   buildMobileRecentThreads,
   canCreateRootComposeTerminal,
+  hasPromptBranchSelectionChanged,
+  hasPromptOptionValueChanged,
   hasSingleUseRootComposeTargetState,
   mergeMissingPromptDraftAttachments,
   readFolderIdFromLocationState,
@@ -403,6 +405,45 @@ describe("restorePromptDraftAfterOptionChange", () => {
         preservedDraft: draft,
       }),
     ).toBeNull();
+  });
+});
+
+describe("hasPromptOptionValueChanged", () => {
+  it("treats unchanged prompt option values as no-ops", () => {
+    expect(hasPromptOptionValueChanged("codex", "codex")).toBe(false);
+    expect(hasPromptOptionValueChanged(undefined, undefined)).toBe(false);
+  });
+
+  it("detects changed prompt option values", () => {
+    expect(hasPromptOptionValueChanged("codex", "claude")).toBe(true);
+    expect(hasPromptOptionValueChanged(undefined, "auto")).toBe(true);
+  });
+});
+
+describe("hasPromptBranchSelectionChanged", () => {
+  it("treats the same branch selection as a no-op", () => {
+    expect(
+      hasPromptBranchSelectionChanged(
+        { name: "main", isNew: false },
+        { name: "main", isNew: false },
+      ),
+    ).toBe(false);
+    expect(hasPromptBranchSelectionChanged(null, null)).toBe(false);
+  });
+
+  it("detects changed branch selections", () => {
+    expect(
+      hasPromptBranchSelectionChanged(
+        { name: "main", isNew: false },
+        { name: "main", isNew: true },
+      ),
+    ).toBe(true);
+    expect(
+      hasPromptBranchSelectionChanged({ name: "main", isNew: false }, null),
+    ).toBe(true);
+    expect(
+      hasPromptBranchSelectionChanged(null, { name: "develop", isNew: false }),
+    ).toBe(true);
   });
 });
 

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -15,9 +15,11 @@ import {
   buildMobileRecentThreads,
   canCreateRootComposeTerminal,
   hasSingleUseRootComposeTargetState,
+  mergeMissingPromptDraftAttachments,
   readFolderIdFromLocationState,
   readRootComposeFolderTargetFromLocationState,
   readInitialPromptFromLocationState,
+  restorePromptDraftAfterOptionChange,
   resolveRootComposeEffectiveEnvironmentValue,
   resolveRootComposePanelThreadId,
   shouldStartComposingFromLocationState,
@@ -235,6 +237,172 @@ describe("readRootComposeFolderTargetFromLocationState", () => {
   it("returns null when no folder target instruction is present", () => {
     expect(readRootComposeFolderTargetFromLocationState(null)).toBeNull();
     expect(readRootComposeFolderTargetFromLocationState({})).toBeNull();
+  });
+});
+
+describe("mergeMissingPromptDraftAttachments", () => {
+  it("restores attachments that disappeared during option changes", () => {
+    expect(
+      mergeMissingPromptDraftAttachments(
+        [
+          {
+            type: "localFile",
+            path: "notes.md",
+            name: "notes.md",
+            mimeType: "text/markdown",
+            sizeBytes: 32,
+          },
+        ],
+        [
+          {
+            type: "localImage",
+            path: "screenshot.png",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 64,
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        type: "localFile",
+        path: "notes.md",
+        name: "notes.md",
+        mimeType: "text/markdown",
+        sizeBytes: 32,
+      },
+      {
+        type: "localImage",
+        path: "screenshot.png",
+        name: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 64,
+      },
+    ]);
+  });
+
+  it("leaves attachments alone when the preserved paths are still present", () => {
+    expect(
+      mergeMissingPromptDraftAttachments(
+        [
+          {
+            type: "localImage",
+            path: "screenshot.png",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 64,
+          },
+        ],
+        [
+          {
+            type: "localImage",
+            path: "screenshot.png",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 64,
+          },
+        ],
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("restorePromptDraftAfterOptionChange", () => {
+  it("restores a full text draft that an option change cleared", () => {
+    const mention = {
+      start: 0,
+      end: 7,
+      resource: {
+        kind: "path" as const,
+        path: "README.md",
+        source: "workspace" as const,
+        entryKind: "file" as const,
+        label: "README.md",
+      },
+    };
+
+    expect(
+      restorePromptDraftAfterOptionChange({
+        currentDraft: { text: "", mentions: [], attachments: [] },
+        preservedDraft: {
+          text: "README.md please",
+          mentions: [mention],
+          attachments: [
+            {
+              type: "localImage",
+              path: "screenshot.png",
+              name: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 64,
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      text: "README.md please",
+      mentions: [mention],
+      attachments: [
+        {
+          type: "localImage",
+          path: "screenshot.png",
+          name: "screenshot.png",
+          mimeType: "image/png",
+          sizeBytes: 64,
+        },
+      ],
+    });
+  });
+
+  it("merges missing attachments without replacing new draft text", () => {
+    expect(
+      restorePromptDraftAfterOptionChange({
+        currentDraft: {
+          text: "newer text",
+          mentions: [],
+          attachments: [],
+        },
+        preservedDraft: {
+          text: "older text",
+          mentions: [],
+          attachments: [
+            {
+              type: "localImage",
+              path: "screenshot.png",
+              name: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 64,
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      text: "newer text",
+      mentions: [],
+      attachments: [
+        {
+          type: "localImage",
+          path: "screenshot.png",
+          name: "screenshot.png",
+          mimeType: "image/png",
+          sizeBytes: 64,
+        },
+      ],
+    });
+  });
+
+  it("does not rewrite an unchanged draft", () => {
+    const draft = {
+      text: "ship this",
+      mentions: [],
+      attachments: [],
+    };
+
+    expect(
+      restorePromptDraftAfterOptionChange({
+        currentDraft: draft,
+        preservedDraft: draft,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -157,7 +157,10 @@ import {
   buildRootComposeBranchUiState,
   type RootComposeBranchEnvironmentMode,
 } from "./root-compose-branch-ui";
-import { resolveRootComposeThreadEnvironment } from "./root-compose-thread-environment";
+import {
+  resolveRootComposeThreadEnvironment,
+  type RootComposeSelectedBranch,
+} from "./root-compose-thread-environment";
 import { useScopedBranchSelection } from "./root-compose-branch-selection";
 import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
 import { RootComposeEmptyWelcome } from "./RootComposeEmptyWelcome";
@@ -275,6 +278,26 @@ export function restorePromptDraftAfterOptionChange({
   }
 
   return changed ? restoredDraft : null;
+}
+
+export function hasPromptOptionValueChanged<T>(
+  currentValue: T,
+  nextValue: T,
+): boolean {
+  return !Object.is(currentValue, nextValue);
+}
+
+export function hasPromptBranchSelectionChanged(
+  currentBranch: RootComposeSelectedBranch | null,
+  nextBranch: RootComposeSelectedBranch | null,
+): boolean {
+  if (currentBranch === null || nextBranch === null) {
+    return currentBranch !== nextBranch;
+  }
+  return (
+    currentBranch.name !== nextBranch.name ||
+    currentBranch.isNew !== nextBranch.isNew
+  );
 }
 
 interface LegacyProjectComposeRedirectProps {
@@ -934,45 +957,76 @@ export function RootComposeView(props: RootComposeViewProps) {
   }, [promptDraft]);
   const handleSelectedProviderIdChange = useCallback(
     (nextProviderId: string) => {
+      if (!hasPromptOptionValueChanged(selectedProviderId, nextProviderId)) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       setSelectedProviderId(nextProviderId);
     },
-    [setSelectedProviderId, snapshotPromptDraftBeforeOptionChange],
+    [
+      selectedProviderId,
+      setSelectedProviderId,
+      snapshotPromptDraftBeforeOptionChange,
+    ],
   );
   const handleSelectedModelChange = useCallback(
     (nextModel: string) => {
+      if (!hasPromptOptionValueChanged(selectedModel, nextModel)) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       setSelectedModel(nextModel);
     },
-    [setSelectedModel, snapshotPromptDraftBeforeOptionChange],
+    [selectedModel, setSelectedModel, snapshotPromptDraftBeforeOptionChange],
   );
   const handleServiceTierChange = useCallback(
     (nextServiceTier: ServiceTier | undefined) => {
+      if (!hasPromptOptionValueChanged(serviceTier, nextServiceTier)) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       setServiceTier(nextServiceTier);
     },
-    [setServiceTier, snapshotPromptDraftBeforeOptionChange],
+    [serviceTier, setServiceTier, snapshotPromptDraftBeforeOptionChange],
   );
   const handleReasoningLevelChange = useCallback(
     (nextReasoningLevel: ReasoningLevel) => {
+      if (!hasPromptOptionValueChanged(reasoningLevel, nextReasoningLevel)) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       setReasoningLevel(nextReasoningLevel);
     },
-    [setReasoningLevel, snapshotPromptDraftBeforeOptionChange],
+    [reasoningLevel, setReasoningLevel, snapshotPromptDraftBeforeOptionChange],
   );
   const handlePermissionModeChange = useCallback(
     (nextPermissionMode: PermissionMode) => {
+      if (!hasPromptOptionValueChanged(permissionMode, nextPermissionMode)) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       setPermissionMode(nextPermissionMode);
     },
-    [setPermissionMode, snapshotPromptDraftBeforeOptionChange],
+    [permissionMode, setPermissionMode, snapshotPromptDraftBeforeOptionChange],
   );
   const handleEnvironmentSelectionValueChange = useCallback(
     (nextEnvironmentValue: string) => {
+      if (
+        !hasPromptOptionValueChanged(
+          environmentSelectionValue,
+          nextEnvironmentValue,
+        )
+      ) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       setEnvironmentSelectionValue(nextEnvironmentValue);
     },
-    [setEnvironmentSelectionValue, snapshotPromptDraftBeforeOptionChange],
+    [
+      environmentSelectionValue,
+      setEnvironmentSelectionValue,
+      snapshotPromptDraftBeforeOptionChange,
+    ],
   );
   useEffect(() => {
     const preservedDraft = promptOptionDraftSnapshotRef.current;
@@ -1166,6 +1220,8 @@ export function RootComposeView(props: RootComposeViewProps) {
     environmentValue: effectiveEnvironmentValue,
     projectId,
   });
+  const canChangeBranchSelection =
+    projectId !== undefined && effectiveEnvironmentValue !== "";
   const selectedBranchName = selectedBranch?.name ?? "";
   const hostBranchesQuery = useProjectSourceBranches(
     projectId,
@@ -1258,25 +1314,86 @@ export function RootComposeView(props: RootComposeViewProps) {
   );
   const handlePromptBoxBranchChange = useCallback(
     (branch: string) => {
+      const nextBranch: RootComposeSelectedBranch = {
+        name: branch,
+        isNew: false,
+      };
+      if (
+        !canChangeBranchSelection ||
+        !hasPromptBranchSelectionChanged(selectedBranch, nextBranch)
+      ) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       handleBranchChange(branch);
     },
-    [handleBranchChange, snapshotPromptDraftBeforeOptionChange],
+    [
+      canChangeBranchSelection,
+      handleBranchChange,
+      selectedBranch,
+      snapshotPromptDraftBeforeOptionChange,
+    ],
   );
   const handlePromptBoxClearBranch = useCallback(() => {
+    if (
+      !canChangeBranchSelection ||
+      !hasPromptBranchSelectionChanged(selectedBranch, null)
+    ) {
+      return;
+    }
     snapshotPromptDraftBeforeOptionChange();
     handleClearBranch();
-  }, [handleClearBranch, snapshotPromptDraftBeforeOptionChange]);
+  }, [
+    canChangeBranchSelection,
+    handleClearBranch,
+    selectedBranch,
+    snapshotPromptDraftBeforeOptionChange,
+  ]);
   const handlePromptBoxCreateBranchFromSeed = useCallback(() => {
+    const branchName = selectedBranch?.name ?? branchSelectionSeed;
+    const nextBranch =
+      branchName === null
+        ? null
+        : {
+            name: branchName,
+            isNew: true,
+          };
+    if (
+      !canChangeBranchSelection ||
+      !hasPromptBranchSelectionChanged(selectedBranch, nextBranch)
+    ) {
+      return;
+    }
     snapshotPromptDraftBeforeOptionChange();
     handleCreateBranchFromSeed();
-  }, [handleCreateBranchFromSeed, snapshotPromptDraftBeforeOptionChange]);
+  }, [
+    branchSelectionSeed,
+    canChangeBranchSelection,
+    handleCreateBranchFromSeed,
+    selectedBranch,
+    snapshotPromptDraftBeforeOptionChange,
+  ]);
   const handlePromptBoxCreateBranchFrom = useCallback(
     (branch: string) => {
+      const nextBranch: RootComposeSelectedBranch = {
+        name: branch,
+        isNew: true,
+      };
+      if (
+        !canChangeBranchSelection ||
+        !hasPromptBranchSelectionChanged(selectedBranch, nextBranch)
+      ) {
+        return;
+      }
       snapshotPromptDraftBeforeOptionChange();
       handleCreateBranchFrom(branch);
     },
-    [handleCreateBranchFrom, snapshotPromptDraftBeforeOptionChange],
+    [
+      canChangeBranchSelection,
+      handleCreateBranchFrom,
+      selectedBranch,
+      snapshotPromptDraftBeforeOptionChange,
+    ],
   );
 
   const selectedEnvironment = useMemo(

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -98,7 +98,13 @@ import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { promptHistoryEntriesToDrafts } from "@/lib/prompt-history";
 import { getProjectScopedStorageKey } from "@/lib/project-scoped-storage";
-import { promptDraftToInput } from "@/lib/prompt-draft";
+import {
+  arePromptDraftStatesEqual,
+  isPromptDraftEmpty,
+  promptDraftToInput,
+  type PromptDraftAttachment,
+  type PromptDraftState,
+} from "@/lib/prompt-draft";
 import {
   buildForkThreadRequest,
   FORK_THREAD_CREATE_SEED_LOCATION_STATE_KEY,
@@ -206,6 +212,70 @@ type SecondaryPanelChangeHandler = (panel: ThreadSecondaryPanelTab) => void;
 type NullableSecondaryPanelChangeHandler = (
   panel: ThreadSecondaryPanelTab | null,
 ) => void;
+
+export function mergeMissingPromptDraftAttachments(
+  currentAttachments: readonly PromptDraftAttachment[],
+  preservedAttachments: readonly PromptDraftAttachment[],
+): PromptDraftAttachment[] | null {
+  const existingPaths = new Set(
+    currentAttachments.map((attachment) => attachment.path),
+  );
+  const missingAttachments = preservedAttachments.filter(
+    (attachment) => !existingPaths.has(attachment.path),
+  );
+  if (missingAttachments.length === 0) {
+    return null;
+  }
+  return [...currentAttachments, ...missingAttachments];
+}
+
+export function restorePromptDraftAfterOptionChange({
+  currentDraft,
+  preservedDraft,
+}: {
+  currentDraft: PromptDraftState;
+  preservedDraft: PromptDraftState | null;
+}): PromptDraftState | null {
+  if (preservedDraft === null) {
+    return null;
+  }
+  if (arePromptDraftStatesEqual(currentDraft, preservedDraft)) {
+    return null;
+  }
+
+  let restoredDraft = currentDraft;
+  let changed = false;
+
+  if (isPromptDraftEmpty(currentDraft) && !isPromptDraftEmpty(preservedDraft)) {
+    restoredDraft = preservedDraft;
+    changed = true;
+  } else if (
+    currentDraft.text === preservedDraft.text &&
+    currentDraft.mentions !== preservedDraft.mentions &&
+    JSON.stringify(currentDraft.mentions) !==
+      JSON.stringify(preservedDraft.mentions)
+  ) {
+    restoredDraft = {
+      ...restoredDraft,
+      mentions: preservedDraft.mentions,
+    };
+    changed = true;
+  }
+
+  const mergedAttachments = mergeMissingPromptDraftAttachments(
+    restoredDraft.attachments,
+    preservedDraft.attachments,
+  );
+  if (mergedAttachments !== null) {
+    restoredDraft = {
+      ...restoredDraft,
+      attachments: mergedAttachments,
+    };
+    changed = true;
+  }
+
+  return changed ? restoredDraft : null;
+}
 
 interface LegacyProjectComposeRedirectProps {
   projectId: string;
@@ -767,6 +837,7 @@ export function RootComposeView(props: RootComposeViewProps) {
   const primaryHostId = usePrimaryHost()?.id ?? null;
   const uploadPromptAttachment = useUploadPromptAttachment();
   const promptDraft = usePromptDraftStorage({ kind: "new-thread" });
+  const promptOptionDraftSnapshotRef = useRef<PromptDraftState | null>(null);
   const { data: projectPromptHistory = [] } =
     useProjectPromptHistory(projectId);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
@@ -855,6 +926,71 @@ export function RootComposeView(props: RootComposeViewProps) {
     serviceTierSupportByProvider,
   } = creationOptions;
   const executionInputSources = creationOptions.executionInputSources;
+  const snapshotPromptDraftBeforeOptionChange = useCallback(() => {
+    const currentDraft = promptDraft.getCurrent();
+    promptOptionDraftSnapshotRef.current = isPromptDraftEmpty(currentDraft)
+      ? null
+      : currentDraft;
+  }, [promptDraft]);
+  const handleSelectedProviderIdChange = useCallback(
+    (nextProviderId: string) => {
+      snapshotPromptDraftBeforeOptionChange();
+      setSelectedProviderId(nextProviderId);
+    },
+    [setSelectedProviderId, snapshotPromptDraftBeforeOptionChange],
+  );
+  const handleSelectedModelChange = useCallback(
+    (nextModel: string) => {
+      snapshotPromptDraftBeforeOptionChange();
+      setSelectedModel(nextModel);
+    },
+    [setSelectedModel, snapshotPromptDraftBeforeOptionChange],
+  );
+  const handleServiceTierChange = useCallback(
+    (nextServiceTier: ServiceTier | undefined) => {
+      snapshotPromptDraftBeforeOptionChange();
+      setServiceTier(nextServiceTier);
+    },
+    [setServiceTier, snapshotPromptDraftBeforeOptionChange],
+  );
+  const handleReasoningLevelChange = useCallback(
+    (nextReasoningLevel: ReasoningLevel) => {
+      snapshotPromptDraftBeforeOptionChange();
+      setReasoningLevel(nextReasoningLevel);
+    },
+    [setReasoningLevel, snapshotPromptDraftBeforeOptionChange],
+  );
+  const handlePermissionModeChange = useCallback(
+    (nextPermissionMode: PermissionMode) => {
+      snapshotPromptDraftBeforeOptionChange();
+      setPermissionMode(nextPermissionMode);
+    },
+    [setPermissionMode, snapshotPromptDraftBeforeOptionChange],
+  );
+  const handleEnvironmentSelectionValueChange = useCallback(
+    (nextEnvironmentValue: string) => {
+      snapshotPromptDraftBeforeOptionChange();
+      setEnvironmentSelectionValue(nextEnvironmentValue);
+    },
+    [setEnvironmentSelectionValue, snapshotPromptDraftBeforeOptionChange],
+  );
+  useEffect(() => {
+    const preservedDraft = promptOptionDraftSnapshotRef.current;
+    if (preservedDraft === null) {
+      return;
+    }
+
+    promptOptionDraftSnapshotRef.current = null;
+    const restoredDraft = restorePromptDraftAfterOptionChange({
+      currentDraft: promptDraft.getCurrent(),
+      preservedDraft,
+    });
+    if (restoredDraft === null) {
+      return;
+    }
+
+    promptDraft.setDraft(restoredDraft);
+  });
   const providerCliSystemConfig = useSystemConfig();
   const providerCliDaemonPort = isLoopbackOrigin()
     ? (providerCliSystemConfig.data?.hostDaemonPort ?? null)
@@ -1120,6 +1256,28 @@ export function RootComposeView(props: RootComposeViewProps) {
     },
     [refetchSourceBranches],
   );
+  const handlePromptBoxBranchChange = useCallback(
+    (branch: string) => {
+      snapshotPromptDraftBeforeOptionChange();
+      handleBranchChange(branch);
+    },
+    [handleBranchChange, snapshotPromptDraftBeforeOptionChange],
+  );
+  const handlePromptBoxClearBranch = useCallback(() => {
+    snapshotPromptDraftBeforeOptionChange();
+    handleClearBranch();
+  }, [handleClearBranch, snapshotPromptDraftBeforeOptionChange]);
+  const handlePromptBoxCreateBranchFromSeed = useCallback(() => {
+    snapshotPromptDraftBeforeOptionChange();
+    handleCreateBranchFromSeed();
+  }, [handleCreateBranchFromSeed, snapshotPromptDraftBeforeOptionChange]);
+  const handlePromptBoxCreateBranchFrom = useCallback(
+    (branch: string) => {
+      snapshotPromptDraftBeforeOptionChange();
+      handleCreateBranchFrom(branch);
+    },
+    [handleCreateBranchFrom, snapshotPromptDraftBeforeOptionChange],
+  );
 
   const selectedEnvironment = useMemo(
     () =>
@@ -1166,10 +1324,11 @@ export function RootComposeView(props: RootComposeViewProps) {
     (nextProjectId) => {
       const nextRootComposeProjectId = nextProjectId ?? PERSONAL_PROJECT_ID;
       if (nextRootComposeProjectId === projectId) return;
+      snapshotPromptDraftBeforeOptionChange();
       setForkSeed(null);
       setRootComposeProjectId(nextRootComposeProjectId);
     },
-    [projectId, setRootComposeProjectId],
+    [projectId, setRootComposeProjectId, snapshotPromptDraftBeforeOptionChange],
   );
   const shouldFocusPrompt =
     typeof location.state === "object" &&
@@ -2422,7 +2581,8 @@ export function RootComposeView(props: RootComposeViewProps) {
       provider: {
         options: providerOptions,
         selectedId: selectedProviderId,
-        onChange: forkSeed === null ? setSelectedProviderId : undefined,
+        onChange:
+          forkSeed === null ? handleSelectedProviderIdChange : undefined,
         hasMultiple: hasMultipleProviders,
       },
       model: {
@@ -2433,24 +2593,28 @@ export function RootComposeView(props: RootComposeViewProps) {
         isLoading: isLoadingModels,
         loadFailed: modelLoadFailed,
         loadError: modelLoadError,
-        onChange: setSelectedModel,
+        onChange: handleSelectedModelChange,
       },
       serviceTier: {
         value: serviceTier,
-        onChange: setServiceTier,
+        onChange: handleServiceTierChange,
         supported: supportsServiceTier,
         supportByProvider: serviceTierSupportByProvider,
       },
       reasoning: {
         value: reasoningLevel,
         options: reasoningOptions,
-        onChange: setReasoningLevel,
+        onChange: handleReasoningLevelChange,
       },
     }),
     [
       activeModel,
       forkSeed,
       hasMultipleProviders,
+      handleSelectedProviderIdChange,
+      handleReasoningLevelChange,
+      handleSelectedModelChange,
+      handleServiceTierChange,
       isLoadingModels,
       modelLoadFailed,
       modelLoadError,
@@ -2463,10 +2627,6 @@ export function RootComposeView(props: RootComposeViewProps) {
       selectedProviderId,
       serviceTier,
       serviceTierSupportByProvider,
-      setReasoningLevel,
-      setSelectedModel,
-      setSelectedProviderId,
-      setServiceTier,
       supportsServiceTier,
     ],
   );
@@ -2494,7 +2654,7 @@ export function RootComposeView(props: RootComposeViewProps) {
   const environmentConfig = useMemo(
     () => ({
       value: effectiveEnvironmentValue,
-      onChange: setEnvironmentSelectionValue,
+      onChange: handleEnvironmentSelectionValueChange,
       sources: projectSources,
       reuseDisabled: reuseThreadOptions.length === 0,
       disabled: isForkDraft,
@@ -2502,14 +2662,14 @@ export function RootComposeView(props: RootComposeViewProps) {
     [
       effectiveEnvironmentValue,
       isForkDraft,
+      handleEnvironmentSelectionValueChange,
       projectSources,
       reuseThreadOptions.length,
-      setEnvironmentSelectionValue,
     ],
   );
   const worktreeConfig = useMemo(() => {
     const handleWorktreeChange = (environmentId: string) => {
-      setEnvironmentSelectionValue(encodeReuseValue(environmentId));
+      handleEnvironmentSelectionValueChange(encodeReuseValue(environmentId));
     };
     return {
       options: reuseThreadOptions,
@@ -2522,9 +2682,9 @@ export function RootComposeView(props: RootComposeViewProps) {
     };
   }, [
     isForkDraft,
+    handleEnvironmentSelectionValueChange,
     parsedEnvironment,
     reuseThreadOptions,
-    setEnvironmentSelectionValue,
   ]);
   const branchConfig = useMemo(
     () => ({
@@ -2555,10 +2715,10 @@ export function RootComposeView(props: RootComposeViewProps) {
       createDisabledReason: branchUiState.mutationBlocker?.label,
       createDisabledTitle: branchUiState.mutationBlocker?.title,
       disabled: isForkDraft,
-      onChange: handleBranchChange,
-      onClear: handleClearBranch,
-      onCreate: handleCreateBranchFromSeed,
-      onCreateBaseChange: handleCreateBranchFrom,
+      onChange: handlePromptBoxBranchChange,
+      onClear: handlePromptBoxClearBranch,
+      onCreate: handlePromptBoxCreateBranchFromSeed,
+      onCreateBaseChange: handlePromptBoxCreateBranchFrom,
       onOpenChange: handleBranchOpenChange,
       onSearchQueryChange: setBranchSearchQuery,
     }),
@@ -2575,11 +2735,11 @@ export function RootComposeView(props: RootComposeViewProps) {
       branchUiState.placeholder,
       branchUiState.triggerLabel,
       branchUiState.triggerTitle,
-      handleBranchChange,
       handleBranchOpenChange,
-      handleClearBranch,
-      handleCreateBranchFromSeed,
-      handleCreateBranchFrom,
+      handlePromptBoxBranchChange,
+      handlePromptBoxClearBranch,
+      handlePromptBoxCreateBranchFromSeed,
+      handlePromptBoxCreateBranchFrom,
       setBranchSearchQuery,
       selectedBranch?.isNew,
       selectedBranch?.name,
@@ -2589,13 +2749,13 @@ export function RootComposeView(props: RootComposeViewProps) {
     () => ({
       value: permissionMode,
       options: permissionModeOptions,
-      onChange: setPermissionMode,
+      onChange: handlePermissionModeChange,
       supported: supportsPermissionModeSelection,
     }),
     [
+      handlePermissionModeChange,
       permissionMode,
       permissionModeOptions,
-      setPermissionMode,
       supportsPermissionModeSelection,
     ],
   );

--- a/packages/scripts/test/source-cli-wrapper.test.ts
+++ b/packages/scripts/test/source-cli-wrapper.test.ts
@@ -12,6 +12,7 @@ interface SourceCliResult {
 
 interface StatusWrapperPayload {
   childThreads: null;
+  dataDir: null;
   pendingTodos: null;
   project: null;
   thread: null;
@@ -96,6 +97,7 @@ describe("source CLI wrapper", () => {
     const payload: StatusWrapperPayload = JSON.parse(result.stdout);
     expect(payload).toEqual({
       childThreads: null,
+      dataDir: null,
       pendingTodos: null,
       project: null,
       thread: null,


### PR DESCRIPTION
## Summary

- Preserve the full root compose draft around prompt box option changes.
- Restore missing uploaded attachments after provider/model/service tier/reasoning/permission/environment/branch/project changes before submit.
- Avoid stale draft snapshots for no-op option and branch selections, so later user clears/removals are not restored accidentally.
- Add regression coverage for full-draft restoration, attachment merging, and no-op option/branch comparison.
- Align the source CLI wrapper status expectation with the current `bb status --json` payload so CI can run cleanly.

## Root Cause

Option changes could remount or reset prompt box state while draft text was still protected by existing draft storage. Attachments were part of the draft state too, but there was no snapshot/restore guard around those option transitions.

The review-loop found one P2 after the initial fix: no-op option callbacks could leave a stale snapshot ref for a later draft-store render. The wrappers now snapshot only when the option or branch selection actually changes.

The CI failure was a stale test expectation: `bb status --json` now returns `dataDir: null` when no server data directory is available.

## Validation

- review-loop pass 1: no issues found
- review-loop pass 2: one P2 found, validated, fixed; no further pass run due requested two-pass cap
- pnpm exec turbo run test --filter=@bb/app -- --run src/views/RootComposeView.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/scripts -- --run test/source-cli-wrapper.test.ts
- pnpm exec turbo run typecheck --filter=@bb/scripts
- scripts/bb-dev-app current
- eval "$(scripts/bb-dev-app env)" && pnpm bb:dev thread spawn --project proj_personal --provider codex --permission-mode readonly --title "Smoke test" --prompt "Reply only with ok." --json
- pnpm bb:dev thread show thr_ev9v82u6ac --json returned status `idle`
- pnpm bb:dev thread output thr_ev9v82u6ac --json returned `ok`
