### PR TITLE
Queue provider CLI setup actions

### DIFF
--- a/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type {
+  ProviderCliInstallEvent,
+  ProviderCliKey,
+} from "@bb/host-daemon-contract";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InstallHostProviderCliArgs } from "@/lib/api";
+import * as api from "@/lib/api";
+import { appToast } from "@/components/ui/app-toast";
+import type { ProviderCliActionableIssue } from "./provider-cli-install";
+import { useProviderCliInstallRunner } from "./provider-cli-install";
+
+interface DeferredInstall {
+  args: InstallHostProviderCliArgs;
+  reject: (error: unknown) => void;
+  resolve: () => void;
+}
+
+vi.mock("@/components/dialogs/ProviderCliInstallLogDialog", () => ({
+  ProviderCliInstallLogDialog: () => null,
+}));
+
+vi.mock("@/components/ui/app-toast-descriptions", () => ({
+  AppToastCommandDescription: () => null,
+}));
+
+vi.mock("@/components/ui/app-toast", () => ({
+  appToast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(),
+    message: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    installHostProviderCli: vi.fn(),
+  };
+});
+
+const installHostProviderCliMock = vi.mocked(api.installHostProviderCli);
+const appToastMock = vi.mocked(appToast);
+
+let pendingInstalls: DeferredInstall[] = [];
+
+function issueForProvider(
+  provider: Extract<ProviderCliKey, "codex" | "claudeCode">,
+): ProviderCliActionableIssue {
+  const displayName = provider === "codex" ? "Codex" : "Claude Code";
+  const executableName = provider === "codex" ? "codex" : "claude";
+  const action = {
+    kind: "update" as const,
+    label: "Update" as const,
+    commandKind: "exec" as const,
+    command: `${executableName} update`,
+  };
+
+  return {
+    provider,
+    status: {
+      displayName,
+      executableName,
+      executablePath: `/usr/local/bin/${executableName}`,
+      installed: true,
+      installSource: "npmGlobal",
+      currentVersion: "1.0.0",
+      latestVersion: "1.0.1",
+      minimumSupportedVersion: null,
+      npmPackageName: null,
+      npmGlobalPackageVersion: null,
+      installAction: action,
+      needsUpdate: true,
+      versionUnsupported: false,
+    },
+    action,
+    title: `${displayName} update available`,
+    description: "1.0.0 -> 1.0.1",
+    fingerprint: `${provider}:outdated`,
+    toastId: `provider-cli-health:${provider}`,
+  };
+}
+
+function completeInstall(
+  install: DeferredInstall,
+  event: ProviderCliInstallEvent,
+): void {
+  install.args.onEvent(event);
+  install.resolve();
+}
+
+function installAt(index: number): DeferredInstall {
+  const install = pendingInstalls[index];
+  if (install === undefined) {
+    throw new Error(`Expected pending install at index ${index}`);
+  }
+  return install;
+}
+
+beforeEach(() => {
+  pendingInstalls = [];
+  installHostProviderCliMock.mockImplementation(
+    (args) =>
+      new Promise<void>((resolve, reject) => {
+        pendingInstalls.push({ args, reject, resolve });
+      }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useProviderCliInstallRunner", () => {
+  it("queues a second provider CLI setup behind the active one", async () => {
+    const onStatusUpdated = vi.fn();
+    const { result } = renderHook(() =>
+      useProviderCliInstallRunner({
+        hostId: "host_1",
+        onStatusUpdated,
+      }),
+    );
+
+    act(() => {
+      result.current.startInstall(issueForProvider("codex"));
+    });
+
+    expect(installHostProviderCliMock).toHaveBeenCalledTimes(1);
+    expect(installHostProviderCliMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        request: { provider: "codex", actionKind: "update" },
+      }),
+    );
+
+    act(() => {
+      result.current.startInstall(issueForProvider("claudeCode"));
+    });
+
+    expect(installHostProviderCliMock).toHaveBeenCalledTimes(1);
+    expect(appToastMock.warning).not.toHaveBeenCalled();
+    expect(appToastMock.message).toHaveBeenCalledWith(
+      "Claude Code update queued",
+      expect.objectContaining({
+        id: "provider-cli-health-run:claudeCode",
+      }),
+    );
+    expect(result.current.queuedProviders.has("claudeCode")).toBe(true);
+
+    await act(async () => {
+      completeInstall(installAt(0), {
+        type: "completed",
+        provider: "codex",
+        success: true,
+        exitCode: 0,
+        signal: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(installHostProviderCliMock).toHaveBeenCalledTimes(2);
+    });
+    expect(installHostProviderCliMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        request: { provider: "claudeCode", actionKind: "update" },
+      }),
+    );
+    expect(result.current.queuedProviders.has("claudeCode")).toBe(false);
+
+    await act(async () => {
+      completeInstall(installAt(1), {
+        type: "completed",
+        provider: "claudeCode",
+        success: true,
+        exitCode: 0,
+        signal: null,
+      });
+    });
+
+    expect(onStatusUpdated).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -37,7 +37,12 @@ export interface ProviderCliActionableIssue extends ProviderCliIssue {
   action: ProviderCliInstallAction;
 }
 
-type ProviderCliTitlePhase = "progress" | "success" | "failure" | "log";
+type ProviderCliTitlePhase =
+  | "queued"
+  | "progress"
+  | "success"
+  | "failure"
+  | "log";
 type ProviderCliTitleTemplate = (displayName: string) => string;
 
 interface GetProviderCliTitleParams {
@@ -58,7 +63,16 @@ interface ShowProviderCliInstallFailureToastParams {
   toastId: string;
 }
 
+interface ProviderCliInstallJob {
+  hostId: string;
+  issue: ProviderCliActionableIssue;
+}
+
 const PROVIDER_CLI_TITLE_TEMPLATES = {
+  queued: {
+    install: (displayName) => `${displayName} install queued`,
+    update: (displayName) => `${displayName} update queued`,
+  },
   progress: {
     install: (displayName) => `Installing ${displayName}`,
     update: (displayName) => `Updating ${displayName}`,
@@ -218,11 +232,26 @@ function showProviderCliInstallFailureToast({
   });
 }
 
+function showProviderCliInstallQueuedToast(
+  issue: ProviderCliActionableIssue,
+): void {
+  appToast.message(getProviderCliTitle({ issue, phase: "queued" }), {
+    id: getProviderCliRunToastId(issue.provider),
+    description: "Waiting for the current install or update to finish.",
+    duration: Infinity,
+  });
+}
+
 export function useProviderCliInstallRunner({
   hostId,
   onStatusUpdated,
 }: UseProviderCliInstallRunnerArgs) {
+  const queuedInstallsRef = useRef<ProviderCliInstallJob[]>([]);
+  const processNextInstallRef = useRef<() => void>(() => {});
   const runningProviderRef = useRef<ProviderCliKey | null>(null);
+  const [queuedProviders, setQueuedProviders] = useState<
+    ReadonlySet<ProviderCliKey>
+  >(() => new Set());
   const [runningProvider, setRunningProvider] = useState<ProviderCliKey | null>(
     null,
   );
@@ -233,26 +262,37 @@ export function useProviderCliInstallRunner({
     setLogDialogState(null);
   }, []);
 
-  const startInstall = useCallback(
-    (issue: ProviderCliActionableIssue) => {
-      const action = issue.action;
-      if (hostId === null) {
-        appToast.error("Work host unavailable", {
-          description: "Reconnect the bb host and retry the provider CLI setup.",
-        });
-        return;
-      }
-      if (runningProviderRef.current !== null) {
-        appToast.warning("Provider CLI setup already running", {
-          description: "Wait for the current install or update to finish.",
-        });
-        return;
-      }
+  const updateQueuedProvider = useCallback(
+    (provider: ProviderCliKey, queued: boolean) => {
+      setQueuedProviders((previous) => {
+        if (queued && previous.has(provider)) {
+          return previous;
+        }
+        if (!queued && !previous.has(provider)) {
+          return previous;
+        }
+        const next = new Set(previous);
+        if (queued) {
+          next.add(provider);
+        } else {
+          next.delete(provider);
+        }
+        return next;
+      });
+    },
+    [],
+  );
 
-      runningProviderRef.current = issue.provider;
-      setRunningProvider(issue.provider);
+  const runInstall = useCallback(
+    (job: ProviderCliInstallJob) => {
+      const { hostId: installHostId, issue } = job;
+      const { action } = issue;
+      const provider = issue.provider;
+
+      runningProviderRef.current = provider;
+      setRunningProvider(provider);
       appToast.dismiss(issue.toastId);
-      const runToastId = getProviderCliRunToastId(issue.provider);
+      const runToastId = getProviderCliRunToastId(provider);
       let installLogChunks = [`$ ${action.command}\n`];
       let completedEvent: ProviderCliInstallCompletedEvent | null = null;
       let errorMessage: string | null = null;
@@ -263,13 +303,13 @@ export function useProviderCliInstallRunner({
       });
 
       void installHostProviderCli({
-        hostId,
+        hostId: installHostId,
         request: {
-          provider: issue.provider,
+          provider,
           actionKind: action.kind,
         },
         onEvent: (event) => {
-          if (event.provider !== issue.provider) {
+          if (event.provider !== provider) {
             return;
           }
           switch (event.type) {
@@ -335,13 +375,61 @@ export function useProviderCliInstallRunner({
           });
         })
         .finally(() => {
-          if (runningProviderRef.current === issue.provider) {
+          if (runningProviderRef.current === provider) {
             runningProviderRef.current = null;
             setRunningProvider(null);
           }
+          processNextInstallRef.current();
         });
     },
-    [hostId, onStatusUpdated],
+    [onStatusUpdated],
+  );
+
+  const processNextInstall = useCallback(() => {
+    if (runningProviderRef.current !== null) {
+      return;
+    }
+    const nextJob = queuedInstallsRef.current.shift();
+    if (nextJob === undefined) {
+      return;
+    }
+    updateQueuedProvider(nextJob.issue.provider, false);
+    runInstall(nextJob);
+  }, [runInstall, updateQueuedProvider]);
+
+  processNextInstallRef.current = processNextInstall;
+
+  const startInstall = useCallback(
+    (issue: ProviderCliActionableIssue) => {
+      if (hostId === null) {
+        appToast.error("Work host unavailable", {
+          description: "Reconnect the bb host and retry the provider CLI setup.",
+        });
+        return;
+      }
+
+      appToast.dismiss(issue.toastId);
+      if (runningProviderRef.current === issue.provider) {
+        return;
+      }
+      if (
+        queuedInstallsRef.current.some(
+          (job) => job.issue.provider === issue.provider,
+        )
+      ) {
+        showProviderCliInstallQueuedToast(issue);
+        return;
+      }
+      if (runningProviderRef.current !== null) {
+        queuedInstallsRef.current.push({ hostId, issue });
+        updateQueuedProvider(issue.provider, true);
+        showProviderCliInstallQueuedToast(issue);
+        return;
+      }
+
+      runInstall({ hostId, issue });
+    },
+    [hostId, runInstall, updateQueuedProvider],
   );
 
   return {
@@ -351,6 +439,7 @@ export function useProviderCliInstallRunner({
         onClose={handleCloseProviderCliInstallLog}
       />
     ),
+    queuedProviders,
     runningProvider,
     startInstall,
   };

--- a/apps/app/src/components/ui/sonner.stories.tsx
+++ b/apps/app/src/components/ui/sonner.stories.tsx
@@ -180,15 +180,15 @@ const TOAST_EXAMPLES: readonly ToastExample[] = [
     },
   },
   {
-    id: "provider-already-running",
+    id: "provider-queued",
     group: "Provider CLI",
-    label: "setup already running",
+    label: "setup queued",
     source: "ProviderCliHealthToasts",
     usage: ["Click Install/Update while another setup is running"],
     current: {
-      tone: "warning",
-      title: "Provider CLI setup already running",
-      description: "Wait for the current install or update to finish.",
+      tone: "message",
+      title: "Claude Code update queued",
+      description: "Waiting for the current install or update to finish.",
     },
   },
   {

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1095,6 +1095,7 @@ export function RootComposeView(props: RootComposeViewProps) {
   const refetchProviderCliStatus = providerCliStatus.refetch;
   const {
     installLogDialog: providerCliInstallLogDialog,
+    queuedProviders,
     runningProvider,
     startInstall,
   } = useProviderCliInstallRunner({
@@ -3004,7 +3005,7 @@ export function RootComposeView(props: RootComposeViewProps) {
         currentVersion={codexCliStatus.currentVersion}
         minimumSupportedVersion={codexCliStatus.minimumSupportedVersion}
         issue={codexCliIssue}
-        updating={runningProvider === "codex"}
+        updating={runningProvider === "codex" || queuedProviders.has("codex")}
         onUpdate={handleUpdateCodexCli}
       />
     );
@@ -3013,6 +3014,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     codexCliStatus,
     handleUpdateCodexCli,
     isCodexCliVersionBlocked,
+    queuedProviders,
     runningProvider,
   ]);
 


### PR DESCRIPTION
## Summary
- queue provider CLI setup clicks behind the active install/update instead of showing the "already running" warning
- show a queued toast and disable the Codex update banner while Codex is waiting
- update toast story coverage and add a hook regression test for queued provider setup

## Validation
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/provider-cli/provider-cli-install.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app