### PR TITLE
Hide right panel terminal count badge

### DIFF
--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -11,7 +11,6 @@ import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import {
   findLocalPathProjectSourceForHost,
   type EnvironmentStatus,
-  isActiveTerminalSessionStatus,
   PERSONAL_PROJECT_ID,
   type PermissionMode,
   type ProjectSource,
@@ -434,7 +433,6 @@ interface BuildRootComposeTerminalSessionsArgs {
 }
 
 interface RootComposeRightPanelToggleProps {
-  activeTerminalCount: number;
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -455,7 +453,6 @@ function RightPanelFileTabIcon({ path }: RightPanelFileTabIconProps) {
 }
 
 function RootComposeRightPanelToggle({
-  activeTerminalCount,
   isOpen,
   onToggle,
 }: RootComposeRightPanelToggleProps) {
@@ -474,14 +471,6 @@ function RootComposeRightPanelToggle({
       onClick={onToggle}
     >
       <Icon name={rightPanelIconName} />
-      {activeTerminalCount > 0 ? (
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-none text-primary-foreground"
-        >
-          {activeTerminalCount > 9 ? "9+" : activeTerminalCount}
-        </span>
-      ) : null}
     </Button>
   );
 }
@@ -1999,13 +1988,6 @@ export function RootComposeView(props: RootComposeViewProps) {
   const terminalSessions =
     loadedTerminalSessions ?? EMPTY_TERMINAL_SESSIONS;
   const terminalsListLoaded = loadedTerminalSessions !== undefined;
-  const activeTerminalCount = useMemo(
-    () =>
-      terminalSessions.filter((session) =>
-        isActiveTerminalSessionStatus(session.status),
-      ).length,
-    [terminalSessions],
-  );
   const terminalsById = useMemo(
     () => new Map(terminalSessions.map((session) => [session.id, session])),
     [terminalSessions],
@@ -2991,7 +2973,6 @@ export function RootComposeView(props: RootComposeViewProps) {
         className={`fixed z-40 ${ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS}`}
       >
         <RootComposeRightPanelToggle
-          activeTerminalCount={activeTerminalCount}
           isOpen={isSecondaryPanelOpen}
           onToggle={handleToggleSecondaryPanel}
         />

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -27,7 +27,6 @@ interface ThreadHeaderGitAction {
 
 interface ThreadDetailHeaderProps {
   actionsMenu: ReactNode;
-  activeTerminalCount: number;
   /** Pill shown beside the title for side chats and hierarchical child threads. */
   childPillLabel: "child" | "side chat" | null;
   isSecondaryPanelOpen: boolean;
@@ -42,7 +41,6 @@ interface ThreadDetailHeaderProps {
 
 export function ThreadDetailHeader({
   actionsMenu,
-  activeTerminalCount,
   childPillLabel,
   isSecondaryPanelOpen,
   onOpenThreadGitAction,
@@ -133,14 +131,6 @@ export function ThreadDetailHeader({
           onClick={onToggleSecondaryPanel}
         >
           <Icon name={rightPanelIconName} />
-          {activeTerminalCount > 0 ? (
-            <span
-              aria-hidden="true"
-              className="pointer-events-none absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-none text-primary-foreground"
-            >
-              {activeTerminalCount > 9 ? "9+" : activeTerminalCount}
-            </span>
-          ) : null}
         </Button>
       ) : null}
     </>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -14,7 +14,6 @@ import {
   useThreadTimelineController,
 } from "@/components/thread/timeline";
 import {
-  isActiveTerminalSessionStatus,
   resolveEnvironmentMergeBaseBranch,
   type ThreadListEntry,
   type ThreadWithRuntime,
@@ -760,13 +759,6 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
   const closeTerminal = useCloseThreadTerminal();
   const terminalSessions =
     terminalsListQuery.data?.sessions ?? EMPTY_TERMINAL_SESSIONS;
-  const activeTerminalCount = useMemo(
-    () =>
-      terminalSessions.filter((session) =>
-        isActiveTerminalSessionStatus(session.status),
-      ).length,
-    [terminalSessions],
-  );
   const terminalsById = useMemo(
     () => new Map(terminalSessions.map((session) => [session.id, session])),
     [terminalSessions],
@@ -2202,7 +2194,6 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
               : null
         }
         isSecondaryPanelOpen={isSecondaryPanelOpen}
-        activeTerminalCount={activeTerminalCount}
         onOpenThreadGitAction={gitActions.threadGitActionDialog.onOpen}
         onToggleSecondaryPanel={toggleSecondaryPanel}
         pluginActions={<PluginThreadActions threadId={thread.id} />}


### PR DESCRIPTION
## Summary
- remove the terminal count badge from right-panel toggle buttons
- drop the now-unused active terminal count plumbing

## Test
- pnpm exec turbo run typecheck --filter=@bb/app