### PR TITLE
Handle delayed watcher ping ticks

### DIFF
--- a/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
+++ b/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
@@ -107,6 +107,7 @@ export function createParcelWatcherProxy(
   let idCounter = 0;
   let pingNonce = 0;
   let lastPongAt = 0;
+  let lastPingTickAt = 0;
   let pingTimer: ReturnType<typeof setInterval> | null = null;
 
   function nextId(): string {
@@ -123,14 +124,25 @@ export function createParcelWatcherProxy(
 
   function startPing(): void {
     stopPing();
-    lastPongAt = Date.now();
+    const now = Date.now();
+    lastPongAt = now;
+    lastPingTickAt = now;
     pingTimer = setInterval(() => {
       if (channel === null) {
         return;
       }
-      if (Date.now() - lastPongAt > pingTimeoutMs) {
+      const now = Date.now();
+      const sinceLastPingTickMs = now - lastPingTickAt;
+      lastPingTickAt = now;
+      if (sinceLastPingTickMs > pingIntervalMs + pingTimeoutMs) {
+        lastPongAt = now;
+        pingNonce += 1;
+        channel.send({ kind: "ping", nonce: pingNonce });
+        return;
+      }
+      if (now - lastPongAt > pingTimeoutMs) {
         log("warn", "Watcher child unresponsive; killing", {
-          sinceLastPongMs: Date.now() - lastPongAt,
+          sinceLastPongMs: now - lastPongAt,
         });
         killAndRespawn();
         return;

--- a/packages/host-watcher/test/parcel-watcher-proxy.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-proxy.test.ts
@@ -337,6 +337,33 @@ describe("createParcelWatcherProxy", () => {
     }
   });
 
+  it("probes instead of killing when the parent ping timer resumes late", async () => {
+    vi.useFakeTimers();
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      nowSpy.mockReturnValue(0);
+      const { proxy, children, current } = createHarness({
+        pingIntervalMs: 1_000,
+        pingTimeoutMs: 2_500,
+      });
+      await proxy.subscribe("/root", () => {});
+      await flush();
+      expect(children).toHaveLength(1);
+
+      nowSpy.mockReturnValue(4_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flush();
+
+      expect(children[0]?.exited).toBe(false);
+      expect(children).toHaveLength(1);
+      expect(current().parcel.activeDirs()).toEqual(["/root"]);
+      proxy.dispose();
+    } finally {
+      nowSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("backs off a rapid respawn but never permanently gives up", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

Split 4 from #416. This keeps the change limited to host-watcher child ping behavior after parent-side sleep/wake or event-loop delay.

- Track the previous parent ping timer tick in `parcel-watcher-proxy`.
- If the parent timer resumes after a large delay, send a fresh ping to probe the watcher child instead of immediately logging `Watcher child unresponsive; killing` and recycling it.
- Preserve normal wedged-child behavior: if timers are running on schedule and pongs stop, the child is still killed and respawned after the ping timeout.

## Validation

- `pnpm exec turbo run test --filter=@bb/host-watcher`
- `pnpm exec turbo run typecheck --filter=@bb/host-watcher --force`
- `scripts/bb-dev-app current`
  - Confirmed standalone dev instance from this worktree:
    - Repo: `/Users/michael/.bb/worktrees/env_z3f83mbq8p/bb`
    - Server: `http://localhost:24765`
    - Host daemon: `http://127.0.0.1:32765`
    - Data dir: `/Users/michael/.bb-dev/bb-worktrees-env_z3f83mbq8p-bb-8432dc85cc9e`
- `eval "$(scripts/bb-dev-app env)" && pnpm bb:dev status`

## Reproduction / QA Notes

- Simulated delayed parent timer in `parcel-watcher-proxy.test.ts` using fake timers and `Date.now()` jumping from `0` to `4000` with `pingIntervalMs: 1000` and `pingTimeoutMs: 2500`; verified the original child remains alive and subscribed.
- Verified genuinely unresponsive child behavior with the existing ping timeout test by setting the fake child `responsive = false`, advancing timers by `3500ms`, and asserting the child is killed, respawned, and subscriptions replay.
