### PR TITLE
Fix stale "Host is offline" in composer after desktop cold start

### DIFF
--- a/apps/app/src/hooks/cache-owners/system-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/system-cache-effects.ts
@@ -89,6 +89,36 @@ export function refetchErroredRealtimeQueriesOnInitialConnect({
   });
 }
 
+interface InitialConnectInvalidationArgs extends QueryClientArg {
+  /** Timestamp at which the realtime subscriptions became active. */
+  connectedAt: number;
+}
+
+/**
+ * A query that resolved before the realtime subscriptions were active may have
+ * missed change events published in between, and nothing later corrects it:
+ * the initial-connect path never fires again and staleTime defers mount/focus
+ * refetches. On desktop cold start this window is real — the host daemon opens
+ * its session a few hundred ms after the server starts listening, so the first
+ * hosts/providers fetches capture "disconnected" and the `host-connected`
+ * broadcast lands before the app's subscription registers. Invalidate any
+ * realtime query whose data predates the subscription watermark; queries that
+ * resolve after it observe post-subscribe server state and stay untouched.
+ */
+export function invalidateRealtimeQueriesFetchedBeforeInitialConnect({
+  connectedAt,
+  queryClient,
+}: InitialConnectInvalidationArgs): void {
+  for (const queryKey of getServerReconnectInvalidationQueryKeys()) {
+    queryClient.invalidateQueries({
+      queryKey,
+      predicate: (query) =>
+        query.state.dataUpdatedAt !== 0 &&
+        query.state.dataUpdatedAt < connectedAt,
+    });
+  }
+}
+
 /**
  * Refresh `/system/config` after an experiments write: the server broadcast
  * covers other windows, this gives the writing window an immediate re-gate.

--- a/apps/app/src/hooks/realtime-cache-effects.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.ts
@@ -10,6 +10,7 @@ import {
 } from "@bb/domain";
 import {
   invalidateRealtimeQueriesAfterServerReconnect,
+  invalidateRealtimeQueriesFetchedBeforeInitialConnect,
   refetchErroredRealtimeQueriesOnInitialConnect,
 } from "./cache-owners/system-cache-effects";
 import { createBufferedEnvironmentInvalidator } from "./buffered-environment-invalidator";
@@ -308,6 +309,12 @@ export function createRealtimeCacheEffects({
         return;
       }
       refetchErroredRealtimeQueriesOnInitialConnect({ queryClient });
+      // The ws manager flushes subscribe messages before this callback runs,
+      // so "now" is the watermark after which change events are delivered.
+      invalidateRealtimeQueriesFetchedBeforeInitialConnect({
+        connectedAt: Date.now(),
+        queryClient,
+      });
     },
   };
 }

--- a/apps/app/src/hooks/system-cache-effects.test.ts
+++ b/apps/app/src/hooks/system-cache-effects.test.ts
@@ -5,7 +5,9 @@ import { createAppQueryClient } from "@/lib/query-client";
 import {
   environmentDiffFilesQueryKey,
   environmentDiffPatchQueryKey,
+  hostsQueryKey,
   sidebarNavigationQueryKey,
+  systemProvidersQueryKey,
   systemExecutionOptionsQueryKey,
   terminalsQueryKey,
   threadConversationOutlineQueryKey,
@@ -19,7 +21,10 @@ import {
   threadSearchQueryKey,
   threadTimelineQueryKey,
 } from "./queries/query-keys";
-import { invalidateRealtimeQueriesAfterServerReconnect } from "./cache-owners/system-cache-effects";
+import {
+  invalidateRealtimeQueriesAfterServerReconnect,
+  invalidateRealtimeQueriesFetchedBeforeInitialConnect,
+} from "./cache-owners/system-cache-effects";
 
 function createCacheEffectQueryClient() {
   return createAppQueryClient({
@@ -217,6 +222,36 @@ describe("system cache effects", () => {
     }
     queryClient.unmount();
     queryClient.clear();
+  });
+
+  // Desktop cold start: the host daemon opens its session a few hundred ms
+  // after the server starts listening, so hosts/providers fetched in that
+  // window miss the `host-connected` broadcast and would otherwise show
+  // "Host is offline" (and no models) until something remounts the composer.
+  it("invalidates realtime queries whose data predates the initial connect", () => {
+    const queryClient = createCacheEffectQueryClient();
+    const hostsKey = hostsQueryKey();
+    const providersKey = systemProvidersQueryKey();
+    const neverFetchedKey = sidebarNavigationQueryKey();
+    const connectedAt = Date.now();
+    queryClient.setQueryData(hostsKey, [], { updatedAt: connectedAt - 500 });
+    queryClient.setQueryData(
+      providersKey,
+      { providers: [] },
+      { updatedAt: connectedAt + 500 },
+    );
+
+    invalidateRealtimeQueriesFetchedBeforeInitialConnect({
+      connectedAt,
+      queryClient,
+    });
+
+    // Fetched before the subscriptions were active: may have missed events.
+    expect(queryClient.getQueryState(hostsKey)?.isInvalidated).toBe(true);
+    // Fetched after the watermark: observed post-subscribe server state.
+    expect(queryClient.getQueryState(providersKey)?.isInvalidated).toBe(false);
+    // Never fetched: nothing stale to correct.
+    expect(queryClient.getQueryState(neverFetchedKey)).toBeUndefined();
   });
 
   it("refetches an active diff TOC query but evicts the observer-less patch cache after reconnect", async () => {


### PR DESCRIPTION
## Problem

On desktop cold start, the composer shows "Host is offline" and Claude models don't load until you switch to another thread and back.

Server logs show the race: the host daemon opens its session a few hundred ms after the server starts listening (e.g. `Server listening` at `…995267`, `Session opened` at `…995902`). The app window boots inside that gap:

1. The first `GET /hosts` (and providers/execution-options fetches) resolves while the daemon is still connecting → `"disconnected"`, no models.
2. The server broadcasts `host-connected` when the daemon session opens, but the app's `host-list` WS subscription isn't registered yet — the event is missed.
3. Nothing heals it: the initial-connect handler only refetched **errored** queries, and the hosts query succeeded (with now-wrong data). `staleTime: 60_000` keeps it pinned until something remounts the composer — hence the switch-threads-and-back workaround.

## Fix

On initial WS connect, invalidate any realtime query whose `dataUpdatedAt` predates the moment the subscriptions became active (the ws manager flushes subscribe messages before firing the connected callback, so that timestamp is a safe watermark). Queries resolving after the watermark observed post-subscribe server state and are untouched, so a normal load is a near-no-op. This also heals other events missable in the same gap (e.g. thread interruptions from session-open reconciliation).

## Tests

- New unit test: fetched-before → invalidated; fetched-after → untouched; never-fetched → untouched.
- `vitest run src/hooks/system-cache-effects.test.ts src/hooks/realtime-cache-effects.test.ts` — 40 passed.
- `turbo run typecheck --filter=@bb/app` — clean.

## Risk

Worst case is one extra refetch at startup for small list queries that resolved just before the WS opened. The desktop cold-start race itself wasn't reproduced end-to-end (needs a packaged-app relaunch); verified via log-confirmed timeline + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)