### PR TITLE
Speed up native module ABI repairs

### DIFF
--- a/packages/scripts/test/ensure-native-modules.test.mjs
+++ b/packages/scripts/test/ensure-native-modules.test.mjs
@@ -34,11 +34,19 @@ function createBetterSqliteRequire(initialError) {
   }
 
   requireModule.resolve = (request) => {
-    if (request !== "better-sqlite3/package.json") {
-      throw new Error(`Unexpected resolve: ${request}`);
+    if (request === "better-sqlite3/package.json") {
+      return "/tmp/fake-node-modules/better-sqlite3/package.json";
     }
 
-    return "/tmp/fake-node-modules/better-sqlite3/package.json";
+    if (request === "prebuild-install/bin.js") {
+      return "/tmp/fake-node-modules/prebuild-install/bin.js";
+    }
+
+    if (request === "node-gyp/bin/node-gyp.js") {
+      return "/tmp/fake-node-modules/node-gyp/bin/node-gyp.js";
+    }
+
+    throw new Error(`Unexpected resolve: ${request}`);
   };
 
   return {
@@ -50,14 +58,14 @@ function createBetterSqliteRequire(initialError) {
   };
 }
 
-function createEnsureOptions(fakeRequire, execSync) {
+function createEnsureOptions(fakeRequire, execFileSync) {
   return {
     repoRoot: "/repo",
     modules: [
       { name: "better-sqlite3", resolveFrom: "packages/db/package.json" },
     ],
     createRequire: () => fakeRequire,
-    execSync,
+    execFileSync,
     log: vi.fn(),
   };
 }
@@ -77,44 +85,166 @@ describe("ensure-native-modules", () => {
     expect(state.constructorCalls).toBe(1);
   });
 
-  it("rechecks better-sqlite3 after a rebuild succeeds", () => {
+  it("rechecks better-sqlite3 after installing a prebuilt binary", () => {
     const abiError = new Error(
       "The module was compiled against a different NODE_MODULE_VERSION",
     );
     const fake = createBetterSqliteRequire(abiError);
-    const execSync = vi.fn(() => {
+    const execFileSync = vi.fn(() => {
       fake.clearConstructorError();
     });
 
     expect(() =>
-      ensureNativeModules(createEnsureOptions(fake.requireModule, execSync)),
+      ensureNativeModules(
+        createEnsureOptions(fake.requireModule, execFileSync),
+      ),
     ).not.toThrow();
 
-    expect(execSync).toHaveBeenCalledWith("npx --yes node-gyp rebuild", {
-      cwd: "/tmp/fake-node-modules/better-sqlite3",
-      stdio: "inherit",
-    });
+    expect(execFileSync).toHaveBeenCalledWith(
+      process.execPath,
+      ["/tmp/fake-node-modules/prebuild-install/bin.js"],
+      expect.objectContaining({
+        cwd: "/tmp/fake-node-modules/better-sqlite3",
+        encoding: "utf8",
+        env: expect.objectContaining({ npm_config_loglevel: "info" }),
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+    expect(execFileSync).toHaveBeenCalledTimes(1);
     expect(fake.state.constructorCalls).toBe(2);
   });
 
-  it("rebuilds better-sqlite3 when the native binding is missing", () => {
+  it("accepts a prebuilt binary that loads after the installer exits non-zero", () => {
+    const abiError = new Error(
+      "The module was compiled against a different NODE_MODULE_VERSION",
+    );
+    const fake = createBetterSqliteRequire(abiError);
+    const prebuildError = Object.assign(
+      new Error("Command failed: prebuild-install"),
+      {
+        status: 1,
+        stderr:
+          "prebuild-install info unpack resolved to /tmp/fake-node-modules/better-sqlite3/build/Release/better_sqlite3.node\n",
+      },
+    );
+    const execFileSync = vi.fn((nodePath, args) => {
+      if (args[0] === "/tmp/fake-node-modules/prebuild-install/bin.js") {
+        fake.clearConstructorError();
+        throw prebuildError;
+      }
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+    const options = createEnsureOptions(fake.requireModule, execFileSync);
+
+    expect(() => ensureNativeModules(options)).not.toThrow();
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(fake.state.constructorCalls).toBe(2);
+    expect(options.log).toHaveBeenCalledWith(
+      "[ensure-native-modules] Prebuilt better-sqlite3 loaded despite installer failure",
+    );
+  });
+
+  it("falls back to a source rebuild when prebuild repair fails", () => {
     const missingBindingError = new Error(
       "Could not locate the bindings file. Tried: build/Release/better_sqlite3.node",
     );
     const fake = createBetterSqliteRequire(missingBindingError);
-    const execSync = vi.fn(() => {
+    const prebuildError = Object.assign(
+      new Error("Command failed: prebuild-install"),
+      {
+        status: 1,
+        stderr:
+          "prebuild-install info install --build-from-source specified, not attempting download.\n",
+      },
+    );
+    const execFileSync = vi.fn((nodePath, args) => {
+      if (args[0] === "/tmp/fake-node-modules/prebuild-install/bin.js") {
+        throw prebuildError;
+      }
       fake.clearConstructorError();
+    });
+    const options = createEnsureOptions(fake.requireModule, execFileSync);
+
+    expect(() => ensureNativeModules(options)).not.toThrow();
+
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      process.execPath,
+      ["/tmp/fake-node-modules/prebuild-install/bin.js"],
+      expect.objectContaining({
+        cwd: "/tmp/fake-node-modules/better-sqlite3",
+        encoding: "utf8",
+        env: expect.objectContaining({ npm_config_loglevel: "info" }),
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      process.execPath,
+      [
+        "/tmp/fake-node-modules/node-gyp/bin/node-gyp.js",
+        "rebuild",
+        "--release",
+      ],
+      {
+        cwd: "/tmp/fake-node-modules/better-sqlite3",
+        stdio: "inherit",
+      },
+    );
+    expect(fake.state.constructorCalls).toBe(3);
+    expect(options.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "stderr: prebuild-install info install --build-from-source specified",
+      ),
+    );
+    expect(options.log).toHaveBeenCalledWith(
+      expect.stringContaining("Prebuilt better-sqlite3 still failed to load"),
+    );
+  });
+
+  it("rebuilds from source when an installed prebuild is still ABI-mismatched", () => {
+    const abiError = new Error(
+      "The module was compiled against a different NODE_MODULE_VERSION",
+    );
+    const fake = createBetterSqliteRequire(abiError);
+    const execFileSync = vi.fn((nodePath, args) => {
+      if (args[0] === "/tmp/fake-node-modules/node-gyp/bin/node-gyp.js") {
+        fake.clearConstructorError();
+      }
     });
 
     expect(() =>
-      ensureNativeModules(createEnsureOptions(fake.requireModule, execSync)),
+      ensureNativeModules(
+        createEnsureOptions(fake.requireModule, execFileSync),
+      ),
     ).not.toThrow();
 
-    expect(execSync).toHaveBeenCalledWith("npx --yes node-gyp rebuild", {
-      cwd: "/tmp/fake-node-modules/better-sqlite3",
-      stdio: "inherit",
-    });
-    expect(fake.state.constructorCalls).toBe(2);
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      process.execPath,
+      ["/tmp/fake-node-modules/prebuild-install/bin.js"],
+      expect.objectContaining({
+        cwd: "/tmp/fake-node-modules/better-sqlite3",
+        encoding: "utf8",
+        env: expect.objectContaining({ npm_config_loglevel: "info" }),
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      process.execPath,
+      [
+        "/tmp/fake-node-modules/node-gyp/bin/node-gyp.js",
+        "rebuild",
+        "--release",
+      ],
+      {
+        cwd: "/tmp/fake-node-modules/better-sqlite3",
+        stdio: "inherit",
+      },
+    );
+    expect(fake.state.constructorCalls).toBe(3);
   });
 
   it("exits non-zero when the post-rebuild instantiation still fails", () => {
@@ -147,7 +277,7 @@ describe("ensure-native-modules", () => {
             repoRoot: "/repo",
             modules: [{ name: "better-sqlite3", resolveFrom: "packages/db/package.json" }],
             createRequire,
-            execSync() {},
+            execFileSync() {},
             log() {},
           });
         `,

--- a/scripts/ensure-native-modules.mjs
+++ b/scripts/ensure-native-modules.mjs
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,6 +11,33 @@ export const nativeModules = [
 
 function formatThrownValue(err) {
   return err instanceof Error ? err.message : String(err);
+}
+
+function formatChildProcessFailure(err) {
+  const details = [formatThrownValue(err).split("\n")[0]];
+  if (err && typeof err === "object") {
+    if ("status" in err && err.status !== null && err.status !== undefined) {
+      details.push(`exit status: ${String(err.status)}`);
+    }
+    if ("signal" in err && err.signal !== null && err.signal !== undefined) {
+      details.push(`signal: ${String(err.signal)}`);
+    }
+
+    for (const streamName of ["stdout", "stderr"]) {
+      const output = err[streamName];
+      if (output === undefined || output === null) continue;
+
+      const text = Buffer.isBuffer(output)
+        ? output.toString("utf8")
+        : String(output);
+      const trimmed = text.trim();
+      if (trimmed.length > 0) {
+        details.push(`${streamName}: ${trimmed}`);
+      }
+    }
+  }
+
+  return details.join("\n");
 }
 
 export function verifyNativeModule(name, requireModule) {
@@ -29,11 +56,22 @@ function shouldRebuildNativeModule(errorMessage) {
   );
 }
 
+function getRepairableNativeModuleError(name, requireModule) {
+  try {
+    verifyNativeModule(name, requireModule);
+    return null;
+  } catch (err) {
+    const message = formatThrownValue(err);
+    if (!shouldRebuildNativeModule(message)) throw err;
+    return message;
+  }
+}
+
 export function ensureNativeModules({
   repoRoot = defaultRepoRoot,
   modules = nativeModules,
   createRequire: createRequireImpl = createRequire,
-  execSync: execSyncImpl = execSync,
+  execFileSync: execFileSyncImpl = execFileSync,
   log = console.log,
 } = {}) {
   for (const { name, resolveFrom } of modules) {
@@ -44,21 +82,78 @@ export function ensureNativeModules({
       const message = formatThrownValue(err);
       if (!shouldRebuildNativeModule(message)) throw err;
 
-      const pkgDir = dirname(requireModule.resolve(`${name}/package.json`));
+      const pkgJsonPath = requireModule.resolve(`${name}/package.json`);
+      const pkgDir = dirname(pkgJsonPath);
+      const pkgRequire = createRequireImpl(pkgJsonPath);
       log(
-        `[ensure-native-modules] Rebuilding ${name} for Node ${process.versions.node} (ABI ${process.versions.modules})`,
+        `[ensure-native-modules] Installing prebuilt ${name} for Node ${process.versions.node} (ABI ${process.versions.modules})`,
       );
-      execSyncImpl("npx --yes node-gyp rebuild", {
-        cwd: pkgDir,
-        stdio: "inherit",
-      });
-
+      let prebuildInstalled = false;
       try {
-        verifyNativeModule(name, requireModule);
-      } catch (verifyErr) {
+        execFileSyncImpl(
+          process.execPath,
+          [pkgRequire.resolve("prebuild-install/bin.js")],
+          {
+            cwd: pkgDir,
+            encoding: "utf8",
+            env: { ...process.env, npm_config_loglevel: "info" },
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+        prebuildInstalled = true;
+      } catch (prebuildErr) {
+        const message = formatChildProcessFailure(prebuildErr);
+        log(
+          `[ensure-native-modules] Prebuilt ${name} unavailable or unusable: ${message}`,
+        );
+      }
+
+      const prebuildVerifyError = getRepairableNativeModuleError(
+        name,
+        requireModule,
+      );
+      if (prebuildVerifyError === null) {
+        if (!prebuildInstalled) {
+          log(
+            `[ensure-native-modules] Prebuilt ${name} loaded despite installer failure`,
+          );
+        }
+        continue;
+      }
+
+      if (prebuildInstalled) {
+        log(
+          `[ensure-native-modules] Prebuilt ${name} failed to load: ${prebuildVerifyError}`,
+        );
+      } else {
+        log(
+          `[ensure-native-modules] Prebuilt ${name} still failed to load: ${prebuildVerifyError}`,
+        );
+      }
+
+      log(
+        `[ensure-native-modules] Rebuilding ${name} from source for Node ${process.versions.node} (ABI ${process.versions.modules})`,
+      );
+      execFileSyncImpl(
+        process.execPath,
+        [
+          pkgRequire.resolve("node-gyp/bin/node-gyp.js"),
+          "rebuild",
+          "--release",
+        ],
+        {
+          cwd: pkgDir,
+          stdio: "inherit",
+        },
+      );
+
+      const rebuildVerifyError = getRepairableNativeModuleError(
+        name,
+        requireModule,
+      );
+      if (rebuildVerifyError !== null) {
         throw new Error(
-          `[ensure-native-modules] ${name} still failed to load after rebuild: ${formatThrownValue(verifyErr)}`,
-          { cause: verifyErr },
+          `[ensure-native-modules] ${name} still failed to load after rebuild: ${rebuildVerifyError}`,
         );
       }
     }


### PR DESCRIPTION
## Summary
- Try `prebuild-install` before compiling `better-sqlite3` from source when `ensure-native-modules` detects an ABI/missing-binding failure.
- Run `prebuild-install` and `node-gyp` through `process.execPath` so repairs target the Node runtime that launched the helper, not whichever `node` appears first on `PATH`.
- Capture `prebuild-install` stdout/stderr on fallback so silent skips such as `npm_config_build_from_source=true` are visible in the helper log.
- Verify the native module after a failed prebuild command before compiling from source; this avoids the rebuild path when the tarball was unpacked but the installer self-check exited non-zero.
- Expand regression coverage for prebuilt repair, source fallback, fallback diagnostics, installer-failed-but-loadable prebuilds, and mismatched prebuild verification.

## Validation
- `pnpm exec turbo run test --filter=@bb/scripts`
- `pnpm exec prettier --check scripts/ensure-native-modules.mjs packages/scripts/test/ensure-native-modules.test.mjs`
- Throwaway worktree benchmark, Node 22 ABI 127 binary -> Node 26.3.1 ABI 147 repair:
  - before: `12.71s`, source rebuild
  - after: `0.19s`, prebuild install
- Patched Node 26 ABI 147 -> Node 22 ABI 127 repair: `0.13s`, prebuild install
- Manual repro: deleting the worktree `better-sqlite3/build` directory restored from prebuild; keeping an ABI 127 process loaded reproduced a prebuild-installer self-check failure after unpacking.