### PR TITLE
Simplify sidebar display options menu

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -2,16 +2,13 @@ import {
   memo,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
-  useRef,
   useState,
   type CSSProperties,
   type KeyboardEventHandler,
   type MouseEventHandler,
   type PointerEventHandler,
   type ReactNode,
-  type Ref,
 } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -123,25 +120,24 @@ import {
   sidebarCollapsedFoldersAtom,
   sidebarOrganizationModeAtom,
   sidebarSectionOrderAtom,
-  sidebarSortDirectionAtom,
   type SidebarChronologicalSort,
   type CollapsibleSidebarSectionId,
   type SidebarOrganizationMode,
   type SidebarSectionId,
-  type SidebarSortDirection,
 } from "./sidebarCollapsedAtoms";
 import { folderKeyForThreadFolder } from "./folderKeys";
 import { CHRONOLOGICAL_CONTAINER_ID } from "./projectThreadGroups";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
-import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
@@ -516,56 +512,20 @@ function compareProjectThreadItemsByTitleAscending(
     : 0;
 }
 
-function invertNumber(value: number): number {
-  return value === 0 ? 0 : -value;
-}
-
-function invertThreadComparator(
-  compareThreads: ThreadComparator,
+export function getSidebarThreadComparator(
+  sort: SidebarChronologicalSort,
 ): ThreadComparator {
-  return (left, right) => {
-    const result = compareThreads(left, right);
-    return invertNumber(result);
-  };
-}
-
-export function getSidebarThreadComparator({
-  direction,
-  sort,
-}: {
-  direction: SidebarSortDirection;
-  sort: SidebarChronologicalSort;
-}): ThreadComparator {
   const normalizedSort = sort === "none" ? "updated" : sort;
 
   if (normalizedSort === "alpha") {
-    // Title sort's base is *ascending* (A→Z), unlike the time sorts whose
-    // bases descend. So here asc keeps the base and desc inverts it — and the
-    // leaf-thread and mixed folder/thread comparators must apply the same
-    // direction, or folders and threads would sort in opposite order.
-    const comparator: ThreadComparator =
-      direction === "asc"
-        ? compareByTitleAscending
-        : invertThreadComparator(compareByTitleAscending);
-    comparator.compareItems =
-      direction === "asc"
-        ? compareProjectThreadItemsByTitleAscending
-        : (left, right) =>
-            invertNumber(
-              compareProjectThreadItemsByTitleAscending(left, right),
-            );
+    const comparator: ThreadComparator = compareByTitleAscending;
+    comparator.compareItems = compareProjectThreadItemsByTitleAscending;
     return comparator;
   }
 
-  // "created"/"updated" bases list newest / most-recently-active first, so desc
-  // keeps the base and asc inverts it.
-  const baseComparator: ThreadComparator =
-    normalizedSort === "created"
-      ? compareByCreatedAtDescending
-      : compareStandardThreads;
-  return direction === "asc"
-    ? invertThreadComparator(baseComparator)
-    : baseComparator;
+  return normalizedSort === "created"
+    ? compareByCreatedAtDescending
+    : compareStandardThreads;
 }
 
 function ProjectListSectionIconButton({
@@ -651,88 +611,31 @@ function ProjectListThreadsSectionActions({
   );
 }
 
-interface SidebarOrganizeOption {
+// "In one list" is the user-facing name for chronological/drag-ordered mode;
+// the stored atom value stays "chronological".
+const SIDEBAR_ORGANIZE_OPTIONS = [
+  { label: "By project", mode: "project" },
+  { label: "In one list", mode: "chronological" },
+] as const satisfies readonly {
   label: string;
   mode: SidebarOrganizationMode;
-}
+}[];
 
-// "Manual" is the user-facing name for the chronological/drag-ordered mode; the
-// stored atom value stays "chronological".
-const SIDEBAR_ORGANIZE_OPTIONS: readonly SidebarOrganizeOption[] = [
-  { label: "Projects", mode: "project" },
-  { label: "Manual", mode: "chronological" },
-];
-
-interface SidebarOrganizeSegmentedControlProps {
-  value: SidebarOrganizationMode;
-  onChange: (mode: SidebarOrganizationMode) => void;
-}
-
-// Inline segmented control (no shared primitive fits this compact in-menu use).
-// The track sits on the menu's muted fill; the active segment lifts to the
-// popover surface so it reads raised. All colors come from theme tokens.
-function SidebarOrganizeSegmentedControl({
-  value,
-  onChange,
-}: SidebarOrganizeSegmentedControlProps) {
-  return (
-    <div
-      role="radiogroup"
-      aria-label="Organize by"
-      className="mx-2 my-1 flex items-center gap-0.5 rounded-md bg-muted p-0.5"
-    >
-      {SIDEBAR_ORGANIZE_OPTIONS.map((option) => {
-        const selected = value === option.mode;
-        return (
-          <button
-            key={option.mode}
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            onClick={() => onChange(option.mode)}
-            className={cn(
-              "flex-1 cursor-pointer rounded-[0.3125rem] px-2 py-1 text-center text-xs outline-none ring-ring focus-visible:ring-2",
-              LIST_HOVER_TRANSITION,
-              selected
-                ? "bg-popover text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {option.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-interface SidebarSortMenuOptionProps {
-  direction: SidebarSortDirection;
-  label: string;
-  selected: boolean;
-  sort: SidebarChronologicalSort;
-  // Selecting an inactive field activates it descending; selecting the active
-  // field flips its direction.
-  onToggle: (sort: SidebarChronologicalSort) => void;
-}
-
-const SIDEBAR_SORT_OPTIONS: readonly {
-  label: string;
-  sort: SidebarChronologicalSort;
-}[] = [
+const SIDEBAR_SORT_OPTIONS = [
   { label: "Updated at", sort: "updated" },
   { label: "Created at", sort: "created" },
   { label: "Alphabetical", sort: "alpha" },
-];
+] as const satisfies readonly {
+  label: string;
+  sort: SidebarChronologicalSort;
+}[];
 
 function SidebarDisplayMenuTrigger({
   ariaLabel,
-  buttonRef,
   iconName,
   tooltip,
 }: {
   ariaLabel: string;
-  buttonRef?: Ref<HTMLButtonElement>;
   iconName: IconName;
   tooltip: string;
 }) {
@@ -744,7 +647,6 @@ function SidebarDisplayMenuTrigger({
       <TooltipTrigger asChild>
         <DropdownMenuTrigger asChild>
           <Button
-            ref={buttonRef}
             type="button"
             variant="ghost"
             size="icon"
@@ -767,51 +669,9 @@ function SidebarDisplayMenuTrigger({
   );
 }
 
-function SidebarSortMenuOption({
-  direction,
-  label,
-  selected,
-  sort,
-  onToggle,
-}: SidebarSortMenuOptionProps) {
-  return (
-    <DropdownMenuItem
-      onSelect={(event) => {
-        // The display-options menu stays open across every interaction; it
-        // closes only on outside click / Escape. This holds on the mobile sheet
-        // too (the item's onClick honors defaultPrevented).
-        event.preventDefault();
-        onToggle(sort);
-      }}
-      className="flex items-center justify-between gap-3"
-    >
-      <span className="truncate text-xs">{label}</span>
-      {/* No sort field shows no glyph; the active field shows a single arrow
-          that points down for descending and up for ascending. */}
-      <Icon
-        name={direction === "asc" ? "ArrowUp" : "ArrowDown"}
-        aria-hidden="true"
-        className={cn(
-          COARSE_POINTER_ICON_SIZE_CLASS,
-          selected ? "opacity-100" : "opacity-0",
-        )}
-      />
-    </DropdownMenuItem>
-  );
-}
-
-// Where the open display-options menu's trigger last sat on screen. Toggling
-// the organization mode swaps the sidebar's section tree, so the open menu
-// unmounts with the old tree and a sibling remounts with the new one; the
-// outgoing menu records its trigger rect here so the incoming menu can hold
-// the popover at the same on-screen spot instead of re-anchoring mid-
-// interaction. Only one display-options menu is ever open at a time.
-let lastOpenDisplayMenuTriggerPosition: { x: number; y: number } | null = null;
-
 // Single combined display-options menu (organize + sort) rendered on every
-// section header. Both the organization mode and the sort field/direction are
-// global, so any header's menu drives the whole sidebar. The menu stays open
-// across selections and closes only on outside click / Escape.
+// section header. Both the organization mode and the sort field are
+// global, so any header's menu drives the whole sidebar.
 export function SidebarDisplayOptionsMenu({
   open,
   onOpenChange,
@@ -822,126 +682,55 @@ export function SidebarDisplayOptionsMenu({
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,
   );
-  const [sortDirection, setSortDirection] = useAtom(sidebarSortDirectionAtom);
-  // Toggling the organization mode swaps the sidebar's section tree, which
-  // remounts this menu while it is open; Radix then replays the content's
-  // entrance animation, reading as a flash. Suppress the entrance animation
-  // for a menu that mounts already open, until it has closed once.
-  const [mountedWhileOpen, setMountedWhileOpen] = useState(open === true);
-  const isCompactViewport = useIsCompactViewport();
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  // A remounting menu also re-anchors to its new header, which can sit at a
-  // different height — yanking the popover out from under the pointer. Offset
-  // the content back to the outgoing menu's spot until the menu closes; the
-  // next open anchors normally. The mobile drawer is bottom-anchored and never
-  // moves, so it needs no pinning.
-  const [pinOffset, setPinOffset] = useState<{ x: number; y: number } | null>(
-    null,
-  );
-  // Mirror of pinOffset for the effect cleanup below, so recording the
-  // outgoing position doesn't have to re-run the effect on every pin change.
-  const pinOffsetRef = useRef(pinOffset);
-  useLayoutEffect(() => {
-    pinOffsetRef.current = pinOffset;
-  }, [pinOffset]);
-  useLayoutEffect(() => {
-    if (!open || isCompactViewport) {
-      return;
-    }
-    const trigger = triggerRef.current;
-    if (!trigger) {
-      return;
-    }
-    if (mountedWhileOpen && lastOpenDisplayMenuTriggerPosition) {
-      const rect = trigger.getBoundingClientRect();
-      const x = lastOpenDisplayMenuTriggerPosition.x - rect.left;
-      const y = lastOpenDisplayMenuTriggerPosition.y - rect.top;
-      if (x !== 0 || y !== 0) {
-        setPinOffset({ x, y });
-      }
-    }
-    return () => {
-      const rect = trigger.getBoundingClientRect();
-      // Record the EFFECTIVE anchor — trigger position plus any active pin —
-      // so consecutive mode toggles keep the popover at the same visual spot
-      // instead of accumulating drift. A zero rect means the trigger was
-      // already detached; drop the stale position rather than pinning a
-      // future menu to it.
-      const pin = pinOffsetRef.current;
-      lastOpenDisplayMenuTriggerPosition =
-        rect.width > 0 || rect.height > 0
-          ? { x: rect.left + (pin?.x ?? 0), y: rect.top + (pin?.y ?? 0) }
-          : null;
-    };
-  }, [open, isCompactViewport, mountedWhileOpen]);
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (!nextOpen) {
-        setMountedWhileOpen(false);
-        setPinOffset(null);
-      }
-      onOpenChange?.(nextOpen);
-    },
-    [onOpenChange],
-  );
   const selectedSort: SidebarChronologicalSort =
     chronologicalSort === "none" ? "updated" : chronologicalSort;
-  const handleSortToggle = useCallback(
-    (sort: SidebarChronologicalSort) => {
-      if (selectedSort === sort) {
-        // Re-selecting the active field flips its direction.
-        setSortDirection((current) => (current === "desc" ? "asc" : "desc"));
-        return;
-      }
-      // A newly selected field starts in its natural direction: time sorts show
-      // newest first (desc); alphabetical starts A→Z (asc).
-      setChronologicalSort(sort);
-      setSortDirection(sort === "alpha" ? "asc" : "desc");
-    },
-    [selectedSort, setChronologicalSort, setSortDirection],
-  );
 
   return (
-    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <SidebarDisplayMenuTrigger
         ariaLabel="Sidebar display options"
-        buttonRef={triggerRef}
         iconName="SlidersHorizontal"
         tooltip="Display options"
       />
       <DropdownMenuContent
         align="end"
         mobileTitle="Display options"
-        className={cn(
-          "min-w-[13rem]",
-          mountedWhileOpen && "data-[state=open]:animate-none",
-        )}
-        style={
-          pinOffset
-            ? { transform: `translate(${pinOffset.x}px, ${pinOffset.y}px)` }
-            : undefined
-        }
+        className="min-w-[13rem]"
       >
         <DropdownMenuLabel className={CHROME_SECTION_LABEL_CLASS}>
-          Organize by
+          Organize
         </DropdownMenuLabel>
-        <SidebarOrganizeSegmentedControl
-          value={organizationMode}
-          onChange={setOrganizationMode}
-        />
+        <DropdownMenuGroup aria-label="Organize">
+          {SIDEBAR_ORGANIZE_OPTIONS.map((option) => (
+            <DropdownMenuCheckboxItem
+              key={option.mode}
+              checked={organizationMode === option.mode}
+              onCheckedChange={() => {
+                // Close before swapping the sidebar section tree so the newly
+                // mounted header cannot inherit an open menu.
+                onOpenChange?.(false);
+                setOrganizationMode(option.mode);
+              }}
+            >
+              {option.label}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuLabel className={CHROME_SECTION_LABEL_CLASS}>
           Sort by
         </DropdownMenuLabel>
-        {SIDEBAR_SORT_OPTIONS.map((option) => (
-          <SidebarSortMenuOption
-            key={option.sort}
-            {...option}
-            selected={selectedSort === option.sort}
-            direction={sortDirection}
-            onToggle={handleSortToggle}
-          />
-        ))}
+        <DropdownMenuGroup aria-label="Sort by">
+          {SIDEBAR_SORT_OPTIONS.map((option) => (
+            <DropdownMenuCheckboxItem
+              key={option.sort}
+              checked={selectedSort === option.sort}
+              onCheckedChange={() => setChronologicalSort(option.sort)}
+            >
+              {option.label}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -1667,16 +1456,11 @@ function ProjectListComponent({
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,
   );
-  const sortDirection = useAtomValue(sidebarSortDirectionAtom);
   const isFolderOrganizationMode = organizationMode === "chronological";
   const setCollapsedFolderList = useSetAtom(sidebarCollapsedFoldersAtom);
   const sidebarThreadComparator = useMemo<ThreadComparator>(
-    () =>
-      getSidebarThreadComparator({
-        direction: sortDirection,
-        sort: chronologicalSort,
-      }),
-    [chronologicalSort, sortDirection],
+    () => getSidebarThreadComparator(chronologicalSort),
+    [chronologicalSort],
   );
   const collapsedProjectIds = useMemo(
     () => new Set(collapsedProjectIdList),

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.stories.tsx
@@ -5,7 +5,6 @@ import { SidebarDisplayOptionsMenu } from "./ProjectList";
 import {
   sidebarChronologicalSortAtom,
   sidebarOrganizationModeAtom,
-  sidebarSortDirectionAtom,
 } from "./sidebarCollapsedAtoms";
 
 export default {
@@ -17,15 +16,12 @@ export default {
 function StateReadout() {
   const organizationMode = useAtomValue(sidebarOrganizationModeAtom);
   const sort = useAtomValue(sidebarChronologicalSortAtom);
-  const direction = useAtomValue(sidebarSortDirectionAtom);
   return (
     <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-xs">
       <dt className="text-muted-foreground">organize</dt>
       <dd className="font-mono">{organizationMode}</dd>
       <dt className="text-muted-foreground">sort</dt>
       <dd className="font-mono">{sort}</dd>
-      <dt className="text-muted-foreground">direction</dt>
-      <dd className="font-mono">{direction}</dd>
     </dl>
   );
 }
@@ -38,7 +34,6 @@ function InteractiveMenu() {
     const next = createStore();
     next.set(sidebarOrganizationModeAtom, "project");
     next.set(sidebarChronologicalSortAtom, "updated");
-    next.set(sidebarSortDirectionAtom, "desc");
     return next;
   }, []);
 
@@ -64,7 +59,7 @@ export function Overview() {
     <StoryCard>
       <StoryRow
         label="interactive"
-        hint="open the menu · toggle Projects/Manual · pick a sort field, click it again to flip ↑/↓ · the menu stays open"
+        hint="open the menu · toggle By project/In one list · pick a fixed-order sort field"
       >
         <InteractiveMenu />
       </StoryRow>

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
@@ -16,19 +16,16 @@ import { SidebarDisplayOptionsMenu } from "./ProjectList";
 import {
   sidebarChronologicalSortAtom,
   sidebarOrganizationModeAtom,
-  sidebarSortDirectionAtom,
 } from "./sidebarCollapsedAtoms";
 
 function StateProbe() {
   const organizationMode = useAtomValue(sidebarOrganizationModeAtom);
   const chronologicalSort = useAtomValue(sidebarChronologicalSortAtom);
-  const sortDirection = useAtomValue(sidebarSortDirectionAtom);
 
   return (
     <>
       <div data-testid="organization-mode">{organizationMode}</div>
       <div data-testid="chronological-sort">{chronologicalSort}</div>
-      <div data-testid="sort-direction">{sortDirection}</div>
     </>
   );
 }
@@ -37,7 +34,6 @@ function createSidebarViewStore() {
   const store = createStore();
   store.set(sidebarOrganizationModeAtom, "project");
   store.set(sidebarChronologicalSortAtom, "updated");
-  store.set(sidebarSortDirectionAtom, "desc");
   return store;
 }
 
@@ -67,7 +63,7 @@ afterEach(() => {
 });
 
 describe("sidebar display options menu", () => {
-  it("switches organization mode and keeps the menu open", async () => {
+  it("switches organization mode and closes like a standard menu", async () => {
     renderMobileViewOptions(<ControlledDisplayOptionsMenu />);
 
     const trigger = screen.getByRole("button", {
@@ -76,57 +72,83 @@ describe("sidebar display options menu", () => {
     });
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
 
-    const organizeGroup = await screen.findByRole("radiogroup", {
-      name: "Organize by",
+    const organizeGroup = await screen.findByRole("group", {
+      name: "Organize",
     });
-    fireEvent.click(
-      within(organizeGroup).getByRole("radio", { name: "Manual" }),
+    const byProjectOption = within(organizeGroup).getByRole(
+      "menuitemcheckbox",
+      { name: "By project" },
     );
+    const inOneListOption = within(organizeGroup).getByRole(
+      "menuitemcheckbox",
+      { name: "In one list" },
+    );
+
+    expect(byProjectOption.getAttribute("aria-checked")).toBe("true");
+    expect(inOneListOption.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(inOneListOption);
 
     expect(screen.getByTestId("organization-mode").textContent).toBe(
       "chronological",
     );
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(trigger);
+    expect(
+      (
+        await screen.findByRole("menuitemcheckbox", { name: "In one list" })
+      ).getAttribute("aria-checked"),
+    ).toBe("true");
   });
 
-  it("activates a new sort field descending and keeps the menu open", async () => {
+  it("selects one fixed-direction sort field and closes", async () => {
     renderMobileViewOptions(<ControlledDisplayOptionsMenu />);
 
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Created at" }),
-    );
+    const trigger = screen.getByRole("button", {
+      name: "Sidebar display options",
+      hidden: true,
+    });
+
+    const sortGroup = await screen.findByRole("group", { name: "Sort by" });
+    const updatedOption = within(sortGroup).getByRole("menuitemcheckbox", {
+      name: "Updated at",
+    });
+    const createdOption = within(sortGroup).getByRole("menuitemcheckbox", {
+      name: "Created at",
+    });
+
+    expect(updatedOption.getAttribute("aria-checked")).toBe("true");
+    expect(createdOption.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(createdOption);
 
     expect(screen.getByTestId("chronological-sort").textContent).toBe(
       "created",
     );
-    expect(screen.getByTestId("sort-direction").textContent).toBe("desc");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(trigger);
+    const reopenedSortGroup = await screen.findByRole("group", {
+      name: "Sort by",
+    });
     expect(
-      screen.queryByRole("menuitem", { name: "Created at" }),
-    ).not.toBeNull();
+      within(reopenedSortGroup)
+        .getByRole("menuitemcheckbox", { name: "Created at" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      within(reopenedSortGroup)
+        .getByRole("menuitemcheckbox", { name: "Updated at" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
   });
 
-  it("flips direction when re-selecting the active sort field", async () => {
-    renderMobileViewOptions(<ControlledDisplayOptionsMenu />);
-
-    // "Updated at" is the seeded active field (desc); re-selecting it flips.
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Updated at" }),
-    );
-
-    expect(screen.getByTestId("chronological-sort").textContent).toBe(
-      "updated",
-    );
-    expect(screen.getByTestId("sort-direction").textContent).toBe("asc");
-  });
-
-  it("starts alphabetical ascending", async () => {
+  it("selects alphabetical order", async () => {
     renderMobileViewOptions(<ControlledDisplayOptionsMenu />);
 
     fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Alphabetical" }),
+      await screen.findByRole("menuitemcheckbox", { name: "Alphabetical" }),
     );
 
     expect(screen.getByTestId("chronological-sort").textContent).toBe("alpha");
-    expect(screen.getByTestId("sort-direction").textContent).toBe("asc");
   });
 });

--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -8,7 +8,6 @@ const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "bb.sidebar.collapsedSections";
 const SIDEBAR_SECTION_ORDER_STORAGE_KEY = "bb.sidebar.sectionOrder";
 const ORGANIZATION_MODE_STORAGE_KEY = "bb.sidebar.organizationMode";
 const CHRONOLOGICAL_SORT_STORAGE_KEY = "bb.sidebar.chronologicalSort";
-const SORT_DIRECTION_STORAGE_KEY = "bb.sidebar.sortDirection";
 const COLLAPSED_FOLDERS_STORAGE_KEY = "bb.sidebar.collapsedFolders";
 
 export type SidebarSectionId = "pinned" | "projects" | "threads";
@@ -21,12 +20,10 @@ export type CollapsibleSidebarSectionId =
 // "project" keeps the per-project grouping; "chronological" is the persisted
 // value for the cross-project Folders view that replaced the old None view.
 export type SidebarOrganizationMode = "project" | "chronological";
-// Controls thread ordering in both grouped and ungrouped sidebar views.
-// "updated" reuses the status-aware activity heuristic; "created" sorts by
-// the literal createdAt field; "alpha" sorts by display title. "none" is a
-// legacy/internal value that the runtime normalizes back to "updated".
+// Controls thread ordering in both grouped and ungrouped sidebar views. Time
+// sorts show newest first and alphabetical sorts A→Z. "none" is a legacy value
+// that the runtime normalizes back to "updated".
 export type SidebarChronologicalSort = "updated" | "created" | "alpha" | "none";
-export type SidebarSortDirection = "asc" | "desc";
 
 export const DEFAULT_SIDEBAR_SECTION_ORDER: readonly SidebarSectionId[] = [
   "pinned",
@@ -86,13 +83,6 @@ export const sidebarChronologicalSortAtom =
     createJsonLocalStorage<SidebarChronologicalSort>(),
     { getOnInit: true },
   );
-
-export const sidebarSortDirectionAtom = atomWithStorage<SidebarSortDirection>(
-  SORT_DIRECTION_STORAGE_KEY,
-  "desc",
-  createJsonLocalStorage<SidebarSortDirection>(),
-  { getOnInit: true },
-);
 
 // Collapsed folder keys (see buildFolderKey in folderKeys.ts). A plain string[],
 // matching collapsedThreadIds / collapsedProjectIds.

--- a/apps/app/src/components/sidebar/sortComparator.test.ts
+++ b/apps/app/src/components/sidebar/sortComparator.test.ts
@@ -85,70 +85,33 @@ function order(comparator: ThreadComparator, entries: ThreadListEntry[]) {
 }
 
 describe("getSidebarThreadComparator", () => {
-  it("created: desc lists newest first, asc lists oldest first", () => {
+  it("created lists newest first", () => {
     expect(
-      order(
-        getSidebarThreadComparator({ sort: "created", direction: "desc" }),
-        [apple, banana, cherry],
-      ),
-    ).toEqual(["thr_c", "thr_b", "thr_a"]);
-    expect(
-      order(getSidebarThreadComparator({ sort: "created", direction: "asc" }), [
-        apple,
-        banana,
-        cherry,
-      ]),
-    ).toEqual(["thr_a", "thr_b", "thr_c"]);
-  });
-
-  it("updated: desc lists most recent first, asc inverts", () => {
-    expect(
-      order(
-        getSidebarThreadComparator({ sort: "updated", direction: "desc" }),
-        [apple, banana, cherry],
-      ),
-    ).toEqual(["thr_c", "thr_b", "thr_a"]);
-    expect(
-      order(getSidebarThreadComparator({ sort: "updated", direction: "asc" }), [
-        apple,
-        banana,
-        cherry,
-      ]),
-    ).toEqual(["thr_a", "thr_b", "thr_c"]);
-  });
-
-  it("alpha: asc is A→Z and desc is Z→A", () => {
-    expect(
-      order(getSidebarThreadComparator({ sort: "alpha", direction: "asc" }), [
-        cherry,
-        apple,
-        banana,
-      ]),
-    ).toEqual(["thr_a", "thr_b", "thr_c"]);
-    expect(
-      order(getSidebarThreadComparator({ sort: "alpha", direction: "desc" }), [
-        apple,
-        cherry,
-        banana,
-      ]),
+      order(getSidebarThreadComparator("created"), [apple, banana, cherry]),
     ).toEqual(["thr_c", "thr_b", "thr_a"]);
   });
 
-  // Regression: leaf threads and mixed folder/thread items must sort the same
-  // direction, or folders and threads appear in opposite alphabetical order.
-  it("alpha: leaf and item comparators agree in direction", () => {
-    for (const direction of ["asc", "desc"] as const) {
-      const comparator = getSidebarThreadComparator({
-        sort: "alpha",
-        direction,
-      });
-      expect(comparator.compareItems).toBeDefined();
-      const leafSign = Math.sign(comparator(apple, banana));
-      const itemSign = Math.sign(
-        comparator.compareItems!(threadItem(apple), threadItem(banana)),
-      );
-      expect(itemSign).toBe(leafSign);
-    }
+  it("updated lists most recent first", () => {
+    expect(
+      order(getSidebarThreadComparator("updated"), [apple, banana, cherry]),
+    ).toEqual(["thr_c", "thr_b", "thr_a"]);
+  });
+
+  it("alphabetical lists A→Z", () => {
+    expect(
+      order(getSidebarThreadComparator("alpha"), [cherry, apple, banana]),
+    ).toEqual(["thr_a", "thr_b", "thr_c"]);
+  });
+
+  // Regression: leaf threads and mixed folder/thread items must both sort A→Z.
+  it("alphabetical leaf and item comparators agree", () => {
+    const comparator = getSidebarThreadComparator("alpha");
+    expect(comparator.compareItems).toBeDefined();
+    const leafSign = Math.sign(comparator(apple, banana));
+    const itemSign = Math.sign(
+      comparator.compareItems!(threadItem(apple), threadItem(banana)),
+    );
+    expect(itemSign).toBe(leafSign);
   });
 });
 


### PR DESCRIPTION
## Summary
- replace the custom organize control and sort arrows with shared dropdown check items
- keep updated and created sorts newest-first and alphabetical sorting A-to-Z
- remove persisted sort direction and custom menu positioning/lifecycle behavior

## Testing
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (191 files, 1239 tests)
- verified the desktop menu and selection behavior in the running dev app
