### PR TITLE
[codex] Align sidebar workflow indicator

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -101,6 +101,7 @@ function renderProjectRow(
   onToggleProjectCollapsed = vi.fn(),
   threadListState: ProjectThreadListState = { status: "ready", threads: [] },
   isActive = false,
+  collapsedEnvironmentIds: Set<string> = new Set(),
 ) {
   const onToggleEnvironmentCollapsed = vi.fn();
   const result = render(
@@ -112,7 +113,7 @@ function renderProjectRow(
         isCollapsed={false}
         compareThreads={() => 0}
         collapsedThreadIds={new Set()}
-        collapsedEnvironmentIds={new Set()}
+        collapsedEnvironmentIds={collapsedEnvironmentIds}
         isLocalPathInvalid={false}
         onToggleProjectCollapsed={onToggleProjectCollapsed}
         onToggleThreadCollapsed={vi.fn()}
@@ -215,6 +216,47 @@ describe("ProjectRow interactions", () => {
       }),
     );
     expect(onToggleEnvironmentCollapsed).toHaveBeenCalledWith("env_test");
+  });
+
+  it("shows workflow rollup instead of the generic spinner for collapsed worktree workflow activity", () => {
+    renderProjectRow(
+      vi.fn(),
+      {
+        status: "ready",
+        threads: [
+          makeThread({
+            id: "thr_worktree_workflow",
+            status: "active",
+            environmentId: "env_test",
+            environmentName: "Feature workspace",
+            environmentBranchName: "feat/menu-close",
+            environmentWorkspaceDisplayKind: "managed-worktree",
+            activity: { activeWorkflowCount: 1 },
+            runtime: {
+              displayStatus: "active",
+              hostReconnectGraceExpiresAt: null,
+            },
+          }),
+          makeThread({
+            id: "thr_worktree_sibling",
+            environmentId: "env_test",
+            environmentName: "Feature workspace",
+            environmentBranchName: "feat/menu-close",
+            environmentWorkspaceDisplayKind: "managed-worktree",
+          }),
+        ],
+      },
+      false,
+      new Set(["env_test"]),
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Expand Feature workspace threads",
+      }),
+    ).not.toBeNull();
+    expect(screen.getByLabelText("Workflow running")).not.toBeNull();
+    expect(screen.queryByLabelText("Thread working")).toBeNull();
   });
 
   it("closes the worktree actions menu after selecting rename", async () => {

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1120,8 +1120,8 @@ function EnvironmentThreadGroupHeader({
   const displayName = environmentName || branchName || "Worktree";
   const iconName: IconName = "FolderGit";
   // Collapsed: the header speaks for its hidden children through one status
-  // glyph (pending > working > unread). Expanded: the children show their own
-  // glyphs, and the synthetic header has no status of its own.
+  // glyph. Expanded: the children show their own glyphs, and the synthetic
+  // header has no status of its own.
   const showRollupGlyph =
     isCollapsed &&
     (childActivity.pending || childActivity.working || childActivity.unread);
@@ -1185,9 +1185,7 @@ function EnvironmentThreadGroupHeader({
             <ThreadStatusGlyph
               hasPendingInteraction={childActivity.pending}
               isBusy={childActivity.runtimeWorking}
-              isWorkflowActive={
-                !childActivity.runtimeWorking && childActivity.workflow
-              }
+              isWorkflowActive={childActivity.workflow}
               showUnreadBadge={childActivity.unread}
               unreadBadgeTone={childActivity.unreadError ? "error" : "default"}
             />

--- a/apps/app/src/components/sidebar/ThreadRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.stories.tsx
@@ -97,6 +97,41 @@ function UnreadDoneThreadRowCycle() {
   );
 }
 
+function WorkflowActiveThreadRow() {
+  return (
+    <StoryThreadRow
+      projectId="proj_demo"
+      thread={makeThread({
+        title: "Background workflow audit",
+        titleFallback: "Background workflow audit",
+        activity: { activeWorkflowCount: 1 },
+      })}
+      isActive={false}
+      options={defaultOption}
+    />
+  );
+}
+
+function WorkflowAndRuntimeActiveThreadRow() {
+  return (
+    <StoryThreadRow
+      projectId="proj_demo"
+      thread={makeThread({
+        title: "Workflow and foreground turn",
+        titleFallback: "Workflow and foreground turn",
+        status: "active",
+        runtime: {
+          displayStatus: "active",
+          hostReconnectGraceExpiresAt: null,
+        },
+        activity: { activeWorkflowCount: 1 },
+      })}
+      isActive={false}
+      options={defaultOption}
+    />
+  );
+}
+
 const defaultOption: ThreadRowOptions = {
   kind: "default",
   depth: 1,
@@ -217,6 +252,22 @@ export function Overview() {
             isActive={false}
             options={defaultOption}
           />
+        </SidebarStage>
+      </StoryRow>
+      <StoryRow
+        label="active workflow"
+        hint="runtime is idle, background workflow is active - far-right reserved slot shows the animated workflow glyph"
+      >
+        <SidebarStage>
+          <WorkflowActiveThreadRow />
+        </SidebarStage>
+      </StoryRow>
+      <StoryRow
+        label="active workflow + runtime"
+        hint="workflow activity wins over the generic runtime spinner so the sidebar matches the workflow banner"
+      >
+        <SidebarStage>
+          <WorkflowAndRuntimeActiveThreadRow />
         </SidebarStage>
       </StoryRow>
       <StoryRow
@@ -514,6 +565,29 @@ export function Overview() {
             isActive={false}
             options={childOption}
           />
+        </SidebarStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function ActiveWorkflow() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="active workflow"
+        hint="workflow-only activity uses the working color and SVG shimmer"
+      >
+        <SidebarStage>
+          <WorkflowActiveThreadRow />
+        </SidebarStage>
+      </StoryRow>
+      <StoryRow
+        label="active workflow + runtime"
+        hint="the workflow glyph still shows when the foreground runtime is active"
+      >
+        <SidebarStage>
+          <WorkflowAndRuntimeActiveThreadRow />
         </SidebarStage>
       </StoryRow>
     </StoryCard>

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import type { ThreadListEntry } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadRow, type ThreadRowOptions } from "./ThreadRow";
+import { SIDEBAR_WORKING_STATUS_COLOR_CLASS } from "./sidebarRowClasses";
 
 vi.mock("@/components/thread/ThreadActionsMenu", () => ({
   ThreadActionsContextMenu: ({ children }: { children: ReactNode }) => (
@@ -113,7 +114,7 @@ function renderThreadRow({
 afterEach(cleanup);
 
 describe("ThreadRow", () => {
-  it("shows a workflow glyph for an idle thread with an active workflow", () => {
+  it("shows an animated working-colored workflow glyph for an idle thread with an active workflow", () => {
     renderThreadRow({
       thread: createThread({
         title: "Workflow thread",
@@ -121,11 +122,14 @@ describe("ThreadRow", () => {
       }),
     });
 
-    expect(screen.getByLabelText("Workflow running")).not.toBeNull();
+    const workflowIcon = screen.getByLabelText("Workflow running");
+    const workflowIconClasses = Array.from(workflowIcon.classList);
+    expect(workflowIconClasses).toContain("animate-shine-icon");
+    expect(workflowIconClasses).toContain(SIDEBAR_WORKING_STATUS_COLOR_CLASS);
     expect(screen.queryByLabelText("Thread working")).toBeNull();
   });
 
-  it("keeps the spinner for active runtime work even with an active workflow", () => {
+  it("shows the workflow glyph for active workflow work even while runtime work is active", () => {
     renderThreadRow({
       thread: createThread({
         title: "Active workflow thread",
@@ -138,8 +142,8 @@ describe("ThreadRow", () => {
       }),
     });
 
-    expect(screen.getByLabelText("Thread working")).not.toBeNull();
-    expect(screen.queryByLabelText("Workflow running")).toBeNull();
+    expect(screen.getByLabelText("Workflow running")).not.toBeNull();
+    expect(screen.queryByLabelText("Thread working")).toBeNull();
   });
 
   it("renders an already-unread successful thread as a settled dot on initial load", () => {

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -206,7 +206,11 @@ export function ThreadStatusGlyph({
     return (
       <Icon
         name="Workflow"
-        className={cn("text-muted-foreground", COARSE_POINTER_ICON_SIZE_CLASS)}
+        className={cn(
+          "animate-shine-icon",
+          SIDEBAR_WORKING_STATUS_COLOR_CLASS,
+          COARSE_POINTER_ICON_SIZE_CLASS,
+        )}
         aria-label="Workflow running"
       />
     );
@@ -296,9 +300,7 @@ function ThreadRowComponent({
   const threadRuntimeBusy =
     isRuntimeBusyThread(thread) && !hasPendingInteraction;
   const threadWorkflowActive =
-    !threadRuntimeBusy &&
-    !hasPendingInteraction &&
-    hasActiveWorkflowActivity(thread);
+    !hasPendingInteraction && hasActiveWorkflowActivity(thread);
   const threadIsBusy = isBusyThread(thread) && !hasPendingInteraction;
   const showUnreadBadge =
     !hasPendingInteraction && !threadIsBusy && isUnreadDoneThread(thread);
@@ -326,7 +328,7 @@ function ThreadRowComponent({
     ? threadRuntimeBusy || childActivity.runtimeWorking
     : threadRuntimeBusy;
   const trailingIsWorkflowActive = hasHiddenChildren
-    ? !trailingRuntimeBusy && (threadWorkflowActive || childActivity.workflow)
+    ? threadWorkflowActive || childActivity.workflow
     : threadWorkflowActive;
   const trailingIsBusy = trailingRuntimeBusy;
   const trailingShowUnreadBadge = hasHiddenChildren

--- a/apps/app/src/components/sidebar/ThreadSearchResultRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadSearchResultRow.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ThreadListEntry } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadSearchResultRow } from "./ThreadSearchResultRow";
+
+function createThread(
+  overrides: Partial<ThreadListEntry> = {},
+): ThreadListEntry {
+  return {
+    id: "thr_search_result_test",
+    projectId: "proj_test",
+    environmentId: null,
+    providerId: "codex",
+    title: "Search result thread",
+    titleFallback: "Search result thread",
+    folderId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    childOrigin: null,
+    archivedAt: null,
+    pinnedAt: null,
+    pinSortKey: null,
+    deletedAt: null,
+    lastReadAt: 0,
+    latestAttentionAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    activity: { activeWorkflowCount: 0 },
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("ThreadSearchResultRow", () => {
+  it("shows workflow activity instead of the generic runtime spinner", () => {
+    render(
+      <ThreadSearchResultRow
+        id="row-workflow"
+        isActive={false}
+        matches={[]}
+        onActive={vi.fn()}
+        onSelect={vi.fn()}
+        projectName="bb"
+        thread={createThread({
+          status: "active",
+          activity: { activeWorkflowCount: 1 },
+          runtime: {
+            displayStatus: "active",
+            hostReconnectGraceExpiresAt: null,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Workflow running")).not.toBeNull();
+    expect(screen.queryByLabelText("Thread working")).toBeNull();
+  });
+});

--- a/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
@@ -136,9 +136,7 @@ function ThreadSearchResultRowComponent({
   const threadRuntimeBusy =
     isRuntimeBusyThread(thread) && !hasPendingInteraction;
   const threadWorkflowActive =
-    !threadRuntimeBusy &&
-    !hasPendingInteraction &&
-    hasActiveWorkflowActivity(thread);
+    !hasPendingInteraction && hasActiveWorkflowActivity(thread);
   const threadIsBusy = isBusyThread(thread) && !hasPendingInteraction;
   // For recents and title-only matches, the second line shows the project and
   // when the thread was last active.

--- a/apps/app/src/lib/thread-activity.test.ts
+++ b/apps/app/src/lib/thread-activity.test.ts
@@ -233,6 +233,23 @@ describe("thread-activity", () => {
       });
     });
 
+    it("keeps workflow activity visible when the same child also has runtime work", () => {
+      const workflowAndRuntimeChild = makeChild({
+        activity: { activeWorkflowCount: 1 },
+        runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+        status: "active",
+      });
+
+      expect(getCollapsedChildActivity([workflowAndRuntimeChild])).toEqual({
+        pending: false,
+        working: true,
+        runtimeWorking: true,
+        workflow: true,
+        unread: false,
+        unreadError: false,
+      });
+    });
+
     it("never flags 'unread' for parented children", () => {
       const unreadButParented = makeChild({
         latestAttentionAt: 20,

--- a/apps/app/src/lib/thread-activity.ts
+++ b/apps/app/src/lib/thread-activity.ts
@@ -31,8 +31,11 @@ export function isBusyThread(
  * The signals a collapsed parent row surfaces on behalf of its hidden children.
  * A collapsed row renders these through its single trailing status glyph, using
  * the same priority as a leaf row: failed unread work is loudest, then pending
- * user input, then unread success, then working. Expanded rows show their own
- * status, since the children are then visible with their own glyphs.
+ * user input, then workflow work, then unread success, then generic runtime
+ * work. Expanded rows show their own status, since the children are then
+ * visible with their own glyphs. Workflow work is tracked separately from
+ * runtime work so the sidebar can use the same workflow-specific signal as the
+ * prompt banner instead of collapsing it into a generic spinner.
  */
 export interface CollapsedChildActivity {
   /** At least one child is blocked on the user (needs input). */
@@ -82,13 +85,21 @@ export function getCollapsedChildActivity(
       pending = true;
       continue;
     }
-    if (isRuntimeBusyThread(thread)) {
+    const childRuntimeWorking = isRuntimeBusyThread(thread);
+    const childWorkflowActive = hasActiveWorkflowActivity(thread);
+    if (childRuntimeWorking) {
       runtimeWorking = true;
       working = true;
-    } else if (hasActiveWorkflowActivity(thread)) {
+    }
+    if (childWorkflowActive) {
       workflow = true;
       working = true;
-    } else if (isUnreadDoneThread(thread)) {
+    }
+    if (
+      !childRuntimeWorking &&
+      !childWorkflowActive &&
+      isUnreadDoneThread(thread)
+    ) {
       unread = true;
       if (thread.status === "error") {
         unreadError = true;

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -1374,6 +1374,10 @@ export function listActiveBackgroundTaskCountsByThreadIds(
       AND json_extract(active_event.data, '$.item.status') = 'pending'
       AND json_extract(active_event.data, '$.item.taskType') =
         ${LOCAL_WORKFLOW_TASK_TYPE}
+      AND COALESCE(
+        json_extract(active_event.data, '$.item.skipTranscript'),
+        0
+      ) = 0
     GROUP BY active_event.thread_id
     ORDER BY active_event.thread_id
   `);

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -3074,6 +3074,7 @@ describe("events", () => {
       itemStatus: string;
       taskStatus: string;
       taskType: string;
+      skipTranscript?: boolean;
     }) =>
       JSON.stringify({
         item: {
@@ -3083,7 +3084,7 @@ describe("events", () => {
           description: "fixture background task",
           status: args.itemStatus,
           taskStatus: args.taskStatus,
-          skipTranscript: false,
+          skipTranscript: args.skipTranscript ?? false,
         },
       });
 
@@ -3170,6 +3171,21 @@ describe("events", () => {
           itemStatus: "completed",
           taskStatus: "completed",
           taskType: LOCAL_WORKFLOW_TASK_TYPE,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 7,
+        scope: turnScope("turn-1"),
+        type: "item/started",
+        itemId: "task:wf-skip-transcript",
+        itemKind: "backgroundTask",
+        data: taskData({
+          itemId: "task:wf-skip-transcript",
+          itemStatus: "pending",
+          taskStatus: "running",
+          taskType: LOCAL_WORKFLOW_TASK_TYPE,
+          skipTranscript: true,
         }),
       },
     ]);


### PR DESCRIPTION
## Summary

Align the sidebar workflow indicator with the prompt workflow banner so visible active workflow work is represented by the workflow glyph instead of the generic loading spinner across sidebar surfaces.

## What changed

- Show the workflow glyph for active workflow activity even when the foreground runtime is also active.
- Style the workflow glyph with the loading spinner working color and `animate-shine-icon` shimmer so it visually matches active `Working...` messages.
- Apply that priority across thread rows, thread search results, and collapsed worktree rollups.
- Preserve workflow activity in collapsed child rollups when a hidden child has both runtime and workflow work.
- Exclude `skipTranscript` workflows from sidebar active workflow counts to match the banner hidden-workflow behavior.
- Add focused sidebar stories and regression tests for workflow-only and workflow-plus-runtime states.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ThreadRow.test.tsx src/lib/thread-activity.test.ts src/components/sidebar/ProjectRow.interactions.test.tsx src/components/sidebar/ThreadSearchResultRow.test.tsx`
- `pnpm exec turbo run test --filter=@bb/db -- test/data/events.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/db`
- `git diff --check`