### PR TITLE
Fix Simple Notes task checkbox alignment

### DIFF
--- a/examples/plugins/simple-notes/app.test.tsx
+++ b/examples/plugins/simple-notes/app.test.tsx
@@ -63,6 +63,46 @@ describe("simple notes nav panel", () => {
     expect(styles).toContain("font-size: 1.75em");
   });
 
+  it("aligns task checkboxes with the first label line without flattening later content spacing", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "tasks.md" },
+      {
+        rpc: {
+          listNotes: () =>
+            listNotesResult([
+              {
+                path: "tasks.md",
+                title: "Tasks",
+                preview: "A task list",
+                modifiedAtMs: Date.now(),
+              },
+            ]),
+          readNote: () => ({
+            content: "# Tasks\n\n- [ ] First task",
+            sha256: "sha-tasks",
+          }),
+          renameToTitle: () => ({ path: "tasks.md" }),
+        },
+      },
+    );
+
+    await slot.findByText("First task");
+    const styles = document.head.querySelector(
+      "style[data-bb-simple-notes-styles]",
+    )?.textContent;
+
+    expect(styles).toContain(
+      'ul[data-type="taskList"] li > div > p:first-child { margin-top: 0; }',
+    );
+    expect(styles).toContain(
+      'ul[data-type="taskList"] li > div > p { line-height: 1.75; }',
+    );
+    expect(styles).toContain(
+      ".tiptap ul, .bb-simple-notes-editor .tiptap ol { margin: 1.25em 0 0;",
+    );
+  });
+
   it("creates a note over rpc and opens it", async () => {
     const slot = renderSlot(
       app.navPanels[0]!,

--- a/examples/plugins/simple-notes/app.tsx
+++ b/examples/plugins/simple-notes/app.tsx
@@ -120,6 +120,7 @@ const EDITOR_CSS = `
 }
 .bb-simple-notes-editor .tiptap ul[data-type="taskList"] li > div { flex: 1 1 auto; min-width: 0; }
 .bb-simple-notes-editor .tiptap ul[data-type="taskList"] li > div > p { line-height: 1.75; }
+.bb-simple-notes-editor .tiptap ul[data-type="taskList"] li > div > p:first-child { margin-top: 0; }
 .bb-simple-notes-editor .tiptap ul[data-type="taskList"] input[type="checkbox"] {
   display: block; width: 15px; height: 15px; accent-color: var(--primary); cursor: pointer; margin: 0;
 }


### PR DESCRIPTION
## Summary

- align task-list checkboxes with the first line of their labels
- preserve paragraph and nested-list spacing for later task content
- add focused regression coverage for the task-list CSS

## Validation

- `pnpm exec turbo run test typecheck --filter=bb-plugin-simple-notes --force` (4 tests passed)
- `bb plugin build`
- `git diff --check origin/main...HEAD`