### PR TITLE
Keep plugin sidebar active on nested routes

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -42,7 +42,8 @@ function PluginNavSidebarItemList({
           pluginId: panel.pluginId,
           path: panel.path,
         });
-        const isActive = location.pathname === path;
+        const isActive =
+          location.pathname === path || location.pathname.startsWith(`${path}/`);
         return (
           <Button
             key={`${panel.pluginId}/${panel.id}`}

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -277,6 +277,38 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
     expect(screen.getByText("board panel body")).toBeDefined();
   });
 
+  it("keeps the sidebar entry active on nested plugin panel routes", () => {
+    setPluginSlotRegistrations(
+      "simple-notes",
+      registrationSet({
+        navPanels: [
+          {
+            id: "simple-notes",
+            title: "Simple notes",
+            icon: "note",
+            path: "simple-notes",
+            component: Board,
+          },
+        ],
+      }),
+    );
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/plugins/simple-notes/simple-notes/bb-plugin-marketplaces-and-compatible-updates.md",
+        ]}
+      >
+        <PluginNavSidebarItems />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Simple notes" }).getAttribute(
+        "aria-current",
+      ),
+    ).toBe("page");
+  });
+
   it("shows a placeholder for an unknown plugin panel route", () => {
     render(
       <MemoryRouter initialEntries={["/plugins/ghost/board"]}>


### PR DESCRIPTION
## Summary

- keep plugin nav sidebar entries highlighted on nested panel routes
- require a slash-delimited descendant to avoid prefix collisions
- add regression coverage for a nested Simple Notes document URL

## Tests

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/plugin/plugin-slot-mounts.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app --force`