### PR TITLE
Add selection add-to-chat popouts

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -613,124 +613,336 @@ interface GitDiffCardRawDiffBodyProps {
   onSelectionAddToChat?: (text: string) => void;
 }
 
-function formatLineRange(startLineNumber: number, endLineNumber: number) {
-  return startLineNumber === endLineNumber
-    ? String(startLineNumber)
-    : `${startLineNumber}-${endLineNumber}`;
+type DiffPatchDisplayStyle = "unified" | "split";
+type DiffPatchLinePrefix = " " | "+" | "-";
+
+interface DiffPatchLine {
+  hunkIndex: number;
+  newLineNumber: number | null;
+  oldLineNumber: number | null;
+  prefix: DiffPatchLinePrefix;
+  selectionSide: SelectionSide | null;
+  splitLineIndex: number;
+  text: string;
+  unifiedLineIndex: number;
 }
 
-function getDiffLineText({
-  fileDiff,
+function getDiffPatchDisplayStyle(
+  fileDiffOptions: Record<string, string | boolean | number>,
+): DiffPatchDisplayStyle {
+  return fileDiffOptions.diffStyle === "split" ? "split" : "unified";
+}
+
+function trimDiffLineEnding(line: string) {
+  return line.replace(/(?:\r\n|\n|\r)$/u, "");
+}
+
+function getDiffLineNumberFromIndex({
+  hunkLineIndex,
+  hunkStart,
+  lineIndex,
+}: {
+  hunkLineIndex: number;
+  hunkStart: number;
+  lineIndex: number;
+}) {
+  return hunkStart + (lineIndex - hunkLineIndex);
+}
+
+function formatPrefixedDiffPath(path: string, prefix: "a" | "b") {
+  if (path === "/dev/null") {
+    return path;
+  }
+  return path.startsWith(`${prefix}/`) ? path : `${prefix}/${path}`;
+}
+
+function getDiffPatchPaths(fileDiff: ParsedGitDiffFile) {
+  const currentPath = normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
+  const previousPath = normalizeGitDiffPath(fileDiff.prevName) ?? currentPath;
+  const gitOldPath = previousPath === "/dev/null" ? currentPath : previousPath;
+  const gitNewPath = currentPath === "/dev/null" ? previousPath : currentPath;
+  return {
+    diffGitOldPath: formatPrefixedDiffPath(gitOldPath, "a"),
+    diffGitNewPath: formatPrefixedDiffPath(gitNewPath, "b"),
+    oldHeaderPath:
+      fileDiff.type === "new"
+        ? "/dev/null"
+        : formatPrefixedDiffPath(previousPath, "a"),
+    newHeaderPath:
+      fileDiff.type === "deleted"
+        ? "/dev/null"
+        : formatPrefixedDiffPath(currentPath, "b"),
+  };
+}
+
+function collectDiffPatchLines(fileDiff: ParsedGitDiffFile): DiffPatchLine[] {
+  const patchLines: DiffPatchLine[] = [];
+
+  fileDiff.hunks.forEach((hunk, hunkIndex) => {
+    let unifiedLineIndex = hunk.unifiedLineStart;
+    let splitLineIndex = hunk.splitLineStart;
+    let deletionLineIndex = hunk.deletionLineIndex;
+    let additionLineIndex = hunk.additionLineIndex;
+
+    for (const content of hunk.hunkContent) {
+      if (content.type === "context") {
+        for (let offset = 0; offset < content.lines; offset += 1) {
+          const oldLineIndex = deletionLineIndex + offset;
+          const newLineIndex = additionLineIndex + offset;
+          const lineText =
+            fileDiff.additionLines[newLineIndex] ??
+            fileDiff.deletionLines[oldLineIndex];
+          if (lineText === undefined) {
+            continue;
+          }
+          patchLines.push({
+            hunkIndex,
+            newLineNumber: getDiffLineNumberFromIndex({
+              hunkLineIndex: hunk.additionLineIndex,
+              hunkStart: hunk.additionStart,
+              lineIndex: newLineIndex,
+            }),
+            oldLineNumber: getDiffLineNumberFromIndex({
+              hunkLineIndex: hunk.deletionLineIndex,
+              hunkStart: hunk.deletionStart,
+              lineIndex: oldLineIndex,
+            }),
+            prefix: " ",
+            selectionSide: null,
+            splitLineIndex: splitLineIndex + offset,
+            text: trimDiffLineEnding(lineText),
+            unifiedLineIndex: unifiedLineIndex + offset,
+          });
+        }
+        unifiedLineIndex += content.lines;
+        splitLineIndex += content.lines;
+        deletionLineIndex += content.lines;
+        additionLineIndex += content.lines;
+        continue;
+      }
+
+      const splitCount = Math.max(content.deletions, content.additions);
+      const unifiedCount = content.deletions + content.additions;
+      for (let offset = 0; offset < content.deletions; offset += 1) {
+        const oldLineIndex = deletionLineIndex + offset;
+        const lineText = fileDiff.deletionLines[oldLineIndex];
+        if (lineText === undefined) {
+          continue;
+        }
+        patchLines.push({
+          hunkIndex,
+          newLineNumber: null,
+          oldLineNumber: getDiffLineNumberFromIndex({
+            hunkLineIndex: hunk.deletionLineIndex,
+            hunkStart: hunk.deletionStart,
+            lineIndex: oldLineIndex,
+          }),
+          prefix: "-",
+          selectionSide: "deletions",
+          splitLineIndex: splitLineIndex + offset,
+          text: trimDiffLineEnding(lineText),
+          unifiedLineIndex: unifiedLineIndex + offset,
+        });
+      }
+      for (let offset = 0; offset < content.additions; offset += 1) {
+        const newLineIndex = additionLineIndex + offset;
+        const lineText = fileDiff.additionLines[newLineIndex];
+        if (lineText === undefined) {
+          continue;
+        }
+        patchLines.push({
+          hunkIndex,
+          newLineNumber: getDiffLineNumberFromIndex({
+            hunkLineIndex: hunk.additionLineIndex,
+            hunkStart: hunk.additionStart,
+            lineIndex: newLineIndex,
+          }),
+          oldLineNumber: null,
+          prefix: "+",
+          selectionSide: "additions",
+          splitLineIndex: splitLineIndex + offset,
+          text: trimDiffLineEnding(lineText),
+          unifiedLineIndex: unifiedLineIndex + content.deletions + offset,
+        });
+      }
+      unifiedLineIndex += unifiedCount;
+      splitLineIndex += splitCount;
+      deletionLineIndex += content.deletions;
+      additionLineIndex += content.additions;
+    }
+  });
+
+  return patchLines;
+}
+
+function getDiffPatchLineSelectionIndex(
+  line: DiffPatchLine,
+  displayStyle: DiffPatchDisplayStyle,
+) {
+  return displayStyle === "split" ? line.splitLineIndex : line.unifiedLineIndex;
+}
+
+function getDiffPatchSelectionPointIndex({
+  displayStyle,
   lineNumber,
+  patchLines,
   side,
 }: {
-  fileDiff: ParsedGitDiffFile;
+  displayStyle: DiffPatchDisplayStyle;
   lineNumber: number;
-  side?: SelectionSide;
-}): string | null {
-  if (side === undefined) {
-    return (
-      getDiffLineText({ fileDiff, lineNumber, side: "additions" }) ??
-      getDiffLineText({ fileDiff, lineNumber, side: "deletions" })
+  patchLines: DiffPatchLine[];
+  side: SelectionSide | undefined;
+}) {
+  const sides: SelectionSide[] =
+    side === undefined ? ["additions", "deletions"] : [side];
+  for (const candidateSide of sides) {
+    const line = patchLines.find((patchLine) =>
+      candidateSide === "additions"
+        ? patchLine.newLineNumber === lineNumber
+        : patchLine.oldLineNumber === lineNumber,
+    );
+    if (line !== undefined) {
+      return getDiffPatchLineSelectionIndex(line, displayStyle);
+    }
+  }
+  return null;
+}
+
+function isDiffPatchLineSelectedInSplitView({
+  line,
+  range,
+}: {
+  line: DiffPatchLine;
+  range: SelectedLineRange;
+}) {
+  const startSide = range.side ?? range.endSide ?? "additions";
+  const endSide = range.endSide ?? startSide;
+  if (startSide !== endSide || line.selectionSide === null) {
+    return true;
+  }
+  return line.selectionSide === startSide;
+}
+
+function getSelectedDiffPatchLines({
+  displayStyle,
+  patchLines,
+  range,
+}: {
+  displayStyle: DiffPatchDisplayStyle;
+  patchLines: DiffPatchLine[];
+  range: SelectedLineRange;
+}) {
+  const startIndex = getDiffPatchSelectionPointIndex({
+    displayStyle,
+    lineNumber: range.start,
+    patchLines,
+    side: range.side,
+  });
+  const endIndex = getDiffPatchSelectionPointIndex({
+    displayStyle,
+    lineNumber: range.end,
+    patchLines,
+    side: range.endSide ?? range.side,
+  });
+  if (startIndex === null || endIndex === null) {
+    return [];
+  }
+
+  const firstIndex = Math.min(startIndex, endIndex);
+  const lastIndex = Math.max(startIndex, endIndex);
+  return patchLines.filter((line) => {
+    const lineIndex = getDiffPatchLineSelectionIndex(line, displayStyle);
+    if (lineIndex < firstIndex || lineIndex > lastIndex) {
+      return false;
+    }
+    if (displayStyle === "unified") {
+      return true;
+    }
+    return isDiffPatchLineSelectedInSplitView({ line, range });
+  });
+}
+
+function formatUnifiedDiffRange(start: number, count: number) {
+  return count === 1 ? String(start) : `${start},${count}`;
+}
+
+function getMinimumLineNumber(lineNumbers: number[]) {
+  return lineNumbers.length > 0 ? Math.min(...lineNumbers) : null;
+}
+
+function buildDiffPatchHunkHeader(lines: DiffPatchLine[]) {
+  const oldLineNumbers = lines
+    .map((line) => line.oldLineNumber)
+    .filter((lineNumber) => lineNumber !== null);
+  const newLineNumbers = lines
+    .map((line) => line.newLineNumber)
+    .filter((lineNumber) => lineNumber !== null);
+  const oldStart =
+    getMinimumLineNumber(oldLineNumbers) ??
+    Math.max(0, (getMinimumLineNumber(newLineNumbers) ?? 1) - 1);
+  const newStart =
+    getMinimumLineNumber(newLineNumbers) ??
+    Math.max(0, (getMinimumLineNumber(oldLineNumbers) ?? 1) - 1);
+  return `@@ -${formatUnifiedDiffRange(
+    oldStart,
+    oldLineNumbers.length,
+  )} +${formatUnifiedDiffRange(newStart, newLineNumbers.length)} @@`;
+}
+
+function groupDiffPatchLinesByHunk(lines: DiffPatchLine[]) {
+  const groups: DiffPatchLine[][] = [];
+  for (const line of lines) {
+    const previousGroup = groups.at(-1);
+    if (previousGroup?.at(-1)?.hunkIndex === line.hunkIndex) {
+      previousGroup.push(line);
+    } else {
+      groups.push([line]);
+    }
+  }
+  return groups;
+}
+
+function buildUnifiedDiffPatchText({
+  fileDiff,
+  lines,
+}: {
+  fileDiff: ParsedGitDiffFile;
+  lines: DiffPatchLine[];
+}) {
+  const paths = getDiffPatchPaths(fileDiff);
+  const patchTextLines = [
+    `diff --git ${paths.diffGitOldPath} ${paths.diffGitNewPath}`,
+    `--- ${paths.oldHeaderPath}`,
+    `+++ ${paths.newHeaderPath}`,
+  ];
+  for (const group of groupDiffPatchLinesByHunk(lines)) {
+    patchTextLines.push(
+      buildDiffPatchHunkHeader(group),
+      ...group.map((line) => `${line.prefix}${line.text}`),
     );
   }
-
-  const lines =
-    side === "additions" ? fileDiff.additionLines : fileDiff.deletionLines;
-  for (const hunk of fileDiff.hunks) {
-    const hunkStart =
-      side === "additions" ? hunk.additionStart : hunk.deletionStart;
-    const hunkCount =
-      side === "additions" ? hunk.additionCount : hunk.deletionCount;
-    if (lineNumber < hunkStart || lineNumber >= hunkStart + hunkCount) {
-      continue;
-    }
-    const lineIndex =
-      (side === "additions" ? hunk.additionLineIndex : hunk.deletionLineIndex) +
-      (lineNumber - hunkStart);
-    return lines[lineIndex] ?? null;
-  }
-  return lines[lineNumber - 1] ?? null;
-}
-
-function getDiffSelectionPath(
-  fileDiff: ParsedGitDiffFile,
-  side: SelectionSide,
-) {
-  if (side === "deletions") {
-    return normalizeGitDiffPath(fileDiff.prevName) ?? fileDiff.name;
-  }
-  return normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
-}
-
-function getDiffSelectionSideLabel(side: SelectionSide) {
-  return side === "additions" ? "after change" : "before change";
-}
-
-function buildSingleSideDiffSelectionText({
-  endLineNumber,
-  fileDiff,
-  side,
-  startLineNumber,
-}: {
-  endLineNumber: number;
-  fileDiff: ParsedGitDiffFile;
-  side: SelectionSide;
-  startLineNumber: number;
-}): string | null {
-  const start = Math.min(startLineNumber, endLineNumber);
-  const end = Math.max(startLineNumber, endLineNumber);
-  const selectedLines: string[] = [];
-  for (let lineNumber = start; lineNumber <= end; lineNumber += 1) {
-    const lineText = getDiffLineText({ fileDiff, lineNumber, side });
-    if (lineText !== null) {
-      selectedLines.push(lineText);
-    }
-  }
-  const selectedText = selectedLines.join("\n").trimEnd();
-  if (selectedText.trim().length === 0) {
-    return null;
-  }
-  const sideLabel = getDiffSelectionSideLabel(side);
-  return `${getDiffSelectionPath(fileDiff, side)}:${formatLineRange(
-    start,
-    end,
-  )} (${sideLabel})\n${selectedText}`;
+  return patchTextLines.join("\n");
 }
 
 function buildDiffLineSelectionText({
+  displayStyle,
   fileDiff,
   range,
 }: {
+  displayStyle: DiffPatchDisplayStyle;
   fileDiff: ParsedGitDiffFile;
   range: SelectedLineRange;
 }): string | null {
-  const startSide = range.side ?? range.endSide ?? "additions";
-  const endSide = range.endSide ?? startSide;
-  if (startSide === endSide) {
-    return buildSingleSideDiffSelectionText({
-      fileDiff,
-      side: startSide,
-      startLineNumber: range.start,
-      endLineNumber: range.end,
-    });
+  const patchLines = collectDiffPatchLines(fileDiff);
+  const selectedLines = getSelectedDiffPatchLines({
+    displayStyle,
+    patchLines,
+    range,
+  });
+  if (selectedLines.length === 0) {
+    return null;
   }
-
-  const selections = [
-    buildSingleSideDiffSelectionText({
-      fileDiff,
-      side: startSide,
-      startLineNumber: range.start,
-      endLineNumber: range.start,
-    }),
-    buildSingleSideDiffSelectionText({
-      fileDiff,
-      side: endSide,
-      startLineNumber: range.end,
-      endLineNumber: range.end,
-    }),
-  ].filter((selection) => selection !== null);
-  return selections.length > 0 ? selections.join("\n\n") : null;
+  return buildUnifiedDiffPatchText({ fileDiff, lines: selectedLines });
 }
 
 function getDiffShadowRoots(containerElement: HTMLElement | null) {
@@ -764,52 +976,85 @@ function getDiffDomLineText(lineElement: HTMLElement): string {
   return (lineElement.textContent ?? "").trimEnd();
 }
 
-function buildDiffDomSelectionSection({
-  fileDiff,
-  range,
-  rows,
-  side,
-}: {
-  fileDiff: ParsedGitDiffFile;
-  range: SelectedLineRange;
-  rows: HTMLElement[];
-  side: SelectionSide;
-}): string | null {
-  const selectedText = rows
-    .map(getDiffDomLineText)
-    .filter((text) => text.trim().length > 0)
-    .join("\n")
-    .trimEnd();
-  if (selectedText.trim().length === 0) {
+function getDiffDomLineIndex(lineElement: HTMLElement) {
+  const [unifiedLineIndex, splitLineIndex] = (
+    lineElement.dataset.lineIndex ?? ""
+  )
+    .split(",")
+    .map((value) => Number.parseInt(value, 10));
+  if (
+    unifiedLineIndex === undefined ||
+    splitLineIndex === undefined ||
+    !Number.isFinite(unifiedLineIndex) ||
+    !Number.isFinite(splitLineIndex)
+  ) {
     return null;
   }
+  return { splitLineIndex, unifiedLineIndex };
+}
 
-  const lineNumbers = rows
-    .map(getDiffDomLineNumber)
-    .filter((lineNumber) => lineNumber !== null);
-  const start =
-    lineNumbers.length > 0
-      ? Math.min(...lineNumbers)
-      : Math.min(range.start, range.end);
-  const end =
-    lineNumbers.length > 0
-      ? Math.max(...lineNumbers)
-      : Math.max(range.start, range.end);
-  const sideLabel = getDiffSelectionSideLabel(side);
-  return `${getDiffSelectionPath(fileDiff, side)}:${formatLineRange(
-    start,
-    end,
-  )} (${sideLabel})\n${selectedText}`;
+function getDiffDomPatchPrefix(lineElement: HTMLElement): DiffPatchLinePrefix {
+  switch (lineElement.dataset.lineType) {
+    case "change-deletion":
+      return "-";
+    case "change-addition":
+      return "+";
+    default:
+      return " ";
+  }
+}
+
+function getDiffDomPatchLine({
+  hunkIndex,
+  lineElement,
+}: {
+  hunkIndex: number;
+  lineElement: HTMLElement;
+}): DiffPatchLine | null {
+  const lineIndex = getDiffDomLineIndex(lineElement);
+  if (lineIndex === null) {
+    return null;
+  }
+  const lineNumber = getDiffDomLineNumber(lineElement);
+  const prefix = getDiffDomPatchPrefix(lineElement);
+  const side = getDiffDomLineSide(lineElement);
+  return {
+    hunkIndex,
+    newLineNumber:
+      lineNumber !== null &&
+      (prefix === "+" || (prefix === " " && side === "additions"))
+        ? lineNumber
+        : null,
+    oldLineNumber:
+      lineNumber !== null &&
+      (prefix === "-" || (prefix === " " && side === "deletions"))
+        ? lineNumber
+        : null,
+    prefix,
+    selectionSide: prefix === " " ? null : side,
+    splitLineIndex: lineIndex.splitLineIndex,
+    text: getDiffDomLineText(lineElement),
+    unifiedLineIndex: lineIndex.unifiedLineIndex,
+  };
+}
+
+function mergeDiffDomContextLine(
+  existingLine: DiffPatchLine,
+  nextLine: DiffPatchLine,
+) {
+  return {
+    ...existingLine,
+    newLineNumber: existingLine.newLineNumber ?? nextLine.newLineNumber,
+    oldLineNumber: existingLine.oldLineNumber ?? nextLine.oldLineNumber,
+  };
 }
 
 function buildDiffDomSelectionText({
   containerElement,
   fileDiff,
-  range,
 }: {
   containerElement: HTMLElement | null;
   fileDiff: ParsedGitDiffFile;
-  range: SelectedLineRange;
 }): string | null {
   if (containerElement === null) {
     return null;
@@ -822,9 +1067,6 @@ function buildDiffDomSelectionText({
       "[data-selected-line][data-line]",
     )) {
       const text = getDiffDomLineText(row);
-      if (text.trim().length === 0) {
-        continue;
-      }
       const lineIndex = row.dataset.lineIndex ?? "";
       const side = getDiffDomLineSide(row);
       const key = `${lineIndex}:${side}:${text}`;
@@ -840,32 +1082,35 @@ function buildDiffDomSelectionText({
     return null;
   }
 
-  const deletionRows = selectedRows.filter(
-    (row) => getDiffDomLineSide(row) === "deletions",
-  );
-  const additionRows = selectedRows.filter(
-    (row) => getDiffDomLineSide(row) === "additions",
-  );
-  const sections = [
-    deletionRows.length === 0
-      ? null
-      : buildDiffDomSelectionSection({
-          fileDiff,
-          range,
-          rows: deletionRows,
-          side: "deletions",
-        }),
-    additionRows.length === 0
-      ? null
-      : buildDiffDomSelectionSection({
-          fileDiff,
-          range,
-          rows: additionRows,
-          side: "additions",
-        }),
-  ].filter((section) => section !== null);
-
-  return sections.length > 0 ? sections.join("\n\n") : null;
+  const patchLineMap = new Map<string, DiffPatchLine>();
+  for (const row of selectedRows) {
+    const patchLine = getDiffDomPatchLine({ hunkIndex: 0, lineElement: row });
+    if (patchLine === null) {
+      continue;
+    }
+    const key = [
+      patchLine.unifiedLineIndex,
+      patchLine.splitLineIndex,
+      patchLine.prefix,
+      patchLine.text,
+    ].join(":");
+    const existingLine = patchLineMap.get(key);
+    patchLineMap.set(
+      key,
+      existingLine !== undefined && patchLine.prefix === " "
+        ? mergeDiffDomContextLine(existingLine, patchLine)
+        : (existingLine ?? patchLine),
+    );
+  }
+  const patchLines = Array.from(patchLineMap.values()).sort((lineA, lineB) => {
+    if (lineA.unifiedLineIndex !== lineB.unifiedLineIndex) {
+      return lineA.unifiedLineIndex - lineB.unifiedLineIndex;
+    }
+    return lineA.prefix.localeCompare(lineB.prefix);
+  });
+  return patchLines.length > 0
+    ? buildUnifiedDiffPatchText({ fileDiff, lines: patchLines })
+    : null;
 }
 
 function GitDiffCardRawDiffBody({
@@ -874,19 +1119,19 @@ function GitDiffCardRawDiffBody({
   onSelectionAddToChat,
 }: GitDiffCardRawDiffBodyProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const displayStyle = getDiffPatchDisplayStyle(fileDiffOptions);
   const buildSelectionText = useCallback(
     (range: SelectedLineRange) =>
-      buildDiffLineSelectionText({ fileDiff, range }),
-    [fileDiff],
+      buildDiffLineSelectionText({ displayStyle, fileDiff, range }),
+    [displayStyle, fileDiff],
   );
   const buildFallbackSelectionText = useCallback(
     ({
       containerElement,
-      range,
     }: {
       containerElement: HTMLElement | null;
       range: SelectedLineRange;
-    }) => buildDiffDomSelectionText({ containerElement, fileDiff, range }),
+    }) => buildDiffDomSelectionText({ containerElement, fileDiff }),
     [fileDiff],
   );
   const lineSelectionActions = usePierreLineSelectionActions({

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -7,10 +7,16 @@ import {
   useRef,
   useState,
 } from "react";
-import type { FileContents } from "@pierre/diffs";
+import type {
+  FileContents,
+  FileDiffOptions,
+  SelectedLineRange,
+  SelectionSide,
+} from "@pierre/diffs";
 import { FileDiff as DiffView } from "@pierre/diffs/react";
 import { useIntersectionObserver } from "usehooks-ts";
 import { Button } from "@/components/ui/button.js";
+import { usePierreLineSelectionActions } from "./PierreLineSelectionActions.js";
 import {
   getWrappedImageIndex,
   ImageLightbox,
@@ -604,17 +610,369 @@ function GitDiffCardImageBody({
 interface GitDiffCardRawDiffBodyProps {
   fileDiff: ParsedGitDiffFile;
   fileDiffOptions: Record<string, string | boolean | number>;
+  onSelectionAddToChat?: (text: string) => void;
+}
+
+function formatLineRange(startLineNumber: number, endLineNumber: number) {
+  return startLineNumber === endLineNumber
+    ? String(startLineNumber)
+    : `${startLineNumber}-${endLineNumber}`;
+}
+
+function getDiffLineText({
+  fileDiff,
+  lineNumber,
+  side,
+}: {
+  fileDiff: ParsedGitDiffFile;
+  lineNumber: number;
+  side?: SelectionSide;
+}): string | null {
+  if (side === undefined) {
+    return (
+      getDiffLineText({ fileDiff, lineNumber, side: "additions" }) ??
+      getDiffLineText({ fileDiff, lineNumber, side: "deletions" })
+    );
+  }
+
+  const lines =
+    side === "additions" ? fileDiff.additionLines : fileDiff.deletionLines;
+  for (const hunk of fileDiff.hunks) {
+    const hunkStart =
+      side === "additions" ? hunk.additionStart : hunk.deletionStart;
+    const hunkCount =
+      side === "additions" ? hunk.additionCount : hunk.deletionCount;
+    if (lineNumber < hunkStart || lineNumber >= hunkStart + hunkCount) {
+      continue;
+    }
+    const lineIndex =
+      (side === "additions" ? hunk.additionLineIndex : hunk.deletionLineIndex) +
+      (lineNumber - hunkStart);
+    return lines[lineIndex] ?? null;
+  }
+  return lines[lineNumber - 1] ?? null;
+}
+
+function getDiffSelectionPath(
+  fileDiff: ParsedGitDiffFile,
+  side: SelectionSide,
+) {
+  if (side === "deletions") {
+    return normalizeGitDiffPath(fileDiff.prevName) ?? fileDiff.name;
+  }
+  return normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
+}
+
+function buildSingleSideDiffSelectionText({
+  endLineNumber,
+  fileDiff,
+  side,
+  startLineNumber,
+}: {
+  endLineNumber: number;
+  fileDiff: ParsedGitDiffFile;
+  side: SelectionSide;
+  startLineNumber: number;
+}): string | null {
+  const start = Math.min(startLineNumber, endLineNumber);
+  const end = Math.max(startLineNumber, endLineNumber);
+  const selectedLines: string[] = [];
+  for (let lineNumber = start; lineNumber <= end; lineNumber += 1) {
+    const lineText = getDiffLineText({ fileDiff, lineNumber, side });
+    if (lineText !== null) {
+      selectedLines.push(lineText);
+    }
+  }
+  const selectedText = selectedLines.join("\n").trimEnd();
+  if (selectedText.trim().length === 0) {
+    return null;
+  }
+  const sideLabel = side === "additions" ? "new" : "old";
+  return `${getDiffSelectionPath(fileDiff, side)}:${formatLineRange(
+    start,
+    end,
+  )} (${sideLabel})\n${selectedText}`;
+}
+
+function buildDiffLineSelectionText({
+  fileDiff,
+  range,
+}: {
+  fileDiff: ParsedGitDiffFile;
+  range: SelectedLineRange;
+}): string | null {
+  const startSide = range.side ?? range.endSide ?? "additions";
+  const endSide = range.endSide ?? startSide;
+  if (startSide === endSide) {
+    return buildSingleSideDiffSelectionText({
+      fileDiff,
+      side: startSide,
+      startLineNumber: range.start,
+      endLineNumber: range.end,
+    });
+  }
+
+  const selections = [
+    buildSingleSideDiffSelectionText({
+      fileDiff,
+      side: startSide,
+      startLineNumber: range.start,
+      endLineNumber: range.start,
+    }),
+    buildSingleSideDiffSelectionText({
+      fileDiff,
+      side: endSide,
+      startLineNumber: range.end,
+      endLineNumber: range.end,
+    }),
+  ].filter((selection) => selection !== null);
+  return selections.length > 0 ? selections.join("\n\n") : null;
+}
+
+function getDiffShadowRoots(containerElement: HTMLElement | null) {
+  if (containerElement === null) {
+    return [];
+  }
+  return Array.from(containerElement.querySelectorAll("diffs-container"))
+    .map((container) => container.shadowRoot)
+    .filter((root) => root !== null);
+}
+
+function anchorPointFromElement(element: Element): { x: number; y: number } {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}
+
+function resolveDiffDomSelectionAnchorPoint({
+  containerElement,
+}: {
+  containerElement: HTMLElement | null;
+}): { x: number; y: number } | null {
+  for (const root of getDiffShadowRoots(containerElement)) {
+    const utilityButton = root.querySelector("[data-utility-button]");
+    if (utilityButton !== null) {
+      return anchorPointFromElement(utilityButton);
+    }
+  }
+
+  for (const root of getDiffShadowRoots(containerElement)) {
+    const selectedNumber = root.querySelector(
+      "[data-selected-line][data-column-number]",
+    );
+    if (selectedNumber !== null) {
+      return anchorPointFromElement(selectedNumber);
+    }
+    const selectedLine = root.querySelector("[data-selected-line][data-line]");
+    if (selectedLine !== null) {
+      const rect = selectedLine.getBoundingClientRect();
+      return {
+        x: rect.left,
+        y: rect.top + rect.height / 2,
+      };
+    }
+  }
+
+  return null;
+}
+
+function getDiffDomLineSide(lineElement: HTMLElement): SelectionSide {
+  const codeElement = lineElement.closest("[data-deletions],[data-additions]");
+  if (codeElement?.hasAttribute("data-deletions")) {
+    return "deletions";
+  }
+  if (codeElement?.hasAttribute("data-additions")) {
+    return "additions";
+  }
+  return lineElement.dataset.lineType === "change-deletion"
+    ? "deletions"
+    : "additions";
+}
+
+function getDiffDomLineNumber(lineElement: HTMLElement): number | null {
+  const lineNumber = Number.parseInt(lineElement.dataset.line ?? "", 10);
+  return Number.isFinite(lineNumber) ? lineNumber : null;
+}
+
+function getDiffDomLineText(lineElement: HTMLElement): string {
+  return (lineElement.textContent ?? "").trimEnd();
+}
+
+function buildDiffDomSelectionSection({
+  fileDiff,
+  range,
+  rows,
+  side,
+}: {
+  fileDiff: ParsedGitDiffFile;
+  range: SelectedLineRange;
+  rows: HTMLElement[];
+  side: SelectionSide;
+}): string | null {
+  const selectedText = rows
+    .map(getDiffDomLineText)
+    .filter((text) => text.trim().length > 0)
+    .join("\n")
+    .trimEnd();
+  if (selectedText.trim().length === 0) {
+    return null;
+  }
+
+  const lineNumbers = rows
+    .map(getDiffDomLineNumber)
+    .filter((lineNumber) => lineNumber !== null);
+  const start =
+    lineNumbers.length > 0
+      ? Math.min(...lineNumbers)
+      : Math.min(range.start, range.end);
+  const end =
+    lineNumbers.length > 0
+      ? Math.max(...lineNumbers)
+      : Math.max(range.start, range.end);
+  const sideLabel = side === "additions" ? "new" : "old";
+  return `${getDiffSelectionPath(fileDiff, side)}:${formatLineRange(
+    start,
+    end,
+  )} (${sideLabel})\n${selectedText}`;
+}
+
+function buildDiffDomSelectionText({
+  containerElement,
+  fileDiff,
+  range,
+}: {
+  containerElement: HTMLElement | null;
+  fileDiff: ParsedGitDiffFile;
+  range: SelectedLineRange;
+}): string | null {
+  if (containerElement === null) {
+    return null;
+  }
+
+  const selectedRows: HTMLElement[] = [];
+  const seenRows = new Set<string>();
+  for (const root of getDiffShadowRoots(containerElement)) {
+    for (const row of root.querySelectorAll<HTMLElement>(
+      "[data-selected-line][data-line]",
+    )) {
+      const text = getDiffDomLineText(row);
+      if (text.trim().length === 0) {
+        continue;
+      }
+      const lineIndex = row.dataset.lineIndex ?? "";
+      const side = getDiffDomLineSide(row);
+      const key = `${lineIndex}:${side}:${text}`;
+      if (seenRows.has(key)) {
+        continue;
+      }
+      seenRows.add(key);
+      selectedRows.push(row);
+    }
+  }
+
+  if (selectedRows.length === 0) {
+    return null;
+  }
+
+  const deletionRows = selectedRows.filter(
+    (row) => getDiffDomLineSide(row) === "deletions",
+  );
+  const additionRows = selectedRows.filter(
+    (row) => getDiffDomLineSide(row) === "additions",
+  );
+  const sections = [
+    deletionRows.length === 0
+      ? null
+      : buildDiffDomSelectionSection({
+          fileDiff,
+          range,
+          rows: deletionRows,
+          side: "deletions",
+        }),
+    additionRows.length === 0
+      ? null
+      : buildDiffDomSelectionSection({
+          fileDiff,
+          range,
+          rows: additionRows,
+          side: "additions",
+        }),
+  ].filter((section) => section !== null);
+
+  return sections.length > 0 ? sections.join("\n\n") : null;
 }
 
 function GitDiffCardRawDiffBody({
   fileDiff,
   fileDiffOptions,
+  onSelectionAddToChat,
 }: GitDiffCardRawDiffBodyProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buildSelectionText = useCallback(
+    (range: SelectedLineRange) =>
+      buildDiffLineSelectionText({ fileDiff, range }),
+    [fileDiff],
+  );
+  const buildFallbackSelectionText = useCallback(
+    ({
+      containerElement,
+      range,
+    }: {
+      containerElement: HTMLElement | null;
+      range: SelectedLineRange;
+    }) => buildDiffDomSelectionText({ containerElement, fileDiff, range }),
+    [fileDiff],
+  );
+  const lineSelectionActions = usePierreLineSelectionActions({
+    buildFallbackSelectionText,
+    buildSelectionText,
+    containerRef,
+    enabled: onSelectionAddToChat !== undefined,
+    onSelectionAddToChat,
+    resolveAnchorPoint: resolveDiffDomSelectionAnchorPoint,
+  });
+  const options = useMemo<FileDiffOptions<undefined>>(
+    () => ({
+      ...fileDiffOptions,
+      enableGutterUtility: onSelectionAddToChat !== undefined,
+      enableLineSelection: onSelectionAddToChat !== undefined,
+      lineHoverHighlight:
+        onSelectionAddToChat === undefined ? "disabled" : "number",
+      onGutterUtilityClick:
+        onSelectionAddToChat === undefined
+          ? undefined
+          : lineSelectionActions.onGutterUtilityClick,
+      onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
+      onLineSelectionEnd: lineSelectionActions.onLineSelectionEnd,
+      onLineSelectionStart: lineSelectionActions.onLineSelectionStart,
+    }),
+    [
+      fileDiffOptions,
+      lineSelectionActions.onGutterUtilityClick,
+      lineSelectionActions.onLineSelectionChange,
+      lineSelectionActions.onLineSelectionEnd,
+      lineSelectionActions.onLineSelectionStart,
+      onSelectionAddToChat,
+    ],
+  );
   return (
-    <div className="overflow-x-auto">
+    <div
+      ref={containerRef}
+      className="overflow-x-auto"
+      onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
+      onPointerMoveCapture={lineSelectionActions.onPointerMoveCapture}
+      onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
+    >
       <div className="w-full max-w-full" style={GIT_DIFF_CARD_VIEW_STYLE}>
-        <DiffView fileDiff={fileDiff} options={fileDiffOptions} />
+        <DiffView
+          fileDiff={fileDiff}
+          options={options}
+          selectedLines={lineSelectionActions.selectedRange}
+        />
       </div>
+      {lineSelectionActions.menu}
     </div>
   );
 }
@@ -625,6 +983,7 @@ interface GitDiffCardSvgBodyProps {
   fileDiff: ParsedGitDiffFile;
   fileDiffLabel: string;
   fileDiffOptions: Record<string, string | boolean | number>;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 function GitDiffCardSvgBody({
@@ -633,6 +992,7 @@ function GitDiffCardSvgBody({
   fileDiff,
   fileDiffLabel,
   fileDiffOptions,
+  onSelectionAddToChat,
 }: GitDiffCardSvgBodyProps) {
   return displayMode === "preview" ? (
     <GitDiffCardImageBody
@@ -644,6 +1004,7 @@ function GitDiffCardSvgBody({
     <GitDiffCardRawDiffBody
       fileDiff={fileDiff}
       fileDiffOptions={fileDiffOptions}
+      onSelectionAddToChat={onSelectionAddToChat}
     />
   );
 }
@@ -657,6 +1018,7 @@ export interface GitDiffCardBodyProps {
    * file message aligns to that gutter so its text lines up with the diff body.
    */
   reservesCollapseGutter: boolean;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 /**
@@ -673,6 +1035,7 @@ export function GitDiffCardBody({
   diffViewOptions,
   svgDisplayMode,
   reservesCollapseGutter,
+  onSelectionAddToChat,
 }: GitDiffCardBodyProps) {
   const {
     bodySentinelRef,
@@ -728,11 +1091,13 @@ export function GitDiffCardBody({
           fileDiff={enrichedFileDiff}
           fileDiffLabel={fileDiffLabel}
           fileDiffOptions={fileDiffOptions}
+          onSelectionAddToChat={onSelectionAddToChat}
         />
       ) : (
         <GitDiffCardRawDiffBody
           fileDiff={enrichedFileDiff}
           fileDiffOptions={fileDiffOptions}
+          onSelectionAddToChat={onSelectionAddToChat}
         />
       )}
     </div>

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -663,6 +663,10 @@ function getDiffSelectionPath(
   return normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
 }
 
+function getDiffSelectionSideLabel(side: SelectionSide) {
+  return side === "additions" ? "after change" : "before change";
+}
+
 function buildSingleSideDiffSelectionText({
   endLineNumber,
   fileDiff,
@@ -687,7 +691,7 @@ function buildSingleSideDiffSelectionText({
   if (selectedText.trim().length === 0) {
     return null;
   }
-  const sideLabel = side === "additions" ? "new" : "old";
+  const sideLabel = getDiffSelectionSideLabel(side);
   return `${getDiffSelectionPath(fileDiff, side)}:${formatLineRange(
     start,
     end,
@@ -791,7 +795,7 @@ function buildDiffDomSelectionSection({
     lineNumbers.length > 0
       ? Math.max(...lineNumbers)
       : Math.max(range.start, range.end);
-  const sideLabel = side === "additions" ? "new" : "old";
+  const sideLabel = getDiffSelectionSideLabel(side);
   return `${getDiffSelectionPath(fileDiff, side)}:${formatLineRange(
     start,
     end,

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -738,46 +738,6 @@ function getDiffShadowRoots(containerElement: HTMLElement | null) {
     .filter((root) => root !== null);
 }
 
-function anchorPointFromElement(element: Element): { x: number; y: number } {
-  const rect = element.getBoundingClientRect();
-  return {
-    x: rect.left + rect.width / 2,
-    y: rect.top + rect.height / 2,
-  };
-}
-
-function resolveDiffDomSelectionAnchorPoint({
-  containerElement,
-}: {
-  containerElement: HTMLElement | null;
-}): { x: number; y: number } | null {
-  for (const root of getDiffShadowRoots(containerElement)) {
-    const utilityButton = root.querySelector("[data-utility-button]");
-    if (utilityButton !== null) {
-      return anchorPointFromElement(utilityButton);
-    }
-  }
-
-  for (const root of getDiffShadowRoots(containerElement)) {
-    const selectedNumber = root.querySelector(
-      "[data-selected-line][data-column-number]",
-    );
-    if (selectedNumber !== null) {
-      return anchorPointFromElement(selectedNumber);
-    }
-    const selectedLine = root.querySelector("[data-selected-line][data-line]");
-    if (selectedLine !== null) {
-      const rect = selectedLine.getBoundingClientRect();
-      return {
-        x: rect.left,
-        y: rect.top + rect.height / 2,
-      };
-    }
-  }
-
-  return null;
-}
-
 function getDiffDomLineSide(lineElement: HTMLElement): SelectionSide {
   const codeElement = lineElement.closest("[data-deletions],[data-additions]");
   if (codeElement?.hasAttribute("data-deletions")) {
@@ -931,7 +891,6 @@ function GitDiffCardRawDiffBody({
     containerRef,
     enabled: onSelectionAddToChat !== undefined,
     onSelectionAddToChat,
-    resolveAnchorPoint: resolveDiffDomSelectionAnchorPoint,
   });
   const options = useMemo<FileDiffOptions<undefined>>(
     () => ({

--- a/apps/app/src/components/git-diff/PierreLineSelectionActions.tsx
+++ b/apps/app/src/components/git-diff/PierreLineSelectionActions.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -8,13 +9,22 @@ import {
   type RefObject,
 } from "react";
 import type { SelectedLineRange } from "@pierre/diffs";
-import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
+import {
+  anchorPointFromMouseEvent,
+  selectionAnchorFromPointerRelease,
+  type MessageProseSelection,
+  type SelectionAnchor,
+  type SelectionAnchorPoint,
+  type SelectionAnchorSide,
+} from "@/components/thread/timeline/SelectableMessageProse.js";
 import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
 
-export interface PierreLineSelectionAnchorPoint {
-  x: number;
-  y: number;
-}
+const LINE_SELECTION_MENU_INLINE_OFFSET_PX = 72;
+
+let documentPointerStartPoint: SelectionAnchorPoint | null = null;
+let documentPointerReleaseAnchor: SelectionAnchor | null = null;
+
+export type PierreLineSelectionAnchorPoint = SelectionAnchorPoint;
 
 export interface UsePierreLineSelectionActionsArgs {
   buildFallbackSelectionText?: (args: {
@@ -26,6 +36,7 @@ export interface UsePierreLineSelectionActionsArgs {
   enabled: boolean;
   onSelectionAddToChat?: (text: string) => void;
   resolveAnchorPoint?: (args: {
+    anchorSide: SelectionAnchorSide;
     containerElement: HTMLElement | null;
     pointerAnchorPoint: PierreLineSelectionAnchorPoint | null;
     range: SelectedLineRange;
@@ -44,32 +55,23 @@ export interface PierreLineSelectionActions {
   selectedRange: SelectedLineRange | null;
 }
 
-function anchorPointFromPointerEvent(
-  event: Pick<ReactPointerEvent<HTMLElement>, "clientX" | "clientY">,
-): PierreLineSelectionAnchorPoint | null {
-  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
-    return null;
-  }
-  return { x: event.clientX, y: event.clientY };
-}
-
 function fallbackAnchorPoint(
   containerElement: HTMLElement | null,
-): PierreLineSelectionAnchorPoint {
+): SelectionAnchor {
   const rect = containerElement?.getBoundingClientRect();
   if (!rect) {
-    return { x: 0, y: 0 };
+    return { point: { x: 0, y: 0 }, side: "top" };
   }
-  return { x: rect.left + 24, y: rect.top + 24 };
+  return { point: { x: rect.left + 24, y: rect.top + 24 }, side: "top" };
 }
 
 function buildMenuSelection({
+  anchor,
   containerElement,
-  pointerAnchorPoint,
   text,
 }: {
+  anchor: SelectionAnchor | null;
   containerElement: HTMLElement | null;
-  pointerAnchorPoint: PierreLineSelectionAnchorPoint | null;
   text: string;
 }): MessageProseSelection | null {
   const trimmedText = text.trim();
@@ -77,14 +79,148 @@ function buildMenuSelection({
     return null;
   }
 
-  const anchorPoint =
-    pointerAnchorPoint ?? fallbackAnchorPoint(containerElement);
+  const selectionAnchor = anchor ?? fallbackAnchorPoint(containerElement);
+  const anchorPoint = selectionAnchor.point;
   return {
     text: trimmedText,
     rect: new DOMRect(anchorPoint.x, anchorPoint.y, 0, 0),
     anchorPoint,
-    anchorSide: "top",
+    anchorSide: selectionAnchor.side,
   };
+}
+
+function isGutterUtilityPointerEvent(
+  event: ReactPointerEvent<HTMLElement>,
+): boolean {
+  return isGutterUtilityPath(event.nativeEvent.composedPath());
+}
+
+function isGutterUtilityPath(path: EventTarget[]): boolean {
+  return path.some(
+    (target) =>
+      target instanceof Element &&
+      (target.hasAttribute("data-utility-button") ||
+        target.hasAttribute("data-gutter-utility-slot") ||
+        target.getAttribute("slot") === "gutter-utility-slot" ||
+        target.getAttribute("name") === "gutter-utility-slot"),
+  );
+}
+
+function getPierreShadowRoots(containerElement: HTMLElement | null) {
+  if (containerElement === null) {
+    return [];
+  }
+  return Array.from(containerElement.querySelectorAll("diffs-container"))
+    .map((container) => container.shadowRoot)
+    .filter((root) => root !== null);
+}
+
+function selectedLineAttributeMatchesSide(
+  element: HTMLElement,
+  anchorSide: SelectionAnchorSide,
+) {
+  const value = element.getAttribute("data-selected-line");
+  if (value === "single") {
+    return true;
+  }
+  return anchorSide === "bottom" ? value === "last" : value === "first";
+}
+
+function getBoundarySelectedLine(
+  rows: HTMLElement[],
+  anchorSide: SelectionAnchorSide,
+) {
+  const matchingRow = rows.find((row) =>
+    selectedLineAttributeMatchesSide(row, anchorSide),
+  );
+  if (matchingRow !== undefined) {
+    return matchingRow;
+  }
+  return rows
+    .map((row) => ({ row, rect: row.getBoundingClientRect() }))
+    .filter(({ rect }) => rect.width > 0 || rect.height > 0)
+    .sort((first, second) =>
+      anchorSide === "bottom"
+        ? second.rect.bottom - first.rect.bottom
+        : first.rect.top - second.rect.top,
+    )[0]?.row;
+}
+
+function anchorPointFromSelectedLine(
+  lineElement: HTMLElement,
+  anchorSide: SelectionAnchorSide,
+): SelectionAnchorPoint {
+  const rect = lineElement.getBoundingClientRect();
+  return {
+    x:
+      rect.left +
+      Math.min(LINE_SELECTION_MENU_INLINE_OFFSET_PX, rect.width / 2),
+    y: anchorSide === "bottom" ? rect.bottom : rect.top,
+  };
+}
+
+function resolveSelectedLineAnchorPoint({
+  anchorSide,
+  containerElement,
+}: {
+  anchorSide: SelectionAnchorSide;
+  containerElement: HTMLElement | null;
+}): SelectionAnchorPoint | null {
+  for (const root of getPierreShadowRoots(containerElement)) {
+    const selectedLine = getBoundarySelectedLine(
+      Array.from(
+        root.querySelectorAll<HTMLElement>("[data-selected-line][data-line]"),
+      ),
+      anchorSide,
+    );
+    if (selectedLine !== undefined) {
+      return anchorPointFromSelectedLine(selectedLine, anchorSide);
+    }
+  }
+
+  for (const root of getPierreShadowRoots(containerElement)) {
+    const selectedNumber = getBoundarySelectedLine(
+      Array.from(
+        root.querySelectorAll<HTMLElement>(
+          "[data-selected-line][data-column-number]",
+        ),
+      ),
+      anchorSide,
+    );
+    if (selectedNumber !== undefined) {
+      const rect = selectedNumber.getBoundingClientRect();
+      return {
+        x: rect.right + LINE_SELECTION_MENU_INLINE_OFFSET_PX,
+        y: anchorSide === "bottom" ? rect.bottom : rect.top,
+      };
+    }
+  }
+
+  return null;
+}
+
+function resolveUtilityButtonAnchorPoint({
+  anchorSide,
+  containerElement,
+}: {
+  anchorSide: SelectionAnchorSide;
+  containerElement: HTMLElement | null;
+}): SelectionAnchorPoint | null {
+  for (const root of getPierreShadowRoots(containerElement)) {
+    const utilityButton = root.querySelector("[data-utility-button]");
+    if (utilityButton === null) {
+      continue;
+    }
+    const rect = utilityButton.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      continue;
+    }
+    return {
+      x: rect.right + LINE_SELECTION_MENU_INLINE_OFFSET_PX,
+      y: anchorSide === "bottom" ? rect.bottom : rect.top,
+    };
+  }
+  return null;
 }
 
 function areSelectedLineRangesEqual(
@@ -105,6 +241,40 @@ function areSelectedLineRangesEqual(
   );
 }
 
+function anchorSideFromLineRange(
+  range: SelectedLineRange,
+): SelectionAnchorSide | null {
+  if (range.end > range.start) {
+    return "bottom";
+  }
+  if (range.end < range.start) {
+    return "top";
+  }
+  return null;
+}
+
+function anchorSideFromSelectionStart({
+  range,
+  startRange,
+}: {
+  range: SelectedLineRange;
+  startRange: SelectedLineRange | null;
+}): SelectionAnchorSide | null {
+  if (startRange === null) {
+    return null;
+  }
+  const startLine = startRange.start;
+  const lowerLine = Math.min(range.start, range.end);
+  const upperLine = Math.max(range.start, range.end);
+  if (startLine <= lowerLine && upperLine > startLine) {
+    return "bottom";
+  }
+  if (startLine >= upperLine && lowerLine < startLine) {
+    return "top";
+  }
+  return null;
+}
+
 export function usePierreLineSelectionActions({
   buildFallbackSelectionText,
   buildSelectionText,
@@ -121,21 +291,171 @@ export function usePierreLineSelectionActions({
   );
   const [activeSelection, setActiveSelection] =
     useState<MessageProseSelection | null>(null);
-  const lastPointerAnchorPointRef =
-    useRef<PierreLineSelectionAnchorPoint | null>(null);
+  const pointerStartPointRef = useRef<SelectionAnchorPoint | null>(null);
+  const lastPointerReleaseAnchorRef = useRef<SelectionAnchor | null>(null);
+  const lastLineSelectionAnchorRef = useRef<SelectionAnchor | null>(null);
+  const lastUtilityAnchorRef = useRef<SelectionAnchor | null>(null);
+  const lineSelectionStartRangeRef = useRef<SelectedLineRange | null>(null);
+  const currentLineRangeRef = useRef<SelectedLineRange | null>(null);
   const suppressedSelectionEndRangeRef = useRef<SelectedLineRange | null>(null);
 
-  const capturePointerAnchorPoint = useCallback(
+  const handlePointerDownCapture = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
-      lastPointerAnchorPointRef.current = anchorPointFromPointerEvent(event);
+      if (!enabled) {
+        return;
+      }
+      const point = anchorPointFromMouseEvent(event);
+      if (isGutterUtilityPointerEvent(event)) {
+        lastUtilityAnchorRef.current =
+          point === null
+            ? null
+            : {
+                point,
+                side: lastLineSelectionAnchorRef.current?.side ?? "top",
+              };
+        return;
+      }
+      documentPointerReleaseAnchor = null;
+      pointerStartPointRef.current = point;
+      documentPointerStartPoint = point;
     },
-    [],
+    [enabled],
   );
+
+  const handlePointerMoveCapture = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || !isGutterUtilityPointerEvent(event)) {
+        return;
+      }
+      const point = anchorPointFromMouseEvent(event);
+      lastUtilityAnchorRef.current =
+        point === null
+          ? null
+          : {
+              point,
+              side: lastLineSelectionAnchorRef.current?.side ?? "top",
+            };
+    },
+    [enabled],
+  );
+
+  const handlePointerUpCapture = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled) {
+        return;
+      }
+      if (isGutterUtilityPointerEvent(event)) {
+        const point = anchorPointFromMouseEvent(event);
+        lastUtilityAnchorRef.current =
+          point === null
+            ? null
+            : {
+                point,
+                side: lastLineSelectionAnchorRef.current?.side ?? "top",
+              };
+        return;
+      }
+      const pointerStartPoint =
+        pointerStartPointRef.current ?? documentPointerStartPoint;
+      pointerStartPointRef.current = null;
+      documentPointerStartPoint = null;
+      if (pointerStartPoint === null) {
+        return;
+      }
+      const anchor = selectionAnchorFromPointerRelease(
+        pointerStartPoint,
+        event,
+      );
+      if (anchor === null) {
+        return;
+      }
+      lastPointerReleaseAnchorRef.current = anchor;
+      documentPointerReleaseAnchor = anchor;
+      if (currentLineRangeRef.current !== null) {
+        lastLineSelectionAnchorRef.current = anchor;
+      }
+    },
+    [enabled],
+  );
+
+  useEffect(() => {
+    if (!enabled || typeof document === "undefined") {
+      return;
+    }
+
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      const path = event.composedPath();
+      if (isGutterUtilityPath(path)) {
+        return;
+      }
+      const point = anchorPointFromMouseEvent(event);
+      documentPointerReleaseAnchor = null;
+      pointerStartPointRef.current = point;
+      documentPointerStartPoint = point;
+    };
+    const handleDocumentPointerUp = (event: PointerEvent) => {
+      if (isGutterUtilityPath(event.composedPath())) {
+        return;
+      }
+      const pointerStartPoint =
+        pointerStartPointRef.current ?? documentPointerStartPoint;
+      pointerStartPointRef.current = null;
+      documentPointerStartPoint = null;
+      if (pointerStartPoint === null) {
+        return;
+      }
+      const anchor = selectionAnchorFromPointerRelease(
+        pointerStartPoint,
+        event,
+      );
+      if (anchor === null) {
+        return;
+      }
+      lastPointerReleaseAnchorRef.current = anchor;
+      documentPointerReleaseAnchor = anchor;
+      if (currentLineRangeRef.current !== null) {
+        lastLineSelectionAnchorRef.current = anchor;
+      }
+    };
+    const handleDocumentPointerCancel = () => {
+      pointerStartPointRef.current = null;
+      documentPointerStartPoint = null;
+    };
+
+    document.addEventListener("pointerdown", handleDocumentPointerDown, true);
+    document.addEventListener("pointerup", handleDocumentPointerUp, true);
+    document.addEventListener(
+      "pointercancel",
+      handleDocumentPointerCancel,
+      true,
+    );
+    return () => {
+      document.removeEventListener(
+        "pointerdown",
+        handleDocumentPointerDown,
+        true,
+      );
+      document.removeEventListener("pointerup", handleDocumentPointerUp, true);
+      document.removeEventListener(
+        "pointercancel",
+        handleDocumentPointerCancel,
+        true,
+      );
+    };
+  }, [enabled]);
 
   const dismissSelection = useCallback(() => {
     setActiveRange(null);
     setPreviewRange(null);
     setActiveSelection(null);
+    currentLineRangeRef.current = null;
+    pointerStartPointRef.current = null;
+    lastPointerReleaseAnchorRef.current = null;
+    lastLineSelectionAnchorRef.current = null;
+    lastUtilityAnchorRef.current = null;
+    lineSelectionStartRangeRef.current = null;
+    documentPointerStartPoint = null;
+    documentPointerReleaseAnchor = null;
   }, []);
 
   const handleGutterUtilityClick = useCallback(
@@ -151,16 +471,45 @@ export function usePierreLineSelectionActions({
           range,
         }) ??
         "";
-      const pointerAnchorPoint = lastPointerAnchorPointRef.current;
-      const anchorPoint =
-        resolveAnchorPoint?.({
-          containerElement,
-          pointerAnchorPoint,
+      const pointerAnchor =
+        lastLineSelectionAnchorRef.current ??
+        lastPointerReleaseAnchorRef.current ??
+        documentPointerReleaseAnchor;
+      const interactionAnchor = pointerAnchor ?? lastUtilityAnchorRef.current;
+      const rangeAnchorSide =
+        anchorSideFromSelectionStart({
           range,
-        }) ?? pointerAnchorPoint;
+          startRange: lineSelectionStartRangeRef.current,
+        }) ?? anchorSideFromLineRange(range);
+      const anchorSide =
+        pointerAnchor?.side ??
+        rangeAnchorSide ??
+        lastUtilityAnchorRef.current?.side ??
+        "top";
+      const resolvedAnchorPoint =
+        resolveAnchorPoint?.({
+          anchorSide,
+          containerElement,
+          pointerAnchorPoint: interactionAnchor?.point ?? null,
+          range,
+        }) ??
+        resolveSelectedLineAnchorPoint({
+          anchorSide,
+          containerElement,
+        }) ??
+        resolveUtilityButtonAnchorPoint({
+          anchorSide,
+          containerElement,
+        }) ??
+        interactionAnchor?.point ??
+        null;
+      const anchor =
+        resolvedAnchorPoint === null
+          ? interactionAnchor
+          : { point: resolvedAnchorPoint, side: anchorSide };
       const selection = buildMenuSelection({
+        anchor,
         containerElement,
-        pointerAnchorPoint: anchorPoint,
         text: selectionText,
       });
       if (selection === null) {
@@ -168,9 +517,11 @@ export function usePierreLineSelectionActions({
         setActiveRange(null);
         setPreviewRange(null);
         setActiveSelection(null);
+        currentLineRangeRef.current = null;
         return;
       }
       suppressedSelectionEndRangeRef.current = null;
+      currentLineRangeRef.current = range;
       setActiveRange(range);
       setPreviewRange(range);
       setActiveSelection(selection);
@@ -190,6 +541,9 @@ export function usePierreLineSelectionActions({
         return;
       }
       suppressedSelectionEndRangeRef.current = null;
+      currentLineRangeRef.current = range;
+      lastLineSelectionAnchorRef.current = null;
+      lineSelectionStartRangeRef.current = range;
       setActiveRange(null);
       setActiveSelection(null);
       setPreviewRange(range);
@@ -203,6 +557,7 @@ export function usePierreLineSelectionActions({
         return;
       }
       suppressedSelectionEndRangeRef.current = null;
+      currentLineRangeRef.current = range;
       setPreviewRange(range);
     },
     [enabled],
@@ -220,8 +575,15 @@ export function usePierreLineSelectionActions({
         )
       ) {
         suppressedSelectionEndRangeRef.current = null;
+        currentLineRangeRef.current = null;
         setPreviewRange(null);
         return;
+      }
+      currentLineRangeRef.current = range;
+      const pointerAnchor =
+        lastPointerReleaseAnchorRef.current ?? documentPointerReleaseAnchor;
+      if (range !== null && pointerAnchor !== null) {
+        lastLineSelectionAnchorRef.current = pointerAnchor;
       }
       setPreviewRange(range);
     },
@@ -264,9 +626,9 @@ export function usePierreLineSelectionActions({
     onLineSelectionChange: handleLineSelectionChange,
     onLineSelectionEnd: handleLineSelectionEnd,
     onLineSelectionStart: handleLineSelectionStart,
-    onPointerDownCapture: capturePointerAnchorPoint,
-    onPointerMoveCapture: capturePointerAnchorPoint,
-    onPointerUpCapture: capturePointerAnchorPoint,
+    onPointerDownCapture: handlePointerDownCapture,
+    onPointerMoveCapture: handlePointerMoveCapture,
+    onPointerUpCapture: handlePointerUpCapture,
     selectedRange: activeRange ?? previewRange,
   };
 }

--- a/apps/app/src/components/git-diff/PierreLineSelectionActions.tsx
+++ b/apps/app/src/components/git-diff/PierreLineSelectionActions.tsx
@@ -1,0 +1,272 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import type { SelectedLineRange } from "@pierre/diffs";
+import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
+import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
+
+export interface PierreLineSelectionAnchorPoint {
+  x: number;
+  y: number;
+}
+
+export interface UsePierreLineSelectionActionsArgs {
+  buildFallbackSelectionText?: (args: {
+    containerElement: HTMLElement | null;
+    range: SelectedLineRange;
+  }) => string | null;
+  buildSelectionText: (range: SelectedLineRange) => string | null;
+  containerRef: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  onSelectionAddToChat?: (text: string) => void;
+  resolveAnchorPoint?: (args: {
+    containerElement: HTMLElement | null;
+    pointerAnchorPoint: PierreLineSelectionAnchorPoint | null;
+    range: SelectedLineRange;
+  }) => PierreLineSelectionAnchorPoint | null;
+}
+
+export interface PierreLineSelectionActions {
+  menu: ReactNode;
+  onLineSelectionChange: (range: SelectedLineRange | null) => void;
+  onLineSelectionEnd: (range: SelectedLineRange | null) => void;
+  onLineSelectionStart: (range: SelectedLineRange | null) => void;
+  onGutterUtilityClick: (range: SelectedLineRange) => void;
+  onPointerDownCapture: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerMoveCapture: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerUpCapture: (event: ReactPointerEvent<HTMLElement>) => void;
+  selectedRange: SelectedLineRange | null;
+}
+
+function anchorPointFromPointerEvent(
+  event: Pick<ReactPointerEvent<HTMLElement>, "clientX" | "clientY">,
+): PierreLineSelectionAnchorPoint | null {
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+    return null;
+  }
+  return { x: event.clientX, y: event.clientY };
+}
+
+function fallbackAnchorPoint(
+  containerElement: HTMLElement | null,
+): PierreLineSelectionAnchorPoint {
+  const rect = containerElement?.getBoundingClientRect();
+  if (!rect) {
+    return { x: 0, y: 0 };
+  }
+  return { x: rect.left + 24, y: rect.top + 24 };
+}
+
+function buildMenuSelection({
+  containerElement,
+  pointerAnchorPoint,
+  text,
+}: {
+  containerElement: HTMLElement | null;
+  pointerAnchorPoint: PierreLineSelectionAnchorPoint | null;
+  text: string;
+}): MessageProseSelection | null {
+  const trimmedText = text.trim();
+  if (trimmedText.length === 0) {
+    return null;
+  }
+
+  const anchorPoint =
+    pointerAnchorPoint ?? fallbackAnchorPoint(containerElement);
+  return {
+    text: trimmedText,
+    rect: new DOMRect(anchorPoint.x, anchorPoint.y, 0, 0),
+    anchorPoint,
+    anchorSide: "top",
+  };
+}
+
+function areSelectedLineRangesEqual(
+  first: SelectedLineRange | null,
+  second: SelectedLineRange | null,
+) {
+  if (first === second) {
+    return true;
+  }
+  if (first === null || second === null) {
+    return false;
+  }
+  return (
+    first.start === second.start &&
+    first.end === second.end &&
+    first.side === second.side &&
+    first.endSide === second.endSide
+  );
+}
+
+export function usePierreLineSelectionActions({
+  buildFallbackSelectionText,
+  buildSelectionText,
+  containerRef,
+  enabled,
+  onSelectionAddToChat,
+  resolveAnchorPoint,
+}: UsePierreLineSelectionActionsArgs): PierreLineSelectionActions {
+  const [activeRange, setActiveRange] = useState<SelectedLineRange | null>(
+    null,
+  );
+  const [previewRange, setPreviewRange] = useState<SelectedLineRange | null>(
+    null,
+  );
+  const [activeSelection, setActiveSelection] =
+    useState<MessageProseSelection | null>(null);
+  const lastPointerAnchorPointRef =
+    useRef<PierreLineSelectionAnchorPoint | null>(null);
+  const suppressedSelectionEndRangeRef = useRef<SelectedLineRange | null>(null);
+
+  const capturePointerAnchorPoint = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      lastPointerAnchorPointRef.current = anchorPointFromPointerEvent(event);
+    },
+    [],
+  );
+
+  const dismissSelection = useCallback(() => {
+    setActiveRange(null);
+    setPreviewRange(null);
+    setActiveSelection(null);
+  }, []);
+
+  const handleGutterUtilityClick = useCallback(
+    (range: SelectedLineRange) => {
+      if (!enabled) {
+        return;
+      }
+      const containerElement = containerRef.current;
+      const selectionText =
+        buildSelectionText(range) ??
+        buildFallbackSelectionText?.({
+          containerElement,
+          range,
+        }) ??
+        "";
+      const pointerAnchorPoint = lastPointerAnchorPointRef.current;
+      const anchorPoint =
+        resolveAnchorPoint?.({
+          containerElement,
+          pointerAnchorPoint,
+          range,
+        }) ?? pointerAnchorPoint;
+      const selection = buildMenuSelection({
+        containerElement,
+        pointerAnchorPoint: anchorPoint,
+        text: selectionText,
+      });
+      if (selection === null) {
+        suppressedSelectionEndRangeRef.current = range;
+        setActiveRange(null);
+        setPreviewRange(null);
+        setActiveSelection(null);
+        return;
+      }
+      suppressedSelectionEndRangeRef.current = null;
+      setActiveRange(range);
+      setPreviewRange(range);
+      setActiveSelection(selection);
+    },
+    [
+      buildFallbackSelectionText,
+      buildSelectionText,
+      containerRef,
+      enabled,
+      resolveAnchorPoint,
+    ],
+  );
+
+  const handleLineSelectionStart = useCallback(
+    (range: SelectedLineRange | null) => {
+      if (!enabled) {
+        return;
+      }
+      suppressedSelectionEndRangeRef.current = null;
+      setActiveRange(null);
+      setActiveSelection(null);
+      setPreviewRange(range);
+    },
+    [enabled],
+  );
+
+  const handleLineSelectionChange = useCallback(
+    (range: SelectedLineRange | null) => {
+      if (!enabled) {
+        return;
+      }
+      suppressedSelectionEndRangeRef.current = null;
+      setPreviewRange(range);
+    },
+    [enabled],
+  );
+
+  const handleLineSelectionEnd = useCallback(
+    (range: SelectedLineRange | null) => {
+      if (!enabled) {
+        return;
+      }
+      if (
+        areSelectedLineRangesEqual(
+          range,
+          suppressedSelectionEndRangeRef.current,
+        )
+      ) {
+        suppressedSelectionEndRangeRef.current = null;
+        setPreviewRange(null);
+        return;
+      }
+      setPreviewRange(range);
+    },
+    [enabled],
+  );
+
+  const handleSelectionAddToChat = useCallback(
+    (text: string) => {
+      onSelectionAddToChat?.(text);
+      dismissSelection();
+    },
+    [dismissSelection, onSelectionAddToChat],
+  );
+
+  const menu = useMemo(
+    () =>
+      enabled ? (
+        <TimelineSelectionMenu
+          selection={activeSelection}
+          onAddToChat={
+            onSelectionAddToChat === undefined
+              ? undefined
+              : handleSelectionAddToChat
+          }
+          onDismiss={dismissSelection}
+        />
+      ) : null,
+    [
+      activeSelection,
+      dismissSelection,
+      enabled,
+      handleSelectionAddToChat,
+      onSelectionAddToChat,
+    ],
+  );
+
+  return {
+    menu,
+    onGutterUtilityClick: handleGutterUtilityClick,
+    onLineSelectionChange: handleLineSelectionChange,
+    onLineSelectionEnd: handleLineSelectionEnd,
+    onLineSelectionStart: handleLineSelectionStart,
+    onPointerDownCapture: capturePointerAnchorPoint,
+    onPointerMoveCapture: capturePointerAnchorPoint,
+    onPointerUpCapture: capturePointerAnchorPoint,
+    selectedRange: activeRange ?? previewRange,
+  };
+}

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -1,5 +1,6 @@
 import {
   type CSSProperties,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -10,9 +11,8 @@ import type { FileOptions } from "@pierre/diffs/react";
 import type { SelectedLineRange, SupportedLanguages } from "@pierre/diffs";
 import type { UrlTransform } from "react-markdown";
 import { Button } from "@/components/ui/button.js";
-import {
-  COARSE_POINTER_TEXT_SM_CLASS,
-} from "@/components/ui/coarse-pointer-sizing.js";
+import { usePierreLineSelectionActions } from "@/components/git-diff/PierreLineSelectionActions.js";
+import { COARSE_POINTER_TEXT_SM_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
 import { CopyButton } from "@/components/ui/copy-button.js";
 import { Icon } from "@/components/ui/icon.js";
@@ -39,6 +39,7 @@ import {
   type CodeOverflowModeChangeHandler,
 } from "@/lib/code-overflow-mode";
 import { cn } from "@/lib/utils";
+import { SecondaryPanelSelectionActions } from "./SecondaryPanelSelectionActions.js";
 
 export interface FilePreviewFile {
   cacheKey?: string;
@@ -82,6 +83,7 @@ export interface FilePreviewProps {
   path: string;
   copyPath?: string | null;
   headerMode?: FilePreviewHeaderMode;
+  onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
   markdownLinkRouting?: MarkdownLinkRouting;
   statusLabel?: WorkspaceFilePreviewStatusLabel | null;
@@ -93,10 +95,12 @@ interface FilePreviewBodyProps {
   lineOverflowMode: CodeOverflowMode;
   viewMode: FilePreviewViewMode;
   markdownLinkRouting?: MarkdownLinkRouting;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 interface HtmlFilePreviewBodyProps {
   lineOverflowMode: CodeOverflowMode;
+  onSelectionAddToChat?: (text: string) => void;
   state: Extract<FilePreviewState, { kind: "html" }>;
   viewMode: FilePreviewViewMode;
 }
@@ -128,6 +132,7 @@ interface FilePreviewPathProps {
 
 interface MarkdownFilePreviewProps {
   file: FilePreviewFile;
+  onSelectionAddToChat?: (text: string) => void;
   urlTransform?: UrlTransform;
   markdownLinkRouting?: MarkdownLinkRouting;
 }
@@ -151,6 +156,8 @@ interface FilePreviewCodeProps {
   file: FilePreviewFile;
   lineOverflowMode: CodeOverflowMode;
   lineRange: FilePreviewLineRange | null;
+  onSelectionAddToChat?: (text: string) => void;
+  path: string;
 }
 
 interface FilePreviewWorkerPoolStats {
@@ -292,6 +299,7 @@ export function FilePreview({
   path,
   copyPath = null,
   headerMode = "file",
+  onSelectionAddToChat,
   onOpenInEditor,
   markdownLinkRouting,
   statusLabel = null,
@@ -370,6 +378,7 @@ export function FilePreview({
         lineOverflowMode={lineOverflowMode}
         viewMode={bodyViewMode}
         markdownLinkRouting={markdownLinkRouting}
+        onSelectionAddToChat={onSelectionAddToChat}
       />
     </div>
   );
@@ -381,6 +390,7 @@ function FilePreviewBody({
   lineOverflowMode,
   viewMode,
   markdownLinkRouting,
+  onSelectionAddToChat,
 }: FilePreviewBodyProps) {
   if (state.kind === "loading") {
     return <FilePreviewLoading />;
@@ -418,6 +428,7 @@ function FilePreviewBody({
     return (
       <HtmlFilePreviewBody
         lineOverflowMode={lineOverflowMode}
+        onSelectionAddToChat={onSelectionAddToChat}
         state={state}
         viewMode={viewMode}
       />
@@ -429,6 +440,7 @@ function FilePreviewBody({
         file={state.file}
         urlTransform={state.markdownUrlTransform}
         markdownLinkRouting={markdownLinkRouting}
+        onSelectionAddToChat={onSelectionAddToChat}
       />
     );
   }
@@ -437,6 +449,8 @@ function FilePreviewBody({
       file={state.file}
       lineOverflowMode={lineOverflowMode}
       lineRange={state.lineRange ?? null}
+      onSelectionAddToChat={onSelectionAddToChat}
+      path={path}
     />
   );
 }
@@ -497,9 +511,7 @@ function FilePreviewHeader({
             {onOpenInEditor ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <OpenInEditorButton
-                    onClick={() => onOpenInEditor(path)}
-                  />
+                  <OpenInEditorButton onClick={() => onOpenInEditor(path)} />
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Open in editor</TooltipContent>
               </Tooltip>
@@ -631,6 +643,7 @@ function FilePreviewLineWrapButton({
 
 function HtmlFilePreviewBody({
   lineOverflowMode,
+  onSelectionAddToChat,
   state,
   viewMode,
 }: HtmlFilePreviewBodyProps) {
@@ -655,6 +668,8 @@ function HtmlFilePreviewBody({
           file={state.file}
           lineOverflowMode={lineOverflowMode}
           lineRange={state.lineRange}
+          onSelectionAddToChat={onSelectionAddToChat}
+          path={state.file.name}
         />
       </div>
     </>
@@ -663,6 +678,7 @@ function HtmlFilePreviewBody({
 
 function MarkdownFilePreview({
   file,
+  onSelectionAddToChat,
   urlTransform,
   markdownLinkRouting,
 }: MarkdownFilePreviewProps) {
@@ -671,14 +687,19 @@ function MarkdownFilePreview({
     // viewer reads as a distinct surface from the white chat — one tonal step
     // lighter than the recessed header (matching the raised-body / recessed-
     // header pairing used elsewhere in this panel).
-    <div className="flex-auto bg-surface-raised px-4 py-4">
-      <MarkdownPreview
-        allowHtml
-        content={file.contents}
-        urlTransform={urlTransform}
-        linkRouting={markdownLinkRouting}
-      />
-    </div>
+    <SecondaryPanelSelectionActions
+      className="contents"
+      onSelectionAddToChat={onSelectionAddToChat}
+    >
+      <div className="flex-auto bg-surface-raised px-4 py-4">
+        <MarkdownPreview
+          allowHtml
+          content={file.contents}
+          urlTransform={urlTransform}
+          linkRouting={markdownLinkRouting}
+        />
+      </div>
+    </SecondaryPanelSelectionActions>
   );
 }
 
@@ -790,6 +811,38 @@ function findPreviewTargetLine(
   return null;
 }
 
+function formatLineRange(startLineNumber: number, endLineNumber: number) {
+  return startLineNumber === endLineNumber
+    ? String(startLineNumber)
+    : `${startLineNumber}-${endLineNumber}`;
+}
+
+function buildFilePreviewLineSelectionText({
+  contents,
+  path,
+  range,
+}: {
+  contents: string;
+  path: string;
+  range: SelectedLineRange;
+}): string | null {
+  const startLineNumber = Math.max(1, Math.min(range.start, range.end));
+  const endLineNumber = Math.max(
+    startLineNumber,
+    Math.max(range.start, range.end),
+  );
+  const lines = contents.split(/\r\n|\n|\r/);
+  const selectedLines = lines.slice(startLineNumber - 1, endLineNumber);
+  if (selectedLines.length === 0) {
+    return null;
+  }
+  const selectedText = selectedLines.join("\n").trimEnd();
+  if (selectedText.trim().length === 0) {
+    return null;
+  }
+  return `${path}:${formatLineRange(startLineNumber, endLineNumber)}\n${selectedText}`;
+}
+
 function FilePreviewLoading() {
   return (
     <div className="space-y-2 px-4 pt-4" aria-busy>
@@ -815,6 +868,8 @@ function FilePreviewCode({
   file,
   lineOverflowMode,
   lineRange,
+  onSelectionAddToChat,
+  path,
 }: FilePreviewCodeProps) {
   const preferredTheme = usePreferredTheme();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -823,25 +878,61 @@ function FilePreviewCode({
   const [workerPoolStats, setWorkerPoolStats] =
     useState<FilePreviewWorkerPoolStats | null>(null);
   const [, rerenderAfterWorkerPoolChange] = useState(0);
+  const buildSelectionText = useCallback(
+    (range: SelectedLineRange) =>
+      buildFilePreviewLineSelectionText({
+        contents: file.contents,
+        path,
+        range,
+      }),
+    [file.contents, path],
+  );
+  const lineSelectionActions = usePierreLineSelectionActions({
+    buildSelectionText,
+    containerRef,
+    enabled: onSelectionAddToChat !== undefined,
+    onSelectionAddToChat,
+  });
   const options = useMemo<FileOptions<undefined>>(
     () => ({
       themeType: preferredTheme,
       overflow: lineOverflowMode,
       disableFileHeader: true,
-      enableLineSelection: lineRange !== null,
+      enableGutterUtility: onSelectionAddToChat !== undefined,
+      enableLineSelection:
+        lineRange !== null || onSelectionAddToChat !== undefined,
+      lineHoverHighlight:
+        onSelectionAddToChat === undefined ? "disabled" : "number",
+      onGutterUtilityClick:
+        onSelectionAddToChat === undefined
+          ? undefined
+          : lineSelectionActions.onGutterUtilityClick,
+      onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
+      onLineSelectionEnd: lineSelectionActions.onLineSelectionEnd,
+      onLineSelectionStart: lineSelectionActions.onLineSelectionStart,
     }),
-    [lineOverflowMode, lineRange, preferredTheme],
+    [
+      lineOverflowMode,
+      lineRange,
+      lineSelectionActions.onGutterUtilityClick,
+      lineSelectionActions.onLineSelectionChange,
+      lineSelectionActions.onLineSelectionEnd,
+      lineSelectionActions.onLineSelectionStart,
+      onSelectionAddToChat,
+      preferredTheme,
+    ],
   );
-  const selectedLines = useMemo<SelectedLineRange | null>(
-    () =>
-      lineRange === null
-        ? null
-        : {
-            start: lineRange.startLineNumber,
-            end: lineRange.endLineNumber,
-          },
-    [lineRange],
-  );
+  const selectedLines = useMemo<SelectedLineRange | null>(() => {
+    if (lineSelectionActions.selectedRange !== null) {
+      return lineSelectionActions.selectedRange;
+    }
+    return lineRange === null
+      ? null
+      : {
+          start: lineRange.startLineNumber,
+          end: lineRange.endLineNumber,
+        };
+  }, [lineRange, lineSelectionActions.selectedRange]);
   const targetLineNumber = selectedLines?.start ?? null;
 
   useEffect(() => {
@@ -879,7 +970,9 @@ function FilePreviewCode({
   // once the cache entry for this exact file appears so syntax highlighting
   // replaces the plain-text fallback.
   const workerHighlightCacheState =
-    workerPool?.getFileResultCache(file) !== undefined ? "highlighted" : "plain";
+    workerPool?.getFileResultCache(file) !== undefined
+      ? "highlighted"
+      : "plain";
 
   useEffect(() => {
     const cleanupContainer = containerRef.current;
@@ -939,6 +1032,9 @@ function FilePreviewCode({
       className="min-h-0 flex-auto"
       style={FILE_PREVIEW_VIEW_STYLE}
       data-file-preview-line-number={targetLineNumber ?? undefined}
+      onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
+      onPointerMoveCapture={lineSelectionActions.onPointerMoveCapture}
+      onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
     >
       <PierreFile
         key={`${file.cacheKey ?? file.name}:${workerHighlightCacheState}`}
@@ -947,6 +1043,7 @@ function FilePreviewCode({
         options={options}
         selectedLines={selectedLines}
       />
+      {lineSelectionActions.menu}
     </div>
   );
 }

--- a/apps/app/src/components/secondary-panel/SecondaryPanelSelectionActions.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelSelectionActions.tsx
@@ -1,0 +1,268 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
+import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
+import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
+
+interface SecondaryPanelSelectionActionsProps {
+  children: ReactNode;
+  className?: string;
+  onSelectionAddToChat?: (text: string) => void;
+}
+
+interface SelectionAnchorPoint {
+  x: number;
+  y: number;
+}
+
+interface SelectionAnchor {
+  point: SelectionAnchorPoint;
+  side: "top" | "bottom";
+}
+
+const SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
+
+function firstClientRect(range: Range): DOMRect | null {
+  const rects = range.getClientRects();
+  for (let index = 0; index < rects.length; index += 1) {
+    const rect = rects.item(index);
+    if (rect === null) {
+      continue;
+    }
+    if (rect.width > 0 || rect.height > 0) {
+      return rect;
+    }
+  }
+  const rect = range.getBoundingClientRect();
+  return rect.width > 0 || rect.height > 0 ? rect : null;
+}
+
+function anchorPointFromMouseEvent(
+  event: Pick<MouseEvent, "clientX" | "clientY">,
+): SelectionAnchorPoint | null {
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+    return null;
+  }
+  return { x: event.clientX, y: event.clientY };
+}
+
+function selectionAnchorFromPointerRelease(
+  startPoint: SelectionAnchorPoint | null,
+  releaseEvent: Pick<MouseEvent, "clientX" | "clientY">,
+): SelectionAnchor | null {
+  const releasePoint = anchorPointFromMouseEvent(releaseEvent);
+  if (releasePoint === null) {
+    return null;
+  }
+
+  return {
+    point: releasePoint,
+    side:
+      startPoint !== null &&
+      releasePoint.y - startPoint.y > SELECTION_DRAG_DIRECTION_THRESHOLD_PX
+        ? "bottom"
+        : "top",
+  };
+}
+
+function isEventTargetWithinNode(
+  event: Event,
+  node: HTMLElement | null,
+): boolean {
+  if (node === null || !(event.target instanceof Node)) return false;
+  return node.contains(event.target);
+}
+
+function selectionRangeTouchesNode(range: Range, node: HTMLElement): boolean {
+  const { commonAncestorContainer } = range;
+  if (node.contains(commonAncestorContainer)) {
+    return true;
+  }
+  if (
+    typeof range.intersectsNode === "function" &&
+    (() => {
+      try {
+        return range.intersectsNode(node);
+      } catch {
+        return false;
+      }
+    })()
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function readSelectionWithinPanel({
+  anchor,
+  node,
+  pointerStartedInNode,
+}: {
+  anchor: SelectionAnchor | null;
+  node: HTMLElement | null;
+  pointerStartedInNode: boolean;
+}): MessageProseSelection | null {
+  if (node === null || typeof window === "undefined") return null;
+
+  const selection = window.getSelection();
+  if (
+    selection === null ||
+    selection.rangeCount === 0 ||
+    selection.isCollapsed
+  ) {
+    return null;
+  }
+
+  const text = selection.toString().trim();
+  if (text.length === 0) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!pointerStartedInNode && !selectionRangeTouchesNode(range, node)) {
+    return null;
+  }
+
+  const selectionAnchor = anchor ?? null;
+  const rect =
+    firstClientRect(range) ??
+    (selectionAnchor === null
+      ? node.getBoundingClientRect()
+      : new DOMRect(selectionAnchor.point.x, selectionAnchor.point.y, 0, 0));
+  const nextSelection: MessageProseSelection = { text, rect };
+  if (selectionAnchor !== null) {
+    nextSelection.anchorPoint = selectionAnchor.point;
+    nextSelection.anchorSide = selectionAnchor.side;
+  }
+  return nextSelection;
+}
+
+export function SecondaryPanelSelectionActions({
+  children,
+  className,
+  onSelectionAddToChat,
+}: SecondaryPanelSelectionActionsProps) {
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const pointerStartedInNodeRef = useRef(false);
+  const pointerStartPointRef = useRef<SelectionAnchorPoint | null>(null);
+  const pointerIsDownRef = useRef(false);
+  const lastPointerReleaseAnchorRef = useRef<SelectionAnchor | null>(null);
+  const isPointerCoarse = usePointerCoarse();
+  const [selection, setSelection] = useState<MessageProseSelection | null>(
+    null,
+  );
+  const isEnabled = !isPointerCoarse;
+
+  const dismissSelection = useCallback(() => {
+    setSelection(null);
+  }, []);
+
+  const reportSelection = useCallback((anchor: SelectionAnchor | null) => {
+    setSelection(
+      readSelectionWithinPanel({
+        anchor,
+        node: nodeRef.current,
+        pointerStartedInNode: pointerStartedInNodeRef.current,
+      }),
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!isEnabled || typeof window === "undefined") return;
+
+    let frame: number | null = null;
+    const cancelFrame = () => {
+      if (frame === null) return;
+      window.cancelAnimationFrame(frame);
+      frame = null;
+    };
+    const scheduleReport = (anchor: SelectionAnchor | null = null) => {
+      cancelFrame();
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        reportSelection(anchor);
+      });
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      cancelFrame();
+      pointerStartedInNodeRef.current = isEventTargetWithinNode(
+        event,
+        nodeRef.current,
+      );
+      pointerStartPointRef.current = pointerStartedInNodeRef.current
+        ? anchorPointFromMouseEvent(event)
+        : null;
+      pointerIsDownRef.current = true;
+    };
+    const handlePointerRelease = (event: PointerEvent | MouseEvent) => {
+      const anchor = pointerStartedInNodeRef.current
+        ? selectionAnchorFromPointerRelease(pointerStartPointRef.current, event)
+        : null;
+      if (anchor !== null) {
+        lastPointerReleaseAnchorRef.current = anchor;
+      }
+      pointerIsDownRef.current = false;
+      pointerStartPointRef.current = null;
+      scheduleReport(anchor);
+    };
+    const handlePointerCancel = () => {
+      pointerIsDownRef.current = false;
+      pointerStartPointRef.current = null;
+      scheduleReport(lastPointerReleaseAnchorRef.current);
+    };
+    const handleSelectionChange = () => {
+      if (pointerIsDownRef.current) {
+        return;
+      }
+      scheduleReport(lastPointerReleaseAnchorRef.current);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("pointerup", handlePointerRelease);
+    document.addEventListener("pointercancel", handlePointerCancel);
+    document.addEventListener("mouseup", handlePointerRelease);
+    document.addEventListener("selectionchange", handleSelectionChange);
+    document.addEventListener("keyup", handleSelectionChange);
+    return () => {
+      cancelFrame();
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("pointerup", handlePointerRelease);
+      document.removeEventListener("pointercancel", handlePointerCancel);
+      document.removeEventListener("mouseup", handlePointerRelease);
+      document.removeEventListener("selectionchange", handleSelectionChange);
+      document.removeEventListener("keyup", handleSelectionChange);
+    };
+  }, [isEnabled, reportSelection]);
+
+  const handleAddToChat = useCallback(
+    (text: string) => {
+      onSelectionAddToChat?.(text);
+      setSelection(null);
+    },
+    [onSelectionAddToChat],
+  );
+
+  if (!isEnabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      <div ref={nodeRef} className={className}>
+        {children}
+      </div>
+      <TimelineSelectionMenu
+        selection={selection}
+        onAddToChat={
+          onSelectionAddToChat === undefined ? undefined : handleAddToChat
+        }
+        onDismiss={dismissSelection}
+      />
+    </>
+  );
+}

--- a/apps/app/src/components/secondary-panel/SecondaryPanelSelectionActions.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelSelectionActions.tsx
@@ -6,7 +6,13 @@ import {
   type ReactNode,
 } from "react";
 import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
-import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
+import {
+  anchorPointFromMouseEvent,
+  selectionAnchorFromPointerRelease,
+  type MessageProseSelection,
+  type SelectionAnchor,
+  type SelectionAnchorPoint,
+} from "@/components/thread/timeline/SelectableMessageProse.js";
 import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
 
 interface SecondaryPanelSelectionActionsProps {
@@ -14,18 +20,6 @@ interface SecondaryPanelSelectionActionsProps {
   className?: string;
   onSelectionAddToChat?: (text: string) => void;
 }
-
-interface SelectionAnchorPoint {
-  x: number;
-  y: number;
-}
-
-interface SelectionAnchor {
-  point: SelectionAnchorPoint;
-  side: "top" | "bottom";
-}
-
-const SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
 
 function firstClientRect(range: Range): DOMRect | null {
   const rects = range.getClientRects();
@@ -40,34 +34,6 @@ function firstClientRect(range: Range): DOMRect | null {
   }
   const rect = range.getBoundingClientRect();
   return rect.width > 0 || rect.height > 0 ? rect : null;
-}
-
-function anchorPointFromMouseEvent(
-  event: Pick<MouseEvent, "clientX" | "clientY">,
-): SelectionAnchorPoint | null {
-  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
-    return null;
-  }
-  return { x: event.clientX, y: event.clientY };
-}
-
-function selectionAnchorFromPointerRelease(
-  startPoint: SelectionAnchorPoint | null,
-  releaseEvent: Pick<MouseEvent, "clientX" | "clientY">,
-): SelectionAnchor | null {
-  const releasePoint = anchorPointFromMouseEvent(releaseEvent);
-  if (releasePoint === null) {
-    return null;
-  }
-
-  return {
-    point: releasePoint,
-    side:
-      startPoint !== null &&
-      releasePoint.y - startPoint.y > SELECTION_DRAG_DIRECTION_THRESHOLD_PX
-        ? "bottom"
-        : "top",
-  };
 }
 
 function isEventTargetWithinNode(
@@ -200,15 +166,19 @@ export function SecondaryPanelSelectionActions({
       pointerIsDownRef.current = true;
     };
     const handlePointerRelease = (event: PointerEvent | MouseEvent) => {
-      const anchor = pointerStartedInNodeRef.current
-        ? selectionAnchorFromPointerRelease(pointerStartPointRef.current, event)
-        : null;
+      const anchor =
+        pointerStartedInNodeRef.current && pointerStartPointRef.current !== null
+          ? selectionAnchorFromPointerRelease(
+              pointerStartPointRef.current,
+              event,
+            )
+          : null;
       if (anchor !== null) {
         lastPointerReleaseAnchorRef.current = anchor;
       }
       pointerIsDownRef.current = false;
       pointerStartPointRef.current = null;
-      scheduleReport(anchor);
+      scheduleReport(anchor ?? lastPointerReleaseAnchorRef.current);
     };
     const handlePointerCancel = () => {
       pointerIsDownRef.current = false;

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -136,6 +136,7 @@ export interface ThreadSecondaryPanelProps {
   workspaceRootPath?: string | null;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
+  onSelectionAddToChat?: (text: string) => void;
   /**
    * When true the conversation pane is collapsed: this panel expands to fill
    * the content area (its max size is lifted). Always false in the
@@ -217,6 +218,7 @@ export function ThreadSecondaryPanel({
   workspaceRootPath,
   onOpenFileInEditor,
   onOpenFilePreview,
+  onSelectionAddToChat,
   isConversationCollapsed,
   onToggleConversationCollapse,
   reserveLeftForDesktopTrafficLights,
@@ -521,6 +523,7 @@ export function ThreadSecondaryPanel({
             gitDiffViewOptions={gitDiffViewOptions}
             onOpenFileInEditor={onOpenFileInEditor}
             onOpenFilePreview={onOpenFilePreview}
+            onSelectionAddToChat={onSelectionAddToChat}
             workspaceRootPath={workspaceRootPath}
           />
         ) : (

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -48,6 +48,7 @@ export interface GitDiffTabContentProps {
   gitDiffViewOptions: Record<string, string | boolean | number>;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
+  onSelectionAddToChat?: (text: string) => void;
   workspaceRootPath?: string | null;
 }
 
@@ -61,6 +62,7 @@ export interface WorkspaceFilePreviewTabContentProps {
   environmentId?: string | null;
   lineRange: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
+  onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
   source: EnvironmentFilePreviewSource | null;
   statusLabel: WorkspaceFilePreviewStatusLabel | null;
@@ -71,6 +73,7 @@ export interface ProjectFilePreviewTabContentProps {
   activePath: string;
   copyPath?: string | null;
   lineRange: FilePreviewLineRange | null;
+  onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
   projectId: string;
 }
@@ -81,6 +84,7 @@ export interface HostFilePreviewTabContentProps {
   environmentId?: string | null;
   lineRange: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
+  onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
   threadId: string;
 }
@@ -90,6 +94,7 @@ export interface ThreadStorageFilePreviewTabContentProps {
   copyPath?: string | null;
   lineRange: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
+  onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
   threadId: string;
 }
@@ -140,6 +145,7 @@ export function GitDiffTabContent({
   gitDiffViewOptions,
   onOpenFileInEditor,
   onOpenFilePreview,
+  onSelectionAddToChat,
   workspaceRootPath,
 }: GitDiffTabContentProps) {
   const isQueryEnabled =
@@ -230,9 +236,7 @@ export function GitDiffTabContent({
       <div className={cn(PANEL_SCROLL_SLOT_CLASS, "px-4 pb-3")}>
         <div className="rounded-lg border border-border bg-surface-raised px-3 py-2 text-xs text-muted-foreground">
           <p className="font-medium text-foreground">Workspace unavailable</p>
-          <p className="mt-1 leading-5">
-            {diffFilesResponse.failure.message}
-          </p>
+          <p className="mt-1 leading-5">{diffFilesResponse.failure.message}</p>
         </div>
       </div>
     );
@@ -286,6 +290,7 @@ export function GitDiffTabContent({
       onOpenFileInEditor={onOpenFileInEditor}
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
+      onSelectionAddToChat={onSelectionAddToChat}
     />
   );
 }
@@ -304,6 +309,7 @@ export function WorkspaceFilePreviewTabContent({
   environmentId,
   lineRange,
   markdownLinkRouting,
+  onSelectionAddToChat,
   onOpenInEditor,
   source,
   statusLabel,
@@ -329,6 +335,7 @@ export function WorkspaceFilePreviewTabContent({
       isLoading={isWorkspaceFilePreviewLoading}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
+      onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       statusLabel={statusLabel}
     />
@@ -339,6 +346,7 @@ export function ProjectFilePreviewTabContent({
   activePath,
   copyPath = null,
   lineRange,
+  onSelectionAddToChat,
   onOpenInEditor,
   projectId,
 }: ProjectFilePreviewTabContentProps) {
@@ -356,6 +364,7 @@ export function ProjectFilePreviewTabContent({
       filePreview={projectFilePreview}
       isLoading={isProjectFilePreviewLoading}
       lineRange={lineRange}
+      onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       statusLabel={null}
     />
@@ -368,6 +377,7 @@ export function HostFilePreviewTabContent({
   environmentId,
   lineRange,
   markdownLinkRouting,
+  onSelectionAddToChat,
   onOpenInEditor,
   threadId,
 }: HostFilePreviewTabContentProps) {
@@ -387,6 +397,7 @@ export function HostFilePreviewTabContent({
       isLoading={isHostFilePreviewLoading}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
+      onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       statusLabel={null}
     />
@@ -398,6 +409,7 @@ export function ThreadStorageFilePreviewTabContent({
   copyPath = null,
   lineRange,
   markdownLinkRouting,
+  onSelectionAddToChat,
   onOpenInEditor,
   threadId,
 }: ThreadStorageFilePreviewTabContentProps) {
@@ -416,6 +428,7 @@ export function ThreadStorageFilePreviewTabContent({
       isLoading={isThreadStorageFilePreviewLoading}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
+      onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       threadId={threadId}
     />

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -26,6 +26,7 @@ interface FilePreviewBaseProps {
   isLoading: boolean;
   lineRange?: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
+  onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
 }
 
@@ -87,6 +88,7 @@ export function SecondaryPanelFilePreview({
   isLoading,
   lineRange = null,
   markdownLinkRouting,
+  onSelectionAddToChat,
   onOpenInEditor,
   statusLabel = null,
 }: SecondaryPanelFilePreviewProps) {
@@ -96,6 +98,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{ kind: isNotFound ? "not-found" : "error" }}
@@ -108,6 +111,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{ kind: "loading" }}
@@ -121,6 +125,7 @@ export function SecondaryPanelFilePreview({
         <FilePreviewSurface
           path={activePath}
           copyPath={copyPath}
+          onSelectionAddToChat={onSelectionAddToChat}
           onOpenInEditor={onOpenInEditor}
           statusLabel={statusLabel}
           state={{
@@ -137,6 +142,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{
@@ -159,6 +165,7 @@ export function SecondaryPanelFilePreview({
         <FilePreviewSurface
           path={activePath}
           copyPath={copyPath}
+          onSelectionAddToChat={onSelectionAddToChat}
           onOpenInEditor={onOpenInEditor}
           statusLabel={statusLabel}
           state={{ kind: "empty" }}
@@ -169,6 +176,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         markdownLinkRouting={markdownLinkRouting}
         statusLabel={statusLabel}
@@ -187,6 +195,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{ kind: "image", url: filePreview.url }}
@@ -199,6 +208,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         statusLabel={statusLabel}
         state={{ kind: "video", url: filePreview.url }}
@@ -210,6 +220,7 @@ export function SecondaryPanelFilePreview({
     <FilePreviewSurface
       path={activePath}
       copyPath={copyPath}
+      onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       statusLabel={statusLabel}
       state={{
@@ -228,6 +239,7 @@ export function ThreadStorageFilePreview({
   isLoading,
   lineRange,
   markdownLinkRouting,
+  onSelectionAddToChat,
   onOpenInEditor,
   threadId,
 }: ThreadStorageFilePreviewProps) {
@@ -241,6 +253,7 @@ export function ThreadStorageFilePreview({
       isLoading={isLoading}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
+      onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
     />
   );

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -107,13 +107,9 @@ function buildBinaryImagePreviewPlan(
   }
   const previousPath = entry.previousPath ?? entry.path;
   const oldSource: BinaryImagePreviewSource | null =
-    entry.changeKind === "added"
-      ? null
-      : { path: previousPath, side: "old" };
+    entry.changeKind === "added" ? null : { path: previousPath, side: "old" };
   const newSource: BinaryImagePreviewSource | null =
-    entry.changeKind === "deleted"
-      ? null
-      : { path: entry.path, side: "new" };
+    entry.changeKind === "deleted" ? null : { path: entry.path, side: "new" };
   return {
     identity: `${entry.changeKind}:${oldSource?.path ?? ""}:${
       newSource?.path ?? ""
@@ -138,6 +134,7 @@ export interface DiffFileCardProps {
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 /**
@@ -186,6 +183,7 @@ function areDiffFileCardPropsEqual(
     previous.onOpenFileInEditor === next.onOpenFileInEditor &&
     previous.onOpenFilePreview === next.onOpenFilePreview &&
     previous.onRequestFileContents === next.onRequestFileContents &&
+    previous.onSelectionAddToChat === next.onSelectionAddToChat &&
     arePatchStatesEqual(previous.patchState, next.patchState)
   );
 }
@@ -287,6 +285,7 @@ export const DiffFileCard = memo(function DiffFileCard({
   onOpenFileInEditor,
   onOpenFilePreview,
   onRequestFileContents,
+  onSelectionAddToChat,
 }: DiffFileCardProps) {
   const headerModel = useMemo(() => buildDiffEntryHeaderModel(entry), [entry]);
   // The single file's patch, parsed only once it has loaded. The patch hook
@@ -409,6 +408,7 @@ export const DiffFileCard = memo(function DiffFileCard({
           onRetry={onRetry}
           onOpenFilePreview={onOpenFilePreview}
           onRequestFileContents={onRequestFileContents}
+          onSelectionAddToChat={onSelectionAddToChat}
           binaryImagePreviewState={
             shouldDirectlyPreviewBinaryImage
               ? binaryImagePreviewState
@@ -431,6 +431,7 @@ interface DiffFileCardBodyProps {
   onRetry: () => void;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
+  onSelectionAddToChat?: (text: string) => void;
   binaryImagePreviewState?: BinaryImagePreviewState;
 }
 
@@ -490,6 +491,7 @@ function DiffFileCardBody({
   onRetry,
   onOpenFilePreview,
   onRequestFileContents,
+  onSelectionAddToChat,
   binaryImagePreviewState,
 }: DiffFileCardBodyProps) {
   if (binaryImagePreviewState !== undefined) {
@@ -600,6 +602,7 @@ function DiffFileCardBody({
       truncated={patchState.truncated ?? false}
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
+      onSelectionAddToChat={onSelectionAddToChat}
     />
   );
 }
@@ -613,6 +616,7 @@ interface DiffFileCardRenderedBodyProps {
   truncated: boolean;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 /**
@@ -631,6 +635,7 @@ function DiffFileCardRenderedBody({
   truncated,
   onOpenFilePreview,
   onRequestFileContents,
+  onSelectionAddToChat,
 }: DiffFileCardRenderedBodyProps) {
   const bodyState = useGitDiffCardBody({
     fileDiff: parsedFile,
@@ -646,6 +651,7 @@ function DiffFileCardRenderedBody({
         diffViewOptions={diffViewOptions}
         svgDisplayMode={svgDisplayMode}
         reservesCollapseGutter
+        onSelectionAddToChat={onSelectionAddToChat}
       />
       {truncated ? (
         <div className={DIFF_FILE_CARD_NOTICE_CLASS}>

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
@@ -61,6 +61,7 @@ export interface DiffFilesPanelProps {
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 /**
@@ -85,6 +86,7 @@ export function DiffFilesPanel({
   onOpenFileInEditor,
   onOpenFilePreview,
   onRequestFileContents,
+  onSelectionAddToChat,
 }: DiffFilesPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { requestPaths, getPatchState, retry, loadPath, seedInitialPatches } =
@@ -224,6 +226,7 @@ export function DiffFilesPanel({
                 onOpenFileInEditor={onOpenFileInEditor}
                 onOpenFilePreview={onOpenFilePreview}
                 onRequestFileContents={onRequestFileContents}
+                onSelectionAddToChat={onSelectionAddToChat}
               />
             </div>
           );
@@ -248,6 +251,7 @@ interface DiffFileRowProps {
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 function DiffFileRow({
@@ -262,6 +266,7 @@ function DiffFileRow({
   onOpenFileInEditor,
   onOpenFilePreview,
   onRequestFileContents,
+  onSelectionAddToChat,
 }: DiffFileRowProps) {
   const stateAtom = useMemo(
     () => diffFileCardStateAtomFamily({ diffIdentity, path: entry.path }),
@@ -299,6 +304,7 @@ function DiffFileRow({
       onOpenFileInEditor={onOpenFileInEditor}
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
+      onSelectionAddToChat={onSelectionAddToChat}
     />
   );
 }

--- a/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
@@ -8,6 +8,7 @@ import type { ThreadTerminalController } from "./useThreadTerminalController";
 interface ThreadTerminalContentProps {
   controller: ThreadTerminalController;
   onOpenLink?: MarkdownPreviewLinkHandler;
+  onSelectionAddToChat?: (text: string) => void;
 }
 
 interface InactiveTerminalContent {
@@ -56,6 +57,7 @@ function getInactiveTerminalContent({
 export function ThreadTerminalContent({
   controller,
   onOpenLink,
+  onSelectionAddToChat,
 }: ThreadTerminalContentProps) {
   if (controller.hasTerminalQueryError) {
     return (
@@ -120,6 +122,7 @@ export function ThreadTerminalContent({
     <ThreadTerminalView
       isPanelOpen={controller.isPanelOpen}
       onOpenLink={onOpenLink}
+      onSelectionAddToChat={onSelectionAddToChat}
       onTitleChange={controller.handleActiveTerminalTitleChange}
       onUserInput={controller.handleActiveTerminalUserInput}
       session={controller.activeSession}

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
@@ -8,6 +8,7 @@ import {
 interface ThreadTerminalPanelProps {
   canCreateTerminal: boolean;
   onOpenLink?: MarkdownPreviewLinkHandler;
+  onSelectionAddToChat?: (text: string) => void;
   panelStateId?: string;
   target: ThreadTerminalTarget;
 }
@@ -15,6 +16,7 @@ interface ThreadTerminalPanelProps {
 export function ThreadTerminalPanel({
   canCreateTerminal,
   onOpenLink,
+  onSelectionAddToChat,
   panelStateId,
   target,
 }: ThreadTerminalPanelProps) {
@@ -33,6 +35,7 @@ export function ThreadTerminalPanel({
         <ThreadTerminalContent
           controller={terminalController}
           onOpenLink={onOpenLink}
+          onSelectionAddToChat={onSelectionAddToChat}
         />
       </div>
     </section>

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import "@xterm/xterm/css/xterm.css";
 import type { ITheme, Terminal as XTermTerminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
@@ -11,12 +17,25 @@ import {
   openUrlInExternalBrowser,
   useOpenUrlByPreference,
 } from "@/lib/url-open-routing";
+import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
+import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
 import { buildTerminalWebSocketUrl } from "./terminal-websocket-url";
 
 const TERMINAL_FONT_FAMILY =
   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace";
+const TERMINAL_SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
 
 type TerminalFitScheduler = () => void;
+
+interface TerminalSelectionAnchorPoint {
+  x: number;
+  y: number;
+}
+
+interface TerminalSelectionAnchor {
+  point: TerminalSelectionAnchorPoint;
+  side: "top" | "bottom";
+}
 
 interface HasVisibleTerminalSizeArgs {
   containerElement: HTMLElement;
@@ -77,6 +96,7 @@ function buildTerminalTheme(): ITheme {
 interface ThreadTerminalViewProps {
   isPanelOpen: boolean;
   onOpenLink?: MarkdownPreviewLinkHandler;
+  onSelectionAddToChat?: (text: string) => void;
   onTitleChange?: TerminalTitleChangeHandler;
   onUserInput?: () => void;
   session: TerminalSession;
@@ -172,6 +192,63 @@ function hasVisibleTerminalSize({
   const width = entry?.contentRect.width ?? containerElement.clientWidth;
   const height = entry?.contentRect.height ?? containerElement.clientHeight;
   return width > 0 && height > 0;
+}
+
+function terminalSelectionAnchorPointFromEvent(
+  event: Pick<MouseEvent, "clientX" | "clientY">,
+): TerminalSelectionAnchorPoint | null {
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+    return null;
+  }
+  return { x: event.clientX, y: event.clientY };
+}
+
+function terminalSelectionAnchorFromPointerRelease(
+  startPoint: TerminalSelectionAnchorPoint | null,
+  releaseEvent: Pick<MouseEvent, "clientX" | "clientY">,
+): TerminalSelectionAnchor | null {
+  const releasePoint = terminalSelectionAnchorPointFromEvent(releaseEvent);
+  if (releasePoint === null) {
+    return null;
+  }
+
+  return {
+    point: releasePoint,
+    side:
+      startPoint !== null &&
+      releasePoint.y - startPoint.y >
+        TERMINAL_SELECTION_DRAG_DIRECTION_THRESHOLD_PX
+        ? "bottom"
+        : "top",
+  };
+}
+
+function buildTerminalSelection({
+  anchor,
+  containerElement,
+  text,
+}: {
+  anchor: TerminalSelectionAnchor | null;
+  containerElement: HTMLElement;
+  text: string;
+}): MessageProseSelection | null {
+  const trimmedText = text.trim();
+  if (trimmedText.length === 0) {
+    return null;
+  }
+
+  const selection: MessageProseSelection = {
+    text: trimmedText,
+    rect:
+      anchor === null
+        ? containerElement.getBoundingClientRect()
+        : new DOMRect(anchor.point.x, anchor.point.y, 0, 0),
+  };
+  if (anchor !== null) {
+    selection.anchorPoint = anchor.point;
+    selection.anchorSide = anchor.side;
+  }
+  return selection;
 }
 
 function writeTerminalStatus({ terminal, text }: WriteTerminalStatusArgs): void {
@@ -283,12 +360,22 @@ function handleTerminalServerMessage({
 export function ThreadTerminalView({
   isPanelOpen,
   onOpenLink,
+  onSelectionAddToChat,
   onTitleChange,
   onUserInput,
   session,
 }: ThreadTerminalViewProps) {
+  const [activeSelection, setActiveSelection] =
+    useState<MessageProseSelection | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XTermTerminal | null>(null);
+  const pointerIsDownRef = useRef(false);
+  const pointerStartPointRef = useRef<TerminalSelectionAnchorPoint | null>(
+    null,
+  );
+  const lastPointerReleaseAnchorRef = useRef<TerminalSelectionAnchor | null>(
+    null,
+  );
   const onTitleChangeRef = useRef<TerminalTitleChangeHandler | undefined>(
     onTitleChange,
   );
@@ -319,6 +406,75 @@ export function ThreadTerminalView({
   onTitleChangeRef.current = onTitleChange;
   onUserInputRef.current = onUserInput;
 
+  const reportTerminalSelection = useCallback(
+    (anchor: TerminalSelectionAnchor | null) => {
+      const terminal = terminalRef.current;
+      const container = containerRef.current;
+      if (!terminal || !container) {
+        setActiveSelection(null);
+        return;
+      }
+      setActiveSelection(
+        buildTerminalSelection({
+          anchor,
+          containerElement: container,
+          text: terminal.getSelection(),
+        }),
+      );
+    },
+    [],
+  );
+
+  const clearTerminalSelection = useCallback(() => {
+    terminalRef.current?.clearSelection();
+    setActiveSelection(null);
+  }, []);
+
+  const handleSelectionAddToChat = useCallback(
+    (text: string) => {
+      onSelectionAddToChat?.(text);
+      clearTerminalSelection();
+    },
+    [clearTerminalSelection, onSelectionAddToChat],
+  );
+
+  const handleTerminalPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      pointerIsDownRef.current = true;
+      pointerStartPointRef.current =
+        terminalSelectionAnchorPointFromEvent(event);
+    },
+    [],
+  );
+
+  const handleTerminalPointerRelease = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const anchor = terminalSelectionAnchorFromPointerRelease(
+        pointerStartPointRef.current,
+        event,
+      );
+      lastPointerReleaseAnchorRef.current = anchor;
+      pointerIsDownRef.current = false;
+      pointerStartPointRef.current = null;
+      window.requestAnimationFrame(() => {
+        reportTerminalSelection(anchor);
+      });
+    },
+    [reportTerminalSelection],
+  );
+
+  const handleTerminalPointerCancel = useCallback(() => {
+    pointerIsDownRef.current = false;
+    pointerStartPointRef.current = null;
+    window.requestAnimationFrame(() => {
+      reportTerminalSelection(lastPointerReleaseAnchorRef.current);
+    });
+  }, [reportTerminalSelection]);
+
+  useEffect(() => {
+    setActiveSelection(null);
+  }, [session.id]);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) {
@@ -334,7 +490,9 @@ export function ThreadTerminalView({
       suppressedWriteCount: 0,
     };
     let resizeAnimationFrame: number | null = null;
+    let selectionAnimationFrame: number | null = null;
     let resizeObserver: ResizeObserver | null = null;
+    let selectionChangeDisposable: { dispose: () => void } | null = null;
 
     async function mountTerminal(containerElement: HTMLDivElement): Promise<void> {
       const [
@@ -478,6 +636,18 @@ export function ThreadTerminalView({
         }
         onTitleChangeRef.current?.(title);
       });
+      const scheduleSelectionReport = () => {
+        if (pointerIsDownRef.current || selectionAnimationFrame !== null) {
+          return;
+        }
+        selectionAnimationFrame = window.requestAnimationFrame(() => {
+          selectionAnimationFrame = null;
+          reportTerminalSelection(lastPointerReleaseAnchorRef.current);
+        });
+      };
+      selectionChangeDisposable = activeTerminal.onSelectionChange(
+        scheduleSelectionReport,
+      );
 
       resizeObserver = new ResizeObserver((entries) => {
         if (!hasVisibleTerminalSize({ containerElement, entries })) {
@@ -500,13 +670,17 @@ export function ThreadTerminalView({
       if (resizeAnimationFrame !== null) {
         window.cancelAnimationFrame(resizeAnimationFrame);
       }
+      if (selectionAnimationFrame !== null) {
+        window.cancelAnimationFrame(selectionAnimationFrame);
+      }
       resizeObserver?.disconnect();
+      selectionChangeDisposable?.dispose();
       socket?.close();
       terminal?.dispose();
       terminalRef.current = null;
       scheduleFitRef.current = null;
     };
-  }, [session.id, session.threadId]);
+  }, [reportTerminalSelection, session.id, session.threadId]);
 
   useEffect(() => {
     if (!isPanelOpen) {
@@ -537,10 +711,24 @@ export function ThreadTerminalView({
   }, [preferredTheme, appThemeEpoch]);
 
   return (
-    <div className="h-full min-h-0 w-full overflow-hidden bg-background p-2">
+    <div
+      className="h-full min-h-0 w-full overflow-hidden bg-background p-2"
+      onPointerDown={handleTerminalPointerDown}
+      onPointerUp={handleTerminalPointerRelease}
+      onPointerCancel={handleTerminalPointerCancel}
+    >
       <div
         ref={containerRef}
         className="h-full min-h-0 w-full overflow-hidden"
+      />
+      <TimelineSelectionMenu
+        selection={activeSelection}
+        onAddToChat={
+          onSelectionAddToChat === undefined
+            ? undefined
+            : handleSelectionAddToChat
+        }
+        onDismiss={clearTerminalSelection}
       />
     </div>
   );

--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef, type ReactNode } from "react";
 
-interface SelectionAnchorPoint {
+export interface SelectionAnchorPoint {
   x: number;
   y: number;
 }
 
-type SelectionAnchorSide = "top" | "bottom";
+export type SelectionAnchorSide = "top" | "bottom";
 
-interface SelectionAnchor {
+export interface SelectionAnchor {
   point: SelectionAnchorPoint;
   side: SelectionAnchorSide;
 }
@@ -124,7 +124,7 @@ function toMessageProseSelection({
   return selection;
 }
 
-function anchorPointFromMouseEvent(
+export function anchorPointFromMouseEvent(
   event: Pick<MouseEvent, "clientX" | "clientY">,
 ): SelectionAnchorPoint | null {
   if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
@@ -133,7 +133,7 @@ function anchorPointFromMouseEvent(
   return { x: event.clientX, y: event.clientY };
 }
 
-function selectionAnchorFromPointerRelease(
+export function selectionAnchorFromPointerRelease(
   startPoint: SelectionAnchorPoint | null,
   releaseEvent: Pick<MouseEvent, "clientX" | "clientY">,
 ): SelectionAnchor | null {
@@ -152,7 +152,10 @@ function selectionAnchorFromPointerRelease(
   };
 }
 
-function isEventTargetWithinNode(event: Event, node: HTMLElement | null): boolean {
+function isEventTargetWithinNode(
+  event: Event,
+  node: HTMLElement | null,
+): boolean {
   if (node === null || !(event.target instanceof Node)) return false;
   return node.contains(event.target);
 }
@@ -303,7 +306,8 @@ export function SelectableMessageProse({
         return;
       }
       const clickAnchor =
-        selectionAnchorFromPointerRelease(null, event) ?? lastPointerReleaseAnchor;
+        selectionAnchorFromPointerRelease(null, event) ??
+        lastPointerReleaseAnchor;
       if (event.detail === 2) {
         scheduleAfterMultiClickDelay(clickAnchor);
         return;

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.test.tsx
@@ -59,7 +59,7 @@ describe("TimelineSelectionMenu", () => {
     expect(screen.queryByRole("button")).toBeNull();
   });
 
-  it("anchors to the pointer release point when one is available", () => {
+  it("renders from a pointer release point without a physical anchor node", () => {
     const { container } = render(
       <TimelineSelectionMenu
         selection={makeSelection({ anchorPoint: { x: 42, y: 84 } })}
@@ -68,13 +68,8 @@ describe("TimelineSelectionMenu", () => {
       />,
     );
 
-    const anchor = container.querySelector('[aria-hidden="true"]');
-    expect(anchor).toBeInstanceOf(HTMLElement);
-    if (!(anchor instanceof HTMLElement)) {
-      throw new Error("Expected selection menu anchor to render");
-    }
-    expect(anchor.style.left).toBe("42px");
-    expect(anchor.style.top).toBe("84px");
+    expect(screen.getByRole("button", { name: "Add to chat" })).toBeTruthy();
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
   });
 
   it("uses the selected anchor side when positioning from a pointer release", () => {

--- a/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineSelectionMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type MouseEvent } from "react";
+import { useEffect, useRef, type MouseEvent } from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { Icon, type IconName } from "../../ui/icon.js";
 import { preventOverlayTriggerSelection } from "../../ui/overlay-trigger.js";
@@ -27,9 +27,11 @@ export interface TimelineSelectionMenuProps {
 
 function ActionButton({
   action,
+  onDismiss,
   selection,
 }: {
   action: SelectionAction;
+  onDismiss: () => void;
   selection: MessageProseSelection;
 }) {
   return (
@@ -44,6 +46,7 @@ function ActionButton({
         // Clear the lingering highlight so the source text doesn't read as
         // "still selected" after the quote/side-chat has been created.
         window.getSelection()?.removeAllRanges();
+        onDismiss();
       }}
     >
       <Icon
@@ -68,17 +71,9 @@ export function TimelineSelectionMenu({
   onDismiss,
 }: TimelineSelectionMenuProps) {
   const open = selection !== null;
-
-  // Constrain the floating menu to the thread column so it never overlaps the
-  // sidebar or secondary panel. The anchor sits inside `[data-thread-window]`,
-  // so resolve that ancestor as the Radix collision boundary.
-  const [collisionBoundary, setCollisionBoundary] =
-    useState<HTMLElement | null>(null);
-  const anchorRef = useCallback((node: HTMLDivElement | null) => {
-    setCollisionBoundary(
-      node?.closest<HTMLElement>("[data-thread-window]") ?? null,
-    );
-  }, []);
+  const virtualAnchorRef = useRef({
+    getBoundingClientRect: () => new DOMRect(0, 0, 0, 0),
+  });
 
   // Dismiss on scroll/resize rather than re-anchoring: the captured rect goes
   // stale the moment the viewport moves, so closing is the honest behavior.
@@ -122,6 +117,8 @@ export function TimelineSelectionMenu({
   const anchorLeft = anchorPoint?.x ?? rect.left + rect.width / 2;
   const anchorTop = anchorPoint?.y ?? rect.top;
   const anchorSide = selection.anchorSide ?? "top";
+  virtualAnchorRef.current.getBoundingClientRect = () =>
+    new DOMRect(anchorLeft, anchorTop, 0, 0);
 
   return (
     <PopoverPrimitive.Root
@@ -131,28 +128,15 @@ export function TimelineSelectionMenu({
       }}
     >
       {/*
-        Zero-size anchor pinned to the pointer release point and gesture side,
-        falling back to the selection rect.
+        Use a virtual viewport anchor. A real fixed-position anchor can be
+        distorted by transformed ancestors in diff/preview panels.
       */}
-      <PopoverPrimitive.Anchor asChild>
-        <div
-          ref={anchorRef}
-          aria-hidden="true"
-          style={{
-            position: "fixed",
-            left: anchorLeft,
-            top: anchorTop,
-            width: 0,
-            height: 0,
-          }}
-        />
-      </PopoverPrimitive.Anchor>
+      <PopoverPrimitive.Anchor virtualRef={virtualAnchorRef} />
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
           side={anchorSide}
           align="center"
           sideOffset={6}
-          collisionBoundary={collisionBoundary}
           collisionPadding={8}
           className={SELECTION_MENU_CONTENT_CLASS}
           onEscapeKeyDown={() => onDismiss()}
@@ -166,7 +150,11 @@ export function TimelineSelectionMenu({
                   className="mx-0.5 h-4 w-px bg-border"
                 />
               ) : null}
-              <ActionButton action={action} selection={selection} />
+              <ActionButton
+                action={action}
+                onDismiss={onDismiss}
+                selection={selection}
+              />
             </div>
           ))}
         </PopoverPrimitive.Content>

--- a/apps/app/src/lib/prompt-draft.ts
+++ b/apps/app/src/lib/prompt-draft.ts
@@ -47,6 +47,27 @@ export function emptyPromptDraftState(): PromptDraftState {
   };
 }
 
+function normalizeQuotedSelectionText(text: string): string {
+  const lines = text.replace(/\r\n|\r/gu, "\n").split("\n");
+  const normalizedLines: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    const previousLine = normalizedLines.at(-1);
+    const nextLine = lines[index + 1];
+    if (
+      line.trim().length === 0 &&
+      previousLine?.startsWith(">") === true &&
+      nextLine?.startsWith(">") === true
+    ) {
+      continue;
+    }
+    normalizedLines.push(line);
+  }
+
+  return normalizedLines.join("\n").trim();
+}
+
 /**
  * Append a quoted selection to the draft text as a `> `-prefixed blockquote
  * block. The editor parses these blocks into real blockquote nodes; the user
@@ -59,7 +80,7 @@ export function appendQuoteToDraftText(
 ): PromptDraftState {
   // Guard the boundary: an empty/whitespace-only selection would otherwise
   // emit a bare "> " block and make an empty draft look dirty.
-  const trimmed = quotedText.trim();
+  const trimmed = normalizeQuotedSelectionText(quotedText);
   if (trimmed === "") return state;
 
   const block = trimmed
@@ -68,8 +89,7 @@ export function appendQuoteToDraftText(
     .join("\n");
 
   // Trailing newline so the reply paragraph sits below the quote.
-  const text =
-    state.text === "" ? `${block}\n` : `${state.text}\n${block}\n`;
+  const text = state.text === "" ? `${block}\n` : `${state.text}\n${block}\n`;
 
   return { ...state, text };
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -859,6 +859,16 @@ export function RootComposeView(props: RootComposeViewProps) {
   const primaryHostId = usePrimaryHost()?.id ?? null;
   const uploadPromptAttachment = useUploadPromptAttachment();
   const promptDraft = usePromptDraftStorage({ kind: "new-thread" });
+  const handleRootPanelSelectionAddToChat = useCallback(
+    (text: string) => {
+      promptDraft.addQuote(text);
+      setStartedComposing(true);
+      window.requestAnimationFrame(() => {
+        promptBoxRef.current?.focusEnd();
+      });
+    },
+    [promptDraft],
+  );
   const promptOptionDraftSnapshotRef = useRef<PromptDraftState | null>(null);
   const { data: projectPromptHistory = [] } =
     useProjectPromptHistory(projectId);
@@ -2568,6 +2578,7 @@ export function RootComposeView(props: RootComposeViewProps) {
       <ThreadTerminalPanel
         canCreateTerminal={canCreateRootTerminal}
         onOpenLink={handleOpenPanelLink}
+        onSelectionAddToChat={handleRootPanelSelectionAddToChat}
         panelStateId={ROOT_COMPOSE_FIXED_PANEL_STATE_ID}
         target={rootPanelTerminalTarget}
       />
@@ -2593,6 +2604,7 @@ export function RootComposeView(props: RootComposeViewProps) {
         environmentId={activeWorkspaceFileEnvironmentId}
         lineRange={activeWorkspaceFileLineRange}
         onOpenInEditor={handleOpenWorkspaceFileInEditor}
+        onSelectionAddToChat={handleRootPanelSelectionAddToChat}
         source={activeWorkspaceFileSource}
         statusLabel={activeWorkspaceFileStatusLabel}
         threadId={rootPanelThreadId}
@@ -2604,6 +2616,7 @@ export function RootComposeView(props: RootComposeViewProps) {
         copyPath={projectFileCopyPath}
         lineRange={activeWorkspaceFileLineRange}
         onOpenInEditor={handleOpenProjectFileInEditor}
+        onSelectionAddToChat={handleRootPanelSelectionAddToChat}
         projectId={activeWorkspaceFileProjectPreviewId}
       />
     ) : activeHostFilePath !== null ? (
@@ -2614,6 +2627,7 @@ export function RootComposeView(props: RootComposeViewProps) {
           environmentId={activeRootHostFileEnvironmentId}
           lineRange={activeHostFileLineRange}
           onOpenInEditor={handleOpenHostFileInEditor}
+          onSelectionAddToChat={handleRootPanelSelectionAddToChat}
           threadId={activeRootHostFileThreadId}
         />
       ) : (
@@ -2631,6 +2645,7 @@ export function RootComposeView(props: RootComposeViewProps) {
           copyPath={storageFileCopyPath}
           lineRange={activeStorageFileLineRange}
           onOpenInEditor={handleOpenStorageFileInEditor}
+          onSelectionAddToChat={handleRootPanelSelectionAddToChat}
           threadId={activeRootStorageFileThreadId}
         />
       ) : (
@@ -3036,6 +3051,7 @@ export function RootComposeView(props: RootComposeViewProps) {
           onFileTabReorder: reorderFileTab,
           onOpenNewTab: handleOpenNewTab,
           onOpenFilePreview: handleOpenFilePreview,
+          onSelectionAddToChat: handleRootPanelSelectionAddToChat,
           onPanelFocus: handleSecondaryPanelFocus,
           onPanelChange: handleSecondaryPanelChange,
         }}

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -155,7 +155,8 @@ const areThreadSecondaryPanelPropsEqual: ThreadSecondaryPanelPropsEqual = (
   previous.onOpenNewTab === next.onOpenNewTab &&
   previous.onFileTabReorder === next.onFileTabReorder &&
   previous.onOpenFileInEditor === next.onOpenFileInEditor &&
-  previous.onOpenFilePreview === next.onOpenFilePreview;
+  previous.onOpenFilePreview === next.onOpenFilePreview &&
+  previous.onSelectionAddToChat === next.onSelectionAddToChat;
 
 const areThreadTimelinePanePropsEqual: ThreadTimelinePanePropsEqual = (
   previous,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2006,6 +2006,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     <ThreadTerminalPanel
       canCreateTerminal={canCreateTerminal}
       onOpenLink={handleOpenTimelineLink}
+      onSelectionAddToChat={handleSelectionAddToChat}
       target={{ kind: "thread", threadId: thread.id }}
     />
   ) : isNewTabActive ? (
@@ -2027,6 +2028,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       lineRange={activeWorkspaceFileLineRange}
       markdownLinkRouting={workspaceMarkdownLinkRouting}
       onOpenInEditor={handleOpenFileInEditor}
+      onSelectionAddToChat={handleSelectionAddToChat}
       source={activeWorkspaceFileSource}
       statusLabel={activeWorkspaceFileStatusLabel}
       threadId={thread.id}
@@ -2039,6 +2041,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       lineRange={activeHostFileLineRange}
       markdownLinkRouting={hostMarkdownLinkRouting}
       onOpenInEditor={handleOpenHostFileInEditor}
+      onSelectionAddToChat={handleSelectionAddToChat}
       threadId={thread.id}
     />
   ) : activeStorageFilePath ? (
@@ -2048,6 +2051,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       lineRange={activeStorageFileLineRange}
       markdownLinkRouting={storageMarkdownLinkRouting}
       onOpenInEditor={handleOpenStorageFileInEditor}
+      onSelectionAddToChat={handleSelectionAddToChat}
       threadId={thread.id}
     />
   ) : undefined;
@@ -2130,6 +2134,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
           onFileTabReorder: reorderFileTab,
           onOpenNewTab: handleOpenNewTab,
           onOpenFilePreview: handleOpenFilePreview,
+          onSelectionAddToChat: handleSelectionAddToChat,
           onPanelFocus: handleSecondaryPanelFocus,
           onPanelChange: handleSecondaryPanelChange,
           showGitDiffTab: canUseGitUi,


### PR DESCRIPTION
## Summary
- add selection Add to chat popouts for diff, raw file preview, markdown preview, and terminal surfaces
- wire Pierre line selections with live drag feedback and viewport-anchored popout positioning
- keep the selection popout focused on Add to chat / side-chat actions

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check
- dev-browser manual QA on the diff panel popout and drag selection feedback

Tests were not run.