### PR TITLE
Fix builtin plugin hot reload in development

### DIFF
--- a/apps/cli/src/__tests__/plugin-dev-loop.test.ts
+++ b/apps/cli/src/__tests__/plugin-dev-loop.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createPluginDevLoop,
-  isIgnoredPluginDevPath,
-} from "../plugin-dev-loop.js";
+import { createPluginDevLoop, isIgnoredPluginDevPath } from "@bb/plugin-build";
+import { canDevelopPlugin } from "../commands/plugin.js";
+
+describe("canDevelopPlugin", () => {
+  it("allows builtins while the user-installed Plugins experiment is off", () => {
+    expect(canDevelopPlugin(false, { source: "builtin:automations" })).toBe(
+      true,
+    );
+    expect(canDevelopPlugin(false, { source: "path:/tmp/plugin" })).toBe(false);
+  });
+});
 
 describe("createPluginDevLoop", () => {
   beforeEach(() => {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -6,8 +6,11 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { Command } from "commander";
 import { scaffoldPlugin } from "@bb/templates/plugin-scaffold";
 import { action } from "../action.js";
-import { buildPluginApp, buildPluginServer } from "@bb/plugin-build";
-import { createPluginDevLoop } from "../plugin-dev-loop.js";
+import {
+  buildPluginApp,
+  buildPluginServer,
+  createPluginDevLoop,
+} from "@bb/plugin-build";
 import { runPluginCliCommand } from "../plugin-cli-proxy.js";
 import { resolveBbCliVersion } from "../version.js";
 import { outputJson, type JsonOutputOptions } from "./helpers.js";
@@ -48,6 +51,13 @@ interface PluginMutationResult {
   error?: string;
   plugin?: PluginEntry;
   plugins?: PluginEntry[];
+}
+
+export function canDevelopPlugin(
+  pluginsExperimentEnabled: boolean,
+  entry: Pick<PluginEntry, "source">,
+): boolean {
+  return pluginsExperimentEnabled || entry.source.startsWith("builtin:");
 }
 
 interface PluginSettingDescriptor {
@@ -435,12 +445,6 @@ export function registerPluginCommands(
         // checkouts).
         const realDir = await realpath(rootDir).catch(() => rootDir);
         const list = await callPlugins<PluginListResponse>(getUrl(), "", "GET");
-        if (!list.enabled) {
-          console.error(
-            'Plugins are disabled — enable the "Plugins" experiment in Settings → Experiments.',
-          );
-          process.exit(1);
-        }
         const entry = list.plugins.find(
           (candidate) =>
             candidate.rootDir === rootDir || candidate.rootDir === realDir,
@@ -448,6 +452,12 @@ export function registerPluginCommands(
         if (!entry) {
           console.error(
             `This directory is not installed as a plugin — run \`bb plugin install ${path ?? "."}\` first, then re-run \`bb plugin dev\`.`,
+          );
+          process.exit(1);
+        }
+        if (!canDevelopPlugin(list.enabled, entry)) {
+          console.error(
+            'Plugins are disabled — enable the "Plugins" experiment in Settings → Experiments.',
           );
           process.exit(1);
         }

--- a/apps/server/scripts/dev-supervisor.mjs
+++ b/apps/server/scripts/dev-supervisor.mjs
@@ -12,6 +12,7 @@ void runDevSupervisor({
   childArgs: ["--conditions=source", "--import", "tsx", "src/index.ts"],
   childCommand: process.execPath,
   childCwd: packageRoot,
+  childEnv: { BB_MANAGED_DEV_BUILTIN_PLUGIN_HOT_RELOAD: "1" },
   unexpectedRestartBackoff: DEFAULT_UNEXPECTED_RESTART_BACKOFF,
   serviceName: "server",
 }).catch((error) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -370,6 +370,8 @@ export function createApp(
     appVersion: deps.config.appVersion,
     isEnabled: () => getExperiments(deps.db).plugins,
     isConnectEnabled: () => getExperiments(deps.db).bbConnect,
+    watchBuiltinPluginSources:
+      process.env.BB_MANAGED_DEV_BUILTIN_PLUGIN_HOT_RELOAD === "1",
   });
   // Bridge the thread lifecycle seams to this service's plugins (§4.5).
   setPluginThreadEventEmitter(pluginService.events);

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -1,3 +1,4 @@
+import { watch, type FSWatcher } from "node:fs";
 import { mkdir, readFile, rm, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
@@ -15,7 +16,7 @@ import {
 } from "@bb/domain";
 // The build engine's natives (esbuild, Tailwind oxide) are dynamically
 // imported inside buildPluginApp — importing this loads nothing heavy.
-import { buildPluginApp } from "@bb/plugin-build";
+import { buildPluginApp, createPluginDevLoop } from "@bb/plugin-build";
 import { createNodeBbSdk, type BbSdk } from "@bb/sdk";
 import { deleteSecretFile, readOrCreateSecretFile } from "@bb/secret-storage";
 import type { ServerLogger } from "../../types.js";
@@ -246,6 +247,8 @@ export interface PluginServiceDeps {
   isConnectEnabled: () => boolean;
   /** Declared first-party plugins installed by default; test-only override. */
   builtinPlugins?: readonly BuiltinPluginRegistration[];
+  /** Managed source-development only: rebuild and reload builtin frontends. */
+  watchBuiltinPluginSources?: boolean;
   /** Factory-execution time box; overridable in tests. */
   loadTimeoutMs?: number;
   /** Bound on awaiting a service's start() promise at dispose; tests shrink it. */
@@ -779,6 +782,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
   // marker yet) and double-start the plugin's services.
   const lifecycleChains = new Map<string, Promise<void>>();
   const disposingPluginIds = new Set<string>();
+  const builtinSourceWatchers: FSWatcher[] = [];
 
   function withLifecycleLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const previous = lifecycleChains.get(id) ?? Promise.resolve();
@@ -2095,11 +2099,51 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     async start() {
       await reconcileBuiltins();
       await loadAll();
+      if (deps.watchBuiltinPluginSources) {
+        for (const builtin of builtinPlugins) {
+          const row = listInstalledPlugins(deps.db).find(
+            (candidate) =>
+              candidate.source === builtinPluginSource(builtin.name),
+          );
+          if (row === undefined) continue;
+          const manifest = await readPluginManifest(builtin.rootDir);
+          const loop = createPluginDevLoop({
+            pluginId: row.id,
+            hasApp: manifest.appEntry !== undefined,
+            buildApp: async () => {
+              await buildPluginApp(builtin.rootDir);
+            },
+            reloadPlugin: async () => {
+              await withLifecycleLock(row.id, async () => {
+                const current = getInstalledPlugin(deps.db, row.id);
+                if (current === undefined || !shouldLoadRow(current)) return;
+                await disposeOne(row.id);
+                await loadOne(current);
+              });
+              await syncCliSkill();
+              notifyPluginsChanged();
+            },
+            log: (message) => logger.info(`plugin ${row.id}: ${message}`),
+          });
+          const watcher = watch(
+            builtin.rootDir,
+            { recursive: true },
+            (_event, filename) => {
+              if (typeof filename === "string" && filename.length > 0) {
+                loop.handleChange(filename);
+              }
+            },
+          );
+          watcher.on("close", () => loop.dispose());
+          builtinSourceWatchers.push(watcher);
+        }
+      }
       await syncCliSkill();
       notifyPluginsChanged();
     },
 
     async stop() {
+      for (const watcher of builtinSourceWatchers.splice(0)) watcher.close();
       await disposeAll();
       await syncCliSkill();
       notifyPluginsChanged();

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -119,6 +119,7 @@ function createService(args: {
   isEnabled?: () => boolean;
   isConnectEnabled?: () => boolean;
   rootDir?: string;
+  watchBuiltinPluginSources?: boolean;
 }): PluginService {
   return createPluginService({
     db: args.db,
@@ -138,6 +139,7 @@ function createService(args: {
         rootDir: args.rootDir ?? fixtureRoot,
       },
     ],
+    watchBuiltinPluginSources: args.watchBuiltinPluginSources,
     loadTimeoutMs: 2000,
   });
 }
@@ -308,6 +310,54 @@ describe("builtin plugin reconciliation", () => {
       stdout: "builtin builtin-fixture",
     });
   });
+
+  it("rebuilds and serves a new builtin app hash after a source edit while Plugins is off", async () => {
+    const mutableRoot = join(workDir, "bb-plugin-hot-builtin");
+    await mkdir(mutableRoot, { recursive: true });
+    await writeFile(
+      join(mutableRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-hot-builtin",
+        version: "0.1.0",
+        type: "module",
+        bb: { server: "./server.ts", app: "./app.tsx" },
+      }),
+    );
+    await writeFile(
+      join(mutableRoot, "server.ts"),
+      "export default function plugin() {}\n",
+    );
+    await writeFile(
+      join(mutableRoot, "app.tsx"),
+      "export default function App() { return <div>before</div>; }\n",
+    );
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      builtinName: "hot",
+      isEnabled: () => false,
+      rootDir: mutableRoot,
+      watchBuiltinPluginSources: true,
+    });
+    await service.start();
+    const before = service.list()[0]?.app.bundle;
+    expect(before).not.toBeNull();
+
+    await writeFile(
+      join(mutableRoot, "app.tsx"),
+      "export default function App() { return <div>after</div>; }\n",
+    );
+    let after = service.list()[0]?.app.bundle;
+    const deadline = Date.now() + 20_000;
+    while (after?.hash === before?.hash && Date.now() < deadline) {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+      after = service.list()[0]?.app.bundle;
+    }
+    expect(after?.hash).not.toBe(before?.hash);
+    await expect(
+      readFile(join(mutableRoot, "dist", "app.js"), "utf8"),
+    ).resolves.toContain("after");
+  }, 30_000);
 
   it("rejects unknown builtin install sources clearly", async () => {
     service = createService({ db, dataDir: join(workDir, "data") });

--- a/packages/plugin-build/src/index.ts
+++ b/packages/plugin-build/src/index.ts
@@ -16,3 +16,4 @@ export {
   buildPluginServer,
   type PluginServerBuildResult,
 } from "./build-plugin-server.js";
+export * from "./plugin-dev-loop.js";

--- a/packages/plugin-build/src/plugin-dev-loop.ts
+++ b/packages/plugin-build/src/plugin-dev-loop.ts
@@ -1,27 +1,4 @@
-/**
- * The `bb plugin dev` watch loop (plugin design §5.1 dev loop), separated
- * from the command wiring so the batching/ordering behavior is testable with
- * injected build/reload/log functions. The command feeds raw watcher events
- * into {@link PluginDevLoop.handleChange}; the loop debounces them into
- * change batches and runs one cycle per batch:
- *
- *   1. plugin declares `bb.app` → rebuild the frontend bundle (a build
- *      failure prints the error and skips the reload — the on-disk bundle is
- *      unchanged, and a broken source tree should not churn backend
- *      services; the next save retries);
- *   2. POST /plugins/reload?id=<id> — the server re-runs the backend factory,
- *      refreshes the bundle hash, and broadcasts `plugins-changed`, which
- *      drives both the contributions refetch and the live frontend reload in
- *      open pages.
- *
- * Cycles are serialized (a change during a running cycle starts a new
- * debounce window) and failures never exit the loop.
- */
-
 const DEFAULT_DEBOUNCE_MS = 300;
-
-/** Output directories a cycle must never retrigger on (dist/ is written by
- * the loop's own rebuild — watching it would loop forever). */
 const IGNORED_SEGMENTS = new Set(["dist", "node_modules", ".git"]);
 
 export function isIgnoredPluginDevPath(relativePath: string): boolean {
@@ -32,10 +9,8 @@ export function isIgnoredPluginDevPath(relativePath: string): boolean {
 
 export interface PluginDevLoopDeps {
   pluginId: string;
-  /** Whether the manifest declares a `bb.app` frontend entry. */
   hasApp: boolean;
   buildApp: () => Promise<void>;
-  /** Rejects with the server's error message on a failed reload. */
   reloadPlugin: () => Promise<void>;
   log: (line: string) => void;
   debounceMs?: number;
@@ -43,9 +18,7 @@ export interface PluginDevLoopDeps {
 }
 
 export interface PluginDevLoop {
-  /** Feed one watcher event (path relative to the plugin root). */
   handleChange: (relativePath: string) => void;
-  /** Resolves when every started cycle has finished (test synchronization). */
   settled: () => Promise<void>;
   dispose: () => void;
 }
@@ -60,17 +33,19 @@ export function createPluginDevLoop(deps: PluginDevLoopDeps): PluginDevLoop {
   const pending = new Set<string>();
   let timer: ReturnType<typeof setTimeout> | null = null;
   let disposed = false;
-  // Cycles chain onto this tail — one at a time, in batch order.
   let queueTail: Promise<void> = Promise.resolve();
-
   async function runCycle(files: readonly string[]): Promise<void> {
     if (disposed) return;
-    const parts = [`${files.length} file${files.length === 1 ? "" : "s"} changed`];
+    const parts = [
+      `${files.length} file${files.length === 1 ? "" : "s"} changed`,
+    ];
     if (deps.hasApp) {
       const startedAt = now();
       try {
         await deps.buildApp();
-        parts.push(`rebuilt app in ${Math.max(0, Math.round(now() - startedAt))}ms`);
+        parts.push(
+          `rebuilt app in ${Math.max(0, Math.round(now() - startedAt))}ms`,
+        );
       } catch (error) {
         parts.push(`build failed: ${errorMessage(error)}`);
         deps.log(`${parts.join(" · ")} — fix and save to retry`);
@@ -85,7 +60,6 @@ export function createPluginDevLoop(deps: PluginDevLoopDeps): PluginDevLoop {
     }
     deps.log(parts.join(" · "));
   }
-
   function flush(): void {
     timer = null;
     if (pending.size === 0) return;
@@ -93,7 +67,6 @@ export function createPluginDevLoop(deps: PluginDevLoopDeps): PluginDevLoop {
     pending.clear();
     queueTail = queueTail.then(() => runCycle(files));
   }
-
   return {
     handleChange(relativePath) {
       if (disposed || isIgnoredPluginDevPath(relativePath)) return;
@@ -101,9 +74,7 @@ export function createPluginDevLoop(deps: PluginDevLoopDeps): PluginDevLoop {
       if (timer !== null) clearTimeout(timer);
       timer = setTimeout(flush, debounceMs);
     },
-    settled() {
-      return queueTail;
-    },
+    settled: () => queueTail,
     dispose() {
       disposed = true;
       if (timer !== null) clearTimeout(timer);


### PR DESCRIPTION
## Summary
- enable builtin plugin source watching only in managed server development sessions
- share the existing debounced frontend build-and-reload loop between the CLI and server
- allow `bb plugin dev` for builtins while the user-installed Plugins experiment is disabled
- keep generated `dist/`, dependency, and git paths excluded from watch cycles

## Verification
- `pnpm exec turbo run test --filter=@bb/cli --filter=@bb/server --force`
- `pnpm exec turbo run typecheck --filter=@bb/plugin-build --filter=@bb/cli --filter=@bb/server`
- `pnpm exec turbo run build --filter=@bb/cli --filter=@bb/server`
- `git diff --check`
