### PR TITLE
Tint search-result match highlight a subtle manilla

### DIFF
--- a/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
@@ -82,7 +82,7 @@ function HighlightedText({ ranges, text }: HighlightedTextProps) {
     nodes.push(
       <mark
         key={`${range.start}:${range.end}`}
-        className="rounded-sm bg-sidebar-accent px-0 text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)]"
+        className="rounded-sm bg-[var(--sidebar-search-match)] px-0 text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-search-match-border)]"
       >
         {text.slice(range.start, range.end)}
       </mark>,

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -429,6 +429,13 @@
   --sidebar-accent: color-mix(in oklch, var(--ink) 8%, var(--canvas));
   --sidebar-accent-foreground: var(--ink);
   --sidebar-border: color-mix(in oklch, var(--ink) 14%, var(--canvas));
+  /* Search-match highlight: a manilla-folder tint over the canvas. Chromatic on
+     purpose (the neutral ramp can't make beige) and mixed with the canvas so it
+     tracks custom palettes instead of stranding a fixed swatch. Mix in oklab, not
+     oklch: in the polar space the achromatic canvas drags the manilla hue toward
+     0° and the result comes out salmon — oklab carries the hue through. */
+  --sidebar-search-match: color-mix(in oklab, oklch(0.8 0.13 88), var(--canvas) 76%);
+  --sidebar-search-match-border: color-mix(in oklab, oklch(0.8 0.13 88), var(--canvas) 60%);
   --sidebar-ring: var(--primary);
   --font-sans: "Inter Variable", Inter, sans-serif;
   --font-serif: Georgia, serif;
@@ -618,6 +625,10 @@
   --sidebar-accent: color-mix(in oklch, var(--ink) 12%, var(--canvas));
   --sidebar-accent-foreground: var(--ink);
   --sidebar-border: color-mix(in oklch, var(--ink) 18.1%, var(--canvas));
+  /* Search-match highlight: see the light block (oklab mix, same hue caveat).
+     Mixed with the (dark) canvas so the manilla reads as a muted tan. */
+  --sidebar-search-match: color-mix(in oklab, oklch(0.8 0.13 88), var(--canvas) 80%);
+  --sidebar-search-match-border: color-mix(in oklab, oklch(0.8 0.13 88), var(--canvas) 67%);
   --sidebar-ring: var(--primary);
   --font-sans: "Inter Variable", Inter, sans-serif;
   --font-serif: Georgia, serif;


### PR DESCRIPTION
## What

Search-result match highlights in the sidebar (`ThreadSearchResultRow`) used the neutral `sidebar-accent` gray. They now read as a subtle manilla/beige — light cream in light mode, muted tan in dark.

## How

- Added a dedicated, intentionally-chromatic token pair in `theme.css` (light + dark): `--sidebar-search-match` (fill) and `--sidebar-search-match-border` (ring), mirroring the existing `--pill-surface-selected` / `…-border` pattern. The neutral ramp can't produce a hue, so the manilla is a real color anchor mixed with `var(--canvas)` — it still tracks custom palettes (Nord/Dracula re-anchor the canvas) and tones down on the dark surface.
- Mixed **in oklab, not oklch**: in the polar space the achromatic canvas drags the hue toward 0° and the chip comes out salmon. oklab carries the hue through. (Same class of trap `theme.test.ts` already documents for `transparent` mixes.)
- Pointed the `<mark>` at the new tokens.

## Notes

- These tokens are intentionally outside the neutral-ramp guards in `theme.test.ts` (they don't use the `var(--ink) N%` form), so they're correctly exempt; all 17 theme tests still pass.
- Visual: Ladle story `sidebar--thread-search-result--overview` (light + dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)