### PR TITLE
Preview binary image diffs directly

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -199,10 +199,7 @@ function getImageSizeStat(
   changeKind: GitDiffFileChangeKind,
 ): DiffImageSizeStat | null {
   if (enrichment.status !== "ready-image") return null;
-  const addedBytes = changeKind === "deleted" ? null : enrichment.newSizeBytes;
-  const removedBytes = changeKind === "added" ? null : enrichment.oldSizeBytes;
-  if (addedBytes === null && removedBytes === null) return null;
-  return { addedBytes, removedBytes };
+  return getGitDiffCardImageSizeStat(enrichment, changeKind);
 }
 
 export interface UseGitDiffCardBodyArgs {
@@ -450,9 +447,14 @@ interface GitDiffCardImageBodyProps {
   fitToFrame?: boolean;
 }
 
+export interface GitDiffCardImagePreview {
+  oldImageUrl: string | null;
+  newImageUrl: string | null;
+}
+
 function getGitDiffCardImageUrls(
   enrichment: DiffFileEnrichmentState,
-): { oldImageUrl: string | null; newImageUrl: string | null } | null {
+): GitDiffCardImagePreview | null {
   if (
     enrichment.status !== "ready-image" &&
     enrichment.status !== "ready-svg"
@@ -465,28 +467,36 @@ function getGitDiffCardImageUrls(
   };
 }
 
-function GitDiffCardImageBody({
-  enrichment,
+export function getGitDiffCardImageSizeStat(
+  preview: {
+    oldSizeBytes: number | null;
+    newSizeBytes: number | null;
+  },
+  changeKind: GitDiffFileChangeKind,
+): DiffImageSizeStat | null {
+  const addedBytes = changeKind === "deleted" ? null : preview.newSizeBytes;
+  const removedBytes = changeKind === "added" ? null : preview.oldSizeBytes;
+  if (addedBytes === null && removedBytes === null) return null;
+  return { addedBytes, removedBytes };
+}
+
+export interface GitDiffCardImagePreviewBodyProps {
+  preview: GitDiffCardImagePreview;
+  fileDiffLabel: string;
+  fitToFrame?: boolean;
+}
+
+export function GitDiffCardImagePreviewBody({
+  preview,
   fileDiffLabel,
   fitToFrame = false,
-}: GitDiffCardImageBodyProps) {
+}: GitDiffCardImagePreviewBodyProps) {
   const [expandedImageIndex, setExpandedImageIndex] = useState<number | null>(
     null,
   );
-  if (enrichment.status === "idle" || enrichment.status === "loading") {
-    return <GitDiffCardBodySkeleton />;
-  }
-  const imageUrls = getGitDiffCardImageUrls(enrichment);
-  if (imageUrls === null) {
-    return (
-      <div className="px-3 py-3 text-xs text-muted-foreground">
-        No preview available for this image.
-      </div>
-    );
-  }
   const imageSides = buildGitDiffCardImageSides(
-    imageUrls.oldImageUrl,
-    imageUrls.newImageUrl,
+    preview.oldImageUrl,
+    preview.newImageUrl,
   );
   if (imageSides.length === 0) {
     return (
@@ -563,6 +573,31 @@ function GitDiffCardImageBody({
         onClose={() => setExpandedImageIndex(null)}
       />
     </>
+  );
+}
+
+function GitDiffCardImageBody({
+  enrichment,
+  fileDiffLabel,
+  fitToFrame = false,
+}: GitDiffCardImageBodyProps) {
+  if (enrichment.status === "idle" || enrichment.status === "loading") {
+    return <GitDiffCardBodySkeleton />;
+  }
+  const preview = getGitDiffCardImageUrls(enrichment);
+  if (preview === null) {
+    return (
+      <div className="px-3 py-3 text-xs text-muted-foreground">
+        No preview available for this image.
+      </div>
+    );
+  }
+  return (
+    <GitDiffCardImagePreviewBody
+      preview={preview}
+      fileDiffLabel={fileDiffLabel}
+      fitToFrame={fitToFrame}
+    />
   );
 }
 

--- a/apps/app/src/components/git-diff/git-diff-parsing.ts
+++ b/apps/app/src/components/git-diff/git-diff-parsing.ts
@@ -160,12 +160,17 @@ const IMAGE_GIT_DIFF_FILE_EXTENSIONS: ReadonlySet<string> = new Set([
   "webp",
 ]);
 
-export function isImageGitDiffFile(file: ParsedGitDiffFile): boolean {
-  const path = normalizeGitDiffPath(file.name) ?? file.name;
-  const extension = path.split(".").pop()?.toLowerCase();
+export function isPreviewableImagePath(path: string | undefined): boolean {
+  const normalizedPath = normalizeGitDiffPath(path);
+  if (normalizedPath === undefined) return false;
+  const extension = normalizedPath.split(".").pop()?.toLowerCase();
   return (
     extension !== undefined && IMAGE_GIT_DIFF_FILE_EXTENSIONS.has(extension)
   );
+}
+
+export function isImageGitDiffFile(file: ParsedGitDiffFile): boolean {
+  return isPreviewableImagePath(file.name);
 }
 
 export function isSvgGitDiffFile(file: ParsedGitDiffFile): boolean {

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.stories.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.stories.tsx
@@ -44,16 +44,6 @@ const TALL_PATCH = [
   "",
 ].join("\n");
 
-// Git emits this (no `--binary`) for an added image; it parses to a zero-hunk
-// file the card routes to its inline image preview.
-const ADDED_IMAGE_PATCH = [
-  "diff --git a/assets/logo.png b/assets/logo.png",
-  "new file mode 100644",
-  "index 0000000..2222222",
-  "Binary files /dev/null and b/assets/logo.png differ",
-  "",
-].join("\n");
-
 // A 1x1 transparent PNG so the image-preview branch has something to render.
 const IMAGE_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/Qo3AAAAAElFTkSuQmCC";
@@ -192,7 +182,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="image change"
-        hint="a binary image routes to an inline preview instead of a No renderable diff notice"
+        hint="an on_demand binary image previews directly from file bytes without first loading a binary patch"
       >
         <CardStage
           entry={{
@@ -202,11 +192,6 @@ export function Overview() {
             deletions: 0,
             binary: true,
             loadMode: "on_demand",
-          }}
-          patchState={{
-            status: "loaded",
-            patch: ADDED_IMAGE_PATCH,
-            truncated: false,
           }}
           onRequestFileContents={imageContentsRequester}
         />

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DiffFileEntry } from "@bb/server-contract";
+import type {
+  DiffFileContentsResult,
+  RequestDiffFileContents,
+} from "@/components/git-diff/GitDiffCardBody";
+import type { DiffPatchState } from "@/hooks/queries/use-environment-diff-patches";
+import { DiffFileCard } from "./DiffFileCard";
+
+const IMAGE_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/Qo3AAAAAElFTkSuQmCC";
+
+function buildEntry(overrides: Partial<DiffFileEntry> = {}): DiffFileEntry {
+  return {
+    path: "src/file.ts",
+    previousPath: null,
+    changeKind: "modified",
+    additions: 1,
+    deletions: 1,
+    binary: false,
+    origin: "tracked",
+    loadMode: "auto",
+    ...overrides,
+  };
+}
+
+function renderCard({
+  entry,
+  onLoadPatch = vi.fn(),
+  onRequestFileContents,
+  patchState = { status: "idle" },
+}: {
+  entry: DiffFileEntry;
+  onLoadPatch?: () => void;
+  onRequestFileContents?: RequestDiffFileContents;
+  patchState?: DiffPatchState;
+}) {
+  render(
+    <DiffFileCard
+      entry={entry}
+      diffViewOptions={{}}
+      isCollapsed={false}
+      onToggleCollapsed={() => {}}
+      patchState={patchState}
+      onLoadPatch={onLoadPatch}
+      onRetry={() => {}}
+      onRequestFileContents={onRequestFileContents}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DiffFileCard", () => {
+  it("previews on-demand binary images without loading the binary patch", async () => {
+    const imageResult: DiffFileContentsResult = {
+      kind: "image",
+      dataUrl: IMAGE_DATA_URL,
+      sizeBytes: 20_480,
+    };
+    const onLoadPatch = vi.fn();
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(
+      async () => imageResult,
+    );
+
+    renderCard({
+      entry: buildEntry({
+        path: "assets/logo.png",
+        changeKind: "added",
+        additions: 0,
+        deletions: 0,
+        binary: true,
+        loadMode: "on_demand",
+      }),
+      onLoadPatch,
+      onRequestFileContents,
+    });
+
+    const preview = await screen.findByRole("img", {
+      name: "assets/logo.png",
+    });
+
+    expect(preview.getAttribute("src")).toBe(IMAGE_DATA_URL);
+    expect(screen.queryByText("Load diff")).toBeNull();
+    expect(onLoadPatch).not.toHaveBeenCalled();
+    expect(onRequestFileContents).toHaveBeenCalledTimes(1);
+    expect(onRequestFileContents).toHaveBeenCalledWith(
+      "assets/logo.png",
+      "new",
+    );
+  });
+
+  it("keeps the load gate for non-image binary files", async () => {
+    const onLoadPatch = vi.fn();
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(async () => ({
+      kind: "image",
+      dataUrl: IMAGE_DATA_URL,
+      sizeBytes: 20_480,
+    }));
+
+    renderCard({
+      entry: buildEntry({
+        path: "assets/archive.bin",
+        additions: 0,
+        deletions: 0,
+        binary: true,
+        loadMode: "on_demand",
+      }),
+      onLoadPatch,
+      onRequestFileContents,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Binary file.")).toBeTruthy();
+    });
+    expect(screen.getByText("Load diff")).toBeTruthy();
+    expect(onRequestFileContents).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the load gate when an image-looking path is not previewable", async () => {
+    const onLoadPatch = vi.fn();
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(
+      async () => null,
+    );
+
+    renderCard({
+      entry: buildEntry({
+        path: "assets/not-actually-image.png",
+        additions: 0,
+        deletions: 0,
+        binary: true,
+        loadMode: "on_demand",
+      }),
+      onLoadPatch,
+      onRequestFileContents,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Binary file.")).toBeTruthy();
+    });
+    expect(screen.getByText("Load diff")).toBeTruthy();
+    expect(onRequestFileContents).toHaveBeenCalledTimes(2);
+    expect(onLoadPatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -1,19 +1,26 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useIntersectionObserver } from "usehooks-ts";
 import type { DiffFileEntry } from "@bb/server-contract";
 import {
+  getGitDiffCardImageSizeStat,
   GitDiffCardBody,
+  GitDiffCardImagePreviewBody,
   useGitDiffCardBody,
+  type DiffFileContentsResult,
+  type DiffImageSizeStat,
+  type GitDiffCardImagePreview,
   type GitDiffCardSvgDisplayMode,
   type RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import {
   GitDiffCardHeader,
+  GitDiffCardImageSizeStat,
   GitDiffCardRawToggle,
   gitDiffCardHeaderWrapperClass,
   type GitDiffCardHeaderModel,
 } from "@/components/git-diff/GitDiffCardHeader";
 import {
+  isPreviewableImagePath,
   isSvgGitDiffFile,
   parseGitDiffFiles,
   type ParsedGitDiffFile,
@@ -49,6 +56,70 @@ function buildDiffEntryHeaderModel(
     changeKind: entry.changeKind,
     insertions: entry.additions,
     deletions: entry.deletions,
+  };
+}
+
+interface BinaryImagePreviewSource {
+  path: string;
+  side: "old" | "new";
+}
+
+interface BinaryImagePreviewPlan {
+  identity: string;
+  old: BinaryImagePreviewSource | null;
+  new: BinaryImagePreviewSource | null;
+}
+
+interface ReadyBinaryImagePreview extends GitDiffCardImagePreview {
+  oldSizeBytes: number | null;
+  newSizeBytes: number | null;
+}
+
+type BinaryImageContentsResult = Extract<
+  DiffFileContentsResult,
+  { kind: "image" }
+>;
+
+type BinaryImagePreviewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; preview: ReadyBinaryImagePreview }
+  | { status: "unavailable" }
+  | { status: "error" };
+
+const EMPTY_BINARY_IMAGE_PREVIEW_STATE: BinaryImagePreviewState = {
+  status: "idle",
+};
+
+function isPreviewableBinaryImageEntry(entry: DiffFileEntry): boolean {
+  return (
+    entry.binary &&
+    (isPreviewableImagePath(entry.path) ||
+      isPreviewableImagePath(entry.previousPath ?? undefined))
+  );
+}
+
+function buildBinaryImagePreviewPlan(
+  entry: DiffFileEntry,
+): BinaryImagePreviewPlan | null {
+  if (!isPreviewableBinaryImageEntry(entry)) {
+    return null;
+  }
+  const previousPath = entry.previousPath ?? entry.path;
+  const oldSource: BinaryImagePreviewSource | null =
+    entry.changeKind === "added"
+      ? null
+      : { path: previousPath, side: "old" };
+  const newSource: BinaryImagePreviewSource | null =
+    entry.changeKind === "deleted"
+      ? null
+      : { path: entry.path, side: "new" };
+  return {
+    identity: `${entry.changeKind}:${oldSource?.path ?? ""}:${
+      newSource?.path ?? ""
+    }`,
+    old: oldSource,
+    new: newSource,
   };
 }
 
@@ -119,6 +190,91 @@ function areDiffFileCardPropsEqual(
   );
 }
 
+async function resolveBinaryImagePreviewSource(
+  source: BinaryImagePreviewSource | null,
+  fetcher: RequestDiffFileContents,
+): Promise<BinaryImageContentsResult | null> {
+  if (source === null) {
+    return null;
+  }
+  const result = await fetcher(source.path, source.side);
+  return result?.kind === "image" ? result : null;
+}
+
+function useBinaryImagePreview({
+  enabled,
+  onRequestFileContents,
+  plan,
+}: {
+  enabled: boolean;
+  onRequestFileContents?: RequestDiffFileContents;
+  plan: BinaryImagePreviewPlan | null;
+}): BinaryImagePreviewState {
+  const [state, setState] = useState<BinaryImagePreviewState>(
+    EMPTY_BINARY_IMAGE_PREVIEW_STATE,
+  );
+  const statusRef = useRef<BinaryImagePreviewState["status"]>("idle");
+  const planIdentity = plan?.identity ?? "none";
+
+  useEffect(() => {
+    statusRef.current = "idle";
+    setState(EMPTY_BINARY_IMAGE_PREVIEW_STATE);
+  }, [planIdentity, onRequestFileContents]);
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      plan === null ||
+      onRequestFileContents === undefined ||
+      statusRef.current !== "idle"
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    statusRef.current = "loading";
+    setState({ status: "loading" });
+
+    void Promise.all([
+      resolveBinaryImagePreviewSource(plan.old, onRequestFileContents),
+      resolveBinaryImagePreviewSource(plan.new, onRequestFileContents),
+    ])
+      .then(([oldResult, newResult]) => {
+        if (cancelled) return;
+        if (oldResult === null && newResult === null) {
+          statusRef.current = "unavailable";
+          setState({ status: "unavailable" });
+          return;
+        }
+        statusRef.current = "ready";
+        setState({
+          status: "ready",
+          preview: {
+            oldImageUrl: oldResult?.dataUrl ?? null,
+            newImageUrl: newResult?.dataUrl ?? null,
+            oldSizeBytes: oldResult?.sizeBytes ?? null,
+            newSizeBytes: newResult?.sizeBytes ?? null,
+          },
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          statusRef.current = "error";
+          setState({ status: "error" });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      if (statusRef.current === "loading") {
+        statusRef.current = "idle";
+      }
+    };
+  }, [enabled, onRequestFileContents, plan]);
+
+  return state;
+}
+
 export const DiffFileCard = memo(function DiffFileCard({
   entry,
   diffViewOptions,
@@ -153,6 +309,26 @@ export const DiffFileCard = memo(function DiffFileCard({
   };
   const changedLines = entry.additions + entry.deletions;
   const isBodyHidden = isCollapsed;
+  const binaryImagePreviewPlan = useMemo(
+    () => buildBinaryImagePreviewPlan(entry),
+    [entry],
+  );
+  const shouldDirectlyPreviewBinaryImage =
+    binaryImagePreviewPlan !== null && onRequestFileContents !== undefined;
+  const binaryImagePreviewState = useBinaryImagePreview({
+    enabled: !isBodyHidden && shouldDirectlyPreviewBinaryImage,
+    onRequestFileContents,
+    plan: binaryImagePreviewPlan,
+  });
+  const binaryImageSizeStat = useMemo<DiffImageSizeStat | null>(() => {
+    if (binaryImagePreviewState.status !== "ready") {
+      return null;
+    }
+    return getGitDiffCardImageSizeStat(
+      binaryImagePreviewState.preview,
+      entry.changeKind,
+    );
+  }, [binaryImagePreviewState, entry.changeKind]);
   const supportsSvgRawToggle =
     !isBodyHidden &&
     parsedFile !== null &&
@@ -201,6 +377,15 @@ export const DiffFileCard = memo(function DiffFileCard({
           isCollapsed={isCollapsed}
           onToggleCollapsed={onToggleCollapsed}
           hasChanges
+          statSlot={
+            shouldDirectlyPreviewBinaryImage ? (
+              binaryImageSizeStat !== null ? (
+                <GitDiffCardImageSizeStat stat={binaryImageSizeStat} />
+              ) : (
+                <span />
+              )
+            ) : undefined
+          }
           actionSlot={
             supportsSvgRawToggle ? (
               <GitDiffCardRawToggle
@@ -224,6 +409,11 @@ export const DiffFileCard = memo(function DiffFileCard({
           onRetry={onRetry}
           onOpenFilePreview={onOpenFilePreview}
           onRequestFileContents={onRequestFileContents}
+          binaryImagePreviewState={
+            shouldDirectlyPreviewBinaryImage
+              ? binaryImagePreviewState
+              : undefined
+          }
         />
       )}
     </div>
@@ -241,10 +431,53 @@ interface DiffFileCardBodyProps {
   onRetry: () => void;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
+  binaryImagePreviewState?: BinaryImagePreviewState;
 }
 
 const DIFF_FILE_CARD_NOTICE_CLASS =
   "flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-3 text-xs text-muted-foreground";
+
+function DiffFileCardBodySkeleton() {
+  return (
+    <div className="space-y-1.5 px-3 py-3">
+      <Skeleton className="h-3 w-full rounded-sm" />
+      <Skeleton className="h-3 w-[96%] rounded-sm" />
+      <Skeleton className="h-3 w-[93%] rounded-sm" />
+      <Skeleton className="h-3 w-[90%] rounded-sm" />
+      <Skeleton className="h-3 w-[87%] rounded-sm" />
+      <Skeleton className="h-3 w-[84%] rounded-sm" />
+    </div>
+  );
+}
+
+function DiffFileCardLoadDiffNotice({
+  changedLines,
+  entry,
+  onLoadPatch,
+}: {
+  changedLines: number;
+  entry: DiffFileEntry;
+  onLoadPatch: () => void;
+}) {
+  return (
+    <div className={DIFF_FILE_CARD_NOTICE_CLASS}>
+      <span>
+        {entry.binary
+          ? "Binary file."
+          : `${changedLines.toLocaleString()} changed lines.`}
+      </span>
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        className="h-auto p-0 text-xs underline underline-offset-4 hover:underline"
+        onClick={onLoadPatch}
+      >
+        Load diff
+      </Button>
+    </div>
+  );
+}
 
 function DiffFileCardBody({
   entry,
@@ -257,7 +490,34 @@ function DiffFileCardBody({
   onRetry,
   onOpenFilePreview,
   onRequestFileContents,
+  binaryImagePreviewState,
 }: DiffFileCardBodyProps) {
+  if (binaryImagePreviewState !== undefined) {
+    if (
+      binaryImagePreviewState.status === "idle" ||
+      binaryImagePreviewState.status === "loading"
+    ) {
+      return <DiffFileCardBodySkeleton />;
+    }
+    if (binaryImagePreviewState.status === "ready") {
+      return (
+        <GitDiffCardImagePreviewBody
+          preview={binaryImagePreviewState.preview}
+          fileDiffLabel={formatDiffEntryLabel(entry)}
+        />
+      );
+    }
+    if (patchState.status === "idle") {
+      return (
+        <DiffFileCardLoadDiffNotice
+          entry={entry}
+          changedLines={changedLines}
+          onLoadPatch={onLoadPatch}
+        />
+      );
+    }
+  }
+
   if (patchState.status === "error") {
     return (
       <div className={DIFF_FILE_CARD_NOTICE_CLASS}>
@@ -297,22 +557,11 @@ function DiffFileCardBody({
 
   if (entry.loadMode === "on_demand" && patchState.status === "idle") {
     return (
-      <div className={DIFF_FILE_CARD_NOTICE_CLASS}>
-        <span>
-          {entry.binary
-            ? "Binary file."
-            : `${changedLines.toLocaleString()} changed lines.`}
-        </span>
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="h-auto p-0 text-xs underline underline-offset-4 hover:underline"
-          onClick={onLoadPatch}
-        >
-          Load diff
-        </Button>
-      </div>
+      <DiffFileCardLoadDiffNotice
+        entry={entry}
+        changedLines={changedLines}
+        onLoadPatch={onLoadPatch}
+      />
     );
   }
 
@@ -338,16 +587,7 @@ function DiffFileCardBody({
       );
     }
 
-    return (
-      <div className="space-y-1.5 px-3 py-3">
-        <Skeleton className="h-3 w-full rounded-sm" />
-        <Skeleton className="h-3 w-[96%] rounded-sm" />
-        <Skeleton className="h-3 w-[93%] rounded-sm" />
-        <Skeleton className="h-3 w-[90%] rounded-sm" />
-        <Skeleton className="h-3 w-[87%] rounded-sm" />
-        <Skeleton className="h-3 w-[84%] rounded-sm" />
-      </div>
-    );
+    return <DiffFileCardBodySkeleton />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- preview on-demand binary image rows directly from file bytes instead of requiring Load diff
- keep non-image binaries on the existing Binary file / Load diff path
- share image preview rendering and byte-size stat helpers with the existing diff card body
- add regression coverage for direct image preview and fallback behavior

## Validation
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/git-diff/git-diff-parsing.test.ts src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app