### PR TITLE
Fix Codex model/list failures for max and ultra efforts

### DIFF
--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -47,12 +47,14 @@ export interface PersistedPermissionModeSelectionField {
 
 function isReasoningLevel(value: string): value is ReasoningLevel {
   return (
+    value === "none" ||
     value === "low" ||
     value === "medium" ||
     value === "high" ||
     value === "xhigh" ||
     value === "ultracode" ||
-    value === "max"
+    value === "max" ||
+    value === "ultra"
   );
 }
 

--- a/apps/app/src/lib/reasoning-labels.ts
+++ b/apps/app/src/lib/reasoning-labels.ts
@@ -14,4 +14,5 @@ export const REASONING_LABELS: Record<ReasoningLevel, string> = {
   xhigh: "Extra High",
   ultracode: "Ultracode",
   max: "Max",
+  ultra: "Ultra",
 };

--- a/apps/cli/src/commands/helpers.ts
+++ b/apps/cli/src/commands/helpers.ts
@@ -2,6 +2,7 @@ import { createInterface } from "node:readline/promises";
 import {
   PERSONAL_PROJECT_ID,
   reasoningLevelSchema,
+  reasoningLevelValues,
   type ReasoningLevel,
 } from "@bb/domain";
 import type {
@@ -19,13 +20,7 @@ export {
   requireThreadIdOrSelf,
 } from "../context-env.js";
 
-const REASONING_LEVELS: ReasoningLevel[] = [
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-];
+const REASONING_LEVELS: readonly ReasoningLevel[] = reasoningLevelValues;
 
 export interface JsonOutputOptions {
   json?: boolean;

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -3045,7 +3045,8 @@ describe("public thread data routes", () => {
         projectId: project.id,
         providerId: "codex",
         model: "gpt-5.5",
-        reasoningLevel: "max",
+        // ultracode is Claude-only; stale for Codex project defaults.
+        reasoningLevel: "ultracode",
         permissionMode: "full",
         serviceTier: "default",
       });

--- a/apps/server/test/services/plugins/plugin-thread-events.test.ts
+++ b/apps/server/test/services/plugins/plugin-thread-events.test.ts
@@ -212,7 +212,8 @@ describe("plugin thread lifecycle events", () => {
           title: "Rollback event test",
           input: [{ type: "text", text: "hello", mentions: [] }],
           model: "gpt-5",
-          reasoningLevel: "max",
+          // Force validation failure after insert so the create rolls back.
+          reasoningLevel: "ultracode",
           environment: { type: "reuse", environmentId: environment.id },
         }),
       });

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -64,21 +64,30 @@ describe("appendCustomModels", () => {
     ).toEqual(["low", "medium", "high", "xhigh", "ultracode", "max"]);
   });
 
-  it("caps codex and pi custom models at xhigh (no max)", () => {
-    for (const providerId of ["codex", "pi"] as const) {
-      const { models } = appendCustomModels({
-        customModels: [{ providerId, model: "custom-model" }],
-        models: [],
-        providerId,
-        selectedOnlyModels: [],
-      });
+  it("uses the provider reasoning ladder for codex and pi custom models", () => {
+    const { models: codexModels } = appendCustomModels({
+      customModels: [{ providerId: "codex", model: "custom-model" }],
+      models: [],
+      providerId: "codex",
+      selectedOnlyModels: [],
+    });
+    expect(
+      codexModels[0].supportedReasoningEfforts.map(
+        (effort) => effort.reasoningEffort,
+      ),
+    ).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
 
-      expect(
-        models[0].supportedReasoningEfforts.map(
-          (effort) => effort.reasoningEffort,
-        ),
-      ).toEqual(["low", "medium", "high", "xhigh"]);
-    }
+    const { models: piModels } = appendCustomModels({
+      customModels: [{ providerId: "pi", model: "custom-model" }],
+      models: [],
+      providerId: "pi",
+      selectedOnlyModels: [],
+    });
+    expect(
+      piModels[0].supportedReasoningEfforts.map(
+        (effort) => effort.reasoningEffort,
+      ),
+    ).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
   it("falls back to the model id when displayName is omitted", () => {

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -612,12 +612,12 @@ describe("thread runtime config", () => {
           threadId: thread.id,
           requestedExecution: {
             model: "gpt-5.4",
-            reasoningLevel: "max",
+            reasoningLevel: "ultracode",
             source: "client/turn/requested",
           },
         }),
       ).rejects.toThrow(
-        "Provider codex does not support max reasoning level. Supported reasoning levels: low, medium, high, xhigh.",
+        "Provider codex does not support ultracode reasoning level. Supported reasoning levels: low, medium, high, xhigh, max, ultra.",
       );
     });
   });

--- a/packages/agent-providers/src/catalog.ts
+++ b/packages/agent-providers/src/catalog.ts
@@ -63,8 +63,8 @@ export interface ProviderServerCapabilities {
   /**
    * The coarse, ordered per-provider reasoning ladder. Used as a fallback when
    * a precise per-model `supportedReasoningEfforts` set is unavailable. Mirrors
-   * daemon-side translation: codex rejects "max"/"ultracode" provider-wide and
-   * the pi bridge caps at xhigh, so those ladders stop at xhigh.
+   * daemon-side translation: Codex can expose "max"/"ultra" on some models but
+   * not "ultracode"; the pi bridge caps at xhigh.
    */
   reasoningLevels: readonly ReasoningLevel[];
 }
@@ -164,7 +164,9 @@ const CODEX_SERVER_CAPABILITIES: ProviderServerCapabilities = {
   supportsWorkflows: false,
   supportsExecutionOverride: false,
   backsHostDaemonAiServices: true,
-  reasoningLevels: ["low", "medium", "high", "xhigh"],
+  // Per-model list from app-server is authoritative; this ladder is the
+  // fallback for custom models / missing catalogs. "ultra" is Codex-only.
+  reasoningLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
 };
 
 const CLAUDE_SERVER_CAPABILITIES: ProviderServerCapabilities = {

--- a/packages/agent-providers/test/catalog.test.ts
+++ b/packages/agent-providers/test/catalog.test.ts
@@ -139,7 +139,7 @@ describe("agent provider catalog", () => {
       supportsWorkflows: false,
       supportsExecutionOverride: false,
       backsHostDaemonAiServices: true,
-      reasoningLevels: ["low", "medium", "high", "xhigh"],
+      reasoningLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
     });
     expect(getBuiltInAgentProviderServerCapabilities("claude-code")).toEqual({
       supportsWorkflows: true,

--- a/packages/agent-runtime/src/acp/bridge/model-catalog.ts
+++ b/packages/agent-runtime/src/acp/bridge/model-catalog.ts
@@ -155,6 +155,7 @@ const ACP_NATIVE_REASONING_LEVEL_BY_VALUE: Readonly<
   xhigh: "xhigh",
   ultracode: "ultracode",
   max: "max",
+  ultra: "ultra",
 };
 
 const ACP_NATIVE_REASONING_VALUE_CANDIDATES_BY_LEVEL: Readonly<
@@ -167,6 +168,7 @@ const ACP_NATIVE_REASONING_VALUE_CANDIDATES_BY_LEVEL: Readonly<
   xhigh: ["xhigh"],
   ultracode: ["ultracode", "xhigh"],
   max: ["max", "xhigh"],
+  ultra: ["ultra", "max"],
 };
 
 function acpNativeValueToReasoningLevel(
@@ -369,6 +371,7 @@ const EFFORT_DISPLAY_WORDS: Readonly<Record<string, string>> = {
   high: "High",
   low: "Low",
   max: "Max",
+  ultra: "Ultra",
   none: "None",
 };
 

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -63,6 +63,8 @@ function toSdkEffort(
   // "none" (thinking-off) is a Cursor-only level; Claude Code models never
   // expose it, so this is a defensive floor that reconciliation never reaches.
   if (reasoningLevel === "none") return "low";
+  // "ultra" is a Codex-only top tier; if it ever reaches Claude, floor to max.
+  if (reasoningLevel === "ultra") return "max";
   return reasoningLevel;
 }
 

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -1640,7 +1640,57 @@ describe("codex provider adapter", () => {
     });
   });
 
-  it("buildCommand rejects max reasoning level because Codex does not support it", () => {
+  it("buildCommand maps max reasoning level through to Codex", () => {
+    const adapter = createCodexProviderAdapter();
+    const cmd = adapter.buildCommandPlan({
+      type: "thread/start",
+      cwd: "/tmp/worktree",
+      threadId: "bb-thread-1",
+      input: [promptTextInput({ text: "hello" })],
+      instructionMode: "append",
+      options: {
+        ...fullProviderExecutionContext,
+        model: "gpt-5.6-luna",
+        reasoningLevel: "max",
+      },
+    });
+
+    expect(cmd).toMatchObject({
+      method: "thread/start",
+      params: {
+        config: {
+          model_reasoning_effort: "max",
+        },
+      },
+    });
+  });
+
+  it("buildCommand maps ultra reasoning level through to Codex", () => {
+    const adapter = createCodexProviderAdapter();
+    const cmd = adapter.buildCommandPlan({
+      type: "thread/start",
+      cwd: "/tmp/worktree",
+      threadId: "bb-thread-1",
+      input: [promptTextInput({ text: "hello" })],
+      instructionMode: "append",
+      options: {
+        ...fullProviderExecutionContext,
+        model: "gpt-5.6-sol",
+        reasoningLevel: "ultra",
+      },
+    });
+
+    expect(cmd).toMatchObject({
+      method: "thread/start",
+      params: {
+        config: {
+          model_reasoning_effort: "ultra",
+        },
+      },
+    });
+  });
+
+  it("buildCommand rejects ultracode because Codex does not support it", () => {
     const adapter = createCodexProviderAdapter();
 
     expect(() =>
@@ -1652,11 +1702,11 @@ describe("codex provider adapter", () => {
         instructionMode: "append",
         options: {
           ...fullProviderExecutionContext,
-          model: "gpt-5.4",
-          reasoningLevel: "max",
+          model: "gpt-5.6-sol",
+          reasoningLevel: "ultracode",
         },
       }),
-    ).toThrow("Codex does not support max reasoning level.");
+    ).toThrow("Codex does not support the ultracode reasoning level.");
   });
 
   it("buildCommand thread/start replaces instructions as base instructions", () => {
@@ -5339,5 +5389,61 @@ describe("codex provider adapter", () => {
     });
     expect(result.models).toHaveLength(1);
     expect(result.selectedOnlyModels).toHaveLength(0);
+  });
+
+  it("parseModelListResult accepts max and ultra as distinct levels", () => {
+    const adapter = createCodexProviderAdapter();
+    const result = adapter.parseModelListResult({
+      data: [
+        {
+          id: "gpt-5.6-sol",
+          model: "gpt-5.6-sol",
+          displayName: "GPT-5.6-Sol",
+          description: "Latest frontier agentic coding model.",
+          supportedReasoningEfforts: [
+            {
+              reasoningEffort: "low",
+              description: "Fast responses with lighter reasoning",
+            },
+            {
+              reasoningEffort: "max",
+              description: "Maximum reasoning depth for the hardest problems",
+            },
+            {
+              reasoningEffort: "ultra",
+              description:
+                "Maximum reasoning with automatic task delegation",
+            },
+          ],
+          defaultReasoningEffort: "ultra",
+          isDefault: false,
+        },
+      ],
+    });
+
+    expect(result.models).toEqual([
+      {
+        id: "gpt-5.6-sol",
+        model: "gpt-5.6-sol",
+        displayName: "GPT-5.6-Sol",
+        description: "Latest frontier agentic coding model.",
+        supportedReasoningEfforts: [
+          {
+            reasoningEffort: "low",
+            description: "Fast responses with lighter reasoning",
+          },
+          {
+            reasoningEffort: "max",
+            description: "Maximum reasoning depth for the hardest problems",
+          },
+          {
+            reasoningEffort: "ultra",
+            description: "Maximum reasoning with automatic task delegation",
+          },
+        ],
+        defaultReasoningEffort: "ultra",
+        isDefault: false,
+      },
+    ]);
   });
 });

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -37,7 +37,10 @@ import type { ThreadResumeParams } from "./generated/codex-app-server/schema/v2/
 import type { ThreadStartParams } from "./generated/codex-app-server/schema/v2/ThreadStartParams.js";
 import type { UserInput as CodexUserInput } from "./generated/codex-app-server/schema/v2/UserInput.js";
 import type { AskForApproval } from "./generated/codex-app-server/schema/v2/AskForApproval.js";
-import { parseModelsResponse } from "./models.js";
+import {
+  mapBbReasoningLevelToCodex,
+  parseModelsResponse,
+} from "./models.js";
 import {
   buildShellEnvironmentPolicyConfig,
   extractResultText,
@@ -662,24 +665,16 @@ function toCodexServiceTier(tier: ServiceTier | undefined): "fast" | undefined {
 function toCodexReasoningEffort(
   reasoningLevel: ReasoningLevel,
 ): CodexReasoningEffort {
-  switch (reasoningLevel) {
-    case "low":
-      return "low";
-    case "medium":
-      return "medium";
-    case "high":
-      return "high";
-    case "xhigh":
-      return "xhigh";
-    case "none":
-      // "none" (thinking-off) is a Cursor-only level; Codex models never
-      // expose it, so model-switch reconciliation maps it away before here.
-      throw new Error("Codex does not support the none reasoning level.");
-    case "ultracode":
-      throw new Error("Codex does not support ultracode reasoning level.");
-    case "max":
-      throw new Error("Codex does not support max reasoning level.");
+  const codexEffort = mapBbReasoningLevelToCodex(reasoningLevel);
+  if (codexEffort == null) {
+    // "none" is Cursor-only; "ultracode" is Claude-specific. Codex models
+    // never expose either, so model-switch reconciliation maps them away
+    // before here — but fail closed if something slips through.
+    throw new Error(
+      `Codex does not support the ${reasoningLevel} reasoning level.`,
+    );
   }
+  return codexEffort;
 }
 
 function toCodexUserInput(input: PromptInput[]): CodexUserInput[] {

--- a/packages/agent-runtime/src/codex/models.test.ts
+++ b/packages/agent-runtime/src/codex/models.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapBbReasoningLevelToCodex,
+  mapCodexReasoningLevelToBb,
+  parseModelsResponse,
+} from "./models.js";
+
+describe("mapCodexReasoningLevelToBb", () => {
+  it("passes through known BB levels including ultra", () => {
+    expect(mapCodexReasoningLevelToBb("low")).toBe("low");
+    expect(mapCodexReasoningLevelToBb("max")).toBe("max");
+    expect(mapCodexReasoningLevelToBb("xhigh")).toBe("xhigh");
+    expect(mapCodexReasoningLevelToBb("ultra")).toBe("ultra");
+  });
+
+  it("returns null for unknown values", () => {
+    expect(mapCodexReasoningLevelToBb("ludicrous")).toBeNull();
+    expect(mapCodexReasoningLevelToBb(42)).toBeNull();
+    expect(mapCodexReasoningLevelToBb(undefined)).toBeNull();
+  });
+});
+
+describe("mapBbReasoningLevelToCodex", () => {
+  it("passes through ultra, max, and standard levels", () => {
+    expect(mapBbReasoningLevelToCodex("ultra")).toBe("ultra");
+    expect(mapBbReasoningLevelToCodex("max")).toBe("max");
+    expect(mapBbReasoningLevelToCodex("high")).toBe("high");
+  });
+
+  it("returns null for none and ultracode", () => {
+    expect(mapBbReasoningLevelToCodex("none")).toBeNull();
+    expect(mapBbReasoningLevelToCodex("ultracode")).toBeNull();
+  });
+});
+
+describe("parseModelsResponse", () => {
+  it("parses a live-shaped Codex payload with max and ultra", () => {
+    const models = parseModelsResponse({
+      data: [
+        {
+          id: "gpt-5.5",
+          model: "gpt-5.5",
+          displayName: "GPT-5.5",
+          description: "Frontier model",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "Low" },
+            { reasoningEffort: "medium", description: "Medium" },
+            { reasoningEffort: "high", description: "High" },
+            { reasoningEffort: "xhigh", description: "XHigh" },
+          ],
+          defaultReasoningEffort: "medium",
+          isDefault: true,
+        },
+        {
+          id: "gpt-5.6-sol",
+          model: "gpt-5.6-sol",
+          displayName: "GPT-5.6-Sol",
+          description: "Latest frontier",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "Low" },
+            { reasoningEffort: "medium", description: "Medium" },
+            { reasoningEffort: "high", description: "High" },
+            { reasoningEffort: "xhigh", description: "XHigh" },
+            { reasoningEffort: "max", description: "Max" },
+            {
+              reasoningEffort: "ultra",
+              description: "Maximum with delegation",
+            },
+          ],
+          defaultReasoningEffort: "low",
+          isDefault: false,
+        },
+      ],
+    });
+
+    expect(models).toHaveLength(2);
+    expect(models[0]?.id).toBe("gpt-5.5");
+    expect(models[1]?.supportedReasoningEfforts.map((e) => e.reasoningEffort)).toEqual(
+      ["low", "medium", "high", "xhigh", "max", "ultra"],
+    );
+    expect(models[1]?.defaultReasoningEffort).toBe("low");
+  });
+
+  it("skips unknown reasoning efforts without rejecting the model", () => {
+    const models = parseModelsResponse({
+      data: [
+        {
+          id: "future-model",
+          model: "future-model",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "Low" },
+            { reasoningEffort: "quantum", description: "Brand new" },
+            { reasoningEffort: "high", description: "High" },
+          ],
+          defaultReasoningEffort: "quantum",
+        },
+      ],
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]?.supportedReasoningEfforts.map((e) => e.reasoningEffort)).toEqual(
+      ["low", "high"],
+    );
+    // Unknown default falls back to first supported effort.
+    expect(models[0]?.defaultReasoningEffort).toBe("low");
+  });
+
+  it("falls back to default efforts when every effort is unknown", () => {
+    const models = parseModelsResponse({
+      data: [
+        {
+          id: "odd-model",
+          model: "odd-model",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "quantum", description: "Brand new" },
+          ],
+          defaultReasoningEffort: "quantum",
+        },
+      ],
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]?.supportedReasoningEfforts.map((e) => e.reasoningEffort)).toEqual(
+      ["low", "medium", "high", "xhigh"],
+    );
+    expect(models[0]?.defaultReasoningEffort).toBe("low");
+  });
+
+  it("skips malformed model entries and keeps valid ones", () => {
+    const models = parseModelsResponse({
+      data: [
+        { notAModel: true },
+        null,
+        "garbage",
+        {
+          id: "good",
+          model: "good",
+          displayName: "Good",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "medium", description: "Medium" },
+          ],
+          defaultReasoningEffort: "medium",
+          isDefault: true,
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "good",
+        model: "good",
+        displayName: "Good",
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "Medium" },
+        ],
+        defaultReasoningEffort: "medium",
+        isDefault: true,
+      },
+    ]);
+  });
+
+  it("uses defaults when supportedReasoningEfforts is empty", () => {
+    const models = parseModelsResponse({
+      data: [
+        {
+          id: "codex-mini",
+          model: "codex-mini",
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: "medium",
+          isDefault: true,
+        },
+      ],
+    });
+
+    expect(models[0]?.supportedReasoningEfforts.map((e) => e.reasoningEffort)).toEqual(
+      ["low", "medium", "high", "xhigh"],
+    );
+    expect(models[0]?.defaultReasoningEffort).toBe("medium");
+  });
+
+  it("throws when the envelope is not a model list", () => {
+    expect(() => parseModelsResponse(null)).toThrow(
+      "Invalid response from codex model/list.",
+    );
+    expect(() => parseModelsResponse({})).toThrow(
+      "Invalid response from codex model/list.",
+    );
+    expect(() => parseModelsResponse({ data: "nope" })).toThrow(
+      "Invalid response from codex model/list.",
+    );
+  });
+
+  it("throws when every model entry is unusable", () => {
+    expect(() =>
+      parseModelsResponse({
+        data: [{ missing: "id" }, null, 3],
+      }),
+    ).toThrow("Codex model/list returned no supported models.");
+  });
+});

--- a/packages/agent-runtime/src/codex/models.ts
+++ b/packages/agent-runtime/src/codex/models.ts
@@ -1,67 +1,160 @@
-import type { AvailableModel } from "@bb/domain";
+import {
+  reasoningEffortsForLevels,
+  reasoningLevelSchema,
+  type AvailableModel,
+  type ModelReasoningEffort,
+  type ReasoningLevel,
+} from "@bb/domain";
 import { z } from "zod";
 
-const reasoningLevelSchema = z.enum(["low", "medium", "high", "xhigh"]);
+const DEFAULT_REASONING_EFFORTS: readonly ModelReasoningEffort[] =
+  reasoningEffortsForLevels(["low", "medium", "high", "xhigh"]);
 
-const reasoningEffortOptionSchema = z
+const codexModelIdentitySchema = z
   .object({
-    reasoningEffort: reasoningLevelSchema,
-    description: z.string(),
+    id: z.string().min(1),
+    model: z.string().min(1),
   })
   .passthrough();
 
-const DEFAULT_REASONING_EFFORTS: z.infer<typeof reasoningEffortOptionSchema>[] =
-  [
-    { reasoningEffort: "low", description: "Low reasoning effort" },
-    { reasoningEffort: "medium", description: "Medium reasoning effort" },
-    { reasoningEffort: "high", description: "High reasoning effort" },
-    { reasoningEffort: "xhigh", description: "Extra high reasoning effort" },
-  ];
+/** Map a Codex-native reasoning effort string into a BB ReasoningLevel. */
+export function mapCodexReasoningLevelToBb(
+  value: unknown,
+): ReasoningLevel | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  // Codex levels that BB knows about (including Codex-only "ultra") pass
+  // through via the shared schema. Unknown future names soft-fail to null.
+  const parsed = reasoningLevelSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
 
-const codexModelSchema = z
-  .object({
-    id: z.string(),
-    model: z.string(),
-    displayName: z.string().optional(),
-    description: z.string().optional(),
-    isDefault: z.boolean().optional(),
-    supportedReasoningEfforts: z.array(reasoningEffortOptionSchema).optional(),
-    defaultReasoningEffort: reasoningLevelSchema.optional(),
-  })
-  .passthrough();
+/**
+ * Map a BB ReasoningLevel to the string Codex app-server expects for
+ * `model_reasoning_effort`. Returns null for levels Codex never accepts
+ * (currently only "none").
+ *
+ * "ultracode" is Claude-specific and is not sent to Codex; callers should not
+ * offer it for Codex models. "ultra" is the Codex-native top tier and passes
+ * through as-is.
+ */
+export function mapBbReasoningLevelToCodex(
+  level: ReasoningLevel,
+): string | null {
+  switch (level) {
+    case "none":
+    case "ultracode":
+      return null;
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+    case "max":
+    case "ultra":
+      return level;
+  }
+}
 
-const codexModelListResponseSchema = z
-  .object({
-    data: z.array(codexModelSchema),
-  })
-  .passthrough();
+function cloneDefaultReasoningEfforts(): ModelReasoningEffort[] {
+  return DEFAULT_REASONING_EFFORTS.map((effort) => ({ ...effort }));
+}
+
+function parseReasoningEffortOption(
+  raw: unknown,
+): ModelReasoningEffort | null {
+  if (raw == null || typeof raw !== "object") {
+    return null;
+  }
+  const record = raw as Record<string, unknown>;
+  const level = mapCodexReasoningLevelToBb(record.reasoningEffort);
+  if (!level) {
+    return null;
+  }
+  const description =
+    typeof record.description === "string" && record.description.length > 0
+      ? record.description
+      : reasoningEffortsForLevels([level])[0].description;
+  return {
+    reasoningEffort: level,
+    description,
+  };
+}
+
+function parseSupportedReasoningEfforts(
+  raw: unknown,
+): ModelReasoningEffort[] {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return cloneDefaultReasoningEfforts();
+  }
+
+  const efforts: ModelReasoningEffort[] = [];
+  const seen = new Set<ReasoningLevel>();
+  for (const item of raw) {
+    const effort = parseReasoningEffortOption(item);
+    if (!effort || seen.has(effort.reasoningEffort)) {
+      continue;
+    }
+    seen.add(effort.reasoningEffort);
+    efforts.push(effort);
+  }
+
+  // All efforts unknown/unmapped — fall back rather than rejecting the model.
+  return efforts.length > 0 ? efforts : cloneDefaultReasoningEfforts();
+}
 
 function toAvailableModel(
-  raw: z.infer<typeof codexModelSchema>,
+  raw: z.infer<typeof codexModelIdentitySchema>,
 ): AvailableModel {
-  const efforts = raw.supportedReasoningEfforts?.length
-    ? raw.supportedReasoningEfforts
-    : DEFAULT_REASONING_EFFORTS;
+  const efforts = parseSupportedReasoningEfforts(
+    raw.supportedReasoningEfforts,
+  );
+  const mappedDefault = mapCodexReasoningLevelToBb(raw.defaultReasoningEffort);
+  const defaultReasoningEffort =
+    mappedDefault &&
+    efforts.some((effort) => effort.reasoningEffort === mappedDefault)
+      ? mappedDefault
+      : efforts[0].reasoningEffort;
 
   return {
     id: raw.id,
     model: raw.model,
-    displayName: raw.displayName ?? raw.model,
-    description: raw.description ?? "",
+    displayName:
+      typeof raw.displayName === "string" && raw.displayName.length > 0
+        ? raw.displayName
+        : raw.model,
+    description: typeof raw.description === "string" ? raw.description : "",
     supportedReasoningEfforts: efforts,
-    defaultReasoningEffort:
-      raw.defaultReasoningEffort ?? efforts[0].reasoningEffort,
-    isDefault: raw.isDefault ?? false,
+    defaultReasoningEffort,
+    isDefault: raw.isDefault === true,
   };
 }
 
+/**
+ * Parse Codex `model/list` results.
+ *
+ * Soft by design: unknown reasoning efforts are skipped, malformed model
+ * entries are skipped, and only a completely unusable payload fails hard.
+ * This keeps the model picker working when Codex introduces new effort names.
+ */
 export function parseModelsResponse(result: unknown): AvailableModel[] {
-  const parsed = codexModelListResponseSchema.safeParse(result);
-  if (!parsed.success) {
+  if (result == null || typeof result !== "object") {
     throw new Error("Invalid response from codex model/list.");
   }
 
-  const models = parsed.data.data.map(toAvailableModel);
+  const data = (result as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error("Invalid response from codex model/list.");
+  }
+
+  const models: AvailableModel[] = [];
+  for (const entry of data) {
+    const identity = codexModelIdentitySchema.safeParse(entry);
+    if (!identity.success) {
+      continue;
+    }
+    models.push(toAvailableModel(identity.data));
+  }
 
   if (models.length === 0) {
     throw new Error("Codex model/list returned no supported models.");

--- a/packages/bb-app/src/public-sdk.ts
+++ b/packages/bb-app/src/public-sdk.ts
@@ -22,7 +22,13 @@ export type ThreadStatus =
   | "error";
 
 export type PermissionMode = "full" | "workspace-write" | "readonly";
-export type ReasoningLevel = "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningLevel =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultra";
 export type ServiceTier = "fast" | "default";
 export type ExecutionInputSource = "explicit" | "client-preference";
 

--- a/packages/domain/src/reasoning-efforts.ts
+++ b/packages/domain/src/reasoning-efforts.ts
@@ -29,6 +29,10 @@ export const MAX_REASONING_EFFORT: ModelReasoningEffort = {
   reasoningEffort: "max",
   description: "Maximum reasoning effort",
 };
+export const ULTRA_REASONING_EFFORT: ModelReasoningEffort = {
+  reasoningEffort: "ultra",
+  description: "Maximum reasoning with automatic task delegation",
+};
 
 export const ALL_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
   LOW_REASONING_EFFORT,
@@ -37,6 +41,7 @@ export const ALL_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
   XHIGH_REASONING_EFFORT,
   ULTRACODE_REASONING_EFFORT,
   MAX_REASONING_EFFORT,
+  ULTRA_REASONING_EFFORT,
 ];
 
 const REASONING_EFFORT_BY_LEVEL: Record<ReasoningLevel, ModelReasoningEffort> =
@@ -48,6 +53,7 @@ const REASONING_EFFORT_BY_LEVEL: Record<ReasoningLevel, ModelReasoningEffort> =
     xhigh: XHIGH_REASONING_EFFORT,
     ultracode: ULTRACODE_REASONING_EFFORT,
     max: MAX_REASONING_EFFORT,
+    ultra: ULTRA_REASONING_EFFORT,
   };
 
 // Expands coarse reasoning levels into the descriptive picker entries above.

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -7,6 +7,8 @@ import { z } from "zod";
  * "ultracode" sits between "xhigh" and "max" because its underlying effort IS
  * xhigh (plus standing workflow orchestration) — a model without ultracode
  * support should reconcile down to xhigh, not up to max.
+ * "ultra" is a Codex-native top tier (max effort plus automatic task
+ * delegation) exposed only by some models; it ranks above "max".
  */
 export const reasoningLevelValues = [
   "none",
@@ -16,6 +18,7 @@ export const reasoningLevelValues = [
   "xhigh",
   "ultracode",
   "max",
+  "ultra",
 ] as const;
 export const reasoningLevelSchema = z.enum(reasoningLevelValues);
 export type ReasoningLevel = z.infer<typeof reasoningLevelSchema>;

--- a/packages/domain/test/reasoning-level.test.ts
+++ b/packages/domain/test/reasoning-level.test.ts
@@ -22,6 +22,12 @@ describe("reconcileReasoningLevel", () => {
     ).toBe("ultracode");
   });
 
+  it("reconciles ultra down toward max when ultra is unavailable", () => {
+    expect(
+      reconcileReasoningLevel("ultra", ["low", "medium", "high", "xhigh", "max"]),
+    ).toBe("max");
+  });
+
 
   it("keeps the previous level when the new model supports it", () => {
     expect(


### PR DESCRIPTION
## Summary
- Soft-parse Codex `model/list` so unknown efforts/malformed entries no longer fail the entire picker.
- Add first-class `ultra` reasoning level (label **Ultra**) distinct from Claude's `ultracode`.
- Pass `max` and `ultra` through to Codex `model_reasoning_effort`; update Codex fallback ladder and UI labels.

## Context
Codex CLI 0.144 started returning `max` and `ultra` on newer models. BB's parser only accepted `low|medium|high|xhigh`, which threw `Invalid response from codex model/list` and blocked all Codex model loading.

## Test plan
- [x] Unit tests for soft parsing, ultra/max mapping (`models.test.ts`, adapter tests)
- [x] Domain reconcile test for ultra → max
- [x] Agent-providers catalog + server execution-options tests
- [x] Typecheck: domain, agent-runtime, agent-providers, app, server, cli
- [ ] Manually: open Codex model picker and confirm models load with Ultra where supported