### PR TITLE
Align desktop sidebar shortcut hint

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -47,6 +47,7 @@ import {
   CHROME_ROW_CLASS,
   getBbDesktopInfo,
   MACOS_CHROME_CONTROL_NO_DRAG_CLASS,
+  MACOS_CHROME_TRAFFIC_LIGHT_AXIS_NUDGE_CLASS,
   MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
@@ -229,7 +230,10 @@ function SidebarTriggerOverlay({
         />
         <AppCommandShortcutHint
           shortcut={shortcut}
-          className="absolute left-full ml-1"
+          className={cn(
+            "absolute left-full ml-1",
+            MACOS_CHROME_TRAFFIC_LIGHT_AXIS_NUDGE_CLASS,
+          )}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- align the desktop sidebar shortcut hint with the macOS traffic-light control axis
- reuse the shared title-bar alignment token so browser positioning stays unchanged

## Tests
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (1,257 tests)