### PR TITLE
Render Codex subagent activity as nested delegations

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -3611,6 +3611,223 @@ describe("codex provider adapter", () => {
     );
   });
 
+  it("materializes Codex subagent activity as a nested delegation lifecycle", () => {
+    const adapter = createCodexProviderAdapter();
+
+    expect(
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: "subagent-call-1",
+            kind: "started",
+            agentThreadId: "agent-thread-1",
+            agentPath: "/root/audit_do_browser",
+          },
+        },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        type: "item/started",
+        threadId: "root-provider-thread",
+        providerThreadId: "root-provider-thread",
+        scope: turnScope("parent-turn"),
+        item: expect.objectContaining({
+          type: "toolCall",
+          id: "subagent-call-1",
+          tool: "spawnAgent",
+          status: "pending",
+          arguments: {
+            senderThreadId: "root-provider-thread",
+            receiverThreadIds: ["agent-thread-1"],
+            description: "/root/audit_do_browser",
+          },
+        }),
+      }),
+    ]);
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "child-turn-1",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("child-turn-1"),
+        parentToolCallId: "subagent-call-1",
+      }),
+    );
+
+    expect(
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: "interaction-1",
+            kind: "interacted",
+            agentThreadId: "agent-thread-1",
+            agentPath: "/root/audit_do_browser",
+          },
+        },
+      }),
+    ).toEqual([]);
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("item/completed", {
+          threadId: "root-provider-thread",
+          turnId: "child-turn-1",
+          completedAtMs: 0,
+          item: {
+            type: "agentMessage",
+            id: "child-message-1",
+            text: "Audit complete.",
+            phase: null,
+            memoryCitation: null,
+          },
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          id: "child-message-1",
+          parentToolCallId: "subagent-call-1",
+        }),
+      }),
+    );
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/completed", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "child-turn-1",
+            status: "completed",
+            error: null,
+          }),
+        }),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("child-turn-1"),
+      }),
+      expect.objectContaining({
+        type: "item/completed",
+        scope: turnScope("parent-turn"),
+        item: expect.objectContaining({
+          type: "toolCall",
+          id: "subagent-call-1",
+          tool: "spawnAgent",
+          status: "completed",
+        }),
+      }),
+    ]);
+  });
+
+  it("links concurrent Codex subagents to child turns in activity order", () => {
+    const adapter = createCodexProviderAdapter();
+
+    for (const index of [1, 2]) {
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: `subagent-call-${index}`,
+            kind: "started",
+            agentThreadId: `agent-thread-${index}`,
+            agentPath: `/root/agent_${index}`,
+          },
+        },
+      });
+    }
+
+    for (const index of [1, 2]) {
+      expect(
+        adapter.translateEvent(
+          codexEvent("turn/started", {
+            threadId: "root-provider-thread",
+            turn: codexTurn({
+              id: `child-turn-${index}`,
+              status: "inProgress",
+              error: null,
+            }),
+          }),
+        ),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "turn/started",
+          scope: turnScope(`child-turn-${index}`),
+          parentToolCallId: `subagent-call-${index}`,
+        }),
+      );
+    }
+  });
+
+  it("terminalizes an open Codex subagent when activity is interrupted", () => {
+    const adapter = createCodexProviderAdapter();
+    const startedActivity = {
+      jsonrpc: "2.0" as const,
+      method: "item/completed",
+      params: {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-call-1",
+          kind: "started",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/audit",
+        },
+      },
+    };
+    adapter.translateEvent(startedActivity);
+
+    const interruptedEvents = adapter.translateEvent({
+      ...startedActivity,
+      params: {
+        ...startedActivity.params,
+        item: {
+          ...startedActivity.params.item,
+          id: "interrupt-activity-1",
+          kind: "interrupted",
+        },
+      },
+    });
+    expect(interruptedEvents).toEqual([
+      expect.objectContaining({
+        type: "item/completed",
+        scope: turnScope("parent-turn"),
+        item: expect.objectContaining({
+          id: "subagent-call-1",
+          status: "interrupted",
+        }),
+      }),
+    ]);
+
+    expect(adapter.translateEvent(startedActivity)).toHaveLength(0);
+  });
+
   it.each(["spawnAgent", "resumeAgent"] as const)(
     "stamps pending same-provider child turn events for %s",
     (tool) => {

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -74,6 +74,12 @@ import {
   codexRawResponseItemCompletedParamsSchema,
   codexThreadClosedParamsSchema,
 } from "./schemas.js";
+import {
+  buildCodexSubAgentCompletedEvent,
+  buildCodexSubAgentStartedEvent,
+  parseCodexSubAgentActivityEvent,
+  type CodexTrackedSubAgent,
+} from "./subagent-activity-translation.js";
 
 interface CodexPermissionSettings {
   approvalPolicy: AskForApproval;
@@ -1110,6 +1116,8 @@ export function createCodexProviderAdapter(
     CodexPendingDelegationTurnLink[]
   >();
   const pendingDelegationCallIds = new Set<string>();
+  const trackedSubAgentsByCallId = new Map<string, CodexTrackedSubAgent>();
+  const trackedSubAgentCallIdsByAgentThreadId = new Map<string, string>();
 
   function stageThreadGitWritableRoots(
     args: RecordThreadGitWritableRootsArgs,
@@ -1241,6 +1249,16 @@ export function createCodexProviderAdapter(
   function clearCodexDelegationParentState(providerThreadId: string): void {
     delegationParentToolCallIdsByProviderThreadId.delete(providerThreadId);
     pendingDelegationTurnLinksByProviderThreadId.delete(providerThreadId);
+    for (const [callId, tracked] of trackedSubAgentsByCallId) {
+      if (
+        tracked.parentProviderThreadId !== providerThreadId &&
+        tracked.agentThreadId !== providerThreadId
+      ) {
+        continue;
+      }
+      clearTrackedSubAgentLinks(tracked);
+      trackedSubAgentsByCallId.delete(callId);
+    }
   }
 
   function queueNativeTurnStartClientRequestId(args: {
@@ -1393,6 +1411,53 @@ export function createCodexProviderAdapter(
     pendingDelegationCallIds.add(args.callId);
   }
 
+  function removePendingDelegationCall(callId: string): void {
+    pendingDelegationCallIds.delete(callId);
+    for (const [
+      providerThreadId,
+      pendingLinks,
+    ] of pendingDelegationTurnLinksByProviderThreadId) {
+      const remainingLinks = pendingLinks.filter(
+        (pendingLink) => pendingLink.callId !== callId,
+      );
+      if (remainingLinks.length === 0) {
+        pendingDelegationTurnLinksByProviderThreadId.delete(providerThreadId);
+      } else if (remainingLinks.length !== pendingLinks.length) {
+        pendingDelegationTurnLinksByProviderThreadId.set(
+          providerThreadId,
+          remainingLinks,
+        );
+      }
+    }
+  }
+
+  function clearTrackedSubAgentLinks(tracked: CodexTrackedSubAgent): void {
+    removePendingDelegationCall(tracked.callId);
+    if (
+      trackedSubAgentCallIdsByAgentThreadId.get(tracked.agentThreadId) ===
+      tracked.callId
+    ) {
+      trackedSubAgentCallIdsByAgentThreadId.delete(tracked.agentThreadId);
+    }
+    if (
+      delegationParentToolCallIdsByProviderThreadId.get(
+        tracked.agentThreadId,
+      ) === tracked.callId
+    ) {
+      delegationParentToolCallIdsByProviderThreadId.delete(
+        tracked.agentThreadId,
+      );
+    }
+    for (const [
+      turnId,
+      parentToolCallId,
+    ] of delegationParentToolCallIdsByTurnId) {
+      if (parentToolCallId === tracked.callId) {
+        delegationParentToolCallIdsByTurnId.delete(turnId);
+      }
+    }
+  }
+
   function consumePendingDelegationTurnLink(args: {
     providerThreadId: string | undefined;
     turnId: string;
@@ -1513,6 +1578,116 @@ export function createCodexProviderAdapter(
       observeCodexDelegationToolCall(parentLinkedEvent);
       return parentLinkedEvent;
     });
+  }
+
+  function completeCodexTrackedSubAgent(args: {
+    status: "completed" | "failed" | "interrupted";
+    tracked: CodexTrackedSubAgent;
+  }): ThreadEvent | null {
+    if (args.tracked.terminal) {
+      return null;
+    }
+    args.tracked.terminal = true;
+    clearTrackedSubAgentLinks(args.tracked);
+    return buildCodexSubAgentCompletedEvent(args);
+  }
+
+  function translateCodexSubAgentActivity(
+    event: ProviderRuntimeEvent,
+  ): ThreadEvent[] | null {
+    const activity = parseCodexSubAgentActivityEvent(event);
+    if (!activity) {
+      return null;
+    }
+
+    switch (activity.item.kind) {
+      case "started": {
+        if (trackedSubAgentsByCallId.has(activity.item.id)) {
+          return [];
+        }
+        const tracked: CodexTrackedSubAgent = {
+          agentPath: activity.item.agentPath,
+          agentThreadId: activity.item.agentThreadId,
+          callId: activity.item.id,
+          parentProviderThreadId: activity.providerThreadId,
+          parentTurnId: activity.turnId,
+          terminal: false,
+        };
+        trackedSubAgentsByCallId.set(tracked.callId, tracked);
+        trackedSubAgentCallIdsByAgentThreadId.set(
+          tracked.agentThreadId,
+          tracked.callId,
+        );
+
+        const [startedEvent] = attachCodexDelegationParentLinks([
+          buildCodexSubAgentStartedEvent(tracked),
+        ]);
+        if (
+          startedEvent?.type === "item/started" &&
+          startedEvent.item.type === "toolCall"
+        ) {
+          tracked.parentToolCallId = startedEvent.item.parentToolCallId;
+        }
+        // Codex currently multiplexes child turns onto the root provider
+        // thread, even though the activity includes a distinct agent thread
+        // id. Queue a FIFO fallback in addition to the explicit id mapping.
+        enqueuePendingDelegationTurnLink({
+          callId: tracked.callId,
+          parentTurnId: tracked.parentTurnId,
+          providerThreadId: tracked.parentProviderThreadId,
+        });
+        return startedEvent ? [startedEvent] : [];
+      }
+      case "interacted":
+        // Messaging an existing agent is activity within the original
+        // delegation, not a new timeline row.
+        return [];
+      case "interrupted": {
+        const callId = trackedSubAgentCallIdsByAgentThreadId.get(
+          activity.item.agentThreadId,
+        );
+        const tracked = callId
+          ? trackedSubAgentsByCallId.get(callId)
+          : undefined;
+        if (!tracked) {
+          return [];
+        }
+        const completed = completeCodexTrackedSubAgent({
+          tracked,
+          status: "interrupted",
+        });
+        return completed ? [completed] : [];
+      }
+    }
+  }
+
+  function completeFinishedCodexSubAgentTurns(
+    events: ThreadEvent[],
+  ): ThreadEvent[] {
+    const completedEvents: ThreadEvent[] = [];
+    for (const event of events) {
+      completedEvents.push(event);
+      if (event.type !== "turn/completed") {
+        continue;
+      }
+      const turnId = requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      });
+      const callId = delegationParentToolCallIdsByTurnId.get(turnId);
+      const tracked = callId ? trackedSubAgentsByCallId.get(callId) : undefined;
+      if (!tracked) {
+        continue;
+      }
+      const completed = completeCodexTrackedSubAgent({
+        tracked,
+        status: event.status,
+      });
+      if (completed) {
+        completedEvents.push(completed);
+      }
+    }
+    return completedEvents;
   }
 
   function consumeCodexRawResponseItem(event: ProviderRuntimeEvent): boolean {
@@ -1891,13 +2066,21 @@ export function createCodexProviderAdapter(
         return [];
       }
 
+      const subAgentActivityEvents = translateCodexSubAgentActivity(event);
+      if (subAgentActivityEvents !== null) {
+        reconcileRawCommandOutputLifecycle(subAgentActivityEvents);
+        return applyRecoveredCommandOutput(subAgentActivityEvents);
+      }
+
       const translatedEvents = translateCodexEvent(event).flatMap(
         attachAcceptedUserMessageCorrelation,
       );
       const parentLinkedEvents =
         attachCodexDelegationParentLinks(translatedEvents);
-      reconcileRawCommandOutputLifecycle(parentLinkedEvents);
-      return applyRecoveredCommandOutput(parentLinkedEvents);
+      const completedSubAgentEvents =
+        completeFinishedCodexSubAgentTurns(parentLinkedEvents);
+      reconcileRawCommandOutputLifecycle(completedSubAgentEvents);
+      return applyRecoveredCommandOutput(completedSubAgentEvents);
     },
 
     translateAcceptedCommand({ command, providerThreadId }) {

--- a/packages/agent-runtime/src/codex/event-translation.ts
+++ b/packages/agent-runtime/src/codex/event-translation.ts
@@ -521,6 +521,10 @@ function translateCodexItem(
           result: parsedItem.agentsStates,
         },
       };
+    case "subAgentActivity":
+      // The adapter translates this statefully so it can correlate the
+      // activity with the child turn and close the synthetic delegation row.
+      return { kind: "ignored" };
     case "webSearch": {
       if (shouldIgnoreCodexWebItem(parsedItem)) {
         return { kind: "ignored" };

--- a/packages/agent-runtime/src/codex/schemas.ts
+++ b/packages/agent-runtime/src/codex/schemas.ts
@@ -333,6 +333,19 @@ const codexThreadItemEnvelopeSchema = z
   })
   .passthrough();
 
+export const codexSubAgentActivityItemSchema = z
+  .object({
+    type: z.literal("subAgentActivity"),
+    id: z.string(),
+    kind: z.enum(["started", "interacted", "interrupted"]),
+    agentThreadId: z.string(),
+    agentPath: z.string(),
+  })
+  .passthrough();
+export type CodexSubAgentActivityItem = z.infer<
+  typeof codexSubAgentActivityItemSchema
+>;
+
 export const codexHandledThreadItemSchema = z.discriminatedUnion("type", [
   z
     .object({
@@ -412,6 +425,7 @@ export const codexHandledThreadItemSchema = z.discriminatedUnion("type", [
       agentsStates: z.record(z.string(), z.unknown()),
     })
     .passthrough(),
+  codexSubAgentActivityItemSchema,
   z
     .object({
       type: z.literal("webSearch"),

--- a/packages/agent-runtime/src/codex/subagent-activity-translation.ts
+++ b/packages/agent-runtime/src/codex/subagent-activity-translation.ts
@@ -1,0 +1,109 @@
+import type {
+  ThreadEvent,
+  ThreadEventItem,
+  ThreadEventItemStatus,
+} from "@bb/domain";
+import { turnScope } from "@bb/domain";
+import type { ProviderRuntimeEvent } from "../runtime-json-rpc.js";
+import {
+  codexBridgeEnvelopeSchema,
+  codexSubAgentActivityItemSchema,
+  type CodexSubAgentActivityItem,
+} from "./schemas.js";
+
+export interface CodexSubAgentActivityEvent {
+  item: CodexSubAgentActivityItem;
+  providerThreadId: string;
+  turnId: string;
+}
+
+export interface CodexTrackedSubAgent {
+  agentPath: string;
+  agentThreadId: string;
+  callId: string;
+  parentProviderThreadId: string;
+  parentToolCallId?: string;
+  parentTurnId: string;
+  terminal: boolean;
+}
+
+export function parseCodexSubAgentActivityEvent(
+  event: ProviderRuntimeEvent,
+): CodexSubAgentActivityEvent | null {
+  const envelope = codexBridgeEnvelopeSchema.safeParse(event);
+  if (!envelope.success || envelope.data.method !== "item/completed") {
+    return null;
+  }
+
+  const params = envelope.data.params;
+  if (!params) {
+    return null;
+  }
+  const item = codexSubAgentActivityItemSchema.safeParse(params.item);
+  if (
+    !item.success ||
+    typeof params.threadId !== "string" ||
+    typeof params.turnId !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    item: item.data,
+    providerThreadId: params.threadId,
+    turnId: params.turnId,
+  };
+}
+
+function buildSubAgentToolCallItem(
+  tracked: CodexTrackedSubAgent,
+  status: ThreadEventItemStatus,
+): Extract<ThreadEventItem, { type: "toolCall" }> {
+  return {
+    type: "toolCall",
+    id: tracked.callId,
+    tool: "spawnAgent",
+    arguments: {
+      senderThreadId: tracked.parentProviderThreadId,
+      receiverThreadIds: [tracked.agentThreadId],
+      description: tracked.agentPath,
+    },
+    status,
+    ...(tracked.parentToolCallId
+      ? { parentToolCallId: tracked.parentToolCallId }
+      : {}),
+    ...(status === "pending"
+      ? {}
+      : {
+          result: {
+            agentPath: tracked.agentPath,
+            agentThreadId: tracked.agentThreadId,
+          },
+        }),
+  };
+}
+
+export function buildCodexSubAgentStartedEvent(
+  tracked: CodexTrackedSubAgent,
+): ThreadEvent {
+  return {
+    type: "item/started",
+    threadId: tracked.parentProviderThreadId,
+    providerThreadId: tracked.parentProviderThreadId,
+    scope: turnScope(tracked.parentTurnId),
+    item: buildSubAgentToolCallItem(tracked, "pending"),
+  };
+}
+
+export function buildCodexSubAgentCompletedEvent(args: {
+  status: Exclude<ThreadEventItemStatus, "pending">;
+  tracked: CodexTrackedSubAgent;
+}): ThreadEvent {
+  return {
+    type: "item/completed",
+    threadId: args.tracked.parentProviderThreadId,
+    providerThreadId: args.tracked.parentProviderThreadId,
+    scope: turnScope(args.tracked.parentTurnId),
+    item: buildSubAgentToolCallItem(args.tracked, args.status),
+  };
+}


### PR DESCRIPTION
## Summary

- Parse Codex `subAgentActivity` notifications at the provider boundary.
- Materialize stable `spawnAgent` lifecycles and link multiplexed child turns beneath them.
- Ignore interaction noise and terminalize delegation rows on completion or interruption.

## Verification

- `pnpm exec turbo run test --filter=@bb/agent-runtime` (766 tests)
- `pnpm exec turbo run test --filter=@bb/thread-view -- test/timeline-cli-rendering.snapshots.test.ts` (41 tests)
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/thread-view`
- `pnpm exec turbo run build --filter=@bb/host-daemon`
- Live MultiAgentV2 replay: 3 starts, 3 matching completions, 3 linked child turns, 26 nested child items, 0 unhandled events.

## Notes

- This fixes new event ingestion; previously persisted `provider/unhandled` events are not rewritten.