### PR TITLE
Show SVG previews in git diffs

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCard.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.tsx
@@ -1,14 +1,16 @@
-import { memo, useMemo } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useIntersectionObserver } from "usehooks-ts";
 import { cn } from "@/lib/utils";
 import {
   GitDiffCardBody,
   useGitDiffCardBody,
+  type GitDiffCardSvgDisplayMode,
   type RequestDiffFileContents,
 } from "./GitDiffCardBody";
 import {
   GitDiffCardHeader,
   GitDiffCardImageSizeStat,
+  GitDiffCardRawToggle,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
 } from "./GitDiffCardHeader";
@@ -123,6 +125,16 @@ export const GitDiffCard = memo(function GitDiffCard({
     isRendering,
     onRequestFileContents,
   });
+  const [svgDisplayMode, setSvgDisplayMode] =
+    useState<GitDiffCardSvgDisplayMode>("preview");
+  useEffect(() => {
+    setSvgDisplayMode("preview");
+  }, [fileDiff]);
+  const toggleSvgDisplayMode = () => {
+    setSvgDisplayMode((currentMode) =>
+      currentMode === "preview" ? "raw" : "preview",
+    );
+  };
   // Pure renames + identical content land here with zero hunks; nothing for the
   // body to show, so force-collapse and disable the chevron. Image preview cards
   // have a body despite their zero hunks.
@@ -176,12 +188,22 @@ export const GitDiffCard = memo(function GitDiffCard({
               )
             ) : undefined
           }
+          actionSlot={
+            bodyState.isSvgPreviewCard && !isBodyHidden ? (
+              <GitDiffCardRawToggle
+                fileLabel={bodyState.fileDiffLabel}
+                isRaw={svgDisplayMode === "raw"}
+                onToggle={toggleSvgDisplayMode}
+              />
+            ) : undefined
+          }
         />
       </div>
       {!isBodyHidden ? (
         <GitDiffCardBody
           state={bodyState}
           diffViewOptions={diffViewOptions}
+          svgDisplayMode={svgDisplayMode}
           reservesCollapseGutter={supportsCollapse}
         />
       ) : null}

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -14,12 +14,14 @@ import { Button } from "@/components/ui/button.js";
 import {
   getWrappedImageIndex,
   ImageLightbox,
+  IMAGE_TRANSPARENCY_CHECKER_STYLE,
 } from "@/components/ui/image-lightbox.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import {
   formatGitDiffFileLabel,
   enrichGitDiffFileForContext,
   isImageGitDiffFile,
+  isSvgGitDiffFile,
   normalizeGitDiffPath,
   type GitDiffFileChangeKind,
   type ParsedGitDiffFile,
@@ -50,6 +52,8 @@ export interface DiffImageSizeStat {
   addedBytes: number | null;
   removedBytes: number | null;
 }
+
+export type GitDiffCardSvgDisplayMode = "preview" | "raw";
 
 const GIT_DIFF_CARD_VIEW_STYLE = {
   "--diffs-font-size": "12px",
@@ -82,6 +86,12 @@ type DiffFileEnrichmentState =
       newImageUrl: string | null;
       oldSizeBytes: number | null;
       newSizeBytes: number | null;
+    }
+  | {
+      status: "ready-svg";
+      fileDiff: ParsedGitDiffFile;
+      oldImageUrl: string | null;
+      newImageUrl: string | null;
     }
   | { status: "unavailable" }
   | { status: "error" };
@@ -167,6 +177,23 @@ function isImagePreviewCard(
   );
 }
 
+function isSvgPreviewCard(
+  fileDiff: ParsedGitDiffFile,
+  onRequestFileContents: RequestDiffFileContents | undefined,
+): boolean {
+  return (
+    fileDiff.type !== "rename-pure" &&
+    onRequestFileContents !== undefined &&
+    isSvgGitDiffFile(fileDiff)
+  );
+}
+
+function svgTextToDataUrl(contents: string): string | null {
+  const trimmedContents = contents.trim();
+  if (trimmedContents.length === 0) return null;
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(trimmedContents)}`;
+}
+
 function getImageSizeStat(
   enrichment: DiffFileEnrichmentState,
   changeKind: GitDiffFileChangeKind,
@@ -194,6 +221,7 @@ export interface GitDiffCardBodyState {
   enrichedFileDiff: ParsedGitDiffFile;
   fileDiffLabel: string;
   isImageCard: boolean;
+  isSvgPreviewCard: boolean;
   shouldGateDeletedDiff: boolean;
   shouldRenderDiffView: boolean;
   loadDeletedDiff: () => void;
@@ -218,6 +246,7 @@ export function useGitDiffCardBody({
 }: UseGitDiffCardBodyArgs): GitDiffCardBodyState {
   const isDeletedFile = changeKind === "deleted";
   const isImageCard = isImagePreviewCard(fileDiff, onRequestFileContents);
+  const isSvgCard = isSvgPreviewCard(fileDiff, onRequestFileContents);
   const fileDiffLabel = useMemo(
     () => formatGitDiffFileLabel(fileDiff),
     [fileDiff],
@@ -252,18 +281,18 @@ export function useGitDiffCardBody({
     enrichmentStatusRef.current = "idle";
     setEnrichment({ status: "idle" });
     setHasLoadedDeletedDiff(false);
-  }, [fileContentPlan.identity]);
+  }, [fileContentPlan.identity, isImageCard, isSvgCard]);
   useEffect(() => {
     if (isBodyVisible) {
       setHasBodyEnteredViewport(true);
     }
   }, [isBodyVisible]);
   // The deleted-file gate defers the expensive text-diff renderer (and the old
-  // file fetch behind it) until the user asks for it. Image previews have no
-  // such renderer, so they load on viewport entry like added/modified images, so
-  // the header size and preview appear without a "Load diff" step.
+  // file fetch behind it) until the user asks for it. Image/SVG previews load
+  // on viewport entry like added/modified images, so the header size and
+  // preview appear without a "Load diff" step.
   const shouldGateDeletedDiff =
-    isDeletedFile && !isImageCard && !hasLoadedDeletedDiff;
+    isDeletedFile && !isImageCard && !isSvgCard && !hasLoadedDeletedDiff;
   const shouldRenderDiffView =
     hasBodyEnteredViewport && !isRendering && !shouldGateDeletedDiff;
   // Fire the fetch once the diff view is actually renderable. Effect deps
@@ -304,15 +333,26 @@ export function useGitDiffCardBody({
           setEnrichment({ status: "unavailable" });
           return;
         }
+        const enrichedFileDiff = enrichGitDiffFileForContext({
+          fileDiff,
+          oldFile: oldResult.file,
+          newFile: newResult.file,
+          patchText,
+        });
+        if (isSvgCard) {
+          enrichmentStatusRef.current = "ready-svg";
+          setEnrichment({
+            status: "ready-svg",
+            fileDiff: enrichedFileDiff,
+            oldImageUrl: svgTextToDataUrl(oldResult.file.contents),
+            newImageUrl: svgTextToDataUrl(newResult.file.contents),
+          });
+          return;
+        }
         enrichmentStatusRef.current = "ready";
         setEnrichment({
           status: "ready",
-          fileDiff: enrichGitDiffFileForContext({
-            fileDiff,
-            oldFile: oldResult.file,
-            newFile: newResult.file,
-            patchText,
-          }),
+          fileDiff: enrichedFileDiff,
         });
       })
       .catch(() => {
@@ -327,10 +367,12 @@ export function useGitDiffCardBody({
         enrichmentStatusRef.current = "idle";
       }
     };
-  }, [fileContentPlan, fileDiff, patchText, shouldRenderDiffView]);
+  }, [fileContentPlan, fileDiff, isSvgCard, patchText, shouldRenderDiffView]);
 
   const enrichedFileDiff = useMemo<ParsedGitDiffFile>(() => {
-    if (enrichment.status !== "ready") return fileDiff;
+    if (enrichment.status !== "ready" && enrichment.status !== "ready-svg") {
+      return fileDiff;
+    }
     return enrichment.fileDiff;
   }, [fileDiff, enrichment]);
 
@@ -349,6 +391,7 @@ export function useGitDiffCardBody({
     enrichedFileDiff,
     fileDiffLabel,
     isImageCard,
+    isSvgPreviewCard: isSvgCard,
     shouldGateDeletedDiff,
     shouldRenderDiffView,
     loadDeletedDiff,
@@ -404,11 +447,28 @@ function getGitDiffCardImageAlt(
 interface GitDiffCardImageBodyProps {
   enrichment: DiffFileEnrichmentState;
   fileDiffLabel: string;
+  fitToFrame?: boolean;
+}
+
+function getGitDiffCardImageUrls(
+  enrichment: DiffFileEnrichmentState,
+): { oldImageUrl: string | null; newImageUrl: string | null } | null {
+  if (
+    enrichment.status !== "ready-image" &&
+    enrichment.status !== "ready-svg"
+  ) {
+    return null;
+  }
+  return {
+    oldImageUrl: enrichment.oldImageUrl,
+    newImageUrl: enrichment.newImageUrl,
+  };
 }
 
 function GitDiffCardImageBody({
   enrichment,
   fileDiffLabel,
+  fitToFrame = false,
 }: GitDiffCardImageBodyProps) {
   const [expandedImageIndex, setExpandedImageIndex] = useState<number | null>(
     null,
@@ -416,7 +476,8 @@ function GitDiffCardImageBody({
   if (enrichment.status === "idle" || enrichment.status === "loading") {
     return <GitDiffCardBodySkeleton />;
   }
-  if (enrichment.status !== "ready-image") {
+  const imageUrls = getGitDiffCardImageUrls(enrichment);
+  if (imageUrls === null) {
     return (
       <div className="px-3 py-3 text-xs text-muted-foreground">
         No preview available for this image.
@@ -424,9 +485,16 @@ function GitDiffCardImageBody({
     );
   }
   const imageSides = buildGitDiffCardImageSides(
-    enrichment.oldImageUrl,
-    enrichment.newImageUrl,
+    imageUrls.oldImageUrl,
+    imageUrls.newImageUrl,
   );
+  if (imageSides.length === 0) {
+    return (
+      <div className="px-3 py-3 text-xs text-muted-foreground">
+        No preview available for this image.
+      </div>
+    );
+  }
   const expandedImageSide =
     expandedImageIndex === null ? undefined : imageSides[expandedImageIndex];
   const stepExpandedImage = (direction: "previous" | "next") => {
@@ -442,18 +510,35 @@ function GitDiffCardImageBody({
   };
   return (
     <>
-      <div className="flex items-start gap-3 px-3 py-3">
+      <div
+        className={
+          fitToFrame
+            ? imageSides.length > 1
+              ? "grid grid-cols-1 gap-3 px-3 py-3 sm:grid-cols-2"
+              : "grid grid-cols-1 gap-3 px-3 py-3"
+            : "flex items-start gap-3 px-3 py-3"
+        }
+      >
         {imageSides.map((side, index) => (
           <figure key={side.url} className="min-w-0">
             <button
               type="button"
-              className="block max-w-full cursor-zoom-in"
+              className={
+                fitToFrame
+                  ? "flex h-64 w-full cursor-zoom-in items-center justify-center rounded-md border border-border bg-surface-recessed p-3"
+                  : "block max-w-full cursor-zoom-in"
+              }
               onClick={() => setExpandedImageIndex(index)}
             >
               <img
                 src={side.url}
                 alt={getGitDiffCardImageAlt(fileDiffLabel, side)}
-                className="block max-h-80 max-w-full rounded-md border border-border object-contain"
+                style={IMAGE_TRANSPARENCY_CHECKER_STYLE}
+                className={
+                  fitToFrame
+                    ? "block h-full w-full object-contain"
+                    : "block max-h-80 max-w-full rounded-md border border-border object-contain"
+                }
               />
             </button>
             {side.caption !== null ? (
@@ -481,9 +566,57 @@ function GitDiffCardImageBody({
   );
 }
 
+interface GitDiffCardRawDiffBodyProps {
+  fileDiff: ParsedGitDiffFile;
+  fileDiffOptions: Record<string, string | boolean | number>;
+}
+
+function GitDiffCardRawDiffBody({
+  fileDiff,
+  fileDiffOptions,
+}: GitDiffCardRawDiffBodyProps) {
+  return (
+    <div className="overflow-x-auto">
+      <div className="w-full max-w-full" style={GIT_DIFF_CARD_VIEW_STYLE}>
+        <DiffView fileDiff={fileDiff} options={fileDiffOptions} />
+      </div>
+    </div>
+  );
+}
+
+interface GitDiffCardSvgBodyProps {
+  displayMode: GitDiffCardSvgDisplayMode;
+  enrichment: DiffFileEnrichmentState;
+  fileDiff: ParsedGitDiffFile;
+  fileDiffLabel: string;
+  fileDiffOptions: Record<string, string | boolean | number>;
+}
+
+function GitDiffCardSvgBody({
+  displayMode,
+  enrichment,
+  fileDiff,
+  fileDiffLabel,
+  fileDiffOptions,
+}: GitDiffCardSvgBodyProps) {
+  return displayMode === "preview" ? (
+    <GitDiffCardImageBody
+      enrichment={enrichment}
+      fileDiffLabel={fileDiffLabel}
+      fitToFrame
+    />
+  ) : (
+    <GitDiffCardRawDiffBody
+      fileDiff={fileDiff}
+      fileDiffOptions={fileDiffOptions}
+    />
+  );
+}
+
 export interface GitDiffCardBodyProps {
   state: GitDiffCardBodyState;
   diffViewOptions: Record<string, string | boolean | number>;
+  svgDisplayMode: GitDiffCardSvgDisplayMode;
   /**
    * Whether the surrounding card reserves a collapse-chevron gutter. The deleted
    * file message aligns to that gutter so its text lines up with the diff body.
@@ -495,14 +628,15 @@ export interface GitDiffCardBodyProps {
  * The single shared diff-card body for both the timeline ({@link GitDiffCard})
  * and the diff tab (`DiffFileCard`). It renders the lazily-enriched
  * `@pierre/diffs` `FileDiff` (with context expansion), the deleted-file load
- * gate, the in-viewport render skeleton, and — for binary image changes — the
- * inline `<img>` preview with its lightbox. The data layer lives in
- * {@link useGitDiffCardBody}; both callers feed its result in as `state` so the
- * card can also read the image header stat synchronously.
+ * gate, the in-viewport render skeleton, and inline `<img>` previews for binary
+ * image changes or SVGs. The data layer lives in {@link useGitDiffCardBody};
+ * both callers feed its result in as `state` so the card can also read the image
+ * header stat synchronously.
  */
 export function GitDiffCardBody({
   state,
   diffViewOptions,
+  svgDisplayMode,
   reservesCollapseGutter,
 }: GitDiffCardBodyProps) {
   const {
@@ -511,6 +645,7 @@ export function GitDiffCardBody({
     enrichedFileDiff,
     fileDiffLabel,
     isImageCard,
+    isSvgPreviewCard,
     shouldGateDeletedDiff,
     shouldRenderDiffView,
     loadDeletedDiff,
@@ -551,12 +686,19 @@ export function GitDiffCardBody({
           enrichment={enrichment}
           fileDiffLabel={fileDiffLabel}
         />
+      ) : isSvgPreviewCard ? (
+        <GitDiffCardSvgBody
+          displayMode={svgDisplayMode}
+          enrichment={enrichment}
+          fileDiff={enrichedFileDiff}
+          fileDiffLabel={fileDiffLabel}
+          fileDiffOptions={fileDiffOptions}
+        />
       ) : (
-        <div className="overflow-x-auto">
-          <div className="w-full max-w-full" style={GIT_DIFF_CARD_VIEW_STYLE}>
-            <DiffView fileDiff={enrichedFileDiff} options={fileDiffOptions} />
-          </div>
-        </div>
+        <GitDiffCardRawDiffBody
+          fileDiff={enrichedFileDiff}
+          fileDiffOptions={fileDiffOptions}
+        />
       )}
     </div>
   );

--- a/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
@@ -55,6 +55,8 @@ export interface GitDiffCardHeaderProps {
    * swap has no line counts to tally.
    */
   statSlot?: ReactNode;
+  /** Small controls rendered beside the stats, such as the SVG raw toggle. */
+  actionSlot?: ReactNode;
 }
 
 const BYTES_PER_UNIT = 1024;
@@ -96,6 +98,34 @@ export function GitDiffCardImageSizeStat({
   );
 }
 
+export interface GitDiffCardRawToggleProps {
+  fileLabel: string;
+  isRaw: boolean;
+  onToggle: () => void;
+}
+
+export function GitDiffCardRawToggle({
+  fileLabel,
+  isRaw,
+  onToggle,
+}: GitDiffCardRawToggleProps) {
+  const label = isRaw
+    ? `Show image preview for ${fileLabel}`
+    : `Show raw SVG diff for ${fileLabel}`;
+  return (
+    <button
+      type="button"
+      className="inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring aria-pressed:bg-state-active aria-pressed:text-foreground"
+      onClick={onToggle}
+      aria-label={label}
+      aria-pressed={isRaw}
+      title={label}
+    >
+      <Icon name="Code" aria-hidden className="size-3.5" />
+    </button>
+  );
+}
+
 /**
  * Returns the old/new path pair to render as a `from -> to` rename affordance,
  * or null when the file is not a rename/copy. Renames and copies both carry a
@@ -124,6 +154,7 @@ export function GitDiffCardHeader({
   onToggleCollapsed,
   hasChanges,
   statSlot,
+  actionSlot,
 }: GitDiffCardHeaderProps) {
   const isAddedFile = model.changeKind === "added";
   const isDeletedFile = model.changeKind === "deleted";
@@ -226,6 +257,7 @@ export function GitDiffCardHeader({
         </span>
       </span>
       <span className="flex shrink-0 items-center gap-1">
+        {actionSlot}
         {statSlot ?? (
           <DiffStatsTally
             insertions={headerInsertions}

--- a/apps/app/src/components/git-diff/git-diff-parsing.ts
+++ b/apps/app/src/components/git-diff/git-diff-parsing.ts
@@ -1,8 +1,4 @@
-import {
-  parsePatchFiles,
-  processFile,
-  type FileContents,
-} from "@pierre/diffs";
+import { parsePatchFiles, processFile, type FileContents } from "@pierre/diffs";
 import type { GitDiffFileChangeKind } from "@bb/server-contract";
 
 export type ParsedGitDiffFile = ReturnType<
@@ -149,10 +145,10 @@ export function normalizeGitDiffPath(
   return trimmedPath && trimmedPath.length > 0 ? trimmedPath : undefined;
 }
 
-// Browser-renderable raster formats only. SVG is deliberately absent. SVG
-// diffs arrive as regular text hunks, which are more informative than a
-// rendered preview. TIFF/HEIC are absent because `<img>` can't render them
-// in every browser we support.
+// Browser-renderable raster formats only. SVG diffs arrive as regular text
+// hunks, so SVG preview support is handled separately and keeps a raw toggle.
+// TIFF/HEIC are absent because `<img>` can't render them in every browser we
+// support.
 const IMAGE_GIT_DIFF_FILE_EXTENSIONS: ReadonlySet<string> = new Set([
   "avif",
   "bmp",
@@ -170,6 +166,11 @@ export function isImageGitDiffFile(file: ParsedGitDiffFile): boolean {
   return (
     extension !== undefined && IMAGE_GIT_DIFF_FILE_EXTENSIONS.has(extension)
   );
+}
+
+export function isSvgGitDiffFile(file: ParsedGitDiffFile): boolean {
+  const path = normalizeGitDiffPath(file.name) ?? file.name;
+  return path.toLowerCase().endsWith(".svg");
 }
 
 function getGitDiffPathAliases(path: string | undefined): string[] {

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -1,17 +1,20 @@
-import { memo, useMemo } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useIntersectionObserver } from "usehooks-ts";
 import type { DiffFileEntry } from "@bb/server-contract";
 import {
   GitDiffCardBody,
   useGitDiffCardBody,
+  type GitDiffCardSvgDisplayMode,
   type RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import {
   GitDiffCardHeader,
+  GitDiffCardRawToggle,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
 } from "@/components/git-diff/GitDiffCardHeader";
 import {
+  isSvgGitDiffFile,
   parseGitDiffFiles,
   type ParsedGitDiffFile,
 } from "@/components/git-diff/git-diff-parsing";
@@ -129,10 +132,7 @@ export const DiffFileCard = memo(function DiffFileCard({
   onOpenFilePreview,
   onRequestFileContents,
 }: DiffFileCardProps) {
-  const headerModel = useMemo(
-    () => buildDiffEntryHeaderModel(entry),
-    [entry],
-  );
+  const headerModel = useMemo(() => buildDiffEntryHeaderModel(entry), [entry]);
   // The single file's patch, parsed only once it has loaded. The patch hook
   // returns whole-file patch text; we parse just this file (not a blob).
   const parsedFile = useMemo<ParsedGitDiffFile | null>(() => {
@@ -141,8 +141,24 @@ export const DiffFileCard = memo(function DiffFileCard({
     }
     return parseGitDiffFiles(patchState.patch)[0] ?? null;
   }, [patchState.patch, patchState.status]);
+  const [svgDisplayMode, setSvgDisplayMode] =
+    useState<GitDiffCardSvgDisplayMode>("preview");
+  useEffect(() => {
+    setSvgDisplayMode("preview");
+  }, [entry.path, entry.previousPath, patchState.patch]);
+  const toggleSvgDisplayMode = () => {
+    setSvgDisplayMode((currentMode) =>
+      currentMode === "preview" ? "raw" : "preview",
+    );
+  };
   const changedLines = entry.additions + entry.deletions;
   const isBodyHidden = isCollapsed;
+  const supportsSvgRawToggle =
+    !isBodyHidden &&
+    parsedFile !== null &&
+    parsedFile.type !== "rename-pure" &&
+    onRequestFileContents !== undefined &&
+    isSvgGitDiffFile(parsedFile);
 
   // Detect when this card's sticky header is pinned to the panel top: a
   // zero-height sentinel sits just above the header, so once it scrolls out of
@@ -185,6 +201,15 @@ export const DiffFileCard = memo(function DiffFileCard({
           isCollapsed={isCollapsed}
           onToggleCollapsed={onToggleCollapsed}
           hasChanges
+          actionSlot={
+            supportsSvgRawToggle ? (
+              <GitDiffCardRawToggle
+                fileLabel={headerModel.label}
+                isRaw={svgDisplayMode === "raw"}
+                onToggle={toggleSvgDisplayMode}
+              />
+            ) : undefined
+          }
         />
       </div>
       {isBodyHidden ? null : (
@@ -194,6 +219,7 @@ export const DiffFileCard = memo(function DiffFileCard({
           diffViewOptions={diffViewOptions}
           parsedFile={parsedFile}
           patchState={patchState}
+          svgDisplayMode={svgDisplayMode}
           onLoadPatch={onLoadPatch}
           onRetry={onRetry}
           onOpenFilePreview={onOpenFilePreview}
@@ -210,6 +236,7 @@ interface DiffFileCardBodyProps {
   diffViewOptions: Record<string, string | boolean | number>;
   parsedFile: ParsedGitDiffFile | null;
   patchState: DiffPatchState;
+  svgDisplayMode: GitDiffCardSvgDisplayMode;
   onLoadPatch: () => void;
   onRetry: () => void;
   onOpenFilePreview?: (path: string) => void;
@@ -225,6 +252,7 @@ function DiffFileCardBody({
   diffViewOptions,
   parsedFile,
   patchState,
+  svgDisplayMode,
   onLoadPatch,
   onRetry,
   onOpenFilePreview,
@@ -328,6 +356,7 @@ function DiffFileCardBody({
       parsedFile={parsedFile}
       patchText={patchState.truncated ? undefined : patchState.patch}
       diffViewOptions={diffViewOptions}
+      svgDisplayMode={svgDisplayMode}
       truncated={patchState.truncated ?? false}
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
@@ -340,6 +369,7 @@ interface DiffFileCardRenderedBodyProps {
   parsedFile: ParsedGitDiffFile;
   patchText?: string;
   diffViewOptions: Record<string, string | boolean | number>;
+  svgDisplayMode: GitDiffCardSvgDisplayMode;
   truncated: boolean;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
@@ -357,6 +387,7 @@ function DiffFileCardRenderedBody({
   parsedFile,
   patchText,
   diffViewOptions,
+  svgDisplayMode,
   truncated,
   onOpenFilePreview,
   onRequestFileContents,
@@ -373,6 +404,7 @@ function DiffFileCardRenderedBody({
       <GitDiffCardBody
         state={bodyState}
         diffViewOptions={diffViewOptions}
+        svgDisplayMode={svgDisplayMode}
         reservesCollapseGutter
       />
       {truncated ? (

--- a/apps/app/src/components/secondary-panel/git-diff/useDiffFileContentsRequester.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useDiffFileContentsRequester.ts
@@ -111,7 +111,8 @@ function buildDiffFileTarget(
 }
 
 // Browser-renderable raster image MIME types. Mirrors the extension allowlist
-// in `isImageGitDiffFile` (SVG is text, so it diffs as hunks, not a preview).
+// in `isImageGitDiffFile`. SVG remains a text result; the card converts that
+// text into a preview data URL while keeping the raw diff toggle available.
 const PREVIEWABLE_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set([
   "image/avif",
   "image/bmp",
@@ -125,10 +126,11 @@ const PREVIEWABLE_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * Map a `/diff/file` response into the card's `DiffFileContentsResult`. UTF-8
- * content becomes a `text` side @pierre/diffs can expand context from. A base64
- * blob with a browser-renderable image MIME type becomes an `image` side the
- * card previews inline (with its byte size for the header `+/-` delta). Anything
- * else (binary, non-image) yields `null` so the card leaves that side blank.
+ * content becomes a `text` side @pierre/diffs can expand context from and, for
+ * SVG files, preview inline. A base64 blob with a browser-renderable image MIME
+ * type becomes an `image` side the card previews inline (with its byte size for
+ * the header `+/-` delta). Anything else (binary, non-image) yields `null` so
+ * the card leaves that side blank.
  */
 function toDiffFileContentsResult(
   path: string,

--- a/apps/app/src/components/ui/image-lightbox.tsx
+++ b/apps/app/src/components/ui/image-lightbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, type CSSProperties } from "react";
 import { Button } from "./button.js";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "./dialog.js";
 import { Icon } from "@/components/ui/icon.js";
@@ -10,6 +10,17 @@ export const imageLightboxKeyActionValues = [
 ] as const;
 export type ImageLightboxKeyAction =
   (typeof imageLightboxKeyActionValues)[number];
+
+const IMAGE_TRANSPARENCY_CHECKER_BASE =
+  "color-mix(in oklch, var(--ink) 5%, var(--canvas))";
+const IMAGE_TRANSPARENCY_CHECKER_MARK =
+  "color-mix(in oklch, var(--ink) 14%, var(--canvas))";
+
+export const IMAGE_TRANSPARENCY_CHECKER_STYLE: CSSProperties = {
+  backgroundColor: IMAGE_TRANSPARENCY_CHECKER_BASE,
+  backgroundImage: `conic-gradient(${IMAGE_TRANSPARENCY_CHECKER_MARK} 25%, ${IMAGE_TRANSPARENCY_CHECKER_BASE} 0 50%, ${IMAGE_TRANSPARENCY_CHECKER_MARK} 0 75%, ${IMAGE_TRANSPARENCY_CHECKER_BASE} 0)`,
+  backgroundSize: "16px 16px",
+};
 
 export interface ImageLightboxKeyActionInput {
   event: Pick<
@@ -140,6 +151,7 @@ export function ImageLightbox({
   return (
     <Dialog open={true} onOpenChange={(open) => !open && onClose()}>
       <DialogContent
+        aria-describedby={undefined}
         className="left-0 top-0 flex h-screen w-screen max-w-none translate-x-0 translate-y-0 items-center justify-center border-none bg-transparent p-0 shadow-none data-[state=closed]:slide-out-to-left-0 data-[state=closed]:slide-out-to-top-0 data-[state=open]:slide-in-from-left-0 data-[state=open]:slide-in-from-top-0 sm:rounded-none [&>button]:hidden"
         onClick={(event) => {
           if (event.target === event.currentTarget) {
@@ -151,7 +163,8 @@ export function ImageLightbox({
         <img
           src={imageSrc}
           alt={imageAlt}
-          className="max-h-[82vh] max-w-[90vw] rounded bg-background object-contain"
+          style={IMAGE_TRANSPARENCY_CHECKER_STYLE}
+          className="max-h-[82vh] max-w-[90vw] rounded object-contain"
         />
 
         {hasNavigation ? (


### PR DESCRIPTION
## Summary
- render SVG git diffs as image previews by default while keeping raw diff available behind a compact code icon
- share the checkered transparency background between SVG previews and the image lightbox
- keep SVG preview panes constrained so transparent/vector assets do not stretch the diff card

## Tests
- pnpm exec prettier --check apps/app/src/components/git-diff/GitDiffCard.tsx apps/app/src/components/git-diff/GitDiffCardHeader.tsx apps/app/src/components/git-diff/GitDiffCardBody.tsx apps/app/src/components/git-diff/git-diff-parsing.ts apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx apps/app/src/components/secondary-panel/git-diff/useDiffFileContentsRequester.ts apps/app/src/components/ui/image-lightbox.tsx
- pnpm exec turbo run test --filter=@bb/app -- src/components/git-diff/git-diff-parsing.test.ts src/components/ui/image-lightbox.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app