### PR TITLE
Fix getbb.app sign-in flow

### DIFF
--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit",
     "spike:origin": "tsx scripts/spike-origin.mts",
     "spike:client": "tsx scripts/spike-client.mts"

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { dashboardSignInUrl } from "./worker";
+
+describe("connect sign-in page", () => {
+  it("points unauthenticated visitors at the dashboard auth flow with returnTo", () => {
+    expect(
+      dashboardSignInUrl(
+        "https://getbb.app",
+        "https://sawyer.getbb.app/thread/thr_123?view=full",
+      ),
+    ).toBe(
+      "https://getbb.app/dashboard?returnTo=https%3A%2F%2Fsawyer.getbb.app%2Fthread%2Fthr_123%3Fview%3Dfull",
+    );
+  });
+
+  it("uses the configured app origin for staging", () => {
+    expect(
+      dashboardSignInUrl(
+        "https://vibecodethis.site",
+        "https://sawyer.vibecodethis.site/",
+      ),
+    ).toBe(
+      "https://vibecodethis.site/dashboard?returnTo=https%3A%2F%2Fsawyer.vibecodethis.site%2F",
+    );
+  });
+});

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -25,8 +25,15 @@ function text(body: string, status: number): Response {
 
 // Matches the bb dashboard's visual language (Inter, --canvas/--ink tokens,
 // dark primary button, bb logo) since this plain worker can't bundle React.
-function signInPage(handle: string, appUrl: string): Response {
+export function dashboardSignInUrl(appUrl: string, returnTo: string): string {
+  const url = new URL("/dashboard", appUrl);
+  url.searchParams.set("returnTo", returnTo);
+  return url.toString();
+}
+
+function signInPage(handle: string, appUrl: string, returnTo: string): Response {
   const host = new URL(appUrl).host;
+  const signInUrl = dashboardSignInUrl(appUrl, returnTo);
   return new Response(
     `<!doctype html><html lang="en"><head><meta charset="utf-8">
      <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -61,7 +68,7 @@ function signInPage(handle: string, appUrl: string): Response {
        <div class="card">
          <h1>This is <code>${handle}</code>'s bb</h1>
          <p>Sign in with the account that owns this server to reach it.</p>
-         <a class="btn" href="${appUrl}">Sign in at ${host}</a>
+         <a class="btn" href="${signInUrl}">Sign in at ${host}</a>
        </div>
      </div></body></html>`,
     { status: 401, headers: { "content-type": "text/html; charset=utf-8" } },
@@ -130,9 +137,9 @@ export default {
     // Visitor request — require a session owned by this handle's account.
     const cookie = parseCookie(request.headers.get("cookie"), SESSION_COOKIE);
     const appUrl = `https://${env.BASE_DOMAIN}`;
-    if (!cookie) return signInPage(handle, appUrl);
+    if (!cookie) return signInPage(handle, appUrl, url.toString());
     const userId = await verifySessionCookie(cookie, env.BETTER_AUTH_SECRET, db);
-    if (!userId) return signInPage(handle, appUrl);
+    if (!userId) return signInPage(handle, appUrl, url.toString());
     if (userId !== resolved.userId) return text("bb connect: not your server\n", 403);
 
     // WebSocket upgrades (bb's /ws, terminals) can't be cached — proxy directly.

--- a/apps/connect/vitest.config.ts
+++ b/apps/connect/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/apps/web/src/lib/connect-return-to.test.ts
+++ b/apps/web/src/lib/connect-return-to.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { DASHBOARD_PATH, connectReturnTo } from "./connect-return-to";
+
+describe("connect return-to URLs", () => {
+  it("accepts immediate connect subdomains for the current app domain", () => {
+    expect(
+      connectReturnTo(
+        "https://sawyer.getbb.app/projects?tab=threads",
+        "https://getbb.app",
+      ),
+    ).toBe("https://sawyer.getbb.app/projects?tab=threads");
+  });
+
+  it("accepts staging connect subdomains", () => {
+    expect(
+      connectReturnTo(
+        "https://sawyer.vibecodethis.site/",
+        "https://vibecodethis.site",
+      ),
+    ).toBe("https://sawyer.vibecodethis.site/");
+  });
+
+  it("rejects nested subdomains and off-domain return targets", () => {
+    expect(
+      connectReturnTo("https://a.b.getbb.app/", "https://getbb.app"),
+    ).toBeNull();
+    expect(
+      connectReturnTo("https://evil.test/", "https://getbb.app"),
+    ).toBeNull();
+  });
+
+  it("rejects protocol downgrades", () => {
+    expect(
+      connectReturnTo("http://sawyer.getbb.app/", "https://getbb.app"),
+    ).toBeNull();
+  });
+
+  it("exports the dashboard path used by landing sign-in links", () => {
+    expect(DASHBOARD_PATH).toBe("/dashboard");
+  });
+});

--- a/apps/web/src/lib/connect-return-to.ts
+++ b/apps/web/src/lib/connect-return-to.ts
@@ -1,0 +1,34 @@
+export const DASHBOARD_PATH = "/dashboard";
+
+function appBaseDomain(appHostname: string): string {
+  return appHostname.startsWith("www.")
+    ? appHostname.slice("www.".length)
+    : appHostname;
+}
+
+export function connectReturnTo(
+  rawReturnTo: string | null,
+  appOrigin: string,
+): string | null {
+  if (!rawReturnTo) return null;
+
+  let appUrl: URL;
+  let returnToUrl: URL;
+  try {
+    appUrl = new URL(appOrigin);
+    returnToUrl = new URL(rawReturnTo);
+  } catch {
+    return null;
+  }
+
+  if (returnToUrl.protocol !== appUrl.protocol) return null;
+
+  const baseDomain = appBaseDomain(appUrl.hostname);
+  const suffix = `.${baseDomain}`;
+  if (!returnToUrl.hostname.endsWith(suffix)) return null;
+
+  const handle = returnToUrl.hostname.slice(0, -suffix.length);
+  if (!handle || handle.includes(".")) return null;
+
+  return returnToUrl.toString();
+}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import appCss from "../styles.css?url";
 import { Button } from "@/components/ui/button";
@@ -20,12 +20,24 @@ import {
   getDashboard,
 } from "@/server/fns";
 import bbIcon from "../assets/bb-icon.png";
+import { DASHBOARD_PATH, connectReturnTo } from "@/lib/connect-return-to";
+
+interface DashboardSearch {
+  returnTo: string | null;
+}
+
+function validateDashboardSearch(search: Record<string, unknown>): DashboardSearch {
+  return {
+    returnTo: typeof search.returnTo === "string" ? search.returnTo : null,
+  };
+}
 
 export const Route = createFileRoute("/dashboard")({
   head: () => ({
     meta: [{ title: "bb connect" }],
     links: [{ rel: "stylesheet", href: appCss }],
   }),
+  validateSearch: validateDashboardSearch,
   loader: () => getDashboard(),
   component: Home,
 });
@@ -47,6 +59,13 @@ function Shell({ children }: { children: React.ReactNode }) {
 
 function Home() {
   const data = Route.useLoaderData();
+  const search = Route.useSearch();
+
+  useEffect(() => {
+    if (!data.authed) return;
+    const returnTo = connectReturnTo(search.returnTo, window.location.origin);
+    if (returnTo) window.location.assign(returnTo);
+  }, [data.authed, search.returnTo]);
 
   if (!data.authed) {
     return (
@@ -61,7 +80,9 @@ function Home() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <Button onClick={() => void signInWithGithub()}>Continue with GitHub</Button>
+            <Button onClick={() => void signInWithGithub(search.returnTo)}>
+              Continue with GitHub
+            </Button>
           </CardContent>
         </Card>
       </Shell>
@@ -81,11 +102,12 @@ function Home() {
   );
 }
 
-async function signInWithGithub() {
+async function signInWithGithub(returnTo: string | null) {
+  const callbackURL = connectReturnTo(returnTo, window.location.origin) ?? DASHBOARD_PATH;
   const res = await fetch("/api/auth/sign-in/social", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ provider: "github", callbackURL: "/dashboard" }),
+    body: JSON.stringify({ provider: "github", callbackURL }),
   });
   const data = (await res.json().catch(() => ({}))) as { url?: string };
   if (data.url) window.location.href = data.url;

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -33,6 +33,7 @@ import { initAnalytics, trackLandingEvent } from "../landing/analytics";
 import bbIcon from "../assets/bb-icon.png";
 import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
+import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import { ClaudeIcon, CursorIcon, OpenAiIcon, OpencodeIcon, PiIcon } from "../landing/icons";
 import type { CtaPlacement } from "../landing/site";
 import {
@@ -1701,6 +1702,7 @@ function LandingPage() {
         </a>
         <div className="nav-links">
           <GitHubLink placement="nav">GitHub</GitHubLink>
+          <a href={DASHBOARD_PATH}>Sign in</a>
           <DownloadLink placement="nav" className="btn btn-primary btn-sm">
             Download for macOS
           </DownloadLink>


### PR DESCRIPTION
## Context
Connect e2e feedback found that scanning a BB Connect QR/deep link sent users to `getbb.app`, but pressing the sign-in button only returned them to the landing page. There was also no Sign in path exposed from the public landing page.

## Summary
- Point unauthenticated Connect subdomain sign-in pages at `/dashboard?returnTo=<original URL>` instead of the apex landing page.
- Add a public landing-page Sign in link to `/dashboard`.
- Validate Connect return targets on the dashboard and pass valid `*.getbb.app` / staging subdomain URLs through as the Better Auth `callbackURL`, including the already-authenticated case.
- Add focused regression tests for Connect sign-in URL generation and dashboard return-target validation.

## Verification
- `pnpm exec turbo run test --filter=@bb/web --filter=@bb/connect` passed.
- `pnpm exec turbo run typecheck --filter=@bb/web --filter=@bb/connect` passed.
- `pnpm exec turbo run build --filter=@bb/web --filter=@bb/connect` passed. `@bb/connect` has no build task; Turbo built `@bb/web`. The web build emitted the existing local missing-secrets warning for auth/PostHog/Resend secrets.