### PR TITLE
feat(app): add @project mentions in the message composer

### DIFF
--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.test.ts
@@ -12,6 +12,7 @@ import {
   promptEditorClipboardTextFromSlice,
   promptEditorContentFromValue,
   promptEditorInlineContentFromValue,
+  promptMentionResourceFromSuggestion,
   promptEditorValueFromDoc,
   type PromptEditorValue,
 } from "./prompt-editor-serialization";
@@ -481,6 +482,41 @@ describe("prompt editor markdown serialization (doc -> markdown text)", () => {
 });
 
 describe("prompt editor serialization", () => {
+  it("builds a project mention resource from a project suggestion", () => {
+    expect(
+      promptMentionResourceFromSuggestion({
+        kind: "project",
+        path: "project:proj_abc",
+        replacement: "project:proj_abc",
+        projectId: "proj_abc",
+        name: "Alpha Service",
+      }),
+    ).toEqual({
+      kind: "project",
+      projectId: "proj_abc",
+      label: "Alpha Service",
+    });
+  });
+
+  it("round-trips a project mention through the editor document", () => {
+    const value: PromptEditorValue = {
+      text: "look at @project:proj_abc please",
+      mentions: [
+        {
+          start: "look at ".length,
+          end: "look at @project:proj_abc".length,
+          resource: {
+            kind: "project",
+            projectId: "proj_abc",
+            label: "Alpha Service",
+          },
+        },
+      ],
+    };
+
+    expect(roundTrip(value)).toEqual(value);
+  });
+
   it("builds command mention resources from provider command suggestions", () => {
     expect(
       promptCommandResourceFromSuggestion({

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
@@ -507,6 +507,14 @@ export function promptMentionResourceFromSuggestion(
     };
   }
 
+  if (suggestion.kind === "project") {
+    return {
+      kind: "project",
+      projectId: suggestion.projectId,
+      label: suggestion.name.trim() || suggestion.projectId,
+    };
+  }
+
   return {
     kind: "path",
     source: suggestion.source,

--- a/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
+++ b/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
@@ -91,12 +91,13 @@ function groupSections<TKind extends string, TItem>(args: {
 }
 
 type PathMentionSectionKind = "workspace" | "thread-storage";
-type MentionSectionKind = "threads" | PathMentionSectionKind;
+type MentionSectionKind = "threads" | "projects" | PathMentionSectionKind;
 type PathMentionSuggestion = Extract<PromptMentionSuggestion, { kind: "path" }>;
 type SecondaryContextKind = "path" | "project";
 
 const MENTION_SECTION_ORDER: readonly MentionSectionKind[] = [
   "threads",
+  "projects",
   "workspace",
   "thread-storage",
 ];
@@ -106,6 +107,9 @@ function getMentionSectionKind(
 ): MentionSectionKind {
   if (item.kind === "thread") {
     return "threads";
+  }
+  if (item.kind === "project") {
+    return "projects";
   }
   return getPathSectionKind(item);
 }
@@ -119,6 +123,9 @@ function getPathSectionKind(
 function getMentionSectionLabel(kind: MentionSectionKind): string {
   if (kind === "threads") {
     return "Threads";
+  }
+  if (kind === "projects") {
+    return "Projects";
   }
   return getPathSectionLabel(kind);
 }
@@ -138,6 +145,10 @@ function getMentionTitle(item: PromptMentionSuggestion): string {
   if (item.kind === "thread") {
     const title = item.title || item.path;
     return item.projectName ? `${title} · ${item.projectName}` : title;
+  }
+
+  if (item.kind === "project") {
+    return `Project: ${item.name}`;
   }
 
   return `${getPathSectionLabel(getPathSectionKind(item))}: ${item.path}`;
@@ -296,6 +307,8 @@ function MentionResults({
                 secondaryContext = item.projectName ?? null;
                 secondaryContextKind =
                   item.projectName === undefined ? null : "project";
+              } else if (item.kind === "project") {
+                primary = item.name;
               } else {
                 const directory = directoryFromPath(item.path);
                 primary = item.name;

--- a/apps/app/src/components/promptbox/mentions/prompt-mention-clipboard.test.ts
+++ b/apps/app/src/components/promptbox/mentions/prompt-mention-clipboard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { serializedTextForPromptMentionResource } from "./prompt-mention-clipboard";
+
+describe("serializedTextForPromptMentionResource", () => {
+  it("serializes a project mention as an @project token", () => {
+    expect(
+      serializedTextForPromptMentionResource({
+        kind: "project",
+        projectId: "proj_abc",
+        label: "Alpha Service",
+      }),
+    ).toBe("@project:proj_abc");
+  });
+
+  it("serializes a thread mention as an @thread token", () => {
+    expect(
+      serializedTextForPromptMentionResource({
+        kind: "thread",
+        threadId: "thr_abc",
+        projectId: "proj_abc",
+        label: "Some thread",
+      }),
+    ).toBe("@thread:thr_abc");
+  });
+});

--- a/apps/app/src/components/promptbox/mentions/prompt-mention-clipboard.ts
+++ b/apps/app/src/components/promptbox/mentions/prompt-mention-clipboard.ts
@@ -57,6 +57,9 @@ export function serializedTextForPromptMentionResource(
   if (resource.kind === "thread") {
     return `@thread:${resource.threadId}`;
   }
+  if (resource.kind === "project") {
+    return `@project:${resource.projectId}`;
+  }
   if (resource.kind === "command") {
     return `${resource.trigger}${resource.name}`;
   }

--- a/apps/app/src/components/promptbox/mentions/prompt-mention-display.ts
+++ b/apps/app/src/components/promptbox/mentions/prompt-mention-display.ts
@@ -23,6 +23,9 @@ export function promptMentionIconLabel(
   if (resource.kind === "thread") {
     return "Thread";
   }
+  if (resource.kind === "project") {
+    return "Project";
+  }
   if (resource.kind === "command") {
     return resource.source === "skill" ? "Skill" : "Command";
   }
@@ -41,6 +44,9 @@ export function promptMentionIconName(
 ): IconName {
   if (resource.kind === "thread") {
     return "MessageSquare";
+  }
+  if (resource.kind === "project") {
+    return "FolderGit";
   }
   if (resource.kind === "command") {
     return promptCommandIconName(resource);

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -12,8 +12,8 @@ export type PromptPathMentionEntryKind = "file" | "directory";
  * One row in the mention menu. The `replacement` field is the literal text
  * inserted into the prompt after the user picks the suggestion (e.g.
  * `apps/app/src/foo.ts` for workspace files,
- * `thread-storage:notes/foo.md` for thread-storage files, or
- * `thread:thr_abc` for threads).
+ * `thread-storage:notes/foo.md` for thread-storage files,
+ * `thread:thr_abc` for threads, or `project:proj_abc` for projects).
  */
 export type PromptMentionSuggestion =
   | {
@@ -32,6 +32,13 @@ export type PromptMentionSuggestion =
       projectName?: string;
       threadId: string;
       title?: string;
+    }
+  | {
+      kind: "project";
+      path: string;
+      replacement: string;
+      projectId: string;
+      name: string;
     };
 
 /**

--- a/apps/app/src/components/thread/timeline/ConversationMessageMentions.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageMentions.tsx
@@ -3,7 +3,10 @@ import { Link } from "react-router-dom";
 import type { PromptMentionResource, PromptTextMention } from "@bb/domain";
 import { Icon } from "@/components/ui/icon.js";
 import { RouteAnchor } from "@/components/ui/app-route-anchor.js";
-import { getThreadRoutePath } from "@/lib/route-paths";
+import {
+  getProjectComposeRoutePath,
+  getThreadRoutePath,
+} from "@/lib/route-paths";
 import { cn } from "@/lib/utils";
 import {
   PROMPT_MENTION_PILL_CLASS,
@@ -166,6 +169,19 @@ export function PromptMentionPill({
           projectId: resource.projectId,
           threadId: resource.threadId,
         })}
+        title={title}
+      >
+        {labelNode}
+      </Link>
+    );
+  }
+
+  if (resource.kind === "project") {
+    return (
+      <Link
+        className={mentionPillClassName(true)}
+        {...clipboardAttributes}
+        to={getProjectComposeRoutePath(resource.projectId)}
         title={title}
       >
         {labelNode}

--- a/apps/app/src/hooks/projectMentionSuggestions.test.ts
+++ b/apps/app/src/hooks/projectMentionSuggestions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectMentionSuggestions,
+  type ProjectMentionCandidate,
+} from "./projectMentionSuggestions";
+
+const PROJECTS: ProjectMentionCandidate[] = [
+  { id: "proj_alpha", name: "Alpha Service" },
+  { id: "proj_beta", name: "Beta Dashboard" },
+  { id: "proj_personal", name: "Personal" },
+];
+
+describe("buildProjectMentionSuggestions", () => {
+  it("returns nothing for an empty query", () => {
+    expect(
+      buildProjectMentionSuggestions({
+        projects: PROJECTS,
+        query: "   ",
+        limit: 8,
+      }),
+    ).toEqual([]);
+  });
+
+  it("fuzzy-matches by project name and serializes a project reference", () => {
+    const suggestions = buildProjectMentionSuggestions({
+      projects: PROJECTS,
+      query: "alpha",
+      limit: 8,
+    });
+
+    expect(suggestions).toEqual([
+      {
+        kind: "project",
+        path: "project:proj_alpha",
+        replacement: "project:proj_alpha",
+        projectId: "proj_alpha",
+        name: "Alpha Service",
+      },
+    ]);
+  });
+
+  it("matches by project id", () => {
+    const suggestions = buildProjectMentionSuggestions({
+      projects: PROJECTS,
+      query: "proj_beta",
+      limit: 8,
+    });
+
+    expect(suggestions.map((suggestion) => suggestion.projectId)).toEqual([
+      "proj_beta",
+    ]);
+  });
+
+  it("honors the limit", () => {
+    const suggestions = buildProjectMentionSuggestions({
+      projects: PROJECTS,
+      query: "e",
+      limit: 1,
+    });
+
+    expect(suggestions.length).toBe(1);
+  });
+
+  it("falls back to the id when a project has no name", () => {
+    const suggestions = buildProjectMentionSuggestions({
+      projects: [{ id: "proj_nameless", name: "  " }],
+      query: "proj_nameless",
+      limit: 8,
+    });
+
+    expect(suggestions[0]?.name).toBe("proj_nameless");
+  });
+});

--- a/apps/app/src/hooks/projectMentionSuggestions.ts
+++ b/apps/app/src/hooks/projectMentionSuggestions.ts
@@ -1,0 +1,65 @@
+import { fuzzyMatchText } from "@bb/fuzzy-match";
+import type { PromptMentionSuggestion } from "@/components/promptbox/mentions/types";
+import { compareCodepoint } from "@/lib/codepoint-compare";
+
+export type ProjectMentionSuggestion = Extract<
+  PromptMentionSuggestion,
+  { kind: "project" }
+>;
+
+/** A project the mention menu can offer, reduced to what the picker needs. */
+export interface ProjectMentionCandidate {
+  id: string;
+  name: string;
+}
+
+export interface BuildProjectMentionSuggestionsArgs {
+  projects: readonly ProjectMentionCandidate[];
+  query: string;
+  limit: number;
+}
+
+function getProjectSearchTexts(
+  project: ProjectMentionCandidate,
+): readonly string[] {
+  const name = project.name.trim();
+  return name ? [name, project.id] : [project.id];
+}
+
+function toProjectMentionSuggestion(
+  project: ProjectMentionCandidate,
+): ProjectMentionSuggestion {
+  return {
+    kind: "project",
+    path: `project:${project.id}`,
+    replacement: `project:${project.id}`,
+    projectId: project.id,
+    name: project.name.trim() || project.id,
+  };
+}
+
+export function buildProjectMentionSuggestions(
+  args: BuildProjectMentionSuggestionsArgs,
+): ProjectMentionSuggestion[] {
+  const trimmedQuery = args.query.trim();
+  if (trimmedQuery.length === 0 || args.limit <= 0) {
+    return [];
+  }
+
+  const matches = fuzzyMatchText({
+    items: args.projects,
+    query: trimmedQuery,
+    getText: getProjectSearchTexts,
+    limit: args.projects.length,
+  });
+
+  return matches
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.item.name.localeCompare(right.item.name) ||
+        compareCodepoint(left.item.id, right.item.id),
+    )
+    .slice(0, args.limit)
+    .map((match) => toProjectMentionSuggestion(match.item));
+}

--- a/apps/app/src/hooks/usePromptMentions.ts
+++ b/apps/app/src/hooks/usePromptMentions.ts
@@ -2,6 +2,10 @@ import { useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { buildPathMentionSuggestions } from "./pathMentionSuggestions";
+import {
+  buildProjectMentionSuggestions,
+  type ProjectMentionCandidate,
+} from "./projectMentionSuggestions";
 import { useSidebarNavigation } from "./queries/sidebar-navigation-query";
 import { useThreadMentionCandidates } from "./queries/thread-queries";
 import { buildThreadMentionSuggestions } from "./threadMentionSuggestions";
@@ -26,15 +30,26 @@ export interface UsePromptMentionsResult {
 interface BuildPromptMentionSuggestionsArgs {
   pathSuggestions: readonly PromptMentionSuggestion[];
   threadSuggestions: readonly PromptMentionSuggestion[];
+  projectSuggestions: readonly PromptMentionSuggestion[];
   trimmedQuery: string;
 }
 
 function buildPromptMentionSuggestions(
   args: BuildPromptMentionSuggestionsArgs,
 ): PromptMentionSuggestion[] {
+  // A query containing "/" reads as a file path, so paths lead; otherwise the
+  // named entities (threads then projects) lead and paths trail.
   return args.trimmedQuery.includes("/")
-    ? [...args.pathSuggestions, ...args.threadSuggestions]
-    : [...args.threadSuggestions, ...args.pathSuggestions];
+    ? [
+        ...args.pathSuggestions,
+        ...args.threadSuggestions,
+        ...args.projectSuggestions,
+      ]
+    : [
+        ...args.threadSuggestions,
+        ...args.projectSuggestions,
+        ...args.pathSuggestions,
+      ];
 }
 
 function buildProjectNamesById(
@@ -49,6 +64,21 @@ function buildProjectNamesById(
     projectNamesById.set(project.id, project.name);
   }
   return projectNamesById;
+}
+
+// The sidebar bootstrap keeps the personal project separate from the named
+// project list; project mentions offer both so every project is reachable.
+function buildProjectMentionCandidates(
+  sidebarNavigation: SidebarBootstrapResponse | undefined,
+): ProjectMentionCandidate[] {
+  if (!sidebarNavigation) {
+    return [];
+  }
+
+  return [
+    ...sidebarNavigation.projects,
+    sidebarNavigation.personalProject,
+  ].map((project) => ({ id: project.id, name: project.name }));
 }
 
 export function usePromptMentions(
@@ -77,6 +107,10 @@ export function usePromptMentions(
     () => buildProjectNamesById(projectNamesQuery.data),
     [projectNamesQuery.data],
   );
+  const projectCandidates = useMemo(
+    () => buildProjectMentionCandidates(projectNamesQuery.data),
+    [projectNamesQuery.data],
+  );
 
   const currentThreadId = options.currentThreadId;
   const pathSuggestions = useMemo(
@@ -102,16 +136,30 @@ export function usePromptMentions(
     threadsQuery.data,
     trimmedQuery,
   ]);
+  const projectSuggestions = useMemo(() => {
+    return buildProjectMentionSuggestions({
+      projects: projectCandidates,
+      query: trimmedQuery,
+      limit: PROMPT_MENTION_SOURCE_LIMIT,
+    });
+  }, [projectCandidates, trimmedQuery]);
   const suggestions = useMemo(
     () =>
       hasQuery
         ? buildPromptMentionSuggestions({
             pathSuggestions,
             threadSuggestions,
+            projectSuggestions,
             trimmedQuery,
           })
         : [],
-    [hasQuery, pathSuggestions, threadSuggestions, trimmedQuery],
+    [
+      hasQuery,
+      pathSuggestions,
+      threadSuggestions,
+      projectSuggestions,
+      trimmedQuery,
+    ],
   );
 
   // Loading flips on only when there are zero suggestions to show. Once the

--- a/apps/app/src/lib/route-paths.ts
+++ b/apps/app/src/lib/route-paths.ts
@@ -93,6 +93,14 @@ export function getLegacyProjectComposeRoutePath(projectId: string): string {
   return `/projects/${projectId}`;
 }
 
+// Opens a project's compose view. The personal project has no `/projects/:id`
+// surface — its compose view is the app root — so it routes there instead.
+export function getProjectComposeRoutePath(projectId: string): string {
+  return isProjectlessProjectId(projectId)
+    ? getRootComposeRoutePath()
+    : getLegacyProjectComposeRoutePath(projectId);
+}
+
 export function getProjectSettingsRoutePath(projectId: string): string {
   return `/projects/${projectId}/settings`;
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -116,6 +116,7 @@ import { useNavigateToThreadAfterCreatePreference } from "@/lib/root-compose-cre
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import {
   getThreadRoutePath,
+  getProjectComposeRoutePath,
   getRootComposeRoutePath,
   getSurfaceAwareThreadRoutePath,
   isRoutePath,
@@ -2102,6 +2103,9 @@ export function RootComposeView(props: RootComposeViewProps) {
               threadId: resource.threadId,
             }),
           );
+      }
+      if (resource.kind === "project") {
+        return () => navigate(getProjectComposeRoutePath(resource.projectId));
       }
       if (resource.kind !== "path" || resource.entryKind !== "file") {
         return null;

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -86,6 +86,7 @@ import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import type { PromptDraftAttachment } from "@/lib/prompt-draft";
 import { createLocalStorageEnumStorage } from "@/lib/browser-storage";
 import {
+  getProjectComposeRoutePath,
   getSurfaceAwareThreadRoutePath,
   isRoutePath,
   type ThreadRoutePathArgs,
@@ -1037,6 +1038,9 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
               threadId: resource.threadId,
             }),
           );
+      }
+      if (resource.kind === "project") {
+        return () => navigate(getProjectComposeRoutePath(resource.projectId));
       }
       if (resource.kind !== "path" || resource.entryKind !== "file") {
         return null;

--- a/packages/bb-app/src/public-sdk.ts
+++ b/packages/bb-app/src/public-sdk.ts
@@ -51,6 +51,11 @@ export interface PromptTextMention {
         threadId: string;
       }
     | {
+        kind: "project";
+        label: string;
+        projectId: string;
+      }
+    | {
         kind: "path";
         entryKind: "directory" | "file";
         label: string;

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -165,6 +165,11 @@ export const promptMentionResourceSchema = z.discriminatedUnion("kind", [
     label: z.string(),
   }),
   z.object({
+    kind: z.literal("project"),
+    projectId: z.string(),
+    label: z.string(),
+  }),
+  z.object({
     kind: z.literal("path"),
     source: promptMentionPathSourceSchema,
     entryKind: promptMentionPathEntryKindSchema,


### PR DESCRIPTION
## Summary

Adds the ability to `@`-mention a **project** in the message composer, mirroring how threads are already mentioned.

- A project mention serializes to `@project:proj_id` (parallel to `@thread:thr_id`) and carries a new `{ kind: "project", projectId, label }` mention resource added to `promptMentionResourceSchema` in `@bb/domain`.
- Renders as a pill with the `FolderGit` icon; clicking it navigates to the project's compose view (personal → app root), from both the timeline and the composer.
- The mention picker gains a **Projects** section, fed by the sidebar bootstrap (named projects **plus** the personal project), fuzzy-matched by name/id.
- The agent receives the literal `@project:proj_id` token — same passthrough model as thread mentions, so **no server changes were needed**.
- Kept the public `bb-app` SDK's hand-mirrored mention union in sync with the new variant.

## Product notes

- The picker currently includes **all** projects, including the current one and the personal project. Easy to narrow if undesired.

## Tests

- New regression tests: project suggestion builder (`projectMentionSuggestions.test.ts`), editor round-trip (`prompt-editor-serialization.test.ts`), clipboard serialization (`prompt-mention-clipboard.test.ts`).
- `turbo run typecheck` passes for `@bb/domain`, `@bb/app`, `@bb/sdk`, `bb-app`.
- 186 mention-related app tests pass.
- Adversarial multi-agent review of the diff surfaced one contract gap (public SDK mirror), now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)