### PR TITLE
Consistent hover-motion + persistent menu hover across the UI

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -4,11 +4,19 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEventHandler,
+  type PointerEventHandler,
   type RefObject,
 } from "react";
 import { useDebounceValue } from "usehooks-ts";
 import { Button } from "@/components/ui/button.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
+import {
+  MENU_ITEM_LAST_HOVERED_CLASS,
+  MenuHoverProvider,
+  useMenuItemHover,
+} from "@/components/ui/menu-item-hover.js";
 import {
   COARSE_POINTER_COMPACT_ICON_SIZE_CLASS,
   COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
@@ -98,7 +106,7 @@ const DETACHED_LABEL_PREFIX = "Detached";
 // branch popover reads as the same family of menu as the other pickers
 // (text-xs, px-2 py-[0.3125rem]).
 const BRANCH_PICKER_ROW_CLASS_NAME =
-  "flex w-full min-w-0 items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-left text-xs outline-none transition-colors hover:bg-state-hover hover:text-foreground focus-visible:bg-state-hover focus-visible:text-foreground";
+  "flex w-full min-w-0 items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-left text-xs outline-none hover:bg-state-hover hover:text-foreground focus-visible:bg-state-hover focus-visible:text-foreground";
 const BRANCH_PICKER_HEADER_BASE_CLASS_NAME =
   "text-xs font-medium text-muted-foreground";
 const BRANCH_PICKER_HEADER_STICKY_CLASS_NAME =
@@ -190,6 +198,8 @@ interface BranchPickerRowButtonProps {
   disabled?: boolean;
   emphasizeLabel?: boolean;
   onSelect: () => void;
+  onPointerEnter?: PointerEventHandler<HTMLButtonElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLButtonElement>;
 }
 
 interface BranchPickerSearchProps {
@@ -461,18 +471,27 @@ function BranchPickerRowButton({
   disabled = false,
   emphasizeLabel = false,
   onSelect,
+  onPointerEnter: callerPointerEnter,
+  onKeyDown: callerKeyDown,
 }: BranchPickerRowButtonProps) {
+  const { hoverProps } = useMenuItemHover({
+    onPointerEnter: callerPointerEnter,
+    onKeyDown: callerKeyDown,
+  });
   return (
     <button
       type="button"
       className={cn(
         BRANCH_PICKER_ROW_CLASS_NAME,
+        LIST_HOVER_TRANSITION,
+        MENU_ITEM_LAST_HOVERED_CLASS,
         disabled &&
           "cursor-not-allowed text-muted-foreground opacity-60 hover:bg-transparent hover:text-muted-foreground",
       )}
       disabled={disabled}
       title={title ?? label}
       onClick={onSelect}
+      {...hoverProps}
     >
       <Icon
         name={icon}
@@ -943,6 +962,7 @@ export function BranchPicker({
           disabled={disabled}
           aria-label="Branch"
           className={cn(
+            LIST_HOVER_TRANSITION,
             variant === "default" &&
               "h-8 w-full min-w-0 justify-between rounded-md border-border bg-background px-2.5 text-sm font-normal shadow-none hover:bg-state-hover",
             variant === "minimal" &&
@@ -1008,212 +1028,217 @@ export function BranchPicker({
           showOptionsSearch && "md:min-w-40",
         )}
       >
-        {showOptionsSearch ? (
-          <BranchPickerSearch
-            inputRef={inputRef}
-            query={query}
-            enterSelection={enterSelection}
-            onEnterSelection={selectEnterBranch}
-            onQueryChange={setQuery}
-          />
-        ) : null}
-        <div
-          className="min-h-0 max-h-[60vh] overflow-y-auto overscroll-contain px-1 pb-1 pt-0 md:max-h-80"
-          onWheel={(event) => {
-            event.stopPropagation();
-          }}
-        >
-          {menuCopy.title ? (
-            <BranchPickerSectionHeader
-              label={menuCopy.title}
-              subtitle={titleSubtitle}
-              subtitleTitle={titleSubtitleTitle}
-              sticky={!isCheckoutMenu}
+        <MenuHoverProvider>
+          {showOptionsSearch ? (
+            <BranchPickerSearch
+              inputRef={inputRef}
+              query={query}
+              enterSelection={enterSelection}
+              onEnterSelection={selectEnterBranch}
+              onQueryChange={setQuery}
             />
           ) : null}
-          {isCheckoutMenu ? (
-            <>
-              {currentOptionItemLabel !== null && onClear ? (
+          <div
+            className="min-h-0 max-h-[60vh] overflow-y-auto overscroll-contain px-1 pb-1 pt-0 md:max-h-80"
+            onWheel={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            {menuCopy.title ? (
+              <BranchPickerSectionHeader
+                label={menuCopy.title}
+                subtitle={titleSubtitle}
+                subtitleTitle={titleSubtitleTitle}
+                sticky={!isCheckoutMenu}
+              />
+            ) : null}
+            {isCheckoutMenu ? (
+              <>
+                {currentOptionItemLabel !== null && onClear ? (
+                  <BranchPickerRowButton
+                    icon="GitMerge"
+                    label={currentOptionItemLabel}
+                    title={currentOptionTitle ?? currentOptionItemLabel}
+                    selected={activeCheckoutIntent === "current"}
+                    onSelect={() => {
+                      setCheckoutIntent("current");
+                      onClear();
+                      closePicker();
+                    }}
+                  />
+                ) : null}
+                {showCreateItem && onCreate ? (
+                  <BranchPickerRowButton
+                    icon="Plus"
+                    label={CREATE_NEW_BRANCH_LABEL}
+                    title={createDisabledTitle ?? CREATE_NEW_BRANCH_LABEL}
+                    selected={activeCheckoutIntent === "new"}
+                    disabled={createDisabled}
+                    onSelect={() => {
+                      setCheckoutIntent("new");
+                      onCreate();
+                    }}
+                  />
+                ) : null}
                 <BranchPickerRowButton
                   icon="GitMerge"
-                  label={currentOptionItemLabel}
-                  title={currentOptionTitle ?? currentOptionItemLabel}
-                  selected={activeCheckoutIntent === "current"}
+                  label="Checkout"
+                  title={optionDisabledTitle ?? "Checkout an existing branch"}
+                  selected={activeCheckoutIntent === "checkout"}
+                  disabled={branchOptionsDisabled}
                   onSelect={() => {
-                    setCheckoutIntent("current");
-                    onClear();
-                    closePicker();
+                    setCheckoutIntent("checkout");
                   }}
                 />
-              ) : null}
-              {showCreateItem && onCreate ? (
-                <BranchPickerRowButton
-                  icon="Plus"
-                  label={CREATE_NEW_BRANCH_LABEL}
-                  title={createDisabledTitle ?? CREATE_NEW_BRANCH_LABEL}
-                  selected={activeCheckoutIntent === "new"}
-                  disabled={createDisabled}
-                  onSelect={() => {
-                    setCheckoutIntent("new");
-                    onCreate();
-                  }}
-                />
-              ) : null}
-              <BranchPickerRowButton
-                icon="GitMerge"
-                label="Checkout"
-                title={optionDisabledTitle ?? "Checkout an existing branch"}
-                selected={activeCheckoutIntent === "checkout"}
-                disabled={branchOptionsDisabled}
-                onSelect={() => {
-                  setCheckoutIntent("checkout");
-                }}
-              />
-              {showBranchChooser ? (
-                <>
-                  <div className="my-1 h-px bg-border/60" />
-                  <BranchPickerSectionHeader
-                    label={checkoutBranchSectionLabel}
-                    subtitle={
-                      optionsSectionDisabled
-                        ? branchChooserDisabledDescription
-                        : undefined
-                    }
-                    subtitleTitle={branchChooserDisabledTitle}
-                  />
-                  {optionsSectionDisabled ? null : (
-                    <>
-                      {activeCheckoutIntent === "checkout" ? (
-                        <>
-                          {filteredCheckoutTargetOptions.length > 0
-                            ? filteredCheckoutTargetOptions.map((branch) => (
-                                <BranchPickerRowButton
-                                  key={branch}
-                                  icon="GitMerge"
-                                  label={branch}
-                                  title={branch}
-                                  selected={branch === value}
-                                  onSelect={() => selectCheckoutTarget(branch)}
-                                />
-                              ))
-                            : null}
-                          {filteredCheckoutTargetOptions.length === 0 ? (
-                            <p className="px-2 py-3 text-center text-xs text-muted-foreground">
-                              {loading
-                                ? "Loading branches..."
-                                : "No local branches found."}
-                            </p>
-                          ) : null}
-                        </>
-                      ) : (
-                        <>
-                          <BranchPickerBranchOptions
-                            options={filteredBranchOptions}
-                            selectedValue={value}
-                            onSelect={selectBranchAndClose}
-                          />
-                          {filteredBranchOptions.length === 0 ? (
-                            <p className="px-2 py-3 text-center text-xs text-muted-foreground">
-                              {loading
-                                ? "Loading branches..."
-                                : "No branches found."}
-                            </p>
-                          ) : null}
-                        </>
-                      )}
-                    </>
-                  )}
-                </>
-              ) : null}
-            </>
-          ) : (
-            <>
-              {hasCurrentItem ? (
-                <>
-                  {currentOptionItemLabel !== null &&
-                  menuCopy.currentSectionLabel ? (
+                {showBranchChooser ? (
+                  <>
+                    <div className="my-1 h-px bg-border/60" />
                     <BranchPickerSectionHeader
-                      label={menuCopy.currentSectionLabel}
+                      label={checkoutBranchSectionLabel}
+                      subtitle={
+                        optionsSectionDisabled
+                          ? branchChooserDisabledDescription
+                          : undefined
+                      }
+                      subtitleTitle={branchChooserDisabledTitle}
                     />
-                  ) : null}
-                  {currentOptionItemLabel !== null && onClear ? (
-                    <BranchPickerRowButton
-                      icon="GitMerge"
-                      label={currentOptionItemLabel}
-                      title={currentOptionTitle ?? currentOptionItemLabel}
-                      selected={!isCreatingNew && value === null}
-                      onSelect={() => {
-                        onClear();
-                        closePicker();
-                      }}
-                    />
-                  ) : null}
-                </>
-              ) : null}
-              {hasOptionsSection ? (
-                <>
-                  {menuCopy.optionsSectionLabel ? (
-                    <>
-                      {hasCurrentItem ? (
-                        <div className="my-1 h-px bg-border/60" />
-                      ) : null}
-                      <BranchPickerSectionHeader
-                        label={menuCopy.optionsSectionLabel}
-                        subtitle={
-                          optionsSectionDisabled
-                            ? branchChooserDisabledDescription
-                            : undefined
-                        }
-                        subtitleTitle={branchChooserDisabledTitle}
-                      />
-                    </>
-                  ) : null}
-                  {optionsSectionDisabled ? null : (
-                    <>
-                      {showCreateItem && onCreate ? (
-                        createDisabled ? (
-                          <BranchPickerUnavailableRow
-                            icon="Plus"
-                            label={CREATE_NEW_BRANCH_LABEL}
-                            description={createDisabledDescription}
-                            title={createDisabledTitle}
-                          />
+                    {optionsSectionDisabled ? null : (
+                      <>
+                        {activeCheckoutIntent === "checkout" ? (
+                          <>
+                            {filteredCheckoutTargetOptions.length > 0
+                              ? filteredCheckoutTargetOptions.map((branch) => (
+                                  <BranchPickerRowButton
+                                    key={branch}
+                                    icon="GitMerge"
+                                    label={branch}
+                                    title={branch}
+                                    selected={branch === value}
+                                    onSelect={() =>
+                                      selectCheckoutTarget(branch)
+                                    }
+                                  />
+                                ))
+                              : null}
+                            {filteredCheckoutTargetOptions.length === 0 ? (
+                              <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+                                {loading
+                                  ? "Loading branches..."
+                                  : "No local branches found."}
+                              </p>
+                            ) : null}
+                          </>
                         ) : (
-                          <BranchPickerRowButton
-                            icon="Plus"
-                            label={CREATE_NEW_BRANCH_LABEL}
-                            title={createDisabledTitle}
-                            selected={isCreatingNew}
-                            onSelect={() => {
-                              onCreate();
-                              closePicker();
-                            }}
-                          />
-                        )
-                      ) : null}
-                      <BranchPickerBranchOptions
-                        options={filteredBranchOptions}
-                        selectedValue={value}
-                        onSelect={selectBranchAndClose}
+                          <>
+                            <BranchPickerBranchOptions
+                              options={filteredBranchOptions}
+                              selectedValue={value}
+                              onSelect={selectBranchAndClose}
+                            />
+                            {filteredBranchOptions.length === 0 ? (
+                              <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+                                {loading
+                                  ? "Loading branches..."
+                                  : "No branches found."}
+                              </p>
+                            ) : null}
+                          </>
+                        )}
+                      </>
+                    )}
+                  </>
+                ) : null}
+              </>
+            ) : (
+              <>
+                {hasCurrentItem ? (
+                  <>
+                    {currentOptionItemLabel !== null &&
+                    menuCopy.currentSectionLabel ? (
+                      <BranchPickerSectionHeader
+                        label={menuCopy.currentSectionLabel}
                       />
-                      {filteredBranchOptions.length === 0 && !showCreateItem ? (
-                        <p className="px-2 py-3 text-center text-xs text-muted-foreground">
-                          {loading
-                            ? "Loading branches..."
-                            : "No branches found."}
-                        </p>
-                      ) : null}
-                    </>
-                  )}
-                </>
-              ) : hasCurrentItem ? null : (
-                <p className="px-2 py-6 text-center text-xs text-muted-foreground">
-                  {loading ? "Loading branches..." : "No branches found."}
-                </p>
-              )}
-            </>
-          )}
-        </div>
+                    ) : null}
+                    {currentOptionItemLabel !== null && onClear ? (
+                      <BranchPickerRowButton
+                        icon="GitMerge"
+                        label={currentOptionItemLabel}
+                        title={currentOptionTitle ?? currentOptionItemLabel}
+                        selected={!isCreatingNew && value === null}
+                        onSelect={() => {
+                          onClear();
+                          closePicker();
+                        }}
+                      />
+                    ) : null}
+                  </>
+                ) : null}
+                {hasOptionsSection ? (
+                  <>
+                    {menuCopy.optionsSectionLabel ? (
+                      <>
+                        {hasCurrentItem ? (
+                          <div className="my-1 h-px bg-border/60" />
+                        ) : null}
+                        <BranchPickerSectionHeader
+                          label={menuCopy.optionsSectionLabel}
+                          subtitle={
+                            optionsSectionDisabled
+                              ? branchChooserDisabledDescription
+                              : undefined
+                          }
+                          subtitleTitle={branchChooserDisabledTitle}
+                        />
+                      </>
+                    ) : null}
+                    {optionsSectionDisabled ? null : (
+                      <>
+                        {showCreateItem && onCreate ? (
+                          createDisabled ? (
+                            <BranchPickerUnavailableRow
+                              icon="Plus"
+                              label={CREATE_NEW_BRANCH_LABEL}
+                              description={createDisabledDescription}
+                              title={createDisabledTitle}
+                            />
+                          ) : (
+                            <BranchPickerRowButton
+                              icon="Plus"
+                              label={CREATE_NEW_BRANCH_LABEL}
+                              title={createDisabledTitle}
+                              selected={isCreatingNew}
+                              onSelect={() => {
+                                onCreate();
+                                closePicker();
+                              }}
+                            />
+                          )
+                        ) : null}
+                        <BranchPickerBranchOptions
+                          options={filteredBranchOptions}
+                          selectedValue={value}
+                          onSelect={selectBranchAndClose}
+                        />
+                        {filteredBranchOptions.length === 0 &&
+                        !showCreateItem ? (
+                          <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+                            {loading
+                              ? "Loading branches..."
+                              : "No branches found."}
+                          </p>
+                        ) : null}
+                      </>
+                    )}
+                  </>
+                ) : hasCurrentItem ? null : (
+                  <p className="px-2 py-6 text-center text-xs text-muted-foreground">
+                    {loading ? "Loading branches..." : "No branches found."}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </MenuHoverProvider>
       </PopoverContent>
     </Popover>
   );

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -16,6 +16,7 @@ import {
   COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
 } from "@/components/ui/coarse-pointer-sizing.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import { getEnvironmentWorkspaceLabelIconName } from "@/lib/environment-workspace-display";
 import { cn } from "@/lib/utils";
 import {
@@ -158,6 +159,7 @@ export function EnvironmentPickerUI({
           className={cn(
             OPTION_BASE_CLASS_NAME,
             !disabled && OPTION_INTERACTIVE_CLASS_NAME,
+            !disabled && LIST_HOVER_TRANSITION,
             muted && OPTION_MUTED_CLASS_NAME,
             disabled && "cursor-default disabled:opacity-100",
             className,
@@ -324,7 +326,10 @@ function EnvironmentMenuItem({
         if (disabled) return;
         onSelect();
       }}
-      className="flex items-start justify-between gap-3 whitespace-normal"
+      className={cn(
+        "flex items-start justify-between gap-3 whitespace-normal",
+        LIST_HOVER_TRANSITION,
+      )}
     >
       <span className="flex min-w-0 flex-1 items-start gap-2">
         <Icon

--- a/apps/app/src/components/pickers/OptionPicker.tsx
+++ b/apps/app/src/components/pickers/OptionPicker.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import { cn } from "@/lib/utils";
 
 export const OPTION_BASE_CLASS_NAME =
@@ -186,6 +187,7 @@ export function OptionPicker<T extends string>({
       className={cn(
         OPTION_BASE_CLASS_NAME,
         OPTION_INTERACTIVE_CLASS_NAME,
+        LIST_HOVER_TRANSITION,
         muted && OPTION_MUTED_CLASS_NAME,
         selectedIsWarning && OPTION_WARNING_TEXT_CLASS_NAME,
         selectedIsWarning && OPTION_WARNING_INTERACTIVE_CLASS_NAME,
@@ -243,7 +245,10 @@ export function OptionPicker<T extends string>({
             <DropdownMenuItem
               key={option.value}
               onSelect={() => onChange(option.value)}
-              className="flex items-start justify-between gap-3 whitespace-normal"
+              className={cn(
+                "flex items-start justify-between gap-3 whitespace-normal",
+                LIST_HOVER_TRANSITION,
+              )}
             >
               <span
                 className={cn(

--- a/apps/app/src/components/pickers/PermissionModePicker.tsx
+++ b/apps/app/src/components/pickers/PermissionModePicker.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from "react";
 import type { PermissionMode } from "@bb/domain";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
+import { cn } from "@/lib/utils";
 import { OptionPicker, type PickerOption } from "./OptionPicker";
 
 type PermissionModeOption = PickerOption<PermissionMode>;
@@ -86,7 +88,7 @@ export function PermissionModePicker({
       value={value}
       options={compactOptions}
       onChange={onChange}
-      className={className}
+      className={cn(LIST_HOVER_TRANSITION, className)}
       contentClassName="max-w-72"
       muted={muted}
       defaultOpen={defaultOpen}

--- a/apps/app/src/components/pickers/WorktreePicker.tsx
+++ b/apps/app/src/components/pickers/WorktreePicker.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.js";
 import { Icon } from "@/components/ui/icon.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import {
   COARSE_POINTER_COMPACT_ICON_SIZE_CLASS,
   COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
@@ -86,6 +87,7 @@ export function WorktreePicker({
           className={cn(
             OPTION_BASE_CLASS_NAME,
             !disabled && OPTION_INTERACTIVE_CLASS_NAME,
+            !disabled && LIST_HOVER_TRANSITION,
             muted && OPTION_MUTED_CLASS_NAME,
             disabled && "cursor-default disabled:opacity-100",
           )}
@@ -154,7 +156,10 @@ function WorktreeMenuItem({
   return (
     <DropdownMenuItem
       onSelect={() => onSelect(option.environmentId)}
-      className="flex flex-col items-stretch gap-1 py-2"
+      className={cn(
+        "flex flex-col items-stretch gap-1 py-2",
+        LIST_HOVER_TRANSITION,
+      )}
     >
       <span className="flex min-w-0 items-center gap-2">
         <Icon

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -51,6 +51,7 @@ interface ProjectActionsMenuItemsProps extends ProjectActionsMenuBaseProps {
 interface ProjectActionMenuItemProps {
   children: ReactNode;
   className?: string;
+  variant?: "default" | "destructive";
   icon: IconName;
   onSelect?: (event: Event) => void;
   surface: ProjectActionsMenuSurface;
@@ -67,6 +68,7 @@ function stopProjectActionsMenuClickPropagation(event: MouseEvent) {
 function ProjectActionMenuItem({
   children,
   className,
+  variant,
   icon,
   onSelect,
   surface,
@@ -80,14 +82,25 @@ function ProjectActionMenuItem({
 
   if (surface === "context") {
     return (
-      <ContextMenuItem className={className} onSelect={onSelect}>
+      <ContextMenuItem
+        className={cn(
+          className,
+          variant === "destructive" &&
+            "text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive",
+        )}
+        onSelect={onSelect}
+      >
         {content}
       </ContextMenuItem>
     );
   }
 
   return (
-    <DropdownMenuItem className={className} onSelect={onSelect}>
+    <DropdownMenuItem
+      className={className}
+      variant={variant}
+      onSelect={onSelect}
+    >
       {content}
     </DropdownMenuItem>
   );
@@ -159,7 +172,7 @@ function ProjectActionsMenuItems({
       <ProjectActionMenuItem
         surface={surface}
         icon="Trash2"
-        className="text-destructive focus:text-destructive"
+        variant="destructive"
         onSelect={() => {
           requestDelete(project);
         }}

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/components/dialogs/ConfirmDeleteDialog";
 import { CHROME_SECTION_LABEL_CLASS } from "@/components/ui/chromeStyleTokens";
 import { Icon, type IconName } from "@/components/ui/icon.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import { Skeleton } from "@/components/ui/skeleton.js";
 import {
   SidebarGroupContent,
@@ -227,6 +228,7 @@ interface LocalSourcePathTarget {
 
 const PROJECT_LIST_ACTION_BUTTON_CLASS = cn(
   SIDEBAR_ROW_BASE_CLASS,
+  LIST_HOVER_TRANSITION,
   SIDEBAR_STANDARD_ROW_PADDING_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   COARSE_POINTER_ROW_HEIGHT_CLASS,
@@ -255,7 +257,8 @@ const PROJECT_LIST_SEARCH_CLOSE_BUTTON_CLASS =
   "h-6 w-6 shrink-0 rounded-md p-0 text-muted-foreground ring-sidebar-ring hover:bg-sidebar-border/60 hover:text-sidebar-foreground focus-visible:ring-2 max-md:pointer-coarse:h-8 max-md:pointer-coarse:w-8";
 
 const PROJECT_LIST_SECTION_ACTION_BUTTON_CLASS = cn(
-  "inline-flex items-center justify-center rounded-md text-muted-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2 disabled:opacity-50",
+  "inline-flex items-center justify-center rounded-md text-muted-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2 disabled:opacity-50",
+  LIST_HOVER_TRANSITION,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
 );
 
@@ -708,6 +711,7 @@ function SidebarDisplayMenuTrigger({
             className={cn(
               "rounded-md p-0 text-muted-foreground",
               "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
+              LIST_HOVER_TRANSITION,
               COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
             )}
           >
@@ -1113,7 +1117,8 @@ export function TopLevelSidebarSection({
               }
               className={cn(
                 !collapseControl.isCollapsed && SIDEBAR_HOVER_ACTIONS_CLASS,
-                "relative z-20 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
+                "relative z-20 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
+                LIST_HOVER_TRANSITION,
               )}
               onClick={handleCollapseControlClick}
               onPointerDown={stopCollapseControlPointerDown}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/ui/dropdown-menu.js";
 import { EmptyState } from "@/components/ui/empty-state.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import {
   SidebarMenuItem,
   SidebarMenuSkeleton,
@@ -95,6 +96,7 @@ import { SidebarFolderRow } from "./SidebarFolderRow";
 import { sidebarCollapsedFoldersAtom } from "./sidebarCollapsedAtoms";
 import {
   SIDEBAR_PROJECT_GROUP_LINE_CLASS,
+  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
   SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_SELECTED_STATE_CLASS,
   SIDEBAR_ROW_STATIC_STATE_CLASS,
@@ -1052,7 +1054,7 @@ function EnvironmentThreadGroupHeaderActions({
             className={cn(
               "rounded-md p-0 text-muted-foreground",
               "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
-              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+              SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
             )}
           >
             <Icon
@@ -2124,7 +2126,8 @@ function ProjectRowComponent({
             tier="project"
             className={cn(
               SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
-              "group/project-row flex w-full items-center rounded-md text-sm transition-colors",
+              "group/project-row flex w-full items-center rounded-md text-sm",
+              LIST_HOVER_TRANSITION,
               isActive
                 ? SIDEBAR_ROW_SELECTED_STATE_CLASS
                 : SIDEBAR_ROW_STATIC_STATE_CLASS,
@@ -2139,6 +2142,7 @@ function ProjectRowComponent({
               className={cn(
                 "pointer-events-none relative z-10 flex shrink-0 items-center justify-center rounded-md text-muted-foreground",
                 PROJECT_ROW_LEADING_SLOT_CLASS,
+                LIST_HOVER_TRANSITION,
               )}
               aria-hidden
             >
@@ -2196,7 +2200,7 @@ function ProjectRowComponent({
                 onOpenChange={setIsDropdownActionsOpen}
                 triggerClassName={cn(
                   "relative z-10 text-subtle-foreground hover:bg-transparent hover:text-foreground",
-                  COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+                  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
                 )}
               />
               <Button

--- a/apps/app/src/components/sidebar/SidebarChildToggleChevron.tsx
+++ b/apps/app/src/components/sidebar/SidebarChildToggleChevron.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/components/ui/icon.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import { SIDEBAR_HOVER_ACTIONS_CLASS } from "@/components/ui/sidebar-hover-actions.js";
 import { cn } from "@/lib/utils";
 
@@ -31,7 +32,8 @@ export function SidebarChildToggleChevron({
       }}
       className={cn(
         revealOnHover ? SIDEBAR_HOVER_ACTIONS_CLASS : "pointer-events-auto",
-        "relative z-10 inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
+        "relative z-10 inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
+        LIST_HOVER_TRANSITION,
       )}
     >
       <Icon

--- a/apps/app/src/components/sidebar/SidebarFolderRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarFolderRow.tsx
@@ -26,6 +26,7 @@ import {
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
 } from "@/components/ui/coarse-pointer-sizing.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
@@ -36,6 +37,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { CollapsedChildActivity } from "@/lib/thread-activity";
 import {
+  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
   SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_STATIC_STATE_CLASS,
   getSidebarThreadRowPaddingLeft,
@@ -97,6 +99,7 @@ function SidebarFolderRowComponent({
     // positioned box. Mirrors ThreadRow / EnvironmentThreadGroupHeader.
     stickyLevel === undefined && "relative",
     SIDEBAR_ROW_BASE_CLASS,
+    LIST_HOVER_TRANSITION,
     SIDEBAR_ROW_STATIC_STATE_CLASS,
     COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
     dragBindings && !dragBindings.disabled && "select-none",
@@ -200,7 +203,7 @@ function SidebarFolderRowComponent({
                   aria-label={`${label} folder actions`}
                   className={cn(
                     "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground",
-                    COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+                    SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
                   )}
                 >
                   <Icon
@@ -226,10 +229,7 @@ function SidebarFolderRowComponent({
                   </DropdownMenuItem>
                 ) : null}
                 {onRemove ? (
-                  <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
-                    onSelect={onRemove}
-                  >
+                  <DropdownMenuItem variant="destructive" onSelect={onRemove}>
                     <Icon name="Trash2" aria-hidden="true" />
                     Remove
                   </DropdownMenuItem>

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -39,11 +39,13 @@ import {
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getThreadRoutePath } from "@/lib/route-paths";
 import { cn } from "@/lib/utils";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import {
   SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_GLYPH_SLOT_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   SIDEBAR_ROW_SELECTED_STATE_CLASS,
+  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
   SIDEBAR_SUCCESS_STATUS_DOT_CLASS,
   SIDEBAR_WORKING_STATUS_COLOR_CLASS,
   getSidebarThreadRowPaddingLeft,
@@ -344,6 +346,7 @@ function ThreadRowComponent({
     SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
     "group/thread-row",
     SIDEBAR_ROW_BASE_CLASS,
+    LIST_HOVER_TRANSITION,
     parentOptions?.stickyLevel === undefined && "relative",
     options.isCompact
       ? COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS
@@ -351,6 +354,7 @@ function ThreadRowComponent({
     showActive
       ? SIDEBAR_ROW_SELECTED_STATE_CLASS
       : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+    !showActive && "has-[[data-state=open]]:bg-sidebar-accent",
     rowDragBindings && !rowDragBindings.disabled && "select-none",
   );
   const rowStyle = getThreadRowStyle(options.depth);
@@ -437,7 +441,7 @@ function ThreadRowComponent({
               thread={thread}
               triggerClassName={cn(
                 "text-subtle-foreground hover:bg-transparent hover:text-foreground",
-                COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+                SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
               )}
               onOpenChange={setIsDropdownActionsOpen}
             />

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -75,6 +75,9 @@ export const SIDEBAR_ROW_STATIC_STATE_CLASS =
 export const SIDEBAR_ROW_SELECTED_STATE_CLASS =
   "bg-sidebar-border/70 text-sidebar-foreground";
 
+export const SIDEBAR_MORE_ACTION_TRIGGER_CLASS =
+  "relative m-1 h-5 w-5 after:absolute after:left-1/2 after:top-1/2 after:h-7 after:w-7 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] max-md:pointer-coarse:m-0 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:after:hidden";
+
 /**
  * Hairline that runs through an expanded project's thread list, sitting
  * under the center of the project chevron/folder icon. The coarse-pointer

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -51,6 +51,7 @@ interface ThreadActionsMenuItemsProps extends ThreadActionsMenuBaseProps {
 interface ThreadActionMenuItemProps {
   children: ReactNode;
   className?: string;
+  variant?: "default" | "destructive";
   icon: IconName;
   onSelect?: (event: Event) => void;
   surface: ThreadActionsMenuSurface;
@@ -59,6 +60,7 @@ interface ThreadActionMenuItemProps {
 function ThreadActionMenuItem({
   children,
   className,
+  variant,
   icon,
   onSelect,
   surface,
@@ -72,14 +74,25 @@ function ThreadActionMenuItem({
 
   if (surface === "context") {
     return (
-      <ContextMenuItem className={className} onSelect={onSelect}>
+      <ContextMenuItem
+        className={cn(
+          className,
+          variant === "destructive" &&
+            "text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive",
+        )}
+        onSelect={onSelect}
+      >
         {content}
       </ContextMenuItem>
     );
   }
 
   return (
-    <DropdownMenuItem className={className} onSelect={onSelect}>
+    <DropdownMenuItem
+      className={className}
+      variant={variant}
+      onSelect={onSelect}
+    >
       {content}
     </DropdownMenuItem>
   );
@@ -177,7 +190,7 @@ function ThreadActionsMenuItems({
         <ThreadActionMenuItem
           surface={surface}
           icon="Trash2"
-          className="text-destructive focus:text-destructive"
+          variant="destructive"
           onSelect={() => {
             window.setTimeout(() => {
               requestDelete(thread);

--- a/apps/app/src/components/ui/button.tsx
+++ b/apps/app/src/components/ui/button.tsx
@@ -4,9 +4,10 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
+import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 
 const buttonVariants = cva(
-  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  `inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ${CONTROL_HOVER_TRANSITION} focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0`,
   {
     variants: {
       variant: {

--- a/apps/app/src/components/ui/context-menu.tsx
+++ b/apps/app/src/components/ui/context-menu.tsx
@@ -4,6 +4,12 @@ import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 
 import { cn } from "@/lib/utils";
 import { COARSE_POINTER_CHECK_SLOT_CLASS } from "./coarse-pointer-sizing.js";
+import {
+  MENU_ITEM_LAST_HOVERED_CLASS,
+  MenuHoverProvider,
+  useMenuItemHover,
+} from "./menu-item-hover.js";
+import { LIST_HOVER_TRANSITION } from "./motion.js";
 import { Icon } from "@/components/ui/icon.js";
 
 type ContextMenuSubTriggerElement = React.ComponentRef<
@@ -80,20 +86,42 @@ const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
 const ContextMenuSubTrigger = React.forwardRef<
   ContextMenuSubTriggerElement,
   ContextMenuSubTriggerProps
->(({ className, inset, children, ...props }, ref) => (
-  <ContextMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none focus:bg-state-hover focus:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    {children}
-    <Icon name="ChevronRight" className="ml-auto" />
-  </ContextMenuPrimitive.SubTrigger>
-));
+      inset,
+      children,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
+
+    return (
+      <ContextMenuPrimitive.SubTrigger
+        ref={ref}
+        className={cn(
+          "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none focus:bg-state-hover focus:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
+          inset && "pl-8",
+          className,
+        )}
+        {...props}
+        {...hoverProps}
+      >
+        {children}
+        <Icon name="ChevronRight" className="ml-auto" />
+      </ContextMenuPrimitive.SubTrigger>
+    );
+  },
+);
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
 
 const ContextMenuSubContent = React.forwardRef<
@@ -114,7 +142,7 @@ ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 const ContextMenuContent = React.forwardRef<
   ContextMenuContentElement,
   ContextMenuContentProps
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
     <ContextMenuPrimitive.Content
       ref={ref}
@@ -123,7 +151,9 @@ const ContextMenuContent = React.forwardRef<
         className,
       )}
       {...props}
-    />
+    >
+      <MenuHoverProvider>{children}</MenuHoverProvider>
+    </ContextMenuPrimitive.Content>
   </ContextMenuPrimitive.Portal>
 ));
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
@@ -131,68 +161,132 @@ ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
 const ContextMenuItem = React.forwardRef<
   ContextMenuItemElement,
   ContextMenuItemProps
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
-      inset && "pl-8",
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  />
-));
+      inset,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
+
+    return (
+      <ContextMenuPrimitive.Item
+        ref={ref}
+        className={cn(
+          "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
+          inset && "pl-8",
+          className,
+        )}
+        {...props}
+        {...hoverProps}
+      />
+    );
+  },
+);
 ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
 
 const ContextMenuCheckboxItem = React.forwardRef<
   ContextMenuCheckboxItemElement,
   ContextMenuCheckboxItemProps
->(({ className, children, checked, ...props }, ref) => (
-  <ContextMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-2 pr-8 text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+>(
+  (
+    {
       className,
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span
-      className={cn(
-        "absolute right-2 flex items-center justify-center",
-        COARSE_POINTER_CHECK_SLOT_CLASS,
-      )}
-    >
-      <ContextMenuPrimitive.ItemIndicator>
-        <Icon name="Check" className={COARSE_POINTER_CHECK_SLOT_CLASS} />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </ContextMenuPrimitive.CheckboxItem>
-));
+      children,
+      checked,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
+
+    return (
+      <ContextMenuPrimitive.CheckboxItem
+        ref={ref}
+        className={cn(
+          "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-2 pr-8 text-xs outline-none focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
+          className,
+        )}
+        checked={checked}
+        {...props}
+        {...hoverProps}
+      >
+        <span
+          className={cn(
+            "absolute right-2 flex items-center justify-center",
+            COARSE_POINTER_CHECK_SLOT_CLASS,
+          )}
+        >
+          <ContextMenuPrimitive.ItemIndicator>
+            <Icon name="Check" className={COARSE_POINTER_CHECK_SLOT_CLASS} />
+          </ContextMenuPrimitive.ItemIndicator>
+        </span>
+        {children}
+      </ContextMenuPrimitive.CheckboxItem>
+    );
+  },
+);
 ContextMenuCheckboxItem.displayName =
   ContextMenuPrimitive.CheckboxItem.displayName;
 
 const ContextMenuRadioItem = React.forwardRef<
   ContextMenuRadioItemElement,
   ContextMenuRadioItemProps
->(({ className, children, ...props }, ref) => (
-  <ContextMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-8 pr-2 text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
-        <Icon name="Circle" className="h-2 w-2 fill-current" />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </ContextMenuPrimitive.RadioItem>
-));
+      children,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
+
+    return (
+      <ContextMenuPrimitive.RadioItem
+        ref={ref}
+        className={cn(
+          "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-8 pr-2 text-xs outline-none focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
+          className,
+        )}
+        {...props}
+        {...hoverProps}
+      >
+        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+          <ContextMenuPrimitive.ItemIndicator>
+            <Icon name="Circle" className="h-2 w-2 fill-current" />
+          </ContextMenuPrimitive.ItemIndicator>
+        </span>
+        {children}
+      </ContextMenuPrimitive.RadioItem>
+    );
+  },
+);
 ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
 
 const ContextMenuLabel = React.forwardRef<

--- a/apps/app/src/components/ui/copy-button.tsx
+++ b/apps/app/src/components/ui/copy-button.tsx
@@ -9,6 +9,7 @@ import {
 import { copyToClipboardWithToast } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 import { Icon } from "@/components/ui/icon.js";
+import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 
 interface ClipboardCopyOptions {
   text: string;
@@ -78,7 +79,7 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
         aria-label={label}
         {...rest}
         className={cn(
-          "inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground hover:text-foreground focus-visible:opacity-100",
+          `inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground ${CONTROL_HOVER_TRANSITION} hover:text-foreground focus-visible:opacity-100`,
           className,
         )}
         onClick={() => {
@@ -123,7 +124,7 @@ export function CopyableInlineLabel({
     <button
       type="button"
       className={cn(
-        "inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md text-left text-foreground transition-colors hover:text-foreground/80",
+        `inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md text-left text-foreground ${CONTROL_HOVER_TRANSITION} hover:text-foreground/80`,
         className,
       )}
       onClick={() => {

--- a/apps/app/src/components/ui/disclosure.tsx
+++ b/apps/app/src/components/ui/disclosure.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { cn } from "@/lib/utils";
 import { layoutAnimationInFlightCountAtom } from "./layoutAnimationAtoms.js";
+import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 
 const EXPANDABLE_PANEL_TRANSITION_MS = 200;
 const useBrowserLayoutEffect =
@@ -19,7 +20,7 @@ interface ChevronProps {
 }
 
 export const COLLAPSIBLE_HEADER_COLLAPSED_TONE_CLASS =
-  "text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground";
+  `text-muted-foreground ${CONTROL_HOVER_TRANSITION} hover:text-foreground focus-visible:text-foreground`;
 export const COLLAPSIBLE_HEADER_EXPANDED_TONE_CLASS = "text-foreground";
 export const COLLAPSIBLE_HEADER_STATIC_TONE_CLASS = "text-muted-foreground";
 export const COLLAPSIBLE_HEADER_BUTTON_BASE_CLASS =

--- a/apps/app/src/components/ui/dropdown-menu.tsx
+++ b/apps/app/src/components/ui/dropdown-menu.tsx
@@ -17,7 +17,23 @@ import {
   isLastInputKeyboard,
   preventOverlayTriggerSelection,
 } from "./overlay-trigger.js";
+import {
+  MENU_ITEM_LAST_HOVERED_CLASS,
+  MenuHoverProvider,
+  useMenuItemHover,
+} from "./menu-item-hover.js";
+import { LIST_HOVER_TRANSITION } from "./motion.js";
 import { Icon } from "@/components/ui/icon.js";
+
+// Item state by variant: hover (focus) and the persistent last-hovered tile use
+// the same fill, so the highlight reads identically and simply persists on the
+// last item (neutral = state-hover; destructive = a destructive-red tile).
+const MENU_ITEM_NEUTRAL_STATE_CLASS =
+  "focus:bg-state-hover focus:text-foreground data-[last-hovered]:bg-state-hover data-[last-hovered]:text-foreground";
+const MENU_ITEM_DESTRUCTIVE_STATE_CLASS =
+  "text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15";
+const MENU_ITEM_DESTRUCTIVE_TOUCH_CLASS =
+  "text-destructive focus:bg-destructive/15 focus:text-destructive active:bg-destructive/20 active:text-destructive";
 
 // ---------------------------------------------------------------------------
 // Context — separate instance from Popover to avoid cross-contamination
@@ -189,7 +205,7 @@ const DropdownMenuContent = React.forwardRef<
           )}
           {...props}
         >
-          {children}
+          <MenuHoverProvider>{children}</MenuHoverProvider>
         </DropdownMenuPrimitive.Content>
       </DropdownMenuPrimitive.Portal>
     );
@@ -213,21 +229,29 @@ const DropdownMenuItem = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
+    variant?: "default" | "destructive";
   }
 >(
   (
     {
       className,
       inset,
+      variant = "default",
       onSelect,
       disabled,
       textValue: _textValue,
       children,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
       ...domProps
     },
     ref,
   ) => {
     const { isCompactViewport, onOpenChange } = useResponsiveMenu();
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
 
     if (isCompactViewport) {
       return (
@@ -240,6 +264,7 @@ const DropdownMenuItem = React.forwardRef<
           className={cn(
             "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-left text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground active:bg-state-active active:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
             inset && "pl-8",
+            variant === "destructive" && MENU_ITEM_DESTRUCTIVE_TOUCH_CLASS,
             className,
           )}
           data-disabled={disabled ? "" : undefined}
@@ -261,7 +286,11 @@ const DropdownMenuItem = React.forwardRef<
       <DropdownMenuPrimitive.Item
         ref={ref}
         className={cn(
-          "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+          "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-[0.3125rem] text-xs outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+          LIST_HOVER_TRANSITION,
+          variant === "destructive"
+            ? MENU_ITEM_DESTRUCTIVE_STATE_CLASS
+            : MENU_ITEM_NEUTRAL_STATE_CLASS,
           inset && "pl-8",
           className,
         )}
@@ -269,6 +298,7 @@ const DropdownMenuItem = React.forwardRef<
         onSelect={onSelect}
         textValue={_textValue}
         {...domProps}
+        {...hoverProps}
       >
         {children}
       </DropdownMenuPrimitive.Item>
@@ -294,11 +324,17 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       onCheckedChange,
       disabled,
       textValue: _textValue,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
       ...domProps
     },
     ref,
   ) => {
     const { isCompactViewport, onOpenChange } = useResponsiveMenu();
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
 
     if (isCompactViewport) {
       return (
@@ -348,7 +384,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       <DropdownMenuPrimitive.CheckboxItem
         ref={ref}
         className={cn(
-          "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-2 pr-8 text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-2 pr-8 text-xs outline-none focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
           className,
         )}
         checked={checked}
@@ -357,6 +395,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
         disabled={disabled}
         textValue={_textValue}
         {...domProps}
+        {...hoverProps}
       >
         <span
           className={cn(
@@ -402,31 +441,49 @@ function DropdownMenuRadioGroup({
 const DropdownMenuRadioItem = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => {
-  const { isCompactViewport } = useResponsiveMenu();
+>(
+  (
+    {
+      className,
+      children,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const { isCompactViewport } = useResponsiveMenu();
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
 
-  if (isCompactViewport) {
-    return null;
-  }
+    if (isCompactViewport) {
+      return null;
+    }
 
-  return (
-    <DropdownMenuPrimitive.RadioItem
-      ref={ref}
-      className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-8 pr-2 text-xs outline-none transition-colors focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className,
-      )}
-      {...props}
-    >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <Icon name="Circle" className="h-2 w-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.RadioItem>
-  );
-});
+    return (
+      <DropdownMenuPrimitive.RadioItem
+        ref={ref}
+        className={cn(
+          "relative flex cursor-default select-none items-center rounded-sm py-[0.3125rem] pl-8 pr-2 text-xs outline-none focus:bg-state-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
+          className,
+        )}
+        {...props}
+        {...hoverProps}
+      >
+        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+          <DropdownMenuPrimitive.ItemIndicator>
+            <Icon name="Circle" className="h-2 w-2 fill-current" />
+          </DropdownMenuPrimitive.ItemIndicator>
+        </span>
+        {children}
+      </DropdownMenuPrimitive.RadioItem>
+    );
+  },
+);
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 // ---------------------------------------------------------------------------
@@ -540,20 +597,42 @@ const DropdownMenuSubTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
     inset?: boolean;
   }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-[0.3125rem] text-xs outline-none focus:bg-state-hover focus:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    {children}
-    <Icon name="ChevronRight" className="ml-auto" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
+      inset,
+      children,
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const { hoverProps } = useMenuItemHover({
+      onPointerEnter: callerPointerEnter,
+      onKeyDown: callerKeyDown,
+    });
+
+    return (
+      <DropdownMenuPrimitive.SubTrigger
+        ref={ref}
+        className={cn(
+          "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-[0.3125rem] text-xs outline-none focus:bg-state-hover focus:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+          LIST_HOVER_TRANSITION,
+          MENU_ITEM_LAST_HOVERED_CLASS,
+          inset && "pl-8",
+          className,
+        )}
+        {...props}
+        {...hoverProps}
+      >
+        {children}
+        <Icon name="ChevronRight" className="ml-auto" />
+      </DropdownMenuPrimitive.SubTrigger>
+    );
+  },
+);
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName;
 

--- a/apps/app/src/components/ui/input.tsx
+++ b/apps/app/src/components/ui/input.tsx
@@ -6,6 +6,7 @@ import {
   COARSE_POINTER_TEXT_BASE_CLASS,
 } from "./coarse-pointer-sizing.js";
 import { cn } from "@/lib/utils";
+import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
@@ -14,7 +15,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         autoComplete="off"
         className={cn(
-          "flex w-full rounded-md border border-input bg-transparent px-3 py-1 transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          `flex w-full rounded-md border border-input bg-transparent px-3 py-1 ${CONTROL_HOVER_TRANSITION} file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50`,
           COARSE_POINTER_INPUT_HEIGHT_CLASS,
           COARSE_POINTER_TEXT_BASE_CLASS,
           className,

--- a/apps/app/src/components/ui/menu-item-hover.test.tsx
+++ b/apps/app/src/components/ui/menu-item-hover.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MenuHoverProvider, useMenuItemHover } from "./menu-item-hover";
+
+function HoverItem({ label }: { label: string }) {
+  const { hoverProps } = useMenuItemHover();
+  return (
+    <button type="button" {...hoverProps}>
+      {label}
+    </button>
+  );
+}
+
+function Harness() {
+  return (
+    <MenuHoverProvider>
+      <HoverItem label="A" />
+      <HoverItem label="B" />
+    </MenuHoverProvider>
+  );
+}
+
+afterEach(cleanup);
+
+describe("menu persistent last-hovered", () => {
+  it("persists the highlight on the last pointer-hovered item and moves it", () => {
+    render(<Harness />);
+    const a = screen.getByText("A");
+    const b = screen.getByText("B");
+
+    expect(a.hasAttribute("data-last-hovered")).toBe(false);
+
+    fireEvent.pointerEnter(a);
+    expect(a.hasAttribute("data-last-hovered")).toBe(true);
+    expect(b.hasAttribute("data-last-hovered")).toBe(false);
+
+    // The highlight stays on A even though the pointer never re-enters it
+    // (this is the persistence: a bare focus highlight would have cleared).
+    fireEvent.pointerEnter(b);
+    expect(a.hasAttribute("data-last-hovered")).toBe(false);
+    expect(b.hasAttribute("data-last-hovered")).toBe(true);
+  });
+
+  it("hands the highlight back to keyboard navigation", () => {
+    render(<Harness />);
+    const a = screen.getByText("A");
+
+    fireEvent.pointerEnter(a);
+    expect(a.hasAttribute("data-last-hovered")).toBe(true);
+
+    fireEvent.keyDown(a, { key: "ArrowDown" });
+    expect(a.hasAttribute("data-last-hovered")).toBe(false);
+  });
+});

--- a/apps/app/src/components/ui/menu-item-hover.tsx
+++ b/apps/app/src/components/ui/menu-item-hover.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+
+// Keys that mean keyboard navigation has taken over the menu; the persistent
+// pointer highlight yields to Radix's own data-[highlighted]/:focus highlight.
+const MENU_NAV_KEYS = new Set([
+  "ArrowDown",
+  "ArrowUp",
+  "Home",
+  "End",
+  "PageDown",
+  "PageUp",
+]);
+
+export const MENU_ITEM_LAST_HOVERED_CLASS =
+  "data-[last-hovered]:bg-state-hover data-[last-hovered]:text-foreground";
+
+interface MenuHoverContextValue {
+  lastHoveredId: string | null;
+  setLastHovered: (id: string) => void;
+  clearLastHovered: () => void;
+}
+
+const MenuHoverContext = React.createContext<MenuHoverContextValue>({
+  lastHoveredId: null,
+  setLastHovered: () => {},
+  clearLastHovered: () => {},
+});
+
+/**
+ * Tracks the last pointer-hovered menu item so its highlight PERSISTS after the
+ * pointer drifts into the menu's padding, instead of blinking off the way a bare
+ * Radix `:focus`/`data-[highlighted]` highlight does. The highlight only moves
+ * when another item is hovered, and is handed back to Radix the moment keyboard
+ * navigation begins. Mount one provider per open menu surface; the state resets
+ * when the menu closes and the provider unmounts.
+ */
+export function MenuHoverProvider({ children }: { children: React.ReactNode }) {
+  const [lastHoveredId, setLastHoveredId] = React.useState<string | null>(null);
+  const value = React.useMemo<MenuHoverContextValue>(
+    () => ({
+      lastHoveredId,
+      setLastHovered: setLastHoveredId,
+      clearLastHovered: () => setLastHoveredId(null),
+    }),
+    [lastHoveredId],
+  );
+  return (
+    <MenuHoverContext.Provider value={value}>
+      {children}
+    </MenuHoverContext.Provider>
+  );
+}
+
+export interface MenuItemHoverProps {
+  "data-last-hovered": "" | undefined;
+  onPointerEnter: React.PointerEventHandler;
+  onKeyDown: React.KeyboardEventHandler;
+}
+
+/** The item's own handlers, run alongside the persistent-highlight glue. */
+interface MenuItemHoverHandlers {
+  onPointerEnter?: React.PointerEventHandler;
+  onKeyDown?: React.KeyboardEventHandler;
+}
+
+/**
+ * Per-item glue for {@link MenuHoverProvider}. Pass the item's own
+ * `onPointerEnter`/`onKeyDown` (if any) and spread the returned `hoverProps`
+ * directly — the hook merges your handlers with the glue, so a call site stays
+ * a single `{...hoverProps}` instead of hand-merging both handlers.
+ *
+ * It registers the item as last-hovered on pointer enter, exposes a
+ * `data-last-hovered` attribute while it holds the highlight, and clears that
+ * highlight on the first keyboard-navigation key so Radix's focus highlight can
+ * take over. Note: the keyboard hand-off only has somewhere to go on surfaces
+ * with Radix roving focus (real menu items); on plain-button lists the highlight
+ * simply clears on the first arrow key. Outside a provider it is an inert no-op.
+ */
+export function useMenuItemHover(handlers?: MenuItemHoverHandlers): {
+  isLastHovered: boolean;
+  hoverProps: MenuItemHoverProps;
+} {
+  const id = React.useId();
+  const { lastHoveredId, setLastHovered, clearLastHovered } =
+    React.useContext(MenuHoverContext);
+  const isLastHovered = lastHoveredId === id;
+
+  // Hold the caller's handlers in a ref so the merged callbacks stay stable
+  // even when handlers are passed inline.
+  const handlersRef = React.useRef(handlers);
+  handlersRef.current = handlers;
+
+  const onPointerEnter = React.useCallback(
+    (event: React.PointerEvent) => {
+      handlersRef.current?.onPointerEnter?.(event);
+      setLastHovered(id);
+    },
+    [id, setLastHovered],
+  );
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      handlersRef.current?.onKeyDown?.(event);
+      if (MENU_NAV_KEYS.has(event.key)) {
+        clearLastHovered();
+      }
+    },
+    [clearLastHovered],
+  );
+
+  return {
+    isLastHovered,
+    hoverProps: {
+      "data-last-hovered": isLastHovered ? "" : undefined,
+      onPointerEnter,
+      onKeyDown,
+    },
+  };
+}

--- a/apps/app/src/components/ui/motion.ts
+++ b/apps/app/src/components/ui/motion.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared hover-motion heuristic for primitives, so the whole UI speaks one
+ * timing language instead of ad-hoc per-component transitions:
+ *
+ * - CONTROL_HOVER_TRANSITION — interactive controls (buttons, icon buttons):
+ *   the hover/active fill snaps IN instantly (0ms) and eases OUT lazily (150ms).
+ *   Immediate feedback on the way in, never twitchy on the way out. The trick:
+ *   CSS applies the *end state's* transition-duration for each direction, so a
+ *   base `duration-150` governs hover-out while `hover:duration-0` makes
+ *   hover-in instant.
+ * - LIST_HOVER_TRANSITION — dense list/menu rows (menu items, list rows): no
+ *   transition at all (instant both ways), so the highlight tracks the pointer
+ *   and arrow keys exactly, with no lag during fast navigation.
+ *
+ * Reach for one of these rather than a bare `transition-colors` on anything with
+ * a hover/active state.
+ */
+export const CONTROL_HOVER_TRANSITION =
+  "transition-colors duration-150 hover:duration-0";
+
+export const LIST_HOVER_TRANSITION = "transition-none";

--- a/apps/app/src/components/ui/switch.tsx
+++ b/apps/app/src/components/ui/switch.tsx
@@ -1,6 +1,7 @@
 /* shadcn/ui-derived */
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 
 type SwitchProps = Omit<
   React.ComponentPropsWithoutRef<"button">,
@@ -24,7 +25,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
       disabled={disabled}
       data-state={checked ? "checked" : "unchecked"}
       className={cn(
-        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-foreground data-[state=unchecked]:bg-muted",
+        `peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs ${CONTROL_HOVER_TRANSITION} outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-foreground data-[state=unchecked]:bg-muted`,
         className,
       )}
       onClick={(event) => {

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@/components/ui/icon.js";
 import { COARSE_POINTER_TEXT_SM_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
 import { cn } from "@/lib/utils";
+import { CONTROL_HOVER_TRANSITION } from "./motion.js";
 import type { ReactNode } from "react";
 
 const TAB_PILL_DEFAULT_LABEL_MAX_WIDTH_CLASS = "max-w-[180px]";
@@ -46,7 +47,7 @@ export function TabPill({
   return (
     <div
       className={cn(
-        "group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md transition-colors max-md:pointer-coarse:h-9",
+        `group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md ${CONTROL_HOVER_TRANSITION} max-md:pointer-coarse:h-9`,
         COARSE_POINTER_TEXT_SM_CLASS,
         isActive
           ? "bg-muted text-foreground"

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -196,7 +196,7 @@
     pointer-events: none;
     opacity: 0;
     transition-property: opacity;
-    transition-duration: 150ms;
+    transition-duration: 0ms;
   }
 
   .bb-sidebar-hover-actions-row:is(:hover, :has(:focus-visible))
@@ -209,7 +209,7 @@
   .bb-sidebar-hover-actions-fade {
     opacity: 1;
     transition-property: opacity;
-    transition-duration: 150ms;
+    transition-duration: 0ms;
   }
 
   .bb-sidebar-hover-actions-row:is(:hover, :has(:focus-visible))


### PR DESCRIPTION
## Summary

Applies Luke Nittmann fork PR for consistent hover-motion and persistent menu hover states across the app UI.

- Adds shared hover timing tokens for controls and dense list/menu rows.
- Adds a menu hover provider/hook so the last pointer-hovered menu item keeps its highlight while the pointer moves through menu padding.
- Wires the behavior through dropdown/context menus, pickers, sidebar rows, and core controls.
- Adds consistent destructive menu item styling for delete/remove actions.

## Credit

This change is from Luke Nittmann fork PR: https://github.com/lnittman/bb/pull/3

The commit preserves Luke as the git author (`luke <luke.nittmann@gmail.com>`), with Sawyer as committer for the upstream cherry-pick.

## Validation

- `git diff --check origin/main..HEAD`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/ui/menu-item-hover.test.tsx`
- `pnpm exec turbo run test --filter=@bb/app`

All passed locally.