### PR TITLE
[codex] Tag telemetry with app surface

### DIFF
--- a/apps/app/src/hooks/queries/ui-source-queries.ts
+++ b/apps/app/src/hooks/queries/ui-source-queries.ts
@@ -1,4 +1,5 @@
 import { useQuery, type QueryKey } from "@tanstack/react-query";
+import { appSurfaceRequestInit } from "@/lib/app-surface";
 
 /**
  * UI-source status, mirrored from the server's UiSourceState. Not in the typed
@@ -22,7 +23,10 @@ export function uiSourceStatusQueryKey(): QueryKey {
 }
 
 async function fetchUiSourceStatus(): Promise<UiSourceStatus | null> {
-  const response = await fetch("/api/v1/ui/status");
+  const response = await fetch(
+    "/api/v1/ui/status",
+    appSurfaceRequestInit(),
+  );
   // 404 = feature not enabled on this server (no build toolchain). Treat as
   // "nothing to surface" rather than an error.
   if (!response.ok) {

--- a/apps/app/src/hooks/useUiSourceStatusToast.ts
+++ b/apps/app/src/hooks/useUiSourceStatusToast.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { appToast } from "@/components/ui/app-toast";
+import { appSurfaceRequestInit } from "@/lib/app-surface";
 import { useUiSourceStatus } from "./queries/ui-source-queries";
 
 const ERROR_TOAST_ID = "bb-ui-source-error";
@@ -36,9 +37,10 @@ export function useUiSourceStatusToast(): void {
         action: {
           label: "Switch to shipped",
           onClick: () => {
-            void fetch("/api/v1/ui/prod", { method: "POST" }).catch(
-              () => undefined,
-            );
+            void fetch(
+              "/api/v1/ui/prod",
+              appSurfaceRequestInit({ method: "POST" }),
+            ).catch(() => undefined);
             appToast.dismiss(ERROR_TOAST_ID);
           },
         },

--- a/apps/app/src/lib/api-server.ts
+++ b/apps/app/src/lib/api-server.ts
@@ -1,9 +1,10 @@
 import { createApiClient } from "@bb/server-contract";
+import { fetchWithAppSurface } from "./app-surface";
 
 const BASE_URL =
   typeof window === "undefined" ? "http://localhost" : window.location.origin;
 
-const client = createApiClient(BASE_URL);
+const client = createApiClient(BASE_URL, { fetch: fetchWithAppSurface });
 
 export const apiClient = client.api.v1;
 

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -98,6 +98,7 @@ import {
   type ProviderUsageResponse,
 } from "@bb/host-daemon-contract";
 import { apiClient, toRelativeUrl } from "./api-server";
+import { appSurfaceRequestInit } from "./app-surface";
 import {
   buildFilePreview,
   normalizeFilePreviewMimeType,
@@ -350,10 +351,13 @@ export async function loadFilePreview(
   signal?: AbortSignal,
 ): Promise<FilePreview> {
   const response = await requestResponse(
-    fetch(target.url, {
-      method: "GET",
-      signal,
-    }),
+    fetch(
+      target.url,
+      appSurfaceRequestInit({
+        method: "GET",
+        signal,
+      }),
+    ),
   );
   const contentBytes = new Uint8Array(await response.arrayBuffer());
   return buildFilePreview({
@@ -502,11 +506,14 @@ async function postMultipart<T>(
   }
   formData.set("file", file, file.name);
 
-  const res = await fetch(toRelativeUrl(url), {
-    method: "POST",
-    body: formData,
-    signal,
-  });
+  const res = await fetch(
+    toRelativeUrl(url),
+    appSurfaceRequestInit({
+      method: "POST",
+      body: formData,
+      signal,
+    }),
+  );
   if (!res.ok) {
     await throwHttpError(res);
   }

--- a/apps/app/src/lib/app-surface.test.ts
+++ b/apps/app/src/lib/app-surface.test.ts
@@ -1,0 +1,44 @@
+import { APP_SURFACE_HEADER_NAME } from "@bb/config/app-surface";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+import { appSurfaceRequestInit, getAppSurface } from "./app-surface";
+
+const desktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos",
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.0-test",
+} as const;
+
+describe("app surface request metadata", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults browser requests to the web app surface", () => {
+    const init = appSurfaceRequestInit({
+      headers: { "x-existing": "kept" },
+    });
+
+    const headers = new Headers(init.headers);
+    expect(getAppSurface()).toBe("web");
+    expect(headers.get(APP_SURFACE_HEADER_NAME)).toBe("web");
+    expect(headers.get("x-existing")).toBe("kept");
+  });
+
+  it("marks Electron preload requests as desktop", () => {
+    vi.stubGlobal("window", {
+      bbDesktop: createBbDesktopApi(desktopInfo),
+    });
+
+    const init = appSurfaceRequestInit();
+
+    expect(getAppSurface()).toBe("desktop");
+    expect(new Headers(init.headers).get(APP_SURFACE_HEADER_NAME)).toBe(
+      "desktop",
+    );
+  });
+});

--- a/apps/app/src/lib/app-surface.ts
+++ b/apps/app/src/lib/app-surface.ts
@@ -21,16 +21,9 @@ export function appSurfaceRequestInit(init?: RequestInit): RequestInit {
   };
 }
 
-function appSurfaceFetch(
+export function fetchWithAppSurface(
   input: Parameters<typeof fetch>[0],
   init?: RequestInit,
 ): ReturnType<typeof fetch> {
   return fetch(input, appSurfaceRequestInit(init));
 }
-
-export const fetchWithAppSurface: typeof fetch = Object.assign(
-  appSurfaceFetch,
-  {
-    preconnect: fetch.preconnect,
-  },
-);

--- a/apps/app/src/lib/app-surface.ts
+++ b/apps/app/src/lib/app-surface.ts
@@ -1,0 +1,36 @@
+import {
+  APP_SURFACE_DESKTOP,
+  APP_SURFACE_HEADER_NAME,
+  APP_SURFACE_WEB,
+  type AppSurface,
+} from "@bb/config/app-surface";
+
+export function getAppSurface(): AppSurface {
+  if (typeof window !== "undefined" && window.bbDesktop !== undefined) {
+    return APP_SURFACE_DESKTOP;
+  }
+  return APP_SURFACE_WEB;
+}
+
+export function appSurfaceRequestInit(init?: RequestInit): RequestInit {
+  const headers = new Headers(init?.headers);
+  headers.set(APP_SURFACE_HEADER_NAME, getAppSurface());
+  return {
+    ...init,
+    headers,
+  };
+}
+
+function appSurfaceFetch(
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+): ReturnType<typeof fetch> {
+  return fetch(input, appSurfaceRequestInit(init));
+}
+
+export const fetchWithAppSurface: typeof fetch = Object.assign(
+  appSurfaceFetch,
+  {
+    preconnect: fetch.preconnect,
+  },
+);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,6 +17,10 @@ import {
   type WebContents,
 } from "electron";
 import { autoUpdater } from "electron-updater";
+import {
+  APP_SURFACE_DESKTOP,
+  APP_SURFACE_ENV_NAME,
+} from "@bb/config/app-surface";
 import { type Experiments } from "@bb/domain";
 import {
   bbDesktopPopoutMouseEventsIgnoredRequestSchema,
@@ -1263,7 +1267,10 @@ async function startOwnedRuntime(
   const bbProcess = startBbAppProcess({
     bridgePath: args.bridgePath,
     cwd: homedir(),
-    env: process.env,
+    env: {
+      ...process.env,
+      [APP_SURFACE_ENV_NAME]: APP_SURFACE_DESKTOP,
+    },
     logLineLimit: PROCESS_LOG_LINE_LIMIT,
     runtime: resolveBbAppProcessRuntime({
       env: process.env,

--- a/apps/server/src/request-context.ts
+++ b/apps/server/src/request-context.ts
@@ -1,4 +1,9 @@
 import { getConnInfo } from "@hono/node-server/conninfo";
+import {
+  APP_SURFACE_HEADER_NAME,
+  parseAppSurface,
+  type AppSurface,
+} from "@bb/config/app-surface";
 import type { Context } from "hono";
 
 export const TRUSTED_REMOTE_ADDRESS_CONTEXT_KEY = "bbTrustedRemoteAddress";
@@ -28,4 +33,11 @@ export function getTrustedRemoteAddress(
   context: TrustedRemoteAddressReader,
 ): string | undefined {
   return context.get(TRUSTED_REMOTE_ADDRESS_CONTEXT_KEY);
+}
+
+export function resolveRequestAppSurface(
+  context: Context,
+  fallback: AppSurface,
+): AppSurface {
+  return parseAppSurface(context.req.header(APP_SURFACE_HEADER_NAME)) ?? fallback;
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -33,7 +33,11 @@ import {
   setAuthenticatedDaemon,
   verifyAuthenticatedDaemon,
 } from "./internal/auth.js";
-import { captureTrustedRemoteAddress } from "./request-context.js";
+import {
+  captureTrustedRemoteAddress,
+  resolveRequestAppSurface,
+} from "./request-context.js";
+import { runWithTelemetryAppSurface } from "./services/system/telemetry.js";
 import {
   onClientSocketClose,
   onClientSocketMessage,
@@ -290,7 +294,8 @@ export function createApp(
 
   app.use("*", async (context, next) => {
     captureTrustedRemoteAddress(context);
-    await next();
+    const appSurface = resolveRequestAppSurface(context, deps.config.appSurface);
+    return runWithTelemetryAppSurface(appSurface, next);
   });
   app.use(
     "*",

--- a/apps/server/src/services/system/telemetry.ts
+++ b/apps/server/src/services/system/telemetry.ts
@@ -1,4 +1,6 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { readOrCreateSecretFile } from "@bb/secret-storage";
+import type { AppSurface } from "@bb/config/app-surface";
 import type { ServerLogger } from "../../types.js";
 
 /**
@@ -22,6 +24,8 @@ import type { ServerLogger } from "../../types.js";
 
 const POSTHOG_INGESTION_URL = "https://us.i.posthog.com/capture/";
 const TELEMETRY_ID_FILE_NAME = "telemetry-id";
+
+const telemetryAppSurfaceStorage = new AsyncLocalStorage<AppSurface>();
 
 export type TelemetryEvent =
   | { name: "app_started" }
@@ -47,6 +51,7 @@ export interface TelemetryService {
 
 export interface CreateTelemetryServiceArgs {
   apiKey: string;
+  appSurface: AppSurface;
   appVersion: string;
   dataDir: string;
   enabled: boolean;
@@ -60,6 +65,13 @@ const noopTelemetryService: TelemetryService = {
 /** No-op service for tests and other places that need the dependency shape. */
 export function createNoopTelemetryService(): TelemetryService {
   return noopTelemetryService;
+}
+
+export function runWithTelemetryAppSurface<T>(
+  appSurface: AppSurface,
+  callback: () => T,
+): T {
+  return telemetryAppSurfaceStorage.run(appSurface, callback);
 }
 
 export async function createTelemetryService(
@@ -81,13 +93,16 @@ export async function createTelemetryService(
   };
   return {
     capture(event: TelemetryEvent): void {
+      const appSurface = telemetryAppSurfaceStorage.getStore() ?? args.appSurface;
+      const eventProperties = "properties" in event ? event.properties : {};
       const body = JSON.stringify({
         api_key: args.apiKey,
         distinct_id: distinctId,
         event: event.name,
         properties: {
           ...commonProperties,
-          ...("properties" in event ? event.properties : {}),
+          ...eventProperties,
+          app_surface: appSurface,
         },
         timestamp: new Date().toISOString(),
       });
@@ -96,7 +111,14 @@ export async function createTelemetryService(
         headers: { "content-type": "application/json" },
         method: "POST",
       }).catch((error: unknown) => {
-        args.logger.debug({ err: error }, "Telemetry event send failed");
+        args.logger.debug(
+          {
+            app_surface: appSurface,
+            err: error,
+            event: event.name,
+          },
+          "Telemetry event send failed",
+        );
       });
     },
   };

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -165,6 +165,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       ensureClonedUiSource({ repoUrl, ref, into: cloneDir });
   }
   const runtimeConfig: ServerRuntimeConfig = {
+    appSurface: serverConfig.BB_APP_SURFACE,
     appVersion: serverConfig.BB_APP_VERSION,
     automationsAllowScriptRuns: serverConfig.BB_AUTOMATIONS_ALLOW_SCRIPT_RUNS,
     builtinSkillsRootPath: resolveBuiltinSkillsRootPath(),
@@ -198,6 +199,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
   // desktop app both set NODE_ENV=production); dev/source runs never send.
   const telemetry = await createTelemetryService({
     apiKey: serverConfig.BB_POSTHOG_API_KEY,
+    appSurface: serverConfig.BB_APP_SURFACE,
     appVersion: serverConfig.BB_APP_VERSION,
     dataDir: serverConfig.BB_DATA_DIR,
     enabled: serverConfig.BB_TELEMETRY && isProduction,

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -2,6 +2,7 @@ import type {
   CustomAcpAgent,
   CustomProviderModel,
 } from "@bb/config/bb-app-managed-config";
+import type { AppSurface } from "@bb/config/app-surface";
 import type { DbConnection } from "@bb/db";
 import type { FeatureFlags } from "@bb/domain";
 import type { Logger } from "@bb/logger";
@@ -19,6 +20,7 @@ export type ServerLogger = Pick<Logger, "debug" | "error" | "info" | "warn">;
 
 export interface ServerRuntimeConfig {
   appVersion: string;
+  appSurface: AppSurface;
   /**
    * Operator gate for script-mode automations (which execute arbitrary host
    * commands). DEFAULT ENABLED so the feature works out of the box; set

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -123,6 +123,7 @@ export async function createTestAppHarness(
     },
   };
   const config: ServerRuntimeConfig = {
+    appSurface: "web",
     appVersion: "0.0.0-test",
     automationsAllowScriptRuns: true,
     builtinSkillsRootPath: join(dataDir, "builtin-skills"),

--- a/apps/server/test/services/telemetry.test.ts
+++ b/apps/server/test/services/telemetry.test.ts
@@ -2,7 +2,10 @@ import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createTelemetryService } from "../../src/services/system/telemetry.js";
+import {
+  createTelemetryService,
+  runWithTelemetryAppSurface,
+} from "../../src/services/system/telemetry.js";
 
 function createTestLogger() {
   return {
@@ -31,6 +34,7 @@ describe("telemetry service", () => {
   it("sends events with a stable anonymous install id", async () => {
     const telemetry = await createTelemetryService({
       apiKey: "phc_test",
+      appSurface: "web",
       appVersion: "1.2.3",
       dataDir,
       enabled: true,
@@ -38,12 +42,14 @@ describe("telemetry service", () => {
     });
 
     telemetry.capture({ name: "app_started" });
-    telemetry.capture({
-      name: "thread_created",
-      properties: {
-        is_child_thread: true,
-        provider: "claude-code",
-      },
+    runWithTelemetryAppSurface("desktop", () => {
+      telemetry.capture({
+        name: "thread_created",
+        properties: {
+          is_child_thread: true,
+          provider: "claude-code",
+        },
+      });
     });
     telemetry.capture({
       name: "user_message_sent",
@@ -75,6 +81,7 @@ describe("telemetry service", () => {
       event: "app_started",
       properties: {
         app_version: "1.2.3",
+        app_surface: "web",
         arch: process.arch,
         platform: process.platform,
       },
@@ -83,6 +90,7 @@ describe("telemetry service", () => {
       event: "thread_created",
       properties: {
         app_version: "1.2.3",
+        app_surface: "desktop",
         is_child_thread: true,
         provider: "claude-code",
       },
@@ -91,6 +99,7 @@ describe("telemetry service", () => {
       event: "user_message_sent",
       properties: {
         app_version: "1.2.3",
+        app_surface: "web",
         is_child_thread: false,
         message_source: "thread_send",
         provider: "codex",
@@ -101,6 +110,7 @@ describe("telemetry service", () => {
   it("reuses the persisted install id across restarts", async () => {
     const args = {
       apiKey: "phc_test",
+      appSurface: "web" as const,
       appVersion: "1.2.3",
       dataDir,
       enabled: true,
@@ -124,6 +134,7 @@ describe("telemetry service", () => {
   ])("is fully inert when $label", async ({ apiKey, enabled }) => {
     const telemetry = await createTelemetryService({
       apiKey,
+      appSurface: "web",
       appVersion: "1.2.3",
       dataDir,
       enabled,
@@ -140,6 +151,7 @@ describe("telemetry service", () => {
     fetchMock.mockRejectedValue(new Error("offline"));
     const telemetry = await createTelemetryService({
       apiKey: "phc_test",
+      appSurface: "desktop",
       appVersion: "1.2.3",
       dataDir,
       enabled: true,
@@ -149,7 +161,11 @@ describe("telemetry service", () => {
     telemetry.capture({ name: "app_started" });
     await vi.waitFor(() => {
       expect(logger.debug).toHaveBeenCalledWith(
-        { err: expect.any(Error) },
+        {
+          app_surface: "desktop",
+          err: expect.any(Error),
+          event: "app_started",
+        },
         "Telemetry event send failed",
       );
     });

--- a/apps/server/test/system/bb-app-managed-config.test.ts
+++ b/apps/server/test/system/bb-app-managed-config.test.ts
@@ -61,6 +61,7 @@ function createCountingLogger(): CountingLogger {
 function createRuntimeConfig(): ServerRuntimeConfig {
   return {
     appUrl: "https://ambient-app.example.test",
+    appSurface: "web",
     appVersion: "0.0.0-test",
     automationsAllowScriptRuns: true,
     builtinSkillsRootPath: "/tmp/bb-test/builtin-skills",

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -16,6 +16,10 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import {
+  APP_SURFACE_ENV_NAME,
+  APP_SURFACE_WEB,
+} from "@bb/config/app-surface";
+import {
   BB_APP_MANAGED_CONFIG_KEYS,
   bbAppManagedEnvFileSchema,
   formatBbAppConfigPath,
@@ -2112,6 +2116,7 @@ function createServerEnv(args: CreateServerEnvArgs): NodeJS.ProcessEnv {
   return {
     ...args.env,
     BB_APP_VERSION: args.context.appVersion,
+    [APP_SURFACE_ENV_NAME]: APP_SURFACE_WEB,
     BB_DATA_DIR: args.context.dataDir,
     BB_HOST_DAEMON_PORT: String(args.context.daemonPort),
     BB_SERVER_PORT: String(args.context.serverPort),

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -103,6 +103,11 @@
       "types": "./src/client-config.ts",
       "default": "./src/client-config.ts"
     },
+    "./app-surface": {
+      "source": "./src/app-surface.ts",
+      "types": "./src/app-surface.ts",
+      "default": "./src/app-surface.ts"
+    },
     "./skill-storage-paths": {
       "source": "./src/skill-storage-paths.ts",
       "types": "./src/skill-storage-paths.ts",

--- a/packages/config/src/app-surface.ts
+++ b/packages/config/src/app-surface.ts
@@ -1,0 +1,23 @@
+export const APP_SURFACE_HEADER_NAME = "x-bb-app-surface";
+export const APP_SURFACE_ENV_NAME = "BB_APP_SURFACE";
+
+export const APP_SURFACE_VALUES = ["desktop", "web"] as const;
+export type AppSurface = (typeof APP_SURFACE_VALUES)[number];
+
+export const APP_SURFACE_DESKTOP: AppSurface = "desktop";
+export const APP_SURFACE_WEB: AppSurface = "web";
+export const DEFAULT_APP_SURFACE: AppSurface = APP_SURFACE_WEB;
+
+export function parseAppSurface(
+  value: string | null | undefined,
+): AppSurface | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const trimmedValue = value.trim();
+  return APP_SURFACE_VALUES.find((surface) => surface === trimmedValue);
+}
+
+export function formatAppSurfaceValues(): string {
+  return APP_SURFACE_VALUES.join(", ");
+}

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -3,6 +3,13 @@ import { defaultFeatureFlags, hostTypeSchema, type HostType } from "@bb/domain";
 import { DEFAULTS } from "./defaults.js";
 import { defineEnvVar, type EnvVarParseArgs } from "./env.js";
 import {
+  APP_SURFACE_ENV_NAME,
+  DEFAULT_APP_SURFACE,
+  formatAppSurfaceValues,
+  parseAppSurface,
+  type AppSurface,
+} from "./app-surface.js";
+import {
   validateInferenceModel,
   validateTranscriptionModel,
 } from "./inference-model.js";
@@ -30,6 +37,16 @@ export function parseBooleanEnvValue(args: EnvVarParseArgs): boolean {
   }
 
   throw new Error(`${args.name} must be a boolean`);
+}
+
+export function parseAppSurfaceEnvValue(args: EnvVarParseArgs): AppSurface {
+  const parsed = parseAppSurface(args.value);
+  if (parsed !== undefined) {
+    return parsed;
+  }
+  throw new Error(
+    `${args.name} must be one of ${formatAppSurfaceValues()}`,
+  );
 }
 
 export function parseOptionalPortEnvValue(
@@ -141,6 +158,13 @@ export const BB_APP_VERSION_ENV = defineEnvVar<string>({
     "Version of the running bb-app package. The bb-app launcher sets this from packages/bb-app/package.json; defaults to a sentinel for dev/source runs.",
   name: "BB_APP_VERSION",
   parse: parseNonEmptyStringEnvValue,
+});
+
+export const BB_APP_SURFACE_ENV = defineEnvVar<AppSurface>({
+  description:
+    "Internal launcher marker for telemetry attribution. Set by bb-app and desktop launchers.",
+  name: APP_SURFACE_ENV_NAME,
+  parse: parseAppSurfaceEnvValue,
 });
 
 export const BB_APP_URL_ENV = defineEnvVar<string>({
@@ -266,6 +290,7 @@ export const BB_HOST_TYPE_ENV = defineEnvVar<HostType | undefined>({
 });
 
 export const DEFAULT_BB_APP_VERSION = "0.0.0-dev";
+export const DEFAULT_BB_APP_SURFACE = DEFAULT_APP_SURFACE;
 export const DEFAULT_BB_APP_URL = "";
 export const DEFAULT_BB_EXTERNAL_URL = "";
 export const DEFAULT_OPENAI_API_KEY = "";

--- a/packages/config/src/server.ts
+++ b/packages/config/src/server.ts
@@ -1,4 +1,5 @@
 import type { FeatureFlags } from "@bb/domain";
+import type { AppSurface } from "./app-surface.js";
 import {
   loadCommonConfig,
   type CommonConfig,
@@ -9,6 +10,7 @@ import { loadDevAppConfig } from "./dev-app.js";
 import { readEnvVarWithDefault, resolveEnvLoader } from "./env.js";
 import {
   BB_APP_URL_ENV,
+  BB_APP_SURFACE_ENV,
   BB_APP_VERSION_ENV,
   BB_AUTOMATIONS_ALLOW_SCRIPT_RUNS_ENV,
   BB_EXTERNAL_URL_ENV,
@@ -18,6 +20,7 @@ import {
   BB_TELEMETRY_ENV,
   BB_TRANSCRIPTION_ENV,
   DEFAULT_BB_APP_URL,
+  DEFAULT_BB_APP_SURFACE,
   DEFAULT_BB_APP_VERSION,
   DEFAULT_BB_AUTOMATIONS_ALLOW_SCRIPT_RUNS,
   DEFAULT_BB_EXTERNAL_URL,
@@ -36,6 +39,7 @@ import { loadServerPortConfig, type ServerPortConfig } from "./server-port.js";
 export interface ServerConfig
   extends CommonConfig, DatabaseConfig, ServerPortConfig {
   BB_APP_URL: string;
+  BB_APP_SURFACE: AppSurface;
   BB_APP_VERSION: string;
   BB_AUTOMATIONS_ALLOW_SCRIPT_RUNS: boolean;
   BB_DEV_APP_PORT?: number;
@@ -88,6 +92,12 @@ export function loadServerConfig(
       context: loader.context,
       defaultValue: DEFAULT_BB_APP_URL,
       definition: BB_APP_URL_ENV,
+      env: loader.env,
+    }),
+    BB_APP_SURFACE: readEnvVarWithDefault({
+      context: loader.context,
+      defaultValue: DEFAULT_BB_APP_SURFACE,
+      definition: BB_APP_SURFACE_ENV,
       env: loader.env,
     }),
     BB_APP_VERSION: readEnvVarWithDefault({

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -314,6 +314,7 @@ describe("consumer-specific config", () => {
     expect(serverConfig.BB_HOST_DAEMON_PORT).toBe(5555);
     expect(serverConfig.databasePath).toBe("/tmp/bb-data/bb.db");
     expect(serverConfig.BB_APP_URL).toBe("");
+    expect(serverConfig.BB_APP_SURFACE).toBe("web");
     expect(serverConfig.BB_APP_VERSION).toBe("0.0.0-dev");
     expect(serverConfig.BB_EXTERNAL_URL).toBe("");
     expect(serverConfig.BB_INFERENCE).toBe("codex/gpt-5.4-mini");
@@ -362,6 +363,26 @@ describe("consumer-specific config", () => {
     });
 
     expect(serverConfig.BB_APP_VERSION).toBe("0.1.2");
+  });
+
+  it("parses the internal app surface marker for server telemetry", () => {
+    const serverConfig = loadServerConfig({
+      env: createServerRuntimeEnv({
+        BB_APP_SURFACE: "desktop",
+        NODE_ENV: "production",
+      }),
+    });
+
+    expect(serverConfig.BB_APP_SURFACE).toBe("desktop");
+
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_APP_SURFACE: "mobile",
+          NODE_ENV: "production",
+        }),
+      }),
+    ).toThrow("BB_APP_SURFACE must be one of desktop, web");
   });
 
   it("lets tooling read the server port without validating unrelated server env", () => {

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -1,5 +1,5 @@
 import type { Hono } from "hono";
-import { hc } from "hono/client";
+import { hc, type ClientRequestOptions } from "hono/client";
 import type {
   AppTheme,
   AppThemeSelection,
@@ -1108,16 +1108,33 @@ export type PublicApiSchema = ApiSchemaFromRouteDescriptors<
 
 export type PublicApiRoutes = Hono<{}, PublicApiSchema, "/">;
 
+export type PublicApiFetch = (
+  ...args: Parameters<typeof fetch>
+) => ReturnType<typeof fetch>;
+
 /** Omit the options object to use global fetch; provide it to override fetch. */
 export interface PublicApiClientOptions {
-  fetch: typeof fetch;
+  fetch: PublicApiFetch;
+}
+
+function toHonoClientOptions(
+  options: PublicApiClientOptions | undefined,
+): ClientRequestOptions | undefined {
+  if (options === undefined) {
+    return undefined;
+  }
+  // Hono types custom fetch as typeof fetch, but only calls the function.
+  return { fetch: options.fetch as typeof fetch };
 }
 
 export function createPublicApiClient(
   baseUrl: string,
   options?: PublicApiClientOptions,
 ) {
-  return hc<PublicApiRoutes>(`${baseUrl}/api/v1`, options);
+  return hc<PublicApiRoutes>(
+    `${baseUrl}/api/v1`,
+    toHonoClientOptions(options),
+  );
 }
 
 export function createApiClient(

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -224,6 +224,7 @@ async function startIntegrationServer(
     openTimeoutMs: 50,
   });
   const config: ServerRuntimeConfig = {
+    appSurface: "web",
     appVersion: "0.0.0-dev",
     automationsAllowScriptRuns: true,
     builtinSkillsRootPath,


### PR DESCRIPTION
## Summary

- Add shared app surface constants/config so the server knows whether it was launched by the web bb-app or desktop shell.
- Add an app fetch helper that sends `x-bb-app-surface` for typed API calls and direct app/server fetches.
- Wrap server requests with a request-scoped app surface and have the telemetry service attach `app_surface` centrally to emitted telemetry events and send-failure logs.

## Validation

- `pnpm exec turbo run test --filter=@bb/config -- --run test/config.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/telemetry.test.ts test/threads/thread-create-seed-without-run.test.ts test/threads/thread-send-dispatch.test.ts test/public/public-thread-data.test.ts`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/lib/app-surface.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/config --filter=@bb/server --filter=@bb/app --filter=bb-app --filter=@bb/desktop`
- `git diff --check`
