### PR TITLE
Inherit user bb skills in dev

### DIFF
--- a/apps/server/src/services/skills/injected-skills.ts
+++ b/apps/server/src/services/skills/injected-skills.ts
@@ -321,7 +321,7 @@ function excludeOverriddenLowerPriorityUserSources(
         name: source.name,
         sourceRootPath: source.sourceRootPath,
       },
-      "Inherited injected skill overridden by data-dir skill",
+      "Lower-priority injected skill overridden by higher-priority skill",
     );
     return false;
   });
@@ -360,8 +360,8 @@ function excludeCollisions(
 /**
  * Discovers the injected skills for a thread command from built-in skills
  * bundled with the server and data-dir skills under `<dataDir>/skills`.
- * User data-dir skills override same-named built-ins; name collisions among
- * user sources drop all colliding user sources.
+ * User data-dir skills override inherited and built-in skills. Inherited roots
+ * are ordered by priority, so earlier roots override later roots.
  *
  * All source paths are server-machine paths that the local host daemon reads
  * from its filesystem.
@@ -389,7 +389,7 @@ export function resolveInjectedSkillSources(
     skillsRootPath: resolveDataDirSkillsRootPath(args.dataDir),
     sourceType: "data-dir",
   });
-  const inheritedSources = (args.additionalSkillsRootPaths ?? []).flatMap(
+  const inheritedSourceGroups = (args.additionalSkillsRootPaths ?? []).map(
     (skillsRootPath) =>
       readSkillsRoot({
         logger,
@@ -398,13 +398,18 @@ export function resolveInjectedSkillSources(
       }),
   );
 
-  const userSources = [
-    ...dataDirSources,
-    ...excludeOverriddenLowerPriorityUserSources(logger, {
-      higherPrioritySources: dataDirSources,
-      lowerPrioritySources: inheritedSources,
-    }),
-  ];
+  const userSources = inheritedSourceGroups.reduce<
+    HostDaemonInjectedSkillSource[]
+  >(
+    (higherPrioritySources, lowerPrioritySources) => [
+      ...higherPrioritySources,
+      ...excludeOverriddenLowerPriorityUserSources(logger, {
+        higherPrioritySources,
+        lowerPrioritySources,
+      }),
+    ],
+    dataDirSources,
+  );
   const activeBuiltinSources = excludeOverriddenBuiltins(logger, {
     builtinSources,
     userSources,

--- a/apps/server/test/skills/injected-skills.test.ts
+++ b/apps/server/test/skills/injected-skills.test.ts
@@ -323,7 +323,49 @@ describe("injected skill source discovery", () => {
     expect(warnings).toEqual([]);
     expect(infos).toEqual([
       expect.objectContaining({
-        message: "Inherited injected skill overridden by data-dir skill",
+        message:
+          "Lower-priority injected skill overridden by higher-priority skill",
+      }),
+    ]);
+  });
+
+  it("lets earlier inherited skill roots override later inherited roots", async () => {
+    const dataDir = await makeTempDir();
+    const parentSkillsRootPath = path.join(dataDir, "parent-skills");
+    const prodSkillsRootPath = path.join(dataDir, "prod-skills");
+    const builtinSkillsRootPath = path.join(dataDir, "builtin-skills");
+    const parentSkillRoot = await writeSkill({
+      rootPath: parentSkillsRootPath,
+      name: "stories",
+      description: "Parent stories skill.",
+    });
+    await writeSkill({
+      rootPath: prodSkillsRootPath,
+      name: "stories",
+      description: "Prod stories skill.",
+    });
+    const { logger, infos, warnings } = createCapturingLogger();
+
+    const sources = await resolveInjectedSkillSources(logger, {
+      additionalSkillsRootPaths: [parentSkillsRootPath, prodSkillsRootPath],
+      builtinSkillsRootPath,
+      dataDir,
+    });
+
+    expect(sources).toEqual([
+      {
+        sourceType: "data-dir",
+        name: "stories",
+        description: "Parent stories skill.",
+        sourceRootPath: parentSkillRoot,
+        skillFilePath: path.join(parentSkillRoot, "SKILL.md"),
+      },
+    ]);
+    expect(warnings).toEqual([]);
+    expect(infos).toEqual([
+      expect.objectContaining({
+        message:
+          "Lower-priority injected skill overridden by higher-priority skill",
       }),
     ]);
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,13 @@ No agent loads `.bb/AGENTS.md` natively, and provider-native instruction files
 provider-specific. bb reads the files above itself and injects them, so use them
 for guidance you want every bb thread to receive regardless of provider.
 
+## Skills
+
+User-level bb skills live under `<dataDir>/skills/<name>/SKILL.md`; for the
+packaged app this is usually `~/.bb/skills`. Project skills live under
+`<workspace>/.bb/skills/<name>/SKILL.md` and override same-named user or built-in
+skills.
+
 ## Startup Flags
 
 Use launcher flags for per-run startup details:

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -226,7 +226,7 @@ export const BB_CLI_DIR_ENV = defineEnvVar<string | undefined>({
 
 export const BB_INHERITED_SKILLS_ROOTS_ENV = defineEnvVar<string[]>({
   description:
-    "Development-only path list of inherited bb skill roots for managed worktree dev apps",
+    "Development-only path list of lower-priority inherited bb skill roots",
   name: "BB_INHERITED_SKILLS_ROOTS",
   parse: parsePathListEnvValue,
 });

--- a/packages/config/src/runtime.ts
+++ b/packages/config/src/runtime.ts
@@ -12,6 +12,7 @@ export interface DevPortSet {
 
 export interface DevInstanceConfig {
   dataDir: string;
+  homeDir: string;
   instanceId: string;
   ports: DevPortSet;
   repoRoot: string;
@@ -29,6 +30,7 @@ export interface DevProcessEnvArgs {
 }
 
 export interface ResolveInheritedDevSkillsRootPathsArgs {
+  homeDir: string;
   repoRoot: string;
 }
 
@@ -195,6 +197,7 @@ export function resolveDevInstanceConfig(
   const serverUrl = `http://localhost:${ports.serverPort}`;
   return {
     dataDir,
+    homeDir: args.homeDir,
     instanceId,
     ports,
     repoRoot: args.repoRoot,
@@ -214,18 +217,19 @@ export function resolveCurrentDevInstanceConfig(
 export function resolveInheritedDevSkillsRootPaths(
   args: ResolveInheritedDevSkillsRootPathsArgs,
 ): string[] {
+  const roots = [join(resolveProdDataDir({ homeDir: args.homeDir }), "skills")];
   const segments = resolve(args.repoRoot).split(/[\\/]+/u);
   const worktreesIndex = segments.lastIndexOf(MANAGED_WORKTREE_DIR_NAME);
   if (worktreesIndex <= 0) {
-    return [];
+    return roots;
   }
 
   const parentDataDir = segments.slice(0, worktreesIndex).join("/");
   if (parentDataDir.length === 0) {
-    return [];
+    return roots;
   }
 
-  return [join(parentDataDir, "skills")];
+  return Array.from(new Set([join(parentDataDir, "skills"), ...roots]));
 }
 
 export function resolveRuntimeDataDir(args: ResolveRuntimeDataDirArgs): string {
@@ -294,6 +298,7 @@ export function toDevProcessEnv(args: DevProcessEnvArgs): NodeJS.ProcessEnv {
     delete env[key];
   }
   const inheritedSkillsRootPaths = resolveInheritedDevSkillsRootPaths({
+    homeDir: args.config.homeDir,
     repoRoot: args.config.repoRoot,
   });
   return {

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -510,7 +510,7 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
   "hostDaemonOnlineRpcCommandSchema.acpLaunchSpec.modelCli.selectFlag":
     "dynamic ACP model selection omits selectFlag when the agent cannot pin a model at launch.",
   "hostDaemonOnlineRpcCommandSchema.additionalSkillsRootPaths":
-    "host.list_commands includes inherited skill roots only for managed dev-app worktrees; ordinary instances scan data-dir and built-in skills.",
+    "host.list_commands may include inherited skill roots for source-dev app instances; ordinary app instances scan data-dir and built-in skills.",
   "hostDaemonOnlineRpcCommandSchema.query":
     "host.list_files may omit a search string to list files without filtering.",
   "hostDaemonOnlineRpcCommandSchema.path":

--- a/packages/scripts/test/run-dev.test.ts
+++ b/packages/scripts/test/run-dev.test.ts
@@ -100,33 +100,56 @@ describe("run-dev", () => {
   });
 
   it("inherits parent bb skills for managed worktree dev apps", () => {
+    const homeDir = "/Users/tester";
     const repoRoot =
       "/Users/tester/.bb-dev/code-bb-abc123/worktrees/env_feature/bb";
     const config = resolveDevInstanceConfig({
-      homeDir: "/Users/tester",
+      homeDir,
       repoRoot,
     });
 
-    expect(resolveInheritedDevSkillsRootPaths({ repoRoot })).toEqual([
+    const inheritedSkillsRootPaths = [
       "/Users/tester/.bb-dev/code-bb-abc123/skills",
-    ]);
+      "/Users/tester/.bb/skills",
+    ];
+    expect(resolveInheritedDevSkillsRootPaths({ homeDir, repoRoot })).toEqual(
+      inheritedSkillsRootPaths,
+    );
     expect(toDevProcessEnv({ baseEnv: {}, config })).toMatchObject({
-      BB_INHERITED_SKILLS_ROOTS:
-        "/Users/tester/.bb-dev/code-bb-abc123/skills",
+      BB_INHERITED_SKILLS_ROOTS: inheritedSkillsRootPaths.join(path.delimiter),
     });
   });
 
-  it("does not inherit bb skills for ordinary checkout dev apps", () => {
-    const repoRoot = "/Users/tester/src/bb";
+  it("dedupes inherited bb skills for prod-managed worktree dev apps", () => {
+    const homeDir = "/Users/tester";
+    const repoRoot = "/Users/tester/.bb/worktrees/env_feature/bb";
     const config = resolveDevInstanceConfig({
-      homeDir: "/Users/tester",
+      homeDir,
       repoRoot,
     });
 
-    expect(resolveInheritedDevSkillsRootPaths({ repoRoot })).toEqual([]);
-    expect(
-      toDevProcessEnv({ baseEnv: {}, config }).BB_INHERITED_SKILLS_ROOTS,
-    ).toBeUndefined();
+    expect(resolveInheritedDevSkillsRootPaths({ homeDir, repoRoot })).toEqual([
+      "/Users/tester/.bb/skills",
+    ]);
+    expect(toDevProcessEnv({ baseEnv: {}, config })).toMatchObject({
+      BB_INHERITED_SKILLS_ROOTS: "/Users/tester/.bb/skills",
+    });
+  });
+
+  it("inherits prod bb skills for ordinary checkout dev apps", () => {
+    const homeDir = "/Users/tester";
+    const repoRoot = "/Users/tester/src/bb";
+    const config = resolveDevInstanceConfig({
+      homeDir,
+      repoRoot,
+    });
+
+    expect(resolveInheritedDevSkillsRootPaths({ homeDir, repoRoot })).toEqual([
+      "/Users/tester/.bb/skills",
+    ]);
+    expect(toDevProcessEnv({ baseEnv: {}, config })).toMatchObject({
+      BB_INHERITED_SKILLS_ROOTS: "/Users/tester/.bb/skills",
+    });
   });
 
   it("strips parent thread context from dev child processes", () => {


### PR DESCRIPTION
## Summary
- inherit ~/.bb/skills into source-dev app instances so personal bb skills show up in dev typeahead and runtime injection
- preserve override priority for dev instance skills and ordered inherited roots
- document the behavior in configuration docs, the bb guide, and the bb-cli skill

## Tests
- pnpm exec turbo run test --filter=@bb/config --filter=@bb/scripts --filter=@bb/server --filter=@bb/host-daemon-contract --filter=@bb/templates
- pnpm exec turbo run typecheck --filter=@bb/config --filter=@bb/scripts --filter=@bb/server --filter=@bb/host-daemon-contract --filter=@bb/templates
- git diff --check