### PR TITLE
Speed up CI and fix cross-package test cache staleness

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,41 @@
+name: Setup workspace
+description: Set up pnpm + Node, restore the Turbo cache, and install dependencies.
+
+inputs:
+  node-version:
+    description: Node version to install
+    required: true
+  pnpm-version:
+    description: pnpm version to install
+    required: true
+  cache-prefix:
+    description: Distinguishes Turbo cache entries per job type (e.g. checks, test-server)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    - name: Cache Turbo task outputs
+      uses: actions/cache@v4
+      with:
+        path: .turbo/cache
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
+          ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,32 +25,50 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
-          cache: pnpm
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          cache-prefix: checks
 
-      - name: Cache Turbo task outputs
-        uses: actions/cache@v4
+      - name: Build, typecheck, and lint
+        run: pnpm exec turbo run build typecheck lint --cache-dir=.turbo/cache --output-logs=new-only
+
+  # Tests run on their own runners instead of inside the checks job: the big
+  # suites are CPU-bound and previously fought each other (and the builds) for
+  # the same 4 vCPUs, which made tests the critical path of every run.
+  tests:
+    name: Tests (${{ matrix.shard }}, ubuntu-latest, Node 22.x)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: server
+            filter: --filter=@bb/server
+          - shard: app
+            filter: --filter=@bb/app
+          - shard: integration
+            filter: --filter=@bb/integration-tests
+          - shard: packages
+            filter: --filter='!@bb/server' --filter='!@bb/app' --filter='!@bb/integration-tests'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
         with:
-          path: .turbo/cache
-          key: ${{ runner.os }}-node-${{ env.PRIMARY_NODE_VERSION }}-checks-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.PRIMARY_NODE_VERSION }}-checks-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
-            ${{ runner.os }}-node-${{ env.PRIMARY_NODE_VERSION }}-checks-turbo-
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          cache-prefix: test-${{ matrix.shard }}
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Build, typecheck, lint, and test
-        run: pnpm exec turbo run build typecheck lint test --cache-dir=.turbo/cache --output-logs=new-only
+      - name: Test
+        run: pnpm exec turbo run test ${{ matrix.filter }} --cache-dir=.turbo/cache --output-logs=new-only
 
   package-smoke:
     name: Package Smoke (${{ matrix.os }}, Node ${{ matrix.node-version }})
@@ -70,29 +88,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ matrix.node-version }}
-          cache: pnpm
-
-      - name: Cache Turbo task outputs
-        uses: actions/cache@v4
-        with:
-          path: .turbo/cache
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-package-smoke-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-package-smoke-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
-            ${{ runner.os }}-node-${{ matrix.node-version }}-package-smoke-turbo-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          cache-prefix: package-smoke
 
       - name: Smoke bb-app tarball
         run: pnpm exec turbo run smoke:tarball --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only
@@ -123,29 +124,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ matrix.node-version }}
-          cache: pnpm
-
-      - name: Cache Turbo task outputs
-        uses: actions/cache@v4
-        with:
-          path: .turbo/cache
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-compat-smoke-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-compat-smoke-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
-            ${{ runner.os }}-node-${{ matrix.node-version }}-compat-smoke-turbo-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          cache-prefix: compat-smoke
 
       - name: Smoke bb-app tarball
         run: pnpm exec turbo run smoke:tarball --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,15 +1,35 @@
-import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+import {
+  defineWorkspaceTestConfig,
+  findIsolationRequiringTests,
+} from "../../vitest.shared.js";
+
+const isolationTests = findIsolationRequiringTests(__dirname, ["src", "test"]);
 
 export default defineWorkspaceTestConfig({
   test: {
     silent: "passed-only",
-    name: "@bb/server",
-    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
-    exclude: ["dist/**", "node_modules/**"],
     env: {
       BB_DATA_DIR: "/tmp/bb-server-test",
       BB_SERVER_PORT: "49161",
       BB_HOST_DAEMON_PORT: "49162",
     },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "@bb/server",
+          include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+          exclude: ["dist/**", "node_modules/**", ...isolationTests],
+          isolate: false,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "@bb/server:isolated",
+          include: isolationTests,
+        },
+      },
+    ],
   },
 });

--- a/packages/agent-runtime/vitest.config.ts
+++ b/packages/agent-runtime/vitest.config.ts
@@ -1,10 +1,32 @@
-import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+import {
+  defineWorkspaceTestConfig,
+  findIsolationRequiringTests,
+} from "../../vitest.shared.js";
+
+const exclude = ["dist/**", "node_modules/**", "src/integration*.test.ts"];
+const isolationTests = findIsolationRequiringTests(__dirname, ["src"]);
 
 export default defineWorkspaceTestConfig({
   test: {
     silent: "passed-only",
-    name: "@bb/agent-runtime",
-    include: ["src/**/*.test.ts"],
-    exclude: ["dist/**", "node_modules/**", "src/integration*.test.ts"],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "@bb/agent-runtime",
+          include: ["src/**/*.test.ts"],
+          exclude: [...exclude, ...isolationTests],
+          isolate: false,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "@bb/agent-runtime:isolated",
+          include: isolationTests,
+          exclude,
+        },
+      },
+    ],
   },
 });

--- a/tests/integration/vitest.config.ts
+++ b/tests/integration/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineWorkspaceTestConfig({
     // Fake integration suites isolate temp roots, ports, and in-memory state,
     // so we can safely parallelize across files for a large runtime win.
     fileParallelism: true,
+    // No file here mocks modules or stubs globals/env (vitest.shared.ts's
+    // findIsolationRequiringTests would flag it), so workers can reuse their
+    // context across files instead of re-importing the server graph per file.
+    isolate: false,
     globalSetup: ["./global-setup.ts"],
     hookTimeout: Math.ceil(60_000 * timeoutScale),
     include: ["fake/**/*.test.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,8 @@
     },
     "@bb/sdk#test": {
       "dependsOn": [
-        "//#ensure-native-modules"
+        "//#ensure-native-modules",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -248,19 +249,25 @@
       ],
       "outputs": []
     },
-    "typecheck": {},
-    "bb-plugin-automations#typecheck": {
+    // Transit node (no package defines a `topo` script; nothing executes).
+    // It exists so tasks that resolve `@bb/*` imports to *sources* — vitest
+    // and tsc both use the `source` export condition — hash the sources of
+    // dependency packages. Without it, a change in e.g. packages/domain
+    // would cache-hit @bb/server#test/#typecheck and skip them stale.
+    "topo": {
       "dependsOn": [
-        "@bb/shared-ui#typecheck"
+        "^topo"
       ]
     },
-    "bb-plugin-connect#typecheck": {
+    "typecheck": {
       "dependsOn": [
-        "@bb/shared-ui#typecheck",
-        "@bb/tunnel-contract#typecheck"
+        "topo"
       ]
     },
     "@bb/integration-tests#typecheck": {
+      "dependsOn": [
+        "topo"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/server/package.json",
@@ -274,7 +281,8 @@
     },
     "test": {
       "dependsOn": [
-        "//#ensure-native-modules"
+        "//#ensure-native-modules",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -290,7 +298,8 @@
     },
     "@bb/integration-tests#test": {
       "dependsOn": [
-        "//#ensure-native-modules"
+        "//#ensure-native-modules",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -305,7 +314,8 @@
     },
     "test:smoke": {
       "dependsOn": [
-        "//#ensure-native-modules"
+        "//#ensure-native-modules",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -314,7 +324,8 @@
     },
     "@bb/integration-tests#test:smoke": {
       "dependsOn": [
-        "//#ensure-native-modules"
+        "//#ensure-native-modules",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -329,7 +340,8 @@
     },
     "test:integration": {
       "dependsOn": [
-        "//#ensure-native-modules"
+        "//#ensure-native-modules",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -339,7 +351,8 @@
     "@bb/integration-tests#test:integration": {
       "dependsOn": [
         "//#ensure-native-modules",
-        "@bb/agent-runtime#test:integration"
+        "@bb/agent-runtime#test:integration",
+        "topo"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -350,13 +363,6 @@
         "$TURBO_ROOT$/packages/templates/scripts/**",
         "$TURBO_ROOT$/packages/templates/src/**",
         "$TURBO_ROOT$/vitest.shared.ts"
-      ]
-    },
-    "@bb/sdk#typecheck": {},
-    "@bb/server#typecheck": {},
-    "@bb/server#test": {
-      "dependsOn": [
-        "//#ensure-native-modules"
       ]
     },
     "@bb/plugin-sdk#build": {
@@ -371,6 +377,9 @@
       ]
     },
     "@bb/plugin-build#typecheck": {
+      "dependsOn": [
+        "topo"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/app/src/components/ui/theme.css",
@@ -378,12 +387,19 @@
       ]
     },
     "@bb/plugin-registry#typecheck": {
+      "dependsOn": [
+        "topo"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/shared-ui/src/**"
       ]
     },
     "@bb/plugin-registry#test": {
+      "dependsOn": [
+        "//#ensure-native-modules",
+        "topo"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/shared-ui/src/**"

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
 import { mergeConfig, type ViteUserConfig } from "vitest/config";
 
 /**
@@ -14,6 +16,58 @@ import { mergeConfig, type ViteUserConfig } from "vitest/config";
  * conditions through a config plugin, and Vite concatenates these arrays
  * with them during config merge.
  */
+/**
+ * Vitest APIs that mutate worker-global state (the module registry, globals,
+ * or `process.env`). Files calling any of these need their own isolated
+ * worker; running them with `isolate: false` makes mocks bleed across files
+ * or silently fail to apply when the target module is already loaded.
+ */
+const ISOLATION_REQUIRING_API =
+  /\bvi\.(mock|doMock|unmock|doUnmock|resetModules|stubGlobal|stubEnv)\(/;
+
+const TEST_FILE = /\.test\.tsx?$/;
+const SKIP_DIRS = new Set(["node_modules", "dist"]);
+
+/**
+ * Finds test files under `roots` (relative to `pkgDir`) that use
+ * worker-global vitest APIs and therefore must keep the default isolated
+ * worker. Everything else can run in a shared worker context
+ * (`isolate: false`), which skips re-importing the module graph for every
+ * file — by far the dominant cost of the big suites in CI.
+ *
+ * Returns package-relative posix paths, usable directly as vitest
+ * `include`/`exclude` entries.
+ */
+export function findIsolationRequiringTests(
+  pkgDir: string,
+  roots: string[],
+): string[] {
+  const matches: string[] = [];
+  const walk = (dir: string) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(fullPath);
+      } else if (
+        TEST_FILE.test(entry.name) &&
+        ISOLATION_REQUIRING_API.test(readFileSync(fullPath, "utf8"))
+      ) {
+        matches.push(
+          path.relative(pkgDir, fullPath).split(path.sep).join("/"),
+        );
+      }
+    }
+  };
+  for (const root of roots) walk(path.join(pkgDir, root));
+  return matches.sort();
+}
+
 export function defineWorkspaceTestConfig(
   config: ViteUserConfig,
 ): ViteUserConfig {


### PR DESCRIPTION
## Summary

CI wall time (~5–8.5 min per run) was gated on the single **Checks** job, where the four big vitest suites, all builds, and eslint competed for one 4-vCPU runner. Per-task timing from recent runs showed the real cost was vitest's per-file worker isolation re-importing the module graph — e.g. `@bb/server:test` spent 618s importing vs 395s testing; `@bb/app:test` spent 661s importing + 214s creating jsdom envs vs 130s testing.

### Changes

- **Shared worker contexts where safe.** New `findIsolationRequiringTests()` in `vitest.shared.ts` scans test files for worker-global APIs (`vi.mock`, `vi.doMock`, `vi.stubGlobal`, `vi.stubEnv`, …) at config time; those files keep the default isolated worker, everything else runs with `isolate: false`. Applied to `@bb/server`, `@bb/agent-runtime` (two-project split) and `@bb/integration-tests` (wholesale — zero flagged files). Server suite CPU drops 132s → 51s locally. The app suite is untouched: it has real cross-file state leaks under `--no-isolate` (25 failures), so it keeps full isolation.
- **Parallel test shards.** Tests move out of Checks into a `Tests` matrix (server / app / integration / packages), each on its own runner with its own turbo cache key, so a PR touching only one area cache-skips the other shards. Checks now runs only `build typecheck lint`. Repeated setup steps are factored into `.github/actions/setup-workspace`.
- **Cache-correctness fix.** vitest and tsc resolve `@bb/*` imports to package *sources* via the `source` export condition, but `test`/`typecheck` task hashes ignored dependency package sources — a PR touching only `packages/domain` would stale-cache-hit `@bb/server#test`. Added the Turborepo transit-node pattern (`topo` task) and hung `test`/`test:smoke`/`test:integration`/`typecheck` on it. This supersedes the hand-maintained plugin typecheck edges and the empty `@bb/sdk#typecheck`/`@bb/server#typecheck`/`@bb/server#test` overrides, which are deleted.

Expected result: roughly **8.5 min → ~4–4.5 min** wall. Every task hash changes once, so this PR's own run (and the first run after merge) rebuilds all turbo caches — judge cache behavior from the second run onward.

## Tests

- `@bb/server`: 118 files / 958 tests pass with the split config; file/test counts identical to baseline.
- `@bb/agent-runtime`: 37 files / 741 tests pass, parity with baseline.
- `@bb/integration-tests`: 24 files / 54 tests pass with `isolate: false`.
- Full `turbo run test typecheck` across all 47 packages executes cleanly with the transit node.
- Hash probes: a `packages/domain` edit now flips `@bb/server#test`, `@bb/server#typecheck`, `@bb/integration-tests#test`; a `packages/shared-ui` edit flips `bb-plugin-automations#typecheck`; unrelated packages (`@bb/fuzzy-match`) stay stable.
- Turbo dry-runs confirm the four shard filters cover every `test` task exactly once.

## Risks

- `isolate: false` relies on tests not leaking worker-global state through APIs the scanner doesn't catch; the flagged-API list is conservative and the three converted suites are fully green, but a latent order-dependent leak would show up as flakiness in those suites.
- First CI run repopulates all caches, so it will be slower than steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)