### PR TITLE
Fix stale terminal panel tabs

### DIFF
--- a/apps/app/src/components/secondary-panel/terminalPanelTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/terminalPanelTabs.test.ts
@@ -8,8 +8,10 @@ import {
 import {
   buildTerminalSyncedSecondaryFileTabs,
   findActiveTerminalIdInSecondaryFileTabs,
+  getRetainedTerminalTabId,
+  pruneTerminalTabsForSessions,
   syncTerminalTabsInFixedPanelState,
-} from "./threadTerminalTabs";
+} from "./terminalPanelTabs";
 
 type TerminalSessionOverrides = Partial<TerminalSession>;
 
@@ -43,10 +45,80 @@ function tabIds(tabs: readonly TabIdentity[]): string[] {
   return tabs.map((tab) => tab.id);
 }
 
-describe("buildTerminalSyncedSecondaryFileTabs", () => {
+describe("terminalPanelTabs", () => {
+  it("resolves a retained terminal id only from the open active terminal tab", () => {
+    const terminalTab = createTerminalFixedPanelTab({ terminalId: "term_1" });
+    const fileTab = createHostFilePreviewFixedPanelTab({
+      environmentId: "env_1",
+      tab: {
+        lineRange: null,
+        path: "/workspace/file.ts",
+      },
+      threadId: "thr_1",
+    });
+
+    expect(
+      getRetainedTerminalTabId({
+        activeTab: terminalTab,
+        isPanelOpen: true,
+      }),
+    ).toBe("term_1");
+    expect(
+      getRetainedTerminalTabId({
+        activeTab: terminalTab,
+        isPanelOpen: false,
+      }),
+    ).toBeNull();
+    expect(
+      getRetainedTerminalTabId({
+        activeTab: fileTab,
+        isPanelOpen: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("prunes terminal tabs against active or retained terminal sessions", () => {
+    const infoTab = createHostFilePreviewFixedPanelTab({
+      environmentId: "env_1",
+      tab: {
+        lineRange: null,
+        path: "/workspace/file.ts",
+      },
+      threadId: "thr_1",
+    });
+    const retainedTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_retained",
+    });
+    const unretainedTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_unretained",
+    });
+    const runningTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_running",
+    });
+
+    expect(
+      pruneTerminalTabsForSessions({
+        retainedTerminalId: "term_retained",
+        tabs: [infoTab, retainedTerminal, unretainedTerminal, runningTerminal],
+        terminalSessions: [
+          terminalSession({
+            id: "term_retained",
+            status: "disconnected",
+          }),
+          terminalSession({
+            id: "term_unretained",
+            status: "disconnected",
+          }),
+          terminalSession({ id: "term_running" }),
+        ],
+      }),
+    ).toEqual([infoTab, retainedTerminal, runningTerminal]);
+  });
+
   it("adds server terminal sessions missing from local tabs", () => {
     const tabs = buildTerminalSyncedSecondaryFileTabs({
       orderedTabs: [],
+      retainedTerminalId: null,
       terminalSessions: [
         terminalSession({ id: "term_1" }),
         terminalSession({ id: "term_2" }),
@@ -76,6 +148,7 @@ describe("buildTerminalSyncedSecondaryFileTabs", () => {
     });
     const tabs = buildTerminalSyncedSecondaryFileTabs({
       orderedTabs: [localTerminal2, localFile, localTerminal1],
+      retainedTerminalId: null,
       terminalSessions: [
         terminalSession({ id: "term_1" }),
         terminalSession({ id: "term_2" }),
@@ -97,10 +170,50 @@ describe("buildTerminalSyncedSecondaryFileTabs", () => {
         createTerminalFixedPanelTab({ terminalId: "term_stale" }),
         createTerminalFixedPanelTab({ terminalId: "term_1" }),
       ],
+      retainedTerminalId: null,
       terminalSessions: [terminalSession({ id: "term_1" })],
     });
 
     expect(tabIds(tabs)).toEqual(["terminal:term_1:none"]);
+  });
+
+  it("drops disconnected terminal tabs unless they are retained", () => {
+    const disconnectedTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_disconnected",
+    });
+    const runningTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_running",
+    });
+    const sessions = [
+      terminalSession({
+        id: "term_disconnected",
+        status: "disconnected",
+      }),
+      terminalSession({ id: "term_running" }),
+    ];
+
+    expect(
+      tabIds(
+        buildTerminalSyncedSecondaryFileTabs({
+          orderedTabs: [disconnectedTerminal, runningTerminal],
+          retainedTerminalId: null,
+          terminalSessions: sessions,
+        }),
+      ),
+    ).toEqual(["terminal:term_running:none"]);
+
+    expect(
+      tabIds(
+        buildTerminalSyncedSecondaryFileTabs({
+          orderedTabs: [disconnectedTerminal, runningTerminal],
+          retainedTerminalId: "term_disconnected",
+          terminalSessions: sessions,
+        }),
+      ),
+    ).toEqual([
+      "terminal:term_disconnected:none",
+      "terminal:term_running:none",
+    ]);
   });
 
   it("finds the active terminal id only for displayed terminal tabs", () => {
@@ -151,6 +264,7 @@ describe("buildTerminalSyncedSecondaryFileTabs", () => {
       },
     });
     const nextState = syncTerminalTabsInFixedPanelState({
+      retainedTerminalId: null,
       state,
       terminalSessions: [
         terminalSession({ id: "term_1" }),
@@ -181,6 +295,7 @@ describe("buildTerminalSyncedSecondaryFileTabs", () => {
       },
     });
     const nextState = syncTerminalTabsInFixedPanelState({
+      retainedTerminalId: null,
       state,
       terminalSessions: [terminalSession({ id: "term_1" })],
     });
@@ -203,9 +318,45 @@ describe("buildTerminalSyncedSecondaryFileTabs", () => {
 
     expect(
       syncTerminalTabsInFixedPanelState({
+        retainedTerminalId: null,
         state,
         terminalSessions: [terminalSession({ id: "term_1" })],
       }),
     ).toBe(state);
+  });
+
+  it("keeps only a retained disconnected terminal in fixed panel state", () => {
+    const disconnectedTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_disconnected",
+    });
+    const unretainedTerminal = createTerminalFixedPanelTab({
+      terminalId: "term_unretained",
+    });
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: disconnectedTerminal.id,
+        isOpen: true,
+        tabs: [disconnectedTerminal, unretainedTerminal],
+      },
+    });
+    const nextState = syncTerminalTabsInFixedPanelState({
+      retainedTerminalId: "term_disconnected",
+      state,
+      terminalSessions: [
+        terminalSession({
+          id: "term_disconnected",
+          status: "disconnected",
+        }),
+        terminalSession({
+          id: "term_unretained",
+          status: "disconnected",
+        }),
+      ],
+    });
+
+    expect(tabIds(nextState.secondary.tabs)).toEqual([
+      "terminal:term_disconnected:none",
+    ]);
+    expect(nextState.secondary.activeTabId).toBe(disconnectedTerminal.id);
   });
 });

--- a/apps/app/src/components/secondary-panel/terminalPanelTabs.ts
+++ b/apps/app/src/components/secondary-panel/terminalPanelTabs.ts
@@ -2,12 +2,15 @@ import type { TerminalSession } from "@bb/server-contract";
 import {
   createTerminalFixedPanelTab,
   type FixedPanelTabsState,
+  type FixedPanelTab,
   type SecondaryFileFixedPanelTab,
   type SecondaryFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
+import { shouldShowRetainedTerminalSession } from "@/lib/terminal-session-visibility";
 
 interface BuildTerminalSyncedSecondaryFileTabsArgs {
   orderedTabs: readonly SecondaryFileFixedPanelTab[];
+  retainedTerminalId: string | null;
   terminalSessions: readonly TerminalSession[];
 }
 
@@ -17,17 +20,71 @@ interface FindActiveTerminalIdInSecondaryFileTabsArgs {
 }
 
 interface SyncTerminalTabsInFixedPanelStateArgs {
+  retainedTerminalId: string | null;
   state: FixedPanelTabsState;
   terminalSessions: readonly TerminalSession[];
 }
 
+interface GetRetainedTerminalTabIdArgs {
+  activeTab: SecondaryFixedPanelTab | null;
+  isPanelOpen: boolean;
+}
+
+interface PruneTerminalTabsForSessionsArgs {
+  retainedTerminalId: string | null;
+  tabs: readonly FixedPanelTab[];
+  terminalSessions: readonly TerminalSession[];
+}
+
+function getTerminalSessionTabIds({
+  retainedTerminalId,
+  terminalSessions,
+}: {
+  retainedTerminalId: string | null;
+  terminalSessions: readonly TerminalSession[];
+}): ReadonlySet<string> {
+  return new Set(
+    terminalSessions
+      .filter((session) =>
+        shouldShowRetainedTerminalSession({ retainedTerminalId, session }),
+      )
+      .map((session) => session.id),
+  );
+}
+
+export function getRetainedTerminalTabId({
+  activeTab,
+  isPanelOpen,
+}: GetRetainedTerminalTabIdArgs): string | null {
+  return isPanelOpen && activeTab?.kind === "terminal"
+    ? activeTab.terminalId
+    : null;
+}
+
+export function pruneTerminalTabsForSessions({
+  retainedTerminalId,
+  tabs,
+  terminalSessions,
+}: PruneTerminalTabsForSessionsArgs): readonly FixedPanelTab[] {
+  const terminalSessionIds = getTerminalSessionTabIds({
+    retainedTerminalId,
+    terminalSessions,
+  });
+  const nextTabs = tabs.filter(
+    (tab) => tab.kind !== "terminal" || terminalSessionIds.has(tab.terminalId),
+  );
+  return nextTabs.length === tabs.length ? tabs : nextTabs;
+}
+
 export function buildTerminalSyncedSecondaryFileTabs({
   orderedTabs,
+  retainedTerminalId,
   terminalSessions,
 }: BuildTerminalSyncedSecondaryFileTabsArgs): readonly SecondaryFileFixedPanelTab[] {
-  const terminalSessionIds = new Set(
-    terminalSessions.map((session) => session.id),
-  );
+  const terminalSessionIds = getTerminalSessionTabIds({
+    retainedTerminalId,
+    terminalSessions,
+  });
   const seenTerminalIds = new Set<string>();
   const syncedTabs: SecondaryFileFixedPanelTab[] = [];
 
@@ -47,6 +104,9 @@ export function buildTerminalSyncedSecondaryFileTabs({
   }
 
   for (const session of terminalSessions) {
+    if (!shouldShowRetainedTerminalSession({ retainedTerminalId, session })) {
+      continue;
+    }
     if (seenTerminalIds.has(session.id)) {
       continue;
     }
@@ -75,12 +135,14 @@ export function findActiveTerminalIdInSecondaryFileTabs({
 }
 
 export function syncTerminalTabsInFixedPanelState({
+  retainedTerminalId,
   state,
   terminalSessions,
 }: SyncTerminalTabsInFixedPanelStateArgs): FixedPanelTabsState {
-  const terminalSessionIds = new Set(
-    terminalSessions.map((session) => session.id),
-  );
+  const terminalSessionIds = getTerminalSessionTabIds({
+    retainedTerminalId,
+    terminalSessions,
+  });
   const seenTerminalIds = new Set<string>();
   const tabs: SecondaryFixedPanelTab[] = [];
   let changed = false;
@@ -100,6 +162,9 @@ export function syncTerminalTabsInFixedPanelState({
   }
 
   for (const session of terminalSessions) {
+    if (!shouldShowRetainedTerminalSession({ retainedTerminalId, session })) {
+      continue;
+    }
     if (seenTerminalIds.has(session.id)) {
       continue;
     }

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -1,60 +1,135 @@
 // @vitest-environment jsdom
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { TerminalSession } from "@bb/server-contract";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createEmptyFixedPanelTabsState,
   createHostFilePreviewFixedPanelTab,
   createTerminalFixedPanelTab,
-  createThreadInfoFixedPanelTab,
   createThreadStorageFilePreviewFixedPanelTab,
-  type FixedPanelTab,
   getFixedPanelTabsStateStorageKey,
   serializeFixedPanelTabsState,
   FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
 } from "@/lib/fixed-panel-tabs-state";
-import { pruneTerminalTabs, useThreadFileTabs } from "./useThreadFileTabs";
+import { useThreadFileTabs } from "./useThreadFileTabs";
+
+type TerminalSessionOverrides = Partial<TerminalSession>;
+
+function terminalSession(
+  overrides: TerminalSessionOverrides,
+): TerminalSession {
+  return {
+    id: "term_1",
+    threadId: "thr_1",
+    environmentId: "env_1",
+    hostId: "host_1",
+    title: "Terminal",
+    initialCwd: "/workspace",
+    cols: 100,
+    rows: 30,
+    status: "running",
+    exitCode: null,
+    closeReason: null,
+    createdAt: 1,
+    updatedAt: 1,
+    lastUserInputAt: null,
+    ...overrides,
+  };
+}
 
 afterEach(() => {
   cleanup();
   window.localStorage.clear();
 });
 
-describe("pruneTerminalTabs", () => {
-  it("removes terminal tabs that no longer have visible sessions", () => {
-    const infoTab = createThreadInfoFixedPanelTab();
-    const staleTerminalTab = createTerminalFixedPanelTab({
-      terminalId: "term_exited",
+describe("useThreadFileTabs terminal pruning", () => {
+  it("drops disconnected terminal tabs when not retained", async () => {
+    const threadId = "terminal-prune-unretained";
+    const disconnectedTab = createTerminalFixedPanelTab({
+      terminalId: "term_disconnected",
     });
-    const currentTerminalTab = createTerminalFixedPanelTab({
+    const runningTab = createTerminalFixedPanelTab({
       terminalId: "term_running",
     });
-    const tabs: readonly FixedPanelTab[] = [
-      infoTab,
-      staleTerminalTab,
-      currentTerminalTab,
-    ];
-
-    const nextTabs = pruneTerminalTabs({
-      knownTerminalIds: new Set(["term_running"]),
-      tabs,
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: runningTab.id,
+        isOpen: true,
+        tabs: [disconnectedTab, runningTab],
+      },
+      lastUsedAt: Date.now(),
     });
+    window.localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId }),
+      serializeFixedPanelTabsState({ state }),
+    );
 
-    expect(nextTabs).toEqual([infoTab, currentTerminalTab]);
+    const { result } = renderHook(() =>
+      useThreadFileTabs({
+        threadId,
+        environmentId: "env_current",
+        storageFiles: undefined,
+        terminalSessions: [
+          terminalSession({
+            id: "term_disconnected",
+            status: "disconnected",
+          }),
+          terminalSession({ id: "term_running" }),
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.orderedSecondaryFileTabs.map((tab) => tab.id),
+      ).toEqual([runningTab.id]);
+    });
   });
 
-  it("preserves tab array identity when every terminal tab is still visible", () => {
-    const tabs: readonly FixedPanelTab[] = [
-      createThreadInfoFixedPanelTab(),
-      createTerminalFixedPanelTab({ terminalId: "term_running" }),
-    ];
-
-    const nextTabs = pruneTerminalTabs({
-      knownTerminalIds: new Set(["term_running"]),
-      tabs,
+  it("keeps a retained disconnected terminal tab", async () => {
+    const threadId = "terminal-prune-retained";
+    const disconnectedTab = createTerminalFixedPanelTab({
+      terminalId: "term_disconnected",
     });
+    const runningTab = createTerminalFixedPanelTab({
+      terminalId: "term_running",
+    });
+    window.localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId }),
+      serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({
+          secondary: {
+            activeTabId: disconnectedTab.id,
+            isOpen: true,
+            tabs: [disconnectedTab, runningTab],
+          },
+          lastUsedAt: Date.now(),
+        }),
+      }),
+    );
 
-    expect(nextTabs).toBe(tabs);
+    const { result } = renderHook(() =>
+      useThreadFileTabs({
+        threadId,
+        environmentId: "env_current",
+        retainedTerminalId: "term_disconnected",
+        storageFiles: undefined,
+        terminalSessions: [
+          terminalSession({
+            id: "term_disconnected",
+            status: "disconnected",
+          }),
+          terminalSession({ id: "term_running" }),
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.orderedSecondaryFileTabs.map((tab) => tab.id),
+      ).toEqual([disconnectedTab.id, runningTab.id]);
+    });
   });
 });
 

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -16,7 +16,6 @@ import {
   type HostFilePreviewFixedPanelTab,
   type NewTabFixedPanelTab,
   type SideChatFixedPanelTab,
-  type TerminalFixedPanelTab,
   type ThreadStorageFilePreviewFixedPanelTab,
   type WorkspaceFilePreviewFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
@@ -47,6 +46,7 @@ import {
   setSecondaryPanelTabsInState,
   updateSecondaryPanelTabInState,
 } from "./secondaryPanelTabState";
+import { pruneTerminalTabsForSessions } from "./terminalPanelTabs";
 
 interface UseThreadFileTabsParams {
   threadId: string | null | undefined;
@@ -54,17 +54,13 @@ interface UseThreadFileTabsParams {
   fileOwnerThreadId?: string | null;
   preserveWorkspaceTabsAcrossContexts?: boolean;
   projectId?: string | null;
+  retainedTerminalId?: string | null;
   storageFiles: readonly ThreadStorageFileListItem[] | undefined;
   terminalSessions: readonly TerminalSession[] | undefined;
 }
 
 interface ThreadStorageFileListItem {
   path: string;
-}
-
-interface PruneTerminalTabsArgs {
-  knownTerminalIds: ReadonlySet<string>;
-  tabs: readonly FixedPanelTab[];
 }
 
 export interface FileSearchWorkspaceSelection {
@@ -133,10 +129,6 @@ type SecondaryPanelTab =
   | BrowserFixedPanelTab
   | NewTabFixedPanelTab;
 
-function isTerminalTab(tab: FixedPanelTab): tab is TerminalFixedPanelTab {
-  return tab.kind === "terminal";
-}
-
 function isSideChatTab(tab: FixedPanelTab): tab is SideChatFixedPanelTab {
   return tab.kind === "side-chat";
 }
@@ -144,16 +136,6 @@ function isSideChatTab(tab: FixedPanelTab): tab is SideChatFixedPanelTab {
 // Every side chat uses a constant tab title; the message it was triggered from
 // is shown inside the panel ("Replying to" bubble), so the tab needn't echo it.
 const SIDE_CHAT_TAB_TITLE = "Side chat";
-
-export function pruneTerminalTabs({
-  knownTerminalIds,
-  tabs,
-}: PruneTerminalTabsArgs): readonly FixedPanelTab[] {
-  const nextTabs = tabs.filter(
-    (tab) => !isTerminalTab(tab) || knownTerminalIds.has(tab.terminalId),
-  );
-  return nextTabs.length === tabs.length ? tabs : nextTabs;
-}
 
 function createStorageTab(
   environmentId: string | null,
@@ -260,6 +242,7 @@ export function useThreadFileTabs({
   fileOwnerThreadId,
   preserveWorkspaceTabsAcrossContexts = false,
   projectId = null,
+  retainedTerminalId = null,
   storageFiles,
   terminalSessions,
 }: UseThreadFileTabsParams) {
@@ -397,15 +380,13 @@ export function useThreadFileTabs({
   useEffect(() => {
     if (!isThreadResolved || terminalSessions === undefined) return;
     updateFixedPanelTabsState((state) => {
-      const knownTerminalIds = new Set(
-        terminalSessions.map((session) => session.id),
-      );
       const pruned = setPrunedSecondaryTabs({
         activeTabId: state.secondary.activeTabId,
         stateTabs: state.secondary.tabs,
-        tabs: pruneTerminalTabs({
-          knownTerminalIds,
+        tabs: pruneTerminalTabsForSessions({
+          retainedTerminalId,
           tabs: state.secondary.tabs,
+          terminalSessions,
         }),
       });
       return setSecondaryPanelTabsInState({
@@ -415,7 +396,12 @@ export function useThreadFileTabs({
         tabs: pruned.tabs,
       });
     });
-  }, [isThreadResolved, terminalSessions, updateFixedPanelTabsState]);
+  }, [
+    isThreadResolved,
+    retainedTerminalId,
+    terminalSessions,
+    updateFixedPanelTabsState,
+  ]);
 
   const openTab = useCallback(
     (request: OpenSecondaryPanelTabRequest) => {

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TerminalSession } from "@bb/server-contract";
-import { isVisibleTerminalSessionStatus } from "@bb/domain";
 import {
   useCloseTerminal,
   useCloseEnvironmentTerminal,
@@ -22,6 +21,10 @@ import {
   useRemoveFixedRightTerminalTab,
   useSetFixedRightTerminalActiveTerminal,
 } from "@/lib/fixed-panel-tabs";
+import {
+  shouldCloseUnretainedDisconnectedTerminalSession,
+  shouldShowRetainedTerminalSession,
+} from "@/lib/terminal-session-visibility";
 import { normalizeTerminalTitle } from "./thread-terminal-title";
 
 export const DEFAULT_TERMINAL_COLS = 100;
@@ -80,12 +83,10 @@ export function isVisibleTerminalSession({
   retainedTerminalViewId: string | null;
   session: TerminalSession;
 }): boolean {
-  if (!isVisibleTerminalSessionStatus(session.status)) {
-    return false;
-  }
-  return (
-    session.status !== "disconnected" || session.id === retainedTerminalViewId
-  );
+  return shouldShowRetainedTerminalSession({
+    retainedTerminalId: retainedTerminalViewId,
+    session,
+  });
 }
 
 export function shouldCloseDisconnectedTerminalSession({
@@ -95,9 +96,10 @@ export function shouldCloseDisconnectedTerminalSession({
   retainedTerminalViewId: string | null;
   session: TerminalSession;
 }): boolean {
-  return (
-    session.status === "disconnected" && session.id !== retainedTerminalViewId
-  );
+  return shouldCloseUnretainedDisconnectedTerminalSession({
+    retainedTerminalId: retainedTerminalViewId,
+    session,
+  });
 }
 
 export function shouldAutoCloseCleanTerminalSession({

--- a/apps/app/src/lib/terminal-session-visibility.ts
+++ b/apps/app/src/lib/terminal-session-visibility.ts
@@ -1,0 +1,24 @@
+import { isActiveTerminalSessionStatus } from "@bb/domain";
+import type { TerminalSession } from "@bb/server-contract";
+
+interface RetainedTerminalSessionArgs {
+  retainedTerminalId: string | null;
+  session: TerminalSession;
+}
+
+export function shouldShowRetainedTerminalSession({
+  retainedTerminalId,
+  session,
+}: RetainedTerminalSessionArgs): boolean {
+  return (
+    isActiveTerminalSessionStatus(session.status) ||
+    (session.status === "disconnected" && session.id === retainedTerminalId)
+  );
+}
+
+export function shouldCloseUnretainedDisconnectedTerminalSession({
+  retainedTerminalId,
+  session,
+}: RetainedTerminalSessionArgs): boolean {
+  return session.status === "disconnected" && session.id !== retainedTerminalId;
+}

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -676,9 +676,13 @@ describe("resolveRootComposePanelThreadId", () => {
 });
 
 describe("canCreateRootComposeTerminal", () => {
-  it("allows ready environments and host paths", () => {
+  const connectedHostIds = new Set(["host_1"]);
+
+  it("allows ready environments and host paths on connected hosts", () => {
     expect(
       canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: "host_1",
         terminalTarget: { kind: "environment", environmentId: "env_1" },
         environmentStatus: "ready",
       }),
@@ -686,6 +690,8 @@ describe("canCreateRootComposeTerminal", () => {
 
     expect(
       canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: "host_1",
         terminalTarget: { kind: "environment", environmentId: "env_1" },
         environmentStatus: "provisioning",
       }),
@@ -693,6 +699,8 @@ describe("canCreateRootComposeTerminal", () => {
 
     expect(
       canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: undefined,
         terminalTarget: { kind: "host_path", hostId: "host_1", cwd: "/repo" },
         environmentStatus: undefined,
       }),
@@ -700,6 +708,8 @@ describe("canCreateRootComposeTerminal", () => {
 
     expect(
       canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: undefined,
         terminalTarget: { kind: "host_path", hostId: "host_1", cwd: null },
         environmentStatus: undefined,
       }),
@@ -707,8 +717,34 @@ describe("canCreateRootComposeTerminal", () => {
 
     expect(
       canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: "host_1",
         terminalTarget: null,
         environmentStatus: "ready",
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks terminal creation on offline hosts", () => {
+    expect(
+      canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: "host_offline",
+        terminalTarget: { kind: "environment", environmentId: "env_1" },
+        environmentStatus: "ready",
+      }),
+    ).toBe(false);
+
+    expect(
+      canCreateRootComposeTerminal({
+        connectedHostIds,
+        environmentHostId: undefined,
+        terminalTarget: {
+          kind: "host_path",
+          hostId: "host_offline",
+          cwd: "/repo",
+        },
+        environmentStatus: undefined,
       }),
     ).toBe(false);
   });

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -89,7 +89,7 @@ import { useThreads } from "@/hooks/queries/thread-queries";
 import { useCommandSuggestions } from "@/hooks/useCommandSuggestions";
 import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { useLocalOpenTargets } from "@/hooks/useLocalOpenTargets";
-import { usePrimaryHost } from "@/hooks/queries/host-queries";
+import { useHosts } from "@/hooks/queries/host-queries";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { useEscapeToHide } from "@/hooks/useEscapeToHide";
 import { usePromptMentions } from "@/hooks/usePromptMentions";
@@ -179,8 +179,9 @@ import {
 import {
   buildTerminalSyncedSecondaryFileTabs,
   findActiveTerminalIdInSecondaryFileTabs,
+  getRetainedTerminalTabId,
   syncTerminalTabsInFixedPanelState,
-} from "./thread-detail/threadTerminalTabs";
+} from "@/components/secondary-panel/terminalPanelTabs";
 import {
   getActiveFixedSecondaryTab,
   useSetThreadSecondaryPanelSelection,
@@ -397,6 +398,8 @@ interface ResolveRootComposePanelThreadIdArgs {
 }
 
 interface CanCreateRootComposeTerminalArgs {
+  connectedHostIds: ReadonlySet<string>;
+  environmentHostId: string | null | undefined;
   terminalTarget: RootComposeTerminalTarget | null;
   environmentStatus: EnvironmentStatus | undefined;
 }
@@ -702,6 +705,8 @@ export function resolveRootComposePanelThreadId({
 }
 
 export function canCreateRootComposeTerminal({
+  connectedHostIds,
+  environmentHostId,
   terminalTarget,
   environmentStatus,
 }: CanCreateRootComposeTerminalArgs): boolean {
@@ -709,9 +714,14 @@ export function canCreateRootComposeTerminal({
     return false;
   }
   if (terminalTarget.kind === "environment") {
-    return environmentStatus === "ready";
+    return (
+      environmentStatus === "ready" &&
+      environmentHostId !== null &&
+      environmentHostId !== undefined &&
+      connectedHostIds.has(environmentHostId)
+    );
   }
-  return true;
+  return connectedHostIds.has(terminalTarget.hostId);
 }
 
 export function buildRootComposeTerminalSessions({
@@ -875,7 +885,22 @@ export function RootComposeView(props: RootComposeViewProps) {
   const [forkSeed, setForkSeed] = useState<ForkThreadCreateSeed | null>(() =>
     readForkThreadCreateSeedFromLocationState(location.state),
   );
-  const primaryHostId = usePrimaryHost()?.id ?? null;
+  const hostsQuery = useHosts();
+  const connectedHostIds = useMemo(
+    () =>
+      new Set(
+        (hostsQuery.data ?? [])
+          .filter((host) => host.status === "connected")
+          .map((host) => host.id),
+      ),
+    [hostsQuery.data],
+  );
+  const primaryHost = useMemo(() => {
+    const hosts = hostsQuery.data;
+    if (!hosts || hosts.length === 0) return null;
+    return hosts.find((host) => host.status === "connected") ?? hosts[0] ?? null;
+  }, [hostsQuery.data]);
+  const primaryHostId = primaryHost?.id ?? null;
   const uploadPromptAttachment = useUploadPromptAttachment();
   const promptDraft = usePromptDraftStorage({ kind: "new-thread" });
   const promptOptionDraftSnapshotRef = useRef<PromptDraftState | null>(null);
@@ -1696,6 +1721,14 @@ export function RootComposeView(props: RootComposeViewProps) {
   const activeFixedSecondaryTab = getActiveFixedSecondaryTab({
     fixedPanelTabsState,
   });
+  const retainedTerminalId = useMemo(
+    () =>
+      getRetainedTerminalTabId({
+        activeTab: activeFixedSecondaryTab,
+        isPanelOpen: isPersistedSecondaryPanelOpen,
+      }),
+    [activeFixedSecondaryTab, isPersistedSecondaryPanelOpen],
+  );
   const activeFixedSecondaryTabId = activeFixedSecondaryTab?.id ?? null;
   const rawActiveRootStorageFileTab =
     activeFixedSecondaryTab?.kind === "thread-storage-file-preview"
@@ -1891,6 +1924,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     fileOwnerThreadId: rootPanelThreadId,
     preserveWorkspaceTabsAcrossContexts: true,
     projectId: isProjectless ? null : projectId,
+    retainedTerminalId,
     storageFiles: rootThreadStorageFiles?.files,
     terminalSessions: loadedTerminalSessions,
   });
@@ -1912,9 +1946,10 @@ export function RootComposeView(props: RootComposeViewProps) {
         ? orderedSecondaryFileTabs
         : buildTerminalSyncedSecondaryFileTabs({
             orderedTabs: orderedSecondaryFileTabs,
+            retainedTerminalId,
             terminalSessions: loadedTerminalSessions,
           }),
-    [loadedTerminalSessions, orderedSecondaryFileTabs],
+    [loadedTerminalSessions, orderedSecondaryFileTabs, retainedTerminalId],
   );
   useEffect(() => {
     if (!terminalsListLoaded) {
@@ -1922,12 +1957,20 @@ export function RootComposeView(props: RootComposeViewProps) {
     }
     updateFixedPanelTabsState((state) =>
       syncTerminalTabsInFixedPanelState({
+        retainedTerminalId,
         state,
         terminalSessions,
       }),
     );
-  }, [terminalSessions, terminalsListLoaded, updateFixedPanelTabsState]);
+  }, [
+    retainedTerminalId,
+    terminalSessions,
+    terminalsListLoaded,
+    updateFixedPanelTabsState,
+  ]);
   const canCreateRootTerminal = canCreateRootComposeTerminal({
+    connectedHostIds,
+    environmentHostId: rootPanelEnvironment?.hostId,
     terminalTarget: rootPanelTerminalTarget,
     environmentStatus: rootPanelEnvironment?.status,
   });

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -62,6 +62,7 @@ import { assertNever } from "@bb/thread-view";
 import { useCreateThreadInWorktree } from "@/hooks/useCreateThreadInWorktree";
 import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { useLocalOpenTargets } from "@/hooks/useLocalOpenTargets";
+import { useHosts } from "@/hooks/queries/host-queries";
 import { useConnectionAwareQueryState } from "@/hooks/queries/connection-aware-query-state";
 import {
   useCloseThreadTerminal,
@@ -153,8 +154,9 @@ import { useThreadUnreadDividerState } from "./useThreadUnreadDividerState";
 import {
   buildTerminalSyncedSecondaryFileTabs,
   findActiveTerminalIdInSecondaryFileTabs,
+  getRetainedTerminalTabId,
   syncTerminalTabsInFixedPanelState,
-} from "./threadTerminalTabs";
+} from "@/components/secondary-panel/terminalPanelTabs";
 import {
   buildOpenInEditorHandler,
   resolveEnvironmentOpenContext,
@@ -451,6 +453,10 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     activeFixedSecondaryTab,
     isSecondaryPanelOpen: isPersistedSecondaryPanelOpenForSurface,
   });
+  const retainedTerminalId = getRetainedTerminalTabId({
+    activeTab: activeFixedSecondaryTab,
+    isPanelOpen: isPersistedSecondaryPanelOpenForSurface,
+  });
   const activeFixedSecondaryTabId = activeFixedSecondaryTab?.id ?? null;
   const renderSecondaryPanelAsDrawer = useIsCompactViewport();
   const touchFixedPanelTabsState = useTouchFixedPanelTabsState(threadId);
@@ -563,6 +569,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   } = useThreadFileTabs({
     threadId,
     environmentId: thread?.environmentId,
+    retainedTerminalId,
     storageFiles: threadStorageFiles?.files,
     terminalSessions: terminalsListQuery.data?.sessions,
   });
@@ -710,9 +717,10 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     () =>
       buildTerminalSyncedSecondaryFileTabs({
         orderedTabs: orderedSecondaryFileTabs,
+        retainedTerminalId,
         terminalSessions,
       }),
-    [orderedSecondaryFileTabs, terminalSessions],
+    [orderedSecondaryFileTabs, retainedTerminalId, terminalSessions],
   );
   useEffect(() => {
     if (terminalsListQuery.data === undefined) {
@@ -720,11 +728,17 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     }
     updateFixedPanelTabsState((state) =>
       syncTerminalTabsInFixedPanelState({
+        retainedTerminalId,
         state,
         terminalSessions,
       }),
     );
-  }, [terminalSessions, terminalsListQuery.data, updateFixedPanelTabsState]);
+  }, [
+    retainedTerminalId,
+    terminalSessions,
+    terminalsListQuery.data,
+    updateFixedPanelTabsState,
+  ]);
   const hostConnectionNotice = useMemo(
     () => (thread ? buildHostConnectionNotice(thread) : null),
     [thread],
@@ -734,6 +748,21 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     staleTime: 5_000,
   });
   const environment = environmentQuery.data;
+  const hostsQuery = useHosts({
+    enabled:
+      hasThreadDetailBootstrapSettled &&
+      thread?.environmentId !== null &&
+      thread?.environmentId !== undefined,
+  });
+  const connectedHostIds = useMemo(
+    () =>
+      new Set(
+        (hostsQuery.data ?? [])
+          .filter((host) => host.status === "connected")
+          .map((host) => host.id),
+      ),
+    [hostsQuery.data],
+  );
   const forkThreadFromMessage = useForkThreadFromMessage({
     sourceThread: thread ?? null,
   });
@@ -833,7 +862,8 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   const canCreateTerminal =
     thread?.environmentId !== null &&
     thread?.environmentId !== undefined &&
-    environment?.status === "ready";
+    environment?.status === "ready" &&
+    connectedHostIds.has(environment.hostId);
   const createThreadInWorktree = useCreateThreadInWorktree({
     projectId: projectId ?? "",
     environmentId: thread?.environmentId ?? "",

--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -36,7 +36,7 @@ type DaemonSocketClosedDeps = Pick<
 >;
 type ExpiredHostSessionLeaseDeps = Pick<
   AppDeps,
-  "db" | "hub" | "logger" | "pendingInteractions"
+  "db" | "hub" | "logger" | "pendingInteractions" | "terminalSessions"
 >;
 
 export interface HandleHostSessionOpenedArgs {
@@ -89,6 +89,9 @@ export async function handleHostSessionOpened(
 
     if (args.previousSession.status === "active") {
       deps.hub.closeDaemonSession(args.previousSession.id, "replaced");
+      deps.terminalSessions.handleDaemonSessionClosed({
+        sessionId: args.previousSession.id,
+      });
     }
 
     interruptPendingInteractionsForHostThreads(deps, {
@@ -171,6 +174,7 @@ export function handleExpiredHostSessionLeases(
 
   for (const sessionId of args.expiredLeases.expiredSessionIds) {
     deps.hub.closeDaemonSession(sessionId, "expired");
+    deps.terminalSessions.handleDaemonSessionClosed({ sessionId });
   }
   for (const hostId of args.expiredLeases.expiredHostIds) {
     if (!getActiveSession(deps.db, hostId)) {

--- a/apps/server/test/public/public-thread-terminals.test.ts
+++ b/apps/server/test/public/public-thread-terminals.test.ts
@@ -29,12 +29,17 @@ import {
   seedHost,
   seedHostSession,
   seedProjectWithSource,
+  seedSession,
   seedThread,
 } from "../helpers/seed.js";
 import {
   createTestAppHarness,
   type TestAppHarness,
 } from "../helpers/test-app.js";
+import {
+  handleExpiredHostSessionLeases,
+  handleHostSessionOpened,
+} from "../../src/internal/session-owner-side-effects.js";
 import { onDaemonSocketOpen } from "../../src/ws/daemon-protocol.js";
 
 interface FakeDaemonSocket {
@@ -1124,6 +1129,124 @@ describe("public thread terminal routes", () => {
           id: stored.id,
           closeReason: "daemon-disconnect",
           status: "exited",
+        }),
+      }),
+    );
+  });
+
+  it("expires terminals when a replacement daemon session opens before the old socket closes", async () => {
+    const fixture = await createTerminalRouteFixture();
+    harnesses.push(fixture.harness);
+    const stored = createTerminalSession(fixture.harness.db, {
+      cols: 80,
+      daemonSessionId: fixture.session.id,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/terminal-workspace",
+      rows: 24,
+      status: "running",
+      threadId: fixture.thread.id,
+      title: "Terminal 1",
+    });
+    const browserSocket = createFakeBrowserSocket();
+    fixture.harness.hub.registerTerminalClient(stored.id, browserSocket);
+
+    const replacementSession = seedSession(
+      fixture.harness.deps,
+      fixture.host.id,
+    );
+    await handleHostSessionOpened(fixture.harness.deps, {
+      activeThreads: [],
+      hostId: fixture.host.id,
+      openedSession: replacementSession,
+      previousSession: fixture.session,
+    });
+
+    expect(
+      listTerminalSessionsByThread(fixture.harness.db, fixture.thread.id),
+    ).toEqual([
+      expect.objectContaining({
+        id: stored.id,
+        daemonSessionId: null,
+        status: "disconnected",
+      }),
+    ]);
+
+    const replacementSocket = createFakeDaemonSocket();
+    onDaemonSocketOpen(fixture.harness.deps, {
+      hostId: fixture.host.id,
+      sessionId: replacementSession.id,
+      socket: replacementSocket,
+    });
+
+    const closeMessage = await waitForDaemonMessage(replacementSocket);
+    expect(closeMessage).toMatchObject({
+      type: "terminal.close",
+      terminalId: stored.id,
+      reason: "daemon-disconnect",
+    });
+    expect(
+      listTerminalSessionsByThread(fixture.harness.db, fixture.thread.id),
+    ).toEqual([
+      expect.objectContaining({
+        id: stored.id,
+        closeReason: "daemon-disconnect",
+        daemonSessionId: null,
+        status: "exited",
+      }),
+    ]);
+    expect(readBrowserMessages(browserSocket)).toContainEqual(
+      expect.objectContaining({
+        type: "exited",
+        session: expect.objectContaining({
+          id: stored.id,
+          closeReason: "daemon-disconnect",
+          status: "exited",
+        }),
+      }),
+    );
+  });
+
+  it("marks running terminals disconnected when their daemon session lease expires", async () => {
+    const fixture = await createTerminalRouteFixture();
+    harnesses.push(fixture.harness);
+    const stored = createTerminalSession(fixture.harness.db, {
+      cols: 80,
+      daemonSessionId: fixture.session.id,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/terminal-workspace",
+      rows: 24,
+      status: "running",
+      threadId: fixture.thread.id,
+      title: "Terminal 1",
+    });
+    const browserSocket = createFakeBrowserSocket();
+    fixture.harness.hub.registerTerminalClient(stored.id, browserSocket);
+
+    handleExpiredHostSessionLeases(fixture.harness.deps, {
+      expiredLeases: {
+        expiredHostIds: [fixture.host.id],
+        expiredSessionIds: [fixture.session.id],
+        sessionsClosed: 1,
+      },
+    });
+
+    expect(
+      listTerminalSessionsByThread(fixture.harness.db, fixture.thread.id),
+    ).toEqual([
+      expect.objectContaining({
+        daemonSessionId: null,
+        id: stored.id,
+        status: "disconnected",
+      }),
+    ]);
+    expect(readBrowserMessages(browserSocket)).toContainEqual(
+      expect.objectContaining({
+        type: "session-updated",
+        session: expect.objectContaining({
+          id: stored.id,
+          status: "disconnected",
         }),
       }),
     );


### PR DESCRIPTION
## Summary
- centralize terminal session visibility and right-panel terminal tab policy
- prune disconnected/stale terminal tabs unless the open active terminal tab is explicitly retained
- notify terminal lifecycle when daemon sessions are replaced or expire so crash/restart refreshes do not reattach stale running terminals
- block terminal creation UI for environment/host-path targets whose host is offline

## Validation
- pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-terminals.test.ts
- pnpm exec turbo run test --filter=@bb/app -- src/views/RootComposeView.test.ts src/components/secondary-panel/terminalPanelTabs.test.ts src/components/secondary-panel/useThreadFileTabs.test.ts src/components/thread/terminal/useThreadTerminalController.test.ts
- pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/server --filter=@bb/app (exits 0; existing app warnings remain)
- manual API smoke: POST /api/v1/terminals succeeded for thread, environment, and host_path targets against the dev host daemon