### PR TITLE
Simplify sidebar organization and folder handling

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -76,6 +76,13 @@
     outline: 2px solid var(--ring);
     outline-offset: 1px;
   }
+
+  /* Keep the drag cursor stable while crossing rows whose normal pointer
+   * cursor would otherwise override the cursor inherited from the body. */
+  body[data-sidebar-dragging="true"],
+  body[data-sidebar-dragging="true"] * {
+    cursor: grabbing !important;
+  }
 }
 
 @layer components {

--- a/apps/app/src/components/dialogs/ThreadFolderCreateDialog.tsx
+++ b/apps/app/src/components/dialogs/ThreadFolderCreateDialog.tsx
@@ -9,7 +9,6 @@ import {
   DialogTitle,
 } from "@bb/shared-ui/dialog";
 import { Input } from "@bb/shared-ui/input";
-import { normalizeFolderName } from "@/components/sidebar/folderKeys";
 import { useNameValidation } from "./useNameValidation.js";
 import { useRenameDialogAutoFocus } from "./useRenameDialogAutoFocus.js";
 
@@ -118,9 +117,6 @@ function ThreadFolderDialogContent({
 }: ThreadFolderDialogContentProps) {
   const inputId = useId();
   const [name, setName] = useState(initialName);
-  const [folderNameMessage, setFolderNameMessage] = useState<string | null>(
-    null,
-  );
   const [hiddenErrorMessage, setHiddenErrorMessage] = useState<string | null>(
     null,
   );
@@ -134,19 +130,13 @@ function ThreadFolderDialogContent({
 
     const trimmedName = validate(name);
     if (trimmedName === null) return;
-    const normalizedName = normalizeFolderName(trimmedName);
-    if (normalizedName === null) {
-      setFolderNameMessage("Folder name cannot be empty.");
-      return;
-    }
 
     setHiddenErrorMessage(null);
-    onSubmit(normalizedName);
+    onSubmit(trimmedName);
   };
   const displayedServerMessage =
     errorMessage && hiddenErrorMessage !== errorMessage ? errorMessage : null;
-  const displayedMessage =
-    validationMessage ?? folderNameMessage ?? displayedServerMessage;
+  const displayedMessage = validationMessage ?? displayedServerMessage;
 
   return (
     <>
@@ -167,7 +157,6 @@ function ThreadFolderDialogContent({
             disabled={pending}
             onChange={(event) => {
               setName(event.target.value);
-              setFolderNameMessage(null);
               setHiddenErrorMessage(errorMessage ?? null);
               clearMessage();
             }}

--- a/apps/app/src/components/sidebar/FolderGrouping.stories.tsx
+++ b/apps/app/src/components/sidebar/FolderGrouping.stories.tsx
@@ -9,7 +9,7 @@ import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider
 import { SidebarStickyStack } from "@/components/ui/sidebar.js";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import {
-  ChronologicalThreadTree,
+  ChronologicalFolderThreadSections,
   type ProjectThreadListState,
 } from "./ProjectRow";
 import {
@@ -133,7 +133,7 @@ export function ChronologicalFolders() {
         hint="stored folderId groups matching threads across projects"
       >
         <SidebarStage>
-          <ChronologicalThreadTree
+          <ChronologicalFolderThreadSections
             threadListState={projectTree(folderThreads)}
             compareThreads={compareStandardThreads}
             folders={STORY_FOLDERS}
@@ -141,6 +141,9 @@ export function ChronologicalFolders() {
             collapsedEnvironmentIds={new Set()}
             onToggleThreadCollapsed={noop}
             onToggleEnvironmentCollapsed={noop}
+            renderAllThreadsSection={(content) => content}
+            renderFoldersSection={(content) => content}
+            renderThreadsSection={(content) => content}
           />
         </SidebarStage>
       </StoryRow>

--- a/apps/app/src/components/sidebar/PinnedThreadTree.tsx
+++ b/apps/app/src/components/sidebar/PinnedThreadTree.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, type CSSProperties } from "react";
 import { DndContext } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -6,7 +6,10 @@ import {
 } from "@dnd-kit/sortable";
 import type { NeighborReorderRequest } from "@/lib/neighbor-reorder";
 import { ThreadTreeNodeRow } from "./ProjectRow";
-import { useSidebarSortable } from "./sortableMotion";
+import {
+  useSidebarSortable,
+  type SidebarSortableDragBindings,
+} from "./sortableMotion";
 import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
 import type { ProjectThreadNode } from "./projectThreadGroups";
 import {
@@ -14,7 +17,7 @@ import {
   type UseNeighborReorderSortableArgs,
 } from "./useNeighborReorderSortable";
 
-export interface PinnedThreadRootReorderCallbacks {
+interface PinnedThreadRootReorderCallbacks {
   onSettled: () => void;
 }
 
@@ -49,6 +52,9 @@ interface PinnedRootItemProps extends Omit<
   "disabled"
 > {
   consumeClickSuppression?: () => boolean;
+  dragBindings?: SidebarSortableDragBindings;
+  sortableRef?: (element: HTMLDivElement | null) => void;
+  sortableStyle?: CSSProperties;
 }
 
 function getPinnedRootNodeId(node: ProjectThreadNode): string {
@@ -59,11 +65,14 @@ const PinnedRootItem = memo(function PinnedRootItem({
   collapsedEnvironmentIds,
   collapsedThreadIds,
   consumeClickSuppression,
+  dragBindings,
   node,
   onProjectSelect,
   onToggleEnvironmentCollapsed,
   onToggleThreadCollapsed,
   selectedThreadId,
+  sortableRef,
+  sortableStyle,
 }: PinnedRootItemProps) {
   return (
     <ThreadTreeNodeRow
@@ -79,19 +88,17 @@ const PinnedRootItem = memo(function PinnedRootItem({
       onToggleThreadCollapsed={onToggleThreadCollapsed}
       onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
       consumeClickSuppression={consumeClickSuppression}
+      dragBindings={dragBindings}
+      sortableRef={sortableRef}
+      sortableStyle={sortableStyle}
     />
   );
 });
 
 const SortablePinnedRootItem = memo(function SortablePinnedRootItem({
-  collapsedEnvironmentIds,
-  collapsedThreadIds,
   disabled,
   node,
-  onProjectSelect,
-  onToggleEnvironmentCollapsed,
-  onToggleThreadCollapsed,
-  selectedThreadId,
+  ...props
 }: SortablePinnedRootItemProps) {
   const { dragBindings, setNodeRef, style } = useSidebarSortable({
     id: getPinnedRootNodeId(node),
@@ -99,18 +106,9 @@ const SortablePinnedRootItem = memo(function SortablePinnedRootItem({
   });
 
   return (
-    <ThreadTreeNodeRow
-      projectId={node.thread.projectId}
+    <PinnedRootItem
+      {...props}
       node={node}
-      depthOffset={0}
-      isEnvGrouped={false}
-      selectedThreadId={selectedThreadId}
-      collapsedThreadIds={collapsedThreadIds}
-      collapsedEnvironmentIds={collapsedEnvironmentIds}
-      variant="section"
-      onProjectSelect={onProjectSelect}
-      onToggleThreadCollapsed={onToggleThreadCollapsed}
-      onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
       dragBindings={dragBindings}
       sortableRef={setNodeRef}
       sortableStyle={style}

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -14,7 +14,7 @@ import {
   type Ref,
 } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -140,11 +140,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@bb/shared-ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
@@ -182,7 +178,7 @@ interface ProjectListProps {
   threadSearch?: SidebarThreadSearchPanelController;
 }
 
-export interface ProjectListActionButtonsProps {
+interface ProjectListActionButtonsProps {
   onNewChat?: () => void;
   threadSearch?: SidebarThreadSearchInputController;
 }
@@ -289,6 +285,11 @@ type ToggleCollapsedId = (id: string) => void;
 type ToggleCollapsedSidebarSectionId = (
   id: CollapsibleSidebarSectionId,
 ) => void;
+type OpenSidebarMenu =
+  | "projectsDisplayOptions"
+  | "threadsDisplayOptions"
+  | "allThreadsOverflow"
+  | null;
 
 interface TopLevelSidebarSectionProps {
   label: string;
@@ -715,6 +716,15 @@ interface SidebarSortMenuOptionProps {
   onToggle: (sort: SidebarChronologicalSort) => void;
 }
 
+const SIDEBAR_SORT_OPTIONS: readonly {
+  label: string;
+  sort: SidebarChronologicalSort;
+}[] = [
+  { label: "Updated at", sort: "updated" },
+  { label: "Created at", sort: "created" },
+  { label: "Alphabetical", sort: "alpha" },
+];
+
 function SidebarDisplayMenuTrigger({
   ariaLabel,
   buttonRef,
@@ -831,7 +841,9 @@ export function SidebarDisplayOptionsMenu({
   // Mirror of pinOffset for the effect cleanup below, so recording the
   // outgoing position doesn't have to re-run the effect on every pin change.
   const pinOffsetRef = useRef(pinOffset);
-  pinOffsetRef.current = pinOffset;
+  useLayoutEffect(() => {
+    pinOffsetRef.current = pinOffset;
+  }, [pinOffset]);
   useLayoutEffect(() => {
     if (!open || isCompactViewport) {
       return;
@@ -921,27 +933,15 @@ export function SidebarDisplayOptionsMenu({
         <DropdownMenuLabel className={CHROME_SECTION_LABEL_CLASS}>
           Sort by
         </DropdownMenuLabel>
-        <SidebarSortMenuOption
-          label="Updated at"
-          sort="updated"
-          selected={selectedSort === "updated"}
-          direction={sortDirection}
-          onToggle={handleSortToggle}
-        />
-        <SidebarSortMenuOption
-          label="Created at"
-          sort="created"
-          selected={selectedSort === "created"}
-          direction={sortDirection}
-          onToggle={handleSortToggle}
-        />
-        <SidebarSortMenuOption
-          label="Alphabetical"
-          sort="alpha"
-          selected={selectedSort === "alpha"}
-          direction={sortDirection}
-          onToggle={handleSortToggle}
-        />
+        {SIDEBAR_SORT_OPTIONS.map((option) => (
+          <SidebarSortMenuOption
+            key={option.sort}
+            {...option}
+            selected={selectedSort === option.sort}
+            direction={sortDirection}
+            onToggle={handleSortToggle}
+          />
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -1637,49 +1637,39 @@ function ProjectListComponent({
   const [sidebarSectionOrderList, setSidebarSectionOrderList] = useAtom(
     sidebarSectionOrderAtom,
   );
-  const [projectsDisplayOptionsMenuOpen, setProjectsDisplayOptionsMenuOpen] =
-    useState(false);
-  const [threadsDisplayOptionsMenuOpen, setThreadsDisplayOptionsMenuOpen] =
-    useState(false);
-  const [allThreadsOverflowMenuOpen, setAllThreadsOverflowMenuOpen] =
-    useState(false);
-  const handleProjectsDisplayOptionsMenuOpenChange = useCallback(
-    (open: boolean) => {
-      setProjectsDisplayOptionsMenuOpen(open);
-      if (open) {
-        setThreadsDisplayOptionsMenuOpen(false);
-        setAllThreadsOverflowMenuOpen(false);
-      }
+  const [openSidebarMenu, setOpenSidebarMenu] = useState<OpenSidebarMenu>(null);
+  const setSidebarMenuOpen = useCallback(
+    (menu: Exclude<OpenSidebarMenu, null>, open: boolean) => {
+      setOpenSidebarMenu((current) =>
+        open ? menu : current === menu ? null : current,
+      );
     },
     [],
+  );
+  const handleProjectsDisplayOptionsMenuOpenChange = useCallback(
+    (open: boolean) => setSidebarMenuOpen("projectsDisplayOptions", open),
+    [setSidebarMenuOpen],
   );
   const handleThreadsDisplayOptionsMenuOpenChange = useCallback(
-    (open: boolean) => {
-      setThreadsDisplayOptionsMenuOpen(open);
-      if (open) {
-        setProjectsDisplayOptionsMenuOpen(false);
-        setAllThreadsOverflowMenuOpen(false);
-      }
-    },
-    [],
+    (open: boolean) => setSidebarMenuOpen("threadsDisplayOptions", open),
+    [setSidebarMenuOpen],
   );
   const handleAllThreadsOverflowMenuOpenChange = useCallback(
-    (open: boolean) => {
-      setAllThreadsOverflowMenuOpen(open);
-      if (open) {
-        setProjectsDisplayOptionsMenuOpen(false);
-        setThreadsDisplayOptionsMenuOpen(false);
-      }
-    },
-    [],
+    (open: boolean) => setSidebarMenuOpen("allThreadsOverflow", open),
+    [setSidebarMenuOpen],
   );
-  const [organizationMode] = useAtom(sidebarOrganizationModeAtom);
+  const projectsDisplayOptionsMenuOpen =
+    openSidebarMenu === "projectsDisplayOptions";
+  const threadsDisplayOptionsMenuOpen =
+    openSidebarMenu === "threadsDisplayOptions";
+  const allThreadsOverflowMenuOpen = openSidebarMenu === "allThreadsOverflow";
+  const organizationMode = useAtomValue(sidebarOrganizationModeAtom);
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,
   );
-  const [sortDirection] = useAtom(sidebarSortDirectionAtom);
+  const sortDirection = useAtomValue(sidebarSortDirectionAtom);
   const isFolderOrganizationMode = organizationMode === "chronological";
-  const [, setCollapsedFolderList] = useAtom(sidebarCollapsedFoldersAtom);
+  const setCollapsedFolderList = useSetAtom(sidebarCollapsedFoldersAtom);
   const sidebarThreadComparator = useMemo<ThreadComparator>(
     () =>
       getSidebarThreadComparator({
@@ -2237,7 +2227,8 @@ function ProjectListComponent({
               label="Pinned"
               collapseControl={{
                 isCollapsed: collapsedSidebarSectionIds.has("pinned"),
-                onToggleCollapsed: () => toggleSidebarSectionCollapsed("pinned"),
+                onToggleCollapsed: () =>
+                  toggleSidebarSectionCollapsed("pinned"),
               }}
             >
               {pinnedSectionContent}

--- a/apps/app/src/components/sidebar/ProjectListProjects.tsx
+++ b/apps/app/src/components/sidebar/ProjectListProjects.tsx
@@ -43,7 +43,7 @@ export interface ProjectListReorderBindings {
   consumeClickSuppression: ConsumeDragClickSuppression;
 }
 
-export interface ProjectListProjectsProps {
+interface ProjectListProjectsProps {
   status: ConnectionAwareQueryStatus;
   rows: ProjectListRowModel[];
   selectedThreadId?: string;

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -80,15 +80,15 @@ import { getProjectSettingsRoutePath } from "@/lib/route-paths";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { appToast } from "@/components/ui/app-toast";
 import {
+  CollapsedThreadStatusGlyph,
   ThreadRow,
-  ThreadStatusGlyph,
   type ThreadRowOptions,
 } from "./ThreadRow";
 import {
-  buildChronologicalThreadList,
+  buildFolderThreadList,
   buildProjectThreadGroups,
   CHRONOLOGICAL_CONTAINER_ID,
-  getManualOrderItemKey,
+  getSidebarDndItemId,
   type EnvironmentThreadGroup,
   type ProjectThreadItem,
   type ProjectThreadNode,
@@ -154,11 +154,10 @@ export interface ProjectRowProps {
   projectRowStyle?: CSSProperties;
 }
 
-export interface ProjectThreadTreeProps {
+interface ProjectThreadTreeProps {
   projectId: string;
   threadListState: ProjectThreadListState;
   compareThreads: ThreadComparator;
-  folders?: readonly SidebarFolderDefinition[];
   selectedThreadId?: string;
   collapsedThreadIds: Set<string>;
   collapsedEnvironmentIds: Set<string>;
@@ -168,7 +167,7 @@ export interface ProjectThreadTreeProps {
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
 }
 
-export interface ChronologicalThreadTreeProps {
+interface FolderThreadTreeProps {
   threadListState: ProjectThreadListState;
   compareThreads: ThreadComparator;
   folders?: readonly SidebarFolderDefinition[];
@@ -184,13 +183,13 @@ export interface ChronologicalThreadTreeProps {
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
 }
 
-export interface ChronologicalFolderThreadSectionsProps extends ChronologicalThreadTreeProps {
+interface ChronologicalFolderThreadSectionsProps extends FolderThreadTreeProps {
   renderAllThreadsSection: (content: ReactNode) => ReactNode;
   renderFoldersSection: (content: ReactNode) => ReactNode;
   renderThreadsSection: (content: ReactNode) => ReactNode;
 }
 
-export type ProjectThreadTreeVariant = "project" | "section";
+type ProjectThreadTreeVariant = "project" | "section";
 
 type ProjectItemClickCaptureHandler = MouseEventHandler<HTMLLIElement>;
 type ProjectThreadListClickCaptureHandler = MouseEventHandler<HTMLDivElement>;
@@ -242,7 +241,7 @@ interface ThreadTreeItemRowProps {
   consumeClickSuppression?: ConsumeDragClickSuppression;
   dragBindings?: SidebarSortableDragBindings;
   isDropTargetActive?: boolean;
-  manualSort?: ManualThreadTreeDndState;
+  folderDnd?: FolderThreadDndState;
   sortableRef?: (element: HTMLDivElement | null) => void;
   sortableStyle?: CSSProperties;
 }
@@ -264,15 +263,14 @@ interface FolderTreeItemRowProps {
   consumeClickSuppression?: ConsumeDragClickSuppression;
   dragBindings?: SidebarSortableDragBindings;
   isDropTargetActive?: boolean;
-  manualSort?: ManualThreadTreeDndState;
+  folderDnd?: FolderThreadDndState;
   sortableRef?: (element: HTMLDivElement | null) => void;
   sortableStyle?: CSSProperties;
 }
 
-interface ManualThreadTreeDndState {
+interface FolderThreadDndState {
   consumeClickSuppression: ConsumeDragClickSuppression;
   dndContextProps: SidebarReorderDndContextProps;
-  enabled: boolean;
   itemIdsByParentKey: ReadonlyMap<string, readonly string[]>;
   onClickCapture: MouseEventHandler<HTMLElement>;
   // The drop target showing an empty placeholder row while a thread is dragged
@@ -282,18 +280,16 @@ interface ManualThreadTreeDndState {
   dragOverParentKey: string | null;
 }
 
-interface UseManualThreadTreeDndArgs {
+interface UseFolderThreadDndArgs {
   containerId: string;
   enabled: boolean;
   rootItems: readonly ProjectThreadItem[];
 }
 
-type ManualSortableItemKind = "thread" | "folder" | "environment";
-
-interface ManualThreadTreeLookup {
+interface FolderThreadDndLookup {
   folderIdByParentKey: Map<string, string | null>;
   itemIdsByParentKey: Map<string, string[]>;
-  itemKindById: Map<string, ManualSortableItemKind>;
+  itemKindById: Map<string, ProjectThreadItem["kind"]>;
   parentKeyByItemId: Map<string, string>;
   threadByItemId: Map<string, ThreadListEntry>;
 }
@@ -301,7 +297,7 @@ interface ManualThreadTreeLookup {
 // Render key + routing projectId for any item kind. Folders derive from their
 // first nested item, so a folder spanning projects in the Folders view still
 // routes each contained thread to its own project.
-export function getItemKey(item: ProjectThreadItem): string {
+function getItemKey(item: ProjectThreadItem): string {
   switch (item.kind) {
     case "thread":
       return `thread:${item.node.thread.id}`;
@@ -312,7 +308,7 @@ export function getItemKey(item: ProjectThreadItem): string {
   }
 }
 
-export function getItemProjectId(item: ProjectThreadItem): string {
+function getItemProjectId(item: ProjectThreadItem): string {
   switch (item.kind) {
     case "thread":
       return item.node.thread.projectId;
@@ -326,17 +322,11 @@ export function getItemProjectId(item: ProjectThreadItem): string {
   }
 }
 
-function getManualSortableItemKind(
-  item: ProjectThreadItem,
-): ManualSortableItemKind {
-  return item.kind;
-}
-
-function collectManualThreadTreeLookup(
+function collectFolderThreadDndLookup(
   items: readonly ProjectThreadItem[],
   containerId: string,
-): ManualThreadTreeLookup {
-  const lookup: ManualThreadTreeLookup = {
+): FolderThreadDndLookup {
+  const lookup: FolderThreadDndLookup = {
     folderIdByParentKey: new Map([[containerId, null]]),
     itemIdsByParentKey: new Map(),
     itemKindById: new Map(),
@@ -348,12 +338,12 @@ function collectManualThreadTreeLookup(
     siblingItems: readonly ProjectThreadItem[],
     parentKey: string,
   ) => {
-    const itemIds = siblingItems.map(getManualOrderItemKey);
+    const itemIds = siblingItems.map(getSidebarDndItemId);
     lookup.itemIdsByParentKey.set(parentKey, itemIds);
 
     for (const item of siblingItems) {
-      const itemId = getManualOrderItemKey(item);
-      lookup.itemKindById.set(itemId, getManualSortableItemKind(item));
+      const itemId = getSidebarDndItemId(item);
+      lookup.itemKindById.set(itemId, item.kind);
       lookup.parentKeyByItemId.set(itemId, parentKey);
 
       if (item.kind === "thread") {
@@ -369,21 +359,11 @@ function collectManualThreadTreeLookup(
   return lookup;
 }
 
-function hasFolderItems(items: readonly ProjectThreadItem[]): boolean {
-  return items.some(
-    (item) =>
-      item.kind === "folder" ||
-      (item.kind === "thread" && hasFolderItems(item.node.children)) ||
-      (item.kind === "environment" &&
-        item.group.nodes.some((node) => hasFolderItems(node.children))),
-  );
-}
-
 // Resolve where a dragged thread would land. Shared by drag-over (preview +
 // auto-expand) and drag-end (the move) so they never disagree. `toParentKey`
 // is the destination folder key, or the container id for the loose root.
 function resolveThreadDropTarget(
-  lookup: ManualThreadTreeLookup,
+  lookup: FolderThreadDndLookup,
   active: DragEndEvent["active"],
   over: DragEndEvent["over"],
 ): { activeId: string; fromParentKey: string; toParentKey: string } | null {
@@ -417,13 +397,13 @@ function resolveThreadDropTarget(
 // own folder) smooth instead of the inserted row shoving the dragged item down.
 const DRAG_DWELL_MS = 200;
 
-function useManualThreadTreeDnd({
+function useFolderThreadDnd({
   containerId,
   enabled,
   rootItems,
-}: UseManualThreadTreeDndArgs): ManualThreadTreeDndState | null {
+}: UseFolderThreadDndArgs): FolderThreadDndState | null {
   const lookup = useMemo(
-    () => collectManualThreadTreeLookup(rootItems, containerId),
+    () => collectFolderThreadDndLookup(rootItems, containerId),
     [containerId, rootItems],
   );
   const updateThread = useUpdateThread();
@@ -475,7 +455,7 @@ function useManualThreadTreeDnd({
 
       clearDropDwell();
       dwellParentKeyRef.current = targetParentKey;
-      setDragOverParentKey((current) => (current ? null : current));
+      setDragOverParentKey(null);
       if (targetParentKey === null) return;
 
       // Spring-loaded: reveal the placeholder (and expand a collapsed target
@@ -547,7 +527,6 @@ function useManualThreadTreeDnd({
   return {
     consumeClickSuppression,
     dndContextProps,
-    enabled,
     itemIdsByParentKey: lookup.itemIdsByParentKey,
     onClickCapture,
     dragOverParentKey,
@@ -819,22 +798,22 @@ function ProjectThreadTreeGroup({
   );
 }
 
-function ManualSortableList({
+function FolderDndSortableList({
   children,
-  manualSort,
+  folderDnd,
   parentKey,
 }: {
   children: ReactNode;
-  manualSort?: ManualThreadTreeDndState | null;
+  folderDnd?: FolderThreadDndState | null;
   parentKey: string;
 }) {
-  if (!manualSort?.enabled) {
+  if (!folderDnd) {
     return <>{children}</>;
   }
 
   return (
     <SortableContext
-      items={[...(manualSort.itemIdsByParentKey.get(parentKey) ?? [])]}
+      items={[...(folderDnd.itemIdsByParentKey.get(parentKey) ?? [])]}
       strategy={verticalListSortingStrategy}
     >
       {children}
@@ -845,56 +824,44 @@ function ManualSortableList({
 // Registers the loose root as a droppable so drops onto its bare/empty area
 // resolve to the loose container. Drop feedback is the inserted placeholder row
 // (see the loose section), matching how folders preview a drop.
-function ManualDroppableParent({
+function FolderDndDroppableParent({
   children,
-  className,
-  manualSort,
+  folderDnd,
   parentKey,
 }: {
   children: ReactNode;
-  className?: string;
-  manualSort?: ManualThreadTreeDndState | null;
+  folderDnd?: FolderThreadDndState | null;
   parentKey: string;
 }) {
   const { setNodeRef } = useDroppable({
     id: parentKey,
-    disabled: !manualSort?.enabled,
+    disabled: !folderDnd,
   });
 
-  return (
-    <div ref={setNodeRef} className={className}>
-      {children}
-    </div>
-  );
+  return <div ref={setNodeRef}>{children}</div>;
 }
 
-const ManualSortableThreadTreeItemRow = memo(
-  function ManualSortableThreadTreeItemRow({
-    manualSort,
+const FolderDndItemRow = memo(function FolderDndItemRow({
+  folderDnd,
+  ...props
+}: ThreadTreeItemRowProps) {
+  if (!folderDnd || props.item.kind === "environment") {
+    return <ThreadTreeItemRow folderDnd={folderDnd} {...props} />;
+  }
+
+  if (props.item.kind === "folder") {
+    return <DroppableFolderItemRow {...props} folderDnd={folderDnd} />;
+  }
+
+  return <DraggableFolderThreadItemRow {...props} folderDnd={folderDnd} />;
+});
+
+const DraggableFolderThreadItemRow = memo(
+  function DraggableFolderThreadItemRow({
+    folderDnd,
     ...props
-  }: ThreadTreeItemRowProps) {
-    if (!manualSort?.enabled || props.item.kind === "environment") {
-      return <ThreadTreeItemRow manualSort={manualSort} {...props} />;
-    }
-
-    if (props.item.kind === "folder") {
-      return (
-        <ManualDroppableFolderTreeItemRow {...props} manualSort={manualSort} />
-      );
-    }
-
-    return (
-      <ManualDraggableThreadTreeItemRow {...props} manualSort={manualSort} />
-    );
-  },
-);
-
-const ManualDraggableThreadTreeItemRow = memo(
-  function ManualDraggableThreadTreeItemRow({
-    manualSort,
-    ...props
-  }: ThreadTreeItemRowProps & { manualSort: ManualThreadTreeDndState }) {
-    const itemId = getManualOrderItemKey(props.item);
+  }: ThreadTreeItemRowProps & { folderDnd: FolderThreadDndState }) {
+    const itemId = getSidebarDndItemId(props.item);
     const { dragBindings, setNodeRef, style } = useSidebarSortable({
       id: itemId,
       disabled: false,
@@ -903,9 +870,9 @@ const ManualDraggableThreadTreeItemRow = memo(
     return (
       <ThreadTreeItemRow
         {...props}
-        consumeClickSuppression={manualSort.consumeClickSuppression}
+        consumeClickSuppression={folderDnd.consumeClickSuppression}
         dragBindings={dragBindings}
-        manualSort={manualSort}
+        folderDnd={folderDnd}
         sortableRef={setNodeRef}
         sortableStyle={style}
       />
@@ -913,25 +880,23 @@ const ManualDraggableThreadTreeItemRow = memo(
   },
 );
 
-const ManualDroppableFolderTreeItemRow = memo(
-  function ManualDroppableFolderTreeItemRow({
-    manualSort,
-    ...props
-  }: ThreadTreeItemRowProps & { manualSort: ManualThreadTreeDndState }) {
-    const itemId = getManualOrderItemKey(props.item);
-    const { isOver, setNodeRef } = useDroppable({ id: itemId });
+const DroppableFolderItemRow = memo(function DroppableFolderItemRow({
+  folderDnd,
+  ...props
+}: ThreadTreeItemRowProps & { folderDnd: FolderThreadDndState }) {
+  const itemId = getSidebarDndItemId(props.item);
+  const { isOver, setNodeRef } = useDroppable({ id: itemId });
 
-    return (
-      <ThreadTreeItemRow
-        {...props}
-        consumeClickSuppression={manualSort.consumeClickSuppression}
-        isDropTargetActive={isOver}
-        manualSort={manualSort}
-        sortableRef={setNodeRef}
-      />
-    );
-  },
-);
+  return (
+    <ThreadTreeItemRow
+      {...props}
+      consumeClickSuppression={folderDnd.consumeClickSuppression}
+      isDropTargetActive={isOver}
+      folderDnd={folderDnd}
+      sortableRef={setNodeRef}
+    />
+  );
+});
 
 function useArchiveEnvironmentThreadGroupAction({
   environmentId,
@@ -1187,17 +1152,9 @@ function EnvironmentThreadGroupHeader({
               "pointer-events-none absolute inset-0 flex items-center justify-end text-subtle-foreground",
             )}
           >
-            <ThreadStatusGlyph
-              hasPendingInteraction={childActivity.pending}
-              isBackgroundAgentActive={childActivity.backgroundAgent}
-              isBackgroundCommandActive={childActivity.backgroundCommand}
-              isForegroundAgentWorking={childActivity.runtimeWorking}
-              isGoalActive={childActivity.goal}
-              isPlanModeActive={childActivity.planMode}
+            <CollapsedThreadStatusGlyph
+              activity={childActivity}
               isBusy={childActivity.runtimeWorking}
-              isWorkflowActive={childActivity.workflow}
-              showUnreadBadge={childActivity.unread}
-              unreadBadgeTone={childActivity.unreadError ? "error" : "default"}
             />
           </span>
         ) : null}
@@ -1351,7 +1308,7 @@ const EnvironmentThreadGroupRow = memo(function EnvironmentThreadGroupRow({
   );
 });
 
-export const ThreadTreeItemRow = memo(function ThreadTreeItemRow({
+const ThreadTreeItemRow = memo(function ThreadTreeItemRow({
   projectId,
   item,
   depthOffset,
@@ -1369,7 +1326,7 @@ export const ThreadTreeItemRow = memo(function ThreadTreeItemRow({
   consumeClickSuppression,
   dragBindings,
   isDropTargetActive,
-  manualSort,
+  folderDnd,
   sortableRef,
   sortableStyle,
 }: ThreadTreeItemRowProps) {
@@ -1392,7 +1349,7 @@ export const ThreadTreeItemRow = memo(function ThreadTreeItemRow({
         consumeClickSuppression={consumeClickSuppression}
         dragBindings={dragBindings}
         isDropTargetActive={isDropTargetActive}
-        manualSort={manualSort}
+        folderDnd={folderDnd}
         sortableRef={sortableRef}
         sortableStyle={sortableStyle}
       />
@@ -1477,7 +1434,7 @@ const FolderTreeItemRow = memo(function FolderTreeItemRow({
   consumeClickSuppression,
   dragBindings,
   isDropTargetActive = false,
-  manualSort,
+  folderDnd,
   sortableRef,
   sortableStyle,
 }: FolderTreeItemRowProps) {
@@ -1496,7 +1453,7 @@ const FolderTreeItemRow = memo(function FolderTreeItemRow({
   const headerDepth = getThreadRowDepth({ depthOffset, nodeDepth: 0, variant });
   const stickyLevel =
     depthOffset < SIDEBAR_STICKY_PARENT_DEPTH_CAP ? depthOffset : undefined;
-  const showDropPreview = manualSort?.dragOverParentKey === folderKey;
+  const showDropPreview = folderDnd?.dragOverParentKey === folderKey;
   const showChildren = !isCollapsed && folder.items.length > 0;
   // Force the children area open while a thread is dragged over this folder so
   // the empty drop-placeholder row is visible even when the folder is empty.
@@ -1540,9 +1497,9 @@ const FolderTreeItemRow = memo(function FolderTreeItemRow({
         <div className="relative space-y-px">
           <ThreadTreeGroupLine parentRowDepth={headerDepth} />
           {showChildren ? (
-            <ManualSortableList manualSort={manualSort} parentKey={folder.key}>
+            <FolderDndSortableList folderDnd={folderDnd} parentKey={folder.key}>
               {folder.items.map((item) => (
-                <ManualSortableThreadTreeItemRow
+                <FolderDndItemRow
                   key={getItemKey(item)}
                   projectId={getItemProjectId(item)}
                   item={item}
@@ -1558,10 +1515,10 @@ const FolderTreeItemRow = memo(function FolderTreeItemRow({
                   onRemoveFolder={onRemoveFolder}
                   onToggleThreadCollapsed={onToggleThreadCollapsed}
                   onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-                  manualSort={manualSort}
+                  folderDnd={folderDnd}
                 />
               ))}
-            </ManualSortableList>
+            </FolderDndSortableList>
           ) : null}
           {showDropPreview ? (
             <DropPreviewRow
@@ -1696,9 +1653,9 @@ function ThreadTreeLoadingSkeleton() {
   );
 }
 
-interface ManualThreadTreeItemsProps {
+interface FolderThreadTreeItemsProps {
   items: readonly ProjectThreadItem[];
-  manualSort: ManualThreadTreeDndState | null;
+  folderDnd: FolderThreadDndState | null;
   variant: ProjectThreadTreeVariant;
   // Route every row to this project; omit to derive each row's project from its
   // own thread (the cross-project Folders view).
@@ -1722,9 +1679,9 @@ interface ManualThreadTreeItemsProps {
 // The one place that maps thread-tree items to rows. Every sidebar view
 // (project, chronological, folders) renders through this, so a row-prop
 // change lands once instead of being copied across each view's renderer.
-function ManualThreadTreeItems({
+function FolderThreadTreeItems({
   items,
-  manualSort,
+  folderDnd,
   variant,
   projectId,
   depthOffset = 0,
@@ -1739,9 +1696,9 @@ function ManualThreadTreeItems({
   onViewArchivedThreadsInFolder,
   onRenameFolder,
   onRemoveFolder,
-}: ManualThreadTreeItemsProps) {
+}: FolderThreadTreeItemsProps) {
   const rows = items.map((item) => (
-    <ManualSortableThreadTreeItemRow
+    <FolderDndItemRow
       key={getItemKey(item)}
       projectId={projectId ?? getItemProjectId(item)}
       item={item}
@@ -1757,22 +1714,22 @@ function ManualThreadTreeItems({
       onViewArchivedThreadsInFolder={onViewArchivedThreadsInFolder}
       onRenameFolder={onRenameFolder}
       onRemoveFolder={onRemoveFolder}
-      manualSort={manualSort ?? undefined}
+      folderDnd={folderDnd ?? undefined}
     />
   ));
 
   return (
     <ProjectThreadTreeGroup
       variant={variant}
-      onClickCapture={manualSort?.onClickCapture}
+      onClickCapture={folderDnd?.onClickCapture}
     >
       {sortableParentKey !== undefined ? (
-        <ManualSortableList
-          manualSort={manualSort}
+        <FolderDndSortableList
+          folderDnd={folderDnd}
           parentKey={sortableParentKey}
         >
           {rows}
-        </ManualSortableList>
+        </FolderDndSortableList>
       ) : (
         rows
       )}
@@ -1784,7 +1741,6 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
   threadListState,
   compareThreads,
-  folders = EMPTY_FOLDERS,
   selectedThreadId,
   collapsedThreadIds,
   collapsedEnvironmentIds,
@@ -1793,19 +1749,13 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   onToggleThreadCollapsed,
   onToggleEnvironmentCollapsed,
 }: ProjectThreadTreeProps) {
-  const groupBy = "none" as const;
   const projectThreads =
     threadListState.status === "ready"
       ? threadListState.threads
       : EMPTY_PROJECT_THREADS;
   const rootItems = useMemo(
-    () =>
-      buildProjectThreadGroups(projectThreads, compareThreads, {
-        groupBy,
-        containerId: projectId,
-        folders,
-      }),
-    [compareThreads, projectThreads, groupBy, projectId, folders],
+    () => buildProjectThreadGroups(projectThreads, compareThreads),
+    [compareThreads, projectThreads],
   );
 
   if (threadListState.status === "loading") {
@@ -1838,15 +1788,12 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
     );
   }
 
-  // Per-project trees always group by "none", so they never contain folder
-  // items and never enable folder drag-and-drop (folders live only in the
-  // cross-project Folders view; see ChronologicalFolderThreadSections). Rendering
-  // without manual DnD keeps react-query mutations out of a tree that can never
-  // use them.
+  // Per-project trees never contain folder items or enable folder drag-and-drop;
+  // folders live only in the cross-project Folders view below.
   return (
-    <ManualThreadTreeItems
+    <FolderThreadTreeItems
       items={rootItems}
-      manualSort={null}
+      folderDnd={null}
       variant={variant}
       projectId={projectId}
       sortableParentKey={projectId}
@@ -1857,83 +1804,6 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       onToggleThreadCollapsed={onToggleThreadCollapsed}
       onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
     />
-  );
-});
-
-// Folders bucket: root threads across all projects, globally ordered by the
-// chosen comparator before folder bucketing, with descendants nested under
-// their parent. Worktree grouping stays off. Derives projectId per row from its
-// own thread so cross-project rows still route correctly.
-export const ChronologicalThreadTree = memo(function ChronologicalThreadTree({
-  threadListState,
-  compareThreads,
-  folders = EMPTY_FOLDERS,
-  selectedThreadId,
-  collapsedThreadIds,
-  collapsedEnvironmentIds,
-  onProjectSelect,
-  onToggleThreadCollapsed,
-  onToggleEnvironmentCollapsed,
-}: ChronologicalThreadTreeProps) {
-  const groupBy = "folder" as const;
-  const threads =
-    threadListState.status === "ready"
-      ? threadListState.threads
-      : EMPTY_PROJECT_THREADS;
-  const rootItems = useMemo(
-    () =>
-      buildChronologicalThreadList(threads, compareThreads, {
-        groupBy,
-        containerId: CHRONOLOGICAL_CONTAINER_ID,
-        folders,
-      }),
-    [threads, compareThreads, groupBy, folders],
-  );
-  const manualSort = useManualThreadTreeDnd({
-    containerId: CHRONOLOGICAL_CONTAINER_ID,
-    enabled: hasFolderItems(rootItems),
-    rootItems,
-  });
-
-  if (threadListState.status === "loading") {
-    return <ThreadTreeLoadingSkeleton />;
-  }
-
-  if (rootItems.length === 0) {
-    return (
-      <EmptyState
-        message={
-          threadListState.status === "unavailable"
-            ? "Threads unavailable"
-            : "No threads"
-        }
-        icon={getProjectThreadTreeEmptyStateIcon("section")}
-        className={getProjectThreadTreeEmptyStateClassName("section")}
-        iconClassName="size-3.5 text-subtle-foreground/50"
-        messageClassName={getProjectThreadTreeEmptyStateMessageClassName()}
-      />
-    );
-  }
-
-  const tree = (
-    <ManualThreadTreeItems
-      items={rootItems}
-      manualSort={manualSort}
-      variant="section"
-      sortableParentKey={CHRONOLOGICAL_CONTAINER_ID}
-      selectedThreadId={selectedThreadId}
-      collapsedThreadIds={collapsedThreadIds}
-      collapsedEnvironmentIds={collapsedEnvironmentIds}
-      onProjectSelect={onProjectSelect}
-      onToggleThreadCollapsed={onToggleThreadCollapsed}
-      onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-    />
-  );
-
-  return manualSort ? (
-    <DndContext {...manualSort.dndContextProps}>{tree}</DndContext>
-  ) : (
-    tree
   );
 });
 
@@ -1956,35 +1826,29 @@ export const ChronologicalFolderThreadSections = memo(
     renderFoldersSection,
     renderThreadsSection,
   }: ChronologicalFolderThreadSectionsProps) {
-    const groupBy = "folder" as const;
     const threads =
       threadListState.status === "ready"
         ? threadListState.threads
         : EMPTY_PROJECT_THREADS;
     const rootItems = useMemo(
-      () =>
-        buildChronologicalThreadList(threads, compareThreads, {
-          groupBy,
-          containerId: CHRONOLOGICAL_CONTAINER_ID,
-          folders,
-        }),
-      [threads, compareThreads, groupBy, folders],
+      () => buildFolderThreadList(threads, compareThreads, folders),
+      [threads, compareThreads, folders],
     );
-    const manualSort = useManualThreadTreeDnd({
+    const folderItems = rootItems.filter((item) => item.kind === "folder");
+    const folderDnd = useFolderThreadDnd({
       containerId: CHRONOLOGICAL_CONTAINER_ID,
-      enabled: hasFolderItems(rootItems),
+      enabled: folderItems.length > 0,
       rootItems,
     });
-    const folderItems = rootItems.filter((item) => item.kind === "folder");
     const hasFolders = folderItems.length > 0;
     const looseItems = rootItems.filter((item) => item.kind !== "folder");
 
-    // No sortableParentKey: the outer ManualSortableList below provides the
+    // No sortableParentKey: the outer FolderDndSortableList below provides the
     // SortableContext spanning both the folders and loose-threads sections.
     const renderItems = (items: readonly ProjectThreadItem[]) => (
-      <ManualThreadTreeItems
+      <FolderThreadTreeItems
         items={items}
-        manualSort={manualSort}
+        folderDnd={folderDnd}
         variant="section"
         selectedThreadId={selectedThreadId}
         collapsedThreadIds={collapsedThreadIds}
@@ -2015,7 +1879,7 @@ export const ChronologicalFolderThreadSections = memo(
     // with the same inserted placeholder folders use (hiding the empty state so
     // the placeholder reads as the drop slot when the loose list is empty).
     const showLoosePreview =
-      manualSort?.dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID;
+      folderDnd?.dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID;
     const threadsListContent =
       threadListState.status === "loading" ? (
         <ThreadTreeLoadingSkeleton />
@@ -2034,9 +1898,9 @@ export const ChronologicalFolderThreadSections = memo(
           messageClassName={getProjectThreadTreeEmptyStateMessageClassName()}
         />
       );
-    const threadsContent = manualSort?.enabled ? (
-      <ManualDroppableParent
-        manualSort={manualSort}
+    const threadsContent = folderDnd ? (
+      <FolderDndDroppableParent
+        folderDnd={folderDnd}
         parentKey={CHRONOLOGICAL_CONTAINER_ID}
       >
         {threadsListContent}
@@ -2049,14 +1913,14 @@ export const ChronologicalFolderThreadSections = memo(
             })}
           />
         ) : null}
-      </ManualDroppableParent>
+      </FolderDndDroppableParent>
     ) : (
       threadsListContent
     );
 
     const sections = (
-      <ManualSortableList
-        manualSort={manualSort}
+      <FolderDndSortableList
+        folderDnd={folderDnd}
         parentKey={CHRONOLOGICAL_CONTAINER_ID}
       >
         {hasFolders ? (
@@ -2067,11 +1931,11 @@ export const ChronologicalFolderThreadSections = memo(
         ) : (
           renderAllThreadsSection(threadsContent)
         )}
-      </ManualSortableList>
+      </FolderDndSortableList>
     );
 
-    return manualSort ? (
-      <DndContext {...manualSort.dndContextProps}>{sections}</DndContext>
+    return folderDnd ? (
+      <DndContext {...folderDnd.dndContextProps}>{sections}</DndContext>
     ) : (
       sections
     );
@@ -2212,41 +2076,17 @@ function ProjectRowComponent({
                     "pointer-events-none absolute inset-0 flex items-center justify-end text-subtle-foreground max-md:pointer-coarse:hidden",
                   )}
                 >
-                  <ThreadStatusGlyph
-                    hasPendingInteraction={projectActivity.pending}
-                    isBackgroundAgentActive={projectActivity.backgroundAgent}
-                    isBackgroundCommandActive={
-                      projectActivity.backgroundCommand
-                    }
-                    isForegroundAgentWorking={projectActivity.runtimeWorking}
-                    isGoalActive={projectActivity.goal}
-                    isPlanModeActive={projectActivity.planMode}
+                  <CollapsedThreadStatusGlyph
+                    activity={projectActivity}
                     isBusy={projectActivity.working}
-                    isWorkflowActive={projectActivity.workflow}
-                    showUnreadBadge={projectActivity.unread}
-                    unreadBadgeTone={
-                      projectActivity.unreadError ? "error" : "default"
-                    }
                   />
                 </span>
               ) : null}
               {showProjectRollupGlyph ? (
                 <span className="hidden shrink-0 items-center justify-center text-subtle-foreground max-md:pointer-coarse:inline-flex">
-                  <ThreadStatusGlyph
-                    hasPendingInteraction={projectActivity.pending}
-                    isBackgroundAgentActive={projectActivity.backgroundAgent}
-                    isBackgroundCommandActive={
-                      projectActivity.backgroundCommand
-                    }
-                    isForegroundAgentWorking={projectActivity.runtimeWorking}
-                    isGoalActive={projectActivity.goal}
-                    isPlanModeActive={projectActivity.planMode}
+                  <CollapsedThreadStatusGlyph
+                    activity={projectActivity}
                     isBusy={projectActivity.working}
-                    isWorkflowActive={projectActivity.workflow}
-                    showUnreadBadge={projectActivity.unread}
-                    unreadBadgeTone={
-                      projectActivity.unreadError ? "error" : "default"
-                    }
                   />
                 </span>
               ) : null}

--- a/apps/app/src/components/sidebar/SidebarChildToggleChevron.tsx
+++ b/apps/app/src/components/sidebar/SidebarChildToggleChevron.tsx
@@ -3,13 +3,11 @@ import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
 import { SIDEBAR_HOVER_ACTIONS_CLASS } from "@/components/ui/sidebar-hover-actions.js";
 import { cn } from "@bb/shared-ui/lib/utils";
 
-export type SidebarChildToggleHandler = () => void;
-
-export interface SidebarChildToggleChevronProps {
+interface SidebarChildToggleChevronProps {
   isCollapsed: boolean;
   expandLabel: string;
   collapseLabel: string;
-  onToggle: SidebarChildToggleHandler;
+  onToggle: () => void;
   revealOnHover?: boolean;
 }
 

--- a/apps/app/src/components/sidebar/SidebarFolderRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarFolderRow.tsx
@@ -39,7 +39,7 @@ import {
   getSidebarThreadRowPaddingLeft,
 } from "./sidebarRowClasses";
 import { SidebarChildToggleChevron } from "./SidebarChildToggleChevron";
-import { ThreadStatusGlyph } from "./ThreadRow";
+import { CollapsedThreadStatusGlyph } from "./ThreadRow";
 import type { SidebarSortableDragBindings } from "./sortableMotion";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 
@@ -170,17 +170,9 @@ function SidebarFolderRowComponent({
               hasActions && "max-md:pointer-coarse:hidden",
             )}
           >
-            <ThreadStatusGlyph
-              hasPendingInteraction={activity.pending}
-              isBackgroundAgentActive={activity.backgroundAgent}
-              isBackgroundCommandActive={activity.backgroundCommand}
-              isForegroundAgentWorking={activity.runtimeWorking}
-              isGoalActive={activity.goal}
-              isPlanModeActive={activity.planMode}
+            <CollapsedThreadStatusGlyph
+              activity={activity}
               isBusy={activity.working}
-              isWorkflowActive={activity.workflow}
-              showUnreadBadge={activity.unread}
-              unreadBadgeTone={activity.unreadError ? "error" : "default"}
             />
           </span>
         ) : null}
@@ -199,17 +191,9 @@ function SidebarFolderRowComponent({
           >
             {showRollupGlyph ? (
               <span className="hidden shrink-0 items-center justify-center text-subtle-foreground max-md:pointer-coarse:inline-flex">
-                <ThreadStatusGlyph
-                  hasPendingInteraction={activity.pending}
-                  isBackgroundAgentActive={activity.backgroundAgent}
-                  isBackgroundCommandActive={activity.backgroundCommand}
-                  isForegroundAgentWorking={activity.runtimeWorking}
-                  isGoalActive={activity.goal}
-                  isPlanModeActive={activity.planMode}
+                <CollapsedThreadStatusGlyph
+                  activity={activity}
                   isBusy={activity.working}
-                  isWorkflowActive={activity.workflow}
-                  showUnreadBadge={activity.unread}
-                  unreadBadgeTone={activity.unreadError ? "error" : "default"}
                 />
               </span>
             ) : null}

--- a/apps/app/src/components/sidebar/SidebarThreadSearchPanel.tsx
+++ b/apps/app/src/components/sidebar/SidebarThreadSearchPanel.tsx
@@ -12,6 +12,7 @@ import { hasThreadSearchableQuery } from "@/hooks/queries/thread-queries";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   getSidebarThreadSearchOptionId,
+  isSidebarThreadTitleMatch,
   SIDEBAR_THREAD_SEARCH_LISTBOX_ID,
   type SidebarThreadSearchNavigationItem,
 } from "./sidebarThreadSearch";
@@ -54,18 +55,13 @@ interface ThreadSearchMessageProps {
 const RECENT_THREAD_LIMIT = 20;
 const EMPTY_MATCHES: readonly ThreadSearchMatch[] = [];
 const EMPTY_FOLDER_NAMES_BY_ID = new Map<string, string>();
-const TITLE_MATCH_KINDS = new Set<ThreadSearchMatch["sourceKind"]>([
-  "title",
-  "title_fallback",
-]);
-
 // The message (non-title) match drives the deep-link target. Mirrors the row's
 // snippet selection so clicking a result lands on the message shown in the row.
 function getMessageMatchSeq(
   matches: readonly ThreadSearchMatch[],
 ): number | null {
   for (const match of matches) {
-    if (!TITLE_MATCH_KINDS.has(match.sourceKind) && match.sourceSeq !== null) {
+    if (!isSidebarThreadTitleMatch(match) && match.sourceSeq !== null) {
       return match.sourceSeq;
     }
   }

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -323,6 +323,31 @@ export function ThreadStatusGlyph({
   return null;
 }
 
+interface CollapsedThreadStatusGlyphProps {
+  activity: CollapsedChildActivity;
+  isBusy: boolean;
+}
+
+export function CollapsedThreadStatusGlyph({
+  activity,
+  isBusy,
+}: CollapsedThreadStatusGlyphProps) {
+  return (
+    <ThreadStatusGlyph
+      hasPendingInteraction={activity.pending}
+      isBackgroundAgentActive={activity.backgroundAgent}
+      isBackgroundCommandActive={activity.backgroundCommand}
+      isForegroundAgentWorking={activity.runtimeWorking}
+      isGoalActive={activity.goal}
+      isPlanModeActive={activity.planMode}
+      isBusy={isBusy}
+      isWorkflowActive={activity.workflow}
+      showUnreadBadge={activity.unread}
+      unreadBadgeTone={activity.unreadError ? "error" : "default"}
+    />
+  );
+}
+
 function getThreadUnreadBadgeLabel({
   tone,
 }: ThreadUnreadBadgeLabelArgs): string {

--- a/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
@@ -23,6 +23,7 @@ import {
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ThreadStatusGlyph } from "./ThreadRow";
+import { isSidebarThreadTitleMatch } from "./sidebarThreadSearch";
 import {
   SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
@@ -49,11 +50,6 @@ interface HighlightedTextProps {
   ranges: ThreadSearchMatch["highlightRanges"];
   text: string;
 }
-
-const TITLE_SOURCE_KINDS = new Set<ThreadSearchMatch["sourceKind"]>([
-  "title",
-  "title_fallback",
-]);
 
 function clampRange(
   range: ThreadSearchMatch["highlightRanges"][number],
@@ -105,14 +101,14 @@ function getTitleMatch(
   matches: readonly ThreadSearchMatch[],
 ): ThreadSearchMatch | undefined {
   return matches.find(
-    (match) => TITLE_SOURCE_KINDS.has(match.sourceKind) && match.text === title,
+    (match) => isSidebarThreadTitleMatch(match) && match.text === title,
   );
 }
 
 function getSnippetMatch(
   matches: readonly ThreadSearchMatch[],
 ): ThreadSearchMatch | undefined {
-  return matches.find((match) => !TITLE_SOURCE_KINDS.has(match.sourceKind));
+  return matches.find((match) => !isSidebarThreadTitleMatch(match));
 }
 
 function isNonEmptyMetadataPart(value: string | null): value is string {

--- a/apps/app/src/components/sidebar/folderKeys.test.ts
+++ b/apps/app/src/components/sidebar/folderKeys.test.ts
@@ -1,22 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildFolderKey,
-  folderKeyForThreadFolder,
-  normalizeFolderName,
-} from "./folderKeys";
-
-describe("normalizeFolderName", () => {
-  it("trims names without treating slashes as hierarchy", () => {
-    expect(normalizeFolderName(" Work / Q3 ")).toBe("Work / Q3");
-    expect(normalizeFolderName("///")).toBe("///");
-  });
-
-  it("returns null for empty names", () => {
-    expect(normalizeFolderName("   ")).toBeNull();
-    expect(normalizeFolderName(null)).toBeNull();
-    expect(normalizeFolderName(undefined)).toBeNull();
-  });
-});
+import { buildFolderKey, folderKeyForThreadFolder } from "./folderKeys";
 
 describe("buildFolderKey", () => {
   it("namespaces a folder id by its container id", () => {

--- a/apps/app/src/components/sidebar/folderKeys.ts
+++ b/apps/app/src/components/sidebar/folderKeys.ts
@@ -1,11 +1,6 @@
 // Pure helpers for sidebar folder row identity. Folder names are display text;
 // membership lives in `thread.folderId`.
 
-export function normalizeFolderName(name: string | null | undefined): string | null {
-  const normalized = (name ?? "").trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
 export function buildFolderKey(containerId: string, folderId: string): string {
   return `${containerId}::${folderId}`;
 }

--- a/apps/app/src/components/sidebar/pinnedSidebarThreads.ts
+++ b/apps/app/src/components/sidebar/pinnedSidebarThreads.ts
@@ -6,7 +6,7 @@ import {
   type ProjectThreadNode,
 } from "./projectThreadGroups";
 
-export interface PinnedSidebarState {
+interface PinnedSidebarState {
   effectivePinnedThreadIds: Set<string>;
   rootNodes: ProjectThreadNode[];
 }

--- a/apps/app/src/components/sidebar/projectThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.test.ts
@@ -1,12 +1,11 @@
 import type { ThreadListEntry } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
-  bucketIntoFolders,
   buildChronologicalThreadList,
+  buildFolderThreadList,
   buildProjectThreadGroups,
   compareByCreatedAtDescending,
   compareStandardThreads,
-  pruneManualOrderForChildren,
   type ProjectThreadItem,
   type ProjectThreadNode,
   type ThreadComparator,
@@ -538,77 +537,9 @@ describe("buildProjectThreadGroups", () => {
   });
 });
 
-describe("manual order (Sort by: None)", () => {
-  it("orders a flat project section by stored manual order with new items at the top", () => {
-    const items = buildProjectThreadGroups(
-      [
-        createThread({ id: "new", latestAttentionAt: 30 }),
-        createThread({ id: "stored-b", latestAttentionAt: 20 }),
-        createThread({ id: "stored-a", latestAttentionAt: 10 }),
-      ],
-      compareStandardThreads,
-      {
-        groupBy: "none",
-        containerId: "proj_1",
-        manualOrder: {
-          proj_1: ["stored-a", "stored-b"],
-        },
-      },
-    );
-
-    expect(summarizeItems(items)).toEqual(["new", "stored-a", "stored-b"]);
-  });
-
-  it("lets manual folder mode order threads inside a folder", () => {
-    const items = buildProjectThreadGroups(
-      [
-        createThread({
-          id: "a",
-          title: "A",
-          folderId: "fld_work",
-          latestAttentionAt: 30,
-        }),
-        createThread({
-          id: "b",
-          title: "B",
-          folderId: "fld_work",
-          latestAttentionAt: 20,
-        }),
-        createThread({ id: "loose", title: "Loose", latestAttentionAt: 10 }),
-      ],
-      compareStandardThreads,
-      {
-        groupBy: "folder",
-        containerId: "proj_1",
-        folders: [{ id: "fld_work", name: "Work" }],
-        manualOrder: {
-          proj_1: ["loose", "proj_1::fld_work"],
-          "proj_1::fld_work": ["b", "a"],
-        },
-      },
-    );
-
-    expect(summarizeItems(items)).toEqual([
-      { folder: "proj_1::fld_work", name: "Work", items: ["b", "a"] },
-      "loose",
-    ]);
-  });
-
-  it("prunes stale and duplicate stored ids on read", () => {
-    expect(
-      pruneManualOrderForChildren(
-        ["missing", "b", "b", "a"],
-        new Set(["a", "b"]),
-      ),
-    ).toEqual(["b", "a"]);
-  });
-});
-
-const FOLDER_OPTIONS = { groupBy: "folder", containerId: "proj_1" } as const;
-
 describe("folder bucketing", () => {
   it("buckets threads into flat folders by folder id, folders above loose threads", () => {
-    const items = buildProjectThreadGroups(
+    const items = buildFolderThreadList(
       [
         createThread({ id: "a", title: "Plan", folderId: "fld_work_q3" }),
         createThread({ id: "b", title: "Notes", folderId: "fld_work_q3" }),
@@ -616,21 +547,18 @@ describe("folder bucketing", () => {
         createThread({ id: "d", title: "Standalone" }),
       ],
       compareStandardThreads,
-      {
-        ...FOLDER_OPTIONS,
-        folders: [
-          { id: "fld_work", name: "Work" },
-          { id: "fld_work_q3", name: "Work/Q3" },
-        ],
-      },
+      [
+        { id: "fld_work", name: "Work" },
+        { id: "fld_work_q3", name: "Work/Q3" },
+      ],
     );
 
     // Same idle/attention threads tie-break on codepoint id; flat folders render
     // as a block above the loose "Standalone" thread.
     expect(summarizeItems(items)).toEqual([
-      { folder: "proj_1::fld_work", name: "Work", items: ["c"] },
+      { folder: "chronological::fld_work", name: "Work", items: ["c"] },
       {
-        folder: "proj_1::fld_work_q3",
+        folder: "chronological::fld_work_q3",
         name: "Work/Q3",
         items: ["a", "b"],
       },
@@ -639,31 +567,24 @@ describe("folder bucketing", () => {
   });
 
   it("does not derive folders from slashes in titles", () => {
-    const items = buildProjectThreadGroups(
-      [
-        createThread({ id: "a", title: "Work/Q3/Plan" }),
-        createThread({ id: "b", title: "Work/Notes" }),
-      ],
-      compareStandardThreads,
-      FOLDER_OPTIONS,
-    );
+    const items = buildFolderThreadList([
+      createThread({ id: "a", title: "Work/Q3/Plan" }),
+      createThread({ id: "b", title: "Work/Notes" }),
+    ]);
 
     expect(summarizeItems(items)).toEqual(["a", "b"]);
   });
 
   it("renders explicit empty folders without a thread using that id", () => {
-    const items = buildProjectThreadGroups(
+    const items = buildFolderThreadList(
       [createThread({ id: "a", title: "Standalone" })],
       compareStandardThreads,
-      {
-        ...FOLDER_OPTIONS,
-        folders: [{ id: "fld_work_q3", name: "Work/Q3" }],
-      },
+      [{ id: "fld_work_q3", name: "Work/Q3" }],
     );
 
     expect(summarizeItems(items)).toEqual([
       {
-        folder: "proj_1::fld_work_q3",
+        folder: "chronological::fld_work_q3",
         name: "Work/Q3",
         items: [],
       },
@@ -672,7 +593,7 @@ describe("folder bucketing", () => {
   });
 
   it("keeps a folder thread's own children nested under it and ignores child folders", () => {
-    const items = buildProjectThreadGroups(
+    const items = buildFolderThreadList(
       [
         createThread({
           id: "parent",
@@ -687,57 +608,24 @@ describe("folder bucketing", () => {
         }),
       ],
       compareStandardThreads,
-      {
-        ...FOLDER_OPTIONS,
-        folders: [
-          { id: "fld_work", name: "Work" },
-          { id: "fld_ignored", name: "Ignored/Child" },
-        ],
-      },
+      [
+        { id: "fld_work", name: "Work" },
+        { id: "fld_ignored", name: "Ignored/Child" },
+      ],
     );
 
     // Only the top-level parent picks the bucket; the child stays nested under it
     // and does not create a second folder row.
     expect(summarizeItems(items)).toEqual([
       {
-        folder: "proj_1::fld_work",
+        folder: "chronological::fld_work",
         name: "Work",
         items: [{ id: "parent", children: ["child"] }],
       },
-      { folder: "proj_1::fld_ignored", name: "Ignored/Child", items: [] },
-    ]);
-  });
-
-  it("places a worktree environment group inside a folder by its representative", () => {
-    const items = buildProjectThreadGroups(
-      [
-        createThread({
-          id: "w1",
-          title: "Alpha",
-          folderId: "fld_work",
-          environmentId: "env_shared",
-          environmentWorkspaceDisplayKind: "managed-worktree",
-        }),
-        createThread({
-          id: "w2",
-          title: "Beta",
-          folderId: "fld_work",
-          environmentId: "env_shared",
-          environmentWorkspaceDisplayKind: "managed-worktree",
-        }),
-      ],
-      compareStandardThreads,
       {
-        ...FOLDER_OPTIONS,
-        folders: [{ id: "fld_work", name: "Work" }],
-      },
-    );
-
-    expect(summarizeItems(items)).toEqual([
-      {
-        folder: "proj_1::fld_work",
-        name: "Work",
-        items: [{ env: "env_shared", threads: ["w1", "w2"] }],
+        folder: "chronological::fld_ignored",
+        name: "Ignored/Child",
+        items: [],
       },
     ]);
   });
@@ -763,68 +651,66 @@ describe("folder bucketing", () => {
       }),
     ];
 
-    const options = {
-      ...FOLDER_OPTIONS,
-      folders: [
-        { id: "fld_archive", name: "Archive" },
-        { id: "fld_empty", name: "Empty" },
-        { id: "fld_work", name: "Work" },
-      ],
-    };
+    const folders = [
+      { id: "fld_archive", name: "Archive" },
+      { id: "fld_empty", name: "Empty" },
+      { id: "fld_work", name: "Work" },
+    ];
 
     expect(
       summarizeItems(
-        buildProjectThreadGroups(threads, compareStandardThreads, options),
+        buildFolderThreadList(threads, compareStandardThreads, folders),
       ),
     ).toEqual([
       {
-        folder: "proj_1::fld_archive",
+        folder: "chronological::fld_archive",
         name: "Archive",
         items: ["old-active"],
       },
-      { folder: "proj_1::fld_empty", name: "Empty", items: [] },
-      { folder: "proj_1::fld_work", name: "Work", items: ["new-idle"] },
+      { folder: "chronological::fld_empty", name: "Empty", items: [] },
+      {
+        folder: "chronological::fld_work",
+        name: "Work",
+        items: ["new-idle"],
+      },
     ]);
 
     expect(
       summarizeItems(
-        buildProjectThreadGroups(
-          threads,
-          compareByCreatedAtDescending,
-          options,
-        ),
+        buildFolderThreadList(threads, compareByCreatedAtDescending, folders),
       ),
     ).toEqual([
       {
-        folder: "proj_1::fld_archive",
+        folder: "chronological::fld_archive",
         name: "Archive",
         items: ["old-active"],
       },
-      { folder: "proj_1::fld_empty", name: "Empty", items: [] },
-      { folder: "proj_1::fld_work", name: "Work", items: ["new-idle"] },
+      { folder: "chronological::fld_empty", name: "Empty", items: [] },
+      {
+        folder: "chronological::fld_work",
+        name: "Work",
+        items: ["new-idle"],
+      },
     ]);
   });
 
   it("applies alpha descending order to folder rows", () => {
-    const items = buildProjectThreadGroups([], compareAlphaDescending, {
-      ...FOLDER_OPTIONS,
-      folders: [
-        { id: "fld_archive", name: "Archive" },
-        { id: "fld_empty", name: "Empty" },
-        { id: "fld_work", name: "Work" },
-      ],
-    });
+    const items = buildFolderThreadList([], compareAlphaDescending, [
+      { id: "fld_archive", name: "Archive" },
+      { id: "fld_empty", name: "Empty" },
+      { id: "fld_work", name: "Work" },
+    ]);
 
     expect(summarizeItems(items)).toEqual([
-      { folder: "proj_1::fld_work", name: "Work", items: [] },
-      { folder: "proj_1::fld_empty", name: "Empty", items: [] },
-      { folder: "proj_1::fld_archive", name: "Archive", items: [] },
+      { folder: "chronological::fld_work", name: "Work", items: [] },
+      { folder: "chronological::fld_empty", name: "Empty", items: [] },
+      { folder: "chronological::fld_archive", name: "Archive", items: [] },
     ]);
   });
 
   it("rolls descendant count + activity up onto the folder group", () => {
-    const items = bucketIntoFolders(
-      buildProjectThreadGroups([
+    const items = buildFolderThreadList(
+      [
         createThread({
           id: "busy",
           title: "Busy",
@@ -832,10 +718,8 @@ describe("folder bucketing", () => {
           hasPendingInteraction: true,
         }),
         createThread({ id: "quiet", title: "Quiet", folderId: "fld_work" }),
-      ]),
-      "proj_1",
+      ],
       compareStandardThreads,
-      undefined,
       [{ id: "fld_work", name: "Work" }],
     );
 
@@ -848,8 +732,8 @@ describe("folder bucketing", () => {
     expect(folder.group.activity.pending).toBe(true);
   });
 
-  it("folds the chronological list into folders too", () => {
-    const items = buildChronologicalThreadList(
+  it("folds the chronological list into folders", () => {
+    const items = buildFolderThreadList(
       [
         createThread({
           id: "a",
@@ -865,14 +749,10 @@ describe("folder bucketing", () => {
         }),
       ],
       compareByCreatedAtDescending,
-      {
-        groupBy: "folder",
-        containerId: "chronological",
-        folders: [
-          { id: "fld_personal", name: "Personal" },
-          { id: "fld_work", name: "Work" },
-        ],
-      },
+      [
+        { id: "fld_personal", name: "Personal" },
+        { id: "fld_work", name: "Work" },
+      ],
     );
 
     expect(summarizeItems(items)).toEqual([
@@ -882,7 +762,7 @@ describe("folder bucketing", () => {
   });
 
   it("nests a child thread under its parent root inside a folder", () => {
-    const items = buildChronologicalThreadList(
+    const items = buildFolderThreadList(
       [
         createThread({
           id: "parent",
@@ -898,11 +778,7 @@ describe("folder bucketing", () => {
         }),
       ],
       compareByCreatedAtDescending,
-      {
-        groupBy: "folder",
-        containerId: "chronological",
-        folders: [{ id: "fld_work", name: "Work" }],
-      },
+      [{ id: "fld_work", name: "Work" }],
     );
 
     // The child follows its parent into the folder as a nested row rather than
@@ -917,7 +793,7 @@ describe("folder bucketing", () => {
   });
 
   it("combines threads from different projects that share the same folder id", () => {
-    const items = buildChronologicalThreadList(
+    const items = buildFolderThreadList(
       [
         createThread({
           id: "a",
@@ -935,43 +811,11 @@ describe("folder bucketing", () => {
         }),
       ],
       compareByCreatedAtDescending,
-      {
-        groupBy: "folder",
-        containerId: "chronological",
-        folders: [{ id: "fld_work", name: "Work" }],
-      },
+      [{ id: "fld_work", name: "Work" }],
     );
 
     expect(summarizeItems(items)).toEqual([
       { folder: "chronological::fld_work", name: "Work", items: ["a", "b"] },
     ]);
-  });
-
-  describe("regression: Group by: None is unchanged", () => {
-    const slashFixture = [
-      createThread({ id: "a", title: "Work/Q3/Plan", createdAt: 30 }),
-      createThread({ id: "b", title: "Work/Notes", createdAt: 20 }),
-      createThread({ id: "c", title: "Standalone", createdAt: 10 }),
-    ];
-
-    it("returns output deep-equal to the pre-change builder for '/'-titled threads", () => {
-      const baseline = buildProjectThreadGroups(slashFixture);
-      const withNone = buildProjectThreadGroups(
-        slashFixture,
-        compareStandardThreads,
-        { groupBy: "none", containerId: "proj_1" },
-      );
-      expect(withNone).toEqual(baseline);
-    });
-
-    it("never enters the folder branch (no folder items even with slashes)", () => {
-      const withNone = buildProjectThreadGroups(
-        slashFixture,
-        compareStandardThreads,
-        { groupBy: "none", containerId: "proj_1" },
-      );
-      expect(withNone.some((item) => item.kind === "folder")).toBe(false);
-      expect(summarizeItems(withNone)).toEqual(["a", "b", "c"]);
-    });
   });
 });

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -8,12 +8,8 @@ import {
   type CollapsedChildActivity,
 } from "@/lib/thread-activity";
 import { buildFolderKey } from "./folderKeys";
-import type {
-  SidebarGroupBy,
-  SidebarManualOrder,
-} from "./sidebarCollapsedAtoms";
 
-export interface ProjectThreadNodeStats {
+interface ProjectThreadNodeStats {
   childCount: number;
   childActivity: CollapsedChildActivity;
 }
@@ -25,7 +21,7 @@ export interface ProjectThreadNode {
   stats: ProjectThreadNodeStats;
 }
 
-export type EnvironmentThreadGroupNodes = [
+type EnvironmentThreadGroupNodes = [
   ProjectThreadNode,
   ProjectThreadNode,
   ...ProjectThreadNode[],
@@ -60,27 +56,14 @@ export type ProjectThreadItem =
   | { kind: "environment"; group: EnvironmentThreadGroup }
   | { kind: "folder"; group: SidebarFolderGroup };
 
-// Folder grouping, threaded into the three assembly sites. `containerId` scopes
-// folder identity to its section (a `proj_*` id, or the sentinels below). When
-// groupBy is "none" each site early-returns its current output untouched — no
-// folder logic runs.
-export interface SidebarFolderOptions {
-  groupBy: SidebarGroupBy;
-  containerId: string;
-  folders?: readonly SidebarFolderDefinition[];
-  manualOrder?: SidebarManualOrder;
-}
-
-// Container-id sentinels for the global (non-project) sections; project
-// sections use their own `proj_*` id. These namespace folder keys and manual
-// order so "Work" in one section never collides with "Work" in another.
+// Container-id sentinel for the global folder section. It namespaces persisted
+// collapse keys and dnd ids from other sidebar rows.
 export const CHRONOLOGICAL_CONTAINER_ID = "chronological";
-export const PINNED_CONTAINER_ID = "pinned";
 
 // Orders sibling threads. The default keeps active rows pinned to createdAt and
 // inactive rows on attention recency; chronological mode can swap in a literal
 // createdAt comparator instead.
-export type ThreadItemComparator = (
+type ThreadItemComparator = (
   left: ProjectThreadItem,
   right: ProjectThreadItem,
 ) => number;
@@ -321,57 +304,9 @@ function isRootThread(
 export function buildProjectThreadGroups(
   allProjectThreads: readonly ThreadListEntry[],
   compareThreads: ThreadComparator = compareStandardThreads,
-  folderOptions?: SidebarFolderOptions,
 ): ProjectThreadItem[] {
   // Project sections group worktree siblings into synthetic environment rows.
-  return assembleThreadItems(
-    allProjectThreads,
-    compareThreads,
-    true,
-    folderOptions,
-  );
-}
-
-// Build the parent/child thread tree, then apply the section's folder grouping
-// or manual order. `groupEnvironmentThreads` toggles worktree-sibling grouping:
-// on for project sections, off for the chronological "All Threads" bucket so
-// Group by None never adds synthetic environment group rows. Folders and manual
-// order run on the root items, so descendants stay nested under their parent and
-// follow it into its folder. Both entry points share this one assembler so the
-// chronological and project paths cannot silently drift apart.
-function assembleThreadItems(
-  allThreads: readonly ThreadListEntry[],
-  compareThreads: ThreadComparator,
-  groupEnvironmentThreads: boolean,
-  folderOptions?: SidebarFolderOptions,
-): ProjectThreadItem[] {
-  const rootItems = buildThreadTreeItems(
-    allThreads,
-    compareThreads,
-    groupEnvironmentThreads,
-  );
-  // Group by: None — return today's output untouched unless an internal test
-  // path explicitly supplied a manual order for this section.
-  if (folderOptions?.groupBy !== "folder") {
-    if (folderOptions?.manualOrder) {
-      return orderSiblingItems(
-        rootItems,
-        folderOptions.containerId,
-        compareThreads,
-        {
-          manualOrder: folderOptions.manualOrder,
-        },
-      );
-    }
-    return rootItems;
-  }
-  return bucketIntoFolders(
-    rootItems,
-    folderOptions.containerId,
-    compareThreads,
-    folderOptions.manualOrder,
-    folderOptions.folders,
-  );
+  return buildThreadTreeItems(allProjectThreads, compareThreads, true);
 }
 
 function buildThreadTreeItems(
@@ -437,16 +372,28 @@ function buildThreadTreeItems(
 }
 
 // Chronological "All Threads" bucket: root threads are globally ordered by the
-// chosen comparator, descendants stay nested under their parent, and folder
-// grouping/manual order run on the roots. Worktree grouping stays off so Group
-// by None does not add synthetic environment group rows. Side chats are excluded
-// to match buildProjectThreadGroups.
+// chosen comparator and descendants stay nested under their parent. Worktree
+// grouping stays off. Side chats are excluded to match buildProjectThreadGroups.
 export function buildChronologicalThreadList(
   allThreads: readonly ThreadListEntry[],
   compareThreads: ThreadComparator = compareStandardThreads,
-  folderOptions?: SidebarFolderOptions,
 ): ProjectThreadItem[] {
-  return assembleThreadItems(allThreads, compareThreads, false, folderOptions);
+  return buildThreadTreeItems(allThreads, compareThreads, false);
+}
+
+// The global Folders view uses the chronological root tree, then buckets those
+// roots by their durable folder id. Descendants stay nested under their parent.
+export function buildFolderThreadList(
+  allThreads: readonly ThreadListEntry[],
+  compareThreads: ThreadComparator = compareStandardThreads,
+  folders: readonly SidebarFolderDefinition[] = [],
+): ProjectThreadItem[] {
+  return bucketIntoFolders(
+    buildChronologicalThreadList(allThreads, compareThreads),
+    CHRONOLOGICAL_CONTAINER_ID,
+    compareThreads,
+    folders,
+  );
 }
 
 export function isSidebarProjectThread(
@@ -503,10 +450,6 @@ function hasAtLeastTwoThreadNodes(
   return nodes.length >= 2;
 }
 
-interface ManualOrderSiblingOptions {
-  manualOrder?: SidebarManualOrder;
-}
-
 // The thread that orders an item among its siblings.
 function getItemOrderingThread(
   item: ProjectThreadItem,
@@ -529,7 +472,7 @@ function getItemOrderingThread(
   }
 }
 
-export function getManualOrderItemKey(item: ProjectThreadItem): string {
+export function getSidebarDndItemId(item: ProjectThreadItem): string {
   switch (item.kind) {
     case "thread":
       return item.node.thread.id;
@@ -540,72 +483,11 @@ export function getManualOrderItemKey(item: ProjectThreadItem): string {
   }
 }
 
-export function pruneManualOrderForChildren(
-  storedOrder: readonly string[] | undefined,
-  childKeys: ReadonlySet<string>,
-): string[] {
-  if (!storedOrder) {
-    return [];
-  }
-
-  const seen = new Set<string>();
-  const pruned: string[] = [];
-  for (const key of storedOrder) {
-    if (!childKeys.has(key) || seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    pruned.push(key);
-  }
-  return pruned;
-}
-
-function orderItemsByManualOrder(
-  items: readonly ProjectThreadItem[],
-  parentKey: string,
-  compareThreads: ThreadComparator,
-  manualOrder: SidebarManualOrder,
-): ProjectThreadItem[] {
-  const itemsByKey = new Map<string, ProjectThreadItem>();
-  for (const item of items) {
-    itemsByKey.set(getManualOrderItemKey(item), item);
-  }
-
-  const childKeys = new Set(itemsByKey.keys());
-  const prunedOrder = pruneManualOrderForChildren(
-    manualOrder[parentKey],
-    childKeys,
-  );
-  const orderedKeys = new Set(prunedOrder);
-  const unorderedItems = items
-    .filter((item) => !orderedKeys.has(getManualOrderItemKey(item)))
-    .sort((left, right) => compareSiblingItems(left, right, compareThreads));
-  const orderedItems = prunedOrder.flatMap((key) => {
-    const item = itemsByKey.get(key);
-    return item ? [item] : [];
-  });
-
-  return [...unorderedItems, ...orderedItems];
-}
-
-// The one sibling-ordering hook. It orders folders-first, each block by the
-// active comparator. Internal manual-order tests can still supply a stored
-// per-parent order; missing child keys stay at the top in fallback order.
+// Orders folders first, then each block by the active comparator.
 function orderSiblingItems(
   items: readonly ProjectThreadItem[],
-  parentKey: string,
   compareThreads: ThreadComparator,
-  options: ManualOrderSiblingOptions = {},
 ): ProjectThreadItem[] {
-  if (options.manualOrder) {
-    return orderItemsByManualOrder(
-      items,
-      parentKey,
-      compareThreads,
-      options.manualOrder,
-    );
-  }
-
   const decorated = items.map((item) => ({
     item,
     isFolder: item.kind === "folder",
@@ -670,11 +552,10 @@ function buildFolderGroup(
 }
 
 // Fold a top-level item list into flat DB-backed folders plus loose items.
-export function bucketIntoFolders(
+function bucketIntoFolders(
   items: readonly ProjectThreadItem[],
   containerId: string,
   compareThreads: ThreadComparator = compareStandardThreads,
-  manualOrder?: SidebarManualOrder,
   folders: readonly SidebarFolderDefinition[] = [],
 ): ProjectThreadItem[] {
   const folderDefinitionsById = new Map<string, SidebarFolderDefinition>();
@@ -713,12 +594,9 @@ export function bucketIntoFolders(
   }
 
   const folderItemsByName = orderedFolders.map((folder): ProjectThreadItem => {
-    const folderKey = buildFolderKey(containerId, folder.id);
     const children = orderSiblingItems(
       itemsByFolderId.get(folder.id) ?? [],
-      folderKey,
       compareThreads,
-      { manualOrder },
     );
     return {
       kind: "folder",
@@ -726,15 +604,8 @@ export function bucketIntoFolders(
     };
   });
   const folderItems = compareThreads.compareItems
-    ? orderSiblingItems(folderItemsByName, containerId, compareThreads, {
-        manualOrder,
-      })
+    ? orderSiblingItems(folderItemsByName, compareThreads)
     : folderItemsByName;
-  const orderedLooseItems = orderSiblingItems(
-    looseItems,
-    containerId,
-    compareThreads,
-    { manualOrder },
-  );
+  const orderedLooseItems = orderSiblingItems(looseItems, compareThreads);
   return [...folderItems, ...orderedLooseItems];
 }

--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -9,9 +9,7 @@ const SIDEBAR_SECTION_ORDER_STORAGE_KEY = "bb.sidebar.sectionOrder";
 const ORGANIZATION_MODE_STORAGE_KEY = "bb.sidebar.organizationMode";
 const CHRONOLOGICAL_SORT_STORAGE_KEY = "bb.sidebar.chronologicalSort";
 const SORT_DIRECTION_STORAGE_KEY = "bb.sidebar.sortDirection";
-const GROUP_BY_STORAGE_KEY = "bb.sidebar.groupBy";
 const COLLAPSED_FOLDERS_STORAGE_KEY = "bb.sidebar.collapsedFolders";
-const MANUAL_ORDER_STORAGE_KEY = "bb.sidebar.manualOrder";
 
 export type SidebarSectionId = "pinned" | "projects" | "threads";
 export type CollapsibleSidebarSectionId =
@@ -29,12 +27,6 @@ export type SidebarOrganizationMode = "project" | "chronological";
 // legacy/internal value that the runtime normalizes back to "updated".
 export type SidebarChronologicalSort = "updated" | "created" | "alpha" | "none";
 export type SidebarSortDirection = "asc" | "desc";
-// Low-level folder grouping switch used by folder helpers and tests. Runtime
-// sidebar trees enable "folder" only in the Folders organization mode.
-export type SidebarGroupBy = "none" | "folder";
-// Per-parent manual order for Sort: None. Keys are section/folder parent keys;
-// values are child thread ids and child folder keys.
-export type SidebarManualOrder = Record<string, string[]>;
 
 export const DEFAULT_SIDEBAR_SECTION_ORDER: readonly SidebarSectionId[] = [
   "pinned",
@@ -102,27 +94,11 @@ export const sidebarSortDirectionAtom = atomWithStorage<SidebarSortDirection>(
   { getOnInit: true },
 );
 
-// Story/test control for the low-level folder grouping path. Runtime sidebar
-// trees enable "folder" only in the Folders organization mode.
-export const sidebarGroupByAtom = atomWithStorage<SidebarGroupBy>(
-  GROUP_BY_STORAGE_KEY,
-  "none",
-  createJsonLocalStorage<SidebarGroupBy>(),
-  { getOnInit: true },
-);
-
 // Collapsed folder keys (see buildFolderKey in folderKeys.ts). A plain string[],
 // matching collapsedThreadIds / collapsedProjectIds.
 export const sidebarCollapsedFoldersAtom = atomWithStorage<string[]>(
   COLLAPSED_FOLDERS_STORAGE_KEY,
   [],
   createJsonLocalStorage<string[]>(),
-  { getOnInit: true },
-);
-
-export const sidebarManualOrderAtom = atomWithStorage<SidebarManualOrder>(
-  MANUAL_ORDER_STORAGE_KEY,
-  {},
-  createJsonLocalStorage<SidebarManualOrder>(),
   { getOnInit: true },
 );

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -19,10 +19,7 @@ export const SIDEBAR_ROW_GLYPH_SLOT_CLASS =
  * Inner styling only — call sites own wrapper, positioning, fade, and the
  * aria-label.
  */
-export const SIDEBAR_UNREAD_DOT_CLASS_BY_TONE: Record<
-  SidebarUnreadDotTone,
-  string
-> = {
+const SIDEBAR_UNREAD_DOT_CLASS_BY_TONE: Record<SidebarUnreadDotTone, string> = {
   default: `rounded-full bg-foreground ${COARSE_POINTER_DOT_SIZE_CLASS}`,
   error: `rounded-full bg-destructive ${COARSE_POINTER_DOT_SIZE_CLASS}`,
 };
@@ -31,11 +28,6 @@ export const SIDEBAR_UNREAD_DOT_CLASS =
   SIDEBAR_UNREAD_DOT_CLASS_BY_TONE.default;
 
 export const SIDEBAR_WORKING_STATUS_COLOR_CLASS = "text-muted-foreground/50";
-
-export const SIDEBAR_SUCCESS_STATUS_COLOR_CLASS = "text-muted-foreground/60";
-
-export const SIDEBAR_SUCCESS_STATUS_ICON_SIZE_CLASS =
-  "size-3.5 max-md:pointer-coarse:size-4";
 
 export const SIDEBAR_SUCCESS_STATUS_DOT_CLASS =
   "size-[5px] rounded-full bg-muted-foreground/60 max-md:pointer-coarse:size-1.5";

--- a/apps/app/src/components/sidebar/sidebarThreadSearch.ts
+++ b/apps/app/src/components/sidebar/sidebarThreadSearch.ts
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import type { ThreadSearchMatch } from "@bb/server-contract";
 
 export const SIDEBAR_THREAD_SEARCH_LISTBOX_ID =
   "bb-sidebar-thread-search-results";
@@ -46,6 +47,10 @@ export function getSidebarThreadSearchShortcutLabel(): "Cmd+K" | "Ctrl+K" {
 
 export function getSidebarThreadSearchOptionId(rowId: string): string {
   return `${SIDEBAR_THREAD_SEARCH_LISTBOX_ID}-option-${rowId}`;
+}
+
+export function isSidebarThreadTitleMatch(match: ThreadSearchMatch): boolean {
+  return match.sourceKind === "title" || match.sourceKind === "title_fallback";
 }
 
 export function haveSameSidebarThreadSearchNavigationItems(

--- a/apps/app/src/components/sidebar/sortableMotion.ts
+++ b/apps/app/src/components/sidebar/sortableMotion.ts
@@ -23,12 +23,12 @@ export interface SidebarSortableDragBindings {
   setActivatorNodeRef: (element: HTMLElement | null) => void;
 }
 
-export interface UseSidebarSortableArgs {
+interface UseSidebarSortableArgs {
   id: string;
   disabled: boolean;
 }
 
-export interface UseSidebarSortableResult {
+interface UseSidebarSortableResult {
   dragBindings: SidebarSortableDragBindings;
   setNodeRef: (element: HTMLElement | null) => void;
   style: CSSProperties;

--- a/apps/app/src/components/sidebar/threadReadState.ts
+++ b/apps/app/src/components/sidebar/threadReadState.ts
@@ -1,7 +1,7 @@
 import type { Thread } from "@bb/domain";
 import { isThreadRead } from "@/lib/thread-read-state";
 
-export type ThreadReadToggleAction = "mark_read" | "mark_unread";
+type ThreadReadToggleAction = "mark_read" | "mark_unread";
 
 export function getThreadReadToggleAction(
   thread: Pick<Thread, "lastReadAt" | "latestAttentionAt">,

--- a/apps/app/src/components/sidebar/useNeighborReorderSortable.ts
+++ b/apps/app/src/components/sidebar/useNeighborReorderSortable.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { flushSync } from "react-dom";
 import type { DragEndEvent } from "@dnd-kit/core";
 import {
@@ -7,13 +7,7 @@ import {
   type NeighborReorderRequest,
 } from "@/lib/neighbor-reorder";
 
-interface HasSameOptimisticOrderArgs<Item> {
-  getId: (item: Item) => string;
-  items: readonly Item[];
-  order: readonly string[];
-}
-
-export interface NeighborReorderSortableCallbacks {
+interface NeighborReorderSortableCallbacks {
   onSettled: () => void;
 }
 
@@ -27,25 +21,10 @@ export interface UseNeighborReorderSortableArgs<Item> {
   ) => void;
 }
 
-export interface UseNeighborReorderSortableResult<Item> {
+interface UseNeighborReorderSortableResult<Item> {
   handleDragEnd: (event: DragEndEvent) => void;
   itemIds: string[];
   renderedItems: readonly Item[];
-}
-
-function hasSameOptimisticOrder<Item>({
-  getId,
-  items,
-  order,
-}: HasSameOptimisticOrderArgs<Item>): boolean {
-  if (order.length !== items.length) {
-    return false;
-  }
-
-  return order.every((id, index) => {
-    const currentItem = items[index];
-    return currentItem !== undefined && id === getId(currentItem);
-  });
 }
 
 export function useNeighborReorderSortable<Item>({
@@ -119,16 +98,6 @@ export function useNeighborReorderSortable<Item>({
     },
     [disabled, getId, onReorder, renderedItems],
   );
-
-  useEffect(() => {
-    if (!optimisticOrder) {
-      return;
-    }
-
-    if (hasSameOptimisticOrder({ getId, items, order: optimisticOrder })) {
-      setOptimisticOrder(null);
-    }
-  }, [getId, items, optimisticOrder]);
 
   return {
     handleDragEnd,

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type {
+  DragCancelEvent,
+  DragEndEvent,
+  DragStartEvent,
+} from "@dnd-kit/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
+
+const DRAG_START_EVENT = { active: { id: "thread-1" } } as DragStartEvent;
+const DRAG_END_EVENT = {
+  active: { id: "thread-1" },
+  over: { id: "thread-2" },
+} as DragEndEvent;
+const DRAG_CANCEL_EVENT = { active: { id: "thread-1" } } as DragCancelEvent;
+
+afterEach(() => {
+  cleanup();
+  delete document.body.dataset.sidebarDragging;
+});
+
+describe("useSidebarReorderDnd", () => {
+  it("marks the document as dragging until end, cancel, or unmount", () => {
+    const onDragEnd = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useSidebarReorderDnd({ onDragEnd }),
+    );
+
+    act(() => result.current.dndContextProps.onDragStart?.(DRAG_START_EVENT));
+    expect(document.body.dataset.sidebarDragging).toBe("true");
+
+    act(() => result.current.dndContextProps.onDragCancel?.(DRAG_CANCEL_EVENT));
+    expect(document.body.dataset.sidebarDragging).toBeUndefined();
+
+    act(() => result.current.dndContextProps.onDragStart?.(DRAG_START_EVENT));
+    act(() => result.current.dndContextProps.onDragEnd?.(DRAG_END_EVENT));
+    expect(document.body.dataset.sidebarDragging).toBeUndefined();
+    expect(onDragEnd).toHaveBeenCalledWith(DRAG_END_EVENT);
+
+    act(() => result.current.dndContextProps.onDragStart?.(DRAG_START_EVENT));
+    unmount();
+    expect(document.body.dataset.sidebarDragging).toBeUndefined();
+  });
+});

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type MouseEventHandler } from "react";
+import { useCallback, useEffect, useMemo, type MouseEventHandler } from "react";
 import {
   closestCenter,
   KeyboardSensor,
@@ -42,7 +42,15 @@ const SIDEBAR_REORDER_MODIFIERS: Modifier[] = [
   restrictSidebarDragToVerticalAxis,
 ];
 
-export interface UseSidebarReorderDndArgs {
+function setSidebarDraggingCursor(active: boolean): void {
+  if (active) {
+    document.body.dataset.sidebarDragging = "true";
+    return;
+  }
+  delete document.body.dataset.sidebarDragging;
+}
+
+interface UseSidebarReorderDndArgs {
   /**
    * Performs the reorder once a drag settles. The hook clears the drag-click
    * suppression timer before invoking it, so callers only own the reorder.
@@ -67,7 +75,7 @@ export type SidebarReorderDndContextProps = Pick<
   | "modifiers"
 >;
 
-export interface UseSidebarReorderDndResult {
+interface UseSidebarReorderDndResult {
   /** Spread onto the surface's `DndContext`. */
   dndContextProps: SidebarReorderDndContextProps;
   /**
@@ -107,21 +115,30 @@ export function useSidebarReorderDnd({
   );
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
+      setSidebarDraggingCursor(true);
       beginDragClickSuppression();
       onDragStart?.(event);
     },
     [beginDragClickSuppression, onDragStart],
   );
   const handleDragCancel = useCallback(() => {
+    setSidebarDraggingCursor(false);
     clearDragClickSuppressionSoon();
     onDragCancel?.();
   }, [clearDragClickSuppressionSoon, onDragCancel]);
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      setSidebarDraggingCursor(false);
       clearDragClickSuppressionSoon();
       onDragEnd(event);
     },
     [clearDragClickSuppressionSoon, onDragEnd],
+  );
+  useEffect(
+    () => () => {
+      setSidebarDraggingCursor(false);
+    },
+    [],
   );
   const onClickCapture = useCallback<MouseEventHandler<HTMLElement>>(
     (event) => {

--- a/packages/db/src/data/thread-folders.ts
+++ b/packages/db/src/data/thread-folders.ts
@@ -199,12 +199,12 @@ export function deleteThreadFolder(
 
       const now = Date.now();
       const affectedProjects = new Set<string>();
+      tx.update(threads)
+        .set({ folderId: null, updatedAt: now })
+        .where(eq(threads.folderId, input.id))
+        .run();
       for (const thread of matchingThreads) {
         affectedProjects.add(thread.projectId);
-        tx.update(threads)
-          .set({ folderId: null, updatedAt: now })
-          .where(eq(threads.id, thread.id))
-          .run();
         notifier.notifyThread(thread.id, ["title-changed"], {
           projectId: thread.projectId,
         });


### PR DESCRIPTION
## Summary

- remove obsolete manual folder ordering state and duplicate folder-tree render paths
- centralize collapsed activity, pinned rendering, menu state, search classification, and folder membership DnD naming
- bulk-unfile threads when deleting folders and tighten sidebar atom subscriptions
- show a grabbing cursor for every active sidebar drag with lifecycle cleanup coverage

## Validation

- 90 sidebar tests passed
- 47 database thread/folder tests passed
- app, database, and server typechecks passed
- production app build passed
- app lint passed with 0 errors
- Prettier and git diff checks passed
- seeded and verified an isolated live dev instance with 33 threads, 6 folders, nesting, worktrees, activity rollups, archived search, and drag/drop targets

## Risk

The drag/drop mechanics and existing UX are preserved. The implementation removes unused persisted ordering state; folder membership remains durable and sortable views continue using their existing comparators.