### PR TITLE
Reduce native title tooltip noise

### DIFF
--- a/apps/app/src/components/dialogs/ThreadGitActionDialog.tsx
+++ b/apps/app/src/components/dialogs/ThreadGitActionDialog.tsx
@@ -227,9 +227,6 @@ export function ThreadGitActionDialogContent({
       : selectedMergeBaseBranchMissing
         ? missingMergeBaseErrorMessage
         : null);
-  const submitTitle = selectedMergeBaseBranchClassificationPending
-    ? checkingMergeBaseMessage
-    : (mergeBaseValidationErrorMessage ?? undefined);
   const footerMergeBaseMessage =
     visibleMergeBaseErrorMessage ?? visibleMergeBaseStatusMessage;
   const footerMergeBaseMessageIsError = Boolean(visibleMergeBaseErrorMessage);
@@ -397,7 +394,6 @@ export function ThreadGitActionDialogContent({
             disabled={
               dialogCopy.showMergeBase && mergeBaseSubmitBlockMessage !== null
             }
-            title={submitTitle}
           >
             {dialogCopy.submitLabel}
           </Button>

--- a/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardHeader.tsx
@@ -119,7 +119,6 @@ export function GitDiffCardRawToggle({
       onClick={onToggle}
       aria-label={label}
       aria-pressed={isRaw}
-      title={label}
     >
       <Icon name="Code" aria-hidden className="size-3.5" />
     </button>

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -326,7 +326,6 @@ function AppHeader({
           )}
           aria-label="Project settings"
           aria-current={isSettingsView ? "page" : undefined}
-          title="Project settings"
         >
           <Icon name="Settings" />
         </Link>
@@ -341,7 +340,6 @@ function AppHeader({
           )}
           aria-label="Archived threads"
           aria-current={isArchivedView ? "page" : undefined}
-          title="Archived threads"
         >
           <Icon name="Archive" />
         </Link>

--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -254,12 +254,6 @@ function formatCreateBranchTriggerLabel(branch: string | null): string {
     : `New branch from: ${branch}`;
 }
 
-function formatCreateBranchTriggerTitle(branch: string | null): string {
-  return branch === null
-    ? CREATE_NEW_BRANCH_LABEL
-    : `Create a new branch from ${branch}`;
-}
-
 function splitBranchLabel(label: string): BranchLabelParts {
   if (
     label.startsWith(CURRENT_PARENTHESES_LABEL_PREFIX) &&
@@ -948,14 +942,6 @@ export function BranchPicker({
           size="sm"
           disabled={disabled}
           aria-label="Branch"
-          title={
-            triggerTitle ??
-            (isCreatingNew
-              ? formatCreateBranchTriggerTitle(value)
-              : value
-                ? `Branch: ${value}`
-                : unresolvedTriggerLabel)
-          }
           className={cn(
             variant === "default" &&
               "h-8 w-full min-w-0 justify-between rounded-md border-border bg-background px-2.5 text-sm font-normal shadow-none hover:bg-state-hover",
@@ -973,7 +959,10 @@ export function BranchPicker({
           aria-expanded={open}
         >
           {variant === "option" ? (
-            <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>
+            <span
+              className={OPTION_TRIGGER_CONTENT_CLASS_NAME}
+              title={triggerTitle ?? triggerLabel}
+            >
               <Icon
                 name="GitMerge"
                 className={COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS}
@@ -986,7 +975,10 @@ export function BranchPicker({
               />
             </span>
           ) : (
-            <span className="flex min-w-0 items-center overflow-hidden">
+            <span
+              className="flex min-w-0 items-center overflow-hidden"
+              title={triggerTitle ?? triggerLabel}
+            >
               <BranchPickerText
                 label={triggerLabel}
                 emphasizePlainLabel={triggerHasPlainBranchValue}

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -154,7 +154,6 @@ export function EnvironmentPickerUI({
           size="sm"
           aria-label="Environment"
           disabled={disabled}
-          title={`Environment: ${selected.modeLabel}`}
           data-promptbox-icon-only-control=""
           className={cn(
             OPTION_BASE_CLASS_NAME,

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -380,7 +380,6 @@ export function ModelReasoningPicker({
       variant="ghost"
       size="sm"
       aria-label="Provider, model and reasoning"
-      title={triggerTitle}
       disabled={disabled}
       className={cn(
         OPTION_BASE_CLASS_NAME,
@@ -390,7 +389,7 @@ export function ModelReasoningPicker({
         className,
       )}
     >
-      <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>
+      <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME} title={triggerTitle}>
         {showSelectedFastMode ? (
           <Icon
             name="Zap"

--- a/apps/app/src/components/pickers/OptionPicker.tsx
+++ b/apps/app/src/components/pickers/OptionPicker.tsx
@@ -182,7 +182,6 @@ export function OptionPicker<T extends string>({
       variant="ghost"
       size="sm"
       aria-label={label}
-      title={selectedTitle}
       disabled={disabled}
       className={cn(
         OPTION_BASE_CLASS_NAME,
@@ -196,7 +195,7 @@ export function OptionPicker<T extends string>({
         className,
       )}
     >
-      <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>
+      <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME} title={selectedTitle}>
         {SelectedIcon ? <SelectedIcon className="size-3.5 shrink-0" /> : null}
         {selectedCompactLabel ? (
           <>

--- a/apps/app/src/components/pickers/PermissionModePicker.test.tsx
+++ b/apps/app/src/components/pickers/PermissionModePicker.test.tsx
@@ -34,11 +34,14 @@ describe("PermissionModePicker", () => {
     );
 
     const trigger = screen.getByRole("button", { name: "Permission mode" });
+    const expectedTitle =
+      "Permission mode: Plan Mode - Claude Code will plan without normal full-access execution.";
     expect(trigger.textContent).toContain("Plan Mode");
     expect(trigger.className).not.toContain("text-warning-text");
-    expect(trigger.getAttribute("title")).toBe(
-      "Permission mode: Plan Mode - Claude Code will plan without normal full-access execution.",
-    );
+    expect(trigger.getAttribute("title")).toBeNull();
+    expect(
+      trigger.querySelector(`[title="${expectedTitle}"]`),
+    ).not.toBeNull();
   });
 
   it("can keep the chevron visible while disabled", () => {

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -89,8 +89,6 @@ export function ProjectSelector({
           size="sm"
           aria-label="Project"
           disabled={disabled}
-          // Matches OptionPicker's "<label>: <value>" tooltip convention.
-          title={`Project: ${triggerLabel}`}
           data-promptbox-project-control=""
           className={cn(
             OPTION_BASE_CLASS_NAME,

--- a/apps/app/src/components/pickers/WorktreePicker.tsx
+++ b/apps/app/src/components/pickers/WorktreePicker.tsx
@@ -82,7 +82,6 @@ export function WorktreePicker({
           size="sm"
           aria-label="Worktree"
           disabled={disabled}
-          title={`Worktree: ${triggerLabel}`}
           data-promptbox-icon-only-control=""
           className={cn(
             OPTION_BASE_CLASS_NAME,

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -189,7 +189,6 @@ export function ProjectActionsMenu({
             "data-[state=open]:bg-state-active data-[state=open]:text-foreground",
           )}
           aria-label={`${project.name} actions`}
-          title={`${project.name} actions`}
           onClick={(event) => {
             event.stopPropagation();
           }}

--- a/apps/app/src/components/promptbox/AttachmentPreview.tsx
+++ b/apps/app/src/components/promptbox/AttachmentPreview.tsx
@@ -78,7 +78,6 @@ export function AttachmentPreview({
                     type="button"
                     onClick={() => onRemoveAttachment(attachment.path)}
                     className="absolute right-1 top-1 z-10 rounded-full bg-black/55 p-0.5 text-white transition-colors hover:bg-black/70"
-                    title={`Remove ${attachment.name}`}
                     aria-label={`Remove ${attachment.name}`}
                   >
                     <Icon name="X" className="size-3" />

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -116,7 +116,6 @@ export function PromptBoxActionsMenu({
           type="button"
           size="icon"
           variant="ghost"
-          title="Prompt actions"
           aria-label="Prompt actions"
           className={cn(
             COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS,

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2315,7 +2315,6 @@ export function PromptBoxInternal({
             event.preventDefault();
           }}
           onClick={toggleZenMode}
-          title={isZenMode ? "Exit zen mode" : "Enter zen mode"}
           aria-label={isZenMode ? "Exit zen mode" : "Enter zen mode"}
           aria-pressed={isZenMode}
           // Neutralise the ghost variant's `aria-pressed:bg-state-active`
@@ -2443,7 +2442,7 @@ export function PromptBoxInternal({
             type="button"
             size="icon"
             variant="ghost"
-            title="Attach files"
+            aria-label="Attach files"
             disabled={!onAttachFiles || isAttaching}
             onClick={() => attachmentInputRef.current?.click()}
             className={COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS}
@@ -2459,7 +2458,7 @@ export function PromptBoxInternal({
               type="button"
               size="icon"
               variant="ghost"
-              title={
+              aria-label={
                 !voice.isSupported
                   ? "Voice input is not supported in this browser"
                   : "Start voice input"
@@ -2476,7 +2475,7 @@ export function PromptBoxInternal({
               type="button"
               size="icon"
               variant="secondary"
-              title="Stop run"
+              aria-label="Stop run"
               onClick={onStop}
               className={COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS}
             >
@@ -2491,7 +2490,7 @@ export function PromptBoxInternal({
                 type="button"
                 size="sm"
                 variant="default"
-                title="Stop and transcribe recording"
+                aria-label="Stop and transcribe recording"
                 onClick={voice.stop}
                 className={cn(
                   "rounded-r-none",
@@ -2504,7 +2503,7 @@ export function PromptBoxInternal({
                 type="button"
                 size="sm"
                 variant="default"
-                title="Cancel recording"
+                aria-label="Cancel recording"
                 onClick={voice.cancel}
                 className={COARSE_POINTER_PROMPT_COMBO_BUTTON_CLASS}
               >
@@ -2517,7 +2516,7 @@ export function PromptBoxInternal({
                 type="button"
                 size="sm"
                 variant="default"
-                title="Transcribing voice input..."
+                aria-label="Transcribing voice input"
                 disabled
                 className={cn(
                   "rounded-r-none",
@@ -2531,7 +2530,7 @@ export function PromptBoxInternal({
                 type="button"
                 size="sm"
                 variant="default"
-                title="Cancel transcription"
+                aria-label="Cancel transcription"
                 onClick={voice.cancel}
                 className={COARSE_POINTER_PROMPT_COMBO_BUTTON_CLASS}
               >
@@ -2543,7 +2542,7 @@ export function PromptBoxInternal({
               type="submit"
               size="sm"
               variant="default"
-              title={effectiveSubmitTitle}
+              aria-label={effectiveSubmitTitle}
               disabled={!canSubmit}
               className={COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS}
             >

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -110,7 +110,6 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
         <button
           type="button"
           aria-label="Create new thread in this worktree"
-          title="New thread in this worktree"
           onClick={onCreateNewThreadInWorktree}
           className="-ml-1 inline-flex cursor-pointer shrink-0 items-center justify-center rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
         >

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -374,7 +374,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
           )}
           disabled={dragDisabled}
           aria-label={`Reorder queued message ${index + 1}`}
-          title="Reorder queued message"
           {...attributes}
           {...listeners}
         >
@@ -419,7 +418,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
               disabled={sendDisabled}
               onClick={() => onSendImmediately(queuedMessage.id)}
               aria-label="Send now"
-              title="Send now"
             >
               <Icon name="Sent" className="size-4 opacity-70" />
             </Button>
@@ -432,7 +430,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
             disabled={actionDisabled || isProcessing}
             onClick={() => onEdit(queuedMessage.id)}
             aria-label={`Edit queued message ${index + 1}`}
-            title="Edit queued message"
           >
             <Icon name="Edit" className="size-4 opacity-70" />
           </Button>
@@ -444,7 +441,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
             disabled={actionDisabled || isProcessing}
             onClick={() => onDelete(queuedMessage.id)}
             aria-label={`Delete queued message ${index + 1}`}
-            title="Delete queued message"
           >
             <Icon name="Trash2" className="size-4 opacity-70" />
           </Button>

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -566,7 +566,6 @@ function PullRequestMergeSplitButton({
               "inline-flex items-center border-l border-border px-1 data-[state=open]:bg-state-active data-[state=open]:text-foreground",
             )}
             aria-label="Choose pull request merge method"
-            title="Choose pull request merge method"
           >
             <Icon name="ChevronDown" className="size-3" aria-hidden="true" />
           </PromptBannerActionSegmentButton>
@@ -624,7 +623,6 @@ function PullRequestBannerLink({
       target="_blank"
       rel="noopener noreferrer"
       onClick={handlePullRequestClick}
-      title={pullRequest.title}
       aria-label={`Pull request ${pullRequest.number}: ${attentionDisplay.label}`}
       className={cn(
         "flex items-center gap-1.5 text-xs text-muted-foreground no-underline transition-colors hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
@@ -811,7 +809,6 @@ function ReadOnlyContextBanner({
           )}
           role="status"
           aria-label={statusAriaLabel}
-          title={statusAriaLabel}
         >
           <Icon
             name={iconName}

--- a/apps/app/src/components/promptbox/banner/ThreadPromptModeCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptModeCard.tsx
@@ -79,7 +79,6 @@ export function ThreadPromptModeCard({
           <button
             type="button"
             aria-label="Exit plan mode"
-            title="Exit plan mode"
             onClick={onExitPlanMode}
             className="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
           >

--- a/apps/app/src/components/promptbox/editor/PromptMentionPillNodeView.tsx
+++ b/apps/app/src/components/promptbox/editor/PromptMentionPillNodeView.tsx
@@ -104,7 +104,6 @@ export function PromptMentionPillNodeView({
         activate && "cursor-pointer",
       )}
       {...promptMentionClipboardDataAttributes(attrs)}
-      title={title}
       role={activate ? "button" : undefined}
       tabIndex={activate ? 0 : undefined}
       aria-label={activationLabel}

--- a/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
@@ -194,7 +194,6 @@ function NavButton({ icon, label, disabled, onClick }: NavButtonProps) {
       onClick={onClick}
       disabled={disabled}
       aria-label={label}
-      title={label}
       className={cn(
         "flex shrink-0 items-center justify-center text-foreground transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-40",
         COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,

--- a/apps/app/src/components/secondary-panel/ConversationCollapsedRail.tsx
+++ b/apps/app/src/components/secondary-panel/ConversationCollapsedRail.tsx
@@ -82,7 +82,6 @@ export function ConversationCollapsedRail({
         onClick={onExpand}
         aria-label="Expand conversation"
         aria-expanded={false}
-        title="Expand conversation"
         className="flex min-h-0 w-full flex-1 flex-col items-center bg-surface-recessed text-muted-foreground outline-none hover:bg-state-hover focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
       >
         {/*

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -232,10 +232,6 @@ function getToggleAriaLabel(kind: FilePreviewToggleKind): string {
   return kind === "html" ? "HTML view mode" : "Markdown view mode";
 }
 
-function getRawToggleTitle(kind: FilePreviewToggleKind): string {
-  return kind === "html" ? "HTML source" : "Markdown source";
-}
-
 function getFileContentsCopyLabel(kind: FilePreviewToggleKind | null): string {
   if (kind === "markdown") {
     return "Copy markdown";
@@ -490,7 +486,6 @@ function FilePreviewHeader({
                   <CopyButton
                     text={rawContents}
                     label={copyFileContentsLabel}
-                    title={undefined}
                     className="shrink-0 rounded-md hover:bg-state-hover hover:text-foreground"
                   />
                 </TooltipTrigger>
@@ -504,7 +499,6 @@ function FilePreviewHeader({
                 <TooltipTrigger asChild>
                   <OpenInEditorButton
                     onClick={() => onOpenInEditor(path)}
-                    title={null}
                   />
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Open in editor</TooltipContent>
@@ -535,7 +529,6 @@ function FilePreviewHeader({
                   )}
                   onClick={() => onViewModeChange("preview")}
                   aria-pressed={viewMode === "preview"}
-                  title="Rendered preview"
                 >
                   Preview
                 </Button>
@@ -549,7 +542,6 @@ function FilePreviewHeader({
                   )}
                   onClick={() => onViewModeChange("source")}
                   aria-pressed={viewMode === "source"}
-                  title={getRawToggleTitle(toggleKind)}
                 >
                   Raw
                 </Button>
@@ -622,7 +614,6 @@ function FilePreviewLineWrapButton({
             )}
             aria-label={label}
             aria-pressed={lineOverflowMode === "wrap"}
-            title={undefined}
             onClick={() => {
               onLineOverflowModeChange(
                 lineOverflowMode === "wrap" ? "scroll" : "wrap",

--- a/apps/app/src/components/secondary-panel/GitDiffToolbar.tsx
+++ b/apps/app/src/components/secondary-panel/GitDiffToolbar.tsx
@@ -213,9 +213,6 @@ export function GitDiffToolbar({
             aria-label={
               areAllFilesCollapsed ? "Expand all files" : "Collapse all files"
             }
-            title={
-              areAllFilesCollapsed ? "Expand all files" : "Collapse all files"
-            }
           >
             {areAllFilesCollapsed ? (
               <Icon name="ChevronsDown" />
@@ -242,11 +239,6 @@ export function GitDiffToolbar({
                 : "Wrap diff lines"
             }
             aria-pressed={lineOverflowMode === "wrap"}
-            title={
-              lineOverflowMode === "wrap"
-                ? "Disable diff line wrap"
-                : "Wrap diff lines"
-            }
           >
             <Icon name="TextWrap" />
           </Button>
@@ -266,7 +258,6 @@ export function GitDiffToolbar({
               onClick={() => onDisplayModeChange("unified")}
               aria-label="Stacked diff view"
               aria-pressed={displayMode === "unified"}
-              title="Stacked diff view"
             >
               <Icon name="Rows2" />
             </Button>
@@ -281,7 +272,6 @@ export function GitDiffToolbar({
               onClick={() => onDisplayModeChange("split")}
               aria-label="Split diff view"
               aria-pressed={displayMode === "split"}
-              title="Split diff view"
             >
               <Icon name="Columns2" />
             </Button>

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -313,7 +313,6 @@ export function EnvironmentRow({
           <button
             type="button"
             aria-label="Create new thread in this worktree"
-            title="New thread in this worktree"
             onClick={createThreadInWorktree}
             className="inline-flex shrink-0 items-center justify-center rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
           >
@@ -460,7 +459,6 @@ export function PullRequestRow({ pullRequest }: PullRequestRowProps) {
         target="_blank"
         rel="noopener noreferrer"
         onClick={handlePullRequestClick}
-        title={pullRequest.title}
         aria-label={`Pull request ${pullRequest.number}: ${attentionDisplay.label}`}
         className="flex h-5 max-w-full min-w-0 items-center gap-2 text-xs text-foreground no-underline transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
@@ -732,7 +730,6 @@ function ThreadCommitListItem({
       <button
         type="button"
         aria-label={`Copy commit ${commit.shortSha} SHA`}
-        title={commit.sha}
         className={COMMIT_SHA_CHIP_CLASS_NAME}
         onClick={() => {
           void copyToClipboardWithToast(commit.sha, {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -400,7 +400,6 @@ export function ThreadSecondaryPanel({
                 aria-pressed={
                   activeFixedPanel === "thread-info" && !hasActiveFileTab
                 }
-                title="Info"
               >
                 <Icon name="Info" />
               </Button>
@@ -417,7 +416,6 @@ export function ThreadSecondaryPanel({
                 onClick={() => onPanelChange("git-diff")}
                 aria-label="Show diff panel"
                 aria-pressed={isDiffPanelActive && !hasActiveFileTab}
-                title="Diff"
               >
                 <Icon name="FileDiff" />
               </Button>
@@ -450,7 +448,6 @@ export function ThreadSecondaryPanel({
                 onClick={conversationCollapseControl.onClick}
                 aria-label={conversationCollapseControl.label}
                 aria-expanded={conversationCollapseControl.isExpanded}
-                title={conversationCollapseControl.label}
               >
                 <Icon name={conversationCollapseControl.iconName} />
               </Button>
@@ -467,7 +464,6 @@ export function ThreadSecondaryPanel({
               aria-label={
                 renderAsDrawer ? "Close right panel" : "Hide right panel"
               }
-              title={renderAsDrawer ? "Close right panel" : "Hide right panel"}
             >
               <Icon name={togglePanelIconName} />
             </Button>
@@ -596,7 +592,6 @@ function NewTabButton({ onOpenNewTab, usesDesktopChrome }: NewTabButtonProps) {
       )}
       onClick={onOpenNewTab}
       aria-label="Open new tab"
-      title="New tab"
     >
       <Icon name="Plus" />
     </Button>

--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
@@ -223,7 +223,6 @@ export function UsageLimitsSettingsSectionContent({
               className="size-7 text-muted-foreground hover:text-foreground"
               disabled={isFetching}
               onClick={onRefresh}
-              title={undefined}
               aria-label={
                 isFetching
                   ? "Reloading usage data"

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -579,7 +579,6 @@ function ProjectListSectionIconButton({
       type="button"
       size="icon"
       variant="ghost"
-      title={undefined}
       aria-label={ariaLabel}
       disabled={disabled}
       className={PROJECT_LIST_SECTION_ACTION_BUTTON_CLASS}
@@ -706,7 +705,6 @@ function SidebarDisplayMenuTrigger({
             variant="ghost"
             size="icon"
             aria-label={ariaLabel}
-            title={undefined}
             className={cn(
               "rounded-md p-0 text-muted-foreground",
               "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
@@ -1087,7 +1085,6 @@ export function TopLevelSidebarSection({
           "rounded-md pr-1 transition-colors",
           dragBindings && !dragBindings.disabled && "select-none",
         )}
-        title={label}
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
       >
@@ -1097,7 +1094,9 @@ export function TopLevelSidebarSection({
             actions && "pr-[7.5rem] max-md:pointer-coarse:pr-[9.75rem]",
           )}
         >
-          <span className="min-w-0 truncate">{label}</span>
+          <span className="min-w-0 truncate" title={label}>
+            {label}
+          </span>
           {/* Reserve room for the compact section action cluster on the right;
               coarse pointers need a little more. */}
           {collapseControl ? (
@@ -1112,7 +1111,6 @@ export function TopLevelSidebarSection({
                   ? `Expand ${label} section`
                   : `Collapse ${label} section`
               }
-              title={undefined}
               className={cn(
                 !collapseControl.isCollapsed && SIDEBAR_HOVER_ACTIONS_CLASS,
                 "relative z-20 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1049,7 +1049,6 @@ function EnvironmentThreadGroupHeaderActions({
             variant="ghost"
             size="icon"
             aria-label="Worktree actions"
-            title={undefined}
             className={cn(
               "rounded-md p-0 text-muted-foreground",
               "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
@@ -2133,7 +2132,6 @@ function ProjectRowComponent({
                 !projectDragBindings.disabled &&
                 "select-none",
             )}
-            title={project.name}
             {...projectDragBindings?.attributes}
             {...(projectDragBindings?.listeners ?? {})}
           >
@@ -2150,7 +2148,9 @@ function ProjectRowComponent({
               />
             </span>
             <span className="pointer-events-none relative z-10 flex min-w-0 flex-1 items-center gap-1.5 text-left">
-              <span className="min-w-0 truncate">{project.name}</span>
+              <span className="min-w-0 truncate" title={project.name}>
+                {project.name}
+              </span>
               <SidebarChildToggleChevron
                 isCollapsed={isCollapsed}
                 expandLabel={`Expand ${project.name}`}
@@ -2166,7 +2166,6 @@ function ProjectRowComponent({
                   event.stopPropagation();
                   onProjectSelect?.();
                 }}
-                title="Project folder not found. Open project settings to fix."
                 aria-label="Project folder not found"
                 className={cn(
                   "relative z-10 inline-flex shrink-0 items-center justify-center rounded-md text-destructive outline-none ring-sidebar-ring transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2",
@@ -2205,7 +2204,6 @@ function ProjectRowComponent({
                 variant="ghost"
                 size="icon"
                 aria-label={`New thread in ${project.name}`}
-                title="New thread"
                 disabled={!onCreateProjectThread}
                 onClick={(event) => {
                   event.stopPropagation();

--- a/apps/app/src/components/sidebar/SidebarFolderRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarFolderRow.tsx
@@ -198,7 +198,6 @@ function SidebarFolderRowComponent({
                   variant="ghost"
                   size="icon"
                   aria-label={`${label} folder actions`}
-                  title={undefined}
                   className={cn(
                     "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground",
                     COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
@@ -246,7 +245,6 @@ function SidebarFolderRowComponent({
                   variant="ghost"
                   size="icon"
                   aria-label={`New thread in ${label}`}
-                  title={undefined}
                   onClick={(event) => {
                     event.stopPropagation();
                     onCreateThread();

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -339,7 +339,6 @@ function ThreadRowComponent({
   const linkLabel = hasComposerDraft
     ? `Open ${labelTitle} (unsubmitted draft)`
     : `Open ${labelTitle}`;
-  const linkTitle = linkLabel;
   const rowDragBindings = options.dragBindings;
   const rowClassName = cn(
     SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
@@ -378,7 +377,6 @@ function ThreadRowComponent({
           onProjectSelect?.();
         }}
         aria-label={linkLabel}
-        title={linkTitle}
         className={cn(
           "absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2",
           // Draggable rows show a grab affordance; the link still selects on
@@ -387,7 +385,9 @@ function ThreadRowComponent({
         )}
       />
       <span className="flex min-w-0 flex-1 items-center gap-1.5">
-        <span className="min-w-0 truncate">{visibleTitle}</span>
+        <span className="min-w-0 truncate" title={labelTitle}>
+          {visibleTitle}
+        </span>
         {parentOptions && hasChildren ? (
           <SidebarChildToggleChevron
             isCollapsed={isParentCollapsed}

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -211,7 +211,6 @@ export function ThreadActionsMenu({
             "data-[state=open]:bg-state-active data-[state=open]:text-foreground",
           )}
           aria-label="Thread actions"
-          title="Thread actions"
           onClick={(event) => {
             event.stopPropagation();
           }}

--- a/apps/app/src/components/thread/ThreadUnarchiveButton.tsx
+++ b/apps/app/src/components/thread/ThreadUnarchiveButton.tsx
@@ -20,7 +20,6 @@ export function ThreadUnarchiveButton({
       variant="ghost"
       size="icon"
       aria-label={resolvedLabel}
-      title={resolvedLabel}
       onClick={onUnarchive}
       disabled={Boolean(isPending)}
       className={cn("size-6", className)}

--- a/apps/app/src/components/thread/WorkspaceChangesList.tsx
+++ b/apps/app/src/components/thread/WorkspaceChangesList.tsx
@@ -76,7 +76,6 @@ function WorkspaceChangesListItem({
         WORKSPACE_CHANGE_ROW_CLASS,
         "group w-full rounded px-1 text-left transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
       )}
-      title={file.path}
       aria-label={`Open ${file.path}`}
       onClick={() => onFileClick(file)}
     >

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -159,8 +159,6 @@ export function MessageActionBar({
               <CopyButton
                 text={messageText}
                 label="Copy message"
-                // The design-system tooltip replaces the native one below.
-                title={undefined}
                 className={cn(
                   HOVER_REVEAL_CLASS,
                   "max-md:pointer-coarse:hidden",
@@ -263,7 +261,6 @@ export function MessageActionBar({
               type="button"
               className={MOBILE_OVERFLOW_TRIGGER_CLASS}
               aria-label="Message actions"
-              title="Message actions"
             >
               <Icon name="MoreHorizontal" className="size-3" />
             </button>

--- a/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
@@ -87,7 +87,6 @@ function ImageViewWorkRowBody({
         className="block w-full max-w-80 cursor-zoom-in overflow-hidden rounded-lg border border-border bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:max-w-96"
         onClick={() => setLightboxOpen(true)}
         aria-label={`Open image preview: ${imageName}`}
-        title={row.path}
       >
         <img
           src={imageSrc}

--- a/apps/app/src/components/ui/button.tsx
+++ b/apps/app/src/components/ui/button.tsx
@@ -38,7 +38,7 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "title">,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/apps/app/src/components/ui/copy-button.tsx
+++ b/apps/app/src/components/ui/copy-button.tsx
@@ -45,14 +45,13 @@ function useClipboardCopy({
 
 interface CopyButtonProps
   extends ClipboardCopyOptions,
-    Omit<ComponentPropsWithoutRef<"button">, "type" | "onClick"> {
+    Omit<ComponentPropsWithoutRef<"button">, "type" | "onClick" | "title"> {
   iconClassName?: string;
   label?: string;
 }
 
 // forwardRef + prop spreading so it can act as a Radix `asChild` trigger (e.g.
-// wrapped in a Tooltip). `title` defaults to the label but a caller can pass
-// `title={undefined}` to suppress the native tooltip when supplying its own.
+// wrapped in a Tooltip) without also creating a native browser tooltip.
 export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
   function CopyButton(
     {
@@ -77,7 +76,6 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
         ref={ref}
         type="button"
         aria-label={label}
-        title={label}
         {...rest}
         className={cn(
           "inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground hover:text-foreground focus-visible:opacity-100",
@@ -132,9 +130,10 @@ export function CopyableInlineLabel({
         void copy();
       }}
       aria-label={label}
-      title={title ?? label}
     >
-      <span className="min-w-0 truncate">{children ?? text}</span>
+      <span className="min-w-0 truncate" title={title ?? text}>
+        {children ?? text}
+      </span>
       <Icon
         name={copied ? "Check" : "Copy"}
         className={cn("size-3.5 shrink-0 text-muted-foreground", iconClassName)}

--- a/apps/app/src/components/ui/markdown-mermaid-diagram.tsx
+++ b/apps/app/src/components/ui/markdown-mermaid-diagram.tsx
@@ -910,7 +910,6 @@ function MermaidDiagramDialog({
             className="size-7 text-muted-foreground"
             onClick={zoomOut}
             aria-label="Zoom out"
-            title="Zoom out"
           >
             <Icon name="ZoomOut" />
           </Button>
@@ -921,7 +920,6 @@ function MermaidDiagramDialog({
             className="size-7 text-muted-foreground"
             onClick={zoomIn}
             aria-label="Zoom in"
-            title="Zoom in"
           >
             <Icon name="ZoomIn" />
           </Button>
@@ -932,7 +930,6 @@ function MermaidDiagramDialog({
             className="size-7 text-muted-foreground"
             onClick={resetView}
             aria-label="Reset view"
-            title="Reset view"
           >
             <Icon name="RotateCcw" />
           </Button>
@@ -1063,7 +1060,6 @@ export function MarkdownMermaidDiagram({
               onClick={toggleDisplayMode}
               aria-label="Show Mermaid source"
               aria-pressed={displayMode === "source"}
-              title="Show Mermaid source"
             >
               <Icon name="Code" />
             </Button>
@@ -1076,7 +1072,6 @@ export function MarkdownMermaidDiagram({
               className="size-7 text-muted-foreground"
               onClick={() => setIsDialogOpen(true)}
               aria-label="Open Mermaid diagram"
-              title="Open diagram"
             >
               <Icon name="Maximize2" />
             </Button>

--- a/apps/app/src/components/ui/open-in-editor-button.tsx
+++ b/apps/app/src/components/ui/open-in-editor-button.tsx
@@ -10,8 +10,6 @@ interface OpenInEditorButtonProps
   onClick: () => void;
   /** aria-label; defaults to "Open in editor". */
   label?: string;
-  /** Native title. Pass `null` when wrapping in a design-system tooltip. */
-  title?: string | null;
 }
 
 /** Muted icon button that opens the associated file in the user's editor. */
@@ -23,7 +21,6 @@ export const OpenInEditorButton = forwardRef<
     className,
     onClick,
     label = "Open in editor",
-    title = "Open in editor",
     ...props
   },
   ref,
@@ -35,7 +32,6 @@ export const OpenInEditorButton = forwardRef<
       {...props}
       onClick={onClick}
       aria-label={label}
-      title={title ?? undefined}
       className={cn(
         "inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         className,

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -322,7 +322,6 @@ const SidebarRail = React.forwardRef<
       aria-label="Toggle Sidebar"
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",

--- a/apps/app/src/components/ui/split-button.tsx
+++ b/apps/app/src/components/ui/split-button.tsx
@@ -61,7 +61,6 @@ function SplitButton({
           "rounded-r-none border-r-0 pr-1 focus-visible:z-10",
         )}
         aria-label={primaryAction.label}
-        title={primaryAction.label}
         onClick={primaryAction.onSelect}
       >
         {primaryAction.content ?? primaryAction.label}
@@ -77,7 +76,6 @@ function SplitButton({
               "data-[state=open]:bg-state-active data-[state=open]:text-foreground",
             )}
             aria-label={triggerLabel}
-            title={triggerLabel}
           >
             <Icon name="ChevronDown" className="size-3" />
           </button>

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -57,7 +57,6 @@ export function TabPill({
         type="button"
         onClick={onSelect}
         aria-pressed={isActive}
-        title={title}
         className="flex h-full min-w-0 items-center rounded-md pl-2 pr-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
         {leadingVisual ? (
@@ -72,7 +71,10 @@ export function TabPill({
             {leadingVisual}
           </span>
         ) : null}
-        <span className={cn("truncate", labelMaxWidthClass, labelClassName)}>
+        <span
+          className={cn("truncate", labelMaxWidthClass, labelClassName)}
+          title={title}
+        >
           {label}
         </span>
         {secondaryLabel ? (
@@ -89,7 +91,6 @@ export function TabPill({
           onClick={closeAction.onClose}
           disabled={closeAction.isClosing}
           aria-label={closeAction.closeLabel}
-          title={closeAction.closeTooltip}
           data-tab-pill-close
           className={TAB_PILL_CLOSE_BUTTON_CLASS}
         >

--- a/apps/app/src/components/workspace/ChangedFilesDetailRow.tsx
+++ b/apps/app/src/components/workspace/ChangedFilesDetailRow.tsx
@@ -76,7 +76,6 @@ export function ChangedFilesDetailRow({
               variant="ghost"
               size="sm"
               className="h-5 w-auto min-w-0 justify-between gap-1 rounded-sm px-0 text-xs font-normal shadow-none hover:bg-transparent data-[state=open]:bg-transparent data-[state=open]:hover:bg-transparent"
-              title={activeSection.label}
               aria-label="Switch changed files bucket"
             >
               <span className="truncate">{activeSection.label}</span>

--- a/apps/app/src/views/AutomationDetailView.tsx
+++ b/apps/app/src/views/AutomationDetailView.tsx
@@ -256,7 +256,6 @@ export function AutomationDetailContent({
               variant="outline"
               size="sm"
               aria-label="Pause"
-              title="Pause"
               disabled={actionsPending}
               onClick={onPause}
             >
@@ -269,7 +268,6 @@ export function AutomationDetailContent({
               variant="outline"
               size="sm"
               aria-label="Resume"
-              title="Resume"
               disabled={actionsPending}
               onClick={onResume}
             >
@@ -282,7 +280,6 @@ export function AutomationDetailContent({
             variant="outline"
             size="sm"
             aria-label="Run now"
-            title="Run now"
             disabled={actionsPending}
             onClick={onRun}
           >
@@ -295,7 +292,6 @@ export function AutomationDetailContent({
             size="sm"
             className="text-destructive hover:text-destructive"
             aria-label="Delete automation"
-            title="Delete automation"
             disabled={actionsPending}
             onClick={onDelete}
           >

--- a/apps/app/src/views/AutomationsView.tsx
+++ b/apps/app/src/views/AutomationsView.tsx
@@ -220,7 +220,6 @@ function AutomationRow({ entry, actions }: AutomationRowProps) {
             size="icon"
             className="size-6 shrink-0 rounded-md p-0 text-muted-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground"
             aria-label={`${automation.name} actions`}
-            title={`${automation.name} actions`}
           >
             <Icon name="MoreHorizontal" className="size-4" />
           </Button>

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -431,7 +431,6 @@ function RootComposeRightPanelToggle({
       className={`${HEADER_ICON_BUTTON_CLASS} relative`}
       aria-label={rightPanelLabel}
       aria-pressed={isOpen}
-      title={rightPanelLabel}
       onClick={onToggle}
     >
       <Icon name={rightPanelIconName} />
@@ -2893,7 +2892,6 @@ export function RootComposeView(props: RootComposeViewProps) {
             with the prompt controls below the card. */}
         <div
           aria-label={`Forking ${forkSeed.sourceThreadTitle}`}
-          title={`Forking ${forkSeed.sourceThreadTitle}`}
           className="-ml-1.5 inline-flex h-7 max-w-full items-center gap-1.5 rounded-full bg-muted py-0 pl-2.5 pr-1 text-xs font-medium text-muted-foreground"
         >
           <Icon name="Fork" className="size-3.5 shrink-0" aria-hidden />
@@ -2903,7 +2901,6 @@ export function RootComposeView(props: RootComposeViewProps) {
           <button
             type="button"
             aria-label="Cancel fork"
-            title="Cancel fork"
             className="inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={handleCancelForkDraft}
           >

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -122,7 +122,6 @@ export function ThreadDetailHeader({
           className={`${HEADER_ICON_BUTTON_CLASS} relative`}
           aria-label={rightPanelLabel}
           aria-pressed={isSecondaryPanelOpen}
-          title={rightPanelLabel}
           onClick={onToggleSecondaryPanel}
         >
           <Icon name={rightPanelIconName} />

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -312,7 +312,6 @@ function PopoutThreadHeader({
         type="button"
         className={buttonClassName}
         aria-label="Hide popout"
-        title="Hide popout"
         onClick={onHide}
       >
         <Icon name="X" />
@@ -324,7 +323,6 @@ function PopoutThreadHeader({
         type="button"
         className={buttonClassName}
         aria-label="New quick thread"
-        title="New quick thread"
         onClick={onNewQuickThread}
       >
         <Icon name="EditFile" />
@@ -333,7 +331,6 @@ function PopoutThreadHeader({
         type="button"
         className={buttonClassName}
         aria-label="Open in main app"
-        title="Open in main app"
         onClick={onOpenInMain}
       >
         <Icon name="ExternalLink" />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,15 @@
 import tsParser from "@typescript-eslint/parser";
 import reactHooks from "eslint-plugin-react-hooks";
 
+const noBlockingChildProcessSyntaxRestrictions = [
+  {
+    selector:
+      "CallExpression[callee.name='spawnSync'], CallExpression[callee.name='execSync'], CallExpression[callee.name='execFileSync']",
+    message:
+      "Use async child_process APIs instead of blocking sync variants.",
+  },
+];
+
 const noBlockingChildProcessRules = {
   "no-restricted-imports": [
     "error",
@@ -23,13 +32,22 @@ const noBlockingChildProcessRules = {
   ],
   "no-restricted-syntax": [
     "error",
-    {
-      selector:
-        "CallExpression[callee.name='spawnSync'], CallExpression[callee.name='execSync'], CallExpression[callee.name='execFileSync']",
-      message:
-        "Use async child_process APIs instead of blocking sync variants.",
-    },
+    ...noBlockingChildProcessSyntaxRestrictions,
   ],
+};
+
+const noNativeTitleWithAriaLabelSyntaxRestriction = {
+  selector:
+    "JSXOpeningElement:has(> JSXAttribute[name.name='aria-label']):has(> JSXAttribute[name.name='title']) > JSXAttribute[name.name='title']",
+  message:
+    "Do not pair aria-label with a native title tooltip. Use aria-label for the accessible name and a design-system Tooltip, or put title on the truncated text only.",
+};
+
+const noNativeTitleOnButtonPrimitiveSyntaxRestriction = {
+  selector:
+    "JSXOpeningElement[name.name='Button'] > JSXAttribute[name.name='title']",
+  message:
+    "Do not put native title tooltips on the shared Button primitive. Use aria-label for icon-only buttons and a design-system Tooltip when visible hover help is intentional.",
 };
 
 // The server must not access workspace filesystems directly — all workspace
@@ -117,5 +135,17 @@ export default [
     files: ["apps/server/src/**/*.ts"],
     ignores: ["**/*.test.ts", "**/__tests__/**"],
     rules: serverNoWorkspaceAccessRules,
+  },
+  {
+    files: ["apps/app/src/**/*.{ts,tsx}"],
+    ignores: ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...noBlockingChildProcessSyntaxRestrictions,
+        noNativeTitleWithAriaLabelSyntaxRestriction,
+        noNativeTitleOnButtonPrimitiveSyntaxRestriction,
+      ],
+    },
   },
 ];


### PR DESCRIPTION
## Summary
- remove redundant native `title` tooltips from controls that already have accessible labels
- keep full-value hover text on truncated content instead of large clickable hit areas
- add lint/type restrictions to prevent `aria-label` + `title` and `Button title` regressions

## Verification
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/app`

Note: app lint still reports existing React Compiler warnings, but exits successfully with 0 errors.