### PR TITLE
Add GitHub issue label editing

### DIFF
--- a/examples/plugins/github/README.md
+++ b/examples/plugins/github/README.md
@@ -7,7 +7,8 @@ GitHub issues and pull requests inside BB, with one-click agent dispatch.
 - **Sidebar panel** (GitHub logo, full width): Issues and Pull requests tabs
   across every tracked repo, with a repo filter (persisted in localStorage)
   and a New issue form.
-- **Issue detail**: markdown body, comments, comment box, "Send agent".
+- **Issue detail**: markdown body, comments, comment box, status,
+  assignee, and label editing, plus "Send agent".
   Deep-linkable via the URL hash: `#/issues/<owner>/<repo>/<number>`.
 - **Send agent / Review with agent**: spawns a BB worker thread on the issue
   (or a review thread on the PR) in the repo's BB project. The issue/PR then

--- a/examples/plugins/github/app.tsx
+++ b/examples/plugins/github/app.tsx
@@ -415,7 +415,7 @@ function LabelChips({ labels, className }: { labels: string[]; className?: strin
 }
 
 // ---------------------------------------------------------------------------
-// Mutations (status + assignees) with optimistic-friendly callbacks.
+// Mutations (status, assignees, labels) with optimistic-friendly callbacks.
 // ---------------------------------------------------------------------------
 
 function useIssueMutations() {
@@ -432,7 +432,12 @@ function useIssueMutations() {
       rpc.call("setAssignees", { repo, number, assignees }),
     [rpc],
   );
-  return { setIssueState, setAssignees };
+  const setLabels = useCallback(
+    (repo: string, number: number, labels: string[]) =>
+      rpc.call("setLabels", { repo, number, labels }),
+    [rpc],
+  );
+  return { setIssueState, setAssignees, setLabels };
 }
 
 // ---------------------------------------------------------------------------
@@ -1107,6 +1112,67 @@ function AssigneePicker({
   );
 }
 
+function LabelPicker({
+  repo,
+  labels,
+  onToggle,
+}: {
+  repo: string;
+  labels: string[];
+  onToggle: (label: string, enabled: boolean) => void;
+}) {
+  const rpc = useRpc();
+  const [available, setAvailable] = useState<string[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    if (available !== null) return;
+    rpc.call("repositoryLabels", { repo }).then(
+      (result) => {
+        const list = (result as { labels?: unknown })?.labels;
+        setAvailable(Array.isArray(list) ? list.map(String) : []);
+      },
+      (error: unknown) => setLoadError(errorText(error)),
+    );
+  }, [rpc, repo, available]);
+
+  const ordered =
+    available === null
+      ? null
+      : [...new Set([...labels, ...available])].sort((a, b) => a.localeCompare(b));
+
+  return (
+    <DropdownMenu onOpenChange={(open) => open && load()}>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" variant="ghost" className="h-6 px-2 text-xs text-muted-foreground">
+          Edit
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-72 w-56 overflow-y-auto">
+        <DropdownMenuLabel>Labels</DropdownMenuLabel>
+        {loadError !== null ? (
+          <DropdownMenuItem disabled>{loadError}</DropdownMenuItem>
+        ) : ordered === null ? (
+          <DropdownMenuItem disabled>Loading…</DropdownMenuItem>
+        ) : ordered.length === 0 ? (
+          <DropdownMenuItem disabled>No labels in repo</DropdownMenuItem>
+        ) : (
+          ordered.map((label) => (
+            <DropdownMenuCheckboxItem
+              key={label}
+              checked={labels.includes(label)}
+              onCheckedChange={(checked) => onToggle(label, checked === true)}
+              onSelect={(event) => event.preventDefault()}
+            >
+              <span className="min-w-0 truncate">{label}</span>
+            </DropdownMenuCheckboxItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function IssueDetailView({
   repo,
   number,
@@ -1119,7 +1185,7 @@ function IssueDetailView({
   const rpc = useRpc();
   const links = useLinks();
   const { spawn, spawningKey } = useSpawn();
-  const { setIssueState, setAssignees } = useIssueMutations();
+  const { setIssueState, setAssignees, setLabels } = useIssueMutations();
   const [detail, setDetail] = useState<IssueDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [comment, setComment] = useState("");
@@ -1170,6 +1236,24 @@ function IssueDetailView({
       });
     },
     [setAssignees, repo, number, load],
+  );
+
+  const toggleLabel = useCallback(
+    (label: string, enabled: boolean) => {
+      let next: string[] = [];
+      setDetail((prev) => {
+        if (prev === null) return prev;
+        next = enabled
+          ? [...new Set([...prev.labels, label])]
+          : prev.labels.filter((entry) => entry !== label);
+        return { ...prev, labels: next };
+      });
+      setLabels(repo, number, next).catch((err: unknown) => {
+        toast.error(errorText(err));
+        load();
+      });
+    },
+    [setLabels, repo, number, load],
   );
 
   const postComment = useCallback(() => {
@@ -1328,7 +1412,10 @@ function IssueDetailView({
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <SidebarHeading>Labels</SidebarHeading>
+            <div className="flex items-center justify-between">
+              <SidebarHeading>Labels</SidebarHeading>
+              <LabelPicker repo={repo} labels={detail.labels} onToggle={toggleLabel} />
+            </div>
             {detail.labels.length === 0 ? (
               <p className="text-sm text-muted-foreground">None yet</p>
             ) : (

--- a/examples/plugins/github/server.ts
+++ b/examples/plugins/github/server.ts
@@ -5,7 +5,7 @@
 // `origin` remote) plus an optional extraRepos setting. A background service
 // syncs open + recently-closed issues/PRs into the plugin's SQLite cache;
 // the frontend panel and @-mention providers read that cache, while
-// mutations (comment, create, close/reopen, assign) and detail views go
+// mutations (comment, create, close/reopen, assign, label) and detail views go
 // straight through `gh`.
 import { execFile } from "node:child_process";
 import type { BbPluginApi } from "@bb/plugin-sdk";
@@ -386,7 +386,7 @@ export default async function plugin(bb: BbPluginApi) {
     kind: "issue" | "pr",
     repo: string,
     number: number,
-    patch: { state?: string; assignees?: string[] },
+    patch: { state?: string; assignees?: string[]; labels?: string[] },
   ): void {
     if (patch.state !== undefined) {
       db.prepare("UPDATE items SET state = ? WHERE repo = ? AND kind = ? AND number = ?")
@@ -395,6 +395,10 @@ export default async function plugin(bb: BbPluginApi) {
     if (patch.assignees !== undefined) {
       db.prepare("UPDATE items SET assignees = ? WHERE repo = ? AND kind = ? AND number = ?")
         .run(JSON.stringify(patch.assignees), repo, kind, number);
+    }
+    if (patch.labels !== undefined) {
+      db.prepare("UPDATE items SET labels = ? WHERE repo = ? AND kind = ? AND number = ?")
+        .run(JSON.stringify(patch.labels), repo, kind, number);
     }
     bb.realtime.publish("data-changed", {});
   }
@@ -576,6 +580,7 @@ export default async function plugin(bb: BbPluginApi) {
   }
 
   const assignableCache = new Map<string, { users: string[]; fetchedAt: number }>();
+  const labelsCache = new Map<string, { labels: string[]; fetchedAt: number }>();
 
   async function getAssignableUsers(repo: string): Promise<string[]> {
     const cached = assignableCache.get(repo);
@@ -590,6 +595,21 @@ export default async function plugin(bb: BbPluginApi) {
       .sort((a, b) => a.localeCompare(b));
     assignableCache.set(repo, { users, fetchedAt: Date.now() });
     return users;
+  }
+
+  async function getRepoLabels(repo: string): Promise<string[]> {
+    const cached = labelsCache.get(repo);
+    if (cached !== undefined && Date.now() - cached.fetchedAt < 10 * 60_000) {
+      return cached.labels;
+    }
+    const raw = await gh(["api", `repos/${repo}/labels?per_page=100`], 15_000);
+    const entries = JSON.parse(raw) as Array<{ name?: unknown }>;
+    const labels = entries
+      .map((entry) => String(entry?.name ?? "").trim())
+      .filter((name) => name.length > 0)
+      .sort((a, b) => a.localeCompare(b));
+    labelsCache.set(repo, { labels, fetchedAt: Date.now() });
+    return labels;
   }
 
   // ------------------------------------------------------------------
@@ -657,6 +677,13 @@ export default async function plugin(bb: BbPluginApi) {
       return { users: await getAssignableUsers(repo) };
     },
 
+    /** { repo } → labels available in that repo. */
+    async repositoryLabels(input: unknown) {
+      const repo = (input as { repo?: unknown })?.repo;
+      if (!isRepoName(repo)) throw new Error('expected { repo: "owner/name" }');
+      return { labels: await getRepoLabels(repo) };
+    },
+
     /** { repo, number, state: "open"|"closed" } → close or reopen an issue. */
     async setIssueState(input: unknown) {
       const { repo, number } = requireItemInput(input);
@@ -691,6 +718,36 @@ export default async function plugin(bb: BbPluginApi) {
       await gh(args);
       patchCachedItem("issue", repo, number, { assignees: next });
       return { ok: true, assignees: next };
+    },
+
+    /** { repo, number, labels: string[] } → set the exact issue label list. */
+    async setLabels(input: unknown) {
+      const { repo, number } = requireItemInput(input);
+      const raw = (input as { labels?: unknown })?.labels;
+      if (!Array.isArray(raw) || raw.some((label) => typeof label !== "string")) {
+        throw new Error("expected { labels: string[] }");
+      }
+      const next = [
+        ...new Set((raw as string[]).map((label) => label.trim()).filter(Boolean)),
+      ];
+      const currentRaw = await gh([
+        "issue", "view", String(number), "-R", repo, "--json", "labels",
+      ], 15_000);
+      const currentDetail = JSON.parse(currentRaw) as {
+        labels?: Array<{ name?: unknown }>;
+      };
+      const current = (currentDetail.labels ?? [])
+        .map((label) => String(label?.name ?? "").trim())
+        .filter((label) => label.length > 0);
+      const add = next.filter((label) => !current.includes(label));
+      const remove = current.filter((label) => !next.includes(label));
+      if (add.length === 0 && remove.length === 0) return { ok: true, labels: next };
+      const args = ["issue", "edit", String(number), "-R", repo];
+      for (const label of add) args.push("--add-label", label);
+      for (const label of remove) args.push("--remove-label", label);
+      await gh(args);
+      patchCachedItem("issue", repo, number, { labels: next });
+      return { ok: true, labels: next };
     },
 
     /** { repo, number } → live issue detail incl. comments. */


### PR DESCRIPTION
## Summary
- add GitHub plugin RPCs to list repository labels and update an issue's exact label set
- patch cached issue labels after label edits so the panel refreshes immediately
- add a label editor to the GitHub issue detail sidebar

## Validation
- pnpm exec tsc -p examples/plugins/github/tsconfig.json --noEmit
- pnpm exec turbo run test --filter=@bb/cli --force -- src/__tests__/github-example-bundle.test.ts
- git diff --check