### PR TITLE
Fix desktop bb Connect authentication

### DIFF
--- a/apps/desktop/src/connect-desktop-session.ts
+++ b/apps/desktop/src/connect-desktop-session.ts
@@ -12,7 +12,14 @@ const rpcSuccessSchema = z.object({
   }),
 });
 
-export interface DesktopCookieInstaller {
+export interface DesktopCookie {
+  domain?: string;
+  name: string;
+  value: string;
+}
+
+export interface DesktopCookieStore {
+  get(filter: { name: string; url: string }): Promise<DesktopCookie[]>;
   set(details: {
     domain: string;
     expirationDate: number;
@@ -26,12 +33,38 @@ export interface DesktopCookieInstaller {
   }): Promise<void>;
 }
 
+export type ConnectDesktopSessionFailureCode =
+  | "cookie_install_failed"
+  | "cookie_verification_failed"
+  | "invalid_response"
+  | "network"
+  | "request_rejected";
+
+export type ConnectDesktopSessionResult =
+  | { ok: true }
+  | {
+      code: ConnectDesktopSessionFailureCode;
+      detail: string;
+      ok: false;
+    };
+
+function failure(
+  code: ConnectDesktopSessionFailureCode,
+  detail: string,
+): ConnectDesktopSessionResult {
+  return { code, detail, ok: false };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function installConnectDesktopSession(args: {
-  cookieInstaller: DesktopCookieInstaller;
+  cookieStore: DesktopCookieStore;
   fetchImpl?: typeof fetch;
   localServerUrl: string;
   remoteServerUrl: string;
-}): Promise<boolean> {
+}): Promise<ConnectDesktopSessionResult> {
   const fetchImpl = args.fetchImpl ?? globalThis.fetch;
   const rpcUrl = new URL(
     "/api/v1/plugins/connect/rpc/createDesktopSession",
@@ -44,25 +77,60 @@ export async function installConnectDesktopSession(args: {
       headers: { "content-type": "application/json" },
       body: "null",
     });
-  } catch {
-    return false;
+  } catch (error) {
+    return failure("network", errorMessage(error));
   }
-  if (!response.ok) return false;
+  if (!response.ok) {
+    return failure("request_rejected", `HTTP ${response.status}`);
+  }
 
-  const parsed = rpcSuccessSchema.safeParse(await response.json());
-  if (!parsed.success) return false;
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    return failure("invalid_response", errorMessage(error));
+  }
+  const parsed = rpcSuccessSchema.safeParse(body);
+  if (!parsed.success) {
+    return failure("invalid_response", "response did not match the contract");
+  }
+
   const { cookie } = parsed.data.result;
   const remoteOrigin = new URL(args.remoteServerUrl).origin;
-  await args.cookieInstaller.set({
-    domain: cookie.domain,
-    expirationDate: cookie.expiresAt / 1000,
-    httpOnly: true,
-    name: cookie.name,
-    path: "/",
-    sameSite: "lax",
-    secure: remoteOrigin.startsWith("https://"),
-    url: remoteOrigin,
-    value: cookie.value,
-  });
-  return true;
+  try {
+    await args.cookieStore.set({
+      domain: cookie.domain,
+      expirationDate: cookie.expiresAt / 1000,
+      httpOnly: true,
+      name: cookie.name,
+      path: "/",
+      sameSite: "lax",
+      secure: remoteOrigin.startsWith("https://"),
+      url: remoteOrigin,
+      value: cookie.value,
+    });
+  } catch (error) {
+    return failure("cookie_install_failed", errorMessage(error));
+  }
+
+  let installedCookies: DesktopCookie[];
+  try {
+    installedCookies = await args.cookieStore.get({
+      name: cookie.name,
+      url: remoteOrigin,
+    });
+  } catch (error) {
+    return failure("cookie_verification_failed", errorMessage(error));
+  }
+  const installed = installedCookies.some(
+    (candidate) =>
+      candidate.name === cookie.name && candidate.value === cookie.value,
+  );
+  if (!installed) {
+    return failure(
+      "cookie_verification_failed",
+      "Electron did not retain the desktop session cookie",
+    );
+  }
+  return { ok: true };
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1242,12 +1242,58 @@ async function setActiveServerForWindow(
     }
   } else {
     // Remote servers are pure web loads. Owned local runtime keeps running.
-    if (server.source === "connect" && currentRuntime !== null) {
-      await installConnectDesktopSession({
-        cookieInstaller: session.defaultSession.cookies,
+    if (server.source === "connect") {
+      const localRuntimeReady = await ensureBuiltinRuntimeAttached();
+      const electronWindow = BrowserWindow.fromId(args.browserWindow.id);
+      if (
+        !localRuntimeReady ||
+        currentRuntime === null ||
+        electronWindow === null
+      ) {
+        const detail =
+          !localRuntimeReady || currentRuntime === null
+            ? "The local bb server is unavailable, so the desktop app could not create a Connect session."
+            : "The desktop window is no longer available.";
+        createDesktopLogger().warn(
+          `[desktop] Connect authentication failed: ${detail}`,
+        );
+        await loadUrlInApplicationWindow({
+          browserWindow: args.browserWindow,
+          url: createLocalViewUrl({
+            viewModel: {
+              details: `${detail} Try switching servers again after the local server is running.`,
+              kind: "error",
+              logText: "",
+              title: "Could not authenticate with bb Connect",
+            },
+          }),
+        });
+        return;
+      }
+      const result = await installConnectDesktopSession({
+        cookieStore: electronWindow.webContents.session.cookies,
         localServerUrl: currentRuntime.serverUrl,
         remoteServerUrl: server.url,
       });
+      if (!result.ok) {
+        createDesktopLogger().warn(
+          `[desktop] Connect authentication failed (${result.code}): ${result.detail}`,
+        );
+        await loadUrlInApplicationWindow({
+          browserWindow: args.browserWindow,
+          url: createLocalViewUrl({
+            viewModel: {
+              details:
+                "The desktop app could not establish a session for this Connect server. " +
+                `Try switching servers again. (${result.code}: ${result.detail})`,
+              kind: "error",
+              logText: "",
+              title: "Could not authenticate with bb Connect",
+            },
+          }),
+        });
+        return;
+      }
     }
     currentWindowUrl = server.url;
     await loadUrlInApplicationWindow({

--- a/apps/desktop/test/connect-desktop-session.test.ts
+++ b/apps/desktop/test/connect-desktop-session.test.ts
@@ -1,33 +1,52 @@
 import { describe, expect, it, vi } from "vitest";
-import { installConnectDesktopSession } from "../src/connect-desktop-session.js";
+import {
+  type DesktopCookieStore,
+  installConnectDesktopSession,
+} from "../src/connect-desktop-session.js";
+
+function createCookieStore(): DesktopCookieStore {
+  let installed: { name: string; value: string } | null = null;
+  return {
+    async get() {
+      return installed === null ? [] : [installed];
+    },
+    async set(details) {
+      installed = { name: details.name, value: details.value };
+    },
+  };
+}
+
+function successfulResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      result: {
+        cookie: {
+          domain: ".getbb.app",
+          expiresAt: 1_800_000,
+          name: "__Secure-bb-connect.desktop_session",
+          value: "signed-session",
+        },
+      },
+    }),
+  );
+}
 
 describe("installConnectDesktopSession", () => {
-  it("exchanges through the local plugin and installs an HttpOnly cookie", async () => {
-    const set = vi.fn(async () => undefined);
-    const fetchImpl = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            ok: true,
-            result: {
-              cookie: {
-                domain: ".getbb.app",
-                expiresAt: 1_800_000,
-                name: "__Secure-bb-connect.desktop_session",
-                value: "signed-session",
-              },
-            },
-          }),
-        ),
-    );
+  it("exchanges through the local plugin, installs, and verifies the cookie", async () => {
+    const cookieStore = createCookieStore();
+    const set = vi.spyOn(cookieStore, "set");
+    const get = vi.spyOn(cookieStore, "get");
+    const fetchImpl = vi.fn(async () => successfulResponse());
+
     await expect(
       installConnectDesktopSession({
-        cookieInstaller: { set },
+        cookieStore,
         fetchImpl,
         localServerUrl: "http://127.0.0.1:38886",
         remoteServerUrl: "https://laptop.getbb.app",
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ ok: true });
     expect(fetchImpl).toHaveBeenCalledWith(
       new URL(
         "http://127.0.0.1:38886/api/v1/plugins/connect/rpc/createDesktopSession",
@@ -45,18 +64,90 @@ describe("installConnectDesktopSession", () => {
       url: "https://laptop.getbb.app",
       value: "signed-session",
     });
+    expect(get).toHaveBeenCalledWith({
+      name: "__Secure-bb-connect.desktop_session",
+      url: "https://laptop.getbb.app",
+    });
   });
 
-  it("fails closed when the local plugin is unavailable", async () => {
+  it("returns an actionable network failure when the local plugin is unavailable", async () => {
     await expect(
       installConnectDesktopSession({
-        cookieInstaller: { set: vi.fn() },
+        cookieStore: createCookieStore(),
         fetchImpl: async () => {
           throw new Error("offline");
         },
         localServerUrl: "http://127.0.0.1:38886",
         remoteServerUrl: "https://laptop.getbb.app",
       }),
-    ).resolves.toBe(false);
+    ).resolves.toEqual({ code: "network", detail: "offline", ok: false });
+  });
+
+  it("reports rejected and malformed RPC responses", async () => {
+    const args = {
+      cookieStore: createCookieStore(),
+      localServerUrl: "http://127.0.0.1:38886",
+      remoteServerUrl: "https://laptop.getbb.app",
+    };
+    await expect(
+      installConnectDesktopSession({
+        ...args,
+        fetchImpl: async () => new Response("no", { status: 503 }),
+      }),
+    ).resolves.toEqual({
+      code: "request_rejected",
+      detail: "HTTP 503",
+      ok: false,
+    });
+    await expect(
+      installConnectDesktopSession({
+        ...args,
+        fetchImpl: async () => new Response(JSON.stringify({ ok: true })),
+      }),
+    ).resolves.toEqual({
+      code: "invalid_response",
+      detail: "response did not match the contract",
+      ok: false,
+    });
+  });
+
+  it("fails when Electron rejects or does not retain the cookie", async () => {
+    await expect(
+      installConnectDesktopSession({
+        cookieStore: {
+          async get() {
+            return [];
+          },
+          async set() {
+            throw new Error("cookie rejected");
+          },
+        },
+        fetchImpl: async () => successfulResponse(),
+        localServerUrl: "http://127.0.0.1:38886",
+        remoteServerUrl: "https://laptop.getbb.app",
+      }),
+    ).resolves.toEqual({
+      code: "cookie_install_failed",
+      detail: "cookie rejected",
+      ok: false,
+    });
+
+    await expect(
+      installConnectDesktopSession({
+        cookieStore: {
+          async get() {
+            return [];
+          },
+          async set() {},
+        },
+        fetchImpl: async () => successfulResponse(),
+        localServerUrl: "http://127.0.0.1:38886",
+        remoteServerUrl: "https://laptop.getbb.app",
+      }),
+    ).resolves.toEqual({
+      code: "cookie_verification_failed",
+      detail: "Electron did not retain the desktop session cookie",
+      ok: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- install Connect desktop sessions into the destination window session and verify the cookie before navigation
- ensure the local runtime is available and surface actionable authentication failures instead of silently loading the sign-in gate
- cover RPC, network, cookie installation, and cookie retention failures

## Testing

- `pnpm exec turbo run test typecheck --filter=@bb/desktop --force`
- `pnpm exec turbo run build --filter=@bb/desktop --force`
- `git diff --check`