### PR TITLE
Harden host session liveness after sleep

### DIFF
--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -1,11 +1,9 @@
 import { eq } from "drizzle-orm";
 import {
   closeSession,
-  getActiveSession,
   hostDaemonSessions,
   listHostThreadIds,
   type HostDaemonSessionRow,
-  type SweepExpiredLeasesResult,
 } from "@bb/db";
 import type { HostDaemonActiveThread } from "@bb/host-daemon-contract";
 import {
@@ -26,15 +24,13 @@ const DAEMON_RESTARTED_PENDING_INTERACTION_REASON =
   "Host daemon restarted while awaiting user interaction; retry the thread to continue";
 const DAEMON_DISCONNECTED_PENDING_INTERACTION_REASON =
   "Host daemon disconnected while awaiting user interaction; retry the thread to continue";
-const DAEMON_SESSION_EXPIRED_PENDING_INTERACTION_REASON =
-  "Host daemon session expired while awaiting user interaction; retry the thread to continue";
 
 type HostSessionOpenedDeps = LoggedPendingInteractionWorkSessionDeps;
 type DaemonSocketClosedDeps = Pick<
   AppDeps,
   "db" | "hub" | "logger" | "pendingInteractions" | "terminalSessions"
 >;
-type ExpiredHostSessionLeaseDeps = Pick<
+type DaemonDisconnectGraceDeps = Pick<
   AppDeps,
   "db" | "hub" | "logger" | "pendingInteractions" | "terminalSessions"
 >;
@@ -62,10 +58,6 @@ interface CompleteDaemonDisconnectGraceArgs {
 
 interface CompleteDaemonActiveWorkDisconnectGraceArgs {
   hostId: string;
-}
-
-export interface HandleExpiredHostSessionLeasesArgs {
-  expiredLeases: SweepExpiredLeasesResult;
 }
 
 export async function handleHostSessionOpened(
@@ -164,38 +156,11 @@ export function handleDaemonSocketClosed(
   );
 }
 
-export function handleExpiredHostSessionLeases(
-  deps: ExpiredHostSessionLeaseDeps,
-  args: HandleExpiredHostSessionLeasesArgs,
-): void {
-  if (args.expiredLeases.expiredSessionIds.length === 0) {
-    return;
-  }
-
-  for (const sessionId of args.expiredLeases.expiredSessionIds) {
-    deps.hub.closeDaemonSession(sessionId, "expired");
-    deps.terminalSessions.handleDaemonSessionClosed({ sessionId });
-  }
-  for (const hostId of args.expiredLeases.expiredHostIds) {
-    if (!getActiveSession(deps.db, hostId)) {
-      interruptPendingInteractionsForHostThreads(deps, {
-        hostId,
-        reason: DAEMON_SESSION_EXPIRED_PENDING_INTERACTION_REASON,
-      });
-      // A host that never reconnects has no re-register to settle its open
-      // background tasks; mirror the pending-interaction reconciliation here
-      // so lost workflows do not dangle as running forever.
-      settleDanglingBackgroundTasks(deps, { hostId });
-    }
-    notifyHostThreadRuntimeStatusChanged(deps, hostId);
-  }
-}
-
 function completeDaemonDisconnectGrace(
-  deps: ExpiredHostSessionLeaseDeps,
+  deps: DaemonDisconnectGraceDeps,
   args: CompleteDaemonDisconnectGraceArgs,
 ): void {
-  if (getActiveSession(deps.db, args.hostId)) {
+  if (deps.hub.hasDaemonForHost(args.hostId)) {
     return;
   }
 
@@ -215,7 +180,7 @@ function completeDaemonActiveWorkDisconnectGrace(
   deps: Pick<AppDeps, "db" | "hub" | "logger" | "pendingInteractions">,
   args: CompleteDaemonActiveWorkDisconnectGraceArgs,
 ): void {
-  if (getActiveSession(deps.db, args.hostId)) {
+  if (deps.hub.hasDaemonForHost(args.hostId)) {
     return;
   }
 

--- a/apps/server/src/internal/session-state.ts
+++ b/apps/server/src/internal/session-state.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { getActiveSessionById, hostDaemonSessions } from "@bb/db";
+import { getSessionById, hostDaemonSessions } from "@bb/db";
 import type { DbConnection, HostDaemonSessionRow } from "@bb/db";
 import { ApiError } from "../errors.js";
 import { getAuthenticatedDaemon } from "./auth.js";
@@ -17,15 +17,15 @@ export interface RequireAuthenticatedDaemonSessionArgs {
   sessionId: string;
 }
 
-export type InactiveSessionReason = "active" | "closed" | "expired" | "missing";
+export type InactiveSessionReason = "active" | "closed" | "missing";
 
 export interface InactiveSessionLogFields {
   authenticatedHostId?: string;
   closeReason?: string | null;
   closedAt?: number | null;
-  expiredByMs?: number;
   inactiveSessionReason: InactiveSessionReason;
   leaseExpiresAt?: number;
+  leaseStaleByMs?: number;
   sessionHostId?: string;
   sessionId: string;
   sessionStatus?: string;
@@ -37,21 +37,14 @@ export interface GetInactiveSessionLogFieldsArgs {
   sessionId: string;
 }
 
-export function requireActiveSession(db: DbConnection, sessionId: string) {
-  const session = getActiveSessionById(db, { sessionId });
-
-  if (!session) {
-    throw new ApiError(401, "inactive_session", "Session is not active");
-  }
-
-  return session;
-}
-
-export function requireAuthorizedActiveSession(
+export function requireAuthorizedOpenSession(
   db: DbConnection,
   args: RequireAuthorizedActiveSessionArgs,
 ) {
-  const session = requireActiveSession(db, args.sessionId);
+  const session = getSessionById(db, { sessionId: args.sessionId });
+  if (!session || session.status !== "active") {
+    throw new ApiError(401, "inactive_session", "Session is not active");
+  }
   if (session.hostId !== args.hostId) {
     throw new ApiError(
       403,
@@ -67,7 +60,7 @@ export function requireAuthenticatedDaemonSession(
   args: RequireAuthenticatedDaemonSessionArgs,
 ): HostDaemonSessionRow {
   const daemon = getAuthenticatedDaemon(args.context);
-  return requireAuthorizedActiveSession(args.db, {
+  return requireAuthorizedOpenSession(args.db, {
     hostId: daemon.hostId,
     sessionId: args.sessionId,
   });
@@ -105,22 +98,13 @@ export function getInactiveSessionLogFields(
     };
   }
 
-  if (session.leaseExpiresAt <= args.now) {
-    return {
-      authenticatedHostId: args.authenticatedHostId,
-      expiredByMs: args.now - session.leaseExpiresAt,
-      inactiveSessionReason: "expired",
-      leaseExpiresAt: session.leaseExpiresAt,
-      sessionHostId: session.hostId,
-      sessionId: args.sessionId,
-      sessionStatus: session.status,
-    };
-  }
-
   return {
     authenticatedHostId: args.authenticatedHostId,
     inactiveSessionReason: "active",
     leaseExpiresAt: session.leaseExpiresAt,
+    ...(session.leaseExpiresAt <= args.now
+      ? { leaseStaleByMs: args.now - session.leaseExpiresAt }
+      : {}),
     sessionHostId: session.hostId,
     sessionId: args.sessionId,
     sessionStatus: session.status,

--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -33,12 +33,12 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
   const routes = publicApiRoutes.hosts;
 
   get(routes.list, (context) =>
-    context.json(listPublicHostsWithStatus(deps.db)),
+    context.json(listPublicHostsWithStatus(deps)),
   );
 
   get(routes.get, (context) =>
     context.json(
-      requireNonDestroyedHostWithStatus(deps.db, context.req.param("id")),
+      requireNonDestroyedHostWithStatus(deps, context.req.param("id")),
     ),
   );
 
@@ -46,7 +46,7 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
   // `path` lists the host's home directory (resolved on the host).
   get(routes.directory, async (context, query) => {
     const hostId = context.req.param("id");
-    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    requireNonDestroyedHostWithStatus(deps, hostId);
     const result = await callHostRetryableOnlineRpc(deps, {
       hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
@@ -60,7 +60,7 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
 
   post(routes.pathsExist, async (context, payload) => {
     const hostId = context.req.param("id");
-    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    requireNonDestroyedHostWithStatus(deps, hostId);
     const result = await callHostRetryableOnlineRpc(deps, {
       hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
@@ -74,7 +74,7 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
 
   post(routes.pickFolder, async (context, payload) => {
     const hostId = context.req.param("id");
-    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    requireNonDestroyedHostWithStatus(deps, hostId);
     if (payload.clientHostId !== hostId) {
       throw new ApiError(
         409,
@@ -94,7 +94,7 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
 
   get(routes.providerCliStatus, async (context) => {
     const hostId = context.req.param("id");
-    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    requireNonDestroyedHostWithStatus(deps, hostId);
     const result = await callHostRetryableOnlineRpc(deps, {
       hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
@@ -107,7 +107,7 @@ export function registerHostRoutes(app: Hono, deps: AppDeps): void {
 
   post(routes.providerCliInstall, async (context, payload) => {
     const hostId = context.req.param("id");
-    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    requireNonDestroyedHostWithStatus(deps, hostId);
     const result = await callHostOnlineRpc(deps, {
       hostId,
       timeoutMs: PROVIDER_CLI_INSTALL_TIMEOUT_MS,

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -291,7 +291,7 @@ interface ResolveProjectSourcePathArgs {
  * environment's path.
  */
 function resolveEnvironmentPath(
-  deps: Pick<AppDeps, "config" | "db">,
+  deps: Pick<AppDeps, "config" | "db" | "hub">,
   args: ResolveEnvironmentPathArgs,
 ): ResolvedHostPath {
   const environment = requireReadyEnvironment(deps.db, args.environmentId);
@@ -315,7 +315,7 @@ function resolveEnvironmentPath(
  *   primary local host.
  */
 function resolveProjectSourcePath(
-  deps: Pick<AppDeps, "config" | "db">,
+  deps: Pick<AppDeps, "config" | "db" | "hub">,
   args: ResolveProjectSourcePathArgs,
 ): ResolvedHostPath {
   const hostId = args.hostId ?? requirePrimaryHostId(deps);
@@ -354,7 +354,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
   post(routes.create, async (context, payload) => {
     const { source } = payload;
     if (source.type === "local_path") {
-      requireNonDestroyedHostWithStatus(deps.db, source.hostId);
+      requireNonDestroyedHostWithStatus(deps, source.hostId);
       assertPrimaryHostId(deps, { hostId: source.hostId });
     }
     const { project } = createProject(deps.db, deps.hub, {
@@ -444,7 +444,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
   post(routes.createSource, async (context, payload) => {
     requirePublicStandardProject(deps.db, context.req.param("id"));
     if (payload.type === "local_path") {
-      requireNonDestroyedHostWithStatus(deps.db, payload.hostId);
+      requireNonDestroyedHostWithStatus(deps, payload.hostId);
       assertPrimaryHostId(deps, { hostId: payload.hostId });
     }
     const source = createProjectSource(deps.db, deps.hub, {

--- a/apps/server/src/routes/threads/base.ts
+++ b/apps/server/src/routes/threads/base.ts
@@ -111,7 +111,7 @@ function buildThreadResponse(
   }
   if (args.includes.has("host")) {
     response.host = environment
-      ? getNonDestroyedHostWithStatus(deps.db, environment.hostId)
+      ? getNonDestroyedHostWithStatus(deps, environment.hostId)
       : null;
   }
   return response;

--- a/apps/server/src/services/environments/environment-cleanup-internal.ts
+++ b/apps/server/src/services/environments/environment-cleanup-internal.ts
@@ -3,7 +3,6 @@ import { threadScope } from "@bb/domain";
 import {
   countLiveThreadsInEnvironment,
   getEnvironment,
-  getActiveSession,
   hasPendingThreadShutdownInEnvironment,
   listLiveThreadsInEnvironment,
   type DbNotifier,
@@ -102,12 +101,7 @@ function hasConnectedHostDaemon(
   deps: EnvironmentCleanupHostConnectionDeps,
   hostId: string,
 ): boolean {
-  const session = getActiveSession(deps.db, hostId);
-  return (
-    session !== null &&
-    session.leaseExpiresAt > Date.now() &&
-    deps.hub.hasDaemonForHost(hostId)
-  );
+  return deps.hub.hasDaemonForHost(hostId);
 }
 
 function workspaceCanBeDestroyedNow(

--- a/apps/server/src/services/hosts/online-rpc.ts
+++ b/apps/server/src/services/hosts/online-rpc.ts
@@ -15,6 +15,8 @@ import {
 } from "../../ws/hub.js";
 import { ensureHostSessionReadyForWork } from "./host-lifecycle.js";
 
+const HOST_DAEMON_REGISTRATION_WAIT_MS = 1_000;
+
 export interface CallHostOnlineRpcArgs<
   TCommand extends HostDaemonRpcCommand,
 > {
@@ -70,7 +72,14 @@ async function callHostOnlineRpcWithRetry(
   args: CallHostOnlineRpcArgs<HostDaemonRpcCommand>,
   options: { retryOnUnavailable: boolean },
 ): Promise<HostDaemonRpcResultForCommand> {
-  await ensureHostSessionReadyForWork(deps, { hostId: args.hostId });
+  await ensureHostSessionReadyForWork(deps, { hostId: args.hostId }).catch(
+    async (error) => {
+      if (!options.retryOnUnavailable || !isHostUnavailableApiError(error)) {
+        throw error;
+      }
+      await waitForRetryableHostRpcTransport(deps, args.hostId);
+    },
+  );
   const response = await requestHostOnlineRpcResponse(deps, args).catch(
     async (error) => {
       if (
@@ -79,7 +88,7 @@ async function callHostOnlineRpcWithRetry(
       ) {
         throwOnlineRpcError(error);
       }
-      await ensureHostSessionReadyForWork(deps, { hostId: args.hostId });
+      await waitForRetryableHostRpcTransport(deps, args.hostId);
       return requestHostOnlineRpcResponse(deps, args).catch((retryError) => {
         throwOnlineRpcError(retryError);
       });
@@ -99,6 +108,26 @@ async function callHostOnlineRpcWithRetry(
   }
 
   return parseHostDaemonRpcResultForCommand(args.command, response.result);
+}
+
+async function waitForRetryableHostRpcTransport(
+  deps: WorkSessionDeps,
+  hostId: string,
+): Promise<void> {
+  if (deps.hub.hasDaemonForHost(hostId)) {
+    await ensureHostSessionReadyForWork(deps, { hostId });
+    return;
+  }
+  await deps.hub.waitForDaemonForHost(hostId, HOST_DAEMON_REGISTRATION_WAIT_MS);
+  await ensureHostSessionReadyForWork(deps, { hostId });
+}
+
+function isHostUnavailableApiError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.status === 502 &&
+    error.body.code === "host_unavailable"
+  );
 }
 
 function requestHostOnlineRpcResponse(

--- a/apps/server/src/services/hosts/primary-host.ts
+++ b/apps/server/src/services/hosts/primary-host.ts
@@ -1,10 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-  listConnectedHostIds,
-  listPublicHosts,
-  type DbConnection,
-} from "@bb/db";
+import { listPublicHosts, type DbConnection } from "@bb/db";
 import { HOST_ID_FILE_NAME } from "@bb/host-daemon-contract";
 import { ApiError } from "../../errors.js";
 import type { AppDeps } from "../../types.js";
@@ -13,7 +9,7 @@ import {
   requireNonDestroyedHostWithStatus,
 } from "../lib/entity-lookup.js";
 
-type PrimaryHostDeps = Pick<AppDeps, "config" | "db">;
+type PrimaryHostDeps = Pick<AppDeps, "config" | "db" | "hub">;
 
 export interface ReadPrimaryHostIdArgs {
   dataDir: string;
@@ -62,10 +58,11 @@ function resolveSinglePublicHostId(db: DbConnection): string | null {
   return host?.id ?? null;
 }
 
-function resolveSingleConnectedPublicHostId(db: DbConnection): string | null {
-  const connectedHostIds = new Set(listConnectedHostIds(db));
-  const hosts = listPublicHosts(db).filter((host) =>
-    connectedHostIds.has(host.id),
+function resolveSingleConnectedPublicHostId(
+  deps: PrimaryHostDeps,
+): string | null {
+  const hosts = listPublicHosts(deps.db).filter((host) =>
+    deps.hub.hasDaemonForHost(host.id),
   );
   if (hosts.length !== 1) {
     return null;
@@ -77,7 +74,7 @@ function resolveSingleConnectedPublicHostId(db: DbConnection): string | null {
 export function resolvePrimaryHostId(deps: PrimaryHostDeps): string | null {
   return (
     readPrimaryHostIdFromDataDir({ dataDir: deps.config.dataDir }) ??
-    resolveSingleConnectedPublicHostId(deps.db) ??
+    resolveSingleConnectedPublicHostId(deps) ??
     resolveSinglePublicHostId(deps.db)
   );
 }
@@ -102,7 +99,7 @@ export function assertPrimaryHostId(
 
 export function requireConnectedPrimaryHostId(deps: PrimaryHostDeps): string {
   const hostId = requirePrimaryHostId(deps);
-  requireNonDestroyedHostWithStatus(deps.db, hostId);
+  requireNonDestroyedHostWithStatus(deps, hostId);
   requireConnectedHostSession(deps, hostId);
   return hostId;
 }

--- a/apps/server/src/services/lib/entity-lookup.ts
+++ b/apps/server/src/services/lib/entity-lookup.ts
@@ -1,15 +1,16 @@
 import {
-  getActiveSession,
   getEnvironment,
   getHost,
   getNonDestroyedHost,
   getProject,
+  getSessionById,
   getThread,
-  listConnectedHostIds,
   listPublicHosts,
+  type HostDaemonSessionRow,
 } from "@bb/db";
 import type { Environment, Host } from "@bb/domain";
 import type { DbConnection } from "@bb/db";
+import type { NotificationHub } from "../../ws/hub.js";
 import { ApiError } from "../../errors.js";
 import {
   destroyedHostUnavailableDetails,
@@ -26,24 +27,43 @@ type HostRow = NonNullable<ReturnType<typeof getHost>>;
 type ProjectRow = NonNullable<ReturnType<typeof getProject>>;
 type ThreadRow = NonNullable<ReturnType<typeof getThread>>;
 type StandardProject = ProjectRow & { kind: "standard" };
+type HostLookupHub = Pick<NotificationHub, "getDaemonSessionIdForHost">;
+
+interface HostLookupDeps {
+  db: DbConnection;
+  hub: HostLookupHub;
+}
 
 export interface ThreadEnvironmentLookupResult {
   environment: Environment;
   thread: ThreadRow;
 }
 
-function toHostStatus(db: DbConnection, hostId: string): Host["status"] {
-  const host = getNonDestroyedHost(db, hostId);
+function getOpenDaemonSessionForHost(
+  deps: HostLookupDeps,
+  hostId: string,
+): HostDaemonSessionRow | null {
+  const sessionId = deps.hub.getDaemonSessionIdForHost(hostId);
+  if (!sessionId) {
+    return null;
+  }
+
+  const session = getSessionById(deps.db, { sessionId });
+  if (!session || session.hostId !== hostId || session.status !== "active") {
+    return null;
+  }
+  return session;
+}
+
+function toHostStatus(deps: HostLookupDeps, hostId: string): Host["status"] {
+  const host = getNonDestroyedHost(deps.db, hostId);
   if (!host) {
     return "disconnected";
   }
 
-  const session = getActiveSession(db, hostId);
-  if (session) {
-    return "connected";
-  }
-
-  return "disconnected";
+  return getOpenDaemonSessionForHost(deps, hostId)
+    ? "connected"
+    : "disconnected";
 }
 
 function toHostRecord(row: HostRow, status: Host["status"]): Host {
@@ -66,23 +86,24 @@ function isStandardProject(project: ProjectRow): project is StandardProject {
   return project.kind === "standard";
 }
 
-export function listPublicHostsWithStatus(db: DbConnection): Host[] {
-  const rows = listPublicHosts(db);
-  const connectedHostIds = new Set(listConnectedHostIds(db));
+export function listPublicHostsWithStatus(deps: HostLookupDeps): Host[] {
+  const rows = listPublicHosts(deps.db);
 
   return rows.map((row) =>
     toHostRecord(
       row,
-      connectedHostIds.has(row.id) ? "connected" : "disconnected",
+      getOpenDaemonSessionForHost(deps, row.id)
+        ? "connected"
+        : "disconnected",
     ),
   );
 }
 
 export function requireNonDestroyedHostWithStatus(
-  db: DbConnection,
+  deps: HostLookupDeps,
   hostId: string,
 ): Host {
-  const host = getHost(db, hostId);
+  const host = getHost(deps.db, hostId);
   if (!host) {
     throwHostNotFound();
   }
@@ -93,25 +114,25 @@ export function requireNonDestroyedHostWithStatus(
       destroyedHostUnavailableDetails(host.destroyedAt),
     );
   }
-  return toHostRecord(host, toHostStatus(db, host.id));
+  return toHostRecord(host, toHostStatus(deps, host.id));
 }
 
 export function getNonDestroyedHostWithStatus(
-  db: DbConnection,
+  deps: HostLookupDeps,
   hostId: string,
 ): Host | null {
-  const host = getNonDestroyedHost(db, hostId);
+  const host = getNonDestroyedHost(deps.db, hostId);
   if (!host) {
     return null;
   }
-  return toHostRecord(host, toHostStatus(db, host.id));
+  return toHostRecord(host, toHostStatus(deps, host.id));
 }
 
 export function requireConnectedHostSession(
-  deps: Pick<{ db: DbConnection }, "db">,
+  deps: HostLookupDeps,
   hostId: string,
 ) {
-  const session = getActiveSession(deps.db, hostId);
+  const session = getOpenDaemonSessionForHost(deps, hostId);
   if (!session) {
     const host = getHost(deps.db, hostId);
     if (!host) {
@@ -124,7 +145,7 @@ export function requireConnectedHostSession(
         destroyedHostUnavailableDetails(host.destroyedAt),
       );
     }
-    const hostStatus = toHostStatus(deps.db, hostId);
+    const hostStatus = toHostStatus(deps, hostId);
     throwHostUnavailable(
       502,
       "Host is not connected",

--- a/apps/server/src/services/scheduling/automation-sweep.test.ts
+++ b/apps/server/src/services/scheduling/automation-sweep.test.ts
@@ -43,13 +43,19 @@ let projectId: string;
 function buildDeps(
   overrides: { automationsAllowScriptRuns?: boolean } = {},
 ): LoggedPendingInteractionWorkSessionDeps {
+  const hub = {
+    ...noopNotifier,
+    hasDaemonForHost(): boolean {
+      return false;
+    },
+  };
   return {
     config: {
       dataDir: "/tmp/bb-sweep-test",
       automationsAllowScriptRuns: overrides.automationsAllowScriptRuns ?? true,
     },
     db,
-    hub: noopNotifier,
+    hub,
     lifecycleDedupers: {},
     logger: testLogger,
     machineAuth: {},

--- a/apps/server/src/services/system/host-lookup.ts
+++ b/apps/server/src/services/system/host-lookup.ts
@@ -20,12 +20,12 @@ export function resolveSystemLookupHostId(
 ): string {
   if (query.environmentId) {
     const environment = requireEnvironment(deps.db, query.environmentId);
-    requireNonDestroyedHostWithStatus(deps.db, environment.hostId);
+    requireNonDestroyedHostWithStatus(deps, environment.hostId);
     assertPrimaryHostId(deps, { hostId: environment.hostId });
     return environment.hostId;
   }
   if (query.hostId) {
-    requireNonDestroyedHostWithStatus(deps.db, query.hostId);
+    requireNonDestroyedHostWithStatus(deps, query.hostId);
     assertPrimaryHostId(deps, { hostId: query.hostId });
     return query.hostId;
   }

--- a/apps/server/src/services/system/periodic-sweeps.ts
+++ b/apps/server/src/services/system/periodic-sweeps.ts
@@ -22,7 +22,6 @@ import {
   runIncrementalVacuum,
   shouldCompactDatabase,
   shouldRunIncrementalVacuum,
-  sweepExpiredLeases,
   sweepManagedEnvironments,
   threads,
   truncateCompletedEventItemOutputs,
@@ -41,7 +40,6 @@ import {
   runtimeErrorLogFields,
 } from "../lib/error-log-fields.js";
 import { advanceEnvironmentProvisioning } from "../environments/environment-provisioning-internal.js";
-import { handleExpiredHostSessionLeases } from "../../internal/session-owner-side-effects.js";
 import {
   advanceProjectDeletion,
   listProjectsPendingDeletion,
@@ -66,7 +64,6 @@ export type PeriodicSweepJobCategory =
   | "retention"
   | "durable-intent-retry"
   | "orphan-cleanup"
-  | "lifecycle-timeout"
   | "maintenance"
   | "scheduler";
 
@@ -507,13 +504,6 @@ function runClosedSessionPruneSweep(
   });
 }
 
-function runExpiredLeaseSweep(
-  deps: LoggedPendingInteractionWorkSessionDeps,
-): void {
-  const expiredLeases = sweepExpiredLeases(deps.db, deps.hub);
-  handleExpiredHostSessionLeases(deps, { expiredLeases });
-}
-
 function runDestroyedEnvironmentPruneSweep(
   deps: LoggedPendingInteractionWorkSessionDeps,
 ): void {
@@ -545,12 +535,6 @@ const PERIODIC_SWEEP_JOBS: PeriodicSweepJob[] = [
     category: "retention",
     name: "closed-session-prune",
     run: runClosedSessionPruneSweep,
-  },
-  {
-    cadenceMs: 0,
-    category: "lifecycle-timeout",
-    name: "expired-host-session-lease",
-    run: runExpiredLeaseSweep,
   },
   {
     cadenceMs: 0,

--- a/apps/server/src/services/threads/provider-command-typeahead.ts
+++ b/apps/server/src/services/threads/provider-command-typeahead.ts
@@ -66,7 +66,7 @@ export interface ResolveCommandWorkspaceArgs {
  * `requireReadyEnvironment`.
  */
 export function resolveCommandWorkspace(
-  deps: Pick<AppDeps, "config" | "db">,
+  deps: Pick<AppDeps, "config" | "db" | "hub">,
   args: ResolveCommandWorkspaceArgs,
 ): CommandWorkspace {
   if (args.environmentId !== null) {

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -618,7 +618,7 @@ export async function createThreadFromRequest(
         throwEnvironmentNotReady(environment);
       }
       if (environment.status === "provisioning") {
-        requireNonDestroyedHostWithStatus(deps.db, environment.hostId);
+        requireNonDestroyedHostWithStatus(deps, environment.hostId);
       }
       environmentId = environment.id;
       environmentIntent = {

--- a/apps/server/src/services/threads/thread-request-eligibility.ts
+++ b/apps/server/src/services/threads/thread-request-eligibility.ts
@@ -18,7 +18,7 @@ import {
 } from "../hosts/primary-host.js";
 
 type ThreadRequestEnvironment = EnvironmentArgs;
-type ThreadRequestEnvironmentDeps = Pick<AppDeps, "config" | "db">;
+type ThreadRequestEnvironmentDeps = Pick<AppDeps, "config" | "db" | "hub">;
 type HostThreadRequestEnvironment = Extract<
   ThreadRequestEnvironment,
   { type: "host" }
@@ -269,7 +269,7 @@ function resolveHostThreadRequestEnvironment(
     const hostId =
       environment.hostId ?? requireConnectedPrimaryHostId(deps);
     assertPrimaryHostId(deps, { hostId });
-    requireNonDestroyedHostWithStatus(deps.db, hostId);
+    requireNonDestroyedHostWithStatus(deps, hostId);
     return {
       hostId,
       type: "personal",
@@ -277,7 +277,7 @@ function resolveHostThreadRequestEnvironment(
   }
 
   const hostId = requireHostEnvironmentId(environment);
-  requireNonDestroyedHostWithStatus(deps.db, hostId);
+  requireNonDestroyedHostWithStatus(deps, hostId);
   assertPrimaryHostId(deps, { hostId });
 
   if (
@@ -329,7 +329,7 @@ function resolveReuseThreadRequestEnvironment(
     );
   }
   assertReuseWorkspaceProjectCompatibility(projectId, reusedEnvironment);
-  requireNonDestroyedHostWithStatus(deps.db, reusedEnvironment.hostId);
+  requireNonDestroyedHostWithStatus(deps, reusedEnvironment.hostId);
   assertPrimaryHostId(deps, { hostId: reusedEnvironment.hostId });
   return {
     environment: reusedEnvironment,

--- a/apps/server/src/services/threads/thread-runtime-display.ts
+++ b/apps/server/src/services/threads/thread-runtime-display.ts
@@ -1,6 +1,7 @@
 import {
   getEnvironment,
   getLatestSessionForHost,
+  getSessionById,
   listActiveBackgroundTaskCountsByThreadIds,
   listLatestSessionsForHosts,
   type DbConnection,
@@ -17,10 +18,17 @@ import type {
 } from "@bb/domain";
 import type { ThreadResponse } from "@bb/server-contract";
 import { DAEMON_DISCONNECT_GRACE_MS } from "../../constants.js";
+import type { NotificationHub } from "../../ws/hub.js";
 import { canThreadSpawnChild } from "./thread-parent.js";
+
+type ThreadRuntimeDisplayHub = Pick<
+  NotificationHub,
+  "getDaemonSessionIdForHost"
+>;
 
 interface ThreadRuntimeDisplayDeps {
   db: DbConnection;
+  hub: ThreadRuntimeDisplayHub;
 }
 
 interface ResolveThreadRuntimeStateArgs {
@@ -31,6 +39,7 @@ interface ResolveThreadRuntimeStateArgs {
 
 interface ResolveThreadRuntimeStateFromLatestSessionArgs {
   environmentHostId: string | null;
+  hostConnected: boolean;
   latestSession: HostDaemonSessionRow | null;
   now?: number;
   status: ThreadStatus;
@@ -52,6 +61,7 @@ interface ToThreadListEntryResponsesArgs {
 
 interface ToThreadListEntryResponseFromLatestSessionArgs {
   activity: ThreadActivityState;
+  hostConnected: boolean;
   latestSession: HostDaemonSessionRow | null;
   now?: number;
   thread: ThreadWithPendingInteractionState;
@@ -86,6 +96,18 @@ function getDaemonDisconnectGraceExpiresAt(
   return session.closedAt + DAEMON_DISCONNECT_GRACE_MS;
 }
 
+function hasOpenDaemonSessionForHost(
+  deps: ThreadRuntimeDisplayDeps,
+  hostId: string,
+): boolean {
+  const sessionId = deps.hub.getDaemonSessionIdForHost(hostId);
+  if (!sessionId) {
+    return false;
+  }
+  const session = getSessionById(deps.db, { sessionId });
+  return session?.hostId === hostId && session.status === "active";
+}
+
 function toPublicThread(thread: Thread): Thread {
   return {
     id: thread.id,
@@ -114,14 +136,22 @@ export function resolveThreadRuntimeState(
   deps: ThreadRuntimeDisplayDeps,
   args: ResolveThreadRuntimeStateArgs,
 ): ThreadRuntimeState {
-  const latestSession =
-    args.status === "active" && args.environmentHostId !== null
-      ? getLatestSessionForHost(deps.db, {
-          hostId: args.environmentHostId,
-        })
-      : null;
+  if (args.status !== "active" || args.environmentHostId === null) {
+    return threadStatusRuntimeState(args.status);
+  }
+
+  const hostConnected = hasOpenDaemonSessionForHost(
+    deps,
+    args.environmentHostId,
+  );
+  const latestSession = hostConnected
+    ? null
+    : getLatestSessionForHost(deps.db, {
+        hostId: args.environmentHostId,
+      });
   return resolveThreadRuntimeStateFromLatestSession({
     environmentHostId: args.environmentHostId,
+    hostConnected,
     latestSession,
     now: args.now,
     status: args.status,
@@ -135,16 +165,12 @@ function resolveThreadRuntimeStateFromLatestSession(
     return threadStatusRuntimeState(args.status);
   }
 
-  const now = args.now ?? Date.now();
-  const latestSession = args.latestSession;
-  if (
-    latestSession &&
-    latestSession.status === "active" &&
-    latestSession.leaseExpiresAt > now
-  ) {
+  if (args.hostConnected) {
     return threadStatusRuntimeState("active");
   }
 
+  const now = args.now ?? Date.now();
+  const latestSession = args.latestSession;
   if (latestSession) {
     const graceExpiresAt = getDaemonDisconnectGraceExpiresAt(latestSession);
     if (graceExpiresAt !== null && graceExpiresAt > now) {
@@ -218,10 +244,17 @@ export function toThreadListEntryResponses(
       ),
     ),
   ];
-  const latestSessionByHostId = new Map(
-    listLatestSessionsForHosts(deps.db, { hostIds: activeHostIds }).map(
-      (session) => [session.hostId, session],
+  const connectedActiveHostIds = new Set(
+    activeHostIds.filter((hostId) =>
+      hasOpenDaemonSessionForHost(deps, hostId),
     ),
+  );
+  const latestSessionByHostId = new Map(
+    listLatestSessionsForHosts(deps.db, {
+      hostIds: activeHostIds.filter(
+        (hostId) => !connectedActiveHostIds.has(hostId),
+      ),
+    }).map((session) => [session.hostId, session]),
   );
 
   return args.threads.map((thread) =>
@@ -229,6 +262,9 @@ export function toThreadListEntryResponses(
       activity: threadActivityById.get(thread.id) ?? {
         activeWorkflowCount: 0,
       },
+      hostConnected:
+        thread.environmentHostId !== null &&
+        connectedActiveHostIds.has(thread.environmentHostId),
       latestSession:
         thread.environmentHostId === null
           ? null
@@ -255,6 +291,7 @@ function toThreadListEntryResponseFromLatestSession(
     hasPendingInteraction: args.thread.hasPendingInteraction,
     runtime: resolveThreadRuntimeStateFromLatestSession({
       environmentHostId: args.thread.environmentHostId,
+      hostConnected: args.hostConnected,
       latestSession: args.latestSession,
       now: args.now,
       status: thread.status,

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -203,7 +203,7 @@ function resolveSendMode(
 }
 
 function ensureRuntimeCanAcceptActiveSend(
-  deps: Pick<AppDeps, "db">,
+  deps: Pick<AppDeps, "db" | "hub">,
   args: Pick<SendThreadMessageArgs, "environment" | "thread">,
 ): void {
   if (args.thread.status !== "active") {

--- a/apps/server/src/ws/daemon-protocol.ts
+++ b/apps/server/src/ws/daemon-protocol.ts
@@ -9,7 +9,7 @@ import type { AppDeps } from "../types.js";
 import { runtimeErrorLogFields } from "../services/lib/error-log-fields.js";
 import {
   getInactiveSessionLogFields,
-  requireAuthorizedActiveSession,
+  requireAuthorizedOpenSession,
 } from "../internal/session-state.js";
 import { handleDaemonSocketClosed } from "../internal/session-owner-side-effects.js";
 import { notifyDaemonEnvironmentChange } from "../internal/environment-changes.js";
@@ -51,7 +51,7 @@ export async function validateDaemonWebSocket(
     deps,
     args.authorizationHeader,
   );
-  const session = requireAuthorizedActiveSession(deps.db, {
+  const session = requireAuthorizedOpenSession(deps.db, {
     hostId: verified.hostId,
     sessionId,
   });
@@ -107,7 +107,7 @@ export function onDaemonSocketMessage(
   }
 
   try {
-    const session = requireAuthorizedActiveSession(deps.db, {
+    const session = requireAuthorizedOpenSession(deps.db, {
       hostId: args.hostId,
       sessionId: args.sessionId,
     });

--- a/apps/server/src/ws/hub.ts
+++ b/apps/server/src/ws/hub.ts
@@ -85,6 +85,11 @@ interface HostEventWaiter {
   timeout: ReturnType<typeof setTimeout>;
 }
 
+interface DaemonRegistrationWaiter {
+  resolve: (registered: boolean) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
 interface HostOnlineRpcWaiter {
   reject: (reason?: Error) => void;
   resolve: (message: HostDaemonOnlineRpcResponseMessage) => void;
@@ -126,6 +131,10 @@ export class NotificationHub implements DbNotifier {
   private readonly daemonSessions = new Map<
     string,
     { hostId: string; socket: HubSocket }
+  >();
+  private readonly daemonRegistrationWaiters = new Map<
+    string,
+    Set<DaemonRegistrationWaiter>
   >();
   private readonly daemonSessionIdsByHost = new Map<string, string>();
   private readonly hostEventWaiters = new Map<string, Set<HostEventWaiter>>();
@@ -295,6 +304,7 @@ export class NotificationHub implements DbNotifier {
     }
     this.daemonSessions.set(sessionId, { hostId, socket });
     this.daemonSessionIdsByHost.set(hostId, sessionId);
+    this.resolveDaemonRegistrationWaiters(hostId);
   }
 
   unregisterDaemon(sessionId: string): void {
@@ -312,6 +322,38 @@ export class NotificationHub implements DbNotifier {
   hasDaemonForHost(hostId: string): boolean {
     const sessionId = this.daemonSessionIdsByHost.get(hostId);
     return sessionId !== undefined && this.daemonSessions.has(sessionId);
+  }
+
+  getDaemonSessionIdForHost(hostId: string): string | null {
+    const sessionId = this.daemonSessionIdsByHost.get(hostId);
+    if (!sessionId || !this.daemonSessions.has(sessionId)) {
+      return null;
+    }
+    return sessionId;
+  }
+
+  async waitForDaemonForHost(
+    hostId: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    if (this.hasDaemonForHost(hostId)) {
+      return true;
+    }
+
+    return new Promise<boolean>((resolve) => {
+      const waiter: DaemonRegistrationWaiter = {
+        resolve,
+        timeout: setTimeout(() => {
+          this.deleteDaemonRegistrationWaiter(hostId, waiter);
+          resolve(false);
+        }, timeoutMs),
+      };
+      const waiters =
+        this.daemonRegistrationWaiters.get(hostId) ??
+        new Set<DaemonRegistrationWaiter>();
+      waiters.add(waiter);
+      this.daemonRegistrationWaiters.set(hostId, waiters);
+    });
   }
 
   closeDaemonSession(
@@ -626,6 +668,33 @@ export class NotificationHub implements DbNotifier {
       this.deleteHostOnlineRpcWaiter(requestId, waiter);
       waiter.reject(new HostOnlineRpcUnavailableError());
     }
+  }
+
+  private deleteDaemonRegistrationWaiter(
+    hostId: string,
+    waiter: DaemonRegistrationWaiter,
+  ): void {
+    clearTimeout(waiter.timeout);
+    const waiters = this.daemonRegistrationWaiters.get(hostId);
+    if (!waiters) {
+      return;
+    }
+    waiters.delete(waiter);
+    if (waiters.size === 0) {
+      this.daemonRegistrationWaiters.delete(hostId);
+    }
+  }
+
+  private resolveDaemonRegistrationWaiters(hostId: string): void {
+    const waiters = this.daemonRegistrationWaiters.get(hostId);
+    if (!waiters) {
+      return;
+    }
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve(true);
+    }
+    this.daemonRegistrationWaiters.delete(hostId);
   }
 
   private notifyClients(message: ChangedMessage): void {

--- a/apps/server/test/hosts/online-rpc.test.ts
+++ b/apps/server/test/hosts/online-rpc.test.ts
@@ -4,6 +4,8 @@ import {
   type HostDaemonOnlineRpcRequestMessage,
   type HostDaemonOnlineRpcResult,
 } from "@bb/host-daemon-contract";
+import { hostDaemonSessions } from "@bb/db";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { ApiError } from "../../src/errors.js";
 import {
@@ -72,6 +74,99 @@ function registerDropThenReplaceSocket(args: DropThenReplaceSocketArgs): void {
 }
 
 describe("host online RPC retry semantics", () => {
+  it("runs a retryable RPC when the daemon websocket is still registered with a stale lease", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-stale-lease-live-socket",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      harness.hub.unregisterDaemon(session.id);
+      const socket: TestHostRpcSocket = {
+        close() {},
+        send(data) {
+          const request = parseHostRpcRequest(data);
+          requests.push(request);
+          harness.hub.recordHostOnlineRpcResponse({
+            sessionId: session.id,
+            message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+              type: "host-rpc.response",
+              requestId: request.requestId,
+              commandType: request.command.type,
+              ok: true,
+              result: { models: [], selectedOnlyModels: [] },
+            }),
+          });
+        },
+      };
+      harness.hub.registerDaemon(session.id, host.id, socket);
+      harness.db
+        .update(hostDaemonSessions)
+        .set({ leaseExpiresAt: Date.now() - 1000 })
+        .where(eq(hostDaemonSessions.id, session.id))
+        .run();
+
+      await expect(
+        callHostRetryableOnlineRpc(harness.deps, {
+          hostId: host.id,
+          timeoutMs: 1_000,
+          command: { type: "provider.list_models", providerId: "codex" },
+        }),
+      ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
+
+      const updatedSession = harness.db
+        .select()
+        .from(hostDaemonSessions)
+        .where(eq(hostDaemonSessions.id, session.id))
+        .get();
+      expect(updatedSession?.status).toBe("active");
+      expect(requests.map((request) => request.command.type)).toEqual([
+        "provider.list_models",
+      ]);
+    });
+  });
+
+  it("waits briefly for retryable RPCs when the session is active before the daemon websocket registers", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-registration-race",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      harness.hub.unregisterDaemon(session.id);
+
+      setTimeout(() => {
+        const socket: TestHostRpcSocket = {
+          close() {},
+          send(data) {
+            const request = parseHostRpcRequest(data);
+            requests.push(request);
+            harness.hub.recordHostOnlineRpcResponse({
+              sessionId: session.id,
+              message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+                type: "host-rpc.response",
+                requestId: request.requestId,
+                commandType: request.command.type,
+                ok: true,
+                result: { models: [], selectedOnlyModels: [] },
+              }),
+            });
+          },
+        };
+        harness.hub.registerDaemon(session.id, host.id, socket);
+      }, 10);
+
+      await expect(
+        callHostRetryableOnlineRpc(harness.deps, {
+          hostId: host.id,
+          timeoutMs: 1_000,
+          command: { type: "provider.list_models", providerId: "codex" },
+        }),
+      ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
+      expect(requests.map((request) => request.command.type)).toEqual([
+        "provider.list_models",
+      ]);
+    });
+  });
+
   it("retries read-only online RPCs when the current websocket session disappears", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {

--- a/apps/server/test/internal/background-task-reconciliation.test.ts
+++ b/apps/server/test/internal/background-task-reconciliation.test.ts
@@ -3,10 +3,7 @@ import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import { threadScope, turnScope } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { settleDanglingBackgroundTasks } from "../../src/services/threads/background-task-reconciliation.js";
-import {
-  handleDaemonSocketClosed,
-  handleExpiredHostSessionLeases,
-} from "../../src/internal/session-owner-side-effects.js";
+import { handleDaemonSocketClosed } from "../../src/internal/session-owner-side-effects.js";
 import {
   DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS,
   DAEMON_DISCONNECT_GRACE_MS,
@@ -363,27 +360,6 @@ describe("background-task lifecycle reconciliation triggers", () => {
 
       expect(response.status).toBe(201);
       expect(listSettledBackgroundTaskItems(harness, thread.id)).toEqual([]);
-    });
-  });
-
-  it("settles open tasks when the host's session lease expires with no active replacement", async () => {
-    await withTestHarness(async (harness) => {
-      const { host, session, thread } = seedOpenBackgroundTaskThread(harness);
-
-      // Mirror sweepExpiredLeases: the session row is closed before the
-      // owner-side effects run, and the host never reconnects.
-      closeSession(harness.deps.db, harness.deps.hub, session.id, "expired");
-      handleExpiredHostSessionLeases(harness.deps, {
-        expiredLeases: {
-          expiredHostIds: [host.id],
-          expiredSessionIds: [session.id],
-          sessionsClosed: 1,
-        },
-      });
-
-      expect(listSettledBackgroundTaskItems(harness, thread.id)).toEqual([
-        { status: "interrupted", taskStatus: "stopped" },
-      ]);
     });
   });
 

--- a/apps/server/test/internal/internal-environment-change.test.ts
+++ b/apps/server/test/internal/internal-environment-change.test.ts
@@ -1,4 +1,5 @@
-import { getEnvironment } from "@bb/db";
+import { getEnvironment, hostDaemonSessions } from "@bb/db";
+import { eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { onDaemonSocketMessage } from "../../src/ws/daemon-protocol.js";
 import {
@@ -21,6 +22,36 @@ function createTestDaemonSocket(): TestDaemonSocket {
 }
 
 describe("internal environment change websocket hints", () => {
+  it("renews an active session from a late heartbeat after lease expiry", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-late-heartbeat",
+      });
+      const socket = createTestDaemonSocket();
+      harness.db
+        .update(hostDaemonSessions)
+        .set({ leaseExpiresAt: Date.now() - 1000 })
+        .where(eq(hostDaemonSessions.id, session.id))
+        .run();
+
+      onDaemonSocketMessage(harness.deps, {
+        hostId: host.id,
+        sessionId: session.id,
+        socket,
+        raw: JSON.stringify({ type: "heartbeat" }),
+      });
+
+      const updatedSession = harness.db
+        .select()
+        .from(hostDaemonSessions)
+        .where(eq(hostDaemonSessions.id, session.id))
+        .get();
+      expect(updatedSession?.status).toBe("active");
+      expect(updatedSession?.leaseExpiresAt).toBeGreaterThan(Date.now());
+      expect(socket.close).not.toHaveBeenCalled();
+    });
+  });
+
   it("does not resolve host RPC waiters from a different daemon session", async () => {
     await withTestHarness(async (harness) => {
       const hostA = seedHostSession(harness.deps, {

--- a/apps/server/test/public/public-thread-terminals.test.ts
+++ b/apps/server/test/public/public-thread-terminals.test.ts
@@ -37,7 +37,7 @@ import {
   type TestAppHarness,
 } from "../helpers/test-app.js";
 import {
-  handleExpiredHostSessionLeases,
+  handleDaemonSocketClosed,
   handleHostSessionOpened,
 } from "../../src/internal/session-owner-side-effects.js";
 import { onDaemonSocketOpen } from "../../src/ws/daemon-protocol.js";
@@ -1207,7 +1207,7 @@ describe("public thread terminal routes", () => {
     );
   });
 
-  it("marks running terminals disconnected when their daemon session lease expires", async () => {
+  it("marks running terminals disconnected when their daemon socket closes", async () => {
     const fixture = await createTerminalRouteFixture();
     harnesses.push(fixture.harness);
     const stored = createTerminalSession(fixture.harness.db, {
@@ -1224,12 +1224,8 @@ describe("public thread terminal routes", () => {
     const browserSocket = createFakeBrowserSocket();
     fixture.harness.hub.registerTerminalClient(stored.id, browserSocket);
 
-    handleExpiredHostSessionLeases(fixture.harness.deps, {
-      expiredLeases: {
-        expiredHostIds: [fixture.host.id],
-        expiredSessionIds: [fixture.session.id],
-        sessionsClosed: 1,
-      },
+    handleDaemonSocketClosed(fixture.harness.deps, {
+      sessionId: fixture.session.id,
     });
 
     expect(

--- a/apps/server/test/services/entity-lookup.test.ts
+++ b/apps/server/test/services/entity-lookup.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@bb/db";
 import type { Host, Project } from "@bb/domain";
 import { ApiError } from "../../src/errors.js";
+import { NotificationHub } from "../../src/ws/hub.js";
 import {
   requireConnectedHostSession,
   requireNonDestroyedHostWithStatus,
@@ -24,6 +25,7 @@ import {
 interface SetupResult {
   db: DbConnection;
   host: Host;
+  hub: NotificationHub;
   project: Project;
 }
 
@@ -32,6 +34,7 @@ type ThrowingCallback = () => void;
 function setup(): SetupResult {
   const db = createConnection(":memory:");
   migrate(db);
+  const hub = new NotificationHub();
   const hostRow = upsertHost(db, noopNotifier, {
     id: "host_entity_lookup",
     name: "Entity Lookup Host",
@@ -54,7 +57,7 @@ function setup(): SetupResult {
     createdAt: hostRow.createdAt,
     updatedAt: hostRow.updatedAt,
   };
-  return { db, host, project };
+  return { db, host, hub, project };
 }
 
 function captureApiError(callback: ThrowingCallback): ApiError {
@@ -147,10 +150,10 @@ describe("entity lookup lifecycle errors", () => {
   });
 
   it("returns structured host_unavailable details", () => {
-    const { db, host } = setup();
+    const { db, host, hub } = setup();
     try {
       const disconnectedError = captureApiError(() => {
-        requireConnectedHostSession({ db }, host.id);
+        requireConnectedHostSession({ db, hub }, host.id);
       });
       expect(disconnectedError.status).toBe(502);
       expect(disconnectedError.body).toEqual({
@@ -166,7 +169,7 @@ describe("entity lookup lifecycle errors", () => {
 
       updateHost(db, noopNotifier, host.id, { destroyedAt: 456 });
       const destroyedError = captureApiError(() => {
-        requireNonDestroyedHostWithStatus(db, host.id);
+        requireNonDestroyedHostWithStatus({ db, hub }, host.id);
       });
       expect(destroyedError.status).toBe(404);
       expect(destroyedError.body).toEqual({

--- a/apps/server/test/services/managed-environment-cleanup-recovery.test.ts
+++ b/apps/server/test/services/managed-environment-cleanup-recovery.test.ts
@@ -1,5 +1,10 @@
 import { eq } from "drizzle-orm";
-import { createEnvironment, environments, getEnvironment } from "@bb/db";
+import {
+  createEnvironment,
+  environments,
+  getEnvironment,
+  hostDaemonSessions,
+} from "@bb/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   runEnvironmentCleanupAdvance,
@@ -211,6 +216,45 @@ describe("managed environment cleanup recovery sweep", () => {
         isGitRepo: true,
         managed: true,
         path: "/tmp/git-cleanup-without-merge-base",
+        projectId: project.id,
+        status: "retiring",
+        workspaceProvisionType: "managed-worktree",
+      });
+
+      await runEnvironmentCleanupAdvance(harness.deps, {
+        environmentId: environment.id,
+      });
+
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        destroyAttemptId: expect.any(String),
+        status: "destroying",
+      });
+      expect(
+        listQueuedEnvironmentCommands(
+          harness,
+          "environment.destroy",
+          environment.id,
+        ),
+      ).toHaveLength(1);
+    });
+  });
+
+  it("advances cleanup when a daemon socket is live but its lease timestamp is stale", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps);
+      harness.db
+        .update(hostDaemonSessions)
+        .set({ leaseExpiresAt: Date.now() - 1_000 })
+        .where(eq(hostDaemonSessions.id, session.id))
+        .run();
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = createEnvironment(harness.db, harness.hub, {
+        hostId: host.id,
+        isGitRepo: false,
+        managed: true,
+        path: "/tmp/live-daemon-stale-cleanup-lease",
         projectId: project.id,
         status: "retiring",
         workspaceProvisionType: "managed-worktree",

--- a/apps/server/test/services/threads/thread-runtime-display.test.ts
+++ b/apps/server/test/services/threads/thread-runtime-display.test.ts
@@ -21,10 +21,12 @@ import {
   resolveThreadRuntimeState,
   toThreadListEntryResponses,
 } from "../../../src/services/threads/thread-runtime-display.js";
+import { NotificationHub } from "../../../src/ws/hub.js";
 
 interface SetupResult {
   db: DbConnection;
   hostId: string;
+  hub: NotificationHub;
 }
 
 interface OpenTestSessionArgs {
@@ -57,12 +59,23 @@ interface CreateThreadListEntryArgs {
 function setup(): SetupResult {
   const db = createConnection(":memory:");
   migrate(db);
+  const hub = new NotificationHub();
   const host = upsertHost(db, noopNotifier, {
     id: "host-runtime-display",
     name: "Runtime Display Host",
     type: "persistent",
   });
-  return { db, hostId: host.id };
+  return { db, hostId: host.id, hub };
+}
+
+function registerTestDaemon(
+  hub: NotificationHub,
+  args: { hostId: string; sessionId: string },
+): void {
+  hub.registerDaemon(args.sessionId, args.hostId, {
+    close() {},
+    send() {},
+  });
 }
 
 function openTestSession(args: OpenTestSessionArgs) {
@@ -143,8 +156,29 @@ function createThreadListEntry(
 }
 
 describe("thread runtime display", () => {
-  it("keeps active threads active while the latest host session is active", () => {
-    const { db, hostId } = setup();
+  it("keeps active threads active while the host daemon websocket is registered", () => {
+    const { db, hostId, hub } = setup();
+    const now = 1_000;
+    const session = openTestSession({
+      db,
+      hostId,
+      leaseExpiresAt: now - 1,
+    });
+    registerTestDaemon(hub, { hostId, sessionId: session.id });
+
+    expect(
+      resolveThreadRuntimeState(
+        { db, hub },
+        { environmentHostId: hostId, now, status: "active" },
+      ),
+    ).toEqual({
+      displayStatus: "active",
+      hostReconnectGraceExpiresAt: null,
+    } satisfies ThreadRuntimeState);
+  });
+
+  it("does not treat a fresh lease as active without a registered daemon websocket", () => {
+    const { db, hostId, hub } = setup();
     const now = 1_000;
     openTestSession({
       db,
@@ -154,17 +188,17 @@ describe("thread runtime display", () => {
 
     expect(
       resolveThreadRuntimeState(
-        { db },
+        { db, hub },
         { environmentHostId: hostId, now, status: "active" },
       ),
     ).toEqual({
-      displayStatus: "active",
+      displayStatus: "waiting-for-host",
       hostReconnectGraceExpiresAt: null,
     } satisfies ThreadRuntimeState);
   });
 
   it("shows host-reconnecting while a daemon disconnect is inside the grace period", () => {
-    const { db, hostId } = setup();
+    const { db, hostId, hub } = setup();
     const now = 10_000;
     const session = openTestSession({ db, hostId });
     closeTestSession({
@@ -175,7 +209,7 @@ describe("thread runtime display", () => {
 
     expect(
       resolveThreadRuntimeState(
-        { db },
+        { db, hub },
         { environmentHostId: hostId, now, status: "active" },
       ),
     ).toEqual({
@@ -185,7 +219,7 @@ describe("thread runtime display", () => {
   });
 
   it("shows waiting-for-host after the daemon disconnect grace period expires", () => {
-    const { db, hostId } = setup();
+    const { db, hostId, hub } = setup();
     const now = 10_000;
     const session = openTestSession({ db, hostId });
     closeTestSession({
@@ -196,7 +230,7 @@ describe("thread runtime display", () => {
 
     expect(
       resolveThreadRuntimeState(
-        { db },
+        { db, hub },
         { environmentHostId: hostId, now, status: "active" },
       ),
     ).toEqual({
@@ -206,11 +240,11 @@ describe("thread runtime display", () => {
   });
 
   it("uses the thread status directly for non-active statuses", () => {
-    const { db, hostId } = setup();
+    const { db, hostId, hub } = setup();
 
     expect(
       resolveThreadRuntimeState(
-        { db },
+        { db, hub },
         { environmentHostId: hostId, now: 1_000, status: "idle" },
       ),
     ).toEqual({
@@ -220,11 +254,11 @@ describe("thread runtime display", () => {
   });
 
   it("does not require a host id for active threads without an environment host", () => {
-    const { db } = setup();
+    const { db, hub } = setup();
 
     expect(
       resolveThreadRuntimeState(
-        { db },
+        { db, hub },
         { environmentHostId: null, now: 1_000, status: "active" },
       ),
     ).toEqual({
@@ -233,14 +267,15 @@ describe("thread runtime display", () => {
     } satisfies ThreadRuntimeState);
   });
 
-  it("resolves list entry runtime from the latest session per host", () => {
-    const { db, hostId } = setup();
+  it("resolves list entry runtime from daemon registration per host", () => {
+    const { db, hostId, hub } = setup();
     const now = 1_000;
-    openTestSession({
+    const session = openTestSession({
       db,
       hostId,
-      leaseExpiresAt: now + 30_000,
+      leaseExpiresAt: now - 1,
     });
+    registerTestDaemon(hub, { hostId, sessionId: session.id });
     const first = createThreadWithEnvironment({ db, hostId });
     const second = createThreadWithEnvironment({ db, hostId });
     const noHost = createThreadWithEnvironment({
@@ -250,7 +285,7 @@ describe("thread runtime display", () => {
     });
 
     const entries = toThreadListEntryResponses(
-      { db },
+      { db, hub },
       {
         now,
         threads: [

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -15,7 +15,10 @@ import {
 import { describe, expect, it } from "vitest";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
-import { listQueuedThreadCommands } from "../helpers/commands.js";
+import {
+  listQueuedThreadCommands,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
   seedEnvironment,
@@ -214,6 +217,12 @@ describe("idle cold-start activation", () => {
         status: "active",
       });
       // A cold thread.start command (not a warm turn.submit) was dispatched.
+      await waitForQueuedCommand(
+        harness,
+        (queued) =>
+          queued.command.type === "thread.start" &&
+          queued.command.threadId === thread.id,
+      );
       expect(
         listQueuedThreadCommands(harness, "thread.start", thread.id),
       ).toHaveLength(1);
@@ -288,6 +297,12 @@ describe("idle cold-start activation", () => {
         trigger: "user",
       });
 
+      await waitForQueuedCommand(
+        harness,
+        (queued) =>
+          queued.command.type === "thread.start" &&
+          queued.command.threadId === thread.id,
+      );
       expect(
         listQueuedThreadCommands(harness, "thread.start", thread.id),
       ).toHaveLength(1);

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -402,13 +402,10 @@ export type {
 export {
   openSession,
   closeSession,
-  getActiveSession,
-  getActiveSessionById,
   getLatestSessionForHost,
-  getMostRecentlyUpdatedConnectedHostId,
+  getSessionById,
   heartbeatSession,
   listLatestSessionsForHosts,
-  listConnectedHostIds,
 } from "./sessions.js";
 export type {
   GetLatestSessionForHostArgs,
@@ -460,13 +457,11 @@ export {
   pruneClosedSessions,
   pruneDestroyedEnvironments,
   truncateCompletedEventItemOutputs,
-  sweepExpiredLeases,
   sweepManagedEnvironments,
 } from "./sweeps.js";
 export type {
   PruneClosedSessionsArgs,
   PruneClosedSessionsResult,
-  SweepExpiredLeasesResult,
   TruncateCompletedEventItemOutputsArgs,
   TruncateCompletedEventItemOutputsResult,
 } from "./sweeps.js";

--- a/packages/db/src/data/sessions.ts
+++ b/packages/db/src/data/sessions.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { HostType } from "@bb/domain";
 import type { DbConnection, DbTransaction } from "../connection.js";
 import type { DbNotifier } from "../notifier.js";
@@ -9,12 +9,8 @@ import { markHostSeen } from "./hosts.js";
 type SessionReadConnection = DbConnection | DbTransaction;
 export type HostDaemonSessionRow = typeof hostDaemonSessions.$inferSelect;
 
-export interface GetActiveSessionByIdArgs {
+export interface GetSessionByIdArgs {
   sessionId: string;
-}
-
-export interface GetMostRecentlyUpdatedConnectedHostIdArgs {
-  hostType?: HostType;
 }
 
 export interface GetLatestSessionForHostArgs {
@@ -130,22 +126,6 @@ export function closeSession(
   return updated ?? null;
 }
 
-export function getActiveSession(db: SessionReadConnection, hostId: string) {
-  return (
-    db
-      .select()
-      .from(hostDaemonSessions)
-      .where(
-        and(
-          eq(hostDaemonSessions.hostId, hostId),
-          eq(hostDaemonSessions.status, "active"),
-          gt(hostDaemonSessions.leaseExpiresAt, Date.now()),
-        ),
-      )
-      .get() ?? null
-  );
-}
-
 export function getLatestSessionForHost(
   db: SessionReadConnection,
   args: GetLatestSessionForHostArgs,
@@ -203,60 +183,17 @@ export function listLatestSessionsForHosts(
     .all();
 }
 
-export function getActiveSessionById(
+export function getSessionById(
   db: SessionReadConnection,
-  args: GetActiveSessionByIdArgs,
+  args: GetSessionByIdArgs,
 ) {
   return (
     db
       .select()
       .from(hostDaemonSessions)
-      .where(
-        and(
-          eq(hostDaemonSessions.id, args.sessionId),
-          eq(hostDaemonSessions.status, "active"),
-          gt(hostDaemonSessions.leaseExpiresAt, Date.now()),
-        ),
-      )
+      .where(eq(hostDaemonSessions.id, args.sessionId))
       .get() ?? null
   );
-}
-
-export function listConnectedHostIds(db: SessionReadConnection): string[] {
-  return db
-    .select({ hostId: hostDaemonSessions.hostId })
-    .from(hostDaemonSessions)
-    .where(
-      and(
-        eq(hostDaemonSessions.status, "active"),
-        gt(hostDaemonSessions.leaseExpiresAt, Date.now()),
-      ),
-    )
-    .all()
-    .map((row) => row.hostId);
-}
-
-export function getMostRecentlyUpdatedConnectedHostId(
-  db: SessionReadConnection,
-  args: GetMostRecentlyUpdatedConnectedHostIdArgs = {},
-): string | null {
-  const row = db
-    .select({ hostId: hostDaemonSessions.hostId })
-    .from(hostDaemonSessions)
-    .where(
-      and(
-        eq(hostDaemonSessions.status, "active"),
-        gt(hostDaemonSessions.leaseExpiresAt, Date.now()),
-        args.hostType
-          ? eq(hostDaemonSessions.hostType, args.hostType)
-          : undefined,
-      ),
-    )
-    .orderBy(desc(hostDaemonSessions.updatedAt))
-    .limit(1)
-    .get();
-
-  return row?.hostId ?? null;
 }
 
 export function heartbeatSession(

--- a/packages/db/src/data/sweeps.ts
+++ b/packages/db/src/data/sweeps.ts
@@ -9,7 +9,6 @@ import { type ThreadEventItemType } from "@bb/domain";
 import type { DbConnection } from "../connection.js";
 import type { DbNotifier } from "../notifier.js";
 import {
-  hostDaemonSessions,
   environments,
   maintenanceScanCursors,
 } from "../schema.js";
@@ -103,12 +102,6 @@ export interface TruncateCompletedEventItemOutputsResult {
   toolCallResults: number;
   webFetchResultTexts: number;
   webSearchResultTexts: number;
-}
-
-export interface SweepExpiredLeasesResult {
-  expiredHostIds: string[];
-  expiredSessionIds: string[];
-  sessionsClosed: number;
 }
 
 export function pruneClosedSessions(
@@ -336,71 +329,6 @@ export function truncateCompletedEventItemOutputs(
       itemKind: "webSearch",
       outputPath: "resultText",
     }),
-  };
-}
-
-/**
- * Sweep expired leases: sessions past lease timeout.
- * - Close the session (status="closed", closeReason="expired")
- * - Notify host availability changed
- *
- * Returns the closed sessions and hosts so the server can notify runtime
- * display state and close any still-registered sockets.
- */
-export function sweepExpiredLeases(
-  db: DbConnection,
-  notifier: DbNotifier,
-  now?: number,
-): SweepExpiredLeasesResult {
-  const currentTime = now ?? Date.now();
-
-  // Find active sessions past their lease
-  const expiredSessions = db
-    .select()
-    .from(hostDaemonSessions)
-    .where(
-      and(
-        eq(hostDaemonSessions.status, "active"),
-        lt(hostDaemonSessions.leaseExpiresAt, currentTime),
-      ),
-    )
-    .all();
-
-  if (expiredSessions.length === 0) {
-    return {
-      expiredHostIds: [],
-      expiredSessionIds: [],
-      sessionsClosed: 0,
-    };
-  }
-
-  db.update(hostDaemonSessions)
-    .set({
-      status: "closed",
-      closedAt: currentTime,
-      closeReason: "expired",
-      updatedAt: currentTime,
-    })
-    .where(
-      inArray(
-        hostDaemonSessions.id,
-        expiredSessions.map((session) => session.id),
-      ),
-    )
-    .run();
-
-  for (const session of expiredSessions) {
-    notifier.notifyHost(session.hostId, ["host-disconnected"]);
-  }
-
-  const expiredHostIds = [
-    ...new Set(expiredSessions.map((session) => session.hostId)),
-  ];
-
-  return {
-    expiredHostIds,
-    expiredSessionIds: expiredSessions.map((session) => session.id),
-    sessionsClosed: expiredSessions.length,
   };
 }
 

--- a/packages/db/test/data/sessions.test.ts
+++ b/packages/db/test/data/sessions.test.ts
@@ -5,13 +5,10 @@ import { migrate } from "../../src/migrate.js";
 import { noopNotifier } from "../../src/notifier.js";
 import {
   closeSession,
-  getActiveSession,
-  getActiveSessionById,
   getLatestSessionForHost,
-  getMostRecentlyUpdatedConnectedHostId,
+  getSessionById,
   heartbeatSession,
   listLatestSessionsForHosts,
-  listConnectedHostIds,
   openSession,
 } from "../../src/data/sessions.js";
 import { getHost, upsertHost } from "../../src/data/hosts.js";
@@ -46,11 +43,7 @@ describe("sessions", () => {
     expect(session.status).toBe("active");
     expect(session.hostId).toBe(host.id);
 
-    const active = getActiveSession(db, host.id);
-    expect(active?.id).toBe(session.id);
-    expect(getActiveSessionById(db, { sessionId: session.id })?.id).toBe(
-      session.id,
-    );
+    expect(getSessionById(db, { sessionId: session.id })?.id).toBe(session.id);
   });
 
   it("marks the host as seen on open, heartbeat, and close", () => {
@@ -100,7 +93,9 @@ describe("sessions", () => {
     expect(closed?.closeReason).toBe("user-requested");
     expect(closed?.closedAt).toBeTypeOf("number");
 
-    expect(getActiveSession(db, host.id)).toBeNull();
+    expect(getSessionById(db, { sessionId: session.id })?.status).toBe(
+      "closed",
+    );
   });
 
   it("closes old session when opening new one for same host", () => {
@@ -131,8 +126,9 @@ describe("sessions", () => {
     expect(session2.id).not.toBe(session1.id);
 
     // Old session should be closed with reason "replaced"
-    const active = getActiveSession(db, host.id);
-    expect(active?.id).toBe(session2.id);
+    expect(getLatestSessionForHost(db, { hostId: host.id })?.id).toBe(
+      session2.id,
+    );
 
     // Verify session1 is closed
     const old = db
@@ -281,63 +277,6 @@ describe("sessions", () => {
 
     const updated = heartbeatSession(db, session.id, Date.now() + 45_000);
     expect(updated?.leaseExpiresAt).toBeGreaterThan(Date.now());
-  });
-
-  it("does not return expired sessions as active", () => {
-    const { db, host } = setup();
-    const session = openSession(db, noopNotifier, {
-      hostId: host.id,
-      instanceId: "inst-1",
-      hostName: "test-host",
-      hostType: "persistent",
-      dataDir: "/tmp/test-host-data",
-      protocolVersion: 1,
-      heartbeatIntervalMs: 10_000,
-      leaseTimeoutMs: 30_000,
-    });
-
-    db.update(hostDaemonSessions)
-      .set({
-        leaseExpiresAt: Date.now() - 1,
-      })
-      .where(eq(hostDaemonSessions.id, session.id))
-      .run();
-
-    expect(getActiveSession(db, host.id)).toBeNull();
-    expect(getActiveSessionById(db, { sessionId: session.id })).toBeNull();
-  });
-
-  it("lists connected hosts and returns the most recently updated connected host", () => {
-    const { db, host } = setup();
-    const otherHost = upsertHost(db, noopNotifier, {
-      name: "test-host-2",
-      type: "persistent",
-    });
-    const firstSession = openSession(db, noopNotifier, {
-      hostId: host.id,
-      instanceId: "inst-1",
-      hostName: "test-host",
-      hostType: "persistent",
-      dataDir: "/tmp/test-host-data",
-      protocolVersion: 1,
-      heartbeatIntervalMs: 10_000,
-      leaseTimeoutMs: 30_000,
-    });
-    openSession(db, noopNotifier, {
-      hostId: otherHost.id,
-      instanceId: "inst-2",
-      hostName: "test-host-2",
-      hostType: "persistent",
-      dataDir: "/tmp/test-host-data-2",
-      protocolVersion: 1,
-      heartbeatIntervalMs: 10_000,
-      leaseTimeoutMs: 30_000,
-    });
-
-    closeSession(db, noopNotifier, firstSession.id, "replaced");
-
-    expect(listConnectedHostIds(db)).toEqual([otherHost.id]);
-    expect(getMostRecentlyUpdatedConnectedHostId(db)).toBe(otherHost.id);
   });
 
   it("does not overwrite an already closed session", () => {

--- a/packages/db/test/data/sweeps.test.ts
+++ b/packages/db/test/data/sweeps.test.ts
@@ -12,7 +12,6 @@ import {
   COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS,
   pruneClosedSessions,
   pruneDestroyedEnvironments,
-  sweepExpiredLeases,
   sweepManagedEnvironments,
   truncateCompletedEventItemOutputs,
 } from "../../src/data/sweeps.js";
@@ -31,7 +30,6 @@ import {
   environments,
   events,
   hostDaemonSessions,
-  threads,
 } from "../../src/schema.js";
 
 function setup() {
@@ -547,123 +545,6 @@ describe("pruneClosedSessions", () => {
         .where(eq(hostDaemonSessions.status, "closed"))
         .all(),
     ).toHaveLength(1);
-  });
-});
-
-describe("sweepExpiredLeases", () => {
-  it("closes expired sessions without erroring active threads", () => {
-    const { db, host, project } = setup();
-
-    const env = createEnvironment(db, noopNotifier, {
-      projectId: project.id,
-      hostId: host.id,
-      path: "/tmp/env",
-      workspaceProvisionType: "unmanaged",
-      status: "ready",
-    });
-
-    const thread = createThread(db, noopNotifier, {
-      projectId: project.id,
-      environmentId: env.id,
-      providerId: "codex",
-      status: "active",
-    });
-
-    const session = openSession(db, noopNotifier, {
-      hostId: host.id,
-      instanceId: "inst-1",
-      hostName: "test-host",
-      hostType: "persistent",
-      dataDir: "/tmp/test-host-data",
-      protocolVersion: 1,
-      heartbeatIntervalMs: 10_000,
-      leaseTimeoutMs: 30_000,
-    });
-
-    // Set lease to the past
-    db.update(hostDaemonSessions)
-      .set({ leaseExpiresAt: Date.now() - 1000 })
-      .where(eq(hostDaemonSessions.id, session.id))
-      .run();
-
-    const spy: DbNotifier = {
-      notifyThread: vi.fn(),
-      notifyEnvironment: vi.fn(),
-      notifyProject: vi.fn(),
-      notifyHost: vi.fn(),
-      notifySystem: vi.fn(),
-    };
-
-    const result = sweepExpiredLeases(db, spy);
-    expect(result.sessionsClosed).toBe(1);
-    expect(result.expiredHostIds).toEqual([host.id]);
-    expect(result.expiredSessionIds).toEqual([session.id]);
-
-    // Session should be closed
-    const updatedSession = db
-      .select()
-      .from(hostDaemonSessions)
-      .where(eq(hostDaemonSessions.id, session.id))
-      .get();
-    expect(updatedSession?.status).toBe("closed");
-    expect(updatedSession?.closeReason).toBe("expired");
-
-    const updatedThread = db
-      .select()
-      .from(threads)
-      .where(eq(threads.id, thread.id))
-      .get();
-    expect(updatedThread?.status).toBe("active");
-
-    expect(spy.notifyHost).toHaveBeenCalledWith(host.id, ["host-disconnected"]);
-    expect(spy.notifyThread).not.toHaveBeenCalled();
-  });
-
-  it("does not error idle threads on lease expiry", () => {
-    const { db, host, project } = setup();
-
-    const env = createEnvironment(db, noopNotifier, {
-      projectId: project.id,
-      hostId: host.id,
-      path: "/tmp/env",
-      workspaceProvisionType: "unmanaged",
-      status: "ready",
-    });
-
-    const thread = createThread(db, noopNotifier, {
-      projectId: project.id,
-      environmentId: env.id,
-      providerId: "codex",
-      status: "idle",
-    });
-
-    const session = openSession(db, noopNotifier, {
-      hostId: host.id,
-      instanceId: "inst-1",
-      hostName: "test-host",
-      hostType: "persistent",
-      dataDir: "/tmp/test-host-data",
-      protocolVersion: 1,
-      heartbeatIntervalMs: 10_000,
-      leaseTimeoutMs: 30_000,
-    });
-
-    db.update(hostDaemonSessions)
-      .set({ leaseExpiresAt: Date.now() - 1000 })
-      .where(eq(hostDaemonSessions.id, session.id))
-      .run();
-
-    const result = sweepExpiredLeases(db, noopNotifier);
-    expect(result.sessionsClosed).toBe(1);
-    expect(result.expiredHostIds).toEqual([host.id]);
-    expect(result.expiredSessionIds).toEqual([session.id]);
-
-    const updatedThread = db
-      .select()
-      .from(threads)
-      .where(eq(threads.id, thread.id))
-      .get();
-    expect(updatedThread?.status).toBe("idle");
   });
 });
 


### PR DESCRIPTION
## Summary

- Make current host liveness come from the process-local daemon websocket registration in `NotificationHub`, not from `host_daemon_sessions.lease_expires_at`.
- Keep DB session rows as open session metadata/history for session IDs and terminal ownership, but stop using wall-clock lease expiry as the server's online/offline authority.
- Allow authorized daemon websocket reconnects/messages and internal daemon session calls to use an open active session row even when its lease timestamp is stale; daemon messages still renew the lease timestamp.
- Keep retryable host-online RPC tolerant of the open-session-before-websocket-registration race by waiting briefly for hub registration.
- Remove the periodic expired-host-session-lease lifecycle path and the DB helpers that used a fresh lease timestamp as the definition of connected.

## Contract / Lifecycle Notes

- Hub/process memory owns live daemon transport: `hostId -> sessionId -> socket`.
- DB owns durable session metadata: session ID, host ID, instance ID, status, timestamps, terminal FK ownership.
- `lease_expires_at` is no longer the current-liveness boundary in the server process. It remains a renewed metadata field on open sessions, not the authority for host availability.
- A stale active DB row without a hub registration is reported as disconnected and cannot run host RPC/terminal work.
- Socket close/replacement still closes active session rows and runs disconnect side effects.
- No schema migration or persisted data model change.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/db --force`
- `pnpm exec turbo run test --filter=@bb/db -- test/data/sessions.test.ts test/data/sweeps.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/hosts/online-rpc.test.ts test/internal/internal-environment-change.test.ts test/services/managed-environment-cleanup-recovery.test.ts test/services/entity-lookup.test.ts test/services/periodic-sweeps.test.ts test/services/threads/thread-runtime-display.test.ts test/threads/thread-send-dispatch.test.ts src/services/scheduling/automation-sweep.test.ts test/internal/background-task-reconciliation.test.ts test/public/public-thread-terminals.test.ts`
- `git diff --check`
- Standalone dev QA from this worktree with `scripts/bb-dev-app current`:
  - Confirmed server `http://localhost:23274`, data dir `/Users/michael/.bb-dev/bb-worktrees-env_8h372civ3e-bb-844a65f25703`.
  - Simulated sleep/wake by setting live session `hses_f43654khy8` / `host_j96dmzarpv` `lease_expires_at` into the past.
  - Confirmed `GET /api/v1/hosts` reported `host_j96dmzarpv` as `connected` despite the stale lease.
  - Called `GET /api/v1/system/execution-options?hostId=host_j96dmzarpv&providerId=codex`; response was 200 and the real daemon response renewed the same session lease to a future timestamp.
  - Inserted fake active stale session `hses_split3_no_socket_simple_1782502530745` for host `host_split3_no_socket_simple_1782502530745` with no websocket registration; `GET /api/v1/hosts/:id` reported `disconnected`.
  - Stopped the dev instance with `scripts/bb-dev-app stop`.

## Residual Risk

- This intentionally stops using periodic wall-clock lease expiry as an online/offline mechanism. Orphan active rows can remain as DB rows, but they are not considered connected without hub registration. If we want DB tidiness, that should be a separate retention/prune concern, not liveness policy.
