### PR TITLE
Fix favicon default reset

### DIFF
--- a/apps/app/src/lib/favicon-color-preference.test.ts
+++ b/apps/app/src/lib/favicon-color-preference.test.ts
@@ -3,13 +3,32 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
-import { FAVICON_COLORS } from "@bb/domain";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultAppTheme, FAVICON_COLORS } from "@bb/domain";
 import {
   applyInstallIconState,
+  FAVICON_COLOR_SERVER_SYNCED_STORAGE_KEY,
+  FAVICON_COLOR_STORAGE_KEY,
   getAppleTouchIconHref,
   getPwaManifestHref,
+  useFaviconColorSync,
 } from "./favicon-color-preference";
+
+const mocks = vi.hoisted(() => ({
+  updateAppearance: vi.fn(),
+  useSystemConfig: vi.fn(),
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: mocks.useSystemConfig,
+}));
+
+vi.mock("@/hooks/mutations/settings-mutations", () => ({
+  useUpdateAppearance: () => ({
+    mutate: mocks.updateAppearance,
+  }),
+}));
 
 interface WebManifestIcon {
   src: string;
@@ -26,6 +45,19 @@ const publicDir = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../../public",
 );
+
+function setSystemFaviconColor(
+  faviconColor: typeof defaultAppTheme.faviconColor,
+): void {
+  mocks.useSystemConfig.mockReturnValue({
+    data: {
+      appearance: {
+        ...defaultAppTheme,
+        faviconColor,
+      },
+    },
+  });
+}
 
 function publicAssetPath(href: string): string {
   expect(href.startsWith("/")).toBe(true);
@@ -47,6 +79,9 @@ function expectLinkElement(element: HTMLElement | null): HTMLLinkElement {
 describe("favicon color install icons", () => {
   afterEach(() => {
     document.head.replaceChildren();
+    window.localStorage.clear();
+    cleanup();
+    vi.clearAllMocks();
   });
 
   it("maps the default install icon links to the shipped assets", () => {
@@ -111,5 +146,55 @@ describe("favicon color install icons", () => {
         expect(existsSync(publicAssetPath(icon.src))).toBe(true);
       }
     }
+  });
+});
+
+describe("favicon color server sync", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("migrates a cached legacy tint when the server has no stored tint yet", async () => {
+    window.localStorage.setItem(FAVICON_COLOR_STORAGE_KEY, "teal");
+    setSystemFaviconColor("default");
+    mocks.updateAppearance.mockImplementation((_selection, options) => {
+      options?.onSuccess?.();
+    });
+
+    renderHook(() => useFaviconColorSync());
+
+    await waitFor(() =>
+      expect(mocks.updateAppearance).toHaveBeenCalledWith(
+        { themeId: "default", faviconColor: "teal" },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      ),
+    );
+    expect(window.localStorage.getItem(FAVICON_COLOR_STORAGE_KEY)).toBe("teal");
+    expect(
+      window.localStorage.getItem(FAVICON_COLOR_SERVER_SYNCED_STORAGE_KEY),
+    ).toBe("true");
+  });
+
+  it("does not restore a cached tint after the server value has been seen", async () => {
+    window.localStorage.setItem(FAVICON_COLOR_STORAGE_KEY, "teal");
+    setSystemFaviconColor("teal");
+    const { rerender } = renderHook(() => useFaviconColorSync());
+
+    await waitFor(() =>
+      expect(
+        window.localStorage.getItem(FAVICON_COLOR_SERVER_SYNCED_STORAGE_KEY),
+      ).toBe("true"),
+    );
+
+    mocks.updateAppearance.mockClear();
+    setSystemFaviconColor("default");
+    rerender();
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem(FAVICON_COLOR_STORAGE_KEY)).toBeNull(),
+    );
+    expect(mocks.updateAppearance).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/favicon-color-preference.ts
+++ b/apps/app/src/lib/favicon-color-preference.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { atom, getDefaultStore, useSetAtom } from "jotai";
 import {
   defaultFaviconColor,
@@ -13,6 +13,8 @@ import { useSystemConfig } from "@/hooks/queries/system-queries";
 // loads, so the tab icon doesn't flash) and the legacy source for the one-time
 // migration off the old localStorage-only preference.
 export const FAVICON_COLOR_STORAGE_KEY = "bb.faviconColor";
+export const FAVICON_COLOR_SERVER_SYNCED_STORAGE_KEY =
+  "bb.faviconColor.serverSynced";
 
 export const FAVICON_BADGES = ["none", "unread"] as const;
 export type FaviconBadge = (typeof FAVICON_BADGES)[number];
@@ -51,6 +53,24 @@ function cacheFaviconColor(color: FaviconColorPreference): void {
   }
 }
 
+function hasServerSyncedFaviconColor(): boolean {
+  try {
+    return (
+      localStorage.getItem(FAVICON_COLOR_SERVER_SYNCED_STORAGE_KEY) === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function markServerSyncedFaviconColor(): void {
+  try {
+    localStorage.setItem(FAVICON_COLOR_SERVER_SYNCED_STORAGE_KEY, "true");
+  } catch {
+    // Best-effort migration marker; the server value still remains authoritative.
+  }
+}
+
 // Seeded from the boot cache so initializeFavicon() can tint immediately, then
 // reconciled with the server's authoritative value by useFaviconColorSync().
 const faviconColorAtom = atom<FaviconColorPreference>(readCachedFaviconColor());
@@ -60,8 +80,6 @@ function setActiveFaviconColor(color: FaviconColorPreference): void {
   getDefaultStore().set(faviconColorAtom, color);
   cacheFaviconColor(color);
 }
-
-let legacyFaviconColorMigrated = false;
 
 /**
  * Reconciles the favicon tint with the server-stored appearance and re-applies
@@ -74,23 +92,28 @@ export function useFaviconColorSync(): void {
   const { data } = useSystemConfig();
   const appearance = data?.appearance;
   const { mutate: updateAppearance } = useUpdateAppearance();
+  const legacyMigrationRequestedRef = useRef(false);
 
   useEffect(() => {
     if (!appearance) return;
     const legacy = readCachedFaviconColor();
     const needsMigration =
+      !hasServerSyncedFaviconColor() &&
+      !legacyMigrationRequestedRef.current &&
       legacy !== defaultFaviconColor &&
       appearance.faviconColor === defaultFaviconColor;
     if (needsMigration) {
       // Keep showing the legacy tint locally until the server adopts it (so it
       // doesn't flash to default mid-flight), and fire the migration once.
+      legacyMigrationRequestedRef.current = true;
       setActiveFaviconColor(legacy);
-      if (!legacyFaviconColorMigrated) {
-        legacyFaviconColorMigrated = true;
-        updateAppearance({ themeId: appearance.themeId, faviconColor: legacy });
-      }
+      updateAppearance(
+        { themeId: appearance.themeId, faviconColor: legacy },
+        { onSuccess: markServerSyncedFaviconColor },
+      );
       return;
     }
+    markServerSyncedFaviconColor();
     setActiveFaviconColor(appearance.faviconColor);
   }, [appearance, updateAppearance]);
 }


### PR DESCRIPTION
## Summary
- prevent the legacy favicon localStorage migration from re-applying an old tint after the server has stored a preference
- keep the boot favicon cache, but mark when the server-stored favicon color has been observed
- add regression coverage for legacy tint migration and resetting back to Default

## Tests
- pnpm exec turbo run test --filter=@bb/app -- src/lib/favicon-color-preference.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app