### PR TITLE
Add @bb/plugin-sdk/testing

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -549,6 +549,81 @@ hardcoded colors break custom palettes.
 
 ## Testing a plugin
 
+### Unit tests with `@bb/plugin-sdk/testing`
+
+In a bb checkout (workspace/in-repo plugins), `@bb/plugin-sdk/testing` is
+the official vitest harness: a fake plugin host whose `bb` satisfies
+`BbPluginApi` with host-faithful semantics — real better-sqlite3 `:memory:`
+storage (never mock the db), the kv 256KB cap, the same registration
+name-validation and error messages, rpc/cli JSON round-tripping, and
+`threads.spawn` plugin attribution. It is NOT part of the bundled `.d.ts`
+that `bb plugin new` scaffolds ship (V1 is workspace consumers only), so
+standalone plugins outside a checkout cannot import it yet.
+
+Backend (`server.ts`) — `createFakePluginHost()`:
+
+```ts
+import { createFakePluginHost, makeThreadResponse } from "@bb/plugin-sdk/testing";
+import plugin from "./server";
+
+const { bb, harness } = createFakePluginHost({
+  pluginId: "my-plugin",
+  settings: { apiToken: "tok" }, // pre-seeded stored values (secrets included)
+  sdk: { threads: { spawn: async () => ({ id: "th_1" }) } },
+});
+await plugin(bb);
+
+await harness.callRpc("list", { q: "x" });          // JSON round-trip like the wire
+await harness.fetchHttp("POST", "/events", { body }); // real Hono context; auth not enforced
+await harness.runCli(["search", "x"]);              // { exitCode, stdout, stderr }
+const svc = harness.runService("watcher");          // start now; svc.controller.abort(); await svc.done
+await harness.runSchedule("sync");                  // no timers, no cron sweep
+await harness.setSettings({ apiToken: "next" });    // validates + fires onChange like a host save
+await harness.emitThreadEvent("thread.idle", {
+  thread: makeThreadResponse({ id: "th_1" }),       // complete ThreadResponse fixture
+  lastAssistantText: "done",
+});
+await harness.callAgentTool("lookup_doc", { query: "x" }); // parse (zod) + execute
+await harness.dispose();                            // abort services, hooks LIFO, close sqlite; stale bb throws
+```
+
+Inspect: `harness.sdk.calls` / `harness.sdk.callsTo("threads.spawn")` (every
+`bb.sdk` call is recorded; unstubbed methods throw naming the path to stub —
+`harness.sdk.stub("projects.list", fn)` adds one late), `harness.logEntries`,
+`harness.realtimeSignals`, `harness.needsConfigurationMessages`, and
+`harness.registrations` (http routes, rpc methods, services, schedules, cli,
+agent tools, thread actions, mention providers).
+
+Frontend (`app.tsx`) — `@bb/plugin-sdk/testing/app` (vitest + jsdom):
+
+```tsx
+// @vitest-environment jsdom
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+
+// The thunk matters: app.tsx binds the plugin runtime at module load, so
+// loadPluginApp installs the test runtime BEFORE importing it. (For static
+// imports, call installTestPluginRuntime() in a vitest setup file instead.)
+const app = await loadPluginApp(() => import("./app"));
+
+const slot = renderSlot(app.navPanels[0]!, { subPath: "" }, {
+  rpc: { listNotes: () => ({ mounts: [] }) },   // method → handler, calls logged
+  settings: { greeting: "hi" },                 // useSettings() values
+  context: { projectId: "p1", threadId: null }, // useBbContext()
+});
+await slot.findByText("…");                     // Testing Library queries
+slot.rpcCalls; slot.navigateCalls; slot.composer.quotes; // recorded hook activity
+await slot.emitRealtime("notes-changed", null); // push into useRealtime()
+```
+
+`loadPluginApp` validates registrations with the host's own rules (slot id
+patterns, navPanel path, chrome, fileOpener extensions) and returns them
+typed with defaults filled. Working examples:
+`examples/plugins/slack-bot/server.test.ts` (webhook → kv → recorded spawn →
+`thread.idle` reply) and `examples/plugins/notes/app.test.tsx` (nav panel
+tree over rpc + realtime refresh + navigate assertions).
+
+### Live loop against a running bb
+
 - `bb plugin dev` is the loop: save → rebuild (if `bb.app`) → reload; open
   app pages pick new UI up live. Build/reload failures print and keep
   watching.

--- a/examples/plugins/notes/app.test.tsx
+++ b/examples/plugins/notes/app.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+// Frontend tests for the notes plugin's app.tsx, written against the
+// official harness (`@bb/plugin-sdk/testing/app`) — no bb host, no bundle.
+// The thunk import matters: app.tsx binds the plugin runtime at module load,
+// so loadPluginApp installs the test runtime first.
+import { cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+
+const app = await loadPluginApp(() => import("./app"));
+
+afterEach(cleanup);
+
+interface MountFile {
+  path: string;
+  name: string;
+}
+
+function listNotesResult(files: MountFile[]) {
+  return {
+    mounts: [{ name: "Work", root: "/work", files, error: null }],
+  };
+}
+
+describe("notes slot registrations", () => {
+  it("registers the nav panel, thread panel action, and markdown file opener", () => {
+    expect(app.navPanels).toHaveLength(1);
+    expect(app.navPanels[0]).toMatchObject({
+      id: "notes",
+      path: "notes",
+      chrome: "none",
+    });
+    expect(app.threadPanelActions[0]?.id).toBe("note");
+    expect(app.fileOpeners[0]).toMatchObject({
+      id: "editor",
+      extensions: ["md", "mdx", "markdown"],
+    });
+  });
+});
+
+describe("notes nav panel", () => {
+  it("renders the mounted tree from rpc and deep-links notes via toPluginPanel", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "" },
+      {
+        rpc: {
+          listNotes: () =>
+            listNotesResult([{ path: "ideas.md", name: "ideas.md" }]),
+        },
+      },
+    );
+    await slot.findByText("ideas.md");
+    slot.getByText("Select a note to start writing.");
+    expect(slot.rpcCalls).toEqual([{ method: "listNotes", input: null }]);
+
+    fireEvent.click(slot.getByText("ideas.md"));
+    expect(slot.navigateCalls).toEqual([
+      {
+        method: "toPluginPanel",
+        path: "notes",
+        options: { subPath: "0/ideas.md" },
+      },
+    ]);
+  });
+
+  it("refetches the tree when the backend publishes notes-changed", async () => {
+    let files: MountFile[] = [{ path: "ideas.md", name: "ideas.md" }];
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "" },
+      { rpc: { listNotes: () => listNotesResult(files) } },
+    );
+    await slot.findByText("ideas.md");
+
+    files = [...files, { path: "todo.md", name: "todo.md" }];
+    await slot.emitRealtime("notes-changed", null);
+    await slot.findByText("todo.md");
+    expect(slot.rpcCalls.filter((c) => c.method === "listNotes")).toHaveLength(2);
+  });
+
+  it("creates a note over rpc and opens it", async () => {
+    const saved: unknown[] = [];
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "" },
+      {
+        rpc: {
+          listNotes: () => listNotesResult([]),
+          saveNote: (input) => {
+            saved.push(input);
+            return { outcome: "written", sha256: "abc" };
+          },
+        },
+      },
+    );
+    await slot.findByText("No markdown files yet.");
+    fireEvent.change(slot.getByPlaceholderText("new-note.md"), {
+      target: { value: "plan" },
+    });
+    fireEvent.click(slot.getByText("+"));
+    await slot.findByText("Select a note to start writing.");
+    expect(saved).toEqual([
+      {
+        root: "/work",
+        path: "plan.md",
+        content: "# plan\n\n",
+        expectedSha256: null,
+      },
+    ]);
+    expect(slot.navigateCalls).toContainEqual({
+      method: "toPluginPanel",
+      path: "notes",
+      options: { subPath: "0/plan.md" },
+    });
+  });
+});

--- a/examples/plugins/notes/package.json
+++ b/examples/plugins/notes/package.json
@@ -13,11 +13,19 @@
   "keywords": [
     "bb-plugin"
   ],
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts"
+  },
   "devDependencies": {
     "@bb/plugin-sdk": "workspace:*",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
-    "typescript": "^5.7.0"
+    "jsdom": "^29.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.1"
   },
   "dependencies": {
     "@milkdown/crepe": "^7.5.0",

--- a/examples/plugins/notes/vitest.config.ts
+++ b/examples/plugins/notes/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { defineWorkspaceTestConfig } from "../../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  resolve: {
+    // Mirror the plugin tsconfig's "@/*" paths.
+    alias: {
+      "@": path.resolve(import.meta.dirname, "."),
+    },
+  },
+  test: {
+    silent: "passed-only",
+    name: "bb-plugin-notes",
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**"],
+  },
+});

--- a/examples/plugins/slack-bot/package.json
+++ b/examples/plugins/slack-bot/package.json
@@ -5,5 +5,14 @@
   "type": "module",
   "engines": { "bb": ">=0.0" },
   "bb": { "server": "./server.ts" },
-  "keywords": ["bb-plugin"]
+  "keywords": ["bb-plugin"],
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "devDependencies": {
+    "@bb/plugin-sdk": "workspace:*",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.1"
+  }
 }

--- a/examples/plugins/slack-bot/server.test.ts
+++ b/examples/plugins/slack-bot/server.test.ts
@@ -1,0 +1,206 @@
+// Backend tests for the slack-bot hero plugin, written against the official
+// harness (`@bb/plugin-sdk/testing`) — no bb server, no Slack.
+import { createHmac } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createFakePluginHost,
+  makeThreadResponse,
+  type FakePluginHost,
+} from "@bb/plugin-sdk/testing";
+import slackBot from "./server";
+
+const SIGNING_SECRET = "test-signing-secret";
+
+function slackHeaders(rawBody: string): Record<string, string> {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature =
+    "v0=" +
+    createHmac("sha256", SIGNING_SECRET)
+      .update(`v0:${timestamp}:${rawBody}`)
+      .digest("hex");
+  return {
+    "content-type": "application/json",
+    "x-slack-request-timestamp": timestamp,
+    "x-slack-signature": signature,
+  };
+}
+
+function mentionEvent(args: { text: string; ts: string; threadTs?: string }) {
+  return JSON.stringify({
+    type: "event_callback",
+    event: {
+      type: "app_mention",
+      channel: "C42",
+      text: args.text,
+      ts: args.ts,
+      ...(args.threadTs !== undefined ? { thread_ts: args.threadTs } : {}),
+    },
+  });
+}
+
+async function loadConfigured(): Promise<FakePluginHost> {
+  const host = createFakePluginHost({
+    pluginId: "slack-bot",
+    settings: {
+      botToken: "xoxb-test",
+      signingSecret: SIGNING_SECRET,
+      project: "proj-1",
+    },
+    sdk: {
+      threads: {
+        spawn: async () => ({ id: "th_1" }),
+        send: async () => ({ ok: true }),
+      },
+    },
+  });
+  await slackBot(host.bb);
+  return host;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("slack-bot webhook", () => {
+  it("answers the Slack URL-verification handshake", async () => {
+    const { harness } = await loadConfigured();
+    const rawBody = JSON.stringify({
+      type: "url_verification",
+      challenge: "c-123",
+    });
+    const response = await harness.fetchHttp("POST", "/events", {
+      headers: slackHeaders(rawBody),
+      body: rawBody,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ challenge: "c-123" });
+  });
+
+  it("rejects requests whose signature does not verify", async () => {
+    const { harness } = await loadConfigured();
+    const rawBody = mentionEvent({ text: "<@U1> hi", ts: "1.1" });
+    const response = await harness.fetchHttp("POST", "/events", {
+      headers: { ...slackHeaders(rawBody), "x-slack-signature": "v0=nope" },
+      body: rawBody,
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("spawns an attributed BB thread on first mention and stores the kv mapping", async () => {
+    const { bb, harness } = await loadConfigured();
+    const rawBody = mentionEvent({
+      text: "<@U1> run the tests please",
+      ts: "111.222",
+    });
+    const response = await harness.fetchHttp("POST", "/events", {
+      headers: slackHeaders(rawBody),
+      body: rawBody,
+    });
+    expect(response.status).toBe(200);
+
+    expect(harness.sdk.callsTo("threads.spawn")).toEqual([
+      [
+        {
+          projectId: "proj-1",
+          prompt: "run the tests please",
+          environment: { type: "project-default" },
+          title: "Slack: run the tests please",
+          origin: "plugin",
+          originPluginId: "slack-bot",
+        },
+      ],
+    ]);
+    expect(await bb.storage.kv.get("slack:111.222")).toBe("th_1");
+    expect(await bb.storage.kv.get("bb:th_1")).toEqual({
+      channel: "C42",
+      threadTs: "111.222",
+    });
+  });
+
+  it("sends a follow-up to the mapped thread on a second mention", async () => {
+    const { harness } = await loadConfigured();
+    const first = mentionEvent({ text: "<@U1> start", ts: "111.222" });
+    await harness.fetchHttp("POST", "/events", {
+      headers: slackHeaders(first),
+      body: first,
+    });
+    const second = mentionEvent({
+      text: "<@U1> and lint too",
+      ts: "111.333",
+      threadTs: "111.222",
+    });
+    await harness.fetchHttp("POST", "/events", {
+      headers: slackHeaders(second),
+      body: second,
+    });
+
+    expect(harness.sdk.callsTo("threads.spawn")).toHaveLength(1);
+    expect(harness.sdk.callsTo("threads.send")).toEqual([
+      [
+        {
+          threadId: "th_1",
+          mode: "auto",
+          input: [{ type: "text", text: "and lint too" }],
+        },
+      ],
+    ]);
+  });
+
+  it("reports needs-configuration and serves 503 when unconfigured", async () => {
+    const host = createFakePluginHost({ pluginId: "slack-bot" });
+    await slackBot(host.bb);
+    expect(host.harness.needsConfigurationMessages).toHaveLength(1);
+
+    const response = await host.harness.fetchHttp("POST", "/events", {
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(response.status).toBe(503);
+  });
+});
+
+describe("slack-bot thread.idle", () => {
+  it("posts the agent's answer back into the originating Slack thread", async () => {
+    const { bb, harness } = await loadConfigured();
+    const rawBody = mentionEvent({ text: "<@U1> summarize", ts: "9.9" });
+    await harness.fetchHttp("POST", "/events", {
+      headers: slackHeaders(rawBody),
+      body: rawBody,
+    });
+
+    const postMessage = vi.fn(async () => ({
+      json: async () => ({ ok: true }),
+    }));
+    vi.stubGlobal("fetch", postMessage);
+
+    await harness.emitThreadEvent("thread.idle", {
+      thread: makeThreadResponse({ id: "th_1", originPluginId: "slack-bot" }),
+      lastAssistantText: "All tests pass.",
+    });
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const [url, init] = postMessage.mock.calls[0] as unknown as [
+      string,
+      { headers: Record<string, string>; body: string },
+    ];
+    expect(url).toBe("https://slack.com/api/chat.postMessage");
+    expect(init.headers.authorization).toBe("Bearer xoxb-test");
+    expect(JSON.parse(init.body)).toEqual({
+      channel: "C42",
+      thread_ts: "9.9",
+      text: "All tests pass.",
+    });
+  });
+
+  it("ignores idle threads this plugin did not spawn", async () => {
+    const { harness } = await loadConfigured();
+    const postMessage = vi.fn();
+    vi.stubGlobal("fetch", postMessage);
+    const { errors } = await harness.emitThreadEvent("thread.idle", {
+      thread: makeThreadResponse({ id: "th_other" }),
+      lastAssistantText: "hello",
+    });
+    expect(errors).toEqual([]);
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/examples/plugins/slack-bot/tsconfig.json
+++ b/examples/plugins/slack-bot/tsconfig.json
@@ -4,30 +4,18 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "jsx": "react-jsx",
     "lib": [
-      "ES2022",
-      "DOM"
+      "ES2022"
     ],
     "noEmit": true,
     "skipLibCheck": true,
     "types": [
       "node"
-    ],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "./*"
-      ]
-    }
+    ]
   },
   "include": [
     "server.ts",
-    "app.tsx",
-    "app.test.tsx",
-    "vitest.config.ts",
-    "components",
-    "lib",
-    "hooks"
+    "server.test.ts",
+    "vitest.config.ts"
   ]
 }

--- a/examples/plugins/slack-bot/vitest.config.ts
+++ b/examples/plugins/slack-bot/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineWorkspaceTestConfig } from "../../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    name: "bb-plugin-slack-bot",
+    include: ["**/*.test.ts"],
+    exclude: ["node_modules/**"],
+  },
+});

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -4,6 +4,24 @@ The typed facade BB plugin authors compile against. Types only at the root
 (`BbPluginApi`, the app contract); the `./app` subpath is shimmed by
 `bb plugin build` to the host's shared runtime.
 
+## Testing
+
+`./testing` is the official plugin test harness: `createFakePluginHost()`
+returns a `bb` satisfying `BbPluginApi` (real better-sqlite3 `:memory:`
+storage, host-faithful validation and error shapes, a recordable `bb.sdk`
+stub) plus a `harness` that drives rpc/http/cli/services/schedules/settings/
+thread events deterministically. `./testing/app` tests a plugin's `app.tsx`
+without the bb host: `loadPluginApp()` captures typed slot registrations and
+`renderSlot()` mounts a slot with mock hook backends (vitest + jsdom +
+Testing Library). See the "Testing a plugin" section of the
+bb-plugin-authoring skill for patterns, and
+`examples/plugins/{slack-bot,notes}` for working tests.
+
+Workspace/in-repo consumers only for V1: the testing subpaths are not part
+of the bundled `.d.ts` that `bb plugin new` ships into scaffolded plugins
+(`scripts/build-bundled-dts.mjs` bundles only the root and `./app`
+contracts), so standalone plugins outside a checkout cannot use them yet.
+
 ## Dependency surface
 
 The public types reference external type sources: `hono` (`Context` in http

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -13,12 +13,23 @@
       "source": "./src/app.ts",
       "types": "./src/app.ts",
       "default": "./src/app.ts"
+    },
+    "./testing": {
+      "source": "./src/testing/index.ts",
+      "types": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
+    },
+    "./testing/app": {
+      "source": "./src/testing/app.tsx",
+      "types": "./src/testing/app.tsx",
+      "default": "./src/testing/app.tsx"
     }
   },
   "types": "./src/index.ts",
   "scripts": {
     "build": "node scripts/build-bundled-dts.mjs",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "node scripts/build-bundled-dts.mjs --check && tsc --noEmit"
   },
   "devDependencies": {
@@ -26,25 +37,37 @@
     "@bb/sdk": "workspace:*",
     "@bb/server-contract": "workspace:*",
     "@bb/tsconfig": "workspace:*",
+    "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "better-sqlite3": "12.10.0",
+    "cron-parser": "^5.5.0",
     "hono": "4.11.9",
+    "jsdom": "^29.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "rollup": "^4.62.2",
     "rollup-plugin-dts": "^6.4.1",
     "typescript": "^5.7.0",
+    "vitest": "^4.1.1",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.12",
     "@types/react": "^19.0.0",
     "better-sqlite3": ">=12",
+    "cron-parser": "^5.5.0",
     "hono": "^4.11.9",
     "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "zod": "^4.3.6"
   },
   "peerDependenciesMeta": {
+    "@testing-library/react": {
+      "optional": true
+    },
     "@types/better-sqlite3": {
       "optional": true
     },
@@ -54,10 +77,16 @@
     "better-sqlite3": {
       "optional": true
     },
+    "cron-parser": {
+      "optional": true
+    },
     "hono": {
       "optional": true
     },
     "react": {
+      "optional": true
+    },
+    "react-dom": {
       "optional": true
     },
     "zod": {

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { useEffect, useState } from "react";
+import { cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  PluginHomepageSectionProps,
+  PluginNavPanelProps,
+} from "../../app-contract.js";
+import {
+  installTestPluginRuntime,
+  loadPluginApp,
+  renderSlot,
+} from "../app.js";
+
+// Install before touching @bb/plugin-sdk/app — it binds the runtime global
+// at import time (same constraint real plugin app.tsx files have).
+installTestPluginRuntime();
+const { definePluginApp, useBbNavigate, useComposer, useRealtime, useRpc, useSettings } =
+  await import("../../app.js");
+
+afterEach(cleanup);
+
+function Panel({ subPath }: PluginNavPanelProps) {
+  const rpc = useRpc();
+  const navigate = useBbNavigate();
+  const composer = useComposer();
+  const [items, setItems] = useState<string[] | null>(null);
+  const refresh = () => {
+    void rpc
+      .call("listItems", { subPath })
+      .then((result) => setItems(result as string[]))
+      .catch((error: unknown) =>
+        setItems([
+          `error: ${error instanceof Error ? error.message : String(error)}`,
+        ]),
+      );
+  };
+  useEffect(refresh, []);
+  useRealtime("items-changed", refresh);
+  if (items === null) return <div>Loading…</div>;
+  return (
+    <div>
+      {items.map((item) => (
+        <button
+          key={item}
+          onClick={() => navigate.toPluginPanel("panel", { subPath: item })}
+        >
+          {item}
+        </button>
+      ))}
+      <button onClick={() => composer.addQuote("quoted!")}>Quote</button>
+    </div>
+  );
+}
+
+function Section(_props: PluginHomepageSectionProps) {
+  const settings = useSettings();
+  return <div>greeting: {String(settings.values?.greeting)}</div>;
+}
+
+const app = await loadPluginApp(
+  definePluginApp((builder) => {
+    builder.slots.navPanel({
+      id: "panel",
+      title: "Panel",
+      icon: "FileText",
+      path: "panel",
+      component: Panel,
+    });
+    builder.slots.homepageSection({
+      id: "home",
+      title: "Home",
+      component: Section,
+    });
+  }),
+);
+
+describe("loadPluginApp", () => {
+  it("captures typed registrations and fills the chrome default", () => {
+    expect(app.navPanels).toHaveLength(1);
+    expect(app.navPanels[0]).toMatchObject({
+      id: "panel",
+      path: "panel",
+      chrome: "page",
+    });
+    expect(app.homepageSections[0]?.id).toBe("home");
+  });
+
+  it("rejects registrations the host would reject, with the host's message", async () => {
+    await expect(
+      loadPluginApp(
+        definePluginApp((builder) => {
+          builder.slots.navPanel({
+            id: "bad id!",
+            title: "x",
+            icon: "x",
+            path: "p",
+            component: Panel,
+          });
+        }),
+      ),
+    ).rejects.toThrow('slots.navPanel: "id" must match');
+    await expect(loadPluginApp({ default: { nope: true } })).rejects.toThrow(
+      "not definePluginApp(...)",
+    );
+  });
+});
+
+describe("renderSlot", () => {
+  it("wires rpc, realtime, navigate, and composer mocks", async () => {
+    let listing = ["a.md"];
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "" },
+      { rpc: { listItems: () => listing } },
+    );
+    await slot.findByText("a.md");
+    expect(slot.rpcCalls).toEqual([
+      { method: "listItems", input: { subPath: "" } },
+    ]);
+
+    // A realtime push re-fetches and renders the new listing.
+    listing = ["a.md", "b.md"];
+    await slot.emitRealtime("items-changed", null);
+    await slot.findByText("b.md");
+
+    fireEvent.click(slot.getByText("a.md"));
+    expect(slot.navigateCalls).toEqual([
+      {
+        method: "toPluginPanel",
+        path: "panel",
+        options: { subPath: "a.md" },
+      },
+    ]);
+
+    fireEvent.click(slot.getByText("Quote"));
+    expect(slot.composer.quotes).toEqual(["quoted!"]);
+  });
+
+  it("provides settings values and rejects rpc methods without handlers", async () => {
+    const section = renderSlot(
+      app.homepageSections[0]!,
+      { projectId: null },
+      { settings: { greeting: "hi" } },
+    );
+    section.getByText("greeting: hi");
+
+    const slot = renderSlot(app.navPanels[0]!, { subPath: "" }, {});
+    await slot.findByText(
+      'error: no rpc handler for "listItems" — add it to renderSlot options.rpc',
+    );
+    expect(slot.rpcCalls).toEqual([
+      { method: "listItems", input: { subPath: "" } },
+    ]);
+  });
+});

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { BbPluginApi } from "../../backend-contract.js";
+import {
+  createFakePluginHost,
+  makeThreadResponse,
+} from "../index.js";
+
+describe("storage", () => {
+  it("kv round-trips JSON, lists by prefix sorted, and enforces the 256KB cap", async () => {
+    const { bb } = createFakePluginHost();
+    await bb.storage.kv.set("slack:b", { channel: "C1" });
+    await bb.storage.kv.set("slack:a", 42);
+    await bb.storage.kv.set("other", "x");
+    expect(await bb.storage.kv.get("slack:b")).toEqual({ channel: "C1" });
+    expect(await bb.storage.kv.list("slack:")).toEqual(["slack:a", "slack:b"]);
+    expect(await bb.storage.kv.list()).toEqual(["other", "slack:a", "slack:b"]);
+    await bb.storage.kv.delete("slack:a");
+    expect(await bb.storage.kv.get("slack:a")).toBeUndefined();
+
+    await expect(
+      bb.storage.kv.set("big", "x".repeat(256 * 1024)),
+    ).rejects.toThrow(/limit is 262144 \(256KB\)/);
+  });
+
+  it("sqlite() returns one shared database and migrate() is append-only by index", () => {
+    const { bb } = createFakePluginHost();
+    const db = bb.storage.sqlite();
+    bb.storage.migrate(db, [
+      "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)",
+    ]);
+    db.prepare("INSERT INTO notes (body) VALUES (?)").run("hello");
+
+    // A later load appends a statement; the first must not re-run.
+    const again = bb.storage.sqlite();
+    expect(again).toBe(db);
+    bb.storage.migrate(again, [
+      "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)",
+      "ALTER TABLE notes ADD COLUMN starred INTEGER NOT NULL DEFAULT 0",
+    ]);
+    const rows = again.prepare("SELECT body, starred FROM notes").all();
+    expect(rows).toEqual([{ body: "hello", starred: 0 }]);
+  });
+});
+
+describe("settings", () => {
+  function defineSettings(bb: BbPluginApi) {
+    return bb.settings.define({
+      token: { type: "string", label: "Token", secret: true },
+      mode: {
+        type: "select",
+        label: "Mode",
+        options: ["fast", "slow"],
+        default: "fast",
+      },
+      enabled: { type: "boolean", label: "Enabled", default: true },
+    });
+  }
+
+  it("resolves pre-seeded values, defaults, and type mismatches like the host", async () => {
+    const { bb } = createFakePluginHost({
+      settings: { token: "xoxb-1", enabled: false },
+    });
+    const handle = defineSettings(bb);
+    expect(await handle.get()).toEqual({
+      token: "xoxb-1",
+      mode: "fast",
+      enabled: false,
+    });
+  });
+
+  it("setSettings validates, fires onChange with next/prev, and skips no-op updates", async () => {
+    const { bb, harness } = createFakePluginHost();
+    const handle = defineSettings(bb);
+    const changes: Array<{ next: unknown; prev: unknown }> = [];
+    handle.onChange((next, prev) => changes.push({ next, prev }));
+
+    await expect(harness.setSettings({ nope: "x" })).rejects.toThrow(
+      'unknown setting "nope"',
+    );
+    await expect(harness.setSettings({ mode: "warp" })).rejects.toThrow(
+      'must be one of: fast, slow',
+    );
+
+    await harness.setSettings({ token: "xoxb-2", mode: "slow" });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toEqual({
+      next: { token: "xoxb-2", mode: "slow", enabled: true },
+      prev: { token: undefined, mode: "fast", enabled: true },
+    });
+
+    // Same effective values → no listener call.
+    await harness.setSettings({ mode: "slow" });
+    expect(changes).toHaveLength(1);
+
+    // null unsets → back to the default.
+    await harness.setSettings({ mode: null });
+    expect(changes).toHaveLength(2);
+    expect(await handle.get()).toMatchObject({ mode: "fast" });
+  });
+
+  it("rejects duplicate and invalid descriptors at define time", () => {
+    const { bb } = createFakePluginHost();
+    defineSettings(bb);
+    expect(() =>
+      bb.settings.define({ token: { type: "string", label: "Again" } }),
+    ).toThrow('setting "token" is already defined');
+    expect(() =>
+      bb.settings.define({
+        broken: { type: "select", label: "B", options: ["a"], default: "z" },
+      }),
+    ).toThrow('default for setting "broken" must be one of its options');
+  });
+});
+
+describe("rpc", () => {
+  it("callRpc JSON-round-trips input and output and rejects unknown methods", async () => {
+    const { bb, harness } = createFakePluginHost({ pluginId: "notes" });
+    bb.rpc.register({
+      echo: (input: { when: Date }) => ({ got: input, extra: undefined }),
+    });
+    // Dates become strings on the wire; undefined fields are stripped.
+    const result = await harness.callRpc("echo", { when: new Date(0) });
+    expect(result).toEqual({ got: { when: "1970-01-01T00:00:00.000Z" } });
+
+    await expect(harness.callRpc("missing")).rejects.toThrow(
+      'plugin "notes" has no rpc method "missing"',
+    );
+  });
+
+  it("rejects invalid and duplicate registrations", () => {
+    const { bb } = createFakePluginHost();
+    bb.rpc.register({ list: () => [] });
+    expect(() => bb.rpc.register({ list: () => [] })).toThrow(
+      'rpc method "list" is already registered',
+    );
+    expect(() => bb.rpc.register({ "bad name": () => [] })).toThrow(
+      'invalid rpc method name "bad name"',
+    );
+  });
+});
+
+describe("http", () => {
+  it("dispatches to the exact-match route with a real Hono context", async () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.http.route(
+      "POST",
+      "/events",
+      async (context) => {
+        const body = await context.req.json<{ n: number }>();
+        return context.json({ doubled: body.n * 2 });
+      },
+      { auth: "none" },
+    );
+    const response = await harness.fetchHttp("POST", "/events", {
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ n: 21 }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ doubled: 42 });
+
+    await expect(harness.fetchHttp("GET", "/events")).rejects.toThrow(
+      "no http route GET /events is registered",
+    );
+  });
+
+  it("maps a throwing handler to the host's 500 shape", async () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.http.route("GET", "/boom", () => {
+      throw new Error("nope");
+    });
+    const response = await harness.fetchHttp("GET", "/boom");
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "plugin route failed: nope",
+    });
+  });
+});
+
+describe("cli", () => {
+  it("normalizes results and maps throws like the host", async () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.cli.register({
+      name: "docs",
+      summary: "Docs tools",
+      run(argv) {
+        if (argv[0] === "crash") throw new Error("bad flag");
+        return { exitCode: 0, stdout: `ran ${argv.join(" ")}` };
+      },
+    });
+    expect(await harness.runCli(["search", "x"])).toEqual({
+      exitCode: 0,
+      stdout: "ran search x",
+      stderr: "",
+    });
+    expect(await harness.runCli(["crash"])).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: "bb docs failed: bad flag",
+    });
+  });
+
+  it("rejects reserved names", () => {
+    const { bb } = createFakePluginHost();
+    expect(() =>
+      bb.cli.register({
+        name: "thread",
+        summary: "nope",
+        run: () => ({ exitCode: 0 }),
+      }),
+    ).toThrow('cli command name "thread" is reserved by the bb CLI');
+  });
+});
+
+describe("background", () => {
+  it("runService starts once, exposes the AbortController, and resolves on abort", async () => {
+    const { bb, harness } = createFakePluginHost();
+    let sawAbort = false;
+    bb.background.service("watcher", {
+      start(signal) {
+        return new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => {
+            sawAbort = true;
+            resolve();
+          });
+        });
+      },
+    });
+    const { controller, done } = harness.runService("watcher");
+    controller.abort();
+    await done;
+    expect(sawAbort).toBe(true);
+  });
+
+  it("treats NeedsConfigurationError (by name) as needs-configuration, not a crash", async () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.background.service("socket", {
+      start() {
+        throw Object.assign(new Error("set the token first"), {
+          name: "NeedsConfigurationError",
+        });
+      },
+    });
+    await harness.runService("socket").done;
+    expect(harness.needsConfigurationMessages).toEqual(["set the token first"]);
+  });
+
+  it("validates cron expressions at registration and runs schedules on demand", async () => {
+    const { bb, harness } = createFakePluginHost();
+    expect(() =>
+      bb.background.schedule("sync", "not-cron", () => {}),
+    ).toThrow('invalid cron "not-cron" for schedule "sync"');
+
+    let runs = 0;
+    bb.background.schedule("sync", "*/5 * * * *", () => {
+      runs += 1;
+    });
+    await harness.runSchedule("sync");
+    expect(runs).toBe(1);
+  });
+});
+
+describe("thread events", () => {
+  it("emitThreadEvent delivers typed payloads and captures handler errors", async () => {
+    const { bb, harness } = createFakePluginHost();
+    const seen: Array<string | null> = [];
+    bb.on("thread.idle", ({ thread, lastAssistantText }) => {
+      seen.push(`${thread.id}:${lastAssistantText}`);
+    });
+    bb.on("thread.idle", () => {
+      throw new Error("handler exploded");
+    });
+    const { errors } = await harness.emitThreadEvent("thread.idle", {
+      thread: makeThreadResponse({ id: "th_9" }),
+      lastAssistantText: "done",
+    });
+    expect(seen).toEqual(["th_9:done"]);
+    expect(errors).toHaveLength(1);
+    expect(harness.logEntries).toContainEqual({
+      level: "warn",
+      message: "thread.idle handler failed: handler exploded",
+    });
+  });
+
+  it("rejects unknown events at registration", () => {
+    const { bb } = createFakePluginHost();
+    expect(() =>
+      bb.on("thread.deleted" as "thread.idle", () => {}),
+    ).toThrow('unknown event "thread.deleted"');
+  });
+});
+
+describe("sdk", () => {
+  it("records calls with plugin spawn attribution and runs stubs", async () => {
+    const { bb, harness } = createFakePluginHost({
+      pluginId: "slack-bot",
+      sdk: {
+        threads: { spawn: async () => ({ id: "th_1" }) },
+      },
+    });
+    const thread = await bb.sdk.threads.spawn({
+      projectId: "p1",
+      prompt: "hi",
+      environment: { type: "project-default" },
+    });
+    expect(thread).toEqual({ id: "th_1" });
+    expect(harness.sdk.callsTo("threads.spawn")).toEqual([
+      [
+        {
+          projectId: "p1",
+          prompt: "hi",
+          environment: { type: "project-default" },
+          origin: "plugin",
+          originPluginId: "slack-bot",
+        },
+      ],
+    ]);
+  });
+
+  it("throws a stub-naming error for unstubbed methods and accepts late stubs", async () => {
+    const { bb, harness } = createFakePluginHost();
+    expect(() => bb.sdk.projects.list({})).toThrow(
+      'bb.sdk.projects.list is not stubbed',
+    );
+    harness.sdk.stub("projects.list", async () => []);
+    await expect(bb.sdk.projects.list({})).resolves.toEqual([]);
+    // Both calls were recorded, including the unstubbed one.
+    expect(harness.sdk.callsTo("projects.list")).toHaveLength(2);
+  });
+});
+
+describe("agent tools", () => {
+  it("validates zod parameters per call and executes with a default context", async () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.agents.registerTool({
+      name: "lookup_doc",
+      description: "Look up a doc",
+      parameters: z.object({ query: z.string().min(1) }),
+      execute: ({ query }, ctx) => `${query} for ${ctx.threadId}`,
+    });
+    expect(harness.registrations.agentTools[0]?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { query: { type: "string" } },
+    });
+    await expect(
+      harness.callAgentTool("lookup_doc", { query: "hi" }),
+    ).resolves.toBe("hi for thread-test");
+    await expect(
+      harness.callAgentTool("lookup_doc", { query: 3 }),
+    ).rejects.toThrow('tool "lookup_doc" arguments are invalid');
+  });
+});
+
+describe("dispose", () => {
+  it("aborts services, runs hooks LIFO, closes sqlite, and poisons the handle", async () => {
+    const { bb, harness } = createFakePluginHost();
+    const order: string[] = [];
+    bb.onDispose(() => {
+      order.push("first");
+    });
+    bb.onDispose(() => {
+      order.push("second");
+      throw new Error("hook exploded");
+    });
+    bb.background.service("svc", {
+      start(signal) {
+        return new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => {
+            order.push("aborted");
+            resolve();
+          });
+        });
+      },
+    });
+    const db = bb.storage.sqlite();
+    const { done } = harness.runService("svc");
+
+    await harness.dispose();
+    await done;
+    expect(order).toEqual(["aborted", "second", "first"]);
+    expect(db.open).toBe(false);
+    await expect(bb.storage.kv.get("x")).rejects.toThrow(
+      'used a stale API handle',
+    );
+    expect(() => bb.sdk).toThrow("stale");
+    // A second dispose is a no-op.
+    await harness.dispose();
+  });
+});
+
+describe("realtime and status", () => {
+  it("normalizes published payloads and records needs-configuration", () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.realtime.publish("notes-changed", undefined);
+    bb.realtime.publish("notes-changed", { at: new Date(0) });
+    expect(harness.realtimeSignals).toEqual([
+      { channel: "notes-changed", payload: null },
+      {
+        channel: "notes-changed",
+        payload: { at: "1970-01-01T00:00:00.000Z" },
+      },
+    ]);
+    expect(() => bb.realtime.publish("bad", { boom: 1n })).toThrow(
+      "not JSON-serializable",
+    );
+
+    bb.status.needsConfiguration("");
+    bb.status.needsConfiguration("set a token");
+    expect(harness.needsConfigurationMessages).toEqual([
+      "needs configuration",
+      "set a token",
+    ]);
+  });
+});

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -1,0 +1,530 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { act, render, type RenderResult } from "@testing-library/react";
+import {
+  PLUGIN_SLOT_ID_PATTERN,
+  type BbContext,
+  type BbNavigate,
+  type PluginAppDefinition,
+  type PluginAppSetup,
+  type PluginComposerAccessoryRegistration,
+  type PluginComposerApi,
+  type PluginComposerMention,
+  type PluginFileOpenerRegistration,
+  type PluginHomepageSectionRegistration,
+  type PluginNavPanelRegistration,
+  type PluginRpcClient,
+  type PluginSdkApp,
+  type PluginSettingsState,
+  type PluginThreadPanelActionRegistration,
+} from "../app-contract.js";
+
+/**
+ * `@bb/plugin-sdk/testing/app` — the frontend plugin test harness. Tests a
+ * plugin's `app.tsx` source directly under vitest + jsdom, without the bb
+ * host or the esbuild bundle:
+ *
+ * - {@link installTestPluginRuntime} fills `globalThis.__bbPluginRuntime.
+ *   pluginSdkApp` with a test implementation of the `@bb/plugin-sdk/app`
+ *   surface (the same seam `bb plugin build` shims to the real app). It must
+ *   run BEFORE the plugin's `app.tsx` module evaluates, because that module
+ *   binds the runtime at import time — so import `app.tsx` through
+ *   {@link loadPluginApp}'s thunk form, or call the installer from a vitest
+ *   setup file when you prefer static imports.
+ * - {@link loadPluginApp} runs the definition's setup against a validating
+ *   collector (ported from the BB app's interpreter, same error messages)
+ *   and returns the typed slot registrations.
+ * - {@link renderSlot} mounts one registration's component with mock hook
+ *   backends: rpc as a method→handler map with a call log, realtime as a
+ *   channel you can push events into, settings/context as plain values, and
+ *   navigate/composer as recorders.
+ *
+ * Add `// @vitest-environment jsdom` to test files using renderSlot.
+ */
+
+// ---------------------------------------------------------------------------
+// The test-side hook environment (one per renderSlot mount).
+// ---------------------------------------------------------------------------
+
+export interface RpcCall {
+  method: string;
+  input: unknown;
+}
+
+export type NavigateCall =
+  | { method: "toThread"; threadId: string }
+  | { method: "toProject"; projectId: string }
+  | {
+      method: "toPluginPanel";
+      path: string;
+      options?: { subPath?: string; replace?: boolean };
+    };
+
+export interface ComposerLog {
+  quotes: string[];
+  mentions: PluginComposerMention[];
+  focusCount: number;
+}
+
+interface SlotEnv {
+  rpcClient: PluginRpcClient;
+  rpcCalls: RpcCall[];
+  realtimeHandlers: Map<string, Set<(payload: unknown) => void>>;
+  settingsState: PluginSettingsState;
+  bbContext: BbContext;
+  navigate: BbNavigate;
+  navigateCalls: NavigateCall[];
+  composer: PluginComposerApi;
+  composerLog: ComposerLog;
+}
+
+const SlotEnvContext = createContext<SlotEnv | null>(null);
+
+function useSlotEnv(hook: string): SlotEnv {
+  const env = useContext(SlotEnvContext);
+  if (!env) {
+    throw new Error(
+      `${hook}() needs the test slot environment — mount the component via renderSlot(...) from @bb/plugin-sdk/testing/app`,
+    );
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// The fake @bb/plugin-sdk/app runtime.
+// ---------------------------------------------------------------------------
+
+/** Same shape (and checks) as the BB app's real definePluginApp. */
+function definePluginApp(setup: PluginAppSetup): PluginAppDefinition {
+  if (typeof setup !== "function") {
+    throw new Error("definePluginApp expects a setup function");
+  }
+  return Object.freeze({ __bbPluginApp: true as const, setup });
+}
+
+function isPluginAppDefinition(
+  value: unknown,
+): value is PluginAppDefinition {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __bbPluginApp?: unknown }).__bbPluginApp === true &&
+    typeof (value as { setup?: unknown }).setup === "function"
+  );
+}
+
+const testPluginSdkApp = {
+  definePluginApp,
+  useRpc(): PluginRpcClient {
+    return useSlotEnv("useRpc").rpcClient;
+  },
+  useRealtime(channel: string, handler: (payload: unknown) => void): void {
+    const env = useSlotEnv("useRealtime");
+    // Latest handler without resubscribing per render, like the host hook.
+    const handlerRef = useRef(handler);
+    useEffect(() => {
+      handlerRef.current = handler;
+    });
+    useEffect(() => {
+      const listener = (payload: unknown) => handlerRef.current(payload);
+      let listeners = env.realtimeHandlers.get(channel);
+      if (!listeners) {
+        listeners = new Set();
+        env.realtimeHandlers.set(channel, listeners);
+      }
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    }, [env, channel]);
+  },
+  useSettings(): PluginSettingsState {
+    return useSlotEnv("useSettings").settingsState;
+  },
+  useBbContext(): BbContext {
+    return useSlotEnv("useBbContext").bbContext;
+  },
+  useBbNavigate(): BbNavigate {
+    return useSlotEnv("useBbNavigate").navigate;
+  },
+  useComposer(): PluginComposerApi {
+    return useSlotEnv("useComposer").composer;
+  },
+} satisfies PluginSdkApp;
+
+interface PluginRuntimeHost {
+  __bbPluginRuntime?: { pluginSdkApp?: unknown };
+}
+
+/**
+ * Install the test runtime at `globalThis.__bbPluginRuntime.pluginSdkApp`.
+ * Idempotent per module instance; must run before the plugin's `app.tsx`
+ * (and therefore `@bb/plugin-sdk/app`) is imported.
+ */
+export function installTestPluginRuntime(): void {
+  const host = globalThis as PluginRuntimeHost;
+  host.__bbPluginRuntime = {
+    ...host.__bbPluginRuntime,
+    pluginSdkApp: testPluginSdkApp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// loadPluginApp — run setup, capture typed slot registrations.
+// ---------------------------------------------------------------------------
+
+export interface CapturedPluginApp {
+  homepageSections: PluginHomepageSectionRegistration[];
+  navPanels: Array<
+    PluginNavPanelRegistration & { chrome: "page" | "none" }
+  >;
+  threadPanelActions: PluginThreadPanelActionRegistration[];
+  composerAccessories: PluginComposerAccessoryRegistration[];
+  fileOpeners: PluginFileOpenerRegistration[];
+}
+
+type PluginAppModule = { default: unknown };
+
+export type PluginAppSource =
+  | PluginAppDefinition
+  | PluginAppModule
+  | (() => Promise<PluginAppDefinition | PluginAppModule>);
+
+function requireSlotId(kind: string, value: unknown): string {
+  if (typeof value !== "string" || !PLUGIN_SLOT_ID_PATTERN.test(value)) {
+    throw new Error(
+      `${kind}: "id" must match ${String(PLUGIN_SLOT_ID_PATTERN)}, got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+function requireNonEmptyString(
+  kind: string,
+  field: string,
+  value: unknown,
+): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${kind}: "${field}" must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireComponent<T>(kind: string, value: unknown): T {
+  if (typeof value !== "function") {
+    throw new Error(`${kind}: "component" must be a React component function`);
+  }
+  return value as T;
+}
+
+function requireUniqueId(kind: string, seen: Set<string>, id: string): void {
+  if (seen.has(id)) {
+    throw new Error(`${kind}: duplicate id "${id}"`);
+  }
+  seen.add(id);
+}
+
+/**
+ * Validation ported from the BB app's collector
+ * (apps/app/src/lib/plugin-app-definition.ts) so a registration the host
+ * would reject fails here with the same message.
+ */
+function collectRegistrations(
+  definition: PluginAppDefinition,
+): CapturedPluginApp {
+  const captured: CapturedPluginApp = {
+    homepageSections: [],
+    navPanels: [],
+    threadPanelActions: [],
+    composerAccessories: [],
+    fileOpeners: [],
+  };
+  const seenIds = {
+    homepageSection: new Set<string>(),
+    navPanel: new Set<string>(),
+    threadPanelAction: new Set<string>(),
+    composerAccessory: new Set<string>(),
+    fileOpener: new Set<string>(),
+  };
+
+  definition.setup({
+    slots: {
+      homepageSection(registration) {
+        const kind = "slots.homepageSection";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.homepageSection, id);
+        captured.homepageSections.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          component: requireComponent(kind, registration.component),
+        });
+      },
+      navPanel(registration) {
+        const kind = "slots.navPanel";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.navPanel, id);
+        const path = requireNonEmptyString(kind, "path", registration.path);
+        if (!PLUGIN_SLOT_ID_PATTERN.test(path)) {
+          throw new Error(
+            `${kind}: "path" must match ${String(PLUGIN_SLOT_ID_PATTERN)} (it becomes a URL segment), got ${JSON.stringify(path)}`,
+          );
+        }
+        const chrome = registration.chrome ?? "page";
+        if (chrome !== "page" && chrome !== "none") {
+          throw new Error(
+            `${kind}: "chrome" must be "page" or "none" when set, got ${JSON.stringify(registration.chrome)}`,
+          );
+        }
+        if (
+          registration.headerContent !== undefined &&
+          typeof registration.headerContent !== "function"
+        ) {
+          throw new Error(
+            `${kind}: "headerContent" must be a React component function when set`,
+          );
+        }
+        captured.navPanels.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          icon: requireNonEmptyString(kind, "icon", registration.icon),
+          path,
+          component: requireComponent(kind, registration.component),
+          chrome,
+          ...(registration.headerContent !== undefined
+            ? { headerContent: registration.headerContent }
+            : {}),
+        });
+      },
+      threadPanelAction(registration) {
+        const kind = "slots.threadPanelAction";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.threadPanelAction, id);
+        if (
+          registration.run !== undefined &&
+          typeof registration.run !== "function"
+        ) {
+          throw new Error(`${kind}: "run" must be a function when set`);
+        }
+        captured.threadPanelActions.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          ...(registration.icon !== undefined
+            ? { icon: requireNonEmptyString(kind, "icon", registration.icon) }
+            : {}),
+          component: requireComponent(kind, registration.component),
+          ...(registration.run !== undefined ? { run: registration.run } : {}),
+        });
+      },
+      composerAccessory(registration) {
+        const kind = "slots.composerAccessory";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.composerAccessory, id);
+        captured.composerAccessories.push({
+          id,
+          component: requireComponent(kind, registration.component),
+        });
+      },
+      fileOpener(registration) {
+        const kind = "slots.fileOpener";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.fileOpener, id);
+        const rawExtensions = registration?.extensions;
+        if (!Array.isArray(rawExtensions) || rawExtensions.length === 0) {
+          throw new Error(
+            `${kind}: "extensions" must be a non-empty array of lowercase extensions without the dot`,
+          );
+        }
+        const extensions = rawExtensions.map((extension) => {
+          if (
+            typeof extension !== "string" ||
+            !/^[a-z0-9]+$/.test(extension)
+          ) {
+            throw new Error(
+              `${kind}: extensions must be lowercase alphanumerics without the dot, got ${JSON.stringify(extension)}`,
+            );
+          }
+          return extension;
+        });
+        captured.fileOpeners.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          extensions,
+          component: requireComponent(kind, registration.component),
+        });
+      },
+    },
+  });
+
+  return captured;
+}
+
+/**
+ * Install the test runtime, resolve the plugin app definition, and capture
+ * its slot registrations. Pass a thunk (`() => import("../app.tsx")`) so the
+ * plugin module evaluates after the runtime is installed — a static import
+ * would bind `definePluginApp` before the installer runs.
+ */
+export async function loadPluginApp(
+  source: PluginAppSource,
+): Promise<CapturedPluginApp> {
+  installTestPluginRuntime();
+  const resolved = typeof source === "function" ? await source() : source;
+  const definition = isPluginAppDefinition(resolved)
+    ? resolved
+    : (resolved as PluginAppModule).default;
+  if (!isPluginAppDefinition(definition)) {
+    throw new Error(
+      "the bundle's default export is not definePluginApp(...) from @bb/plugin-sdk/app",
+    );
+  }
+  return collectRegistrations(definition);
+}
+
+// ---------------------------------------------------------------------------
+// renderSlot — mount one registration's component with mock hook backends.
+// ---------------------------------------------------------------------------
+
+export interface RenderSlotOptions {
+  /**
+   * Backing handlers for `useRpc().call`: method name → implementation.
+   * Inputs and results are JSON-round-tripped like the wire; a method
+   * without a handler rejects, and a throwing handler rejects with its
+   * message (what the real rpc client surfaces).
+   */
+  rpc?: Record<string, (input: unknown) => unknown>;
+  /** `useSettings()` values; omitted → `{ values: undefined, isLoading: false }`. */
+  settings?: Record<string, string | boolean>;
+  /** `useBbContext()` selection; both default to null. */
+  context?: { projectId?: string | null; threadId?: string | null };
+}
+
+export interface RenderedSlot extends RenderResult {
+  /** Every `useRpc().call`, in order. */
+  rpcCalls: RpcCall[];
+  /**
+   * Push a realtime event to `useRealtime(channel, …)` subscribers, wrapped
+   * in act. The payload is JSON-round-tripped like `bb.realtime.publish`.
+   */
+  emitRealtime(channel: string, payload: unknown): Promise<void>;
+  /** Every `useBbNavigate()` call, in order. */
+  navigateCalls: NavigateCall[];
+  /** Everything written through `useComposer()`. */
+  composer: ComposerLog;
+}
+
+export function renderSlot<Props extends object>(
+  registration: { component: ComponentType<Props> },
+  props: Props,
+  options: RenderSlotOptions = {},
+): RenderedSlot {
+  const rpcCalls: RpcCall[] = [];
+  const rpcHandlers = options.rpc ?? {};
+  const rpcClient: PluginRpcClient = {
+    async call(method, input) {
+      const normalizedInput =
+        input === undefined ? null : JSON.parse(JSON.stringify(input));
+      rpcCalls.push({ method, input: normalizedInput });
+      const handler = rpcHandlers[method];
+      if (!handler) {
+        throw new Error(
+          `no rpc handler for "${method}" — add it to renderSlot options.rpc`,
+        );
+      }
+      const result = await handler(normalizedInput);
+      const json = JSON.stringify(result);
+      return json === undefined ? undefined : (JSON.parse(json) as unknown);
+    },
+  };
+
+  const realtimeHandlers = new Map<string, Set<(payload: unknown) => void>>();
+
+  const navigateCalls: NavigateCall[] = [];
+  const navigate: BbNavigate = {
+    toThread(threadId) {
+      navigateCalls.push({ method: "toThread", threadId });
+    },
+    toProject(projectId) {
+      navigateCalls.push({ method: "toProject", projectId });
+    },
+    toPluginPanel(path, panelOptions) {
+      navigateCalls.push({
+        method: "toPluginPanel",
+        path,
+        ...(panelOptions !== undefined ? { options: panelOptions } : {}),
+      });
+    },
+  };
+
+  const projectId = options.context?.projectId ?? null;
+  const threadId = options.context?.threadId ?? null;
+
+  const composerLog: ComposerLog = {
+    quotes: [],
+    mentions: [],
+    focusCount: 0,
+  };
+  const composer: PluginComposerApi = {
+    scope:
+      threadId !== null
+        ? { kind: "thread", threadId }
+        : { kind: "new-thread", projectId },
+    addQuote(text) {
+      composerLog.quotes.push(text);
+    },
+    insertMention(mention) {
+      composerLog.mentions.push(mention);
+    },
+    focus() {
+      composerLog.focusCount += 1;
+    },
+  };
+
+  const env: SlotEnv = {
+    rpcClient,
+    rpcCalls,
+    realtimeHandlers,
+    settingsState: { values: options.settings, isLoading: false },
+    bbContext: { projectId, threadId },
+    navigate,
+    navigateCalls,
+    composer,
+    composerLog,
+  };
+
+  const Component = registration.component;
+  const element: ReactElement = (
+    <SlotEnvContext.Provider value={env}>
+      <Component {...props} />
+    </SlotEnvContext.Provider>
+  );
+  const result = render(element);
+
+  return {
+    ...result,
+    rerender(ui: ReactNode) {
+      result.rerender(
+        <SlotEnvContext.Provider value={env}>{ui}</SlotEnvContext.Provider>,
+      );
+    },
+    rpcCalls,
+    async emitRealtime(channel, payload) {
+      const normalized =
+        payload === undefined ? null : JSON.parse(JSON.stringify(payload));
+      const listeners = realtimeHandlers.get(channel);
+      await act(async () => {
+        for (const listener of [...(listeners ?? [])]) {
+          listener(normalized);
+        }
+      });
+    },
+    navigateCalls,
+    composer: composerLog,
+  };
+}

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -1,0 +1,1291 @@
+import Database from "better-sqlite3";
+import { CronExpressionParser } from "cron-parser";
+import { Hono } from "hono";
+import { z } from "zod";
+import type {
+  BbPluginApi,
+  PluginAgentToolContext,
+  PluginAgentToolResult,
+  PluginAgents,
+  PluginBackground,
+  PluginCli,
+  PluginCliCommandInfo,
+  PluginCliContext,
+  PluginCliResult,
+  PluginHttp,
+  PluginHttpAuthMode,
+  PluginHttpHandler,
+  PluginKvStorage,
+  PluginLogger,
+  PluginMentionItem,
+  PluginMentionSearchContext,
+  PluginRealtime,
+  PluginRpc,
+  PluginSettingDescriptor,
+  PluginSettingDescriptors,
+  PluginSettingValue,
+  PluginSettings,
+  PluginSettingsValues,
+  PluginStatusApi,
+  PluginStorage,
+  PluginThreadActionContext,
+  PluginThreadActionResult,
+  PluginThreadEventHandler,
+  PluginThreadEventName,
+  PluginThreadEventPayloads,
+  PluginUi,
+} from "../backend-contract.js";
+import {
+  createFakeSdk,
+  type FakeSdkHarness,
+  type FakeSdkOverrides,
+} from "./fake-sdk.js";
+
+/**
+ * `createFakePluginHost` — an in-process stand-in for the BB server's plugin
+ * runtime (apps/server/src/services/plugins/plugin-api.ts), for unit-testing
+ * a plugin's `server.ts` without a server. `bb` satisfies {@link BbPluginApi};
+ * `harness` drives and inspects it.
+ *
+ * Faithful where a plugin can observe it: registration name validation and
+ * error messages, the kv 256KB cap, append-only sqlite migrations, settings
+ * read/update semantics (including onChange), rpc/cli invocation shapes
+ * (JSON round-tripping, exit-code normalization), `threads.spawn`
+ * attribution, and dispose order (services aborted, hooks LIFO, sqlite
+ * closed, stale handles throw).
+ *
+ * Deliberately different from the real host:
+ * - storage is in-memory: kv in a Map, `storage.sqlite()` one shared
+ *   better-sqlite3 `:memory:` handle (same data across calls, like the
+ *   host's shared file), secret settings alongside plain values (no files).
+ * - `bb.sdk` is always bound (no listen gate) and every unstubbed method
+ *   throws instead of hitting a server.
+ * - http auth modes are recorded but not enforced — signature checks and
+ *   token handling inside handlers still run.
+ * - background services/schedules never run on timers; `harness.runService`
+ *   and `harness.runSchedule` invoke them deterministically.
+ */
+
+/** Same shape (and name) the real host throws for stale API handles. */
+export class PluginContextStaleError extends Error {
+  constructor(pluginId: string) {
+    super(
+      `plugin "${pluginId}" used a stale API handle — it was reloaded or disabled; ` +
+        `re-entry happens via a fresh factory call`,
+    );
+    this.name = "PluginContextStaleError";
+  }
+}
+
+/** JSON values ≤256KB; larger writes are rejected with a clear error. */
+const KV_VALUE_MAX_BYTES = 256 * 1024;
+
+const PLUGIN_HTTP_METHODS = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+]);
+
+const RPC_METHOD_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const BACKGROUND_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CLI_COMMAND_NAME_PATTERN = /^[a-z0-9-]+$/;
+const AGENT_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const THREAD_ACTION_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MENTION_PROVIDER_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const SETTING_KEY_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Copies of the server's hand-maintained reserved-name lists
+ * (RESERVED_BB_CLI_COMMANDS / RESERVED_AGENT_TOOL_NAMES in
+ * apps/server/src/services/plugins/plugin-api.ts) so registrations fail here
+ * the same way they fail there. Update alongside the server lists.
+ */
+const RESERVED_BB_CLI_COMMANDS: readonly string[] = [
+  "automation",
+  "environment",
+  "guide",
+  "help",
+  "manager",
+  "plugin",
+  "project",
+  "provider",
+  "status",
+  "theme",
+  "thread",
+  "ui",
+];
+const RESERVED_AGENT_TOOL_NAMES: readonly string[] = [
+  "update_environment_directory",
+];
+
+export type FakeLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface FakeLogEntry {
+  level: FakeLogLevel;
+  message: string;
+}
+
+export interface FakeHttpRouteRecord {
+  method: string;
+  path: string;
+  auth: PluginHttpAuthMode;
+  handler: PluginHttpHandler;
+}
+
+export interface FakeScheduleRecord {
+  name: string;
+  cron: string;
+  fn: () => void | Promise<void>;
+}
+
+export interface FakeServiceRecord {
+  name: string;
+  start: (signal: AbortSignal) => void | Promise<void>;
+}
+
+export interface FakeCliRecord {
+  name: string;
+  summary: string;
+  commands: PluginCliCommandInfo[];
+  run: (
+    argv: string[],
+    ctx: PluginCliContext,
+  ) => PluginCliResult | Promise<PluginCliResult>;
+}
+
+export interface FakeAgentToolRecord {
+  name: string;
+  description: string;
+  instructions: string | null;
+  /** JSON-schema object the host would send providers. */
+  inputSchema: unknown;
+  parse(
+    input: unknown,
+  ): { ok: true; value: unknown } | { ok: false; error: string };
+  execute(
+    params: unknown,
+    ctx: PluginAgentToolContext,
+  ): PluginAgentToolResult | Promise<PluginAgentToolResult>;
+}
+
+export interface FakeThreadActionRecord {
+  id: string;
+  title: string;
+  icon: string | null;
+  confirm: string | null;
+  run: (
+    ctx: PluginThreadActionContext,
+  ) => PluginThreadActionResult | Promise<PluginThreadActionResult>;
+}
+
+export interface FakeMentionProviderRecord {
+  id: string;
+  label: string;
+  search: (
+    ctx: PluginMentionSearchContext,
+  ) => PluginMentionItem[] | Promise<PluginMentionItem[]>;
+  resolve: (
+    itemId: string,
+  ) => { context: string } | Promise<{ context: string }>;
+}
+
+export interface FakeRealtimeSignal {
+  channel: string;
+  /** JSON-round-tripped, like the WS broadcast; `undefined` → `null`. */
+  payload: unknown;
+}
+
+/** Everything the plugin registered, exposed raw for assertions. */
+export interface FakePluginRegistrations {
+  settingsDescriptors: PluginSettingDescriptors;
+  httpRoutes: FakeHttpRouteRecord[];
+  rpcMethods: string[];
+  services: FakeServiceRecord[];
+  schedules: FakeScheduleRecord[];
+  cli: FakeCliRecord | null;
+  agentTools: FakeAgentToolRecord[];
+  threadActions: FakeThreadActionRecord[];
+  mentionProviders: FakeMentionProviderRecord[];
+}
+
+export interface FakePluginHarness {
+  readonly pluginId: string;
+  /** Every `bb.log` line, in order. */
+  readonly logEntries: FakeLogEntry[];
+  /** Every `bb.realtime.publish`, payload normalized like the wire. */
+  readonly realtimeSignals: FakeRealtimeSignal[];
+  /** Every `bb.status.needsConfiguration` message, in order. */
+  readonly needsConfigurationMessages: string[];
+  /** Recorded `bb.sdk` calls + stub control. */
+  readonly sdk: FakeSdkHarness;
+  readonly registrations: FakePluginRegistrations;
+  /**
+   * Apply a settings update the way the host's settings save does:
+   * validate against the declared descriptors (`null` unsets), store, and
+   * fire `onChange` listeners when effective values changed. Throws on
+   * unknown keys or wrong value types.
+   */
+  setSettings(
+    values: Record<string, PluginSettingValue | null>,
+  ): Promise<void>;
+  /**
+   * Invoke a registered rpc method with host semantics: the input and the
+   * result are JSON-round-tripped, and a handler failure rejects with an
+   * `Error` carrying the handler's message (what the frontend rpc client
+   * would surface). Throws for unregistered methods.
+   */
+  callRpc(method: string, input?: unknown): Promise<unknown>;
+  /**
+   * Invoke the plugin's CLI command with host semantics: the result's
+   * exitCode must be a number, stdout/stderr default to "", and a throwing
+   * run() becomes `{ exitCode: 1, stderr: "bb <name> failed: …" }`.
+   */
+  runCli(argv: string[], ctx?: PluginCliContext): Promise<PluginCliResult>;
+  /**
+   * Dispatch a request to a registered `bb.http` route (exact method+path
+   * match, like the host's V1 router) through a real Hono context. Auth
+   * modes are not enforced. A throwing handler yields the host's 500
+   * `{ ok: false, error: "plugin route failed: …" }` response.
+   */
+  fetchHttp(
+    method: string,
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response>;
+  /**
+   * Start a registered background service once, deterministically. `done`
+   * settles when `start` returns; abort `controller` to signal shutdown.
+   * A thrown NeedsConfigurationError (matched by name, like the host) is
+   * recorded via needsConfiguration and resolves `done`; other errors
+   * reject it.
+   */
+  runService(name: string): { controller: AbortController; done: Promise<void> };
+  /** Run a registered schedule's function once (no timers, no cron sweep). */
+  runSchedule(name: string): Promise<void>;
+  /**
+   * Deliver a thread lifecycle event to every `bb.on` handler. Handlers run
+   * sequentially; errors are caught and logged like the host's
+   * fire-and-forget dispatch, and returned for assertions.
+   */
+  emitThreadEvent<E extends PluginThreadEventName>(
+    event: E,
+    payload: PluginThreadEventPayloads[E],
+  ): Promise<{ errors: unknown[] }>;
+  /**
+   * Call a registered agent tool the way a provider tool-call would:
+   * arguments go through the tool's parse step (zod-validated for zod
+   * registrations; a parse failure throws), then execute. `ctx` fields
+   * default to "thread-test"/"project-test" and a fresh signal.
+   */
+  callAgentTool(
+    name: string,
+    input: unknown,
+    ctx?: Partial<PluginAgentToolContext>,
+  ): Promise<PluginAgentToolResult>;
+  /**
+   * Dispose like a host reload/disable: abort services started via
+   * runService, run onDispose hooks LIFO (isolated), close sqlite handles,
+   * then poison the `bb` handle (further use throws
+   * PluginContextStaleError). Idempotent.
+   */
+  dispose(): Promise<void>;
+}
+
+export interface CreateFakePluginHostOptions {
+  /** Defaults to "test-plugin". */
+  pluginId?: string;
+  /**
+   * Pre-seeded stored settings values (as if saved before this load) —
+   * including secret ones, which the fake keeps in memory instead of
+   * files. Values with the wrong type for their descriptor fall back to
+   * the descriptor default on read, like the host.
+   */
+  settings?: Record<string, PluginSettingValue>;
+  /** Initial `bb.sdk` stubs; extend later via `harness.sdk.stub`. */
+  sdk?: FakeSdkOverrides;
+}
+
+export interface FakePluginHost {
+  bb: BbPluginApi;
+  harness: FakePluginHarness;
+}
+
+// ---------------------------------------------------------------------------
+// Settings descriptor validation — ported from the server's
+// plugin-settings.ts so plugins trip over the same errors here.
+// ---------------------------------------------------------------------------
+
+const settingsBaseFields = {
+  label: z.string().min(1),
+  description: z.string().min(1).optional(),
+};
+
+const settingDescriptorSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("string"),
+      ...settingsBaseFields,
+      secret: z.literal(true).optional(),
+      default: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("boolean"),
+      ...settingsBaseFields,
+      default: z.boolean().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("select"),
+      ...settingsBaseFields,
+      options: z.array(z.string().min(1)).min(1),
+      default: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("project"),
+      ...settingsBaseFields,
+      default: z.string().optional(),
+    })
+    .strict(),
+]);
+
+function registerSettingDescriptors(
+  target: PluginSettingDescriptors,
+  added: Record<string, unknown>,
+): PluginSettingDescriptors {
+  const validated: PluginSettingDescriptors = {};
+  for (const [key, raw] of Object.entries(added)) {
+    if (!SETTING_KEY_PATTERN.test(key)) {
+      throw new Error(
+        `invalid setting key "${key}" — use letters, digits, "-" and "_"`,
+      );
+    }
+    if (key in target) {
+      throw new Error(`setting "${key}" is already defined`);
+    }
+    const parsed = settingDescriptorSchema.safeParse(raw);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const path = issue?.path.join(".") ?? "";
+      throw new Error(
+        `invalid descriptor for setting "${key}"${path ? ` (${path})` : ""}: ${issue?.message ?? "unknown error"}`,
+      );
+    }
+    const descriptor = parsed.data;
+    if (
+      descriptor.type === "select" &&
+      descriptor.default !== undefined &&
+      !descriptor.options.includes(descriptor.default)
+    ) {
+      throw new Error(
+        `default for setting "${key}" must be one of its options`,
+      );
+    }
+    validated[key] = descriptor;
+  }
+  Object.assign(target, validated);
+  return validated;
+}
+
+/** Effective typed values: stored value when valid, else the default, else undefined. */
+function readSettingsValues(
+  descriptors: PluginSettingDescriptors,
+  stored: Map<string, PluginSettingValue>,
+): Record<string, PluginSettingValue | undefined> {
+  const values: Record<string, PluginSettingValue | undefined> = {};
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    let value = stored.get(key);
+    const expected = descriptor.type === "boolean" ? "boolean" : "string";
+    if (typeof value !== expected) value = undefined;
+    if (
+      descriptor.type === "select" &&
+      typeof value === "string" &&
+      !descriptor.options.includes(value)
+    ) {
+      value = undefined;
+    }
+    values[key] = value ?? descriptor.default;
+  }
+  return values;
+}
+
+function validateSettingsUpdate(
+  descriptors: PluginSettingDescriptors,
+  values: Record<string, unknown>,
+): string[] {
+  const errors: string[] = [];
+  for (const [key, value] of Object.entries(values)) {
+    const descriptor: PluginSettingDescriptor | undefined = descriptors[key];
+    if (!descriptor) {
+      errors.push(`unknown setting "${key}"`);
+      continue;
+    }
+    if (value === null) continue; // unset
+    if (descriptor.type === "boolean") {
+      if (typeof value !== "boolean") {
+        errors.push(`setting "${key}" expects a boolean`);
+      }
+      continue;
+    }
+    if (typeof value !== "string") {
+      errors.push(`setting "${key}" expects a string`);
+      continue;
+    }
+    if (descriptor.type === "select" && !descriptor.options.includes(value)) {
+      errors.push(
+        `setting "${key}" must be one of: ${descriptor.options.join(", ")}`,
+      );
+    }
+  }
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+
+function isNeedsConfigurationError(error: unknown): error is Error {
+  return error instanceof Error && error.name === "NeedsConfigurationError";
+}
+
+/** Duck-typed zod detection, same as the host (plugins may carry their own zod). */
+function isZodSchemaLike(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { safeParse?: unknown }).safeParse === "function"
+  );
+}
+
+function summarizeParseIssues(error: unknown): string {
+  const issues = (
+    error as { issues?: Array<{ path?: PropertyKey[]; message?: string }> }
+  )?.issues;
+  if (Array.isArray(issues) && issues.length > 0) {
+    return issues
+      .map((issue) => {
+        const path =
+          Array.isArray(issue.path) && issue.path.length > 0
+            ? issue.path.join(".")
+            : "(input)";
+        return `${path}: ${issue.message ?? "invalid"}`;
+      })
+      .join("; ");
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function jsonRoundTrip(value: unknown, what: string): unknown {
+  if (value === undefined) return undefined;
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    json = undefined;
+  }
+  if (json === undefined) {
+    throw new Error(`${what} is not JSON-serializable`);
+  }
+  return JSON.parse(json);
+}
+
+export function createFakePluginHost(
+  options: CreateFakePluginHostOptions = {},
+): FakePluginHost {
+  const pluginId = options.pluginId ?? "test-plugin";
+  let invalidated = false;
+  let disposed = false;
+
+  function assertLive(): void {
+    if (invalidated) throw new PluginContextStaleError(pluginId);
+  }
+
+  // --- log ---
+  const logEntries: FakeLogEntry[] = [];
+  function emitLog(level: FakeLogLevel, message: string): void {
+    logEntries.push({ level, message });
+  }
+  const log: PluginLogger = {
+    debug: (message) => emitLog("debug", message),
+    info: (message) => emitLog("info", message),
+    warn: (message) => emitLog("warn", message),
+    error: (message) => emitLog("error", message),
+  };
+
+  // --- storage ---
+  const kvRows = new Map<string, string>();
+  const kv: PluginKvStorage = {
+    async get(key) {
+      assertLive();
+      const raw = kvRows.get(key);
+      if (raw === undefined) return undefined;
+      return JSON.parse(raw);
+    },
+    async set(key, value) {
+      assertLive();
+      const json = JSON.stringify(value);
+      if (json === undefined) {
+        throw new Error(`kv value for "${key}" is not JSON-serializable`);
+      }
+      const bytes = Buffer.byteLength(json, "utf8");
+      if (bytes > KV_VALUE_MAX_BYTES) {
+        throw new Error(
+          `kv value for "${key}" is ${bytes} bytes; the limit is ${KV_VALUE_MAX_BYTES} (256KB). ` +
+            `Store large data in storage.sqlite() instead.`,
+        );
+      }
+      kvRows.set(key, json);
+    },
+    async delete(key) {
+      assertLive();
+      kvRows.delete(key);
+    },
+    async list(prefix) {
+      assertLive();
+      return [...kvRows.keys()]
+        .filter((key) => prefix === undefined || key.startsWith(prefix))
+        .sort();
+    },
+  };
+
+  // One shared :memory: handle: every sqlite() call sees the same data,
+  // like the host's handles over one on-disk file.
+  let sqliteHandle: Database.Database | undefined;
+  const storage: PluginStorage = {
+    kv,
+    sqlite() {
+      assertLive();
+      if (!sqliteHandle) {
+        sqliteHandle = new Database(":memory:");
+        sqliteHandle.pragma("busy_timeout = 5000");
+      }
+      return sqliteHandle;
+    },
+    migrate(database, statements) {
+      assertLive();
+      database.exec(
+        "CREATE TABLE IF NOT EXISTS _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)",
+      );
+      const applied = new Set(
+        (
+          database.prepare("SELECT id FROM _bb_migrations").all() as Array<{
+            id: number;
+          }>
+        ).map((row) => row.id),
+      );
+      const record = database.prepare(
+        "INSERT INTO _bb_migrations (id, applied_at) VALUES (?, ?)",
+      );
+      database.transaction(() => {
+        statements.forEach((statement, index) => {
+          if (applied.has(index)) return;
+          database.exec(statement);
+          record.run(index, Date.now());
+        });
+      })();
+    },
+  };
+
+  // --- settings ---
+  const settingsDescriptors: PluginSettingDescriptors = {};
+  const settingsListeners: Array<
+    (
+      next: Record<string, PluginSettingValue | undefined>,
+      prev: Record<string, PluginSettingValue | undefined>,
+    ) => void
+  > = [];
+  const storedSettings = new Map<string, PluginSettingValue>(
+    Object.entries(options.settings ?? {}),
+  );
+
+  const settings: PluginSettings = {
+    define(descriptors) {
+      assertLive();
+      registerSettingDescriptors(
+        settingsDescriptors,
+        descriptors as Record<string, unknown>,
+      );
+      type Values = PluginSettingsValues<typeof descriptors>;
+      return {
+        async get() {
+          assertLive();
+          return readSettingsValues(
+            settingsDescriptors,
+            storedSettings,
+          ) as Values;
+        },
+        onChange(listener) {
+          assertLive();
+          settingsListeners.push(
+            listener as (typeof settingsListeners)[number],
+          );
+        },
+      };
+    },
+  };
+
+  // --- http ---
+  const httpRoutes: FakeHttpRouteRecord[] = [];
+  const http: PluginHttp = {
+    route(method, path, handler, opts) {
+      assertLive();
+      const normalizedMethod = String(method).toUpperCase();
+      if (!PLUGIN_HTTP_METHODS.has(normalizedMethod)) {
+        throw new Error(
+          `invalid http method "${String(method)}" — use one of: ${[...PLUGIN_HTTP_METHODS].join(", ")}`,
+        );
+      }
+      if (typeof path !== "string" || !path.startsWith("/")) {
+        throw new Error(
+          `http route path must be a string starting with "/", got ${JSON.stringify(path)}`,
+        );
+      }
+      if (typeof handler !== "function") {
+        throw new Error(
+          `http route handler for ${normalizedMethod} ${path} must be a function`,
+        );
+      }
+      const auth = opts?.auth ?? "local";
+      if (auth !== "local" && auth !== "token" && auth !== "none") {
+        throw new Error(
+          `invalid auth mode "${String(auth)}" for ${normalizedMethod} ${path} — use "local", "token", or "none"`,
+        );
+      }
+      if (
+        httpRoutes.some(
+          (route) => route.method === normalizedMethod && route.path === path,
+        )
+      ) {
+        throw new Error(
+          `http route ${normalizedMethod} ${path} is already registered`,
+        );
+      }
+      httpRoutes.push({ method: normalizedMethod, path, auth, handler });
+    },
+  };
+
+  // --- rpc ---
+  const rpcHandlers = new Map<string, (input: unknown) => unknown>();
+  const rpc: PluginRpc = {
+    register(handlers) {
+      assertLive();
+      for (const [name, handler] of Object.entries(handlers)) {
+        if (!RPC_METHOD_PATTERN.test(name)) {
+          throw new Error(
+            `invalid rpc method name "${name}" — use letters, digits, "-" and "_"`,
+          );
+        }
+        if (typeof handler !== "function") {
+          throw new Error(`rpc method "${name}" must be a function`);
+        }
+        if (rpcHandlers.has(name)) {
+          throw new Error(`rpc method "${name}" is already registered`);
+        }
+        rpcHandlers.set(name, handler as (input: unknown) => unknown);
+      }
+    },
+  };
+
+  // --- realtime ---
+  const realtimeSignals: FakeRealtimeSignal[] = [];
+  const realtime: PluginRealtime = {
+    publish(channel, payload) {
+      assertLive();
+      if (typeof channel !== "string" || channel.length === 0) {
+        throw new Error("realtime channel must be a non-empty string");
+      }
+      const normalized =
+        payload === undefined
+          ? null
+          : (jsonRoundTrip(
+              payload,
+              `realtime payload for channel "${channel}"`,
+            ) ?? null);
+      realtimeSignals.push({ channel, payload: normalized });
+    },
+  };
+
+  // --- background ---
+  const services: FakeServiceRecord[] = [];
+  const schedules: FakeScheduleRecord[] = [];
+  const background: PluginBackground = {
+    service(name, service) {
+      assertLive();
+      if (typeof name !== "string" || !BACKGROUND_NAME_PATTERN.test(name)) {
+        throw new Error(
+          `invalid service name ${JSON.stringify(name)} — use letters, digits, "-" and "_"`,
+        );
+      }
+      if (services.some((record) => record.name === name)) {
+        throw new Error(`background service "${name}" is already registered`);
+      }
+      if (typeof service?.start !== "function") {
+        throw new Error(
+          `background service "${name}" must provide a start(signal) function`,
+        );
+      }
+      services.push({ name, start: service.start.bind(service) });
+    },
+    schedule(name, cron, fn) {
+      assertLive();
+      if (typeof name !== "string" || !BACKGROUND_NAME_PATTERN.test(name)) {
+        throw new Error(
+          `invalid schedule name ${JSON.stringify(name)} — use letters, digits, "-" and "_"`,
+        );
+      }
+      if (schedules.some((record) => record.name === name)) {
+        throw new Error(`schedule "${name}" is already registered`);
+      }
+      try {
+        CronExpressionParser.parse(String(cron));
+      } catch (error) {
+        throw new Error(
+          `invalid cron ${JSON.stringify(cron)} for schedule "${name}": ${errorMessage(error)}`,
+        );
+      }
+      if (typeof fn !== "function") {
+        throw new Error(`schedule "${name}" must provide a function`);
+      }
+      schedules.push({ name, cron: String(cron), fn });
+    },
+  };
+
+  // --- cli ---
+  const cliRecord: { registration: FakeCliRecord | null } = {
+    registration: null,
+  };
+  const cli: PluginCli = {
+    register(registration) {
+      assertLive();
+      const name = registration?.name;
+      if (typeof name !== "string" || !CLI_COMMAND_NAME_PATTERN.test(name)) {
+        throw new Error(
+          `invalid cli command name ${JSON.stringify(name)} — use lowercase letters, digits, and "-"`,
+        );
+      }
+      if (RESERVED_BB_CLI_COMMANDS.includes(name)) {
+        throw new Error(
+          `cli command name "${name}" is reserved by the bb CLI — pick another name`,
+        );
+      }
+      if (
+        typeof registration.summary !== "string" ||
+        registration.summary.trim().length === 0
+      ) {
+        throw new Error(`cli command "${name}" must provide a summary`);
+      }
+      const commands = registration.commands ?? [];
+      if (!Array.isArray(commands)) {
+        throw new Error(`cli command "${name}" commands must be an array`);
+      }
+      const validatedCommands = commands.map((command, index) => {
+        if (
+          typeof command?.name !== "string" ||
+          !CLI_COMMAND_NAME_PATTERN.test(command.name) ||
+          typeof command.summary !== "string" ||
+          typeof command.usage !== "string"
+        ) {
+          throw new Error(
+            `cli command "${name}" commands[${index}] must be { name: [a-z0-9-]+, summary, usage }`,
+          );
+        }
+        return {
+          name: command.name,
+          summary: command.summary,
+          usage: command.usage,
+        };
+      });
+      if (typeof registration.run !== "function") {
+        throw new Error(
+          `cli command "${name}" must provide a run(argv, ctx) function`,
+        );
+      }
+      cliRecord.registration = {
+        name,
+        summary: registration.summary,
+        commands: validatedCommands,
+        run: registration.run.bind(registration),
+      };
+    },
+  };
+
+  // --- agents ---
+  const agentTools: FakeAgentToolRecord[] = [];
+  const agents: PluginAgents = {
+    registerTool(tool: {
+      name: string;
+      description: string;
+      instructions?: string;
+      parameters: unknown;
+      execute(
+        params: never,
+        ctx: PluginAgentToolContext,
+      ): PluginAgentToolResult | Promise<PluginAgentToolResult>;
+    }) {
+      assertLive();
+      const name = tool?.name;
+      if (typeof name !== "string" || !AGENT_TOOL_NAME_PATTERN.test(name)) {
+        throw new Error(
+          `invalid tool name ${JSON.stringify(name)} — use letters, digits, "-" and "_"`,
+        );
+      }
+      if (RESERVED_AGENT_TOOL_NAMES.includes(name)) {
+        throw new Error(
+          `tool name "${name}" is a built-in bb tool — pick another name`,
+        );
+      }
+      if (
+        typeof tool.description !== "string" ||
+        tool.description.trim().length === 0
+      ) {
+        throw new Error(`tool "${name}" must provide a description`);
+      }
+      if (
+        tool.instructions !== undefined &&
+        typeof tool.instructions !== "string"
+      ) {
+        throw new Error(`tool "${name}" instructions must be a string`);
+      }
+      if (typeof tool.execute !== "function") {
+        throw new Error(
+          `tool "${name}" must provide an execute(params, ctx) function`,
+        );
+      }
+      const parameters: unknown = tool.parameters;
+      let inputSchema: unknown;
+      let parse: FakeAgentToolRecord["parse"];
+      if (isZodSchemaLike(parameters)) {
+        try {
+          inputSchema = z.toJSONSchema(parameters as z.ZodType, {
+            io: "input",
+          });
+        } catch (error) {
+          throw new Error(
+            `tool "${name}" parameters look like a zod schema but could not be converted to JSON Schema (${errorMessage(error)}) — use zod 4, or pass a plain JSON-schema object`,
+          );
+        }
+        parse = (input) => {
+          const result = (parameters as z.ZodType).safeParse(input);
+          if (result.success) return { ok: true, value: result.data };
+          return { ok: false, error: summarizeParseIssues(result.error) };
+        };
+      } else if (
+        typeof parameters === "object" &&
+        parameters !== null &&
+        !Array.isArray(parameters)
+      ) {
+        try {
+          inputSchema = JSON.parse(JSON.stringify(parameters));
+        } catch {
+          throw new Error(
+            `tool "${name}" parameters JSON schema is not JSON-serializable`,
+          );
+        }
+        parse = (input) => ({ ok: true, value: input });
+      } else {
+        throw new Error(
+          `tool "${name}" parameters must be a zod schema or a JSON-schema object`,
+        );
+      }
+      const record: FakeAgentToolRecord = {
+        name,
+        description: tool.description,
+        instructions:
+          tool.instructions !== undefined && tool.instructions.trim().length > 0
+            ? tool.instructions
+            : null,
+        inputSchema,
+        parse,
+        execute: (
+          tool.execute as (
+            params: unknown,
+            ctx: PluginAgentToolContext,
+          ) => PluginAgentToolResult | Promise<PluginAgentToolResult>
+        ).bind(tool),
+      };
+      const existingIndex = agentTools.findIndex(
+        (existing) => existing.name === name,
+      );
+      if (existingIndex >= 0) {
+        agentTools[existingIndex] = record;
+      } else {
+        agentTools.push(record);
+      }
+    },
+  };
+
+  // --- ui ---
+  const threadActions: FakeThreadActionRecord[] = [];
+  const mentionProviders: FakeMentionProviderRecord[] = [];
+  const ui: PluginUi = {
+    registerThreadAction(action) {
+      assertLive();
+      const id = action?.id;
+      if (typeof id !== "string" || !THREAD_ACTION_ID_PATTERN.test(id)) {
+        throw new Error(
+          `invalid thread action id ${JSON.stringify(id)} — use letters, digits, "-" and "_"`,
+        );
+      }
+      if (threadActions.some((record) => record.id === id)) {
+        throw new Error(`thread action "${id}" is already registered`);
+      }
+      if (
+        typeof action.title !== "string" ||
+        action.title.trim().length === 0
+      ) {
+        throw new Error(`thread action "${id}" must provide a title`);
+      }
+      if (action.icon !== undefined && typeof action.icon !== "string") {
+        throw new Error(`thread action "${id}" icon must be a string`);
+      }
+      if (action.confirm !== undefined && typeof action.confirm !== "string") {
+        throw new Error(`thread action "${id}" confirm must be a string`);
+      }
+      if (typeof action.run !== "function") {
+        throw new Error(
+          `thread action "${id}" must provide a run({ threadId, projectId }) function`,
+        );
+      }
+      threadActions.push({
+        id,
+        title: action.title,
+        icon:
+          action.icon !== undefined && action.icon.trim().length > 0
+            ? action.icon
+            : null,
+        confirm:
+          action.confirm !== undefined && action.confirm.trim().length > 0
+            ? action.confirm
+            : null,
+        run: action.run.bind(action),
+      });
+    },
+    registerMentionProvider(provider) {
+      assertLive();
+      const id = provider?.id;
+      if (typeof id !== "string" || !MENTION_PROVIDER_ID_PATTERN.test(id)) {
+        throw new Error(
+          `invalid mention provider id ${JSON.stringify(id)} — use letters, digits, "-" and "_"`,
+        );
+      }
+      if (mentionProviders.some((record) => record.id === id)) {
+        throw new Error(`mention provider "${id}" is already registered`);
+      }
+      if (
+        typeof provider.label !== "string" ||
+        provider.label.trim().length === 0
+      ) {
+        throw new Error(`mention provider "${id}" must provide a label`);
+      }
+      if (typeof provider.search !== "function") {
+        throw new Error(
+          `mention provider "${id}" must provide a search({ query, projectId, threadId }) function`,
+        );
+      }
+      if (typeof provider.resolve !== "function") {
+        throw new Error(
+          `mention provider "${id}" must provide a resolve(itemId) function`,
+        );
+      }
+      mentionProviders.push({
+        id,
+        label: provider.label.trim(),
+        search: provider.search.bind(provider),
+        resolve: provider.resolve.bind(provider),
+      });
+    },
+  };
+
+  // --- status ---
+  const needsConfigurationMessages: string[] = [];
+  const status: PluginStatusApi = {
+    needsConfiguration(message) {
+      assertLive();
+      needsConfigurationMessages.push(
+        typeof message === "string" && message.length > 0
+          ? message
+          : "needs configuration",
+      );
+    },
+  };
+
+  // --- sdk ---
+  const { sdk, harness: sdkHarness } = createFakeSdk({
+    pluginId,
+    overrides: options.sdk,
+  });
+
+  // --- thread events / dispose ---
+  const threadEventHandlers: {
+    [E in PluginThreadEventName]: Array<PluginThreadEventHandler<E>>;
+  } = {
+    "thread.created": [],
+    "thread.idle": [],
+    "thread.failed": [],
+  };
+  const disposeHooks: Array<() => void | Promise<void>> = [];
+  const serviceControllers: AbortController[] = [];
+
+  const bb: BbPluginApi = {
+    pluginId,
+    log,
+    settings,
+    storage,
+    http,
+    rpc,
+    realtime,
+    background,
+    cli,
+    agents,
+    ui,
+    status,
+    get sdk() {
+      assertLive();
+      return sdk;
+    },
+    on(event, handler) {
+      assertLive();
+      const handlers = threadEventHandlers[event];
+      if (handlers === undefined) {
+        throw new Error(
+          `unknown event "${String(event)}" — supported events: ${Object.keys(
+            threadEventHandlers,
+          ).join(", ")}`,
+        );
+      }
+      handlers.push(handler);
+    },
+    onDispose(hook) {
+      assertLive();
+      disposeHooks.push(hook);
+    },
+  };
+
+  const harness: FakePluginHarness = {
+    pluginId,
+    logEntries,
+    realtimeSignals,
+    needsConfigurationMessages,
+    sdk: sdkHarness,
+    registrations: {
+      settingsDescriptors,
+      httpRoutes,
+      get rpcMethods() {
+        return [...rpcHandlers.keys()];
+      },
+      services,
+      schedules,
+      get cli() {
+        return cliRecord.registration;
+      },
+      agentTools,
+      threadActions,
+      mentionProviders,
+    },
+
+    async setSettings(values) {
+      const errors = validateSettingsUpdate(settingsDescriptors, values);
+      if (errors.length > 0) {
+        throw new Error(errors.join("; "));
+      }
+      const prev = readSettingsValues(settingsDescriptors, storedSettings);
+      for (const [key, value] of Object.entries(values)) {
+        if (value === null) storedSettings.delete(key);
+        else storedSettings.set(key, value);
+      }
+      const next = readSettingsValues(settingsDescriptors, storedSettings);
+      if (JSON.stringify(next) === JSON.stringify(prev)) return;
+      for (const listener of settingsListeners) {
+        try {
+          listener(next, prev);
+        } catch (error) {
+          emitLog(
+            "warn",
+            `settings onChange listener failed: ${errorMessage(error)}`,
+          );
+        }
+      }
+    },
+
+    async callRpc(method, input) {
+      const handler = rpcHandlers.get(method);
+      if (!handler) {
+        throw new Error(`plugin "${pluginId}" has no rpc method "${method}"`);
+      }
+      const parsedInput =
+        input === undefined
+          ? undefined
+          : jsonRoundTrip(input, `rpc "${method}" input`);
+      const result = await handler(parsedInput);
+      // Same round-trip as the dispatcher: a bigint/circular result is this
+      // call's clear error, not a serializer crash later.
+      const json = JSON.stringify(result);
+      return json === undefined ? undefined : (JSON.parse(json) as unknown);
+    },
+
+    async runCli(argv, ctx = {}) {
+      const registration = cliRecord.registration;
+      if (!registration) {
+        throw new Error(`plugin "${pluginId}" registers no CLI command`);
+      }
+      try {
+        const result = await registration.run(argv, ctx);
+        if (typeof result?.exitCode !== "number") {
+          throw new Error(
+            "cli run() must return { exitCode: number, stdout?, stderr? }",
+          );
+        }
+        return {
+          exitCode: result.exitCode,
+          stdout: typeof result.stdout === "string" ? result.stdout : "",
+          stderr: typeof result.stderr === "string" ? result.stderr : "",
+        };
+      } catch (error) {
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: `bb ${registration.name} failed: ${errorMessage(error)}`,
+        };
+      }
+    },
+
+    async fetchHttp(method, path, init) {
+      const normalizedMethod = String(method).toUpperCase();
+      const pathname = new URL(path, "http://plugin.test").pathname;
+      const route = httpRoutes.find(
+        (candidate) =>
+          candidate.method === normalizedMethod &&
+          candidate.path === pathname,
+      );
+      if (!route) {
+        throw new Error(
+          `no http route ${normalizedMethod} ${pathname} is registered — ` +
+            `registered: ${
+              httpRoutes.map((r) => `${r.method} ${r.path}`).join(", ") ||
+              "(none)"
+            }`,
+        );
+      }
+      const app = new Hono();
+      app.on(route.method, route.path, async (context) => {
+        try {
+          const response = await route.handler(context);
+          if (!(response instanceof Response)) {
+            throw new Error("http route handler must return a Response");
+          }
+          return response;
+        } catch (error) {
+          const message = errorMessage(error);
+          emitLog(
+            "warn",
+            `http ${route.method} ${route.path} failed: ${message}`,
+          );
+          return context.json(
+            { ok: false, error: `plugin route failed: ${message}` },
+            500,
+          );
+        }
+      });
+      return app.request(path, { ...init, method: normalizedMethod });
+    },
+
+    runService(name) {
+      const service = services.find((record) => record.name === name);
+      if (!service) {
+        throw new Error(`no background service "${name}" is registered`);
+      }
+      const controller = new AbortController();
+      serviceControllers.push(controller);
+      // start() runs synchronously (like the host's post-factory start), so
+      // it observes an abort() issued right after runService returns.
+      let started: Promise<void>;
+      try {
+        started = Promise.resolve(service.start(controller.signal)).then(
+          () => undefined,
+        );
+      } catch (error) {
+        started = Promise.reject(error);
+      }
+      const done = started.catch((error: unknown) => {
+        if (isNeedsConfigurationError(error)) {
+          needsConfigurationMessages.push(error.message);
+          return undefined;
+        }
+        throw error;
+      });
+      return { controller, done };
+    },
+
+    async runSchedule(name) {
+      const schedule = schedules.find((record) => record.name === name);
+      if (!schedule) {
+        throw new Error(`no schedule "${name}" is registered`);
+      }
+      await schedule.fn();
+    },
+
+    async emitThreadEvent(event, payload) {
+      const errors: unknown[] = [];
+      for (const handler of [...threadEventHandlers[event]]) {
+        try {
+          await handler(payload);
+        } catch (error) {
+          errors.push(error);
+          emitLog("warn", `${event} handler failed: ${errorMessage(error)}`);
+        }
+      }
+      return { errors };
+    },
+
+    async callAgentTool(name, input, ctx) {
+      const record = agentTools.find((tool) => tool.name === name);
+      if (!record) {
+        throw new Error(`no agent tool "${name}" is registered`);
+      }
+      const parsed = record.parse(input);
+      if (!parsed.ok) {
+        throw new Error(`tool "${name}" arguments are invalid: ${parsed.error}`);
+      }
+      return record.execute(parsed.value, {
+        threadId: ctx?.threadId ?? "thread-test",
+        projectId: ctx?.projectId ?? "project-test",
+        signal: ctx?.signal ?? new AbortController().signal,
+      });
+    },
+
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      // Host order (§3): services first, then hooks LIFO (isolated), then
+      // vended sqlite handles, then handle invalidation.
+      for (const controller of serviceControllers) controller.abort();
+      for (const hook of [...disposeHooks].reverse()) {
+        try {
+          await hook();
+        } catch (error) {
+          emitLog("warn", `dispose hook failed: ${errorMessage(error)}`);
+        }
+      }
+      if (sqliteHandle) {
+        try {
+          sqliteHandle.close();
+        } catch (error) {
+          emitLog("warn", `sqlite close failed: ${errorMessage(error)}`);
+        }
+      }
+      invalidated = true;
+    },
+  };
+
+  return { bb, harness };
+}

--- a/packages/plugin-sdk/src/testing/fake-sdk.ts
+++ b/packages/plugin-sdk/src/testing/fake-sdk.ts
@@ -1,0 +1,138 @@
+import type { BbSdk } from "@bb/sdk";
+
+/**
+ * Recordable `bb.sdk` stand-in for {@link createFakePluginHost}. Every call
+ * through the fake is recorded (post plugin-attribution defaulting, so
+ * assertions see what the server would receive); calls without a stubbed
+ * implementation throw with a message naming the exact path to stub.
+ */
+
+/** One recorded `bb.sdk` call. `path` is dot-joined, e.g. "threads.spawn". */
+export interface FakeSdkCall {
+  path: string;
+  args: unknown[];
+}
+
+/**
+ * A stub keeps the real method's parameter types but may return anything —
+ * tests usually only build the fields the plugin reads, not the full wire
+ * response.
+ */
+type LooseStub<F> = F extends (...args: infer A) => unknown
+  ? (...args: A) => unknown
+  : never;
+
+/**
+ * Stub implementations keyed like `BbSdk`: an object per area with a subset
+ * of its methods, or a function for the root-level members (`on`).
+ */
+export type FakeSdkOverrides = {
+  [K in keyof BbSdk]?: BbSdk[K] extends (...args: never[]) => unknown
+    ? LooseStub<BbSdk[K]>
+    : { [M in keyof BbSdk[K]]?: LooseStub<BbSdk[K][M]> };
+};
+
+export interface FakeSdkHarness {
+  /** Every `bb.sdk` call in order, including ones whose stub threw. */
+  readonly calls: FakeSdkCall[];
+  /** Argument lists of the calls to one dot-joined path. */
+  callsTo(path: string): unknown[][];
+  /** Add or replace one method's implementation after creation. */
+  stub(path: string, implementation: (...args: never[]) => unknown): void;
+}
+
+/**
+ * Mirrors the server's `wrapSdkForPlugin`: `threads.spawn` defaults
+ * `origin` to "plugin" and `originPluginId` to the plugin's id unless the
+ * caller set them explicitly.
+ */
+function withSpawnAttribution(pluginId: string, args: unknown[]): unknown[] {
+  const [first, ...rest] = args;
+  if (typeof first !== "object" || first === null) return args;
+  const spawnArgs = first as { origin?: string; originPluginId?: string };
+  const origin = spawnArgs.origin ?? "plugin";
+  return [
+    {
+      ...spawnArgs,
+      origin,
+      ...(origin === "plugin"
+        ? { originPluginId: spawnArgs.originPluginId ?? pluginId }
+        : {}),
+    },
+    ...rest,
+  ];
+}
+
+export function createFakeSdk(options: {
+  pluginId: string;
+  overrides?: FakeSdkOverrides;
+}): { sdk: BbSdk; harness: FakeSdkHarness } {
+  const calls: FakeSdkCall[] = [];
+  const stubs = new Map<string, (...args: unknown[]) => unknown>();
+
+  for (const [key, value] of Object.entries(options.overrides ?? {})) {
+    if (typeof value === "function") {
+      stubs.set(key, value as (...args: unknown[]) => unknown);
+      continue;
+    }
+    for (const [method, implementation] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (typeof implementation === "function") {
+        stubs.set(
+          `${key}.${method}`,
+          implementation as (...args: unknown[]) => unknown,
+        );
+      }
+    }
+  }
+
+  function invoke(path: string, rawArgs: unknown[]): unknown {
+    const args =
+      path === "threads.spawn"
+        ? withSpawnAttribution(options.pluginId, rawArgs)
+        : rawArgs;
+    calls.push({ path, args });
+    const stub = stubs.get(path);
+    if (!stub) {
+      throw new Error(
+        `bb.sdk.${path} is not stubbed — pass an implementation via ` +
+          `createFakePluginHost({ sdk: { ... } }) or harness.sdk.stub("${path}", fn)`,
+      );
+    }
+    return stub(...args);
+  }
+
+  const nodes = new Map<string, unknown>();
+  /** Callable-and-traversable proxy: `sdk.threads.spawn(...)` and `sdk.on(...)` both work. */
+  function node(path: string): unknown {
+    const cached = nodes.get(path);
+    if (cached) return cached;
+    const created = new Proxy(function () {}, {
+      get(_target, prop) {
+        // Not thenable: an accidentally awaited node must not hang.
+        if (typeof prop !== "string" || prop === "then") return undefined;
+        return node(path === "" ? prop : `${path}.${prop}`);
+      },
+      apply(_target, _thisArg, args: unknown[]) {
+        return invoke(path, args);
+      },
+    });
+    nodes.set(path, created);
+    return created;
+  }
+
+  const harness: FakeSdkHarness = {
+    calls,
+    callsTo(path) {
+      return calls.filter((call) => call.path === path).map((call) => call.args);
+    },
+    stub(path, implementation) {
+      stubs.set(path, implementation as (...args: unknown[]) => unknown);
+    },
+  };
+
+  // The proxy is the genuinely unknowable boundary: it answers any BbSdk
+  // shape at runtime, and the type is re-imposed here once.
+  return { sdk: node("") as BbSdk, harness };
+}

--- a/packages/plugin-sdk/src/testing/fixtures.ts
+++ b/packages/plugin-sdk/src/testing/fixtures.ts
@@ -1,0 +1,37 @@
+import type { ThreadResponse } from "@bb/server-contract";
+
+/**
+ * A complete, deterministic `ThreadResponse` for thread lifecycle event
+ * payloads (`harness.emitThreadEvent`). Defaults are the minimal idle
+ * thread; override the fields the test cares about. If the contract grows a
+ * required field, this builder fails typecheck — update the default here.
+ */
+export function makeThreadResponse(
+  overrides: Partial<ThreadResponse> = {},
+): ThreadResponse {
+  return {
+    id: "thread-1",
+    projectId: "project-1",
+    environmentId: null,
+    providerId: "test-provider",
+    title: null,
+    titleFallback: null,
+    folderId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    childOrigin: null,
+    originPluginId: null,
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+    canSpawnChild: true,
+    ...overrides,
+  };
+}

--- a/packages/plugin-sdk/src/testing/index.ts
+++ b/packages/plugin-sdk/src/testing/index.ts
@@ -1,0 +1,34 @@
+/**
+ * `@bb/plugin-sdk/testing` — the backend plugin test harness: a fake BB
+ * plugin host (`createFakePluginHost`) whose `bb` satisfies `BbPluginApi`,
+ * plus fixtures. Workspace/in-repo consumers only for V1: this subpath is
+ * not part of the bundled `.d.ts` scaffolded plugins receive.
+ *
+ * The frontend harness (loadPluginApp/renderSlot) lives at
+ * `@bb/plugin-sdk/testing/app` so backend-only tests never load React.
+ */
+export {
+  createFakePluginHost,
+  PluginContextStaleError,
+  type CreateFakePluginHostOptions,
+  type FakeAgentToolRecord,
+  type FakeCliRecord,
+  type FakeHttpRouteRecord,
+  type FakeLogEntry,
+  type FakeLogLevel,
+  type FakeMentionProviderRecord,
+  type FakePluginHarness,
+  type FakePluginHost,
+  type FakePluginRegistrations,
+  type FakeRealtimeSignal,
+  type FakeScheduleRecord,
+  type FakeServiceRecord,
+  type FakeThreadActionRecord,
+} from "./fake-plugin-host.js";
+export {
+  createFakeSdk,
+  type FakeSdkCall,
+  type FakeSdkHarness,
+  type FakeSdkOverrides,
+} from "./fake-sdk.js";
+export { makeThreadResponse } from "./fixtures.js";

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    name: "@bb/plugin-sdk",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -986,17 +986,45 @@ importers:
       '@bb/plugin-sdk':
         specifier: workspace:*
         version: link:../../../packages/plugin-sdk
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.13
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@2.0.1)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(typescript@5.9.3))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  examples/plugins/slack-bot: {}
+  examples/plugins/slack-bot:
+    devDependencies:
+      '@bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-sdk
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(typescript@5.9.3))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/plugins/small-ux-pack: {}
 
@@ -1585,10 +1613,6 @@ importers:
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(typescript@5.9.3))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugin-sdk:
-    dependencies:
-      react:
-        specifier: ^19.0.0
-        version: 19.2.4
     devDependencies:
       '@bb/domain':
         specifier: workspace:*
@@ -1602,6 +1626,9 @@ importers:
       '@bb/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
@@ -1614,9 +1641,21 @@ importers:
       better-sqlite3:
         specifier: 12.10.0
         version: 12.10.0
+      cron-parser:
+        specifier: ^5.5.0
+        version: 5.5.0
       hono:
         specifier: 4.11.9
         version: 4.11.9
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@2.0.1)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
       rollup:
         specifier: ^4.62.2
         version: 4.62.2
@@ -1626,6 +1665,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(typescript@5.9.3))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -11545,7 +11587,6 @@ snapshots:
       '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -11554,13 +11595,10 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1':
-    optional: true
+  '@asamuzakjp/generational-cache@1.0.1': {}
 
-  '@asamuzakjp/nwsapi@2.3.9':
-    optional: true
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -12209,7 +12247,6 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-    optional: true
 
   '@chevrotain/types@11.1.2': {}
 
@@ -12537,14 +12574,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@csstools/color-helpers@6.1.0':
-    optional: true
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -12552,20 +12587,16 @@ snapshots:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
-    optional: true
 
-  '@csstools/css-tokenizer@4.0.0':
-    optional: true
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.5.0': {}
 
@@ -13218,7 +13249,6 @@ snapshots:
   '@exodus/bytes@1.15.1(@noble/hashes@2.0.1)':
     optionalDependencies:
       '@noble/hashes': 2.0.1
-    optional: true
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -17320,7 +17350,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-    optional: true
 
   bignumber.js@9.3.1: {}
 
@@ -17702,7 +17731,6 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
-    optional: true
 
   csstype@3.2.3: {}
 
@@ -17900,7 +17928,6 @@ snapshots:
       whatwg-url: 16.0.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   date-fns@4.1.0: {}
 
@@ -17916,8 +17943,7 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -18209,8 +18235,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  entities@8.0.0:
-    optional: true
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -19241,7 +19266,6 @@ snapshots:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   html-url-attributes@3.0.1: {}
 
@@ -19387,8 +19411,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -19484,7 +19507,6 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   jsesc@3.1.0: {}
 
@@ -19689,8 +19711,7 @@ snapshots:
 
   lru-cache@11.2.7: {}
 
-  lru-cache@11.5.1:
-    optional: true
+  lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -19917,8 +19938,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.27.1:
-    optional: true
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
@@ -20569,7 +20589,6 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
-    optional: true
 
   parseurl@1.3.3: {}
 
@@ -21446,7 +21465,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scheduler@0.27.0: {}
 
@@ -21756,8 +21774,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
 
@@ -21875,7 +21892,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   trim-lines@3.0.1: {}
 
@@ -22496,7 +22512,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
   web-namespaces@2.0.1: {}
 
@@ -22504,13 +22519,11 @@ snapshots:
 
   web-vitals@5.3.0: {}
 
-  webidl-conversions@8.0.1:
-    optional: true
+  webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
-  whatwg-mimetype@5.0.0:
-    optional: true
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1(@noble/hashes@2.0.1):
     dependencies:
@@ -22519,7 +22532,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   which@2.0.2:
     dependencies:
@@ -22636,8 +22648,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
   xmlbuilder2@4.0.3:
     dependencies:
@@ -22648,8 +22659,7 @@ snapshots:
 
   xmlbuilder@15.1.1: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,13 @@ import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 
-const workspaceRoots = ["apps", "packages", "tests"] as const;
+const workspaceRoots = [
+  "apps",
+  "packages",
+  "tests",
+  // Example plugins carry harness-based tests (@bb/plugin-sdk/testing).
+  "examples/plugins",
+] as const;
 
 function discoverVitestProjects(): string[] {
   return workspaceRoots


### PR DESCRIPTION
The official test harness for bb plugins, as two new (additive) subpath exports of `@bb/plugin-sdk`. No existing plugin-sdk APIs change.

## `@bb/plugin-sdk/testing` — backend fake host

```ts
const { bb, harness } = createFakePluginHost({
  pluginId?: string,                                // default "test-plugin"
  settings?: Record<string, string | boolean>,      // pre-seeded stored values (secrets included, in-memory)
  sdk?: FakeSdkOverrides,                           // per-area/per-method stubs, loose return types
});
```

`bb` satisfies `BbPluginApi`; semantics are ported from `apps/server/src/services/plugins/plugin-api.ts` wherever a plugin can observe them: registration name validation and error messages, the kv 256KB cap, append-only `storage.migrate`, settings descriptor validation + effective-value resolution, rpc/realtime JSON round-tripping, cron validation via cron-parser, reserved CLI/tool names, `threads.spawn` plugin attribution, and the dispose order (services aborted → hooks LIFO → sqlite closed → stale handle throws `PluginContextStaleError`). Storage is real better-sqlite3 `:memory:` (one shared handle, like the host's shared file) — never a mocked db.

`harness` drives and inspects it:

- `setSettings(values)` — validates like the settings route, fires `onChange` with `(next, prev)`
- `callRpc(method, input?)` / `runCli(argv, ctx?)` / `fetchHttp(method, path, init?)` — host-faithful invocation (JSON round trips, exit-code normalization, real Hono context; a throwing route yields the host's 500 `{ ok: false, error: "plugin route failed: …" }`)
- `runService(name)` → `{ controller: AbortController, done }` (synchronous start, no timers; `NeedsConfigurationError` by name → recorded, not a crash) and `runSchedule(name)`
- `emitThreadEvent(event, payload)` — typed against `PluginThreadEventPayloads`, returns caught handler errors
- `callAgentTool(name, input, ctx?)` — parse (zod) + execute with default context
- `sdk.calls` / `sdk.callsTo(path)` / `sdk.stub(path, fn)` — every `bb.sdk` call recorded; unstubbed methods throw naming the exact path to stub
- `logEntries`, `realtimeSignals`, `needsConfigurationMessages`, `registrations` (routes, rpc methods, services, schedules, cli, agent tools, thread actions, mention providers), `dispose()`
- `makeThreadResponse(overrides?)` — complete deterministic `ThreadResponse` fixture (typecheck fails here if the contract grows)

## `@bb/plugin-sdk/testing/app` — frontend harness

- `installTestPluginRuntime()` fills `globalThis.__bbPluginRuntime.pluginSdkApp` with a `satisfies PluginSdkApp` test implementation (the same seam `bb plugin build` shims).
- `loadPluginApp(() => import("./app"))` installs the runtime **before** the plugin module evaluates (it binds the runtime at import time), runs `setup` against a collector ported from `apps/app/src/lib/plugin-app-definition.ts` (same validation, same messages, `chrome` default filled), and returns typed registrations.
- `renderSlot(registration, props, { rpc, settings, context })` mounts the component via Testing Library + jsdom with mock hook backends and returns the render result plus `rpcCalls`, `emitRealtime(channel, payload)`, `navigateCalls`, and a composer log (`quotes`/`mentions`/`focusCount`).

## Proof tests

- `examples/plugins/slack-bot/server.test.ts` (7 tests): URL-verification handshake, signature rejection, first mention → signed webhook → kv mapping → recorded `threads.spawn` with `origin: "plugin"` attribution, follow-up `threads.send`, unconfigured 503 + needs-configuration, and `thread.idle` posting the answer back to the Slack thread (global fetch stubbed).
- `examples/plugins/notes/app.test.tsx` (4 tests): slot registrations, nav-panel tree over rpc, realtime-driven refetch, `toPluginPanel` deep links, and note creation over rpc.
- `packages/plugin-sdk/src/testing/__tests__` (25 tests): kv cap, append-only migrations, settings onChange/no-op/unset, rpc & http & cli semantics, service abort + NeedsConfigurationError, cron validation, thread events, sdk recording/attribution/late stubs, zod agent tools, dispose order + stale-handle poisoning, realtime normalization.

Example packages gain `test` scripts + vitest configs, and root `vitest.config.ts` project discovery now includes `examples/plugins` so the suites aren't silently skipped.

## Docs & scope decisions

- bb-plugin-authoring `SKILL.md` Testing section rewritten around the harness with copy-pasteable patterns (host-loop guidance kept as a subsection); `packages/plugin-sdk/README.md` documents the subpaths.
- **Not** in the bundled `.d.ts` for scaffolded plugins (V1 is workspace/in-repo consumers only — the harness runtime-imports better-sqlite3/hono/cron-parser/react, which standalone scaffolds don't carry). Documented in the README, the skill, and the module docblock.
- Reserved-name lists (`RESERVED_BB_CLI_COMMANDS`, `RESERVED_AGENT_TOOL_NAMES`) are duplicated from the server with pointer comments (the contract package cannot import `apps/server`); both are already hand-maintained lists there.

## Validation

- `turbo run typecheck --filter=@bb/plugin-sdk --filter=@bb/server --filter=@bb/app` ✓ (includes the bundled-dts staleness check)
- `turbo run test --filter=@bb/plugin-sdk --filter=bb-plugin-slack-bot --filter=bb-plugin-notes` ✓ 36/36
- `apps/server` `plugin-authoring-docs.test.ts` (skill durability) ✓ 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)