### PR TITLE
fix(app): restore zen mode height animation

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -402,6 +402,39 @@ describe("PromptBoxInternal controlled value sync", () => {
 });
 
 describe("PromptBoxInternal zen mode layout", () => {
+  it("animates the prompt box height when toggling zen mode", async () => {
+    const storageKey = "bb.test.promptbox.zen-height-animation";
+    window.localStorage.removeItem(storageKey);
+
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          zenMode: { storageKey },
+        })}
+      />,
+    );
+
+    const form = document.querySelector("[data-promptbox]");
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error("Prompt box form was not rendered");
+    }
+
+    vi.spyOn(form, "getBoundingClientRect")
+      .mockReturnValueOnce(new DOMRect(0, 0, 320, 96))
+      .mockReturnValueOnce(new DOMRect(0, 0, 320, 512))
+      .mockReturnValue(new DOMRect(0, 0, 320, 512));
+
+    fireEvent.click(screen.getByRole("button", { name: "Enter zen mode" }));
+
+    await waitFor(() => {
+      expect(form.style.transition).toContain("height 240ms");
+      expect(form.style.height).toBe("512px");
+    });
+
+    fireEvent.transitionEnd(form, { propertyName: "height" });
+    window.localStorage.removeItem(storageKey);
+  });
+
   it("keeps long editor content constrained to the scroll area", async () => {
     const storageKey = "bb.test.promptbox.zen-layout";
     window.localStorage.removeItem(storageKey);

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1572,7 +1572,7 @@ export function PromptBoxInternal({
     formElement.addEventListener("transitionend", handleTransitionEnd);
 
     return cleanup;
-  }, [zenModeLayout]);
+  }, [isZenMode, zenModeLayout]);
 
   const trimmedValue = value.trim();
   const hasAttachments = attachments.length > 0;
@@ -2088,7 +2088,10 @@ export function PromptBoxInternal({
     setIsZenMode((previous) => !previous);
 
     requestAnimationFrame(() => {
-      editorRef.current?.commands.focus();
+      const currentEditor = editorRef.current;
+      if (!currentEditor || currentEditor.isDestroyed) return;
+
+      currentEditor.commands.focus();
       scheduleRevealEditorSelection();
     });
   }, [scheduleRevealEditorSelection, setIsZenMode]);


### PR DESCRIPTION
## Summary
- restore the zen-mode height animation effect by rerunning it when `isZenMode` changes
- guard the queued editor focus callback after zen toggles if the TipTap editor has already torn down
- add a regression test that verifies the prompt box applies the measured height transition

## Regression
Introduced in `b96107fa9` (TER-10: Add rich prompt editor mentions), where the textarea-specific animation dependencies were simplified and `isZenMode` was accidentally dropped.

## Validation
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
