### PR TITLE
Fix prompt banner PR pill height

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -171,6 +171,29 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).not.toContain('alt="Checks success"');
   });
 
+  it("uses the compact pull request pill height inside the banner row", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadPromptContextBanner
+        gitSection={null}
+        gitSectionPending={false}
+        archivedSection={null}
+        environmentGoneSection={null}
+        parentThreadSection={null}
+        childThreadsSection={null}
+        pullRequestSection={{ pullRequest: pullRequestFixture }}
+        expandedSection={null}
+        onToggleSection={noop}
+      />,
+    );
+
+    expect(markup).toMatch(
+      /class="(?=[^"]*\bh-4\b)(?=[^"]*cursor-pointer)[^"]*"/,
+    );
+    expect(markup).not.toMatch(
+      /class="(?=[^"]*\bh-5\b)(?=[^"]*cursor-pointer)[^"]*"/,
+    );
+  });
+
   it("uses the selected pull request merge method as the action label without a merge icon", () => {
     const markup = renderToStaticMarkup(
       <ThreadPromptContextBanner

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -632,7 +632,7 @@ function PullRequestBannerLink({
         SEGMENT_SHRINK_CLASS,
       )}
     >
-      <PullRequestStatusPill pullRequest={pullRequest} />
+      <PullRequestStatusPill pullRequest={pullRequest} className="h-4" />
       {showLabel ? (
         <span
           className="min-w-0 truncate"


### PR DESCRIPTION
## Summary
- shrink the prompt context banner PR pill to the compact row height
- add a regression test that prevents the PR pill from using the taller default height in the banner

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app