### PR TITLE
Fix timeline bottom stick after catch-up scroll

### DIFF
--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -365,6 +365,47 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     expect(scrollArea.scrollTop).toBe(300);
   });
 
+  it("keeps sticking after manual scroll reaches bottom before more growth", () => {
+    const { scrollArea } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+    });
+    mockScrollAreaRect(scrollArea);
+
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 150,
+    });
+
+    fireEvent.wheel(scrollArea, { deltaY: 1_000 });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 300,
+    });
+    fireEvent.scroll(scrollArea);
+
+    fireEvent.wheel(scrollArea, { deltaY: 200 });
+
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 450,
+      clientHeight: 100,
+      scrollTop: scrollArea.scrollTop,
+    });
+    fireEvent.scroll(scrollArea);
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "",
+      offsetWithinRow: 0,
+      atBottom: true,
+    });
+
+    getLatestResizeObserver().trigger();
+
+    expect(scrollArea.scrollTop).toBe(350);
+  });
+
   it("preserves bottom intent when unmounting during transient off-bottom layout", () => {
     const { scrollArea, rowElements, unmount } = renderTimeline({
       threadId: "thread-a",

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -517,9 +517,17 @@ export function BottomAnchoredScrollBody({
       window.performance.now() + USER_SCROLL_INTENT_MS;
   }, []);
 
-  const markWheelScrollIntent = useCallback(() => {
-    markUserScrollIntent();
-  }, [markUserScrollIntent]);
+  const markWheelScrollIntent = useCallback(
+    (event: WheelEvent) => {
+      const scrollArea = scrollAreaRef.current;
+      if (event.deltaY > 0 && scrollArea && isScrolledNearBottom(scrollArea)) {
+        userScrollIntentUntilRef.current = 0;
+        return;
+      }
+      markUserScrollIntent();
+    },
+    [markUserScrollIntent],
+  );
 
   const markTouchStartScrollIntent = useCallback(() => {
     markUserScrollIntent();
@@ -557,6 +565,7 @@ export function BottomAnchoredScrollBody({
     if (isScrolledNearBottom(scrollArea)) {
       userDetachedFromBottomRef.current = false;
       shouldStickToBottomRef.current = true;
+      userScrollIntentUntilRef.current = 0;
       setIsAtBottom(true);
       // A deliberate scroll to the bottom during the restore settle window means
       // the user no longer wants the saved row; stop re-applying it.


### PR DESCRIPTION
## Summary
- clear stale scroll-away intent once the timeline is confirmed at bottom
- ignore trailing downward wheel input while already at bottom so momentum cannot re-arm detachment
- add a regression test for manual catch-up followed by streaming growth

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app