### PR TITLE
fix(app): use timeline accent for unread divider

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -969,12 +969,12 @@ function TimelineUnreadDivider({ autoScroll }: TimelineUnreadDividerProps) {
       role="separator"
       aria-label="New messages"
       className={cn(
-        "flex items-center gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-file-accent",
+        "flex items-center gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-timeline-accent",
       )}
       data-testid="thread-unread-divider"
     >
       <span className="shrink-0">New</span>
-      <span className="h-px min-w-0 flex-1 bg-file-accent" aria-hidden />
+      <span className="h-px min-w-0 flex-1 bg-timeline-accent" aria-hidden />
     </div>
   );
 }

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -969,12 +969,12 @@ function TimelineUnreadDivider({ autoScroll }: TimelineUnreadDividerProps) {
       role="separator"
       aria-label="New messages"
       className={cn(
-        "flex items-center gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-destructive-text",
+        "flex items-center gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-file-accent",
       )}
       data-testid="thread-unread-divider"
     >
       <span className="shrink-0">New</span>
-      <span className="h-px min-w-0 flex-1 bg-destructive" aria-hidden />
+      <span className="h-px min-w-0 flex-1 bg-file-accent" aria-hidden />
     </div>
   );
 }

--- a/apps/app/src/components/thread/timeline/TimelineTitleView.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineTitleView.tsx
@@ -66,9 +66,9 @@ function accentToneClass(
     case "subtle":
       return "text-subtle-foreground";
     case "file":
-      // File-path segments are emphasized targets tinted with the file accent;
-      // keep the medium weight so they read as the row's anchor.
-      return em ? "font-medium text-file-accent" : "text-file-accent";
+      // File-path segments are emphasized timeline targets; keep the medium
+      // weight so they read as the row's anchor.
+      return em ? "font-medium text-timeline-accent" : "text-timeline-accent";
     default:
       return assertNever(accent);
   }

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -22,6 +22,7 @@
    * settled/closed-turn machinery, and a text-only destructive that clears AA in
    * dark mode (the --destructive fill is below the 4.5:1 text floor there). */
   --color-readback-foreground: var(--readback-foreground);
+  --color-timeline-accent: var(--timeline-accent);
   --color-file-accent: var(--file-accent);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
@@ -342,9 +343,10 @@
   --subtle-foreground: oklch(0.5 0 0);
   /* Recede tier between muted (7.77:1) and subtle (6.00:1); ~6.83:1 on white. */
   --readback-foreground: oklch(0.47 0 0);
-  /* Soft "paper blue" accent for file-path titles — the one tint in the
-   * otherwise-achromatic timeline. ~5.0:1 on white. */
-  --file-accent: oklch(0.55 0.1 250);
+  /* Soft "paper blue" timeline accent — the one tint in the otherwise
+   * achromatic timeline. ~5.0:1 on white. */
+  --timeline-accent: oklch(0.55 0.1 250);
+  --file-accent: var(--timeline-accent);
   /* Interactive-state fills: translucent ink so the same hover/active step
    * reads consistently on canvas, cards, and recessed surfaces alike. Over the
    * canvas these match an opaque ink-over-canvas mix exactly; on elevated
@@ -545,8 +547,9 @@
   --subtle-foreground: oklch(0.68 0 0);
   /* Recede tier between muted (9.14:1) and subtle (6.35:1); ~7.24:1 on canvas. */
   --readback-foreground: oklch(0.715 0 0);
-  /* Soft "paper blue" file-path accent, lifted for the dark canvas (~6:1). */
-  --file-accent: oklch(0.72 0.09 250);
+  /* Soft "paper blue" timeline accent, lifted for the dark canvas (~6:1). */
+  --timeline-accent: oklch(0.72 0.09 250);
+  --file-accent: var(--timeline-accent);
   /* Interactive-state fills: translucent ink so the same hover/active step
    * reads consistently on canvas, cards, and recessed surfaces alike. */
   --state-hover: color-mix(in oklab, var(--ink) 13.8%, transparent);

--- a/apps/app/src/components/ui/theme.stories.tsx
+++ b/apps/app/src/components/ui/theme.stories.tsx
@@ -387,6 +387,7 @@ export function Overview() {
             <Swatch token="warning" fill="bg-warning" />
             <Swatch token="attention" fill="bg-attention" />
             <Swatch token="success" fill="bg-success" />
+            <Swatch token="timeline-accent" fill="bg-timeline-accent" />
             <Swatch token="diff-added" fill="bg-diff-added" />
             <Swatch token="diff-removed" fill="bg-diff-removed" />
           </div>

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -222,6 +222,9 @@ describe("theme.css Cadence text tokens", () => {
       /--color-readback-foreground:\s*var\(--readback-foreground\);/,
     );
     expect(css).toMatch(
+      /--color-timeline-accent:\s*var\(--timeline-accent\);/,
+    );
+    expect(css).toMatch(
       /--color-destructive-text:\s*var\(--destructive-text\);/,
     );
     expect(css).toMatch(/--text-2xs:\s*0\.625rem;/);
@@ -235,11 +238,15 @@ describe("theme.css Cadence text tokens", () => {
       const readbackForeground = parseOklch(
         variableValue(block, "readback-foreground"),
       );
+      const timelineAccent = parseOklch(variableValue(block, "timeline-accent"));
       const destructiveText = parseOklch(
         variableValue(block, "destructive-text"),
       );
 
       expect(contrastRatio(readbackForeground, canvas)).toBeGreaterThanOrEqual(
+        4.5,
+      );
+      expect(contrastRatio(timelineAccent, canvas)).toBeGreaterThanOrEqual(
         4.5,
       );
       expect(contrastRatio(destructiveText, canvas)).toBeGreaterThanOrEqual(

--- a/apps/app/src/lib/themes/catppuccin.ts
+++ b/apps/app/src/lib/themes/catppuccin.ts
@@ -16,7 +16,8 @@ export const catppuccinThemeCss = `
   /* Accent: Mauve */
   --primary: #8839ef;
   --primary-foreground: #eff1f5;
-  --file-accent: #1e66f5; /* Blue — the one path tint */
+  --timeline-accent: #1e66f5; /* Blue — the timeline tint */
+  --file-accent: var(--timeline-accent);
 
   /* Text tiers: Subtext1 / Subtext0 / Overlay1 */
   --muted-foreground: #5c5f77;
@@ -61,7 +62,8 @@ export const catppuccinThemeCss = `
   /* Accent: Mauve */
   --primary: #cba6f7;
   --primary-foreground: #1e1e2e;
-  --file-accent: #89b4fa; /* Blue */
+  --timeline-accent: #89b4fa; /* Blue */
+  --file-accent: var(--timeline-accent);
 
   /* Text tiers: Subtext1 / Subtext0 / Overlay1 */
   --muted-foreground: #bac2de;

--- a/apps/app/src/lib/themes/dracula.ts
+++ b/apps/app/src/lib/themes/dracula.ts
@@ -13,7 +13,8 @@ export const draculaThemeCss = `
   --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
   --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
   --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
-  --file-accent: #1f6f8b;
+  --timeline-accent: #1f6f8b;
+  --file-accent: var(--timeline-accent);
   --destructive: #c4314b;
   --destructive-text: #b3243d;
   --warning: #b8762e;
@@ -62,7 +63,8 @@ export const draculaThemeCss = `
   --ink: #f8f8f2;
   --primary: #bd93f9;
   --primary-foreground: #282a36;
-  --file-accent: #8be9fd;
+  --timeline-accent: #8be9fd;
+  --file-accent: var(--timeline-accent);
   --destructive: #ff5555;
   --destructive-text: #ff7b7b;
   --warning: #ffb86c;

--- a/apps/app/src/lib/themes/gruvbox.ts
+++ b/apps/app/src/lib/themes/gruvbox.ts
@@ -13,7 +13,8 @@ export const gruvboxThemeCss = `
   --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
   --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
   --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
-  --file-accent: #076678;
+  --timeline-accent: #076678;
+  --file-accent: var(--timeline-accent);
   --destructive: #cc241d;
   --destructive-text: #9d0006;
   --warning: #d65d0e;
@@ -62,7 +63,8 @@ export const gruvboxThemeCss = `
   --ink: #ebdbb2;
   --primary: #83a598;
   --primary-foreground: #282828;
-  --file-accent: #83a598;
+  --timeline-accent: #83a598;
+  --file-accent: var(--timeline-accent);
   --destructive: #fb4934;
   --destructive-text: #fb4934;
   --warning: #fe8019;

--- a/apps/app/src/lib/themes/nord.ts
+++ b/apps/app/src/lib/themes/nord.ts
@@ -15,7 +15,8 @@ export const nordThemeCss = `
   --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
   --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
   --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
-  --file-accent: #5e81ac;
+  --timeline-accent: #5e81ac;
+  --file-accent: var(--timeline-accent);
   --destructive: #bf616a;
   --destructive-text: #a1343d;
   --warning: #d08770;
@@ -64,7 +65,8 @@ export const nordThemeCss = `
   --ink: #d8dee9;
   --primary: #88c0d0;
   --primary-foreground: #2e3440;
-  --file-accent: #88c0d0;
+  --timeline-accent: #88c0d0;
+  --file-accent: var(--timeline-accent);
   --destructive: #bf616a;
   --destructive-text: #d6868d;
   --warning: #d08770;

--- a/apps/app/src/lib/themes/solarized.ts
+++ b/apps/app/src/lib/themes/solarized.ts
@@ -12,7 +12,8 @@ export const solarizedThemeCss = `
   --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
   --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
   --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
-  --file-accent: #268bd2;
+  --timeline-accent: #268bd2;
+  --file-accent: var(--timeline-accent);
   --destructive: #dc322f;
   --destructive-text: #c12321;
   --warning: #cb4b16;
@@ -61,7 +62,8 @@ export const solarizedThemeCss = `
   --ink: #93a1a1;
   --primary: #268bd2;
   --primary-foreground: #002b36;
-  --file-accent: #2aa198;
+  --timeline-accent: #2aa198;
+  --file-accent: var(--timeline-accent);
   --destructive: #dc322f;
   --destructive-text: #e8645f;
   --warning: #cb4b16;


### PR DESCRIPTION
## Summary
- add a semantic `timeline-accent` theme token for the timeline
- map it to bb’s existing soft paper-blue timeline tint in the default theme and to each built-in palette’s blue/cyan accent
- keep `file-accent` aliased to `timeline-accent` so existing file-path styling stays aligned
- use `timeline-accent` for timeline title accents and the unread divider instead of destructive red

## Rationale
- Red/destructive remains reserved for errors and destructive states.
- `primary` is not the right semantic fit here: in the default bb theme it is neutral, and in custom palettes it is the general product/control accent.
- The timeline already has one chromatic blue/cyan affordance for link-like timeline targets, so `timeline-accent` makes the unread marker match that visual language without borrowing an error token or a file-specific name.

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/ui/theme.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app