### PR TITLE
Composer: align send button and plus menu

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -71,6 +71,18 @@ describe("PromptBoxActionsMenu", () => {
     expect(screen.queryByRole("menuitem", { name: "Create App" })).toBeNull();
   });
 
+  it("opens below the plus trigger aligned to the trigger start", async () => {
+    render(
+      <PromptBoxActionsMenu actions={promptActions} onAction={() => {}} />,
+    );
+
+    await openPromptActionsMenu();
+
+    const menu = screen.getByRole("menu", { name: "Prompt actions" });
+    expect(menu.getAttribute("data-side")).toBe("bottom");
+    expect(menu.getAttribute("data-align")).toBe("start");
+  });
+
   it("fires the selected action", async () => {
     const onAction = vi.fn();
     render(<PromptBoxActionsMenu actions={promptActions} onAction={onAction} />);

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -129,8 +129,9 @@ export function PromptBoxActionsMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         aria-label="Prompt actions"
-        align="end"
-        side="top"
+        align="start"
+        side="bottom"
+        sideOffset={4}
         className="w-36"
         mobileTitle="Prompt actions"
         onCloseAutoFocus={(event) => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2440,7 +2440,7 @@ export function PromptBoxInternal({
         </div>
       ) : null}
 
-      <div className="flex shrink-0 flex-row items-center gap-3 px-3.5 pt-1.5">
+      <div className="flex shrink-0 flex-row items-center gap-3 pl-3.5 pr-2 pt-1.5">
         <div
           className="flex min-w-0 flex-1 flex-row items-center gap-1"
           aria-live="polite"
@@ -2558,7 +2558,7 @@ export function PromptBoxInternal({
               variant="default"
               aria-label={effectiveSubmitTitle}
               disabled={!canSubmit}
-              className={COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS}
+              className={cn("ml-1", COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS)}
             >
               {isSubmitting ? (
                 <Icon name="Spinner" className="size-4 animate-spin" />


### PR DESCRIPTION
Based on Luke Nittmann's fork PR: https://github.com/lnittman/bb/pull/5

## Summary
- Open the prompt-actions plus menu below the trigger, aligned to the trigger start.
- Adjust composer footer right padding so the send button aligns with the expand control.
- Add a small left gap before the send button and cover the menu placement with a focused test.

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxActionsMenu.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxActionsMenu.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx
- git diff --check

Commit includes `Co-authored-by: Luke Nittmann <luke.nittmann@gmail.com>`.

Preview from the worktree: http://100.64.158.8:16631/