### PR TITLE
Fix two-finger history swipe

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -16,7 +16,11 @@
   html.bb-app-shell-root,
   body.bb-app-shell {
     overflow: hidden;
-    overscroll-behavior: none;
+    /*
+     * Suppress vertical rubber-banding without blocking the native horizontal
+     * two-finger back/forward gesture.
+     */
+    overscroll-behavior-y: none;
   }
 
   html.bb-app-shell-root[data-bb-popout-route],


### PR DESCRIPTION
## Summary
- preserve native horizontal two-finger back/forward gestures by scoping shell overscroll suppression to the vertical axis
- keep vertical rubber-banding suppressed on the app shell

## Tests
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run build --filter=@bb/app