### PR TITLE
Update landing hero and automation preview

### DIFF
--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -23,7 +23,6 @@ import {
   SidebarLeftIcon,
   SidebarRightIcon,
   Tick02Icon,
-  ZapIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { createFileRoute } from "@tanstack/react-router";
@@ -430,9 +429,6 @@ const CircleCheckIcon = ({ className }: IconProps) => (
 );
 const MessageQuestionGlyph = ({ className }: IconProps) => (
   <HugeiconsIcon icon={MessageQuestionIcon} className={className} />
-);
-const BoltIcon = ({ className }: IconProps) => (
-  <HugeiconsIcon icon={ZapIcon} className={className} />
 );
 const PaperPlane = ({ className }: IconProps) => (
   <HugeiconsIcon icon={SentIcon} className={className} />
@@ -1350,88 +1346,195 @@ function AgentChat() {
   );
 }
 
-/* ── Band 3 visual: automation run receipt ───────────────────────── */
+/* ── Band 3 visual: mobile automation thread ─────────────────────── */
 
-type Run = {
-  title: string;
-  trigger: string;
-  triggerKind: "cron" | "event";
-  steps: string[];
-  output: string;
+type AutomationMessage = {
+  role: "user" | "agent" | "tool";
+  text: string;
 };
 
-const RUNS: Run[] = [
-  {
-    title: "Nightly docs sync",
-    trigger: "0 2 * * *",
-    triggerKind: "cron",
-    steps: ["spawned “sync docs”", "worker ran locally", "reviewed 14 files"],
-    output: "PR #418 ready",
-  },
+type AutomationScenario = {
+  title: string;
+  prompt: string;
+  promptWidth: string;
+  branch: string;
+  messages: AutomationMessage[];
+};
+
+const AUTOMATION_SCENARIOS: AutomationScenario[] = [
   {
     title: "Issue triage",
-    trigger: "on new issue",
-    triggerKind: "event",
-    steps: ["read the new issue", "spawned an agent thread", "drafted a summary"],
-    output: "posted to Slack",
+    prompt: "triage every new issue",
+    promptWidth: "144px",
+    branch: "bb/issue-triage",
+    messages: [
+      { role: "user", text: "triage every new issue" },
+      {
+        role: "agent",
+        text: "I'll set up an automation for every new issue.",
+      },
+      { role: "tool", text: "created trigger: on new issue" },
+      { role: "tool", text: "configured action: open triage thread" },
+      {
+        role: "agent",
+        text: "Done. New issues will get a local bb thread and Slack summary.",
+      },
+    ],
+  },
+  {
+    title: "Nightly docs sync",
+    prompt: "run nightly docs sync",
+    promptWidth: "137px",
+    branch: "bb/sync-docs",
+    messages: [
+      { role: "user", text: "run nightly docs sync" },
+      {
+        role: "agent",
+        text: "I'll create a local 2am automation for the docs sync.",
+      },
+      { role: "tool", text: "created schedule: 0 2 * * *" },
+      { role: "tool", text: "configured action: run docs worker" },
+      {
+        role: "agent",
+        text: "Done. Each run will open a thread and prepare the PR.",
+      },
+    ],
   },
   {
     title: "Watch failing jobs",
-    trigger: "on job failed",
-    triggerKind: "event",
-    steps: ["inspected the CI logs", "found a flaky timeout", "pushed a fix"],
-    output: "opened fix branch",
+    prompt: "watch failing jobs",
+    promptWidth: "112px",
+    branch: "bb/fix-ci",
+    messages: [
+      { role: "user", text: "watch failing jobs" },
+      {
+        role: "agent",
+        text: "I'll set up an automation that reacts to failed CI jobs.",
+      },
+      { role: "tool", text: "created trigger: on job failed" },
+      { role: "tool", text: "configured action: inspect logs and spawn fix" },
+      {
+        role: "agent",
+        text: "Done. Failures will start a worker thread automatically.",
+      },
+    ],
   },
 ];
 
-// A compact, BB-native "run receipt": trigger + status pill + steps that check
-// in one by one + final output. It cycles one automation at a time. The card
-// shell stays put — only its contents cycle: they build in, hold, then fade out
-// together before the next run's contents appear (CSS reveals, no card flash).
+// A phone-sized bb thread preview: a prompt types into the composer, sends, then
+// the matching automation transcript streams into the feed.
 function AutomationRun() {
-  const { cycle, leaving } = useCycle(3800, 400);
-  const run = RUNS[cycle % RUNS.length];
-  const outAt = 0.25 + run.steps.length * 0.5;
-  const doneAt = outAt + 0.2;
+  const { cycle, leaving } = useCycle(7600, 500);
+  const run = AUTOMATION_SCENARIOS[cycle % AUTOMATION_SCENARIOS.length];
+  const promptStyle = {
+    "--automation-prompt-width": run.promptWidth,
+  } as CSSProperties;
   return (
-    <div className="runcard" aria-label="An automation run">
-      <div className={leaving ? "run-body leaving" : "run-body"} key={cycle}>
-        <div className="run-head">
-          <span className="run-title">{run.title}</span>
-          <span className="run-status" aria-hidden>
-            <span className="rs rs-run" style={{ animationDelay: `${doneAt}s` }}>
-              <span className="rs-dot" />
-              Running
+    <div className="mockup-wrap mockup-wrap-automation">
+      <div
+        className="mock mock-automation-mobile"
+        aria-label="Mobile bb preview showing an automation prompt and streamed thread messages"
+      >
+        <div className="mock-bar">
+          <div className="bar-left">
+            <span className="bar-menu" aria-hidden>
+              <PanelIcon className="ri bar-ic" />
             </span>
-            <span className="rs rs-done" style={{ animationDelay: `${doneAt}s` }}>
-              <CheckIcon className="rs-check" />
-              Done
+          </div>
+          <div className="bar-main">
+            <span className="bar-title">{run.title}</span>
+            <span className="bar-actions">
+              <span className="commit-btn" aria-hidden>
+                Automation
+              </span>
             </span>
-          </span>
+          </div>
         </div>
-        <div className="run-trigger">
-          {run.triggerKind === "cron" ? (
-            <ClockIcon className="tg-ic" />
-          ) : (
-            <BoltIcon className="tg-ic" />
-          )}
-          <span className="mono">{run.trigger}</span>
-        </div>
-        <div className="run-steps">
-          {run.steps.map((step, i) => (
-            <div
-              className="run-step"
-              key={step}
-              style={{ animationDelay: `${0.25 + i * 0.5}s` }}
-            >
-              <CheckIcon className="st-check" />
-              <span>{step}</span>
+
+        <div
+          className={
+            leaving
+              ? "mock-body automation-body leaving"
+              : "mock-body automation-body"
+          }
+          key={cycle}
+        >
+          <div className="main">
+            <div className="feed feed-live automation-feed">
+              {run.messages.map((message, i) => {
+                const style = { animationDelay: `${3.2 + i * 0.68}s` };
+                if (message.role === "user") {
+                  return (
+                    <div
+                      className="msg-user automation-msg"
+                      key={`${message.role}-${message.text}`}
+                      style={style}
+                    >
+                      {message.text}
+                    </div>
+                  );
+                }
+                if (message.role === "tool") {
+                  return (
+                    <div
+                      className="msg-step automation-msg automation-tool"
+                      key={`${message.role}-${message.text}`}
+                      style={style}
+                    >
+                      <ChevronRight className="step-chev" />
+                      {message.text}
+                    </div>
+                  );
+                }
+                return (
+                  <div
+                    className="msg-say automation-msg"
+                    key={`${message.role}-${message.text}`}
+                    style={style}
+                  >
+                    {message.text}
+                  </div>
+                );
+              })}
             </div>
-          ))}
-        </div>
-        <div className="run-output" style={{ animationDelay: `${outAt}s` }}>
-          <span className="out-arrow">→</span>
-          <span>{run.output}</span>
+
+            <div className="composer automation-composer">
+              <div className="composer-box automation-composer-box">
+                <div className="composer-top">
+                  <span className="composer-input automation-typeahead">
+                    <span
+                      className="automation-type-text"
+                      style={promptStyle}
+                    >
+                      {run.prompt}
+                    </span>
+                    <span className="automation-caret" aria-hidden />
+                  </span>
+                  <Maximize2 className="cb-expand" />
+                </div>
+                <div className="composer-row">
+                  <span className="model">
+                    <OpenAiIcon className="model-ic" />
+                    Codex
+                    <ChevronDown className="chev-sm" />
+                  </span>
+                  <span className="composer-actions" aria-hidden>
+                    <Paperclip className="composer-clip" />
+                    <span className="send-btn automation-send">
+                      <SendIcon className="send-ic" />
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div className="context-row automation-context">
+                <span className="ctx">
+                  <GitBranchIcon className="ctx-ic" />
+                  <span className="ctx-branch">{run.branch}</span>
+                </span>
+                <Spinner className="ctx-spin" />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1574,8 +1677,8 @@ function LandingPage() {
         </h1>
         <p className="lde-expand">(Loop Development Environment)</p>
         <p className="sub">
-          Orchestrate your coding agents. Drive it yourself, or let your agents
-          and automations drive it for you.
+          bb can control, customize, and automate itself, laying the groundwork
+          for your own software factory.
         </p>
 
         <InstallOptions placement="hero" />

--- a/apps/landing/src/site.ts
+++ b/apps/landing/src/site.ts
@@ -26,4 +26,4 @@ export function downloadMacosHref(placement: CtaPlacement): string {
 
 export const SITE_TITLE = "bb: the IDE for loop-driven development";
 export const SITE_DESCRIPTION =
-  "Orchestrate your coding agents. Drive it yourself, or let your agents and automations drive it for you. Fully open source and local-first, with Claude Code, Codex, Cursor, Pi, and OpenCode.";
+  "bb can control, customize, and automate itself, laying the groundwork for your own software factory. Fully open source and local-first, with Claude Code, Codex, Cursor, Pi, and OpenCode.";

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -444,7 +444,7 @@ code,
 
 .lde-expand {
   margin: 9px auto 0;
-  font-size: 13px;
+  font-size: 15px;
   letter-spacing: 0.01em;
   color: var(--subtle);
 }
@@ -1901,185 +1901,151 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   }
 }
 
-/* ── Band 3 visual: automation run receipt ──────────────────────── */
-/* A compact, BB-native card that cycles one automation at a time. The motion is
-   text/status/checkmark reveals (restarted by the keyed remount) — no graphic.
-   Uses the page's card language and typography. */
+/* ── Band 3 visual: mobile bb app mock ──────────────────────────── */
 
-.runcard {
+.mockup-wrap-automation {
+  width: min(100%, 360px);
+  margin: 0;
+}
+
+.mock-automation-mobile {
   width: 100%;
-  max-width: 360px;
-  padding: 16px 18px 17px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--bg);
-  box-shadow: 0 14px 36px -22px color-mix(in oklab, var(--ink) 32%, transparent);
-  text-align: left;
+  border-radius: 22px;
 }
 
-/* The card shell stays mounted; only its contents cycle. The outgoing run's
-   contents fade out (held in layout so the card keeps its height) before the
-   next run's contents build in. */
-.run-body.leaving {
-  animation: rc-leave 0.4s ease forwards;
+.mock-automation-mobile .mock-bar {
+  height: 42px;
 }
 
-@keyframes rc-leave {
+.mock-automation-mobile .bar-left {
+  width: auto;
+  gap: 10px;
+  padding: 0 10px 0 14px;
+}
+
+.mock-automation-mobile .bar-main {
+  padding: 0 12px;
+}
+
+.mock-automation-mobile .bar-actions {
+  display: none;
+}
+
+.automation-body {
+  height: 438px;
+  border-top: 0;
+}
+
+.automation-body.leaving {
+  animation: automation-leave 0.5s ease forwards;
+}
+
+.mock-automation-mobile .main {
+  min-height: 0;
+}
+
+.automation-feed {
+  padding: 18px 18px 16px;
+  gap: 11px;
+}
+
+.automation-msg {
+  opacity: 0;
+  transform: translateY(8px);
+  animation: automation-msg-in 0.44s ease forwards;
+}
+
+.automation-tool {
+  color: var(--accent);
+}
+
+.automation-composer {
+  padding: 12px;
+}
+
+.automation-composer-box {
+  padding: 11px 12px;
+}
+
+.automation-typeahead {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-height: 30px;
+  padding-right: 20px;
+  color: var(--ink);
+}
+
+.automation-type-text {
+  display: inline-block;
+  width: 0;
+  max-width: min(100%, var(--automation-prompt-width));
+  overflow: hidden;
+  white-space: nowrap;
+  animation:
+    automation-type 1.45s steps(28, end) 0.25s forwards,
+    automation-clear 0.2s ease 2.95s forwards;
+}
+
+.automation-caret {
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  flex-shrink: 0;
+  background: currentColor;
+  color: var(--ink);
+  animation:
+    automation-caret-blink 0.8s step-end infinite,
+    automation-clear 0.2s ease 2.95s forwards;
+}
+
+.automation-send {
+  animation: automation-send-pulse 0.42s ease 2.7s both;
+}
+
+.automation-context {
+  gap: 5px;
+}
+
+.automation-context .ctx {
+  max-width: 100%;
+}
+
+@keyframes automation-type {
+  to {
+    width: min(100%, var(--automation-prompt-width));
+  }
+}
+
+@keyframes automation-clear {
   to {
     opacity: 0;
   }
 }
 
-.run-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-}
-
-.run-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--ink);
-}
-
-/* Two stacked pills: Running crossfades to Done at the run's end. */
-.run-status {
-  position: relative;
-  flex-shrink: 0;
-  width: 80px;
-  height: 22px;
-}
-
-.rs {
-  position: absolute;
-  right: 0;
-  top: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 2px 9px;
-  border-radius: 99px;
-  font-size: 11.5px;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.rs-run {
-  color: var(--accent);
-  background: var(--surface);
-  border: 1px solid var(--border-soft);
-  animation: rc-out 0.4s ease forwards;
-}
-
-.rs-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  animation: rc-blink 1.1s ease-in-out infinite;
-}
-
-.rs-done {
-  opacity: 0;
-  color: var(--ok);
-  background: var(--surface);
-  border: 1px solid var(--border-soft);
-  animation: rc-in 0.4s ease forwards;
-}
-
-.rs-check {
-  width: 12px;
-  height: 12px;
-}
-
-.run-trigger {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 5px;
-  font-size: 12px;
-  color: var(--subtle);
-}
-
-.tg-ic {
-  width: 13px;
-  height: 13px;
-  flex-shrink: 0;
-}
-
-.run-steps {
-  margin-top: 15px;
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-}
-
-.run-step {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: var(--dim);
-  animation: rc-step 0.45s ease backwards;
-}
-
-.st-check {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-  color: var(--ok);
-}
-
-.run-output {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 14px;
-  padding-top: 12px;
-  border-top: 1px dashed var(--border);
-  font-size: 13.5px;
-  font-weight: 600;
-  color: var(--ink);
-  animation: rc-step 0.45s ease backwards;
-}
-
-.out-arrow {
-  color: var(--accent);
-  font-weight: 700;
-}
-
-@keyframes rc-step {
-  from {
+@keyframes automation-caret-blink {
+  50% {
     opacity: 0;
-    transform: translateY(3px);
   }
+}
+
+@keyframes automation-send-pulse {
+  50% {
+    transform: translateY(-1px) scale(1.04);
+    box-shadow: 0 8px 18px -12px color-mix(in oklab, var(--ink) 60%, transparent);
+  }
+}
+
+@keyframes automation-msg-in {
   to {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
-@keyframes rc-out {
+@keyframes automation-leave {
   to {
     opacity: 0;
-    transform: translateY(-3px);
-  }
-}
-
-@keyframes rc-in {
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes rc-blink {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
   }
 }
 
@@ -2540,22 +2506,26 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
     animation: none;
   }
 
-  .runcard,
-  .run-step,
-  .run-output,
-  .rs-run,
-  .rs-done,
-  .rs-dot {
+  .automation-body,
+  .automation-msg,
+  .automation-type-text,
+  .automation-caret,
+  .automation-send {
     animation: none;
   }
 
-  /* Static completed receipt when motion is reduced. */
-  .rs-run {
+  .automation-msg {
+    opacity: 1;
+    transform: none;
+  }
+
+  .automation-type-text {
+    clip-path: none;
     opacity: 0;
   }
 
-  .rs-done {
-    opacity: 1;
+  .automation-caret {
+    opacity: 0;
   }
 
   .tg-msg,


### PR DESCRIPTION
Summary:
- Restore the LDE hero headline with updated software-factory subtitle and metadata description.
- Replace the automation receipt card with a mobile app-preview mock that types prompts and streams setup messages.
- Tune the automation mock chrome, context row, and reduced-motion behavior.

Validation:
- pnpm exec turbo run typecheck --filter=@bb/landing
- pnpm exec turbo run build --filter=@bb/landing