### PR TITLE
[codex] Show background subagent tasks

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { isBackgroundAgentTaskType } from "@bb/domain";
 import type { TimelineWorkflowWorkRow } from "@bb/server-contract";
 import { durationToCompactString } from "@bb/thread-view";
 import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
@@ -15,12 +16,48 @@ const CARD_ROW_HEIGHT = 32;
 const BODY_ID = "thread-background-commands-card-body";
 const TOGGLE_ID = "thread-background-commands-card-toggle";
 
+interface BackgroundActivityDisplay {
+  icon: "Terminal" | "UserRoundPlus";
+  label: string;
+  runningPrefix: string;
+}
+
+function backgroundActivityDisplay(
+  row: TimelineWorkflowWorkRow,
+): BackgroundActivityDisplay {
+  if (isBackgroundAgentTaskType(row.taskType)) {
+    return {
+      icon: "UserRoundPlus",
+      label: "Background agent",
+      runningPrefix: "Running background agent:",
+    };
+  }
+  return {
+    icon: "Terminal",
+    label: "Background command",
+    runningPrefix: "Running background command:",
+  };
+}
+
+function backgroundActivityGroupLabel(
+  rows: readonly TimelineWorkflowWorkRow[],
+): string {
+  const hasAgent = rows.some((row) => isBackgroundAgentTaskType(row.taskType));
+  const hasCommand = rows.some(
+    (row) => !isBackgroundAgentTaskType(row.taskType),
+  );
+  if (hasAgent && hasCommand) {
+    return "Background activity";
+  }
+  return hasAgent ? "Background agents" : "Background commands";
+}
+
 /**
- * Live elapsed time since the command started, ticking every second. Blank for
- * the first second to avoid sub-second flicker on entry. Mirrors the workflow
- * card's duration treatment.
+ * Live elapsed time since the background task started, ticking every second.
+ * Blank for the first second to avoid sub-second flicker on entry. Mirrors the
+ * workflow card's duration treatment.
  */
-function CommandDuration({ startedAt }: { startedAt: number }) {
+function BackgroundActivityDuration({ startedAt }: { startedAt: number }) {
   const [elapsed, setElapsed] = useState(() => Date.now() - startedAt);
   useEffect(() => {
     setElapsed(Date.now() - startedAt);
@@ -35,7 +72,7 @@ function CommandDuration({ startedAt }: { startedAt: number }) {
   return <>{durationToCompactString(elapsed)}</>;
 }
 
-function CommandSummary({
+function BackgroundActivitySummary({
   row,
   showDuration,
   active = false,
@@ -44,6 +81,7 @@ function CommandSummary({
   showDuration: boolean;
   active?: boolean;
 }) {
+  const display = backgroundActivityDisplay(row);
   return (
     <span className="flex min-w-0 flex-1 items-center gap-1 text-left">
       {/* Verb + description truncate as one unit so the trailing controls
@@ -54,7 +92,7 @@ function CommandSummary({
             active ? activityMetaClass("active") : "text-muted-foreground"
           }
         >
-          Running background command:{" "}
+          {display.runningPrefix}{" "}
         </span>
         <span
           className={
@@ -73,7 +111,7 @@ function CommandSummary({
             active ? activityMetaClass("active") : "text-muted-foreground",
           )}
         >
-          <CommandDuration startedAt={row.startedAt} />
+          <BackgroundActivityDuration startedAt={row.startedAt} />
         </span>
       ) : null}
     </span>
@@ -87,12 +125,11 @@ export interface ThreadBackgroundCommandsCardProps {
 }
 
 /**
- * Prompt-stack card for running backgrounded shell commands (Bash
- * run_in_background), independent of the workflow card. Collapsed it shows the
- * most recent command; when several are running it appends "+N more" and the
- * card expands to list the other running commands. Each command also keeps its
- * own timeline row carrying the terminal outcome; this card only tracks the
- * live ones and drops out once none remain.
+ * Prompt-stack card for running non-workflow background tasks, independent of
+ * the workflow card. Collapsed it shows the most recent task; when several are
+ * running it appends "+N more" and expands to list the rest. Each task also
+ * keeps its own timeline row carrying the terminal outcome; this card only
+ * tracks the live ones and drops out once none remain.
  */
 export function ThreadBackgroundCommandsCard({
   commands,
@@ -105,10 +142,12 @@ export function ThreadBackgroundCommandsCard({
   }
   const others = commands.slice(1);
   const hasMore = others.length > 0;
+  const primaryDisplay = backgroundActivityDisplay(primary);
+  const groupLabel = backgroundActivityGroupLabel(commands);
 
   return (
     <PromptStackCard
-      ariaLabel="Background commands"
+      ariaLabel={groupLabel}
       className="overflow-hidden"
       style={{ minHeight: CARD_ROW_HEIGHT }}
     >
@@ -119,7 +158,7 @@ export function ThreadBackgroundCommandsCard({
             id={TOGGLE_ID}
             aria-expanded={isExpanded}
             aria-controls={BODY_ID}
-            aria-label={`Background commands: ${primary.description}`}
+            aria-label={`${groupLabel}: ${primary.description}`}
             onClick={onToggle}
             className={activityRowClass(
               "active",
@@ -127,11 +166,15 @@ export function ThreadBackgroundCommandsCard({
             )}
           >
             <Icon
-              name="Terminal"
+              name={primaryDisplay.icon}
               className={activityIconClass("active", "size-3.5 shrink-0")}
               aria-hidden="true"
             />
-            <CommandSummary row={primary} showDuration={false} active />
+            <BackgroundActivitySummary
+              row={primary}
+              showDuration={false}
+              active
+            />
             <span className={activityMetaClass("active", "shrink-0")}>
               +{others.length} more
             </span>
@@ -151,14 +194,14 @@ export function ThreadBackgroundCommandsCard({
               "active",
               "flex min-h-8 w-full min-w-0 cursor-default items-center gap-1.5 rounded-none px-3 py-1.5 text-xs text-foreground",
             )}
-            aria-label={`Background command: ${primary.description}`}
+            aria-label={`${primaryDisplay.label}: ${primary.description}`}
           >
             <Icon
-              name="Terminal"
+              name={primaryDisplay.icon}
               className={activityIconClass("active", "size-3.5 shrink-0")}
               aria-hidden="true"
             />
-            <CommandSummary row={primary} showDuration active />
+            <BackgroundActivitySummary row={primary} showDuration active />
           </div>
         )}
       </div>
@@ -177,29 +220,32 @@ export function ThreadBackgroundCommandsCard({
         >
           <div className="overflow-hidden bg-popover">
             <div className="flex flex-col gap-0.5 py-1">
-              {others.map((row) => (
-                <div
-                  key={row.id}
-                  // px-3 matches the full-width header row's padding so the
-                  // icon lines up under the header icon.
-                  className="flex min-w-0 items-center gap-1.5 px-3 py-0.5 text-xs"
-                >
-                  <Icon
-                    name="Terminal"
-                    className="size-3.5 shrink-0 text-muted-foreground/60"
-                    aria-hidden="true"
-                  />
-                  <span
-                    className="min-w-0 flex-1 truncate text-muted-foreground"
-                    title={row.description}
+              {others.map((row) => {
+                const display = backgroundActivityDisplay(row);
+                return (
+                  <div
+                    key={row.id}
+                    // px-3 matches the full-width header row's padding so the
+                    // icon lines up under the header icon.
+                    className="flex min-w-0 items-center gap-1.5 px-3 py-0.5 text-xs"
                   >
-                    {row.description}
-                  </span>
-                  <span className="shrink-0 whitespace-nowrap text-subtle-foreground">
-                    <CommandDuration startedAt={row.startedAt} />
-                  </span>
-                </div>
-              ))}
+                    <Icon
+                      name={display.icon}
+                      className="size-3.5 shrink-0 text-muted-foreground/60"
+                      aria-hidden="true"
+                    />
+                    <span
+                      className="min-w-0 flex-1 truncate text-muted-foreground"
+                      title={row.description}
+                    >
+                      {row.description}
+                    </span>
+                    <span className="shrink-0 whitespace-nowrap text-subtle-foreground">
+                      <BackgroundActivityDuration startedAt={row.startedAt} />
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </section>

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -16,7 +16,10 @@ import {
   type QueryCacheNotifyEvent,
   type QueryClient,
 } from "@tanstack/react-query";
-import { isBackgroundCommandTaskType } from "@bb/domain";
+import {
+  isBackgroundAgentTaskType,
+  isBackgroundCommandTaskType,
+} from "@bb/domain";
 import type {
   ThreadChildOrigin,
   ThreadRuntimeDisplayStatus,
@@ -1364,10 +1367,14 @@ function leadingIconForWorkRow(
     case "delegation":
       return "UserRoundPlus";
     case "workflow":
-      // Backgrounded shell commands reuse the workflow row but read as commands.
-      return isBackgroundCommandTaskType(row.taskType)
-        ? "Terminal"
-        : "ListTodo";
+      // Background tasks reuse the workflow row shape but read by task type.
+      if (isBackgroundCommandTaskType(row.taskType)) {
+        return "Terminal";
+      }
+      if (isBackgroundAgentTaskType(row.taskType)) {
+        return "UserRoundPlus";
+      }
+      return "ListTodo";
     case "approval":
       return "Lock";
     case "question":

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -191,6 +191,7 @@ interface TimelineEventRowSelection {
 }
 
 interface TimelineWindowRowsArgs {
+  includeParentContext?: boolean;
   rows: readonly StoredEventRow[];
   threadId: string;
 }
@@ -456,6 +457,13 @@ function ensureTimelineWindowParentedRows(
       }
     }
     rows = mergeStoredEventRowsById([...rows, ...newChildRows]);
+  }
+
+  if (args.includeParentContext === false) {
+    return {
+      contextOnlyToolCallIds: new Set(),
+      rows,
+    };
   }
 
   const contextOnlyToolCallIds = new Set<string>();
@@ -1246,14 +1254,14 @@ export function buildTimelineTurnSummaryDetails(
   // validated against the requested turn, that turn's start must be at or
   // before the latest selected turn row. Accepted input rows may sit after
   // sourceSeqEnd, so the lifecycle lookup uses the widened context cutoff.
-  const turnStartedRows = hasCurrentStartedRow
+  const requestedTurnStartedRows = hasCurrentStartedRow
     ? []
     : listStoredTurnStartedRowsByTurnIdsUpToSequence(db, {
         threadId: thread.id,
         sequenceCutoff: contextSequenceCutoff,
         turnIds: [options.turnId],
       });
-  if (!hasCurrentStartedRow && turnStartedRows.length === 0) {
+  if (!hasCurrentStartedRow && requestedTurnStartedRows.length === 0) {
     throw new ApiError(
       400,
       "invalid_request",
@@ -1269,14 +1277,23 @@ export function buildTimelineTurnSummaryDetails(
     },
     useExactEventRowBounds: exactEventRowsForRequestedTurn.removedRows,
   });
+  const eventRowsWithParentedChildren = ensureTimelineWindowParentedRows(db, {
+    includeParentContext: false,
+    threadId: thread.id,
+    rows: mergeStoredEventRowsById([...requestedTurnStartedRows, ...eventRows]),
+  }).rows;
+  const eventRowsWithTurnStarts = ensureTimelineWindowTurnStartedRows(db, {
+    threadId: thread.id,
+    rows: eventRowsWithParentedChildren,
+  });
   const eventRowsWithBackgroundTaskState =
     ensureTimelineWindowBackgroundTaskStateRows(db, {
       threadId: thread.id,
-      rows: eventRows,
+      rows: eventRowsWithTurnStarts,
     });
   const children = buildThreadTimelineTurnDetailsFromEvents({
-    events: [...turnStartedRows, ...eventRowsWithBackgroundTaskState].map(
-      (row) => toThreadEventWithMeta(row),
+    events: eventRowsWithBackgroundTaskState.map((row) =>
+      toThreadEventWithMeta(row),
     ),
     options: {
       includeProviderUnhandledOperations,

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -1149,6 +1149,150 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("hydrates parent turn-summary details with delegated child rows", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const providerThreadId = "provider-thread-1";
+
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 2,
+        type: "item/started",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "agent-call",
+            tool: "Agent",
+            arguments: {
+              description: "Map old Telegram integration",
+              subagent_type: "general-purpose",
+              prompt: "Map the old Telegram integration.",
+            },
+            status: "pending",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "agent-call",
+            tool: "Agent",
+            arguments: {
+              description: "Map old Telegram integration",
+              subagent_type: "general-purpose",
+              prompt: "Map the old Telegram integration.",
+            },
+            status: "completed",
+            result: "Async agent launched successfully.",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 4,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("child-turn"),
+        sequence: 5,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("child-turn"),
+        sequence: 6,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "agentMessage",
+            id: "child-message",
+            text: "Child mapped the Telegram integration.",
+            parentToolCallId: "agent-call",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("child-turn"),
+        sequence: 7,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+      expect(timelineResponse.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(timelineResponse),
+      );
+      const parentTurnRow = timeline.rows.find(
+        (row): row is TimelineTurnRow =>
+          row.kind === "turn" && row.turnId === "parent-turn",
+      );
+      expect(parentTurnRow).toBeDefined();
+      if (!parentTurnRow) {
+        throw new Error("Expected parent turn row");
+      }
+
+      const detailsResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=${parentTurnRow.turnId}&sourceSeqStart=${parentTurnRow.sourceSeqStart}&sourceSeqEnd=${parentTurnRow.sourceSeqEnd}`,
+      );
+      expect(detailsResponse.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(detailsResponse),
+      );
+      const delegation = details.rows.find(
+        (
+          row,
+        ): row is Extract<
+          TimelineRow,
+          { kind: "work"; workKind: "delegation" }
+        > => row.kind === "work" && row.workKind === "delegation",
+      );
+
+      expect(delegation).toBeDefined();
+      expect(delegation?.callId).toBe("agent-call");
+      expect(delegation?.childRows).toContainEqual(
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Child mapped the Telegram integration.",
+        }),
+      );
+    });
+  });
+
   it("hydrates turn-summary details with future accepted input context", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedThreadFixture(harness);

--- a/packages/agent-runtime/src/claude-code/task-translation.test.ts
+++ b/packages/agent-runtime/src/claude-code/task-translation.test.ts
@@ -287,7 +287,7 @@ describe("claude-code background task translation", () => {
     expect(stoppedItem.outputFile).toBeUndefined();
   });
 
-  it("does not materialize foreground subagent tasks (delegation owns them)", () => {
+  it("materializes subagent tasks while preserving the delegation tool call", () => {
     const adapter = createClaudeCodeProviderAdapter();
     const allEvents: ThreadEvent[] = [];
 
@@ -298,7 +298,26 @@ describe("claude-code background task translation", () => {
       );
     }
 
-    expect(collectTaskEvents(allEvents)).toHaveLength(0);
+    const taskEvents = collectTaskEvents(allEvents);
+    expect(taskEvents.map((event) => event.type)).toEqual([
+      "item/started",
+      "item/backgroundTask/completed",
+    ]);
+    expect(backgroundTaskItem(taskEvents[0]!)).toMatchObject({
+      id: "task:a35aa0d9e98a8e8e6",
+      taskType: "local_agent",
+      description: "Single subagent reply test",
+      status: "pending",
+      taskStatus: "running",
+      parentToolCallId: "toolu_01W1cLr7AsTRvbya9LM5LSAV",
+    });
+    expect(backgroundTaskItem(taskEvents[1]!)).toMatchObject({
+      id: "task:a35aa0d9e98a8e8e6",
+      taskType: "local_agent",
+      status: "completed",
+      taskStatus: "completed",
+      summary: "Single subagent reply test",
+    });
     // The session still renders: the Task tool call itself is a started item.
     expect(
       allEvents.some(
@@ -547,4 +566,32 @@ describe("claude-code background task translation", () => {
     });
   });
 
+  it("materializes background subagents with legacy task_type local_subagent", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const events = adapter.translateEvent(
+      {
+        type: "system",
+        subtype: "task_started",
+        task_id: "sub-1",
+        tool_use_id: "toolu_sub_1",
+        description: "background subagent",
+        task_type: "local_subagent",
+        subagent_type: "Explore",
+        uuid: "u-1",
+        session_id: "s-1",
+      },
+      { threadId: "bb-thread-1" },
+    );
+
+    const taskEvents = collectTaskEvents(events);
+    expect(taskEvents).toHaveLength(1);
+    expect(backgroundTaskItem(taskEvents[0]!)).toMatchObject({
+      id: "task:sub-1",
+      taskType: "local_subagent",
+      description: "background subagent",
+      status: "pending",
+      taskStatus: "running",
+      parentToolCallId: "toolu_sub_1",
+    });
+  });
 });

--- a/packages/agent-runtime/src/claude-code/task-translation.ts
+++ b/packages/agent-runtime/src/claude-code/task-translation.ts
@@ -12,6 +12,7 @@ import {
   LOCAL_BASH_TASK_TYPE,
   LOCAL_WORKFLOW_TASK_TYPE,
   backgroundTaskItemStatus,
+  isBackgroundAgentTaskType,
   isSettledBackgroundTaskStatus,
   threadScope,
   turnScope,
@@ -266,12 +267,15 @@ function buildClaudeTaskCompletedEvent(
 
 /**
  * Task types bb materializes as background-task timeline rows: dynamic
- * workflows and backgrounded shell commands. Other task types (subagents,
- * monitors) share the event family but stay on their own render paths.
+ * workflows, backgrounded shell commands, and backgrounded agents. Other task
+ * types such as monitors share the event family but stay on their own render
+ * paths.
  */
 function isMaterializedTaskType(taskType: string): boolean {
   return (
-    taskType === LOCAL_WORKFLOW_TASK_TYPE || taskType === LOCAL_BASH_TASK_TYPE
+    taskType === LOCAL_WORKFLOW_TASK_TYPE ||
+    taskType === LOCAL_BASH_TASK_TYPE ||
+    isBackgroundAgentTaskType(taskType)
   );
 }
 
@@ -279,8 +283,8 @@ function isMaterializedTaskType(taskType: string): boolean {
  * Translates the SDK task event family (task_started / task_progress /
  * task_updated / task_notification). Returns null when the message is not a
  * task message; returns [] for task messages that are intentionally not
- * materialized (subagent/monitor task types — foreground subagents already
- * render via delegation rows — and events for unknown/settled tasks).
+ * materialized (monitor/unknown task types and events for unknown/settled
+ * tasks).
  */
 export function translateClaudeTaskMessage(
   args: TranslateClaudeTaskMessageArgs,

--- a/packages/agent-runtime/src/claude-code/visibility.ts
+++ b/packages/agent-runtime/src/claude-code/visibility.ts
@@ -434,9 +434,8 @@ function describeParsedClaudeRawEvent(
           };
         case "status":
           return { kind: "sdk/system:status", coverage: "normalized" };
-        // Workflow tasks translate into backgroundTask item events; other
-        // task types are deliberately not materialized (foreground subagents
-        // render via delegation rows).
+        // Supported task types translate into backgroundTask item events.
+        // Unsupported task types remain normalized noise.
         case "task_notification":
         case "task_progress":
         case "task_started":

--- a/packages/domain/src/background-task.ts
+++ b/packages/domain/src/background-task.ts
@@ -2,23 +2,30 @@ import { z } from "zod";
 
 /**
  * Raw SDK task-type discriminants for the background tasks bb materializes as
- * timeline rows: dynamic workflows (the Workflow tool) and backgrounded shell
- * commands (Bash with run_in_background). Both share the provider task event
- * family (task_started / task_progress / task_updated / task_notification).
- * Other task types (subagents, monitors) share the family too but are not
- * materialized — foreground subagents already render via delegation rows.
+ * timeline rows: dynamic workflows (the Workflow tool), backgrounded shell
+ * commands (Bash with run_in_background), and backgrounded subagents. They
+ * share the provider task event family (task_started / task_progress /
+ * task_updated / task_notification). Other task types such as monitors share
+ * the family too but are not materialized.
  */
 export const LOCAL_WORKFLOW_TASK_TYPE = "local_workflow";
 export const LOCAL_BASH_TASK_TYPE = "local_bash";
+export const LOCAL_AGENT_TASK_TYPE = "local_agent";
+export const LOCAL_SUBAGENT_TASK_TYPE = "local_subagent";
 
 /**
- * Whether a background task renders as a "background command" row rather than a
- * workflow row. Everything bb materializes that is not a dynamic workflow is a
- * backgrounded shell command, so unknown future materialized types default to
- * the safer command presentation.
+ * Whether a background task renders as a "background command" row rather than
+ * a workflow or background agent row.
  */
 export function isBackgroundCommandTaskType(taskType: string): boolean {
-  return taskType !== LOCAL_WORKFLOW_TASK_TYPE;
+  return taskType === LOCAL_BASH_TASK_TYPE;
+}
+
+export function isBackgroundAgentTaskType(taskType: string): boolean {
+  return (
+    taskType === LOCAL_AGENT_TASK_TYPE ||
+    taskType === LOCAL_SUBAGENT_TASK_TYPE
+  );
 }
 
 /**

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -230,11 +230,10 @@ export const toolCallProgressEventSchema = z.object({
 
 /**
  * A materialized provider background task. Dynamic workflows (taskType
- * "local_workflow") and backgrounded shell commands (taskType "local_bash")
- * become items; foreground subagents share the same provider event family but
- * stay on the delegation rendering path. The item id is derived from the
- * provider task id and stays stable across the started → progress* → completed
- * lifecycle.
+ * "local_workflow"), backgrounded shell commands (taskType "local_bash"), and
+ * backgrounded subagents (taskType "local_agent" / "local_subagent") become
+ * items. The item id is derived from the provider task id and stays stable
+ * across the started → progress* → completed lifecycle.
  */
 export const threadEventBackgroundTaskItemSchema = z.object({
   type: z.literal("backgroundTask"),

--- a/packages/templates/scripts/generate-templates.mjs
+++ b/packages/templates/scripts/generate-templates.mjs
@@ -1,4 +1,11 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
@@ -190,14 +197,7 @@ export type TemplateId = keyof TemplateVariables;
 `;
 
 if (process.argv.includes("--check")) {
-  const currentOutput = await readFile(outputPath, "utf8").catch((error) => {
-    if (error && typeof error === "object" && "code" in error) {
-      if (error.code === "ENOENT") {
-        return null;
-      }
-    }
-    throw error;
-  });
+  const currentOutput = await readCurrentOutput();
   if (currentOutput !== output) {
     console.error(
       "Generated templates are out of date. Run `node packages/templates/scripts/generate-templates.mjs`.",
@@ -208,4 +208,42 @@ if (process.argv.includes("--check")) {
 }
 
 await mkdir(path.dirname(outputPath), { recursive: true });
-await writeFile(outputPath, output, "utf8");
+if ((await readCurrentOutput()) !== output) {
+  await writeOutputAtomically(outputPath, output);
+}
+
+async function readCurrentOutput() {
+  return readFile(outputPath, "utf8").catch((error) => {
+    if (error && typeof error === "object" && "code" in error) {
+      if (error.code === "ENOENT") {
+        return null;
+      }
+    }
+    throw error;
+  });
+}
+
+async function writeOutputAtomically(filePath, content) {
+  const temporaryPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+
+  try {
+    await writeFile(temporaryPath, content, "utf8");
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    await unlink(temporaryPath).catch((unlinkError) => {
+      if (
+        unlinkError &&
+        typeof unlinkError === "object" &&
+        "code" in unlinkError &&
+        unlinkError.code === "ENOENT"
+      ) {
+        return;
+      }
+      throw unlinkError;
+    });
+    throw error;
+  }
+}

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -147,8 +147,8 @@ function selectActiveWorkflowMessage(
   for (const message of messages) {
     if (
       message.kind !== "workflow" ||
-      // The prompt-box active banner is workflow-only; backgrounded shell
-      // commands surface inline in the timeline, not in the banner.
+      // The prompt-box active workflow banner is workflow-only; non-workflow
+      // background tasks use the separate background-activity card.
       message.taskType !== LOCAL_WORKFLOW_TASK_TYPE ||
       message.status !== "pending" ||
       message.skipTranscript
@@ -165,19 +165,74 @@ function selectActiveWorkflowMessage(
   return best;
 }
 
+type EventProjectionCallMessage = Extract<
+  EventProjectionMessage,
+  { callId: string }
+>;
+
+function isEventProjectionCallMessage(
+  message: EventProjectionMessage,
+): message is EventProjectionCallMessage {
+  switch (message.kind) {
+    case "command":
+    case "delegation":
+    case "file-edit":
+    case "image-view":
+    case "tool-call":
+    case "web-fetch":
+    case "web-search":
+      return true;
+    case "assistant-text":
+    case "debug/raw-event":
+    case "error":
+    case "operation":
+    case "permission-grant-lifecycle":
+    case "user":
+    case "user-question-lifecycle":
+    case "workflow":
+      return false;
+  }
+}
+
+function buildCallMessageById(
+  messages: readonly EventProjectionMessage[],
+): ReadonlyMap<string, EventProjectionCallMessage> {
+  const byId = new Map<string, EventProjectionCallMessage>();
+  for (const message of messages) {
+    if (!isEventProjectionCallMessage(message)) {
+      continue;
+    }
+    byId.set(message.callId, message);
+  }
+  return byId;
+}
+
+function isDirectBackgroundTaskForCurrentAgent(
+  message: EventProjectionWorkflowMessage,
+  callMessageById: ReadonlyMap<string, EventProjectionCallMessage>,
+): boolean {
+  if (!message.parentToolCallId) {
+    return true;
+  }
+  const spawningCall = callMessageById.get(message.parentToolCallId);
+  return spawningCall ? spawningCall.parentToolCallId === undefined : true;
+}
+
 function selectActiveBackgroundCommandMessages(
   messages: readonly EventProjectionMessage[],
 ): EventProjectionWorkflowMessage[] {
-  // Running backgrounded shell commands, most recently started first. Feeds the
-  // background-commands prompt-box card, which is independent of the
-  // workflow-only banner driven by selectActiveWorkflowMessage.
+  // Running non-workflow background tasks, most recently started first. Feeds
+  // the background-activity prompt-box card, independent of the workflow-only
+  // banner driven by selectActiveWorkflowMessage.
+  const callMessageById = buildCallMessageById(messages);
   const running: EventProjectionWorkflowMessage[] = [];
   for (const message of messages) {
     if (
       message.kind !== "workflow" ||
       message.taskType === LOCAL_WORKFLOW_TASK_TYPE ||
       message.status !== "pending" ||
-      message.skipTranscript
+      message.skipTranscript ||
+      !isDirectBackgroundTaskForCurrentAgent(message, callMessageById)
     ) {
       continue;
     }

--- a/packages/thread-view/src/event-projection.ts
+++ b/packages/thread-view/src/event-projection.ts
@@ -40,8 +40,8 @@ export interface EventProjectionState {
    */
   activeWorkflow: EventProjectionWorkflowMessage | null;
   /**
-   * Root-projection-only running backgrounded shell commands, most recently
-   * started first, for the background-commands prompt-box card. Independent of
+   * Root-projection-only running non-workflow background tasks, most recently
+   * started first, for the background-activity prompt-box card. Independent of
    * `activeWorkflow`. Empty for nested child projections.
    */
   activeBackgroundCommands: EventProjectionWorkflowMessage[];

--- a/packages/thread-view/src/timeline-row-title.ts
+++ b/packages/thread-view/src/timeline-row-title.ts
@@ -1,4 +1,5 @@
 import {
+  isBackgroundAgentTaskType,
   isBackgroundCommandTaskType,
   isSettledWorkflowAgentState,
 } from "@bb/domain";
@@ -890,6 +891,24 @@ function backgroundCommandVerbForStatus(status: TimelineRowStatus): {
   }
 }
 
+function backgroundAgentVerbForStatus(status: TimelineRowStatus): {
+  text: string;
+  shimmer: boolean;
+} {
+  switch (status) {
+    case "pending":
+      return { text: "Running background agent:", shimmer: true };
+    case "completed":
+      return { text: "Ran background agent:", shimmer: false };
+    case "error":
+      return { text: "Background agent failed:", shimmer: false };
+    case "interrupted":
+      return { text: "Background agent interrupted:", shimmer: false };
+    default:
+      return assertNever(status);
+  }
+}
+
 function mapBackgroundCommandTitle(
   row: TimelineViewWorkflowWorkRow,
 ): TimelineTitle {
@@ -905,9 +924,27 @@ function mapBackgroundCommandTitle(
   });
 }
 
+function mapBackgroundAgentTitle(
+  row: TimelineViewWorkflowWorkRow,
+): TimelineTitle {
+  const verb = backgroundAgentVerbForStatus(row.status);
+  return makeTitle({
+    segments: [
+      segment(verb.text, { shimmer: verb.shimmer }),
+      segment(row.description, { em: true, truncate: true }),
+    ],
+    decorations: filterNull([
+      durationDecoration(row.startedAt, row.completedAt),
+    ]),
+  });
+}
+
 function mapWorkflowTitle(row: TimelineViewWorkflowWorkRow): TimelineTitle {
   if (isBackgroundCommandTaskType(row.taskType)) {
     return mapBackgroundCommandTitle(row);
+  }
+  if (isBackgroundAgentTaskType(row.taskType)) {
+    return mapBackgroundAgentTitle(row);
   }
   const verb = workflowVerbForStatus(row.status);
   const name = row.workflowName ?? row.description;

--- a/packages/thread-view/src/tool-activity-projection.ts
+++ b/packages/thread-view/src/tool-activity-projection.ts
@@ -13,7 +13,6 @@ import type {
 } from "./exec-lifecycle.js";
 import { messageId } from "./format-helpers.js";
 import {
-  areThreadEventScopesEqual,
   eventProjectionMessageThreadScopeFields,
   eventProjectionMessageTurnScopeFields,
 } from "./message-scope.js";
@@ -349,19 +348,6 @@ function createRunningExecCall(
   }
 }
 
-function assertMatchingExecutionKind(
-  existing: RunningExecCall,
-  incoming: ProviderExecutionUpdate,
-): void {
-  if (existing.kind === incoming.kind) {
-    return;
-  }
-
-  throw new Error(
-    `Cannot merge ${existing.kind} with ${incoming.kind} for call ${incoming.callId}`,
-  );
-}
-
 interface CommandExecutionFieldsTarget {
   approvalStatus: EventProjectionApprovalLifecycleStatus | null;
   command: string;
@@ -484,7 +470,6 @@ function mergeRunningExecutionMetadata(
   existing: RunningExecCall,
   incoming: ProviderExecutionUpdate,
 ): void {
-  assertMatchingExecutionKind(existing, incoming);
   switch (incoming.kind) {
     case "command":
       if (existing.kind !== "command") return;
@@ -508,10 +493,10 @@ function upsertRunningExecCall(
   threadId: string,
   turnId: string | undefined,
 ): RunningExecCall {
-  const scopeFields = turnId
-    ? eventProjectionMessageTurnScopeFields(turnId)
-    : eventProjectionMessageThreadScopeFields();
   if (!existing) {
+    const scopeFields = turnId
+      ? eventProjectionMessageTurnScopeFields(turnId)
+      : eventProjectionMessageThreadScopeFields();
     return createRunningExecCall(incoming, meta, threadId, scopeFields.scope);
   }
 
@@ -522,12 +507,9 @@ function upsertRunningExecCall(
   //   "keep longest" — begin events carry partial output, end events carry full output
   //   "keep terminal" — first terminal state wins unless a later error arrives
 
-  // keep first
-  if (!areThreadEventScopesEqual(existing.scope, scopeFields.scope)) {
-    throw new Error(
-      `Cannot merge execution messages with different scopes for call ${incoming.callId}`,
-    );
-  }
+  // keep first: provider background work can outlive its spawning turn, and a
+  // late terminal event for the same call id may arrive scoped to a later turn.
+  // Preserve the original placement while still merging terminal state/output.
   mergeRunningExecutionMetadata(existing, incoming);
   mergeExecutionCompletion(existing, incoming);
   if (!existing.parentToolCallId && incoming.parentToolCallId) {

--- a/packages/thread-view/test/background-task-timeline.test.ts
+++ b/packages/thread-view/test/background-task-timeline.test.ts
@@ -93,6 +93,7 @@ function bashTaskItem(args: {
   summary?: string;
   id?: string;
   description?: string;
+  parentToolCallId?: string;
 }): ThreadEventBackgroundTaskItem {
   return {
     type: "backgroundTask",
@@ -103,6 +104,30 @@ function bashTaskItem(args: {
     taskStatus: args.taskStatus,
     skipTranscript: false,
     ...(args.summary ? { summary: args.summary } : {}),
+    ...(args.parentToolCallId
+      ? { parentToolCallId: args.parentToolCallId }
+      : {}),
+  };
+}
+
+function agentTaskItem(args: {
+  taskStatus: ThreadEventBackgroundTaskItem["taskStatus"];
+  status: ThreadEventBackgroundTaskItem["status"];
+  id?: string;
+  description?: string;
+  parentToolCallId?: string;
+}): ThreadEventBackgroundTaskItem {
+  return {
+    type: "backgroundTask",
+    id: args.id ?? "task:agent-1",
+    taskType: "local_agent",
+    description: args.description ?? "Map test coverage",
+    status: args.status,
+    taskStatus: args.taskStatus,
+    skipTranscript: false,
+    ...(args.parentToolCallId
+      ? { parentToolCallId: args.parentToolCallId }
+      : {}),
   };
 }
 
@@ -474,7 +499,7 @@ describe("background task timeline projection", () => {
     );
 
     // A running shell command never hijacks the workflow banner, but it does
-    // drive its own independent background-commands card.
+    // drive the independent background-activity card.
     expect(timeline.activeWorkflow).toBeNull();
     expect(timeline.activeBackgroundCommands).toHaveLength(1);
     expect(timeline.activeBackgroundCommands[0]).toMatchObject({
@@ -484,7 +509,7 @@ describe("background task timeline projection", () => {
     });
   });
 
-  it("lists running background commands most-recent-first and excludes workflows", () => {
+  it("lists running background commands and agents most-recent-first and excludes workflows", () => {
     const timeline = buildTimeline(
       [
         turnStarted("turn-1", 1),
@@ -528,17 +553,150 @@ describe("background task timeline projection", () => {
           },
           4,
         ),
-        turnCompleted("turn-1", 5),
+        withMeta(
+          {
+            type: "item/started",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: agentTaskItem({
+              status: "pending",
+              taskStatus: "running",
+              id: "task:agent-latest",
+              description: "Inspect related code",
+            }),
+          },
+          5,
+        ),
+        turnCompleted("turn-1", 6),
       ],
       { includeNestedRows: false, turnMessageDetail: "summary" },
     );
 
-    // The workflow drives the workflow banner; the two shell commands drive the
-    // background-commands card, ordered most recently started first.
+    // The workflow drives the workflow banner; non-workflow background tasks
+    // drive the background-activity card, ordered most recently started first.
     expect(timeline.activeWorkflow).toMatchObject({ taskType: "local_workflow" });
     expect(
       timeline.activeBackgroundCommands.map((row) => row.itemId),
-    ).toEqual(["task:cmd-late", "task:cmd-early"]);
+    ).toEqual(["task:agent-latest", "task:cmd-late", "task:cmd-early"]);
+  });
+
+  it("excludes background tasks spawned inside a background agent from the parent active list", () => {
+    const timeline = buildTimeline(
+      [
+        turnStarted("turn-1", 1),
+        withMeta(
+          {
+            type: "item/started",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: {
+              type: "toolCall",
+              id: "toolu-root-agent",
+              tool: "Agent",
+              arguments: {
+                description: "Sleep then write poem",
+                prompt: "Sleep then write poem",
+              },
+              status: "pending",
+            },
+          },
+          2,
+        ),
+        withMeta(
+          {
+            type: "item/started",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: agentTaskItem({
+              status: "pending",
+              taskStatus: "running",
+              id: "task:root-agent",
+              description: "Sleep then write poem",
+              parentToolCallId: "toolu-root-agent",
+            }),
+          },
+          3,
+        ),
+        withMeta(
+          {
+            type: "item/started",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: {
+              type: "commandExecution",
+              id: "toolu-nested-bash",
+              command: "sleep 10",
+              cwd: "/tmp",
+              status: "pending",
+              approvalStatus: null,
+              parentToolCallId: "toolu-root-agent",
+            },
+          },
+          4,
+        ),
+        withMeta(
+          {
+            type: "item/started",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: bashTaskItem({
+              status: "pending",
+              taskStatus: "running",
+              id: "task:nested-bash",
+              description: "Wait 10 seconds",
+              parentToolCallId: "toolu-nested-bash",
+            }),
+          },
+          5,
+        ),
+        turnCompleted("turn-1", 6),
+        turnStarted("turn-2", 7),
+        withMeta(
+          {
+            type: "item/backgroundTask/completed",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: threadScope(),
+            item: bashTaskItem({
+              status: "completed",
+              taskStatus: "completed",
+              id: "task:nested-bash",
+              description: "Wait 10 seconds",
+              parentToolCallId: "toolu-nested-bash",
+              summary: "Wait 10 seconds",
+            }),
+          },
+          8,
+        ),
+        withMeta(
+          {
+            type: "item/completed",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-2"),
+            item: {
+              type: "toolCall",
+              id: "toolu-nested-bash",
+              tool: "unknown",
+              status: "completed",
+              result: "(Bash completed with no output)",
+              parentToolCallId: "toolu-root-agent",
+            },
+          },
+          9,
+        ),
+      ],
+      { includeNestedRows: false, turnMessageDetail: "summary" },
+    );
+
+    expect(
+      timeline.activeBackgroundCommands.map((row) => row.itemId),
+    ).toEqual(["task:root-agent"]);
   });
 
   it("hides skip_transcript tasks from the timeline", () => {


### PR DESCRIPTION
## Summary

- Materialize Claude background subagent task events (`local_agent` / `local_subagent`) through the existing background-task timeline path.
- Label and icon background-agent rows separately from background shell commands in the timeline and prompt-stack background activity card.
- Filter the prompt-stack background activity list so nested tasks spawned inside subagents do not bubble up into the parent thread banner.
- Fix timeline projection for late background command completions where Claude starts a call as `commandExecution` and later completes the same call as a generic `toolCall` in a later turn.
- Hydrate delegated child rows when expanding turn-summary details so existing foreground delegation rows show their children.
- Make template generation idempotent and atomic to avoid concurrent CI tasks typechecking a partially rewritten generated file.

## Root Cause

Claude now reports subagents through the same background task event family used by workflows and background shell commands, but bb only materialized workflows and `local_bash` tasks. After adding subagent materialization, nested background tasks from those subagents could leak into the parent prompt-stack card because the active background list was selected from the flat projection before semantic delegation nesting. The dev thread `thr_95ntvv5xkm` also exposed a provider-shape mismatch: a background command started as `commandExecution`, then completed later as an `unknown` `toolCall` in a later turn, which the projection previously rejected as a cross-scope merge.

The first CI run then exposed an unrelated generator race: multiple Turbo build tasks invoke template generation while other tasks typecheck imports from the generated file. The generator used to rewrite the tracked generated file directly, so another task could observe a truncated intermediate file. The generator now skips unchanged writes and replaces changed output atomically.

## Validation

- `pnpm exec turbo run test --filter=@bb/agent-runtime -- src/claude-code/task-translation.test.ts`
- `pnpm exec turbo run test --filter=@bb/thread-view -- test/background-task-timeline.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-data.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/server --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --filter=@bb/server --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/templates --filter=@bb/server --force`
- `pnpm exec turbo run build typecheck lint test --cache-dir=.turbo/cache --output-logs=new-only`
- `git diff --check`

## Manual Verification

- Restarted dev app with `scripts/bb-dev-app current`.
- Confirmed `http://localhost:17599/threads/thr_95ntvv5xkm` returns `200`.
- Confirmed `GET /api/v1/threads/thr_95ntvv5xkm/timeline?segmentLimit=100` returns `200`.
- Confirmed that completed thread reports no active background activity.
