### PR TITLE
Add landing email signup backed by a Resend audience

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -69,6 +69,17 @@ jobs:
           fi
           printf '%s' "$LANDING_POSTHOG_KEY" | pnpm --filter @bb/landing exec wrangler secret put LANDING_POSTHOG_KEY
 
+      - name: Sync landing email signup secret
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: |
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "RESEND_API_KEY is required for the landing email signup."
+            exit 1
+          fi
+          printf '%s' "$RESEND_API_KEY" | pnpm --filter @bb/landing exec wrangler secret put RESEND_API_KEY
+
       - name: Deploy landing
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -20,10 +20,13 @@ The deployable static site lands in `apps/landing/dist/client/`.
 
 ## Deploy
 
-The site ships as a Cloudflare Workers assets-only deploy (no server runtime —
-see `wrangler.jsonc`), live at <https://getbb.app> (and
-<https://bb-landing.sawyer-7bb.workers.dev>). Pushes to `main` touching
-`apps/landing/**` auto-deploy via `.github/workflows/deploy-landing.yml`.
+The site is prerendered to static assets, but a thin Worker (`src/worker.ts`)
+runs first for two first-party paths: the `/download/macos` redirect and the
+`/api/subscribe` email-signup endpoint (see `run_worker_first` in
+`wrangler.jsonc`). Everything else is served straight from `dist/client`. Live
+at <https://getbb.app> (and <https://bb-landing.sawyer-7bb.workers.dev>). Pushes
+to `main` touching `apps/landing/**` auto-deploy via
+`.github/workflows/deploy-landing.yml`.
 
 ```bash
 pnpm exec turbo run build --filter=@bb/landing
@@ -31,6 +34,19 @@ pnpm --filter @bb/landing run deploy
 ```
 
 Requires a wrangler login with workers write access (`wrangler login`).
+
+## Email signup
+
+The footer signup field POSTs `{ email }` to `/api/subscribe`. The Worker adds
+the address to a Resend audience (`POST /audiences/{id}/contacts`) so Resend
+owns unsubscribe and preference state. Configuration:
+
+- `RESEND_AUDIENCE_ID` — the target audience ("bb users"), a plain `var` in
+  `wrangler.jsonc` (not secret).
+- `RESEND_API_KEY` — Worker secret. The deploy workflow syncs it from the
+  `RESEND_API_KEY` GitHub Actions secret; set that once with workers write
+  access. Without both set, `/api/subscribe` returns `503 not configured`
+  (forks and local dev ship signup disabled).
 
 ## Analytics
 
@@ -51,6 +67,7 @@ is unavailable.
 | `landing_download_macos_clicked` | `/download/macos` redirect Worker | `placement`: nav / hero / closer / footer / direct, `download_target`, UTM params when available |
 | `landing_github_clicked` | GitHub links | `placement` |
 | `landing_cli_command_copied` | Copy button on the install command | `placement`, `command` |
+| `landing_email_subscribed` | Email signup submitted successfully | `placement` |
 
 These pair with the app-side `app_started` / `thread_created` telemetry events
 (see `apps/server/src/services/system/telemetry.ts`) to form the ad → page view

--- a/apps/landing/src/analytics.ts
+++ b/apps/landing/src/analytics.ts
@@ -23,6 +23,10 @@ export type LandingEvent =
   | {
       name: "landing_cli_command_copied";
       properties: { placement: CtaPlacement; command: string };
+    }
+  | {
+      name: "landing_email_subscribed";
+      properties: { placement: CtaPlacement };
     };
 
 let client: PostHog | null = null;

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -28,7 +28,7 @@ import {
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, FormEvent, ReactNode } from "react";
 
 import { trackLandingEvent } from "../analytics";
 import bbIcon from "../assets/bb-icon.png";
@@ -36,7 +36,7 @@ import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
 import { ClaudeIcon, CursorIcon, OpenAiIcon, PiIcon } from "../icons";
 import type { CtaPlacement } from "../site";
-import { CLI_COMMAND, GITHUB_URL, downloadMacosHref } from "../site";
+import { CLI_COMMAND, GITHUB_URL, SUBSCRIBE_PATH, downloadMacosHref } from "../site";
 
 export const Route = createFileRoute("/")({
   component: LandingPage,
@@ -162,6 +162,92 @@ function InstallOptions({ placement }: { placement: CtaPlacement }) {
         </span>
       </div>
     </div>
+  );
+}
+
+/* ── Email signup ─────────────────────────────────────────────────── */
+
+type SubscribeStatus = "idle" | "submitting" | "success" | "error";
+
+// Email capture that POSTs to the first-party /api/subscribe Worker route,
+// which adds the address to the bb marketing audience in Resend. JS-enhanced:
+// it submits inline and swaps to a confirmation rather than navigating.
+function EmailSignup({ placement }: { placement: CtaPlacement }) {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<SubscribeStatus>("idle");
+  const [error, setError] = useState("");
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (status === "submitting") {
+      return;
+    }
+    setStatus("submitting");
+    setError("");
+    try {
+      const response = await fetch(SUBSCRIBE_PATH, {
+        body: JSON.stringify({ email }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setError(body.error ?? "Something went wrong. Try again.");
+        setStatus("error");
+        return;
+      }
+      trackLandingEvent({ name: "landing_email_subscribed", properties: { placement } });
+      setStatus("success");
+    } catch {
+      setError("Could not reach the server. Try again.");
+      setStatus("error");
+    }
+  };
+
+  if (status === "success") {
+    return (
+      <p className="subscribe-done" role="status">
+        <HugeiconsIcon icon={CheckmarkCircle02Icon} className="subscribe-done-ic" />
+        You&rsquo;re on the list. We&rsquo;ll be in touch.
+      </p>
+    );
+  }
+
+  return (
+    <form className="subscribe-form" onSubmit={submit} noValidate>
+      <input
+        className="subscribe-input"
+        type="email"
+        name="email"
+        inputMode="email"
+        autoComplete="email"
+        required
+        placeholder="you@example.com"
+        aria-label="Email address"
+        aria-invalid={status === "error"}
+        value={email}
+        onChange={(event) => {
+          setEmail(event.target.value);
+          if (status === "error") {
+            setStatus("idle");
+          }
+        }}
+      />
+      <button
+        type="submit"
+        className="btn btn-primary subscribe-btn"
+        disabled={status === "submitting"}
+      >
+        {status === "submitting" ? "Subscribing…" : "Subscribe"}
+      </button>
+      {status === "error" ? (
+        <span className="subscribe-error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </form>
   );
 }
 
@@ -1547,7 +1633,7 @@ function LandingPage() {
       </section>
 
       <section className="closer" data-reveal>
-        <h2 className="sec-title">Start your first loop.</h2>
+        <h2 className="sec-title">Put your agents to work.</h2>
         <p>Free, open source, and local-first. Install in under a minute.</p>
         <InstallOptions placement="closer" />
         <div className="cta-row cta-row-secondary">
@@ -1555,6 +1641,12 @@ function LandingPage() {
             View on GitHub
           </GitHubLink>
         </div>
+      </section>
+
+      <section className="subscribe" data-reveal>
+        <h2 className="subscribe-title">Stay in the loop.</h2>
+        <p>Product updates and what we&rsquo;re building next. No spam.</p>
+        <EmailSignup placement="footer" />
       </section>
 
       <footer className="footer">

--- a/apps/landing/src/site.ts
+++ b/apps/landing/src/site.ts
@@ -2,6 +2,9 @@ export const GITHUB_URL = "https://github.com/ymichael/bb";
 export const DOWNLOAD_MACOS_URL =
   "https://github.com/ymichael/bb/releases/tag/desktop-latest";
 export const DOWNLOAD_MACOS_REDIRECT_PATH = "/download/macos";
+/** First-party endpoint that adds an email to the bb marketing audience.
+ *  Handled by the Worker (see worker.ts), not a prerendered asset. */
+export const SUBSCRIBE_PATH = "/api/subscribe";
 export const CLI_COMMAND = "npx bb-app@latest";
 
 /** Where on the page a CTA lives, for click-through comparison. */

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -2307,8 +2307,102 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   margin-top: 12px;
 }
 
-.footer {
+/* ── Email signup ───────────────────────────────────────────────── */
+
+/* A slim, secondary strip — deliberately lighter than the closer above it so
+   the two don't read as the same centered band twice. */
+.subscribe {
   border-top: 1px solid var(--border-soft);
+  padding: 44px 0;
+  text-align: center;
+}
+
+.subscribe-title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.subscribe p {
+  color: var(--dim);
+  margin-top: 5px;
+  font-size: 14px;
+}
+
+.subscribe-form {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin: 18px auto 0;
+  max-width: 440px;
+}
+
+.subscribe-input {
+  flex: 1 1 240px;
+  min-width: 0;
+  padding: 10px 14px;
+  font-size: 14.5px;
+  font-family: inherit;
+  color: var(--ink);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 2px);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.subscribe-input::placeholder {
+  color: var(--subtle);
+}
+
+.subscribe-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent);
+}
+
+.subscribe-input[aria-invalid="true"] {
+  border-color: var(--del);
+}
+
+.subscribe-btn {
+  flex: 0 0 auto;
+  cursor: pointer;
+}
+
+.subscribe-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+  transform: none;
+}
+
+/* The validation message takes the full width so it sits under the row. */
+.subscribe-error {
+  flex-basis: 100%;
+  color: var(--del);
+  font-size: 13.5px;
+}
+
+.subscribe-done {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 28px;
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.subscribe-done-ic {
+  width: 18px;
+  height: 18px;
+  color: var(--ok);
+  flex-shrink: 0;
+}
+
+.footer {
   padding: 32px 0 52px;
   display: flex;
   justify-content: space-between;

--- a/apps/landing/src/worker.ts
+++ b/apps/landing/src/worker.ts
@@ -1,4 +1,8 @@
-import { DOWNLOAD_MACOS_REDIRECT_PATH, DOWNLOAD_MACOS_URL } from "./site";
+import {
+  DOWNLOAD_MACOS_REDIRECT_PATH,
+  DOWNLOAD_MACOS_URL,
+  SUBSCRIBE_PATH,
+} from "./site";
 import type { CtaPlacement } from "./site";
 
 const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/?ip=0";
@@ -6,12 +10,20 @@ const DOWNLOAD_EVENT_NAME = "landing_download_macos_clicked";
 const DOWNLOAD_TARGET = "macos";
 const TRACKING_SOURCE = "landing_worker_redirect";
 const MAX_URL_PROPERTY_LENGTH = 2048;
+const RESEND_CONTACTS_URL = "https://api.resend.com/audiences";
+const MAX_EMAIL_LENGTH = 254;
+// Permissive single-line email shape; Resend does the authoritative validation.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type DownloadPlacement = CtaPlacement | "direct";
 
 type LandingWorkerEnv = {
   ASSETS: AssetFetcher;
   LANDING_POSTHOG_KEY?: string;
+  // Set in production via wrangler secret / vars; unset on forks and local dev,
+  // where /api/subscribe reports that signup is not configured.
+  RESEND_API_KEY?: string;
+  RESEND_AUDIENCE_ID?: string;
 };
 
 type AssetFetcher = {
@@ -71,11 +83,95 @@ const worker: LandingWorker = {
       return redirectToMacosDownload();
     }
 
+    if (requestUrl.pathname === SUBSCRIBE_PATH) {
+      return handleSubscribe(request, env);
+    }
+
     return env.ASSETS.fetch(request);
   },
 };
 
 export default worker;
+
+function jsonResponse(body: object, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "Cache-Control": "no-store", "content-type": "application/json" },
+    status,
+  });
+}
+
+// Adds the submitted email to the bb marketing audience in Resend. Same-origin
+// only (the form lives on this site), so no CORS handling is needed.
+async function handleSubscribe(
+  request: Request,
+  env: LandingWorkerEnv,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed." }, 405);
+  }
+  if (!env.RESEND_API_KEY || !env.RESEND_AUDIENCE_ID) {
+    return jsonResponse({ error: "Email signup is not configured." }, 503);
+  }
+
+  const email = await readEmail(request);
+  if (!email) {
+    return jsonResponse({ error: "Enter a valid email address." }, 400);
+  }
+
+  let resendResponse: Response;
+  try {
+    resendResponse = await fetch(
+      `${RESEND_CONTACTS_URL}/${env.RESEND_AUDIENCE_ID}/contacts`,
+      {
+        body: JSON.stringify({ email, unsubscribed: false }),
+        headers: {
+          Authorization: `Bearer ${env.RESEND_API_KEY}`,
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    );
+  } catch {
+    return jsonResponse({ error: "Could not reach the signup service." }, 502);
+  }
+
+  // Resend returns 2xx for new contacts and, for an already-subscribed email,
+  // either 2xx or an "already exists" error — both mean the visitor is on the
+  // list, so treat them as success.
+  if (resendResponse.ok || (await isAlreadySubscribed(resendResponse))) {
+    return jsonResponse({ ok: true }, 200);
+  }
+  return jsonResponse({ error: "Could not add you to the list." }, 502);
+}
+
+async function readEmail(request: Request): Promise<string | null> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return null;
+  }
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  const value = (payload as { email?: unknown }).email;
+  if (typeof value !== "string") {
+    return null;
+  }
+  const email = value.trim();
+  if (email.length > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.test(email)) {
+    return null;
+  }
+  return email;
+}
+
+async function isAlreadySubscribed(response: Response): Promise<boolean> {
+  if (response.status !== 409 && response.status !== 422) {
+    return false;
+  }
+  const body = await response.text();
+  return /already/i.test(body);
+}
 
 function isDownloadMacosRequest(requestUrl: URL): boolean {
   return (

--- a/apps/landing/wrangler.jsonc
+++ b/apps/landing/wrangler.jsonc
@@ -1,7 +1,7 @@
 // Cloudflare Workers static-assets deploy of the prerendered landing site.
 // The site is fully prerendered at build time (see vite.config.ts), so this
-// Worker only runs for first-party download redirects; other requests are
-// served directly from dist/client assets.
+// Worker only runs for first-party download redirects and the email-signup
+// endpoint; other requests are served directly from dist/client assets.
 // Deploy: pnpm exec turbo run build --filter=@bb/landing && pnpm --filter @bb/landing run deploy
 {
   "$schema": "node_modules/wrangler/config-schema.json",
@@ -12,10 +12,15 @@
   "assets": {
     "directory": "./dist/client",
     "binding": "ASSETS",
-    "run_worker_first": ["/download/macos*"]
+    "run_worker_first": ["/download/macos*", "/api/subscribe"]
+  },
+  // Resend audience that /api/subscribe adds emails to ("bb users").
+  // Not a secret — only the API key is.
+  "vars": {
+    "RESEND_AUDIENCE_ID": "299db4ee-f3db-476d-9847-0bf4344d9c44"
   },
   "secrets": {
-    "required": ["LANDING_POSTHOG_KEY"]
+    "required": ["LANDING_POSTHOG_KEY", "RESEND_API_KEY"]
   },
   "routes": [
     { "pattern": "getbb.app", "custom_domain": true },


### PR DESCRIPTION
## Summary

Adds a **"Stay in the loop."** email signup above the landing footer that subscribes visitors to the **"bb users"** Resend marketing audience.

Because the landing site is fully prerendered static assets + a thin custom Cloudflare Worker (TanStack Start *server* routes aren't deployed here), the endpoint lives in the existing `worker.ts`, matching the established `/download/macos` pattern:

- **`POST /api/subscribe`** — validates the email and adds it to the audience via Resend's Audiences API (`POST /audiences/{id}/contacts`). Returns `405` (non-POST), `400` (bad email), `503` (not configured), `200` on success; an already-subscribed email is treated as success.
- **Config** — `RESEND_API_KEY` as a Worker secret (synced in `deploy-landing.yml` from the `RESEND_API_KEY` Actions secret, which is already set on the repo), `RESEND_AUDIENCE_ID` as a wrangler `var`. With either unset the endpoint returns `503`, so forks/local dev ship signup disabled.
- Renames the closer heading to **"Put your agents to work."** so it no longer echoes the signup's "Stay in the loop." tagline.
- Adds a `landing_email_subscribed` PostHog event and updates the landing README.

The "bb users" audience was created out-of-band via the Resend API; its id is the `RESEND_AUDIENCE_ID` var.

## Test plan

- `turbo run typecheck lint build --filter=@bb/landing` — all green; the page prerenders with the form in the static HTML.
- Exercised the real worker handler end-to-end against the live Resend audience: `405` / `400` (invalid + malformed) / `503` (unconfigured) / `200` (real contact added) / `200` (duplicate) / asset passthrough — then deleted the test contact.
- Verified idle / error / success form states and the closer + footer layout via browser screenshots at desktop and mobile widths.

## Notes / risks

- Same-origin form → endpoint, so no CORS handling.
- Submitting the form won't work under `vite dev` (the Worker doesn't run there); it works once deployed.