### PR TITLE
Fix desktop sidebar alignment in fullscreen

### DIFF
--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/lib/iframe-drag-guard", () => ({
 vi.mock("@/lib/bb-desktop", () => ({
   BROWSER_SIDEBAR_TRIGGER_INSET_CLASS: "",
   CHROME_ROW_CLASS: "",
+  DEFAULT_DESKTOP_WINDOW_STATE: { isFullScreen: false },
   MACOS_CHROME_CONTROL_AXIS_CLASS: "",
   MACOS_CHROME_CONTROL_NO_DRAG_CLASS: "",
   MACOS_CHROME_TRAFFIC_LIGHT_AXIS_NUDGE_CLASS: "",
@@ -61,6 +62,7 @@ vi.mock("@/lib/bb-desktop", () => ({
   MACOS_WINDOW_DRAG_CLASS: "",
   MACOS_WINDOW_NO_DRAG_CLASS: "",
   getBbDesktopInfo: () => null,
+  shouldReserveMacosTrafficLights: () => false,
   shouldUseMacosDesktopChrome: () => false,
 }));
 

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -48,8 +48,10 @@ import {
   MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
+  shouldReserveMacosTrafficLights,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
+import { useDesktopWindowState } from "@/hooks/useDesktopWindowState";
 import {
   getLegacyProjectComposeRoutePath,
   getProjectArchivedRoutePath,
@@ -163,6 +165,7 @@ function resetSidebarResizeDocumentState(): void {
 }
 
 interface SidebarTriggerOverlayProps {
+  reserveMacosTrafficLights: boolean;
   usesDesktopChrome: boolean;
 }
 
@@ -175,13 +178,14 @@ interface SidebarTriggerOverlayProps {
  * slides the header content smoothly past it rather than snapping around a
  * toggle that mounts/unmounts in the header.
  *
- * Desktop chrome offsets it clear of the macOS traffic lights and keeps the
- * strip a window-drag region; only the button itself is no-drag, so the title
- * strip above and below the (shorter) button stays draggable rather than
- * becoming an oversized dead zone. Browser chrome has no traffic lights, so it
- * sits flush at the top-left with a small inset.
+ * Desktop chrome keeps the strip a window-drag region; only the button itself
+ * is no-drag, so the title strip above and below the (shorter) button stays
+ * draggable rather than becoming an oversized dead zone. When macOS traffic
+ * lights are visible it offsets past them; in fullscreen, where the lights are
+ * hidden, it uses the same small top-left inset as browser chrome.
  */
 function SidebarTriggerOverlay({
+  reserveMacosTrafficLights,
   usesDesktopChrome,
 }: SidebarTriggerOverlayProps) {
   if (usesDesktopChrome) {
@@ -191,7 +195,10 @@ function SidebarTriggerOverlay({
         className={cn(
           "fixed top-0 z-50",
           CHROME_ROW_CLASS,
-          MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
+          reserveMacosTrafficLights
+            ? MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS
+            : "left-0",
+          !reserveMacosTrafficLights && BROWSER_SIDEBAR_TRIGGER_INSET_CLASS,
           MACOS_WINDOW_DRAG_CLASS,
         )}
       >
@@ -432,7 +439,12 @@ export function AppLayout({ children }: AppLayoutProps) {
   const animationFrameRef = useRef<number | null>(null);
   const showHeader = !isThreadView && !isRootView;
   const [desktopInfo] = useState(getBbDesktopInfo);
+  const desktopWindowState = useDesktopWindowState();
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
+  const reserveMacosTrafficLights = shouldReserveMacosTrafficLights({
+    desktopInfo,
+    windowState: desktopWindowState,
+  });
   const sidebarProviderStyle: SidebarProviderStyle = {
     "--sidebar-width": `${sidebarWidth}px`,
   };
@@ -669,7 +681,10 @@ export function AppLayout({ children }: AppLayoutProps) {
               </main>
             </div>
           </SidebarInset>
-          <SidebarTriggerOverlay usesDesktopChrome={usesDesktopChrome} />
+          <SidebarTriggerOverlay
+            reserveMacosTrafficLights={reserveMacosTrafficLights}
+            usesDesktopChrome={usesDesktopChrome}
+          />
         </SidebarStateBridge>
         <ProjectPathDialog
           target={quickCreateProject.projectPathDialog.target}

--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -11,8 +11,10 @@ import {
   MACOS_COLLAPSED_HEADER_RESERVE_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
+  shouldReserveMacosTrafficLights,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
+import { useDesktopWindowState } from "@/hooks/useDesktopWindowState";
 import { cn } from "@bb/shared-ui/lib/utils";
 
 /**
@@ -38,7 +40,12 @@ export function AppPageHeader({
   const isSidebarShowing = useIsSidebarShowing();
   const isCompactViewport = useIsCompactViewport();
   const [desktopInfo] = useState(getBbDesktopInfo);
+  const desktopWindowState = useDesktopWindowState();
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
+  const reserveMacosTrafficLights = shouldReserveMacosTrafficLights({
+    desktopInfo,
+    windowState: desktopWindowState,
+  });
   const shouldReserveSidebarTrigger =
     isCompactViewport || !isSidebarShowing;
   return (
@@ -67,14 +74,15 @@ export function AppPageHeader({
           // build (no traffic lights).
           usesDesktopChrome && MACOS_CHROME_CONTROL_AXIS_CLASS,
           // The sidebar toggle is pinned at the app's top-left (see AppLayout's
-          // SidebarTriggerOverlay). On desktop, reserve its footprint only when
-          // the sidebar is collapsed and content shares that row with the fixed
-          // button. On compact viewports, the sidebar opens as an overlay that
-          // covers the header, so keep the reserve stable across open/closed
-          // drawer state instead of shifting content behind the overlay.
+          // SidebarTriggerOverlay). Reserve the fixed button's footprint when
+          // the sidebar is collapsed and content shares that row with it; macOS
+          // traffic lights add extra left space only while they are visible. On
+          // compact viewports, the sidebar opens as an overlay that covers the
+          // header, so keep the reserve stable across open/closed drawer state
+          // instead of shifting content behind the overlay.
           "transition-[padding] duration-200 ease-linear",
           shouldReserveSidebarTrigger &&
-            (usesDesktopChrome
+            (reserveMacosTrafficLights
               ? MACOS_COLLAPSED_HEADER_RESERVE_CLASS
               : BROWSER_COLLAPSED_HEADER_RESERVE_CLASS),
         )}

--- a/apps/app/src/hooks/useDesktopWindowState.ts
+++ b/apps/app/src/hooks/useDesktopWindowState.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import type { BbDesktopWindowState } from "@bb/desktop-contract";
+import {
+  DEFAULT_DESKTOP_WINDOW_STATE,
+  getBbDesktopInfo,
+} from "@/lib/bb-desktop";
+
+export function useDesktopWindowState(): BbDesktopWindowState {
+  const [windowState, setWindowState] = useState<BbDesktopWindowState>(
+    DEFAULT_DESKTOP_WINDOW_STATE,
+  );
+
+  useEffect(() => {
+    const desktopApi = getBbDesktopInfo();
+    let cancelled = false;
+
+    const unsubscribe = desktopApi?.onWindowStateChange?.((nextState) => {
+      setWindowState(nextState);
+    });
+
+    void desktopApi?.getWindowState?.().then((nextState) => {
+      if (!cancelled) {
+        setWindowState(nextState);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, []);
+
+  return windowState;
+}

--- a/apps/app/src/lib/bb-desktop.test.ts
+++ b/apps/app/src/lib/bb-desktop.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import type { BbDesktopInfo } from "@bb/desktop-contract";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+import { shouldReserveMacosTrafficLights } from "./bb-desktop";
+
+const desktopInfo: BbDesktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos",
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.0-test",
+};
+
+describe("desktop chrome geometry", () => {
+  it("reserves macOS traffic-light space only when lights are visible", () => {
+    const desktopApi = createBbDesktopApi(desktopInfo);
+
+    expect(
+      shouldReserveMacosTrafficLights({
+        desktopInfo: desktopApi,
+        windowState: { isFullScreen: false },
+      }),
+    ).toBe(true);
+    expect(
+      shouldReserveMacosTrafficLights({
+        desktopInfo: desktopApi,
+        windowState: { isFullScreen: true },
+      }),
+    ).toBe(false);
+    expect(
+      shouldReserveMacosTrafficLights({
+        desktopInfo: null,
+        windowState: { isFullScreen: false },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -1,6 +1,7 @@
 import type {
   BbDesktopApi,
   BbDesktopBrowserApi,
+  BbDesktopWindowState,
   BbDesktopPopoutApi,
 } from "@bb/desktop-contract";
 
@@ -74,6 +75,9 @@ export const MACOS_CHROME_TRAFFIC_LIGHT_AXIS_NUDGE_CLASS =
   MACOS_CHROME_CONTROL_AXIS_CLASS;
 
 export type BbDesktopInfoResult = BbDesktopApi | null;
+export const DEFAULT_DESKTOP_WINDOW_STATE: BbDesktopWindowState = {
+  isFullScreen: false,
+};
 
 export function getBbDesktopInfo(): BbDesktopInfoResult {
   if (typeof window === "undefined") {
@@ -86,6 +90,16 @@ export function shouldUseMacosDesktopChrome(
   desktopInfo: BbDesktopInfoResult,
 ): boolean {
   return desktopInfo?.platform === "macos";
+}
+
+export function shouldReserveMacosTrafficLights({
+  desktopInfo,
+  windowState,
+}: {
+  desktopInfo: BbDesktopInfoResult;
+  windowState: BbDesktopWindowState;
+}): boolean {
+  return shouldUseMacosDesktopChrome(desktopInfo) && !windowState.isFullScreen;
 }
 
 /**

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -24,7 +24,9 @@ vi.mock("@/lib/browser-view-bounds-sync", () => ({
 }));
 
 vi.mock("@/lib/bb-desktop", () => ({
+  DEFAULT_DESKTOP_WINDOW_STATE: { isFullScreen: false },
   getBbDesktopInfo: () => null,
+  shouldReserveMacosTrafficLights: () => false,
   shouldUseMacosDesktopChrome: () => false,
 }));
 

--- a/apps/desktop/src/desktop-window-command-ipc.ts
+++ b/apps/desktop/src/desktop-window-command-ipc.ts
@@ -2,6 +2,10 @@
 // by the trusted React renderer.
 
 export const BB_DESKTOP_OPEN_NEW_TAB_CHANNEL = "bb-desktop:open-new-tab";
+export const BB_DESKTOP_GET_WINDOW_STATE_CHANNEL =
+  "bb-desktop:get-window-state";
+export const BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL =
+  "bb-desktop:window-state-changed";
 export const BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL =
   "bb-desktop:close-window-request";
 export const BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL =

--- a/apps/desktop/src/desktop-window-factory.ts
+++ b/apps/desktop/src/desktop-window-factory.ts
@@ -62,7 +62,14 @@ export interface DesktopBrowserWindow extends StatefulBrowserWindow {
   isMinimized(): boolean;
   loadURL(url: string): Promise<void>;
   maximize(): void;
-  on(eventName: "close" | "closed", listener: () => void): void;
+  on(
+    eventName:
+      | "close"
+      | "closed"
+      | "enter-full-screen"
+      | "leave-full-screen",
+    listener: () => void,
+  ): void;
   once(eventName: "ready-to-show", listener: () => void): void;
   restore(): void;
   setFullScreen(isFullScreen: boolean): void;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -30,6 +30,7 @@ import {
   getDesktopThreadRoutePath,
   type BbDesktopInfo,
   type BbDesktopPopoutThreadRef,
+  type BbDesktopWindowState,
 } from "@bb/desktop-contract";
 import {
   serverMessageLenientSchema,
@@ -96,7 +97,9 @@ import { BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL } from "./desktop-browser-ipc.js";
 import {
   BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
   BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
+  BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
   CLOSE_WINDOW_REQUEST_TIMEOUT_MS,
 } from "./desktop-window-command-ipc.js";
 import {
@@ -409,6 +412,29 @@ function sendDesktopInfoChanged(): void {
   for (const browserWindow of BrowserWindow.getAllWindows()) {
     browserWindow.webContents.send(BB_DESKTOP_INFO_CHANGED_CHANNEL, info);
   }
+}
+
+function getDesktopWindowState(
+  browserWindow: Pick<DesktopBrowserWindow, "isFullScreen"> | null,
+): BbDesktopWindowState {
+  return {
+    isFullScreen: browserWindow?.isFullScreen() ?? false,
+  };
+}
+
+function getSenderDesktopWindowState(
+  event: IpcMainInvokeEvent,
+): BbDesktopWindowState {
+  return getDesktopWindowState(BrowserWindow.fromWebContents(event.sender));
+}
+
+function sendDesktopWindowStateChanged(
+  browserWindow: DesktopBrowserWindow,
+): void {
+  browserWindow.webContents.send(
+    BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
+    getDesktopWindowState(browserWindow),
+  );
 }
 
 function createDesktopLogger(): DesktopAutoUpdateLogger {
@@ -793,6 +819,12 @@ function registerApplicationWindow(browserWindow: DesktopBrowserWindow): void {
   const webContentsId = browserWindow.webContents.id;
   applicationWindowWebContentsIds.add(webContentsId);
   registerDesktopContextMenu({ webContents: browserWindow.webContents });
+  browserWindow.on("enter-full-screen", () => {
+    sendDesktopWindowStateChanged(browserWindow);
+  });
+  browserWindow.on("leave-full-screen", () => {
+    sendDesktopWindowStateChanged(browserWindow);
+  });
   browserWindow.on("closed", () => {
     applicationWindowWebContentsIds.delete(webContentsId);
   });
@@ -1134,6 +1166,9 @@ async function finishQuit(): Promise<void> {
 function registerDesktopUpdateIpc(): void {
   ipcMain.handle(BB_DESKTOP_GET_INFO_CHANNEL, () => {
     return getCurrentDesktopInfo();
+  });
+  ipcMain.handle(BB_DESKTOP_GET_WINDOW_STATE_CHANNEL, (event) => {
+    return getSenderDesktopWindowState(event);
   });
   ipcMain.handle(BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL, async () => {
     await Promise.all([

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,6 +5,7 @@ import {
   bbDesktopBrowserSnapshotSchema,
   bbDesktopBrowserStateSchema,
   bbDesktopInfoSchema,
+  bbDesktopWindowStateSchema,
   bbDesktopPopoutMouseEventsIgnoredRequestSchema,
   bbDesktopPopoutThreadChangedPayloadSchema,
   type BbDesktopApi,
@@ -24,6 +25,8 @@ import {
   type BbDesktopPopoutThreadChangedHandler,
   type BbDesktopPopoutUnsubscribe,
   type BbDesktopTheme,
+  type BbDesktopWindowState,
+  type BbDesktopWindowStateChangeHandler,
 } from "@bb/desktop-contract";
 import {
   BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL,
@@ -51,7 +54,9 @@ import {
 import {
   BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
   BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
+  BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
 } from "./desktop-window-command-ipc.js";
 import {
   BB_DESKTOP_POPOUT_OPEN_IN_MAIN_CHANNEL,
@@ -86,12 +91,26 @@ function createInitialDesktopInfo(): BbDesktopInfo {
   };
 }
 
+function createInitialDesktopWindowState(): BbDesktopWindowState {
+  return {
+    isFullScreen: false,
+  };
+}
+
 const listeners = new Set<BbDesktopInfoChangeHandler>();
+const windowStateListeners = new Set<BbDesktopWindowStateChangeHandler>();
 let currentInfo = createInitialDesktopInfo();
+let currentWindowState = createInitialDesktopWindowState();
 
 function notifyListeners(): void {
   for (const listener of listeners) {
     listener(currentInfo);
+  }
+}
+
+function notifyWindowStateListeners(): void {
+  for (const listener of windowStateListeners) {
+    listener(currentWindowState);
   }
 }
 
@@ -105,12 +124,35 @@ function applyDesktopInfoPayload(payload: unknown): BbDesktopInfo | null {
   return currentInfo;
 }
 
+function applyDesktopWindowStatePayload(
+  payload: unknown,
+): BbDesktopWindowState | null {
+  const parsed = bbDesktopWindowStateSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+  currentWindowState = parsed.data;
+  notifyWindowStateListeners();
+  return currentWindowState;
+}
+
 async function invokeDesktopInfo(channel: string): Promise<BbDesktopInfo> {
   try {
     const payload: unknown = await ipcRenderer.invoke(channel);
     return applyDesktopInfoPayload(payload) ?? currentInfo;
   } catch {
     return currentInfo;
+  }
+}
+
+async function invokeDesktopWindowState(): Promise<BbDesktopWindowState> {
+  try {
+    const payload: unknown = await ipcRenderer.invoke(
+      BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
+    );
+    return applyDesktopWindowStatePayload(payload) ?? currentWindowState;
+  } catch {
+    return currentWindowState;
   }
 }
 
@@ -282,6 +324,9 @@ const bbDesktopApi: BbDesktopApi = {
   getInfo() {
     return invokeDesktopInfo(BB_DESKTOP_GET_INFO_CHANNEL);
   },
+  getWindowState() {
+    return invokeDesktopWindowState();
+  },
   installUpdate() {
     return invokeInstallUpdate();
   },
@@ -289,6 +334,14 @@ const bbDesktopApi: BbDesktopApi = {
     listeners.add(listener);
     return () => {
       listeners.delete(listener);
+    };
+  },
+  onWindowStateChange(
+    listener: BbDesktopWindowStateChangeHandler,
+  ): BbDesktopInfoUnsubscribe {
+    windowStateListeners.add(listener);
+    return () => {
+      windowStateListeners.delete(listener);
     };
   },
   onOpenNewTab(listener): BbDesktopInfoUnsubscribe {
@@ -314,6 +367,13 @@ const bbDesktopApi: BbDesktopApi = {
 ipcRenderer.on(BB_DESKTOP_INFO_CHANGED_CHANNEL, (_event, payload: unknown) => {
   applyDesktopInfoPayload(payload);
 });
+
+ipcRenderer.on(
+  BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
+  (_event, payload: unknown) => {
+    applyDesktopWindowStatePayload(payload);
+  },
+);
 
 ipcRenderer.on(BB_DESKTOP_OPEN_NEW_TAB_CHANNEL, () => {
   for (const listener of openNewTabListeners) {
@@ -395,6 +455,7 @@ ipcRenderer.on(
 );
 
 void invokeDesktopInfo(BB_DESKTOP_GET_INFO_CHANNEL);
+void invokeDesktopWindowState();
 
 contextBridge.exposeInMainWorld(
   BB_DESKTOP_SPELLCHECK_GLOBAL_NAME,

--- a/apps/desktop/test/desktop-window-factory.test.ts
+++ b/apps/desktop/test/desktop-window-factory.test.ts
@@ -191,7 +191,14 @@ class FakeDesktopWindow implements DesktopBrowserWindow {
     this.maximized = true;
   }
 
-  on(eventName: "close" | "closed", listener: () => void): void {
+  on(
+    eventName:
+      | "close"
+      | "closed"
+      | "enter-full-screen"
+      | "leave-full-screen",
+    listener: () => void,
+  ): void {
     if (eventName === "closed") {
       this.closedListeners.push(listener);
     }

--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -7,6 +7,7 @@ import type {
   BbDesktopBrowserState,
   BbDesktopInfo,
   BbDesktopPopoutThreadChangedPayload,
+  BbDesktopWindowState,
 } from "@bb/desktop-contract";
 import {
   BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL,
@@ -41,7 +42,9 @@ import {
 import {
   BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
   BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
+  BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
 } from "../src/desktop-window-command-ipc.js";
 import { BB_DESKTOP_SPELLCHECK_GLOBAL_NAME } from "../src/desktop-spellcheck-contract.js";
 
@@ -66,6 +69,9 @@ const electronMock = vi.hoisted(() => {
     updateAvailable: false,
     updateDownloaded: false,
     version: "0.0.0-test",
+  };
+  const desktopWindowState: BbDesktopWindowState = {
+    isFullScreen: false,
   };
   const invokeCalls: string[] = [];
   const listeners = new Map<string, IpcRendererListener>();
@@ -123,10 +129,17 @@ const electronMock = vi.hoisted(() => {
     ipcRenderer: {
       invoke(
         channel: string,
-      ): Promise<BbDesktopInfo | BbDesktopPopoutThreadChangedPayload> {
+      ): Promise<
+        | BbDesktopInfo
+        | BbDesktopPopoutThreadChangedPayload
+        | BbDesktopWindowState
+      > {
         invokeCalls.push(channel);
         if (channel === "bb-desktop:popout:get-current-thread") {
           return Promise.resolve(currentPopoutThread);
+        }
+        if (channel === "bb-desktop:get-window-state") {
+          return Promise.resolve(desktopWindowState);
         }
         return Promise.resolve(desktopInfo);
       },
@@ -278,6 +291,9 @@ describe("desktop preload browser API", () => {
     await expect(api.popout.getCurrentThread()).resolves.toBeNull();
     api.setTheme("dark");
     await api.checkForUpdates();
+    await expect(api.getWindowState?.()).resolves.toEqual({
+      isFullScreen: false,
+    });
     await api.installUpdate();
 
     expect(electronMock.sendCalls).toEqual([
@@ -341,6 +357,9 @@ describe("desktop preload browser API", () => {
       BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL,
     );
     expect(electronMock.invokeCalls).toContain(
+      BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
+    );
+    expect(electronMock.invokeCalls).toContain(
       BB_DESKTOP_INSTALL_UPDATE_CHANNEL,
     );
     expect(electronMock.invokeCalls).toContain(
@@ -357,6 +376,7 @@ describe("desktop preload browser API", () => {
     let closeWindowRequestCount = 0;
     let openNewTabCount = 0;
     const popoutThreads: BbDesktopPopoutThreadChangedPayload[] = [];
+    const windowStates: BbDesktopWindowState[] = [];
     const state: BbDesktopBrowserState = {
       tabId: "browser:a",
       url: "https://example.com/",
@@ -397,6 +417,9 @@ describe("desktop preload browser API", () => {
       closeWindowRequestCount += 1;
       return true;
     });
+    api.onWindowStateChange?.((windowState) => {
+      windowStates.push(windowState);
+    });
     api.popout.onThreadChanged((thread) => {
       popoutThreads.push(thread);
     });
@@ -418,6 +441,10 @@ describe("desktop preload browser API", () => {
       payload: { tabId: "browser:a", dataUrl: 42 },
     });
     emitIpcPayload({
+      channel: BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
+      payload: { isFullScreen: false, extra: true },
+    });
+    emitIpcPayload({
       channel: BB_DESKTOP_BROWSER_STATE_CHANNEL,
       payload: state,
     });
@@ -432,6 +459,10 @@ describe("desktop preload browser API", () => {
     emitIpcPayload({
       channel: BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
       payload: snapshot,
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
+      payload: { isFullScreen: true },
     });
     emitIpcPayload({
       channel: BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
@@ -458,6 +489,7 @@ describe("desktop preload browser API", () => {
     expect(openTabs).toEqual([openTab]);
     expect(scopedOpenTabs).toEqual([scopedOpenTab]);
     expect(snapshots).toEqual([snapshot]);
+    expect(windowStates).toEqual([{ isFullScreen: true }]);
     expect(closeWindowRequestCount).toBe(1);
     expect(openNewTabCount).toBe(1);
     expect(electronMock.sendCalls).toContainEqual({

--- a/packages/desktop-contract/src/info.ts
+++ b/packages/desktop-contract/src/info.ts
@@ -15,11 +15,23 @@ export const bbDesktopInfoSchema = z.object({
 });
 export type BbDesktopInfo = z.infer<typeof bbDesktopInfoSchema>;
 
+export const bbDesktopWindowStateSchema = z
+  .object({
+    isFullScreen: z.boolean(),
+  })
+  .strict();
+export type BbDesktopWindowState = z.infer<
+  typeof bbDesktopWindowStateSchema
+>;
+
 export const bbDesktopThemeSchema = z.enum(["light", "dark"]);
 export type BbDesktopTheme = z.infer<typeof bbDesktopThemeSchema>;
 
 export type BbDesktopInfoChangeHandler = (info: BbDesktopInfo) => void;
 export type BbDesktopInfoUnsubscribe = () => void;
+export type BbDesktopWindowStateChangeHandler = (
+  state: BbDesktopWindowState,
+) => void;
 export type BbDesktopOpenNewTabHandler = () => void;
 export type BbDesktopCloseWindowRequestHandler = () => boolean;
 
@@ -39,8 +51,21 @@ export interface BbDesktopApi extends BbDesktopInfo {
   popout: BbDesktopPopoutApi;
   checkForUpdates(): Promise<BbDesktopInfo>;
   getInfo(): Promise<BbDesktopInfo>;
+  /**
+   * Current native window state for renderer chrome geometry. Optional for
+   * version skew with desktop shells that predate this bridge; callers should
+   * feature-detect and fall back to the normal window layout.
+   */
+  getWindowState?(): Promise<BbDesktopWindowState>;
   installUpdate(): Promise<void>;
   onChange(listener: BbDesktopInfoChangeHandler): BbDesktopInfoUnsubscribe;
+  /**
+   * Subscribe to native window state pushes for this BrowserWindow. Optional
+   * for version skew with desktop shells that predate fullscreen-aware chrome.
+   */
+  onWindowStateChange?(
+    listener: BbDesktopWindowStateChangeHandler,
+  ): BbDesktopInfoUnsubscribe;
   /**
    * Subscribe to native desktop requests to open the current thread's secondary
    * panel new-tab page. Optional for desktop shells that predate this command.

--- a/packages/desktop-contract/test/version-feed.test.ts
+++ b/packages/desktop-contract/test/version-feed.test.ts
@@ -3,6 +3,7 @@ import {
   bbDesktopInfoSchema,
   bbDesktopThemeSchema,
   bbDesktopVersionFeedSchema,
+  bbDesktopWindowStateSchema,
 } from "../src/index.js";
 
 const checkedAt = "2026-05-21T00:00:00.000Z";
@@ -25,6 +26,18 @@ describe("desktop info schema", () => {
   it("accepts the desktop theme values", () => {
     expect(bbDesktopThemeSchema.safeParse("dark").success).toBe(true);
     expect(bbDesktopThemeSchema.safeParse("system").success).toBe(false);
+  });
+
+  it("accepts strict desktop window state payloads", () => {
+    expect(
+      bbDesktopWindowStateSchema.safeParse({ isFullScreen: true }).success,
+    ).toBe(true);
+    expect(
+      bbDesktopWindowStateSchema.safeParse({
+        isFullScreen: true,
+        extra: true,
+      }).success,
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a desktop window-state bridge for fullscreen changes
- stop reserving macOS traffic-light space when the desktop app is fullscreen
- cover the fullscreen chrome policy and preload/window-state bridge with tests

## Tests
- pnpm exec turbo run typecheck --filter=@bb/desktop-contract --filter=@bb/desktop --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/desktop-contract --filter=@bb/desktop --filter=@bb/app

## Notes
- Rebased onto origin/main before opening this PR.