### PR TITLE
Disable single-dollar inline LaTeX so chat prices stay literal

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.stories.tsx
+++ b/apps/app/src/components/ui/markdown-preview.stories.tsx
@@ -107,7 +107,7 @@ $ pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@b
 \`\`\``;
 
 const MATH_MARKDOWN = `Inline math sits in the prose, like the mass–energy
-relation $E = mc^2$ or the quadratic root $x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$.
+relation $$E = mc^2$$ or the quadratic root $$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$.
 
 Display math gets its own centered block:
 
@@ -115,8 +115,8 @@ $$
 \\int_{-\\infty}^{\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}
 $$
 
-Escaped dollars stay literal text, so a budget line like \\$5 to \\$10 reads as
-written. Invalid TeX such as $\\frac{1}{$ surfaces a contained error instead of
+Single dollars stay literal text, so a budget line like $5 to $10 reads as
+written. Invalid TeX such as $$\\frac{1}{$$ surfaces a contained error instead of
 breaking the document.`;
 
 const MERMAID_MARKDOWN = `A Mermaid flowchart renders as a diagram:
@@ -224,7 +224,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="math (LaTeX)"
-        hint="inline $…$ and display $$…$$ render with KaTeX; escaped \\$ stays literal; invalid TeX is contained"
+        hint="inline $$…$$ and display $$ blocks render with KaTeX; single $ stays literal; invalid TeX is contained"
       >
         <PreviewStage>
           <MarkdownPreview content={MATH_MARKDOWN} />

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -180,11 +180,23 @@ describe("MarkdownPreview", () => {
 
   it("renders inline LaTeX math with KaTeX", () => {
     const { container } = render(
-      <MarkdownPreview content={"Mass-energy is $E = mc^2$ exactly."} />,
+      <MarkdownPreview content={"Mass-energy is $$E = mc^2$$ exactly."} />,
     );
 
     expect(container.querySelector(".katex")).not.toBeNull();
     expect(container.querySelector(".katex-display")).toBeNull();
+  });
+
+  it("leaves single-dollar spans as literal text", () => {
+    const { container } = render(
+      <MarkdownPreview
+        content={"It went from $5 to $10 last week, so $x$ stays literal."}
+      />,
+    );
+
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container.textContent).toContain("$5 to $10");
+    expect(container.textContent).toContain("$x$");
   });
 
   it("renders display LaTeX math blocks with KaTeX", () => {
@@ -209,7 +221,7 @@ describe("MarkdownPreview", () => {
     const { container } = render(
       <MarkdownPreview
         allowHtml
-        content={"$a^2 + b^2 = c^2$\n\n<script>alert(1)</script>"}
+        content={"$$a^2 + b^2 = c^2$$\n\n<script>alert(1)</script>"}
       />,
     );
 
@@ -220,7 +232,7 @@ describe("MarkdownPreview", () => {
 
   it("contains invalid TeX instead of throwing", () => {
     const { container } = render(
-      <MarkdownPreview content={"Broken: $\\frac{1}{$ keeps rendering."} />,
+      <MarkdownPreview content={"Broken: $$\\frac{1}{$$ keeps rendering."} />,
     );
 
     expect(container.querySelector(".katex-error")).not.toBeNull();

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -1220,13 +1220,13 @@ function MarkdownPreviewComponent({
   // `whitespace-pre-wrap` behavior. The two mention props are mutually exclusive
   // in practice but are honoured independently here.
   const remarkPlugins = useMemo(
-    () => [
+    (): NonNullable<ReactMarkdownOptions["remarkPlugins"]> => [
       remarkGfm,
-      // `remark-math` with single-dollar math left ON (the default), matching
-      // GitHub: `$x$` is inline and `$$x$$` is block. The known trade-off is that
-      // a line with two unescaped `$` (e.g. "$5 to $10", "$HOME and $PATH") parses
-      // the span between them as math; authors escape a literal dollar with `\$`.
-      remarkMath,
+      // `remark-math` with single-dollar math OFF: micromark pairs any two
+      // unescaped `$` on a line, so "$5 to $10" or "$HOME and $PATH" render the
+      // span between them as math — and literal dollars dominate chat (#511).
+      // Inline math needs `$$x$$`; `$$` on its own lines is still a block.
+      [remarkMath, { singleDollarTextMath: false }],
       ...(threadMentions !== undefined || promptMentions !== undefined
         ? [remarkBreaks]
         : []),


### PR DESCRIPTION
## Summary

Fixes #511 — dollar amounts in chat (e.g. "$5 to $10") were rendered as inline KaTeX math because `micromark-extension-math` pairs any two unescaped `$` on a line with no delimiter constraints.

- Set `remark-math`'s `singleDollarTextMath: false` in `MarkdownPreview`: single-`$` spans (prices, env vars, and single-dollar TeX) stay literal text.
- Inline math still renders with `$$x^2$$`; display `$$` blocks are unchanged.
- Updated tests: new regression test that `$5 to $10` / `$x$` stay literal; existing inline/sanitize/invalid-TeX tests moved to `$$` syntax.
- Updated the markdown-preview math story and hint copy to match.

Trade-off: model output using single-dollar inline math now shows raw TeX. If that proves annoying, a follow-up can preprocess `$x$` / `\(x\)` into `$$x$$` on top of this.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app` — clean
- `pnpm exec turbo run test --filter=@bb/app -- markdown-preview` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)