### PR TITLE
bb connect: fix multi-server pairing — redeem returns the paired server's subdomain

### DIFF
--- a/apps/web/src/routes/api.connect.redeem.tsx
+++ b/apps/web/src/routes/api.connect.redeem.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { redeemConnectCode } from "@/server/api";
+import { depsFromEnv, redeemConnectCode } from "@/server/api";
 import { getEnv } from "@/server/env";
 
 // Unauthenticated by design — the connect code itself is the credential.
@@ -9,7 +9,7 @@ export const Route = createFileRoute("/api/connect/redeem")({
     handlers: {
       POST: async ({ request }) => {
         const body = (await request.json().catch(() => ({}))) as { code?: string };
-        const result = await redeemConnectCode(getEnv(), body.code ?? "");
+        const result = await redeemConnectCode(depsFromEnv(getEnv()), body.code ?? "");
         if ("error" in result) {
           return Response.json({ error: result.error }, { status: result.status });
         }

--- a/apps/web/src/server/api.test.ts
+++ b/apps/web/src/server/api.test.ts
@@ -14,7 +14,9 @@ import {
   createServer,
   disconnectServer,
   getAccountState,
+  redeemConnectCode,
 } from "./api.js";
+import { sha256Hex } from "./tokens.js";
 
 // Real in-memory SQLite (never mock the DB): apply the same connect-db
 // migration chain the worker runs, then drive the product-state functions.
@@ -190,6 +192,55 @@ describe("createConnectCode (per-server minting + reuse)", () => {
     if ("error" in first || "error" in second) throw new Error("mint failed");
     expect(second.code).not.toBe(first.code);
     expect(db.select().from(connectCode).all()).toHaveLength(2);
+  });
+});
+
+describe("redeemConnectCode (multi-server routing label)", () => {
+  it("returns the redeemed server's subdomain, not the account handle", async () => {
+    seedUser("u1");
+    await claimHandle(deps, "u1", "sawyer");
+    const desktop = await createServer(deps, "u1", "sawyer-desktop");
+    if (!("ok" in desktop)) throw new Error("setup");
+
+    // Primary starts unpaired (no credential hash); second server is the redeem target.
+    const primary = db.select().from(server).where(eq(server.subdomain, "sawyer")).get();
+    expect(primary?.credentialHash).toBeNull();
+
+    const minted = await createConnectCode(deps, "u1", { serverId: desktop.server.id });
+    if ("error" in minted) throw new Error(minted.error);
+
+    const result = await redeemConnectCode(deps, minted.code);
+    if ("error" in result) throw new Error(`${result.error} (${result.status})`);
+
+    // (a) Wire handle is the second server's routing label, not the primary account handle.
+    expect(result.handle).toBe("sawyer-desktop");
+    expect(result.serverId).toBe(desktop.server.id);
+    // (b) tunnelUrl is keyed by that subdomain.
+    expect(result.tunnelUrl).toBe("wss://sawyer-desktop.getbb.app/__tunnel");
+    expect(result.credential.startsWith("bbcred_")).toBe(true);
+
+    // (c) Credential hash lands on the second server only; primary is untouched.
+    const second = db.select().from(server).where(eq(server.id, desktop.server.id)).get();
+    expect(second?.credentialHash).toBe(await sha256Hex(result.credential));
+    expect(second?.revokedAt).toBeNull();
+
+    const primaryAfter = db.select().from(server).where(eq(server.subdomain, "sawyer")).get();
+    expect(primaryAfter?.credentialHash).toBeNull();
+  });
+
+  it("returns the primary handle when redeeming a primary-server code", async () => {
+    seedUser("u1");
+    await claimHandle(deps, "u1", "sawyer");
+    const primary = db.select().from(server).where(eq(server.subdomain, "sawyer")).get();
+    const minted = await createConnectCode(deps, "u1", { serverId: primary!.id });
+    if ("error" in minted) throw new Error(minted.error);
+
+    const result = await redeemConnectCode(deps, minted.code);
+    if ("error" in result) throw new Error(`${result.error} (${result.status})`);
+
+    // Primary server: subdomain === account handle — byte-identical pre-fix behavior.
+    expect(result.handle).toBe("sawyer");
+    expect(result.tunnelUrl).toBe("wss://sawyer.getbb.app/__tunnel");
   });
 });
 

--- a/apps/web/src/server/api.ts
+++ b/apps/web/src/server/api.ts
@@ -408,19 +408,39 @@ export async function disconnectServer(
 }
 
 /**
+ * Rows affected by a drizzle `.run()` across D1 (`meta.changes`) and
+ * better-sqlite3 (`changes`) drivers.
+ */
+function rowsChanged(result: unknown): number {
+  if (result && typeof result === "object") {
+    const r = result as { meta?: { changes?: number }; changes?: number };
+    if (typeof r.meta?.changes === "number") return r.meta.changes;
+    if (typeof r.changes === "number") return r.changes;
+  }
+  return 0;
+}
+
+/**
  * Redeem a connect code (called by the tunnel client — the code is the
  * credential). Atomically consumes the code, mints a durable tunnel credential,
- * pins it (hashed) on the server row, returns plaintext once. Worker-only (D1),
- * so it stays env-based and uses the D1 `.meta.changes` result shape.
+ * pins it (hashed) on the server row, returns plaintext once.
+ *
+ * `handle` is the redeemed server's routing label (its subdomain). For the
+ * primary server this equals the account handle, so primary pairing is
+ * byte-identical to the pre-multi-server behavior. The tunnel client uses
+ * this field to build serverUrl / share URLs — it must not be the account's
+ * primary handle when a non-primary server was paired.
+ *
+ * Accepts `Deps` (D1 in the worker via `depsFromEnv`, better-sqlite3 in tests).
  */
 export async function redeemConnectCode(
-  env: Env,
+  deps: Pick<Deps, "db" | "baseDomain">,
   code: string,
 ): Promise<
   | { credential: string; serverId: string; handle: string | null; tunnelUrl: string | null }
   | { error: string; status: number }
 > {
-  const db = drizzle(env.DB);
+  const { db, baseDomain } = deps;
   const normalized = code.trim().toUpperCase();
   if (!normalized) return { error: "missing-code", status: 400 };
 
@@ -434,7 +454,7 @@ export async function redeemConnectCode(
     .set({ consumedAt: new Date() })
     .where(and(eq(connectCode.code, normalized), isNull(connectCode.consumedAt)))
     .run();
-  if (consumed.meta.changes === 0) return { error: "already-used", status: 409 };
+  if (rowsChanged(consumed) === 0) return { error: "already-used", status: 409 };
 
   const credential = generateToken("bbcred_", 32);
   await db
@@ -445,12 +465,14 @@ export async function redeemConnectCode(
 
   const srv = await db.select().from(server).where(eq(server.id, row.serverId)).get();
   const prof = await db.select().from(profile).where(eq(profile.userId, row.userId)).get();
+  // Routing label of the redeemed server (not necessarily the account handle).
+  const handle = srv?.subdomain ?? prof?.handle ?? null;
   return {
     credential,
     serverId: row.serverId,
-    handle: prof?.handle ?? null,
-    // Keyed by this server's subdomain (which may be non-primary), not the handle.
-    tunnelUrl: srv ? `wss://${srv.subdomain}.${env.BASE_DOMAIN}/__tunnel` : null,
+    handle,
+    // Keyed by this server's subdomain (which may be non-primary), not the account handle.
+    tunnelUrl: srv ? `wss://${srv.subdomain}.${baseDomain}/__tunnel` : null,
   };
 }
 

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -108,6 +108,18 @@ describe("sharePublicUrl", () => {
       ),
     ).toBe("https://sawyer--8000.getbb.app");
   });
+
+  it("uses a non-primary routing label when multi-server pairing stored one", () => {
+    expect(
+      sharePublicUrl(
+        {
+          serverUrl: "https://sawyer-desktop.getbb.app",
+          handle: "sawyer-desktop",
+        },
+        8000,
+      ),
+    ).toBe("https://sawyer-desktop--8000.getbb.app");
+  });
 });
 
 describe("parseSharePort / serverOwnPort", () => {
@@ -599,6 +611,49 @@ describe("connect plugin", () => {
     );
     expect(status.url).toBe("http://sawyer.localhost:59329");
     expect(status.paired).toBe(true);
+  });
+
+  it("pair stores a non-primary routing label from redeem (multi-server)", async () => {
+    // Cloud returns the redeemed server's subdomain, not the account handle.
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            credential: "bbcred_second",
+            handle: "sawyer-desktop",
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { bb, harness } = await loadPlugin();
+
+    const status = (await harness.callRpc("pair", {
+      code: "ABCD",
+      baseUrl: "http://localhost:59332",
+    })) as ConnectStatus;
+
+    expect(status.paired).toBe(true);
+    expect(status.handle).toBe("sawyer-desktop");
+    expect(status.url).toBe("http://sawyer-desktop.localhost:59332");
+
+    const stored = (await bb.storage.kv.get(CREDENTIAL_KV_KEY)) as {
+      serverUrl: string;
+      handle: string;
+      credential: string;
+    };
+    expect(stored).toEqual({
+      serverUrl: "http://sawyer-desktop.localhost:59332",
+      handle: "sawyer-desktop",
+      credential: "bbcred_second",
+    });
+
+    // Share URLs follow the stored label, not the account primary handle.
+    const exposed = (await harness.callRpc("expose", { port: 8000 })) as {
+      port: number;
+      url: string;
+    };
+    expect(exposed.url).toBe("http://sawyer-desktop--8000.localhost:59332");
   });
 
   it("disconnect clears the stored credential", async () => {

--- a/plugins/connect/src/credential.ts
+++ b/plugins/connect/src/credential.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import type { PluginKvStorage } from "@bb/plugin-sdk";
 
 // The durable tunnel credential lives in the plugin's kv storage (bb.db).
+// `handle` is the paired server's routing label (subdomain), which may differ
+// from the account's primary handle when multiple bbs are connected.
 export const connectCredentialSchema = z.object({
   serverUrl: z.string().min(1),
   handle: z.string().min(1),

--- a/plugins/connect/src/redeem.ts
+++ b/plugins/connect/src/redeem.ts
@@ -5,6 +5,12 @@ export const DEFAULT_CONNECT_BASE_URL = "https://getbb.app";
 
 export interface RedeemedCredential {
   credential: string;
+  /**
+   * Routing label of the redeemed server (its subdomain). Equal to the
+   * account handle for the primary server; a distinct label when pairing an
+   * additional bb. Used to build serverUrl and share URLs — not necessarily
+   * the account's primary handle.
+   */
   handle: string;
 }
 
@@ -65,7 +71,10 @@ export function deriveConnectBaseUrl(serverUrl: string): string {
   return new URL(serverUrl).origin.replace(/\/\/[^.]+\./, "//");
 }
 
-/** `https://getbb.app` + `sawyer` → `https://sawyer.getbb.app`. */
+/**
+ * `https://getbb.app` + routing label → `https://<label>.getbb.app`.
+ * `handle` is the redeemed server's subdomain (primary or additional).
+ */
 export function serverUrlForHandle(baseUrl: string, handle: string): string {
   const url = new URL(baseUrl);
   return `${url.protocol}//${handle}.${url.host}`;

--- a/plugins/connect/src/shares.ts
+++ b/plugins/connect/src/shares.ts
@@ -51,7 +51,9 @@ export function parseSharePort(raw: unknown): number {
 }
 
 /**
- * Public share URL for a port: `https://<handle>--<port>.<base-domain>`.
+ * Public share URL for a port: `https://<label>--<port>.<base-domain>`.
+ * `credential.handle` is the paired server's routing label (subdomain),
+ * which may be a non-primary label when multiple bbs are connected.
  * Base domain is derived from the credential's serverUrl the same way the
  * connect apex is (e.g. `https://sawyer.getbb.app` → `getbb.app`).
  */

--- a/plugins/connect/src/types.ts
+++ b/plugins/connect/src/types.ts
@@ -22,8 +22,13 @@ export interface ConnectStatus {
    */
   state: ConnectStateName;
   paired: boolean;
+  /**
+   * Routing label of the paired server (subdomain). Equal to the account
+   * handle for the primary bb; a distinct label when an additional bb is
+   * paired. Null when unpaired.
+   */
   handle: string | null;
-  /** Public URL, e.g. https://<handle>.getbb.app; null when not paired. */
+  /** Public URL, e.g. https://<label>.getbb.app; null when not paired. */
   url: string | null;
   /**
    * getbb.app dashboard URL to mint connect codes — derived from the paired


### PR DESCRIPTION
## Summary

Multi-server pairing (#566) let one account pair up to five bbs, each with its own subdomain — but pairing a second bb never actually worked. `redeemConnectCode` returned the account's **primary handle** as `handle` regardless of which server the code was minted for, and the tunnel client builds its `serverUrl` (and share URLs) from that label. Every additional bb therefore stored `https://<primary-handle>.getbb.app`, dialed the primary label's TunnelDO, and failed the gate's credential-hash check (the credential hash lives on the *second* server row) — a permanent 401/reconnect loop, with every paired bb showing the same single URL.

**Fix (cloud-side, backward compatible):** redeem now returns the redeemed server's routing label — `srv.subdomain` — as `handle`. For the primary server the subdomain equals the account handle (backfilled by migration 0003), so existing pairings are byte-identical. The plugin already treats `handle` as the routing label everywhere (pair URL, tunnel dial, `<label>--<port>` share URLs), so it needed only doc-comment updates stating the contract.

Supporting change: `redeemConnectCode` moves from env-based to the existing `Deps` injection pattern (`depsFromEnv` at the route) so the regression test can run against real in-memory SQLite; a small `rowsChanged()` helper reads both the D1 (`meta.changes`) and better-sqlite3 (`changes`) result shapes.

## Tests

- New regression in `apps/web/src/server/api.test.ts`: redeeming a code minted for a second server returns that server's subdomain + tunnel URL and writes the credential hash to that row only (fails without the fix); primary-server redeem asserted unchanged.
- New client-contract tests in `plugins/connect/src/connect.test.ts`: pair() with a non-primary label stores the right `serverUrl`/`handle`, and port shares expose at `<label>--<port>`.
- `turbo run typecheck test --filter=@bb/web --filter=bb-plugin-connect`: 5/5 tasks, 30 + 38 tests passing.
- Adversarial review of the diff by a second agent: ship verdict, no blockers/should-fixes.

## Risks

- Wire field `handle` changes *semantics* (account handle → routing label of the redeemed server) but is identical for primary servers, and the only consumer (connect plugin) already used it as the routing label. Old plugins get the correct behavior for free.
- Any second bb paired before this deploys holds a wrong stored URL and must re-pair with a fresh code after the web worker ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)