### PR TITLE
fix(app): submit /compact in one Enter from the command menu

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -28,6 +28,7 @@ import {
   type PromptBoxHandle,
   type TypeaheadConfig,
 } from "./PromptBoxInternal";
+import type { ProviderCommandSuggestion } from "./mentions/types";
 
 type PromptBoxProps = ComponentProps<typeof PromptBoxInternal>;
 
@@ -771,5 +772,147 @@ describe("PromptBoxInternal prompt actions", () => {
 
     await waitFor(() => expect(latestValue(changes)).toContain("clean up"));
     expect(latestValue(changes)).not.toBe("/goal ");
+  });
+});
+
+describe("PromptBoxInternal command typeahead submit", () => {
+  const compactSuggestion: ProviderCommandSuggestion = {
+    kind: "command",
+    name: "compact",
+    source: "command",
+    origin: "builtin",
+    description: "Compact context",
+    argumentHint: null,
+  };
+  const userSkillSuggestion: ProviderCommandSuggestion = {
+    kind: "command",
+    name: "review",
+    source: "skill",
+    origin: "user",
+    description: "Review a PR",
+    argumentHint: null,
+  };
+
+  function renderCommandPromptBox(suggestion: ProviderCommandSuggestion) {
+    const onSubmit = vi.fn();
+    const changes: PromptChange[] = [];
+    const promptBoxRef = createRef<PromptBoxHandle>();
+
+    function Harness() {
+      const [value, setValue] = useState("");
+      const [mentionRanges, setMentionRanges] = useState<PromptTextMention[]>(
+        [],
+      );
+      return (
+        <PromptBoxInternal
+          value={value}
+          mentionRanges={mentionRanges}
+          onChange={(nextValue, nextMentions) => {
+            changes.push({ mentions: nextMentions, value: nextValue });
+            setValue(nextValue);
+            setMentionRanges(nextMentions);
+          }}
+          onSubmit={onSubmit}
+          typeahead={{
+            mention: {
+              suggestions: [],
+              isLoading: false,
+              isError: false,
+              onQueryChange: () => {},
+            },
+            command: {
+              trigger: "/",
+              suggestions: [suggestion],
+              isLoading: false,
+              isError: false,
+              hasMore: false,
+              isLoadingMore: false,
+              loadMore: () => {},
+              onQueryChange: () => {},
+            },
+          }}
+          mentionMenuPlacement="bottom"
+          promptBoxRef={promptBoxRef}
+        />
+      );
+    }
+
+    render(<Harness />);
+    return { changes, onSubmit, promptBoxRef };
+  }
+
+  async function openCommandMenu(
+    promptBoxRef: RefObject<PromptBoxHandle | null>,
+    token: string,
+    name: string,
+  ) {
+    await focusPromptEnd(promptBoxRef);
+    await act(async () => {
+      promptBoxRef.current?.insertTextAtCursor(token);
+    });
+    await act(async () => {});
+    await waitFor(() => expect(screen.queryByText(name)).not.toBeNull());
+  }
+
+  it("submits when a built-in command is selected with Enter", async () => {
+    const { changes, onSubmit, promptBoxRef } =
+      renderCommandPromptBox(compactSuggestion);
+    await openCommandMenu(promptBoxRef, "/compact", "compact");
+
+    await act(async () => {
+      fireEvent.keyDown(getPromptEditorElement(), { key: "Enter" });
+    });
+    await act(async () => {});
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    // The command mention is applied (and therefore submitted), not left as
+    // bare text — Codex reads the mention to trigger compaction and Claude
+    // sends the `/compact` text as-is.
+    expect(latestChange(changes)?.mentions).toEqual([
+      {
+        start: 0,
+        end: "/compact".length,
+        resource: {
+          kind: "command",
+          trigger: "/",
+          name: "compact",
+          source: "command",
+          origin: "builtin",
+          label: "compact",
+          argumentHint: null,
+        },
+      },
+    ]);
+  });
+
+  it("does not submit when a non-built-in command is selected with Enter", async () => {
+    const { changes, onSubmit, promptBoxRef } =
+      renderCommandPromptBox(userSkillSuggestion);
+    await openCommandMenu(promptBoxRef, "/review", "review");
+
+    await act(async () => {
+      fireEvent.keyDown(getPromptEditorElement(), { key: "Enter" });
+    });
+    await act(async () => {});
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    // The pill is still inserted so the user can add arguments before sending.
+    expect(latestChange(changes)?.mentions?.[0]?.resource).toMatchObject({
+      name: "review",
+      origin: "user",
+    });
+  });
+
+  it("does not submit when a built-in command is selected with Tab", async () => {
+    const { onSubmit, promptBoxRef } =
+      renderCommandPromptBox(compactSuggestion);
+    await openCommandMenu(promptBoxRef, "/compact", "compact");
+
+    await act(async () => {
+      fireEvent.keyDown(getPromptEditorElement(), { key: "Tab" });
+    });
+    await act(async () => {});
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2053,6 +2053,19 @@ export function PromptBoxInternal({
     resetZenModeAfterSubmit();
   }, [canSubmit, onSubmit, resetZenModeAfterSubmit]);
 
+  // A no-argument built-in command (currently only `/compact`) is a complete
+  // action the moment it is selected, so applying it with Enter should also
+  // submit instead of leaving the pill parked for a second Enter. The submit is
+  // deferred to this effect — keyed on the flag — so `onSubmit` runs after the
+  // applied command mention has propagated into the parent draft (applying the
+  // pill updates the draft on the next render, not synchronously).
+  const [pendingCommandSubmit, setPendingCommandSubmit] = useState(false);
+  useEffect(() => {
+    if (!pendingCommandSubmit) return;
+    setPendingCommandSubmit(false);
+    submitPrompt();
+  }, [pendingCommandSubmit, submitPrompt]);
+
   const submitModifierPrompt = useCallback(() => {
     if (!canModifierSubmit || !onModifierSubmit) return;
     onModifierSubmit();
@@ -2198,6 +2211,16 @@ export function PromptBoxInternal({
             activeSuggestions[selectedIndex] ?? activeSuggestions[0];
           if (selected) {
             applyTrigger(selected);
+            // Built-in commands (e.g. `/compact`) take no arguments, so picking
+            // one with Enter both inserts the pill and submits. Tab still only
+            // inserts, and mention suggestions are unaffected.
+            if (
+              event.key === "Enter" &&
+              selected.kind === "command" &&
+              selected.origin === "builtin"
+            ) {
+              setPendingCommandSubmit(true);
+            }
           }
           return true;
         }
@@ -2349,6 +2372,7 @@ export function PromptBoxInternal({
       onModifierSubmit,
       resetHistorySession,
       selectedIndex,
+      setPendingCommandSubmit,
       showTypeaheadMenu,
       submitModifierPrompt,
       submitPrompt,


### PR DESCRIPTION
## Problem

Typing `/compact` in the composer couldn't be sent in one action. `/compact` opens the command typeahead as an exact match, and while that menu is open **Enter inserts the pill instead of submitting** — so the built-in `/compact` command needed a *second* Enter to actually send. That reads as "can't submit `/compact` alone."

## Fix

`apps/app/src/components/promptbox/PromptBoxInternal.tsx` — built-in commands take no arguments, so selecting one with **Enter** now both inserts the pill and submits (the submit is deferred one render so `onSubmit` sees the applied command mention, not the pre-apply draft).

Scoped carefully:
- **Enter on `/compact`** (built-in) → inserts + submits
- **Enter on a normal skill/user command** (e.g. `/review`) → still just inserts the pill, so arguments can be typed
- **Tab on `/compact`** → still just inserts (Tab = complete, not send)

This works for both providers: Codex reads the mention to run native compaction, and Claude receives the `/compact` text as-is (the Claude adapter already passes it through unchanged; the pill's mention is bb-internal and never reaches Claude Code).

## Tests

Three regression tests in `PromptBoxInternal.test.tsx` (built-in+Enter submits, non-built-in+Enter does not, built-in+Tab does not) — they fail before the fix and pass after. `@bb/app` typecheck, all 161 promptbox tests, and ESLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)