### PR TITLE
Grant desktop microphone audio input

### DIFF
--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>

--- a/apps/desktop/test/electron-builder-config.test.ts
+++ b/apps/desktop/test/electron-builder-config.test.ts
@@ -81,6 +81,8 @@ const signingEnvironmentKeys = [
   "CSC_LINK",
   "CSC_NAME",
 ];
+const audioInputEntitlementPattern =
+  /<key>com\.apple\.security\.device\.audio-input<\/key>\s*<true\s*\/>/u;
 
 type ElectronBuilderConfig = z.infer<typeof electronBuilderConfigSchema>;
 type EnvironmentOverrides = Record<string, string | undefined>;
@@ -345,6 +347,27 @@ describe("electron-builder signing config", () => {
     await expect(
       access(resolve(desktopPackageRoot, config.mac.entitlementsInherit)),
     ).resolves.toBeUndefined();
+  });
+
+  it("grants audio input to the signed app and helper processes", async () => {
+    const configText = await readFile(
+      resolve(desktopPackageRoot, "electron-builder.config.json"),
+      "utf8",
+    );
+    const config = electronBuilderConfigSchema.parse(JSON.parse(configText));
+    const entitlementPaths = [
+      config.mac.entitlements,
+      config.mac.entitlementsInherit,
+    ];
+
+    for (const entitlementPath of entitlementPaths) {
+      const entitlements = await readFile(
+        resolve(desktopPackageRoot, entitlementPath),
+        "utf8",
+      );
+
+      expect(entitlements).toMatch(audioInputEntitlementPattern);
+    }
   });
 
   it("keeps the updater provider pointed at desktop-latest release assets", async () => {


### PR DESCRIPTION
## What changed

- grant `com.apple.security.device.audio-input` to the signed desktop app
- grant the same capability to Electron helper processes
- add regression coverage for both checked-in entitlement files

## Why

The signed and notarized desktop app uses Hardened Runtime but did not declare Apple's audio-input entitlement. Chromium could enumerate microphones and return live-looking tracks, while every captured audio sample was zero. Direct Core Audio capture from the same Yeti microphone contained a real signal, isolating the failure to the packaged app's signing capabilities.

This restores actual microphone samples for both the system default and explicitly selected input devices.

## Validation

- `plutil -lint apps/desktop/build/entitlements.mac.plist apps/desktop/build/entitlements.mac.inherit.plist`
- `pnpm exec turbo run test --filter=@bb/desktop -- test/electron-builder-config.test.ts` (14 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/desktop`
