### PR TITLE
Add desktop startup smoke tests

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -113,6 +113,9 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm exec turbo run desktop:build --filter=@bb/desktop --force --output-logs=new-only
 
+      - name: Smoke test packaged desktop app
+        run: pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force --output-logs=new-only
+
       - name: Generate desktop version feed
         run: pnpm --dir apps/desktop run desktop:version-feed
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -69,6 +69,7 @@ pnpm exec turbo run dev --filter=@bb/desktop
 
 ```bash
 pnpm exec turbo run desktop:build --filter=@bb/desktop
+pnpm exec turbo run smoke:packaged --filter=@bb/desktop
 ```
 
 Artifacts are written under `apps/desktop/release/`. The desktop build is

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
     "dist": "pnpm run prepare-runtime && pnpm run desktop:build",
     "package": "pnpm run prepare-runtime && pnpm run build && node scripts/run-electron-builder.mjs --mac --dir --arm64",
     "prepare-runtime": "pnpm exec turbo run build --filter=bb-app --output-logs=new-only",
+    "smoke:packaged": "node scripts/smoke-packaged-app.mjs",
     "start": "pnpm run package && node scripts/run-packaged-app.mjs",
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -1,0 +1,416 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { access, readFile, readdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const desktopPackageRoot = resolve(scriptDirectory, "..");
+const releaseDir = join(desktopPackageRoot, "release");
+const appBinaryRelativePath = join("bb.app", "Contents", "MacOS", "bb");
+const startupTimeoutMs = 20_000;
+const exitTimeoutMs = 5_000;
+const postReadySettleMs = 300;
+const maxCapturedOutputCharacters = 20_000;
+
+function writeJson(response, body) {
+  response.writeHead(200, {
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function writeHtml(response, html) {
+  response.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+  });
+  response.end(html);
+}
+
+function writeNotFound(response) {
+  response.writeHead(404, {
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify({ message: "not found" }));
+}
+
+function createDesktopVersionFeed(version) {
+  return {
+    schemaVersion: 1,
+    channel: "latest",
+    platform: "macos",
+    version,
+    releaseDate: new Date(0).toISOString(),
+    releaseName: `bb desktop ${version}`,
+    releaseNotes: null,
+    minimumSystemVersion: null,
+    files: [
+      {
+        url: "https://example.invalid/bb.zip",
+        sha512: "smoke",
+        size: 0,
+      },
+    ],
+    path: "bb.zip",
+    sha512: "smoke",
+    stagingPercentage: null,
+  };
+}
+
+function renderSmokePage(expectedDesktopVersion) {
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>bb packaged desktop smoke</title>
+<main>packaged desktop smoke</main>
+<script>
+(async () => {
+  let ok = false;
+  let reason = "";
+  try {
+    if (typeof window.bbDesktop !== "object" || window.bbDesktop === null) {
+      reason = "missing window.bbDesktop";
+    } else if (typeof window.bbDesktop.getInfo !== "function") {
+      reason = "missing window.bbDesktop.getInfo";
+    } else {
+      const info = await window.bbDesktop.getInfo();
+      const expectedVersion = ${JSON.stringify(expectedDesktopVersion)};
+      ok =
+        window.bbDesktop.platform === "macos" &&
+        window.bbDesktop.version === expectedVersion &&
+        info.version === expectedVersion;
+      reason = ok ? "" : "unexpected desktop bridge info";
+    }
+  } catch (error) {
+    reason = error instanceof Error ? error.message : String(error);
+  }
+  const params = new URLSearchParams({
+    ok: ok ? "1" : "0",
+    reason,
+  });
+  await fetch("/smoke/preload-ready?" + params.toString(), { method: "POST" });
+})();
+</script>`;
+}
+
+async function readDesktopPackageVersion() {
+  const packageJsonText = await readFile(
+    join(desktopPackageRoot, "package.json"),
+    "utf8",
+  );
+  const packageJson = JSON.parse(packageJsonText);
+  if (
+    typeof packageJson !== "object" ||
+    packageJson === null ||
+    typeof packageJson.version !== "string" ||
+    packageJson.version.length === 0
+  ) {
+    throw new Error("apps/desktop/package.json must define a version");
+  }
+  return packageJson.version;
+}
+
+async function resolvePackagedAppBinary() {
+  const entries = await readdir(releaseDir, { withFileTypes: true });
+  const macOutputDirectories = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("mac"))
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const directory of macOutputDirectories) {
+    const appBinary = join(releaseDir, directory, appBinaryRelativePath);
+    try {
+      await access(appBinary);
+      return appBinary;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error(`No packaged bb.app found under ${releaseDir}`);
+}
+
+async function startSmokeServer({ dataDir, expectedDesktopVersion }) {
+  let resolvePreloadReady = () => {};
+  const preloadReady = new Promise((resolvePromise) => {
+    resolvePreloadReady = resolvePromise;
+  });
+  const server = createServer((request, response) => {
+    if (request.url === "/health") {
+      writeJson(response, { ok: true });
+      return;
+    }
+
+    if (request.url === "/api/v1/system/config") {
+      writeJson(response, {
+        appearance: {
+          customCss: null,
+          faviconColor: "default",
+          themeId: "default",
+        },
+        customThemes: [],
+        dataDir,
+        experiments: {
+          claudeCodeMockCliTraffic: false,
+          popoutChat: false,
+          popoutChatHotkey: "Alt+Space",
+          uiForking: false,
+        },
+        featureFlags: {
+          placeholder: false,
+        },
+        hostDaemonPort: 38887,
+        voiceTranscriptionEnabled: false,
+      });
+      return;
+    }
+
+    if (request.url === "/desktop-version.json") {
+      writeJson(response, createDesktopVersionFeed(expectedDesktopVersion));
+      return;
+    }
+
+    if (request.url === "/" || request.url === "/index.html") {
+      writeHtml(response, renderSmokePage(expectedDesktopVersion));
+      return;
+    }
+
+    if (request.url?.startsWith("/smoke/preload-ready") === true) {
+      const url = new URL(request.url, "http://127.0.0.1");
+      resolvePreloadReady({
+        ok: url.searchParams.get("ok") === "1",
+        reason: url.searchParams.get("reason") ?? "",
+      });
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+
+    writeNotFound(response);
+  });
+
+  await new Promise((resolvePromise) => {
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected desktop smoke server to listen on a TCP port");
+  }
+
+  return {
+    close: async () => {
+      await new Promise((resolvePromise, rejectPromise) => {
+        server.close((error) => {
+          if (error) {
+            rejectPromise(error);
+            return;
+          }
+          resolvePromise();
+        });
+      });
+    },
+    port: address.port,
+    preloadReady,
+  };
+}
+
+function appendOutput(chunks, chunk) {
+  chunks.push(String(chunk));
+  let totalLength = chunks.reduce((total, value) => total + value.length, 0);
+  while (totalLength > maxCapturedOutputCharacters && chunks.length > 1) {
+    const removed = chunks.shift();
+    totalLength -= removed.length;
+  }
+}
+
+function formatProcessOutput({ stdout, stderr }) {
+  const stdoutText = stdout.join("").trim();
+  const stderrText = stderr.join("").trim();
+  return [
+    stdoutText.length > 0 ? `stdout:\n${stdoutText}` : "",
+    stderrText.length > 0 ? `stderr:\n${stderrText}` : "",
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
+}
+
+async function waitForPreloadReady({ child, preloadReady, stdout, stderr }) {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      rejectPromise(
+        new Error(
+          `Timed out waiting for the packaged Electron app to report ready.\n${formatProcessOutput(
+            { stdout, stderr },
+          )}`,
+        ),
+      );
+    }, startupTimeoutMs);
+
+    const handleExit = (code, signal) => {
+      cleanup();
+      rejectPromise(
+        new Error(
+          `Packaged Electron app exited before startup completed: code=${String(
+            code,
+          )} signal=${String(signal)}.\n${formatProcessOutput({
+            stdout,
+            stderr,
+          })}`,
+        ),
+      );
+    };
+    const handleError = (error) => {
+      cleanup();
+      rejectPromise(
+        new Error(
+          `Could not launch packaged Electron app: ${
+            error instanceof Error ? error.message : String(error)
+          }.\n${formatProcessOutput({ stdout, stderr })}`,
+        ),
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", handleExit);
+      child.off("error", handleError);
+    };
+
+    child.once("exit", handleExit);
+    child.once("error", handleError);
+    preloadReady.then(
+      (result) => {
+        cleanup();
+        resolvePromise(result);
+      },
+      (error) => {
+        cleanup();
+        rejectPromise(error);
+      },
+    );
+  });
+}
+
+async function sleep(delayMs) {
+  await new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, delayMs);
+  });
+}
+
+async function waitForProcessExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return true;
+  }
+
+  return await new Promise((resolvePromise) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolvePromise(false);
+    }, timeoutMs);
+
+    const handleExit = () => {
+      cleanup();
+      resolvePromise(true);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", handleExit);
+    };
+
+    child.once("exit", handleExit);
+  });
+}
+
+async function stopPackagedApp(child) {
+  if (await waitForProcessExit(child, 0)) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+  if (await waitForProcessExit(child, exitTimeoutMs)) {
+    return;
+  }
+
+  child.kill("SIGKILL");
+  await waitForProcessExit(child, exitTimeoutMs);
+}
+
+async function smokePackagedApp() {
+  if (process.platform !== "darwin") {
+    throw new Error("Packaged desktop smoke only runs on macOS.");
+  }
+
+  const desktopVersion = await readDesktopPackageVersion();
+  const appBinary = await resolvePackagedAppBinary();
+  const smokeRoot = await mkdtemp(join(tmpdir(), "bb-desktop-packaged-smoke-"));
+  const dataDir = join(smokeRoot, "data");
+  const userDataDir = join(smokeRoot, "user-data");
+  const smokeServer = await startSmokeServer({
+    dataDir,
+    expectedDesktopVersion: desktopVersion,
+  });
+  const serverUrl = `http://127.0.0.1:${smokeServer.port}`;
+  const stdout = [];
+  const stderr = [];
+  const childEnv = {
+    ...process.env,
+    BB_DATA_DIR: dataDir,
+    BB_DESKTOP_OPEN_DEVTOOLS: "0",
+    BB_DESKTOP_VERSION_FEED_URL: `${serverUrl}/desktop-version.json`,
+    BB_SERVER_PORT: String(smokeServer.port),
+  };
+  delete childEnv.BB_DESKTOP_APP_URL;
+  delete childEnv.BB_DESKTOP_NODE_EXEC_PATH;
+  delete childEnv.ELECTRON_RUN_AS_NODE;
+
+  const child = spawn(appBinary, [`--user-data-dir=${userDataDir}`], {
+    env: childEnv,
+  });
+  child.stdout.on("data", (chunk) => {
+    appendOutput(stdout, chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    appendOutput(stderr, chunk);
+  });
+
+  try {
+    const preloadReady = await waitForPreloadReady({
+      child,
+      preloadReady: smokeServer.preloadReady,
+      stdout,
+      stderr,
+    });
+    if (!preloadReady.ok) {
+      throw new Error(
+        `Packaged desktop preload bridge did not become ready: ${preloadReady.reason}`,
+      );
+    }
+
+    await sleep(postReadySettleMs);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `Packaged Electron app exited after startup: code=${String(
+          child.exitCode,
+        )} signal=${String(child.signalCode)}.\n${formatProcessOutput({
+          stdout,
+          stderr,
+        })}`,
+      );
+    }
+
+    console.log(`Packaged desktop smoke passed: ${appBinary}`);
+  } finally {
+    await stopPackagedApp(child);
+    await smokeServer.close();
+    await rm(smokeRoot, { force: true, recursive: true });
+  }
+}
+
+await smokePackagedApp().catch((error) => {
+  const message =
+    error instanceof Error ? (error.stack ?? error.message) : error;
+  console.error(message);
+  process.exitCode = 1;
+});

--- a/apps/desktop/test/preload-build.test.ts
+++ b/apps/desktop/test/preload-build.test.ts
@@ -1,16 +1,302 @@
-import { execFile } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import {
+  execFile,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import { promisify } from "node:util";
 import { z } from "zod";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const require = createRequire(__filename);
+const electronBinary = require("electron") as string;
 const desktopPackageRoot = process.cwd();
+const ELECTRON_STARTUP_TIMEOUT_MS = 15_000;
+const ELECTRON_EXIT_TIMEOUT_MS = 5_000;
+const ELECTRON_POST_READY_SETTLE_MS = 300;
 
 const desktopPackageJsonSchema = z.object({
   version: z.string().min(1),
 });
+
+interface DesktopSmokeServer {
+  close(): Promise<void>;
+  port: number;
+  preloadReady: Promise<PreloadReadyResult>;
+}
+
+interface PreloadReadyResult {
+  ok: boolean;
+  reason: string;
+}
+
+interface StartDesktopSmokeServerArgs {
+  dataDir: string;
+  expectedDesktopVersion: string;
+}
+
+function writeJson(response: ServerResponse, body: unknown): void {
+  response.writeHead(200, {
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function writeHtml(response: ServerResponse, html: string): void {
+  response.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+  });
+  response.end(html);
+}
+
+function writeNotFound(response: ServerResponse): void {
+  response.writeHead(404, {
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify({ message: "not found" }));
+}
+
+function renderSmokePage(expectedDesktopVersion: string): string {
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>bb desktop smoke</title>
+<main>desktop smoke</main>
+<script>
+(async () => {
+  let ok = false;
+  let reason = "";
+  try {
+    if (typeof window.bbDesktop !== "object" || window.bbDesktop === null) {
+      reason = "missing window.bbDesktop";
+    } else if (typeof window.bbDesktop.getInfo !== "function") {
+      reason = "missing window.bbDesktop.getInfo";
+    } else {
+      const info = await window.bbDesktop.getInfo();
+      const expectedVersion = ${JSON.stringify(expectedDesktopVersion)};
+      ok = window.bbDesktop.version === expectedVersion && info.version === expectedVersion;
+      reason = ok ? "" : "unexpected desktop version";
+    }
+  } catch (error) {
+    reason = error instanceof Error ? error.message : String(error);
+  }
+  const params = new URLSearchParams({
+    ok: ok ? "1" : "0",
+    reason,
+  });
+  await fetch("/smoke/preload-ready?" + params.toString(), { method: "POST" });
+})();
+</script>`;
+}
+
+async function startDesktopSmokeServer(
+  args: StartDesktopSmokeServerArgs,
+): Promise<DesktopSmokeServer> {
+  let resolvePreloadReady: (result: PreloadReadyResult) => void = () => {};
+  const preloadReady = new Promise<PreloadReadyResult>((resolvePromise) => {
+    resolvePreloadReady = resolvePromise;
+  });
+  const server = createServer(
+    (request: IncomingMessage, response: ServerResponse) => {
+      if (request.url === "/health") {
+        writeJson(response, { ok: true });
+        return;
+      }
+
+      if (request.url === "/api/v1/system/config") {
+        writeJson(response, {
+          appearance: {
+            customCss: null,
+            faviconColor: "default",
+            themeId: "default",
+          },
+          customThemes: [],
+          dataDir: args.dataDir,
+          experiments: {
+            claudeCodeMockCliTraffic: false,
+            popoutChat: false,
+            popoutChatHotkey: "Alt+Space",
+            uiForking: false,
+          },
+          featureFlags: {
+            placeholder: false,
+          },
+          hostDaemonPort: 38887,
+          voiceTranscriptionEnabled: false,
+        });
+        return;
+      }
+
+      if (request.url === "/" || request.url === "/index.html") {
+        writeHtml(response, renderSmokePage(args.expectedDesktopVersion));
+        return;
+      }
+
+      if (request.url?.startsWith("/smoke/preload-ready") === true) {
+        const url = new URL(request.url, "http://127.0.0.1");
+        resolvePreloadReady({
+          ok: url.searchParams.get("ok") === "1",
+          reason: url.searchParams.get("reason") ?? "",
+        });
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+
+      writeNotFound(response);
+    },
+  );
+
+  await new Promise<void>((resolvePromise) => {
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected desktop smoke server to listen on a TCP port");
+  }
+
+  return {
+    close: async () => {
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        server.close((error) => {
+          if (error) {
+            rejectPromise(error);
+            return;
+          }
+          resolvePromise();
+        });
+      });
+    },
+    port: address.port,
+    preloadReady,
+  };
+}
+
+function formatProcessOutput(args: {
+  stderr: string[];
+  stdout: string[];
+}): string {
+  const stdout = args.stdout.join("").trim();
+  const stderr = args.stderr.join("").trim();
+  return [
+    stdout.length > 0 ? `stdout:\n${stdout}` : "",
+    stderr.length > 0 ? `stderr:\n${stderr}` : "",
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
+}
+
+async function waitForPreloadReady(args: {
+  child: ChildProcessWithoutNullStreams;
+  preloadReady: Promise<PreloadReadyResult>;
+  stderr: string[];
+  stdout: string[];
+  timeoutMs: number;
+}): Promise<PreloadReadyResult> {
+  return await new Promise<PreloadReadyResult>(
+    (resolvePromise, rejectPromise) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        rejectPromise(
+          new Error(
+            `Timed out waiting for the Electron smoke page to report ready.\n${formatProcessOutput(
+              args,
+            )}`,
+          ),
+        );
+      }, args.timeoutMs);
+
+      const handleExit = (
+        code: number | null,
+        signal: NodeJS.Signals | null,
+      ) => {
+        cleanup();
+        rejectPromise(
+          new Error(
+            `Electron exited before startup completed: code=${String(
+              code,
+            )} signal=${String(signal)}.\n${formatProcessOutput(args)}`,
+          ),
+        );
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        args.child.off("exit", handleExit);
+      };
+
+      args.child.once("exit", handleExit);
+      args.preloadReady.then(
+        (result) => {
+          cleanup();
+          resolvePromise(result);
+        },
+        (error: unknown) => {
+          cleanup();
+          rejectPromise(error);
+        },
+      );
+    },
+  );
+}
+
+async function sleep(delayMs: number): Promise<void> {
+  await new Promise<void>((resolvePromise) => {
+    setTimeout(resolvePromise, delayMs);
+  });
+}
+
+async function waitForProcessExit(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return true;
+  }
+
+  return await new Promise<boolean>((resolvePromise) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolvePromise(false);
+    }, timeoutMs);
+
+    const handleExit = () => {
+      cleanup();
+      resolvePromise(true);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", handleExit);
+    };
+
+    child.once("exit", handleExit);
+  });
+}
+
+async function stopElectron(
+  child: ChildProcessWithoutNullStreams,
+): Promise<void> {
+  if (await waitForProcessExit(child, 0)) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+  if (await waitForProcessExit(child, ELECTRON_EXIT_TIMEOUT_MS)) {
+    return;
+  }
+
+  child.kill("SIGKILL");
+  await waitForProcessExit(child, ELECTRON_EXIT_TIMEOUT_MS);
+}
 
 async function readDesktopPackageVersion(): Promise<string> {
   const packageJsonText = await readFile(
@@ -25,8 +311,10 @@ async function readDesktopPackageVersion(): Promise<string> {
 // builds the entry asar around it), the preload must have the desktop version
 // baked in at build time (not read from `process.env` at runtime, which is
 // empty in packaged builds), the bb-app bridge must be ESM (it imports
-// `bb-app/dist/bb-app.js`), and every entry needs its source map alongside it
-// for crash-symbolication in shipped builds. One smoke test asserts all four.
+// `bb-app/dist/bb-app.js`), every entry needs its source map alongside it
+// for crash-symbolication in shipped builds, and the compiled Electron entry
+// must launch far enough for the preload bridge to answer from a real window.
+// One smoke test asserts all of those artifact-level contracts.
 describe("desktop build", () => {
   it("emits package-compatible Electron entries", async () => {
     const desktopVersion = await readDesktopPackageVersion();
@@ -74,5 +362,70 @@ describe("desktop build", () => {
         access(resolve(desktopPackageRoot, "dist", mapPath)),
       ).resolves.toBeUndefined();
     }
-  });
+
+    const smokeRoot = await mkdtemp(join(tmpdir(), "bb-desktop-smoke-"));
+    const smokeServer = await startDesktopSmokeServer({
+      dataDir: join(smokeRoot, "data"),
+      expectedDesktopVersion: desktopVersion,
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      BB_DATA_DIR: join(smokeRoot, "data"),
+      BB_DESKTOP_AUTO_UPDATE: "0",
+      BB_DESKTOP_OPEN_DEVTOOLS: "0",
+      BB_DESKTOP_VERSION_CHECK: "0",
+      BB_SERVER_PORT: String(smokeServer.port),
+    };
+    delete childEnv.BB_DESKTOP_APP_URL;
+    delete childEnv.BB_DESKTOP_NODE_EXEC_PATH;
+    delete childEnv.ELECTRON_RUN_AS_NODE;
+
+    const child = spawn(
+      electronBinary,
+      [`--user-data-dir=${join(smokeRoot, "user-data")}`, "."],
+      {
+        cwd: desktopPackageRoot,
+        env: childEnv,
+      },
+    );
+    child.stdout.on("data", (chunk) => {
+      stdout.push(String(chunk));
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr.push(String(chunk));
+    });
+
+    try {
+      const preloadReady = await waitForPreloadReady({
+        child,
+        preloadReady: smokeServer.preloadReady,
+        stderr,
+        stdout,
+        timeoutMs: ELECTRON_STARTUP_TIMEOUT_MS,
+      });
+      expect(preloadReady).toEqual({ ok: true, reason: "" });
+
+      await sleep(ELECTRON_POST_READY_SETTLE_MS);
+      expect(
+        child.exitCode,
+        `Electron exited after startup.\n${formatProcessOutput({
+          stderr,
+          stdout,
+        })}`,
+      ).toBeNull();
+      expect(
+        child.signalCode,
+        `Electron exited after startup.\n${formatProcessOutput({
+          stderr,
+          stdout,
+        })}`,
+      ).toBeNull();
+    } finally {
+      await stopElectron(child);
+      await smokeServer.close();
+      await rm(smokeRoot, { force: true, recursive: true });
+    }
+  }, 30_000);
 });

--- a/apps/desktop/test/preload-build.test.ts
+++ b/apps/desktop/test/preload-build.test.ts
@@ -363,6 +363,10 @@ describe("desktop build", () => {
       ).resolves.toBeUndefined();
     }
 
+    if (process.platform !== "darwin") {
+      return;
+    }
+
     const smokeRoot = await mkdtemp(join(tmpdir(), "bb-desktop-smoke-"));
     const smokeServer = await startDesktopSmokeServer({
       dataDir: join(smokeRoot, "data"),

--- a/packages/scripts/test/source-cli-wrapper.test.ts
+++ b/packages/scripts/test/source-cli-wrapper.test.ts
@@ -12,6 +12,7 @@ interface SourceCliResult {
 
 interface StatusWrapperPayload {
   childThreads: null;
+  dataDir: null;
   pendingTodos: null;
   project: null;
   thread: null;
@@ -96,6 +97,7 @@ describe("source CLI wrapper", () => {
     const payload: StatusWrapperPayload = JSON.parse(result.stdout);
     expect(payload).toEqual({
       childThreads: null,
+      dataDir: null,
       pendingTodos: null,
       project: null,
       thread: null,

--- a/turbo.json
+++ b/turbo.json
@@ -130,6 +130,13 @@
         "*"
       ]
     },
+    "@bb/desktop#smoke:packaged": {
+      "cache": false,
+      "outputs": [],
+      "passThroughEnv": [
+        "*"
+      ]
+    },
     "@bb/desktop#dev": {
       "dependsOn": [
         "bb-app#build"


### PR DESCRIPTION
## Summary
- add a built Electron startup smoke test that launches the compiled desktop entry and verifies the preload bridge from a real window
- add a post-package smoke script that launches the packaged macOS .app from apps/desktop/release and verifies window.bbDesktop.getInfo()
- run the packaged smoke in the desktop release workflow before artifact upload

## Validation
- pnpm exec turbo run typecheck --filter=@bb/desktop --output-logs=new-only
- pnpm exec turbo run test --filter=@bb/desktop --force --output-logs=new-only
- pnpm exec turbo run desktop:build --filter=@bb/desktop --force --output-logs=new-only
- pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force --output-logs=new-only

## Risk
- post-package smoke validates the built .app bundle used for release artifacts, not a mounted DMG or extracted ZIP install flow
