### PR TITLE
Align prompt context banner action padding

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -434,7 +434,7 @@ function BannerActionSlot({
 }) {
   return (
     <div
-      className="ml-auto flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
+      className="ml-auto flex shrink-0 items-center gap-1.5 pr-2 text-xs text-muted-foreground"
       data-promptbox-hide-compact={hideInCompact ? "" : undefined}
       data-promptbox-hide-tiny=""
     >

--- a/packages/scripts/test/source-cli-wrapper.test.ts
+++ b/packages/scripts/test/source-cli-wrapper.test.ts
@@ -12,6 +12,7 @@ interface SourceCliResult {
 
 interface StatusWrapperPayload {
   childThreads: null;
+  dataDir: null;
   pendingTodos: null;
   project: null;
   thread: null;
@@ -96,6 +97,7 @@ describe("source CLI wrapper", () => {
     const payload: StatusWrapperPayload = JSON.parse(result.stdout);
     expect(payload).toEqual({
       childThreads: null,
+      dataDir: null,
       pendingTodos: null,
       project: null,
       thread: null,


### PR DESCRIPTION
## Summary
- add right-side padding to the prompt context banner action slot so banner actions align with the queued message and promptbox gutters
- update the source CLI wrapper test for the current `bb status --json` payload shape (`dataDir: null` when the server config is unavailable)

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/scripts