### PR TITLE
Add a composer focus shortcut

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -529,7 +529,6 @@ export function ModelReasoningPicker({
     [isPreviewing, onModelChange, onSelectedProviderChange, previewProviderId],
   );
 
-  useAppCommandContext("promptAvailable", !disabled);
   useAppCommandContext("modelPickerOpen", open && !disabled);
   useAppCommandHandler("modelPicker.toggle", ({ target }) => {
     if (disabled) return false;

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -14,6 +14,10 @@ import type {
   ThreadTimelineActivePromptMode,
 } from "@bb/domain";
 import {
+  useAppCommandContext,
+  useAppCommandHandler,
+} from "@/components/commands/AppCommandProvider";
+import {
   PromptBoxInternal,
   type AttachmentsConfig,
   type HistoryConfig,
@@ -247,6 +251,11 @@ function FollowUpPromptBoxWithComposer({
       : undefined;
   const canStopRuntime = onStopRuntime !== undefined;
   const promptBoxRef = useRef<PromptBoxHandle>(null);
+  useAppCommandContext("promptAvailable", true);
+  useAppCommandHandler("composer.focus", () => {
+    promptBoxRef.current?.focusEnd();
+    return promptBoxRef.current !== null;
+  });
   const voice = usePromptVoice(promptBoxRef);
   const onModifierSubmit = composer.canModifierSubmit
     ? composer.onModifierSubmit

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -8,6 +8,10 @@ import {
 } from "react";
 import type { ProjectSource, PromptTextMention } from "@bb/domain";
 import {
+  useAppCommandContext,
+  useAppCommandHandler,
+} from "@/components/commands/AppCommandProvider";
+import {
   ExecutionControls,
   type ExecutionControlsProps,
   type ExecutionPermissionConfig,
@@ -202,6 +206,11 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   execution,
 }: NewThreadPromptBoxUIProps) {
   const promptBoxRef = useRef<PromptBoxHandle>(null);
+  useAppCommandContext("promptAvailable", true);
+  useAppCommandHandler("composer.focus", () => {
+    promptBoxRef.current?.focusEnd();
+    return promptBoxRef.current !== null;
+  });
   useImperativeHandle(
     externalPromptBoxRef,
     () => ({

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -31,6 +31,8 @@ import type {
   TypeaheadMenuState,
   TypeaheadTrigger,
 } from "@/components/promptbox/mentions/types";
+import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
+import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
 import { commandPillDismissedRangeEnd } from "@/components/promptbox/mentions/command-trigger";
 import { findActiveTrigger } from "@/components/promptbox/mentions/find-active-trigger";
 import { canLoadMoreCommandResults } from "@/components/promptbox/mentions/mention-menu-scroll";
@@ -1013,6 +1015,7 @@ export function PromptBoxInternal({
   promptBoxRef,
   focusEndKey,
 }: PromptBoxInternalProps) {
+  const focusComposerShortcut = useAppCommandShortcut("composer.focus");
   const {
     isSubmitting = false,
     disabled: submitDisabled = false,
@@ -2479,7 +2482,7 @@ export function PromptBoxInternal({
         emitAttachmentFiles(Array.from(event.dataTransfer.files));
       }}
       className={cn(
-        "relative w-full rounded-xl border border-border bg-background shadow-lift",
+        "group/promptbox relative w-full rounded-xl border border-border bg-background shadow-lift",
         "transition-[border-radius] duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
         showVoiceActionGroup && "rounded-3xl",
         // Zen toggles only the *height* of the box; the inset padding stays
@@ -2522,6 +2525,10 @@ export function PromptBoxInternal({
               isZenMode && "min-h-0 flex flex-1 flex-col",
             )}
           >
+            <AppCommandShortcutHint
+              shortcut={focusComposerShortcut}
+              className="absolute right-10 top-2 z-20 group-focus-within/promptbox:hidden"
+            />
             <Button
               type="button"
               size="icon"

--- a/apps/app/src/lib/app-command-metadata.ts
+++ b/apps/app/src/lib/app-command-metadata.ts
@@ -117,6 +117,11 @@ export const APP_COMMAND_GROUPS: readonly AppCommandGroup[] = [
     label: "Composer and models",
     commands: [
       command(
+        "composer.focus",
+        "Focus composer",
+        "Focus the active composer's input and move the caret to the end.",
+      ),
+      command(
         "modelPicker.toggle",
         "Toggle model picker",
         "Open or close the focused composer's model picker.",

--- a/apps/server/src/services/system/app-keybindings.ts
+++ b/apps/server/src/services/system/app-keybindings.ts
@@ -96,6 +96,10 @@ export const DEFAULT_APP_KEYBINDINGS: AppKeybindings = [
     ...mainWithoutModal,
     desktopOnly: true,
   }),
+  binding("composer.focus", "c", { mod: true, shift: true }, {
+    all: ["mainSurface", "promptAvailable"],
+    none: ["modalOpen", "terminalFocus", "browserFocus"],
+  }),
   binding("modelPicker.toggle", "m", { mod: true, shift: true }, {
     all: ["mainSurface", "promptAvailable"],
     none: ["modalOpen", "terminalFocus", "browserFocus"],

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -65,6 +65,18 @@ describe("app keybindings", () => {
         { desktopOnly: true, key: "t" },
       ]);
       expect(
+        config.defaultKeybindings.find(
+          (binding) => binding.command === "composer.focus",
+        ),
+      ).toMatchObject({
+        desktopOnly: false,
+        shortcut: { key: "c", mod: true, shift: true },
+        when: {
+          all: ["mainSurface", "promptAvailable"],
+          none: ["modalOpen", "terminalFocus", "browserFocus"],
+        },
+      });
+      expect(
         config.defaultKeybindings
           .filter((binding) => binding.desktopOnly)
           .map((binding) => binding.command),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ before bb receives them.
 | Workspace | Quick open file / toggle diff | `Mod+P` / `Mod+D`             | All clients              |
 | Workspace | Open terminal                 | `Mod+Shift+Enter` / `Mod+Shift+T` | Web / desktop         |
 | Workspace | Open in preferred app         | `Mod+O`                       | All clients              |
+| Composer  | Focus composer                | `Mod+Shift+C`                 | All clients              |
 | Composer  | Toggle model picker           | `Mod+Shift+M`                 | All clients              |
 | Browser   | Focus location / reload       | `Mod+L` / `Mod+R`             | Desktop embedded browser |
 | Questions | Choose visible answer 1–9     | `1` … `9`                     | While a question is open |

--- a/packages/domain/src/app-keybindings.ts
+++ b/packages/domain/src/app-keybindings.ts
@@ -40,6 +40,7 @@ export const APP_COMMAND_IDS = [
   "file.quickOpen",
   "diff.toggle",
   "terminal.open",
+  "composer.focus",
   "modelPicker.toggle",
   "browser.focusLocation",
   "browser.reload",


### PR DESCRIPTION
## Summary
- add a configurable `composer.focus` command with `Mod+Shift+C` as the default
- focus new-thread and follow-up composers without changing the draft
- show the shortcut hint while the primary modifier is held and the composer is unfocused
- document and validate the server-owned default binding

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/app --force` (1270 tests)
- `pnpm exec turbo run test --filter=@bb/server --force` (984 tests)
- manual QA through the managed dev app and bb connect share