### PR TITLE
Keep Codex subagent usage out of parent context reports

### DIFF
--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -54,6 +54,14 @@ import {
 const STORED_EVENT_SEQUENCE_LOOKUP_CHUNK_SIZE = 250;
 
 const isRootTurnStartedEventData = sql`COALESCE(json_extract(${events.data}, '$.parentToolCallId'), '') = ''`;
+const isNotNestedTurnUsageEvent = sql`NOT EXISTS (
+  SELECT 1
+  FROM events AS nested_turn_started
+  WHERE nested_turn_started.thread_id = ${events.threadId}
+    AND nested_turn_started.turn_id = ${events.turnId}
+    AND nested_turn_started.type = 'turn/started'
+    AND COALESCE(json_extract(nested_turn_started.data, '$.parentToolCallId'), '') <> ''
+)`;
 const isEnvironmentDirectoryUpdateEventData = sql`json_extract(${events.data}, '$.operation') = 'environment_directory_update'`;
 
 export interface InsertEventInput {
@@ -1823,7 +1831,11 @@ function listLatestRowsForContextWindowUsage(
     .select(storedEventRowFields)
     .from(events)
     .where(
-      and(eq(events.threadId, args.threadId), eq(events.type, args.eventType)),
+      and(
+        eq(events.threadId, args.threadId),
+        eq(events.type, args.eventType),
+        isNotNestedTurnUsageEvent,
+      ),
     )
     .orderBy(desc(events.sequence))
     .limit(1)
@@ -1840,6 +1852,7 @@ function listLatestRowsForContextWindowUsage(
       and(
         eq(events.threadId, args.threadId),
         eq(events.type, args.eventType),
+        isNotNestedTurnUsageEvent,
         sql`json_extract(${events.data}, ${args.contextWindowJsonPath}) IS NOT NULL`,
       ),
     )
@@ -2262,28 +2275,39 @@ function pruneLatestRowsForContextWindowUsageBeforeSequence(
     return 0;
   }
 
-  // The timeline needs the latest totals row plus the latest older row that
-  // still carries a non-null modelContextWindow.
+  // The timeline needs the latest root-turn totals row plus the latest older
+  // root-turn row that still carries a non-null modelContextWindow. Usage from
+  // nested turns belongs to subagents and must not replace either report.
   const result = db.run(
-    sql`DELETE FROM events
+    sql`WITH root_usage AS (
+          SELECT usage.id, usage.sequence, usage.data
+          FROM events AS usage
+          WHERE usage.thread_id = ${args.threadId}
+            AND usage.type = ${args.eventType}
+            AND NOT EXISTS (
+              SELECT 1
+              FROM events AS nested_turn_started
+              WHERE nested_turn_started.thread_id = usage.thread_id
+                AND nested_turn_started.turn_id = usage.turn_id
+                AND nested_turn_started.type = 'turn/started'
+                AND COALESCE(json_extract(nested_turn_started.data, '$.parentToolCallId'), '') <> ''
+            )
+        )
+        DELETE FROM events
         WHERE ${events.threadId} = ${args.threadId}
           AND ${events.type} = ${args.eventType}
           AND ${events.sequence} <= ${args.sequenceCutoff}
           AND ${events.id} NOT IN (
-            SELECT latest.id
-            FROM events latest
-            WHERE latest.thread_id = ${args.threadId}
-              AND latest.type = ${args.eventType}
-            ORDER BY latest.sequence DESC
+            SELECT root_usage.id
+            FROM root_usage
+            ORDER BY root_usage.sequence DESC
             LIMIT 1
           )
           AND ${events.id} NOT IN (
-            SELECT latest_context.id
-            FROM events latest_context
-            WHERE latest_context.thread_id = ${args.threadId}
-              AND latest_context.type = ${args.eventType}
-              AND json_extract(latest_context.data, ${args.contextWindowJsonPath}) IS NOT NULL
-            ORDER BY latest_context.sequence DESC
+            SELECT root_usage.id
+            FROM root_usage
+            WHERE json_extract(root_usage.data, ${args.contextWindowJsonPath}) IS NOT NULL
+            ORDER BY root_usage.sequence DESC
             LIMIT 1
           )`,
   );

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -806,6 +806,63 @@ describe("events", () => {
     ).toEqual([2, 3]);
   });
 
+  it("keeps nested-turn context usage from replacing the root turn report", () => {
+    const { db, thread } = setup();
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "turn/started",
+        ...createTurnEventFields({ turnId: "turn-root" }),
+        data: "{}",
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "thread/contextWindowUsage/updated",
+        ...createTurnEventFields({ turnId: "turn-root" }),
+        data: createContextWindowUsageData({
+          modelContextWindow: 200_000,
+          usedTokens: 80_000,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
+        type: "turn/started",
+        ...createTurnEventFields({ turnId: "turn-subagent" }),
+        data: JSON.stringify({ parentToolCallId: "call-subagent" }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 4,
+        type: "thread/contextWindowUsage/updated",
+        ...createTurnEventFields({ turnId: "turn-subagent" }),
+        data: createContextWindowUsageData({
+          modelContextWindow: 200_000,
+          usedTokens: 15_000,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 5,
+        type: "thread/contextWindowUsage/updated",
+        ...createTurnEventFields({ turnId: "turn-root" }),
+        data: createContextWindowUsageData({
+          modelContextWindow: null,
+          usedTokens: 90_000,
+        }),
+      },
+    ]);
+
+    expect(
+      listContextWindowUsageRows(db, {
+        threadId: thread.id,
+      }).map((row) => row.sequence),
+    ).toEqual([2, 5]);
+  });
+
   it("lists bounded timeline segment anchors with request shape rules", () => {
     const { db, thread } = setup();
 
@@ -2106,6 +2163,60 @@ describe("events", () => {
     expect(
       listEvents(db, { threadId: thread.id }).map((event) => event.sequence),
     ).toEqual([1, 4]);
+  });
+
+  it("preserves root token usage instead of a newer nested-turn report while pruning", () => {
+    const { db, thread } = setup();
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "thread/tokenUsage/updated",
+        ...createTurnEventFields({ turnId: "turn-root" }),
+        data: createTokenUsageData({
+          totalTokens: 80_000,
+          modelContextWindow: 200_000,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "thread/tokenUsage/updated",
+        ...createTurnEventFields({ turnId: "turn-root" }),
+        data: createTokenUsageData({
+          totalTokens: 90_000,
+          modelContextWindow: null,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
+        type: "turn/started",
+        ...createTurnEventFields({ turnId: "turn-subagent" }),
+        data: JSON.stringify({ parentToolCallId: "call-subagent" }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 4,
+        type: "thread/tokenUsage/updated",
+        ...createTurnEventFields({ turnId: "turn-subagent" }),
+        data: createTokenUsageData({
+          totalTokens: 15_000,
+          modelContextWindow: 200_000,
+        }),
+      },
+    ]);
+
+    const removed = pruneTokenUsageEventsBeforeSequence(db, {
+      threadId: thread.id,
+      sequenceCutoff: 4,
+    });
+
+    expect(removed).toBe(1);
+    expect(
+      listEvents(db, { threadId: thread.id }).map((event) => event.sequence),
+    ).toEqual([1, 2, 3]);
   });
 
   it("prunes context-window rows before a sequence cutoff but keeps the latest usage row and latest context row", () => {

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -300,8 +300,8 @@ describe("slow query index plans", () => {
       logger,
       predicate: (fields) =>
         fields.operation === "run" &&
-        fields.sql.startsWith("DELETE FROM events") &&
-        fields.sql.includes("latest_context"),
+        fields.sql.includes("DELETE FROM events") &&
+        fields.sql.includes("root_usage"),
     });
     assertEmittedQueryPlanUsesIndex({
       db,
@@ -310,11 +310,9 @@ describe("slow query index plans", () => {
       params: [
         thread.id,
         "thread/contextWindowUsage/updated",
+        thread.id,
+        "thread/contextWindowUsage/updated",
         sequenceCutoff,
-        thread.id,
-        "thread/contextWindowUsage/updated",
-        thread.id,
-        "thread/contextWindowUsage/updated",
         "$.contextWindowUsage.modelContextWindow",
       ],
     });


### PR DESCRIPTION
## Summary
- exclude nested-turn usage events from the parent thread context-window report
- preserve root-turn usage and context rows during event pruning
- add regressions for live selection, pruning, and the indexed query plan

## Testing
- pnpm exec turbo run test --filter=@bb/db --force
- pnpm exec turbo run typecheck --filter=@bb/db
- pnpm exec prettier packages/db/src/data/events.ts packages/db/test/data/events.test.ts packages/db/test/query-plans.test.ts --check
- git diff --check