### PR TITLE
[codex] Fix OpenCode ACP permission approvals

### DIFF
--- a/apps/server/src/services/interactions/pending-interaction-validation.ts
+++ b/apps/server/src/services/interactions/pending-interaction-validation.ts
@@ -311,7 +311,8 @@ export function validatePendingInteractionResolution(
     } else if (
       resolution.decision === "allow_for_session" &&
       (interaction.payload.subject.kind === "command" ||
-        interaction.payload.subject.kind === "file_change")
+        interaction.payload.subject.kind === "file_change") &&
+      interaction.payload.subject.sessionGrant !== null
     ) {
       throw new ApiError(
         400,

--- a/apps/server/test/services/pending-interactions.test.ts
+++ b/apps/server/test/services/pending-interactions.test.ts
@@ -870,6 +870,66 @@ describe("pending interaction lifecycle", () => {
     });
   });
 
+  it("allows command session approvals when no BB session grant was requested", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-pending-interaction-command-opaque-session",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "acp-opencode",
+      });
+
+      const created = registerPendingInteraction(
+        harness.deps,
+        harness.deps.pendingInteractions,
+        {
+          threadId: thread.id,
+          turnId: "turn-command-opaque-session",
+          providerId: "acp-opencode",
+          providerThreadId: "provider-thread-command-opaque-session",
+          providerRequestId: "request-command-opaque-session",
+          payload: createCommandApprovalPayload({
+            itemId: "item-command-opaque-session",
+            reason: "Needs provider-side session approval",
+            command: "cd backend && pnpm test",
+            sessionGrant: null,
+            availableDecisions: ["allow_once", "allow_for_session", "deny"],
+          }),
+        },
+      );
+      if (created.outcome === "rejected") {
+        throw new Error(
+          `Expected interaction registration to succeed: ${created.reason}`,
+        );
+      }
+
+      expect(
+        harness.deps.pendingInteractions.resolvePendingInteraction({
+          threadId: thread.id,
+          interactionId: created.interaction.id,
+          resolution: createAllowForSessionResolution(null),
+        }),
+      ).toEqual(
+        expect.objectContaining({
+          status: "resolving",
+          resolution: {
+            decision: "allow_for_session",
+            grantedPermissions: null,
+          },
+        }),
+      );
+    });
+  });
+
   it("rejects narrowed command session approval grants", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -1043,7 +1043,7 @@ describe("acp adapter interactive requests", () => {
     });
   });
 
-  it("decodes non-execute permission requests as permission grants", () => {
+  it("decodes opaque permission requests as command approvals", () => {
     const adapter = createAdapter();
     const decoded = adapter.decodeInteractiveRequest?.({
       id: 8,
@@ -1062,13 +1062,52 @@ describe("acp adapter interactive requests", () => {
     expect(decoded?.payload).toEqual({
       kind: "approval",
       subject: {
-        kind: "permission_grant",
+        kind: "command",
         itemId: "call-2",
-        toolName: "Fetch docs",
-        permissions: { network: null, fileSystem: null },
+        command: "Fetch docs",
+        cwd: null,
+        actions: [{ type: "unknown", command: "Fetch docs" }],
+        sessionGrant: null,
       },
       reason: null,
       availableDecisions: ["allow_once", "deny"],
+    });
+  });
+
+  it("uses the full tool title for OpenCode shell permission requests", () => {
+    const adapter = createAdapter();
+    const command =
+      'cd backend && rg -ln "check_module_stub" scripts/ 2>/dev/null';
+    const decoded = adapter.decodeInteractiveRequest?.({
+      id: 10,
+      method: "acp/permission/request",
+      params: {
+        threadId: "thread-1",
+        providerThreadId: "sess-1",
+        turnId: null,
+        toolCall: {
+          toolCallId: "call-opencode",
+          title: command,
+        },
+        options: [
+          { optionId: "allow", name: "Allow", kind: "allow_once" },
+          { optionId: "always", name: "Always", kind: "allow_always" },
+          { optionId: "deny", name: "Deny", kind: "reject_once" },
+        ],
+      },
+    });
+    expect(decoded?.payload).toEqual({
+      kind: "approval",
+      subject: {
+        kind: "command",
+        itemId: "call-opencode",
+        command,
+        cwd: null,
+        actions: [{ type: "unknown", command }],
+        sessionGrant: null,
+      },
+      reason: null,
+      availableDecisions: ["allow_once", "allow_for_session", "deny"],
     });
   });
 

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -452,6 +452,19 @@ function buildAcpApprovalDecisions(
   return decisions.length > 0 ? decisions : ["deny"];
 }
 
+function buildOpaqueAcpPermissionCommand(toolCall: {
+  command?: string;
+  title?: string;
+  kind?: string;
+}): string {
+  return (
+    toOptionalString(toolCall.command) ??
+    toOptionalString(toolCall.title) ??
+    toolCall.kind ??
+    "ACP permission request"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Adapter factory
 // ---------------------------------------------------------------------------
@@ -1402,11 +1415,9 @@ export function createAcpProviderAdapter(
         return null;
       }
       const toolCall = parsed.data.toolCall;
-      const command =
-        toolCall?.kind === "execute"
-          ? (toOptionalString(toolCall.command) ??
-            toOptionalString(toolCall.title))
-          : undefined;
+      const command = toolCall
+        ? buildOpaqueAcpPermissionCommand(toolCall)
+        : "ACP permission request";
       return {
         requestId: request.id,
         method: request.method,
@@ -1415,23 +1426,14 @@ export function createAcpProviderAdapter(
         turnId: parsed.data.turnId,
         payload: {
           kind: "approval",
-          subject:
-            toolCall && command
-              ? {
-                  kind: "command",
-                  itemId: toolCall.toolCallId,
-                  command,
-                  cwd: null,
-                  actions: [{ type: "unknown", command }],
-                  sessionGrant: null,
-                }
-              : {
-                  kind: "permission_grant",
-                  itemId: toolCall?.toolCallId ?? "acp-permission",
-                  toolName:
-                    toOptionalString(toolCall?.title) ?? toolCall?.kind ?? null,
-                  permissions: { network: null, fileSystem: null },
-                },
+          subject: {
+            kind: "command",
+            itemId: toolCall?.toolCallId ?? "acp-permission",
+            command,
+            cwd: null,
+            actions: [{ type: "unknown", command }],
+            sessionGrant: null,
+          },
           reason: null,
           availableDecisions: buildAcpApprovalDecisions(parsed.data),
         },


### PR DESCRIPTION
## Summary
- Treat opaque ACP permission requests as command approvals instead of empty BB permission grants.
- Allow provider-side session approvals with no BB session grant to resolve with a bare decision.
- Add regressions for OpenCode title-only shell permission requests and ACP session approvals.

## Root cause
OpenCode ACP permission prompts were registered as `permission_grant` interactions with `{ network: null, fileSystem: null }`. The UI then submitted an allow resolution containing no actual grant, and server validation rejected it with `Allowed permission resolutions must grant at least one permission`.

## Validation
- `pnpm exec turbo run test --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/server`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/server`