### PR TITLE
Remove automations plugin settings

### DIFF
--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -233,7 +233,6 @@ describe("automation data access", () => {
 
     await sweepDueAutomations(bb, db, {
       pluginDataDir: "/tmp",
-      allowScriptRuns: true,
       serverUrl: "http://127.0.0.1:38886",
       now: 1000,
     });
@@ -321,7 +320,6 @@ describe("automation service", () => {
       bb,
       db,
       pluginDataDir: "/tmp",
-      getAllowScriptRuns: async () => true,
       serverUrl: "http://127.0.0.1:38886",
     });
 

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -137,7 +137,7 @@ describe("automations server plugin harness", () => {
     vi.useRealTimers();
   });
 
-  it("boots through server.ts and registers settings, rpc, cli, thread events, and sweep service", async () => {
+  it("boots through server.ts and registers rpc, cli, thread events, and sweep service", async () => {
     const { harness } = await bootAutomationsPlugin();
 
     expect([...harness.registrations.rpcMethods].sort()).toEqual(rpcMethods);
@@ -150,9 +150,7 @@ describe("automations server plugin harness", () => {
       "thread.failed": 1,
       "thread.deleted": 1,
     });
-    expect(harness.registrations.settingsDescriptors.allowScriptRuns).toEqual(
-      expect.objectContaining({ type: "boolean", default: true }),
-    );
+    expect(harness.registrations.settingsDescriptors).toEqual({});
 
     await harness.dispose();
   });

--- a/plugins/automations/src/server.ts
+++ b/plugins/automations/src/server.ts
@@ -13,32 +13,15 @@ function resolveServerUrl(): string {
 }
 
 export default async function plugin(bb: BbPluginApi) {
-  const settings = bb.settings.define({
-    allowScriptRuns: {
-      type: "boolean",
-      label: "Allow script automations",
-      description: "Allow automations to run stored bash/sh/node/python3 scripts on the server.",
-      default: true,
-    },
-  });
-
   const db = bb.storage.sqlite();
   bb.storage.migrate(db, migrations);
   const pluginDataDir = pluginDataDirFromDb(db);
   await ingestLegacyImport({ bb, db, pluginDataDir });
 
-  let allowScriptRuns = (await settings.get()).allowScriptRuns;
-  settings.onChange((next) => {
-    allowScriptRuns = next.allowScriptRuns;
-  });
-
-  const getAllowScriptRuns = async (): Promise<boolean> => allowScriptRuns;
-
   const service = createAutomationService({
     bb,
     db,
     pluginDataDir,
-    getAllowScriptRuns,
     serverUrl: resolveServerUrl(),
   });
 
@@ -69,7 +52,6 @@ export default async function plugin(bb: BbPluginApi) {
         try {
           await sweepDueAutomations(bb, db, {
             pluginDataDir,
-            allowScriptRuns,
             serverUrl: resolveServerUrl(),
           });
         } catch (error) {

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -124,15 +124,6 @@ function assertNotRecursiveCreation(
   }
 }
 
-function assertScriptRunsAllowed(
-  allowScriptRuns: boolean,
-  execution: AutomationExecution,
-): void {
-  if (execution.mode === "script" && !allowScriptRuns) {
-    throw new Error("Script automations are disabled on this server");
-  }
-}
-
 async function resolveStoredExecution(args: {
   pluginDataDir: string;
   automationId: string;
@@ -221,7 +212,6 @@ export function createAutomationService(args: {
   bb: ServiceApi;
   db: Db;
   pluginDataDir: string;
-  getAllowScriptRuns: () => Promise<boolean>;
   serverUrl: string;
 }): AutomationService {
   const { bb, db, pluginDataDir, serverUrl } = args;
@@ -261,11 +251,9 @@ export function createAutomationService(args: {
 
     async create(payload) {
       await requireProjectAvailable(bb, payload.projectId);
-      const allowScriptRuns = await args.getAllowScriptRuns();
       const now = Date.now();
       validateTrigger(payload.trigger, now);
       assertNotRecursiveCreation(db, payload.createdByThreadId);
-      assertScriptRunsAllowed(allowScriptRuns, payload.execution);
       const automationId = createAutomationId();
       const storedExecution = await resolveStoredExecution({
         pluginDataDir,
@@ -295,7 +283,6 @@ export function createAutomationService(args: {
     async update(input) {
       await requireProjectAvailable(bb, input.projectId);
       const current = requireProjectAutomation(db, input);
-      const allowScriptRuns = await args.getAllowScriptRuns();
       const now = Date.now();
       const patch: Parameters<typeof updateAutomation>[1]["patch"] = {};
       if (input.name !== undefined) patch.name = input.name;
@@ -305,7 +292,6 @@ export function createAutomationService(args: {
         patch.nextRunAt = current.enabled ? computeNextRunAt(input.trigger, now) : null;
       }
       if (input.execution !== undefined) {
-        assertScriptRunsAllowed(allowScriptRuns, input.execution);
         patch.execution = await resolveStoredExecution({
           pluginDataDir,
           automationId: current.id,
@@ -366,8 +352,6 @@ export function createAutomationService(args: {
     async run(input) {
       const automation = requireProjectAutomation(db, input);
       const execution = parseAutomationExecution(automation.execution);
-      const allowScriptRuns = await args.getAllowScriptRuns();
-      assertScriptRunsAllowed(allowScriptRuns, execution);
       const now = Date.now();
       const { run, deduped } = createManualRun(db, {
         automationId: automation.id,

--- a/plugins/automations/src/sweep.ts
+++ b/plugins/automations/src/sweep.ts
@@ -63,7 +63,6 @@ async function processDueAutomation(
     pluginDataDir: string;
     automation: AutomationRow;
     now: number;
-    allowScriptRuns: boolean;
     agentHostsAvailable: boolean;
     serverUrl: string;
   },
@@ -93,13 +92,6 @@ async function processDueAutomation(
   }
 
   if (execution.mode === "agent" && !args.agentHostsAvailable) {
-    return;
-  }
-
-  if (execution.mode === "script" && !args.allowScriptRuns) {
-    bb.log.warn(
-      `Skipping due script automation ${args.automation.id}: script runs are disabled`,
-    );
     return;
   }
 
@@ -169,7 +161,6 @@ export async function sweepDueAutomations(
   db: Db,
   args: {
     pluginDataDir: string;
-    allowScriptRuns: boolean;
     serverUrl: string;
     now?: number;
   },
@@ -183,7 +174,6 @@ export async function sweepDueAutomations(
         pluginDataDir: args.pluginDataDir,
         automation,
         now,
-        allowScriptRuns: args.allowScriptRuns,
         agentHostsAvailable,
         serverUrl: args.serverUrl,
       });


### PR DESCRIPTION
## Summary
- Remove the built-in automations plugin settings descriptor for script automation runs
- Drop the server/service/sweep plumbing for the old allowScriptRuns gate
- Update focused tests to assert the plugin no longer declares settings

## Tests
- pnpm exec turbo run typecheck --filter=bb-plugin-automations
- pnpm exec turbo run test --filter=bb-plugin-automations --force

## Risk
- Script automations remain enabled unconditionally, matching the previous default behavior.