### PR TITLE
Add 0.0.29 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## 0.0.29
+
+This release expands agent and model support, introduces a redesigned Settings experience, and includes workflow improvements and reliability fixes across bb.
+
+### More agents, models, and skills
+
+- Added support for Grok Build and Hermes Agent.
+- Codex now supports 5.6-Sol, Terra, and Luna.
+- Skills and `/` autocomplete now work across Pi and ACP providers, including OpenCode, omp, Grok, Hermes, Cursor, and custom ACP agents.
+- Side chats can now use a different model, reasoning level, or service tier while remaining safely read-only.
+
+### Redesigned Settings
+
+- Settings now uses dedicated pages with sidebar navigation.
+- Choose which microphone bb uses for voice input.
+- Manually check for updates from Settings → Updates.
+- On macOS, enable Caffeinate to keep the machine awake while bb is running.
+- Discord and GitHub links now live under Settings → Community.
+
+### Workflow improvements
+
+- Right-click local file links to open them in a specific editor, choose a preview, or copy the file name or path.
+- Queued messages now render mention pills correctly.
+- `bb thread archive` now also archives child threads and side chats.
+- `bb thread wait` now waits up to 20 minutes by default, better matching real agent workloads.
+- Agent shells more reliably use the correct workspace-managed `bb` CLI.
+
+### Fixes and polish
+
+- Fixed the app becoming unresponsive after creating, renaming, or removing a folder from a sidebar menu.
+- Fixed manually marked unread threads remaining unread after reopening.
+- Fixed sidebar alignment in macOS fullscreen mode.
+- Fixed clipped focus rings in the composer toolbar.
+- Simplified thread-row cursors and removed the terminal-count badge from the right-panel toggle.
+- Renamed the sidebar feedback action to “Report a bug.”
+
+### Experiments
+
+New experiment to let you connect to bb from other computers.


### PR DESCRIPTION
## Summary

- add a user-facing changelog for bb 0.0.29
- highlight new agents and Codex models, Settings improvements, workflow updates, and fixes
- keep bb Connect remote access framed as an experiment

## Testing

- `git diff --check`