### PR TITLE
Fix bb connect dev WebSockets

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -33,7 +33,12 @@
       href="/apple-touch-icon.png"
       id="apple-touch-icon"
     />
-    <link rel="manifest" href="/manifest.webmanifest" id="app-manifest" />
+    <link
+      rel="manifest"
+      href="/manifest.webmanifest"
+      id="app-manifest"
+      crossorigin="use-credentials"
+    />
     <script>
       (function () {
         var dev = "%MODE%" === "development";

--- a/apps/app/src/lib/dev-websocket-url.test.ts
+++ b/apps/app/src/lib/dev-websocket-url.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildDevWebSocketUrl } from "./dev-websocket-url";
+
+function installWindowLocation(url: string): void {
+  const location = new URL(url);
+  vi.stubGlobal("window", {
+    location: {
+      host: location.host,
+      hostname: location.hostname,
+      protocol: location.protocol,
+    },
+  });
+}
+
+describe("buildDevWebSocketUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("connects directly to the backend for HTTP source dev", () => {
+    vi.stubGlobal("__BB_DEV_WS_BROWSER_HOST_PORT__", 23_802);
+    installWindowLocation("http://devbox.local:15802/threads/thr_1");
+
+    expect(buildDevWebSocketUrl({ path: "/ws" })).toBe(
+      "ws://devbox.local:23802/ws",
+    );
+  });
+
+  it("uses the proxied app origin for HTTPS bb connect shares", () => {
+    vi.stubGlobal("__BB_DEV_WS_BROWSER_HOST_PORT__", 23_802);
+    installWindowLocation(
+      "https://sawyer--15802.getbb.app/threads/thr_jew2ruik89",
+    );
+
+    expect(buildDevWebSocketUrl({ path: "/ws" })).toBe(
+      "wss://sawyer--15802.getbb.app/ws",
+    );
+  });
+
+  it("preserves terminal websocket paths on the proxied app origin", () => {
+    vi.stubGlobal("__BB_DEV_WS_BROWSER_HOST_PORT__", 23_802);
+    installWindowLocation("https://dev.example.test:15802/threads/thr_1");
+
+    expect(
+      buildDevWebSocketUrl({ path: "/ws/terminals/term_1" }),
+    ).toBe("wss://dev.example.test:15802/ws/terminals/term_1");
+  });
+
+  it("returns undefined outside the dev build", () => {
+    installWindowLocation("https://app.example.test/threads/thr_1");
+
+    expect(buildDevWebSocketUrl({ path: "/ws" })).toBeUndefined();
+  });
+});

--- a/apps/app/src/lib/dev-websocket-url.ts
+++ b/apps/app/src/lib/dev-websocket-url.ts
@@ -4,6 +4,16 @@ interface BuildDevWebSocketUrlArgs {
 
 function resolveBrowserHostDevWebSocketBaseUrl(port: number): string {
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+
+  // HTTPS dev origins are typically reverse proxies or bb connect shares.
+  // Their public origin does not expose the backend's local TCP port, so keep
+  // the socket on the app origin and let Vite proxy /ws to the server.
+  if (window.location.protocol === "https:") {
+    return `${protocol}//${window.location.host}/ws`;
+  }
+
+  // Direct sockets remain preferable for ordinary localhost/LAN source dev:
+  // they survive backend restarts more reliably than Vite's WS proxy.
   return `${protocol}//${window.location.hostname}:${port}/ws`;
 }
 

--- a/apps/app/vite.dev.config.ts
+++ b/apps/app/vite.dev.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
         target: viteDevConfig.serverHttpOrigin,
         changeOrigin: true,
       },
+      "/ws": {
+        target: viteDevConfig.serverHttpOrigin,
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- proxy dev realtime and terminal WebSockets through Vite for HTTPS origins such as bb connect shares
- preserve direct backend sockets for ordinary HTTP localhost and LAN source development
- send credentials when loading the owner-gated web app manifest
- add regression coverage for direct, proxied, terminal, and production URL behavior

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force` (1373 tests)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings)
- live WebSocket opened through the Vite app port and reached the bb server