### PR TITLE
Add CSV file previews

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -281,6 +281,41 @@
   }
 
   /*
+   * Opt out of the global thin scrollbar into always-visible classic
+   * scrollbars for two-axis data surfaces (e.g. the CSV table preview).
+   * Native thin scrollbars render as macOS overlay bars that fade out and
+   * give a wide table no persistent horizontal-scroll affordance. Chromium
+   * only honors `::-webkit-scrollbar` customization when `scrollbar-width`
+   * and `scrollbar-color` are both `auto`, so those resets are what
+   * re-enable the persistent chrome below.
+   */
+  .persistent-scrollbar {
+    scrollbar-width: auto;
+    scrollbar-color: auto;
+  }
+
+  .persistent-scrollbar::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  .persistent-scrollbar::-webkit-scrollbar-track,
+  .persistent-scrollbar::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  .persistent-scrollbar::-webkit-scrollbar-thumb {
+    background-color: color-mix(in oklab, var(--foreground) 20%, transparent);
+    border-radius: 9999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  .persistent-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--foreground) 40%, transparent);
+  }
+
+  /*
    * Soft right-edge fade for single-line text that is clipped horizontally
    * (e.g. a queued-message preview). Fades the text out instead of a hard
    * `…` ellipsis. Self-gating: short text doesn't reach the fade zone, so the

--- a/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
@@ -48,7 +48,7 @@ import { FilePreview } from "...";
   state={{
     kind: "ready",
     lineRange: null,
-    showMarkdownModeToggle: true,
+    textPreviewKind: "markdown",
     file,
   }}
 />;
@@ -107,10 +107,17 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = "Button";
 `;
 
+const SAMPLE_METRICS_CSV = `Name,Status,Revenue,Notes
+Ada Lovelace,Active,12800,"Renewal call booked, asked for CSV export"
+Grace Hopper,Trial,4200,"Prefers yearly billing"
+Katherine Johnson,Active,9600,"Needs ""Executive Summary"" column added"
+`;
+
 const README_PATH = "docs/right-panel/README.md";
 const DIAGRAM_PATH = "docs/right-panel/preview-flow.md";
 const BUTTON_PATH = "apps/app/src/components/ui/button.tsx";
 const DELETED_BUTTON_PATH = "apps/app/src/components/ui/legacy-button.tsx";
+const METRICS_PATH = "reports/customers.csv";
 const SCREENSHOT_PATH = "docs/screenshots/right-panel.svg";
 const STORY_WORKSPACE_ROOT = "/Users/alex/Code/bb";
 
@@ -156,7 +163,7 @@ export function Overview() {
             state={{
               kind: "ready",
               lineRange: null,
-              showMarkdownModeToggle: true,
+              textPreviewKind: "markdown",
               file: { name: "README.md", contents: SAMPLE_README_MD },
             }}
           />
@@ -174,8 +181,26 @@ export function Overview() {
             state={{
               kind: "ready",
               lineRange: null,
-              showMarkdownModeToggle: true,
+              textPreviewKind: "markdown",
               file: { name: "preview-flow.md", contents: SAMPLE_DIAGRAM_MD },
+            }}
+          />
+        </PreviewStage>
+      </StoryRow>
+      <StoryRow
+        label="CSV file"
+        hint="CSV previews render as a table with a Raw toggle for the original source"
+      >
+        <PreviewStage>
+          <FilePreview
+            path={METRICS_PATH}
+            copyPath={copyPathFor(METRICS_PATH)}
+            onOpenInEditor={noopOpenInEditor}
+            state={{
+              kind: "ready",
+              lineRange: null,
+              textPreviewKind: "csv",
+              file: { name: "customers.csv", contents: SAMPLE_METRICS_CSV },
             }}
           />
         </PreviewStage>
@@ -192,7 +217,7 @@ export function Overview() {
             state={{
               kind: "ready",
               lineRange: null,
-              showMarkdownModeToggle: true,
+              textPreviewKind: null,
               file: {
                 name: "Button.tsx",
                 contents: SAMPLE_BUTTON_TSX,
@@ -215,7 +240,7 @@ export function Overview() {
             state={{
               kind: "ready",
               lineRange: null,
-              showMarkdownModeToggle: true,
+              textPreviewKind: null,
               file: {
                 name: "legacy-button.tsx",
                 contents: SAMPLE_BUTTON_TSX,

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -9,7 +9,11 @@ import {
 } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { FilePreview } from "./FilePreview";
+import {
+  FilePreview,
+  buildCsvPreviewData,
+  getCsvTruncationNote,
+} from "./FilePreview";
 import { SecondaryPanelFilePreview } from "./ThreadStorageFilePreview";
 
 interface MockPierreFileProps {
@@ -498,6 +502,42 @@ describe("FilePreview", () => {
     expect(
       screen.queryByRole("table", { name: "customers.csv CSV preview" }),
     ).toBeNull();
+  });
+
+  it("caps oversized CSV previews and reports the visible data-row count", () => {
+    const columnCount = 105;
+    const dataRowCount = 501;
+    const header = Array.from({ length: columnCount }, (_, i) => `c${i + 1}`);
+    const lines = [header.join(",")];
+    for (let rowIndex = 0; rowIndex < dataRowCount; rowIndex += 1) {
+      lines.push(header.map((name) => `${name}r${rowIndex + 1}`).join(","));
+    }
+
+    const preview = buildCsvPreviewData(lines.join("\n"));
+
+    // rows includes the header, so the cap keeps 500 data rows.
+    expect(preview.rows.length).toBe(501);
+    expect(preview.rows.at(-1)?.[0]).toBe("c1r500");
+    expect(preview.columnCount).toBe(100);
+    expect(preview.truncatedRows).toBe(true);
+    expect(preview.truncatedColumns).toBe(true);
+    // The footnote counts data rows, not parsed rows.
+    expect(getCsvTruncationNote(preview, preview.rows.length - 1)).toBe(
+      "Showing the first 500 rows and 100 columns.",
+    );
+  });
+
+  it("does not report truncation for a CSV exactly at the row cap", () => {
+    const lines = ["name"];
+    for (let rowIndex = 0; rowIndex < 500; rowIndex += 1) {
+      lines.push(`r${rowIndex + 1}`);
+    }
+
+    const preview = buildCsvPreviewData(`${lines.join("\n")}\n`);
+
+    expect(preview.rows.length).toBe(501);
+    expect(preview.truncatedRows).toBe(false);
+    expect(getCsvTruncationNote(preview, preview.rows.length - 1)).toBeNull();
   });
 
   it("uses the CSV table preview for loaded CSV text files", () => {

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -140,7 +140,7 @@ describe("FilePreview", () => {
             contents: "export const marker = true;",
           },
           lineRange: null,
-          showMarkdownModeToggle: false,
+          textPreviewKind: null,
         }}
       />,
     );
@@ -188,7 +188,7 @@ describe("FilePreview", () => {
             contents: "export const marker = true;",
           },
           lineRange: null,
-          showMarkdownModeToggle: false,
+          textPreviewKind: null,
         }}
       />,
     );
@@ -205,7 +205,8 @@ describe("FilePreview", () => {
   });
 
   it("remounts the code view when the highlighted file cache resolves", async () => {
-    const cacheKey = "file-preview:/api/v1/projects/proj/files/content:thread-read-state.ts";
+    const cacheKey =
+      "file-preview:/api/v1/projects/proj/files/content:thread-read-state.ts";
 
     render(
       <FilePreview
@@ -219,7 +220,7 @@ describe("FilePreview", () => {
             contents: "export const marker = true;",
           },
           lineRange: null,
-          showMarkdownModeToggle: false,
+          textPreviewKind: null,
         }}
       />,
     );
@@ -253,7 +254,7 @@ describe("FilePreview", () => {
             contents: "export const marker = true;",
           },
           lineRange: null,
-          showMarkdownModeToggle: false,
+          textPreviewKind: null,
         }}
       />,
     );
@@ -286,7 +287,7 @@ describe("FilePreview", () => {
             contents: "export const marker = true;",
           },
           lineRange: null,
-          showMarkdownModeToggle: false,
+          textPreviewKind: null,
         }}
       />,
     );
@@ -312,7 +313,7 @@ describe("FilePreview", () => {
             contents: "export const marker = true;",
           },
           lineRange: null,
-          showMarkdownModeToggle: false,
+          textPreviewKind: null,
         }}
       />,
     );
@@ -345,7 +346,7 @@ describe("FilePreview", () => {
             contents: "# Preview\n\nRaw markdown.",
           },
           lineRange: null,
-          showMarkdownModeToggle: true,
+          textPreviewKind: "markdown",
         }}
       />,
     );
@@ -375,7 +376,7 @@ describe("FilePreview", () => {
             contents: "# Preview\n\nRaw markdown.",
           },
           lineRange: null,
-          showMarkdownModeToggle: true,
+          textPreviewKind: "markdown",
         }}
       />,
     );
@@ -405,7 +406,7 @@ describe("FilePreview", () => {
             contents: "# Preview\n\nRaw markdown.",
           },
           lineRange: null,
-          showMarkdownModeToggle: true,
+          textPreviewKind: "markdown",
         }}
       />,
     );
@@ -432,7 +433,7 @@ describe("FilePreview", () => {
             contents: "# Preview\n\nRaw markdown.",
           },
           lineRange: null,
-          showMarkdownModeToggle: true,
+          textPreviewKind: "markdown",
         }}
       />,
     );
@@ -445,6 +446,81 @@ describe("FilePreview", () => {
     expect((await screen.findByRole("tooltip")).textContent).toBe(
       "Open in editor",
     );
+  });
+
+  it("renders CSV previews as a table by default", () => {
+    render(
+      <FilePreview
+        path="reports/customers.csv"
+        state={{
+          kind: "ready",
+          file: {
+            name: "customers.csv",
+            contents:
+              'Name,Note\n"Ada, Lovelace","said ""hello"""\nGrace,"line two"',
+          },
+          lineRange: null,
+          textPreviewKind: "csv",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("table", { name: "customers.csv CSV preview" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("columnheader", { name: "Name" })).not.toBeNull();
+    expect(screen.getByRole("columnheader", { name: "Note" })).not.toBeNull();
+    expect(screen.getByRole("cell", { name: "Ada, Lovelace" })).not.toBeNull();
+    expect(screen.getByRole("cell", { name: 'said "hello"' })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Copy CSV" })).not.toBeNull();
+    expect(screen.queryByTestId("pierre-file")).toBeNull();
+  });
+
+  it("toggles CSV previews back to raw source", async () => {
+    render(
+      <FilePreview
+        path="reports/customers.csv"
+        state={{
+          kind: "ready",
+          file: {
+            name: "customers.csv",
+            contents: "Name,Score\nAda,10\n",
+          },
+          lineRange: null,
+          textPreviewKind: "csv",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    await screen.findByTestId("pierre-file");
+    expect(
+      screen.queryByRole("table", { name: "customers.csv CSV preview" }),
+    ).toBeNull();
+  });
+
+  it("uses the CSV table preview for loaded CSV text files", () => {
+    render(
+      <SecondaryPanelFilePreview
+        activePath="exports/scores.csv"
+        filePreview={{
+          kind: "text",
+          content: "Name,Score\nAda,10\n",
+          mimeType: "application/octet-stream",
+          name: "scores.csv",
+          path: "exports/scores.csv",
+          url: "/api/v1/preview/scores",
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("table", { name: "scores.csv CSV preview" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("cell", { name: "Ada" })).not.toBeNull();
+    expect(screen.getByRole("cell", { name: "10" })).not.toBeNull();
   });
 
   it("does not show the file preview actions menu for non-text previews", () => {
@@ -476,7 +552,9 @@ describe("FilePreview", () => {
       />,
     );
 
-    await waitFor(() => expect(pierreMock.state.lastFile?.cacheKey).toBeTruthy());
+    await waitFor(() =>
+      expect(pierreMock.state.lastFile?.cacheKey).toBeTruthy(),
+    );
     const firstCacheKey = pierreMock.state.lastFile?.cacheKey;
 
     view.rerender(

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -74,7 +74,7 @@ export type FilePreviewState =
       kind: "ready";
       file: FilePreviewFile;
       lineRange: FilePreviewLineRange | null;
-      showMarkdownModeToggle: boolean;
+      textPreviewKind: TextFilePreviewKind | null;
       markdownUrlTransform?: UrlTransform;
     };
 
@@ -137,6 +137,11 @@ interface MarkdownFilePreviewProps {
   markdownLinkRouting?: MarkdownLinkRouting;
 }
 
+interface CsvFilePreviewProps {
+  file: FilePreviewFile;
+  onSelectionAddToChat?: (text: string) => void;
+}
+
 interface FilePreviewImageProps {
   url: string;
   alt: string;
@@ -177,16 +182,21 @@ interface GetInitialFilePreviewViewModeArgs {
   toggleKind: FilePreviewToggleKind | null;
 }
 
+interface CsvPreviewData {
+  columnCount: number;
+  rows: string[][];
+  truncatedColumns: boolean;
+  truncatedRows: boolean;
+}
+
 type FilePreviewViewMode = "preview" | "source";
-type FilePreviewToggleKind = "html" | "markdown";
+export type TextFilePreviewKind = "csv" | "markdown";
+type FilePreviewToggleKind = "csv" | "html" | "markdown";
 export type FilePreviewHeaderMode = "file" | "none";
 type IframeLoadState = "loading" | "loaded" | "error";
 
-const MARKDOWN_EXTENSIONS: ReadonlySet<string> = new Set([
-  "md",
-  "mdx",
-  "markdown",
-]);
+const CSV_PREVIEW_MAX_COLUMNS = 100;
+const CSV_PREVIEW_MAX_ROWS = 500;
 
 const FILE_PREVIEW_VIEW_STYLE = {
   "--diffs-font-size": "12px",
@@ -214,32 +224,33 @@ const IFRAME_LOADING_INDICATOR_DELAY_MS = 160;
 const FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS =
   "h-5 w-5 rounded-sm p-0 [&_svg]:size-3 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";
 
-function isMarkdownFile(name: string): boolean {
-  const extension = name.split(".").pop()?.toLowerCase();
-  return extension !== undefined && MARKDOWN_EXTENSIONS.has(extension);
-}
-
 function getFilePreviewToggleKind(
   state: FilePreviewState,
 ): FilePreviewToggleKind | null {
   if (state.kind === "html") {
     return "html";
   }
-  if (
-    state.kind === "ready" &&
-    state.showMarkdownModeToggle &&
-    isMarkdownFile(state.file.name)
-  ) {
-    return "markdown";
+  if (state.kind === "ready") {
+    return state.textPreviewKind;
   }
   return null;
 }
 
 function getToggleAriaLabel(kind: FilePreviewToggleKind): string {
-  return kind === "html" ? "HTML view mode" : "Markdown view mode";
+  switch (kind) {
+    case "csv":
+      return "CSV view mode";
+    case "html":
+      return "HTML view mode";
+    case "markdown":
+      return "Markdown view mode";
+  }
 }
 
 function getFileContentsCopyLabel(kind: FilePreviewToggleKind | null): string {
+  if (kind === "csv") {
+    return "Copy CSV";
+  }
   if (kind === "markdown") {
     return "Copy markdown";
   }
@@ -273,7 +284,7 @@ function getInitialFilePreviewViewMode({
   lineRange,
   toggleKind,
 }: GetInitialFilePreviewViewModeArgs): FilePreviewViewMode {
-  if (toggleKind === "markdown") {
+  if (toggleKind === "csv" || toggleKind === "markdown") {
     return "preview";
   }
   return lineRange === null ? "preview" : "source";
@@ -291,7 +302,90 @@ function usesCodeViewLayout(
     return false;
   }
 
-  return !isMarkdownFile(state.file.name) || viewMode === "source";
+  return state.textPreviewKind === null || viewMode === "source";
+}
+
+function parseCsvRows(contents: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let quotedField = false;
+  let endedWithLineBreak = false;
+
+  for (let index = 0; index < contents.length; index += 1) {
+    const character = contents[index];
+    endedWithLineBreak = false;
+
+    if (inQuotes) {
+      if (character === '"') {
+        if (contents[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += character;
+      }
+      continue;
+    }
+
+    if (character === '"' && field.length === 0) {
+      inQuotes = true;
+      quotedField = true;
+      continue;
+    }
+
+    if (character === ",") {
+      row.push(field);
+      field = "";
+      quotedField = false;
+      continue;
+    }
+
+    if (character === "\n" || character === "\r") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+      quotedField = false;
+      endedWithLineBreak = true;
+      if (character === "\r" && contents[index + 1] === "\n") {
+        index += 1;
+      }
+      continue;
+    }
+
+    field += character;
+  }
+
+  if (
+    field.length > 0 ||
+    row.length > 0 ||
+    quotedField ||
+    !endedWithLineBreak
+  ) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function buildCsvPreviewData(contents: string): CsvPreviewData {
+  const parsedRows = parseCsvRows(contents);
+  const columnCount = parsedRows.reduce(
+    (maximum, row) => Math.max(maximum, row.length),
+    0,
+  );
+
+  return {
+    columnCount: Math.min(columnCount, CSV_PREVIEW_MAX_COLUMNS),
+    rows: parsedRows.slice(0, CSV_PREVIEW_MAX_ROWS),
+    truncatedColumns: columnCount > CSV_PREVIEW_MAX_COLUMNS,
+    truncatedRows: parsedRows.length > CSV_PREVIEW_MAX_ROWS,
+  };
 }
 
 export function FilePreview({
@@ -340,9 +434,14 @@ export function FilePreview({
   // documents still scroll the outer panel rather than an inner box.
   const usesMarkdownPreviewLayout =
     state.kind === "ready" &&
-    isMarkdownFile(state.file.name) &&
+    state.textPreviewKind === "markdown" &&
     bodyViewMode === "preview";
-  const usesContentHeightLayout = usesCodeLayout || usesMarkdownPreviewLayout;
+  const usesCsvPreviewLayout =
+    state.kind === "ready" &&
+    state.textPreviewKind === "csv" &&
+    bodyViewMode === "preview";
+  const usesContentHeightLayout =
+    usesCodeLayout || usesMarkdownPreviewLayout || usesCsvPreviewLayout;
 
   // Establish a `@container/page` scope so MarkdownPreview's `100cqw`-based
   // table breakout sizes against this panel, not the viewport.
@@ -434,7 +533,15 @@ function FilePreviewBody({
       />
     );
   }
-  if (isMarkdownFile(state.file.name) && viewMode === "preview") {
+  if (state.textPreviewKind === "csv" && viewMode === "preview") {
+    return (
+      <CsvFilePreview
+        file={state.file}
+        onSelectionAddToChat={onSelectionAddToChat}
+      />
+    );
+  }
+  if (state.textPreviewKind === "markdown" && viewMode === "preview") {
     return (
       <MarkdownFilePreview
         file={state.file}
@@ -698,6 +805,98 @@ function MarkdownFilePreview({
           urlTransform={urlTransform}
           linkRouting={markdownLinkRouting}
         />
+      </div>
+    </SecondaryPanelSelectionActions>
+  );
+}
+
+function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
+  const preview = useMemo(
+    () => buildCsvPreviewData(file.contents),
+    [file.contents],
+  );
+  const headerRow = preview.rows[0] ?? [];
+  const bodyRows = preview.rows.slice(1);
+  const columns = Array.from({ length: preview.columnCount }, (_, index) => ({
+    index,
+    label: headerRow[index] ?? "",
+  }));
+  const tableWidth = `max(100%, ${3 + columns.length * 18}rem)`;
+
+  return (
+    <SecondaryPanelSelectionActions
+      className="contents"
+      onSelectionAddToChat={onSelectionAddToChat}
+    >
+      <div className="flex-auto bg-surface-raised px-4 py-4">
+        <div className="overflow-auto rounded-md border border-border bg-background">
+          <table
+            className="min-w-full table-fixed border-separate border-spacing-0 font-mono text-xs leading-5"
+            aria-label={`${file.name} CSV preview`}
+            style={{ width: tableWidth }}
+          >
+            <colgroup>
+              <col className="w-12" />
+              {columns.map((column) => (
+                <col key={column.index} className="w-72" />
+              ))}
+            </colgroup>
+            <thead>
+              <tr>
+                <th
+                  scope="col"
+                  className="sticky left-0 top-0 z-30 w-12 min-w-12 border-b border-r border-border bg-surface-recessed-solid px-2 py-1 text-right font-medium text-muted-foreground"
+                >
+                  #
+                </th>
+                {columns.map((column) => (
+                  <th
+                    key={column.index}
+                    scope="col"
+                    className="sticky top-0 z-20 w-72 max-w-72 border-b border-r border-border bg-surface-recessed-solid px-2 py-1 text-left font-medium text-foreground"
+                    title={column.label}
+                  >
+                    <span className="block max-w-full truncate">
+                      {column.label || `Column ${column.index + 1}`}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {bodyRows.map((row, rowIndex) => (
+                <tr key={rowIndex}>
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 w-12 min-w-12 border-b border-r border-border bg-surface-recessed-solid px-2 py-1 text-right font-medium text-muted-foreground"
+                  >
+                    {rowIndex + 2}
+                  </th>
+                  {columns.map((column) => {
+                    const cell = row[column.index] ?? "";
+                    return (
+                      <td
+                        key={column.index}
+                        className="w-72 max-w-72 overflow-hidden border-b border-r border-border px-2 py-1 align-top text-foreground"
+                        title={cell}
+                      >
+                        <span className="block max-w-full truncate">
+                          {cell}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {preview.truncatedRows || preview.truncatedColumns ? (
+          <p className="mt-2 text-xs leading-5 text-muted-foreground">
+            Showing the first {preview.rows.length.toLocaleString()} rows and{" "}
+            {preview.columnCount.toLocaleString()} columns.
+          </p>
+        ) : null}
       </div>
     </SecondaryPanelSelectionActions>
   );

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -305,7 +305,14 @@ function usesCodeViewLayout(
   return state.textPreviewKind === null || viewMode === "source";
 }
 
-function parseCsvRows(contents: string): string[][] {
+interface ParsedCsvRows {
+  rows: string[][];
+  truncatedRows: boolean;
+}
+
+// Stops scanning once `maxRows` rows are collected, so a multi-megabyte CSV
+// only pays for the previewed prefix.
+function parseCsvRows(contents: string, maxRows: number): ParsedCsvRows {
   const rows: string[][] = [];
   let row: string[] = [];
   let field = "";
@@ -354,6 +361,9 @@ function parseCsvRows(contents: string): string[][] {
       if (character === "\r" && contents[index + 1] === "\n") {
         index += 1;
       }
+      if (rows.length >= maxRows) {
+        return { rows, truncatedRows: index + 1 < contents.length };
+      }
       continue;
     }
 
@@ -370,22 +380,45 @@ function parseCsvRows(contents: string): string[][] {
     rows.push(row);
   }
 
-  return rows;
+  return { rows, truncatedRows: false };
 }
 
-function buildCsvPreviewData(contents: string): CsvPreviewData {
-  const parsedRows = parseCsvRows(contents);
-  const columnCount = parsedRows.reduce(
+export function buildCsvPreviewData(contents: string): CsvPreviewData {
+  // +1: the first parsed row is the header, so the cap counts data rows.
+  const { rows, truncatedRows } = parseCsvRows(
+    contents,
+    CSV_PREVIEW_MAX_ROWS + 1,
+  );
+  // Column stats only consider the previewed rows; a wider row past the row
+  // cap won't flag truncatedColumns. Fine for a preview.
+  const columnCount = rows.reduce(
     (maximum, row) => Math.max(maximum, row.length),
     0,
   );
 
   return {
     columnCount: Math.min(columnCount, CSV_PREVIEW_MAX_COLUMNS),
-    rows: parsedRows.slice(0, CSV_PREVIEW_MAX_ROWS),
+    rows,
     truncatedColumns: columnCount > CSV_PREVIEW_MAX_COLUMNS,
-    truncatedRows: parsedRows.length > CSV_PREVIEW_MAX_ROWS,
+    truncatedRows,
   };
+}
+
+export function getCsvTruncationNote(
+  preview: CsvPreviewData,
+  dataRowCount: number,
+): string | null {
+  const limits: string[] = [];
+  if (preview.truncatedRows) {
+    limits.push(`${dataRowCount.toLocaleString()} rows`);
+  }
+  if (preview.truncatedColumns) {
+    limits.push(`${preview.columnCount.toLocaleString()} columns`);
+  }
+  if (limits.length === 0) {
+    return null;
+  }
+  return `Showing the first ${limits.join(" and ")}.`;
 }
 
 export function FilePreview({
@@ -436,19 +469,25 @@ export function FilePreview({
     state.kind === "ready" &&
     state.textPreviewKind === "markdown" &&
     bodyViewMode === "preview";
+  // The CSV table needs one scroller that owns both axes: its sticky header
+  // row and row-number gutter only stick against their own scrollport, and
+  // splitting the axes (panel scrolls vertically, inner box horizontally)
+  // strands the horizontal scrollbar at the bottom of the full-height table
+  // and lets the sticky gutter paint over the panel header. So fill the panel
+  // like the iframe layout and let CsvFilePreview scroll internally.
   const usesCsvPreviewLayout =
     state.kind === "ready" &&
     state.textPreviewKind === "csv" &&
     bodyViewMode === "preview";
-  const usesContentHeightLayout =
-    usesCodeLayout || usesMarkdownPreviewLayout || usesCsvPreviewLayout;
+  const usesFullHeightLayout = usesIframeLayout || usesCsvPreviewLayout;
+  const usesContentHeightLayout = usesCodeLayout || usesMarkdownPreviewLayout;
 
   // Establish a `@container/page` scope so MarkdownPreview's `100cqw`-based
   // table breakout sizes against this panel, not the viewport.
   return (
     <div
       className={
-        usesIframeLayout
+        usesFullHeightLayout
           ? "@container/page flex h-full min-h-0 flex-col"
           : usesContentHeightLayout
             ? "@container/page flex min-h-full flex-col"
@@ -822,14 +861,22 @@ function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
     label: headerRow[index] ?? "",
   }));
   const tableWidth = `max(100%, ${3 + columns.length * 18}rem)`;
+  const truncationNote = getCsvTruncationNote(preview, bodyRows.length);
 
   return (
     <SecondaryPanelSelectionActions
       className="contents"
       onSelectionAddToChat={onSelectionAddToChat}
     >
-      <div className="flex-auto bg-surface-raised px-4 py-4">
-        <div className="overflow-auto rounded-md border border-border bg-background">
+      {/* Single scroll container for both axes: the sticky header row and
+          row-number gutter stick against this box, the horizontal scrollbar
+          stays visible at the panel bottom, and the sticky cells are clipped
+          here so they can't paint over the panel header. */}
+      <div className="flex min-h-0 flex-auto flex-col bg-surface-raised px-4 py-4">
+        {/* overscroll-contain: panning a wide table past its edge must not
+            chain into the browser back/forward gesture (kept alive globally —
+            see app.css overscroll notes) or scroll an ancestor. */}
+        <div className="persistent-scrollbar min-h-0 overflow-auto overscroll-contain rounded-md border border-border bg-background">
           <table
             className="min-w-full table-fixed border-separate border-spacing-0 font-mono text-xs leading-5"
             aria-label={`${file.name} CSV preview`}
@@ -891,12 +938,11 @@ function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
             </tbody>
           </table>
         </div>
-        {preview.truncatedRows || preview.truncatedColumns ? (
-          <p className="mt-2 text-xs leading-5 text-muted-foreground">
-            Showing the first {preview.rows.length.toLocaleString()} rows and{" "}
-            {preview.columnCount.toLocaleString()} columns.
+        {truncationNote === null ? null : (
+          <p className="mt-2 shrink-0 text-xs leading-5 text-muted-foreground">
+            {truncationNote}
           </p>
-        ) : null}
+        )}
       </div>
     </SecondaryPanelSelectionActions>
   );

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -1,6 +1,7 @@
 import {
   FilePreview as FilePreviewSurface,
   type FilePreviewFile,
+  type TextFilePreviewKind,
 } from "./FilePreview";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
 import { HttpError } from "@/lib/api";
@@ -11,7 +12,11 @@ import type {
   TextFilePreview,
   WorkspaceFilePreviewStatusLabel,
 } from "@/lib/file-preview";
-import { isHtmlFilePreviewPath } from "@/lib/file-preview";
+import {
+  isCsvFilePreview,
+  isHtmlFilePreviewPath,
+  isMarkdownFilePreview,
+} from "@/lib/file-preview";
 
 // Generic HTML comes from arbitrary worktree/storage files. Allow scripts for
 // realistic previews, but omit allow-same-origin so the frame gets an opaque
@@ -77,6 +82,18 @@ function buildTextPreviewFile({
     name: filePreview.name ?? activePath,
     contents: filePreview.content,
   };
+}
+
+function getTextPreviewKind(
+  filePreview: TextFilePreview,
+): TextFilePreviewKind | null {
+  if (isCsvFilePreview(filePreview)) {
+    return "csv";
+  }
+  if (isMarkdownFilePreview(filePreview)) {
+    return "markdown";
+  }
+  return null;
 }
 
 export function SecondaryPanelFilePreview({
@@ -183,7 +200,7 @@ export function SecondaryPanelFilePreview({
         state={{
           kind: "ready",
           lineRange,
-          showMarkdownModeToggle: true,
+          textPreviewKind: getTextPreviewKind(filePreview),
           file: buildTextPreviewFile({ activePath, filePreview }),
         }}
       />

--- a/apps/app/src/lib/file-preview.test.ts
+++ b/apps/app/src/lib/file-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   areEnvironmentFilePreviewSourcesEqual,
   buildFilePreview,
+  isCsvFilePreview,
   isMarkdownFilePreview,
   normalizeFilePreviewMimeType,
 } from "./file-preview";
@@ -182,5 +183,30 @@ describe("file-preview", () => {
     expect(isMarkdownFilePreview(markdownByPath)).toBe(true);
     expect(isMarkdownFilePreview(markdownByMime)).toBe(true);
     expect(isMarkdownFilePreview(plainText)).toBe(false);
+  });
+
+  it("detects CSV text previews by extension and mime type", () => {
+    const csvByPath = buildFilePreview({
+      contentBytes: new TextEncoder().encode("name,score\nAda,10\n"),
+      mimeType: "text/plain",
+      path: "reports/scores.csv",
+      url: "/files/reports/scores.csv",
+    });
+    const csvByMime = buildFilePreview({
+      contentBytes: new TextEncoder().encode("name,score\nAda,10\n"),
+      mimeType: "text/csv",
+      path: "reports/scores",
+      url: "/files/reports/scores",
+    });
+    const plainText = buildFilePreview({
+      contentBytes: new TextEncoder().encode("name,score\nAda,10\n"),
+      mimeType: "text/plain",
+      path: "reports/scores.txt",
+      url: "/files/reports/scores.txt",
+    });
+
+    expect(isCsvFilePreview(csvByPath)).toBe(true);
+    expect(isCsvFilePreview(csvByMime)).toBe(true);
+    expect(isCsvFilePreview(plainText)).toBe(false);
   });
 });

--- a/apps/app/src/lib/file-preview.ts
+++ b/apps/app/src/lib/file-preview.ts
@@ -20,6 +20,8 @@ const UTF8_TEXT_MIME_TYPES = new Set([
 
 const MARKDOWN_FILE_EXTENSIONS = [".md", ".markdown"];
 const MARKDOWN_MIME_TYPES = new Set(["text/markdown", "text/x-markdown"]);
+const CSV_FILE_EXTENSIONS = [".csv"];
+const CSV_MIME_TYPES = new Set(["application/csv", "text/csv"]);
 const HTML_FILE_EXTENSION = ".html";
 const NULL_CHARACTER = "\u0000";
 
@@ -195,6 +197,13 @@ function hasMarkdownExtension(path: string): boolean {
   );
 }
 
+function hasCsvExtension(path: string): boolean {
+  const normalizedPath = path.toLowerCase();
+  return CSV_FILE_EXTENSIONS.some((extension) =>
+    normalizedPath.endsWith(extension),
+  );
+}
+
 export function isHtmlFilePreviewPath(path: string): boolean {
   return path.toLowerCase().endsWith(HTML_FILE_EXTENSION);
 }
@@ -212,6 +221,15 @@ export function isMarkdownFilePreview(preview: FilePreview): boolean {
     (MARKDOWN_MIME_TYPES.has(preview.mimeType) ||
       hasMarkdownExtension(preview.path) ||
       (preview.name ? hasMarkdownExtension(preview.name) : false))
+  );
+}
+
+export function isCsvFilePreview(preview: FilePreview): boolean {
+  return (
+    preview.kind === "text" &&
+    (CSV_MIME_TYPES.has(preview.mimeType) ||
+      hasCsvExtension(preview.path) ||
+      (preview.name ? hasCsvExtension(preview.name) : false))
   );
 }
 


### PR DESCRIPTION
## Summary
- add CSV detection alongside the existing markdown/image/PDF preview routing
- render CSV text previews as a scrollable table with row numbers, sticky headers, fixed-width columns, and truncation for long cell values
- keep the existing Preview/Raw toggle behavior and copy labeling for CSV files
- add focused unit coverage and a Ladle story for the CSV preview path

<img width="1214" height="1532" alt="CleanShot 2026-07-07 at 15 54 58@2x" src="https://github.com/user-attachments/assets/d0c86eaa-d4e3-45c8-867c-1a4f6e37fd92" />
