### PR TITLE
Fix multi-server status and attention indicators

### DIFF
--- a/apps/app/src/components/sidebar/ServerRail.test.tsx
+++ b/apps/app/src/components/sidebar/ServerRail.test.tsx
@@ -105,6 +105,7 @@ describe("ServerRail", () => {
           source: "builtin",
           url: "http://127.0.0.1:1",
           active: true,
+          hasAttention: true,
         }),
         serverEntry({
           id: "remote",
@@ -112,6 +113,13 @@ describe("ServerRail", () => {
           source: "connect",
           url: "https://studio.example",
           status: "offline",
+        }),
+        serverEntry({
+          id: "attention",
+          name: "Laptop",
+          source: "connect",
+          url: "https://laptop.example",
+          hasAttention: true,
         }),
       ]),
     });
@@ -125,7 +133,13 @@ describe("ServerRail", () => {
     expect(builtinTile.getAttribute("aria-current")).toBe("true");
     // Healthy server shows no dot; offline one does.
     expect(screen.queryByTestId("server-rail-status-builtin")).toBeNull();
+    expect(screen.queryByTestId("server-rail-attention-builtin")).toBeNull();
     expect(screen.getByTestId("server-rail-status-remote")).toBeDefined();
+    const attentionDot = screen.getByTestId(
+      "server-rail-attention-attention",
+    );
+    expect(attentionDot.className).toContain("right-1.5");
+    expect(attentionDot.className).toContain("top-1.5");
 
     fireEvent.click(screen.getByTestId("server-rail-tile-remote"));
     expect(servers.setActive).toHaveBeenCalledWith("remote");

--- a/apps/app/src/components/sidebar/ServerRail.tsx
+++ b/apps/app/src/components/sidebar/ServerRail.tsx
@@ -43,6 +43,10 @@ function ServerTile({ server }: { server: BbDesktopServerListEntry }) {
           backgroundColor: `color-mix(in oklab, ${colorHex} 18%, transparent)`,
         }
       : undefined;
+  const hasConnectivityProblem =
+    server.status === "offline" || server.status === "incompatible";
+  const showsAttention =
+    !server.active && !hasConnectivityProblem && server.hasAttention === true;
 
   return (
     <Tooltip>
@@ -77,12 +81,16 @@ function ServerTile({ server }: { server: BbDesktopServerListEntry }) {
               {tileGlyph(server.name)}
             </span>
           )}
-          {/* Status stays quiet unless something is wrong. */}
-          {server.status === "offline" || server.status === "incompatible" ? (
+          {/* Connectivity problems take precedence over work attention. */}
+          {hasConnectivityProblem || showsAttention ? (
             <span
-              data-testid={`server-rail-status-${server.id}`}
+              data-testid={
+                hasConnectivityProblem
+                  ? `server-rail-status-${server.id}`
+                  : `server-rail-attention-${server.id}`
+              }
               className={cn(
-                "absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full ring-2 ring-sidebar",
+                "absolute right-1.5 top-1.5 size-1.5 rounded-full ring-2 ring-sidebar",
                 server.status === "offline"
                   ? "bg-muted-foreground"
                   : "bg-destructive",
@@ -93,8 +101,9 @@ function ServerTile({ server }: { server: BbDesktopServerListEntry }) {
       </TooltipTrigger>
       <TooltipContent side="right">
         <div className="font-medium">{server.name}</div>
-        <div className="text-muted-foreground">
+        <div className="text-primary-foreground">
           {server.url} · {STATUS_LABELS[server.status]}
+          {showsAttention ? " · Needs attention" : null}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -109,6 +109,11 @@ import {
   SERVER_STATUS_PROBE_TIMEOUT_MS,
 } from "./server-status.js";
 import {
+  fetchServerAttention,
+  SERVER_ATTENTION_POLL_INTERVAL_MS,
+  SERVER_ATTENTION_REQUEST_TIMEOUT_MS,
+} from "./server-attention.js";
+import {
   createDesktopShutdownState,
   registerDesktopShutdownSignalHandlers,
 } from "./desktop-shutdown.js";
@@ -353,6 +358,9 @@ let desktopBridgePath: string | null = null;
 let desktopUserDataPath: string | null = null;
 let builtinLastProbe: ServerProbeResult | null = null;
 const remoteServerStatuses = new Map<string, BbDesktopServerStatus>();
+const serverAttentionStates = new Map<string, boolean>();
+let serverAttentionRefreshInFlight: Promise<void> | null = null;
+let serverAttentionRefreshTimer: ReturnType<typeof setInterval> | null = null;
 let serverStatusRefreshToken = 0;
 let serverStatusProbeInFlight: Promise<void> | null = null;
 
@@ -675,6 +683,58 @@ function scheduleServerStatusRefresh(): void {
     .finally(() => {
       serverStatusProbeInFlight = null;
     });
+}
+
+async function refreshServerAttention(): Promise<void> {
+  if (serverRegistry === null) {
+    return;
+  }
+  const entries = await Promise.all(
+    serverRegistry.list().map(async (server) => {
+      const hasAttention = await fetchServerAttention({
+        fetchImpl: (input, init) => session.defaultSession.fetch(input, init),
+        serverUrl: server.url,
+        timeoutMs: SERVER_ATTENTION_REQUEST_TIMEOUT_MS,
+      });
+      return [server.id, hasAttention] as const;
+    }),
+  );
+  serverAttentionStates.clear();
+  for (const [serverId, hasAttention] of entries) {
+    serverAttentionStates.set(serverId, hasAttention ?? false);
+  }
+}
+
+function scheduleServerAttentionRefresh(): void {
+  if (serverAttentionRefreshInFlight !== null) {
+    return;
+  }
+  serverAttentionRefreshInFlight = refreshServerAttention()
+    .then(() => {
+      sendServersChanged();
+    })
+    .finally(() => {
+      serverAttentionRefreshInFlight = null;
+    });
+}
+
+function startServerAttentionPolling(): void {
+  if (serverAttentionRefreshTimer !== null) {
+    return;
+  }
+  scheduleServerAttentionRefresh();
+  serverAttentionRefreshTimer = setInterval(
+    scheduleServerAttentionRefresh,
+    SERVER_ATTENTION_POLL_INTERVAL_MS,
+  );
+}
+
+function stopServerAttentionPolling(): void {
+  if (serverAttentionRefreshTimer === null) {
+    return;
+  }
+  clearInterval(serverAttentionRefreshTimer);
+  serverAttentionRefreshTimer = null;
 }
 
 function installCurrentApplicationMenu(): void {
@@ -1078,6 +1138,7 @@ function buildServerListEntries(args: {
     return {
       active: server.id === args.activeServerId,
       color: tileStyle.color,
+      hasAttention: serverAttentionStates.get(server.id) ?? false,
       icon: tileStyle.icon,
       id: server.id,
       name: server.name,
@@ -1095,9 +1156,29 @@ async function refreshServerStatuses(): Promise<void> {
   const token = serverStatusRefreshToken + 1;
   serverStatusRefreshToken = token;
   const servers = serverRegistry.list();
+  const localServerUrl = currentRuntime?.serverUrl;
+  if (localServerUrl !== undefined) {
+    await Promise.all(
+      servers
+        .filter((server) => server.source === "connect")
+        .map(async (server) => {
+          const result = await installConnectDesktopSession({
+            cookieStore: session.defaultSession.cookies,
+            localServerUrl,
+            remoteServerUrl: server.url,
+          });
+          if (!result.ok) {
+            createDesktopLogger().warn(
+              `[desktop] Connect status authentication failed (${result.code}): ${result.detail}`,
+            );
+          }
+        }),
+    );
+  }
   const remoteStatuses = await probeRemoteServerStatuses({
     probe: (serverUrl) =>
       probeBbServer({
+        fetchImpl: (input, init) => session.defaultSession.fetch(input, init),
         serverUrl,
         timeoutMs: SERVER_STATUS_PROBE_TIMEOUT_MS,
       }),
@@ -1315,6 +1396,7 @@ function registerDesktopServerIpc(): void {
     // Return cached statuses immediately so an offline remote cannot stall
     // settings mounts. Coalesced probes push updates via servers:changed.
     scheduleServerStatusRefresh();
+    scheduleServerAttentionRefresh();
     // Soft-trigger connect sync when the last attempt is older than 60s.
     connectServerSync?.onListRequested();
     const browserWindow = BrowserWindow.fromWebContents(event.sender);
@@ -1366,6 +1448,7 @@ function registerDesktopServerIpc(): void {
         server: {
           active: false,
           color: null,
+          hasAttention: false,
           icon: null,
           id: result.server.id,
           name: result.server.name,
@@ -1394,6 +1477,7 @@ function registerDesktopServerIpc(): void {
       return;
     }
     remoteServerStatuses.delete(parsed.data.id);
+    serverAttentionStates.delete(parsed.data.id);
     // Windows pointing at the removed server fall back to the builtin entry.
     for (const browserWindow of BrowserWindow.getAllWindows()) {
       if (
@@ -1859,6 +1943,7 @@ function handleBeforeQuit(event: Event): void {
 
 async function finishQuit(): Promise<void> {
   stopSystemConfigSync();
+  stopServerAttentionPolling();
   desktopUpdateService?.stop();
   desktopAutoUpdateService?.stop();
   desktopBrowserViewManager?.destroyAll();
@@ -2353,6 +2438,7 @@ async function runDesktopApp(): Promise<void> {
   activeServerState = createActiveServerState({
     defaultServerId: BUILTIN_SERVER_ID,
   });
+  startServerAttentionPolling();
   const logger = createDesktopLogger();
   connectServerSync = createConnectServerSync({
     getLocalServerUrl: () => currentRuntime?.serverUrl ?? null,
@@ -2364,6 +2450,7 @@ async function runDesktopApp(): Promise<void> {
   connectServerSync.start();
   serverRegistry.onChange(() => {
     refreshApplicationMenuAndProbeStatuses();
+    scheduleServerAttentionRefresh();
     sendServersChanged();
   });
 

--- a/apps/desktop/src/server-attention.ts
+++ b/apps/desktop/src/server-attention.ts
@@ -1,0 +1,38 @@
+import { systemAttentionResponseSchema } from "@bb/server-contract";
+
+export const SERVER_ATTENTION_POLL_INTERVAL_MS = 5_000;
+export const SERVER_ATTENTION_REQUEST_TIMEOUT_MS = 2_000;
+
+export type ServerAttentionFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+export async function fetchServerAttention(args: {
+  fetchImpl: ServerAttentionFetch;
+  serverUrl: string;
+  timeoutMs: number;
+}): Promise<boolean | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, args.timeoutMs);
+
+  try {
+    const url = new URL("/api/v1/system/attention", args.serverUrl).toString();
+    const response = await args.fetchImpl(url, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const parsed = systemAttentionResponseSchema.safeParse(
+      await response.json(),
+    );
+    return parsed.success ? parsed.data.hasAttention : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/desktop/src/server-probe.ts
+++ b/apps/desktop/src/server-probe.ts
@@ -18,6 +18,11 @@ export type ServerProbeResult =
   | IncompatibleServerProbeResult
   | UnavailableServerProbeResult;
 
+export type ServerProbeFetch = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
 export interface CompatibleServerProbeResult {
   kind: "compatible";
   serverUrl: string;
@@ -36,6 +41,7 @@ export interface UnavailableServerProbeResult {
 }
 
 export interface ProbeBbServerArgs {
+  fetchImpl?: ServerProbeFetch;
   serverUrl: string;
   timeoutMs: number;
 }
@@ -47,6 +53,7 @@ export interface WaitForCompatibleServerArgs {
 }
 
 interface FetchJsonArgs<TValue> {
+  fetchImpl: ServerProbeFetch;
   schema: z.ZodType<TValue>;
   timeoutMs: number;
   url: string;
@@ -106,7 +113,7 @@ async function fetchJson<TValue>(
   }, args.timeoutMs);
 
   try {
-    const response = await fetch(args.url, {
+    const response = await args.fetchImpl(args.url, {
       signal: controller.signal,
     });
     if (!response.ok) {
@@ -149,7 +156,9 @@ function formatFetchFailure(result: FetchJsonFailureResult): string {
 export async function probeBbServer(
   args: ProbeBbServerArgs,
 ): Promise<ServerProbeResult> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
   const healthResult = await fetchJson({
+    fetchImpl,
     schema: healthResponseSchema,
     timeoutMs: args.timeoutMs,
     url: endpointUrl(args.serverUrl, "/health"),
@@ -180,6 +189,7 @@ export async function probeBbServer(
   }
 
   const configResult = await fetchJson({
+    fetchImpl,
     schema: systemConfigResponseSchema,
     timeoutMs: args.timeoutMs,
     url: endpointUrl(args.serverUrl, "/api/v1/system/config"),

--- a/apps/desktop/test/server-attention.test.ts
+++ b/apps/desktop/test/server-attention.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchServerAttention } from "../src/server-attention.js";
+
+describe("fetchServerAttention", () => {
+  it("returns the typed attention state", async () => {
+    const fetchImpl = vi.fn(async () => Response.json({ hasAttention: true }));
+
+    await expect(
+      fetchServerAttention({
+        fetchImpl,
+        serverUrl: "https://studio.example/base",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://studio.example/api/v1/system/attention",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("returns null for unavailable or incompatible responses", async () => {
+    await expect(
+      fetchServerAttention({
+        fetchImpl: async () => new Response("not found", { status: 404 }),
+        serverUrl: "https://old.example",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBeNull();
+
+    await expect(
+      fetchServerAttention({
+        fetchImpl: async () => Response.json({ hasAttention: "yes" }),
+        serverUrl: "https://wrong.example",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/desktop/test/server-probe.test.ts
+++ b/apps/desktop/test/server-probe.test.ts
@@ -3,8 +3,11 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
-import { probeBbServer } from "../src/server-probe.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  probeBbServer,
+  type ServerProbeFetch,
+} from "../src/server-probe.js";
 
 interface TestServer {
   close(): Promise<void>;
@@ -65,6 +68,30 @@ afterEach(async () => {
 });
 
 describe("probeBbServer", () => {
+  it("uses the provided authenticated fetch implementation", async () => {
+    const fetchImpl = vi
+      .fn<ServerProbeFetch>()
+      .mockResolvedValueOnce(Response.json({ ok: true }))
+      .mockResolvedValueOnce(
+        Response.json({
+          hostDaemonPort: 4_242,
+          voiceTranscriptionEnabled: false,
+        }),
+      );
+
+    await expect(
+      probeBbServer({
+        fetchImpl,
+        serverUrl: "https://studio.example",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({
+      kind: "compatible",
+      serverUrl: "https://studio.example",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it("accepts a server with bb health and system config endpoints", async () => {
     const testServer = await startTestServer({
       handler(request, response) {

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -7,6 +7,7 @@ import {
   getExperiments,
   getStoredFaviconColor,
   getStoredThemeId,
+  hasActiveThreadAttention,
   setAppSettings,
   setAppKeybindingOverrides,
   setExperiments,
@@ -65,6 +66,10 @@ export function registerSystemRoutes(
   const routes = publicApiRoutes.system;
 
   const themeRoot = resolveThemeRootPath(deps.config.dataDir);
+
+  get(routes.attention, (context) =>
+    context.json({ hasAttention: hasActiveThreadAttention(deps.db) }),
+  );
 
   function resolvePrimaryHostPlatform() {
     const hostId = resolvePrimaryHostId(deps);

--- a/apps/server/test/system/attention.test.ts
+++ b/apps/server/test/system/attention.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { systemAttentionResponseSchema } from "@bb/server-contract";
+import { readJson } from "../helpers/json.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+describe("system attention", () => {
+  it("returns the cross-server favicon attention summary", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/system/attention");
+      expect(response.status).toBe(200);
+      expect(
+        systemAttentionResponseSchema.parse(await readJson(response)),
+      ).toEqual({ hasAttention: false });
+    });
+  });
+});

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -84,6 +84,7 @@ export {
   countNonDeletedAssignedChildThreads,
   getThread,
   getThreadExecutionOverride,
+  hasActiveThreadAttention,
   setThreadExecutionOverride,
   hasNonTerminalThreadInEnvironment,
   hasPendingThreadShutdownInEnvironment,

--- a/packages/db/src/data/threads.ts
+++ b/packages/db/src/data/threads.ts
@@ -8,6 +8,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   ne,
   or,
   sql,
@@ -1121,6 +1122,49 @@ export function listThreadsWithPendingInteractionState(
   const rows = query.all();
 
   return rows.map(toThreadWithPendingInteractionState);
+}
+
+/**
+ * Whether the active, sidebar-visible thread set contains work that would
+ * light the app favicon: an unread attention timestamp or a pending user
+ * interaction. Kept as an existence query because the desktop shell polls
+ * this summary for every registered server.
+ */
+export function hasActiveThreadAttention(db: DbConnection): boolean {
+  const visibleThread = or(
+    ne(threads.originKind, "side-chat"),
+    and(
+      isNull(threads.originKind),
+      or(isNull(threads.childOrigin), ne(threads.childOrigin, "side-chat")),
+    ),
+  );
+  const unreadThread = or(
+    isNull(threads.lastReadAt),
+    lt(threads.lastReadAt, threads.latestAttentionAt),
+  );
+
+  const row = db
+    .select({ id: threads.id })
+    .from(threads)
+    .leftJoin(
+      pendingInteractions,
+      and(
+        eq(pendingInteractions.threadId, threads.id),
+        eq(pendingInteractions.status, "pending"),
+      ),
+    )
+    .where(
+      and(
+        isNull(threads.archivedAt),
+        isNull(threads.deletedAt),
+        visibleThread,
+        or(unreadThread, isNotNull(pendingInteractions.id)),
+      ),
+    )
+    .limit(1)
+    .get();
+
+  return row !== undefined;
 }
 
 export function listThreadsWithPendingInteractionStateForProjects(

--- a/packages/db/test/data/threads.test.ts
+++ b/packages/db/test/data/threads.test.ts
@@ -9,6 +9,7 @@ import {
   countNonDeletedAssignedChildThreads,
   getThread,
   getThreadExecutionOverride,
+  hasActiveThreadAttention,
   setThreadExecutionOverride,
   hasPendingThreadShutdownInEnvironment,
   listHostThreadIds,
@@ -28,6 +29,7 @@ import {
   applyThreadLifecycleEvent,
   requireThreadLifecycleEventApplied,
 } from "../../src/data/threads.js";
+import { createPendingInteraction } from "../../src/data/pending-interactions.js";
 import {
   createThreadFolder,
   deleteThreadFolder,
@@ -64,6 +66,55 @@ function mustCreateThreadFolder(
 }
 
 describe("threads", () => {
+  it("summarizes favicon attention for active sidebar threads", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const { db, project } = setup();
+      const thread = createThread(db, noopNotifier, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+      expect(hasActiveThreadAttention(db)).toBe(false);
+
+      vi.setSystemTime(2_000);
+      markThreadAttentionRequested(db, noopNotifier, {
+        threadId: thread.id,
+      });
+      expect(hasActiveThreadAttention(db)).toBe(true);
+
+      updateThread(db, noopNotifier, thread.id, { lastReadAt: 2_000 });
+      expect(hasActiveThreadAttention(db)).toBe(false);
+
+      createPendingInteraction(db, {
+        payload: "{}",
+        providerId: "codex",
+        providerRequestId: "request-1",
+        providerThreadId: "provider-thread-1",
+        threadId: thread.id,
+        turnId: "turn-1",
+      });
+      expect(hasActiveThreadAttention(db)).toBe(true);
+
+      archiveThread(db, noopNotifier, thread.id);
+      expect(hasActiveThreadAttention(db)).toBe(false);
+
+      const sideChat = createThread(db, noopNotifier, {
+        originKind: "side-chat",
+        projectId: project.id,
+        providerId: "codex",
+        sourceThreadId: thread.id,
+      });
+      vi.setSystemTime(3_000);
+      markThreadAttentionRequested(db, noopNotifier, {
+        threadId: sideChat.id,
+      });
+      expect(hasActiveThreadAttention(db)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("creates and retrieves a thread", () => {
     const { db, project } = setup();
     const thread = createThread(db, noopNotifier, {

--- a/packages/desktop-contract/src/servers.ts
+++ b/packages/desktop-contract/src/servers.ts
@@ -20,6 +20,8 @@ export const bbDesktopServerListEntrySchema = z
     active: z.boolean(),
     /** Favicon palette id, or null for the default (token) tile color. */
     color: z.string().nullable(),
+    /** Omitted by desktop shells that predate cross-server attention polling. */
+    hasAttention: z.boolean().optional(),
     /** Hugeicons registry name, or null for the letter glyph. */
     icon: z.string().nullable(),
     id: z.string().min(1),

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -107,6 +107,13 @@ export const systemConfigResponseSchema = z.object({
 });
 export type SystemConfigResponse = z.infer<typeof systemConfigResponseSchema>;
 
+export const systemAttentionResponseSchema = z.object({
+  hasAttention: z.boolean(),
+});
+export type SystemAttentionResponse = z.infer<
+  typeof systemAttentionResponseSchema
+>;
+
 /**
  * Theme catalog: the on-disk custom-theme directory plus the discovered custom
  * themes and the active palette. Drives `bb theme list` / `bb theme dir`.

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -109,6 +109,7 @@ import type {
   SendQueuedMessageRequest,
   SendQueuedMessageResponse,
   SidebarBootstrapResponse,
+  SystemAttentionResponse,
   SystemConfigReloadResponse,
   SystemConfigResponse,
   SystemExecutionOptionsQuery,
@@ -1010,6 +1011,12 @@ export const publicApiRoutes = {
   },
 
   system: {
+    attention: defineRoute({
+      path: "/system/attention",
+      method: "get",
+      request: noRequest(),
+      response: jsonResponse<SystemAttentionResponse>(),
+    }),
     config: defineRoute({
       path: "/system/config",
       method: "get",


### PR DESCRIPTION
## Summary

- authenticate bb Connect compatibility probes through the Electron session so healthy remote machines are not marked incompatible
- poll a lightweight server attention summary and show favicon-equivalent dots on inactive machine tiles
- position machine indicators over the glyph and keep server tooltip details readable on tinted backgrounds

## Validation

- `pnpm exec turbo run test --filter=@bb/db -- test/data/threads.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/system/attention.test.ts`
- `pnpm exec turbo run test --filter=@bb/desktop -- test/server-probe.test.ts test/server-attention.test.ts`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ServerRail.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server-contract --filter=@bb/desktop-contract --filter=@bb/server --filter=@bb/desktop --filter=@bb/app`
- `pnpm exec turbo run build --filter=@bb/desktop`