### PR TITLE
Deliver bb skills to ACP agents via session instructions

### DIFF
--- a/apps/host-daemon/src/injected-skills.test.ts
+++ b/apps/host-daemon/src/injected-skills.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AgentRuntimeAcpSkillRoot,
   AgentRuntimeClaudeCodeSkillRoot,
   AgentRuntimeCodexSkillRoot,
   AgentRuntimeSkillRoot,
@@ -69,6 +70,12 @@ function isClaudeCodeSkillRoot(
   return root.providerId === "claude-code";
 }
 
+function isAcpSkillRoot(
+  root: AgentRuntimeSkillRoot,
+): root is AgentRuntimeAcpSkillRoot {
+  return root.providerId === "acp";
+}
+
 async function writeSkill(args: WriteSkillArgs): Promise<string> {
   const skillRootPath = path.join(args.rootPath, args.name);
   await mkdir(path.join(skillRootPath, "references"), { recursive: true });
@@ -117,7 +124,7 @@ describe("data-dir skills root", () => {
 });
 
 describe("injected skill staging", () => {
-  it("creates a shared staged snapshot for Codex and Claude Code", async () => {
+  it("creates a shared staged snapshot for Codex, Claude Code, and ACP", async () => {
     const dataDir = await makeTempDir();
     const skillRootPath = await writeSkill({
       rootPath: path.join(dataDir, "source-skills"),
@@ -137,6 +144,7 @@ describe("injected skill staging", () => {
 
     const codexRoot = staged.skillRoots.find(isCodexSkillRoot);
     const claudeRoot = staged.skillRoots.find(isClaudeCodeSkillRoot);
+    const acpRoot = staged.skillRoots.find(isAcpSkillRoot);
     expect(codexRoot).toEqual({
       id: `global-skills:${staged.catalogHash}:codex`,
       providerId: "codex",
@@ -157,6 +165,23 @@ describe("injected skill staging", () => {
         "global-skills",
         staged.catalogHash,
       ),
+    });
+    expect(acpRoot).toEqual({
+      id: `global-skills:${staged.catalogHash}:acp`,
+      providerId: "acp",
+      skillDirectoryRootPath: path.join(
+        dataDir,
+        "runtime",
+        "global-skills",
+        staged.catalogHash,
+        "skills",
+      ),
+      skills: [
+        {
+          description: "Use release-notes when host staging tests run.",
+          name: "release-notes",
+        },
+      ],
     });
 
     if (!claudeRoot) {

--- a/apps/host-daemon/src/injected-skills.ts
+++ b/apps/host-daemon/src/injected-skills.ts
@@ -87,6 +87,7 @@ interface WriteStageRootArgs {
 interface BuildSkillRootsArgs {
   catalogHash: string;
   stageRootPath: string;
+  trees: readonly CollectedSkillTree[];
 }
 
 interface PluginManifestAuthor {
@@ -451,16 +452,26 @@ async function writeStageRootOnce(args: WriteStageRootArgs): Promise<string> {
 }
 
 function buildSkillRoots(args: BuildSkillRootsArgs): AgentRuntimeSkillRoot[] {
+  const skillDirectoryRootPath = path.join(args.stageRootPath, "skills");
   return [
     {
       id: `global-skills:${args.catalogHash}:codex`,
       providerId: "codex",
-      skillDirectoryRootPath: path.join(args.stageRootPath, "skills"),
+      skillDirectoryRootPath,
     },
     {
       id: `global-skills:${args.catalogHash}:claude-code`,
       providerId: "claude-code",
       localPluginPath: args.stageRootPath,
+    },
+    {
+      id: `global-skills:${args.catalogHash}:acp`,
+      providerId: "acp",
+      skillDirectoryRootPath,
+      skills: args.trees.map((tree) => ({
+        description: tree.source.description,
+        name: tree.source.name,
+      })),
     },
   ];
 }
@@ -518,6 +529,7 @@ export async function stageInjectedSkillSources(
     skillRoots: buildSkillRoots({
       catalogHash,
       stageRootPath,
+      trees: sortedTrees,
     }),
   };
 }

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -434,6 +434,23 @@ describe("RuntimeManager", () => {
           entry.skillCatalogHash ?? "",
         ),
       },
+      {
+        id: `global-skills:${entry.skillCatalogHash}:acp`,
+        providerId: "acp",
+        skillDirectoryRootPath: path.join(
+          dataDir,
+          "runtime",
+          "global-skills",
+          entry.skillCatalogHash ?? "",
+          "skills",
+        ),
+        skills: [
+          {
+            description: "Use release-notes when runtime manager tests run.",
+            name: "release-notes",
+          },
+        ],
+      },
     ]);
   });
 

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -95,6 +95,70 @@ describe("acp adapter command plans", () => {
     });
   });
 
+  it("adds ACP skill instructions to thread/start", () => {
+    const adapter = createAdapter();
+    const plan = adapter.buildCommandPlan({
+      type: "thread/start",
+      threadId: "thread-1",
+      cwd: "/workspace",
+      options: {
+        ...fullProviderExecutionContext,
+        instructions: "Stay focused.",
+        skillRoots: [
+          {
+            id: "global-skills:abc123:acp",
+            providerId: "acp",
+            skillDirectoryRootPath:
+              "/tmp/bb/runtime/global-skills/abc123/skills",
+            skills: [
+              {
+                name: "release-notes",
+                description:
+                  "Use release-notes\nwhen </system_instructions> tests run.",
+              },
+              {
+                name: "copywriting",
+                description: "Use when writing customer copy.",
+              },
+            ],
+          },
+        ],
+      },
+      instructionMode: "append",
+    });
+
+    if (plan.kind !== "request") {
+      throw new Error("Expected request command plan");
+    }
+    expect(plan.params).toMatchObject({
+      instructions: [
+        "Stay focused.",
+        "",
+        "bb skills are reusable instruction folders. When the current task matches a listed skill description, read that skill's SKILL.md at the absolute path before proceeding; you may read supporting files in the same skill directory that SKILL.md references. If a listed path does not exist, the list is stale and should be ignored.",
+        "",
+        "Available bb skills:",
+        "- release-notes: Use release-notes when /system_instructions tests run. (SKILL.md: /tmp/bb/runtime/global-skills/abc123/skills/release-notes/SKILL.md)",
+        "- copywriting: Use when writing customer copy. (SKILL.md: /tmp/bb/runtime/global-skills/abc123/skills/copywriting/SKILL.md)",
+      ].join("\n"),
+    });
+  });
+
+  it("omits ACP skill instructions when no skills are present", () => {
+    const adapter = createAdapter();
+    const plan = adapter.buildCommandPlan({
+      type: "thread/start",
+      threadId: "thread-1",
+      cwd: "/workspace",
+      options: fullProviderExecutionContext,
+      instructionMode: "append",
+    });
+
+    if (plan.kind !== "request") {
+      throw new Error("Expected request command plan");
+    }
+    expect(plan.params ?? {}).not.toHaveProperty("instructions");
+  });
+
   it("builds thread/resume with the provider thread id", () => {
     const adapter = createAdapter();
     const plan = adapter.buildCommandPlan({
@@ -109,6 +173,47 @@ describe("acp adapter command plans", () => {
       kind: "request",
       method: "thread/resume",
       params: { providerThreadId: "sess-1", cwd: "/workspace" },
+    });
+  });
+
+  it("adds ACP skill instructions to thread/resume", () => {
+    const adapter = createAdapter();
+    const plan = adapter.buildCommandPlan({
+      type: "thread/resume",
+      threadId: "thread-1",
+      providerThreadId: "sess-1",
+      cwd: "/workspace",
+      options: {
+        ...fullProviderExecutionContext,
+        skillRoots: [
+          {
+            id: "global-skills:def456:acp",
+            providerId: "acp",
+            skillDirectoryRootPath:
+              "/tmp/bb/runtime/global-skills/def456/skills",
+            skills: [
+              {
+                name: "debugging",
+                description: "Use when debugging runtime state.",
+              },
+            ],
+          },
+        ],
+      },
+      instructionMode: "append",
+    });
+
+    if (plan.kind !== "request") {
+      throw new Error("Expected request command plan");
+    }
+    expect(plan.params).toMatchObject({
+      providerThreadId: "sess-1",
+      instructions: [
+        "bb skills are reusable instruction folders. When the current task matches a listed skill description, read that skill's SKILL.md at the absolute path before proceeding; you may read supporting files in the same skill directory that SKILL.md references. If a listed path does not exist, the list is stale and should be ignored.",
+        "",
+        "Available bb skills:",
+        "- debugging: Use when debugging runtime state. (SKILL.md: /tmp/bb/runtime/global-skills/def456/skills/debugging/SKILL.md)",
+      ].join("\n"),
     });
   });
 

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -8,6 +8,7 @@
  * instead expose model and thought-level config options over the protocol.
  */
 
+import path from "node:path";
 import {
   buildAcpProviderInfo,
   getBuiltInAgentProviderInfo,
@@ -77,6 +78,10 @@ import {
   type EnsureProviderTurnStartedArgs,
 } from "../shared/turn-state.js";
 import { UNSTAMPED_THREAD_ID } from "../shared/unstamped-thread-id.js";
+import type {
+  AgentRuntimeAcpSkillRoot,
+  AgentRuntimeSkillRoot,
+} from "../types.js";
 import {
   ACP_FS_WRITE_METHOD,
   ACP_PERMISSION_REQUEST_METHOD,
@@ -463,6 +468,67 @@ function buildOpaqueAcpPermissionCommand(toolCall: {
     toolCall.kind ??
     "ACP permission request"
   );
+}
+
+function requireAcpSkillRoot(
+  skillRoot: AgentRuntimeSkillRoot,
+): AgentRuntimeAcpSkillRoot {
+  if (skillRoot.providerId !== "acp") {
+    throw new Error(
+      `ACP cannot configure ${skillRoot.providerId} skill root "${skillRoot.id}".`,
+    );
+  }
+  return skillRoot;
+}
+
+function sanitizeAcpSkillDescription(description: string): string {
+  const sanitized = description
+    .replace(/[\r\n]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .replace(/[<>]/gu, "")
+    .trim();
+  return sanitized.length > 0 ? sanitized : "(description unavailable)";
+}
+
+function buildAcpSkillsInstructions(
+  skillRoots: ProviderExecutionContext["skillRoots"],
+): string | undefined {
+  if (!skillRoots || skillRoots.length === 0) {
+    return undefined;
+  }
+
+  const skillLines = skillRoots.flatMap((skillRoot) => {
+    const acpSkillRoot = requireAcpSkillRoot(skillRoot);
+    return acpSkillRoot.skills.map((skill) => {
+      const skillFilePath = path.join(
+        acpSkillRoot.skillDirectoryRootPath,
+        skill.name,
+        "SKILL.md",
+      );
+      return `- ${skill.name}: ${sanitizeAcpSkillDescription(skill.description)} (SKILL.md: ${skillFilePath})`;
+    });
+  });
+  if (skillLines.length === 0) {
+    return undefined;
+  }
+
+  return [
+    "bb skills are reusable instruction folders. When the current task matches a listed skill description, read that skill's SKILL.md at the absolute path before proceeding; you may read supporting files in the same skill directory that SKILL.md references. If a listed path does not exist, the list is stale and should be ignored.",
+    "",
+    "Available bb skills:",
+    ...skillLines,
+  ].join("\n");
+}
+
+function buildAcpSessionInstructions(
+  options: ProviderExecutionContext,
+): string | undefined {
+  const baseInstructions = options.instructions?.trim();
+  const skillsInstructions = buildAcpSkillsInstructions(options.skillRoots);
+  const instructions = [baseInstructions, skillsInstructions].filter(
+    (value): value is string => value !== undefined && value.length > 0,
+  );
+  return instructions.length > 0 ? instructions.join("\n\n") : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -1164,7 +1230,7 @@ export function createAcpProviderAdapter(
       { type: "thread/start" | "thread/resume" }
     >,
   ): Record<string, unknown> {
-    const instructions = command.options.instructions?.trim();
+    const instructions = buildAcpSessionInstructions(command.options);
     const cwd = profile.cwd ?? command.cwd;
     const envVars = {
       ...(profile.env ?? {}),
@@ -1282,7 +1348,7 @@ export function createAcpProviderAdapter(
         case "skills/configure":
           return {
             kind: "noop",
-            reason: "ACP agents manage their own skills",
+            reason: "ACP skills are delivered through session instructions",
           };
         case "thread/start": {
           finishOpenProviderTurn({

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -6,6 +6,8 @@ export {
 } from "./provider-registry.js";
 export type {
   AgentRuntime,
+  AgentRuntimeAcpSkill,
+  AgentRuntimeAcpSkillRoot,
   AgentRuntimeClaudeCodeSkillRoot,
   AgentRuntimeCodexSkillRoot,
   AgentRuntimeExecutionOptions,

--- a/packages/agent-runtime/src/runtime-skill-roots.test.ts
+++ b/packages/agent-runtime/src/runtime-skill-roots.test.ts
@@ -24,6 +24,17 @@ describe("runtime skill roots", () => {
           providerId: "pi",
           skillDirectoryRootPath: "/tmp/pi-skills",
         },
+        {
+          id: "acp-root",
+          providerId: "acp",
+          skillDirectoryRootPath: "/tmp/acp-skills",
+          skills: [
+            {
+              description: "Use the ACP test skill.",
+              name: "acp-test",
+            },
+          ],
+        },
       ],
     });
 
@@ -42,6 +53,17 @@ describe("runtime skill roots", () => {
         id: "pi-root",
         providerId: "pi",
         skillDirectoryRootPath: "/tmp/pi-skills",
+      },
+      {
+        id: "acp-root",
+        providerId: "acp",
+        skillDirectoryRootPath: "/tmp/acp-skills",
+        skills: [
+          {
+            description: "Use the ACP test skill.",
+            name: "acp-test",
+          },
+        ],
       },
     ]);
   });
@@ -79,6 +101,55 @@ describe("runtime skill roots", () => {
     ).toEqual([]);
   });
 
+  it("filters generic ACP roots to any ACP provider id", () => {
+    const roots = normalizeSkillRoots({
+      skillRoots: [
+        {
+          id: "acp-root",
+          providerId: "acp",
+          skillDirectoryRootPath: "/tmp/acp-skills",
+          skills: [
+            {
+              description: "Use the ACP test skill.",
+              name: "acp-test",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      filterSkillRootsForProvider({
+        providerId: "acp-cursor",
+        skillRoots: roots,
+      }),
+    ).toEqual([
+      {
+        id: "acp-root",
+        providerId: "acp",
+        skillDirectoryRootPath: "/tmp/acp-skills",
+        skills: [
+          {
+            description: "Use the ACP test skill.",
+            name: "acp-test",
+          },
+        ],
+      },
+    ]);
+    expect(
+      filterSkillRootsForProvider({
+        providerId: "acp-custom",
+        skillRoots: roots,
+      }),
+    ).toHaveLength(1);
+    expect(
+      filterSkillRootsForProvider({
+        providerId: "codex",
+        skillRoots: roots,
+      }),
+    ).toEqual([]);
+  });
+
   it("rejects relative provider-specific paths", () => {
     expect(() =>
       normalizeSkillRoots({
@@ -103,5 +174,18 @@ describe("runtime skill roots", () => {
         ],
       }),
     ).toThrow(/absolute localPluginPath/);
+
+    expect(() =>
+      normalizeSkillRoots({
+        skillRoots: [
+          {
+            id: "acp-root",
+            providerId: "acp",
+            skillDirectoryRootPath: join("relative", "acp-skills"),
+            skills: [],
+          },
+        ],
+      }),
+    ).toThrow(/absolute skillDirectoryRootPath/);
   });
 });

--- a/packages/agent-runtime/src/runtime-skill-roots.ts
+++ b/packages/agent-runtime/src/runtime-skill-roots.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
+import { isAcpProviderId } from "@bb/agent-providers";
 import type {
+  AgentRuntimeAcpSkillRoot,
   AgentRuntimeClaudeCodeSkillRoot,
   AgentRuntimeCodexSkillRoot,
   AgentRuntimePiSkillRoot,
@@ -35,8 +37,8 @@ export function normalizeSkillRoots(
 export function filterSkillRootsForProvider(
   args: FilterSkillRootsForProviderArgs,
 ): readonly AgentRuntimeSkillRoot[] {
-  return args.skillRoots.filter(
-    (skillRoot) => skillRoot.providerId === args.providerId,
+  return args.skillRoots.filter((skillRoot) =>
+    skillRootAppliesToProvider({ providerId: args.providerId, skillRoot }),
   );
 }
 
@@ -44,6 +46,8 @@ function normalizeSkillRoot(
   skillRoot: AgentRuntimeSkillRoot,
 ): AgentRuntimeSkillRoot {
   switch (skillRoot.providerId) {
+    case "acp":
+      return normalizeAcpSkillRoot(skillRoot);
     case "claude-code":
       return normalizeClaudeCodeSkillRoot(skillRoot);
     case "codex":
@@ -53,6 +57,37 @@ function normalizeSkillRoot(
     default:
       return assertKnownSkillRootProvider(skillRoot);
   }
+}
+
+function skillRootAppliesToProvider(args: {
+  providerId: string;
+  skillRoot: AgentRuntimeSkillRoot;
+}): boolean {
+  if (args.skillRoot.providerId === "acp") {
+    return isAcpProviderId(args.providerId);
+  }
+  return args.skillRoot.providerId === args.providerId;
+}
+
+function normalizeAcpSkillRoot(
+  skillRoot: AgentRuntimeAcpSkillRoot,
+): AgentRuntimeAcpSkillRoot {
+  assertAbsoluteSkillRootPath({
+    id: skillRoot.id,
+    path: skillRoot.skillDirectoryRootPath,
+    pathField: "skillDirectoryRootPath",
+    providerId: skillRoot.providerId,
+  });
+
+  return {
+    id: skillRoot.id,
+    providerId: skillRoot.providerId,
+    skillDirectoryRootPath: skillRoot.skillDirectoryRootPath,
+    skills: skillRoot.skills.map((skill) => ({
+      description: skill.description,
+      name: skill.name,
+    })),
+  };
 }
 
 function normalizeClaudeCodeSkillRoot(

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -36,7 +36,20 @@ export interface AgentRuntimePiSkillRoot {
   skillDirectoryRootPath: string;
 }
 
+export interface AgentRuntimeAcpSkill {
+  description: string;
+  name: string;
+}
+
+export interface AgentRuntimeAcpSkillRoot {
+  id: string;
+  providerId: "acp";
+  skillDirectoryRootPath: string;
+  skills: readonly AgentRuntimeAcpSkill[];
+}
+
 export type AgentRuntimeSkillRoot =
+  | AgentRuntimeAcpSkillRoot
   | AgentRuntimeClaudeCodeSkillRoot
   | AgentRuntimeCodexSkillRoot
   | AgentRuntimePiSkillRoot;


### PR DESCRIPTION
## Summary

ACP providers (opencode, omp, Grok Build, Hermes Agent, Cursor, and custom launch specs) previously received no injected bb skills: the daemon's skill staging only built roots for `codex` and `claude-code`, and the ACP adapter refused `skills/configure` outright.

This delivers skills to ACP agents through session instructions instead of native per-agent skill directories:

- **New `AgentRuntimeAcpSkillRoot` variant** (`providerId: "acp"`) carrying the staged skills directory root plus per-skill `{name, description}` metadata.
- **Daemon staging** (`buildSkillRoots`) now emits the ACP root alongside the codex/claude-code roots, from the same content-hashed staged catalog.
- **Root-to-provider matching** is centralized in `filterSkillRootsForProvider`: an `"acp"` root applies to any provider matching `isAcpProviderId` (the `acp-` prefix), so known, built-in, and custom ACP agents are all covered; exact-match behavior for codex/claude-code/pi is unchanged.
- **The ACP adapter** renders a compact skills section — intro guidance, then one line per skill with name, sanitized description, and the absolute staged SKILL.md path — and joins it with the base instructions on both `thread/start` and `thread/resume`. The bridge already prepends instructions to the session's first prompt inside `<system_instructions>`, so agents read skills on demand with their own file tools.
- Descriptions are sanitized (newlines collapsed, angle brackets stripped) so freeform text cannot break the section; the section is omitted entirely when no skills are staged. Mid-session `skills/configure` stays a no-op — new sessions pick up catalog changes naturally via the runtime-manager's entry replacement on catalog-hash change.

The listed paths are the daemon-host staged paths (immutable, content-hashed, kept alive by the existing cleanup keyed on live entries' catalog hash), never server-machine source paths, so multi-host setups work. No server changes were needed — the server already resolves and ships the skill set provider-agnostically.

## Tests

- Full `@bb/agent-runtime` and `@bb/host-daemon` suites pass; typecheck passes including `@bb/server`.
- New/updated tests: daemon root shape with staged paths + metadata, exact rendered note on start and resume, omission when no skills, hostile-description sanitization, provider filtering.
- Verified end to end on a dev instance: a real Grok Build (`acp-grok`) session echoed back the injected skills section with correct staged paths for all built-ins plus a user skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)