### PR TITLE
Fix prompt editor clipboard newlines

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -238,10 +238,24 @@ async function focusPromptEnd(promptBoxRef: RefObject<PromptBoxHandle | null>) {
 }
 
 function pastePlainText(text: string) {
+  pasteClipboard({ plainText: text });
+}
+
+function pasteClipboard({
+  html = "",
+  plainText = "",
+}: {
+  html?: string;
+  plainText?: string;
+}) {
   fireEvent.paste(getPromptEditorElement(), {
     clipboardData: {
       items: [],
-      getData: (type: string) => (type === "text/plain" ? text : ""),
+      getData: (type: string) => {
+        if (type === "text/html") return html;
+        if (type === "text/plain") return plainText;
+        return "";
+      },
     },
   });
 }
@@ -428,6 +442,19 @@ describe("PromptBoxInternal zen mode layout", () => {
 });
 
 describe("PromptBoxInternal prompt actions", () => {
+  it("preserves blockquote structure when pasting copied blockquote html", async () => {
+    const { changes, promptBoxRef } = renderPromptBox("");
+
+    await focusPromptEnd(promptBoxRef);
+    pasteClipboard({
+      html: "<blockquote><p>quoted</p></blockquote>",
+      plainText: "> quoted",
+    });
+
+    await waitFor(() => expect(latestValue(changes)).toBe("> quoted"));
+    expect(getPromptEditorElement().querySelector("blockquote")).not.toBeNull();
+  });
+
   it("places prompt actions before the right-side action cluster", () => {
     renderPromptBox("");
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -63,6 +63,7 @@ import {
 import { promptEditorExtensions } from "./editor/prompt-editor-extensions";
 import {
   promptCommandResourceFromSuggestion,
+  promptEditorClipboardTextFromSlice,
   promptEditorContentFromValue,
   promptEditorInlineContentFromValue,
   promptEditorValueFromDoc,
@@ -1221,6 +1222,8 @@ export function PromptBoxInternal({
           ...(id ? { id } : {}),
           role: "textbox",
         },
+        clipboardTextSerializer: (slice, view) =>
+          promptEditorClipboardTextFromSlice(slice, view.state.schema),
         handleDOMEvents: {
           auxclick: (_view, event) => {
             return suppressPromptEditorAnchorActivation(event);

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -4,7 +4,7 @@ import type {
   PromptMentionCommandTrigger,
   PromptTextMention,
 } from "@bb/domain";
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { Node as ProseMirrorNode, Slice } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
 import { EditorContent, useEditor, type Editor } from "@tiptap/react";
 import {
@@ -67,6 +67,7 @@ import {
   promptEditorContentFromValue,
   promptEditorInlineContentFromValue,
   promptEditorValueFromDoc,
+  promptEditorValueFromSlice,
   parsePromptEditorMentionAttrs,
   promptMentionResourceFromSuggestion,
   type PromptEditorValue,
@@ -74,6 +75,7 @@ import {
 import {
   exitTrailingBlockquoteBreak,
   insertParagraphBeforeBlockquote,
+  removeEmptyBlockquotes,
 } from "./editor/prompt-editor-blockquote";
 import { exitHeading } from "./editor/prompt-editor-heading";
 import { applyPromptListNewline } from "./editor/prompt-editor-list";
@@ -504,6 +506,36 @@ function promptEditorValueFromPlainText(
   );
 }
 
+function promptEditorSliceHasBlockquote(slice: Slice): boolean {
+  let hasBlockquote = false;
+  slice.content.descendants((node) => {
+    if (node.type.name === "blockquote") {
+      hasBlockquote = true;
+      return false;
+    }
+    return true;
+  });
+  return hasBlockquote;
+}
+
+function plainTextHasQuoteLine(text: string): boolean {
+  return normalizePastedPlainText(text)
+    .split("\n")
+    .some((line) => line === ">" || line.startsWith("> "));
+}
+
+function trimTrailingPromptNewlines(value: PromptEditorValue): PromptEditorValue {
+  const text = value.text.replace(/\n+$/u, "");
+  if (text.length === value.text.length) {
+    return value;
+  }
+
+  return {
+    text,
+    mentions: value.mentions.filter((mention) => mention.end <= text.length),
+  };
+}
+
 function promptEditorValueFromRichHtml(html: string): ParsedRichClipboardValue {
   const document = new DOMParser().parseFromString(html, "text/html");
   let text = "";
@@ -655,6 +687,15 @@ function promptEditorValueFromClipboardPaste(
   }
 
   return promptEditorValueFromRichHtml(html).value;
+}
+
+function runAfterClipboardCut(callback: () => void): void {
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(callback);
+    return;
+  }
+
+  setTimeout(callback, 0);
 }
 
 function revealPromptEditorSelection({
@@ -1241,6 +1282,14 @@ export function PromptBoxInternal({
             onCommandQueryChange(null);
             return false;
           },
+          cut: () => {
+            runAfterClipboardCut(() => {
+              const currentEditor = editorRef.current;
+              if (!currentEditor || currentEditor.isDestroyed) return;
+              removeEmptyBlockquotes(currentEditor);
+            });
+            return false;
+          },
           click: (_view, event) => {
             return suppressPromptEditorAnchorActivation(event);
           },
@@ -1254,7 +1303,7 @@ export function PromptBoxInternal({
         handleKeyDown: (_view, event) => {
           return handleEditorKeyDownRef.current(event);
         },
-        handlePaste: (_view, event) => {
+        handlePaste: (view, event, slice) => {
           const attachFiles = onAttachFilesRef.current;
           const clipboardItems = Array.from(event.clipboardData?.items ?? []);
           const pastedFiles = clipboardItems
@@ -1265,6 +1314,35 @@ export function PromptBoxInternal({
           if (attachFiles && pastedFiles.length > 0) {
             event.preventDefault();
             void attachFiles(pastedFiles);
+            return true;
+          }
+
+          const plainText = event.clipboardData?.getData("text/plain") ?? "";
+          const sliceHasBlockquote = promptEditorSliceHasBlockquote(slice);
+          if (sliceHasBlockquote || plainTextHasQuoteLine(plainText)) {
+            event.preventDefault();
+            const pastedValue = trimTrailingPromptNewlines(
+              sliceHasBlockquote
+                ? promptEditorValueFromSlice(slice, view.state.schema)
+                : promptEditorValueFromPlainText(plainText, promptActions),
+            );
+            if (pastedValue.text.length === 0) return true;
+
+            const currentEditor = editorRef.current;
+            const pastedContent =
+              promptEditorContentFromValue(pastedValue).content ?? [];
+            currentEditor
+              ?.chain()
+              .focus()
+              .insertContent(pastedContent)
+              .run();
+            if (currentEditor && !currentEditor.isDestroyed) {
+              const nextValue = trimTrailingPromptNewlines(
+                promptEditorValueFromDoc(currentEditor.state.doc),
+              );
+              editorValueKeyRef.current = promptEditorValueKey(nextValue);
+              onChangeRef.current(nextValue.text, nextValue.mentions);
+            }
             return true;
           }
 

--- a/apps/app/src/components/promptbox/editor/prompt-editor-blockquote.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-blockquote.test.ts
@@ -7,6 +7,7 @@ import { promptEditorValueFromDoc } from "./prompt-editor-serialization";
 import {
   createExitTrailingBlockquoteBreakTransaction,
   createInsertParagraphBeforeBlockquoteTransaction,
+  createRemoveEmptyBlockquotesTransaction,
 } from "./prompt-editor-blockquote";
 
 const schema = getSchema([
@@ -171,5 +172,51 @@ describe("createInsertParagraphBeforeBlockquoteTransaction", () => {
     );
 
     expect(createInsertParagraphBeforeBlockquoteTransaction(state)).toBeNull();
+  });
+});
+
+describe("createRemoveEmptyBlockquotesTransaction", () => {
+  it("removes an empty blockquote left after cutting quote text", () => {
+    const state = stateFromJson(
+      {
+        type: "doc",
+        content: [
+          {
+            type: "blockquote",
+            content: [{ type: "paragraph" }],
+          },
+        ],
+      },
+      2,
+    );
+
+    const transaction = createRemoveEmptyBlockquotesTransaction(state);
+    expect(transaction).not.toBeNull();
+    const nextState = state.apply(transaction!);
+
+    expect(nextState.doc.toString()).toBe("doc(paragraph)");
+    expect(promptEditorValueFromDoc(nextState.doc).text).toBe("");
+  });
+
+  it("keeps non-empty blockquotes", () => {
+    const state = stateFromJson(
+      {
+        type: "doc",
+        content: [
+          {
+            type: "blockquote",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "quote" }],
+              },
+            ],
+          },
+        ],
+      },
+      2,
+    );
+
+    expect(createRemoveEmptyBlockquotesTransaction(state)).toBeNull();
   });
 });

--- a/apps/app/src/components/promptbox/editor/prompt-editor-blockquote.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-blockquote.ts
@@ -69,10 +69,45 @@ export function createExitTrailingBlockquoteBreakTransaction(
     .scrollIntoView();
 }
 
+export function createRemoveEmptyBlockquotesTransaction(
+  state: EditorState,
+): Transaction | null {
+  const paragraphType = state.schema.nodes.paragraph;
+  if (!paragraphType) return null;
+
+  const ranges: Array<{ from: number; to: number }> = [];
+  state.doc.descendants((node, pos) => {
+    if (node.type.name === "blockquote" && node.textContent.length === 0) {
+      ranges.push({ from: pos, to: pos + node.nodeSize });
+    }
+  });
+  if (ranges.length === 0) return null;
+
+  let transaction = state.tr;
+  for (const range of [...ranges].reverse()) {
+    const from = transaction.mapping.map(range.from);
+    const to = transaction.mapping.map(range.to);
+    if (from === 0 && to === transaction.doc.content.size) {
+      transaction = transaction.replaceWith(from, to, paragraphType.create());
+    } else {
+      transaction = transaction.delete(from, to);
+    }
+  }
+
+  return transaction.docChanged ? transaction.scrollIntoView() : null;
+}
+
 export function exitTrailingBlockquoteBreak(editor: Editor): boolean {
   const transaction = createExitTrailingBlockquoteBreakTransaction(
     editor.state,
   );
+  if (transaction === null) return false;
+  editor.view.dispatch(transaction);
+  return true;
+}
+
+export function removeEmptyBlockquotes(editor: Editor): boolean {
+  const transaction = createRemoveEmptyBlockquotesTransaction(editor.state);
   if (transaction === null) return false;
   editor.view.dispatch(transaction);
   return true;

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getSchema } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
-import { Node } from "@tiptap/pm/model";
+import { Node, Slice } from "@tiptap/pm/model";
 import type { PromptTextMention } from "@bb/domain";
 import {
   PromptMentionExtension,
@@ -9,6 +9,7 @@ import {
 } from "./prompt-mention-extension";
 import {
   promptCommandResourceFromSuggestion,
+  promptEditorClipboardTextFromSlice,
   promptEditorContentFromValue,
   promptEditorInlineContentFromValue,
   promptEditorValueFromDoc,
@@ -114,6 +115,40 @@ describe("prompt editor serialization round-trip", () => {
     expect(result.mentions[0]!.start).toBe(mention.start);
     expect(result.mentions[0]!.end).toBe(mention.end);
     expect(result.mentions[0]!.resource).toEqual(mention.resource);
+  });
+});
+
+describe("prompt editor clipboard serialization", () => {
+  function clipboardText(content: unknown[]): string {
+    const doc = Node.fromJSON(schema, { type: "doc", content });
+    return promptEditorClipboardTextFromSlice(
+      new Slice(doc.content, 0, 0),
+      schema,
+    );
+  }
+
+  it("copies separate prompt lines with a single newline", () => {
+    expect(
+      clipboardText([
+        { type: "paragraph", content: [{ type: "text", text: "first" }] },
+        { type: "paragraph", content: [{ type: "text", text: "second" }] },
+      ]),
+    ).toBe("first\nsecond");
+  });
+
+  it("copies hard-break prompt lines with the same single newline", () => {
+    expect(
+      clipboardText([
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "first" },
+            { type: "hardBreak" },
+            { type: "text", text: "second" },
+          ],
+        },
+      ]),
+    ).toBe("first\nsecond");
   });
 });
 

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
@@ -150,6 +150,22 @@ describe("prompt editor clipboard serialization", () => {
       ]),
     ).toBe("first\nsecond");
   });
+
+  it("copies a blockquote without adding a trailing blank line", () => {
+    expect(
+      clipboardText([
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "quoted" }],
+            },
+          ],
+        },
+      ]),
+    ).toBe("> quoted");
+  });
 });
 
 describe("prompt editor markdown serialization (doc -> markdown text)", () => {

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
@@ -6,7 +6,7 @@ import {
   type PromptTextMention,
 } from "@bb/domain";
 import type { JSONContent } from "@tiptap/react";
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { Node as ProseMirrorNode, Schema, Slice } from "@tiptap/pm/model";
 import type {
   PromptMentionSuggestion,
   ProviderCommandSuggestion,
@@ -471,6 +471,18 @@ export function promptEditorValueFromDoc(
   appendChildren(doc);
 
   return { text, mentions };
+}
+
+export function promptEditorClipboardTextFromSlice(
+  slice: Slice,
+  schema: Schema,
+): string {
+  const doc = schema.topNodeType.createAndFill(null, slice.content);
+  if (doc) {
+    return promptEditorValueFromDoc(doc).text;
+  }
+
+  return slice.content.textBetween(0, slice.content.size, "\n");
 }
 
 export function promptMentionResourceFromSuggestion(

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
@@ -473,16 +473,26 @@ export function promptEditorValueFromDoc(
   return { text, mentions };
 }
 
+export function promptEditorValueFromSlice(
+  slice: Slice,
+  schema: Schema,
+): PromptEditorValue {
+  const doc = schema.topNodeType.createAndFill(null, slice.content);
+  if (doc) {
+    return promptEditorValueFromDoc(doc);
+  }
+
+  return {
+    text: slice.content.textBetween(0, slice.content.size, "\n"),
+    mentions: [],
+  };
+}
+
 export function promptEditorClipboardTextFromSlice(
   slice: Slice,
   schema: Schema,
 ): string {
-  const doc = schema.topNodeType.createAndFill(null, slice.content);
-  if (doc) {
-    return promptEditorValueFromDoc(doc).text;
-  }
-
-  return slice.content.textBetween(0, slice.content.size, "\n");
+  return promptEditorValueFromSlice(slice, schema).text;
 }
 
 export function promptMentionResourceFromSuggestion(


### PR DESCRIPTION
## Summary
- serialize copied prompt editor content with prompt text semantics so separate visual lines copy as a single newline
- preserve blockquote structure when pasting copied blockquote HTML or quote-prefixed plaintext back into the prompt editor
- remove empty blockquote shells left behind after cutting blockquote text
- add regression coverage for blockquote copy, paste, and cut cleanup

## Test plan
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/promptbox/PromptBoxInternal.test.tsx src/components/promptbox/editor/prompt-editor-blockquote.test.ts src/components/promptbox/editor/prompt-editor-serialization.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app