### PR TITLE
Fix root compose right panel toggle

### DIFF
--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -4,7 +4,10 @@ import type { ComponentProps, ReactNode } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@/components/ui/hooks/use-compact-viewport.js";
-import { RootComposeSecondaryContent } from "./RootComposeSecondaryContent";
+import {
+  ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
+  RootComposeSecondaryContent,
+} from "./RootComposeSecondaryContent";
 
 type RootComposeSecondaryContentProps = ComponentProps<
   typeof RootComposeSecondaryContent
@@ -199,6 +202,49 @@ describe("RootComposeSecondaryContent desktop layout", () => {
     expect(strip.className).toContain("h-[48px]");
     expect(strip.className).toContain("[app-region:drag]");
     expect(strip.className).toContain("[-webkit-app-region:drag]");
+  });
+
+  // Electron resolves app-regions in DOM order (later wins), and the drag strip
+  // renders after root compose's fixed right-panel toggle, so the strip itself
+  // must carve the toggle's footprint back out — a no-drag on the toggle would
+  // be re-added by the strip's own drag rect and the closed panel could never
+  // be opened. jsdom can't run the native region resolution, so these lock the
+  // class/DOM contract that drives it: the cutout is a child of the strip
+  // (resolved after it) at the pinned toggle's shared position.
+  it("carves the pinned toggle footprint out of the drag strip while the panel is closed", () => {
+    setMacosDesktopChrome();
+
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: false,
+    });
+
+    const strip = screen.getByTestId("root-compose-main-window-drag-strip");
+    const cutout = screen.getByTestId("root-compose-drag-strip-toggle-cutout");
+    expect(cutout.parentElement).toBe(strip);
+    expect(cutout.className).toContain("[app-region:no-drag]");
+    expect(cutout.className).toContain("[-webkit-app-region:no-drag]");
+    for (const positionClass of ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS.split(
+      " ",
+    )) {
+      expect(cutout.className).toContain(positionClass);
+    }
+  });
+
+  it("keeps the drag strip whole while the panel is open (the panel chrome carves instead)", () => {
+    setMacosDesktopChrome();
+
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: true,
+    });
+
+    expect(
+      screen.getByTestId("root-compose-main-window-drag-strip"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByTestId("root-compose-drag-strip-toggle-cutout"),
+    ).toBeNull();
   });
 
   it("syncs the panel group when persisted open state arrives after mount", () => {

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -21,9 +21,11 @@ import { secondaryPanelWidthPercentAtom } from "@/components/secondary-panel/thr
 import { PANEL_COLLAPSE_TRANSITION_CLASS } from "@/components/secondary-panel/panelTransitionTokens";
 import { PAGE_SHELL_CONTENT_STYLE } from "@/components/ui/page-shell-content-style.js";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import { COARSE_POINTER_HEADER_ICON_BUTTON_CLASS } from "@/components/ui/coarse-pointer-sizing.js";
 import {
   CHROME_ROW_HEIGHT_CLASS,
   getBbDesktopInfo,
+  MACOS_APP_REGION_NO_DRAG_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
@@ -32,6 +34,17 @@ import { cn } from "@/lib/utils";
 const CLOSED_MAIN_PANEL_SIZE_PERCENT = 100;
 const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
 const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
+
+// Where root compose pins its right-panel toggle in the viewport corner (see
+// rootPanelToggle in RootComposeView, which shares this constant). The window
+// drag strip below must carve this same footprint back out of the macOS drag
+// region while the panel is closed: Electron resolves app-regions in DOM order
+// (later wins), and the strip renders after the fixed toggle, so a no-drag on
+// the toggle itself would just be re-added by the strip's own drag rect. The
+// carve has to live inside the strip, and this constant keeps the two footprints
+// from drifting apart.
+export const ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS =
+  "right-4 top-2.5";
 
 type RootSecondaryPanelProps = Omit<
   ComponentProps<typeof ThreadSecondaryPanel>,
@@ -242,7 +255,26 @@ export function RootComposeSecondaryContent({
                     CHROME_ROW_HEIGHT_CLASS,
                     MACOS_WINDOW_DRAG_CLASS,
                   )}
-                />
+                >
+                  {/* While the panel is closed the main panel spans the full
+                      width and the pinned right-panel toggle overlays this
+                      strip, so carve its footprint out of the drag region — as
+                      a child of the strip it resolves after the strip's own
+                      drag rect and wins. Open, the toggle sits over the panel
+                      chrome instead (whose reserved slot does the carving), so
+                      the strip stays fully draggable. */}
+                  {!isSecondaryPanelOpen ? (
+                    <div
+                      data-testid="root-compose-drag-strip-toggle-cutout"
+                      className={cn(
+                        "absolute",
+                        ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
+                        COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
+                        MACOS_APP_REGION_NO_DRAG_CLASS,
+                      )}
+                    />
+                  ) : null}
+                </div>
               ) : null}
               <div className="@container/page min-h-0 flex-1 overflow-y-auto">
                 <div

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -154,7 +154,10 @@ import {
   useRootComposeProjectId,
   useSetRootComposeProjectId,
 } from "@/lib/root-compose-selection";
-import { RootComposeSecondaryContent } from "./RootComposeSecondaryContent";
+import {
+  ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
+  RootComposeSecondaryContent,
+} from "./RootComposeSecondaryContent";
 import {
   buildRootComposeBranchUiState,
   type RootComposeBranchEnvironmentMode,
@@ -2814,9 +2817,14 @@ export function RootComposeView(props: RootComposeViewProps) {
   // matching slot via inlinePanelToggle="reserved", and the pinned button lands
   // centered over it). The drawer layout has no pinned slot, so there the toggle
   // only opens the drawer and its close control lives inside the drawer.
+  // The shared position class keeps this footprint paired with the no-drag
+  // cutout the macOS window-drag strip carves for it while the panel is closed
+  // (see RootComposeSecondaryContent).
   const rootPanelToggle =
     !renderSecondaryPanelAsDrawer || !isSecondaryPanelOpen ? (
-      <div className="fixed right-4 top-2.5 z-40">
+      <div
+        className={`fixed z-40 ${ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS}`}
+      >
         <RootComposeRightPanelToggle
           activeTerminalCount={activeTerminalCount}
           isOpen={isSecondaryPanelOpen}


### PR DESCRIPTION
## Summary
- carve the pinned root-compose right-panel toggle out of the macOS drag strip while the panel is closed
- share the pinned toggle position between the real toggle and the no-drag cutout
- add regression coverage for the drag-strip cutout DOM/class contract

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (0 errors, existing warnings)
- pnpm -C apps/app exec vitest run --config vitest.config.ts src/views/RootComposeSecondaryContent.test.tsx

Note: `pnpm exec turbo run test --filter=@bb/app -- apps/app/src/views/RootComposeSecondaryContent.test.tsx` is currently blocked in this shell by the root `//#ensure-native-modules` pre-task being killed with exit 137 before app tests start, so the focused Vitest command above was run directly as a validation bypass.