### PR TITLE
Harden host liveness after sleep

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -145,8 +145,7 @@ export function ModelReasoningPicker({
   const ProviderIcon = selectedProvider?.icon;
   const selectedModelOption = modelOptions.find((m) => m.value === modelValue);
   const selectedModelLabel = selectedModelOption?.label ?? modelValue;
-  const hasSelectedModel =
-    modelOptions.length > 0 && selectedModelLabel.trim().length > 0;
+  const hasSelectedModel = selectedModelLabel.trim().length > 0;
   const selectedProviderLabel = selectedProvider?.label ?? selectedProviderId;
   const selectedModelLoadErrorMatches =
     modelLoadError?.providerId === selectedProviderId;

--- a/apps/app/src/components/promptbox/ExecutionControls.test.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.test.tsx
@@ -75,6 +75,27 @@ describe("ExecutionControls", () => {
     expect(screen.queryByTitle("Claude Code")).not.toBeNull();
   });
 
+  it("keeps showing the known model when model options fail to load", () => {
+    const props = makeExecutionControlsProps();
+    renderExecutionControls({
+      ...props,
+      model: {
+        ...props.model,
+        active: { model: "o4-mini" },
+        options: [],
+        loadFailed: true,
+        loadError: { providerId: "codex", code: "failed" },
+      },
+    });
+
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+
+    expect(trigger.textContent).toContain("o4-mini");
+    expect(trigger.textContent).not.toContain("Failed to load models");
+  });
+
   it("maps disabled fast mode to the explicit default service tier", () => {
     const onServiceTierChange = vi.fn();
     renderExecutionControls({

--- a/apps/server/src/internal/session-state.ts
+++ b/apps/server/src/internal/session-state.ts
@@ -1,5 +1,9 @@
 import { eq } from "drizzle-orm";
-import { getActiveSessionById, hostDaemonSessions } from "@bb/db";
+import {
+  getActiveSessionById,
+  getSessionById,
+  hostDaemonSessions,
+} from "@bb/db";
 import type { DbConnection, HostDaemonSessionRow } from "@bb/db";
 import { ApiError } from "../errors.js";
 import { getAuthenticatedDaemon } from "./auth.js";
@@ -52,6 +56,25 @@ export function requireAuthorizedActiveSession(
   args: RequireAuthorizedActiveSessionArgs,
 ) {
   const session = requireActiveSession(db, args.sessionId);
+  if (session.hostId !== args.hostId) {
+    throw new ApiError(
+      403,
+      "invalid_request",
+      "Session does not belong to the authenticated host",
+    );
+  }
+
+  return session;
+}
+
+export function requireAuthorizedOpenSession(
+  db: DbConnection,
+  args: RequireAuthorizedActiveSessionArgs,
+) {
+  const session = getSessionById(db, { sessionId: args.sessionId });
+  if (!session || session.status !== "active") {
+    throw new ApiError(401, "inactive_session", "Session is not active");
+  }
   if (session.hostId !== args.hostId) {
     throw new ApiError(
       403,

--- a/apps/server/src/services/environments/environment-cleanup-internal.ts
+++ b/apps/server/src/services/environments/environment-cleanup-internal.ts
@@ -3,7 +3,6 @@ import { threadScope } from "@bb/domain";
 import {
   countLiveThreadsInEnvironment,
   getEnvironment,
-  getActiveSession,
   hasPendingThreadShutdownInEnvironment,
   listLiveThreadsInEnvironment,
   type DbNotifier,
@@ -102,12 +101,7 @@ function hasConnectedHostDaemon(
   deps: EnvironmentCleanupHostConnectionDeps,
   hostId: string,
 ): boolean {
-  const session = getActiveSession(deps.db, hostId);
-  return (
-    session !== null &&
-    session.leaseExpiresAt > Date.now() &&
-    deps.hub.hasDaemonForHost(hostId)
-  );
+  return deps.hub.hasDaemonForHost(hostId);
 }
 
 function workspaceCanBeDestroyedNow(

--- a/apps/server/src/services/hosts/host-lifecycle.ts
+++ b/apps/server/src/services/hosts/host-lifecycle.ts
@@ -1,4 +1,4 @@
-import { getHost } from "@bb/db";
+import { getHost, getSessionById, heartbeatSession } from "@bb/db";
 import type { WorkSessionDeps } from "../../types.js";
 import { ApiError } from "../../errors.js";
 import { requireConnectedHostSession } from "../lib/entity-lookup.js";
@@ -12,5 +12,25 @@ export async function ensureHostSessionReadyForWork(
     throw new ApiError(404, "host_not_found", "Host not found");
   }
 
-  return requireConnectedHostSession(deps, host.id);
+  try {
+    return requireConnectedHostSession(deps, host.id);
+  } catch (error) {
+    const liveSessionId = deps.hub.getDaemonSessionIdForHost(host.id);
+    if (!liveSessionId) {
+      throw error;
+    }
+    const session = getSessionById(deps.db, { sessionId: liveSessionId });
+    if (!session || session.hostId !== host.id || session.status !== "active") {
+      throw error;
+    }
+    const renewedSession = heartbeatSession(
+      deps.db,
+      session.id,
+      Date.now() + session.leaseTimeoutMs,
+    );
+    if (!renewedSession) {
+      throw error;
+    }
+    return renewedSession;
+  }
 }

--- a/apps/server/src/services/hosts/online-rpc.ts
+++ b/apps/server/src/services/hosts/online-rpc.ts
@@ -15,6 +15,8 @@ import {
 } from "../../ws/hub.js";
 import { ensureHostSessionReadyForWork } from "./host-lifecycle.js";
 
+const HOST_DAEMON_REGISTRATION_WAIT_MS = 1_000;
+
 export interface CallHostOnlineRpcArgs<
   TCommand extends HostDaemonRpcCommand,
 > {
@@ -79,7 +81,7 @@ async function callHostOnlineRpcWithRetry(
       ) {
         throwOnlineRpcError(error);
       }
-      await ensureHostSessionReadyForWork(deps, { hostId: args.hostId });
+      await waitForRetryableHostRpcTransport(deps, args.hostId);
       return requestHostOnlineRpcResponse(deps, args).catch((retryError) => {
         throwOnlineRpcError(retryError);
       });
@@ -99,6 +101,18 @@ async function callHostOnlineRpcWithRetry(
   }
 
   return parseHostDaemonRpcResultForCommand(args.command, response.result);
+}
+
+async function waitForRetryableHostRpcTransport(
+  deps: WorkSessionDeps,
+  hostId: string,
+): Promise<void> {
+  await ensureHostSessionReadyForWork(deps, { hostId });
+  if (deps.hub.hasDaemonForHost(hostId)) {
+    return;
+  }
+  await deps.hub.waitForDaemonForHost(hostId, HOST_DAEMON_REGISTRATION_WAIT_MS);
+  await ensureHostSessionReadyForWork(deps, { hostId });
 }
 
 function requestHostOnlineRpcResponse(

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -42,6 +42,14 @@ interface BuildModelLoadErrorArgs {
   provider: ProviderInfo;
 }
 
+interface OmittedSystemExecutionOptionsErrorLogFields {
+  errorCode: string;
+  errorDetails?: unknown;
+  errorMessage: string;
+  errorRetryable?: boolean;
+  errorStatus: number;
+}
+
 type ModelListResult = Pick<
   SystemExecutionOptionsResponse,
   "modelLoadError" | "models" | "selectedOnlyModels"
@@ -107,6 +115,23 @@ function canOmitKnownAcpAgentsForError(error: unknown): error is ApiError {
   );
 }
 
+function omittedSystemExecutionOptionsErrorLogFields(
+  error: ApiError,
+): OmittedSystemExecutionOptionsErrorLogFields {
+  const fields: OmittedSystemExecutionOptionsErrorLogFields = {
+    errorCode: error.body.code,
+    errorMessage: error.body.message,
+    errorStatus: error.status,
+  };
+  if (error.body.details !== undefined) {
+    fields.errorDetails = error.body.details;
+  }
+  if (error.body.retryable !== undefined) {
+    fields.errorRetryable = error.body.retryable;
+  }
+  return fields;
+}
+
 async function listInstalledKnownAcpAgents(
   deps: AppDeps,
   hostId: string,
@@ -147,7 +172,7 @@ async function listInstalledKnownAcpAgents(
     }
     deps.logger.warn(
       {
-        err: error,
+        ...omittedSystemExecutionOptionsErrorLogFields(error),
         hostId,
       },
       "Failed to resolve known ACP agent status",
@@ -182,7 +207,7 @@ function resolveSystemProviderInfosPlan(
       throw error;
     }
     deps.logger.warn(
-      { err: error },
+      omittedSystemExecutionOptionsErrorLogFields(error),
       "Failed to resolve host for known ACP agent status",
     );
     return {
@@ -429,7 +454,7 @@ async function loadSystemProviderModels(
     }
     deps.logger.warn(
       {
-        err: error,
+        ...omittedSystemExecutionOptionsErrorLogFields(error),
         hostId,
         providerId: provider.id,
       },

--- a/apps/server/src/services/system/periodic-sweeps.ts
+++ b/apps/server/src/services/system/periodic-sweeps.ts
@@ -509,8 +509,14 @@ function runClosedSessionPruneSweep(
 
 function runExpiredLeaseSweep(
   deps: LoggedPendingInteractionWorkSessionDeps,
+  now: number,
 ): void {
-  const expiredLeases = sweepExpiredLeases(deps.db, deps.hub);
+  const expiredLeases = sweepExpiredLeases(
+    deps.db,
+    deps.hub,
+    now,
+    deps.hub.listDaemonSessionIds(),
+  );
   handleExpiredHostSessionLeases(deps, { expiredLeases });
 }
 

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -108,6 +108,7 @@ interface FormatQueuedMessageInputForSenderArgs {
 
 const STALE_QUEUED_MESSAGE_CLAIM_MS = 5 * 60 * 1000;
 const QUEUED_MESSAGE_CLAIM_LOST_CODE = "queued_message_claim_lost";
+const activeQueuedMessageClaimTokens = new Set<string>();
 
 function sendQueuedMessagePayload(
   queuedMessage: ThreadQueuedMessage,
@@ -162,6 +163,22 @@ function releaseQueuedMessageClaims(
       id: queuedMessage.id,
       claimToken: queuedMessage.claimToken,
     });
+  }
+}
+
+async function withActiveQueuedMessageClaims<T>(
+  queuedMessages: readonly ClaimedQueuedMessage[],
+  task: () => Promise<T>,
+): Promise<T> {
+  for (const queuedMessage of queuedMessages) {
+    activeQueuedMessageClaimTokens.add(queuedMessage.claimToken);
+  }
+  try {
+    return await task();
+  } finally {
+    for (const queuedMessage of queuedMessages) {
+      activeQueuedMessageClaimTokens.delete(queuedMessage.claimToken);
+    }
   }
 }
 
@@ -425,11 +442,13 @@ export async function sendQueuedMessage(
 ): Promise<ThreadQueuedMessage> {
   const queuedMessages = claimQueuedThreadMessageForSend(deps, args);
   try {
-    return await sendClaimedQueuedMessage(deps, {
-      mode: args.mode,
-      queuedMessages,
-      threadId: args.threadId,
-    });
+    return await withActiveQueuedMessageClaims(queuedMessages, () =>
+      sendClaimedQueuedMessage(deps, {
+        mode: args.mode,
+        queuedMessages,
+        threadId: args.threadId,
+      }),
+    );
   } catch (error) {
     releaseQueuedMessageClaims(deps, queuedMessages);
     throw error;
@@ -460,11 +479,13 @@ export async function sendNextQueuedMessageIfPresent(
   }
 
   try {
-    await sendClaimedQueuedMessageForThread(deps, {
-      mode: "auto",
-      queuedMessages: nextQueuedMessages,
-      thread,
-    });
+    await withActiveQueuedMessageClaims(nextQueuedMessages, () =>
+      sendClaimedQueuedMessageForThread(deps, {
+        mode: "auto",
+        queuedMessages: nextQueuedMessages,
+        thread,
+      }),
+    );
   } catch (error) {
     releaseQueuedMessageClaims(deps, nextQueuedMessages);
     if (isQueuedMessageClaimLostError(error)) {
@@ -532,6 +553,7 @@ export async function runQueuedMessageAutoSendSweep(
 ): Promise<void> {
   releaseStaleQueuedMessageClaims(deps.db, deps.hub, {
     claimedBefore: Date.now() - STALE_QUEUED_MESSAGE_CLAIM_MS,
+    protectedClaimTokens: [...activeQueuedMessageClaimTokens],
   });
 
   for (const candidate of listIdleThreadsWithQueuedMessages(deps.db)) {

--- a/apps/server/src/ws/daemon-protocol.ts
+++ b/apps/server/src/ws/daemon-protocol.ts
@@ -10,6 +10,7 @@ import { runtimeErrorLogFields } from "../services/lib/error-log-fields.js";
 import {
   getInactiveSessionLogFields,
   requireAuthorizedActiveSession,
+  requireAuthorizedOpenSession,
 } from "../internal/session-state.js";
 import { handleDaemonSocketClosed } from "../internal/session-owner-side-effects.js";
 import { notifyDaemonEnvironmentChange } from "../internal/environment-changes.js";
@@ -107,7 +108,7 @@ export function onDaemonSocketMessage(
   }
 
   try {
-    const session = requireAuthorizedActiveSession(deps.db, {
+    const session = requireAuthorizedOpenSession(deps.db, {
       hostId: args.hostId,
       sessionId: args.sessionId,
     });

--- a/apps/server/src/ws/hub.ts
+++ b/apps/server/src/ws/hub.ts
@@ -85,6 +85,11 @@ interface HostEventWaiter {
   timeout: ReturnType<typeof setTimeout>;
 }
 
+interface DaemonRegistrationWaiter {
+  resolve: (registered: boolean) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
 interface HostOnlineRpcWaiter {
   reject: (reason?: Error) => void;
   resolve: (message: HostDaemonOnlineRpcResponseMessage) => void;
@@ -126,6 +131,10 @@ export class NotificationHub implements DbNotifier {
   private readonly daemonSessions = new Map<
     string,
     { hostId: string; socket: HubSocket }
+  >();
+  private readonly daemonRegistrationWaiters = new Map<
+    string,
+    Set<DaemonRegistrationWaiter>
   >();
   private readonly daemonSessionIdsByHost = new Map<string, string>();
   private readonly hostEventWaiters = new Map<string, Set<HostEventWaiter>>();
@@ -295,6 +304,7 @@ export class NotificationHub implements DbNotifier {
     }
     this.daemonSessions.set(sessionId, { hostId, socket });
     this.daemonSessionIdsByHost.set(hostId, sessionId);
+    this.resolveDaemonRegistrationWaiters(hostId);
   }
 
   unregisterDaemon(sessionId: string): void {
@@ -312,6 +322,42 @@ export class NotificationHub implements DbNotifier {
   hasDaemonForHost(hostId: string): boolean {
     const sessionId = this.daemonSessionIdsByHost.get(hostId);
     return sessionId !== undefined && this.daemonSessions.has(sessionId);
+  }
+
+  getDaemonSessionIdForHost(hostId: string): string | null {
+    const sessionId = this.daemonSessionIdsByHost.get(hostId);
+    if (!sessionId || !this.daemonSessions.has(sessionId)) {
+      return null;
+    }
+    return sessionId;
+  }
+
+  listDaemonSessionIds(): string[] {
+    return [...this.daemonSessions.keys()];
+  }
+
+  async waitForDaemonForHost(
+    hostId: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    if (this.hasDaemonForHost(hostId)) {
+      return true;
+    }
+
+    return new Promise<boolean>((resolve) => {
+      const waiter: DaemonRegistrationWaiter = {
+        resolve,
+        timeout: setTimeout(() => {
+          this.deleteDaemonRegistrationWaiter(hostId, waiter);
+          resolve(false);
+        }, timeoutMs),
+      };
+      const waiters =
+        this.daemonRegistrationWaiters.get(hostId) ??
+        new Set<DaemonRegistrationWaiter>();
+      waiters.add(waiter);
+      this.daemonRegistrationWaiters.set(hostId, waiters);
+    });
   }
 
   closeDaemonSession(
@@ -626,6 +672,33 @@ export class NotificationHub implements DbNotifier {
       this.deleteHostOnlineRpcWaiter(requestId, waiter);
       waiter.reject(new HostOnlineRpcUnavailableError());
     }
+  }
+
+  private deleteDaemonRegistrationWaiter(
+    hostId: string,
+    waiter: DaemonRegistrationWaiter,
+  ): void {
+    clearTimeout(waiter.timeout);
+    const waiters = this.daemonRegistrationWaiters.get(hostId);
+    if (!waiters) {
+      return;
+    }
+    waiters.delete(waiter);
+    if (waiters.size === 0) {
+      this.daemonRegistrationWaiters.delete(hostId);
+    }
+  }
+
+  private resolveDaemonRegistrationWaiters(hostId: string): void {
+    const waiters = this.daemonRegistrationWaiters.get(hostId);
+    if (!waiters) {
+      return;
+    }
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve(true);
+    }
+    this.daemonRegistrationWaiters.delete(hostId);
   }
 
   private notifyClients(message: ChangedMessage): void {

--- a/apps/server/test/hosts/online-rpc.test.ts
+++ b/apps/server/test/hosts/online-rpc.test.ts
@@ -4,6 +4,8 @@ import {
   type HostDaemonOnlineRpcRequestMessage,
   type HostDaemonOnlineRpcResult,
 } from "@bb/host-daemon-contract";
+import { hostDaemonSessions } from "@bb/db";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { ApiError } from "../../src/errors.js";
 import {
@@ -72,6 +74,99 @@ function registerDropThenReplaceSocket(args: DropThenReplaceSocketArgs): void {
 }
 
 describe("host online RPC retry semantics", () => {
+  it("renews a stale lease when the daemon websocket is still registered", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-stale-lease-live-socket",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      harness.hub.unregisterDaemon(session.id);
+      const socket: TestHostRpcSocket = {
+        close() {},
+        send(data) {
+          const request = parseHostRpcRequest(data);
+          requests.push(request);
+          harness.hub.recordHostOnlineRpcResponse({
+            sessionId: session.id,
+            message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+              type: "host-rpc.response",
+              requestId: request.requestId,
+              commandType: request.command.type,
+              ok: true,
+              result: { models: [], selectedOnlyModels: [] },
+            }),
+          });
+        },
+      };
+      harness.hub.registerDaemon(session.id, host.id, socket);
+      harness.db
+        .update(hostDaemonSessions)
+        .set({ leaseExpiresAt: Date.now() - 1000 })
+        .where(eq(hostDaemonSessions.id, session.id))
+        .run();
+
+      await expect(
+        callHostRetryableOnlineRpc(harness.deps, {
+          hostId: host.id,
+          timeoutMs: 1_000,
+          command: { type: "provider.list_models", providerId: "codex" },
+        }),
+      ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
+
+      const updatedSession = harness.db
+        .select()
+        .from(hostDaemonSessions)
+        .where(eq(hostDaemonSessions.id, session.id))
+        .get();
+      expect(updatedSession?.leaseExpiresAt).toBeGreaterThan(Date.now());
+      expect(requests.map((request) => request.command.type)).toEqual([
+        "provider.list_models",
+      ]);
+    });
+  });
+
+  it("waits briefly for retryable RPCs when the session is active before the daemon websocket registers", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-registration-race",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      harness.hub.unregisterDaemon(session.id);
+
+      setTimeout(() => {
+        const socket: TestHostRpcSocket = {
+          close() {},
+          send(data) {
+            const request = parseHostRpcRequest(data);
+            requests.push(request);
+            harness.hub.recordHostOnlineRpcResponse({
+              sessionId: session.id,
+              message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+                type: "host-rpc.response",
+                requestId: request.requestId,
+                commandType: request.command.type,
+                ok: true,
+                result: { models: [], selectedOnlyModels: [] },
+              }),
+            });
+          },
+        };
+        harness.hub.registerDaemon(session.id, host.id, socket);
+      }, 10);
+
+      await expect(
+        callHostRetryableOnlineRpc(harness.deps, {
+          hostId: host.id,
+          timeoutMs: 1_000,
+          command: { type: "provider.list_models", providerId: "codex" },
+        }),
+      ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
+      expect(requests.map((request) => request.command.type)).toEqual([
+        "provider.list_models",
+      ]);
+    });
+  });
+
   it("retries read-only online RPCs when the current websocket session disappears", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {

--- a/apps/server/test/internal/internal-environment-change.test.ts
+++ b/apps/server/test/internal/internal-environment-change.test.ts
@@ -1,4 +1,5 @@
-import { getEnvironment } from "@bb/db";
+import { getEnvironment, hostDaemonSessions } from "@bb/db";
+import { eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { onDaemonSocketMessage } from "../../src/ws/daemon-protocol.js";
 import {
@@ -21,6 +22,36 @@ function createTestDaemonSocket(): TestDaemonSocket {
 }
 
 describe("internal environment change websocket hints", () => {
+  it("renews an active session from a late heartbeat after lease expiry", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-late-heartbeat",
+      });
+      const socket = createTestDaemonSocket();
+      harness.db
+        .update(hostDaemonSessions)
+        .set({ leaseExpiresAt: Date.now() - 1000 })
+        .where(eq(hostDaemonSessions.id, session.id))
+        .run();
+
+      onDaemonSocketMessage(harness.deps, {
+        hostId: host.id,
+        sessionId: session.id,
+        socket,
+        raw: JSON.stringify({ type: "heartbeat" }),
+      });
+
+      const updatedSession = harness.db
+        .select()
+        .from(hostDaemonSessions)
+        .where(eq(hostDaemonSessions.id, session.id))
+        .get();
+      expect(updatedSession?.status).toBe("active");
+      expect(updatedSession?.leaseExpiresAt).toBeGreaterThan(Date.now());
+      expect(socket.close).not.toHaveBeenCalled();
+    });
+  });
+
   it("does not resolve host RPC waiters from a different daemon session", async () => {
     await withTestHarness(async (harness) => {
       const hostA = seedHostSession(harness.deps, {

--- a/apps/server/test/services/managed-environment-cleanup-recovery.test.ts
+++ b/apps/server/test/services/managed-environment-cleanup-recovery.test.ts
@@ -1,5 +1,10 @@
 import { eq } from "drizzle-orm";
-import { createEnvironment, environments, getEnvironment } from "@bb/db";
+import {
+  createEnvironment,
+  environments,
+  getEnvironment,
+  hostDaemonSessions,
+} from "@bb/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   runEnvironmentCleanupAdvance,
@@ -211,6 +216,45 @@ describe("managed environment cleanup recovery sweep", () => {
         isGitRepo: true,
         managed: true,
         path: "/tmp/git-cleanup-without-merge-base",
+        projectId: project.id,
+        status: "retiring",
+        workspaceProvisionType: "managed-worktree",
+      });
+
+      await runEnvironmentCleanupAdvance(harness.deps, {
+        environmentId: environment.id,
+      });
+
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        destroyAttemptId: expect.any(String),
+        status: "destroying",
+      });
+      expect(
+        listQueuedEnvironmentCommands(
+          harness,
+          "environment.destroy",
+          environment.id,
+        ),
+      ).toHaveLength(1);
+    });
+  });
+
+  it("advances cleanup when a daemon socket is live but its lease timestamp is stale", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps);
+      harness.db
+        .update(hostDaemonSessions)
+        .set({ leaseExpiresAt: Date.now() - 1_000 })
+        .where(eq(hostDaemonSessions.id, session.id))
+        .run();
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = createEnvironment(harness.db, harness.hub, {
+        hostId: host.id,
+        isGitRepo: false,
+        managed: true,
+        path: "/tmp/live-daemon-stale-cleanup-lease",
         projectId: project.id,
         status: "retiring",
         workspaceProvisionType: "managed-worktree",

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -537,6 +537,45 @@ describe("resolveSystemExecutionOptions", () => {
     );
   });
 
+  it("logs model load fallback errors without stack-bearing err objects", async () => {
+    await withTestHarness(async (harness) => {
+      const warn = vi.fn();
+      harness.deps.logger = { ...harness.deps.logger, warn };
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-execution-options-concise-model-log",
+      });
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelErrorsByProviderId: {
+          codex: {
+            errorCode: "command_failed",
+            errorMessage: "model list failed",
+          },
+        },
+      });
+
+      await resolveSystemExecutionOptions(harness.deps, {
+        hostId: host.id,
+        providerId: "codex",
+      });
+
+      const providerModelWarning = warn.mock.calls.find(
+        ([, message]) => message === "Failed to resolve provider models",
+      );
+      expect(providerModelWarning).toBeDefined();
+      expect(providerModelWarning?.[0]).toMatchObject({
+        errorCode: "command_failed",
+        errorMessage: "model list failed",
+        errorRetryable: false,
+        errorStatus: 502,
+        hostId: host.id,
+        providerId: "codex",
+      });
+      expect(providerModelWarning?.[0]).not.toHaveProperty("err");
+    });
+  });
+
   it("includes custom ACP agents and sends their launch spec when loading models", async () => {
     await withTestHarness(
       {

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -406,6 +406,7 @@ export {
   getActiveSessionById,
   getLatestSessionForHost,
   getMostRecentlyUpdatedConnectedHostId,
+  getSessionById,
   heartbeatSession,
   listLatestSessionsForHosts,
   listConnectedHostIds,

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -8,6 +8,7 @@ import {
   isNull,
   lt,
   min,
+  notInArray,
   or,
 } from "drizzle-orm";
 import type { PermissionMode, PromptInput } from "@bb/domain";
@@ -85,6 +86,7 @@ export type DeleteClaimedQueuedThreadMessageArgs = ClaimedQueuedThreadMessageMut
 
 export interface ReleaseStaleQueuedMessageClaimsArgs {
   claimedBefore: number;
+  protectedClaimTokens?: readonly string[];
 }
 
 export interface ReorderQueuedThreadMessageSuccess {
@@ -984,18 +986,21 @@ export function releaseStaleQueuedMessageClaims(
   notifier: DbNotifier,
   args: ReleaseStaleQueuedMessageClaimsArgs,
 ): number {
+  const protectedClaimTokens = [...(args.protectedClaimTokens ?? [])];
+  const staleClaimWhere = and(
+    isNotNull(queuedThreadMessages.claimedAt),
+    lt(queuedThreadMessages.claimedAt, args.claimedBefore),
+    ...(protectedClaimTokens.length > 0
+      ? [notInArray(queuedThreadMessages.claimToken, protectedClaimTokens)]
+      : []),
+  );
   const staleRows = db
     .select({
       id: queuedThreadMessages.id,
       threadId: queuedThreadMessages.threadId,
     })
     .from(queuedThreadMessages)
-    .where(
-      and(
-        isNotNull(queuedThreadMessages.claimedAt),
-        lt(queuedThreadMessages.claimedAt, args.claimedBefore),
-      ),
-    )
+    .where(staleClaimWhere)
     .all();
   if (staleRows.length === 0) {
     return 0;
@@ -1005,12 +1010,7 @@ export function releaseStaleQueuedMessageClaims(
   const result = db
     .update(queuedThreadMessages)
     .set({ claimedAt: null, claimToken: null, updatedAt: now })
-    .where(
-      and(
-        isNotNull(queuedThreadMessages.claimedAt),
-        lt(queuedThreadMessages.claimedAt, args.claimedBefore),
-      ),
-    )
+    .where(staleClaimWhere)
     .run();
 
   for (const threadId of new Set(staleRows.map((row) => row.threadId))) {

--- a/packages/db/src/data/sessions.ts
+++ b/packages/db/src/data/sessions.ts
@@ -13,6 +13,10 @@ export interface GetActiveSessionByIdArgs {
   sessionId: string;
 }
 
+export interface GetSessionByIdArgs {
+  sessionId: string;
+}
+
 export interface GetMostRecentlyUpdatedConnectedHostIdArgs {
   hostType?: HostType;
 }
@@ -218,6 +222,19 @@ export function getActiveSessionById(
           gt(hostDaemonSessions.leaseExpiresAt, Date.now()),
         ),
       )
+      .get() ?? null
+  );
+}
+
+export function getSessionById(
+  db: SessionReadConnection,
+  args: GetSessionByIdArgs,
+) {
+  return (
+    db
+      .select()
+      .from(hostDaemonSessions)
+      .where(eq(hostDaemonSessions.id, args.sessionId))
       .get() ?? null
   );
 }

--- a/packages/db/src/data/sweeps.ts
+++ b/packages/db/src/data/sweeps.ts
@@ -4,6 +4,7 @@ import {
   sql,
   lt,
   inArray,
+  notInArray,
 } from "drizzle-orm";
 import { type ThreadEventItemType } from "@bb/domain";
 import type { DbConnection } from "../connection.js";
@@ -351,19 +352,24 @@ export function sweepExpiredLeases(
   db: DbConnection,
   notifier: DbNotifier,
   now?: number,
+  protectedSessionIds: readonly string[] = [],
 ): SweepExpiredLeasesResult {
   const currentTime = now ?? Date.now();
+  const whereClauses = [
+    eq(hostDaemonSessions.status, "active"),
+    lt(hostDaemonSessions.leaseExpiresAt, currentTime),
+  ];
+  if (protectedSessionIds.length > 0) {
+    whereClauses.push(
+      notInArray(hostDaemonSessions.id, [...protectedSessionIds]),
+    );
+  }
 
   // Find active sessions past their lease
   const expiredSessions = db
     .select()
     .from(hostDaemonSessions)
-    .where(
-      and(
-        eq(hostDaemonSessions.status, "active"),
-        lt(hostDaemonSessions.leaseExpiresAt, currentTime),
-      ),
-    )
+    .where(and(...whereClauses))
     .all();
 
   if (expiredSessions.length === 0) {

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -247,6 +247,63 @@ describe("queued thread messages", () => {
     }
   });
 
+  it("does not release stale queued message claims protected by a live owner", () => {
+    const { db, thread } = setup();
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      nowSpy.mockReturnValue(1_000);
+      const protectedQueuedMessage = createQueuedThreadMessage(db, noopNotifier, {
+        threadId: thread.id,
+        content: defaultInput,
+        model: "gpt-5",
+        reasoningLevel: "medium",
+        permissionMode: "full",
+        serviceTier: "default",
+      });
+      const releasableQueuedMessage = createQueuedThreadMessage(db, noopNotifier, {
+        threadId: thread.id,
+        content: altInput,
+        model: "gpt-5",
+        reasoningLevel: "medium",
+        permissionMode: "full",
+        serviceTier: "default",
+      });
+      const protectedClaim = claimQueuedThreadMessage(
+        db,
+        noopNotifier,
+        protectedQueuedMessage.id,
+      );
+      const releasableClaim = claimQueuedThreadMessage(
+        db,
+        noopNotifier,
+        releasableQueuedMessage.id,
+      );
+      if (!protectedClaim || !releasableClaim) {
+        throw new Error("Expected queued message claims");
+      }
+
+      nowSpy.mockReturnValue(10_000);
+      expect(
+        releaseStaleQueuedMessageClaims(db, noopNotifier, {
+          claimedBefore: 5_000,
+          protectedClaimTokens: [protectedClaim.claimToken],
+        }),
+      ).toBe(1);
+
+      expect(getQueuedThreadMessage(db, protectedQueuedMessage.id)?.claimToken).toBe(
+        protectedClaim.claimToken,
+      );
+      expect(
+        getQueuedThreadMessage(db, releasableQueuedMessage.id)?.claimToken,
+      ).toBeNull();
+      expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
+        releasableQueuedMessage.id,
+      ]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it("claims the oldest queued message first", () => {
     const { db, thread } = setup();
     const nowSpy = vi.spyOn(Date, "now");

--- a/packages/db/test/data/sweeps.test.ts
+++ b/packages/db/test/data/sweeps.test.ts
@@ -619,6 +619,48 @@ describe("sweepExpiredLeases", () => {
     expect(spy.notifyThread).not.toHaveBeenCalled();
   });
 
+  it("does not close expired sessions that are protected by a live daemon websocket", () => {
+    const { db, host } = setup();
+
+    const session = openSession(db, noopNotifier, {
+      hostId: host.id,
+      instanceId: "inst-1",
+      hostName: "test-host",
+      hostType: "persistent",
+      dataDir: "/tmp/test-host-data",
+      protocolVersion: 1,
+      heartbeatIntervalMs: 10_000,
+      leaseTimeoutMs: 30_000,
+    });
+
+    const now = Date.now();
+    db.update(hostDaemonSessions)
+      .set({ leaseExpiresAt: now - 1000 })
+      .where(eq(hostDaemonSessions.id, session.id))
+      .run();
+
+    const spy: DbNotifier = {
+      notifyThread: vi.fn(),
+      notifyEnvironment: vi.fn(),
+      notifyProject: vi.fn(),
+      notifyHost: vi.fn(),
+      notifySystem: vi.fn(),
+    };
+
+    const result = sweepExpiredLeases(db, spy, now, [session.id]);
+
+    expect(result.sessionsClosed).toBe(0);
+    expect(result.expiredHostIds).toEqual([]);
+    expect(result.expiredSessionIds).toEqual([]);
+    const updatedSession = db
+      .select()
+      .from(hostDaemonSessions)
+      .where(eq(hostDaemonSessions.id, session.id))
+      .get();
+    expect(updatedSession?.status).toBe("active");
+    expect(spy.notifyHost).not.toHaveBeenCalled();
+  });
+
   it("does not error idle threads on lease expiry", () => {
     const { db, host, project } = setup();
 

--- a/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
+++ b/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
@@ -107,6 +107,7 @@ export function createParcelWatcherProxy(
   let idCounter = 0;
   let pingNonce = 0;
   let lastPongAt = 0;
+  let lastPingTickAt = 0;
   let pingTimer: ReturnType<typeof setInterval> | null = null;
 
   function nextId(): string {
@@ -123,14 +124,25 @@ export function createParcelWatcherProxy(
 
   function startPing(): void {
     stopPing();
-    lastPongAt = Date.now();
+    const now = Date.now();
+    lastPongAt = now;
+    lastPingTickAt = now;
     pingTimer = setInterval(() => {
       if (channel === null) {
         return;
       }
-      if (Date.now() - lastPongAt > pingTimeoutMs) {
+      const now = Date.now();
+      const sinceLastPingTickMs = now - lastPingTickAt;
+      lastPingTickAt = now;
+      if (sinceLastPingTickMs > pingIntervalMs + pingTimeoutMs) {
+        lastPongAt = now;
+        pingNonce += 1;
+        channel.send({ kind: "ping", nonce: pingNonce });
+        return;
+      }
+      if (now - lastPongAt > pingTimeoutMs) {
         log("warn", "Watcher child unresponsive; killing", {
-          sinceLastPongMs: Date.now() - lastPongAt,
+          sinceLastPongMs: now - lastPongAt,
         });
         killAndRespawn();
         return;

--- a/packages/host-watcher/test/parcel-watcher-proxy.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-proxy.test.ts
@@ -337,6 +337,33 @@ describe("createParcelWatcherProxy", () => {
     }
   });
 
+  it("probes instead of killing when the parent ping timer resumes late", async () => {
+    vi.useFakeTimers();
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      nowSpy.mockReturnValue(0);
+      const { proxy, children, current } = createHarness({
+        pingIntervalMs: 1_000,
+        pingTimeoutMs: 2_500,
+      });
+      await proxy.subscribe("/root", () => {});
+      await flush();
+      expect(children).toHaveLength(1);
+
+      nowSpy.mockReturnValue(4_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flush();
+
+      expect(children[0]?.exited).toBe(false);
+      expect(children).toHaveLength(1);
+      expect(current().parcel.activeDirs()).toEqual(["/root"]);
+      proxy.dispose();
+    } finally {
+      nowSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("backs off a rapid respawn but never permanently gives up", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

- treat live daemon websocket/hub presence as stronger liveness evidence than stale wall-clock lease timestamps after sleep/wake
- allow late daemon heartbeats and retryable host RPCs to recover cleanly across reconnect registration races
- keep the promptbox showing the known selected model when model option loading fails
- make model-load fallback logs concise instead of stack-heavy `ApiError` dumps
- avoid sleep-delayed watcher ping timers killing the watcher child immediately
- protect in-process queued-message claim tokens from stale wall-clock release

## Contracts and lifecycle

- No external HTTP API, daemon websocket schema, or persisted schema migration changes.
- `@bb/db` now exposes `getSessionById`.
- `sweepExpiredLeases` accepts protected live session ids.
- `releaseStaleQueuedMessageClaims` accepts optional protected claim tokens.
- `NotificationHub` now exposes daemon registration waiters and live daemon session introspection.
- Server session validation gained an authorized-open-session path for already-open daemon sockets whose persisted lease timestamp is stale.

## Validation

- `pnpm exec turbo run test --filter=@bb/db -- test/data/sweeps.test.ts test/data/queued-thread-messages.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/hosts/online-rpc.test.ts test/internal/internal-environment-change.test.ts test/system/execution-options.test.ts test/services/managed-environment-cleanup-recovery.test.ts`
- `pnpm exec turbo run test --filter=@bb/host-watcher -- test/parcel-watcher-proxy.test.ts`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/ExecutionControls.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/host-watcher`
- `pnpm exec turbo run typecheck --filter=@bb/db`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run typecheck --filter=@bb/app`
