### PR TITLE
Add command shortcuts for sidebar threads

### DIFF
--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -39,6 +39,13 @@ import {
   haveSameSidebarThreadSearchNavigationItems,
   type SidebarThreadSearchNavigationItem,
 } from "./sidebarThreadSearch";
+import {
+  EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS,
+  getSidebarThreadShortcutIndex,
+  getSidebarThreadShortcutTargets,
+  SidebarThreadShortcutKeysContext,
+  type SidebarThreadShortcutTarget,
+} from "./sidebarThreadShortcuts";
 
 const BUG_REPORT_NEW_ISSUE_URL = "https://github.com/ymichael/bb/issues/new";
 const SIDEBAR_FOOTER_ACTION_CLASS = cn(
@@ -80,6 +87,13 @@ export function AppSidebar({
   const [threadSearchActiveIndex, setThreadSearchActiveIndex] = useState(0);
   const [threadSearchNavigationItems, setThreadSearchNavigationItems] =
     useState<readonly SidebarThreadSearchNavigationItem[]>([]);
+  const [threadShortcutKeysById, setThreadShortcutKeysById] = useState<
+    ReadonlyMap<string, string>
+  >(EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS);
+  const sidebarRef = useRef<HTMLDivElement | null>(null);
+  const threadShortcutTargetsRef = useRef<
+    readonly SidebarThreadShortcutTarget[]
+  >([]);
   const threadSearchInputRef = useRef<HTMLInputElement | null>(null);
   const isPointerCoarse = usePointerCoarse();
   const threadSearchActiveDescendantId =
@@ -159,6 +173,19 @@ export function AppSidebar({
     });
   }, [closeOnMobile, navigate]);
 
+  const showThreadShortcuts = useCallback(() => {
+    const targets = getSidebarThreadShortcutTargets(sidebarRef.current);
+    threadShortcutTargetsRef.current = targets;
+    setThreadShortcutKeysById(
+      new Map(targets.map((target) => [target.threadId, target.key])),
+    );
+  }, []);
+
+  const hideThreadShortcuts = useCallback(() => {
+    threadShortcutTargetsRef.current = [];
+    setThreadShortcutKeysById(EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS);
+  }, []);
+
   const handleThreadSearchKeyDown = useCallback<
     KeyboardEventHandler<HTMLDivElement>
   >(
@@ -230,6 +257,21 @@ export function AppSidebar({
 
   useEffect(() => {
     const handleGlobalKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Meta") {
+        showThreadShortcuts();
+        return;
+      }
+
+      const threadShortcutIndex = getSidebarThreadShortcutIndex(event);
+      if (threadShortcutIndex !== null) {
+        const target = threadShortcutTargetsRef.current[threadShortcutIndex];
+        if (target) {
+          event.preventDefault();
+          target.element.click();
+        }
+        return;
+      }
+
       if (
         event.key.toLowerCase() !== "k" ||
         event.shiftKey ||
@@ -242,13 +284,25 @@ export function AppSidebar({
       handleThreadSearchActivate();
     };
 
+    const handleGlobalKeyUp = (event: KeyboardEvent) => {
+      if (event.key === "Meta") {
+        hideThreadShortcuts();
+      }
+    };
+
     window.addEventListener("keydown", handleGlobalKeyDown);
-    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
-  }, [handleThreadSearchActivate]);
+    window.addEventListener("keyup", handleGlobalKeyUp);
+    window.addEventListener("blur", hideThreadShortcuts);
+    return () => {
+      window.removeEventListener("keydown", handleGlobalKeyDown);
+      window.removeEventListener("keyup", handleGlobalKeyUp);
+      window.removeEventListener("blur", hideThreadShortcuts);
+    };
+  }, [handleThreadSearchActivate, hideThreadShortcuts, showThreadShortcuts]);
 
   return (
-    <>
-      <Sidebar onKeyDown={handleThreadSearchKeyDown}>
+    <SidebarThreadShortcutKeysContext.Provider value={threadShortcutKeysById}>
+      <Sidebar ref={sidebarRef} onKeyDown={handleThreadSearchKeyDown}>
         {showTopReserve ? (
           /* Top reserve that keeps the sidebar's content (New Thread / New
              Projects) anchored below the title-bar chrome, mirroring
@@ -365,6 +419,6 @@ export function AppSidebar({
           onMouseDown={onResizeMouseDown}
         />
       </Sidebar>
-    </>
+    </SidebarThreadShortcutKeysContext.Provider>
   );
 }

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -6,6 +6,10 @@ import type { ReactNode } from "react";
 import type { ThreadListEntry } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadRow, type ThreadRowOptions } from "./ThreadRow";
+import {
+  EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS,
+  SidebarThreadShortcutKeysContext,
+} from "./sidebarThreadShortcuts";
 
 vi.mock("@/components/thread/ThreadActionsMenu", () => ({
   ThreadActionsContextMenu: ({ children }: { children: ReactNode }) => (
@@ -68,21 +72,29 @@ const DEFAULT_OPTIONS: ThreadRowOptions = {
 function ThreadRowTestHarness({
   isActive = false,
   options = DEFAULT_OPTIONS,
+  shortcutKey,
   thread,
 }: {
   isActive?: boolean;
   options?: ThreadRowOptions;
+  shortcutKey?: string;
   thread: ThreadListEntry;
 }) {
+  const shortcutKeys = shortcutKey
+    ? new Map([[thread.id, shortcutKey]])
+    : EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS;
+
   return (
     <MemoryRouter>
-      <ThreadRow
-        projectId={thread.projectId}
-        thread={thread}
-        isActive={isActive}
-        hasComposerDraft={false}
-        options={options}
-      />
+      <SidebarThreadShortcutKeysContext.Provider value={shortcutKeys}>
+        <ThreadRow
+          projectId={thread.projectId}
+          thread={thread}
+          isActive={isActive}
+          hasComposerDraft={false}
+          options={options}
+        />
+      </SidebarThreadShortcutKeysContext.Provider>
     </MemoryRouter>
   );
 }
@@ -90,16 +102,19 @@ function ThreadRowTestHarness({
 function renderThreadRow({
   isActive = false,
   options = DEFAULT_OPTIONS,
+  shortcutKey,
   thread = createThread(),
 }: {
   isActive?: boolean;
   options?: ThreadRowOptions;
+  shortcutKey?: string;
   thread?: ThreadListEntry;
 }) {
   const result = render(
     <ThreadRowTestHarness
       isActive={isActive}
       options={options}
+      shortcutKey={shortcutKey}
       thread={thread}
     />,
   );
@@ -110,6 +125,7 @@ function renderThreadRow({
         <ThreadRowTestHarness
           isActive={isActive}
           options={options}
+          shortcutKey={shortcutKey}
           thread={nextThread}
         />,
       );
@@ -120,6 +136,21 @@ function renderThreadRow({
 afterEach(cleanup);
 
 describe("ThreadRow", () => {
+  it("shows its Command shortcut in place of the trailing status", () => {
+    renderThreadRow({
+      shortcutKey: "3",
+      thread: createThread({ hasPendingInteraction: true }),
+    });
+
+    expect(screen.getByText("⌘3")).not.toBeNull();
+    expect(screen.queryByLabelText("Thread needs user input")).toBeNull();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Thread" })
+        .getAttribute("aria-keyshortcuts"),
+    ).toBe("Meta+3");
+  });
+
   it("shows an unread error before pending or active work", () => {
     renderThreadRow({
       thread: createThread({

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -58,6 +58,7 @@ import {
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import type { SidebarSortableDragBindings } from "./sortableMotion";
 import { SidebarChildToggleChevron } from "./SidebarChildToggleChevron";
+import { useSidebarThreadShortcutKey } from "./sidebarThreadShortcuts";
 
 interface ThreadRowBaseOptions {
   depth: number;
@@ -421,6 +422,7 @@ function ThreadRowComponent({
   const setConversationCollapsed = useSetAtom(
     getThreadConversationCollapsedAtom(thread.id),
   );
+  const shortcutKey = useSidebarThreadShortcutKey(thread.id);
   const showActive = isActive;
   const hasPendingInteraction = thread.hasPendingInteraction;
   const threadRuntimeBusy =
@@ -524,6 +526,8 @@ function ThreadRowComponent({
     <>
       <NavLink
         to={getThreadRoutePath({ projectId, threadId: thread.id })}
+        data-sidebar-thread-shortcut-target=""
+        data-sidebar-thread-id={thread.id}
         onClick={() => {
           // Selecting a thread/agent row restores its conversation without
           // disturbing any other thread's collapsed conversation state.
@@ -531,6 +535,7 @@ function ThreadRowComponent({
           onProjectSelect?.();
         }}
         aria-label={linkLabel}
+        aria-keyshortcuts={shortcutKey ? `Meta+${shortcutKey}` : undefined}
         className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
       />
       <span className="flex min-w-0 flex-1 items-center gap-1.5">
@@ -548,56 +553,69 @@ function ThreadRowComponent({
         ) : null}
         {hasComposerDraft ? <ThreadDraftIndicator /> : null}
       </span>
-      <span
-        className={cn(
-          "flex shrink-0 items-center justify-end max-md:pointer-coarse:pointer-events-none",
-          COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
-        )}
-      >
+      {shortcutKey ? (
+        <kbd
+          aria-hidden="true"
+          className="pointer-events-none inline-flex h-5 min-w-7 shrink-0 items-center justify-center rounded-md bg-sidebar-accent px-1 text-xs font-medium tabular-nums text-muted-foreground shadow-[inset_0_0_0_1px_var(--sidebar-border)]"
+        >
+          ⌘{shortcutKey}
+        </kbd>
+      ) : (
         <span
           className={cn(
-            "relative shrink-0",
-            COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+            "flex shrink-0 items-center justify-end max-md:pointer-coarse:pointer-events-none",
+            COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
           )}
         >
           <span
-            data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
             className={cn(
-              SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-              "absolute inset-0 flex items-center justify-center",
+              "relative shrink-0",
+              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
             )}
           >
-            <ThreadTrailingIndicator
-              hasPendingInteraction={trailingHasPendingInteraction}
-              isBackgroundAgentActive={trailingBackgroundAgentActive}
-              isBackgroundCommandActive={trailingBackgroundCommandActive}
-              isForegroundAgentWorking={trailingRuntimeBusy}
-              isGoalActive={trailingGoalActive}
-              isPlanModeActive={trailingPlanModeActive}
-              isBusy={trailingIsBusy}
-              isWorkflowActive={trailingIsWorkflowActive}
-              showUnreadBadge={trailingShowUnreadBadge}
-              unreadBadgeTone={trailingUnreadBadgeTone}
-            />
-          </span>
-          <div
-            data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
-            className={cn(
-              SIDEBAR_HOVER_ACTIONS_CLASS,
-              "absolute inset-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
-            )}
-          >
-            <ThreadActionsMenu
-              thread={thread}
-              triggerClassName={cn(
-                "text-subtle-foreground hover:bg-transparent hover:text-foreground",
-                SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+            <span
+              data-sidebar-hover-actions-open={
+                isActionsOpen ? "true" : undefined
+              }
+              className={cn(
+                SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+                "absolute inset-0 flex items-center justify-center",
               )}
-              onOpenChange={setIsDropdownActionsOpen}
-            />
-          </div>
+            >
+              <ThreadTrailingIndicator
+                hasPendingInteraction={trailingHasPendingInteraction}
+                isBackgroundAgentActive={trailingBackgroundAgentActive}
+                isBackgroundCommandActive={trailingBackgroundCommandActive}
+                isForegroundAgentWorking={trailingRuntimeBusy}
+                isGoalActive={trailingGoalActive}
+                isPlanModeActive={trailingPlanModeActive}
+                isBusy={trailingIsBusy}
+                isWorkflowActive={trailingIsWorkflowActive}
+                showUnreadBadge={trailingShowUnreadBadge}
+                unreadBadgeTone={trailingUnreadBadgeTone}
+              />
+            </span>
+            <div
+              data-sidebar-hover-actions-open={
+                isActionsOpen ? "true" : undefined
+              }
+              className={cn(
+                SIDEBAR_HOVER_ACTIONS_CLASS,
+                "absolute inset-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+              )}
+            >
+              <ThreadActionsMenu
+                thread={thread}
+                triggerClassName={cn(
+                  "text-subtle-foreground hover:bg-transparent hover:text-foreground",
+                  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+                )}
+                onOpenChange={setIsDropdownActionsOpen}
+              />
+            </div>
+          </span>
         </span>
-      </span>
+      )}
     </>
   );
 

--- a/apps/app/src/components/sidebar/sidebarThreadShortcuts.test.ts
+++ b/apps/app/src/components/sidebar/sidebarThreadShortcuts.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import {
+  getSidebarThreadShortcutIndex,
+  getSidebarThreadShortcutTargets,
+} from "./sidebarThreadShortcuts";
+
+function appendShortcutTarget(root: HTMLElement, threadId?: string) {
+  const target = document.createElement("a");
+  target.dataset.sidebarThreadShortcutTarget = "";
+  if (threadId) {
+    target.dataset.sidebarThreadId = threadId;
+  }
+  root.append(target);
+  return target;
+}
+
+describe("sidebar thread shortcuts", () => {
+  it("assigns 1 through 9 in rendered row order", () => {
+    const root = document.createElement("aside");
+    appendShortcutTarget(root);
+    const elements = Array.from({ length: 10 }, (_, index) =>
+      appendShortcutTarget(root, `thr_${index + 1}`),
+    );
+
+    const targets = getSidebarThreadShortcutTargets(root);
+
+    expect(targets).toHaveLength(9);
+    expect(
+      targets.map(({ element, key, threadId }) => ({ element, key, threadId })),
+    ).toEqual(
+      elements.slice(0, 9).map((element, index) => ({
+        element,
+        key: String(index + 1),
+        threadId: `thr_${index + 1}`,
+      })),
+    );
+  });
+
+  it("recognizes only unmodified Command plus a numbered shortcut", () => {
+    const event = {
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: "4",
+      metaKey: true,
+      shiftKey: false,
+    };
+
+    expect(getSidebarThreadShortcutIndex(event)).toBe(3);
+    expect(getSidebarThreadShortcutIndex({ ...event, metaKey: false })).toBe(
+      null,
+    );
+    expect(getSidebarThreadShortcutIndex({ ...event, shiftKey: true })).toBe(
+      null,
+    );
+    expect(getSidebarThreadShortcutIndex({ ...event, key: "0" })).toBe(null);
+  });
+});

--- a/apps/app/src/components/sidebar/sidebarThreadShortcuts.ts
+++ b/apps/app/src/components/sidebar/sidebarThreadShortcuts.ts
@@ -1,0 +1,82 @@
+import { createContext, useContext } from "react";
+
+const SIDEBAR_THREAD_SHORTCUT_TARGET_SELECTOR =
+  "[data-sidebar-thread-shortcut-target]";
+
+export const MAX_SIDEBAR_THREAD_SHORTCUTS = 9;
+
+export interface SidebarThreadShortcutTarget {
+  element: HTMLAnchorElement;
+  key: string;
+  threadId: string;
+}
+
+interface SidebarThreadShortcutKeyboardEvent {
+  altKey: boolean;
+  ctrlKey: boolean;
+  defaultPrevented: boolean;
+  key: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+export const EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS: ReadonlyMap<string, string> =
+  new Map();
+
+export const SidebarThreadShortcutKeysContext = createContext<
+  ReadonlyMap<string, string>
+>(EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS);
+
+export function getSidebarThreadShortcutTargets(
+  root: HTMLElement | null,
+): SidebarThreadShortcutTarget[] {
+  if (!root) {
+    return [];
+  }
+
+  const elements = root.querySelectorAll<HTMLAnchorElement>(
+    SIDEBAR_THREAD_SHORTCUT_TARGET_SELECTOR,
+  );
+  const targets: SidebarThreadShortcutTarget[] = [];
+
+  for (const element of elements) {
+    const threadId = element.dataset.sidebarThreadId;
+    if (!threadId) {
+      continue;
+    }
+
+    targets.push({
+      element,
+      key: String(targets.length + 1),
+      threadId,
+    });
+    if (targets.length === MAX_SIDEBAR_THREAD_SHORTCUTS) {
+      break;
+    }
+  }
+
+  return targets;
+}
+
+export function getSidebarThreadShortcutIndex(
+  event: SidebarThreadShortcutKeyboardEvent,
+): number | null {
+  if (
+    event.defaultPrevented ||
+    !event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    !/^[1-9]$/.test(event.key)
+  ) {
+    return null;
+  }
+
+  return Number(event.key) - 1;
+}
+
+export function useSidebarThreadShortcutKey(
+  threadId: string,
+): string | undefined {
+  return useContext(SidebarThreadShortcutKeysContext).get(threadId);
+}


### PR DESCRIPTION
## Summary

- Show ⌘1 through ⌘9 beside the first nine rendered sidebar threads while Command is held.
- Navigate through each thread row’s existing link behavior when its shortcut is pressed.
- Clear transient shortcut state on Command release or window blur and expose the active shortcut to assistive technology.

## Testing

- pnpm exec turbo run build --filter=@bb/app
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force -- src/components/sidebar/ThreadRow.test.tsx src/components/sidebar/sidebarThreadShortcuts.test.ts