### PR TITLE
[codex] Syntax-highlight and soft-wrap fenced code blocks

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -72,6 +72,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^1.7.4",
+    "sugar-high": "^1.2.1",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
     "unist-util-visit": "^5.1.0",

--- a/apps/app/src/components/ui/markdown-code-highlight.css
+++ b/apps/app/src/components/ui/markdown-code-highlight.css
@@ -1,0 +1,33 @@
+/*
+ * Syntax-highlight palette for fenced code blocks (sugar-high output).
+ *
+ * Scoped to `.bb-code-highlight` so the `--sh-*` token colors never leak past a
+ * code block. Intentionally NOT in theme.css/app.css: this is a self-contained,
+ * code-only palette, not part of the shared neutral ramp guarded by theme.test.
+ *
+ * Restrained and achromatic-leaning to match bb's calm chroma - identifiers ride
+ * the neutral foreground and punctuation/comments ride the existing muted/subtle
+ * tiers; only keywords, strings, types/numbers, and entities carry a low-chroma
+ * hue, lifted in dark mode the same way the app's neutral ramp is.
+ */
+.bb-code-highlight {
+  --sh-space: inherit;
+  --sh-identifier: var(--foreground);
+  --sh-sign: var(--muted-foreground);
+  --sh-comment: var(--subtle-foreground);
+  --sh-keyword: oklch(0.5 0.16 18);
+  --sh-string: oklch(0.46 0.1 150);
+  --sh-class: oklch(0.5 0.12 250);
+  --sh-property: oklch(0.46 0.1 264);
+  --sh-entity: oklch(0.47 0.13 292);
+  --sh-jsxliterals: oklch(0.47 0.13 292);
+}
+
+.dark .bb-code-highlight {
+  --sh-keyword: oklch(0.74 0.14 18);
+  --sh-string: oklch(0.78 0.12 150);
+  --sh-class: oklch(0.76 0.11 250);
+  --sh-property: oklch(0.78 0.1 264);
+  --sh-entity: oklch(0.78 0.12 292);
+  --sh-jsxliterals: oklch(0.78 0.12 292);
+}

--- a/apps/app/src/components/ui/markdown-code-highlight.ts
+++ b/apps/app/src/components/ui/markdown-code-highlight.ts
@@ -1,0 +1,46 @@
+import { highlight } from "sugar-high";
+import { c, css, go, java, python, rust } from "sugar-high/presets";
+
+// sugar-high's core highlighter targets JavaScript/JSX/TypeScript. These presets
+// extend it to the other languages agents emit most often. A language without a
+// preset falls through to the core highlighter, which still tokenizes
+// identifiers, strings, and comments rather than failing.
+const PRESET_BY_LANGUAGE: Record<string, typeof rust> = {
+  rust,
+  rs: rust,
+  python,
+  py: python,
+  go,
+  c,
+  "c++": c,
+  cpp: c,
+  cc: c,
+  h: c,
+  hpp: c,
+  java,
+  kotlin: java,
+  kt: java,
+  css,
+  scss: css,
+  less: css,
+};
+
+export interface HighlightMarkdownCodeArgs {
+  code: string;
+  language: string | null;
+}
+
+/**
+ * Returns sugar-high HTML for a fenced code block. sugar-high HTML-escapes the
+ * input (`<` becomes `&lt;`), so the returned markup is safe to inject with
+ * dangerouslySetInnerHTML; the input is fenced code text, never user-authored
+ * HTML. Token colors come from the `--sh-*` custom properties scoped to
+ * `.bb-code-highlight` (see markdown-code-highlight.css).
+ */
+export function highlightMarkdownCode({
+  code,
+  language,
+}: HighlightMarkdownCodeArgs): string {
+  const preset = language === null ? undefined : PRESET_BY_LANGUAGE[language];
+  return highlight(code, preset);
+}

--- a/apps/app/src/components/ui/markdown-preview.stories.tsx
+++ b/apps/app/src/components/ui/markdown-preview.stories.tsx
@@ -82,21 +82,28 @@ GFM task list:
 
 const CODE_MARKDOWN = `Inline \`useMemo\` and \`useCallback\` for memoisation.
 
-Fenced code block with language tag (shows the language label + copy button):
+Fenced blocks are syntax-highlighted and carry a language label, a wrap toggle, and a copy button:
 
 \`\`\`ts
 import { useMemo } from "react";
 
+// Doubles a value, memoised.
 export function useDoubled(value: number) {
   return useMemo(() => value * 2, [value]);
 }
 \`\`\`
 
-Fenced code block without a language tag:
+Non-JavaScript languages highlight via presets (Python shown here):
+
+\`\`\`python
+def fib(n: int) -> int:
+    return n if n < 2 else fib(n - 1) + fib(n - 2)
+\`\`\`
+
+Long lines scroll horizontally until you toggle wrap (no language tag):
 
 \`\`\`
-$ pnpm exec turbo run typecheck --filter=@bb/app
-✓ typecheck (2.7s)
+$ pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/cli && echo "all packages clean"
 \`\`\``;
 
 const MERMAID_MARKDOWN = `A Mermaid flowchart renders as a diagram:

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -25,6 +25,36 @@ afterEach(() => {
 });
 
 describe("MarkdownPreview", () => {
+  it("syntax-highlights fenced code blocks", () => {
+    const { container } = render(
+      <MarkdownPreview content={"```ts\nconst x = 1;\n```"} />,
+    );
+    expect(container.querySelector(".sh__line")).not.toBeNull();
+    expect(container.querySelector(".sh__token--keyword")).not.toBeNull();
+  });
+
+  it("HTML-escapes fenced code so it cannot inject markup", () => {
+    const { container } = render(
+      <MarkdownPreview
+        content={'```ts\nconst html = "<script>alert(1)</script>";\n```'}
+      />,
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain("<script>alert(1)</script>");
+  });
+
+  it("toggles soft wrap on a fenced code block", () => {
+    const { container } = render(
+      <MarkdownPreview content={"```ts\nconst value = 1;\n```"} />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre?.classList.contains("overflow-x-auto")).toBe(true);
+    expect(pre?.classList.contains("whitespace-pre-wrap")).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "Wrap long lines" }));
+    expect(pre?.classList.contains("whitespace-pre-wrap")).toBe(true);
+    expect(pre?.classList.contains("overflow-x-auto")).toBe(false);
+  });
+
   it("renders inline-code Markdown file paths as local file links", () => {
     render(
       <MarkdownPreview

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -28,6 +28,8 @@ import {
   getMarkdownCodeLanguage,
   isMarkdownCodeBlock,
 } from "./markdown-code-block.js";
+import { highlightMarkdownCode } from "./markdown-code-highlight.js";
+import "./markdown-code-highlight.css";
 import { normalizeLocalFileMarkdownLinks } from "./markdown-local-file-link-normalize.js";
 import {
   buildLocalFileAnchorHref,
@@ -515,6 +517,16 @@ function MarkdownCode({
   const codeText = String(children ?? "").replace(/\n$/, "");
   const language = getMarkdownCodeLanguage({ className: codeClassName });
   const isBlock = isMarkdownCodeBlock({ codeText, language });
+  const [softWrap, setSoftWrap] = useState(false);
+  // Highlight only fenced blocks (mermaid renders as a diagram, inline code stays
+  // plain). The HTML is escaped by sugar-high, so dangerouslySetInnerHTML is safe.
+  const highlightedHtml = useMemo(
+    () =>
+      isBlock && language !== "mermaid"
+        ? highlightMarkdownCode({ code: codeText, language })
+        : null,
+    [isBlock, language, codeText],
+  );
   if (isBlock) {
     if (language === "mermaid") {
       return (
@@ -531,18 +543,43 @@ function MarkdownCode({
           <span className="font-mono text-xs uppercase text-muted-foreground">
             {language ?? ""}
           </span>
-          <CopyButton text={codeText} label="Copy code" />
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              aria-pressed={softWrap}
+              aria-label={softWrap ? "Disable line wrap" : "Wrap long lines"}
+              onClick={() => {
+                setSoftWrap((value) => !value);
+              }}
+              className="inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:text-foreground aria-pressed:text-foreground"
+            >
+              <Icon name="TextWrap" className="size-3" />
+            </button>
+            <CopyButton text={codeText} label="Copy code" />
+          </div>
         </div>
-        <pre className="overflow-x-auto px-3 pb-3 pt-1">
-          <code
-            className={cn(
-              "font-mono text-xs",
-              language ? `language-${language}` : "",
-            )}
-            {...props}
-          >
-            {codeText}
-          </code>
+        <pre
+          className={cn(
+            "bb-code-highlight px-3 pb-3 pt-1",
+            softWrap
+              ? "whitespace-pre-wrap [overflow-wrap:anywhere]"
+              : "overflow-x-auto",
+          )}
+        >
+          {highlightedHtml === null ? (
+            <code className="font-mono text-xs" {...props}>
+              {codeText}
+            </code>
+          ) : (
+            <code
+              className={cn(
+                "font-mono text-xs",
+                language ? `language-${language}` : "",
+              )}
+              dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              {...props}
+            />
+          )}
         </pre>
       </div>
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       sonner:
         specifier: ^1.7.4
         version: 1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sugar-high:
+        specifier: ^1.2.1
+        version: 1.2.1
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -8605,6 +8608,9 @@ packages:
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
+  sugar-high@1.2.1:
+    resolution: {integrity: sha512-C2E0iSC0Gwv+7t32ATFxgiH6fxskoSfd/nF5z11pQSrgJHYjY8/U11K+X0izV9ZyPNPwaomtn6uF7y11MxVNQA==}
 
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
@@ -17494,6 +17500,8 @@ snapshots:
       inline-style-parser: 0.2.7
 
   stylis@4.4.0: {}
+
+  sugar-high@1.2.1: {}
 
   sumchecker@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Add syntax highlighting for fenced Markdown code blocks in `MarkdownPreview` using `sugar-high`.
- Add a per-block soft-wrap toggle for long code lines while preserving copy behavior.
- Cover highlighting, HTML escaping, and wrap toggling with MarkdownPreview tests.

## Attribution
Original fork PR: https://github.com/lnittman/bb/pull/1
Original author: @lnittman

The commit includes:

```text
Co-authored-by: Luke Nittmann <luke.nittmann@gmail.com>
```

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/ui/markdown-preview.test.tsx`
