### PR TITLE
Align composer stop button with submit

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2610,11 +2610,11 @@ export function PromptBoxInternal({
           {showStop ? (
             <Button
               type="button"
-              size="icon"
+              size="sm"
               variant="secondary"
               aria-label="Stop run"
               onClick={onStop}
-              className={COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS}
+              className={cn("ml-1", COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS)}
             >
               <Icon
                 name="Square"


### PR DESCRIPTION
## Summary
- Make the composer stop button use the same final-action sizing and spacing as the submit button
- Keep the existing stop icon and secondary styling intact

## Tests
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/promptbox/PromptBoxInternal.test.tsx