### PR TITLE
Raise bb connect per-account server limit from 5 to 10

### DIFF
--- a/apps/web/src/server/api.test.ts
+++ b/apps/web/src/server/api.test.ts
@@ -5,7 +5,13 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { connectCode, schema, server, user } from "@bb/connect-db";
+import {
+  connectCode,
+  MAX_SERVERS_PER_ACCOUNT,
+  schema,
+  server,
+  user,
+} from "@bb/connect-db";
 import {
   type Deps,
   checkAvailability,
@@ -133,11 +139,13 @@ describe("createServer (connect another bb)", () => {
   it("enforces the per-account server cap", async () => {
     seedUser("u1");
     await claimHandle(deps, "u1", "sawyer");
-    // One primary already; add up to the cap (5), then the next is rejected.
-    for (let i = 1; i < 5; i++) {
+    // One primary already; add up to the cap, then the next is rejected.
+    for (let i = 1; i < MAX_SERVERS_PER_ACCOUNT; i++) {
       expect("ok" in (await createServer(deps, "u1", `sawyer-${i}`))).toBe(true);
     }
-    expect(db.select().from(server).where(eq(server.userId, "u1")).all()).toHaveLength(5);
+    expect(db.select().from(server).where(eq(server.userId, "u1")).all()).toHaveLength(
+      MAX_SERVERS_PER_ACCOUNT,
+    );
     expect(await createServer(deps, "u1", "sawyer-over")).toEqual({ error: "server-limit" });
   });
 
@@ -287,7 +295,7 @@ describe("getAccountState (adaptive single / multi)", () => {
     expect(state.handle).toBeNull();
     expect(state.servers).toHaveLength(0);
     expect(state.githubLogin).toBe("sawyerhood");
-    expect(state.maxServers).toBe(5);
+    expect(state.maxServers).toBe(MAX_SERVERS_PER_ACCOUNT);
   });
 
   it("returns one server, flagged primary, after a claim", async () => {

--- a/packages/connect-db/src/constants.ts
+++ b/packages/connect-db/src/constants.ts
@@ -66,7 +66,7 @@ export const RESERVED_HANDLES: ReadonlySet<string> = new Set([
 ]);
 
 /** Per-account resource ceilings enforced at the gate (open-signup abuse guard). */
-export const MAX_SERVERS_PER_ACCOUNT = 5;
+export const MAX_SERVERS_PER_ACCOUNT = 10;
 export const MAX_MACHINES_PER_ACCOUNT = 5;
 
 /** Connect-code lifetimes. */

--- a/packages/connect-db/test/schema.test.ts
+++ b/packages/connect-db/test/schema.test.ts
@@ -298,7 +298,7 @@ describe("validateSubdomain (shares the handle grammar)", () => {
 
 describe("multi-server policy", () => {
   it("raises the per-account server cap for multi-server", () => {
-    expect(MAX_SERVERS_PER_ACCOUNT).toBe(5);
+    expect(MAX_SERVERS_PER_ACCOUNT).toBe(10);
   });
 });
 


### PR DESCRIPTION
## Summary
- Raise `MAX_SERVERS_PER_ACCOUNT` from 5 to 10 so accounts can pair more bbs on bb connect.
- Update connect-db and web API tests; cap enforcement tests assert against the constant rather than a hardcoded value.
- `MAX_MACHINES_PER_ACCOUNT` (execution hosts) stays at 5.

## Tests
- `pnpm exec turbo run test --filter=@bb/connect-db --filter=@bb/web --force`