### PR TITLE
feat(landing): add OpenCode to supported providers

### DIFF
--- a/apps/landing/src/icons.tsx
+++ b/apps/landing/src/icons.tsx
@@ -79,3 +79,27 @@ export function CursorIcon({ className }: { className?: string }) {
     </svg>
   );
 }
+
+// opencode brand mark (opencode.ai/brand). Rendered in currentColor so it
+// adapts to light/dark like the other provider glyphs; the lower-inner square
+// uses reduced opacity to preserve the two-tone layered look of the mark.
+// The viewBox pads the 240x300 mark into a centered square at ~80% so it sits
+// at a comparable visual size to the other (square) provider icons rather than
+// filling the slot edge-to-edge.
+export function OpencodeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="-72 -42 384 384"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <title>opencode</title>
+      <path d="M180 240H60V120H180V240Z" fill="currentColor" fillOpacity={0.45} />
+      <path
+        d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -34,7 +34,7 @@ import { trackLandingEvent } from "../analytics";
 import bbIcon from "../assets/bb-icon.png";
 import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
-import { ClaudeIcon, CursorIcon, OpenAiIcon, PiIcon } from "../icons";
+import { ClaudeIcon, CursorIcon, OpenAiIcon, OpencodeIcon, PiIcon } from "../icons";
 import type { CtaPlacement } from "../site";
 import { CLI_COMMAND, GITHUB_URL, SUBSCRIBE_PATH, downloadMacosHref } from "../site";
 
@@ -377,6 +377,7 @@ function ProviderChips() {
       <OpenAiIcon className="plogo" />
       <CursorIcon className="plogo" />
       <PiIcon className="plogo" />
+      <OpencodeIcon className="plogo" />
     </>
   );
 }
@@ -1494,7 +1495,7 @@ function SpawnSidebar() {
       <div className="sb-head">
         <img src={bbIcon} alt="" className="sb-mark" />
         <span className="sb-title">Threads</span>
-        <span className="sb-active">4 active</span>
+        <span className="sb-active">5 active</span>
       </div>
       <div className={leaving ? "sb-list leaving" : "sb-list"} key={cycle}>
         <SpawnRow
@@ -1530,6 +1531,14 @@ function SpawnSidebar() {
             status="running"
             at={1.4}
             doneAt={3.7}
+          />
+          <SpawnRow
+            icon={<OpencodeIcon className="sb-ic" />}
+            name="OpenCode"
+            task="Add integration tests"
+            status="running"
+            at={1.8}
+            doneAt={3.4}
           />
         </div>
       </div>
@@ -1604,9 +1613,9 @@ function LandingPage() {
         visual={<SpawnSidebar />}
       >
         <p>
-          Claude Code, Codex, Cursor, and Pi all live in bb. Give a task to
-          whichever fits, and have one agent spawn and manage another, each in
-          its own thread.
+          Claude Code, Codex, Cursor, Pi, and OpenCode all live in bb. Give a
+          task to whichever fits, and have one agent spawn and manage another,
+          each in its own thread.
         </p>
         <p>
           Each runs on your own subscription: the provider plan you already pay

--- a/apps/landing/src/site.ts
+++ b/apps/landing/src/site.ts
@@ -23,4 +23,4 @@ export function downloadMacosHref(placement: CtaPlacement): string {
 
 export const SITE_TITLE = "bb: the IDE for loop-driven development";
 export const SITE_DESCRIPTION =
-  "Orchestrate your coding agents. Drive it yourself, or let your agents and automations drive it for you. Fully open source and local-first, with Claude Code, Codex, Cursor, and Pi.";
+  "Orchestrate your coding agents. Drive it yourself, or let your agents and automations drive it for you. Fully open source and local-first, with Claude Code, Codex, Cursor, Pi, and OpenCode.";


### PR DESCRIPTION
## Summary

We now support OpenCode, so this adds it to the marketing landing page alongside Claude Code, Codex, Cursor, and Pi.

- **New `OpencodeIcon`** in the landing app's standalone `icons.tsx` (copied from `apps/app`, which the landing app can't depend on).
- Added OpenCode to the **hero "Works with" chips** and the **"gang's all here" provider chips**.
- Added an **OpenCode worker row** to the animated `SpawnSidebar`, and bumped the header count **4 → 5 active**.
- Updated the body copy and **`SITE_DESCRIPTION`** meta (page/OG description) to list OpenCode.

OpenCode is placed last in each list (after Pi) for consistency.

## Tests

- `turbo run typecheck --filter=@bb/landing` ✅
- `turbo run lint --filter=@bb/landing` ✅
- Manual browser check on the running dev server: `5 active`, all five sidebar rows render (Claude Code, Codex, Cursor, Pi, OpenCode), five provider chips including `opencode` in both chip rows, and the updated meta description present in the server-rendered `<head>`.

## Risks

Low — marketing-page copy/visual change only, no runtime/product behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)