### PR TITLE
Right panel polish: stable toggle, no-reflow open/close, tab-strip cleanup

### DIFF
--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { Icon, type IconName } from "@/components/ui/icon.js";
 import { EmptyStatePanel } from "@/components/ui/empty-state.js";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import { usePointerCoarse } from "@/components/ui/hooks/use-pointer-coarse.js";
 import { Input } from "@/components/ui/input.js";
 import { TruncateStart } from "@/components/ui/truncate-start.js";
@@ -365,7 +366,8 @@ function FileResultRow({
       onMouseEnter={onActivate}
       title={getFileSearchResultTitle(suggestion)}
       className={cn(
-        "w-full scroll-mt-7 rounded px-2 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "w-full scroll-mt-7 rounded px-2 py-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        LIST_HOVER_TRANSITION,
         COARSE_POINTER_TEXT_SM_CLASS,
         isActive ? "bg-state-active" : "hover:bg-state-hover",
       )}
@@ -556,10 +558,13 @@ export function NewTabFileSearch({
 
     // Focus synchronously, then again on the next frame to win the focus race
     // against the panel/tab content mounting in the same commit, which can
-    // otherwise pull focus away from the input.
-    inputRef.current?.focus();
+    // otherwise pull focus away from the input. `preventScroll` so focusing never
+    // scrolls an ancestor to reveal the input — during the panel's open swipe the
+    // content is briefly wider than the panel, and a scroll there would shift the
+    // whole panel content sideways.
+    inputRef.current?.focus({ preventScroll: true });
     const frame = requestAnimationFrame(() => {
-      inputRef.current?.focus();
+      inputRef.current?.focus({ preventScroll: true });
     });
     return () => cancelAnimationFrame(frame);
   }, [focusRequest, isPointerCoarse]);

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -96,6 +96,13 @@ export function SecondaryPanelTabStrip({
   const [overflow, setOverflow] = useState<TabStripOverflowState>(
     INITIAL_OVERFLOW_STATE,
   );
+  // Scroll capacity (max scrollLeft). Measured only on resize / tab-list change,
+  // never per scroll: reading scrollWidth/clientWidth in a scroll handler forces
+  // a synchronous reflow, which thrashes at narrow widths where every edge
+  // crossing (and its fade/chevron repaint) re-dirties layout. The scroll handler
+  // then reads only scrollLeft, which is cheap and doesn't flush layout.
+  const maxScrollLeftRef = useRef(0);
+  const scrollFrameRef = useRef<number | null>(null);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
   const {
     beginDragClickSuppression,
@@ -115,42 +122,85 @@ export function SecondaryPanelTabStrip({
       ? null
       : (fileTabs.find((tab) => tab.id === draggingTabId) ?? null);
 
-  const recomputeOverflow = useCallback(() => {
+  // Cheap: reads only scrollLeft (no layout flush) against the cached capacity.
+  const applyEdgeFlags = useCallback(() => {
     const viewport = viewportRef.current;
     if (viewport === null) {
       return;
     }
-    const { scrollLeft, scrollWidth, clientWidth } = viewport;
-    const maxScrollLeft = scrollWidth - clientWidth;
+    const maxScrollLeft = maxScrollLeftRef.current;
     const isScrollable = maxScrollLeft > EDGE_EPSILON_PX;
-    setOverflow({
-      canScrollLeft: isScrollable && scrollLeft > EDGE_EPSILON_PX,
-      canScrollRight:
-        isScrollable && scrollLeft < maxScrollLeft - EDGE_EPSILON_PX,
-    });
+    const { scrollLeft } = viewport;
+    const canScrollLeft = isScrollable && scrollLeft > EDGE_EPSILON_PX;
+    const canScrollRight =
+      isScrollable && scrollLeft < maxScrollLeft - EDGE_EPSILON_PX;
+    // Return the existing state object when neither flag changed so React bails
+    // out of re-rendering. With the tab tree memoized, a real change only
+    // repaints the always-mounted edge fades/chevrons (an opacity toggle).
+    setOverflow((prev) =>
+      prev.canScrollLeft === canScrollLeft &&
+      prev.canScrollRight === canScrollRight
+        ? prev
+        : { canScrollLeft, canScrollRight },
+    );
   }, []);
 
-  // Track the viewport's own scrolling and resizing. The ResizeObserver also
-  // fires once on observe, seeding the initial overflow state.
+  // Expensive (reads scrollWidth/clientWidth): run only on resize / tab change,
+  // then re-derive the edge flags from the fresh capacity.
+  const measureCapacity = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (viewport === null) {
+      return;
+    }
+    maxScrollLeftRef.current = viewport.scrollWidth - viewport.clientWidth;
+    applyEdgeFlags();
+  }, [applyEdgeFlags]);
+
+  // Track the viewport's own scrolling and resizing. The ResizeObserver fires
+  // once on observe (seeding the initial capacity + flags) and on every resize
+  // (including the panel's drag-resize, which changes clientWidth).
   useEffect(() => {
     const viewport = viewportRef.current;
     if (viewport === null) {
       return;
     }
-    viewport.addEventListener("scroll", recomputeOverflow, { passive: true });
-    const resizeObserver = new ResizeObserver(recomputeOverflow);
+    // rAF-throttle: a trackpad fires a burst of scroll events; coalesce them into
+    // one edge-flag check per frame.
+    const handleScroll = () => {
+      if (scrollFrameRef.current !== null) {
+        return;
+      }
+      scrollFrameRef.current = window.requestAnimationFrame(() => {
+        scrollFrameRef.current = null;
+        applyEdgeFlags();
+      });
+    };
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+    const resizeObserver = new ResizeObserver(measureCapacity);
     resizeObserver.observe(viewport);
     return () => {
-      viewport.removeEventListener("scroll", recomputeOverflow);
+      viewport.removeEventListener("scroll", handleScroll);
       resizeObserver.disconnect();
+      if (scrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
     };
-  }, [recomputeOverflow]);
+  }, [applyEdgeFlags, measureCapacity]);
 
   // The set of tabs can change width without resizing the viewport (open/close,
-  // rename), so recompute whenever the tab list changes.
+  // rename), so re-measure capacity whenever the tab list changes.
   useEffect(() => {
-    recomputeOverflow();
-  }, [fileTabs, recomputeOverflow]);
+    measureCapacity();
+  }, [fileTabs, measureCapacity]);
+
+  // A web-font swap changes the tabs' intrinsic width (and so scrollWidth)
+  // without resizing the viewport or changing the tab list, which would leave the
+  // cached capacity stale. Re-measure once fonts settle. (document.fonts is
+  // absent in jsdom, hence the optional chain.)
+  useEffect(() => {
+    void document.fonts?.ready?.then(() => measureCapacity());
+  }, [measureCapacity]);
 
   // Bring the active tab into view on mount and on every active-tab change. This
   // is the single hook that covers click, keyboard focus, and programmatic
@@ -178,14 +228,20 @@ export function SecondaryPanelTabStrip({
       return;
     }
     const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY === 0) {
+      // Let native horizontal trackpad gestures scroll the strip themselves; only
+      // translate a primarily-vertical wheel into horizontal movement. (A mostly
+      // horizontal swipe can carry small deltaY noise — don't hijack it.)
+      if (
+        event.deltaY === 0 ||
+        Math.abs(event.deltaX) >= Math.abs(event.deltaY)
+      ) {
         return;
       }
-      const { scrollLeft, scrollWidth, clientWidth } = viewport;
-      const maxScrollLeft = scrollWidth - clientWidth;
+      const maxScrollLeft = maxScrollLeftRef.current;
       if (maxScrollLeft <= EDGE_EPSILON_PX) {
         return;
       }
+      const { scrollLeft } = viewport;
       const canScrollInWheelDirection =
         event.deltaY > 0
           ? scrollLeft < maxScrollLeft - EDGE_EPSILON_PX
@@ -193,7 +249,11 @@ export function SecondaryPanelTabStrip({
       if (!canScrollInWheelDirection) {
         return;
       }
-      viewport.scrollLeft += event.deltaY;
+      // Clamp against the cached capacity instead of re-reading scrollWidth.
+      viewport.scrollLeft = Math.min(
+        maxScrollLeft,
+        Math.max(0, scrollLeft + event.deltaY),
+      );
       event.preventDefault();
     };
     viewport.addEventListener("wheel", handleWheel, { passive: false });
@@ -251,73 +311,107 @@ export function SecondaryPanelTabStrip({
     ? MACOS_APP_REGION_NO_DRAG_CLASS
     : null;
 
+  // Memoize the sortable tab tree so the overflow-flag state — which flips every
+  // time you reach a scroll edge, i.e. constantly at narrow widths — re-renders
+  // only the edge fades/chevrons, never the tabs. Without this, each edge
+  // crossing reconciles the whole list and re-runs useSortable for every tab,
+  // which is what kept narrow-width scrolling stuttery.
+  const dndTabs = useMemo(
+    () => (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragCancel={handleDragCancel}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+          {fileTabs.map((tab) => (
+            <SortableFileTab
+              key={tab.id}
+              activeTabRef={activeTabRef}
+              dragDisabled={dragDisabled}
+              noDragClass={noDragClass}
+              tab={tab}
+            />
+          ))}
+        </SortableContext>
+        {/* The lifted tab follows the pointer on both axes and must not be
+            clipped by the viewport's `overflow` or stretch its scroll width, so
+            render it as a fixed-position clone portaled out of the strip rather
+            than translating the in-place tab. */}
+        {createPortal(
+          <DragOverlay className="cursor-grabbing">
+            {draggingTab === null ? null : <FileTab tab={draggingTab} />}
+          </DragOverlay>,
+          document.body,
+        )}
+      </DndContext>
+    ),
+    [
+      sensors,
+      handleDragStart,
+      handleDragCancel,
+      handleDragEnd,
+      tabIds,
+      fileTabs,
+      dragDisabled,
+      noDragClass,
+      draggingTab,
+    ],
+  );
+
   return (
-    // Sized to its tabs (no `flex-1`) so the New Tab button that follows it
-    // stays immediately to the right of the last tab instead of being pushed to
-    // the far panel edge by leftover space. It still shrinks (`min-w-0`) when the
-    // tabs overflow, scrolling them under the edge fades/chevrons.
+    // Hugs its tabs (no `flex-1`) and shrinks (`min-w-0`) to scroll them under
+    // the edge fades/chevrons when they overflow. The New Tab button is pinned
+    // ahead of the strip (left-aligned), so it holds a fixed position instead of
+    // riding the last tab rightward as tabs are added.
     <div
       data-testid="secondary-panel-tab-strip"
       className="group relative flex min-w-0 items-center"
     >
-      {overflow.canScrollLeft ? (
-        <OverflowFade placement="left" className="z-10" />
-      ) : null}
-      {overflow.canScrollRight ? (
-        <OverflowFade placement="right" className="z-10" />
-      ) : null}
+      {/* Fades + chevrons stay mounted and just toggle opacity as you reach an
+          edge — mounting/unmounting them mid-scroll committed DOM and dirtied
+          layout every edge crossing, which at narrow widths is constant. */}
+      <OverflowFade
+        placement="left"
+        className={cn(
+          "z-10 transition-opacity",
+          overflow.canScrollLeft ? "opacity-100" : "opacity-0",
+        )}
+      />
+      <OverflowFade
+        placement="right"
+        className={cn(
+          "z-10 transition-opacity",
+          overflow.canScrollRight ? "opacity-100" : "opacity-0",
+        )}
+      />
       <div
         ref={viewportRef}
         onClickCapture={handleClickCapture}
-        className="no-scrollbar flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden scroll-smooth"
+        // No `scroll-smooth` here: wheel translation assigns scrollLeft directly
+        // (see the wheel handler), and CSS smooth-scroll would turn each wheel
+        // notch into its own ~150ms animation — the strip advances, sits frozen
+        // between notches, then jumps. Letting it track 1:1 matches native
+        // horizontal trackpad scrolling. The chevron buttons opt back into smooth
+        // per-call via `scrollBy({ behavior: "smooth" })`.
+        className="no-scrollbar flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden"
       >
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragStart={handleDragStart}
-          onDragCancel={handleDragCancel}
-          onDragEnd={handleDragEnd}
-        >
-          <SortableContext
-            items={tabIds}
-            strategy={horizontalListSortingStrategy}
-          >
-            {fileTabs.map((tab) => (
-              <SortableFileTab
-                key={tab.id}
-                activeTabRef={activeTabRef}
-                dragDisabled={dragDisabled}
-                noDragClass={noDragClass}
-                tab={tab}
-              />
-            ))}
-          </SortableContext>
-          {/* The lifted tab follows the pointer on both axes and must not be
-              clipped by the viewport's `overflow` or stretch its scroll width,
-              so render it as a fixed-position clone portaled out of the strip
-              rather than translating the in-place tab. */}
-          {createPortal(
-            <DragOverlay className="cursor-grabbing">
-              {draggingTab === null ? null : <FileTab tab={draggingTab} />}
-            </DragOverlay>,
-            document.body,
-          )}
-        </DndContext>
+        {dndTabs}
       </div>
-      {overflow.canScrollLeft ? (
-        <TabStripScrollChevron
-          direction="left"
-          className={chevronNoDragClass}
-          onClick={() => scrollByStep(-1)}
-        />
-      ) : null}
-      {overflow.canScrollRight ? (
-        <TabStripScrollChevron
-          direction="right"
-          className={chevronNoDragClass}
-          onClick={() => scrollByStep(1)}
-        />
-      ) : null}
+      <TabStripScrollChevron
+        direction="left"
+        canScroll={overflow.canScrollLeft}
+        className={chevronNoDragClass}
+        onClick={() => scrollByStep(-1)}
+      />
+      <TabStripScrollChevron
+        direction="right"
+        canScroll={overflow.canScrollRight}
+        className={chevronNoDragClass}
+        onClick={() => scrollByStep(1)}
+      />
     </div>
   );
 }
@@ -376,12 +470,14 @@ function SortableFileTab({
 
 interface TabStripScrollChevronProps {
   direction: "left" | "right";
+  canScroll: boolean;
   className: string | null;
   onClick: () => void;
 }
 
 function TabStripScrollChevron({
   direction,
+  canScroll,
   className,
   onClick,
 }: TabStripScrollChevronProps) {
@@ -391,26 +487,44 @@ function TabStripScrollChevron({
       variant="ghost"
       size="sm"
       // Decorative scroll control: every tab is already reachable via Tab, so
-      // keep the chevron out of the tab order to avoid duplicate stops.
+      // keep the chevron out of the tab order (tabIndex -1) to avoid duplicate
+      // stops. It stays mounted (so reaching an edge is an opacity toggle, not a
+      // DOM commit); when there's nothing to scroll, aria-hidden +
+      // pointer-events-none + opacity-0 (below) make it inert and invisible.
+      // Deliberately NOT the `disabled` attribute: Button carries
+      // `disabled:opacity-50`, which would beat the `opacity-0` hide and leave
+      // both chevrons painted at half opacity on every strip that doesn't
+      // overflow. aria-hidden already removes it from assistive tech, so
+      // `disabled` would add no a11y here anyway.
       tabIndex={-1}
+      aria-hidden={!canScroll}
       onClick={onClick}
       aria-label={
         direction === "left" ? "Scroll tabs left" : "Scroll tabs right"
       }
       className={cn(
-        // Solid panel-surface fills, so the chevron fully occludes the tab
-        // labels beneath it instead of letting them bleed through. The normal
-        // state matches the fade edge; hover/focus use `bg-muted` rather than
-        // translucent state overlays because these controls sit on top of
-        // partially hidden tab content.
-        "absolute z-50 shrink-0 bg-background hover:bg-muted focus-visible:bg-muted",
+        // The chevron rides the edge fade instead of occluding the tab beneath
+        // it: its backdrop is the same transparent→surface gradient as the
+        // OverflowFade (stacked over the always-on fade), so the edge tab
+        // dissolves smoothly under the arrow rather than being hard-cut by a
+        // solid tile. The ghost hover fill is suppressed so hovering never
+        // re-introduces that opaque block; the arrow brightens on hover instead.
+        // The arrow is edge-aligned (justify-start/end) so it hugs the opaque
+        // edge of the fade and clears the central tabs — rather than nudging the
+        // button itself outward, which a clipping ancestor would cut off.
+        "absolute z-50 shrink-0 text-muted-foreground hover:bg-transparent focus-visible:bg-transparent",
+        direction === "left"
+          ? "left-0 justify-start bg-gradient-to-l from-transparent to-background"
+          : "right-0 justify-end bg-gradient-to-r from-transparent to-background",
         COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
-        // Revealed only while the strip is hovered (or the chevron itself is
-        // focused) so the chevrons don't permanently cover the edge tabs;
-        // `pointer-events` follow visibility so a hidden chevron never
-        // intercepts clicks meant for the tab beneath it.
-        "pointer-events-none opacity-0 transition group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100",
-        direction === "left" ? "left-0" : "right-0",
+        // Always mounted (so reaching an edge toggles opacity rather than
+        // committing/removing DOM mid-scroll), revealed only while the strip is
+        // hovered/focused AND there is actually more to scroll in this direction.
+        // `pointer-events` follow visibility so a hidden chevron never intercepts
+        // clicks meant for the tab beneath it.
+        "pointer-events-none opacity-0 transition-opacity",
+        canScroll &&
+          "group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100",
         className,
       )}
     >

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -109,7 +109,6 @@ function ShellRow({
             onOpenNewTab={noop}
             isConversationCollapsed={false}
             onToggleConversationCollapse={noop}
-            reserveLeftForDesktopTrafficLights={false}
             renderAsDrawer
           />
         </PanelStage>
@@ -231,7 +230,6 @@ function FileTabsShellInner({
         onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
-        reserveLeftForDesktopTrafficLights={false}
         renderAsDrawer
       />
     </PanelStage>
@@ -341,7 +339,6 @@ function TerminalTabsShellInner({
         onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
-        reserveLeftForDesktopTrafficLights={false}
         renderAsDrawer
       />
     </PanelStage>

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -57,7 +57,6 @@ import {
 import {
   CHROME_ROW_CLASS,
   getBbDesktopInfo,
-  MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
@@ -128,6 +127,19 @@ export interface ThreadSecondaryPanelProps {
   showGitDiffTab?: boolean;
   showInfoTab?: boolean;
   showNewTabButton?: boolean;
+  /**
+   * How the panel's own inline hide control (top chrome, trailing edge) renders
+   * on the wide layout:
+   * - "button": render it (the default).
+   * - "reserved": render an invisible spacer of the same footprint — used when a
+   *   toggle is pinned outside the panel (root compose's fixed overlay) and must
+   *   land over a reserved slot with the tab strip kept clear of it.
+   * - "hidden": render nothing, leaving no slot — used when a stable toggle lives
+   *   elsewhere (the thread-detail full-width header) and the trailing controls
+   *   should sit flush at the edge.
+   * The drawer layout always renders the button (it carries its own close).
+   */
+  inlinePanelToggle?: "button" | "reserved" | "hidden";
   onPanelFocus: () => void;
   onPanelChange: (panel: ThreadSecondaryPanelTab) => void;
   onCollapse: () => void;
@@ -151,15 +163,6 @@ export interface ThreadSecondaryPanelProps {
    * conversation.
    */
   onToggleConversationCollapse: () => void;
-  /**
-   * When true, the panel is the top-left-most surface under the macOS
-   * traffic-light strip (desktop macOS + main sidebar collapsed + conversation
-   * collapsed, so only the 36px rail sits to the panel's left). Adds the full
-   * traffic-light reserve on the top chrome so the leading tabs clear the pinned
-   * sidebar-collapse trigger — which floats over the header and overhangs the
-   * rail — landing them one gap to its right rather than jammed under it.
-   */
-  reserveLeftForDesktopTrafficLights: boolean;
   /**
    * When true, render only the aside content — skip the PanelResizeHandle +
    * Panel wrappers that are only meaningful inside a desktop PanelGroup.
@@ -210,6 +213,7 @@ export function ThreadSecondaryPanel({
   showGitDiffTab = true,
   showInfoTab = true,
   showNewTabButton = true,
+  inlinePanelToggle = "button",
   onPanelFocus,
   onPanelChange,
   onCollapse,
@@ -221,7 +225,6 @@ export function ThreadSecondaryPanel({
   onSelectionAddToChat,
   isConversationCollapsed,
   onToggleConversationCollapse,
-  reserveLeftForDesktopTrafficLights,
   renderAsDrawer,
 }: ThreadSecondaryPanelProps) {
   const activeFileTab = fileTabs?.find((tab) => tab.isActive);
@@ -269,7 +272,12 @@ export function ThreadSecondaryPanel({
     resolveActiveFixedPanel({ activeTab, canUseGitUi }) ?? "thread-info";
   const isDiffPanelActive = activeFixedPanel === "git-diff";
   const shouldShowGitDiffTab = canUseGitUi && showGitDiffTab !== false;
-  const shouldRenderFileTabContent = isOpen;
+  // Inline, the panel slides out at a fixed width (clipped by the panel), so the
+  // body content must stay mounted through the close animation (and across
+  // open/close) instead of unmounting the instant `isOpen` flips — otherwise
+  // everything but the tab strip vanishes while the panel is still sliding. The
+  // drawer mounts its content only while open.
+  const shouldRenderFileTabContent = isOpen || !renderAsDrawer;
   const {
     gitDiffTarget,
     gitDiffSelectOptions,
@@ -351,15 +359,46 @@ export function ThreadSecondaryPanel({
     <aside
       ref={panelRef}
       aria-hidden={!isOpen}
+      // Swipe mode keeps the body mounted while closed, so mark the whole panel
+      // inert when hidden — otherwise focusable content (e.g. the new-tab search
+      // input's mount autofocus) could pull keyboard focus into the off-screen
+      // panel. The open control lives outside this aside on every surface.
+      inert={!isOpen}
       onFocusCapture={handlePanelFocusCapture}
+      // Swipe mode: the content is held at the panel's open width and absolutely
+      // pinned to the panel's LEFT edge, while the Panel's own flex width animates
+      // and its overflow-hidden clips the content into view. Two things matter:
+      //   1. No transform/opacity on the content, so it is never promoted to a
+      //      compositor layer — a composited layer is positioned by the GPU on a
+      //      separate thread from the main-thread clip and visibly drifts out of
+      //      sync mid-slide (invisible to getBoundingClientRect, which reports the
+      //      main-thread layout value). A pure layout clip stays locked.
+      //   2. `absolute left-0`, not block flow: when the fixed-width content is
+      //      wider than the mid-animation panel, the panel's flex layout CENTERS
+      //      the overflow (so the left edge clips by a width-dependent amount and
+      //      the padding breathes). Pinning left-0 keeps the content's left edge
+      //      flush to the panel edge at every width.
+      // The left border rides the content (like the sidebar's sliding panel) so it
+      // slides out with the panel on close instead of fading on its own timeline.
+      // Hold the fixed open width only while NOT dragging the resize handle.
+      // During a drag the panel width tracks the cursor (and can briefly animate),
+      // and a fixed width would desync from it — the content's right edge would
+      // pull off the panel edge. While resizing, fill the panel (left-0 + right-0
+      // below) so the content is always exactly the panel's current width.
+      style={
+        !renderAsDrawer && !isSecondaryPanelResizing
+          ? { width: `var(--secondary-swipe-width, ${persistedWidthPercent}cqw)` }
+          : undefined
+      }
       className={cn(
-        "flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background",
+        "flex h-full min-h-0 flex-col overflow-hidden bg-background",
+        // Drawer: fill the drawer shell. Inline: the fixed-width, left-pinned
+        // content the panel clips into view (or fills the panel while resizing).
+        renderAsDrawer && "min-w-0 flex-1",
         !renderAsDrawer && [
-          "transition-[transform,opacity,background-color]",
-          PANEL_COLLAPSE_TRANSITION_CLASS,
-          isOpen
-            ? "opacity-100"
-            : "pointer-events-none translate-x-[8%] opacity-0",
+          "absolute inset-y-0 left-0 border-l border-border-seam-vertical",
+          isSecondaryPanelResizing && "right-0",
+          !isOpen && "pointer-events-none",
         ],
       )}
     >
@@ -374,8 +413,6 @@ export function ThreadSecondaryPanel({
             // straight up to the top with no seam.
             "min-w-0 justify-between gap-2 px-4",
             usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
-            reserveLeftForDesktopTrafficLights &&
-              MACOS_TRAFFIC_LIGHT_RESERVE_CLASS,
           )}
         >
           <div
@@ -422,16 +459,16 @@ export function ThreadSecondaryPanel({
                 <Icon name="FileDiff" />
               </Button>
             ) : null}
+            {showNewTabButton ? (
+              <NewTabButton
+                onOpenNewTab={onOpenNewTab}
+                usesDesktopChrome={usesDesktopChrome}
+              />
+            ) : null}
             {visibleFileTabs && visibleFileTabs.length > 0 ? (
               <SecondaryPanelTabStrip
                 fileTabs={visibleFileTabs}
                 onReorderTab={onFileTabReorder}
-                usesDesktopChrome={usesDesktopChrome}
-              />
-            ) : null}
-            {showNewTabButton ? (
-              <NewTabButton
-                onOpenNewTab={onOpenNewTab}
                 usesDesktopChrome={usesDesktopChrome}
               />
             ) : null}
@@ -454,21 +491,31 @@ export function ThreadSecondaryPanel({
                 <Icon name={conversationCollapseControl.iconName} />
               </Button>
             ) : null}
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={cn(
-                SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS,
-                usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
-              )}
-              onClick={onClose}
-              aria-label={
-                renderAsDrawer ? "Close right panel" : "Hide right panel"
-              }
-            >
-              <Icon name={togglePanelIconName} />
-            </Button>
+            {renderAsDrawer || inlinePanelToggle === "button" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS,
+                  usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+                )}
+                onClick={onClose}
+                aria-label={
+                  renderAsDrawer ? "Close right panel" : "Hide right panel"
+                }
+              >
+                <Icon name={togglePanelIconName} />
+              </Button>
+            ) : inlinePanelToggle === "reserved" ? (
+              // A toggle pinned outside the panel owns show/hide on this surface
+              // (root compose's fixed overlay); reserve this slot's footprint so
+              // the tab strip stays clear and the pinned toggle lands over it.
+              <div
+                aria-hidden
+                className={SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS}
+              />
+            ) : null}
           </div>
         </div>
         {isDiffPanelActive && !hasActiveFileTab ? (
@@ -567,9 +614,20 @@ export function ThreadSecondaryPanel({
         order={2}
         style={SECONDARY_RESIZABLE_PANEL_STYLE}
         className={cn(
-          "min-w-0 overflow-hidden transition-[flex-grow,flex-basis,opacity]",
-          PANEL_COLLAPSE_TRANSITION_CLASS,
-          isOpen ? "opacity-100" : "opacity-0",
+          // `overflow-clip`, not `overflow-hidden`: while swiping, the held-width
+          // content is wider than the animating panel, which makes an
+          // `overflow-hidden` panel a horizontal SCROLL container — and the
+          // new-tab search input's mount autofocus then scrolls it to reveal
+          // itself, shifting all the content sideways by ~50px (the "padding
+          // breathes / left edge cut off" bug). `clip` clips identically but is
+          // not scrollable, so nothing can ever offset the content.
+          "min-w-0 overflow-clip",
+          // The Panel's own flex width is the animation: it grows to make room and
+          // its overflow clips the left-pinned content into view — one main-thread
+          // layout animation, so the clip and the content it reveals can never
+          // desync. `relative` anchors the absolutely left-pinned content; no
+          // opacity, since the content is revealed rather than faded.
+          `relative transition-[flex-grow,flex-basis] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
         )}
       >
         {asideMarkup}
@@ -626,23 +684,37 @@ function SecondaryPanelResizeHandle({
         "group relative shrink-0 overflow-visible bg-transparent transition-[width,opacity,background-color] before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
         PANEL_COLLAPSE_TRANSITION_CLASS,
         isConversationCollapsed ? "cursor-default" : "cursor-col-resize",
-        // While collapsed the handle's hairline would sit flush against the
-        // collapsed rail's recessed edge, doubling the seam. Drag is disabled
-        // in that state anyway, so fold the handle to zero width and hide it;
-        // the rail's recessed background is then the single clean edge.
+        // Zero-width: the visible panel border lives on the content (aside
+        // border-l), so this handle is purely the drag hit area + hover seam and
+        // sits exactly on that border instead of in a 1px slot to its left (which
+        // left the hit area and hover highlight a pixel off the border). Hidden +
+        // non-interactive when closed or while the conversation is collapsed.
         isOpen && !isConversationCollapsed
-          ? "w-px opacity-100"
+          ? "w-0 opacity-100"
           : "pointer-events-none w-0 opacity-0",
         isResizing && "bg-accent/20",
       )}
       aria-label="Resize thread and right panel"
     >
+      {/*
+        The panel's persistent left border lives on the content (aside
+        `border-l`) so it slides with the panel on open/close. This seam is only
+        the resize affordance — transparent at rest (so it doesn't double the
+        content border), brightening on hover/drag.
+      */}
       <span
+        // Sit on the handle's right edge (`left-full`), which is the panel's left
+        // edge where the content border-l lives, so the hover/drag highlight lands
+        // exactly on the border instead of a pixel to its left at the handle's
+        // center.
         className={cn(
-          "pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border-seam-vertical transition-colors",
+          // z-10 so the highlight paints over the adjacent content's border-l
+          // (the content renders after the handle) instead of being hidden behind
+          // it — otherwise the hover/drag highlight is invisible.
+          "pointer-events-none absolute inset-y-0 left-full z-10 w-px transition-colors",
           isResizing
             ? "bg-accent-foreground/50"
-            : "group-hover:bg-accent-foreground/35",
+            : "bg-transparent group-hover:bg-accent-foreground/35",
         )}
       />
     </PanelResizeHandle>

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
@@ -548,7 +548,6 @@ function NewTabPanelStory({
         onPanelFocus={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
-        reserveLeftForDesktopTrafficLights={false}
         renderAsDrawer
         showGitDiffTab
       />

--- a/apps/app/src/components/secondary-panel/launcherRow.tsx
+++ b/apps/app/src/components/secondary-panel/launcherRow.tsx
@@ -5,13 +5,17 @@ import {
 } from "@/components/ui/coarse-pointer-sizing.js";
 import { Icon } from "@/components/ui/icon.js";
 import { CHROME_SECTION_LABEL_CLASS } from "@/components/ui/chromeStyleTokens";
+import { LIST_HOVER_TRANSITION } from "@/components/ui/motion.js";
 import { cn } from "@/lib/utils";
 
 // Shared shell for the secondary-panel launcher rows — the app/file/recent
 // results in the New tab page and the browser tab's recently-visited list — so
 // density, hover, and the trailing open-affordance stay identical across both
-// surfaces rather than drifting in two parallel class bundles.
-const LAUNCHER_ROW_SHELL_CLASS = `group flex w-full min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left transition-colors focus-visible:outline-none ${COARSE_POINTER_TEXT_SM_CLASS}`;
+// surfaces rather than drifting in two parallel class bundles. These are dense,
+// arrow-navigable list rows, so the hover/active fill is instant both ways
+// (LIST_HOVER_TRANSITION) — the highlight tracks the pointer and arrow keys
+// exactly instead of lagging behind fast navigation.
+const LAUNCHER_ROW_SHELL_CLASS = `group flex w-full min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left ${LIST_HOVER_TRANSITION} focus-visible:outline-none ${COARSE_POINTER_TEXT_SM_CLASS}`;
 export const LAUNCHER_ROW_BASE_CLASS = `${LAUNCHER_ROW_SHELL_CLASS} focus-visible:ring-1 focus-visible:ring-ring`;
 export const LAUNCHER_ACTION_ROW_BASE_CLASS = `${LAUNCHER_ROW_SHELL_CLASS} focus-visible:bg-state-hover focus-visible:text-foreground`;
 export const LAUNCHER_ROW_ICON_CLASS = `flex shrink-0 items-center justify-center overflow-hidden text-muted-foreground ${COARSE_POINTER_ICON_SIZE_CLASS}`;

--- a/apps/app/src/components/secondary-panel/useSecondaryPanelResize.ts
+++ b/apps/app/src/components/secondary-panel/useSecondaryPanelResize.ts
@@ -143,6 +143,15 @@ export function useSecondaryPanelResize({
       }
 
       lastSecondaryPanelSizeRef.current = size;
+      // Mirror the live panel size onto the content's fixed width (container-query
+      // units against the horizontal group) for swipe mode: the content holds the
+      // open width while the panel's width transition clips it, and tracks the
+      // size live during a drag-resize. Guarding size > 0 leaves the width at the
+      // last open value through a collapse, so the content swipes out cleanly.
+      secondaryPanelRef.current?.style.setProperty(
+        "--secondary-swipe-width",
+        `${size}cqw`,
+      );
     },
     [],
   );

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -1,17 +1,22 @@
 import { Icon } from "@/components/ui/icon.js";
 import { COARSE_POINTER_TEXT_SM_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
 import { cn } from "@/lib/utils";
-import { CONTROL_HOVER_TRANSITION } from "./motion.js";
+import { LIST_HOVER_TRANSITION } from "./motion.js";
 import type { ReactNode } from "react";
 
 const TAB_PILL_DEFAULT_LABEL_MAX_WIDTH_CLASS = "max-w-[180px]";
+// No transition: the tab strip is a swept, list-like row, so the affordance
+// reveal (icon→close) and the close button's own hover tile both snap instantly,
+// matching the pill's instant hover (LIST_HOVER_TRANSITION) instead of trailing
+// the pointer. The instant swap also removes the icon/close cross-fade overlap,
+// so the close button needs no background to mask the icon underneath it.
 const TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS =
-  "inline-flex size-4 shrink-0 items-center justify-center rounded transition-opacity hover:bg-muted-foreground/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none max-md:pointer-coarse:size-5";
+  "inline-flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted-foreground/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none max-md:pointer-coarse:size-5";
 export const TAB_PILL_AFFORDANCE_ICON_CLASS =
   "size-3.5 max-md:pointer-coarse:size-5";
-export const TAB_PILL_CLOSE_BUTTON_CLASS = `pointer-events-none absolute left-2 top-1/2 z-10 -translate-y-1/2 bg-inherit ${TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS} opacity-0 hover:opacity-100 group-hover/tab-pill:pointer-events-auto group-hover/tab-pill:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-30 max-md:pointer-coarse:pointer-events-auto max-md:pointer-coarse:opacity-100`;
+export const TAB_PILL_CLOSE_BUTTON_CLASS = `pointer-events-none absolute left-1.5 top-1/2 z-10 -translate-y-1/2 ${TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS} opacity-0 hover:opacity-100 group-hover/tab-pill:pointer-events-auto group-hover/tab-pill:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-30 max-md:pointer-coarse:pointer-events-auto max-md:pointer-coarse:opacity-100`;
 const TAB_PILL_LEADING_VISUAL_CLASS =
-  "mr-1.5 inline-flex size-4 shrink-0 items-center justify-center transition-opacity [&_svg]:size-3.5 max-md:pointer-coarse:size-5 max-md:pointer-coarse:[&_svg]:size-5";
+  "mr-1.5 inline-flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5 max-md:pointer-coarse:size-5 max-md:pointer-coarse:[&_svg]:size-5";
 
 export interface TabPillCloseAction {
   onClose: () => void;
@@ -47,7 +52,7 @@ export function TabPill({
   return (
     <div
       className={cn(
-        `group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md ${CONTROL_HOVER_TRANSITION} max-md:pointer-coarse:h-9`,
+        `group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md ${LIST_HOVER_TRANSITION} max-md:pointer-coarse:h-9`,
         COARSE_POINTER_TEXT_SM_CLASS,
         isActive
           ? "bg-muted text-foreground"
@@ -58,7 +63,7 @@ export function TabPill({
         type="button"
         onClick={onSelect}
         aria-pressed={isActive}
-        className="flex h-full min-w-0 items-center rounded-md pl-2 pr-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="flex h-full min-w-0 items-center rounded-md pl-1.5 pr-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
         {leadingVisual ? (
           <span

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -33,7 +33,6 @@ type RootSecondaryPanelProps = Omit<
   | "isConversationCollapsed"
   | "onToggleConversationCollapse"
   | "renderAsDrawer"
-  | "reserveLeftForDesktopTrafficLights"
 > & {
   renderBrowserDeck?: (args: {
     canShowNativeBrowserView: boolean;
@@ -183,7 +182,6 @@ export function RootComposeSecondaryContent({
       renderAsDrawer={false}
       isConversationCollapsed={false}
       onToggleConversationCollapse={noopToggleConversationCollapse}
-      reserveLeftForDesktopTrafficLights={false}
     />
   ) : null;
   const drawerSecondaryPanelContent = renderAsDrawer ? (
@@ -193,13 +191,16 @@ export function RootComposeSecondaryContent({
       renderAsDrawer={true}
       isConversationCollapsed={false}
       onToggleConversationCollapse={noopToggleConversationCollapse}
-      reserveLeftForDesktopTrafficLights={false}
     />
   ) : null;
 
   return (
     <div className="-mx-4 -mb-4 -mt-4 flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip md:-mx-5 md:-mb-5 md:-mt-5">
-      <div className="flex h-full w-full min-w-0">
+      {/* Size container so the secondary panel's content can be pinned to its
+          open width in container-query units (cqw) — a fixed-width layer that
+          translates in (rather than reflowing) while the panel's flex width
+          animates as a spacer to make room. */}
+      <div className="@container flex h-full w-full min-w-0">
         <PanelGroup
           ref={horizontalPanelGroupRef}
           direction="horizontal"
@@ -218,6 +219,8 @@ export function RootComposeSecondaryContent({
             order={1}
             className={cn(
               "min-w-0 overflow-clip transition-[flex-grow,flex-basis]",
+              // Match the secondary panel's swipe timing so the shared boundary
+              // moves uniformly as the panel opens/closes.
               PANEL_COLLAPSE_TRANSITION_CLASS,
             )}
           >

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2760,9 +2760,14 @@ export function RootComposeView(props: RootComposeViewProps) {
     },
     [openWorkspaceFile],
   );
+  // Keep the panel toggle pinned to the viewport corner in the wide layout so it
+  // stays mounted and fixed in place across open/close (the panel reserves a
+  // matching slot via inlinePanelToggle="reserved", and the pinned button lands
+  // centered over it). The drawer layout has no pinned slot, so there the toggle
+  // only opens the drawer and its close control lives inside the drawer.
   const rootPanelToggle =
-    !isSecondaryPanelOpen ? (
-      <div className="fixed right-4 top-2 z-40">
+    !renderSecondaryPanelAsDrawer || !isSecondaryPanelOpen ? (
+      <div className="fixed right-4 top-2.5 z-40">
         <RootComposeRightPanelToggle
           activeTerminalCount={activeTerminalCount}
           isOpen={isSecondaryPanelOpen}
@@ -3131,6 +3136,7 @@ export function RootComposeView(props: RootComposeViewProps) {
           showGitDiffTab: false,
           showInfoTab: false,
           showNewTabButton: true,
+          inlinePanelToggle: "reserved",
           onClose: closeSecondaryPanel,
           onCollapse: closeSecondaryPanel,
           onOpenFileInEditor: handleOpenWorkspaceFileInEditor,

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -57,7 +57,11 @@ export function ThreadDetailHeader({
     ? "Hide right panel"
     : "Show right panel";
   const rightPanelIconName = renderAsDrawer ? "PanelBottom" : "PanelRight";
-  const showRightPanelToggle = renderAsDrawer || !isSecondaryPanelOpen;
+  // The header is a full-width bar, so the toggle holds a stable position at the
+  // window edge — keep it mounted across open/close on wide layouts (the panel no
+  // longer renders its own inline hide control). The drawer still hides it while
+  // open, since the drawer carries its own close affordance.
+  const showRightPanelToggle = !renderAsDrawer || !isSecondaryPanelOpen;
 
   const center = (
     <>

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -9,11 +9,6 @@ import {
   type ReactNode,
 } from "react";
 import {
-  getBbDesktopInfo,
-  shouldUseMacosDesktopChrome,
-} from "@/lib/bb-desktop";
-import { useOptionalIsSidebarShowing } from "@/components/ui/sidebar.js";
-import {
   Panel,
   PanelGroup,
   type ImperativePanelGroupHandle,
@@ -45,7 +40,7 @@ const TIMELINE_PANEL_MIN_SIZE_PERCENT = 30;
 
 type ThreadTimelinePaneProps = Omit<
   ComponentProps<typeof ThreadTimelinePane>,
-  "footer" | "header"
+  "footer"
 >;
 type ThreadSecondaryPanelProps = Omit<
   ComponentProps<typeof ThreadSecondaryPanel>,
@@ -53,7 +48,6 @@ type ThreadSecondaryPanelProps = Omit<
   | "renderAsDrawer"
   | "isConversationCollapsed"
   | "onToggleConversationCollapse"
-  | "reserveLeftForDesktopTrafficLights"
   | "browserDeck"
 > & {
   renderBrowserDeck?: (args: {
@@ -243,17 +237,6 @@ export function ThreadDetailSecondaryContent({
   const persistedSecondaryWidthPercent = useAtomValue(
     secondaryPanelWidthPercentAtom,
   );
-  // When the main sidebar is collapsed on macOS desktop, the traffic-light
-  // cluster sits over the leftmost content (no expanded sidebar to absorb it).
-  // The rail's chevron and the secondary panel's tab strip need to clear that
-  // zone; nothing-to-do otherwise (web, or sidebar covers the cluster).
-  const [desktopInfo] = useState(getBbDesktopInfo);
-  const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
-  const optionalIsMainSidebarShowing = useOptionalIsSidebarShowing();
-  const isMainSidebarShowing =
-    surface === "popout" ? false : optionalIsMainSidebarShowing === true;
-  const isLeftmostSurfaceUnderTrafficLights =
-    usesDesktopChrome && !isMainSidebarShowing && !renderAsDrawer;
   // Collapsing the conversation only makes sense on a wide viewport with the
   // secondary panel open — there is otherwise nothing to expand into.
   const canCollapseConversation = isSecondaryPanelOpen && !renderAsDrawer;
@@ -424,11 +407,10 @@ export function ThreadDetailSecondaryContent({
       renderAsDrawer={false}
       isConversationCollapsed={isConversationCollapsedActive}
       onToggleConversationCollapse={onToggleConversationCollapse}
-      // Panel is leftmost only when the rail (36px) is the only thing between
-      // it and the window edge — i.e. the conversation is also collapsed.
-      reserveLeftForDesktopTrafficLights={
-        isLeftmostSurfaceUnderTrafficLights && isConversationCollapsedActive
-      }
+      // The full-width header bar owns the (stable) right-panel toggle, so the
+      // panel drops its own inline hide control entirely — no reserved slot, so
+      // the trailing expand control sits flush at the edge.
+      inlinePanelToggle="hidden"
       metadataContent={metadataContent}
     />
   ) : null;
@@ -439,7 +421,6 @@ export function ThreadDetailSecondaryContent({
       renderAsDrawer={true}
       isConversationCollapsed={false}
       onToggleConversationCollapse={onToggleConversationCollapse}
-      reserveLeftForDesktopTrafficLights={false}
       metadataContent={metadataContent}
     />
   ) : null;
@@ -452,6 +433,12 @@ export function ThreadDetailSecondaryContent({
       )}
     >
       {/*
+        The thread header is a full-width bar above the split, so its right-aligned
+        actions stay anchored to the window edge instead of riding the timeline
+        panel's width as the secondary panel opens and closes.
+      */}
+      {header}
+      {/*
         When collapsed we keep the resizable PanelGroup mounted (the timeline
         lifts to 0% and the panel to 100% via the layout effect) and slot the
         36px rail in beside it as a plain flex sibling. This sidesteps the
@@ -460,13 +447,11 @@ export function ThreadDetailSecondaryContent({
         panel's content (live iframes, parsed diffs, scroll position) is
         never torn down and re-created when toggling collapse.
       */}
-      <div className="flex h-full w-full min-w-0">
+      <div className="flex min-h-0 w-full min-w-0 flex-1">
         <ConversationCollapsedRail
           collapsed={isConversationCollapsedActive}
           isWorking={isConversationWorking}
-          reserveTopForDesktopTrafficLights={
-            isLeftmostSurfaceUnderTrafficLights
-          }
+          reserveTopForDesktopTrafficLights={false}
           onExpand={onToggleConversationCollapse}
         />
         <PanelGroup
@@ -475,7 +460,12 @@ export function ThreadDetailSecondaryContent({
           key={stableTimeline.threadId}
           ref={horizontalPanelGroupRef}
           direction="horizontal"
-          className="h-full min-w-0 flex-1"
+          // Query container so the secondary panel can hold its content at the
+          // panel's open width in cqw and clip it into view instead of reflowing
+          // (see ThreadSecondaryPanel swipe mode). Scoping it to the group — not
+          // the rail+group row — keeps cqw equal to the panel's own width even
+          // when the conversation-collapsed rail is present.
+          className="@container h-full min-w-0 flex-1"
           // react-resizable-panels sets an INLINE `overflow: hidden` on the group
           // root, which is still programmatically scrollable. A `scrollIntoView`
           // from the app-preview iframe (clicking an in-page `#anchor`) walks up
@@ -513,11 +503,7 @@ export function ThreadDetailSecondaryContent({
                 isConversationCollapsedActive && "opacity-0",
               )}
             >
-              <ThreadTimelinePane
-                {...stableTimeline}
-                footer={footer}
-                header={header}
-              />
+              <ThreadTimelinePane {...stableTimeline} footer={footer} />
             </div>
           </Panel>
           {inlineSecondaryPanelContent}

--- a/apps/app/src/views/thread-detail/ThreadTimelinePane.tsx
+++ b/apps/app/src/views/thread-detail/ThreadTimelinePane.tsx
@@ -13,7 +13,6 @@ interface ThreadTimelinePaneProps extends ThreadTimelineSurfaceProps {
   canSpawnChild: boolean;
   footer: ReactNode;
   hasOlderTimelineRows: boolean;
-  header: ReactNode;
   isLoadingOlderTimelineRows: boolean;
   isStopping: boolean;
   onLoadOlderRows: () => void;
@@ -31,7 +30,6 @@ export function ThreadTimelinePane({
   threadChildOrigin,
   footer,
   hasOlderTimelineRows,
-  header,
   hostConnectionNotice,
   isLoadingOlderTimelineRows,
   isThreadTimelinePending,
@@ -63,7 +61,6 @@ export function ThreadTimelinePane({
       data-thread-window=""
       className="flex h-full min-h-0 min-w-0 flex-col overflow-clip"
     >
-      {header}
       <PageShell
         key={threadId}
         scrollBehavior="bottom-anchor"


### PR DESCRIPTION
Closes #435.

- Stable toggle + full-width thread header. One toggle that holds position across open/close; on a thread, a full-width header bar above the split so its actions stay pinned to the window edge.
- No-reflow open/close. Content is held at the panel's open width and the panel clips it in (root compose and threads), so it slides instead of reflowing. Same easing, still interruptible.
- Tab-strip cleanup. Pin the `+` to the left, arrows ride the edge fade, cached scroll capacity for smooth narrow-width scrolling, pill padding/radius/hover tidied.

No new deps, nothing touching the token system. `@bb/app` typecheck and tests green. Checked across drawer, popout, conversation-collapse, macOS desktop chrome, and drag-resize.

https://github.com/user-attachments/assets/c03a672d-c4e1-4c8c-9e82-d9353b66596d
