### PR TITLE
Close side tabs before desktop window

### DIFF
--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2284,30 +2284,6 @@ export function RootComposeView(props: RootComposeViewProps) {
     openCompactDrawer();
     setNewTabFocusRequest((current) => current + 1);
   }, [openCompactDrawer, openTab]);
-  const handleCloseWindowRequest = useCallback(() => {
-    if (
-      !isPersistedSecondaryPanelOpen ||
-      activeFixedSecondaryTab === null ||
-      !isSecondaryFileTab(activeFixedSecondaryTab)
-    ) {
-      return false;
-    }
-    closeTab(activeFixedSecondaryTab.id);
-    return true;
-  }, [activeFixedSecondaryTab, closeTab, isPersistedSecondaryPanelOpen]);
-  useEffect(() => {
-    if (props.surface !== "page") {
-      return;
-    }
-    const desktopInfo = getBbDesktopInfo();
-    if (
-      desktopInfo === null ||
-      desktopInfo.onCloseWindowRequest === undefined
-    ) {
-      return;
-    }
-    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
-  }, [handleCloseWindowRequest, props.surface]);
   const handleToggleSecondaryPanel = useCallback(() => {
     if (isSecondaryPanelOpen) {
       closeSecondaryPanel();
@@ -2409,6 +2385,42 @@ export function RootComposeView(props: RootComposeViewProps) {
       rootPanelTerminalTarget,
     ],
   );
+  const handleCloseWindowRequest = useCallback(() => {
+    // Gate on the visible panel state, not the persisted flag: on compact
+    // viewports the drawer can be dismissed while tabs stay persisted, and
+    // Cmd+W must not consume hidden tabs.
+    if (
+      !isSecondaryPanelOpen ||
+      activeFixedSecondaryTab === null ||
+      !isSecondaryFileTab(activeFixedSecondaryTab)
+    ) {
+      return false;
+    }
+    if (activeFixedSecondaryTab.kind === "terminal") {
+      handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
+    } else {
+      closeTab(activeFixedSecondaryTab.id);
+    }
+    return true;
+  }, [
+    activeFixedSecondaryTab,
+    closeTab,
+    handleCloseTerminalTab,
+    isSecondaryPanelOpen,
+  ]);
+  useEffect(() => {
+    if (props.surface !== "page") {
+      return;
+    }
+    const desktopInfo = getBbDesktopInfo();
+    if (
+      desktopInfo === null ||
+      desktopInfo.onCloseWindowRequest === undefined
+    ) {
+      return;
+    }
+    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
+  }, [handleCloseWindowRequest, props.surface]);
   const fileTabs = (() => {
     const filenameOf = (path: string) => path.split("/").at(-1) ?? path;
     const tabs = syncedOrderedSecondaryFileTabs.map(

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -126,6 +126,7 @@ import {
 import { resolveAbsoluteFilePath } from "@/lib/absolute-file-path";
 import { getBrowserUrlHost } from "@/lib/browser-url";
 import {
+  getBbDesktopInfo,
   getDesktopBrowserApi,
   isDesktopBrowserAvailable,
 } from "@/lib/bb-desktop";
@@ -174,6 +175,7 @@ import {
   useThreadFileTabs,
   type FileSearchSelection,
 } from "@/components/secondary-panel/useThreadFileTabs";
+import { isSecondaryFileTab } from "@/components/secondary-panel/secondaryPanelTabState";
 import { resolveRightPanelFileVisual } from "@/components/secondary-panel/rightPanelFileVisuals";
 import { ThreadTerminalPanel } from "@/components/thread/terminal/ThreadTerminalPanel";
 import {
@@ -2282,6 +2284,30 @@ export function RootComposeView(props: RootComposeViewProps) {
     openCompactDrawer();
     setNewTabFocusRequest((current) => current + 1);
   }, [openCompactDrawer, openTab]);
+  const handleCloseWindowRequest = useCallback(() => {
+    if (
+      !isPersistedSecondaryPanelOpen ||
+      activeFixedSecondaryTab === null ||
+      !isSecondaryFileTab(activeFixedSecondaryTab)
+    ) {
+      return false;
+    }
+    closeTab(activeFixedSecondaryTab.id);
+    return true;
+  }, [activeFixedSecondaryTab, closeTab, isPersistedSecondaryPanelOpen]);
+  useEffect(() => {
+    if (props.surface !== "page") {
+      return;
+    }
+    const desktopInfo = getBbDesktopInfo();
+    if (
+      desktopInfo === null ||
+      desktopInfo.onCloseWindowRequest === undefined
+    ) {
+      return;
+    }
+    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
+  }, [handleCloseWindowRequest, props.surface]);
   const handleToggleSecondaryPanel = useCallback(() => {
     if (isSecondaryPanelOpen) {
       closeSecondaryPanel();

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2396,6 +2396,16 @@ export function RootComposeView(props: RootComposeViewProps) {
       activeFixedSecondaryTab !== null &&
       isSecondaryFileTab(activeFixedSecondaryTab)
     ) {
+      // A lone new-tab placeholder respawns on close (an effect reopens one
+      // whenever the panel would otherwise be empty), so hide the panel
+      // instead of churning the placeholder.
+      if (
+        activeFixedSecondaryTab.kind === "new-tab" &&
+        fixedPanelTabsState.secondary.tabs.length === 1
+      ) {
+        closeSecondaryPanel();
+        return true;
+      }
       if (activeFixedSecondaryTab.kind === "terminal") {
         handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
       } else {
@@ -2411,6 +2421,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     activeFixedSecondaryTab,
     closeSecondaryPanel,
     closeTab,
+    fixedPanelTabsState.secondary.tabs,
     handleCloseTerminalTab,
     isSecondaryPanelOpen,
   ]);

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2389,21 +2389,27 @@ export function RootComposeView(props: RootComposeViewProps) {
     // Gate on the visible panel state, not the persisted flag: on compact
     // viewports the drawer can be dismissed while tabs stay persisted, and
     // Cmd+W must not consume hidden tabs.
-    if (
-      !isSecondaryPanelOpen ||
-      activeFixedSecondaryTab === null ||
-      !isSecondaryFileTab(activeFixedSecondaryTab)
-    ) {
+    if (!isSecondaryPanelOpen) {
       return false;
     }
-    if (activeFixedSecondaryTab.kind === "terminal") {
-      handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
-    } else {
-      closeTab(activeFixedSecondaryTab.id);
+    if (
+      activeFixedSecondaryTab !== null &&
+      isSecondaryFileTab(activeFixedSecondaryTab)
+    ) {
+      if (activeFixedSecondaryTab.kind === "terminal") {
+        handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
+      } else {
+        closeTab(activeFixedSecondaryTab.id);
+      }
+      return true;
     }
+    // No closable tab is active: hide the panel before letting the next
+    // Cmd+W close the window.
+    closeSecondaryPanel();
     return true;
   }, [
     activeFixedSecondaryTab,
+    closeSecondaryPanel,
     closeTab,
     handleCloseTerminalTab,
     isSecondaryPanelOpen,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -146,6 +146,7 @@ import {
   useThreadFileTabs,
   type FileSearchSelection,
 } from "@/components/secondary-panel/useThreadFileTabs";
+import { isSecondaryFileTab } from "@/components/secondary-panel/secondaryPanelTabState";
 import { useThreadOpenFileSignal } from "@/components/secondary-panel/useThreadOpenFileSignal";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import type { SecondaryPanelFileTab } from "@/components/secondary-panel/ThreadSecondaryPanel";
@@ -1075,6 +1076,26 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     openCompactDrawer();
     setNewTabFocusRequest((current) => current + 1);
   }, [openCompactDrawer, openNewTab]);
+  const handleCloseWindowRequest = useCallback(() => {
+    if (
+      !isPersistedSecondaryPanelOpenForSurface ||
+      activeFixedSecondaryTab === null ||
+      !isSecondaryFileTab(activeFixedSecondaryTab)
+    ) {
+      return false;
+    }
+    if (activeFixedSecondaryTab.kind === "side-chat") {
+      closeSideChatTab(activeFixedSecondaryTab.id);
+    } else {
+      closeTab(activeFixedSecondaryTab.id);
+    }
+    return true;
+  }, [
+    activeFixedSecondaryTab,
+    closeSideChatTab,
+    closeTab,
+    isPersistedSecondaryPanelOpenForSurface,
+  ]);
   useEffect(() => {
     if (props.surface !== "page") {
       return;
@@ -1085,6 +1106,19 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     }
     return desktopInfo.onOpenNewTab(handleOpenNewTab);
   }, [handleOpenNewTab, props.surface]);
+  useEffect(() => {
+    if (props.surface !== "page") {
+      return;
+    }
+    const desktopInfo = getBbDesktopInfo();
+    if (
+      desktopInfo === null ||
+      desktopInfo.onCloseWindowRequest === undefined
+    ) {
+      return;
+    }
+    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
+  }, [handleCloseWindowRequest, props.surface]);
   useEffect(() => {
     if (props.surface !== "page" || getBbDesktopInfo() === null) {
       return;

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1076,26 +1076,6 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     openCompactDrawer();
     setNewTabFocusRequest((current) => current + 1);
   }, [openCompactDrawer, openNewTab]);
-  const handleCloseWindowRequest = useCallback(() => {
-    if (
-      !isPersistedSecondaryPanelOpenForSurface ||
-      activeFixedSecondaryTab === null ||
-      !isSecondaryFileTab(activeFixedSecondaryTab)
-    ) {
-      return false;
-    }
-    if (activeFixedSecondaryTab.kind === "side-chat") {
-      closeSideChatTab(activeFixedSecondaryTab.id);
-    } else {
-      closeTab(activeFixedSecondaryTab.id);
-    }
-    return true;
-  }, [
-    activeFixedSecondaryTab,
-    closeSideChatTab,
-    closeTab,
-    isPersistedSecondaryPanelOpenForSurface,
-  ]);
   useEffect(() => {
     if (props.surface !== "page") {
       return;
@@ -1106,19 +1086,6 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     }
     return desktopInfo.onOpenNewTab(handleOpenNewTab);
   }, [handleOpenNewTab, props.surface]);
-  useEffect(() => {
-    if (props.surface !== "page") {
-      return;
-    }
-    const desktopInfo = getBbDesktopInfo();
-    if (
-      desktopInfo === null ||
-      desktopInfo.onCloseWindowRequest === undefined
-    ) {
-      return;
-    }
-    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
-  }, [handleCloseWindowRequest, props.surface]);
   useEffect(() => {
     if (props.surface !== "page" || getBbDesktopInfo() === null) {
       return;
@@ -1186,6 +1153,45 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     },
     [closeTerminal, removeFixedTerminalTab, threadId],
   );
+  const handleCloseWindowRequest = useCallback(() => {
+    // Gate on the visible panel state, not the persisted flag: on compact
+    // viewports the drawer can be dismissed while tabs stay persisted, and
+    // Cmd+W must not consume hidden tabs.
+    if (
+      !isSecondaryPanelOpen ||
+      activeFixedSecondaryTab === null ||
+      !isSecondaryFileTab(activeFixedSecondaryTab)
+    ) {
+      return false;
+    }
+    if (activeFixedSecondaryTab.kind === "terminal") {
+      handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
+    } else if (activeFixedSecondaryTab.kind === "side-chat") {
+      closeSideChatTab(activeFixedSecondaryTab.id);
+    } else {
+      closeTab(activeFixedSecondaryTab.id);
+    }
+    return true;
+  }, [
+    activeFixedSecondaryTab,
+    closeSideChatTab,
+    closeTab,
+    handleCloseTerminalTab,
+    isSecondaryPanelOpen,
+  ]);
+  useEffect(() => {
+    if (props.surface !== "page") {
+      return;
+    }
+    const desktopInfo = getBbDesktopInfo();
+    if (
+      desktopInfo === null ||
+      desktopInfo.onCloseWindowRequest === undefined
+    ) {
+      return;
+    }
+    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
+  }, [handleCloseWindowRequest, props.surface]);
   const handleChangedFileClick = useCallback(
     (selection: WorkspaceChangedFileSelection) => {
       const openTarget = resolveWorkspaceChangedFileOpenTarget(selection);

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1157,23 +1157,29 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     // Gate on the visible panel state, not the persisted flag: on compact
     // viewports the drawer can be dismissed while tabs stay persisted, and
     // Cmd+W must not consume hidden tabs.
-    if (
-      !isSecondaryPanelOpen ||
-      activeFixedSecondaryTab === null ||
-      !isSecondaryFileTab(activeFixedSecondaryTab)
-    ) {
+    if (!isSecondaryPanelOpen) {
       return false;
     }
-    if (activeFixedSecondaryTab.kind === "terminal") {
-      handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
-    } else if (activeFixedSecondaryTab.kind === "side-chat") {
-      closeSideChatTab(activeFixedSecondaryTab.id);
-    } else {
-      closeTab(activeFixedSecondaryTab.id);
+    if (
+      activeFixedSecondaryTab !== null &&
+      isSecondaryFileTab(activeFixedSecondaryTab)
+    ) {
+      if (activeFixedSecondaryTab.kind === "terminal") {
+        handleCloseTerminalTab(activeFixedSecondaryTab.terminalId);
+      } else if (activeFixedSecondaryTab.kind === "side-chat") {
+        closeSideChatTab(activeFixedSecondaryTab.id);
+      } else {
+        closeTab(activeFixedSecondaryTab.id);
+      }
+      return true;
     }
+    // No closable tab is active (e.g. thread-info or git-diff): hide the
+    // panel before letting the next Cmd+W close the window.
+    closeSecondaryPanel();
     return true;
   }, [
     activeFixedSecondaryTab,
+    closeSecondaryPanel,
     closeSideChatTab,
     closeTab,
     handleCloseTerminalTab,

--- a/apps/desktop/src/desktop-window-command-ipc.ts
+++ b/apps/desktop/src/desktop-window-command-ipc.ts
@@ -2,3 +2,6 @@
 // by the trusted React renderer.
 
 export const BB_DESKTOP_OPEN_NEW_TAB_CHANNEL = "bb-desktop:open-new-tab";
+export const BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL =
+  "bb-desktop:close-window-request";
+export const BB_DESKTOP_CLOSE_WINDOW_CHANNEL = "bb-desktop:close-window";

--- a/apps/desktop/src/desktop-window-command-ipc.ts
+++ b/apps/desktop/src/desktop-window-command-ipc.ts
@@ -4,4 +4,9 @@
 export const BB_DESKTOP_OPEN_NEW_TAB_CHANNEL = "bb-desktop:open-new-tab";
 export const BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL =
   "bb-desktop:close-window-request";
-export const BB_DESKTOP_CLOSE_WINDOW_CHANNEL = "bb-desktop:close-window";
+export const BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL =
+  "bb-desktop:close-window-response";
+// How long main waits for the renderer to answer a close request before
+// closing the window itself, so a crashed, hung, or still-loading renderer
+// cannot make Cmd+W inert.
+export const CLOSE_WINDOW_REQUEST_TIMEOUT_MS = 1000;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -88,7 +88,11 @@ import {
   BB_DESKTOP_SET_THEME_CHANNEL,
 } from "./desktop-update-ipc.js";
 import { BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL } from "./desktop-browser-ipc.js";
-import { BB_DESKTOP_OPEN_NEW_TAB_CHANNEL } from "./desktop-window-command-ipc.js";
+import {
+  BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
+  BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+  BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+} from "./desktop-window-command-ipc.js";
 import {
   createDesktopBrowserViewManager,
   type DesktopBrowserViewManager,
@@ -464,6 +468,12 @@ function shouldEnableServerDaemonLogsMenu(): boolean {
   );
 }
 
+function isDesktopCloseCommandTarget(
+  value: unknown,
+): value is Pick<BrowserWindow, "webContents"> {
+  return value instanceof BrowserWindow;
+}
+
 function refreshApplicationMenu(): void {
   installApplicationMenu({
     createNewWindow() {
@@ -475,6 +485,15 @@ function refreshApplicationMenu(): void {
     openNewTab() {
       desktopWindowFactory?.sendToFocusedWindow(
         BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+        null,
+      );
+    },
+    closeWindowOrSideTab(browserWindow) {
+      if (!isDesktopCloseCommandTarget(browserWindow)) {
+        return;
+      }
+      browserWindow.webContents.send(
+        BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
         null,
       );
     },
@@ -1103,6 +1122,10 @@ function registerDesktopUpdateIpc(): void {
       return;
     }
     nativeTheme.themeSource = parsed.data;
+  });
+
+  ipcMain.on(BB_DESKTOP_CLOSE_WINDOW_CHANNEL, (event) => {
+    BrowserWindow.fromWebContents(event.sender)?.close();
   });
   // The in-app browser tab hands off the current address to the system
   // browser. The URL originates from a possibly-hostile page, so only open

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -89,9 +89,10 @@ import {
 } from "./desktop-update-ipc.js";
 import { BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL } from "./desktop-browser-ipc.js";
 import {
-  BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
   BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+  BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  CLOSE_WINDOW_REQUEST_TIMEOUT_MS,
 } from "./desktop-window-command-ipc.js";
 import {
   createDesktopBrowserViewManager,
@@ -468,10 +469,36 @@ function shouldEnableServerDaemonLogsMenu(): boolean {
   );
 }
 
-function isDesktopCloseCommandTarget(
-  value: unknown,
-): value is Pick<BrowserWindow, "webContents"> {
-  return value instanceof BrowserWindow;
+// Close requests routed through the renderer, keyed by webContents id. If the
+// renderer never answers (crashed, hung, or still loading), the timer closes
+// the window from the main process like the native close role used to.
+const pendingCloseWindowRequests = new Map<number, NodeJS.Timeout>();
+
+function requestRendererWindowClose(browserWindow: BrowserWindow): void {
+  const webContentsId = browserWindow.webContents.id;
+  const pending = pendingCloseWindowRequests.get(webContentsId);
+  if (pending !== undefined) {
+    clearTimeout(pending);
+  }
+  pendingCloseWindowRequests.set(
+    webContentsId,
+    setTimeout(() => {
+      pendingCloseWindowRequests.delete(webContentsId);
+      if (!browserWindow.isDestroyed()) {
+        browserWindow.close();
+      }
+    }, CLOSE_WINDOW_REQUEST_TIMEOUT_MS),
+  );
+  browserWindow.webContents.send(BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL, null);
+}
+
+function closeFocusedDetachedDevTools(): void {
+  for (const browserWindow of BrowserWindow.getAllWindows()) {
+    if (browserWindow.webContents.isDevToolsFocused()) {
+      browserWindow.webContents.closeDevTools();
+      return;
+    }
+  }
 }
 
 function refreshApplicationMenu(): void {
@@ -489,13 +516,23 @@ function refreshApplicationMenu(): void {
       );
     },
     closeWindowOrSideTab(browserWindow) {
-      if (!isDesktopCloseCommandTarget(browserWindow)) {
+      if (browserWindow === undefined) {
+        // A focused detached DevTools window is the key window but never
+        // surfaces as a BaseWindow here; the native close role used to
+        // close it.
+        closeFocusedDetachedDevTools();
         return;
       }
-      browserWindow.webContents.send(
-        BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
-        null,
-      );
+      if (
+        !(browserWindow instanceof BrowserWindow) ||
+        browserWindow === logViewerWindow
+      ) {
+        // Windows that don't run the app preload can't answer the renderer
+        // round trip, so close them directly.
+        browserWindow.close();
+        return;
+      }
+      requestRendererWindowClose(browserWindow);
     },
     openServerDaemonLogs() {
       void openServerDaemonLogs();
@@ -1124,8 +1161,15 @@ function registerDesktopUpdateIpc(): void {
     nativeTheme.themeSource = parsed.data;
   });
 
-  ipcMain.on(BB_DESKTOP_CLOSE_WINDOW_CHANNEL, (event) => {
-    BrowserWindow.fromWebContents(event.sender)?.close();
+  ipcMain.on(BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL, (event, payload) => {
+    const pending = pendingCloseWindowRequests.get(event.sender.id);
+    if (pending !== undefined) {
+      clearTimeout(pending);
+      pendingCloseWindowRequests.delete(event.sender.id);
+    }
+    if (payload === false) {
+      BrowserWindow.fromWebContents(event.sender)?.close();
+    }
   });
   // The in-app browser tab hands off the current address to the system
   // browser. The URL originates from a possibly-hostile page, so only open

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -1,4 +1,9 @@
-import { app, Menu, type MenuItemConstructorOptions } from "electron";
+import {
+  app,
+  Menu,
+  type BaseWindow,
+  type MenuItemConstructorOptions,
+} from "electron";
 
 export const SERVER_DAEMON_LOGS_MENU_LABEL = "Server & Daemon Logs";
 export const OPEN_NEW_TAB_ACCELERATOR = "CmdOrCtrl+T";
@@ -10,7 +15,7 @@ export const TOGGLE_DEVELOPER_TOOLS_ACCELERATOR = "Command+Option+I";
 
 export interface InstallApplicationMenuArgs {
   openNewTab(): void;
-  closeWindowOrSideTab(browserWindow: unknown): void;
+  closeWindowOrSideTab(browserWindow: BaseWindow | undefined): void;
   createNewWindow(): void;
   openServerDaemonLogs(): void;
   serverDaemonLogsMenuEnabled: boolean;
@@ -70,7 +75,7 @@ export function buildApplicationMenuTemplate(
         {
           accelerator: CLOSE_WINDOW_ACCELERATOR,
           click(_menuItem, browserWindow) {
-            args.closeWindowOrSideTab(browserWindow ?? undefined);
+            args.closeWindowOrSideTab(browserWindow);
           },
           label: CLOSE_WINDOW_MENU_LABEL,
         },

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -3,11 +3,14 @@ import { app, Menu, type MenuItemConstructorOptions } from "electron";
 export const SERVER_DAEMON_LOGS_MENU_LABEL = "Server & Daemon Logs";
 export const OPEN_NEW_TAB_ACCELERATOR = "CmdOrCtrl+T";
 export const OPEN_NEW_TAB_MENU_LABEL = "New Tab";
+export const CLOSE_WINDOW_ACCELERATOR = "CmdOrCtrl+W";
+export const CLOSE_WINDOW_MENU_LABEL = "Close Window";
 export const TOGGLE_DEVELOPER_TOOLS_MENU_LABEL = "Toggle Developer Tools";
 export const TOGGLE_DEVELOPER_TOOLS_ACCELERATOR = "Command+Option+I";
 
 export interface InstallApplicationMenuArgs {
   openNewTab(): void;
+  closeWindowOrSideTab(browserWindow: unknown): void;
   createNewWindow(): void;
   openServerDaemonLogs(): void;
   serverDaemonLogsMenuEnabled: boolean;
@@ -64,7 +67,13 @@ export function buildApplicationMenuTemplate(
           label: "New Window",
         },
         { type: "separator" },
-        { role: "close" },
+        {
+          accelerator: CLOSE_WINDOW_ACCELERATOR,
+          click(_menuItem, browserWindow) {
+            args.closeWindowOrSideTab(browserWindow ?? undefined);
+          },
+          label: CLOSE_WINDOW_MENU_LABEL,
+        },
       ],
     },
     {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -14,6 +14,7 @@ import {
   type BbDesktopBrowserSnapshotHandler,
   type BbDesktopBrowserStateHandler,
   type BbDesktopBrowserUnsubscribe,
+  type BbDesktopCloseWindowRequestHandler,
   type BbDesktopInfo,
   type BbDesktopInfoChangeHandler,
   type BbDesktopInfoUnsubscribe,
@@ -47,7 +48,11 @@ import {
   BB_DESKTOP_BROWSER_STATE_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
 } from "./desktop-browser-ipc.js";
-import { BB_DESKTOP_OPEN_NEW_TAB_CHANNEL } from "./desktop-window-command-ipc.js";
+import {
+  BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
+  BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+  BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+} from "./desktop-window-command-ipc.js";
 import {
   BB_DESKTOP_POPOUT_OPEN_IN_MAIN_CHANNEL,
   BB_DESKTOP_POPOUT_GET_CURRENT_THREAD_CHANNEL,
@@ -118,6 +123,8 @@ const browserOpenTabListeners = new Set<BbDesktopBrowserOpenTabHandler>();
 const browserScopedOpenTabListeners =
   new Set<BbDesktopBrowserScopedOpenTabHandler>();
 const browserSnapshotListeners = new Set<BbDesktopBrowserSnapshotHandler>();
+const closeWindowRequestListeners =
+  new Set<BbDesktopCloseWindowRequestHandler>();
 const openNewTabListeners = new Set<BbDesktopOpenNewTabHandler>();
 const popoutThreadChangedListeners =
   new Set<BbDesktopPopoutThreadChangedHandler>();
@@ -261,6 +268,12 @@ const bbDesktopApi: BbDesktopApi = {
       openNewTabListeners.delete(listener);
     };
   },
+  onCloseWindowRequest(listener): BbDesktopInfoUnsubscribe {
+    closeWindowRequestListeners.add(listener);
+    return () => {
+      closeWindowRequestListeners.delete(listener);
+    };
+  },
   openExternalUrl(url: string): void {
     ipcRenderer.send(BB_DESKTOP_OPEN_EXTERNAL_URL_CHANNEL, url);
   },
@@ -276,6 +289,16 @@ ipcRenderer.on(BB_DESKTOP_INFO_CHANGED_CHANNEL, (_event, payload: unknown) => {
 ipcRenderer.on(BB_DESKTOP_OPEN_NEW_TAB_CHANNEL, () => {
   for (const listener of openNewTabListeners) {
     listener();
+  }
+});
+
+ipcRenderer.on(BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL, () => {
+  let handled = false;
+  for (const listener of closeWindowRequestListeners) {
+    handled = listener() || handled;
+  }
+  if (!handled) {
+    ipcRenderer.send(BB_DESKTOP_CLOSE_WINDOW_CHANNEL, null);
   }
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -49,8 +49,8 @@ import {
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
 } from "./desktop-browser-ipc.js";
 import {
-  BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
   BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+  BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
 } from "./desktop-window-command-ipc.js";
 import {
@@ -297,9 +297,9 @@ ipcRenderer.on(BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL, () => {
   for (const listener of closeWindowRequestListeners) {
     handled = listener() || handled;
   }
-  if (!handled) {
-    ipcRenderer.send(BB_DESKTOP_CLOSE_WINDOW_CHANNEL, null);
-  }
+  // Always answer: main closes the window on `false` and falls back to
+  // closing it itself if no answer arrives in time.
+  ipcRenderer.send(BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL, handled);
 });
 
 ipcRenderer.on(BB_DESKTOP_BROWSER_STATE_CHANNEL, (_event, payload: unknown) => {

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -1,6 +1,8 @@
 import type { MenuItemConstructorOptions } from "electron";
 import { describe, expect, it, vi } from "vitest";
 import {
+  CLOSE_WINDOW_ACCELERATOR,
+  CLOSE_WINDOW_MENU_LABEL,
   OPEN_NEW_TAB_ACCELERATOR,
   OPEN_NEW_TAB_MENU_LABEL,
   SERVER_DAEMON_LOGS_MENU_LABEL,
@@ -47,6 +49,7 @@ function findSubmenuItem(
 describe("application menu", () => {
   it("shows a developer tools toggle in the view menu", () => {
     const template = buildApplicationMenuTemplate({
+      closeWindowOrSideTab() {},
       createNewWindow() {},
       openNewTab() {},
       openServerDaemonLogs() {},
@@ -67,6 +70,7 @@ describe("application menu", () => {
   it("shows a new-tab command in the file menu", () => {
     const openNewTab = vi.fn();
     const template = buildApplicationMenuTemplate({
+      closeWindowOrSideTab() {},
       createNewWindow() {},
       openNewTab,
       openServerDaemonLogs() {},
@@ -89,8 +93,37 @@ describe("application menu", () => {
     expect(openNewTab).toHaveBeenCalledOnce();
   });
 
+  it("routes the close-window accelerator through the app before closing", () => {
+    const closeWindowOrSideTab = vi.fn();
+    const browserWindow = {};
+    const template = buildApplicationMenuTemplate({
+      closeWindowOrSideTab,
+      createNewWindow() {},
+      openNewTab() {},
+      openServerDaemonLogs() {},
+      serverDaemonLogsMenuEnabled: true,
+    });
+
+    const menuItem = findSubmenuItem({
+      itemLabel: CLOSE_WINDOW_MENU_LABEL,
+      parentLabel: "File",
+      template,
+    });
+
+    expect(menuItem).not.toBeNull();
+    expect(menuItem?.accelerator).toBe(CLOSE_WINDOW_ACCELERATOR);
+    expect(menuItem?.role).toBeUndefined();
+    menuItem?.click?.(
+      undefined as never,
+      browserWindow as never,
+      undefined as never,
+    );
+    expect(closeWindowOrSideTab).toHaveBeenCalledWith(browserWindow);
+  });
+
   it("shows an enabled server and daemon logs item for owned runtimes", () => {
     const template = buildApplicationMenuTemplate({
+      closeWindowOrSideTab() {},
       createNewWindow() {},
       openNewTab() {},
       openServerDaemonLogs() {},
@@ -109,6 +142,7 @@ describe("application menu", () => {
 
   it("shows a disabled server and daemon logs item for attached runtimes", () => {
     const template = buildApplicationMenuTemplate({
+      closeWindowOrSideTab() {},
       createNewWindow() {},
       openNewTab() {},
       openServerDaemonLogs() {},

--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -39,8 +39,8 @@ import {
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
 } from "../src/desktop-browser-ipc.js";
 import {
-  BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
   BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+  BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
 } from "../src/desktop-window-command-ipc.js";
 
@@ -410,9 +410,9 @@ describe("desktop preload browser API", () => {
     expect(snapshots).toEqual([snapshot]);
     expect(closeWindowRequestCount).toBe(1);
     expect(openNewTabCount).toBe(1);
-    expect(electronMock.sendCalls).not.toContainEqual({
-      channel: BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
-      payload: null,
+    expect(electronMock.sendCalls).toContainEqual({
+      channel: BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
+      payload: true,
     });
     expect(popoutThreads).toEqual([
       { projectId: "proj_a", threadId: "thr_a" },
@@ -420,7 +420,7 @@ describe("desktop preload browser API", () => {
     ]);
   });
 
-  it("asks main to close the window when no close-window listener handles the request", async () => {
+  it("answers unhandled close-window requests so main closes the window", async () => {
     await loadPreload();
 
     emitIpcPayload({
@@ -429,8 +429,8 @@ describe("desktop preload browser API", () => {
     });
 
     expect(electronMock.sendCalls).toContainEqual({
-      channel: BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
-      payload: null,
+      channel: BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
+      payload: false,
     });
   });
 });

--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -38,7 +38,11 @@ import {
   BB_DESKTOP_BROWSER_STATE_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
 } from "../src/desktop-browser-ipc.js";
-import { BB_DESKTOP_OPEN_NEW_TAB_CHANNEL } from "../src/desktop-window-command-ipc.js";
+import {
+  BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
+  BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+  BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+} from "../src/desktop-window-command-ipc.js";
 
 const electronMock = vi.hoisted(() => {
   interface IpcRendererEvent {}
@@ -300,6 +304,7 @@ describe("desktop preload browser API", () => {
     const openTabs: BbDesktopBrowserOpenTabRequest[] = [];
     const scopedOpenTabs: BbDesktopBrowserScopedOpenTabRequest[] = [];
     const snapshots: BbDesktopBrowserSnapshot[] = [];
+    let closeWindowRequestCount = 0;
     let openNewTabCount = 0;
     const popoutThreads: BbDesktopPopoutThreadChangedPayload[] = [];
     const state: BbDesktopBrowserState = {
@@ -337,6 +342,10 @@ describe("desktop preload browser API", () => {
     });
     api.onOpenNewTab?.(() => {
       openNewTabCount += 1;
+    });
+    api.onCloseWindowRequest?.(() => {
+      closeWindowRequestCount += 1;
+      return true;
     });
     api.popout.onThreadChanged((thread) => {
       popoutThreads.push(thread);
@@ -379,6 +388,10 @@ describe("desktop preload browser API", () => {
       payload: null,
     });
     emitIpcPayload({
+      channel: BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+      payload: null,
+    });
+    emitIpcPayload({
       channel: BB_DESKTOP_POPOUT_THREAD_CHANGED_CHANNEL,
       payload: { projectId: "proj_a", threadId: "thr_a", extra: true },
     });
@@ -395,10 +408,29 @@ describe("desktop preload browser API", () => {
     expect(openTabs).toEqual([openTab]);
     expect(scopedOpenTabs).toEqual([scopedOpenTab]);
     expect(snapshots).toEqual([snapshot]);
+    expect(closeWindowRequestCount).toBe(1);
     expect(openNewTabCount).toBe(1);
+    expect(electronMock.sendCalls).not.toContainEqual({
+      channel: BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
+      payload: null,
+    });
     expect(popoutThreads).toEqual([
       { projectId: "proj_a", threadId: "thr_a" },
       null,
     ]);
+  });
+
+  it("asks main to close the window when no close-window listener handles the request", async () => {
+    await loadPreload();
+
+    emitIpcPayload({
+      channel: BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+      payload: null,
+    });
+
+    expect(electronMock.sendCalls).toContainEqual({
+      channel: BB_DESKTOP_CLOSE_WINDOW_CHANNEL,
+      payload: null,
+    });
   });
 });

--- a/apps/server/src/services/interactions/pending-interaction-validation.ts
+++ b/apps/server/src/services/interactions/pending-interaction-validation.ts
@@ -311,7 +311,8 @@ export function validatePendingInteractionResolution(
     } else if (
       resolution.decision === "allow_for_session" &&
       (interaction.payload.subject.kind === "command" ||
-        interaction.payload.subject.kind === "file_change")
+        interaction.payload.subject.kind === "file_change") &&
+      interaction.payload.subject.sessionGrant !== null
     ) {
       throw new ApiError(
         400,

--- a/apps/server/test/services/pending-interactions.test.ts
+++ b/apps/server/test/services/pending-interactions.test.ts
@@ -870,6 +870,66 @@ describe("pending interaction lifecycle", () => {
     });
   });
 
+  it("allows command session approvals when no BB session grant was requested", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-pending-interaction-command-opaque-session",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        providerId: "acp-opencode",
+      });
+
+      const created = registerPendingInteraction(
+        harness.deps,
+        harness.deps.pendingInteractions,
+        {
+          threadId: thread.id,
+          turnId: "turn-command-opaque-session",
+          providerId: "acp-opencode",
+          providerThreadId: "provider-thread-command-opaque-session",
+          providerRequestId: "request-command-opaque-session",
+          payload: createCommandApprovalPayload({
+            itemId: "item-command-opaque-session",
+            reason: "Needs provider-side session approval",
+            command: "cd backend && pnpm test",
+            sessionGrant: null,
+            availableDecisions: ["allow_once", "allow_for_session", "deny"],
+          }),
+        },
+      );
+      if (created.outcome === "rejected") {
+        throw new Error(
+          `Expected interaction registration to succeed: ${created.reason}`,
+        );
+      }
+
+      expect(
+        harness.deps.pendingInteractions.resolvePendingInteraction({
+          threadId: thread.id,
+          interactionId: created.interaction.id,
+          resolution: createAllowForSessionResolution(null),
+        }),
+      ).toEqual(
+        expect.objectContaining({
+          status: "resolving",
+          resolution: {
+            decision: "allow_for_session",
+            grantedPermissions: null,
+          },
+        }),
+      );
+    });
+  });
+
   it("rejects narrowed command session approval grants", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -1043,7 +1043,7 @@ describe("acp adapter interactive requests", () => {
     });
   });
 
-  it("decodes non-execute permission requests as permission grants", () => {
+  it("decodes opaque permission requests as command approvals", () => {
     const adapter = createAdapter();
     const decoded = adapter.decodeInteractiveRequest?.({
       id: 8,
@@ -1062,13 +1062,52 @@ describe("acp adapter interactive requests", () => {
     expect(decoded?.payload).toEqual({
       kind: "approval",
       subject: {
-        kind: "permission_grant",
+        kind: "command",
         itemId: "call-2",
-        toolName: "Fetch docs",
-        permissions: { network: null, fileSystem: null },
+        command: "Fetch docs",
+        cwd: null,
+        actions: [{ type: "unknown", command: "Fetch docs" }],
+        sessionGrant: null,
       },
       reason: null,
       availableDecisions: ["allow_once", "deny"],
+    });
+  });
+
+  it("uses the full tool title for OpenCode shell permission requests", () => {
+    const adapter = createAdapter();
+    const command =
+      'cd backend && rg -ln "check_module_stub" scripts/ 2>/dev/null';
+    const decoded = adapter.decodeInteractiveRequest?.({
+      id: 10,
+      method: "acp/permission/request",
+      params: {
+        threadId: "thread-1",
+        providerThreadId: "sess-1",
+        turnId: null,
+        toolCall: {
+          toolCallId: "call-opencode",
+          title: command,
+        },
+        options: [
+          { optionId: "allow", name: "Allow", kind: "allow_once" },
+          { optionId: "always", name: "Always", kind: "allow_always" },
+          { optionId: "deny", name: "Deny", kind: "reject_once" },
+        ],
+      },
+    });
+    expect(decoded?.payload).toEqual({
+      kind: "approval",
+      subject: {
+        kind: "command",
+        itemId: "call-opencode",
+        command,
+        cwd: null,
+        actions: [{ type: "unknown", command }],
+        sessionGrant: null,
+      },
+      reason: null,
+      availableDecisions: ["allow_once", "allow_for_session", "deny"],
     });
   });
 

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -452,6 +452,19 @@ function buildAcpApprovalDecisions(
   return decisions.length > 0 ? decisions : ["deny"];
 }
 
+function buildOpaqueAcpPermissionCommand(toolCall: {
+  command?: string;
+  title?: string;
+  kind?: string;
+}): string {
+  return (
+    toOptionalString(toolCall.command) ??
+    toOptionalString(toolCall.title) ??
+    toolCall.kind ??
+    "ACP permission request"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Adapter factory
 // ---------------------------------------------------------------------------
@@ -1402,11 +1415,9 @@ export function createAcpProviderAdapter(
         return null;
       }
       const toolCall = parsed.data.toolCall;
-      const command =
-        toolCall?.kind === "execute"
-          ? (toOptionalString(toolCall.command) ??
-            toOptionalString(toolCall.title))
-          : undefined;
+      const command = toolCall
+        ? buildOpaqueAcpPermissionCommand(toolCall)
+        : "ACP permission request";
       return {
         requestId: request.id,
         method: request.method,
@@ -1415,23 +1426,14 @@ export function createAcpProviderAdapter(
         turnId: parsed.data.turnId,
         payload: {
           kind: "approval",
-          subject:
-            toolCall && command
-              ? {
-                  kind: "command",
-                  itemId: toolCall.toolCallId,
-                  command,
-                  cwd: null,
-                  actions: [{ type: "unknown", command }],
-                  sessionGrant: null,
-                }
-              : {
-                  kind: "permission_grant",
-                  itemId: toolCall?.toolCallId ?? "acp-permission",
-                  toolName:
-                    toOptionalString(toolCall?.title) ?? toolCall?.kind ?? null,
-                  permissions: { network: null, fileSystem: null },
-                },
+          subject: {
+            kind: "command",
+            itemId: toolCall?.toolCallId ?? "acp-permission",
+            command,
+            cwd: null,
+            actions: [{ type: "unknown", command }],
+            sessionGrant: null,
+          },
           reason: null,
           availableDecisions: buildAcpApprovalDecisions(parsed.data),
         },

--- a/packages/desktop-contract/src/info.ts
+++ b/packages/desktop-contract/src/info.ts
@@ -21,6 +21,7 @@ export type BbDesktopTheme = z.infer<typeof bbDesktopThemeSchema>;
 export type BbDesktopInfoChangeHandler = (info: BbDesktopInfo) => void;
 export type BbDesktopInfoUnsubscribe = () => void;
 export type BbDesktopOpenNewTabHandler = () => void;
+export type BbDesktopCloseWindowRequestHandler = () => boolean;
 
 export interface BbDesktopApi extends BbDesktopInfo {
   /**
@@ -46,6 +47,15 @@ export interface BbDesktopApi extends BbDesktopInfo {
    */
   onOpenNewTab?(
     listener: BbDesktopOpenNewTabHandler,
+  ): BbDesktopInfoUnsubscribe;
+  /**
+   * Subscribe to native desktop close-window requests. Return true when the
+   * renderer handled the request, for example by closing an active secondary
+   * panel tab; returning false preserves the native close-window fallback.
+   * Optional for desktop shells that predate this command.
+   */
+  onCloseWindowRequest?(
+    listener: BbDesktopCloseWindowRequestHandler,
   ): BbDesktopInfoUnsubscribe;
   /**
    * Open a URL in the user's default system browser, leaving the in-app


### PR DESCRIPTION
## Summary
- route the desktop Cmd/Ctrl+W menu command through the renderer before closing the native window
- close the active secondary-panel file/browser/new/terminal/side-chat tab when one is open
- preserve native window close behavior when no renderer handler consumes the request

## Validation
- pnpm exec turbo run test --filter=@bb/desktop
- pnpm exec turbo run typecheck --filter=@bb/desktop --filter=@bb/app --force
- git diff --check