### PR TITLE
Show thread handoff action when model controls are hidden

### DIFF
--- a/apps/app/src/components/promptbox/ExecutionControls.test.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.test.tsx
@@ -96,6 +96,44 @@ describe("ExecutionControls", () => {
     expect(trigger.textContent).not.toContain("Failed to load models");
   });
 
+  it("shows the picker footer action even when model controls are unavailable", () => {
+    const onClick = vi.fn();
+    const props = makeExecutionControlsProps();
+
+    renderExecutionControls({
+      ...props,
+      provider: {
+        options: [],
+        hasMultiple: false,
+      },
+      model: {
+        ...props.model,
+        selected: "",
+        options: [],
+      },
+      reasoning: {
+        ...props.reasoning,
+        options: [],
+      },
+      footerAction: {
+        label: "Handoff to new thread",
+        onClick,
+      },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Handoff to new thread" }),
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it("maps disabled fast mode to the explicit default service tier", () => {
     const onServiceTierChange = vi.fn();
     renderExecutionControls({

--- a/apps/app/src/components/promptbox/ExecutionControls.tsx
+++ b/apps/app/src/components/promptbox/ExecutionControls.tsx
@@ -88,7 +88,8 @@ export const ExecutionControls = memo(function ExecutionControls({
     model.loadFailed ||
     model.options.length > 0 ||
     canSwitchProviders ||
-    selectedProviderId.length > 0;
+    selectedProviderId.length > 0 ||
+    footerAction !== undefined;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- keep the model picker available when a footer action is provided
- preserves the thread handoff shortcut inside the model picker footer for providers without visible model controls
- add a regression test for the footer-action-only picker case

## Validation
- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/ExecutionControls.test.tsx src/views/thread-detail/ThreadDetailPromptArea.test.tsx src/components/pickers/ModelReasoningPicker.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check

## Notes
- Verified in the dev app that the Claude Code thread shows the handoff action inside the opened model picker footer.