### PR TITLE
Fix root compose window drag strip

### DIFF
--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -27,11 +27,23 @@ interface RenderRootComposeArgs {
   isSecondaryPanelOpen: boolean;
 }
 
+type TestDesktopWindow = {
+  bbDesktop?: { platform: "macos" };
+};
+
 const panelGroupState = vi.hoisted(() => ({
   setLayout: vi.fn(),
 }));
 
 const noop = () => {};
+
+function setMacosDesktopChrome(): void {
+  (window as unknown as TestDesktopWindow).bbDesktop = { platform: "macos" };
+}
+
+function clearDesktopChrome(): void {
+  delete (window as unknown as TestDesktopWindow).bbDesktop;
+}
 
 vi.mock("jotai", async (importOriginal) => ({
   ...(await importOriginal<typeof import("jotai")>()),
@@ -170,10 +182,25 @@ function renderRootCompose(args: RenderRootComposeArgs) {
 
 afterEach(() => {
   cleanup();
+  clearDesktopChrome();
   panelGroupState.setLayout.mockReset();
 });
 
 describe("RootComposeSecondaryContent desktop layout", () => {
+  it("marks the root compose top strip as a macOS window drag region", () => {
+    setMacosDesktopChrome();
+
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: false,
+    });
+
+    const strip = screen.getByTestId("root-compose-main-window-drag-strip");
+    expect(strip.className).toContain("h-[48px]");
+    expect(strip.className).toContain("[app-region:drag]");
+    expect(strip.className).toContain("[-webkit-app-region:drag]");
+  });
+
   it("syncs the panel group when persisted open state arrives after mount", () => {
     const view = renderRootCompose({
       isCompactViewport: false,

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -21,6 +21,12 @@ import { secondaryPanelWidthPercentAtom } from "@/components/secondary-panel/thr
 import { PANEL_COLLAPSE_TRANSITION_CLASS } from "@/components/secondary-panel/panelTransitionTokens";
 import { PAGE_SHELL_CONTENT_STYLE } from "@/components/ui/page-shell-content-style.js";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import {
+  CHROME_ROW_HEIGHT_CLASS,
+  getBbDesktopInfo,
+  MACOS_WINDOW_DRAG_CLASS,
+  shouldUseMacosDesktopChrome,
+} from "@/lib/bb-desktop";
 import { cn } from "@/lib/utils";
 
 const CLOSED_MAIN_PANEL_SIZE_PERCENT = 100;
@@ -69,6 +75,8 @@ export function RootComposeSecondaryContent({
   }, [persistedSecondaryWidthPercent]);
   const [isCompactDrawerContentSettled, setIsCompactDrawerContentSettled] =
     useState(false);
+  const [desktopInfo] = useState(getBbDesktopInfo);
+  const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   const compactDrawerContentSettleFrameRef = useRef<number | null>(null);
   const compactDrawerContentSettleGenerationRef = useRef(0);
   const compactDrawerContentSettleStateRef = useRef({
@@ -225,6 +233,17 @@ export function RootComposeSecondaryContent({
             )}
           >
             <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+              {usesDesktopChrome ? (
+                <div
+                  data-testid="root-compose-main-window-drag-strip"
+                  aria-hidden="true"
+                  className={cn(
+                    "absolute inset-x-0 top-0 z-10 shrink-0",
+                    CHROME_ROW_HEIGHT_CLASS,
+                    MACOS_WINDOW_DRAG_CLASS,
+                  )}
+                />
+              ) : null}
               <div className="@container/page min-h-0 flex-1 overflow-y-auto">
                 <div
                   className={cn(


### PR DESCRIPTION
## Summary
- add a macOS-only drag strip over the root compose top chrome gap
- cover the desktop drag-region classes with a focused regression test

## Tests
- pnpm exec turbo run test --filter=@bb/app -- --run src/views/RootComposeSecondaryContent.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app

## Risk
- Low: desktop-only draggable overlay in the empty top band of root compose.