### PR TITLE
fix(app): nest parented tasks in Manually sidebar mode

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1711,7 +1711,7 @@ interface ManualThreadTreeItemsProps {
 }
 
 // The one place that maps thread-tree items to rows. Every sidebar view
-// (project, flat chronological, folders) renders through this, so a row-prop
+// (project, chronological, folders) renders through this, so a row-prop
 // change lands once instead of being copied across each view's renderer.
 function ManualThreadTreeItems({
   items,
@@ -1851,11 +1851,10 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   );
 });
 
-// Flat Folders bucket: one top-level row per non-pinned thread across all
-// projects, globally ordered by the chosen comparator before folder bucketing.
-// It intentionally drops parent/child nesting and worktree grouping so nothing
-// hides behind a collapsed parent. Derives projectId per row from its own
-// thread so cross-project rows still route correctly.
+// Folders bucket: root threads across all projects, globally ordered by the
+// chosen comparator before folder bucketing, with descendants nested under
+// their parent. Worktree grouping stays off. Derives projectId per row from its
+// own thread so cross-project rows still route correctly.
 export const ChronologicalThreadTree = memo(function ChronologicalThreadTree({
   threadListState,
   compareThreads,

--- a/apps/app/src/components/sidebar/projectThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.test.ts
@@ -866,6 +866,41 @@ describe("folder bucketing", () => {
     ]);
   });
 
+  it("nests a child thread under its parent root inside a folder", () => {
+    const items = buildChronologicalThreadList(
+      [
+        createThread({
+          id: "parent",
+          title: "Parent",
+          folderId: "fld_work",
+          createdAt: 20,
+        }),
+        createThread({
+          id: "child",
+          parentThreadId: "parent",
+          title: "Child",
+          createdAt: 10,
+        }),
+      ],
+      compareByCreatedAtDescending,
+      {
+        groupBy: "folder",
+        containerId: "chronological",
+        folders: [{ id: "fld_work", name: "Work" }],
+      },
+    );
+
+    // The child follows its parent into the folder as a nested row rather than
+    // splitting out as a loose top-level thread.
+    expect(summarizeItems(items)).toEqual([
+      {
+        folder: "chronological::fld_work",
+        name: "Work",
+        items: [{ id: "parent", children: ["child"] }],
+      },
+    ]);
+  });
+
   it("combines threads from different projects that share the same folder id", () => {
     const items = buildChronologicalThreadList(
       [

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -323,10 +323,32 @@ export function buildProjectThreadGroups(
   compareThreads: ThreadComparator = compareStandardThreads,
   folderOptions?: SidebarFolderOptions,
 ): ProjectThreadItem[] {
-  const rootItems = buildThreadTreeItems(
+  // Project sections group worktree siblings into synthetic environment rows.
+  return assembleThreadItems(
     allProjectThreads,
     compareThreads,
     true,
+    folderOptions,
+  );
+}
+
+// Build the parent/child thread tree, then apply the section's folder grouping
+// or manual order. `groupEnvironmentThreads` toggles worktree-sibling grouping:
+// on for project sections, off for the chronological "All Threads" bucket so
+// Group by None never adds synthetic environment group rows. Folders and manual
+// order run on the root items, so descendants stay nested under their parent and
+// follow it into its folder. Both entry points share this one assembler so the
+// chronological and project paths cannot silently drift apart.
+function assembleThreadItems(
+  allThreads: readonly ThreadListEntry[],
+  compareThreads: ThreadComparator,
+  groupEnvironmentThreads: boolean,
+  folderOptions?: SidebarFolderOptions,
+): ProjectThreadItem[] {
+  const rootItems = buildThreadTreeItems(
+    allThreads,
+    compareThreads,
+    groupEnvironmentThreads,
   );
   // Group by: None — return today's output untouched unless an internal test
   // path explicitly supplied a manual order for this section.
@@ -414,45 +436,17 @@ function buildThreadTreeItems(
   return buildSortedItems(rootNodes, compareThreads, groupEnvironmentThreads);
 }
 
-// Chronological "All Threads" bucket: parent/child links still form a tree,
-// but worktree grouping stays off so Group by None does not add synthetic group
-// rows. Side chats are excluded to match buildProjectThreadGroups.
+// Chronological "All Threads" bucket: root threads are globally ordered by the
+// chosen comparator, descendants stay nested under their parent, and folder
+// grouping/manual order run on the roots. Worktree grouping stays off so Group
+// by None does not add synthetic environment group rows. Side chats are excluded
+// to match buildProjectThreadGroups.
 export function buildChronologicalThreadList(
   allThreads: readonly ThreadListEntry[],
   compareThreads: ThreadComparator = compareStandardThreads,
   folderOptions?: SidebarFolderOptions,
 ): ProjectThreadItem[] {
-  // Folder grouping (and the test-only manual-order path) need a flat,
-  // globally-sorted list; everything else keeps main's parent/child tree.
-  if (folderOptions?.groupBy === "folder" || folderOptions?.manualOrder) {
-    const items = allThreads
-      .filter(isSidebarProjectThread)
-      .sort(compareThreads)
-      .map(
-        (thread): ProjectThreadItem => ({
-          kind: "thread",
-          node: {
-            thread,
-            children: [],
-            depth: 0,
-            stats: buildStatsForHiddenThreads([]),
-          },
-        }),
-      );
-    if (folderOptions.groupBy === "folder") {
-      return bucketIntoFolders(
-        items,
-        folderOptions.containerId,
-        compareThreads,
-        folderOptions.manualOrder,
-        folderOptions.folders,
-      );
-    }
-    return orderSiblingItems(items, folderOptions.containerId, compareThreads, {
-      manualOrder: folderOptions.manualOrder,
-    });
-  }
-  return buildThreadTreeItems(allThreads, compareThreads, false);
+  return assembleThreadItems(allThreads, compareThreads, false, folderOptions);
 }
 
 export function isSidebarProjectThread(


### PR DESCRIPTION
## What

Restores parent/child **nesting** in the sidebar's **"Manually"** (chronological) organization mode. Child/subtask threads now render indented under their parent again, instead of as flat top-level rows.

## Why / history

- **#219** introduced "Manually" mode as a flat list.
- **#319** (*"Nest sidebar children when grouping is disabled"*) changed it to nest parent/child threads.
- **#258** (*sidebar folders*) regressed #319: `buildChronologicalThreadList` began flattening every thread to `children: []`, and the renderers (`ChronologicalThreadTree` / `ChronologicalFolderThreadSections`) hard-code `groupBy: "folder"` — routing manual mode through the flat branch and leaving #319's nesting path unreachable. Projects mode kept nesting the whole time via `buildProjectThreadGroups`.

## Change

`buildProjectThreadGroups` and `buildChronologicalThreadList` were near-identical and had drifted apart — that divergence *is* the bug. Both now route through one shared `assembleThreadItems` helper, differing only by the `groupEnvironmentThreads` flag (on for projects, off for chronological). Folder grouping / manual order run on the root items, so descendants stay nested under their parent and follow it into its folder — matching Projects mode.

Intentional trade-off: in Manually mode you can no longer drag a *child* into a different folder independently of its parent (children follow their parent), identical to Projects mode.

## Tests

- `@bb/app` typecheck: pass
- All sidebar tests: 81/81 pass
- Added regression test `nests a child thread under its parent root inside a folder` — verified it **fails on the old flat code** (produced a loose `'child'` row) and **passes with the fix**.
- Manually QA'd in the dev app: switching Organize by → Manually shows the three subtasks nested under the manager thread with the tree guide line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)