### PR TITLE
Enable slash-command skill autocomplete for all providers

### DIFF
--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -1117,10 +1117,82 @@ describe("discoverProviderCommands (codex)", () => {
 });
 
 describe("resolveCommandScanRoots", () => {
-  it("returns no roots for a provider without a command surface", async () => {
+  it("scans shared bb skill roots for pi", async () => {
     const fixture = await makeWorkspaceFixture();
     const roots = resolveCommandScanRoots({
       providerId: "pi",
+      cwd: fixture.cwd,
+      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
+      additionalSkillsRootPaths: [path.join(fixture.dataDir, "inherited")],
+      dataDir: fixture.dataDir,
+      homeDir: fixture.homeDir,
+      codexHome: fixture.codexHome,
+    });
+    expect(roots).toEqual([
+      {
+        rootPath: path.join(fixture.cwd, ".bb", "skills"),
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "project",
+      },
+      {
+        rootPath: path.join(fixture.dataDir, "skills"),
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "user",
+      },
+      {
+        rootPath: path.join(fixture.dataDir, "inherited"),
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "user",
+      },
+      {
+        rootPath: fixture.builtinSkillsRootPath,
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "user",
+      },
+    ]);
+  });
+
+  it("scans shared bb skill roots for ACP providers", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const roots = resolveCommandScanRoots({
+      providerId: "acp-cursor",
+      cwd: null,
+      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
+      additionalSkillsRootPaths: [],
+      dataDir: fixture.dataDir,
+      homeDir: fixture.homeDir,
+      codexHome: fixture.codexHome,
+    });
+    expect(roots).toEqual([
+      {
+        rootPath: path.join(fixture.dataDir, "skills"),
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "user",
+      },
+      {
+        rootPath: fixture.builtinSkillsRootPath,
+        shape: "skill",
+        namePrefix: "",
+        source: "skill",
+        origin: "user",
+      },
+    ]);
+  });
+
+  it("returns no roots for an unknown provider", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const roots = resolveCommandScanRoots({
+      providerId: "unknown-provider",
       cwd: fixture.cwd,
       builtinSkillsRootPath: fixture.builtinSkillsRootPath,
       additionalSkillsRootPaths: [],

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -1059,9 +1059,54 @@ export async function resolveProviderCommandScanRoots(
 }
 
 /**
+ * Shared bb skill roots scanned for every provider that exposes slash-command
+ * typeahead: project `.bb/skills`, data-dir skills, inherited roots, and
+ * built-in skills. Project roots are skipped when `cwd` is null.
+ */
+function pushBbSkillCommandScanRoots(
+  roots: CommandScanRoot[],
+  resolution: CommandRootResolution,
+): void {
+  if (resolution.cwd !== null) {
+    roots.push({
+      rootPath: path.join(resolution.cwd, ".bb", "skills"),
+      shape: "skill",
+      namePrefix: "",
+      source: "skill",
+      origin: "project",
+    });
+  }
+  roots.push({
+    rootPath: resolveDataDirSkillsRootPath(resolution.dataDir),
+    shape: "skill",
+    namePrefix: "",
+    source: "skill",
+    origin: "user",
+  });
+  for (const rootPath of resolution.additionalSkillsRootPaths) {
+    roots.push({
+      rootPath,
+      shape: "skill",
+      namePrefix: "",
+      source: "skill",
+      origin: "user",
+    });
+  }
+  roots.push({
+    rootPath: resolution.builtinSkillsRootPath,
+    shape: "skill",
+    namePrefix: "",
+    source: "skill",
+    origin: "user",
+  });
+}
+
+/**
  * Build the ordered set of roots to scan for a provider. Project (cwd-dependent)
  * roots are skipped when `cwd` is null; user-home roots are always included.
- * Providers without a command surface (e.g. `pi`) yield an empty root set.
+ * Every provider that injects bb skills also scans those roots for typeahead;
+ * Claude Code and Codex add their native skill/command directories on top.
+ * Unknown provider ids yield an empty root set.
  */
 export function resolveCommandScanRoots(
   resolution: CommandRootResolution,
@@ -1188,6 +1233,17 @@ export function resolveCommandScanRoots(
       source: "skill",
       origin: "user",
     });
+    return roots;
+  }
+
+  // Pi and all ACP agents (built-in `acp-cursor` and dynamic `acp-*`) receive
+  // the shared bb skills catalog at runtime and expose the same set in
+  // slash-command typeahead. No provider-native command directories.
+  if (
+    resolution.providerId === "pi" ||
+    resolution.providerId.startsWith("acp-")
+  ) {
+    pushBbSkillCommandScanRoots(roots, resolution);
     return roots;
   }
 

--- a/apps/host-daemon/src/injected-skills.test.ts
+++ b/apps/host-daemon/src/injected-skills.test.ts
@@ -16,6 +16,7 @@ import type {
   AgentRuntimeAcpSkillRoot,
   AgentRuntimeClaudeCodeSkillRoot,
   AgentRuntimeCodexSkillRoot,
+  AgentRuntimePiSkillRoot,
   AgentRuntimeSkillRoot,
 } from "@bb/agent-runtime";
 import type { HostDaemonInjectedSkillSource } from "@bb/host-daemon-contract";
@@ -68,6 +69,12 @@ function isClaudeCodeSkillRoot(
   root: AgentRuntimeSkillRoot,
 ): root is AgentRuntimeClaudeCodeSkillRoot {
   return root.providerId === "claude-code";
+}
+
+function isPiSkillRoot(
+  root: AgentRuntimeSkillRoot,
+): root is AgentRuntimePiSkillRoot {
+  return root.providerId === "pi";
 }
 
 function isAcpSkillRoot(
@@ -124,7 +131,7 @@ describe("data-dir skills root", () => {
 });
 
 describe("injected skill staging", () => {
-  it("creates a shared staged snapshot for Codex, Claude Code, and ACP", async () => {
+  it("creates a shared staged snapshot for Codex, Claude Code, Pi, and ACP", async () => {
     const dataDir = await makeTempDir();
     const skillRootPath = await writeSkill({
       rootPath: path.join(dataDir, "source-skills"),
@@ -144,6 +151,7 @@ describe("injected skill staging", () => {
 
     const codexRoot = staged.skillRoots.find(isCodexSkillRoot);
     const claudeRoot = staged.skillRoots.find(isClaudeCodeSkillRoot);
+    const piRoot = staged.skillRoots.find(isPiSkillRoot);
     const acpRoot = staged.skillRoots.find(isAcpSkillRoot);
     expect(codexRoot).toEqual({
       id: `global-skills:${staged.catalogHash}:codex`,
@@ -164,6 +172,17 @@ describe("injected skill staging", () => {
         "runtime",
         "global-skills",
         staged.catalogHash,
+      ),
+    });
+    expect(piRoot).toEqual({
+      id: `global-skills:${staged.catalogHash}:pi`,
+      providerId: "pi",
+      skillDirectoryRootPath: path.join(
+        dataDir,
+        "runtime",
+        "global-skills",
+        staged.catalogHash,
+        "skills",
       ),
     });
     expect(acpRoot).toEqual({

--- a/apps/host-daemon/src/injected-skills.ts
+++ b/apps/host-daemon/src/injected-skills.ts
@@ -465,6 +465,11 @@ function buildSkillRoots(args: BuildSkillRootsArgs): AgentRuntimeSkillRoot[] {
       localPluginPath: args.stageRootPath,
     },
     {
+      id: `global-skills:${args.catalogHash}:pi`,
+      providerId: "pi",
+      skillDirectoryRootPath,
+    },
+    {
       id: `global-skills:${args.catalogHash}:acp`,
       providerId: "acp",
       skillDirectoryRootPath,

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -435,6 +435,17 @@ describe("RuntimeManager", () => {
         ),
       },
       {
+        id: `global-skills:${entry.skillCatalogHash}:pi`,
+        providerId: "pi",
+        skillDirectoryRootPath: path.join(
+          dataDir,
+          "runtime",
+          "global-skills",
+          entry.skillCatalogHash ?? "",
+          "skills",
+        ),
+      },
+      {
         id: `global-skills:${entry.skillCatalogHash}:acp`,
         providerId: "acp",
         skillDirectoryRootPath: path.join(

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -599,8 +599,8 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     const projectId = context.req.param("id");
     requirePublicProject(deps.db, projectId);
 
-    // Providers without a command surface (pi, anything unknown) have no
-    // typeahead entries, so skip the daemon roundtrip entirely.
+    // Providers without a skills composer action have no typeahead entries,
+    // so skip the daemon roundtrip entirely.
     if (!providerHasCommandSurface(query.provider)) {
       return context.json({ commands: [], truncated: false });
     }

--- a/apps/server/src/services/threads/provider-command-typeahead.test.ts
+++ b/apps/server/src/services/threads/provider-command-typeahead.test.ts
@@ -5,7 +5,9 @@ describe("providerHasCommandSurface", () => {
   it("derives command typeahead support from provider-declared skills actions", () => {
     expect(providerHasCommandSurface("codex")).toBe(true);
     expect(providerHasCommandSurface("claude-code")).toBe(true);
-    expect(providerHasCommandSurface("pi")).toBe(false);
+    expect(providerHasCommandSurface("pi")).toBe(true);
+    expect(providerHasCommandSurface("acp-cursor")).toBe(true);
+    expect(providerHasCommandSurface("acp-my-agent")).toBe(true);
     expect(providerHasCommandSurface("unknown-provider")).toBe(false);
   });
 });

--- a/apps/server/src/services/threads/provider-command-typeahead.ts
+++ b/apps/server/src/services/threads/provider-command-typeahead.ts
@@ -1,5 +1,7 @@
 import {
+  buildAcpProviderInfo,
   getBuiltInAgentProviderInfo,
+  isAcpProviderId,
   isAgentProviderId,
 } from "@bb/agent-providers";
 import { getEnvironment, getProjectSourceByHost } from "@bb/db";
@@ -35,13 +37,32 @@ const BUILT_IN_PROVIDER_COMMANDS: ProviderCommand[] = [
   },
 ];
 
+function providerComposerHasSkillsAction(
+  composerActions: readonly { kind: string }[],
+): boolean {
+  return composerActions.some((action) => action.kind === "skills");
+}
+
+/**
+ * Whether the provider declares a skills composer action (slash-command
+ * typeahead). Built-in providers are looked up in the catalog; dynamic ACP
+ * providers (`acp-*`) share the ACP catalog template via `buildAcpProviderInfo`.
+ */
 export function providerHasCommandSurface(providerId: string): boolean {
-  if (!isAgentProviderId(providerId)) {
-    return false;
+  if (isAgentProviderId(providerId)) {
+    return providerComposerHasSkillsAction(
+      getBuiltInAgentProviderInfo(providerId).composerActions,
+    );
   }
-  return getBuiltInAgentProviderInfo(providerId).composerActions.some(
-    (action) => action.kind === "skills",
-  );
+  if (isAcpProviderId(providerId)) {
+    return providerComposerHasSkillsAction(
+      buildAcpProviderInfo({
+        id: providerId,
+        displayName: providerId,
+      }).composerActions,
+    );
+  }
+  return false;
 }
 
 export interface CommandWorkspace {

--- a/apps/server/test/public/public-project-commands.test.ts
+++ b/apps/server/test/public/public-project-commands.test.ts
@@ -293,7 +293,7 @@ describe("public project command typeahead route", () => {
   it("returns an empty list without an RPC for a provider with no command surface", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
-        id: "host-commands-pi",
+        id: "host-commands-unknown",
       });
       const { project } = seedProjectWithSource(harness.deps, {
         hostId: host.id,
@@ -309,7 +309,7 @@ describe("public project command typeahead route", () => {
       });
 
       const response = await harness.app.request(
-        `/api/v1/projects/${project.id}/commands?provider=pi&environmentId=${environment.id}`,
+        `/api/v1/projects/${project.id}/commands?provider=unknown-provider&environmentId=${environment.id}`,
       );
 
       expect(response.status).toBe(200);
@@ -317,6 +317,46 @@ describe("public project command typeahead route", () => {
       expect(body).toEqual({ commands: [], truncated: false });
       // No daemon roundtrip for a provider without a command surface.
       expect(stub.requests).toEqual([]);
+    });
+  });
+
+  it("lists skills for pi via the shared command surface", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-commands-pi",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/pi-commands-env",
+      });
+      const stub = registerCommandRpc(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        commands: [
+          skill("bb-cli", "user", { description: "Use the bb CLI" }),
+        ],
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/projects/${project.id}/commands?provider=pi&environmentId=${environment.id}`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = commandListResponseSchema.parse(await readJson(response));
+      expect(body.commands.map((command) => command.name)).toEqual([
+        "compact",
+        "bb-cli",
+      ]);
+      expect(stub.requests[0]?.command).toEqual({
+        type: "host.list_commands",
+        providerId: "pi",
+        cwd: "/tmp/pi-commands-env",
+        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+      });
     });
   });
 

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -828,7 +828,7 @@ describe("resolveSystemExecutionOptions", () => {
               id: "acp-example-agent",
               displayName: "Example Agent",
               available: true,
-              composerActions: [],
+              composerActions: [{ kind: "skills", trigger: "/" }],
               capabilities: expect.objectContaining({
                 supportsFork: false,
                 supportsServiceTier: true,

--- a/packages/agent-providers/src/catalog.ts
+++ b/packages/agent-providers/src/catalog.ts
@@ -132,8 +132,15 @@ const CLAUDE_COMPOSER_ACTIONS: ProviderComposerAction[] = [
   },
 ];
 
-const PI_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
-const ACP_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
+// Skills are injected into every provider runtime (bb skills catalog). The
+// `/` skills composer action unlocks slash-command typeahead for those same
+// skills on every provider surface, not just Codex/Claude Code.
+const PI_COMPOSER_ACTIONS: ProviderComposerAction[] = [
+  { kind: "skills", trigger: "/" },
+];
+const ACP_COMPOSER_ACTIONS: ProviderComposerAction[] = [
+  { kind: "skills", trigger: "/" },
+];
 
 // Shared by all ACP (Agent Client Protocol) providers: the external agent owns
 // its own model selection, tool execution, and session naming, so BB-side

--- a/packages/agent-providers/test/catalog.test.ts
+++ b/packages/agent-providers/test/catalog.test.ts
@@ -70,7 +70,7 @@ describe("agent provider catalog", () => {
           supportsFork: true,
           supportedPermissionModes: ["full"],
         },
-        composerActions: [],
+        composerActions: [{ kind: "skills", trigger: "/" }],
         available: true,
       },
       {
@@ -84,7 +84,7 @@ describe("agent provider catalog", () => {
           supportsFork: false,
           supportedPermissionModes: ["full", "workspace-write", "readonly"],
         },
-        composerActions: [],
+        composerActions: [{ kind: "skills", trigger: "/" }],
         available: true,
       },
     ]);
@@ -118,7 +118,7 @@ describe("agent provider catalog", () => {
         supportsFork: false,
         supportedPermissionModes: ["full", "workspace-write", "readonly"],
       },
-      composerActions: [],
+      composerActions: [{ kind: "skills", trigger: "/" }],
       available: true,
     });
 


### PR DESCRIPTION
## Summary
- Declare a `/` skills composer action for Pi and all ACP providers so the composer opens skill typeahead on every agent surface.
- Extend `host.list_commands` to scan shared bb skill roots (project `.bb/skills`, data-dir, inherited, built-ins) for `pi` and `acp-*`.
- Inject a Pi skill root during host-daemon staging so Pi sessions receive the same staged bb skills catalog as Codex/Claude/ACP.
- Teach `providerHasCommandSurface` to recognize dynamic `acp-*` agents, not only built-in catalog ids.

## Test plan
- [x] `pnpm exec turbo run test --filter=@bb/agent-providers --filter=@bb/host-daemon --filter=@bb/server`
- [x] `pnpm exec turbo run typecheck --filter=@bb/agent-providers --filter=@bb/host-daemon --filter=@bb/server`
- [x] Manual: dev app commands API returns `close-out` and built-ins for `pi` and `acp-cursor`
- [ ] In the app: pick Pi/ACP, type `/`, confirm skills appear; select a skill and send