### PR TITLE
[codex] Update file viewer header actions

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
@@ -112,6 +112,11 @@ const DIAGRAM_PATH = "docs/right-panel/preview-flow.md";
 const BUTTON_PATH = "apps/app/src/components/ui/button.tsx";
 const DELETED_BUTTON_PATH = "apps/app/src/components/ui/legacy-button.tsx";
 const SCREENSHOT_PATH = "docs/screenshots/right-panel.svg";
+const STORY_WORKSPACE_ROOT = "/Users/alex/Code/bb";
+
+function copyPathFor(path: string) {
+  return `${STORY_WORKSPACE_ROOT}/${path}`;
+}
 
 const SAMPLE_IMAGE_URL =
   "data:image/svg+xml;utf8," +
@@ -141,11 +146,12 @@ export function Overview() {
     <StoryCard>
       <StoryRow
         label="markdown file"
-        hint="Header shows path + Preview/Raw toggle; body renders with react-markdown + GFM"
+        hint="Header shows a copyable path, direct markdown-copy icon, open-in-editor icon, and Preview/Raw toggle"
       >
         <PreviewStage>
           <FilePreview
             path={README_PATH}
+            copyPath={copyPathFor(README_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{
               kind: "ready",
@@ -158,11 +164,12 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="markdown file with Mermaid"
-        hint="Preview mode renders the Mermaid diagram with open/zoom controls; Raw keeps the original fence"
+        hint="Preview mode renders the Mermaid diagram; the header copy icon copies the original markdown"
       >
         <PreviewStage>
           <FilePreview
             path={DIAGRAM_PATH}
+            copyPath={copyPathFor(DIAGRAM_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{
               kind: "ready",
@@ -175,11 +182,12 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="typescript / react file"
-        hint="No markdown toggle for code files; Pierre File highlights via Shiki"
+        hint="Code previews use direct content-copy and line-wrap controls without an overflow menu"
       >
         <PreviewStage>
           <FilePreview
             path={BUTTON_PATH}
+            copyPath={copyPathFor(BUTTON_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{
               kind: "ready",
@@ -201,6 +209,7 @@ export function Overview() {
         <PreviewStage>
           <FilePreview
             path={DELETED_BUTTON_PATH}
+            copyPath={copyPathFor(DELETED_BUTTON_PATH)}
             onOpenInEditor={noopOpenInEditor}
             statusLabel="deleted"
             state={{
@@ -218,11 +227,12 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="image file"
-        hint="Image previews render inside the same header chrome (path, copy, open-in-editor)"
+        hint="Image previews keep the same copyable path and open-in-editor header chrome"
       >
         <PreviewStage>
           <FilePreview
             path={SCREENSHOT_PATH}
+            copyPath={copyPathFor(SCREENSHOT_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{ kind: "image", url: SAMPLE_IMAGE_URL }}
           />
@@ -235,6 +245,7 @@ export function Overview() {
         <PreviewStage>
           <FilePreview
             path={README_PATH}
+            copyPath={copyPathFor(README_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{ kind: "empty" }}
           />
@@ -247,6 +258,7 @@ export function Overview() {
         <PreviewStage>
           <FilePreview
             path={README_PATH}
+            copyPath={copyPathFor(README_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{ kind: "not-found" }}
           />
@@ -259,6 +271,7 @@ export function Overview() {
         <PreviewStage>
           <FilePreview
             path={README_PATH}
+            copyPath={copyPathFor(README_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{ kind: "error" }}
           />
@@ -271,6 +284,7 @@ export function Overview() {
         <PreviewStage>
           <FilePreview
             path={README_PATH}
+            copyPath={copyPathFor(README_PATH)}
             onOpenInEditor={noopOpenInEditor}
             state={{ kind: "loading" }}
           />

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -109,12 +109,6 @@ vi.mock("@pierre/diffs/react", async () => {
 
 vi.mock("@/lib/clipboard", () => clipboardMock);
 
-async function openFilePreviewActionsMenu() {
-  const trigger = screen.getByRole("button", { name: "File preview actions" });
-  fireEvent.pointerDown(trigger, { button: 0 });
-  return screen.findByRole("menuitem", { name: "Copy raw file" });
-}
-
 describe("FilePreview", () => {
   beforeEach(() => {
     pierreMock.state.cachedFileKeys.clear();
@@ -131,6 +125,7 @@ describe("FilePreview", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("rerenders the code view when the Pierre worker pool advances", async () => {
@@ -247,7 +242,7 @@ describe("FilePreview", () => {
     });
   });
 
-  it("renders a compact file preview actions menu in the header", async () => {
+  it("renders compact direct file preview header controls", () => {
     render(
       <FilePreview
         path="apps/app/src/lib/thread-read-state.ts"
@@ -263,23 +258,21 @@ describe("FilePreview", () => {
       />,
     );
 
-    const actionsButton = screen.getByRole("button", {
-      name: "File preview actions",
+    expect(
+      screen.queryByRole("button", { name: "File preview actions" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy file contents" })).not.toBe(
+      null,
+    );
+
+    const wrapButton = screen.getByRole("button", {
+      name: "Wrap lines",
     });
 
-    expect(actionsButton.className).toContain("h-5");
-    expect(actionsButton.className).toContain("w-5");
-    expect(actionsButton.className).toContain("[&_svg]:size-3");
-
-    await openFilePreviewActionsMenu();
-    expect(
-      screen
-        .getByRole("menuitemcheckbox", { name: "Wrap" })
-        .getAttribute("aria-checked"),
-    ).toBe("false");
-    expect(
-      screen.getByRole("menuitem", { name: "Copy raw file" }),
-    ).not.toBeNull();
+    expect(wrapButton.className).toContain("h-5");
+    expect(wrapButton.className).toContain("w-5");
+    expect(wrapButton.className).toContain("[&_svg]:size-3");
+    expect(wrapButton.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("lets source previews grow to content height so the sticky header stays bounded by the full file", () => {
@@ -308,7 +301,7 @@ describe("FilePreview", () => {
     ).toBe(true);
   });
 
-  it("toggles source line wrap from the file preview actions menu", async () => {
+  it("toggles source line wrap from the header button", async () => {
     render(
       <FilePreview
         path="apps/app/src/lib/thread-read-state.ts"
@@ -324,23 +317,24 @@ describe("FilePreview", () => {
       />,
     );
 
-    await openFilePreviewActionsMenu();
-    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Wrap" }));
+    fireEvent.click(screen.getByRole("button", { name: "Wrap lines" }));
     await waitFor(() => {
       expect(
-        screen.queryByRole("menuitemcheckbox", { name: "Wrap" }),
-      ).toBeNull();
+        screen
+          .getByRole("button", { name: "Disable line wrap" })
+          .getAttribute("aria-pressed"),
+      ).toBe("true");
     });
 
-    await openFilePreviewActionsMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Disable line wrap" }));
     expect(
       screen
-        .getByRole("menuitemcheckbox", { name: "Wrap" })
-        .getAttribute("aria-checked"),
-    ).toBe("true");
+        .getByRole("button", { name: "Wrap lines" })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
   });
 
-  it("copies loaded raw file contents from the file preview actions menu", async () => {
+  it("copies loaded markdown contents from the header copy button", async () => {
     render(
       <FilePreview
         path="docs/right-panel/README.md"
@@ -356,8 +350,7 @@ describe("FilePreview", () => {
       />,
     );
 
-    await openFilePreviewActionsMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Copy raw file" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy markdown" }));
 
     await waitFor(() => {
       expect(clipboardMock.copyToClipboardWithToast).toHaveBeenCalledWith(
@@ -368,6 +361,90 @@ describe("FilePreview", () => {
         },
       );
     });
+  });
+
+  it("copies the file path with a toast when clicking the header path", async () => {
+    render(
+      <FilePreview
+        path="docs/right-panel/README.md"
+        copyPath="/Users/tester/project/docs/right-panel/README.md"
+        state={{
+          kind: "ready",
+          file: {
+            name: "README.md",
+            contents: "# Preview\n\nRaw markdown.",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: true,
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy file path" }));
+
+    await waitFor(() => {
+      expect(clipboardMock.copyToClipboardWithToast).toHaveBeenCalledWith(
+        "/Users/tester/project/docs/right-panel/README.md",
+        {
+          errorMessage: "Failed to copy file path",
+          successMessage: "File path copied",
+        },
+      );
+    });
+  });
+
+  it("shows a tooltip for the file path", async () => {
+    render(
+      <FilePreview
+        path="docs/right-panel/README.md"
+        copyPath="/Users/tester/project/docs/right-panel/README.md"
+        state={{
+          kind: "ready",
+          file: {
+            name: "README.md",
+            contents: "# Preview\n\nRaw markdown.",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: true,
+        }}
+      />,
+    );
+
+    fireEvent.pointerMove(
+      screen.getByRole("button", { name: "Copy file path" }),
+      { pointerType: "mouse" },
+    );
+
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Copy file path",
+    );
+  });
+
+  it("shows a tooltip for the external editor button", async () => {
+    render(
+      <FilePreview
+        path="docs/right-panel/README.md"
+        onOpenInEditor={vi.fn()}
+        state={{
+          kind: "ready",
+          file: {
+            name: "README.md",
+            contents: "# Preview\n\nRaw markdown.",
+          },
+          lineRange: null,
+          showMarkdownModeToggle: true,
+        }}
+      />,
+    );
+
+    fireEvent.pointerMove(
+      screen.getByRole("button", { name: "Open in editor" }),
+      { pointerType: "mouse" },
+    );
+
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Open in editor",
+    );
   });
 
   it("does not show the file preview actions menu for non-text previews", () => {

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -15,18 +15,17 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
 import { CopyButton } from "@/components/ui/copy-button.js";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu.js";
 import { Icon } from "@/components/ui/icon.js";
 import { OpenInEditorButton } from "@/components/ui/open-in-editor-button.js";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
 import { MarkdownPreview } from "@/components/ui/markdown-preview.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip.js";
 import { TruncateStart } from "@/components/ui/truncate-start.js";
 import { usePreferredTheme } from "@/hooks/useTheme";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
@@ -116,11 +115,15 @@ interface FilePreviewHeaderProps {
   onViewModeChange: (mode: FilePreviewViewMode) => void;
 }
 
-interface FilePreviewActionsMenuProps {
-  rawContents: string | null;
+interface FilePreviewLineWrapButtonProps {
   showLineOverflowToggle: boolean;
   lineOverflowMode: CodeOverflowMode;
   onLineOverflowModeChange: CodeOverflowModeChangeHandler;
+}
+
+interface FilePreviewPathProps {
+  path: string;
+  copyPath: string | null;
 }
 
 interface MarkdownFilePreviewProps {
@@ -231,6 +234,20 @@ function getToggleAriaLabel(kind: FilePreviewToggleKind): string {
 
 function getRawToggleTitle(kind: FilePreviewToggleKind): string {
   return kind === "html" ? "HTML source" : "Markdown source";
+}
+
+function getFileContentsCopyLabel(kind: FilePreviewToggleKind | null): string {
+  if (kind === "markdown") {
+    return "Copy markdown";
+  }
+  if (kind === "html") {
+    return "Copy HTML source";
+  }
+  return "Copy file contents";
+}
+
+function getLineWrapToggleLabel(lineOverflowMode: CodeOverflowMode): string {
+  return lineOverflowMode === "wrap" ? "Disable line wrap" : "Wrap lines";
 }
 
 function getFilePreviewLineRange(
@@ -441,8 +458,8 @@ function FilePreviewHeader({
   viewMode,
   onViewModeChange,
 }: FilePreviewHeaderProps) {
-  const showActionsMenu = showLineOverflowToggle || rawContents !== null;
-  const showHeaderControls = showActionsMenu || toggleKind !== null;
+  const showHeaderControls = showLineOverflowToggle || toggleKind !== null;
+  const copyFileContentsLabel = getFileContentsCopyLabel(toggleKind);
 
   return (
     // The wrapper carries an opaque `bg-background` base so the translucent
@@ -455,15 +472,7 @@ function FilePreviewHeader({
             name="File"
             className="size-3.5 shrink-0 text-subtle-foreground"
           />
-          <TruncateStart
-            className={cn(
-              "min-w-0 font-mono font-medium leading-5 text-file-accent",
-              COARSE_POINTER_TEXT_SM_CLASS,
-            )}
-            title={path}
-          >
-            {path}
-          </TruncateStart>
+          <FilePreviewPath path={path} copyPath={copyPath} />
           {statusLabel === null ? null : (
             <span
               className={cn(
@@ -474,27 +483,42 @@ function FilePreviewHeader({
               ({statusLabel})
             </span>
           )}
-          {copyPath === null ? null : (
-            <CopyButton
-              text={copyPath}
-              label="Copy file path"
-              className="shrink-0 rounded-md hover:bg-state-hover hover:text-foreground"
-            />
-          )}
-          {onOpenInEditor ? (
-            <OpenInEditorButton onClick={() => onOpenInEditor(path)} />
-          ) : null}
+          <TooltipProvider delayDuration={300}>
+            {rawContents === null ? null : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CopyButton
+                    text={rawContents}
+                    label={copyFileContentsLabel}
+                    title={undefined}
+                    className="shrink-0 rounded-md hover:bg-state-hover hover:text-foreground"
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {copyFileContentsLabel}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {onOpenInEditor ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <OpenInEditorButton
+                    onClick={() => onOpenInEditor(path)}
+                    title={null}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Open in editor</TooltipContent>
+              </Tooltip>
+            ) : null}
+          </TooltipProvider>
         </div>
         {showHeaderControls ? (
           <div className="ml-auto flex shrink-0 items-center gap-1">
-            {showActionsMenu ? (
-              <FilePreviewActionsMenu
-                rawContents={rawContents}
-                showLineOverflowToggle={showLineOverflowToggle}
-                lineOverflowMode={lineOverflowMode}
-                onLineOverflowModeChange={onLineOverflowModeChange}
-              />
-            ) : null}
+            <FilePreviewLineWrapButton
+              showLineOverflowToggle={showLineOverflowToggle}
+              lineOverflowMode={lineOverflowMode}
+              onLineOverflowModeChange={onLineOverflowModeChange}
+            />
             {toggleKind !== null ? (
               <div
                 className="inline-flex shrink-0 items-center gap-0.5 rounded-md border border-border p-0.5"
@@ -538,59 +562,79 @@ function FilePreviewHeader({
   );
 }
 
-function FilePreviewActionsMenu({
-  rawContents,
-  showLineOverflowToggle,
-  lineOverflowMode,
-  onLineOverflowModeChange,
-}: FilePreviewActionsMenuProps) {
+function FilePreviewPath({ path, copyPath }: FilePreviewPathProps) {
+  const copyTarget = copyPath ?? path;
+  const label = "Copy file path";
+  const className = cn(
+    "min-w-0 font-mono font-medium leading-5 text-file-accent",
+    COARSE_POINTER_TEXT_SM_CLASS,
+  );
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className={cn(
-            FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
-            "text-muted-foreground",
-          )}
-          aria-label="File preview actions"
-          title="File preview actions"
-        >
-          <Icon name="MoreHorizontal" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        mobileTitle="File preview actions"
-        className="w-44"
-      >
-        {showLineOverflowToggle ? (
-          <DropdownMenuCheckboxItem
-            checked={lineOverflowMode === "wrap"}
-            onCheckedChange={(checked) =>
-              onLineOverflowModeChange(checked ? "wrap" : "scroll")
-            }
-            textValue="Wrap"
-          >
-            Wrap
-          </DropdownMenuCheckboxItem>
-        ) : null}
-        {rawContents === null ? null : (
-          <DropdownMenuItem
-            onSelect={() => {
-              void copyToClipboardWithToast(rawContents, {
-                successMessage: null,
-                errorMessage: "Failed to copy",
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              className,
+              "cursor-pointer rounded-sm text-left underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            )}
+            aria-label={label}
+            onClick={() => {
+              void copyToClipboardWithToast(copyTarget, {
+                successMessage: "File path copied",
+                errorMessage: "Failed to copy file path",
               });
             }}
           >
-            Copy raw file
-          </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            <TruncateStart>{path}</TruncateStart>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function FilePreviewLineWrapButton({
+  showLineOverflowToggle,
+  lineOverflowMode,
+  onLineOverflowModeChange,
+}: FilePreviewLineWrapButtonProps) {
+  if (!showLineOverflowToggle) {
+    return null;
+  }
+
+  const label = getLineWrapToggleLabel(lineOverflowMode);
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={cn(
+              FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
+              "text-muted-foreground",
+            )}
+            aria-label={label}
+            aria-pressed={lineOverflowMode === "wrap"}
+            title={undefined}
+            onClick={() => {
+              onLineOverflowModeChange(
+                lineOverflowMode === "wrap" ? "scroll" : "wrap",
+              );
+            }}
+          >
+            <Icon name="TextWrap" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/apps/app/src/components/ui/open-in-editor-button.tsx
+++ b/apps/app/src/components/ui/open-in-editor-button.tsx
@@ -1,25 +1,47 @@
+import { forwardRef, type ComponentPropsWithoutRef } from "react";
 import { Icon } from "@/components/ui/icon.js";
+import { cn } from "@/lib/utils";
 
-interface OpenInEditorButtonProps {
+interface OpenInEditorButtonProps
+  extends Omit<
+    ComponentPropsWithoutRef<"button">,
+    "type" | "onClick" | "title"
+  > {
   onClick: () => void;
   /** aria-label; defaults to "Open in editor". */
   label?: string;
+  /** Native title. Pass `null` when wrapping in a design-system tooltip. */
+  title?: string | null;
 }
 
 /** Muted icon button that opens the associated file in the user's editor. */
-export function OpenInEditorButton({
-  onClick,
-  label = "Open in editor",
-}: OpenInEditorButtonProps) {
+export const OpenInEditorButton = forwardRef<
+  HTMLButtonElement,
+  OpenInEditorButtonProps
+>(function OpenInEditorButton(
+  {
+    className,
+    onClick,
+    label = "Open in editor",
+    title = "Open in editor",
+    ...props
+  },
+  ref,
+) {
   return (
     <button
+      ref={ref}
       type="button"
+      {...props}
       onClick={onClick}
       aria-label={label}
-      title="Open in editor"
-      className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      title={title ?? undefined}
+      className={cn(
+        "inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        className,
+      )}
     >
       <Icon name="ExternalLink" aria-hidden className="size-3" />
     </button>
   );
-}
+});


### PR DESCRIPTION
## Summary

Updates the file viewer header controls to remove the overflow actions menu and expose the expected actions directly.

## Changes

- Remove the `...` file preview actions menu and the old `Copy raw file` menu item.
- Make the header copy icon copy the loaded file contents, with Markdown-specific copy labeling.
- Make the file path itself copy the file path and show a toast.
- Add tooltips for the file path, file contents copy icon, line wrap toggle, and open-in-editor icon.
- Update FilePreview tests and Ladle stories for the new header behavior.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/secondary-panel/FilePreview.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
