### PR TITLE
Fix project-scoped worktree preference

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Host, ProjectSource } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EnvironmentPickerUI } from "./EnvironmentPicker";
+
+const host: Host = {
+  id: "host_test",
+  name: "Local host",
+  type: "persistent",
+  status: "connected",
+  lastSeenAt: null,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const sources: readonly ProjectSource[] = [
+  {
+    id: "src_test",
+    projectId: "proj_test",
+    type: "local_path",
+    hostId: host.id,
+    path: "/tmp/project",
+    isDefault: true,
+    createdAt: 0,
+    updatedAt: 0,
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("EnvironmentPickerUI", () => {
+  it("disables new worktree without disabling local work for non-git sources", () => {
+    render(
+      <EnvironmentPickerUI
+        value={`host:${host.id}:local`}
+        onChange={vi.fn()}
+        sources={sources}
+        host={host}
+        isLocal
+        worktreeDisabledReason="Project source is not a git repository"
+        modal={false}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Environment" }), {
+      button: 0,
+    });
+
+    const localItem = screen.getByRole("menuitem", { name: /Work locally/u });
+    const worktreeItem = screen.getByRole("menuitem", {
+      name: /New worktree/u,
+    });
+
+    expect(localItem.getAttribute("aria-disabled")).toBeNull();
+    expect(worktreeItem.getAttribute("aria-disabled")).toBe("true");
+    expect(
+      screen.getByText("Project source is not a git repository"),
+    ).toBeTruthy();
+  });
+});

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -58,6 +58,8 @@ export interface EnvironmentPickerUIProps {
    * reuse. The entry is always rendered so the affordance stays
    * discoverable; it just can't be selected. */
   reuseDisabled?: boolean;
+  /** Reason to disable "New worktree" while leaving local/remote work usable. */
+  worktreeDisabledReason?: string | null;
   /** Render with the dim, hover-to-foreground treatment used inside the prompt box. */
   muted?: boolean;
   /** Render as a non-interactive label while preserving the selected mode. */
@@ -76,6 +78,7 @@ export function EnvironmentPickerUI({
   host,
   isLocal,
   reuseDisabled,
+  worktreeDisabledReason,
   muted,
   disabled = false,
   className,
@@ -105,6 +108,8 @@ export function EnvironmentPickerUI({
   const workspaceDisabledReason = hasSource
     ? null
     : "Project source unavailable";
+  const newWorktreeDisabledReason =
+    workspaceDisabledReason ?? worktreeDisabledReason ?? null;
   const reuseDisabledReason = reuseDisabled
     ? "No worktrees in this project yet"
     : null;
@@ -203,6 +208,7 @@ export function EnvironmentPickerUI({
           hostUnavailableReason={hostUnavailableReason}
           localLabel={localLabel}
           workspaceDisabledReason={workspaceDisabledReason}
+          worktreeDisabledReason={newWorktreeDisabledReason}
           reuseDisabledReason={reuseDisabledReason}
           selectedType={parsed?.type}
           value={value}
@@ -224,6 +230,8 @@ interface EnvironmentOptionsSectionProps {
   localLabel: string;
   /** Why the local/worktree options are unavailable, or null when usable. */
   workspaceDisabledReason: string | null;
+  /** Why the worktree option is unavailable, or null when usable. */
+  worktreeDisabledReason: string | null;
   /** Why the reuse option is unavailable, or null when usable. */
   reuseDisabledReason: string | null;
   selectedType:
@@ -239,6 +247,7 @@ function EnvironmentOptionsSection({
   hostUnavailableReason,
   localLabel,
   workspaceDisabledReason,
+  worktreeDisabledReason,
   reuseDisabledReason,
   selectedType,
   value,
@@ -248,6 +257,8 @@ function EnvironmentOptionsSection({
   const worktreeValue = hostId ? encodeHostValue(hostId, "worktree") : null;
   const workspaceDisabled = workspaceDisabledReason !== null;
   const workspaceDisabledDescription = workspaceDisabledReason ?? undefined;
+  const worktreeDisabled = worktreeDisabledReason !== null;
+  const worktreeDisabledDescription = worktreeDisabledReason ?? undefined;
 
   return (
     <DropdownMenuGroup>
@@ -277,10 +288,10 @@ function EnvironmentOptionsSection({
           />
           <EnvironmentMenuItem
             label="New worktree"
-            description={workspaceDisabledDescription}
+            description={worktreeDisabledDescription}
             icon={getEnvironmentWorkspaceLabelIconName("managed-worktree")}
             selected={worktreeValue !== null && value === worktreeValue}
-            disabled={workspaceDisabled || worktreeValue === null}
+            disabled={worktreeDisabled || worktreeValue === null}
             onSelect={() => {
               if (worktreeValue !== null) onChange(worktreeValue);
             }}

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Host, ProjectSource } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadEnvSlot } from "./NewThreadPromptBox";
+
+const host: Host = {
+  id: "host_test",
+  name: "Local host",
+  type: "persistent",
+  status: "connected",
+  lastSeenAt: null,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const sources: readonly ProjectSource[] = [
+  {
+    id: "src_test",
+    projectId: "proj_test",
+    type: "local_path",
+    hostId: host.id,
+    path: "/tmp/project",
+    isDefault: true,
+    createdAt: 0,
+    updatedAt: 0,
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ThreadEnvSlot", () => {
+  it("forwards worktree disabled reasons to the environment picker", () => {
+    render(
+      <ThreadEnvSlot
+        environment={{
+          value: `host:${host.id}:local`,
+          onChange: vi.fn(),
+          sources,
+          host,
+          isLocal: true,
+          worktreeDisabledReason: "Project source is not a git repository",
+        }}
+        branch={{
+          value: null,
+          currentBranch: null,
+          isNew: false,
+          options: [],
+          onChange: vi.fn(),
+        }}
+        worktree={{
+          options: [],
+          value: null,
+          onChange: vi.fn(),
+        }}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Environment" }), {
+      button: 0,
+    });
+
+    const worktreeItem = screen.getByRole("menuitem", {
+      name: /New worktree/u,
+    });
+
+    expect(worktreeItem.getAttribute("aria-disabled")).toBe("true");
+    expect(worktreeItem.getAttribute("data-disabled")).toBe("");
+  });
+});

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
@@ -71,4 +71,34 @@ describe("ThreadEnvSlot", () => {
     expect(worktreeItem.getAttribute("aria-disabled")).toBe("true");
     expect(worktreeItem.getAttribute("data-disabled")).toBe("");
   });
+
+  it("hides the branch picker when branch controls are not applicable", () => {
+    render(
+      <ThreadEnvSlot
+        environment={{
+          value: `host:${host.id}:local`,
+          onChange: vi.fn(),
+          sources,
+          host,
+          isLocal: true,
+        }}
+        branch={{
+          value: null,
+          currentBranch: null,
+          isNew: false,
+          hidden: true,
+          options: [],
+          triggerLabel: "Unknown checkout",
+          onChange: vi.fn(),
+        }}
+        worktree={{
+          options: [],
+          value: null,
+          onChange: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Unknown checkout")).toBeNull();
+  });
 });

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -69,6 +69,7 @@ export interface NewThreadBranchConfig {
   value: string | null;
   currentBranch?: string | null;
   isNew: boolean;
+  hidden?: boolean;
   options: readonly string[];
   remoteOptions?: readonly string[];
   priorityOptions?: readonly string[];
@@ -326,7 +327,8 @@ export function ThreadEnvSlot({
     [environment.value],
   );
   const branchMenuKind = getBranchPickerMenuKind({ parsedEnvironment });
-  const showBranchPicker = parsedEnvironment?.type === "host";
+  const showBranchPicker =
+    parsedEnvironment?.type === "host" && branch.hidden !== true;
   const showWorktreePicker = parsedEnvironment?.type === "reuse";
   return (
     <>
@@ -400,6 +402,7 @@ export interface NewThreadConnectedBranchConfig {
   value: string | null;
   currentBranch?: string | null;
   isNew: boolean;
+  hidden?: boolean;
   options: readonly string[];
   remoteOptions?: readonly string[];
   loading?: boolean;
@@ -488,6 +491,7 @@ function ConnectedThreadModeBranch({
       value: branch.value,
       currentBranch: branch.currentBranch,
       isNew: allowCreate && branch.isNew,
+      hidden: branch.hidden,
       options: branch.options,
       remoteOptions: branch.remoteOptions,
       loading: branch.loading,

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -61,6 +61,7 @@ export interface NewThreadEnvironmentConfig {
   /** When true, the picker's "Reuse existing worktree" entry is disabled.
    * Caller signals the project has no worktree envs available. */
   reuseDisabled?: boolean;
+  worktreeDisabledReason?: string | null;
   disabled?: boolean;
 }
 
@@ -386,6 +387,7 @@ export interface NewThreadConnectedEnvironmentConfig {
   /** When true, the "Reuse existing worktree" entry in the env picker is
    * disabled — caller signals the project has no worktree envs available. */
   reuseDisabled?: boolean;
+  worktreeDisabledReason?: string | null;
   disabled?: boolean;
 }
 

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -316,7 +316,11 @@ interface ThreadEnvSlotProps {
   worktree: NewThreadWorktreeConfig;
 }
 
-function ThreadEnvSlot({ environment, branch, worktree }: ThreadEnvSlotProps) {
+export function ThreadEnvSlot({
+  environment,
+  branch,
+  worktree,
+}: ThreadEnvSlotProps) {
   const parsedEnvironment = useMemo(
     () => parseEnvironmentValue(environment.value),
     [environment.value],
@@ -333,6 +337,7 @@ function ThreadEnvSlot({ environment, branch, worktree }: ThreadEnvSlotProps) {
         host={environment.host}
         isLocal={environment.isLocal}
         reuseDisabled={environment.reuseDisabled}
+        worktreeDisabledReason={environment.worktreeDisabledReason}
         disabled={environment.disabled}
         className="shrink-0"
         muted

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -1,11 +1,13 @@
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+import { atomFamily } from "jotai-family";
 import { useCallback } from "react";
 import type { PermissionMode, ReasoningLevel, ServiceTier } from "@bb/domain";
 import {
   createLocalStorageEnumStorage,
   rawStringLocalStorage,
 } from "@/lib/browser-storage";
+import { getProjectScopedStorageKey } from "@/lib/project-scoped-storage";
 
 const MODEL_STORAGE_KEY = "bb.promptbox.model";
 const SERVICE_TIER_STORAGE_KEY = "bb.promptbox.service-tier";
@@ -112,6 +114,14 @@ const environmentSelectionAtom = atomWithStorage<string>(
   rawStringLocalStorage,
   { getOnInit: true },
 );
+const projectEnvironmentSelectionAtomFamily = atomFamily((projectId: string) =>
+  atomWithStorage<string>(
+    getProjectScopedStorageKey(ENVIRONMENT_STORAGE_KEY, projectId),
+    "",
+    rawStringLocalStorage,
+    { getOnInit: true },
+  ),
+);
 
 export function usePromptBoxProviderPreference(): PersistedStringSelectionField {
   const [value, setAtomValue] = useAtom(providerIdAtom);
@@ -135,8 +145,7 @@ export function usePromptBoxModelPreference(): PersistedStringSelectionField {
   return { setValue, value };
 }
 
-export function usePromptBoxServiceTierPreference():
-  PersistedServiceTierSelectionField {
+export function usePromptBoxServiceTierPreference(): PersistedServiceTierSelectionField {
   const [value, setAtomValue] = useAtom(serviceTierAtom);
   const setValue = useCallback(
     (nextValue: StoredServiceTier) => {
@@ -147,8 +156,7 @@ export function usePromptBoxServiceTierPreference():
   return { setValue, value };
 }
 
-export function usePromptBoxReasoningLevelPreference():
-  PersistedReasoningLevelSelectionField {
+export function usePromptBoxReasoningLevelPreference(): PersistedReasoningLevelSelectionField {
   const [value, setAtomValue] = useAtom(reasoningLevelAtom);
   const setValue = useCallback(
     (nextValue: StoredReasoningLevel) => {
@@ -159,8 +167,7 @@ export function usePromptBoxReasoningLevelPreference():
   return { setValue, value };
 }
 
-export function usePromptBoxPermissionModePreference():
-  PersistedPermissionModeSelectionField {
+export function usePromptBoxPermissionModePreference(): PersistedPermissionModeSelectionField {
   const [value, setAtomValue] = useAtom(permissionModeAtom);
   const setValue = useCallback(
     (nextValue: StoredPermissionMode) => {
@@ -171,9 +178,15 @@ export function usePromptBoxPermissionModePreference():
   return { setValue, value };
 }
 
-export function usePromptBoxEnvironmentPreference():
-  PersistedStringSelectionField {
-  const [value, setAtomValue] = useAtom(environmentSelectionAtom);
+export function usePromptBoxEnvironmentPreference(
+  projectId?: string | null,
+): PersistedStringSelectionField {
+  const normalizedProjectId = projectId?.trim();
+  const atom =
+    normalizedProjectId && normalizedProjectId.length > 0
+      ? projectEnvironmentSelectionAtomFamily(normalizedProjectId)
+      : environmentSelectionAtom;
+  const [value, setAtomValue] = useAtom(atom);
   const setValue = useCallback(
     (nextValue: string) => {
       setAtomValue(nextValue);

--- a/apps/app/src/hooks/thread-creation-options/selection-state.ts
+++ b/apps/app/src/hooks/thread-creation-options/selection-state.ts
@@ -38,6 +38,7 @@ export interface UsePromptModelReasoningOptions {
   initialReasoningLevel?: ReasoningLevel;
   initialPermissionMode?: PermissionMode;
   initialEnvironmentSelectionValue?: string;
+  preferenceProjectId?: string | null;
 }
 
 export interface UseNewThreadCreationOptions extends UsePromptModelReasoningOptions {

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { SystemExecutionOptionsResponse } from "@bb/server-contract";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "@/lib/api";
@@ -109,7 +109,7 @@ afterEach(() => {
 });
 
 describe("useThreadCreationOptions", () => {
-  it("uses project-agnostic persisted defaults for new-thread prompt boxes", async () => {
+  it("uses global execution defaults and project-scoped environment for new-thread prompt boxes", async () => {
     window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
     window.localStorage.setItem("bb.promptbox.model", "global-model");
     window.localStorage.setItem("bb.promptbox.service-tier", "default");
@@ -128,7 +128,10 @@ describe("useThreadCreationOptions", () => {
     setProjectScopedValue("bb.promptbox.service-tier", "fast");
     setProjectScopedValue("bb.promptbox.reasoning", "low");
     setProjectScopedValue("bb.promptbox.permission-mode", "readonly");
-    setProjectScopedValue("bb.promptbox.environment", "host:project-host:local");
+    setProjectScopedValue(
+      "bb.promptbox.environment",
+      "host:project-host:local",
+    );
 
     const { wrapper } = createQueryClientTestHarness();
 
@@ -136,6 +139,7 @@ describe("useThreadCreationOptions", () => {
       () =>
         useThreadCreationOptions({
           scope: "new-thread",
+          preferenceProjectId: PROJECT_ID,
           initialProviderId: "initial-provider",
           initialModel: "initial-model",
           initialServiceTier: "fast",
@@ -172,9 +176,33 @@ describe("useThreadCreationOptions", () => {
       expect(result.current.reasoningLevel).toBe("high");
       expect(result.current.permissionMode).toBe("workspace-write");
       expect(result.current.environmentSelectionValue).toBe(
-        "host:global-host:worktree",
+        "host:project-host:local",
       );
     });
+  });
+
+  it("persists new-thread environment selection under the project key", () => {
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "new-thread",
+          preferenceProjectId: PROJECT_ID,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.setEnvironmentSelectionValue("host:project-host:worktree");
+    });
+
+    expect(window.localStorage.getItem("bb.promptbox.environment")).toBeNull();
+    expect(
+      window.localStorage.getItem(
+        getProjectScopedStorageKey("bb.promptbox.environment", PROJECT_ID),
+      ),
+    ).toBe("host:project-host:worktree");
   });
 
   it("loads provider composer actions for environmentless component-local threads", async () => {

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -149,6 +149,7 @@ export function useThreadCreationOptions(
     initialPermissionMode,
     initialReasoningLevel,
     initialServiceTier,
+    preferenceProjectId,
     resetKey,
     scope = "new-thread",
   } = options ?? {};
@@ -165,7 +166,7 @@ export function useThreadCreationOptions(
   const {
     setValue: setStoredEnvironmentSelectionValue,
     value: storedEnvironmentSelectionValue,
-  } = usePromptBoxEnvironmentPreference();
+  } = usePromptBoxEnvironmentPreference(preferenceProjectId);
   // Reuse env values are intentionally NEVER persisted to localStorage —
   // they represent a transient "create one thread in this worktree" intent,
   // not a project default.

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -4,6 +4,7 @@ import {
   type ThreadListEntry,
 } from "@bb/domain";
 import type {
+  ProjectBranchesResponse,
   ProjectWithThreadsResponse,
   SidebarBootstrapResponse,
   TerminalSession,
@@ -17,6 +18,7 @@ import {
   hasPromptBranchSelectionChanged,
   hasPromptOptionValueChanged,
   hasSingleUseRootComposeTargetState,
+  isProjectSourceWorktreeUnavailable,
   mergeMissingPromptDraftAttachments,
   readFolderIdFromLocationState,
   readRootComposeFolderTargetFromLocationState,
@@ -128,6 +130,26 @@ function makeTerminalSession(
     createdAt: 1,
     updatedAt: 1,
     lastUserInputAt: null,
+    ...overrides,
+  };
+}
+
+function makeProjectBranchesResponse(
+  overrides: Partial<ProjectBranchesResponse>,
+): ProjectBranchesResponse {
+  return {
+    branches: [],
+    branchesTruncated: false,
+    checkout: { kind: "branch", branchName: "main", headSha: null },
+    defaultBranch: "main",
+    defaultBranchRelation: "equal",
+    defaultWorktreeBaseBranch: "main",
+    hasUncommittedChanges: false,
+    operation: { kind: "none" },
+    originDefaultBranch: "main",
+    remoteBranches: [],
+    remoteBranchesTruncated: false,
+    selectedBranch: null,
     ...overrides,
   };
 }
@@ -503,6 +525,29 @@ describe("shouldNavigateAfterThreadCreate", () => {
         isForkDraft: true,
         navigateToThreadAfterCreate: false,
       }),
+    ).toBe(true);
+  });
+});
+
+describe("isProjectSourceWorktreeUnavailable", () => {
+  it("treats unknown checkout metadata as unavailable for worktree creation", () => {
+    expect(isProjectSourceWorktreeUnavailable(undefined)).toBe(false);
+    expect(
+      isProjectSourceWorktreeUnavailable(makeProjectBranchesResponse({})),
+    ).toBe(false);
+    expect(
+      isProjectSourceWorktreeUnavailable(
+        makeProjectBranchesResponse({
+          checkout: {
+            kind: "unknown",
+            reason: "Path is not a git repository",
+          },
+          defaultBranch: null,
+          defaultBranchRelation: null,
+          defaultWorktreeBaseBranch: null,
+          originDefaultBranch: null,
+        }),
+      ),
     ).toBe(true);
   });
 });

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2980,6 +2980,7 @@ export function RootComposeView(props: RootComposeViewProps) {
         branchEnvironmentMode === "local"
           ? (branchUiState.currentOptionLabel ?? undefined)
           : undefined,
+      hidden: projectSourceWorktreeUnavailable,
       optionDisabledReason: branchUiState.mutationBlocker?.label,
       optionDisabledTitle: branchUiState.mutationBlocker?.title,
       createDisabledReason: branchUiState.mutationBlocker?.label,
@@ -2998,6 +2999,7 @@ export function RootComposeView(props: RootComposeViewProps) {
       branchEnvironmentMode,
       isForkDraft,
       priorityBranchOptions,
+      projectSourceWorktreeUnavailable,
       remoteBranchOptions,
       branchUiState.currentBranch,
       branchUiState.currentOptionLabel,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -21,6 +21,7 @@ import {
 } from "@bb/domain";
 import type { OpenInTargetContext } from "@bb/host-daemon-contract";
 import type {
+  ProjectBranchesResponse,
   SidebarBootstrapResponse,
   TerminalSession,
 } from "@bb/server-contract";
@@ -387,6 +388,9 @@ interface ResolveRootComposeEffectiveEnvironmentValueArgs {
   reuseThreadOptionsLoading: boolean;
 }
 
+const NON_GIT_PROJECT_SOURCE_WORKTREE_DISABLED_REASON =
+  "Project source is not a git repository";
+
 interface ShouldNavigateAfterThreadCreateArgs {
   isForkDraft: boolean;
   navigateToThreadAfterCreate: boolean;
@@ -620,6 +624,15 @@ function buildReuseThreadOptions(
     return left.environmentId.localeCompare(right.environmentId);
   });
   return options;
+}
+
+function isNonGitProjectSourceCheckout(
+  data: ProjectBranchesResponse | undefined,
+): boolean {
+  return (
+    data?.checkout.kind === "unknown" &&
+    data.checkout.reason === "Path is not a git repository"
+  );
 }
 
 export function resolveRootComposeEffectiveEnvironmentValue({
@@ -966,6 +979,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     null;
   const creationOptions = useThreadCreationOptions({
     scope: "new-thread",
+    preferenceProjectId: projectId,
     initialProviderId: projectDefaultExecutionOptions?.providerId,
     initialModel: projectDefaultExecutionOptions?.model,
     initialServiceTier: projectDefaultExecutionOptions?.serviceTier,
@@ -1283,6 +1297,29 @@ export function RootComposeView(props: RootComposeViewProps) {
     },
   );
   const activeBranchesQuery = hostBranchesQuery;
+  const projectSourceIsNonGit = isNonGitProjectSourceCheckout(
+    activeBranchesQuery.data,
+  );
+  const selectedEnvironmentRequestsManagedWorktree =
+    parsedEnvironment?.type === "host" && parsedEnvironment.mode === "worktree";
+  const managedWorktreeAvailabilityPending =
+    selectedEnvironmentRequestsManagedWorktree &&
+    !isProjectless &&
+    activeBranchesQuery.isLoading;
+  const managedWorktreeUnavailable =
+    selectedEnvironmentRequestsManagedWorktree && projectSourceIsNonGit;
+  useEffect(() => {
+    if (
+      !projectSourceIsNonGit ||
+      parsedEnvironment?.type !== "host" ||
+      parsedEnvironment.mode !== "worktree"
+    ) {
+      return;
+    }
+    setEnvironmentSelectionValue(
+      encodeHostValue(parsedEnvironment.hostId, "local"),
+    );
+  }, [parsedEnvironment, projectSourceIsNonGit, setEnvironmentSelectionValue]);
   const branchOptions = useMemo(() => {
     const branches = activeBranchesQuery.data?.branches ?? [];
     const selectedRef = activeBranchesQuery.data?.selectedBranch;
@@ -1555,6 +1592,8 @@ export function RootComposeView(props: RootComposeViewProps) {
       submittedInput.length === 0 ||
       createThread.isPending ||
       isCodexCliVersionBlocked ||
+      managedWorktreeAvailabilityPending ||
+      managedWorktreeUnavailable ||
       (forkSeed === null && !selectedEnvironment)
     ) {
       return;
@@ -1622,6 +1661,8 @@ export function RootComposeView(props: RootComposeViewProps) {
     executionInputSources,
     forkSeed,
     isCodexCliVersionBlocked,
+    managedWorktreeAvailabilityPending,
+    managedWorktreeUnavailable,
     navigate,
     navigateToThreadAfterCreate,
     permissionMode,
@@ -1647,6 +1688,8 @@ export function RootComposeView(props: RootComposeViewProps) {
     createThread.isPending ||
     promptInput.length === 0 ||
     (forkSeed === null && !selectedEnvironment) ||
+    managedWorktreeAvailabilityPending ||
+    managedWorktreeUnavailable ||
     (branchEnvironmentMode === "local" &&
       selectedBranch !== null &&
       branchUiState.mutationBlocker !== null);
@@ -2878,12 +2921,16 @@ export function RootComposeView(props: RootComposeViewProps) {
       onChange: handleEnvironmentSelectionValueChange,
       sources: projectSources,
       reuseDisabled: reuseThreadOptions.length === 0,
+      worktreeDisabledReason: projectSourceIsNonGit
+        ? NON_GIT_PROJECT_SOURCE_WORKTREE_DISABLED_REASON
+        : null,
       disabled: isForkDraft,
     }),
     [
       effectiveEnvironmentValue,
       isForkDraft,
       handleEnvironmentSelectionValueChange,
+      projectSourceIsNonGit,
       projectSources,
       reuseThreadOptions.length,
     ],

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -388,7 +388,7 @@ interface ResolveRootComposeEffectiveEnvironmentValueArgs {
   reuseThreadOptionsLoading: boolean;
 }
 
-const NON_GIT_PROJECT_SOURCE_WORKTREE_DISABLED_REASON =
+const PROJECT_SOURCE_WORKTREE_DISABLED_REASON =
   "Project source is not a git repository";
 
 interface ShouldNavigateAfterThreadCreateArgs {
@@ -626,13 +626,10 @@ function buildReuseThreadOptions(
   return options;
 }
 
-function isNonGitProjectSourceCheckout(
+export function isProjectSourceWorktreeUnavailable(
   data: ProjectBranchesResponse | undefined,
 ): boolean {
-  return (
-    data?.checkout.kind === "unknown" &&
-    data.checkout.reason === "Path is not a git repository"
-  );
+  return data?.checkout.kind === "unknown";
 }
 
 export function resolveRootComposeEffectiveEnvironmentValue({
@@ -1297,7 +1294,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     },
   );
   const activeBranchesQuery = hostBranchesQuery;
-  const projectSourceIsNonGit = isNonGitProjectSourceCheckout(
+  const projectSourceWorktreeUnavailable = isProjectSourceWorktreeUnavailable(
     activeBranchesQuery.data,
   );
   const selectedEnvironmentRequestsManagedWorktree =
@@ -1307,10 +1304,11 @@ export function RootComposeView(props: RootComposeViewProps) {
     !isProjectless &&
     activeBranchesQuery.isLoading;
   const managedWorktreeUnavailable =
-    selectedEnvironmentRequestsManagedWorktree && projectSourceIsNonGit;
+    selectedEnvironmentRequestsManagedWorktree &&
+    projectSourceWorktreeUnavailable;
   useEffect(() => {
     if (
-      !projectSourceIsNonGit ||
+      !projectSourceWorktreeUnavailable ||
       parsedEnvironment?.type !== "host" ||
       parsedEnvironment.mode !== "worktree"
     ) {
@@ -1319,7 +1317,11 @@ export function RootComposeView(props: RootComposeViewProps) {
     setEnvironmentSelectionValue(
       encodeHostValue(parsedEnvironment.hostId, "local"),
     );
-  }, [parsedEnvironment, projectSourceIsNonGit, setEnvironmentSelectionValue]);
+  }, [
+    parsedEnvironment,
+    projectSourceWorktreeUnavailable,
+    setEnvironmentSelectionValue,
+  ]);
   const branchOptions = useMemo(() => {
     const branches = activeBranchesQuery.data?.branches ?? [];
     const selectedRef = activeBranchesQuery.data?.selectedBranch;
@@ -2921,8 +2923,8 @@ export function RootComposeView(props: RootComposeViewProps) {
       onChange: handleEnvironmentSelectionValueChange,
       sources: projectSources,
       reuseDisabled: reuseThreadOptions.length === 0,
-      worktreeDisabledReason: projectSourceIsNonGit
-        ? NON_GIT_PROJECT_SOURCE_WORKTREE_DISABLED_REASON
+      worktreeDisabledReason: projectSourceWorktreeUnavailable
+        ? PROJECT_SOURCE_WORKTREE_DISABLED_REASON
         : null,
       disabled: isForkDraft,
     }),
@@ -2930,7 +2932,7 @@ export function RootComposeView(props: RootComposeViewProps) {
       effectiveEnvironmentValue,
       isForkDraft,
       handleEnvironmentSelectionValueChange,
-      projectSourceIsNonGit,
+      projectSourceWorktreeUnavailable,
       projectSources,
       reuseThreadOptions.length,
     ],


### PR DESCRIPTION
## Summary
- scope the root compose environment/worktree preference by project
- disable new worktree mode for non-git project sources while keeping local folder work available
- hide git branch checkout controls when the selected project source is not a git checkout
- normalize stale worktree selections back to local mode for non-git projects

Fixes #445

## Tests
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/NewThreadPromptBox.test.tsx src/views/RootComposeView.test.ts src/hooks/useThreadCreationOptions.test.tsx src/components/pickers/EnvironmentPicker.test.tsx
- git diff --check
- browser-checked http://100.64.158.8:12995/?cacheBust=0d738fcf7
