### PR TITLE
Full-history conversation outline for the thread TOC minimap

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.stories.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.stories.tsx
@@ -98,7 +98,14 @@ export function Default() {
         footer={null}
         maxWidthClassName="max-w-3xl"
         contentClassName="gap-2 pt-4"
-        scrollOverlay={<ThreadTableOfContents timelineRows={timelineRows} />}
+        scrollOverlay={
+          <ThreadTableOfContents
+            threadId="thr_toc_story"
+            timelineRows={timelineRows}
+            hasOlderTimelineRows={false}
+            loadOlderTimelineRows={() => {}}
+          />
+        }
       >
         <ThreadTimelineSurface
           activeThinking={null}

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -1,8 +1,32 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TimelineRow } from "@bb/server-contract";
+import type {
+  ThreadConversationOutlineItem,
+  ThreadConversationOutlineResponse,
+  TimelineRow,
+} from "@bb/server-contract";
+
+// The minimap now sources items from the conversation-outline query, so the
+// component needs a QueryClient unless we mock the hook. Mocking also lets us
+// drive the outline (and the scroll surface) directly without a provider tree.
+vi.mock("@/components/ui/bottom-anchored-scroll-body.js", () => ({
+  useBottomAnchoredScroll: vi.fn(),
+}));
+
+vi.mock("@/hooks/queries/thread-queries", () => ({
+  useThreadConversationOutline: vi.fn(),
+}));
+
+import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
+import { useThreadConversationOutline } from "@/hooks/queries/thread-queries";
 import {
   findActiveItemIds,
   ThreadTableOfContents,
@@ -40,7 +64,17 @@ function userConversationRow(index = 1): TimelineRow {
   };
 }
 
-function TocHost({ timelineRows }: { timelineRows: readonly TimelineRow[] }) {
+function TocHost({
+  hasOlderTimelineRows = false,
+  loadOlderTimelineRows = () => {},
+  threadId = "thr_toc_test",
+  timelineRows,
+}: {
+  hasOlderTimelineRows?: boolean;
+  loadOlderTimelineRows?: () => void | Promise<void>;
+  threadId?: string;
+  timelineRows: readonly TimelineRow[];
+}) {
   return (
     <div
       ref={(node) => {
@@ -52,7 +86,12 @@ function TocHost({ timelineRows }: { timelineRows: readonly TimelineRow[] }) {
       }}
       data-scroll-overlay=""
     >
-      <ThreadTableOfContents timelineRows={timelineRows} />
+      <ThreadTableOfContents
+        threadId={threadId}
+        timelineRows={timelineRows}
+        hasOlderTimelineRows={hasOlderTimelineRows}
+        loadOlderTimelineRows={loadOlderTimelineRows}
+      />
     </div>
   );
 }
@@ -109,6 +148,24 @@ function createScrollElement({
   return scrollElement;
 }
 
+function outlineResponse(
+  items: ThreadConversationOutlineItem[],
+): ThreadConversationOutlineResponse {
+  return { items, maxSeq: items.length };
+}
+
+function setOutline(items: ThreadConversationOutlineItem[] | undefined): void {
+  vi.mocked(useThreadConversationOutline).mockReturnValue({
+    data: items === undefined ? undefined : outlineResponse(items),
+  } as ReturnType<typeof useThreadConversationOutline>);
+}
+
+function timelineRowElement(id: string): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-timeline-row-id", id);
+  return el;
+}
+
 const userItems: TocItem[] = [
   { id: "user-1", label: "First prompt", role: "user" },
   { id: "user-2", label: "Second prompt", role: "user" },
@@ -118,6 +175,9 @@ const agentItems: TocItem[] = [
   { id: "agent-1", label: "First response", role: "assistant" },
   { id: "agent-2", label: "Second response", role: "assistant" },
 ];
+
+let scrollElement: HTMLElement;
+let scrollElementIntoView: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.stubGlobal("ResizeObserver", ResizeObserverMock);
@@ -129,11 +189,26 @@ beforeEach(() => {
     }),
   );
   vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+  scrollElement = document.createElement("div");
+  scrollElementIntoView = vi.fn();
+  vi.mocked(useBottomAnchoredScroll).mockReturnValue({
+    getScrollElement: () => scrollElement,
+    isAtBottom: false,
+    scrollToBottom: vi.fn(),
+    scrollElementIntoView,
+    scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+    captureScrollAnchor: vi.fn(),
+  } as unknown as ReturnType<typeof useBottomAnchoredScroll>);
+
+  // Default: outline not loaded, so the minimap falls back to timelineRows.
+  setOutline(undefined);
 });
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  vi.clearAllMocks();
 });
 
 describe("ThreadTableOfContents", () => {
@@ -178,6 +253,159 @@ describe("ThreadTableOfContents", () => {
     );
 
     expect(screen.queryByText("Your messages")).not.toBeNull();
+  });
+
+  it("renders the full conversation outline, including attachment-only labels", async () => {
+    setOutline([
+      {
+        id: "u1",
+        role: "user",
+        preview: "First question",
+        attachmentSummary: null,
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        preview: "First answer",
+        attachmentSummary: null,
+      },
+      {
+        id: "u2",
+        role: "user",
+        preview: "Second question",
+        attachmentSummary: null,
+      },
+      {
+        id: "u3",
+        role: "user",
+        preview: "",
+        attachmentSummary: { imageCount: 1, fileCount: 0 },
+      },
+    ]);
+
+    // timelineRows is empty: the minimap lists the full thread from the outline,
+    // not just the loaded window.
+    render(<TocHost timelineRows={[]} />);
+
+    expect(await screen.findByText("First question")).not.toBeNull();
+    expect(screen.getByText("Second question")).not.toBeNull();
+    expect(screen.getByText("Image attachment")).not.toBeNull();
+    // The agent tab is offered because the outline has assistant messages.
+    expect(screen.getByText("Agent messages")).not.toBeNull();
+  });
+
+  it("scrolls straight to a message already loaded in the window", async () => {
+    scrollElement.appendChild(timelineRowElement("u2"));
+    const loadOlder = vi.fn();
+    setOutline([
+      {
+        id: "u1",
+        role: "user",
+        preview: "First question",
+        attachmentSummary: null,
+      },
+      {
+        id: "u2",
+        role: "user",
+        preview: "Loaded question",
+        attachmentSummary: null,
+      },
+      {
+        id: "u3",
+        role: "user",
+        preview: "Third question",
+        attachmentSummary: null,
+      },
+    ]);
+
+    render(
+      <TocHost
+        timelineRows={[]}
+        hasOlderTimelineRows
+        loadOlderTimelineRows={loadOlder}
+      />,
+    );
+    fireEvent.click(await screen.findByText("Loaded question"));
+
+    await waitFor(() => expect(scrollElementIntoView).toHaveBeenCalledTimes(1));
+    expect(loadOlder).not.toHaveBeenCalled();
+  });
+
+  it("auto-paginates older pages to reach an unloaded message, then scrolls to it", async () => {
+    // The target isn't in the loaded window; loadOlder simulates it paginating
+    // in, mirroring the real controller prepending older rows to the DOM.
+    const loadOlder = vi.fn(() => {
+      scrollElement.appendChild(timelineRowElement("u_old"));
+    });
+    setOutline([
+      {
+        id: "u_old",
+        role: "user",
+        preview: "Ancient question",
+        attachmentSummary: null,
+      },
+      {
+        id: "u2",
+        role: "user",
+        preview: "Second question",
+        attachmentSummary: null,
+      },
+      {
+        id: "u3",
+        role: "user",
+        preview: "Third question",
+        attachmentSummary: null,
+      },
+    ]);
+
+    render(
+      <TocHost
+        timelineRows={[]}
+        hasOlderTimelineRows
+        loadOlderTimelineRows={loadOlder}
+      />,
+    );
+    fireEvent.click(await screen.findByText("Ancient question"));
+
+    await waitFor(() => expect(loadOlder).toHaveBeenCalled());
+    await waitFor(() => expect(scrollElementIntoView).toHaveBeenCalled());
+  });
+
+  it("does not paginate when there are no older pages to load", async () => {
+    const loadOlder = vi.fn();
+    setOutline([
+      {
+        id: "missing",
+        role: "user",
+        preview: "Unreachable",
+        attachmentSummary: null,
+      },
+      {
+        id: "u2",
+        role: "user",
+        preview: "Second question",
+        attachmentSummary: null,
+      },
+      {
+        id: "u3",
+        role: "user",
+        preview: "Third question",
+        attachmentSummary: null,
+      },
+    ]);
+
+    render(
+      <TocHost
+        timelineRows={[]}
+        hasOlderTimelineRows={false}
+        loadOlderTimelineRows={loadOlder}
+      />,
+    );
+    fireEvent.click(await screen.findByText("Unreachable"));
+
+    // hasOlder is false, so the loop body never runs; no scroll, no pagination.
+    await waitFor(() => expect(loadOlder).not.toHaveBeenCalled());
+    expect(scrollElementIntoView).not.toHaveBeenCalled();
   });
 
   it("tracks the conversation item nearest the viewport top away from bottom", () => {

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -1,16 +1,12 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  ThreadConversationOutlineItem,
   TimelineConversationAttachments,
   TimelineRow,
 } from "@bb/server-contract";
 import { useScrollOverflowState } from "@/components/thread/timeline/useScrollOverflowState";
 import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
+import { useThreadConversationOutline } from "@/hooks/queries/thread-queries";
 import { cn } from "@/lib/utils";
 
 export interface TocItem {
@@ -27,13 +23,26 @@ interface ActiveItemIds {
 }
 
 interface ThreadTableOfContentsProps {
+  threadId: string;
+  /**
+   * The currently-loaded timeline window. Used for scroll-spy (which loaded row
+   * is in view) and as a fallback item source until the full outline loads — the
+   * minimap itself renders the full thread via {@link useThreadConversationOutline}.
+   */
   timelineRows: readonly TimelineRow[];
+  hasOlderTimelineRows: boolean;
+  /** Loads the next older timeline page; awaited while jumping to an unloaded row. */
+  loadOlderTimelineRows: () => void | Promise<void>;
 }
 
 const TOC_MIN_VISIBLE_WIDTH_PX = 56 * 16;
 const TOC_BOTTOM_ACTIVE_THRESHOLD_PX = 4;
 // Only worth showing once the conversation has enough user turns to navigate.
 const TOC_MIN_USER_MESSAGES = 3;
+// Hard stop so a pagination bug can never spin the jump loop forever.
+const TOC_JUMP_MAX_PAGE_LOADS = 1000;
+// Frames to wait for prepended rows to commit before paginating again.
+const TOC_JUMP_RENDER_FRAMES = 6;
 
 function toPreviewLabel(text: string): string {
   return text.replace(/\s+/g, " ").trim();
@@ -63,6 +72,26 @@ function toTocLabel({
   return textLabel || toAttachmentPreviewLabel(attachments);
 }
 
+function toAttachmentSummaryLabel(
+  summary: ThreadConversationOutlineItem["attachmentSummary"],
+): string {
+  if (!summary) return "Message";
+  const totalCount = summary.imageCount + summary.fileCount;
+  if (totalCount === 0) return "Message";
+  if (totalCount === 1) {
+    return summary.imageCount === 1 ? "Image attachment" : "File attachment";
+  }
+  return `${totalCount} attachments`;
+}
+
+function outlineItemToTocItem(item: ThreadConversationOutlineItem): TocItem {
+  return {
+    id: item.id,
+    label: item.preview || toAttachmentSummaryLabel(item.attachmentSummary),
+    role: item.role,
+  };
+}
+
 function TocPanelTab({
   label,
   active,
@@ -89,10 +118,34 @@ function TocPanelTab({
   );
 }
 
-function useConversationTocItems(timelineRows: readonly TimelineRow[]) {
+/**
+ * Builds the user/agent item lists for the minimap. Prefers the full
+ * conversation outline (the whole thread, independent of pagination); falls
+ * back to the loaded timeline window so the minimap still renders on first
+ * paint and in environments without the outline endpoint (e.g. stories).
+ */
+function useConversationTocItems({
+  outlineItems,
+  timelineRows,
+}: {
+  outlineItems: readonly ThreadConversationOutlineItem[] | undefined;
+  timelineRows: readonly TimelineRow[];
+}) {
   return useMemo(() => {
     const userItems: TocItem[] = [];
     const agentItems: TocItem[] = [];
+
+    if (outlineItems && outlineItems.length > 0) {
+      for (const item of outlineItems) {
+        const tocItem = outlineItemToTocItem(item);
+        if (tocItem.role === "user") {
+          userItems.push(tocItem);
+        } else {
+          agentItems.push(tocItem);
+        }
+      }
+      return { agentItems, userItems };
+    }
 
     for (const row of timelineRows) {
       if (row.kind !== "conversation") continue;
@@ -109,7 +162,7 @@ function useConversationTocItems(timelineRows: readonly TimelineRow[]) {
     }
 
     return { agentItems, userItems };
-  }, [timelineRows]);
+  }, [outlineItems, timelineRows]);
 }
 
 function useThreadTocVisible(rootElement: HTMLDivElement | null): boolean {
@@ -170,6 +223,16 @@ function findTimelineRowElement(
       (row) => row.dataset.timelineRowId === rowId,
     ) ?? null
   );
+}
+
+function waitForAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window === "undefined") {
+      resolve();
+      return;
+    }
+    window.requestAnimationFrame(() => resolve());
+  });
 }
 
 function isScrollElementNearBottom(scrollElement: HTMLElement): boolean {
@@ -242,16 +305,29 @@ export function findActiveItemIds({
 }
 
 export function ThreadTableOfContents({
+  threadId,
   timelineRows,
+  hasOlderTimelineRows,
+  loadOlderTimelineRows,
 }: ThreadTableOfContentsProps) {
   const bottomAnchor = useBottomAnchoredScroll();
-  const { agentItems, userItems } = useConversationTocItems(timelineRows);
+  // Source the minimap from the full thread outline. Enabled whenever the
+  // thread id is present (not gated on `tocVisible`): the TOC_MIN_USER_MESSAGES
+  // early-return can unmount the root before it is measured, and gating the
+  // query on visibility would then deadlock a short loaded window that the full
+  // thread would otherwise fill.
+  const outlineQuery = useThreadConversationOutline(threadId);
+  const { agentItems, userItems } = useConversationTocItems({
+    outlineItems: outlineQuery.data?.items,
+    timelineRows,
+  });
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
   const tocVisible = useThreadTocVisible(rootElement);
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<TocTab>("user");
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
   const [activeAgentId, setActiveAgentId] = useState<string | null>(null);
+  const [pendingJumpId, setPendingJumpId] = useState<string | null>(null);
   const {
     aboveOverflow,
     belowOverflow,
@@ -261,6 +337,8 @@ export function ThreadTableOfContents({
   } = useScrollOverflowState<HTMLDivElement>({
     measureOverflow: true,
   });
+  const railRef = useRef<HTMLDivElement>(null);
+  const tickEls = useRef(new Map<string, HTMLElement>());
   const itemEls = useRef(new Map<string, HTMLElement>());
   const activeIdsRef = useRef<ActiveItemIds>({ agent: null, user: null });
   const activeUpdateFrameRef = useRef<number | null>(null);
@@ -268,6 +346,24 @@ export function ThreadTableOfContents({
   const activeTab = tab === "agent" && hasAgentMessages ? "agent" : "user";
   const items = activeTab === "user" ? userItems : agentItems;
   const activeId = activeTab === "user" ? activeUserId : activeAgentId;
+
+  // Mirror the latest pagination props into refs so the async jump loop always
+  // reads current values rather than the ones captured when the click fired.
+  const hasOlderRef = useRef(hasOlderTimelineRows);
+  hasOlderRef.current = hasOlderTimelineRows;
+  const loadOlderRef = useRef(loadOlderTimelineRows);
+  loadOlderRef.current = loadOlderTimelineRows;
+  const jumpInProgressRef = useRef(false);
+  // Switching threads remounts this component (PageShell is keyed by threadId).
+  // The jump loop checks this after each await so it stops paginating a thread
+  // the user has already left instead of firing requests against a stale closure.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const updateActiveItems = useCallback(() => {
     const scrollElement = bottomAnchor?.getScrollElement() ?? null;
@@ -317,6 +413,30 @@ export function ThreadTableOfContents({
     };
   }, [bottomAnchor, scheduleActiveItemsUpdate, tocVisible]);
 
+  // Keep the active tick visible when the rail overflows (long threads make the
+  // full-history rail taller than the viewport).
+  useEffect(() => {
+    if (!tocVisible) return;
+    const container = railRef.current;
+    const el = activeUserId ? tickEls.current.get(activeUserId) : null;
+    if (!container || !el) return;
+    const containerRect = container.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const pad = 12;
+    if (elRect.top < containerRect.top + pad) {
+      container.scrollTo({
+        top: container.scrollTop - (containerRect.top + pad - elRect.top),
+      });
+    } else if (elRect.bottom > containerRect.bottom - pad) {
+      container.scrollTo({
+        top:
+          container.scrollTop + (elRect.bottom - (containerRect.bottom - pad)),
+      });
+    }
+    // `userItems` is a dep so the active tick re-centers when the rail content
+    // swaps (e.g. the full outline replacing the loaded-window fallback).
+  }, [activeUserId, tocVisible, userItems]);
+
   useEffect(() => {
     if (!tocVisible) return;
     const container = scrollRef.current;
@@ -338,16 +458,59 @@ export function ThreadTableOfContents({
   }, [activeId, open, scrollRef, tocVisible]);
 
   const handleSelect = useCallback(
-    (id: string) => {
-      const scrollElement = bottomAnchor?.getScrollElement();
-      const row = scrollElement
-        ? findTimelineRowElement(scrollElement, id)
-        : null;
-      if (!row) return;
-      bottomAnchor?.scrollElementIntoView({
-        element: row,
-        options: { block: "start", inline: "nearest" },
-      });
+    async (id: string) => {
+      const getScrollElement = () => bottomAnchor?.getScrollElement() ?? null;
+      const scrollToRow = (element: HTMLElement) => {
+        bottomAnchor?.scrollElementIntoView({
+          element,
+          options: { block: "start", inline: "nearest" },
+        });
+      };
+
+      let row = findTimelineRowElement(getScrollElement(), id);
+      if (row) {
+        scrollToRow(row);
+        return;
+      }
+      // The target message hasn't been paginated into the loaded window yet.
+      // Page older windows in until it appears (or history is exhausted), then
+      // scroll to it.
+      if (jumpInProgressRef.current) return;
+      jumpInProgressRef.current = true;
+      setPendingJumpId(id);
+      try {
+        let loads = 0;
+        while (!row && hasOlderRef.current && loads < TOC_JUMP_MAX_PAGE_LOADS) {
+          loads += 1;
+          try {
+            await Promise.resolve(loadOlderRef.current());
+          } catch {
+            // Pagination failed (offline / server error). History can't
+            // advance, so stop looping; the post-loop lookup below still
+            // scrolls if enough was already loaded. Catching here keeps the
+            // rejection from escaping the fire-and-forget `void handleSelect`
+            // call as an unhandled rejection.
+            break;
+          }
+          if (!mountedRef.current) return;
+          // Wait for the prepended rows to commit, retrying across a few frames
+          // before deciding the row is in an even older page.
+          for (let frame = 0; frame < TOC_JUMP_RENDER_FRAMES && !row; frame++) {
+            await waitForAnimationFrame();
+            if (!mountedRef.current) return;
+            row = findTimelineRowElement(getScrollElement(), id);
+          }
+        }
+        // If the row still isn't loaded after exhausting older pages the jump is
+        // a no-op. Outline ids are projected by the same builder as timeline
+        // rows, so a visible-but-unreachable entry is effectively impossible; we
+        // fail silently rather than surface an error for a row the user sees.
+        if (!row) row = findTimelineRowElement(getScrollElement(), id);
+        if (row) scrollToRow(row);
+      } finally {
+        jumpInProgressRef.current = false;
+        setPendingJumpId(null);
+      }
     },
     [bottomAnchor],
   );
@@ -371,14 +534,19 @@ export function ThreadTableOfContents({
       {tocVisible ? (
         <div className="relative">
           <div
+            ref={railRef}
             aria-hidden
-            className="flex w-8 cursor-pointer flex-col items-center gap-2 py-2"
+            className="no-scrollbar flex max-h-[calc(100vh-7rem)] w-8 cursor-pointer flex-col items-center gap-2 overflow-y-auto py-2"
           >
             {userItems.map((item) => (
               <span
                 key={item.id}
+                ref={(node) => {
+                  if (node) tickEls.current.set(item.id, node);
+                  else tickEls.current.delete(item.id);
+                }}
                 className={cn(
-                  "h-[3px] rounded-full transition-all duration-150",
+                  "h-[3px] shrink-0 rounded-full transition-all duration-150",
                   item.id === activeUserId
                     ? "w-5 bg-foreground/30 group-hover/toc:bg-foreground/70"
                     : "w-3 bg-foreground/5 group-hover/toc:bg-foreground/20",
@@ -423,6 +591,7 @@ export function ThreadTableOfContents({
                   <ul className="flex flex-col">
                     {items.map((item) => {
                       const active = item.id === activeId;
+                      const pending = item.id === pendingJumpId;
                       return (
                         <li key={item.id}>
                           <button
@@ -431,7 +600,10 @@ export function ThreadTableOfContents({
                               else itemEls.current.delete(item.id);
                             }}
                             type="button"
-                            onClick={() => handleSelect(item.id)}
+                            aria-busy={pending}
+                            onClick={() => {
+                              void handleSelect(item.id);
+                            }}
                             className={cn(
                               "flex w-full cursor-pointer rounded-md px-2 py-1.5 text-left transition-colors",
                               active
@@ -445,6 +617,7 @@ export function ThreadTableOfContents({
                                 active
                                   ? "text-foreground"
                                   : "text-muted-foreground",
+                                pending && "animate-pulse",
                               )}
                             >
                               {item.label}

--- a/apps/app/src/hooks/cache-owners/cache-invalidation-groups.ts
+++ b/apps/app/src/hooks/cache-owners/cache-invalidation-groups.ts
@@ -3,6 +3,7 @@ import { getCachedProjectThreadListInvalidationQueryKeys } from "./query-cache";
 import {
   allProjectPathsQueryKeyPrefix,
   allProjectSourceBranchesQueryKeyPrefix,
+  allThreadConversationOutlineQueryKeyPrefix,
   allThreadPendingInteractionsQueryKeyPrefix,
   allThreadQueuedMessagesQueryKeyPrefix,
   allThreadQueryKeyPrefix,
@@ -20,6 +21,7 @@ import {
   threadPromptHistoryQueryKey,
   threadPromptHistoryQueryKeyPrefix,
   threadQueryKey,
+  threadConversationOutlineQueryKeyPrefix,
   threadSearchQueryKeyPrefix,
   threadsQueryKey,
   threadTimelineQueryKeyPrefix,
@@ -105,10 +107,12 @@ export function getThreadTimelineInvalidationQueryKeys({
   return threadId
     ? [
         threadTimelineQueryKeyPrefix(threadId),
+        threadConversationOutlineQueryKeyPrefix(threadId),
         threadTimelineTurnSummaryDetailsQueryKeyPrefix(threadId),
       ]
     : [
         allThreadTimelineQueryKeyPrefix(),
+        allThreadConversationOutlineQueryKeyPrefix(),
         allThreadTimelineTurnSummaryDetailsQueryKeyPrefix(),
       ];
 }
@@ -127,8 +131,14 @@ export function getThreadTimelineWindowInvalidationQueryKeys({
   threadId,
 }: ThreadScopedInvalidationArgs): QueryKey[] {
   return threadId
-    ? [threadTimelineQueryKeyPrefix(threadId)]
-    : [allThreadTimelineQueryKeyPrefix()];
+    ? [
+        threadTimelineQueryKeyPrefix(threadId),
+        threadConversationOutlineQueryKeyPrefix(threadId),
+      ]
+    : [
+        allThreadTimelineQueryKeyPrefix(),
+        allThreadConversationOutlineQueryKeyPrefix(),
+      ];
 }
 
 export function getThreadQueueContentInvalidationQueryKeys({

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -54,6 +54,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
   "hooks/cache-owners/cache-invalidation-groups.ts": [
     "allProjectPathsQueryKeyPrefix",
     "allProjectSourceBranchesQueryKeyPrefix",
+    "allThreadConversationOutlineQueryKeyPrefix",
     "allThreadPendingInteractionsQueryKeyPrefix",
     "allThreadQueryKeyPrefix",
     "allThreadQueuedMessagesQueryKeyPrefix",
@@ -66,6 +67,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "projectSourceBranchesQueryKeyPrefix",
     "projectsQueryKey",
     "sidebarNavigationQueryKey",
+    "threadConversationOutlineQueryKeyPrefix",
     "threadPendingInteractionsQueryKey",
     "threadPromptHistoryQueryKey",
     "threadPromptHistoryQueryKeyPrefix",

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -50,6 +50,8 @@ export const ENVIRONMENT_DIFF_FILE_QUERY_KEY = "environmentDiffFile";
 export const ENVIRONMENT_FILE_PREVIEW_QUERY_KEY = "environmentFilePreview";
 export const ENVIRONMENT_PATHS_QUERY_KEY = "environmentPaths";
 export const THREAD_TIMELINE_QUERY_KEY = "threadTimeline";
+export const THREAD_CONVERSATION_OUTLINE_QUERY_KEY =
+  "threadConversationOutline";
 export const THREAD_TIMELINE_TURN_SUMMARY_DETAILS_QUERY_KEY =
   "threadTimelineTurnSummaryDetails";
 export const SYSTEM_PROVIDERS_QUERY_KEY = "systemProviders";
@@ -309,6 +311,17 @@ export type EnvironmentMergeBaseBranchesQueryKeyPrefix = readonly [
 export type ThreadTimelineQueryKey = readonly [
   typeof THREAD_TIMELINE_QUERY_KEY,
   string,
+];
+export type ThreadConversationOutlineQueryKey = readonly [
+  typeof THREAD_CONVERSATION_OUTLINE_QUERY_KEY,
+  string,
+];
+export type ThreadConversationOutlineQueryKeyPrefix = readonly [
+  typeof THREAD_CONVERSATION_OUTLINE_QUERY_KEY,
+  string,
+];
+export type AllThreadConversationOutlineQueryKeyPrefix = readonly [
+  typeof THREAD_CONVERSATION_OUTLINE_QUERY_KEY,
 ];
 export interface ThreadTimelineTurnSummaryDetailsQueryIdentity {
   sourceSeqEnd: number;
@@ -833,6 +846,22 @@ export function threadTimelineQueryKey(
   threadId: string,
 ): ThreadTimelineQueryKey {
   return [THREAD_TIMELINE_QUERY_KEY, threadId];
+}
+
+export function threadConversationOutlineQueryKey(
+  threadId: string,
+): ThreadConversationOutlineQueryKey {
+  return [THREAD_CONVERSATION_OUTLINE_QUERY_KEY, threadId];
+}
+
+export function threadConversationOutlineQueryKeyPrefix(
+  threadId: string,
+): ThreadConversationOutlineQueryKeyPrefix {
+  return [THREAD_CONVERSATION_OUTLINE_QUERY_KEY, threadId];
+}
+
+export function allThreadConversationOutlineQueryKeyPrefix(): AllThreadConversationOutlineQueryKeyPrefix {
+  return [THREAD_CONVERSATION_OUTLINE_QUERY_KEY];
 }
 
 export function threadTimelineTurnSummaryDetailsQueryKey({

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -19,6 +19,7 @@ import type {
   ThreadResponse,
   ThreadSearchResponse,
   ThreadWithIncludesResponse,
+  ThreadConversationOutlineResponse,
   ThreadStorageFileListResponse,
   ThreadStoragePathListResponse,
   ThreadTimelineResponse,
@@ -64,6 +65,7 @@ import {
   threadStoragePathsQueryKey,
   threadStorageFilePreviewQueryKey,
   threadHostFilePreviewQueryKey,
+  threadConversationOutlineQueryKey,
   threadTimelineQueryKey,
   threadTimelineTurnSummaryDetailsQueryKey,
   threadsQueryKey,
@@ -792,6 +794,35 @@ export function useThreadTimeline(
         previousQuery?.queryKey,
         id,
       ),
+  });
+}
+
+/**
+ * Full conversation outline (every user/agent message) for a thread's
+ * table-of-contents minimap. Unlike {@link useThreadTimeline}, this is not
+ * paginated — it always reflects the whole thread — so the minimap can show
+ * messages that have not yet been scrolled/paged into the loaded window. It is
+ * invalidated by the same realtime `events-appended` signal as the timeline
+ * window, so it stays in sync as new messages arrive.
+ */
+export function useThreadConversationOutline(
+  id: string,
+  options?: ThreadTimelineQueryOptions,
+) {
+  const enabled = (options?.enabled ?? true) && Boolean(id);
+  useThreadDetailRealtimeSubscription(id, { enabled });
+
+  return useQuery<ThreadConversationOutlineResponse>({
+    queryKey: threadConversationOutlineQueryKey(id),
+    queryFn: async ({ signal }) => {
+      const threadId = requireThreadId(id, "useThreadConversationOutline");
+      return api.getThreadConversationOutline({ id: threadId, signal });
+    },
+    enabled,
+    refetchOnMount: options?.refetchOnMount ?? true,
+    ...(options?.staleTime === undefined
+      ? {}
+      : { staleTime: options.staleTime }),
   });
 }
 

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -73,6 +73,7 @@ import type {
   ThreadStoragePathsQuery,
   TerminalListQuery,
   TerminalSession,
+  ThreadConversationOutlineResponse,
   ThreadTimelineResponse,
   TimelineTurnSummaryDetailsRequest,
   TimelineTurnSummaryDetailsResponse,
@@ -1504,6 +1505,23 @@ export async function getThreadTimeline({
             : {}),
         },
       },
+      requestOptions(signal),
+    ),
+  );
+}
+
+interface GetThreadConversationOutlineArgs {
+  id: string;
+  signal?: AbortSignal;
+}
+
+export async function getThreadConversationOutline({
+  id,
+  signal,
+}: GetThreadConversationOutlineArgs): Promise<ThreadConversationOutlineResponse> {
+  return request<ThreadConversationOutlineResponse>(
+    apiClient.threads[":id"]["conversation-outline"].$get(
+      { param: { id } },
       requestOptions(signal),
     ),
   );

--- a/apps/app/src/views/thread-detail/ThreadTimelinePane.tsx
+++ b/apps/app/src/views/thread-detail/ThreadTimelinePane.tsx
@@ -72,7 +72,14 @@ export function ThreadTimelinePane({
         contentClassName="gap-2 pt-4"
         footerClassName="chat-prompt-box"
         footer={footer}
-        scrollOverlay={<ThreadTableOfContents timelineRows={timelineRows} />}
+        scrollOverlay={
+          <ThreadTableOfContents
+            threadId={threadId}
+            timelineRows={timelineRows}
+            hasOlderTimelineRows={hasOlderTimelineRows}
+            loadOlderTimelineRows={onLoadOlderRows}
+          />
+        }
       >
         <ThreadTimelineSurface
           activeThinking={activeThinking}

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -12,6 +12,7 @@ import {
   typedRoutes,
   type PublicApiSchema,
   type ThreadComposerBootstrapResponse,
+  type ThreadConversationOutlineResponse,
   type ThreadTimelineQuery,
 } from "@bb/server-contract";
 import type {
@@ -39,6 +40,7 @@ import {
 import { requireThreadStoragePath } from "../../services/threads/thread-storage.js";
 import { toThreadQueuedMessage } from "../../services/threads/thread-queued-messages.js";
 import {
+  buildThreadConversationOutline,
   buildThreadTimeline,
   buildTimelineTurnSummaryDetails,
   THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT,
@@ -342,6 +344,21 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
   // whole window — the big streaming win.
   const timelineCache = createThreadTimelineCache();
   const timelineLatestRowsCache = createTimelineLatestRowsCache();
+  // The conversation outline reprojects the entire thread, so memoize it per
+  // (thread, maxSeq): repeated polls at a stable revision are served from
+  // cache. Any appended event bumps maxSeq and forces a rebuild, so a thread
+  // streaming many deltas rebuilds per batch — acceptable because the client
+  // only fetches the outline when the minimap is mounted and refetches are
+  // driven by the (debounced) realtime invalidation, not per token. The key
+  // omits the provider/env inputs the timeline cache tracks because the outline
+  // emits only event-derived fields (id/role/preview/attachment counts); add
+  // them here if the outline ever surfaces a provider- or workspace-derived
+  // value. A small LRU bounds memory across many viewed threads.
+  const conversationOutlineCache = new Map<
+    string,
+    ThreadConversationOutlineResponse
+  >();
+  const CONVERSATION_OUTLINE_CACHE_MAX_ENTRIES = 128;
 
   get(routes.timeline, (context, query) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
@@ -399,6 +416,37 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     return context.json(
       delta === undefined ? full : { ...full, rows: [], delta },
     );
+  });
+
+  get(routes.conversationOutline, (context) => {
+    const thread = requirePublicThread(deps.db, context.req.param("id"));
+    const maxSeq = getLatestThreadSequence(deps.db, { threadId: thread.id });
+    const cacheKey = `${thread.id}:${maxSeq}`;
+    const cached = conversationOutlineCache.get(cacheKey);
+    if (cached !== undefined) {
+      // Re-insert to mark most-recently-used.
+      conversationOutlineCache.delete(cacheKey);
+      conversationOutlineCache.set(cacheKey, cached);
+      return context.json(cached);
+    }
+    const response = buildThreadConversationOutline(deps.db, thread, {
+      maxSeq,
+      providerDisplayName: resolveThreadProviderDisplayName(
+        deps,
+        thread.providerId,
+      ),
+    });
+    conversationOutlineCache.set(cacheKey, response);
+    while (
+      conversationOutlineCache.size > CONVERSATION_OUTLINE_CACHE_MAX_ENTRIES
+    ) {
+      const oldest = conversationOutlineCache.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      conversationOutlineCache.delete(oldest);
+    }
+    return context.json(response);
   });
 
   get(routes.timelineTurnSummaryDetails, (context, query) => {

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -8,7 +8,11 @@ import {
 } from "@bb/thread-view";
 import type { ClientTurnRequestId, Thread } from "@bb/domain";
 import type {
+  ThreadConversationOutlineItem,
+  ThreadConversationOutlineResponse,
+  TimelineConversationAttachments,
   TimelinePaginationCursor,
+  ThreadConversationOutlineAttachmentSummary,
   ThreadTimelineResponse,
   TimelineTurnSummaryDetailsResponse,
 } from "@bb/server-contract";
@@ -814,13 +818,11 @@ function selectStandardTimelineEventRows(
     threadId: thread.id,
     rows: selectedRowsWithContext.rows,
   });
-  const selectedRowsWithParentedTurnStarts = ensureTimelineWindowTurnStartedRows(
-    db,
-    {
+  const selectedRowsWithParentedTurnStarts =
+    ensureTimelineWindowTurnStartedRows(db, {
       threadId: thread.id,
       rows: selectedRowsWithParentedContext.rows,
-    },
-  );
+    });
 
   return {
     acceptedClientRequestContextRows: selectedRowsWithContext.contextRows,
@@ -1079,6 +1081,99 @@ export function buildThreadTimeline(
     ...options,
     includeProfile: false,
   }).response;
+}
+
+export interface BuildThreadConversationOutlineOptions {
+  /** Thread high-water event sequence this outline reflects (echoed to clients). */
+  maxSeq: number;
+  providerDisplayName?: string;
+}
+
+const CONVERSATION_OUTLINE_PREVIEW_MAX_LENGTH = 200;
+
+function toConversationOutlinePreview(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= CONVERSATION_OUTLINE_PREVIEW_MAX_LENGTH) {
+    return normalized;
+  }
+  return normalized.slice(0, CONVERSATION_OUTLINE_PREVIEW_MAX_LENGTH).trimEnd();
+}
+
+function toConversationOutlineAttachmentSummary(
+  attachments: TimelineConversationAttachments | null,
+): ThreadConversationOutlineAttachmentSummary | null {
+  if (!attachments) {
+    return null;
+  }
+  const imageCount = attachments.webImages + attachments.localImages;
+  const fileCount = attachments.localFiles;
+  if (imageCount === 0 && fileCount === 0) {
+    return null;
+  }
+  return { imageCount, fileCount };
+}
+
+/**
+ * Projects the entire thread into a lightweight conversation outline for the
+ * table-of-contents minimap. Unlike {@link buildThreadTimeline}, this is not
+ * paginated: it reads every event and reuses the same
+ * {@link buildThreadTimelineFromEvents} projection so each outline item's `id`
+ * is identical to the timeline row it represents. That identity is what lets
+ * the minimap scroll-spy the loaded window and jump to a message once it is
+ * paginated in. Only conversation rows survive, and each is reduced to the few
+ * fields the minimap renders.
+ */
+export function buildThreadConversationOutline(
+  db: DbConnection,
+  thread: Thread,
+  options: BuildThreadConversationOutlineOptions,
+): ThreadConversationOutlineResponse {
+  const rawEventRows = listRecentStoredEventRows(db, {
+    threadId: thread.id,
+    excludedTypes: THREAD_TIMELINE_EXCLUDED_EVENT_TYPES,
+  });
+  const decodedRawEvents = rawEventRows.map((row) =>
+    toThreadEventWithMeta(row),
+  );
+  const decodedEvents = compactThreadTimelineSummaryEvents(decodedRawEvents);
+  const acceptedClientRequestContext: AcceptedClientRequestContext = {
+    acceptedClientRequestEvents: selectAcceptedClientRequestContextRows(db, {
+      rows: rawEventRows,
+      threadId: thread.id,
+    }).map((row) => toThreadEventWithMeta(row)),
+  };
+  const timeline = buildThreadTimelineFromEvents({
+    acceptedClientRequestContext,
+    contextWindowEvents: [],
+    events: decodedEvents,
+    options: {
+      includeDebugRawEvents: false,
+      includeNestedRows: false,
+      includeProviderUnhandledOperations: false,
+      isLatestPage: true,
+      providerDisplayName: options.providerDisplayName,
+      providerId: thread.providerId,
+      threadName: thread.title ?? thread.titleFallback ?? "",
+      threadStatus: thread.status,
+      turnMessageDetail: "summary",
+      workspaceRoot: resolveThreadWorkspaceRoot(db, thread),
+    },
+  });
+  const items: ThreadConversationOutlineItem[] = [];
+  for (const row of timeline.rows) {
+    if (row.kind !== "conversation") {
+      continue;
+    }
+    items.push({
+      id: row.id,
+      role: row.role,
+      preview: toConversationOutlinePreview(row.text),
+      attachmentSummary: toConversationOutlineAttachmentSummary(
+        row.attachments,
+      ),
+    });
+  }
+  return { items, maxSeq: options.maxSeq };
 }
 
 export function buildTimelineTurnSummaryDetails(

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -27,6 +27,7 @@ import {
 import {
   type TimelineRow,
   threadComposerBootstrapResponseSchema,
+  threadConversationOutlineResponseSchema,
   threadQueuedMessageListResponseSchema,
   threadTimelineResponseSchema,
   threadWithIncludesResponseSchema,
@@ -225,6 +226,223 @@ describe("public thread data routes", () => {
           ]),
         }),
       );
+    });
+  });
+
+  it("returns the full conversation outline beyond the paginated timeline window", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+
+      // Three message turns, each: user request -> turn start -> assistant
+      // message -> turn complete. Segment anchors are the user-message rows, so
+      // a `segmentLimit=1` timeline page exposes only the last turn while the
+      // outline must still cover all three.
+      const seedMessageTurn = (args: {
+        requestId: number;
+        startSequence: number;
+        text: string;
+        turnId: string;
+      }) => {
+        seedEvent(harness.deps, {
+          threadId: thread.id,
+          environmentId: environment.id,
+          sequence: args.startSequence,
+          type: "client/turn/requested",
+          scope: threadScope(),
+          data: {
+            direction: "outbound",
+            requestId: encodeClientTurnRequestIdNumber({
+              value: args.requestId,
+            }),
+            input: [{ type: "text", text: args.text }],
+            target: { kind: "new-turn" },
+            execution: {
+              model: "gpt-5",
+              reasoningLevel: "medium",
+              permissionMode: "full",
+              serviceTier: "default",
+              source: "client/turn/requested",
+            },
+            initiator: "user",
+            senderThreadId: null,
+            request: { method: "turn/start", params: {} },
+            source: "tell",
+          },
+        });
+        seedEvent(harness.deps, {
+          threadId: thread.id,
+          environmentId: environment.id,
+          providerThreadId: "provider-thread-1",
+          scope: turnScope(args.turnId),
+          sequence: args.startSequence + 1,
+          type: "turn/started",
+          data: {},
+        });
+        seedEvent(harness.deps, {
+          threadId: thread.id,
+          environmentId: environment.id,
+          providerThreadId: "provider-thread-1",
+          scope: turnScope(args.turnId),
+          sequence: args.startSequence + 2,
+          type: "item/completed",
+          data: {
+            item: {
+              type: "agentMessage",
+              id: `${args.turnId}-assistant`,
+              text: `${args.text} — answered.`,
+            },
+          },
+        });
+        seedEvent(harness.deps, {
+          threadId: thread.id,
+          environmentId: environment.id,
+          providerThreadId: "provider-thread-1",
+          scope: turnScope(args.turnId),
+          sequence: args.startSequence + 3,
+          type: "turn/completed",
+          data: { status: "completed" },
+        });
+      };
+
+      seedMessageTurn({
+        requestId: 101,
+        startSequence: 1,
+        text: "First question",
+        turnId: "turn-1",
+      });
+      seedMessageTurn({
+        requestId: 102,
+        startSequence: 5,
+        text: "Second question",
+        turnId: "turn-2",
+      });
+      seedMessageTurn({
+        requestId: 103,
+        startSequence: 9,
+        text: "Third question",
+        turnId: "turn-3",
+      });
+
+      // A single-segment timeline page only holds the last turn.
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline?segmentLimit=1`,
+      );
+      expect(timelineResponse.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(timelineResponse),
+      );
+      expect(timeline.timelinePage.hasOlderRows).toBe(true);
+      const windowedConversationIds = timeline.rows
+        .filter((row) => row.kind === "conversation")
+        .map((row) => row.id);
+
+      const outlineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/conversation-outline`,
+      );
+      expect(outlineResponse.status).toBe(200);
+      const outline = threadConversationOutlineResponseSchema.parse(
+        await readJson(outlineResponse),
+      );
+
+      // The outline covers every message in the thread, not just the page.
+      expect(outline.items.filter((item) => item.role === "user")).toHaveLength(
+        3,
+      );
+      expect(
+        outline.items.filter((item) => item.role === "assistant"),
+      ).toHaveLength(3);
+      expect(outline.items.length).toBeGreaterThan(
+        windowedConversationIds.length,
+      );
+      expect(outline.maxSeq).toBe(12);
+      expect(outline.items.map((item) => item.preview)).toEqual([
+        "First question",
+        "First question — answered.",
+        "Second question",
+        "Second question — answered.",
+        "Third question",
+        "Third question — answered.",
+      ]);
+
+      // Ids must match the timeline exactly so the minimap can scroll-spy the
+      // loaded window and jump to any row once it is paginated in.
+      const outlineIds = new Set(outline.items.map((item) => item.id));
+      for (const id of windowedConversationIds) {
+        expect(outlineIds.has(id)).toBe(true);
+      }
+    });
+  });
+
+  it("returns an empty conversation outline for a thread with no events", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness);
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/conversation-outline`,
+      );
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toEqual({
+        items: [],
+        maxSeq: 0,
+      });
+    });
+  });
+
+  it("summarizes attachment-only messages in the conversation outline", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+
+      // A user message with no text but a file attachment: the outline should
+      // emit an empty preview plus attachment counts (and never leak the path).
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        sequence: 1,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        data: {
+          direction: "outbound",
+          requestId: encodeClientTurnRequestIdNumber({ value: 501 }),
+          input: [
+            { type: "text", text: "" },
+            {
+              type: "localFile",
+              path: "/tmp/secret-attachment-project/report.pdf",
+              name: "report.pdf",
+              sizeBytes: 12,
+            },
+          ],
+          target: { kind: "new-turn" },
+          execution: {
+            model: "gpt-5",
+            reasoningLevel: "medium",
+            permissionMode: "full",
+            serviceTier: "default",
+            source: "client/turn/requested",
+          },
+          initiator: "user",
+          senderThreadId: null,
+          request: { method: "turn/start", params: {} },
+          source: "tell",
+        },
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/conversation-outline`,
+      );
+      expect(response.status).toBe(200);
+      const outline = threadConversationOutlineResponseSchema.parse(
+        await readJson(response),
+      );
+      const userItem = outline.items.find((item) => item.role === "user");
+      expect(userItem).toBeDefined();
+      expect(userItem?.preview).toBe("");
+      expect(userItem?.attachmentSummary).toEqual({
+        imageCount: 0,
+        fileCount: 1,
+      });
+      // The slim summary must not carry the on-disk path.
+      expect(JSON.stringify(outline)).not.toContain("report.pdf");
     });
   });
 

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -623,6 +623,54 @@ export type ThreadTimelineResponse = z.infer<
   typeof threadTimelineResponseSchema
 >;
 
+/**
+ * Lightweight attachment counts for a conversation-outline item. The full
+ * {@link timelineConversationAttachmentsSchema} carries image URLs and file
+ * paths the outline never renders, so the outline ships only the counts the
+ * minimap needs to label an attachment-only message.
+ */
+export const threadConversationOutlineAttachmentSummarySchema = z
+  .object({
+    imageCount: z.number().int().nonnegative(),
+    fileCount: z.number().int().nonnegative(),
+  })
+  .strict();
+export type ThreadConversationOutlineAttachmentSummary = z.infer<
+  typeof threadConversationOutlineAttachmentSummarySchema
+>;
+
+/**
+ * A single conversation message in the thread's full table-of-contents
+ * outline. `id` matches the corresponding timeline row id (both are projected
+ * by the same builder), so the minimap can scroll-spy and jump to a row once
+ * it is paginated into the loaded window. `preview` is already whitespace-
+ * normalized and length-clamped server-side to keep the payload small for
+ * very long threads.
+ */
+export const threadConversationOutlineItemSchema = z
+  .object({
+    id: z.string().min(1),
+    role: z.enum(["user", "assistant"]),
+    preview: z.string(),
+    attachmentSummary:
+      threadConversationOutlineAttachmentSummarySchema.nullable(),
+  })
+  .strict();
+export type ThreadConversationOutlineItem = z.infer<
+  typeof threadConversationOutlineItemSchema
+>;
+
+export const threadConversationOutlineResponseSchema = z
+  .object({
+    items: z.array(threadConversationOutlineItemSchema),
+    /** Thread high-water event sequence this outline reflects. */
+    maxSeq: z.number().int().nonnegative(),
+  })
+  .strict();
+export type ThreadConversationOutlineResponse = z.infer<
+  typeof threadConversationOutlineResponseSchema
+>;
+
 export const threadStorageFileListResponseSchema =
   workspaceFileListResponseSchema.extend({
     /**

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -124,6 +124,7 @@ import type {
   ThreadHostFileContentQuery,
   ThreadListQuery,
   ThreadListResponse,
+  ThreadConversationOutlineResponse,
   ThreadOpenRequest,
   ThreadOpenResponse,
   ThreadPendingInteractionsResponse,
@@ -821,6 +822,12 @@ export const publicApiRoutes = {
         threadTimelineQuerySchema,
       ),
       response: jsonResponse<ThreadTimelineResponse>(),
+    }),
+    conversationOutline: defineRoute({
+      path: "/threads/:id/conversation-outline",
+      method: "get",
+      request: noRequest<PathId>(),
+      response: jsonResponse<ThreadConversationOutlineResponse>(),
     }),
     timelineTurnSummaryDetails: defineRoute({
       path: "/threads/:id/timeline/turn-summary-details",


### PR DESCRIPTION
## What & why

The table-of-contents minimap previously listed only the **currently-loaded** timeline window, so on a long thread it was incomplete until you scrolled older pages in. This makes it reflect the **whole thread**, and lets any entry jump to its message — auto-loading older pages as needed.

Builds on the recently-landed right-centered minimap + min-3-user-messages gating + near-bottom active detection (kept as-is).

## How

- **New `GET /threads/:id/conversation-outline`** — a lightweight list of every user/agent message (`id`, `role`, clamped `preview`, attachment counts). It reuses the **same `buildThreadTimelineFromEvents` projection** as the timeline over the full event set, so each outline item's `id` is identical to its timeline row's `id`. That identity is what makes scroll-spy highlighting and click-to-jump work. The handler memoizes per `(thread, maxSeq)`; the client query is invalidated by the same realtime `events-appended` signal as the timeline window.
- **Minimap** renders from the outline (falling back to the loaded window until it loads). Clicking an entry whose message isn't paginated in yet **auto-paginates** older pages until the row appears, then scrolls to it — bounded by a hard cap, resilient to pagination errors, and stops if you switch threads mid-jump. The tick rail is bounded + scrollable so long threads don't overflow.

## Testing

- Full-repo typecheck: all packages pass. Lint clean.
- **@bb/app**: 1062 tests pass (incl. a new `ThreadTableOfContents` jsdom suite covering full-history rendering, attachment-only labels, jump-to-loaded, auto-paginate-to-unloaded, and the no-older-pages case — merged with the existing `findActiveItemIds` scroll-spy tests).
- **@bb/server**: 800 tests pass (incl. a new conversation-outline integration test: a `segmentLimit=1` page shows only the last turn while the outline returns all messages, ids match the timeline window, plus empty-thread and attachment-only-without-path-leak cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)