### PR TITLE
Reuse bb Connect authentication in desktop

### DIFF
--- a/apps/connect/src/servers.test.ts
+++ b/apps/connect/src/servers.test.ts
@@ -14,8 +14,10 @@ import {
 } from "@bb/connect-db";
 
 import {
+  createDesktopSessionCookie,
   listAccountServers,
   resolveAccountUserId,
+  verifyDesktopSessionCookie,
   verifyServerCredential,
 } from "./servers.js";
 import { verifyMachineCredential } from "./session.js";
@@ -46,8 +48,13 @@ afterEach(() => {
 const now = new Date("2026-07-01T12:00:00.000Z");
 
 async function sha256Hex(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
-  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 function seedUser(id: string): void {
@@ -85,6 +92,30 @@ function seedServer(over: {
     })
     .run();
 }
+
+describe("desktop session cookie", () => {
+  it("round-trips account identity until expiry and rejects tampering", async () => {
+    const expiresAt = now.getTime() + 60_000;
+    const cookie = await createDesktopSessionCookie(
+      "acct-a",
+      "test-secret",
+      expiresAt,
+    );
+    await expect(
+      verifyDesktopSessionCookie(cookie, "test-secret", now.getTime()),
+    ).resolves.toBe("acct-a");
+    await expect(
+      verifyDesktopSessionCookie(cookie, "test-secret", expiresAt),
+    ).resolves.toBeNull();
+    await expect(
+      verifyDesktopSessionCookie(
+        `${cookie.slice(0, -1)}x`,
+        "test-secret",
+        now.getTime(),
+      ),
+    ).resolves.toBeNull();
+  });
+});
 
 describe("listAccountServers", () => {
   it("returns only the authenticated account's rows with live from last_seen_at", async () => {
@@ -239,7 +270,11 @@ describe("verifyServerCredential / resolveAccountUserId", () => {
       false,
       ["sign"],
     );
-    const sigBuf = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(token));
+    const sigBuf = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      new TextEncoder().encode(token),
+    );
     const sig = btoa(String.fromCharCode(...new Uint8Array(sigBuf)));
     const cookieValue = `${token}.${sig}`;
 

--- a/apps/connect/src/servers.ts
+++ b/apps/connect/src/servers.ts
@@ -14,6 +14,97 @@ import {
 import type { Env } from "./tunnel-do.js";
 
 const SESSION_COOKIE = "__Secure-better-auth.session_token";
+export const DESKTOP_SESSION_COOKIE = "__Secure-bb-connect.desktop_session";
+export const DESKTOP_SESSION_TTL_MS = 60 * 60 * 1000;
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function stringToBase64Url(value: string): string {
+  return bytesToBase64Url(new TextEncoder().encode(value));
+}
+
+function base64UrlToString(value: string): string | null {
+  try {
+    const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    return new TextDecoder().decode(
+      Uint8Array.from(atob(padded), (character) => character.charCodeAt(0)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function signDesktopSessionPayload(
+  payload: string,
+  secret: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+export async function createDesktopSessionCookie(
+  userId: string,
+  secret: string,
+  expiresAt: number,
+): Promise<string> {
+  const payload = stringToBase64Url(JSON.stringify({ expiresAt, userId }));
+  return `${payload}.${await signDesktopSessionPayload(payload, secret)}`;
+}
+
+export async function verifyDesktopSessionCookie(
+  cookieValue: string,
+  secret: string,
+  now: number = Date.now(),
+): Promise<string | null> {
+  const dot = cookieValue.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const payload = cookieValue.slice(0, dot);
+  const signature = cookieValue.slice(dot + 1);
+  const expected = await signDesktopSessionPayload(payload, secret);
+  if (signature.length !== expected.length) return null;
+  let mismatch = 0;
+  for (let index = 0; index < signature.length; index += 1) {
+    mismatch |= signature.charCodeAt(index) ^ expected.charCodeAt(index);
+  }
+  if (mismatch !== 0) return null;
+
+  const decoded = base64UrlToString(payload);
+  if (decoded === null) return null;
+  try {
+    const value: unknown = JSON.parse(decoded);
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("userId" in value) ||
+      typeof value.userId !== "string" ||
+      !("expiresAt" in value) ||
+      typeof value.expiresAt !== "number" ||
+      value.expiresAt <= now
+    ) {
+      return null;
+    }
+    return value.userId;
+  } catch {
+    return null;
+  }
+}
 
 const serverCredentialCache = new Map<
   string,
@@ -22,8 +113,13 @@ const serverCredentialCache = new Map<
 const SERVER_CRED_TTL_MS = 20_000;
 
 async function sha256Hex(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
-  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 /**
@@ -145,12 +241,19 @@ export async function handleListAccountServers(
   if (request.method !== "GET") {
     return new Response(JSON.stringify({ error: "method_not_allowed" }), {
       status: 405,
-      headers: { "content-type": "application/json; charset=utf-8", allow: "GET" },
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        allow: "GET",
+      },
     });
   }
 
   const db = drizzle(env.DB, { schema });
-  const userId = await resolveAccountUserId(request, env.BETTER_AUTH_SECRET, db);
+  const userId = await resolveAccountUserId(
+    request,
+    env.BETTER_AUTH_SECRET,
+    db,
+  );
   if (!userId) {
     return new Response(JSON.stringify({ error: "unauthorized" }), {
       status: 401,
@@ -163,4 +266,52 @@ export async function handleListAccountServers(
     status: 200,
     headers: { "content-type": "application/json; charset=utf-8" },
   });
+}
+
+/** Exchange a durable pairing credential for a short-lived browser session. */
+export async function handleCreateDesktopSession(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response(JSON.stringify({ error: "method_not_allowed" }), {
+      status: 405,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        allow: "POST",
+      },
+    });
+  }
+  const db = drizzle(env.DB, { schema });
+  const userId = await resolveAccountUserId(
+    request,
+    env.BETTER_AUTH_SECRET,
+    db,
+  );
+  if (!userId) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+  const expiresAt = Date.now() + DESKTOP_SESSION_TTL_MS;
+  const value = await createDesktopSessionCookie(
+    userId,
+    env.BETTER_AUTH_SECRET,
+    expiresAt,
+  );
+  return new Response(
+    JSON.stringify({
+      cookie: {
+        domain: `.${env.BASE_DOMAIN}`,
+        expiresAt,
+        name: DESKTOP_SESSION_COOKIE,
+        value,
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    },
+  );
 }

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -96,11 +96,15 @@ vi.mock("./session.js", () => ({
 }));
 
 vi.mock("./servers.js", () => ({
+  DESKTOP_SESSION_COOKIE: "__Secure-bb-connect.desktop_session",
+  handleCreateDesktopSession: vi.fn(),
   handleListAccountServers: vi.fn(),
+  verifyDesktopSessionCookie: vi.fn(),
 }));
 
 vi.mock("./cache.js", async () => {
-  const actual = await vi.importActual<typeof import("./cache.js")>("./cache.js");
+  const actual =
+    await vi.importActual<typeof import("./cache.js")>("./cache.js");
   return {
     ...actual,
     serveWithCache: vi.fn(
@@ -124,7 +128,12 @@ import {
   verifyMachineCredential,
   verifySessionCookie,
 } from "./session.js";
-import { handleListAccountServers } from "./servers.js";
+import {
+  DESKTOP_SESSION_COOKIE,
+  handleCreateDesktopSession,
+  handleListAccountServers,
+  verifyDesktopSessionCookie,
+} from "./servers.js";
 import { serveWithCache } from "./cache.js";
 import worker, { offlinePage, relativeTime, wantsHtml } from "./worker.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO } from "./tunnel-do.js";
@@ -135,9 +144,13 @@ const mockVerifyMachine = vi.mocked(verifyMachineCredential);
 const mockVerifySession = vi.mocked(verifySessionCookie);
 const mockServeWithCache = vi.mocked(serveWithCache);
 const mockHandleListAccountServers = vi.mocked(handleListAccountServers);
+const mockHandleCreateDesktopSession = vi.mocked(handleCreateDesktopSession);
+const mockVerifyDesktopSession = vi.mocked(verifyDesktopSessionCookie);
 
 /** A resolved server row; overrides let a test tweak one field. */
-function resolvedServer(over: Partial<{ lastSeenAt: Date | null; userId: string }> = {}) {
+function resolvedServer(
+  over: Partial<{ lastSeenAt: Date | null; userId: string }> = {},
+) {
   return {
     userId: over.userId ?? OWNER,
     server: {
@@ -177,7 +190,11 @@ function makeEnv(doFetch: (req: Request) => Promise<Response> | Response) {
   return { env, ctx, captured };
 }
 
-function visitorRequest(host: string, path = "/", init: RequestInit = {}): Request {
+function visitorRequest(
+  host: string,
+  path = "/",
+  init: RequestInit = {},
+): Request {
   const headers = new Headers(init.headers);
   headers.set("host", host);
   return new Request(`https://${host}${path}`, { ...init, headers });
@@ -229,6 +246,26 @@ describe("GET /api/connect/servers", () => {
     );
     expect(res.status).toBe(401);
     expect(mockHandleListAccountServers).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /api/connect/desktop-session", () => {
+  it("intercepts the exchange before tunnel routing", async () => {
+    mockHandleCreateDesktopSession.mockResolvedValue(
+      new Response(JSON.stringify({ cookie: { value: "short-lived" } })),
+    );
+    const { env, ctx, captured } = makeEnv(() => new Response("origin"));
+    const response = await worker.fetch(
+      visitorRequest("sawyer.getbb.app", "/api/connect/desktop-session", {
+        method: "POST",
+        headers: { "x-bb-connect-machine": "paired" },
+      }),
+      env as never,
+      ctx,
+    );
+    expect(response.status).toBe(200);
+    expect(mockHandleCreateDesktopSession).toHaveBeenCalledTimes(1);
+    expect(captured).toHaveLength(0);
   });
 });
 
@@ -294,7 +331,10 @@ describe("gate worker share hosts", () => {
       ctx,
     );
     expect(res.status).toBe(200);
-    expect(mockResolveLabel).toHaveBeenCalledWith("sawyer-desktop", expect.anything());
+    expect(mockResolveLabel).toHaveBeenCalledWith(
+      "sawyer-desktop",
+      expect.anything(),
+    );
     expect(captured[0].headers.get(TUNNEL_TARGET_HEADER)).toBe("3000");
     expect(mockServeWithCache).toHaveBeenCalledWith(
       expect.any(Request),
@@ -330,6 +370,41 @@ describe("gate worker share hosts", () => {
     expect(res.status).toBe(403);
     expect(await res.text()).toContain("not your server");
     expect(captured).toHaveLength(0);
+  });
+
+  it("accepts the short-lived desktop cookie for the owning account", async () => {
+    mockParseCookie.mockImplementation((_header, name) =>
+      name === DESKTOP_SESSION_COOKIE ? "desktop-token" : null,
+    );
+    mockVerifyDesktopSession.mockResolvedValue(OWNER);
+    const { env, ctx, captured } = makeEnv(() => new Response("ok"));
+    const response = await worker.fetch(
+      visitorRequest("sawyer.getbb.app", "/"),
+      env as never,
+      ctx,
+    );
+    expect(response.status).toBe(200);
+    expect(mockVerifyDesktopSession).toHaveBeenCalledWith(
+      "desktop-token",
+      "test-secret",
+    );
+    expect(captured).toHaveLength(1);
+  });
+
+  it("uses the desktop cookie when a stale GitHub session belongs to another account", async () => {
+    mockParseCookie.mockImplementation((_header, name) =>
+      name === DESKTOP_SESSION_COOKIE ? "desktop-token" : "github-token",
+    );
+    mockVerifySession.mockResolvedValue(OTHER);
+    mockVerifyDesktopSession.mockResolvedValue(OWNER);
+    const { env, ctx, captured } = makeEnv(() => new Response("ok"));
+    const response = await worker.fetch(
+      visitorRequest("sawyer.getbb.app", "/"),
+      env as never,
+      ctx,
+    );
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
   });
 
   it("returns 404 for /__tunnel and /internal/* on share hosts", async () => {
@@ -373,7 +448,9 @@ describe("gate worker share hosts", () => {
 
   it("forwards websocket upgrades on share hosts with the target header", async () => {
     // Node's Response rejects status 101; the gate only needs the upgrade path.
-    const { env, ctx, captured } = makeEnv(() => new Response("upgraded", { status: 200 }));
+    const { env, ctx, captured } = makeEnv(
+      () => new Response("upgraded", { status: 200 }),
+    );
     await worker.fetch(
       visitorRequest("sawyer--8000.getbb.app", "/ws", {
         headers: { upgrade: "websocket" },
@@ -417,12 +494,16 @@ describe("gate worker share hosts", () => {
 
 // ── gate offline page (styled 503 vs plain 503) ─────────────────────────────
 
-const OFFLINE_BODY = "bb connect: this server is offline (no tunnel connected)\n";
+const OFFLINE_BODY =
+  "bb connect: this server is offline (no tunnel connected)\n";
 
 function offlineDoResponse(): Response {
   return new Response(OFFLINE_BODY, {
     status: 503,
-    headers: { "content-type": "text/plain; charset=utf-8", [TUNNEL_OFFLINE_HEADER]: "1" },
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      [TUNNEL_OFFLINE_HEADER]: "1",
+    },
   });
 }
 
@@ -439,7 +520,9 @@ describe("gate offline page", () => {
     );
     const { env, ctx } = makeEnv(offlineDoResponse);
     const res = await worker.fetch(
-      visitorRequest("sawyer.getbb.app", "/", { headers: { accept: "text/html" } }),
+      visitorRequest("sawyer.getbb.app", "/", {
+        headers: { accept: "text/html" },
+      }),
       env as never,
       ctx,
     );
@@ -455,7 +538,9 @@ describe("gate offline page", () => {
     mockResolveLabel.mockResolvedValue(resolvedServer({ lastSeenAt: null }));
     const { env, ctx } = makeEnv(offlineDoResponse);
     const res = await worker.fetch(
-      visitorRequest("sawyer.getbb.app", "/", { headers: { accept: "text/html" } }),
+      visitorRequest("sawyer.getbb.app", "/", {
+        headers: { accept: "text/html" },
+      }),
       env as never,
       ctx,
     );
@@ -485,7 +570,9 @@ describe("gate offline page", () => {
       () => new Response("origin down", { status: 503 }),
     );
     const res = await worker.fetch(
-      visitorRequest("sawyer.getbb.app", "/", { headers: { accept: "text/html" } }),
+      visitorRequest("sawyer.getbb.app", "/", {
+        headers: { accept: "text/html" },
+      }),
       env as never,
       ctx,
     );
@@ -501,13 +588,21 @@ describe("gate page helpers", () => {
     expect(relativeTime(new Date(now - 60_000), now)).toBe("1 minute ago");
     expect(relativeTime(new Date(now - 5 * 60_000), now)).toBe("5 minutes ago");
     expect(relativeTime(new Date(now - 60 * 60_000), now)).toBe("1 hour ago");
-    expect(relativeTime(new Date(now - 3 * 60 * 60_000), now)).toBe("3 hours ago");
+    expect(relativeTime(new Date(now - 3 * 60 * 60_000), now)).toBe(
+      "3 hours ago",
+    );
     // Beyond a day → calendar date, not "N hours ago".
-    expect(relativeTime(new Date(now - 3 * 24 * 60 * 60_000), now)).not.toContain("ago");
+    expect(
+      relativeTime(new Date(now - 3 * 24 * 60 * 60_000), now),
+    ).not.toContain("ago");
   });
 
   it("wantsHtml only matches a text/html Accept", () => {
-    expect(wantsHtml(new Request("https://x/", { headers: { accept: "text/html" } }))).toBe(true);
+    expect(
+      wantsHtml(
+        new Request("https://x/", { headers: { accept: "text/html" } }),
+      ),
+    ).toBe(true);
     expect(
       wantsHtml(
         new Request("https://x/", {
@@ -515,7 +610,9 @@ describe("gate page helpers", () => {
         }),
       ),
     ).toBe(true);
-    expect(wantsHtml(new Request("https://x/", { headers: { accept: "*/*" } }))).toBe(false);
+    expect(
+      wantsHtml(new Request("https://x/", { headers: { accept: "*/*" } })),
+    ).toBe(false);
     expect(wantsHtml(new Request("https://x/"))).toBe(false);
   });
 
@@ -554,7 +651,8 @@ function mockDoState(initialStorage: Record<string, unknown> = {}): MockState {
       entries
         .filter((entry) => tag === undefined || entry.tags.includes(tag))
         .map((entry) => entry.ws),
-    getTags: (ws: WebSocket) => entries.find((entry) => entry.ws === ws)?.tags ?? [],
+    getTags: (ws: WebSocket) =>
+      entries.find((entry) => entry.ws === ws)?.tags ?? [],
     acceptWebSocket: (ws: WebSocket, tags: string[] = []) => {
       entries.push({ ws, tags });
     },
@@ -595,7 +693,9 @@ function makeDoEnv() {
   };
 }
 
-function fakeTunnelSocket(send?: (data: ArrayBuffer | ArrayBufferView | string) => void) {
+function fakeTunnelSocket(
+  send?: (data: ArrayBuffer | ArrayBufferView | string) => void,
+) {
   return {
     send: send ?? vi.fn(),
     close: vi.fn(),
@@ -652,7 +752,9 @@ describe("TunnelDO targeted request with old client", () => {
           if (data instanceof ArrayBuffer) {
             sent.push(new Uint8Array(data));
           } else {
-            sent.push(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+            sent.push(
+              new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+            );
           }
         }),
         ["tunnel"],
@@ -671,9 +773,9 @@ describe("TunnelDO targeted request with old client", () => {
       if (frame.type !== "open-http") throw new Error("unreachable");
       expect(frame.target).toBe("8000");
       expect(frame.path).toBe("/foo");
-      expect(frame.headers.every(([n]) => n.toLowerCase() !== TUNNEL_TARGET_HEADER)).toBe(
-        true,
-      );
+      expect(
+        frame.headers.every(([n]) => n.toLowerCase() !== TUNNEL_TARGET_HEADER),
+      ).toBe(true);
 
       // Resolve the hung proxyHttp promise via its resp-head timeout.
       vi.advanceTimersByTime(30_000);
@@ -702,12 +804,16 @@ function captureSent(sent: Uint8Array[]) {
 /** Encode a frame as the ArrayBuffer webSocketMessage receives on the wire. */
 function frameBuffer(frame: Frame): ArrayBuffer {
   const u8 = encodeFrame(frame);
-  return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength) as ArrayBuffer;
+  return u8.buffer.slice(
+    u8.byteOffset,
+    u8.byteOffset + u8.byteLength,
+  ) as ArrayBuffer;
 }
 
 function openHttpStreamId(sent: Uint8Array[], index: number): number {
   const frame = decodeFrame(sent[index]);
-  if (frame.type !== "open-http") throw new Error(`expected open-http at ${index}`);
+  if (frame.type !== "open-http")
+    throw new Error(`expected open-http at ${index}`);
   return frame.streamId;
 }
 
@@ -821,7 +927,8 @@ describe("TunnelDO response relay", () => {
       }
     }
     globalThis.Response = WorkersResponse as never;
-    (globalThis as { WebSocketPair?: unknown }).WebSocketPair = FakeWebSocketPair;
+    (globalThis as { WebSocketPair?: unknown }).WebSocketPair =
+      FakeWebSocketPair;
     try {
       const upgrade = await dob.fetch(
         new Request("https://do.internal/__tunnel?v=1", {
@@ -838,11 +945,16 @@ describe("TunnelDO response relay", () => {
       1000,
       "replaced by a new tunnel connection",
     );
-    expect(vi.mocked(visitor.close)).toHaveBeenCalledWith(1001, "tunnel reconnected");
+    expect(vi.mocked(visitor.close)).toHaveBeenCalledWith(
+      1001,
+      "tunnel reconnected",
+    );
 
     const headResponse = await pendingHead;
     expect(headResponse.status).toBe(502);
-    expect(await headResponse.text()).toContain("tunnel reconnected mid-request");
+    expect(await headResponse.text()).toContain(
+      "tunnel reconnected mid-request",
+    );
     // The mid-body response's stream errors out instead of hanging forever.
     await expect(midBodyResponse.text()).rejects.toBeTruthy();
   });

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -7,7 +7,12 @@ import {
   verifyMachineCredential,
   verifySessionCookie,
 } from "./session.js";
-import { handleListAccountServers } from "./servers.js";
+import {
+  DESKTOP_SESSION_COOKIE,
+  handleCreateDesktopSession,
+  handleListAccountServers,
+  verifyDesktopSessionCookie,
+} from "./servers.js";
 import { serveWithCache } from "./cache.js";
 import { BB_ICON_DATA_URI } from "./bb-icon.js";
 
@@ -19,12 +24,20 @@ const SESSION_COOKIE = "__Secure-better-auth.session_token";
 export const TUNNEL_TARGET_HEADER = "x-bb-tunnel-target";
 
 async function sha256Hex(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
-  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 function text(body: string, status: number): Response {
-  return new Response(body, { status, headers: { "content-type": "text/plain; charset=utf-8" } });
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
 }
 
 // Matches the bb dashboard's visual language (Inter, --canvas/--ink tokens,
@@ -75,7 +88,11 @@ const GATE_STYLE = `
 `;
 
 /** Render a gate page: brand row + centered card, one status, optional refresh. */
-function gatePage(cardBody: string, status: number, metaRefreshSeconds?: number): Response {
+function gatePage(
+  cardBody: string,
+  status: number,
+  metaRefreshSeconds?: number,
+): Response {
   const refresh =
     metaRefreshSeconds !== undefined
       ? `<meta http-equiv="refresh" content="${metaRefreshSeconds}">`
@@ -161,7 +178,10 @@ export function offlinePage(lastSeenAt: Date | null): Response {
  * Build the request forwarded to the TunnelDO. Always strips a visitor-supplied
  * target header; sets it only when the host label is a share (`handle--port`).
  */
-export function requestForTunnelDo(request: Request, target: string | null): Request {
+export function requestForTunnelDo(
+  request: Request,
+  target: string | null,
+): Request {
   const headers = new Headers(request.headers);
   headers.delete(TUNNEL_TARGET_HEADER);
   if (target !== null) {
@@ -176,13 +196,20 @@ export function cacheNamespace(handle: string, target: string | null): string {
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
     const url = new URL(request.url);
     // Account-scoped APIs are handled on the gate before host/label routing so
     // they never proxy through a tunnel to a local bb origin. Auth is
     // machine/server credential or owner session — see servers.ts.
     if (url.pathname === "/api/connect/servers") {
       return handleListAccountServers(request, env);
+    }
+    if (url.pathname === "/api/connect/desktop-session") {
+      return handleCreateDesktopSession(request, env);
     }
 
     const host = request.headers.get("host") ?? url.host;
@@ -196,7 +223,10 @@ export default {
     // receive them if a more specific binding is missing — send them home
     // rather than answering with a confusing "no server" page.
     if (RESERVED_HANDLES.has(label)) {
-      return Response.redirect(`https://${env.BASE_DOMAIN}${url.pathname}${url.search}`, 301);
+      return Response.redirect(
+        `https://${env.BASE_DOMAIN}${url.pathname}${url.search}`,
+        301,
+      );
     }
 
     // Bind the schema so the db satisfies the shared ConnectDb type (also what
@@ -231,7 +261,8 @@ export default {
     }
 
     // Reserve the /__ namespace: never proxy internal paths from outside.
-    if (url.pathname.startsWith("/__")) return text("bb connect: not found\n", 404);
+    if (url.pathname.startsWith("/__"))
+      return text("bb connect: not found\n", 404);
 
     // Daemon → server traffic. Share hosts are visitor-only — no machine path.
     const MACHINE_HEADER = "x-bb-connect-machine";
@@ -251,12 +282,27 @@ export default {
     // Visitor request — require a session owned by this server's account.
     // Identical auth for bare-label and share hosts. Because this check passed,
     // only the owner ever reaches the DO below (and thus its offline 503).
-    const cookie = parseCookie(request.headers.get("cookie"), SESSION_COOKIE);
+    const cookieHeader = request.headers.get("cookie");
+    const cookie = parseCookie(cookieHeader, SESSION_COOKIE);
+    const desktopCookie = parseCookie(cookieHeader, DESKTOP_SESSION_COOKIE);
     const appUrl = `https://${env.BASE_DOMAIN}`;
-    if (!cookie) return signInPage(label, appUrl, url.toString());
-    const userId = await verifySessionCookie(cookie, env.BETTER_AUTH_SECRET, db);
-    if (!userId) return signInPage(label, appUrl, url.toString());
-    if (userId !== resolved.userId) return text("bb connect: not your server\n", 403);
+    if (!cookie && !desktopCookie)
+      return signInPage(label, appUrl, url.toString());
+    const sessionUserId = cookie
+      ? await verifySessionCookie(cookie, env.BETTER_AUTH_SECRET, db)
+      : null;
+    const desktopUserId = desktopCookie
+      ? await verifyDesktopSessionCookie(desktopCookie, env.BETTER_AUTH_SECRET)
+      : null;
+    if (!sessionUserId && !desktopUserId) {
+      return signInPage(label, appUrl, url.toString());
+    }
+    if (
+      sessionUserId !== resolved.userId &&
+      desktopUserId !== resolved.userId
+    ) {
+      return text("bb connect: not your server\n", 403);
+    }
 
     const doRequest = requestForTunnelDo(request, target);
 
@@ -267,8 +313,11 @@ export default {
     // Everything else: serve from the edge cache when the origin allows it,
     // otherwise proxy through the tunnel. Namespace by full host label so a
     // share response never collides with bare-label app assets.
-    const response = await serveWithCache(request, cacheNamespace(label, target), ctx, () =>
-      stub.fetch(doRequest),
+    const response = await serveWithCache(
+      request,
+      cacheNamespace(label, target),
+      ctx,
+      () => stub.fetch(doRequest),
     );
     // Tunnel down + a browser navigation → the styled offline page, using the
     // last_seen_at already resolved for this server. API/asset/fetch requests

--- a/apps/desktop/src/connect-desktop-session.ts
+++ b/apps/desktop/src/connect-desktop-session.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+const rpcSuccessSchema = z.object({
+  ok: z.literal(true),
+  result: z.object({
+    cookie: z.object({
+      domain: z.string().min(1),
+      expiresAt: z.number().int().positive(),
+      name: z.string().min(1),
+      value: z.string().min(1),
+    }),
+  }),
+});
+
+export interface DesktopCookieInstaller {
+  set(details: {
+    domain: string;
+    expirationDate: number;
+    httpOnly: boolean;
+    name: string;
+    path: string;
+    sameSite: "lax";
+    secure: boolean;
+    url: string;
+    value: string;
+  }): Promise<void>;
+}
+
+export async function installConnectDesktopSession(args: {
+  cookieInstaller: DesktopCookieInstaller;
+  fetchImpl?: typeof fetch;
+  localServerUrl: string;
+  remoteServerUrl: string;
+}): Promise<boolean> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  const rpcUrl = new URL(
+    "/api/v1/plugins/connect/rpc/createDesktopSession",
+    args.localServerUrl,
+  );
+  let response: Response;
+  try {
+    response = await fetchImpl(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "null",
+    });
+  } catch {
+    return false;
+  }
+  if (!response.ok) return false;
+
+  const parsed = rpcSuccessSchema.safeParse(await response.json());
+  if (!parsed.success) return false;
+  const { cookie } = parsed.data.result;
+  const remoteOrigin = new URL(args.remoteServerUrl).origin;
+  await args.cookieInstaller.set({
+    domain: cookie.domain,
+    expirationDate: cookie.expiresAt / 1000,
+    httpOnly: true,
+    name: cookie.name,
+    path: "/",
+    sameSite: "lax",
+    secure: remoteOrigin.startsWith("https://"),
+    url: remoteOrigin,
+    value: cookie.value,
+  });
+  return true;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -21,10 +21,7 @@ import {
   APP_SURFACE_DESKTOP,
   APP_SURFACE_ENV_NAME,
 } from "@bb/config/app-surface";
-import {
-  type AppKeybindings,
-  type Experiments,
-} from "@bb/domain";
+import { type AppKeybindings, type Experiments } from "@bb/domain";
 import {
   bbDesktopPopoutMouseEventsIgnoredRequestSchema,
   bbDesktopPopoutThreadChangedPayloadSchema,
@@ -99,6 +96,7 @@ import {
   createConnectServerSync,
   type ConnectServerSync,
 } from "./connect-server-sync.js";
+import { installConnectDesktopSession } from "./connect-desktop-session.js";
 import {
   BUILTIN_SERVER_ID,
   createServerRegistry,
@@ -326,8 +324,7 @@ const logViewerCopyRequestSchema = z
 let desktopWindowFactory: DesktopWindowFactory | null = null;
 let desktopBrowserViewManager: DesktopBrowserViewManager | null = null;
 let currentAppKeybindings: AppKeybindings = [];
-let currentApplicationMenuAccelerators =
-  DEFAULT_APPLICATION_MENU_ACCELERATORS;
+let currentApplicationMenuAccelerators = DEFAULT_APPLICATION_MENU_ACCELERATORS;
 let desktopUpdateService: DesktopUpdateService | null = null;
 let desktopAutoUpdateService: DesktopAutoUpdateService | null = null;
 let currentRuntime: DesktopRuntime | null = null;
@@ -694,10 +691,16 @@ function installCurrentApplicationMenu(): void {
         BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
         null,
       );
-      desktopWindowFactory?.sendToFocusedWindow(BB_DESKTOP_APP_COMMAND_CHANNEL, "panel.newTab");
+      desktopWindowFactory?.sendToFocusedWindow(
+        BB_DESKTOP_APP_COMMAND_CHANNEL,
+        "panel.newTab",
+      );
     },
     openNewThread() {
-      desktopWindowFactory?.sendToFocusedWindow(BB_DESKTOP_APP_COMMAND_CHANNEL, "thread.new");
+      desktopWindowFactory?.sendToFocusedWindow(
+        BB_DESKTOP_APP_COMMAND_CHANNEL,
+        "thread.new",
+      );
     },
     openSettings() {
       desktopWindowFactory?.sendToFocusedWindow(
@@ -1239,6 +1242,13 @@ async function setActiveServerForWindow(
     }
   } else {
     // Remote servers are pure web loads. Owned local runtime keeps running.
+    if (server.source === "connect" && currentRuntime !== null) {
+      await installConnectDesktopSession({
+        cookieInstaller: session.defaultSession.cookies,
+        localServerUrl: currentRuntime.serverUrl,
+        remoteServerUrl: server.url,
+      });
+    }
     currentWindowUrl = server.url;
     await loadUrlInApplicationWindow({
       browserWindow: args.browserWindow,
@@ -1342,8 +1352,7 @@ function registerDesktopServerIpc(): void {
     for (const browserWindow of BrowserWindow.getAllWindows()) {
       if (
         !applicationWindowWebContentsIds.has(browserWindow.webContents.id) ||
-        activeServerState.getActiveServerId(browserWindow.id) !==
-          parsed.data.id
+        activeServerState.getActiveServerId(browserWindow.id) !== parsed.data.id
       ) {
         continue;
       }
@@ -1377,7 +1386,8 @@ function registerDesktopServerIpc(): void {
       if (serverRegistry === null) {
         return;
       }
-      const parsed = bbDesktopServerSetTileStyleRequestSchema.safeParse(payload);
+      const parsed =
+        bbDesktopServerSetTileStyleRequestSchema.safeParse(payload);
       if (!parsed.success) {
         return;
       }
@@ -1425,7 +1435,8 @@ function registerDesktopServerIpc(): void {
       if (serverRegistry === null) {
         return;
       }
-      const parsed = bbDesktopServerSetAutoConnectRequestSchema.safeParse(payload);
+      const parsed =
+        bbDesktopServerSetAutoConnectRequestSchema.safeParse(payload);
       if (!parsed.success) {
         return;
       }
@@ -1436,12 +1447,15 @@ function registerDesktopServerIpc(): void {
     },
   );
 
-  ipcMain.handle(BB_DESKTOP_SERVERS_GET_SHOW_CONNECT_SERVERS_CHANNEL, (event) => {
-    if (!isApplicationWindowSender(event.sender)) {
-      return true;
-    }
-    return serverRegistry?.getShowConnectServers() ?? true;
-  });
+  ipcMain.handle(
+    BB_DESKTOP_SERVERS_GET_SHOW_CONNECT_SERVERS_CHANNEL,
+    (event) => {
+      if (!isApplicationWindowSender(event.sender)) {
+        return true;
+      }
+      return serverRegistry?.getShowConnectServers() ?? true;
+    },
+  );
 
   ipcMain.handle(
     BB_DESKTOP_SERVERS_SET_SHOW_CONNECT_SERVERS_CHANNEL,
@@ -1457,7 +1471,9 @@ function registerDesktopServerIpc(): void {
       if (!parsed.success) {
         return;
       }
-      await serverRegistry.setShowConnectServers(parsed.data.showConnectServers);
+      await serverRegistry.setShowConnectServers(
+        parsed.data.showConnectServers,
+      );
       sendServersChanged();
     },
   );
@@ -2121,8 +2137,7 @@ async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
     timeoutMs: ATTACH_PROBE_TIMEOUT_MS,
   });
   builtinLastProbe = existingProbe;
-  const autoConnect =
-    serverRegistry?.getAutoConnectToLocalServer() ?? true;
+  const autoConnect = serverRegistry?.getAutoConnectToLocalServer() ?? true;
 
   if (existingProbe.kind === "compatible") {
     if (!autoConnect) {

--- a/apps/desktop/test/connect-desktop-session.test.ts
+++ b/apps/desktop/test/connect-desktop-session.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { installConnectDesktopSession } from "../src/connect-desktop-session.js";
+
+describe("installConnectDesktopSession", () => {
+  it("exchanges through the local plugin and installs an HttpOnly cookie", async () => {
+    const set = vi.fn(async () => undefined);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            result: {
+              cookie: {
+                domain: ".getbb.app",
+                expiresAt: 1_800_000,
+                name: "__Secure-bb-connect.desktop_session",
+                value: "signed-session",
+              },
+            },
+          }),
+        ),
+    );
+    await expect(
+      installConnectDesktopSession({
+        cookieInstaller: { set },
+        fetchImpl,
+        localServerUrl: "http://127.0.0.1:38886",
+        remoteServerUrl: "https://laptop.getbb.app",
+      }),
+    ).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        "http://127.0.0.1:38886/api/v1/plugins/connect/rpc/createDesktopSession",
+      ),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(set).toHaveBeenCalledWith({
+      domain: ".getbb.app",
+      expirationDate: 1800,
+      httpOnly: true,
+      name: "__Secure-bb-connect.desktop_session",
+      path: "/",
+      sameSite: "lax",
+      secure: true,
+      url: "https://laptop.getbb.app",
+      value: "signed-session",
+    });
+  });
+
+  it("fails closed when the local plugin is unavailable", async () => {
+    await expect(
+      installConnectDesktopSession({
+        cookieInstaller: { set: vi.fn() },
+        fetchImpl: async () => {
+          throw new Error("offline");
+        },
+        localServerUrl: "http://127.0.0.1:38886",
+        remoteServerUrl: "https://laptop.getbb.app",
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -6,11 +6,7 @@ import {
   createFakePluginHost,
   type FakePluginHost,
 } from "@bb/plugin-sdk/testing";
-import {
-  decodeFrame,
-  encodeFrame,
-  type Frame,
-} from "@bb/tunnel-contract";
+import { decodeFrame, encodeFrame, type Frame } from "@bb/tunnel-contract";
 import { deriveConnectBaseUrl, serverUrlForHandle } from "./redeem.js";
 import {
   headersForLoopbackRequest,
@@ -68,13 +64,10 @@ describe("headersForLoopbackRequest", () => {
     });
 
     expect(
-      headersForLoopbackRequest(
-        [["Origin", "https://evil.example"]],
-        {
-          publicOrigin: "https://sawyer.getbb.app",
-          loopbackOrigin: "http://127.0.0.1:38886",
-        },
-      ),
+      headersForLoopbackRequest([["Origin", "https://evil.example"]], {
+        publicOrigin: "https://sawyer.getbb.app",
+        loopbackOrigin: "http://127.0.0.1:38886",
+      }),
     ).toEqual({ Origin: "https://evil.example" });
   });
 
@@ -209,7 +202,10 @@ describe("isBareBbRealtimeWs", () => {
 // ---------------------------------------------------------------------------
 
 async function listen(
-  handler: (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => void,
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
 ): Promise<{ server: Server; origin: string; port: number }> {
   const server = createServer(handler);
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -240,10 +236,7 @@ function collectFrames(ws: NodeWebSocket): Frame[] {
   return frames;
 }
 
-async function waitFor(
-  pred: () => boolean,
-  timeoutMs = 2000,
-): Promise<void> {
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   const start = Date.now();
   while (!pred()) {
     if (Date.now() - start > timeoutMs) {
@@ -279,12 +272,13 @@ describe("TunnelSession routing", () => {
     cleanups.push(
       () =>
         new Promise<void>((resolve) => primary.server.close(() => resolve())),
-      () =>
-        new Promise<void>((resolve) => share.server.close(() => resolve())),
+      () => new Promise<void>((resolve) => share.server.close(() => resolve())),
     );
 
     const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-    await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+    await new Promise<void>((resolve) =>
+      wss.once("listening", () => resolve()),
+    );
     const wssAddr = wss.address();
     if (wssAddr === null || typeof wssAddr === "string") {
       throw new Error("expected TCP address");
@@ -350,7 +344,9 @@ describe("TunnelSession routing", () => {
       headers: [["Origin", "https://sawyer.getbb.app"]],
       hasBody: false,
     });
-    await waitFor(() => frames.some((f) => f.type === "body-end" && f.streamId === 1));
+    await waitFor(() =>
+      frames.some((f) => f.type === "body-end" && f.streamId === 1),
+    );
     expect(primaryHits).toEqual(["GET /hello"]);
     expect(shareHits).toEqual([]);
 
@@ -368,7 +364,9 @@ describe("TunnelSession routing", () => {
       hasBody: false,
       target: String(share.port),
     });
-    await waitFor(() => frames.some((f) => f.type === "body-end" && f.streamId === 2));
+    await waitFor(() =>
+      frames.some((f) => f.type === "body-end" && f.streamId === 2),
+    );
     expect(shareHits).toHaveLength(1);
     expect(shareHits[0]).toContain("GET /app");
     expect(shareHits[0]).toContain(`host=127.0.0.1:${share.port}`);
@@ -386,7 +384,9 @@ describe("TunnelSession routing", () => {
       hasBody: false,
       target: "59999",
     });
-    await waitFor(() => frames.some((f) => f.type === "resp-head" && f.streamId === 3));
+    await waitFor(() =>
+      frames.some((f) => f.type === "resp-head" && f.streamId === 3),
+    );
     const head = frames.find((f) => f.type === "resp-head" && f.streamId === 3);
     expect(head).toMatchObject({ type: "resp-head", status: 404 });
     const bodyChunks = frames.filter(
@@ -421,11 +421,14 @@ describe("TunnelSession routing", () => {
       res.end(gzippedBody);
     });
     cleanups.push(
-      () => new Promise<void>((resolve) => origin.server.close(() => resolve())),
+      () =>
+        new Promise<void>((resolve) => origin.server.close(() => resolve())),
     );
 
     const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-    await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+    await new Promise<void>((resolve) =>
+      wss.once("listening", () => resolve()),
+    );
     const wssAddr = wss.address();
     if (wssAddr === null || typeof wssAddr === "string") {
       throw new Error("expected TCP address");
@@ -476,8 +479,12 @@ describe("TunnelSession routing", () => {
       headers: [],
       hasBody: false,
     });
-    await waitFor(() => frames.some((f) => f.type === "body-end" && f.streamId === 21));
-    const head = frames.find((f) => f.type === "resp-head" && f.streamId === 21);
+    await waitFor(() =>
+      frames.some((f) => f.type === "body-end" && f.streamId === 21),
+    );
+    const head = frames.find(
+      (f) => f.type === "resp-head" && f.streamId === 21,
+    );
     if (head?.type !== "resp-head") throw new Error("missing resp-head");
     expect(head.status).toBe(200);
     const headerNames = head.headers.map(([name]) => name.toLowerCase());
@@ -487,7 +494,9 @@ describe("TunnelSession routing", () => {
     const relayedBody = Buffer.concat(
       frames
         .filter((f) => f.type === "body-chunk" && f.streamId === 21)
-        .map((f) => (f.type === "body-chunk" ? Buffer.from(f.data) : Buffer.alloc(0))),
+        .map((f) =>
+          f.type === "body-chunk" ? Buffer.from(f.data) : Buffer.alloc(0),
+        ),
     ).toString();
     expect(relayedBody).toBe(plainBody);
 
@@ -501,12 +510,16 @@ describe("TunnelSession routing", () => {
       headers: [["If-None-Match", 'W/"v1"']],
       hasBody: false,
     });
-    await waitFor(() => frames.some((f) => f.type === "body-end" && f.streamId === 22));
+    await waitFor(() =>
+      frames.some((f) => f.type === "body-end" && f.streamId === 22),
+    );
     const revalidated = frames.find(
       (f) => f.type === "resp-head" && f.streamId === 22,
     );
     expect(revalidated).toMatchObject({ type: "resp-head", status: 304 });
-    expect(frames.some((f) => f.type === "body-chunk" && f.streamId === 22)).toBe(false);
+    expect(
+      frames.some((f) => f.type === "body-chunk" && f.streamId === 22),
+    ).toBe(false);
   });
 
   it("tracks remoteClients for bare-handle /ws streams", async () => {
@@ -525,7 +538,9 @@ describe("TunnelSession routing", () => {
     );
 
     const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-    await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+    await new Promise<void>((resolve) =>
+      wss.once("listening", () => resolve()),
+    );
     const wssAddr = wss.address();
     if (wssAddr === null || typeof wssAddr === "string") {
       throw new Error("expected TCP address");
@@ -965,6 +980,52 @@ describe("connect plugin", () => {
     const { harness } = await loadPlugin();
     await expect(harness.callRpc("listAccountServers")).rejects.toThrow(
       "not_paired",
+    );
+  });
+
+  it("createDesktopSession exchanges the stored credential without returning it", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/connect/redeem")) {
+        return new Response(
+          JSON.stringify({ credential: "bbcred_durable", handle: "sawyer" }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/connect/desktop-session")) {
+        return new Response(
+          JSON.stringify({
+            cookie: {
+              domain: ".getbb.app",
+              expiresAt: 2_000_000,
+              name: "__Secure-bb-connect.desktop_session",
+              value: "short-lived-signed-cookie",
+            },
+          }),
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { harness } = await loadPlugin();
+    await harness.callRpc("pair", {
+      code: "ABCD",
+      server: "https://sawyer.getbb.app",
+    });
+    await expect(harness.callRpc("createDesktopSession")).resolves.toEqual({
+      cookie: {
+        domain: ".getbb.app",
+        expiresAt: 2_000_000,
+        name: "__Secure-bb-connect.desktop_session",
+        value: "short-lived-signed-cookie",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sawyer.getbb.app/api/connect/desktop-session",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "x-bb-connect-machine": "bbcred_durable" },
+      }),
     );
   });
 

--- a/plugins/connect/src/desktop-session.ts
+++ b/plugins/connect/src/desktop-session.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { ConnectCredential } from "./credential.js";
+import { ConnectListError } from "./list-servers.js";
+
+const desktopSessionResponseSchema = z.object({
+  cookie: z.object({
+    domain: z.string().min(1),
+    expiresAt: z.number().int().positive(),
+    name: z.string().min(1),
+    value: z.string().min(1),
+  }),
+});
+
+export type DesktopSession = z.infer<typeof desktopSessionResponseSchema>;
+
+export async function fetchDesktopSession(
+  credential: ConnectCredential,
+): Promise<DesktopSession> {
+  const url = `${credential.serverUrl.replace(/\/$/, "")}/api/connect/desktop-session`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "x-bb-connect-machine": credential.credential },
+    });
+  } catch (error) {
+    throw new ConnectListError(
+      "network",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  if (response.status === 401 || response.status === 403) {
+    throw new ConnectListError(
+      "unauthorized",
+      "Desktop session not authorized",
+    );
+  }
+  if (!response.ok) {
+    throw new ConnectListError(
+      "network",
+      `Desktop session failed (${response.status})`,
+    );
+  }
+  const parsed = desktopSessionResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new ConnectListError(
+      "invalid_response",
+      "Desktop session response failed schema validation",
+    );
+  }
+  return parsed.data;
+}

--- a/plugins/connect/src/rpc.ts
+++ b/plugins/connect/src/rpc.ts
@@ -4,6 +4,7 @@ import { ConnectPairError } from "./redeem.js";
 import type { ConnectTunnel } from "./tunnel.js";
 import type { ConnectStatus } from "./types.js";
 import type { ListAccountServersResult } from "./list-servers.js";
+import type { DesktopSession } from "./desktop-session.js";
 
 // Panel-facing rpc surface. `server` is optional: the dashboard command
 // carries both --code and --server, but the panel's paste-a-code field only
@@ -28,6 +29,7 @@ export type ConnectRpcHandlers = {
   unexpose(input: unknown): Promise<{ removed: boolean; port: number }>;
   listShares(): Array<{ port: number; url: string }>;
   listAccountServers(): Promise<ListAccountServersResult>;
+  createDesktopSession(): Promise<DesktopSession>;
 };
 
 export function createRpcHandlers(tunnel: ConnectTunnel): ConnectRpcHandlers {
@@ -72,6 +74,16 @@ export function createRpcHandlers(tunnel: ConnectTunnel): ConnectRpcHandlers {
       } catch (error) {
         // Stable codes for callers (CLI / panel); raw detail stays on the error
         // message for plugin logs when surfaced elsewhere.
+        if (error instanceof ConnectListError) {
+          throw new Error(error.code);
+        }
+        throw error;
+      }
+    },
+    async createDesktopSession() {
+      try {
+        return await tunnel.createDesktopSession();
+      } catch (error) {
         if (error instanceof ConnectListError) {
           throw new Error(error.code);
         }

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -32,6 +32,7 @@ import {
   redeemConnectCode,
   serverUrlForHandle,
 } from "./redeem.js";
+import { fetchDesktopSession, type DesktopSession } from "./desktop-session.js";
 import {
   ShareRegistry,
   shareLoopbackHost,
@@ -100,8 +101,12 @@ export function humanizeTransportError(error: Error, host: string): string {
   const code = (error as NodeJS.ErrnoException).code;
   let reason: string;
   if (code === "ECONNREFUSED") reason = "connection refused";
-  else if (code === "ENOTFOUND" || code === "EAI_AGAIN") reason = "host not found";
-  else if (code === "ETIMEDOUT" || /timed out|timeout|ETIMEDOUT/i.test(error.message))
+  else if (code === "ENOTFOUND" || code === "EAI_AGAIN")
+    reason = "host not found";
+  else if (
+    code === "ETIMEDOUT" ||
+    /timed out|timeout|ETIMEDOUT/i.test(error.message)
+  )
     reason = "timed out";
   else if (code === "ECONNRESET") reason = "connection reset";
   else reason = error.message;
@@ -208,7 +213,8 @@ export class TunnelSession {
   dispose(): void {
     if (this.heartbeat) clearInterval(this.heartbeat);
     for (const s of this.httpStreams.values()) s.abort.abort();
-    for (const s of this.wsStreams.values()) s.socket.close(1001, "tunnel closed");
+    for (const s of this.wsStreams.values())
+      s.socket.close(1001, "tunnel closed");
     this.httpStreams.clear();
     this.wsStreams.clear();
     this.setRemoteClients(0);
@@ -252,7 +258,9 @@ export class TunnelSession {
         return;
       }
       case "body-chunk":
-        this.httpStreams.get(frame.streamId)?.chunks.push(Buffer.from(frame.data));
+        this.httpStreams
+          .get(frame.streamId)
+          ?.chunks.push(Buffer.from(frame.data));
         return;
       case "body-end": {
         const s = this.httpStreams.get(frame.streamId);
@@ -269,7 +277,9 @@ export class TunnelSession {
           s.buffered.push(frame);
           return;
         }
-        s.socket.send(frame.isBinary ? frame.data : Buffer.from(frame.data).toString());
+        s.socket.send(
+          frame.isBinary ? frame.data : Buffer.from(frame.data).toString(),
+        );
         return;
       }
       case "close-stream": {
@@ -538,7 +548,9 @@ export class ConnectTunnel {
         // Raw wire/transport detail goes to the log only; the caller gets a
         // typed ConnectPairError whose code the panel maps to human copy.
         const pairError = asConnectPairError(error);
-        this.options.log.warn(`pair failed (${pairError.code}): ${pairError.message}`);
+        this.options.log.warn(
+          `pair failed (${pairError.code}): ${pairError.message}`,
+        );
         throw pairError;
       }
       const serverUrl = (
@@ -604,6 +616,13 @@ export class ConnectTunnel {
       credential,
     );
     return { servers, selfHandle: credential.handle };
+  }
+
+  async createDesktopSession(): Promise<DesktopSession> {
+    if (this.credential === null) {
+      throw new ConnectListError("not_paired", "this bb is not connected");
+    }
+    return fetchDesktopSession(this.credential);
   }
 
   status(): ConnectStatus {
@@ -791,7 +810,10 @@ export class ConnectTunnel {
     tunnel.on("error", (e: Error) => {
       // Humanize transport failures for the reconnecting card; the raw
       // message still rides the log via the close handler below.
-      this.lastError = humanizeTransportError(e, connectApexHost(credential.serverUrl));
+      this.lastError = humanizeTransportError(
+        e,
+        connectApexHost(credential.serverUrl),
+      );
     });
     tunnel.on("close", (code: number, reason: Buffer) => {
       this.connected = false;


### PR DESCRIPTION
## Summary

- exchange the stored bb Connect pairing credential for a short-lived signed desktop session
- install the scoped HttpOnly cookie in Electron before opening Connect-managed servers
- keep account ownership enforcement at the Connect gate, including stale GitHub-session fallback

## Testing

- `pnpm exec turbo run test typecheck --filter=@bb/connect --filter=bb-plugin-connect --filter=@bb/desktop`
- 296 focused tests passed across Connect worker, plugin, and desktop
- `git diff --check`