### PR TITLE
Polish shortcut hints

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -206,17 +212,24 @@ afterEach(() => {
 });
 
 describe("AppCommandProvider", () => {
-  it("shares primary-modifier hold state and clears it on release or blur", () => {
+  it("shares primary-modifier hold state after 300ms and clears it on release or blur", () => {
+    vi.useFakeTimers();
     renderProvider(<ModifierState />);
 
     expect(screen.getByText("released")).toBeDefined();
     fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+    act(() => vi.advanceTimersByTime(299));
+    expect(screen.getByText("released")).toBeDefined();
+    act(() => vi.advanceTimersByTime(1));
     expect(screen.getByText("held")).toBeDefined();
     fireEvent.keyUp(window, { key: "Control" });
     expect(screen.getByText("released")).toBeDefined();
     fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getByText("held")).toBeDefined();
     fireEvent.blur(window);
     expect(screen.getByText("released")).toBeDefined();
+    vi.useRealTimers();
   });
 
   it("presents the web-capable alias when the primary binding is desktop-only", () => {
@@ -227,8 +240,8 @@ describe("AppCommandProvider", () => {
       </>,
     );
 
-    expect(screen.getByText("Ctrl+Shift+O")).toBeDefined();
-    expect(screen.getByText("Ctrl+Shift+ArrowUp")).toBeDefined();
+    expect(screen.getByText("Ctrl + Shift + O")).toBeDefined();
+    expect(screen.getByText("Ctrl + Shift + ArrowUp")).toBeDefined();
   });
 
   it("falls through declining handlers in priority order", () => {

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -61,6 +61,7 @@ const AppCommandContextValue = createContext<AppCommandProviderValue | null>(
 const AppCommandModifierHeldContext = createContext(false);
 
 const EMPTY_KEYBINDINGS: AppKeybindings = [];
+const SHORTCUT_HINT_HOLD_DELAY_MS = 300;
 
 const EMPTY_CONTEXT: AppCommandContext = {
   mainSurface: false,
@@ -91,6 +92,9 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
   const keybindings = systemConfig.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const isDesktop = getBbDesktopInfo() !== null;
   const [isPrimaryModifierHeld, setIsPrimaryModifierHeld] = useState(false);
+  const modifierHoldTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const keybindingsRef = useRef(keybindings);
   const mainSurfaceRef = useRef(!location.pathname.startsWith("/popout"));
   const handlersRef = useRef(
@@ -105,18 +109,35 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
     const primaryModifier = isMacKeyboardPlatform(browserPlatform())
       ? "Meta"
       : "Control";
+    const clearModifierHold = () => {
+      if (modifierHoldTimerRef.current !== null) {
+        clearTimeout(modifierHoldTimerRef.current);
+        modifierHoldTimerRef.current = null;
+      }
+      setIsPrimaryModifierHeld(false);
+    };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === primaryModifier) setIsPrimaryModifierHeld(true);
+      if (
+        event.key !== primaryModifier ||
+        modifierHoldTimerRef.current !== null
+      ) {
+        return;
+      }
+      modifierHoldTimerRef.current = setTimeout(() => {
+        modifierHoldTimerRef.current = null;
+        setIsPrimaryModifierHeld(true);
+      }, SHORTCUT_HINT_HOLD_DELAY_MS);
     };
     const handleKeyUp = (event: KeyboardEvent) => {
-      if (event.key === primaryModifier) setIsPrimaryModifierHeld(false);
+      if (event.key === primaryModifier) clearModifierHold();
     };
-    const handleBlur = () => setIsPrimaryModifierHeld(false);
+    const handleBlur = () => clearModifierHold();
 
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("keyup", handleKeyUp);
     window.addEventListener("blur", handleBlur);
     return () => {
+      clearModifierHold();
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("blur", handleBlur);
@@ -131,41 +152,39 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
     mainSurfaceRef.current = !location.pathname.startsWith("/popout");
   }, [location.pathname]);
 
-  const registerHandler = useCallback<AppCommandProviderValue["registerHandler"]>(
-    (command, registration) => {
-      const token = Symbol(command);
-      const registrations = handlersRef.current.get(command) ?? new Map();
-      sequenceRef.current += 1;
-      registrations.set(token, {
-        ...registration,
-        sequence: sequenceRef.current,
-      });
-      handlersRef.current.set(command, registrations);
-      return () => {
-        registrations.delete(token);
-        if (registrations.size === 0) {
-          handlersRef.current.delete(command);
-        }
-      };
-    },
-    [],
-  );
+  const registerHandler = useCallback<
+    AppCommandProviderValue["registerHandler"]
+  >((command, registration) => {
+    const token = Symbol(command);
+    const registrations = handlersRef.current.get(command) ?? new Map();
+    sequenceRef.current += 1;
+    registrations.set(token, {
+      ...registration,
+      sequence: sequenceRef.current,
+    });
+    handlersRef.current.set(command, registrations);
+    return () => {
+      registrations.delete(token);
+      if (registrations.size === 0) {
+        handlersRef.current.delete(command);
+      }
+    };
+  }, []);
 
-  const registerContext = useCallback<AppCommandProviderValue["registerContext"]>(
-    (key, source, active) => {
-      const sources = activeContextsRef.current.get(key) ?? new Set<symbol>();
-      if (active) {
-        sources.add(source);
-        activeContextsRef.current.set(key, sources);
-        return;
-      }
-      sources.delete(source);
-      if (sources.size === 0) {
-        activeContextsRef.current.delete(key);
-      }
-    },
-    [],
-  );
+  const registerContext = useCallback<
+    AppCommandProviderValue["registerContext"]
+  >((key, source, active) => {
+    const sources = activeContextsRef.current.get(key) ?? new Set<symbol>();
+    if (active) {
+      sources.add(source);
+      activeContextsRef.current.set(key, sources);
+      return;
+    }
+    sources.delete(source);
+    if (sources.size === 0) {
+      activeContextsRef.current.delete(key);
+    }
+  }, []);
 
   const dispatch = useCallback(
     (command: AppCommandId, target: EventTarget | null): boolean => {
@@ -264,12 +283,7 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
       registerContext,
       registerHandler,
     }),
-    [
-      dispatch,
-      getShortcut,
-      registerContext,
-      registerHandler,
-    ],
+    [dispatch, getShortcut, registerContext, registerHandler],
   );
 
   return (
@@ -362,10 +376,7 @@ export function useAppCommandShortcuts(
 ): ReadonlyMap<AppCommandId, AppShortcutPresentation> {
   const value = useContext(AppCommandContextValue);
   return useMemo(() => {
-    const presentations = new Map<
-      AppCommandId,
-      AppShortcutPresentation
-    >();
+    const presentations = new Map<AppCommandId, AppShortcutPresentation>();
     const platform = browserPlatform();
     for (const command of commands) {
       const shortcut = value?.getShortcut(command);

--- a/apps/app/src/components/commands/AppCommandShortcutHint.tsx
+++ b/apps/app/src/components/commands/AppCommandShortcutHint.tsx
@@ -18,7 +18,7 @@ export function AppCommandShortcutHint({
     <kbd
       aria-hidden="true"
       className={cn(
-        "pointer-events-none inline-flex h-5 min-w-7 shrink-0 items-center justify-center rounded-md bg-surface-raised px-1 text-xs font-medium tabular-nums text-muted-foreground shadow-[inset_0_0_0_1px_var(--border)]",
+        "pointer-events-none inline-flex h-5 min-w-7 shrink-0 items-center justify-center whitespace-nowrap rounded-md bg-surface-raised px-1 text-xs font-medium tabular-nums text-muted-foreground [word-spacing:-0.15em] shadow-[inset_0_0_0_1px_var(--border)]",
         className,
       )}
     >

--- a/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
@@ -68,12 +68,12 @@ describe("KeyboardSettingsSection", () => {
   it("records, clears, and resets a command shortcut", () => {
     render(<KeyboardSettingsSection />);
     const defaults = screen.getByLabelText("Default shortcuts for New thread");
-    expect(within(defaults).getByText("Ctrl+Shift+O")).toBeDefined();
+    expect(within(defaults).getByText("Ctrl + Shift + O")).toBeDefined();
     expect(within(defaults).getByText("Web")).toBeDefined();
-    expect(within(defaults).getByText("Ctrl+N")).toBeDefined();
+    expect(within(defaults).getByText("Ctrl + N")).toBeDefined();
     expect(within(defaults).getByText("Desktop")).toBeDefined();
     const recorder = screen.getByRole("button", {
-      name: "Record shortcut for New thread, current shortcut Ctrl+N",
+      name: "Record shortcut for New thread, current shortcut Ctrl + N",
     });
 
     fireEvent.click(recorder);

--- a/apps/app/src/components/thread/ThreadWorkspaceOpenButton.tsx
+++ b/apps/app/src/components/thread/ThreadWorkspaceOpenButton.tsx
@@ -58,10 +58,7 @@ export function ThreadWorkspaceOpenButton({
       void openTarget(preferredTarget, onOpenPreferredTarget);
     },
     content: (
-      <WorkspaceOpenTargetIcon
-        target={preferredTarget}
-        className="size-5"
-      />
+      <WorkspaceOpenTargetIcon target={preferredTarget} className="size-5" />
     ),
   };
   const secondaryActions: SplitButtonAction[] = targets.map((target) => ({
@@ -78,7 +75,8 @@ export function ThreadWorkspaceOpenButton({
   }));
 
   return (
-    <span className="relative inline-flex">
+    <span className="inline-flex items-center gap-1.5">
+      <AppCommandShortcutHint shortcut={shortcut} />
       <SplitButton
         disabled={isPending}
         className="px-1"
@@ -86,10 +84,6 @@ export function ThreadWorkspaceOpenButton({
         secondaryActions={secondaryActions}
         triggerLabel="Choose workspace open target"
         mobileTitle="Open Workspace"
-      />
-      <AppCommandShortcutHint
-        shortcut={shortcut}
-        className="absolute right-full mr-1"
       />
     </span>
   );

--- a/apps/app/src/lib/app-keybindings.test.ts
+++ b/apps/app/src/lib/app-keybindings.test.ts
@@ -51,7 +51,9 @@ describe("app keybindings", () => {
         false,
       ),
     ).toBe(true);
-    expect(matchesAppShortcut({ ...base, shiftKey: true }, MOD_N, true)).toBe(false);
+    expect(matchesAppShortcut({ ...base, shiftKey: true }, MOD_N, true)).toBe(
+      false,
+    );
   });
 
   it("matches shifted punctuation against its unshifted binding key", () => {
@@ -97,12 +99,14 @@ describe("app keybindings", () => {
     editor.append(child);
     expect(isEditableKeyboardTarget(input)).toBe(true);
     expect(isEditableKeyboardTarget(child)).toBe(true);
-    expect(isEditableKeyboardTarget(document.createElement("button"))).toBe(false);
+    expect(isEditableKeyboardTarget(document.createElement("button"))).toBe(
+      false,
+    );
   });
 
   it("formats platform-specific shortcut labels", () => {
-    expect(formatAppShortcut(MOD_N, "MacIntel")).toBe("⌘N");
-    expect(formatAppShortcut(MOD_N, "Win32")).toBe("Ctrl+N");
+    expect(formatAppShortcut(MOD_N, "MacIntel")).toBe("⌘ N");
+    expect(formatAppShortcut(MOD_N, "Win32")).toBe("Ctrl + N");
     expect(formatAppShortcutAria(MOD_N, "MacIntel")).toBe("Meta+N");
     expect(formatAppShortcutAria(MOD_N, "Win32")).toBe("Control+N");
   });

--- a/apps/app/src/lib/app-keybindings.ts
+++ b/apps/app/src/lib/app-keybindings.ts
@@ -1,8 +1,4 @@
-import type {
-  AppCommandContext,
-  AppKeybinding,
-  AppShortcut,
-} from "@bb/domain";
+import type { AppCommandContext, AppKeybinding, AppShortcut } from "@bb/domain";
 import { isMacKeyboardPlatform } from "@bb/domain";
 
 export interface AppShortcutPresentation {
@@ -21,7 +17,9 @@ export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   ) {
     return true;
   }
-  return target.closest('[contenteditable]:not([contenteditable="false"])') !== null;
+  return (
+    target.closest('[contenteditable]:not([contenteditable="false"])') !== null
+  );
 }
 
 export function matchesAppCommandContext(
@@ -41,10 +39,17 @@ export function formatAppShortcut(
   const useMetaForMod = isMacKeyboardPlatform(platform);
   const showMeta = shortcut.meta || (shortcut.mod && useMetaForMod);
   const showControl = shortcut.control || (shortcut.mod && !useMetaForMod);
-  const key = shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key;
+  const key =
+    shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key;
 
   if (useMetaForMod) {
-    return `${showControl ? "⌃" : ""}${shortcut.alt ? "⌥" : ""}${shortcut.shift ? "⇧" : ""}${showMeta ? "⌘" : ""}${key}`;
+    const parts: string[] = [];
+    if (showControl) parts.push("⌃");
+    if (shortcut.alt) parts.push("⌥");
+    if (shortcut.shift) parts.push("⇧");
+    if (showMeta) parts.push("⌘");
+    parts.push(key);
+    return parts.join(" ");
   }
 
   const parts: string[] = [];
@@ -53,7 +58,7 @@ export function formatAppShortcut(
   if (shortcut.shift) parts.push("Shift");
   if (showMeta) parts.push("Meta");
   parts.push(key);
-  return parts.join("+");
+  return parts.join(" + ");
 }
 
 export function formatAppShortcutAria(
@@ -68,6 +73,8 @@ export function formatAppShortcutAria(
   if (shortcut.alt) parts.push("Alt");
   if (shortcut.shift) parts.push("Shift");
   if (shortcut.meta || (shortcut.mod && useMetaForMod)) parts.push("Meta");
-  parts.push(shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key);
+  parts.push(
+    shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key,
+  );
   return parts.join("+");
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -124,26 +124,25 @@ export function ThreadDetailHeader({
         </Button>
       ) : null}
       {showRightPanelToggle ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className={`${HEADER_ICON_BUTTON_CLASS} relative`}
-          aria-label={
-            panelShortcut
-              ? `${rightPanelLabel} (${panelShortcut.label})`
-              : rightPanelLabel
-          }
-          aria-keyshortcuts={panelShortcut?.ariaKeyshortcuts}
-          aria-pressed={isSecondaryPanelOpen}
-          onClick={onToggleSecondaryPanel}
-        >
-          <Icon name={rightPanelIconName} />
-          <AppCommandShortcutHint
-            shortcut={panelShortcut}
-            className="absolute right-full mr-1"
-          />
-        </Button>
+        <span className="inline-flex items-center gap-1.5">
+          <AppCommandShortcutHint shortcut={panelShortcut} />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={HEADER_ICON_BUTTON_CLASS}
+            aria-label={
+              panelShortcut
+                ? `${rightPanelLabel} (${panelShortcut.label})`
+                : rightPanelLabel
+            }
+            aria-keyshortcuts={panelShortcut?.ariaKeyshortcuts}
+            aria-pressed={isSecondaryPanelOpen}
+            onClick={onToggleSecondaryPanel}
+          >
+            <Icon name={rightPanelIconName} />
+          </Button>
+        </span>
       ) : null}
     </>
   );

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -216,9 +216,7 @@ import {
   useToggleThreadSecondaryPanelSelection,
 } from "./threadSecondaryPanelSelection";
 import { useRouteState } from "@/hooks/useRouteState";
-import {
-  useAppCommandHandler,
-} from "@/components/commands/AppCommandProvider";
+import { useAppCommandHandler } from "@/components/commands/AppCommandProvider";
 
 const EMPTY_PARENT_THREADS: readonly ThreadListEntry[] = [];
 const EMPTY_PROJECT_THREAD_SUBSET_FILTERS =
@@ -1261,16 +1259,10 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     return handleCloseWindowRequest();
   });
   useAppCommandHandler("diff.toggle", () => {
-    if (
-      props.surface !== "page" ||
-      !canUseGitUi
-    ) {
+    if (props.surface !== "page" || !canUseGitUi) {
       return false;
     }
-    if (
-      isSecondaryPanelOpen &&
-      activeFixedSecondaryTab?.kind === "git-diff"
-    ) {
+    if (isSecondaryPanelOpen && activeFixedSecondaryTab?.kind === "git-diff") {
       closeSecondaryPanel();
     } else {
       openSecondaryPanelDiffPanel();
@@ -1924,6 +1916,11 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     canOpenPreferredFileTarget,
     openPathInPreferredFileTarget,
   ]);
+  const workspaceOpenPath = resolveThreadWorkspaceOpenPath({
+    canOpenWorkspace: canOpenPreferredDirectoryTarget,
+    environment,
+    hasWorkspaceOpenTargets: directoryOpenTargets.length > 0,
+  });
   useAppCommandHandler("workspace.openPreferred", () => {
     if (props.surface !== "page") return false;
     if (activeWorkspaceFilePath && handleOpenFileInEditor) {
@@ -1936,6 +1933,13 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
     }
     if (activeStorageFilePath && handleOpenStorageFileInEditor) {
       handleOpenStorageFileInEditor(activeStorageFilePath);
+      return true;
+    }
+    if (workspaceOpenPath && preferredDirectoryTarget) {
+      void openPathInPreferredDirectoryTarget({
+        lineNumber: null,
+        path: workspaceOpenPath,
+      });
       return true;
     }
     return false;
@@ -2199,11 +2203,6 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
       align="end"
     />
   );
-  const workspaceOpenPath = resolveThreadWorkspaceOpenPath({
-    canOpenWorkspace: canOpenPreferredDirectoryTarget,
-    environment,
-    hasWorkspaceOpenTargets: directoryOpenTargets.length > 0,
-  });
   const workspaceOpenButton =
     workspaceOpenPath && preferredDirectoryTarget ? (
       <ThreadWorkspaceOpenButton


### PR DESCRIPTION
## Summary
- space shortcut chord labels and keep compact hints on one line
- reveal shortcut hints after a 300ms modifier hold and prevent header hint collisions
- make Command-O fall back to opening the thread workspace when no file preview is active

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force (200 files, 1,270 tests)
- pnpm exec vitest run apps/app/src/components/commands/AppCommandProvider.test.tsx apps/app/src/lib/app-keybindings.test.ts apps/app/src/views/thread-detail/threadWorkspaceOpenPath.test.ts