### PR TITLE
Default bb CLI connection to local server

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -14,6 +14,10 @@ message agents, or inspect projects, providers, and environments.
 - Prefer `--json` when command output will drive follow-up work.
 - Run `bb guide` for the system overview and `bb guide <chapter>` for full
   command reference.
+- A standalone `bb` CLI with no connection env targets the default local server
+  at `http://127.0.0.1:38886` and host daemon port `38887`. Set
+  `BB_SERVER_URL` and `BB_HOST_DAEMON_PORT` only for remote or non-default
+  targets.
 
 ## Environment Setup Script
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,14 +69,14 @@ starts.
 
 ## Common Keys
 
-| Key                | Command         | When to set             | Used for                                                                                                                 |
-| ------------------ | --------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `BB_APP_URL`       | `bb-app config` | Optional for remote use | Human-facing app URL used for generated links and allowed browser origins. Leave empty for local-only use.               |
-| `BB_INFERENCE`     | `bb-app config` | Optional                | Server-side helper model in `provider/model` format. Defaults to `codex/gpt-5.4-mini`.                                   |
-| `BB_TRANSCRIPTION` | `bb-app config` | Optional                | Voice transcription model in `provider/model` format. Defaults to `codex/gpt-4o-mini-transcribe`.                        |
-| `BB_SERVER_URL`    | `bb-app config` | Remote CLI/host use     | Server URL for standalone `bb` CLI and `host-daemon` commands on the current machine.                                    |
-| `BB_LOG_LEVEL`     | `bb-app config` | Debugging               | Log level for the next bb start: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`.                                  |
-| `OPENAI_API_KEY`   | `bb-app env`    | OpenAI opt-in routes    | Required only when selecting explicit OpenAI provider routes such as `openai/gpt-4o-mini` or `openai/gpt-4o-transcribe`. |
+| Key                | Command         | When to set             | Used for                                                                                                                                       |
+| ------------------ | --------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BB_APP_URL`       | `bb-app config` | Optional for remote use | Human-facing app URL used for generated links and allowed browser origins. Leave empty for local-only use.                                     |
+| `BB_INFERENCE`     | `bb-app config` | Optional                | Server-side helper model in `provider/model` format. Defaults to `codex/gpt-5.4-mini`.                                                         |
+| `BB_TRANSCRIPTION` | `bb-app config` | Optional                | Voice transcription model in `provider/model` format. Defaults to `codex/gpt-4o-mini-transcribe`.                                              |
+| `BB_SERVER_URL`    | `bb-app config` | Remote CLI/host use     | Server URL for standalone `bb` CLI and `host-daemon` commands on the current machine. The CLI defaults to `http://127.0.0.1:38886` when unset. |
+| `BB_LOG_LEVEL`     | `bb-app config` | Debugging               | Log level for the next bb start: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`.                                                        |
+| `OPENAI_API_KEY`   | `bb-app env`    | OpenAI opt-in routes    | Required only when selecting explicit OpenAI provider routes such as `openai/gpt-4o-mini` or `openai/gpt-4o-transcribe`.                       |
 
 By default, helper inference and voice transcription use Codex credentials from
 the host daemon. Run `codex login` on the host for the default path. Set
@@ -84,7 +84,9 @@ provider env keys only when opting into a non-Codex provider route.
 
 `BB_SERVER_URL` does not change where full `npx bb-app` startup binds locally.
 It is for commands that need to target an already-running server, such as the
-bundled `bb` CLI or a standalone host daemon.
+bundled `bb` CLI or a standalone host daemon. The CLI can omit it when targeting
+the default local packaged server at `http://127.0.0.1:38886`; set it for remote
+or non-default servers.
 
 ## Client SSH Targets
 

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -78,7 +78,9 @@ The package also exposes the `bb` CLI for an already-running bb server:
 npx --package bb-app bb --help
 ```
 
-The CLI uses the same `BB_SERVER_URL` and bb config resolution as the SDK.
+The CLI uses the same `BB_SERVER_URL` and bb config resolution as the SDK. When
+unset, it targets the default local packaged server at
+`http://127.0.0.1:38886`.
 
 ## Scripting with the SDK
 

--- a/packages/config/src/cli.ts
+++ b/packages/config/src/cli.ts
@@ -1,5 +1,10 @@
 import { resolveEnvLoader, type EnvLoaderArgs } from "./env.js";
 import { loadHostDaemonPortValue } from "./ports.js";
+import {
+  BB_LOOPBACK_HOST,
+  BB_PROD_HOST_DAEMON_PORT,
+  BB_PROD_SERVER_PORT,
+} from "./runtime.js";
 import { loadServerUrlValue } from "./server-url.js";
 
 export interface CliConfig {
@@ -11,22 +16,41 @@ export interface LoadCliConfigArgs extends EnvLoaderArgs {
   repoRoot?: string;
 }
 
+const DEFAULT_CLI_SERVER_URL = `http://${BB_LOOPBACK_HOST}:${BB_PROD_SERVER_PORT}`;
+
+function hasConfiguredValue(env: NodeJS.ProcessEnv, key: string): boolean {
+  return env[key] !== undefined;
+}
+
 export function loadCliConfig(args: LoadCliConfigArgs = {}): CliConfig {
   const loader = resolveEnvLoader(args);
-  const serverUrl = loadServerUrlValue({
-    ...args,
-    env: loader.env,
-    homeDir: loader.context.homeDir,
-    mode: loader.mode,
-  });
+  const useDevDefaults = loader.mode === "dev" && args.repoRoot !== undefined;
+  const serverUrl =
+    hasConfiguredValue(loader.env, "BB_SERVER_URL") || useDevDefaults
+      ? loadServerUrlValue({
+          ...args,
+          env: loader.env,
+          homeDir: loader.context.homeDir,
+          mode: loader.mode,
+        })
+      : loadServerUrlValue({
+          ...args,
+          env: loader.env,
+          homeDir: loader.context.homeDir,
+          mode: loader.mode,
+          serverUrl: DEFAULT_CLI_SERVER_URL,
+        });
 
   return {
-    BB_HOST_DAEMON_PORT: loadHostDaemonPortValue({
-      ...args,
-      env: loader.env,
-      homeDir: loader.context.homeDir,
-      mode: loader.mode,
-    }),
+    BB_HOST_DAEMON_PORT:
+      hasConfiguredValue(loader.env, "BB_HOST_DAEMON_PORT") || useDevDefaults
+        ? loadHostDaemonPortValue({
+            ...args,
+            env: loader.env,
+            homeDir: loader.context.homeDir,
+            mode: loader.mode,
+          })
+        : BB_PROD_HOST_DAEMON_PORT,
     BB_SERVER_URL: serverUrl,
   };
 }

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -544,14 +544,15 @@ describe("consumer-specific config", () => {
     expect(loggerConfig.BB_LOG_LEVEL).toBe("debug");
   });
 
-  it("requires CLI connection env", () => {
-    expect(() =>
-      loadCliConfig({
-        env: {
-          NODE_ENV: "development",
-        },
-      }),
-    ).toThrow(/BB_SERVER_URL/u);
+  it("defaults CLI connection env to the local app instance", () => {
+    const cliConfig = loadCliConfig({
+      env: {
+        NODE_ENV: "development",
+      },
+    });
+
+    expect(cliConfig.BB_SERVER_URL).toBe("http://127.0.0.1:38886");
+    expect(cliConfig.BB_HOST_DAEMON_PORT).toBe(38887);
   });
 
   it("lets explicit CLI env overrides win over NODE_ENV-selected defaults", () => {


### PR DESCRIPTION
## Summary
- Default the standalone bb CLI connection to the local packaged server when BB_SERVER_URL is unset
- Default the CLI host daemon port to 38887 when BB_HOST_DAEMON_PORT is unset, while preserving source dev repo-root defaults
- Update CLI config docs, package README, and built-in bb-cli skill guidance

## Validation
- pnpm exec turbo run test --filter=@bb/config
- pnpm exec turbo run typecheck --filter=@bb/config
- pnpm exec turbo run test --filter=@bb/cli
- pnpm exec turbo run typecheck --filter=@bb/cli