### PR TITLE
Add dismiss action to provider CLI install toasts

### DIFF
--- a/apps/app/src/components/provider-cli/ProviderCliHealthToasts.tsx
+++ b/apps/app/src/components/provider-cli/ProviderCliHealthToasts.tsx
@@ -147,13 +147,6 @@ export function ProviderCliHealthToasts() {
 
       shownFingerprintsRef.current.add(issue.fingerprint);
       if (hasProviderCliAction(issue)) {
-        const dismissAction =
-          issue.action.kind === "update"
-            ? {
-                label: "Dismiss",
-                onClick: () => dismissIssue(issue),
-              }
-            : undefined;
         appToast.warning(issue.title, {
           id: issue.toastId,
           description: issue.description,
@@ -162,7 +155,10 @@ export function ProviderCliHealthToasts() {
             label: issue.action.label,
             onClick: () => startInstall(issue),
           },
-          ...(dismissAction ? { cancel: dismissAction } : {}),
+          cancel: {
+            label: "Dismiss",
+            onClick: () => dismissIssue(issue),
+          },
         });
       } else {
         appToast.warning(issue.title, {

--- a/apps/app/src/components/ui/sonner.stories.tsx
+++ b/apps/app/src/components/ui/sonner.stories.tsx
@@ -146,6 +146,7 @@ const TOAST_EXAMPLES: readonly ToastExample[] = [
       title: "Codex CLI not installed",
       description: "Install Codex so bb can start Codex sessions.",
       primaryActionLabel: "Install",
+      secondaryActionLabel: "Dismiss",
     },
   },
   {


### PR DESCRIPTION
## Summary
- show a Dismiss action on actionable provider CLI warning toasts, including missing CLI install prompts
- update the toast catalog missing-provider example to show the secondary dismiss action

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app