### PR TITLE
Add settings update check

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BbDesktopInfo } from "@bb/desktop-contract";
+import { appToast } from "@/components/ui/app-toast.js";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+import * as api from "@/lib/api";
+import { UpdatesSettingsSection } from "./UpdatesSettingsSection";
+
+vi.mock("@/components/ui/app-toast.js", () => ({
+  appToast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(),
+    message: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  getSystemVersion: vi.fn(),
+}));
+
+const desktopInfo: BbDesktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos",
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.5",
+};
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function renderUpdatesSettingsSection() {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UpdatesSettingsSection />
+    </QueryClientProvider>,
+  );
+}
+
+function clickCheckForUpdates(): void {
+  fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+}
+
+afterEach(() => {
+  cleanup();
+  delete window.bbDesktop;
+  vi.clearAllMocks();
+});
+
+describe("UpdatesSettingsSection", () => {
+  it("forces the web update check and reports an available update", async () => {
+    vi.mocked(api.getSystemVersion).mockResolvedValue({
+      currentVersion: "0.0.5",
+      latestVersion: "0.0.6",
+      source: "npm",
+      updateAvailable: true,
+      isDevelopment: false,
+      upgradeCommand: "npx bb-app@latest",
+    });
+
+    renderUpdatesSettingsSection();
+    clickCheckForUpdates();
+
+    await waitFor(() => {
+      expect(api.getSystemVersion).toHaveBeenCalledWith({ force: true });
+    });
+    expect(appToast.message).toHaveBeenCalledWith(
+      "bb-app update available",
+      expect.objectContaining({
+        description: "0.0.6 is available. Run `npx bb-app@latest` to update.",
+        duration: Infinity,
+      }),
+    );
+  });
+
+  it("checks for desktop updates through the desktop bridge", async () => {
+    const checkForUpdates = vi.fn().mockResolvedValue({
+      ...desktopInfo,
+      latestVersion: "0.0.6",
+      pendingVersion: "0.0.6",
+      updateAvailable: true,
+      updateDownloaded: true,
+    });
+    window.bbDesktop = {
+      ...createBbDesktopApi(desktopInfo),
+      checkForUpdates,
+    };
+
+    renderUpdatesSettingsSection();
+    clickCheckForUpdates();
+
+    await waitFor(() => {
+      expect(checkForUpdates).toHaveBeenCalledTimes(1);
+    });
+    expect(api.getSystemVersion).not.toHaveBeenCalled();
+    expect(appToast.message).toHaveBeenCalledWith(
+      "Desktop update ready",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "Relaunch" }),
+        description: "bb desktop 0.0.6 is ready to install.",
+        duration: Infinity,
+      }),
+    );
+  });
+});

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { BbDesktopApi, BbDesktopInfo } from "@bb/desktop-contract";
+import type { SystemVersionResponse } from "@bb/server-contract";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  SettingsSection,
+  SettingsWithControl,
+} from "@/components/ui/settings-section.js";
+import { appToast } from "@/components/ui/app-toast.js";
+import { hydrateSystemVersionCache } from "@/hooks/cache-owners/system-version-cache-owner";
+import { getBbDesktopInfo } from "@/lib/bb-desktop";
+import * as api from "@/lib/api";
+
+function updateCheckErrorDescription(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+  return "The update check did not complete.";
+}
+
+function relaunchDesktopUpdate(desktopApi: BbDesktopApi): void {
+  void desktopApi.installUpdate().catch((error: unknown) => {
+    appToast.error("Relaunch failed", {
+      description: updateCheckErrorDescription(error),
+    });
+  });
+}
+
+function desktopUpdateVersionLabel(info: BbDesktopInfo): string | null {
+  return info.pendingVersion ?? info.latestVersion;
+}
+
+function showDesktopUpdateCheckResult(
+  desktopApi: BbDesktopApi,
+  info: BbDesktopInfo,
+): void {
+  const latestVersion = desktopUpdateVersionLabel(info);
+
+  if (info.updateDownloaded) {
+    appToast.message("Desktop update ready", {
+      description:
+        latestVersion === null
+          ? "A desktop update is ready to install."
+          : `bb desktop ${latestVersion} is ready to install.`,
+      duration: Infinity,
+      action: {
+        label: "Relaunch",
+        onClick: () => relaunchDesktopUpdate(desktopApi),
+      },
+    });
+    return;
+  }
+
+  if (info.updateAvailable) {
+    appToast.message("Desktop update available", {
+      description:
+        latestVersion === null
+          ? "An update is available. It will download in the background."
+          : `${latestVersion} is available. It will download in the background.`,
+      duration: Infinity,
+    });
+    return;
+  }
+
+  appToast.success("bb desktop is up to date", {
+    description: `You're running ${info.version}.`,
+  });
+}
+
+function showWebUpdateCheckResult(version: SystemVersionResponse): void {
+  if (version.isDevelopment) {
+    appToast.message("Update checks disabled", {
+      description: "bb-app is running in development mode.",
+    });
+    return;
+  }
+
+  if (version.latestVersion === null) {
+    appToast.warning("Couldn't check for updates", {
+      description: "The npm registry did not return a bb-app version.",
+    });
+    return;
+  }
+
+  if (version.updateAvailable) {
+    appToast.message("bb-app update available", {
+      description:
+        `${version.latestVersion} is available. ` +
+        `Run \`${version.upgradeCommand}\` to update.`,
+      duration: Infinity,
+    });
+    return;
+  }
+
+  appToast.success("bb-app is up to date", {
+    description: `You're running ${version.currentVersion}.`,
+  });
+}
+
+export function UpdatesSettingsSection() {
+  const queryClient = useQueryClient();
+  const [isChecking, setIsChecking] = useState(false);
+  const [desktopShellAvailable] = useState(() => getBbDesktopInfo() !== null);
+
+  async function handleCheckForUpdates(): Promise<void> {
+    if (isChecking) {
+      return;
+    }
+
+    setIsChecking(true);
+    try {
+      const desktopApi = getBbDesktopInfo();
+      if (desktopApi !== null) {
+        showDesktopUpdateCheckResult(
+          desktopApi,
+          await desktopApi.checkForUpdates(),
+        );
+        return;
+      }
+
+      const version = await api.getSystemVersion({ force: true });
+      hydrateSystemVersionCache({ queryClient, version });
+      showWebUpdateCheckResult(version);
+    } catch (error: unknown) {
+      appToast.error("Update check failed", {
+        description: updateCheckErrorDescription(error),
+      });
+    } finally {
+      setIsChecking(false);
+    }
+  }
+
+  return (
+    <SettingsSection title="Updates">
+      <SettingsWithControl
+        label="bb app"
+        description={
+          desktopShellAvailable
+            ? "Check the desktop update feed."
+            : "Check npm for the latest bb-app release."
+        }
+      >
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          aria-busy={isChecking}
+          aria-label="Check for updates"
+          disabled={isChecking}
+          onClick={() => {
+            void handleCheckForUpdates();
+          }}
+        >
+          <Icon
+            name={isChecking ? "Spinner" : "RotateCcw"}
+            className={cn("size-3.5", isChecking && "animate-spin")}
+          />
+          {isChecking ? "Checking" : "Check for updates"}
+        </Button>
+      </SettingsWithControl>
+    </SettingsSection>
+  );
+}

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -204,6 +204,9 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "threadsQueryKey",
   ],
   "hooks/cache-owners/system-config-cache-owner.ts": ["systemConfigQueryKey"],
+  "hooks/cache-owners/system-version-cache-owner.ts": [
+    "systemVersionQueryKey",
+  ],
   "hooks/cache-owners/terminal-cache-owner.ts": [
     "allTerminalsQueryKeyPrefix",
     "TerminalQueryScope",

--- a/apps/app/src/hooks/cache-owners/system-version-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/system-version-cache-owner.ts
@@ -1,0 +1,14 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { SystemVersionResponse } from "@bb/server-contract";
+import { systemVersionQueryKey } from "../queries/query-keys";
+
+export interface HydrateSystemVersionCacheArgs {
+  queryClient: QueryClient;
+  version: SystemVersionResponse;
+}
+
+export function hydrateSystemVersionCache(
+  args: HydrateSystemVersionCacheArgs,
+): void {
+  args.queryClient.setQueryData(systemVersionQueryKey(), args.version);
+}

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -99,7 +99,7 @@ export function useSystemConfig(options?: QueryOptions) {
 export function useSystemVersion(options?: QueryOptions) {
   return useQuery<SystemVersionResponse>({
     queryKey: systemVersionQueryKey(),
-    queryFn: ({ signal }) => api.getSystemVersion(signal),
+    queryFn: ({ signal }) => api.getSystemVersion({ signal }),
     enabled: options?.enabled ?? true,
     ...SERVER_SESSION_QUERY_POLICY,
   });

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -1738,10 +1738,17 @@ export async function listSystemProviders(): Promise<SystemProviderInfo[]> {
 }
 
 export async function getSystemVersion(
-  signal?: AbortSignal,
+  args: { force?: boolean; signal?: AbortSignal } = {},
 ): Promise<SystemVersionResponse> {
   return request<SystemVersionResponse>(
-    apiClient.system.version.$get({}, requestOptions(signal)),
+    apiClient.system.version.$get(
+      {
+        query: {
+          ...(args.force ? { force: "true" as const } : {}),
+        },
+      },
+      requestOptions(args.signal),
+    ),
   );
 }
 

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -39,6 +39,7 @@ import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSet
 import { PluginsSettingsSection } from "@/components/settings/PluginsSettingsSection";
 import { FileOpenersSettingsSection } from "@/components/settings/FileOpenersSettingsSection";
 import { VoiceInputSettingsSection } from "@/components/settings/VoiceInputSettingsSection";
+import { UpdatesSettingsSection } from "@/components/settings/UpdatesSettingsSection";
 import {
   useUpdateAppearance,
   useUpdateExperiments,
@@ -1011,6 +1012,8 @@ export function SettingsView() {
           onRichTextEditingChange={setRichTextEditing}
           onThemePreferenceChange={setPreferredTheme}
         />
+
+        <UpdatesSettingsSection />
 
         <UsageLimitsSettingsSection />
 

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -159,7 +159,11 @@ export function registerSystemRoutes(
     });
   });
 
-  get(routes.version, async (context) =>
-    context.json(await deps.appVersion.getSystemVersion()),
+  get(routes.version, async (context, query) =>
+    context.json(
+      await deps.appVersion.getSystemVersion({
+        forceRefresh: query.force === "true",
+      }),
+    ),
   );
 }

--- a/apps/server/src/services/system/app-version.ts
+++ b/apps/server/src/services/system/app-version.ts
@@ -15,7 +15,13 @@ const npmLatestResponseSchema = z
   .passthrough();
 
 export interface AppVersionService {
-  getSystemVersion(): Promise<SystemVersionResponse>;
+  getSystemVersion(
+    args?: AppVersionGetSystemVersionArgs,
+  ): Promise<SystemVersionResponse>;
+}
+
+export interface AppVersionGetSystemVersionArgs {
+  forceRefresh?: boolean;
 }
 
 export interface CreateAppVersionServiceArgs {
@@ -90,9 +96,15 @@ export function createAppVersionService(
   // fetch returns null even if a stale cached value exists. This is choice
   // "A" (null on failure) and overrides the plan body's earlier suggestion
   // to fall back to the stale cached value with a warning.
-  async function getLatestVersion(): Promise<string | null> {
+  async function getLatestVersion(args?: {
+    forceRefresh?: boolean;
+  }): Promise<string | null> {
     const currentTime = now();
-    if (cache !== null && currentTime - cache.cachedAt < cacheTtlMs) {
+    if (
+      args?.forceRefresh !== true &&
+      cache !== null &&
+      currentTime - cache.cachedAt < cacheTtlMs
+    ) {
       return cache.latestVersion;
     }
     if (inflight !== null) {
@@ -116,7 +128,9 @@ export function createAppVersionService(
   }
 
   return {
-    async getSystemVersion(): Promise<SystemVersionResponse> {
+    async getSystemVersion(
+      args: AppVersionGetSystemVersionArgs = {},
+    ): Promise<SystemVersionResponse> {
       const baseResponse: SystemVersionResponse = {
         currentVersion: config.appVersion,
         latestVersion: null,
@@ -130,7 +144,9 @@ export function createAppVersionService(
         return baseResponse;
       }
 
-      const latestVersion = await getLatestVersion();
+      const latestVersion = await getLatestVersion({
+        forceRefresh: args.forceRefresh,
+      });
       if (latestVersion === null) {
         return baseResponse;
       }

--- a/apps/server/test/public/public-system-version.test.ts
+++ b/apps/server/test/public/public-system-version.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 import type { SystemVersionResponse } from "@bb/server-contract";
+import type { AppVersionGetSystemVersionArgs } from "../../src/services/system/app-version.js";
 import { readJson } from "../helpers/json.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
-function createStubAppVersionService(response: SystemVersionResponse) {
+function createStubAppVersionService(
+  response: SystemVersionResponse,
+  calls?: AppVersionGetSystemVersionArgs[],
+) {
   return {
-    async getSystemVersion(): Promise<SystemVersionResponse> {
+    async getSystemVersion(
+      args: AppVersionGetSystemVersionArgs = {},
+    ): Promise<SystemVersionResponse> {
+      calls?.push(args);
       return response;
     },
   };
@@ -51,6 +58,31 @@ describe("GET /api/v1/system/version", () => {
       expect(body.isDevelopment).toBe(true);
       expect(body.updateAvailable).toBe(false);
       expect(body.latestVersion).toBeNull();
+    });
+  });
+
+  it("passes force=true through to the app-version service", async () => {
+    const calls: AppVersionGetSystemVersionArgs[] = [];
+    await withTestHarness({
+      appVersion: "0.0.5",
+      appVersionService: createStubAppVersionService(
+        {
+          currentVersion: "0.0.5",
+          latestVersion: "0.0.6",
+          source: "npm",
+          updateAvailable: true,
+          isDevelopment: false,
+          upgradeCommand: "npx bb-app@latest",
+        },
+        calls,
+      ),
+      isDevelopment: false,
+    }, async (harness) => {
+      const response = await harness.app.request(
+        "/api/v1/system/version?force=true",
+      );
+      expect(response.status).toBe(200);
+      expect(calls).toEqual([{ forceRefresh: true }]);
     });
   });
 });

--- a/apps/server/test/system/app-version.test.ts
+++ b/apps/server/test/system/app-version.test.ts
@@ -169,6 +169,23 @@ describe("createAppVersionService", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it("bypasses the npm cache for a forced check", async () => {
+    const calls: FetchCall[] = [];
+    const service = createAppVersionService({
+      config: { appVersion: "0.0.5", isDevelopment: false },
+      fetchImpl: createStubFetch(
+        [{ body: { version: "0.0.6" } }, { body: { version: "0.0.7" } }],
+        calls,
+      ),
+      logger: testLogger,
+    });
+    const first = await service.getSystemVersion();
+    const second = await service.getSystemVersion({ forceRefresh: true });
+    expect(first.latestVersion).toBe("0.0.6");
+    expect(second.latestVersion).toBe("0.0.7");
+    expect(calls).toHaveLength(2);
+  });
+
   it("re-fetches once the TTL has expired", async () => {
     const calls: FetchCall[] = [];
     let currentTime = 1_000;

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -121,6 +121,12 @@ export const systemVersionResponseSchema = z.object({
 });
 export type SystemVersionResponse = z.infer<typeof systemVersionResponseSchema>;
 
+export const systemVersionQuerySchema = z.object({
+  /** "true" bypasses the server-side npm latest cache for a manual check. */
+  force: z.enum(["true", "false"]).optional(),
+});
+export type SystemVersionQuery = z.infer<typeof systemVersionQuerySchema>;
+
 export const systemConfigReloadResponseSchema = z.object({
   ok: z.literal(true),
 });

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -106,6 +106,7 @@ import type {
   SystemExecutionOptionsQuery,
   SystemExecutionOptionsResponse,
   SystemProviderInfo,
+  SystemVersionQuery,
   SystemVersionResponse,
   SystemVoiceTranscriptionForm,
   SystemVoiceTranscriptionResponse,
@@ -198,6 +199,7 @@ import {
   setQueuedMessageGroupBoundaryRequestSchema,
   sendQueuedMessageRequestSchema,
   systemExecutionOptionsQuerySchema,
+  systemVersionQuerySchema,
   threadEventWaitQuerySchema,
   threadEventsQuerySchema,
   threadFilesRawQuerySchema,
@@ -1045,7 +1047,9 @@ export const publicApiRoutes = {
     version: defineRoute({
       path: "/system/version",
       method: "get",
-      request: noRequest(),
+      request: optionalQueryRequest<EmptyInput, SystemVersionQuery>(
+        systemVersionQuerySchema,
+      ),
       response: jsonResponse<SystemVersionResponse>(),
     }),
   },


### PR DESCRIPTION
## Summary
- add an Updates section in Settings with a manual check-for-updates button
- route desktop checks through the Electron update bridge and web checks through a forced /system/version lookup
- add server contract support for force-refreshing the cached npm version lookup

## Tests
- pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/server-contract
- pnpm exec turbo run test --filter=@bb/app --filter=@bb/server --force

## Notes
- Manual web checks bypass the server-side npm latest cache; existing automatic version checks keep the cached path.