### PR TITLE
Keep selected model visible after model load failures

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -145,8 +145,7 @@ export function ModelReasoningPicker({
   const ProviderIcon = selectedProvider?.icon;
   const selectedModelOption = modelOptions.find((m) => m.value === modelValue);
   const selectedModelLabel = selectedModelOption?.label ?? modelValue;
-  const hasSelectedModel =
-    modelOptions.length > 0 && selectedModelLabel.trim().length > 0;
+  const hasSelectedModel = selectedModelLabel.trim().length > 0;
   const selectedProviderLabel = selectedProvider?.label ?? selectedProviderId;
   const selectedModelLoadErrorMatches =
     modelLoadError?.providerId === selectedProviderId;

--- a/apps/app/src/components/promptbox/ExecutionControls.test.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.test.tsx
@@ -75,6 +75,27 @@ describe("ExecutionControls", () => {
     expect(screen.queryByTitle("Claude Code")).not.toBeNull();
   });
 
+  it("keeps showing the known model when model options fail to load", () => {
+    const props = makeExecutionControlsProps();
+    renderExecutionControls({
+      ...props,
+      model: {
+        ...props.model,
+        active: { model: "o4-mini" },
+        options: [],
+        loadFailed: true,
+        loadError: { providerId: "codex", code: "failed" },
+      },
+    });
+
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+
+    expect(trigger.textContent).toContain("o4-mini");
+    expect(trigger.textContent).not.toContain("Failed to load models");
+  });
+
   it("maps disabled fast mode to the explicit default service tier", () => {
     const onServiceTierChange = vi.fn();
     renderExecutionControls({

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -42,6 +42,14 @@ interface BuildModelLoadErrorArgs {
   provider: ProviderInfo;
 }
 
+interface ExpectedFallbackErrorLogFields {
+  errorCode: string;
+  errorDetails?: unknown;
+  errorMessage: string;
+  errorRetryable?: boolean;
+  errorStatus: number;
+}
+
 type ModelListResult = Pick<
   SystemExecutionOptionsResponse,
   "modelLoadError" | "models" | "selectedOnlyModels"
@@ -107,6 +115,23 @@ function canOmitKnownAcpAgentsForError(error: unknown): error is ApiError {
   );
 }
 
+function expectedFallbackErrorLogFields(
+  error: ApiError,
+): ExpectedFallbackErrorLogFields {
+  const fields: ExpectedFallbackErrorLogFields = {
+    errorCode: error.body.code,
+    errorMessage: error.body.message,
+    errorStatus: error.status,
+  };
+  if (error.body.details !== undefined) {
+    fields.errorDetails = error.body.details;
+  }
+  if (error.body.retryable !== undefined) {
+    fields.errorRetryable = error.body.retryable;
+  }
+  return fields;
+}
+
 async function listInstalledKnownAcpAgents(
   deps: AppDeps,
   hostId: string,
@@ -147,7 +172,7 @@ async function listInstalledKnownAcpAgents(
     }
     deps.logger.warn(
       {
-        err: error,
+        ...expectedFallbackErrorLogFields(error),
         hostId,
       },
       "Failed to resolve known ACP agent status",
@@ -182,7 +207,7 @@ function resolveSystemProviderInfosPlan(
       throw error;
     }
     deps.logger.warn(
-      { err: error },
+      expectedFallbackErrorLogFields(error),
       "Failed to resolve host for known ACP agent status",
     );
     return {
@@ -429,7 +454,7 @@ async function loadSystemProviderModels(
     }
     deps.logger.warn(
       {
-        err: error,
+        ...expectedFallbackErrorLogFields(error),
         hostId,
         providerId: provider.id,
       },

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -312,6 +312,8 @@ describe("resolveSystemExecutionOptions", () => {
           ],
         },
         async (harness) => {
+          const warn = vi.fn();
+          harness.deps.logger = { ...harness.deps.logger, warn };
           const { host, session } = seedHostSession(harness.deps, {
             id: `host-execution-options-known-acp-status-fails-${failStatusRequest}`,
           });
@@ -380,6 +382,22 @@ describe("resolveSystemExecutionOptions", () => {
               ? ["provider.list_models"]
               : ["known_acp_agents.status", "provider.list_models"],
           );
+          const statusWarning = warn.mock.calls.find(
+            ([, message]) =>
+              message === "Failed to resolve known ACP agent status",
+          );
+          expect(statusWarning).toBeDefined();
+          expect(statusWarning?.[0]).toMatchObject({
+            errorCode: failStatusRequest
+              ? "command_timeout"
+              : "host_unavailable",
+            errorMessage: failStatusRequest
+              ? "Timed out waiting for command result"
+              : "Host is not connected",
+            errorStatus: failStatusRequest ? 504 : 502,
+            hostId: host.id,
+          });
+          expect(statusWarning?.[0]).not.toHaveProperty("err");
         },
       );
     },
@@ -406,6 +424,8 @@ describe("resolveSystemExecutionOptions", () => {
         ],
       },
       async (harness) => {
+        const warn = vi.fn();
+        harness.deps.logger = { ...harness.deps.logger, warn };
         const response = await resolveSystemExecutionOptions(harness.deps, {
           providerId: "codex",
         });
@@ -429,6 +449,17 @@ describe("resolveSystemExecutionOptions", () => {
           providerId: "codex",
           code: "failed",
         });
+        const hostLookupWarning = warn.mock.calls.find(
+          ([, message]) =>
+            message === "Failed to resolve host for known ACP agent status",
+        );
+        expect(hostLookupWarning).toBeDefined();
+        expect(hostLookupWarning?.[0]).toMatchObject({
+          errorCode: "host_unavailable",
+          errorMessage: "Local host daemon is not initialized",
+          errorStatus: 502,
+        });
+        expect(hostLookupWarning?.[0]).not.toHaveProperty("err");
       },
     );
   });
@@ -535,6 +566,45 @@ describe("resolveSystemExecutionOptions", () => {
         expect(response.selectedOnlyModels).toEqual([]);
       },
     );
+  });
+
+  it("logs model load fallback errors without stack-bearing err objects", async () => {
+    await withTestHarness(async (harness) => {
+      const warn = vi.fn();
+      harness.deps.logger = { ...harness.deps.logger, warn };
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-execution-options-concise-model-log",
+      });
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelErrorsByProviderId: {
+          codex: {
+            errorCode: "command_failed",
+            errorMessage: "model list failed",
+          },
+        },
+      });
+
+      await resolveSystemExecutionOptions(harness.deps, {
+        hostId: host.id,
+        providerId: "codex",
+      });
+
+      const providerModelWarning = warn.mock.calls.find(
+        ([, message]) => message === "Failed to resolve provider models",
+      );
+      expect(providerModelWarning).toBeDefined();
+      expect(providerModelWarning?.[0]).toMatchObject({
+        errorCode: "command_failed",
+        errorMessage: "model list failed",
+        errorRetryable: false,
+        errorStatus: 502,
+        hostId: host.id,
+        providerId: "codex",
+      });
+      expect(providerModelWarning?.[0]).not.toHaveProperty("err");
+    });
   });
 
   it("includes custom ACP agents and sends their launch spec when loading models", async () => {


### PR DESCRIPTION
## Summary

- Keep the promptbox model picker showing the known selected/current model label when model options fail to load.
- Replace expected execution-options fallback `err: ApiError` warning payloads with concise structured error fields for known ACP agent status, host lookup, and provider model fallback paths.
- Add focused regression coverage for the promptbox fallback and structured logging paths.

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/promptbox/ExecutionControls.test.tsx`
- `pnpm exec turbo run test --filter=@bb/server -- test/system/execution-options.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --force`
- `git diff --check`
- `scripts/bb-dev-app current`
- `dev-browser --browser bb-split-pr-1-qa7`: seeded `bb.promptbox.model=o4-mini`, aborted `/api/v1/system/execution-options`, opened the new-thread composer, and verified the model control text was `o4-mini` and did not include `Failed to load models`.
