### PR TITLE
Add local file open-in context submenu

### DIFF
--- a/apps/app/src/components/ui/markdown-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-link-routing.ts
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, type ReactNode } from "react";
 import type { MarkdownPreviewLinkHandler } from "./markdown-link.js";
 import type {
   MarkdownAbsoluteLocalFileLinkRouting,
@@ -7,29 +7,49 @@ import type {
   MarkdownRelativeLocalFileLinkRouting,
 } from "./markdown-local-file-link.js";
 
-/** One entry in a local file link's right-click "Open with" menu. */
-export interface MarkdownLocalFileOpenWithItem {
+/** One action in a local file link's right-click menu. */
+export interface MarkdownLocalFileContextMenuAction {
   id: string;
-  label: string;
+  label: ReactNode;
   onSelect: () => void;
+  type?: "action";
 }
 
+export interface MarkdownLocalFileContextMenuSeparator {
+  id: string;
+  type: "separator";
+}
+
+export type MarkdownLocalFileContextMenuLeafItem =
+  | MarkdownLocalFileContextMenuAction
+  | MarkdownLocalFileContextMenuSeparator;
+
+export interface MarkdownLocalFileContextMenuSubmenu {
+  id: string;
+  items: MarkdownLocalFileContextMenuLeafItem[];
+  label: ReactNode;
+  type: "submenu";
+}
+
+export type MarkdownLocalFileContextMenuItem =
+  | MarkdownLocalFileContextMenuLeafItem
+  | MarkdownLocalFileContextMenuSubmenu;
+
 /**
- * Viewer choices for the right-click menu on local file links (e.g. "Open
- * with built-in preview" / plugin file openers). Null/empty = no menu;
- * left-click behavior is unchanged either way.
+ * Right-click menu items for local file links. Null/empty = no menu; left-click
+ * behavior is unchanged either way.
  */
-export type MarkdownLocalFileOpenWithItemsProvider = (
+export type MarkdownLocalFileContextMenuItemsProvider = (
   link: MarkdownPreviewLocalFileLink,
-) => MarkdownLocalFileOpenWithItem[] | null;
+) => MarkdownLocalFileContextMenuItem[] | null;
 
 /**
  * Context, not a routing field: local file links render across the thread
  * timeline and every file-preview surface, whose link routings are built in
  * many places — one provider at the view root covers them all uniformly.
  */
-export const MarkdownLocalFileOpenWithContext =
-  createContext<MarkdownLocalFileOpenWithItemsProvider | null>(null);
+export const MarkdownLocalFileContextMenuContext =
+  createContext<MarkdownLocalFileContextMenuItemsProvider | null>(null);
 
 export interface MarkdownLocalFileLinkRouting {
   absoluteLinks: MarkdownAbsoluteLocalFileLinkRouting;

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MarkdownPreview } from "./markdown-preview";
 import {
-  MarkdownLocalFileOpenWithContext,
+  MarkdownLocalFileContextMenuContext,
   type MarkdownLinkRouting,
 } from "./markdown-link-routing";
 
@@ -77,18 +77,39 @@ describe("MarkdownPreview", () => {
     expect(screen.getByText("src/app.ts").tagName).toBe("CODE");
   });
 
-  it("shows an Open with menu on local file links when the context provides items", () => {
+  it("shows a context menu on local file links when the context provides items", () => {
     const openBuiltin = vi.fn();
+    const openFinder = vi.fn();
     const openWithPlugin = vi.fn();
     render(
-      <MarkdownLocalFileOpenWithContext.Provider
+      <MarkdownLocalFileContextMenuContext.Provider
         value={(link) =>
           link.path.endsWith(".md")
             ? [
                 {
+                  id: "open-in",
+                  items: [
+                    {
+                      id: "finder",
+                      label: "Open in Finder",
+                      onSelect: openFinder,
+                    },
+                  ],
+                  label: "Open in",
+                  type: "submenu",
+                },
+                {
+                  id: "open-in-separator",
+                  type: "separator",
+                },
+                {
                   id: "builtin",
                   label: "Open with built-in preview",
                   onSelect: openBuiltin,
+                },
+                {
+                  id: "separator",
+                  type: "separator",
                 },
                 {
                   id: "notes:editor",
@@ -108,13 +129,15 @@ describe("MarkdownPreview", () => {
             },
           }}
         />
-      </MarkdownLocalFileOpenWithContext.Provider>,
+      </MarkdownLocalFileContextMenuContext.Provider>,
     );
 
     const link = screen.getByRole("link", { name: /notes/ });
     fireEvent.contextMenu(link);
+    expect(screen.getByText("Open in")).not.toBeNull();
     fireEvent.click(screen.getByText("Open with Notes editor"));
     expect(openWithPlugin).toHaveBeenCalledTimes(1);
+    expect(openFinder).not.toHaveBeenCalled();
     expect(openBuiltin).not.toHaveBeenCalled();
 
     // The provider returned null for the .ts link — plain anchor, no menu.

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -15,6 +15,10 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@bb/shared-ui/context-menu";
 import type {
@@ -49,8 +53,9 @@ import {
   type MarkdownRelativeLocalFileLinkRouting,
 } from "./markdown-local-file-link.js";
 import {
-  MarkdownLocalFileOpenWithContext,
+  MarkdownLocalFileContextMenuContext,
   type MarkdownLinkRouting,
+  type MarkdownLocalFileContextMenuItem,
   type MarkdownLocalFileLinkRouting,
 } from "./markdown-link-routing.js";
 import {
@@ -481,10 +486,10 @@ function MarkdownAnchor({
         })
       : null;
   const anchorHref = buildLocalFileAnchorHref(localFileLink, rewrittenHref);
-  const getOpenWithItems = useContext(MarkdownLocalFileOpenWithContext);
-  const openWithItems =
-    localFileLink !== null && getOpenWithItems !== null
-      ? getOpenWithItems(localFileLink)
+  const getContextMenuItems = useContext(MarkdownLocalFileContextMenuContext);
+  const contextMenuItems =
+    localFileLink !== null && getContextMenuItems !== null
+      ? getContextMenuItems(localFileLink)
       : null;
   const handleAnchorClick = (event: MarkdownAnchorEvent) => {
     if (localFileLink && onOpenLocalFileLink) {
@@ -532,22 +537,39 @@ function MarkdownAnchor({
       ) : null}
     </RouteAnchor>
   );
-  if (openWithItems === null || openWithItems.length === 0) {
+  if (contextMenuItems === null || contextMenuItems.length === 0) {
     return anchor;
   }
-  // Local file links with viewer choices get a right-click "Open with" menu
-  // (per-open override of the extension's default opener).
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{anchor}</ContextMenuTrigger>
-      <ContextMenuContent>
-        {openWithItems.map((item) => (
-          <ContextMenuItem key={item.id} onSelect={item.onSelect}>
-            {item.label}
-          </ContextMenuItem>
-        ))}
+      <ContextMenuContent className="min-w-44">
+        {contextMenuItems.map(renderMarkdownLocalFileContextMenuItem)}
       </ContextMenuContent>
     </ContextMenu>
+  );
+}
+
+function renderMarkdownLocalFileContextMenuItem(
+  item: MarkdownLocalFileContextMenuItem,
+) {
+  if (item.type === "separator") {
+    return <ContextMenuSeparator key={item.id} />;
+  }
+  if (item.type === "submenu") {
+    return (
+      <ContextMenuSub key={item.id}>
+        <ContextMenuSubTrigger>{item.label}</ContextMenuSubTrigger>
+        <ContextMenuSubContent className="min-w-44">
+          {item.items.map(renderMarkdownLocalFileContextMenuItem)}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+    );
+  }
+  return (
+    <ContextMenuItem key={item.id} onSelect={item.onSelect}>
+      {item.label}
+    </ContextMenuItem>
   );
 }
 

--- a/apps/app/src/hooks/useLocalOpenTargets.ts
+++ b/apps/app/src/hooks/useLocalOpenTargets.ts
@@ -40,6 +40,11 @@ export interface OpenPathInDirectoryTargetArgs extends OpenLocalPathRequest {
   targetId: WorkspaceOpenTargetId;
 }
 
+export interface OpenPathInFileTargetArgs extends OpenLocalPathRequest {
+  rememberTarget: boolean;
+  targetId: WorkspaceOpenTargetId;
+}
+
 export interface OpenPathInPreferredTargetArgs extends OpenLocalPathRequest {}
 
 interface OpenPathInAvailableTargetArgs extends OpenLocalPathRequest {
@@ -52,9 +57,11 @@ export interface UseLocalOpenTargetsResult {
   canOpenPreferredDirectoryTarget: boolean;
   canOpenPreferredFileTarget: boolean;
   directoryOpenTargets: WorkspaceOpenTarget[];
+  fileOpenTargets: WorkspaceOpenTarget[];
   openPathInDirectoryTarget: (
     args: OpenPathInDirectoryTargetArgs,
   ) => Promise<boolean>;
+  openPathInFileTarget: (args: OpenPathInFileTargetArgs) => Promise<boolean>;
   openPathInPreferredDirectoryTarget: (
     args: OpenPathInPreferredTargetArgs,
   ) => Promise<boolean>;
@@ -97,6 +104,7 @@ interface UseOpenTargetResolutionArgs {
 
 interface OpenTargetResolution {
   directoryOpenTargets: WorkspaceOpenTarget[];
+  fileOpenTargets: WorkspaceOpenTarget[];
   preferredDirectoryTarget: WorkspaceOpenTarget | null;
   preferredFileTarget: WorkspaceOpenTarget | null;
 }
@@ -157,6 +165,17 @@ function useOpenTargetResolution(
       ),
     [args.contextKind, args.workspaceOpenTargets],
   );
+  const fileOpenTargets = useMemo(
+    () =>
+      args.workspaceOpenTargets.filter((target) =>
+        supportsWorkspaceOpenTargetCapability({
+          capability: "openFile",
+          contextKind: args.contextKind,
+          target,
+        }),
+      ),
+    [args.contextKind, args.workspaceOpenTargets],
+  );
   // Resolve locally from the already-gated `workspaceOpenTargets` so that
   // callers passing `enabled: false` don't trigger a daemon fetch via the
   // global atom.
@@ -176,13 +195,14 @@ function useOpenTargetResolution(
         capability: "openFile",
         contextKind: args.contextKind,
         preferredTargetId: args.preferredFileTargetId,
-        targets: args.workspaceOpenTargets,
+        targets: fileOpenTargets,
       }),
-    [args.contextKind, args.preferredFileTargetId, args.workspaceOpenTargets],
+    [args.contextKind, args.preferredFileTargetId, fileOpenTargets],
   );
 
   return {
     directoryOpenTargets,
+    fileOpenTargets,
     preferredDirectoryTarget,
     preferredFileTarget,
   };
@@ -208,6 +228,7 @@ export function useLocalOpenTargets(
     useFileOpenTargetPreference();
   const {
     directoryOpenTargets,
+    fileOpenTargets,
     preferredDirectoryTarget,
     preferredFileTarget,
   } = useOpenTargetResolution({
@@ -312,6 +333,32 @@ export function useLocalOpenTargets(
     },
     [directoryOpenTargets, hasDaemon, openPathInAvailableTarget],
   );
+  const openPathInFileTarget = useCallback(
+    async (request: OpenPathInFileTargetArgs) => {
+      const target = fileOpenTargets.find(
+        (candidate) => candidate.id === request.targetId,
+      );
+      if (!target) {
+        dispatchOpenFailureToast({
+          description: getOpenUnavailableDescription({
+            hasDaemon,
+            targetKind: "file-open-target",
+          }),
+        });
+        return false;
+      }
+
+      return openPathInAvailableTarget({
+        columnNumber: request.columnNumber ?? null,
+        lineNumber: request.lineNumber,
+        path: request.path,
+        rememberTarget: request.rememberTarget,
+        target,
+        targetKind: "file-open-target",
+      });
+    },
+    [fileOpenTargets, hasDaemon, openPathInAvailableTarget],
+  );
 
   const openPathInPreferredDirectoryTarget = useCallback(
     async (request: OpenPathInPreferredTargetArgs) => {
@@ -385,7 +432,9 @@ export function useLocalOpenTargets(
     canOpenPreferredDirectoryTarget: preferredDirectoryTarget !== null,
     canOpenPreferredFileTarget: preferredFileTarget !== null,
     directoryOpenTargets,
+    fileOpenTargets,
     openPathInDirectoryTarget,
+    openPathInFileTarget,
     openPathInPreferredDirectoryTarget,
     openPathInPreferredFileTarget,
     preferredDirectoryTarget,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -23,7 +23,9 @@ import type {
   PullRequestMergeMethod,
   TerminalSession,
 } from "@bb/server-contract";
+import type { WorkspaceOpenTarget } from "@bb/host-daemon-contract";
 import { appToast } from "@/components/ui/app-toast";
+import { copyToClipboardWithToast } from "@/lib/clipboard";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import { useForkThreadFromMessage } from "@/hooks/useForkThreadFromMessage";
 import { isThreadForkable } from "@/lib/fork-thread-request";
@@ -183,8 +185,9 @@ import {
   type ThreadLocalFileLinkResolution,
 } from "@/lib/thread-local-file-links";
 import {
-  MarkdownLocalFileOpenWithContext,
+  MarkdownLocalFileContextMenuContext,
   type MarkdownLinkRouting,
+  type MarkdownLocalFileContextMenuItem,
   type MarkdownLocalFileLinkRouting,
 } from "@/components/ui/markdown-link-routing";
 import {
@@ -224,8 +227,7 @@ const PARENT_THREAD_SELECTOR_FILTERS = {
 } satisfies ProjectThreadSubsetFilters;
 const EMPTY_TERMINAL_SESSIONS: readonly TerminalSession[] = [];
 const DEFAULT_PULL_REQUEST_MERGE_METHOD: PullRequestMergeMethod = "merge";
-const PULL_REQUEST_MERGE_METHOD_STORAGE_KEY =
-  "bb.pullRequest.mergeMethod";
+const PULL_REQUEST_MERGE_METHOD_STORAGE_KEY = "bb.pullRequest.mergeMethod";
 
 function isPullRequestMergeMethod(
   value: string,
@@ -419,6 +421,15 @@ function buildMarkdownPreviewLinkRouting({
     localFile: localFileRouting,
     onOpenLink,
   };
+}
+
+function getLocalFileBasename(path: string): string {
+  const normalizedPath = path.replace(/[\\/]+$/u, "");
+  return normalizedPath.split(/[\\/]/u).at(-1) ?? path;
+}
+
+function buildOpenTargetMenuItemLabel(target: WorkspaceOpenTarget): string {
+  return `Open in ${target.label}`;
 }
 
 export function resolveHostFilePreviewLinkRootPath({
@@ -619,11 +630,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   // each one keeps a live native view that must persist across tab switches, so
   // the deck stays mounted independently of which tab is active.
   const renderBrowserDeck = useCallback(
-    ({
-      canShowNativeBrowserView,
-    }: {
-      canShowNativeBrowserView: boolean;
-    }) => {
+    ({ canShowNativeBrowserView }: { canShowNativeBrowserView: boolean }) => {
       if (browserDeckThreadId === null) {
         return null;
       }
@@ -817,10 +824,12 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   const forkThreadFromMessage = useForkThreadFromMessage({
     sourceThread: thread ?? null,
   });
-  const handleForkMessage =
-    useCallback<ThreadTimelineForkMessageHandler>((target) => {
+  const handleForkMessage = useCallback<ThreadTimelineForkMessageHandler>(
+    (target) => {
       void forkThreadFromMessage(target);
-    }, [forkThreadFromMessage]);
+    },
+    [forkThreadFromMessage],
+  );
   const isForkAvailable = isThreadForkable(thread ?? null);
   const canUseSideChatPanel = props.surface !== "popout";
   const canStartSideChat =
@@ -907,12 +916,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
           senderThreadId: thread.id,
         });
       },
-      [
-        sendMessage,
-        thread?.id,
-        threadOriginKind,
-        threadSourceThreadId,
-      ],
+      [sendMessage, thread?.id, threadOriginKind, threadSourceThreadId],
     );
   const handleSendToMainMessage =
     threadOriginKind === "side-chat" && threadSourceThreadId !== null
@@ -1496,9 +1500,7 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
         return;
       }
       setPullRequestMergeMethod(method);
-      const toastId = appToast.loading(
-        getPullRequestMergeLoadingTitle(method),
-      );
+      const toastId = appToast.loading(getPullRequestMergeLoadingTitle(method));
       try {
         const response = await requestEnvironmentAction.mutateAsync({
           id: environmentId,
@@ -1519,7 +1521,11 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
         });
       }
     },
-    [requestEnvironmentAction, setPullRequestMergeMethod, thread?.environmentId],
+    [
+      requestEnvironmentAction,
+      setPullRequestMergeMethod,
+      thread?.environmentId,
+    ],
   );
   const workspaceBranch = workspaceStatus?.branch;
   const workspaceChangedFilesSection = useMemo(
@@ -1557,7 +1563,9 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     canOpenPreferredDirectoryTarget,
     canOpenPreferredFileTarget,
     directoryOpenTargets,
+    fileOpenTargets,
     openPathInDirectoryTarget,
+    openPathInFileTarget,
     openPathInPreferredDirectoryTarget,
     openPathInPreferredFileTarget,
     preferredDirectoryTarget,
@@ -1913,37 +1921,98 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     threadStorageRootPath,
     workspaceRootPath: workspacePreviewRootPath,
   });
-  // Right-click "Open with" on local file links: per-open viewer choice
-  // between the built-in preview and any plugin opener matching the file's
-  // extension. Only rendered when at least one opener matches.
-  const getLocalFileOpenWithItems = useCallback(
+  // Right-click local file links: per-open native app choices, optional
+  // preview/plugin viewer choices, and utility copy actions. Left-click behavior
+  // stays unchanged.
+  const getLocalFileContextMenuItems = useCallback(
     (link: ThreadTimelineLocalFileLink) => {
       const extension = getFileExtension(link.path);
-      if (extension === null) return null;
-      const matching = pluginFileOpeners.filter((opener) =>
-        opener.extensions.includes(extension),
-      );
-      if (matching.length === 0) return null;
-      return [
-        {
-          id: "builtin",
-          label: "Open with built-in preview",
-          onSelect: () => {
-            handleOpenTimelineLocalFileLink(link, { viewer: "builtin" });
-          },
+      const matching =
+        extension === null
+          ? []
+          : pluginFileOpeners.filter((opener) =>
+              opener.extensions.includes(extension),
+            );
+      const lineNumber = getFilePreviewLineRangeStart({
+        lineRange: link.lineRange,
+      });
+      const openTargetItems = fileOpenTargets.map((target) => ({
+        id: `open-target:${target.id}`,
+        label: buildOpenTargetMenuItemLabel(target),
+        onSelect: () => {
+          void openPathInFileTarget({
+            lineNumber,
+            path: link.path,
+            rememberTarget: false,
+            targetId: target.id,
+          });
         },
-        ...matching.map((opener) => ({
-          id: `${opener.pluginId}:${opener.id}`,
-          label: `Open with ${opener.title}`,
+      }));
+      const items: MarkdownLocalFileContextMenuItem[] = [];
+      if (openTargetItems.length > 0) {
+        items.push({
+          id: "open-in",
+          items: openTargetItems,
+          label: "Open in",
+          type: "submenu",
+        });
+      }
+      if (matching.length > 0) {
+        if (items.length > 0) {
+          items.push({ id: "open-with-separator", type: "separator" });
+        }
+        items.push(
+          {
+            id: "builtin",
+            label: "Open with built-in preview",
+            onSelect: () => {
+              handleOpenTimelineLocalFileLink(link, { viewer: "builtin" });
+            },
+          },
+          ...matching.map((opener) => ({
+            id: `${opener.pluginId}:${opener.id}`,
+            label: `Open with ${opener.title}`,
+            onSelect: () => {
+              handleOpenTimelineLocalFileLink(link, {
+                viewer: { pluginId: opener.pluginId, openerId: opener.id },
+              });
+            },
+          })),
+        );
+      }
+      if (items.length > 0) {
+        items.push({ id: "copy-separator", type: "separator" });
+      }
+      items.push(
+        {
+          id: "copy-path",
+          label: "Copy file path",
           onSelect: () => {
-            handleOpenTimelineLocalFileLink(link, {
-              viewer: { pluginId: opener.pluginId, openerId: opener.id },
+            void copyToClipboardWithToast(link.path, {
+              successMessage: "File path copied",
+              errorMessage: "Failed to copy file path",
             });
           },
-        })),
-      ];
+        },
+        {
+          id: "copy-name",
+          label: "Copy file name",
+          onSelect: () => {
+            void copyToClipboardWithToast(getLocalFileBasename(link.path), {
+              successMessage: "File name copied",
+              errorMessage: "Failed to copy file name",
+            });
+          },
+        },
+      );
+      return items;
     },
-    [handleOpenTimelineLocalFileLink, pluginFileOpeners],
+    [
+      fileOpenTargets,
+      handleOpenTimelineLocalFileLink,
+      openPathInFileTarget,
+      pluginFileOpeners,
+    ],
   );
   const workspaceMarkdownLinkRouting = useMemo(
     () =>
@@ -2278,146 +2347,150 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   );
 
   return (
-    <MarkdownLocalFileOpenWithContext.Provider
-      value={getLocalFileOpenWithItems}
+    <MarkdownLocalFileContextMenuContext.Provider
+      value={getLocalFileContextMenuItems}
     >
-    <UrlOpenRoutingProvider
-      openInAppBrowser={
-        canOpenUrlsInAppBrowser ? openBrowserTabAndReveal : null
-      }
-    >
-      <ThreadDetailSecondaryContent
-        footer={composerFooter}
-        header={timelineHeader}
-        isMetadataLoading={environmentQuery.isLoading}
-        isSecondaryPanelOpen={isSecondaryPanelOpen}
-        isConversationCollapsed={isConversationCollapsed}
-        surface={props.surface}
-        onToggleConversationCollapse={toggleConversationCollapse}
-        metadata={{
-          thread,
-          projectId,
-          parentThreadDisplayName: parentThreadDisplayName ?? null,
-          parentThreads,
-          canAssignToParent,
-          canTakeOverThread,
-          environment: environment ?? null,
-          environmentDisplayHost: environmentDisplayHostContext,
-          workspaceStatus,
-          workspaceStatusError: workspaceStatusError ?? null,
-          workspaceUnavailable,
-          pullRequest,
-          selectedMergeBaseBranch,
-          mergeBaseBranchRef: selectedMergeBaseBranchRef,
-          mergeBaseBranchOptions,
-          mergeBaseRemoteBranchOptions,
-          isLoadingMergeBaseBranchOptions,
-          updateThreadPending:
-            updateThread.isPending || updateEnvironment.isPending,
-          storage: metadataStorage,
-          onAssignParent: handleAssignParent,
-          onMergeBaseBranchChange: handleMergeBaseBranchChange,
-          onMergeBasePickerOpenChange: handleMergeBasePickerOpenChange,
-          onMergeBaseBranchSearchQueryChange: setMergeBaseBranchSearchQuery,
-          onChangedFileClick: canUseGitUi ? handleChangedFileClick : undefined,
-          onCommitClick: canUseGitUi ? handleCommitClick : undefined,
-        }}
-        secondaryPanel={{
-          activeTab: activeFixedSecondaryTab,
-          canUseGitUi,
-          defaultMergeBaseBranch: resolvedDefaultMergeBaseBranch,
-          environmentId: thread.environmentId ?? undefined,
-          workspaceRootPath: environment?.path,
-          fileTabs,
-          fileTabContent,
-          renderBrowserDeck,
-          isBrowserTabActive,
-          sideChatDeck,
-          isSideChatTabActive,
-          isOpen: isSecondaryPanelOpen,
-          onClose: closeSecondaryPanel,
-          onCollapse: closeSecondaryPanel,
-          onOpenFileInEditor: handleOpenFileInEditor,
-          onFileTabReorder: reorderFileTab,
-          onOpenNewTab: handleOpenNewTab,
-          onOpenFilePreview: handleOpenFilePreview,
-          onSelectionAddToChat: handleSelectionAddToChat,
-          onPanelFocus: handleSecondaryPanelFocus,
-          onPanelChange: handleSecondaryPanelChange,
-          showGitDiffTab: canUseGitUi,
-        }}
-        timeline={{
-          activeThinking,
-          canSpawnChild: thread.canSpawnChild,
-          threadChildOrigin: threadOriginKind,
-          hasOlderTimelineRows,
-          hostConnectionNotice,
-          isLoadingOlderTimelineRows,
-          isThreadTimelinePending,
-          timelineError: Boolean(timelineError),
-          onForkMessage: isForkAvailable ? handleForkMessage : undefined,
-          onSideChatMessage: canStartSideChat
-            ? handleSideChatMessage
-            : undefined,
-          onSendToMainMessage: handleSendToMainMessage,
-          onSelectionAddToChat: handleSelectionAddToChat,
-          onSelectionReplyInSideChat: canStartSideChat
-            ? handleSelectionReplyInSideChat
-            : undefined,
-          onLoadOlderRows: loadOlderTimelineRows,
-          onOpenLink: handleOpenTimelineLink,
-          onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
-          onTitleAction: handleTimelineTitleAction,
-          projectId,
-          resolveMentionLink,
-          showOngoingIndicator:
-            thread.status !== "stopping" &&
-            // A pending interaction (question or approval) already renders its
-            // own inline shimmer row, so the bottom indicator would just
-            // duplicate it.
-            !hasPendingInteraction &&
-            isRunningThreadRuntimeDisplayStatus(thread.runtime.displayStatus) &&
-            !isThreadTimelinePending,
-          ongoingIndicatorLabel:
-            thread.runtime.displayStatus === "host-reconnecting"
-              ? "Waiting for reconnection"
+      <UrlOpenRoutingProvider
+        openInAppBrowser={
+          canOpenUrlsInAppBrowser ? openBrowserTabAndReveal : null
+        }
+      >
+        <ThreadDetailSecondaryContent
+          footer={composerFooter}
+          header={timelineHeader}
+          isMetadataLoading={environmentQuery.isLoading}
+          isSecondaryPanelOpen={isSecondaryPanelOpen}
+          isConversationCollapsed={isConversationCollapsed}
+          surface={props.surface}
+          onToggleConversationCollapse={toggleConversationCollapse}
+          metadata={{
+            thread,
+            projectId,
+            parentThreadDisplayName: parentThreadDisplayName ?? null,
+            parentThreads,
+            canAssignToParent,
+            canTakeOverThread,
+            environment: environment ?? null,
+            environmentDisplayHost: environmentDisplayHostContext,
+            workspaceStatus,
+            workspaceStatusError: workspaceStatusError ?? null,
+            workspaceUnavailable,
+            pullRequest,
+            selectedMergeBaseBranch,
+            mergeBaseBranchRef: selectedMergeBaseBranchRef,
+            mergeBaseBranchOptions,
+            mergeBaseRemoteBranchOptions,
+            isLoadingMergeBaseBranchOptions,
+            updateThreadPending:
+              updateThread.isPending || updateEnvironment.isPending,
+            storage: metadataStorage,
+            onAssignParent: handleAssignParent,
+            onMergeBaseBranchChange: handleMergeBaseBranchChange,
+            onMergeBasePickerOpenChange: handleMergeBasePickerOpenChange,
+            onMergeBaseBranchSearchQueryChange: setMergeBaseBranchSearchQuery,
+            onChangedFileClick: canUseGitUi
+              ? handleChangedFileClick
               : undefined,
-          timelineRows,
-          isStopping: thread.status === "stopping",
-          stoppingAnchorAt: thread.updatedAt,
-          threadId: thread.id,
-          threadRuntimeDisplayStatus: thread.runtime.displayStatus,
-          unreadDividerAutoScroll: unreadDividerState.autoScroll,
-          unreadDividerPlacement: unreadDividerState.placement,
-          workspaceRootPath: environment?.path ?? undefined,
-        }}
-      />
-      {canUseGitUi ? (
-        <ThreadGitActionDialog
-          target={gitActions.threadGitActionDialog.target}
-          branchName={threadBranchName}
-          gitStatusDisplay={threadGitStatusDisplay}
-          changedFilesSection={workingTreeChangedFilesSection}
-          showMergeBaseDetails={showBranchComparisonUi}
-          mergeBaseBranch={effectiveMergeBaseBranch}
-          mergeBaseBranchOptions={mergeBaseBranchOptions}
-          mergeBaseBranchRef={selectedMergeBaseBranchRef}
-          mergeBaseRemoteBranchOptions={mergeBaseRemoteBranchOptions}
-          mergeBaseBranchOptionsLoading={isLoadingMergeBaseBranchOptions}
-          onMergeBaseBranchSearchQueryChange={setMergeBaseBranchSearchQuery}
-          onMergeBaseBranchChange={
-            showBranchComparisonUi ? handleMergeBaseBranchChange : undefined
-          }
-          onOpenChange={(open) => {
-            if (!open) {
-              gitActions.threadGitActionDialog.onClose();
-            }
+            onCommitClick: canUseGitUi ? handleCommitClick : undefined,
           }}
-          onCommit={gitActions.handleCommitThread}
-          onSquashMerge={gitActions.handleSquashMergeThread}
+          secondaryPanel={{
+            activeTab: activeFixedSecondaryTab,
+            canUseGitUi,
+            defaultMergeBaseBranch: resolvedDefaultMergeBaseBranch,
+            environmentId: thread.environmentId ?? undefined,
+            workspaceRootPath: environment?.path,
+            fileTabs,
+            fileTabContent,
+            renderBrowserDeck,
+            isBrowserTabActive,
+            sideChatDeck,
+            isSideChatTabActive,
+            isOpen: isSecondaryPanelOpen,
+            onClose: closeSecondaryPanel,
+            onCollapse: closeSecondaryPanel,
+            onOpenFileInEditor: handleOpenFileInEditor,
+            onFileTabReorder: reorderFileTab,
+            onOpenNewTab: handleOpenNewTab,
+            onOpenFilePreview: handleOpenFilePreview,
+            onSelectionAddToChat: handleSelectionAddToChat,
+            onPanelFocus: handleSecondaryPanelFocus,
+            onPanelChange: handleSecondaryPanelChange,
+            showGitDiffTab: canUseGitUi,
+          }}
+          timeline={{
+            activeThinking,
+            canSpawnChild: thread.canSpawnChild,
+            threadChildOrigin: threadOriginKind,
+            hasOlderTimelineRows,
+            hostConnectionNotice,
+            isLoadingOlderTimelineRows,
+            isThreadTimelinePending,
+            timelineError: Boolean(timelineError),
+            onForkMessage: isForkAvailable ? handleForkMessage : undefined,
+            onSideChatMessage: canStartSideChat
+              ? handleSideChatMessage
+              : undefined,
+            onSendToMainMessage: handleSendToMainMessage,
+            onSelectionAddToChat: handleSelectionAddToChat,
+            onSelectionReplyInSideChat: canStartSideChat
+              ? handleSelectionReplyInSideChat
+              : undefined,
+            onLoadOlderRows: loadOlderTimelineRows,
+            onOpenLink: handleOpenTimelineLink,
+            onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
+            onTitleAction: handleTimelineTitleAction,
+            projectId,
+            resolveMentionLink,
+            showOngoingIndicator:
+              thread.status !== "stopping" &&
+              // A pending interaction (question or approval) already renders its
+              // own inline shimmer row, so the bottom indicator would just
+              // duplicate it.
+              !hasPendingInteraction &&
+              isRunningThreadRuntimeDisplayStatus(
+                thread.runtime.displayStatus,
+              ) &&
+              !isThreadTimelinePending,
+            ongoingIndicatorLabel:
+              thread.runtime.displayStatus === "host-reconnecting"
+                ? "Waiting for reconnection"
+                : undefined,
+            timelineRows,
+            isStopping: thread.status === "stopping",
+            stoppingAnchorAt: thread.updatedAt,
+            threadId: thread.id,
+            threadRuntimeDisplayStatus: thread.runtime.displayStatus,
+            unreadDividerAutoScroll: unreadDividerState.autoScroll,
+            unreadDividerPlacement: unreadDividerState.placement,
+            workspaceRootPath: environment?.path ?? undefined,
+          }}
         />
-      ) : null}
-    </UrlOpenRoutingProvider>
-    </MarkdownLocalFileOpenWithContext.Provider>
+        {canUseGitUi ? (
+          <ThreadGitActionDialog
+            target={gitActions.threadGitActionDialog.target}
+            branchName={threadBranchName}
+            gitStatusDisplay={threadGitStatusDisplay}
+            changedFilesSection={workingTreeChangedFilesSection}
+            showMergeBaseDetails={showBranchComparisonUi}
+            mergeBaseBranch={effectiveMergeBaseBranch}
+            mergeBaseBranchOptions={mergeBaseBranchOptions}
+            mergeBaseBranchRef={selectedMergeBaseBranchRef}
+            mergeBaseRemoteBranchOptions={mergeBaseRemoteBranchOptions}
+            mergeBaseBranchOptionsLoading={isLoadingMergeBaseBranchOptions}
+            onMergeBaseBranchSearchQueryChange={setMergeBaseBranchSearchQuery}
+            onMergeBaseBranchChange={
+              showBranchComparisonUi ? handleMergeBaseBranchChange : undefined
+            }
+            onOpenChange={(open) => {
+              if (!open) {
+                gitActions.threadGitActionDialog.onClose();
+              }
+            }}
+            onCommit={gitActions.handleCommitThread}
+            onSquashMerge={gitActions.handleSquashMergeThread}
+          />
+        ) : null}
+      </UrlOpenRoutingProvider>
+    </MarkdownLocalFileContextMenuContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- add generic submenu support to markdown local-file context menus
- group native file open targets under an Open in submenu for local file links
- keep preview/plugin opener actions and copy file utilities available in the same menu

## Tests
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/ui/markdown-preview.test.tsx
- pnpm exec prettier --check apps/app/src/components/ui/markdown-link-routing.ts apps/app/src/components/ui/markdown-preview.tsx apps/app/src/components/ui/markdown-preview.test.tsx apps/app/src/hooks/useLocalOpenTargets.ts apps/app/src/views/thread-detail/ThreadDetailView.tsx
- git diff --check