### PR TITLE
Clamp queued message divider drag bounds

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadQueuedMessage } from "@bb/domain";
 import {
   QueuedMessagesList,
+  clampQueuedMessageDragTransform,
   resolveQueuedMessageDrag,
 } from "./QueuedMessagesList";
 
@@ -39,6 +40,17 @@ function makeGroupedQueuedMessages(): ThreadQueuedMessage[] {
     makeQueuedMessage("q_two", "Second queued message"),
     makeQueuedMessage("q_three", "Third queued message"),
   ];
+}
+
+function rect({ top, bottom }: { top: number; bottom: number }) {
+  return {
+    top,
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 100,
+    width: 100,
+  };
 }
 
 function renderQueuedMessages(queuedMessages: readonly ThreadQueuedMessage[]) {
@@ -212,6 +224,17 @@ describe("QueuedMessagesList", () => {
         { id: "q_three", groupWithNext: false },
       ],
     });
+  });
+
+  it("clamps queued-message drags to the rendered list bottom", () => {
+    expect(
+      clampQueuedMessageDragTransform({
+        draggingNodeRect: rect({ top: 24, bottom: 40 }),
+        listRect: rect({ top: 0, bottom: 72 }),
+        scrollRect: rect({ top: 0, bottom: 128 }),
+        transform: { x: 12, y: 96, scaleX: 1, scaleY: 1 },
+      }),
+    ).toEqual({ x: 0, y: 32, scaleX: 1, scaleY: 1 });
   });
 
   it("re-adopts queued-message order from props when the same rows are restored", () => {

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -6,6 +6,7 @@ import {
   closestCenter,
   useSensor,
   useSensors,
+  type ClientRect,
   type DragEndEvent,
   type Modifier,
 } from "@dnd-kit/core";
@@ -17,6 +18,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import type { Transform } from "@dnd-kit/utilities";
 import type { ThreadQueuedMessage } from "@bb/domain";
 import { Button } from "@/components/ui/button.js";
 import { Icon } from "@/components/ui/icon.js";
@@ -201,6 +203,39 @@ export function resolveQueuedMessageDrag({
       previousQueuedMessageId: nextMessages[messageIndex - 1]?.id ?? null,
       nextQueuedMessageId: nextMessages[messageIndex + 1]?.id ?? null,
     },
+  };
+}
+
+export function clampQueuedMessageDragTransform({
+  draggingNodeRect,
+  listRect,
+  scrollRect,
+  transform,
+}: {
+  draggingNodeRect: ClientRect | null;
+  listRect: ClientRect | null;
+  scrollRect: ClientRect | null;
+  transform: Transform;
+}): Transform {
+  if (!draggingNodeRect || (!listRect && !scrollRect)) {
+    return { ...transform, x: 0 };
+  }
+
+  const boundsTop = Math.max(
+    listRect?.top ?? Number.NEGATIVE_INFINITY,
+    scrollRect?.top ?? Number.NEGATIVE_INFINITY,
+  );
+  const boundsBottom = Math.min(
+    listRect?.bottom ?? Number.POSITIVE_INFINITY,
+    scrollRect?.bottom ?? Number.POSITIVE_INFINITY,
+  );
+  const minY = boundsTop - draggingNodeRect.top;
+  const maxY = boundsBottom - draggingNodeRect.bottom;
+
+  return {
+    ...transform,
+    x: 0,
+    y: Math.min(Math.max(transform.y, minY), maxY),
   };
 }
 
@@ -616,24 +651,17 @@ export function QueuedMessagesList({
     [combinedIds, onReorder, onSetGroupBoundary, orderedMessages],
   );
 
-  // Keep a dragged row from being pulled outside the visible list: clamp the
-  // drag to the list's bounds and to the vertical axis.
+  // Keep a dragged row inside both the visible viewport and the rendered list:
+  // short queues should not gain scrollable overflow below the final row.
   const listRef = useRef<HTMLUListElement>(null);
   const restrictToListBounds = useCallback<Modifier>(
     ({ draggingNodeRect, transform }) => {
-      const listRect =
-        scrollRef.current?.getBoundingClientRect() ??
-        listRef.current?.getBoundingClientRect();
-      if (!listRect || !draggingNodeRect) {
-        return { ...transform, x: 0 };
-      }
-      const minY = listRect.top - draggingNodeRect.top;
-      const maxY = listRect.bottom - draggingNodeRect.bottom;
-      return {
-        ...transform,
-        x: 0,
-        y: Math.min(Math.max(transform.y, minY), maxY),
-      };
+      return clampQueuedMessageDragTransform({
+        draggingNodeRect,
+        listRect: listRef.current?.getBoundingClientRect() ?? null,
+        scrollRect: scrollRef.current?.getBoundingClientRect() ?? null,
+        transform,
+      });
     },
     [scrollRef],
   );


### PR DESCRIPTION
Summary:
- Clamp queued-message drag transforms to the intersection of the scroll viewport and rendered list bounds.
- Prevent the "Messages above send together" divider from creating extra height when dragged below the last row.
- Add a regression test for the rendered-list bottom clamp.

Tests:
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/QueuedMessagesList.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app