### PR TITLE
Repair legacy Codex subagent timelines

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -256,6 +256,127 @@ function tryReadClientTurnRequestedRequestId(
   return event.requestId;
 }
 
+function collectAcceptedRootTurnIds(
+  rows: readonly StoredEventRow[],
+): ReadonlySet<string> {
+  const isRootTargetByRequestId = new Map<ClientTurnRequestId, boolean>();
+  for (const row of rows) {
+    if (row.type !== "client/turn/requested") {
+      continue;
+    }
+    const event = parseStoredEvent(row);
+    if (event.type !== "client/turn/requested") {
+      continue;
+    }
+    isRootTargetByRequestId.set(
+      event.requestId,
+      event.target.kind === "new-turn" || event.target.kind === "thread-start",
+    );
+  }
+
+  const turnIds = new Set<string>();
+  for (const row of rows) {
+    if (row.type !== "turn/input/accepted") {
+      continue;
+    }
+    const event = parseStoredEvent(row);
+    if (
+      event.type === "turn/input/accepted" &&
+      event.scope.kind === "turn" &&
+      isRootTargetByRequestId.get(event.clientRequestId)
+    ) {
+      turnIds.add(event.scope.turnId);
+    }
+  }
+  return turnIds;
+}
+
+function isLegacyCodexSubagentStarted(row: StoredEventRow): boolean {
+  if (
+    row.type !== "provider/unhandled" ||
+    row.scopeKind !== "turn" ||
+    row.turnId === null ||
+    row.providerThreadId === null
+  ) {
+    return false;
+  }
+  const data = parseStoredEventData(row);
+  if (data.providerId !== "codex") {
+    return false;
+  }
+  const rawEvent = asRecord(data.rawEvent);
+  const params = rawEvent ? asRecord(rawEvent.params) : null;
+  const item = params ? asRecord(params.item) : null;
+  return (
+    rawEvent?.jsonrpc === "2.0" &&
+    rawEvent.method === "item/completed" &&
+    params?.threadId === row.providerThreadId &&
+    params.turnId === row.turnId &&
+    item?.type === "subAgentActivity" &&
+    item.kind === "started" &&
+    typeof item.id === "string" &&
+    item.id.length > 0 &&
+    typeof item.agentThreadId === "string" &&
+    item.agentThreadId.length > 0 &&
+    typeof item.agentPath === "string" &&
+    item.agentPath.length > 0
+  );
+}
+
+/**
+ * Legacy Codex rows did not persist child turn parent tool-call IDs. Keep the
+ * full recovered child lineage in a turn-detail selection so the projection
+ * repair can reconstruct it in memory.
+ */
+function collectLegacyCodexChildTurnIds(
+  rows: readonly StoredEventRow[],
+  requestedTurnId: string,
+): ReadonlySet<string> {
+  const acceptedRootTurnIds = collectAcceptedRootTurnIds(rows);
+  const recoveredParentTurnIds = new Set([requestedTurnId]);
+  const pendingByProviderThreadId = new Map<string, number>();
+  const childTurnIds = new Set<string>();
+
+  for (const row of rows) {
+    const providerThreadId = row.providerThreadId;
+    if (
+      isLegacyCodexSubagentStarted(row) &&
+      row.turnId !== null &&
+      recoveredParentTurnIds.has(row.turnId)
+    ) {
+      if (providerThreadId === null) {
+        continue;
+      }
+      const count = pendingByProviderThreadId.get(providerThreadId) ?? 0;
+      pendingByProviderThreadId.set(providerThreadId, count + 1);
+      continue;
+    }
+    if (
+      row.type !== "turn/started" ||
+      row.scopeKind !== "turn" ||
+      row.turnId === null ||
+      row.turnId === requestedTurnId ||
+      providerThreadId === null ||
+      acceptedRootTurnIds.has(row.turnId) ||
+      getStoredEventParentToolCallId(row)
+    ) {
+      continue;
+    }
+    const pending = pendingByProviderThreadId.get(providerThreadId) ?? 0;
+    if (pending === 0) {
+      continue;
+    }
+    childTurnIds.add(row.turnId);
+    recoveredParentTurnIds.add(row.turnId);
+    if (pending === 1) {
+      pendingByProviderThreadId.delete(providerThreadId);
+    } else {
+      pendingByProviderThreadId.set(providerThreadId, pending - 1);
+    }
+  }
+  return childTurnIds;
+}
+
 function tryReadSteerClientTurnRequestedRequestId(
   row: StoredEventRow,
 ): ClientTurnRequestId | null {
@@ -534,10 +655,18 @@ function partitionAcceptedInputRowsByRequestedTurn(
 function filterExactEventRowsForRequestedTurn(
   args: FilterExactEventRowsForRequestedTurnArgs,
 ): FilterExactEventRowsForRequestedTurnResult {
+  const legacyChildTurnIds = collectLegacyCodexChildTurnIds(
+    args.exactEventRows,
+    args.turnId,
+  );
   const rows: StoredEventRow[] = [];
   let removedRows = false;
   for (const row of args.exactEventRows) {
-    if (row.scopeKind === "turn" && row.turnId !== args.turnId) {
+    if (
+      row.scopeKind === "turn" &&
+      row.turnId !== args.turnId &&
+      (row.turnId === null || !legacyChildTurnIds.has(row.turnId))
+    ) {
       removedRows = true;
       continue;
     }

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -1294,6 +1294,243 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("hydrates legacy Codex delegated child rows in parent turn-summary details", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const providerThreadId = "provider-thread-1";
+
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 2,
+        type: "provider/unhandled",
+        data: {
+          providerId: "codex",
+          rawType: "item/completed",
+          rawEvent: {
+            jsonrpc: "2.0",
+            method: "item/completed",
+            params: {
+              threadId: providerThreadId,
+              turnId: "parent-turn",
+              item: {
+                type: "subAgentActivity",
+                id: "legacy-agent-call",
+                kind: "started",
+                agentThreadId: "legacy-child-provider",
+                agentPath: "/root/reviewer",
+              },
+            },
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("child-turn"),
+        sequence: 3,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("child-turn"),
+        sequence: 4,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "agentMessage",
+            id: "child-message",
+            text: "Legacy child completed the review.",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("child-turn"),
+        sequence: 5,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+      seedEvent(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId,
+        scope: turnScope("parent-turn"),
+        sequence: 6,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+      expect(timelineResponse.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(timelineResponse),
+      );
+      const parentTurnRow = timeline.rows.find(
+        (row): row is TimelineTurnRow =>
+          row.kind === "turn" && row.turnId === "parent-turn",
+      );
+      expect(parentTurnRow).toBeDefined();
+      if (!parentTurnRow) {
+        throw new Error("Expected parent turn row");
+      }
+
+      const detailsResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=${parentTurnRow.turnId}&sourceSeqStart=${parentTurnRow.sourceSeqStart}&sourceSeqEnd=${parentTurnRow.sourceSeqEnd}`,
+      );
+      expect(detailsResponse.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(detailsResponse),
+      );
+      const delegation = details.rows.find(
+        (
+          row,
+        ): row is Extract<
+          TimelineRow,
+          { kind: "work"; workKind: "delegation" }
+        > => row.kind === "work" && row.workKind === "delegation",
+      );
+
+      expect(delegation).toMatchObject({
+        status: "completed",
+        childRows: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "conversation",
+            text: "Legacy child completed the review.",
+          }),
+        ]),
+      });
+    });
+  });
+
+  it("hydrates nested legacy Codex delegated rows in parent turn-summary details", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const providerThreadId = "provider-thread-1";
+
+      const legacyStarted = (turnId: string, callId: string) => ({
+        providerId: "codex",
+        rawType: "item/completed",
+        rawEvent: {
+          jsonrpc: "2.0" as const,
+          method: "item/completed",
+          params: {
+            threadId: providerThreadId,
+            turnId,
+            item: {
+              type: "subAgentActivity",
+              id: callId,
+              kind: "started" as const,
+              agentThreadId: `${callId}-provider`,
+              agentPath: `/root/${callId}`,
+            },
+          },
+        },
+      });
+      const seed = (
+        sequence: number,
+        scopeTurnId: string,
+        type: "item/completed" | "provider/unhandled" | "turn/completed" | "turn/started",
+        data: Record<string, unknown>,
+      ) => {
+        seedEvent(harness.deps, {
+          threadId: thread.id,
+          environmentId: environment.id,
+          providerThreadId,
+          scope: turnScope(scopeTurnId),
+          sequence,
+          type,
+          data,
+        });
+      };
+
+      seed(1, "parent-turn", "turn/started", {});
+      seed(2, "parent-turn", "provider/unhandled", legacyStarted("parent-turn", "child-call"));
+      seed(3, "child-turn", "turn/started", {});
+      seed(4, "child-turn", "provider/unhandled", legacyStarted("child-turn", "grandchild-call"));
+      seed(5, "grandchild-turn", "turn/started", {});
+      seed(6, "grandchild-turn", "item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "grandchild-message",
+          text: "Grandchild completed the review.",
+        },
+      });
+      seed(7, "grandchild-turn", "turn/completed", { status: "completed" });
+      seed(8, "child-turn", "turn/completed", { status: "completed" });
+      seed(9, "parent-turn", "turn/completed", { status: "completed" });
+
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+      expect(timelineResponse.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(timelineResponse),
+      );
+      const parentTurnRow = timeline.rows.find(
+        (row): row is TimelineTurnRow =>
+          row.kind === "turn" && row.turnId === "parent-turn",
+      );
+      expect(parentTurnRow).toBeDefined();
+      if (!parentTurnRow) {
+        throw new Error("Expected parent turn row");
+      }
+
+      const detailsResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=${parentTurnRow.turnId}&sourceSeqStart=${parentTurnRow.sourceSeqStart}&sourceSeqEnd=${parentTurnRow.sourceSeqEnd}`,
+      );
+      expect(detailsResponse.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(detailsResponse),
+      );
+      const outerDelegation = details.rows.find(
+        (
+          row,
+        ): row is Extract<
+          TimelineRow,
+          { kind: "work"; workKind: "delegation" }
+        > => row.kind === "work" && row.workKind === "delegation",
+      );
+      const nestedDelegation = outerDelegation?.childRows.find(
+        (
+          row,
+        ): row is Extract<
+          TimelineRow,
+          { kind: "work"; workKind: "delegation" }
+        > => row.kind === "work" && row.workKind === "delegation",
+      );
+
+      expect(nestedDelegation).toMatchObject({
+        status: "completed",
+        childRows: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "conversation",
+            text: "Grandchild completed the review.",
+          }),
+        ]),
+      });
+    });
+  });
+
   it("hydrates turn-summary details with future accepted input context", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedThreadFixture(harness);

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -92,6 +92,7 @@ import {
 } from "./event-projection-state.js";
 import { buildProjectionActiveThinking } from "./reasoning-lifecycle-projection.js";
 import { projectAssistantAndReasoningEvent } from "./assistant-event-projection.js";
+import { repairLegacyCodexSubagentProjection } from "./legacy-codex-subagent-projection.js";
 
 // --- Projection state machine ---
 
@@ -900,7 +901,7 @@ function buildFlatProjectionData(
       continue;
     }
 
-    const error = parseErrorMessage(decoded, meta);
+    const error = parseErrorMessage(decoded, meta, eventParentToolCallId);
     if (error) {
       flushToolActivityBeforeNonToolMessage(state);
       state.messages.push(error);
@@ -998,7 +999,9 @@ export function buildEventProjectionEntries(
     };
   }
 
-  const orderedEvents = getOrderedThreadEvents(events);
+  const orderedEvents = repairLegacyCodexSubagentProjection(
+    getOrderedThreadEvents(events),
+  );
   const flatProjection = buildFlatProjectionData({
     acceptedClientRequestContext:
       options.acceptedClientRequestContext ??
@@ -1033,6 +1036,8 @@ export function buildEventProjection(
     };
   }
 
-  const orderedEvents = getOrderedThreadEvents(events);
+  const orderedEvents = repairLegacyCodexSubagentProjection(
+    getOrderedThreadEvents(events),
+  );
   return buildFullEventProjection(orderedEvents, options);
 }

--- a/packages/thread-view/src/legacy-codex-subagent-projection.ts
+++ b/packages/thread-view/src/legacy-codex-subagent-projection.ts
@@ -1,0 +1,289 @@
+import {
+  requireThreadEventScopeTurnId,
+  turnScope,
+  type ThreadEvent,
+} from "@bb/domain";
+import { z } from "zod";
+import type { ThreadEventWithMeta } from "./group-event-projection-turns.js";
+
+const legacyCodexSubagentActivitySchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  method: z.literal("item/completed"),
+  params: z.object({
+    threadId: z.string().min(1),
+    turnId: z.string().min(1),
+    item: z.object({
+      type: z.literal("subAgentActivity"),
+      id: z.string().min(1),
+      kind: z.enum(["started", "interacted", "interrupted"]),
+      agentThreadId: z.string().min(1),
+      agentPath: z.string().min(1),
+    }),
+  }),
+});
+
+interface LegacyCodexSubagent {
+  agentPath: string;
+  agentThreadId: string;
+  callId: string;
+  logicalThreadId: string;
+  parentProviderThreadId: string;
+  parentTurnId: string;
+}
+
+function parseLegacyCodexSubagentActivity(
+  event: ThreadEvent,
+):
+  | (LegacyCodexSubagent & { kind: "started" | "interacted" | "interrupted" })
+  | null {
+  if (event.type !== "provider/unhandled" || event.providerId !== "codex") {
+    return null;
+  }
+  const parsed = legacyCodexSubagentActivitySchema.safeParse(event.rawEvent);
+  if (
+    !parsed.success ||
+    parsed.data.params.threadId !== event.providerThreadId
+  ) {
+    return null;
+  }
+  const { item, threadId, turnId } = parsed.data.params;
+  return {
+    agentPath: item.agentPath,
+    agentThreadId: item.agentThreadId,
+    callId: item.id,
+    kind: item.kind,
+    logicalThreadId: event.threadId,
+    parentProviderThreadId: threadId,
+    parentTurnId: turnId,
+  };
+}
+
+function buildSyntheticSubagentEvent(
+  tracked: LegacyCodexSubagent,
+  status: "pending" | "completed" | "failed" | "interrupted",
+): ThreadEvent {
+  const item = {
+    type: "toolCall" as const,
+    id: tracked.callId,
+    tool: "spawnAgent",
+    arguments: {
+      senderThreadId: tracked.parentProviderThreadId,
+      // Legacy Codex multiplexed child turns onto the parent provider thread.
+      // The recovered child turn gets an explicit parent below; this receiver
+      // is metadata for the rendered delegation, not a FIFO correlation hint.
+      receiverThreadIds: [tracked.agentThreadId],
+      description: tracked.agentPath,
+    },
+    status,
+    ...(status === "pending"
+      ? {}
+      : {
+          result: {
+            agentPath: tracked.agentPath,
+            agentThreadId: tracked.agentThreadId,
+          },
+        }),
+  };
+  return {
+    type: status === "pending" ? "item/started" : "item/completed",
+    threadId: tracked.logicalThreadId,
+    providerThreadId: tracked.parentProviderThreadId,
+    scope: turnScope(tracked.parentTurnId),
+    item,
+  };
+}
+
+function buildAcceptedRootTurnIds(
+  events: readonly ThreadEventWithMeta[],
+): ReadonlySet<string> {
+  const requestTargetById = new Map<
+    string,
+    Extract<ThreadEvent, { type: "client/turn/requested" }>["target"]
+  >();
+  for (const { event } of events) {
+    if (event.type === "client/turn/requested") {
+      requestTargetById.set(event.requestId, event.target);
+    }
+  }
+
+  const acceptedRootTurnIds = new Set<string>();
+  for (const { event } of events) {
+    if (event.type !== "turn/input/accepted") {
+      continue;
+    }
+    const target = requestTargetById.get(event.clientRequestId);
+    if (target?.kind !== "new-turn" && target?.kind !== "thread-start") {
+      continue;
+    }
+    acceptedRootTurnIds.add(
+      requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      }),
+    );
+  }
+  return acceptedRootTurnIds;
+}
+
+function collectMaterializedToolCallIds(
+  events: readonly ThreadEventWithMeta[],
+): ReadonlySet<string> {
+  const callIds = new Set<string>();
+  for (const { event } of events) {
+    if (
+      (event.type === "item/started" || event.type === "item/completed") &&
+      event.item.type === "toolCall"
+    ) {
+      callIds.add(event.item.id);
+    }
+  }
+  return callIds;
+}
+
+/**
+ * Repairs the event shape emitted before Codex subagent activity was
+ * materialized at ingestion. The stored rows stay immutable; only the replay
+ * projection receives synthetic delegation lifecycle events.
+ */
+export function repairLegacyCodexSubagentProjection(
+  events: readonly ThreadEventWithMeta[],
+): ThreadEventWithMeta[] {
+  const acceptedRootTurnIds = buildAcceptedRootTurnIds(events);
+  const materializedCallIds = collectMaterializedToolCallIds(events);
+  const seenStartedCallIds = new Set<string>();
+  const pendingByProviderThreadId = new Map<string, LegacyCodexSubagent[]>();
+  const openByAgentThreadId = new Map<string, LegacyCodexSubagent>();
+  const openByChildTurnId = new Map<string, LegacyCodexSubagent>();
+  const repaired: ThreadEventWithMeta[] = [];
+
+  const removePending = (tracked: LegacyCodexSubagent): void => {
+    const pending = pendingByProviderThreadId.get(
+      tracked.parentProviderThreadId,
+    );
+    if (!pending) {
+      return;
+    }
+    const remaining = pending.filter(
+      (candidate) => candidate.callId !== tracked.callId,
+    );
+    if (remaining.length === 0) {
+      pendingByProviderThreadId.delete(tracked.parentProviderThreadId);
+    } else if (remaining.length !== pending.length) {
+      pendingByProviderThreadId.set(
+        tracked.parentProviderThreadId,
+        remaining,
+      );
+    }
+  };
+
+  const completeTracked = (
+    tracked: LegacyCodexSubagent,
+    status: "completed" | "failed" | "interrupted",
+    meta: ThreadEventWithMeta["meta"],
+  ): void => {
+    openByAgentThreadId.delete(tracked.agentThreadId);
+    removePending(tracked);
+    for (const [turnId, candidate] of openByChildTurnId) {
+      if (candidate.callId === tracked.callId) {
+        openByChildTurnId.delete(turnId);
+      }
+    }
+    repaired.push({
+      event: buildSyntheticSubagentEvent(tracked, status),
+      meta: {
+        ...meta,
+        id: `${meta.id}:legacy-subagent:${tracked.callId}:completed`,
+      },
+    });
+  };
+
+  for (const eventWithMeta of events) {
+    const { event, meta } = eventWithMeta;
+    const activity = parseLegacyCodexSubagentActivity(event);
+    if (activity) {
+      if (materializedCallIds.has(activity.callId)) {
+        repaired.push(eventWithMeta);
+        continue;
+      }
+      if (activity.kind === "interacted") {
+        continue;
+      }
+      if (activity.kind === "interrupted") {
+        const tracked = openByAgentThreadId.get(activity.agentThreadId);
+        if (tracked) {
+          completeTracked(tracked, "interrupted", meta);
+        }
+        continue;
+      }
+
+      if (seenStartedCallIds.has(activity.callId)) {
+        continue;
+      }
+      seenStartedCallIds.add(activity.callId);
+      const tracked: LegacyCodexSubagent = activity;
+      openByAgentThreadId.set(tracked.agentThreadId, tracked);
+      const pending =
+        pendingByProviderThreadId.get(tracked.parentProviderThreadId) ?? [];
+      pending.push(tracked);
+      pendingByProviderThreadId.set(tracked.parentProviderThreadId, pending);
+      repaired.push({
+        event: buildSyntheticSubagentEvent(tracked, "pending"),
+        meta: {
+          ...meta,
+          id: `${meta.id}:legacy-subagent:${tracked.callId}:started`,
+        },
+      });
+      continue;
+    }
+
+    if (event.type === "turn/started") {
+      const turnId = requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      });
+      if (acceptedRootTurnIds.has(turnId)) {
+        repaired.push(eventWithMeta);
+        continue;
+      }
+      const pending = pendingByProviderThreadId.get(event.providerThreadId);
+      const pendingIndex = event.parentToolCallId
+        ? pending?.findIndex(
+            (candidate) => candidate.callId === event.parentToolCallId,
+          )
+        : pending?.findIndex((candidate) => candidate.parentTurnId !== turnId);
+      if (pending && pendingIndex !== undefined && pendingIndex >= 0) {
+        const [tracked] = pending.splice(pendingIndex, 1);
+        if (pending.length === 0) {
+          pendingByProviderThreadId.delete(event.providerThreadId);
+        }
+        if (tracked) {
+          openByChildTurnId.set(turnId, tracked);
+          repaired.push({
+            ...eventWithMeta,
+            event: event.parentToolCallId
+              ? event
+              : { ...event, parentToolCallId: tracked.callId },
+          });
+          continue;
+        }
+      }
+      repaired.push(eventWithMeta);
+      continue;
+    }
+
+    repaired.push(eventWithMeta);
+
+    if (event.type === "turn/completed") {
+      const turnId = requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      });
+      const tracked = openByChildTurnId.get(turnId);
+      if (tracked) {
+        completeTracked(tracked, event.status, meta);
+      }
+    }
+  }
+
+  return repaired;
+}

--- a/packages/thread-view/src/parse-error-message.ts
+++ b/packages/thread-view/src/parse-error-message.ts
@@ -60,6 +60,7 @@ function getReconnectState(decoded: ThreadEvent): ReconnectState | null {
 export function parseErrorMessage(
   decoded: ThreadEvent,
   meta: EventMeta,
+  parentToolCallId?: string,
 ): EventProjectionErrorMessage | null {
   if (decoded.type !== "provider/error" && decoded.type !== "system/error")
     return null;
@@ -74,6 +75,7 @@ export function parseErrorMessage(
     sourceSeqEnd: meta.seq,
     createdAt: meta.createdAt,
     scope: decoded.scope,
+    ...(parentToolCallId ? { parentToolCallId } : {}),
     rawType: decoded.type,
     message: message || "Error event",
     detail: detail && detail !== message ? detail : null,

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -94,6 +94,37 @@ function getOnlyTimelineWebWorkRow(
   return row;
 }
 
+function legacyCodexSubagentStarted(
+  event: TimelineEventFactory,
+  args: {
+    agentPath: string;
+    agentThreadId: string;
+    callId: string;
+    kind?: "started" | "interacted" | "interrupted";
+    parentProviderThreadId: string;
+    parentTurnId: string;
+  },
+): TimelineFixtureEvent {
+  return event.providerUnhandled({
+    rawType: "item/completed",
+    rawEvent: {
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: args.parentProviderThreadId,
+        turnId: args.parentTurnId,
+        item: {
+          type: "subAgentActivity",
+          id: args.callId,
+          kind: args.kind ?? "started",
+          agentThreadId: args.agentThreadId,
+          agentPath: args.agentPath,
+        },
+      },
+    },
+  });
+}
+
 describe("timeline CLI rendering snapshots", () => {
   it("keeps accepted steer rows outside summaries while preserving summary segments", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
@@ -1134,6 +1165,347 @@ describe("timeline CLI rendering snapshots", () => {
         delegation.childRows.some((row) => row.kind === "turn"),
       ),
     ).toBe(false);
+  });
+
+  it("repairs legacy Codex subagent activity into nested delegations", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const timeline = renderIdleTimeline([
+      event.turnStarted(),
+      legacyCodexSubagentStarted(event, {
+        agentPath: "/root/renderer_fixes",
+        agentThreadId: "renderer-provider",
+        callId: "spawn-renderer",
+        parentProviderThreadId: "root-provider",
+        parentTurnId: "root-turn",
+      }),
+      event.turnStarted({ turnId: "renderer-turn" }),
+      legacyCodexSubagentStarted(event, {
+        agentPath: "/root/storage_fixes",
+        agentThreadId: "storage-provider",
+        callId: "spawn-storage",
+        parentProviderThreadId: "root-provider",
+        parentTurnId: "root-turn",
+      }),
+      event.turnStarted({ turnId: "storage-turn" }),
+      event.assistantCompleted({
+        itemId: "renderer-result",
+        turnId: "renderer-turn",
+        text: "Renderer fixed.",
+      }),
+      event.turnCompleted({ turnId: "renderer-turn" }),
+      event.assistantCompleted({
+        itemId: "storage-result",
+        turnId: "storage-turn",
+        text: "Storage fixed.",
+      }),
+      event.systemError({
+        code: "thread_command_failed",
+        message: "A steer targeted the child turn.",
+        turnId: "storage-turn",
+      }),
+      event.turnCompleted({ turnId: "storage-turn" }),
+      event.assistantCompleted({
+        itemId: "root-result",
+        text: "All work complete.",
+      }),
+      event.turnCompleted(),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegations = allRows.filter(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+    const topLevelChildTurns = timeline.rows.filter(
+      (row) =>
+        row.kind === "turn" &&
+        (row.turnId === "renderer-turn" || row.turnId === "storage-turn"),
+    );
+
+    expect(delegations).toHaveLength(2);
+    expect(delegations.map((delegation) => delegation.status)).toEqual([
+      "completed",
+      "completed",
+    ]);
+    expect(topLevelChildTurns).toHaveLength(0);
+    expect(delegations[0]?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Renderer fixed.",
+          turnId: "renderer-turn",
+        }),
+      ]),
+    );
+    expect(delegations[1]?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Storage fixed.",
+          turnId: "storage-turn",
+        }),
+      ]),
+    );
+  });
+
+  it("does not attach a later accepted root turn to a legacy Codex delegation", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const rootStarted = event.turnStarted();
+    const subagentStarted = legacyCodexSubagentStarted(event, {
+      agentPath: "/root/reviewer",
+      agentThreadId: "reviewer-provider",
+      callId: "spawn-reviewer",
+      parentProviderThreadId: "root-provider",
+      parentTurnId: "root-turn",
+    });
+    const followUp = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Human follow-up",
+    });
+    const timeline = renderIdleTimeline([
+      rootStarted,
+      subagentStarted,
+      followUp,
+      event.turnStarted({ turnId: "human-turn" }),
+      event.inputAccepted({
+        clientRequestId: followUp.data.requestId,
+        turnId: "human-turn",
+      }),
+      event.assistantCompleted({
+        itemId: "human-result",
+        text: "Answered the human.",
+        turnId: "human-turn",
+      }),
+      event.turnCompleted({ turnId: "human-turn" }),
+      event.turnStarted({ turnId: "reviewer-turn" }),
+      event.assistantCompleted({
+        itemId: "reviewer-result",
+        text: "Review complete.",
+        turnId: "reviewer-turn",
+      }),
+      event.turnCompleted({ turnId: "reviewer-turn" }),
+      event.turnCompleted(),
+    ]);
+
+    const allRows = flattenTimelineRows(timeline.rows);
+    const delegation = allRows.find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+
+    expect(delegation?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Review complete.",
+          turnId: "reviewer-turn",
+        }),
+      ]),
+    );
+    expect(delegation?.childRows).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ turnId: "human-turn" }),
+      ]),
+    );
+    expect(allRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Answered the human.",
+          turnId: "human-turn",
+        }),
+      ]),
+    );
+  });
+
+  it("does not let an interrupted legacy subagent consume a later child turn", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const timeline = renderIdleTimeline([
+      event.turnStarted(),
+      legacyCodexSubagentStarted(event, {
+        agentPath: "/root/first",
+        agentThreadId: "first-provider",
+        callId: "spawn-first",
+        parentProviderThreadId: "root-provider",
+        parentTurnId: "root-turn",
+      }),
+      legacyCodexSubagentStarted(event, {
+        agentPath: "/root/second",
+        agentThreadId: "second-provider",
+        callId: "spawn-second",
+        parentProviderThreadId: "root-provider",
+        parentTurnId: "root-turn",
+      }),
+      legacyCodexSubagentStarted(event, {
+        agentPath: "/root/first",
+        agentThreadId: "first-provider",
+        callId: "first-interrupted",
+        kind: "interrupted",
+        parentProviderThreadId: "root-provider",
+        parentTurnId: "root-turn",
+      }),
+      event.turnStarted({ turnId: "second-turn" }),
+      event.assistantCompleted({
+        itemId: "second-result",
+        turnId: "second-turn",
+        text: "Second finished.",
+      }),
+      event.turnCompleted({ turnId: "second-turn" }),
+      event.turnCompleted(),
+    ]);
+
+    const delegations = flattenTimelineRows(timeline.rows).filter(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+
+    expect(delegations).toHaveLength(2);
+    expect(delegations.map((delegation) => delegation.status)).toEqual([
+      "interrupted",
+      "completed",
+    ]);
+    expect(delegations[0]?.childRows).toHaveLength(0);
+    expect(delegations[1]?.childRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Second finished.",
+          turnId: "second-turn",
+        }),
+      ]),
+    );
+  });
+
+  it("completes a legacy delegation when its child turn is already parented", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const timeline = renderIdleTimeline([
+      event.turnStarted(),
+      legacyCodexSubagentStarted(event, {
+        agentPath: "/root/reviewer",
+        agentThreadId: "reviewer-provider",
+        callId: "spawn-reviewer",
+        parentProviderThreadId: "root-provider",
+        parentTurnId: "root-turn",
+      }),
+      event.turnStarted({
+        turnId: "reviewer-turn",
+        parentToolCallId: "spawn-reviewer",
+      }),
+      event.assistantCompleted({
+        itemId: "reviewer-result",
+        turnId: "reviewer-turn",
+        text: "Review complete.",
+      }),
+      event.turnCompleted({ turnId: "reviewer-turn" }),
+      event.turnCompleted(),
+    ]);
+
+    const delegation = flattenTimelineRows(timeline.rows).find(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+
+    expect(delegation).toMatchObject({
+      status: "completed",
+      childRows: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Review complete.",
+          turnId: "reviewer-turn",
+        }),
+      ]),
+    });
+  });
+
+  it("ignores duplicate legacy Codex subagent starts", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const started = {
+      agentPath: "/root/reviewer",
+      agentThreadId: "reviewer-provider",
+      callId: "spawn-reviewer",
+      parentProviderThreadId: "root-provider",
+      parentTurnId: "root-turn",
+    };
+    const timeline = renderIdleTimeline([
+      event.turnStarted(),
+      legacyCodexSubagentStarted(event, started),
+      legacyCodexSubagentStarted(event, started),
+      event.turnStarted({ turnId: "reviewer-turn" }),
+      event.assistantCompleted({
+        itemId: "reviewer-result",
+        turnId: "reviewer-turn",
+        text: "Review complete.",
+      }),
+      event.turnCompleted({ turnId: "reviewer-turn" }),
+      event.turnStarted({ turnId: "later-turn" }),
+      event.assistantCompleted({
+        itemId: "later-result",
+        turnId: "later-turn",
+        text: "Later root work.",
+      }),
+    ]);
+
+    const delegations = flattenTimelineRows(timeline.rows).filter(
+      (
+        row,
+      ): row is Extract<
+        TimelineRow,
+        { kind: "work"; workKind: "delegation" }
+      > => row.kind === "work" && row.workKind === "delegation",
+    );
+
+    expect(delegations).toHaveLength(1);
+    expect(delegations[0]).toMatchObject({ status: "completed" });
+    expect(timeline.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          text: "Later root work.",
+          turnId: "later-turn",
+        }),
+      ]),
+    );
+    expect(delegations[0]?.childRows).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ turnId: "later-turn" }),
+      ]),
+    );
   });
 
   it("does not attach later root turns to Claude receiver-thread delegations", () => {

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -213,6 +213,7 @@ interface SystemErrorArgs extends EventFactoryRowOptions {
   code?: string;
   detail?: string;
   message: string;
+  turnId?: string;
 }
 
 interface ProviderErrorArgs extends ProviderTurnEventOptions {
@@ -806,7 +807,13 @@ export function createTimelineEventFactory(
       };
     },
     systemError(args) {
-      const base = nextThreadScopedRowBase("system-error", args);
+      const base =
+        args.turnId !== undefined
+          ? {
+              ...nextRowBase("system-error", args),
+              scope: turnScope(args.turnId),
+            }
+          : nextThreadScopedRowBase("system-error", args);
       return {
         ...base,
         type: "system/error",


### PR DESCRIPTION
## Fix legacy Codex subagent timelines

This repairs existing threads that were recorded before #589. Those timelines can show Codex native subagent work as unrelated root turns, and then route later child-scoped errors or interactions to the wrong turn.

It complements #589: that PR fixed forward ingestion, but intentionally did not rewrite persisted `provider/unhandled` rows. This PR makes those legacy rows project correctly without mutating stored history.

## Reproduce the original bug

Use a build immediately before #589 (`1912e204f`, the parent of `379a00d5c`), so new events still take the old ingestion path.

1. Create a normal Codex thread with these execution settings:

   | Setting | Value |
   | --- | --- |
   | Model | `gpt-5.6-sol` |
   | Reasoning | `xhigh` |
   | Permission | `full` |
   | Service tier | `default` |

2. Send this prompt (it must use native Codex subagents, not `bb thread spawn`):

   ```text
   Spawn two native subagents in parallel and keep the root turn active until both return.
   - renderer_fixes: inspect packages/thread-view and run one focused test.
   - storage_fixes: inspect packages/agent-runtime and run one focused test.
   Then summarize both results in the root turn.
   ```

3. In the persisted event stream, find Codex `provider/unhandled` rows whose `rawEvent.params.item` is `subAgentActivity` with `kind: "started"`. The following child `turn/started` rows have no `parentToolCallId`.

4. Re-open the thread timeline. The child work appears as root-level turns instead of nested delegation rows. While a child is active, a steer or other child-scoped event can make the active-turn resolver expect that child while the host still has the root turn active.

The model is not part of the parser contract; `gpt-5.6-sol` at `xhigh` is the incident configuration that rapidly produces two overlapping native subagents.

## Root cause

Before #589, Codex native `subAgentActivity` notifications were persisted as opaque `provider/unhandled` events. Their child turns share the parent provider thread and have no persisted `parentToolCallId`. The timeline projector therefore treats each child `turn/started` as a new root.

In the reported thread, two starts (`/root/renderer_fixes` and `/root/storage_fixes`) created two such orphan child turns. Later child-scoped `system/error` rows stayed top-level too, which made the rendered timeline and active-turn state disagree with the still-running root turn.

## Minimal fix

At replay time only, recognize the exact legacy Codex raw-event shape and synthesize a `spawnAgent` lifecycle in memory. When the matching legacy child turn starts, stamp its recovered `parentToolCallId`; all of its transcript and errors then flow through the existing delegation renderer. A terminal child turn completes or interrupts the synthesized lifecycle.

The turn-summary detail endpoint retains only the recoverable legacy child lineage long enough for the same projection repair to run. New events, stored event rows, server/daemon ownership, and database migrations are unchanged.

This fixes the bug because the projector once again has the parent edge it requires before grouping turns. Explicit recovered parent IDs also avoid the stale FIFO link that can otherwise misattach a child after another legacy subagent is interrupted.

## Verification

- Replayed the 2,058-event incident stream: two completed/interrupted delegation rows, no legacy child turn left at the top level.
- Added projection regressions for concurrent children, an interrupted first child, explicitly parented child turns, accepted human roots, and child-scoped errors.
- Added an API regression for expanded turn-summary details.
- `pnpm exec turbo run test --filter=@bb/thread-view --force` — 342 passed.
- `pnpm exec turbo run test --filter=@bb/server --force` — 986 passed.
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --force`
- `pnpm exec turbo run typecheck --filter=@bb/server --force`
