### PR TITLE
Handle transient mobile read failures

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -31,6 +31,7 @@ import {
   useConnectionAwareQueryState,
   type ConnectionAwareQueryStatus,
 } from "@/hooks/queries/connection-aware-query-state";
+import { isTransientReadError } from "@/hooks/queries/query-helpers";
 import { stripProjectThreads } from "@/hooks/queries/project-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useReorderProject } from "@/hooks/mutations/project-mutations";
@@ -1349,6 +1350,9 @@ function ProjectListComponent({
     hasResolvedData: projects !== undefined,
     isFetching: sidebarNavigationQuery.isFetching,
     isLoadingError: sidebarNavigationQuery.isLoadingError,
+    isRecoverableLoadingError: isTransientReadError(
+      sidebarNavigationQuery.error,
+    ),
   });
   const { localDaemonHostId } = useHostDaemon();
   const { threadId: selectedThreadId } = useRouteState();

--- a/apps/app/src/components/thread/timeline/useThreadTimelineController.test.tsx
+++ b/apps/app/src/components/thread/timeline/useThreadTimelineController.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ThreadTimelineResponse } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as api from "@/lib/api";
+import { threadTimelineQueryKey } from "@/hooks/queries/query-keys";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { useThreadTimelineController } from "./useThreadTimelineController";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    getThreadTimeline: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useThreadDetailRealtimeSubscription: vi.fn(),
+}));
+
+vi.mock("@/hooks/useServerConnectionState", () => ({
+  useServerConnectionState: () => "connected",
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeTimelineResponse(): ThreadTimelineResponse {
+  return {
+    rows: [],
+    activePromptMode: null,
+    activeThinking: null,
+    activeWorkflow: null,
+    activeBackgroundCommands: [],
+    pendingTodos: null,
+    goal: null,
+    maxSeq: 0,
+    timelinePage: {
+      kind: "latest",
+      segmentLimit: 20,
+      returnedSegmentCount: 0,
+      hasOlderRows: false,
+      olderCursor: null,
+    },
+  };
+}
+
+describe("useThreadTimelineController", () => {
+  it("keeps an initial timeline refetch in loading state instead of showing the previous error", async () => {
+    const response = makeTimelineResponse();
+    let resolveRefetch: (value: ThreadTimelineResponse) => void = () => {};
+    vi.mocked(api.getThreadTimeline)
+      .mockRejectedValueOnce(
+        new api.HttpError({
+          status: 500,
+          message: "Server error",
+        }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<ThreadTimelineResponse>((resolve) => {
+            resolveRefetch = resolve;
+          }),
+      );
+
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () => useThreadTimelineController({ threadId: "thread-1" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.timelineError).toBeInstanceOf(api.HttpError);
+    });
+
+    act(() => {
+      void queryClient.refetchQueries({
+        queryKey: threadTimelineQueryKey("thread-1"),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.timelineLoading).toBe(true);
+    });
+    expect(result.current.timelineError).toBeNull();
+
+    resolveRefetch(response);
+
+    await waitFor(() => {
+      expect(result.current.timelineLoading).toBe(false);
+      expect(result.current.timelineError).toBeNull();
+      expect(api.getThreadTimeline).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/app/src/components/thread/timeline/useThreadTimelineController.ts
+++ b/apps/app/src/components/thread/timeline/useThreadTimelineController.ts
@@ -4,6 +4,8 @@ import type {
   TimelinePaginationCursor,
   TimelineRow,
 } from "@bb/server-contract";
+import { useConnectionAwareQueryState } from "@/hooks/queries/connection-aware-query-state";
+import { isTransientReadError } from "@/hooks/queries/query-helpers";
 import { useThreadTimeline } from "@/hooks/queries/thread-queries";
 import * as api from "@/lib/api";
 
@@ -494,6 +496,25 @@ export function useThreadTimelineController({
     surfaceKey,
     threadId,
   ]);
+  const timelineRows =
+    loadedTimeline.surfaceKey === surfaceKey && loadedTimeline.rows.length > 0
+      ? loadedTimeline.rows
+      : (latestTimeline?.rows ?? []);
+  const timelineQueryState = useConnectionAwareQueryState({
+    hasResolvedData:
+      latestTimelineQuery.data !== undefined || timelineRows.length > 0,
+    isFetching: latestTimelineQuery.isFetching,
+    isLoadingError: latestTimelineQuery.isLoadingError,
+    isRecoverableLoadingError: isTransientReadError(latestTimelineQuery.error),
+  });
+  const timelineLoading =
+    latestTimelineQuery.isLoading ||
+    (timelineQueryState.status === "loading" && timelineRows.length === 0) ||
+    (latestTimelineQuery.isFetching && timelineRows.length === 0);
+  const timelineError =
+    timelineLoading || timelineQueryState.status !== "unavailable"
+      ? null
+      : latestTimelineQuery.error;
 
   return {
     activePromptMode: latestTimeline?.activePromptMode ?? null,
@@ -506,11 +527,8 @@ export function useThreadTimelineController({
     isLoadingOlderTimelineRows,
     loadOlderTimelineRows,
     pendingTodos: latestTimeline?.pendingTodos ?? null,
-    timelineError: latestTimelineQuery.error,
-    timelineLoading: latestTimelineQuery.isLoading,
-    timelineRows:
-      loadedTimeline.surfaceKey === surfaceKey && loadedTimeline.rows.length > 0
-        ? loadedTimeline.rows
-        : (latestTimeline?.rows ?? []),
+    timelineError,
+    timelineLoading,
+    timelineRows,
   };
 }

--- a/apps/app/src/hooks/queries/connection-aware-query-state.test.ts
+++ b/apps/app/src/hooks/queries/connection-aware-query-state.test.ts
@@ -55,6 +55,26 @@ describe("getConnectionAwareQueryState", () => {
       {
         args: {
           ...baseArgs,
+          isLoadingError: true,
+          isRecoverableLoadingError: true,
+          serverConnectionState: "connected",
+          connectionGracePeriodElapsed: false,
+        },
+        status: "loading",
+      },
+      {
+        args: {
+          ...baseArgs,
+          isLoadingError: true,
+          isRecoverableLoadingError: true,
+          serverConnectionState: "reconnecting",
+          connectionGracePeriodElapsed: true,
+        },
+        status: "unavailable",
+      },
+      {
+        args: {
+          ...baseArgs,
           hasResolvedData: true,
           serverConnectionState: "connected",
         },

--- a/apps/app/src/hooks/queries/connection-aware-query-state.ts
+++ b/apps/app/src/hooks/queries/connection-aware-query-state.ts
@@ -15,6 +15,7 @@ export interface ConnectionAwareQuerySnapshot {
   hasResolvedData: boolean;
   isFetching: boolean;
   isLoadingError: boolean;
+  isRecoverableLoadingError?: boolean;
 }
 
 export interface ConnectionAwareQueryStateArgs
@@ -34,6 +35,7 @@ export function getConnectionAwareQueryState({
   hasResolvedData,
   isFetching,
   isLoadingError,
+  isRecoverableLoadingError = false,
   serverConnectionState,
   connectionGracePeriodElapsed,
 }: ConnectionAwareQueryStateArgs): ConnectionAwareQueryState {
@@ -46,6 +48,15 @@ export function getConnectionAwareQueryState({
     isLoadingError &&
     serverConnectionState !== "connected" &&
     !connectionGracePeriodElapsed
+  ) {
+    return { status: "loading" };
+  }
+
+  if (
+    !hasResolvedData &&
+    isLoadingError &&
+    isRecoverableLoadingError &&
+    (serverConnectionState === "connected" || !connectionGracePeriodElapsed)
   ) {
     return { status: "loading" };
   }
@@ -83,6 +94,7 @@ export function useConnectionAwareQueryState({
   hasResolvedData,
   isFetching,
   isLoadingError,
+  isRecoverableLoadingError,
 }: UseConnectionAwareQueryStateArgs): ConnectionAwareQueryState {
   const serverConnectionState = useServerConnectionState();
   const connectionGracePeriodElapsed = useServerConnectionGracePeriodElapsed();
@@ -93,6 +105,7 @@ export function useConnectionAwareQueryState({
         hasResolvedData,
         isFetching,
         isLoadingError,
+        isRecoverableLoadingError,
         serverConnectionState,
         connectionGracePeriodElapsed,
       }),
@@ -100,6 +113,7 @@ export function useConnectionAwareQueryState({
       hasResolvedData,
       isFetching,
       isLoadingError,
+      isRecoverableLoadingError,
       serverConnectionState,
       connectionGracePeriodElapsed,
     ],

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -36,7 +36,8 @@ import {
   resolveThreadTimelinePlaceholder,
 } from "./query-placeholders";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
-import { requireEnabledQueryArg } from "./query-helpers";
+import { HttpError } from "@/lib/api";
+import { isTransientReadError, requireEnabledQueryArg } from "./query-helpers";
 
 describe("requireEnabledQueryArg", () => {
   it("returns the value when present", () => {
@@ -67,6 +68,22 @@ describe("requireEnabledQueryArg", () => {
         argName: "thread id",
       }),
     ).toThrow("useThread: thread id is required when query is enabled");
+  });
+});
+
+describe("isTransientReadError", () => {
+  it("matches browser transport failures but not HTTP responses", () => {
+    expect(isTransientReadError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isTransientReadError(new TypeError("Load failed"))).toBe(true);
+    expect(isTransientReadError({ name: "AbortError" })).toBe(true);
+    expect(
+      isTransientReadError(
+        new HttpError({ status: 404, message: "Not found" }),
+      ),
+    ).toBe(false);
+    expect(isTransientReadError(new Error("Unexpected parse error"))).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/app/src/hooks/queries/query-helpers.ts
+++ b/apps/app/src/hooks/queries/query-helpers.ts
@@ -1,8 +1,13 @@
+import { toRecord } from "@bb/core-ui";
+import { HttpError } from "@/lib/api";
+
 /**
  * Staleness window for prompt-history queries. Shared by the thread- and
  * project-scoped variants so they age out their cached suggestions together.
  */
 export const PROMPT_HISTORY_STALE_TIME_MS = 10_000;
+export const TRANSIENT_READ_RETRY_COUNT = 2;
+export const TRANSIENT_READ_RETRY_DELAY_MS = 250;
 
 interface RequireEnabledQueryArgArgs<T> {
   value: T | null | undefined;
@@ -27,4 +32,44 @@ export function requireEnabledQueryArg<T>({
     throw new Error(`${hookName}: ${argName} is required when query is enabled`);
   }
   return value;
+}
+
+function normalizeErrorMessage(message: string): string {
+  return message.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+export function isTransientReadError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+
+  if (toRecord(error)?.name === "AbortError") {
+    return true;
+  }
+  if (error instanceof HttpError) {
+    return false;
+  }
+
+  const record = toRecord(error);
+  if (!record || typeof record.message !== "string") {
+    return false;
+  }
+
+  const message = normalizeErrorMessage(record.message);
+  return (
+    message.includes("failed to fetch") ||
+    message.includes("load failed") ||
+    message.includes("networkerror")
+  );
+}
+
+export function shouldRetryTransientReadQuery(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (failureCount >= TRANSIENT_READ_RETRY_COUNT) {
+    return false;
+  }
+
+  return isTransientReadError(error);
 }

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -48,6 +48,8 @@ import {
 import {
   PROMPT_HISTORY_STALE_TIME_MS,
   requireEnabledQueryArg,
+  shouldRetryTransientReadQuery,
+  TRANSIENT_READ_RETRY_DELAY_MS,
 } from "./query-helpers";
 import {
   archivedThreadsListQueryKey,
@@ -505,6 +507,8 @@ export function useThread(id: string, options?: QueryOptions) {
     enabled,
     staleTime: 5_000,
     refetchOnMount: options?.refetchOnMount ?? true,
+    retry: shouldRetryTransientReadQuery,
+    retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
     placeholderData: (previousData, previousQuery) =>
       resolveThreadPlaceholder(previousData, previousQuery?.queryKey, id) ??
       liftThreadListPlaceholder(
@@ -550,6 +554,8 @@ export function useThreadDetailBootstrap(
     },
     enabled,
     staleTime: Infinity,
+    retry: shouldRetryTransientReadQuery,
+    retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
   });
 }
 
@@ -786,6 +792,8 @@ export function useThreadTimeline(
     ...(options?.staleTime === undefined
       ? {}
       : { staleTime: options.staleTime }),
+    retry: shouldRetryTransientReadQuery,
+    retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
     placeholderData: (previousData, previousQuery) =>
       resolveThreadTimelinePlaceholder(
         previousData,

--- a/apps/app/src/lib/query-client.ts
+++ b/apps/app/src/lib/query-client.ts
@@ -9,6 +9,10 @@ import {
   showMutationErrorToast,
 } from "./mutation-errors";
 import { cancelActiveQueryFetchesForBrowserSuspend } from "@/hooks/cache-owners/browser-lifecycle-cache-owner";
+import {
+  shouldRetryTransientReadQuery,
+  TRANSIENT_READ_RETRY_DELAY_MS,
+} from "@/hooks/queries/query-helpers";
 
 export interface CreateAppQueryClientOptions {
   defaultOptions?: QueryClientConfig["defaultOptions"];
@@ -105,7 +109,8 @@ export function createAppQueryClient(
       queries: {
         staleTime: 2000,
         refetchOnWindowFocus: true,
-        retry: 0,
+        retry: shouldRetryTransientReadQuery,
+        retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
         ...defaultOptions?.queries,
       },
     },

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -47,6 +47,7 @@ import {
   useThreadPendingInteractions,
   type ProjectThreadSubsetFilters,
 } from "../../hooks/queries/thread-queries";
+import { isTransientReadError } from "@/hooks/queries/query-helpers";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { ThreadGitActionDialog } from "@/components/dialogs/ThreadGitActionDialog";
 import { PageShell } from "@/components/ui/page-shell.js";
@@ -494,6 +495,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     hasResolvedData: thread !== undefined,
     isFetching: threadDetailBootstrapQuery.isFetching || isFetching,
     isLoadingError,
+    isRecoverableLoadingError: isTransientReadError(error),
   });
   const threadOriginKind = thread?.originKind ?? thread?.childOrigin ?? null;
   const threadSourceThreadId =


### PR DESCRIPTION
## Summary
- retry transient browser read failures globally without retrying HTTP failures
- keep thread, timeline, and sidebar initial-load transport errors in loading/recovery UI instead of terminal error UI
- add regression coverage for transient read classification, connection-aware query state, and timeline refetch rendering

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/lib/query-client.test.ts src/hooks/queries/thread-queries.test.tsx src/hooks/queries/connection-aware-query-state.test.ts src/hooks/queries/query-helpers.test.ts src/components/thread/timeline/useThreadTimelineController.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app

Note: lint exits successfully and still reports the existing app warning set.