### PR TITLE
Log user message telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ docs, start with
 ### Telemetry
 
 Production runs (the desktop app and `npx bb-app`) send anonymous usage
-telemetry (app starts and thread creation counts) to help us understand
-adoption. Identification is a random per-install id stored in your data dir —
-no user, host, project, or workspace data is ever attached. Development/source
-runs never send. Opt out any run with `BB_TELEMETRY=false`. See
+telemetry (app starts, thread creation counts, and user message counts) to help
+us understand adoption. Identification is a random per-install id stored in your
+data dir — no user, host, project, workspace, or message content is ever
+attached. Development/source runs never send. Opt out any run with
+`BB_TELEMETRY=false`. See
 [`apps/server/src/services/system/telemetry.ts`](./apps/server/src/services/system/telemetry.ts).
 
 ## Development

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -69,8 +69,9 @@ is unavailable.
 | `landing_cli_command_copied` | Copy button on the install command | `placement`, `command` |
 | `landing_email_subscribed` | Email signup submitted successfully | `placement` |
 
-These pair with the app-side `app_started` / `thread_created` telemetry events
-(see `apps/server/src/services/system/telemetry.ts`) to form the ad → page view
-→ download/CLI copy → app start → first thread funnel. Web→app identity does
-not join across the download; funnel analysis is aggregate, broken down by
+These pair with the app-side `app_started` / `thread_created` /
+`user_message_sent` telemetry events (see
+`apps/server/src/services/system/telemetry.ts`) to form the ad → page view →
+download/CLI copy → app start → first thread/message funnel. Web→app identity
+does not join across the download; funnel analysis is aggregate, broken down by
 `utm_campaign`.

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -236,6 +236,16 @@ async function createQueuedMessageForThread(
     permissionMode: execution.permissionMode,
     serviceTier: execution.serviceTier,
   });
+  if (senderThreadId === null && payload.input.length > 0) {
+    deps.telemetry.capture({
+      name: "user_message_sent",
+      properties: {
+        is_child_thread: thread.parentThreadId !== null,
+        message_source: "queued_message",
+        provider: thread.providerId,
+      },
+    });
+  }
   if (
     thread.status === "idle" &&
     getLastProviderThreadId(deps, thread.id) !== null

--- a/apps/server/src/services/system/telemetry.ts
+++ b/apps/server/src/services/system/telemetry.ts
@@ -4,10 +4,10 @@ import type { ServerLogger } from "../../types.js";
 /**
  * Anonymous usage telemetry.
  *
- * Sends a small set of product events (app starts, thread creation counts) to
- * PostHog so install/activation funnels can be measured. Identification is a
- * random per-install id persisted in the data dir — no user, host, project, or
- * workspace data is ever attached.
+ * Sends a small set of product events (app starts, thread creation counts, and
+ * user message counts) to PostHog so install/activation funnels can be measured.
+ * Identification is a random per-install id persisted in the data dir — no
+ * user, host, project, workspace, or message content is ever attached.
  *
  * Delivery is intentionally fire-and-forget: events are analytics, not
  * workflow state, so lost sends (offline, PostHog outage, process exit
@@ -29,6 +29,14 @@ export type TelemetryEvent =
       name: "thread_created";
       properties: {
         is_child_thread: boolean;
+        provider: string;
+      };
+    }
+  | {
+      name: "user_message_sent";
+      properties: {
+        is_child_thread: boolean;
+        message_source: "queued_message" | "thread_create" | "thread_send";
         provider: string;
       };
     };

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -723,5 +723,18 @@ export async function createThreadFromRequest(
       provider: request.providerId,
     },
   });
+  if (
+    (request.startedOnBehalfOf?.initiator ?? "user") === "user" &&
+    request.input.length > 0
+  ) {
+    deps.telemetry.capture({
+      name: "user_message_sent",
+      properties: {
+        is_child_thread: parentThread !== null,
+        message_source: "thread_create",
+        provider: request.providerId,
+      },
+    });
+  }
   return thread;
 }

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -298,6 +298,20 @@ function groupedInputForRuntime(
   );
 }
 
+function captureUserMessageSentTelemetry(
+  deps: Pick<LoggedPendingInteractionWorkSessionDeps, "telemetry">,
+  thread: Thread,
+): void {
+  deps.telemetry.capture({
+    name: "user_message_sent",
+    properties: {
+      is_child_thread: thread.parentThreadId !== null,
+      message_source: "thread_send",
+      provider: thread.providerId,
+    },
+  });
+}
+
 function appendAndQueueSendThreadMessageInTransaction({
   beforeAppendInTransaction,
   db,
@@ -404,6 +418,8 @@ export async function sendThreadMessage(
   // Agent-originated CLI sends still appear as normal turn requests in the
   // timeline, while initiator lets policy distinguish the source.
   const initiator: ThreadTurnInitiator = senderThreadId ? "agent" : "user";
+  const shouldCaptureUserMessageSent =
+    args.trigger === "user" && initiator === "user" && input.length > 0;
   const expectedSteerTurnId =
     mode === "auto" || mode === "steer"
       ? getActiveTurnId(deps, thread.id)
@@ -434,6 +450,9 @@ export async function sendThreadMessage(
       thread,
     })
   ) {
+    if (shouldCaptureUserMessageSent) {
+      captureUserMessageSentTelemetry(deps, thread);
+    }
     return;
   }
   const readyEnvironment = requireReadyThreadEnvironment(
@@ -538,6 +557,9 @@ export async function sendThreadMessage(
         projectId: thread.projectId,
       });
     }
+    if (shouldCaptureUserMessageSent) {
+      captureUserMessageSentTelemetry(deps, thread);
+    }
     return;
   }
 
@@ -598,4 +620,7 @@ export async function sendThreadMessage(
       );
     },
   });
+  if (shouldCaptureUserMessageSent) {
+    captureUserMessageSentTelemetry(deps, thread);
+  }
 }

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -37,6 +37,7 @@ import {
 import { renderTemplate } from "@bb/templates";
 import { z } from "zod";
 import { describe, expect, it, vi } from "vitest";
+import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import { loadActiveThreadProvisionContext } from "../../src/services/threads/thread-provisioning-environment.js";
 import {
   reportQueuedCommandError,
@@ -1950,6 +1951,8 @@ describe("public thread data routes", () => {
 
   it("creates and deletes thread queued messages", async () => {
     await withTestHarness(async (harness) => {
+      const capture = vi.fn<TelemetryService["capture"]>();
+      harness.deps.telemetry = { capture };
       const { environment, thread } = seedThreadFixture(harness);
       seedEvent(harness.deps, {
         threadId: thread.id,
@@ -2002,6 +2005,14 @@ describe("public thread data routes", () => {
       ).toMatchObject({
         id: queuedMessage.id,
       });
+      expect(capture).toHaveBeenCalledWith({
+        name: "user_message_sent",
+        properties: {
+          is_child_thread: false,
+          message_source: "queued_message",
+          provider: "codex",
+        },
+      });
 
       const deleteResponse = await harness.app.request(
         `/api/v1/threads/${thread.id}/queued-messages/${queuedMessage.id}`,
@@ -2017,6 +2028,8 @@ describe("public thread data routes", () => {
 
   it("queues public send requests with sender context while the target thread is active", async () => {
     await withTestHarness(async (harness) => {
+      const capture = vi.fn<TelemetryService["capture"]>();
+      harness.deps.telemetry = { capture };
       const { project, thread } = seedThreadFixture(harness, {
         thread: {
           status: "active",
@@ -2064,6 +2077,7 @@ describe("public thread data routes", () => {
           .where(eq(events.threadId, thread.id))
           .all(),
       ).toHaveLength(0);
+      expect(capture).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/test/services/telemetry.test.ts
+++ b/apps/server/test/services/telemetry.test.ts
@@ -45,8 +45,16 @@ describe("telemetry service", () => {
         provider: "claude-code",
       },
     });
+    telemetry.capture({
+      name: "user_message_sent",
+      properties: {
+        is_child_thread: false,
+        message_source: "thread_send",
+        provider: "codex",
+      },
+    });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     const persistedId = (
       await readFile(join(dataDir, "telemetry-id"), "utf8")
     ).trim();
@@ -77,6 +85,15 @@ describe("telemetry service", () => {
         app_version: "1.2.3",
         is_child_thread: true,
         provider: "claude-code",
+      },
+    });
+    expect(calls[2]?.payload).toMatchObject({
+      event: "user_message_sent",
+      properties: {
+        app_version: "1.2.3",
+        is_child_thread: false,
+        message_source: "thread_send",
+        provider: "codex",
       },
     });
   });

--- a/apps/server/test/threads/thread-create-seed-without-run.test.ts
+++ b/apps/server/test/threads/thread-create-seed-without-run.test.ts
@@ -5,8 +5,9 @@ import {
   listEvents,
 } from "@bb/db";
 import { PERSONAL_PROJECT_ID, turnRequestEventDataSchema } from "@bb/domain";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../src/errors.js";
+import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import { createThreadFromRequest } from "../../src/services/threads/thread-create.js";
 import {
   canThreadSpawnChild,
@@ -43,9 +44,62 @@ function threadStartTurnRequest(
   return turnRequestEventDataSchema.parse(JSON.parse(turnRequest.data));
 }
 
+function installTelemetryCaptureSpy(harness: TestAppHarness) {
+  const capture = vi.fn<TelemetryService["capture"]>();
+  harness.deps.telemetry = { capture };
+  return capture;
+}
+
+describe("thread creation telemetry", () => {
+  it("captures initial user messages", async () => {
+    await withTestHarness(async (harness) => {
+      const capture = installTelemetryCaptureSpy(harness);
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-thread-create-telemetry",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/thread-create-telemetry",
+      });
+      seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/thread-create-telemetry",
+      });
+
+      await createThreadFromRequest(harness.deps, {
+        childOrigin: null,
+        environment: {
+          type: "host",
+          hostId: host.id,
+          workspace: {
+            type: "unmanaged",
+            path: "/tmp/thread-create-telemetry",
+          },
+        },
+        input: textInput("Start with telemetry"),
+        origin: "app",
+        projectId: project.id,
+        providerId: "codex",
+        startedOnBehalfOf: null,
+      });
+
+      expect(capture).toHaveBeenCalledWith({
+        name: "user_message_sent",
+        properties: {
+          is_child_thread: false,
+          message_source: "thread_create",
+          provider: "codex",
+        },
+      });
+    });
+  });
+});
+
 describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
   it("persists an agent fork start while cloning the source provider session", async () => {
     await withTestHarness(async (harness) => {
+      const capture = installTelemetryCaptureSpy(harness);
       const { host } = seedHostSession(harness.deps, {
         id: "host-seed-without-run",
       });
@@ -117,6 +171,9 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
       expect(persistedFork?.sourceThreadId).toBe(sourceThread.id);
       expect(persistedFork?.parentThreadId).toBeNull();
       expect(persistedFork?.titleFallback).toBe("Continue from the fork point");
+      expect(capture).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: "user_message_sent" }),
+      );
     });
   });
 
@@ -631,6 +688,7 @@ describe("thread creation child-thread boundary validation", () => {
     await withChildBoundaryHarness(
       "empty-side-chat-preload",
       async ({ harness, hostId, path, projectId, sourceThreadId }) => {
+        const capture = installTelemetryCaptureSpy(harness);
         seedTurnStarted(harness.deps, {
           threadId: sourceThreadId,
           turnId: "turn-parent",
@@ -664,6 +722,9 @@ describe("thread creation child-thread boundary validation", () => {
         expect(queuedStart.command.fork).toEqual({
           sourceProviderThreadId: "provider-parent-session",
         });
+        expect(capture).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: "user_message_sent" }),
+        );
 
         await reportQueuedCommandSuccess(harness, queuedStart, {
           providerThreadId: "provider-side-chat-session",

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -12,7 +12,8 @@ import {
   type Environment,
   type Thread,
 } from "@bb/domain";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
@@ -106,6 +107,12 @@ function seedColdIdleThreadFixture(
   return { environment, thread };
 }
 
+function installTelemetryCaptureSpy(harness: TestAppHarness) {
+  const capture = vi.fn<TelemetryService["capture"]>();
+  harness.deps.telemetry = { capture };
+  return capture;
+}
+
 describe("queued message dispatch gate", () => {
   it("rolls back and sends no host command when the idle thread was archived between claim and dispatch", async () => {
     await withTestHarness(async (harness) => {
@@ -183,6 +190,72 @@ describe("queued message dispatch gate", () => {
         listQueuedThreadCommands(harness, "thread.start", thread.id),
       ).toHaveLength(0);
       expect(getQueuedThreadMessage(harness.db, queued.id)).not.toBeNull();
+    });
+  });
+});
+
+describe("user message telemetry", () => {
+  it("captures direct user sends", async () => {
+    await withTestHarness(async (harness) => {
+      const capture = installTelemetryCaptureSpy(harness);
+      const { environment, thread } = seedColdIdleThreadFixture({
+        harness,
+        value: 5,
+      });
+
+      await sendThreadMessage(harness.deps, {
+        environment,
+        payload: {
+          input: textInput("telemetry user send"),
+          mode: "start",
+          model: "gpt-5",
+          permissionMode: "full",
+          reasoningLevel: "medium",
+          serviceTier: "default",
+        },
+        thread,
+        trigger: "user",
+      });
+
+      expect(capture).toHaveBeenCalledWith({
+        name: "user_message_sent",
+        properties: {
+          is_child_thread: false,
+          message_source: "thread_send",
+          provider: "codex",
+        },
+      });
+    });
+  });
+
+  it("does not capture agent-originated sends", async () => {
+    await withTestHarness(async (harness) => {
+      const capture = installTelemetryCaptureSpy(harness);
+      const { environment, thread } = seedColdIdleThreadFixture({
+        harness,
+        value: 6,
+      });
+      const senderThread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: thread.projectId,
+      });
+
+      await sendThreadMessage(harness.deps, {
+        environment,
+        payload: {
+          input: textInput("telemetry agent send"),
+          mode: "start",
+          model: "gpt-5",
+          permissionMode: "full",
+          reasoningLevel: "medium",
+          senderThreadId: senderThread.id,
+          serviceTier: "default",
+        },
+        thread,
+        trigger: "user",
+      });
+
+      expect(capture).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -185,7 +185,7 @@ export const BB_POSTHOG_API_KEY_ENV = defineEnvVar<string>({
 
 export const BB_TELEMETRY_ENV = defineEnvVar<boolean>({
   description:
-    "Anonymous usage telemetry (app starts and thread creation counts). Set to false to opt out.",
+    "Anonymous usage telemetry (app starts, thread creation counts, and user message counts). Set to false to opt out.",
   name: "BB_TELEMETRY",
   parse: parseBooleanEnvValue,
 });


### PR DESCRIPTION
## Summary
- add anonymous `user_message_sent` telemetry for non-empty user-authored thread messages
- count initial thread prompts, direct sends, and queued user messages while skipping agent-originated sends and queue auto-dispatch
- update telemetry docs and tests for the new event

## Tests
- `pnpm exec turbo run test --filter=@bb/server -- test/services/telemetry.test.ts test/threads/thread-send-dispatch.test.ts test/threads/thread-create-seed-without-run.test.ts test/public/public-thread-data.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server`