### PR TITLE
Honor shortcut hint delay for thread jumps

### DIFF
--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -6,10 +6,7 @@ import {
   type KeyboardEventHandler,
 } from "react";
 import { cn } from "@bb/shared-ui/lib/utils";
-import {
-  isMacKeyboardPlatform,
-  THREAD_JUMP_APP_COMMAND_IDS,
-} from "@bb/domain";
+import { THREAD_JUMP_APP_COMMAND_IDS } from "@bb/domain";
 import { Link, useNavigate } from "react-router-dom";
 import { Icon } from "@bb/shared-ui/icon";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
@@ -56,6 +53,7 @@ import {
   useAppCommandHandler,
   useAppCommandShortcut,
   useAppCommandShortcuts,
+  useIsAppCommandModifierHeld,
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
@@ -116,6 +114,7 @@ export function AppSidebar({
   const threadJumpShortcuts = useAppCommandShortcuts(
     THREAD_JUMP_APP_COMMAND_IDS,
   );
+  const isAppCommandModifierHeld = useIsAppCommandModifierHeld();
   const settingsShortcut = useAppCommandShortcut("settings.open");
 
   const focusThreadSearchInput = useCallback(() => {
@@ -322,33 +321,16 @@ export function AppSidebar({
   );
 
   useEffect(() => {
-    const handleGlobalKeyDown = (event: KeyboardEvent) => {
-      const primaryModifier = isMacKeyboardPlatform(navigator.platform)
-        ? "Meta"
-        : "Control";
-      if (event.key === primaryModifier) {
-        showThreadShortcuts();
-      }
-    };
-
-    const handleGlobalKeyUp = (event: KeyboardEvent) => {
-      const primaryModifier = isMacKeyboardPlatform(navigator.platform)
-        ? "Meta"
-        : "Control";
-      if (event.key === primaryModifier) {
-        hideThreadShortcuts();
-      }
-    };
-
-    window.addEventListener("keydown", handleGlobalKeyDown);
-    window.addEventListener("keyup", handleGlobalKeyUp);
-    window.addEventListener("blur", hideThreadShortcuts);
-    return () => {
-      window.removeEventListener("keydown", handleGlobalKeyDown);
-      window.removeEventListener("keyup", handleGlobalKeyUp);
-      window.removeEventListener("blur", hideThreadShortcuts);
-    };
-  }, [hideThreadShortcuts, showThreadShortcuts]);
+    if (isAppCommandModifierHeld) {
+      showThreadShortcuts();
+      return;
+    }
+    hideThreadShortcuts();
+  }, [
+    hideThreadShortcuts,
+    isAppCommandModifierHeld,
+    showThreadShortcuts,
+  ]);
 
   return (
     <SidebarThreadShortcutKeysContext.Provider value={threadShortcutKeysById}>


### PR DESCRIPTION
## Summary
- use the shared delayed Command-hold state for sidebar thread shortcut labels
- remove the sidebar-specific immediate modifier listener
- preserve immediate Command+1–9 thread navigation

## Tests
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (1,270 tests)
- `git diff --check`