### PR TITLE
Protect active queued message claims from stale release

### DIFF
--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -108,6 +108,7 @@ interface FormatQueuedMessageInputForSenderArgs {
 
 const STALE_QUEUED_MESSAGE_CLAIM_MS = 5 * 60 * 1000;
 const QUEUED_MESSAGE_CLAIM_LOST_CODE = "queued_message_claim_lost";
+const activeQueuedMessageClaimTokens = new Set<string>();
 
 function sendQueuedMessagePayload(
   queuedMessage: ThreadQueuedMessage,
@@ -162,6 +163,22 @@ function releaseQueuedMessageClaims(
       id: queuedMessage.id,
       claimToken: queuedMessage.claimToken,
     });
+  }
+}
+
+async function withActiveQueuedMessageClaims<T>(
+  queuedMessages: readonly ClaimedQueuedMessage[],
+  task: () => Promise<T>,
+): Promise<T> {
+  for (const queuedMessage of queuedMessages) {
+    activeQueuedMessageClaimTokens.add(queuedMessage.claimToken);
+  }
+  try {
+    return await task();
+  } finally {
+    for (const queuedMessage of queuedMessages) {
+      activeQueuedMessageClaimTokens.delete(queuedMessage.claimToken);
+    }
   }
 }
 
@@ -425,11 +442,13 @@ export async function sendQueuedMessage(
 ): Promise<ThreadQueuedMessage> {
   const queuedMessages = claimQueuedThreadMessageForSend(deps, args);
   try {
-    return await sendClaimedQueuedMessage(deps, {
-      mode: args.mode,
-      queuedMessages,
-      threadId: args.threadId,
-    });
+    return await withActiveQueuedMessageClaims(queuedMessages, () =>
+      sendClaimedQueuedMessage(deps, {
+        mode: args.mode,
+        queuedMessages,
+        threadId: args.threadId,
+      }),
+    );
   } catch (error) {
     releaseQueuedMessageClaims(deps, queuedMessages);
     throw error;
@@ -460,11 +479,13 @@ export async function sendNextQueuedMessageIfPresent(
   }
 
   try {
-    await sendClaimedQueuedMessageForThread(deps, {
-      mode: "auto",
-      queuedMessages: nextQueuedMessages,
-      thread,
-    });
+    await withActiveQueuedMessageClaims(nextQueuedMessages, () =>
+      sendClaimedQueuedMessageForThread(deps, {
+        mode: "auto",
+        queuedMessages: nextQueuedMessages,
+        thread,
+      }),
+    );
   } catch (error) {
     releaseQueuedMessageClaims(deps, nextQueuedMessages);
     if (isQueuedMessageClaimLostError(error)) {
@@ -532,6 +553,7 @@ export async function runQueuedMessageAutoSendSweep(
 ): Promise<void> {
   releaseStaleQueuedMessageClaims(deps.db, deps.hub, {
     claimedBefore: Date.now() - STALE_QUEUED_MESSAGE_CLAIM_MS,
+    protectedClaimTokens: [...activeQueuedMessageClaimTokens],
   });
 
   for (const candidate of listIdleThreadsWithQueuedMessages(deps.db)) {

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -8,6 +8,7 @@ import {
   isNull,
   lt,
   min,
+  notInArray,
   or,
 } from "drizzle-orm";
 import type { PermissionMode, PromptInput } from "@bb/domain";
@@ -85,6 +86,7 @@ export type DeleteClaimedQueuedThreadMessageArgs = ClaimedQueuedThreadMessageMut
 
 export interface ReleaseStaleQueuedMessageClaimsArgs {
   claimedBefore: number;
+  protectedClaimTokens: readonly string[];
 }
 
 export interface ReorderQueuedThreadMessageSuccess {
@@ -984,18 +986,26 @@ export function releaseStaleQueuedMessageClaims(
   notifier: DbNotifier,
   args: ReleaseStaleQueuedMessageClaimsArgs,
 ): number {
+  const protectedClaimTokens = [...args.protectedClaimTokens];
+  const staleClaimWhere = and(
+    isNotNull(queuedThreadMessages.claimedAt),
+    lt(queuedThreadMessages.claimedAt, args.claimedBefore),
+    ...(protectedClaimTokens.length > 0
+      ? [
+          or(
+            isNull(queuedThreadMessages.claimToken),
+            notInArray(queuedThreadMessages.claimToken, protectedClaimTokens),
+          )!,
+        ]
+      : []),
+  );
   const staleRows = db
     .select({
       id: queuedThreadMessages.id,
       threadId: queuedThreadMessages.threadId,
     })
     .from(queuedThreadMessages)
-    .where(
-      and(
-        isNotNull(queuedThreadMessages.claimedAt),
-        lt(queuedThreadMessages.claimedAt, args.claimedBefore),
-      ),
-    )
+    .where(staleClaimWhere)
     .all();
   if (staleRows.length === 0) {
     return 0;
@@ -1005,12 +1015,7 @@ export function releaseStaleQueuedMessageClaims(
   const result = db
     .update(queuedThreadMessages)
     .set({ claimedAt: null, claimToken: null, updatedAt: now })
-    .where(
-      and(
-        isNotNull(queuedThreadMessages.claimedAt),
-        lt(queuedThreadMessages.claimedAt, args.claimedBefore),
-      ),
-    )
+    .where(staleClaimWhere)
     .run();
 
   for (const threadId of new Set(staleRows.map((row) => row.threadId))) {

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -236,12 +236,80 @@ describe("queued thread messages", () => {
 
       nowSpy.mockReturnValue(10_000);
       expect(
-        releaseStaleQueuedMessageClaims(db, noopNotifier, { claimedBefore: 5_000 }),
+        releaseStaleQueuedMessageClaims(db, noopNotifier, {
+          claimedBefore: 5_000,
+          protectedClaimTokens: [],
+        }),
       ).toBe(1);
       expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
         queuedMessage.id,
       ]);
       expect(getQueuedThreadMessage(db, queuedMessage.id)?.claimToken).toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("does not release stale queued message claims protected by a live owner", () => {
+    const { db, thread } = setup();
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      nowSpy.mockReturnValue(1_000);
+      const protectedQueuedMessage = createQueuedThreadMessage(
+        db,
+        noopNotifier,
+        {
+          threadId: thread.id,
+          content: defaultInput,
+          model: "gpt-5",
+          reasoningLevel: "medium",
+          permissionMode: "full",
+          serviceTier: "default",
+        },
+      );
+      const releasableQueuedMessage = createQueuedThreadMessage(
+        db,
+        noopNotifier,
+        {
+          threadId: thread.id,
+          content: altInput,
+          model: "gpt-5",
+          reasoningLevel: "medium",
+          permissionMode: "full",
+          serviceTier: "default",
+        },
+      );
+      const protectedClaim = claimQueuedThreadMessage(
+        db,
+        noopNotifier,
+        protectedQueuedMessage.id,
+      );
+      const releasableClaim = claimQueuedThreadMessage(
+        db,
+        noopNotifier,
+        releasableQueuedMessage.id,
+      );
+      if (!protectedClaim || !releasableClaim) {
+        throw new Error("Expected queued message claims");
+      }
+
+      nowSpy.mockReturnValue(10_000);
+      expect(
+        releaseStaleQueuedMessageClaims(db, noopNotifier, {
+          claimedBefore: 5_000,
+          protectedClaimTokens: [protectedClaim.claimToken],
+        }),
+      ).toBe(1);
+
+      expect(
+        getQueuedThreadMessage(db, protectedQueuedMessage.id)?.claimToken,
+      ).toBe(protectedClaim.claimToken);
+      expect(
+        getQueuedThreadMessage(db, releasableQueuedMessage.id)?.claimToken,
+      ).toBeNull();
+      expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
+        releasableQueuedMessage.id,
+      ]);
     } finally {
       nowSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary
- Track queued-message claim tokens owned by this server process while manual and auto sends are active.
- Pass those tokens into stale queued-message claim release so active in-process sends are skipped.
- Keep crash/restart recovery by passing an explicit empty protected-token list when no in-memory owner exists.

## Validation
- `pnpm exec turbo run test --filter=@bb/db -- test/data/queued-thread-messages.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server`
- `scripts/bb-dev-app current`
- `eval "$(scripts/bb-dev-app env)" && pnpm bb:dev status --json`
- `eval "$(scripts/bb-dev-app env)" && pnpm bb:dev thread spawn --project proj_personal --provider codex --permission-mode readonly --title "Smoke test" --prompt "Reply only with ok." --json`
- `eval "$(scripts/bb-dev-app env)" && pnpm bb:dev thread wait thr_gbe4zpuqqa --status idle --timeout 180 --json && pnpm bb:dev thread output thr_gbe4zpuqqa` returned `ok`
- `scripts/bb-dev-app stop`

DB regression coverage proves the boundary directly: `protectedClaimTokens: [activeToken]` skips that stale claim while releasing a second unprotected stale claim; `protectedClaimTokens: []` still releases a stale claim, which is the crash/restart recovery case.