### PR TITLE
Match Automations icon to sidebar theme

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -55,7 +55,13 @@ The manifest is `package.json`:
   at the root (same precedence), or `bb.logoDark` (same rules) — is
   preferred whenever the app is in dark mode, falling back to the light
   logo. Without a logo, contributions fall back to their named `icon` hint
-  or a generic bolt. Picked up on `bb plugin reload`.
+  or a generic bolt. Picked up on `bb plugin reload`. Inline icons must use
+  `currentColor` for their stroke/fill and take their color from semantic
+  text-token classes; never hardcode gray or palette values. An SVG loaded
+  through `<img>` cannot inherit `currentColor`, so omit the logo and use a
+  named `icon` hint when a monochrome glyph should match the surrounding bb
+  chrome. Reserve logo assets for intentionally branded artwork (and provide
+  a dark variant when needed).
 - `engines.bb` — semver range checked against the bb version at load.
 - The plugin id is the package name minus the `bb-plugin-` prefix
   (`bb-plugin-hello` → `hello`); it namespaces routes, storage, settings,

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -294,6 +294,8 @@ describe("bb-plugin-authoring skill", () => {
     expect(skill).toContain("bb.logo");
     expect(skill).toContain("logo-dark.svg");
     expect(skill).toContain("bb.logoDark");
+    expect(skill).toContain("currentColor");
+    expect(skill).toContain("named `icon` hint");
   });
 
   it("documents every frontend slot and its prop fields", () => {

--- a/plugins/automations/logo-dark.svg
+++ b/plugins/automations/logo-dark.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#a1a1aa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>

--- a/plugins/automations/logo.svg
+++ b/plugins/automations/logo.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#52525b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>


### PR DESCRIPTION
## Summary

- use the host Clock icon for Automations so it inherits sidebar theme colors
- document currentColor guidance and the logo SVG limitation in the plugin-authoring skill
- guard the authoring guidance with a documentation test

## Tests

- pnpm exec turbo run test --filter=@bb/app --force -- src/components/plugin/PluginIcon.test.tsx src/components/plugin/plugin-slot-mounts.test.tsx
- pnpm exec turbo run test --filter=@bb/server --force -- test/services/plugins/plugin-authoring-docs.test.ts