### PR TITLE
Fix packaged builtin plugin manifests

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -32,10 +32,9 @@ function PluginNavSidebarItemList({
   const location = useLocation();
   return (
     <div
-      // -mt-1 tightens the seam against the primary-actions block (its py-2
-      // bottom) so the first panel row sits on the same 4px (space-y-1) rhythm
-      // as New thread above it, instead of an 8px gap.
-      className="-mt-1 shrink-0 px-2 pb-2 group-data-[collapsible=icon]:hidden"
+      // Cancel the primary-actions block's bottom padding so plugin panel rows
+      // sit flush under New thread as one continuous action list.
+      className="-mt-2 shrink-0 px-2 pb-2 group-data-[collapsible=icon]:hidden"
       data-testid="plugin-nav-sidebar-items"
     >
       {navPanels.map((panel) => {

--- a/apps/server/scripts/copy-builtin-plugins.ts
+++ b/apps/server/scripts/copy-builtin-plugins.ts
@@ -1,7 +1,8 @@
-import { cp, mkdir, rm, stat } from "node:fs/promises";
+import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { buildPluginApp, buildPluginServer } from "@bb/plugin-build";
+import { z } from "zod";
 import {
   BUILTIN_PLUGINS_DIRECTORY_NAME,
   BUILTIN_PLUGIN_NAMES,
@@ -19,10 +20,20 @@ const targetRoot = path.resolve(
 );
 
 const RUNTIME_DIRS = ["dist", "skills"] as const;
-const RUNTIME_FILES = ["package.json"] as const;
 const LOGO_FILES = LOGO_CONVENTION_EXTENSIONS.map(
   (extension) => `logo.${extension}`,
 );
+
+const pluginPackageJsonSchema = z
+  .object({
+    bb: z
+      .object({
+        server: z.string().min(1),
+        app: z.string().min(1).optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
 
 async function exists(filePath: string): Promise<boolean> {
   try {
@@ -39,6 +50,32 @@ async function copyIfExists(from: string, to: string): Promise<void> {
   }
 }
 
+async function writeRuntimePackageJson(args: {
+  sourceRoot: string;
+  targetDir: string;
+}): Promise<void> {
+  const raw = await readFile(
+    path.join(args.sourceRoot, "package.json"),
+    "utf8",
+  );
+  const packageJson = pluginPackageJsonSchema.parse(JSON.parse(raw));
+  await writeFile(
+    path.join(args.targetDir, "package.json"),
+    `${JSON.stringify(
+      {
+        ...packageJson,
+        bb: {
+          ...packageJson.bb,
+          server: "./dist/server.js",
+          ...(packageJson.bb.app === undefined ? {} : { app: "./dist/app.js" }),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
 async function copyBuiltinPlugin(args: {
   build: boolean;
   name: (typeof BUILTIN_PLUGIN_NAMES)[number];
@@ -53,22 +90,31 @@ async function copyBuiltinPlugin(args: {
   const targetDir = path.join(args.targetRoot, args.name);
   await mkdir(targetDir, { recursive: true });
 
-  for (const fileName of RUNTIME_FILES) {
-    await cp(path.join(args.sourceRoot, fileName), path.join(targetDir, fileName));
-  }
+  await writeRuntimePackageJson({
+    sourceRoot: args.sourceRoot,
+    targetDir,
+  });
   for (const dirName of RUNTIME_DIRS) {
-    await copyIfExists(path.join(args.sourceRoot, dirName), path.join(targetDir, dirName));
+    await copyIfExists(
+      path.join(args.sourceRoot, dirName),
+      path.join(targetDir, dirName),
+    );
   }
   for (const logoFile of LOGO_FILES) {
-    await copyIfExists(path.join(args.sourceRoot, logoFile), path.join(targetDir, logoFile));
+    await copyIfExists(
+      path.join(args.sourceRoot, logoFile),
+      path.join(targetDir, logoFile),
+    );
   }
 }
 
-export async function copyBuiltinPlugins(args: {
-  build?: boolean;
-  sourceModuleDir?: string;
-  targetRoot?: string;
-} = {}): Promise<void> {
+export async function copyBuiltinPlugins(
+  args: {
+    build?: boolean;
+    sourceModuleDir?: string;
+    targetRoot?: string;
+  } = {},
+): Promise<void> {
   const resolvedSourceModuleDir = args.sourceModuleDir ?? sourceModuleDir;
   const resolvedTargetRoot = args.targetRoot ?? targetRoot;
   const build = args.build ?? true;

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -1134,6 +1134,17 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     return sourceKind(source) === "builtin";
   }
 
+  function isPackagedBuiltinAppEntry(args: {
+    kind: ReturnType<typeof sourceKind>;
+    manifest: PluginManifest;
+    rootDir: string;
+  }): boolean {
+    return (
+      args.kind === "builtin" &&
+      args.manifest.appEntry === resolve(args.rootDir, "dist", "app.js")
+    );
+  }
+
   function isBuiltinPluginId(id: string): boolean {
     const row = getInstalledPlugin(deps.db, id);
     return row !== undefined && isBuiltinSource(row.source);
@@ -1215,7 +1226,11 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
       });
       return null;
     }
-    if (sourceKind(row.source) !== "npm") {
+    const kind = sourceKind(row.source);
+    if (
+      kind !== "npm" &&
+      !isPackagedBuiltinAppEntry({ kind, manifest, rootDir: row.rootDir })
+    ) {
       const meta = await readPluginAppBundleMeta(row.rootDir);
       if (meta?.sdkVersion !== PLUGIN_SDK_VERSION) {
         logger.info(
@@ -1528,7 +1543,8 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     // prebuilt dist (a major mismatch is tolerated: the backend runs, the
     // frontend marks the bundle "needs update").
     if (manifest.appEntry !== undefined) {
-      if (sourceKind(args.source) === "npm") {
+      const kind = sourceKind(args.source);
+      if (kind === "npm") {
         const jsPresent = await stat(join(args.rootDir, "dist", "app.js"))
           .then(() => true)
           .catch(() => false);
@@ -1540,7 +1556,9 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             `install refused: npm plugins with a frontend (bb.app) must publish a prebuilt bundle — "${manifest.id}" is missing dist/app.js + dist/app.meta.json`,
           );
         }
-      } else {
+      } else if (
+        !isPackagedBuiltinAppEntry({ kind, manifest, rootDir: args.rootDir })
+      ) {
         try {
           await buildPluginApp(args.rootDir);
         } catch (error) {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -1,9 +1,18 @@
-import { cp, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createConnection, migrate, type DbConnection } from "@bb/db";
+import { PLUGIN_SDK_MAJOR, PLUGIN_SDK_VERSION } from "@bb/domain";
 import type { Logger } from "@bb/logger";
 import {
   createPluginService,
@@ -28,9 +37,80 @@ function loadCount(): number {
   return (globals.__builtinFixtureLoads as number | undefined) ?? 0;
 }
 
+function packagedLoadCount(): number {
+  return (globals.__packagedBuiltinLoads as number | undefined) ?? 0;
+}
+
+async function writePackagedBuiltinSource(workDir: string): Promise<{
+  sourceModuleDir: string;
+  sourceRoot: string;
+}> {
+  const sourceModuleDir = join(workDir, "source-module");
+  const sourceRoot = join(sourceModuleDir, "builtin-plugins", "automations");
+  await mkdir(join(sourceRoot, "dist"), { recursive: true });
+  await mkdir(join(sourceRoot, "skills", "automations"), { recursive: true });
+  await mkdir(join(sourceRoot, "src"), { recursive: true });
+  await writeFile(
+    join(sourceRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "bb-plugin-automations",
+        version: "0.1.0",
+        type: "module",
+        bb: {
+          server: "./src/server.ts",
+          app: "./app.tsx",
+          skills: ["skills"],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await writeFile(
+    join(sourceRoot, "src", "server.ts"),
+    `throw new Error("packaged builtin should not load source");\n`,
+  );
+  await writeFile(
+    join(sourceRoot, "app.tsx"),
+    `throw new Error("packaged builtin should not build app source");\n`,
+  );
+  await writeFile(
+    join(sourceRoot, "dist", "server.js"),
+    `export default function plugin() {
+  globalThis.__packagedBuiltinLoads = (globalThis.__packagedBuiltinLoads ?? 0) + 1;
+}
+`,
+  );
+  await writeFile(
+    join(sourceRoot, "dist", "server.meta.json"),
+    `${JSON.stringify(
+      { sdkMajor: PLUGIN_SDK_MAJOR, sdkVersion: PLUGIN_SDK_VERSION },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(join(sourceRoot, "dist", "app.js"), `export default {};\n`);
+  await writeFile(join(sourceRoot, "dist", "app.css"), `/* built */\n`);
+  await writeFile(
+    join(sourceRoot, "dist", "app.meta.json"),
+    `${JSON.stringify(
+      { sdkMajor: PLUGIN_SDK_MAJOR, sdkVersion: PLUGIN_SDK_VERSION },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(sourceRoot, "skills", "automations", "SKILL.md"),
+    "---\nname: automations\n---\n",
+  );
+  return { sourceModuleDir, sourceRoot };
+}
+
 function createService(args: {
   dataDir: string;
   db: DbConnection;
+  builtinName?: string;
   isEnabled?: () => boolean;
   rootDir?: string;
 }): PluginService {
@@ -45,7 +125,12 @@ function createService(args: {
     dataDir: args.dataDir,
     appVersion: "0.9.0",
     isEnabled: args.isEnabled ?? (() => false),
-    builtinPlugins: [{ name: "fixture", rootDir: args.rootDir ?? fixtureRoot }],
+    builtinPlugins: [
+      {
+        name: args.builtinName ?? "fixture",
+        rootDir: args.rootDir ?? fixtureRoot,
+      },
+    ],
     loadTimeoutMs: 2000,
   });
 }
@@ -57,6 +142,7 @@ describe("builtin plugin reconciliation", () => {
 
   beforeEach(async () => {
     delete globals.__builtinFixtureLoads;
+    delete globals.__packagedBuiltinLoads;
     db = createConnection(":memory:");
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-builtin-plugins-"));
@@ -175,6 +261,63 @@ describe("builtin plugin reconciliation", () => {
       'unknown builtin plugin "missing"',
     );
   });
+
+  it("installs and loads a packaged builtin whose source files are omitted", async () => {
+    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
+    const targetRoot = join(workDir, "builtin-plugins");
+    await copyBuiltinPlugins({ build: false, sourceModuleDir, targetRoot });
+    const copiedRoot = join(targetRoot, "automations");
+
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      builtinName: "automations",
+      rootDir: copiedRoot,
+    });
+    await service.start();
+
+    expect(service.list()).toMatchObject([
+      {
+        id: "automations",
+        source: "builtin:automations",
+        version: "0.1.0",
+        enabled: true,
+        status: "running",
+        app: {
+          hasApp: true,
+          bundle: {
+            compatible: true,
+          },
+        },
+      },
+    ]);
+    expect(packagedLoadCount()).toBe(1);
+  });
+
+  it("explicitly installs a packaged builtin without rebuilding its app bundle", async () => {
+    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
+    const targetRoot = join(workDir, "builtin-plugins");
+    await copyBuiltinPlugins({ build: false, sourceModuleDir, targetRoot });
+    const copiedRoot = join(targetRoot, "automations");
+
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      builtinName: "automations",
+      isEnabled: () => true,
+      rootDir: copiedRoot,
+    });
+
+    await expect(service.install("builtin:automations")).resolves.toMatchObject(
+      {
+        id: "automations",
+        status: "running",
+      },
+    );
+    await expect(
+      readFile(join(copiedRoot, "dist", "app.css"), "utf8"),
+    ).resolves.toBe("/* built */\n");
+  });
 });
 
 describe("builtin plugin packaging", () => {
@@ -189,11 +332,22 @@ describe("builtin plugin packaging", () => {
   });
 
   it("copies only the runtime layout for packaged builtins", async () => {
+    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
     const targetRoot = join(workDir, "builtin-plugins");
 
-    await copyBuiltinPlugins({ build: false, targetRoot });
+    await copyBuiltinPlugins({ build: false, sourceModuleDir, targetRoot });
 
     const copiedRoot = join(targetRoot, "automations");
+    const packageJson = JSON.parse(
+      await readFile(join(copiedRoot, "package.json"), "utf8"),
+    );
+    expect(packageJson).toMatchObject({
+      bb: {
+        server: "./dist/server.js",
+        app: "./dist/app.js",
+        skills: ["skills"],
+      },
+    });
     await expect(stat(join(copiedRoot, "package.json"))).resolves.toBeTruthy();
     await expect(
       stat(join(copiedRoot, "dist", "server.js")),
@@ -206,6 +360,7 @@ describe("builtin plugin packaging", () => {
     ).resolves.toBeTruthy();
     await expect(stat(join(copiedRoot, "skills"))).resolves.toBeTruthy();
     await expect(stat(join(copiedRoot, "src"))).rejects.toThrow();
+    await expect(stat(join(copiedRoot, "app.tsx"))).rejects.toThrow();
     await expect(stat(join(copiedRoot, "node_modules"))).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- rewrite packaged builtin plugin manifests to point at dist runtime entries
- avoid rebuilding packaged builtin app bundles from omitted source files
- tighten plugin nav sidebar spacing so plugin rows sit flush under New thread

## Tests
- pnpm exec turbo run test --filter=@bb/server -- --run test/services/plugins/builtin-plugins.test.ts
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/plugin-slot-mounts.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/server
- pnpm exec turbo run typecheck --filter=@bb/app