### PR TITLE
Fix prompt focus after welcome compose

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -120,10 +120,22 @@ function PromptBoxRaceHarness({
     <PromptBoxInternal
       {...createPromptBoxProps({
         onChange,
-        promptBoxRef,
         value,
       })}
+      promptBoxRef={promptBoxRef}
     />
+  );
+}
+
+function PromptBoxFocusOnMountHarness() {
+  const promptBoxRef = useRef<PromptBoxHandle | null>(null);
+
+  useLayoutEffect(() => {
+    promptBoxRef.current?.focusEnd();
+  }, []);
+
+  return (
+    <PromptBoxInternal {...createPromptBoxProps()} promptBoxRef={promptBoxRef} />
   );
 }
 
@@ -234,6 +246,23 @@ function pastePlainText(text: string) {
   });
 }
 
+function mockPointerCoarse(matches: boolean): () => void {
+  const originalMatchMedia = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+  return () => {
+    window.matchMedia = originalMatchMedia;
+  };
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -286,6 +315,31 @@ describe("suppressPromptEditorAnchorActivation", () => {
 });
 
 describe("PromptBoxInternal controlled value sync", () => {
+  it("honors early focusEnd requests once the editor is ready", async () => {
+    const restoreMatchMedia = mockPointerCoarse(false);
+    try {
+      render(<PromptBoxFocusOnMountHarness />);
+
+      await waitForPromptFocus();
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
+  it("skips passive autofocus on coarse pointers", async () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
+    try {
+      render(<PromptBoxInternal {...createPromptBoxProps()} />);
+
+      await waitFor(() =>
+        expect(getPromptEditorElement()).toBeInstanceOf(HTMLElement),
+      );
+      expect(document.activeElement).not.toBe(getPromptEditorElement());
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
   it("applies an added quote before focus-end insertion can edit the old document", () => {
     const onChange = vi.fn();
     const view = render(

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1001,6 +1001,7 @@ export function PromptBoxInternal({
   const editorScrollContainerRef = useRef<HTMLDivElement>(null);
   const revealSelectionFrameRef = useRef<number | null>(null);
   const promptActionFocusFrameRef = useRef<number | null>(null);
+  const pendingFocusEndRef = useRef(false);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
   const valueRef = useRef(value);
   const mentionRangesRef = useRef<readonly PromptTextMention[]>(mentionRanges);
@@ -1310,6 +1311,15 @@ export function PromptBoxInternal({
   useEffect(() => {
     editorRef.current = editor;
   }, [editor]);
+
+  useLayoutEffect(() => {
+    if (!editor) return;
+    if (!pendingFocusEndRef.current) return;
+
+    pendingFocusEndRef.current = false;
+    focusEditorAtEnd(editor);
+    scheduleRevealEditorSelection();
+  }, [editor, scheduleRevealEditorSelection]);
 
   useLayoutEffect(() => {
     placeholderRef.current = placeholder;
@@ -1718,7 +1728,11 @@ export function PromptBoxInternal({
 
   const focusEnd = useCallback(() => {
     const currentEditor = editorRef.current;
-    if (!currentEditor || currentEditor.isDestroyed) return;
+    if (!currentEditor || currentEditor.isDestroyed) {
+      pendingFocusEndRef.current = true;
+      return;
+    }
+    pendingFocusEndRef.current = false;
     focusEditorAtEnd(currentEditor);
     scheduleRevealEditorSelection();
   }, [scheduleRevealEditorSelection]);

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -61,6 +61,7 @@ import { Icon } from "@/components/ui/icon.js";
 import { PageShell } from "@/components/ui/page-shell.js";
 import { Button } from "@/components/ui/button.js";
 import { useIsCompactViewport } from "@/components/ui/hooks/use-compact-viewport";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { COARSE_POINTER_COMPACT_ICON_SIZE_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
 import { useUploadPromptAttachment } from "@/hooks/mutations/project-mutations";
 import { useCreateThread } from "@/hooks/mutations/thread-runtime-mutations";
@@ -813,6 +814,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     useRootComposeProjectId();
   const location = useLocation();
   const navigate = useNavigate();
+  const isPointerCoarse = usePointerCoarse();
   const [rootComposeFolderId, setRootComposeFolderId] = useState<string | null>(
     () => readFolderIdFromLocationState(location.state),
   );
@@ -1454,11 +1456,12 @@ export function RootComposeView(props: RootComposeViewProps) {
 
   useEffect(() => {
     if (!shouldFocusPrompt) return;
+    if (isPointerCoarse) return;
     const handle = window.requestAnimationFrame(() => {
       promptBoxRef.current?.focusEnd();
     });
     return () => window.cancelAnimationFrame(handle);
-  }, [location.key, shouldFocusPrompt]);
+  }, [isPointerCoarse, location.key, shouldFocusPrompt]);
 
   const handleAttachFiles = useCallback(
     async (files: File[]) => {
@@ -2765,8 +2768,12 @@ export function RootComposeView(props: RootComposeViewProps) {
   // Focus the composer once it mounts in place of the welcome screen.
   useEffect(() => {
     if (!startedComposing) return;
-    promptBoxRef.current?.focusEnd();
-  }, [startedComposing]);
+    if (isPointerCoarse) return;
+    const handle = window.requestAnimationFrame(() => {
+      promptBoxRef.current?.focusEnd();
+    });
+    return () => window.cancelAnimationFrame(handle);
+  }, [isPointerCoarse, startedComposing]);
   const environmentConfig = useMemo(
     () => ({
       value: effectiveEnvironmentValue,


### PR DESCRIPTION
## Summary
- defer focus after the no-projects welcome swaps to the composer
- preserve early prompt `focusEnd()` requests until the Tiptap editor is ready
- keep passive root-compose autofocus disabled on coarse-pointer/mobile devices
- add regression coverage for early desktop focus and skipped coarse-pointer passive autofocus

## Validation
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (exits 0; existing warnings remain)