### PR TITLE
Regenerate plugin starter templates for radix version bumps

### DIFF
--- a/packages/templates/src/generated/plugin-starter-files.generated.ts
+++ b/packages/templates/src/generated/plugin-starter-files.generated.ts
@@ -80,7 +80,7 @@ export const PLUGIN_STARTER_FILES: readonly PluginStarterFile[] = [
 export const PLUGIN_STARTER_DEPENDENCIES: Readonly<Record<string, string>> = {
   "@hugeicons/core-free-icons": "^4.1.3",
   "@hugeicons/react": "^1.1.6",
-  "@radix-ui/react-slot": "^1.2.4",
+  "@radix-ui/react-slot": "^1.3.0",
   "class-variance-authority": "^0.7.1",
   "clsx": "^2.1.1",
   "tailwind-merge": "^3.4.0"
@@ -88,6 +88,6 @@ export const PLUGIN_STARTER_DEPENDENCIES: Readonly<Record<string, string>> = {
 
 /** Runtime-shimmed packages — installed for editor/tsc types only. */
 export const PLUGIN_STARTER_TYPE_DEPENDENCIES: Readonly<Record<string, string>> = {
-  "@radix-ui/react-dialog": "^1.1.15",
+  "@radix-ui/react-dialog": "^1.1.19",
   "vaul": "^1.1.2"
 };


### PR DESCRIPTION
## Summary

Follow-up to #576: the Radix dependency bumps made the generated plugin-starter template file stale, which fails `@bb/templates#test` (`generate-templates.mjs --check`) on main. #576 auto-merged before that check finished since it is not a required check.

This regenerates `plugin-starter-files.generated.ts` (two embedded version ranges: `@radix-ui/react-slot` ^1.3.0, `@radix-ui/react-dialog` ^1.1.19).

## Tests

- `pnpm exec turbo run test --filter=@bb/templates --force` passes on top of main

🤖 Generated with [Claude Code](https://claude.com/claude-code)