### PR TITLE
Remove bb connect GitHub username allowlist

### DIFF
--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -1,16 +1,7 @@
 import { betterAuth } from "better-auth";
-import { APIError } from "better-auth/api";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { drizzle } from "drizzle-orm/d1";
-import { eq } from "drizzle-orm";
-import {
-  account,
-  isGithubUserAllowed,
-  parseAllowedGithubUsers,
-  session,
-  user,
-  verification,
-} from "@bb/connect-db";
+import { account, session, user, verification } from "@bb/connect-db";
 import type { Env } from "./env.js";
 
 export type Auth = ReturnType<typeof createAuth>;
@@ -19,25 +10,9 @@ export type Auth = ReturnType<typeof createAuth>;
  * better-auth bound to the staging D1 via drizzle. GitHub is the only provider.
  * Cookies are scoped to `.${BASE_DOMAIN}` so the tunnel gate on
  * `<handle>.${BASE_DOMAIN}` can validate the same session.
- *
- * While bb connect is invite-only, sign-in is gated on the
- * CONNECT_ALLOWED_GITHUB_USERS allowlist: the GitHub `login` is stored on the
- * user (refreshed every sign-in via overrideUserInfoOnSignIn) and checked both
- * at user creation (signup) and session creation (every subsequent sign-in),
- * so removing a username from the var locks the account out at next login.
  */
 export function createAuth(env: Env) {
   const db = drizzle(env.DB);
-  const allowedGithubUsers = parseAllowedGithubUsers(
-    env.CONNECT_ALLOWED_GITHUB_USERS,
-  );
-  const requireAllowedGithubLogin = (login: string | null | undefined) => {
-    if (!isGithubUserAllowed(allowedGithubUsers, login)) {
-      throw new APIError("FORBIDDEN", {
-        message: "bb connect is invite-only right now.",
-      });
-    }
-  };
   return betterAuth({
     appName: "bb connect",
     secret: env.BETTER_AUTH_SECRET,
@@ -63,29 +38,6 @@ export function createAuth(env: Env) {
         clientSecret: env.GITHUB_CLIENT_SECRET,
         overrideUserInfoOnSignIn: true,
         mapProfileToUser: (profile) => ({ githubLogin: profile.login }),
-      },
-    },
-    databaseHooks: {
-      user: {
-        create: {
-          before: async (userData) => {
-            requireAllowedGithubLogin(
-              (userData as { githubLogin?: string | null }).githubLogin,
-            );
-          },
-        },
-      },
-      session: {
-        create: {
-          before: async (sessionData) => {
-            const row = await db
-              .select({ githubLogin: user.githubLogin })
-              .from(user)
-              .where(eq(user.id, sessionData.userId))
-              .get();
-            requireAllowedGithubLogin(row?.githubLogin);
-          },
-        },
       },
     },
     advanced: {

--- a/apps/web/src/server/env.ts
+++ b/apps/web/src/server/env.ts
@@ -9,11 +9,6 @@ export interface Env {
   GITHUB_CLIENT_SECRET: string;
   BETTER_AUTH_SECRET: string;
   /**
-   * Comma-separated GitHub usernames allowed to sign in while bb connect is
-   * invite-only. Unset or empty means nobody can sign in (fail closed).
-   */
-  CONNECT_ALLOWED_GITHUB_USERS?: string;
-  /**
    * Marketing-page endpoints (see src/landing/endpoints.ts). Unset on forks
    * and local dev: /api/subscribe reports signup as not configured, and the
    * download redirect skips server-side click tracking.

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -22,7 +22,6 @@
   "vars": {
     "BASE_DOMAIN": "vibecodethis.site",
     "APP_URL": "https://vibecodethis.site",
-    "CONNECT_ALLOWED_GITHUB_USERS": "sawyerhood",
     // Resend audience that /api/subscribe adds emails to ("bb users").
     // Not a secret — only the API key is.
     "RESEND_AUDIENCE_ID": "299db4ee-f3db-476d-9847-0bf4344d9c44"
@@ -77,7 +76,6 @@
       "vars": {
         "BASE_DOMAIN": "getbb.app",
         "APP_URL": "https://getbb.app",
-        "CONNECT_ALLOWED_GITHUB_USERS": "sawyerhood",
         "RESEND_AUDIENCE_ID": "299db4ee-f3db-476d-9847-0bf4344d9c44"
       },
       "d1_databases": [

--- a/packages/connect-db/migrations/0002_user_github_login.sql
+++ b/packages/connect-db/migrations/0002_user_github_login.sql
@@ -1,4 +1,4 @@
--- bb connect — GitHub username on user, for the invite-only signup allowlist.
+-- bb connect — GitHub username on user, refreshed from the OAuth profile.
 -- See src/schema.ts `user.githubLogin`.
 
 ALTER TABLE user ADD COLUMN github_login text;

--- a/packages/connect-db/src/constants.ts
+++ b/packages/connect-db/src/constants.ts
@@ -76,29 +76,6 @@ export const SERVER_OFFLINE_AFTER_MS = 90 * 1000;
 /** Token prefixes (mirrors bb's host-key convention; distinct namespaces). */
 export const CLOUD_PAT_PREFIX = "bbc_";
 
-/**
- * Signup/sign-in allowlist while bb connect is invite-only. Parsed from the
- * `CONNECT_ALLOWED_GITHUB_USERS` worker var: comma-separated GitHub usernames,
- * case-insensitive. Unset or empty means nobody can sign in (fail closed).
- */
-export function parseAllowedGithubUsers(
-  value: string | undefined,
-): ReadonlySet<string> {
-  return new Set(
-    (value ?? "")
-      .split(",")
-      .map((name) => name.trim().toLowerCase())
-      .filter((name) => name.length > 0),
-  );
-}
-
-export function isGithubUserAllowed(
-  allowed: ReadonlySet<string>,
-  login: string | null | undefined,
-): boolean {
-  return login != null && allowed.has(login.toLowerCase());
-}
-
 export type HandleValidationError =
   | "too-short"
   | "too-long"

--- a/packages/connect-db/src/schema.ts
+++ b/packages/connect-db/src/schema.ts
@@ -24,8 +24,7 @@ export const user = sqliteTable("user", {
   emailVerified: integer("email_verified", { mode: "boolean" }).notNull().default(false),
   image: text("image"),
   // GitHub username, refreshed from the OAuth profile on every sign-in.
-  // Null only for rows predating the column; the signup allowlist treats
-  // null as not allowed.
+  // Null only for rows predating the column.
   githubLogin: text("github_login"),
   createdAt: timestampMs("created_at").notNull(),
   updatedAt: timestampMs("updated_at").notNull(),

--- a/packages/connect-db/test/schema.test.ts
+++ b/packages/connect-db/test/schema.test.ts
@@ -9,8 +9,6 @@ import {
   CONNECT_CODE_TTL_MS,
   connectCode,
   handleFromHost,
-  isGithubUserAllowed,
-  parseAllowedGithubUsers,
   profile,
   schema,
   server,
@@ -171,23 +169,6 @@ describe("validateHandle", () => {
     expect(validateHandle("api")).toBe("reserved");
     expect(validateHandle("www")).toBe("reserved");
     expect(validateHandle("admin")).toBe("reserved");
-  });
-});
-
-describe("github signup allowlist", () => {
-  it("parses a comma-separated var case-insensitively, ignoring blanks", () => {
-    const allowed = parseAllowedGithubUsers(" SawyerHood, other-user, ,");
-    expect(isGithubUserAllowed(allowed, "sawyerhood")).toBe(true);
-    expect(isGithubUserAllowed(allowed, "SAWYERHOOD")).toBe(true);
-    expect(isGithubUserAllowed(allowed, "other-user")).toBe(true);
-    expect(isGithubUserAllowed(allowed, "stranger")).toBe(false);
-  });
-
-  it("fails closed: unset/empty var and null login are not allowed", () => {
-    expect(isGithubUserAllowed(parseAllowedGithubUsers(undefined), "sawyerhood")).toBe(false);
-    expect(isGithubUserAllowed(parseAllowedGithubUsers(""), "sawyerhood")).toBe(false);
-    expect(isGithubUserAllowed(parseAllowedGithubUsers("sawyerhood"), null)).toBe(false);
-    expect(isGithubUserAllowed(parseAllowedGithubUsers("sawyerhood"), undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the bb connect GitHub username allowlist checks from auth sign-in/session creation
- remove the CONNECT_ALLOWED_GITHUB_USERS worker var from web config/types
- delete stale allowlist helpers, tests, and comments from connect-db

## Tests
- pnpm exec turbo run typecheck --filter=@bb/web --filter=@bb/connect-db
- pnpm exec turbo run test --filter=@bb/connect-db
- pnpm exec turbo run build --filter=@bb/web

Note: the web build prints the existing local missing Worker secrets warning when secrets are not present in the shell.