### PR TITLE
Add thread handoff shortcut

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -13,7 +13,7 @@ import type { ReasoningLevel } from "@bb/domain";
 import { stripModelBrandPrefix } from "./model-brand-prefix";
 import { REASONING_LABELS } from "@/lib/reasoning-labels";
 import { Button } from "@/components/ui/button.js";
-import { Icon } from "@/components/ui/icon.js";
+import { Icon, type IconName } from "@/components/ui/icon.js";
 import {
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ICON_SIZE_SHRINK_CLASS,
@@ -114,6 +114,15 @@ interface ModelReasoningPickerProps {
    * interactive counterpart, just disabled.
    */
   disabled?: boolean;
+  footerAction?: ModelReasoningPickerFooterAction;
+}
+
+export interface ModelReasoningPickerFooterAction {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+  iconName?: IconName;
 }
 
 export function ModelReasoningPicker({
@@ -141,6 +150,7 @@ export function ModelReasoningPicker({
   defaultOpen = false,
   modal = true,
   disabled,
+  footerAction,
 }: ModelReasoningPickerProps) {
   const isCompactViewport = useIsCompactViewport();
   const [open, setOpen] = useState(defaultOpen);
@@ -384,6 +394,16 @@ export function ModelReasoningPicker({
       onSelectedProviderChange,
     ],
   );
+
+  const handleFooterActionClick = useCallback(() => {
+    if (!footerAction || footerAction.disabled) {
+      return;
+    }
+    footerAction.onClick();
+    setOpen(false);
+    setPreviewProviderId(null);
+    setMoreModelsOpen(false);
+  }, [footerAction]);
 
   const TriggerIcon = hasSelectedModel ? ProviderIcon : undefined;
   const triggerTitleModelLabel = modelIsLoading
@@ -670,6 +690,21 @@ export function ModelReasoningPicker({
               </div>
             </>
           ) : null}
+
+          {footerAction ? (
+            <>
+              <div className="border-t border-border" />
+              <div className="p-1">
+                <MenuActionButton
+                  label={footerAction.label}
+                  iconName={footerAction.iconName ?? "MessageSquarePlus"}
+                  disabled={footerAction.disabled}
+                  title={footerAction.title}
+                  onClick={handleFooterActionClick}
+                />
+              </div>
+            </>
+          ) : null}
         </MenuHoverProvider>
       </PopoverContent>
     </Popover>
@@ -897,6 +932,41 @@ function MenuRowButton({
           selected ? "opacity-100" : "opacity-0",
         )}
       />
+    </button>
+  );
+}
+
+function MenuActionButton({
+  label,
+  iconName,
+  disabled,
+  title,
+  onClick,
+}: {
+  label: string;
+  iconName: IconName;
+  disabled?: boolean;
+  title?: string;
+  onClick: () => void;
+}) {
+  const { hoverProps } = useMenuItemHover();
+  const isCompactViewport = useIsCompactViewport();
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      title={title}
+      onClick={onClick}
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 text-xs outline-none hover:bg-state-hover hover:text-foreground disabled:pointer-events-none disabled:opacity-50",
+        LIST_HOVER_TRANSITION,
+        MENU_ITEM_LAST_HOVERED_CLASS,
+        isCompactViewport ? "py-2" : "py-[0.3125rem]",
+      )}
+      {...hoverProps}
+    >
+      <Icon name={iconName} className="size-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 truncate">{label}</span>
     </button>
   );
 }

--- a/apps/app/src/components/promptbox/ExecutionControls.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.tsx
@@ -2,7 +2,10 @@ import { memo } from "react";
 import type { PermissionMode, ReasoningLevel, ServiceTier } from "@bb/domain";
 import type { SystemExecutionOptionsModelLoadError } from "@bb/server-contract";
 import { formatModelLabel } from "@/hooks/useThreadCreationOptions";
-import { ModelReasoningPicker } from "@/components/pickers/ModelReasoningPicker";
+import {
+  ModelReasoningPicker,
+  type ModelReasoningPickerFooterAction,
+} from "@/components/pickers/ModelReasoningPicker";
 import { type PickerOption } from "@/components/pickers/OptionPicker";
 
 export interface ExecutionProviderConfig {
@@ -51,6 +54,7 @@ export interface ExecutionControlsProps {
   model: ExecutionModelConfig;
   serviceTier?: ExecutionServiceTierConfig;
   reasoning: ExecutionReasoningConfig;
+  footerAction?: ModelReasoningPickerFooterAction;
   /**
    * Render the model/reasoning picker as a non-interactive, dimmed label
    * (read-only surfaces, e.g. the side chat inheriting the parent thread's
@@ -64,6 +68,7 @@ export const ExecutionControls = memo(function ExecutionControls({
   model,
   serviceTier,
   reasoning,
+  footerAction,
   disabled,
 }: ExecutionControlsProps) {
   const handleServiceTierChange = serviceTier?.onChange ?? (() => {});
@@ -112,6 +117,7 @@ export const ExecutionControls = memo(function ExecutionControls({
           serviceTierSupportByProvider={serviceTier?.supportByProvider}
           muted
           disabled={disabled}
+          footerAction={footerAction}
         />
       ) : null}
     </>

--- a/apps/app/src/lib/thread-handoff-request.test.ts
+++ b/apps/app/src/lib/thread-handoff-request.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildThreadHandoffLocationState,
+  buildThreadHandoffPromptDraft,
+  readThreadHandoffCreateSeedFromLocationState,
+  THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY,
+  type ThreadHandoffCreateSeed,
+} from "./thread-handoff-request";
+
+const SEED: ThreadHandoffCreateSeed = {
+  environmentId: "env_source",
+  projectId: "proj_source",
+  sourceThreadId: "thr_source",
+  sourceThreadTitle: "Source thread",
+};
+
+describe("thread handoff request", () => {
+  it("builds location state that focuses compose and reuses the source environment", () => {
+    expect(buildThreadHandoffLocationState(SEED)).toEqual({
+      focusPrompt: true,
+      reuseEnvironmentId: "env_source",
+      [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: SEED,
+    });
+  });
+
+  it("reads a valid handoff seed from location state", () => {
+    expect(
+      readThreadHandoffCreateSeedFromLocationState({
+        [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: {
+          ...SEED,
+          sourceThreadTitle: " Source thread ",
+        },
+      }),
+    ).toEqual(SEED);
+  });
+
+  it("builds a prompt draft with a rich mention to the source thread", () => {
+    const draft = buildThreadHandoffPromptDraft(SEED);
+
+    expect(draft.text).toBe("Continue from @thread:thr_source");
+    expect(draft.attachments).toEqual([]);
+    expect(draft.mentions).toEqual([
+      {
+        start: "Continue from ".length,
+        end: "Continue from @thread:thr_source".length,
+        resource: {
+          kind: "thread",
+          projectId: "proj_source",
+          threadId: "thr_source",
+          label: "Source thread",
+        },
+      },
+    ]);
+  });
+
+  it("returns null for unusable handoff state", () => {
+    expect(readThreadHandoffCreateSeedFromLocationState(null)).toBeNull();
+    expect(
+      readThreadHandoffCreateSeedFromLocationState({
+        [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: {
+          ...SEED,
+          sourceThreadId: "",
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/lib/thread-handoff-request.ts
+++ b/apps/app/src/lib/thread-handoff-request.ts
@@ -1,0 +1,90 @@
+import type { PromptTextMention } from "@bb/domain";
+import type { PromptDraftState } from "@/lib/prompt-draft";
+
+export const THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY =
+  "threadHandoffCreateSeed";
+
+export interface ThreadHandoffCreateSeed {
+  environmentId: string | null;
+  projectId: string;
+  sourceThreadId: string;
+  sourceThreadTitle: string;
+}
+
+export interface ThreadHandoffLocationState {
+  focusPrompt: true;
+  reuseEnvironmentId?: string;
+  [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: ThreadHandoffCreateSeed;
+}
+
+export function buildThreadHandoffLocationState(
+  seed: ThreadHandoffCreateSeed,
+): ThreadHandoffLocationState {
+  return {
+    focusPrompt: true,
+    ...(seed.environmentId !== null
+      ? { reuseEnvironmentId: seed.environmentId }
+      : {}),
+    [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: seed,
+  };
+}
+
+export function readThreadHandoffCreateSeedFromLocationState(
+  state: unknown,
+): ThreadHandoffCreateSeed | null {
+  if (!state || typeof state !== "object") return null;
+  const candidate = (state as Record<string, unknown>)[
+    THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY
+  ];
+  if (!candidate || typeof candidate !== "object") return null;
+  const value = candidate as Record<string, unknown>;
+  if (
+    typeof value.projectId !== "string" ||
+    value.projectId.length === 0 ||
+    typeof value.sourceThreadId !== "string" ||
+    value.sourceThreadId.length === 0 ||
+    typeof value.sourceThreadTitle !== "string" ||
+    value.sourceThreadTitle.trim().length === 0
+  ) {
+    return null;
+  }
+  if (
+    value.environmentId !== undefined &&
+    value.environmentId !== null &&
+    typeof value.environmentId !== "string"
+  ) {
+    return null;
+  }
+
+  const environmentId =
+    typeof value.environmentId === "string" && value.environmentId.length > 0
+      ? value.environmentId
+      : null;
+
+  return {
+    environmentId,
+    projectId: value.projectId,
+    sourceThreadId: value.sourceThreadId,
+    sourceThreadTitle: value.sourceThreadTitle.trim(),
+  };
+}
+
+export function buildThreadHandoffPromptDraft(
+  seed: ThreadHandoffCreateSeed,
+): PromptDraftState {
+  const prefix = "Continue from ";
+  const mentionText = `@thread:${seed.sourceThreadId}`;
+  const text = `${prefix}${mentionText}`;
+  const mention: PromptTextMention = {
+    start: prefix.length,
+    end: prefix.length + mentionText.length,
+    resource: {
+      kind: "thread",
+      projectId: seed.projectId,
+      threadId: seed.sourceThreadId,
+      label: seed.sourceThreadTitle,
+    },
+  };
+
+  return { text, mentions: [mention], attachments: [] };
+}

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import type { ReuseThreadOption } from "@/components/pickers/WorktreePicker";
+import { THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY } from "@/lib/thread-handoff-request";
 import {
   buildRootComposeTerminalSessions,
   buildMobileRecentThreads,
@@ -480,6 +481,19 @@ describe("hasSingleUseRootComposeTargetState", () => {
     expect(hasSingleUseRootComposeTargetState({ focusPrompt: true })).toBe(
       true,
     );
+  });
+
+  it("treats handoff seeds as single-use target state", () => {
+    expect(
+      hasSingleUseRootComposeTargetState({
+        [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: {
+          environmentId: "env_source",
+          projectId: "proj_source",
+          sourceThreadId: "thr_source",
+          sourceThreadTitle: "Source thread",
+        },
+      }),
+    ).toBe(true);
   });
 
   it("ignores non-target state", () => {

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -112,6 +112,10 @@ import {
   FORK_THREAD_CREATE_SEED_LOCATION_STATE_KEY,
   type ForkThreadCreateSeed,
 } from "@/lib/fork-thread-request";
+import {
+  buildThreadHandoffPromptDraft,
+  readThreadHandoffCreateSeedFromLocationState,
+} from "@/lib/thread-handoff-request";
 import { useNavigateToThreadAfterCreatePreference } from "@/lib/root-compose-create-preference";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import {
@@ -555,7 +559,8 @@ export function hasSingleUseRootComposeTargetState(state: unknown): boolean {
   return (
     readRootComposeFolderTargetFromLocationState(state) !== null ||
     readReuseEnvironmentIdFromLocationState(state) !== null ||
-    readForkThreadCreateSeedFromLocationState(state) !== null
+    readForkThreadCreateSeedFromLocationState(state) !== null ||
+    readThreadHandoffCreateSeedFromLocationState(state) !== null
   );
 }
 
@@ -1149,6 +1154,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     }
     startInstall(codexCliIssue);
   }, [codexCliIssue, startInstall]);
+  const seedHandoffPrompt = promptDraft.setDraft;
 
   // Seed transient picker state from navigation state: `reuseEnvironmentId`
   // (the "+" affordance on a worktree) seeds the env picker into reuse mode for
@@ -1165,6 +1171,9 @@ export function RootComposeView(props: RootComposeViewProps) {
     const nextForkSeed = readForkThreadCreateSeedFromLocationState(
       location.state,
     );
+    const nextHandoffSeed = readThreadHandoffCreateSeedFromLocationState(
+      location.state,
+    );
     if (!hasSingleUseRootComposeTargetState(location.state)) {
       return;
     }
@@ -1179,13 +1188,24 @@ export function RootComposeView(props: RootComposeViewProps) {
     if (reuseEnvironmentId !== null) {
       setEnvironmentSelectionValue(encodeReuseValue(reuseEnvironmentId));
     }
-    if (nextForkSeed !== null) {
+    if (nextForkSeed !== null && nextHandoffSeed === null) {
       setForkSeed(nextForkSeed);
       setSelectedProviderId(nextForkSeed.providerId);
       setSelectedModel(nextForkSeed.model);
       setReasoningLevel(nextForkSeed.reasoningLevel);
       setPermissionMode(nextForkSeed.permissionMode);
       setServiceTier(nextForkSeed.serviceTier);
+    }
+    if (nextHandoffSeed !== null) {
+      setStartedComposing(true);
+      setRootComposeProjectId(nextHandoffSeed.projectId);
+      setForkSeed(null);
+      if (nextHandoffSeed.environmentId !== null) {
+        setEnvironmentSelectionValue(
+          encodeReuseValue(nextHandoffSeed.environmentId),
+        );
+      }
+      seedHandoffPrompt(buildThreadHandoffPromptDraft(nextHandoffSeed));
     }
     navigate(getRootComposeRoutePath() + location.search, {
       replace: true,
@@ -1195,11 +1215,13 @@ export function RootComposeView(props: RootComposeViewProps) {
     location.search,
     location.state,
     navigate,
+    seedHandoffPrompt,
     setEnvironmentSelectionValue,
     setPermissionMode,
     setReasoningLevel,
     setSelectedModel,
     setSelectedProviderId,
+    setRootComposeProjectId,
     setServiceTier,
   ]);
 

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -5,15 +5,17 @@ import type {
   ThreadQueuedMessage,
   ThreadWithRuntime,
 } from "@bb/domain";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY } from "@/lib/thread-handoff-request";
 import { ThreadDetailPromptArea } from "./ThreadDetailPromptArea";
 
 const mocks = vi.hoisted(() => ({
   createQueuedMessageMutateAsync: vi.fn(),
   defaultExecutionOptions: null as ResolvedThreadExecutionOptions | null,
   deleteQueuedMessageMutateAsync: vi.fn(),
+  navigate: vi.fn(),
   promptDraft: {
     addAttachment: vi.fn(),
     attachments: [],
@@ -38,18 +40,38 @@ const mocks = vi.hoisted(() => ({
   useThreadQueuedMessages: vi.fn(),
 }));
 
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
 vi.mock("@/components/promptbox/FollowUpPromptBox", () => ({
   FollowUpPromptBox: ({
     composer,
+    execution,
     stack,
   }: {
     composer: { submitMode: { kind: string; reason?: string } } | null;
+    execution: {
+      footerAction?: {
+        label: string;
+        onClick: () => void;
+      };
+    };
     stack: ReactNode;
   }) => (
     <div data-testid="follow-up-prompt-box">
       <div data-testid="submit-mode">
         {composer?.submitMode.kind}:{composer?.submitMode.reason ?? ""}
       </div>
+      {execution.footerAction ? (
+        <button type="button" onClick={execution.footerAction.onClick}>
+          {execution.footerAction.label}
+        </button>
+      ) : null}
       {stack}
     </div>
   ),
@@ -363,5 +385,34 @@ describe("ThreadDetailPromptArea", () => {
     expect(screen.getByTestId("submit-mode").textContent).toBe(
       "blocked:loading-pending-interactions",
     );
+  });
+
+  it("opens root compose with a handoff seed for the current thread", () => {
+    renderPromptArea({
+      thread: makeThread({
+        environmentId: "env_1",
+        id: "thr_source",
+        projectId: "proj_source",
+        title: "Source thread",
+        titleFallback: null,
+      }),
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Handoff to new thread" }),
+    );
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/projects/proj_source", {
+      state: {
+        focusPrompt: true,
+        reuseEnvironmentId: "env_1",
+        [THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY]: {
+          environmentId: "env_1",
+          projectId: "proj_source",
+          sourceThreadId: "thr_source",
+          sourceThreadTitle: "Source thread",
+        },
+      },
+    });
   });
 });

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -838,22 +838,26 @@ export function ThreadDetailPromptArea({
   const handleUnarchiveCurrentThread = useCallback(() => {
     unarchiveThread.mutate({ id: thread.id });
   }, [thread.id, unarchiveThread]);
+  const sourceThreadDisplayTitle = getThreadDisplayTitle({
+    id: thread.id,
+    title: thread.title,
+    titleFallback: thread.titleFallback,
+  });
   const handleHandoffToNewThread = useCallback(() => {
     navigate(getProjectComposeRoutePath(thread.projectId), {
       state: buildThreadHandoffLocationState({
         environmentId: thread.environmentId,
         projectId: thread.projectId,
         sourceThreadId: thread.id,
-        sourceThreadTitle: getThreadDisplayTitle(thread),
+        sourceThreadTitle: sourceThreadDisplayTitle,
       }),
     });
   }, [
     navigate,
+    sourceThreadDisplayTitle,
     thread.environmentId,
     thread.id,
     thread.projectId,
-    thread.title,
-    thread.titleFallback,
   ]);
 
   const attachmentsConfig = useMemo(

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import type { IconName } from "@/components/ui/icon.js";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { getFollowUpPromptPlaceholder } from "@/components/promptbox/follow-up-placeholder";
@@ -70,6 +71,9 @@ import { useThreadDefaultExecutionOptions } from "@/hooks/queries/thread-default
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { promptHistoryEntriesToDrafts } from "@/lib/prompt-history";
 import { promptDraftToInput } from "@/lib/prompt-draft";
+import { getProjectComposeRoutePath } from "@/lib/route-paths";
+import { getThreadDisplayTitle } from "@/lib/thread-title";
+import { buildThreadHandoffLocationState } from "@/lib/thread-handoff-request";
 import { appToast } from "@/components/ui/app-toast";
 import {
   FollowUpPromptBox,
@@ -212,6 +216,7 @@ export function ThreadDetailPromptArea({
   composerFocusRequestNonce,
   thread,
 }: ThreadDetailPromptAreaProps) {
+  const navigate = useNavigate();
   const defaultExecutionOptionsQuery = useThreadDefaultExecutionOptions(
     thread.id,
     {
@@ -833,6 +838,23 @@ export function ThreadDetailPromptArea({
   const handleUnarchiveCurrentThread = useCallback(() => {
     unarchiveThread.mutate({ id: thread.id });
   }, [thread.id, unarchiveThread]);
+  const handleHandoffToNewThread = useCallback(() => {
+    navigate(getProjectComposeRoutePath(thread.projectId), {
+      state: buildThreadHandoffLocationState({
+        environmentId: thread.environmentId,
+        projectId: thread.projectId,
+        sourceThreadId: thread.id,
+        sourceThreadTitle: getThreadDisplayTitle(thread),
+      }),
+    });
+  }, [
+    navigate,
+    thread.environmentId,
+    thread.id,
+    thread.projectId,
+    thread.title,
+    thread.titleFallback,
+  ]);
 
   const attachmentsConfig = useMemo(
     () => ({
@@ -919,10 +941,15 @@ export function ThreadDetailPromptArea({
         options: reasoningOptions,
         onChange: setReasoningLevel,
       },
+      footerAction: {
+        label: "Handoff to new thread",
+        onClick: handleHandoffToNewThread,
+      },
     }),
     [
       activeModel,
       hasMultipleProviders,
+      handleHandoffToNewThread,
       isLoadingModels,
       modelLoadFailed,
       modelLoadError,


### PR DESCRIPTION
## Summary
- add a follow-up model picker footer action to hand off the current thread to a new thread
- seed root compose with the same project, same reusable environment when available, and a rich @thread mention to the source thread
- add focused tests for handoff state parsing and prompt-area navigation

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/lib/thread-handoff-request.test.ts src/views/RootComposeView.test.ts src/views/thread-detail/ThreadDetailPromptArea.test.tsx src/components/pickers/ModelReasoningPicker.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check