### PR TITLE
bb connect: fix three tunnel-relay bugs that hang or corrupt responses

### DIFF
--- a/apps/connect/src/tunnel-do.ts
+++ b/apps/connect/src/tunnel-do.ts
@@ -209,6 +209,11 @@ export class TunnelDO {
     for (const existing of this.state.getWebSockets(TUNNEL_TAG)) {
       existing.close(1000, "replaced by a new tunnel connection");
     }
+    // Streams opened over a replaced (or hibernated-away) tunnel belong to
+    // the old client session — the connecting client has no state for them,
+    // so their frames will never arrive. Fail them now: a mid-body response
+    // has no timeout and would otherwise hang its visitor forever.
+    this.abandonStreams("tunnel reconnected mid-request", "tunnel reconnected");
     this.clientProtocolVersion = protocolVersion;
     void this.state.storage.put("protocolVersion", protocolVersion);
     if (serverId) {
@@ -329,6 +334,18 @@ export class TunnelDO {
     }
   }
 
+  /** Fail every in-flight stream: pending HTTP answers `status` 502, visitor sockets close. */
+  private abandonStreams(httpReason: string, wsReason: string): void {
+    for (const streamId of [...this.pendingHttp.keys()]) {
+      this.failHttpStream(streamId, 502, httpReason);
+    }
+    for (const visitor of this.state.getWebSockets()) {
+      if (!this.state.getTags(visitor).includes(TUNNEL_TAG)) {
+        visitor.close(1001, wsReason);
+      }
+    }
+  }
+
   private failHttpStream(streamId: number, status: number, message: string): void {
     const entry = this.pendingHttp.get(streamId);
     if (!entry) return;
@@ -377,14 +394,35 @@ export class TunnelDO {
         const entry = this.pendingHttp.get(frame.streamId);
         if (!entry) return;
         clearTimeout(entry.timeout);
+        const headers = frame.headers.filter(([name]) => !HOP_HEADERS.has(name.toLowerCase()));
+        // Null-body statuses must resolve bodiless: Response throws on a
+        // stream body for 204/205/304, and a throw here would strand the
+        // visitor's request unresolved forever (its timeout is already
+        // cleared). Dev servers answer 304 to every ETag revalidation, so
+        // this is the common path on a reload, not an edge case. The entry
+        // stays until the client's trailing body-end frame clears it.
+        if (frame.status === 204 || frame.status === 205 || frame.status === 304) {
+          entry.resolve(new Response(null, { status: frame.status, headers }));
+          return;
+        }
         const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+        let response: Response;
+        try {
+          response = new Response(readable, { status: frame.status, headers });
+        } catch {
+          // Any other unconstructable response (e.g. an out-of-range status):
+          // answer 502 rather than leaving the request pending.
+          this.pendingHttp.delete(frame.streamId);
+          entry.resolve(
+            new Response(`bb connect: unrelayable origin response (status ${frame.status})\n`, {
+              status: 502,
+              headers: { "content-type": "text/plain; charset=utf-8" },
+            }),
+          );
+          return;
+        }
         entry.writer = writable.getWriter();
-        entry.resolve(
-          new Response(readable, {
-            status: frame.status,
-            headers: frame.headers.filter(([name]) => !HOP_HEADERS.has(name.toLowerCase())),
-          }),
-        );
+        entry.resolve(response);
         return;
       }
       case "body-chunk": {
@@ -436,16 +474,10 @@ export class TunnelDO {
     const tags = this.state.getTags(ws);
     if (tags.includes(TUNNEL_TAG)) {
       // Only react if this socket is still the active tunnel (a replaced
-      // socket closing must not tear down the new tunnel's visitors).
+      // socket closing must not tear down the new tunnel's visitors —
+      // acceptTunnel already abandoned the old socket's streams).
       if (this.tunnelSocket() !== null) return;
-      for (const streamId of [...this.pendingHttp.keys()]) {
-        this.failHttpStream(streamId, 502, "tunnel disconnected mid-request");
-      }
-      for (const visitor of this.state.getWebSockets()) {
-        if (!this.state.getTags(visitor).includes(TUNNEL_TAG)) {
-          visitor.close(1001, "tunnel disconnected");
-        }
-      }
+      this.abandonStreams("tunnel disconnected mid-request", "tunnel disconnected");
       return;
     }
     const attachment = ws.deserializeAttachment() as { streamId: number };

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { decodeFrame } from "@bb/tunnel-contract";
+import { decodeFrame, encodeFrame, type Frame } from "@bb/tunnel-contract";
 
 import { cacheKey } from "./cache";
 import { parseClientProtocolVersion } from "./tunnel-do";
@@ -484,7 +484,7 @@ class FakeWebSocketRequestResponsePair {
 vi.stubGlobal("WebSocketRequestResponsePair", FakeWebSocketRequestResponsePair);
 
 type MockState = {
-  sockets: WebSocket[];
+  addSocket: (ws: WebSocket, tags: string[]) => void;
   storage: Map<string, unknown>;
   restore: Promise<void>;
   api: DurableObjectState;
@@ -492,15 +492,16 @@ type MockState = {
 
 function mockDoState(initialStorage: Record<string, unknown> = {}): MockState {
   const storage = new Map<string, unknown>(Object.entries(initialStorage));
-  const sockets: WebSocket[] = [];
+  const entries: Array<{ ws: WebSocket; tags: string[] }> = [];
   let restore = Promise.resolve();
   const api = {
-    getWebSockets: (tag?: string) => {
-      if (tag === "tunnel" || tag === undefined) return sockets;
-      return [];
-    },
-    acceptWebSocket: (ws: WebSocket) => {
-      sockets.push(ws);
+    getWebSockets: (tag?: string) =>
+      entries
+        .filter((entry) => tag === undefined || entry.tags.includes(tag))
+        .map((entry) => entry.ws),
+    getTags: (ws: WebSocket) => entries.find((entry) => entry.ws === ws)?.tags ?? [],
+    acceptWebSocket: (ws: WebSocket, tags: string[] = []) => {
+      entries.push({ ws, tags });
     },
     setWebSocketAutoResponse: vi.fn(),
     blockConcurrencyWhile: (fn: () => Promise<void>) => {
@@ -519,7 +520,9 @@ function mockDoState(initialStorage: Record<string, unknown> = {}): MockState {
     },
   } as unknown as DurableObjectState;
   return {
-    sockets,
+    addSocket: (ws: WebSocket, tags: string[]) => {
+      entries.push({ ws, tags });
+    },
     storage,
     get restore() {
       return restore;
@@ -552,7 +555,7 @@ describe("TunnelDO targeted request with old client", () => {
     await state.restore;
 
     // Tunnel must look connected for the version gate (vs 503 offline).
-    state.sockets.push(fakeTunnelSocket());
+    state.addSocket(fakeTunnelSocket(), ["tunnel"]);
 
     const res = await dob.fetch(
       new Request("https://do.internal/", {
@@ -567,7 +570,7 @@ describe("TunnelDO targeted request with old client", () => {
     const state = mockDoState({ protocolVersion: 0 });
     const dob = new TunnelDO(state.api, makeDoEnv());
     await state.restore;
-    state.sockets.push(fakeTunnelSocket());
+    state.addSocket(fakeTunnelSocket(), ["tunnel"]);
 
     const res = await dob.fetch(
       new Request("https://do.internal/ws", {
@@ -588,7 +591,7 @@ describe("TunnelDO targeted request with old client", () => {
       const state = mockDoState({ protocolVersion: 1 });
       const dob = new TunnelDO(state.api, makeDoEnv());
       await state.restore;
-      state.sockets.push(
+      state.addSocket(
         fakeTunnelSocket((data) => {
           if (typeof data === "string") return;
           if (data instanceof ArrayBuffer) {
@@ -597,6 +600,7 @@ describe("TunnelDO targeted request with old client", () => {
             sent.push(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
           }
         }),
+        ["tunnel"],
       );
 
       const pending = dob.fetch(
@@ -623,5 +627,168 @@ describe("TunnelDO targeted request with old client", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ── TunnelDO response relay ─────────────────────────────────────────────────
+
+/** Tunnel-socket send handler that records binary frames into `sent`. */
+function captureSent(sent: Uint8Array[]) {
+  return (data: ArrayBuffer | ArrayBufferView | string) => {
+    if (typeof data === "string") return;
+    if (data instanceof ArrayBuffer) {
+      sent.push(new Uint8Array(data));
+    } else {
+      sent.push(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+    }
+  };
+}
+
+/** Encode a frame as the ArrayBuffer webSocketMessage receives on the wire. */
+function frameBuffer(frame: Frame): ArrayBuffer {
+  const u8 = encodeFrame(frame);
+  return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength) as ArrayBuffer;
+}
+
+function openHttpStreamId(sent: Uint8Array[], index: number): number {
+  const frame = decodeFrame(sent[index]);
+  if (frame.type !== "open-http") throw new Error(`expected open-http at ${index}`);
+  return frame.streamId;
+}
+
+describe("TunnelDO response relay", () => {
+  it("relays null-body statuses (304/204) bodiless instead of stranding the visitor", async () => {
+    const sent: Uint8Array[] = [];
+    const state = mockDoState({ protocolVersion: 1 });
+    const dob = new TunnelDO(state.api, makeDoEnv());
+    await state.restore;
+    const tunnel = fakeTunnelSocket(captureSent(sent));
+    state.addSocket(tunnel, ["tunnel"]);
+
+    // A browser revalidating a cached asset (the dev-server reload path).
+    for (const [index, status] of [304, 204].entries()) {
+      const pending = dob.fetch(
+        new Request("https://do.internal/app.js", {
+          headers: { "if-none-match": 'W/"abc"' },
+        }),
+      );
+      const streamId = openHttpStreamId(sent, index);
+      dob.webSocketMessage(
+        tunnel,
+        frameBuffer({
+          type: "resp-head",
+          streamId,
+          status,
+          headers: [
+            ["etag", 'W/"abc"'],
+            ["connection", "keep-alive"],
+          ],
+        }),
+      );
+      dob.webSocketMessage(tunnel, frameBuffer({ type: "body-end", streamId }));
+      const res = await pending;
+      expect(res.status).toBe(status);
+      expect(res.body).toBeNull();
+      expect(res.headers.get("etag")).toBe('W/"abc"');
+      // Hop headers stay filtered on this path too.
+      expect(res.headers.get("connection")).toBeNull();
+    }
+  });
+
+  it("answers 502 for a response status that cannot be constructed", async () => {
+    const sent: Uint8Array[] = [];
+    const state = mockDoState({ protocolVersion: 1 });
+    const dob = new TunnelDO(state.api, makeDoEnv());
+    await state.restore;
+    const tunnel = fakeTunnelSocket(captureSent(sent));
+    state.addSocket(tunnel, ["tunnel"]);
+
+    const pending = dob.fetch(new Request("https://do.internal/weird"));
+    const streamId = openHttpStreamId(sent, 0);
+    dob.webSocketMessage(
+      tunnel,
+      frameBuffer({ type: "resp-head", streamId, status: 199, headers: [] }),
+    );
+    const res = await pending;
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain("unrelayable");
+  });
+
+  it("fails in-flight streams and closes visitor sockets when a new tunnel replaces the old", async () => {
+    const sent: Uint8Array[] = [];
+    const state = mockDoState({ protocolVersion: 1 });
+    const dob = new TunnelDO(state.api, makeDoEnv());
+    await state.restore;
+    const oldTunnel = fakeTunnelSocket(captureSent(sent));
+    state.addSocket(oldTunnel, ["tunnel"]);
+    const visitor = fakeTunnelSocket();
+    state.addSocket(visitor, ["visitor:41"]);
+
+    // One request still awaiting resp-head, one mid-body (its resp-head
+    // timeout is already cleared — the state that used to hang forever).
+    const pendingHead = dob.fetch(new Request("https://do.internal/pending"));
+    const pendingBody = dob.fetch(new Request("https://do.internal/mid-body"));
+    const bodyStreamId = openHttpStreamId(sent, 1);
+    dob.webSocketMessage(
+      oldTunnel,
+      frameBuffer({
+        type: "resp-head",
+        streamId: bodyStreamId,
+        status: 200,
+        headers: [["content-type", "text/plain"]],
+      }),
+    );
+    const midBodyResponse = await pendingBody;
+    expect(midBodyResponse.status).toBe(200);
+
+    // The client reconnects: acceptTunnel replaces the old socket. Node lacks
+    // WebSocketPair and rejects `new Response(null, {status: 101})`, so both
+    // are emulated for the accept call only.
+    const RealResponse = globalThis.Response;
+    class FakeWebSocketPair {
+      0 = fakeTunnelSocket();
+      1 = fakeTunnelSocket();
+    }
+    class WorkersResponse extends RealResponse {
+      readonly webSocket: WebSocket | null;
+      constructor(
+        body?: BodyInit | null,
+        init?: ResponseInit & { webSocket?: WebSocket | null },
+      ) {
+        if (init?.webSocket != null) {
+          super(null, { status: 200 });
+          Object.defineProperty(this, "status", { value: init.status });
+          this.webSocket = init.webSocket;
+        } else {
+          super(body ?? null, init);
+          this.webSocket = null;
+        }
+      }
+    }
+    globalThis.Response = WorkersResponse as never;
+    (globalThis as { WebSocketPair?: unknown }).WebSocketPair = FakeWebSocketPair;
+    try {
+      const upgrade = await dob.fetch(
+        new Request("https://do.internal/__tunnel?v=1", {
+          headers: { upgrade: "websocket" },
+        }),
+      );
+      expect(upgrade.status).toBe(101);
+    } finally {
+      globalThis.Response = RealResponse;
+      delete (globalThis as { WebSocketPair?: unknown }).WebSocketPair;
+    }
+
+    expect(vi.mocked(oldTunnel.close)).toHaveBeenCalledWith(
+      1000,
+      "replaced by a new tunnel connection",
+    );
+    expect(vi.mocked(visitor.close)).toHaveBeenCalledWith(1001, "tunnel reconnected");
+
+    const headResponse = await pendingHead;
+    expect(headResponse.status).toBe(502);
+    expect(await headResponse.text()).toContain("tunnel reconnected mid-request");
+    // The mid-body response's stream errors out instead of hanging forever.
+    await expect(midBodyResponse.text()).rejects.toBeTruthy();
   });
 });

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from "node:http";
+import { gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket, WebSocketServer } from "ws";
 import {
@@ -400,6 +401,112 @@ describe("TunnelSession routing", () => {
     expect(frames.some((f) => f.type === "body-end" && f.streamId === 3)).toBe(
       true,
     );
+  });
+
+  it("drops stale content-length/content-encoding when the origin compresses, and relays 304 bodiless", async () => {
+    const plainBody = "hello ".repeat(200);
+    const gzippedBody = gzipSync(Buffer.from(plainBody));
+    const origin = await listen((req, res) => {
+      if (req.headers["if-none-match"] === 'W/"v1"') {
+        res.writeHead(304, { etag: 'W/"v1"' });
+        res.end();
+        return;
+      }
+      res.writeHead(200, {
+        "content-type": "text/plain",
+        "content-encoding": "gzip",
+        "content-length": String(gzippedBody.length),
+        etag: 'W/"v1"',
+      });
+      res.end(gzippedBody);
+    });
+    cleanups.push(
+      () => new Promise<void>((resolve) => origin.server.close(() => resolve())),
+    );
+
+    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+    const wssAddr = wss.address();
+    if (wssAddr === null || typeof wssAddr === "string") {
+      throw new Error("expected TCP address");
+    }
+    const relayReady = new Promise<NodeWebSocket>((resolve) => {
+      wss.on("connection", (socket) => resolve(socket));
+    });
+    const client = new NodeWebSocket(`ws://127.0.0.1:${wssAddr.port}`);
+    cleanups.push(async () => {
+      client.terminate();
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+    });
+    await waitForOpen(client);
+    const relay = await relayReady;
+    const frames = collectFrames(relay);
+
+    const session = new TunnelSession({
+      tunnel: client,
+      log: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      resolveOrigin: () => ({
+        kind: "ok",
+        resolved: {
+          origin: origin.origin,
+          publicOrigin: "https://sawyer.getbb.app",
+        },
+      }),
+    });
+    session.start();
+    cleanups.push(() => session.dispose());
+
+    const inject = (frame: Frame) => {
+      relay.send(Buffer.from(encodeFrame(frame)));
+    };
+
+    // Compressed 200: fetch decompresses, so the origin's content-encoding
+    // and (compressed-size) content-length must not ride the resp-head —
+    // relaying the smaller length would corrupt framing at the relay.
+    inject({
+      type: "open-http",
+      streamId: 21,
+      method: "GET",
+      path: "/asset.js",
+      headers: [],
+      hasBody: false,
+    });
+    await waitFor(() => frames.some((f) => f.type === "body-end" && f.streamId === 21));
+    const head = frames.find((f) => f.type === "resp-head" && f.streamId === 21);
+    if (head?.type !== "resp-head") throw new Error("missing resp-head");
+    expect(head.status).toBe(200);
+    const headerNames = head.headers.map(([name]) => name.toLowerCase());
+    expect(headerNames).not.toContain("content-encoding");
+    expect(headerNames).not.toContain("content-length");
+    expect(headerNames).toContain("etag");
+    const relayedBody = Buffer.concat(
+      frames
+        .filter((f) => f.type === "body-chunk" && f.streamId === 21)
+        .map((f) => (f.type === "body-chunk" ? Buffer.from(f.data) : Buffer.alloc(0))),
+    ).toString();
+    expect(relayedBody).toBe(plainBody);
+
+    // Revalidation: a 304 relays as resp-head + body-end with no chunks.
+    frames.length = 0;
+    inject({
+      type: "open-http",
+      streamId: 22,
+      method: "GET",
+      path: "/asset.js",
+      headers: [["If-None-Match", 'W/"v1"']],
+      hasBody: false,
+    });
+    await waitFor(() => frames.some((f) => f.type === "body-end" && f.streamId === 22));
+    const revalidated = frames.find(
+      (f) => f.type === "resp-head" && f.streamId === 22,
+    );
+    expect(revalidated).toMatchObject({ type: "resp-head", status: 304 });
+    expect(frames.some((f) => f.type === "body-chunk" && f.streamId === 22)).toBe(false);
   });
 
   it("tracks remoteClients for bare-handle /ws streams", async () => {

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -330,8 +330,16 @@ export class TunnelSession {
         signal: stream.abort.signal,
       });
       const respHeaders: HeaderPair[] = [];
+      // fetch transparently decompresses a compressed origin body, so when
+      // content-encoding is present the origin's content-length describes
+      // compressed bytes we are not forwarding — relaying it would corrupt
+      // the response framing at the relay. Drop both.
+      const decompressed = res.headers.get("content-encoding") !== null;
       res.headers.forEach((v, n) => {
-        if (n.toLowerCase() !== "content-encoding") respHeaders.push([n, v]);
+        const lower = n.toLowerCase();
+        if (lower === "content-encoding") return;
+        if (decompressed && lower === "content-length") return;
+        respHeaders.push([n, v]);
       });
       this.send({
         type: "resp-head",


### PR DESCRIPTION
## Summary

Shared dev servers over bb connect (`https://<handle>--<port>.getbb.app`) hung indefinitely on reload once the browser had cached anything. Tracing that hang surfaced three relay bugs:

1. **304/204/205 responses stranded visitor requests forever** (the reported hang). The TunnelDO `resp-head` handler cleared the 504 timeout, then threw constructing a `Response` with a stream body — null-body statuses forbid one — so the request promise never settled. Dev servers (Vite et al.) answer `304 Not Modified` to every ETag revalidation, making this the common path on reload, not an edge case. Null-body statuses now resolve bodiless, and any other unconstructable response answers 502 instead of hanging.

2. **Compressed origin responses relayed a stale `content-length`.** The tunnel client's `fetch` transparently decompresses, and the client stripped `content-encoding` but forwarded the origin's compressed-size `content-length`, corrupting response framing at the relay. Both headers are now dropped when the origin compressed.

3. **A tunnel reconnect orphaned in-flight streams.** When a new tunnel socket replaced the old one (heartbeat loss, laptop sleep), the old socket's close handler returned early without failing pending requests; mid-body responses — whose resp-head timeout was already cleared — hung forever. `acceptTunnel` now abandons all in-flight HTTP streams (502) and closes orphaned visitor sockets so clients reconnect through the new tunnel.

## Tests

- `pnpm --filter @bb/connect test` (36 passed) and `pnpm --filter bb-plugin-connect test` (40 passed), plus typecheck on both.
- Four new regression tests: bodiless 304/204 relay, unconstructable-status 502, reconnect stream abandonment (DO), and a gzip + 304 relay test against a real local origin (client). All four fail against the unfixed code; the 304 test reproduces the reported hang.
- The DO test mock gained real socket-tag support to exercise `webSocketMessage`/replacement paths under Node.

## Notes

- Fixes 1 and 3 are in the gate worker and take effect on the next `wrangler deploy`; fix 2 ships with the bb app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)