### PR TITLE
Cache desktop server renderers

### DIFF
--- a/apps/app/src/components/sidebar/ServerRail.tsx
+++ b/apps/app/src/components/sidebar/ServerRail.tsx
@@ -101,7 +101,7 @@ function ServerTile({ server }: { server: BbDesktopServerListEntry }) {
       </TooltipTrigger>
       <TooltipContent side="right">
         <div className="font-medium">{server.name}</div>
-        <div className="text-primary-foreground">
+        <div className="text-inherit">
           {server.url} · {STATUS_LABELS[server.status]}
           {showsAttention ? " · Needs attention" : null}
         </div>

--- a/apps/desktop/src/desktop-browser-main-ipc.ts
+++ b/apps/desktop/src/desktop-browser-main-ipc.ts
@@ -21,6 +21,7 @@ import type { DesktopBrowserViewManager } from "./desktop-browser-view.js";
 
 interface DesktopBrowserTabCommandArgs {
   hostWindow: BrowserWindow;
+  rendererWebContentsId: number;
   tabId: string;
 }
 
@@ -33,13 +34,20 @@ interface RegisterDesktopBrowserTabCommandArgs {
 
 function hostWindowFromBrowserIpcEvent(
   event: IpcMainEvent,
+  resolveHostWindow: (senderWebContentsId: number) => BrowserWindow | null,
 ): BrowserWindow | null {
-  return BrowserWindow.fromWebContents(event.sender);
+  return (
+    resolveHostWindow(event.sender.id) ??
+    BrowserWindow.fromWebContents(event.sender)
+  );
 }
 
-function registerTabCommand(args: RegisterDesktopBrowserTabCommandArgs): void {
+function registerTabCommand(
+  args: RegisterDesktopBrowserTabCommandArgs,
+  resolveHostWindow: (senderWebContentsId: number) => BrowserWindow | null,
+): void {
   ipcMain.on(args.channel, (event, payload: unknown) => {
-    const hostWindow = hostWindowFromBrowserIpcEvent(event);
+    const hostWindow = hostWindowFromBrowserIpcEvent(event, resolveHostWindow);
     if (hostWindow === null) {
       return;
     }
@@ -47,19 +55,26 @@ function registerTabCommand(args: RegisterDesktopBrowserTabCommandArgs): void {
     if (!parsed.success) {
       return;
     }
-    args.run({ hostWindow, tabId: parsed.data.tabId });
+    args.run({
+      hostWindow,
+      rendererWebContentsId: event.sender.id,
+      tabId: parsed.data.tabId,
+    });
   });
 }
 
 export function registerDesktopBrowserIpc(
   manager: DesktopBrowserViewManager,
+  resolveHostWindow: (
+    senderWebContentsId: number,
+  ) => BrowserWindow | null = () => null,
 ): void {
   // Every browser command is renderer -> main fire-and-forget; navigation state
   // flows back over `BB_DESKTOP_BROWSER_STATE_CHANNEL`. Each handler resolves
   // its own host window from the sender, so multi-window is safe, and zod-parses
   // the untrusted-content-adjacent payload before touching the view.
   ipcMain.on(BB_DESKTOP_BROWSER_ATTACH_CHANNEL, (event, payload: unknown) => {
-    const hostWindow = hostWindowFromBrowserIpcEvent(event);
+    const hostWindow = hostWindowFromBrowserIpcEvent(event, resolveHostWindow);
     if (hostWindow === null) {
       return;
     }
@@ -67,11 +82,15 @@ export function registerDesktopBrowserIpc(
     if (!parsed.success) {
       return;
     }
-    manager.attach({ hostWindow, request: parsed.data });
+    manager.attach({
+      hostWindow,
+      rendererWebContentsId: event.sender.id,
+      request: parsed.data,
+    });
   });
 
   ipcMain.on(BB_DESKTOP_BROWSER_NAVIGATE_CHANNEL, (event, payload: unknown) => {
-    const hostWindow = hostWindowFromBrowserIpcEvent(event);
+    const hostWindow = hostWindowFromBrowserIpcEvent(event, resolveHostWindow);
     if (hostWindow === null) {
       return;
     }
@@ -79,13 +98,20 @@ export function registerDesktopBrowserIpc(
     if (!parsed.success) {
       return;
     }
-    manager.navigate({ hostWindow, request: parsed.data });
+    manager.navigate({
+      hostWindow,
+      rendererWebContentsId: event.sender.id,
+      request: parsed.data,
+    });
   });
 
   ipcMain.on(
     BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
     (event, payload: unknown) => {
-      const hostWindow = hostWindowFromBrowserIpcEvent(event);
+      const hostWindow = hostWindowFromBrowserIpcEvent(
+        event,
+        resolveHostWindow,
+      );
       if (hostWindow === null) {
         return;
       }
@@ -93,14 +119,21 @@ export function registerDesktopBrowserIpc(
       if (!parsed.success) {
         return;
       }
-      manager.setBounds({ hostWindow, request: parsed.data });
+      manager.setBounds({
+        hostWindow,
+        rendererWebContentsId: event.sender.id,
+        request: parsed.data,
+      });
     },
   );
 
   ipcMain.on(
     BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
     (event, payload: unknown) => {
-      const hostWindow = hostWindowFromBrowserIpcEvent(event);
+      const hostWindow = hostWindowFromBrowserIpcEvent(
+        event,
+        resolveHostWindow,
+      );
       if (hostWindow === null) {
         return;
       }
@@ -108,28 +141,47 @@ export function registerDesktopBrowserIpc(
       if (!parsed.success) {
         return;
       }
-      manager.setVisible({ hostWindow, request: parsed.data });
+      manager.setVisible({
+        hostWindow,
+        rendererWebContentsId: event.sender.id,
+        request: parsed.data,
+      });
     },
   );
 
-  registerTabCommand({
-    channel: BB_DESKTOP_BROWSER_DETACH_CHANNEL,
-    run: (args) => manager.detach(args),
-  });
-  registerTabCommand({
-    channel: BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
-    run: (args) => manager.goBack(args),
-  });
-  registerTabCommand({
-    channel: BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
-    run: (args) => manager.goForward(args),
-  });
-  registerTabCommand({
-    channel: BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
-    run: (args) => manager.reload(args),
-  });
-  registerTabCommand({
-    channel: BB_DESKTOP_BROWSER_STOP_CHANNEL,
-    run: (args) => manager.stop(args),
-  });
+  registerTabCommand(
+    {
+      channel: BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+      run: (args) => manager.detach(args),
+    },
+    resolveHostWindow,
+  );
+  registerTabCommand(
+    {
+      channel: BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
+      run: (args) => manager.goBack(args),
+    },
+    resolveHostWindow,
+  );
+  registerTabCommand(
+    {
+      channel: BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
+      run: (args) => manager.goForward(args),
+    },
+    resolveHostWindow,
+  );
+  registerTabCommand(
+    {
+      channel: BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
+      run: (args) => manager.reload(args),
+    },
+    resolveHostWindow,
+  );
+  registerTabCommand(
+    {
+      channel: BB_DESKTOP_BROWSER_STOP_CHANNEL,
+      run: (args) => manager.stop(args),
+    },
+    resolveHostWindow,
+  );
 }

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -62,6 +62,8 @@ const ERR_ABORTED = -3;
 
 interface BrowserViewEntry {
   view: WebContentsView;
+  hostWindow: DesktopBrowserHostWindow;
+  hostWebContentsId: number;
   lastErrorText: string | null;
   currentMainFrameLocalOriginKey: string | null;
   /**
@@ -74,6 +76,8 @@ interface BrowserViewEntry {
    */
   desiredBounds: BbDesktopBrowserViewBounds;
   popupTimestamps: number[];
+  rendererWebContentsId: number;
+  tabId: string;
   visible: boolean;
 }
 
@@ -115,22 +119,30 @@ export interface CreateDesktopBrowserViewManagerArgs {
   dispatchAppCommand: (args: DispatchDesktopBrowserAppCommandArgs) => void;
   focusHostWebContents: (hostWebContentsId: number) => void;
   partition?: string;
+  sendToRenderer?: (
+    rendererWebContentsId: number,
+    channel: string,
+    payload: DesktopBrowserHostWebContentsPayload,
+  ) => void;
   resolveAppCommand: (input: AppShortcutInput) => AppCommandId | null;
 }
 
 interface HostScopedRequestArgs<TRequest> {
   hostWindow: DesktopBrowserHostWindow;
+  rendererWebContentsId?: number;
   request: TRequest;
 }
 
 interface HostScopedTabArgs {
   hostWindow: DesktopBrowserHostWindow;
+  rendererWebContentsId?: number;
   tabId: string;
 }
 
 interface CreateEntryArgs {
   desiredBounds: BbDesktopBrowserViewBounds;
   hostWindow: DesktopBrowserHostWindow;
+  rendererWebContentsId: number;
   tabId: string;
 }
 
@@ -188,21 +200,30 @@ export interface DesktopBrowserViewManager {
    * already torn down by the time `closed` fires.
    */
   releaseWindow(hostWebContentsId: number): void;
+  releaseRenderer(rendererWebContentsId: number): void;
+  setRendererActive(rendererWebContentsId: number, active: boolean): void;
   destroyAll(): void;
 }
 
 function browserViewKey(
   hostWindow: DesktopBrowserHostWindow,
   tabId: string,
+  rendererWebContentsId = hostWindow.webContents.id,
 ): string {
-  return `${hostWindow.webContents.id}:${tabId}`;
+  return `${rendererWebContentsId}:${tabId}`;
 }
 
 function send(
+  sendToRenderer: CreateDesktopBrowserViewManagerArgs["sendToRenderer"],
   hostWindow: DesktopBrowserHostWindow,
+  rendererWebContentsId: number,
   channel: string,
   payload: DesktopBrowserHostWebContentsPayload,
 ): void {
+  if (sendToRenderer !== undefined) {
+    sendToRenderer(rendererWebContentsId, channel, payload);
+    return;
+  }
   if (hostWindow.isDestroyed() || hostWindow.webContents.isDestroyed()) {
     return;
   }
@@ -320,6 +341,7 @@ export function createDesktopBrowserViewManager(
   const partition = args.partition ?? BB_BROWSER_PARTITION;
   const entries = new Map<string, BrowserViewEntry>();
   const entriesByWebContentsId = new Map<number, BrowserViewEntry>();
+  const inactiveRendererIds = new Set<number>();
   // Host webContents ids with a native resize burst in flight: views of these
   // windows stay hidden regardless of renderer-declared visibility.
   const resizingHostIds = new Set<number>();
@@ -336,7 +358,11 @@ export function createDesktopBrowserViewManager(
     if (entry.view.webContents.isDestroyed()) {
       return;
     }
-    entry.view.setVisible(entry.visible && !isHostResizing(hostWindow));
+    entry.view.setVisible(
+      entry.visible &&
+        !inactiveRendererIds.has(entry.rendererWebContentsId) &&
+        !isHostResizing(hostWindow),
+    );
   }
 
   /**
@@ -362,10 +388,13 @@ export function createDesktopBrowserViewManager(
         const dataUrl = `data:image/jpeg;base64,${image
           .toJPEG(RESIZE_SNAPSHOT_JPEG_QUALITY)
           .toString("base64")}`;
-        send(hostWindow, BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL, {
-          tabId,
-          dataUrl,
-        });
+        send(
+          args.sendToRenderer,
+          hostWindow,
+          entry.rendererWebContentsId,
+          BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
+          { tabId, dataUrl },
+        );
       })
       .catch(() => {
         // No placeholder; the renderer's bare panel background shows instead.
@@ -436,14 +465,19 @@ export function createDesktopBrowserViewManager(
 
   function pushState(
     hostWindow: DesktopBrowserHostWindow,
+    rendererWebContentsId: number,
     tabId: string,
   ): void {
-    const entry = entries.get(browserViewKey(hostWindow, tabId));
+    const entry = entries.get(
+      browserViewKey(hostWindow, tabId, rendererWebContentsId),
+    );
     if (!entry || entry.view.webContents.isDestroyed()) {
       return;
     }
     send(
+      args.sendToRenderer,
       hostWindow,
+      rendererWebContentsId,
       BB_DESKTOP_BROWSER_STATE_CHANNEL,
       buildBrowserState(tabId, entry),
     );
@@ -457,11 +491,7 @@ export function createDesktopBrowserViewManager(
     const webContents = entry.view.webContents;
 
     webContents.on("before-input-event", (event, input) => {
-      if (
-        input.type !== "keyDown" ||
-        input.isAutoRepeat ||
-        input.isComposing
-      ) {
+      if (input.type !== "keyDown" || input.isAutoRepeat || input.isComposing) {
         return;
       }
       const command = args.resolveAppCommand({
@@ -517,13 +547,20 @@ export function createDesktopBrowserViewManager(
         });
         entry.popupTimestamps = decision.timestamps;
         if (decision.allowed) {
-          send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
-            url: openTabUrl,
-          });
-          send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
-            tabId,
-            url: openTabUrl,
-          });
+          send(
+            args.sendToRenderer,
+            hostWindow,
+            entry.rendererWebContentsId,
+            BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,
+            { url: openTabUrl },
+          );
+          send(
+            args.sendToRenderer,
+            hostWindow,
+            entry.rendererWebContentsId,
+            BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL,
+            { tabId, url: openTabUrl },
+          );
         }
       }
       return { action: "deny" };
@@ -561,7 +598,8 @@ export function createDesktopBrowserViewManager(
       menu.popup();
     });
 
-    const refresh = () => pushState(hostWindow, tabId);
+    const refresh = () =>
+      pushState(hostWindow, entry.rendererWebContentsId, tabId);
     webContents.on("did-start-loading", refresh);
     webContents.on("did-stop-loading", refresh);
     webContents.on("did-navigate", (_event, url) => {
@@ -614,15 +652,22 @@ export function createDesktopBrowserViewManager(
     });
     const entry: BrowserViewEntry = {
       view,
+      hostWindow: args.hostWindow,
+      hostWebContentsId: args.hostWindow.webContents.id,
       lastErrorText: null,
       currentMainFrameLocalOriginKey: null,
       desiredBounds: args.desiredBounds,
       popupTimestamps: [],
+      rendererWebContentsId: args.rendererWebContentsId,
+      tabId: args.tabId,
       visible: false,
     };
     wireWebContents(args.hostWindow, args.tabId, entry);
     args.hostWindow.contentView.addChildView(view);
-    entries.set(browserViewKey(args.hostWindow, args.tabId), entry);
+    entries.set(
+      browserViewKey(args.hostWindow, args.tabId, args.rendererWebContentsId),
+      entry,
+    );
     entriesByWebContentsId.set(view.webContents.id, entry);
     return entry;
   }
@@ -666,7 +711,9 @@ export function createDesktopBrowserViewManager(
     args: HostScopedTabArgs,
     fn: (entry: BrowserViewEntry) => void,
   ): void {
-    const entry = entries.get(browserViewKey(args.hostWindow, args.tabId));
+    const entry = entries.get(
+      browserViewKey(args.hostWindow, args.tabId, args.rendererWebContentsId),
+    );
     if (!entry || entry.view.webContents.isDestroyed()) {
       return;
     }
@@ -674,8 +721,16 @@ export function createDesktopBrowserViewManager(
   }
 
   return {
-    attach({ hostWindow, request }) {
-      const key = browserViewKey(hostWindow, request.tabId);
+    attach({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      request,
+    }) {
+      const key = browserViewKey(
+        hostWindow,
+        request.tabId,
+        rendererWebContentsId,
+      );
       const existing = entries.get(key) ?? null;
       // A freshly-created entry starts hidden, so its prior visibility is false.
       const wasVisible = existing?.visible ?? false;
@@ -684,6 +739,7 @@ export function createDesktopBrowserViewManager(
         createEntry({
           desiredBounds: request.bounds,
           hostWindow,
+          rendererWebContentsId,
           tabId: request.tabId,
         });
       setEntryDesiredBounds({ bounds: request.bounds, entry, hostWindow });
@@ -695,80 +751,129 @@ export function createDesktopBrowserViewManager(
       if (
         request.visible &&
         !wasVisible &&
+        !inactiveRendererIds.has(rendererWebContentsId) &&
         !entry.view.webContents.isDestroyed()
       ) {
         entry.view.webContents.focus();
       }
       loadIfNeeded(entry, request.url);
-      pushState(hostWindow, request.tabId);
+      pushState(hostWindow, rendererWebContentsId, request.tabId);
     },
-    detach({ hostWindow, tabId }) {
-      destroyEntry(hostWindow, browserViewKey(hostWindow, tabId));
+    detach({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      tabId,
+    }) {
+      destroyEntry(
+        hostWindow,
+        browserViewKey(hostWindow, tabId, rendererWebContentsId),
+      );
     },
-    navigate({ hostWindow, request }) {
-      withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
-        loadIfNeeded(entry, request.url);
-      });
+    navigate({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      request,
+    }) {
+      withEntry(
+        { hostWindow, rendererWebContentsId, tabId: request.tabId },
+        (entry) => {
+          loadIfNeeded(entry, request.url);
+        },
+      );
     },
-    goBack({ hostWindow, tabId }) {
-      withEntry({ hostWindow, tabId }, (entry) => {
+    goBack({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      tabId,
+    }) {
+      withEntry({ hostWindow, rendererWebContentsId, tabId }, (entry) => {
         if (entry.view.webContents.navigationHistory.canGoBack()) {
           entry.view.webContents.navigationHistory.goBack();
         }
       });
     },
-    goForward({ hostWindow, tabId }) {
-      withEntry({ hostWindow, tabId }, (entry) => {
+    goForward({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      tabId,
+    }) {
+      withEntry({ hostWindow, rendererWebContentsId, tabId }, (entry) => {
         if (entry.view.webContents.navigationHistory.canGoForward()) {
           entry.view.webContents.navigationHistory.goForward();
         }
       });
     },
-    reload({ hostWindow, tabId }) {
-      withEntry({ hostWindow, tabId }, (entry) => {
+    reload({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      tabId,
+    }) {
+      withEntry({ hostWindow, rendererWebContentsId, tabId }, (entry) => {
         entry.view.webContents.reload();
       });
     },
-    stop({ hostWindow, tabId }) {
-      withEntry({ hostWindow, tabId }, (entry) => {
+    stop({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      tabId,
+    }) {
+      withEntry({ hostWindow, rendererWebContentsId, tabId }, (entry) => {
         entry.view.webContents.stop();
       });
     },
-    setBounds({ hostWindow, request }) {
-      withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
-        setEntryDesiredBounds({ bounds: request.bounds, entry, hostWindow });
-      });
+    setBounds({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      request,
+    }) {
+      withEntry(
+        { hostWindow, rendererWebContentsId, tabId: request.tabId },
+        (entry) => {
+          setEntryDesiredBounds({ bounds: request.bounds, entry, hostWindow });
+        },
+      );
     },
-    setVisible({ hostWindow, request }) {
-      withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
-        const wasVisible = entry.visible;
-        entry.visible = request.visible;
-        applyEntryVisibility(entry, hostWindow);
-        // Focus the view only on a real not-visible → visible transition so the
-        // Edit-menu copy/cut/paste roles and Cmd+C target this view's
-        // webContents (the focused one). Skip redundant re-syncs so we never
-        // yank focus away from the React address bar mid-interaction.
-        if (
-          request.visible &&
-          !wasVisible &&
-          !entry.view.webContents.isDestroyed()
-        ) {
-          entry.view.webContents.focus();
-        }
-      });
+    setVisible({
+      hostWindow,
+      rendererWebContentsId = hostWindow.webContents.id,
+      request,
+    }) {
+      withEntry(
+        { hostWindow, rendererWebContentsId, tabId: request.tabId },
+        (entry) => {
+          const wasVisible = entry.visible;
+          entry.visible = request.visible;
+          applyEntryVisibility(entry, hostWindow);
+          // Focus the view only on a real not-visible → visible transition so the
+          // Edit-menu copy/cut/paste roles and Cmd+C target this view's
+          // webContents (the focused one). Skip redundant re-syncs so we never
+          // yank focus away from the React address bar mid-interaction.
+          if (
+            request.visible &&
+            !wasVisible &&
+            !inactiveRendererIds.has(rendererWebContentsId) &&
+            !entry.view.webContents.isDestroyed()
+          ) {
+            entry.view.webContents.focus();
+          }
+        },
+      );
     },
     beginWindowResize(hostWindow) {
       if (isHostResizing(hostWindow)) {
         return;
       }
       resizingHostIds.add(hostWindow.webContents.id);
-      const prefix = `${hostWindow.webContents.id}:`;
-      for (const [key, entry] of entries.entries()) {
-        if (!key.startsWith(prefix) || entry.view.webContents.isDestroyed()) {
+      for (const entry of entries.values()) {
+        if (
+          entry.hostWebContentsId !== hostWindow.webContents.id ||
+          inactiveRendererIds.has(entry.rendererWebContentsId) ||
+          entry.view.webContents.isDestroyed()
+        ) {
           continue;
         }
         if (entry.visible) {
-          startResizeSnapshot(hostWindow, key.slice(prefix.length), entry);
+          startResizeSnapshot(hostWindow, entry.tabId, entry);
         }
       }
     },
@@ -777,38 +882,90 @@ export function createDesktopBrowserViewManager(
         return;
       }
       resizingHostIds.delete(hostWindow.webContents.id);
-      const prefix = `${hostWindow.webContents.id}:`;
-      for (const [key, entry] of entries.entries()) {
-        if (!key.startsWith(prefix) || entry.view.webContents.isDestroyed()) {
+      for (const entry of entries.values()) {
+        if (
+          entry.hostWebContentsId !== hostWindow.webContents.id ||
+          entry.view.webContents.isDestroyed()
+        ) {
           continue;
         }
         if (entry.visible) {
           applyEntryDesiredBounds(entry, hostWindow);
         }
         applyEntryVisibility(entry, hostWindow);
-        send(hostWindow, BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL, {
-          tabId: key.slice(prefix.length),
-          dataUrl: null,
-        });
+        send(
+          args.sendToRenderer,
+          hostWindow,
+          entry.rendererWebContentsId,
+          BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
+          { tabId: entry.tabId, dataUrl: null },
+        );
       }
     },
     releaseWindow(hostWebContentsId) {
       resizingHostIds.delete(hostWebContentsId);
-      const prefix = `${hostWebContentsId}:`;
       for (const [key, entry] of [...entries.entries()]) {
-        if (!key.startsWith(prefix)) {
+        if (entry.hostWebContentsId !== hostWebContentsId) {
           continue;
         }
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);
         clearEntryLocalOriginState(entry);
+        if (!entry.hostWindow.isDestroyed()) {
+          entry.hostWindow.contentView.removeChildView(entry.view);
+        }
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();
         }
       }
     },
+    releaseRenderer(rendererWebContentsId) {
+      inactiveRendererIds.delete(rendererWebContentsId);
+      for (const [key, entry] of [...entries.entries()]) {
+        if (entry.rendererWebContentsId !== rendererWebContentsId) {
+          continue;
+        }
+        entries.delete(key);
+        entriesByWebContentsId.delete(entry.view.webContents.id);
+        clearEntryLocalOriginState(entry);
+        if (!entry.hostWindow.isDestroyed()) {
+          entry.hostWindow.contentView.removeChildView(entry.view);
+        }
+        if (!entry.view.webContents.isDestroyed()) {
+          entry.view.webContents.close();
+        }
+      }
+    },
+    setRendererActive(rendererWebContentsId, active) {
+      if (active) {
+        inactiveRendererIds.delete(rendererWebContentsId);
+      } else {
+        inactiveRendererIds.add(rendererWebContentsId);
+      }
+      let visibleEntry: BrowserViewEntry | null = null;
+      for (const entry of entries.values()) {
+        if (entry.rendererWebContentsId !== rendererWebContentsId) {
+          continue;
+        }
+        entry.view.setVisible(
+          entry.visible &&
+            active &&
+            !resizingHostIds.has(entry.hostWebContentsId),
+        );
+        if (active && entry.visible && visibleEntry === null) {
+          visibleEntry = entry;
+        }
+      }
+      if (
+        visibleEntry !== null &&
+        !visibleEntry.view.webContents.isDestroyed()
+      ) {
+        visibleEntry.view.webContents.focus();
+      }
+    },
     destroyAll() {
       resizingHostIds.clear();
+      inactiveRendererIds.clear();
       for (const [key, entry] of [...entries.entries()]) {
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);

--- a/apps/desktop/src/desktop-reload-shortcut.ts
+++ b/apps/desktop/src/desktop-reload-shortcut.ts
@@ -1,0 +1,29 @@
+export interface DesktopReloadShortcutInput {
+  alt: boolean;
+  control: boolean;
+  isAutoRepeat: boolean;
+  isComposing: boolean;
+  key: string;
+  meta: boolean;
+  shift: boolean;
+  type: string;
+}
+
+export type DesktopReloadShortcut = "reload" | "force-reload";
+
+export function resolveDesktopReloadShortcut(
+  input: DesktopReloadShortcutInput,
+): DesktopReloadShortcut | null {
+  if (
+    input.type !== "keyDown" ||
+    input.isAutoRepeat ||
+    input.isComposing ||
+    input.alt ||
+    input.control ||
+    !input.meta ||
+    input.key.toLowerCase() !== "r"
+  ) {
+    return null;
+  }
+  return input.shift ? "force-reload" : "reload";
+}

--- a/apps/desktop/src/desktop-server-view-cache.ts
+++ b/apps/desktop/src/desktop-server-view-cache.ts
@@ -1,0 +1,275 @@
+import {
+  WebContentsView,
+  type BrowserWindow,
+  type WebContents,
+} from "electron";
+
+export type DesktopServerRendererWebContents = WebContents;
+
+interface ServerViewEntry {
+  serverId: string;
+  view: WebContentsView;
+  webContents: DesktopServerRendererWebContents;
+}
+
+interface WindowCache {
+  activeServerId: string;
+  entries: Map<string, ServerViewEntry>;
+  hostWindow: BrowserWindow;
+  primaryServerId: string;
+}
+
+export interface CreateDesktopServerViewCacheArgs {
+  onRendererCreated(args: {
+    hostWindow: BrowserWindow;
+    serverId: string;
+    webContents: DesktopServerRendererWebContents;
+  }): void;
+  onRendererDestroyed(args: {
+    hostWindow: BrowserWindow;
+    serverId: string;
+    webContentsId: number;
+  }): void;
+  openExternalUrl(url: string): void;
+  preloadPath: string;
+}
+
+export interface ActivateDesktopServerViewArgs {
+  hostWindow: BrowserWindow;
+  serverId: string;
+  url: string;
+}
+
+export interface DesktopServerViewCache {
+  activate(args: ActivateDesktopServerViewArgs): Promise<{
+    previousRendererWebContentsId: number;
+    rendererWebContentsId: number;
+  }>;
+  destroyAll(): void;
+  getActiveWebContents(
+    hostWindow: BrowserWindow,
+  ): DesktopServerRendererWebContents | WebContents;
+  getAllWebContents(hostWindow: BrowserWindow): WebContents[];
+  getHostWindow(webContentsId: number): BrowserWindow | null;
+  registerWindow(args: {
+    hostWindow: BrowserWindow;
+    primaryServerId: string;
+  }): void;
+  reload(hostWindow: BrowserWindow, ignoreCache: boolean): void;
+  removeServer(serverId: string): void;
+}
+
+function fullWindowBounds(hostWindow: BrowserWindow): {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+} {
+  const { height, width } = hostWindow.getContentBounds();
+  return { height, width, x: 0, y: 0 };
+}
+
+async function loadRendererUrl(
+  webContents: DesktopServerRendererWebContents,
+  url: string,
+): Promise<void> {
+  webContents.setZoomFactor(1);
+  try {
+    await webContents.loadURL(url);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("ERR_ABORTED")) {
+      return;
+    }
+    throw error;
+  }
+}
+
+export function createDesktopServerViewCache(
+  args: CreateDesktopServerViewCacheArgs,
+): DesktopServerViewCache {
+  const cachesByWindowId = new Map<number, WindowCache>();
+  const windowByRendererWebContentsId = new Map<number, BrowserWindow>();
+
+  function requireCache(hostWindow: BrowserWindow): WindowCache {
+    const cache = cachesByWindowId.get(hostWindow.id);
+    if (cache === undefined) {
+      throw new Error(`Desktop window ${hostWindow.id} is not registered`);
+    }
+    return cache;
+  }
+
+  function activeWebContents(cache: WindowCache): WebContents {
+    if (cache.activeServerId === cache.primaryServerId) {
+      return cache.hostWindow.webContents;
+    }
+    return (
+      cache.entries.get(cache.activeServerId)?.webContents ??
+      cache.hostWindow.webContents
+    );
+  }
+
+  function destroyEntry(cache: WindowCache, entry: ServerViewEntry): void {
+    cache.entries.delete(entry.serverId);
+    windowByRendererWebContentsId.delete(entry.webContents.id);
+    args.onRendererDestroyed({
+      hostWindow: cache.hostWindow,
+      serverId: entry.serverId,
+      webContentsId: entry.webContents.id,
+    });
+    if (!cache.hostWindow.isDestroyed()) {
+      try {
+        cache.hostWindow.contentView.removeChildView(entry.view);
+      } catch {
+        // The BrowserWindow may already be tearing down its content tree.
+      }
+    }
+    if (!entry.webContents.isDestroyed()) {
+      entry.webContents.close();
+    }
+  }
+
+  function disposeWindow(hostWindow: BrowserWindow): void {
+    const cache = cachesByWindowId.get(hostWindow.id);
+    if (cache === undefined) {
+      return;
+    }
+    cachesByWindowId.delete(hostWindow.id);
+    windowByRendererWebContentsId.delete(hostWindow.webContents.id);
+    for (const entry of [...cache.entries.values()]) {
+      destroyEntry(cache, entry);
+    }
+  }
+
+  return {
+    async activate({ hostWindow, serverId, url }) {
+      const cache = requireCache(hostWindow);
+      const previousRendererWebContentsId = activeWebContents(cache).id;
+
+      if (serverId === cache.primaryServerId) {
+        for (const entry of cache.entries.values()) {
+          entry.view.setVisible(false);
+        }
+        cache.activeServerId = serverId;
+        hostWindow.webContents.focus();
+        return {
+          previousRendererWebContentsId,
+          rendererWebContentsId: hostWindow.webContents.id,
+        };
+      }
+
+      let entry = cache.entries.get(serverId);
+      if (entry !== undefined && entry.webContents.isDestroyed()) {
+        destroyEntry(cache, entry);
+        entry = undefined;
+      }
+      if (entry === undefined) {
+        const view = new WebContentsView({
+          webPreferences: {
+            contextIsolation: true,
+            nodeIntegration: false,
+            preload: args.preloadPath,
+            sandbox: true,
+            spellcheck: true,
+          },
+        });
+        const webContents =
+          view.webContents as DesktopServerRendererWebContents;
+        webContents.session.setSpellCheckerEnabled(true);
+        webContents.setWindowOpenHandler((details) => {
+          args.openExternalUrl(details.url);
+          return { action: "deny" };
+        });
+        view.setBounds(fullWindowBounds(hostWindow));
+        view.setVisible(false);
+        hostWindow.contentView.addChildView(view);
+        entry = { serverId, view, webContents };
+        cache.entries.set(serverId, entry);
+        windowByRendererWebContentsId.set(webContents.id, hostWindow);
+        args.onRendererCreated({ hostWindow, serverId, webContents });
+        try {
+          await loadRendererUrl(webContents, url);
+        } catch (error) {
+          destroyEntry(cache, entry);
+          throw error;
+        }
+      }
+
+      for (const candidate of cache.entries.values()) {
+        candidate.view.setVisible(candidate === entry);
+      }
+      cache.activeServerId = serverId;
+      entry.webContents.focus();
+      return {
+        previousRendererWebContentsId,
+        rendererWebContentsId: entry.webContents.id,
+      };
+    },
+    destroyAll() {
+      for (const cache of [...cachesByWindowId.values()]) {
+        disposeWindow(cache.hostWindow);
+      }
+    },
+    getActiveWebContents(hostWindow) {
+      const cache = cachesByWindowId.get(hostWindow.id);
+      return cache === undefined
+        ? hostWindow.webContents
+        : activeWebContents(cache);
+    },
+    getAllWebContents(hostWindow) {
+      const cache = cachesByWindowId.get(hostWindow.id);
+      if (cache === undefined) {
+        return [hostWindow.webContents];
+      }
+      return [
+        hostWindow.webContents,
+        ...[...cache.entries.values()].map((entry) => entry.webContents),
+      ];
+    },
+    getHostWindow(webContentsId) {
+      return windowByRendererWebContentsId.get(webContentsId) ?? null;
+    },
+    registerWindow({ hostWindow, primaryServerId }) {
+      if (cachesByWindowId.has(hostWindow.id)) {
+        return;
+      }
+      cachesByWindowId.set(hostWindow.id, {
+        activeServerId: primaryServerId,
+        entries: new Map(),
+        hostWindow,
+        primaryServerId,
+      });
+      windowByRendererWebContentsId.set(hostWindow.webContents.id, hostWindow);
+      hostWindow.on("resize", () => {
+        if (hostWindow.isDestroyed()) {
+          return;
+        }
+        const bounds = fullWindowBounds(hostWindow);
+        for (const entry of requireCache(hostWindow).entries.values()) {
+          entry.view.setBounds(bounds);
+        }
+      });
+      hostWindow.once("closed", () => {
+        disposeWindow(hostWindow);
+      });
+    },
+    reload(hostWindow, ignoreCache) {
+      const cache = cachesByWindowId.get(hostWindow.id);
+      const webContents =
+        cache === undefined ? hostWindow.webContents : activeWebContents(cache);
+      if (ignoreCache) {
+        webContents.reloadIgnoringCache();
+        return;
+      }
+      webContents.reload();
+    },
+    removeServer(serverId) {
+      for (const cache of cachesByWindowId.values()) {
+        const entry = cache.entries.get(serverId);
+        if (entry !== undefined) {
+          destroyEntry(cache, entry);
+        }
+      }
+    },
+  };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -15,6 +15,7 @@ import {
   type IpcMainEvent,
   type IpcMainInvokeEvent,
   type WebContents,
+  webContents as electronWebContents,
 } from "electron";
 import { autoUpdater } from "electron-updater";
 import {
@@ -163,6 +164,11 @@ import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
 import { clearPackagedSessionHttpCache } from "./desktop-session-cache.js";
 import {
+  createDesktopServerViewCache,
+  type DesktopServerViewCache,
+} from "./desktop-server-view-cache.js";
+import { resolveDesktopReloadShortcut } from "./desktop-reload-shortcut.js";
+import {
   createPopoutWindowManager,
   type PopoutWindowManager,
 } from "./popout-window.js";
@@ -243,6 +249,7 @@ interface LoadWindowUrlArgs {
 
 interface CreateApplicationWindowArgs {
   initialUrl: string | null;
+  primaryServerId: string;
   stateKey: WindowStateKey | null;
 }
 
@@ -328,6 +335,7 @@ const logViewerCopyRequestSchema = z
 
 let desktopWindowFactory: DesktopWindowFactory | null = null;
 let desktopBrowserViewManager: DesktopBrowserViewManager | null = null;
+let desktopServerViewCache: DesktopServerViewCache | null = null;
 let currentAppKeybindings: AppKeybindings = [];
 let currentApplicationMenuAccelerators = DEFAULT_APPLICATION_MENU_ACCELERATORS;
 let desktopUpdateService: DesktopUpdateService | null = null;
@@ -472,13 +480,89 @@ function getCurrentDesktopInfo(): BbDesktopInfo | null {
   });
 }
 
+function isRegisteredApplicationWindow(browserWindow: BrowserWindow): boolean {
+  return applicationWindowWebContentsIds.has(browserWindow.webContents.id);
+}
+
+function resolveApplicationWindow(
+  webContents: WebContents,
+): BrowserWindow | null {
+  return (
+    desktopServerViewCache?.getHostWindow(webContents.id) ??
+    BrowserWindow.fromWebContents(webContents)
+  );
+}
+
+function sendToActiveApplicationRenderer(
+  browserWindow: BrowserWindow,
+  channel: string,
+  payload: unknown,
+): void {
+  const target =
+    desktopServerViewCache?.getActiveWebContents(browserWindow) ??
+    browserWindow.webContents;
+  if (!target.isDestroyed()) {
+    target.send(channel, payload);
+  }
+}
+
+function sendToAllApplicationRenderers(
+  browserWindow: BrowserWindow,
+  channel: string,
+  payload: unknown,
+): void {
+  const targets = desktopServerViewCache?.getAllWebContents(browserWindow) ?? [
+    browserWindow.webContents,
+  ];
+  for (const target of targets) {
+    if (!target.isDestroyed()) {
+      target.send(channel, payload);
+    }
+  }
+}
+
+function registerApplicationRendererReloadShortcut(
+  browserWindow: BrowserWindow,
+  webContents: WebContents,
+): void {
+  webContents.on("before-input-event", (event, input) => {
+    const shortcut = resolveDesktopReloadShortcut(input);
+    if (shortcut === null) {
+      return;
+    }
+    const cache = desktopServerViewCache;
+    if (
+      cache !== null &&
+      cache.getActiveWebContents(browserWindow).id !== webContents.id
+    ) {
+      return;
+    }
+    event.preventDefault();
+    if (cache !== null) {
+      cache.reload(browserWindow, shortcut === "force-reload");
+    } else if (shortcut === "force-reload") {
+      webContents.reloadIgnoringCache();
+    } else {
+      webContents.reload();
+    }
+  });
+}
+
 function sendDesktopInfoChanged(): void {
   const info = getCurrentDesktopInfo();
   if (info === null) {
     return;
   }
   for (const browserWindow of BrowserWindow.getAllWindows()) {
-    browserWindow.webContents.send(BB_DESKTOP_INFO_CHANGED_CHANNEL, info);
+    if (isRegisteredApplicationWindow(browserWindow)) {
+      sendToAllApplicationRenderers(
+        browserWindow,
+        BB_DESKTOP_INFO_CHANGED_CHANNEL,
+        info,
+      );
+    } else {
+      browserWindow.webContents.send(BB_DESKTOP_INFO_CHANGED_CHANNEL, info);
+    }
   }
 }
 
@@ -493,13 +577,14 @@ function getDesktopWindowState(
 function getSenderDesktopWindowState(
   event: IpcMainInvokeEvent,
 ): BbDesktopWindowState {
-  return getDesktopWindowState(BrowserWindow.fromWebContents(event.sender));
+  return getDesktopWindowState(resolveApplicationWindow(event.sender));
 }
 
 function sendDesktopWindowStateChanged(
   browserWindow: DesktopBrowserWindow,
 ): void {
-  browserWindow.webContents.send(
+  sendToAllApplicationRenderers(
+    browserWindow as BrowserWindow,
     BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
     getDesktopWindowState(browserWindow),
   );
@@ -574,7 +659,9 @@ function shouldEnableServerDaemonLogsMenu(): boolean {
 const pendingCloseWindowRequests = new Map<number, NodeJS.Timeout>();
 
 function requestRendererWindowClose(browserWindow: BrowserWindow): void {
-  const webContentsId = browserWindow.webContents.id;
+  const webContentsId =
+    desktopServerViewCache?.getActiveWebContents(browserWindow).id ??
+    browserWindow.webContents.id;
   const pending = pendingCloseWindowRequests.get(webContentsId);
   if (pending !== undefined) {
     clearTimeout(pending);
@@ -588,7 +675,11 @@ function requestRendererWindowClose(browserWindow: BrowserWindow): void {
       }
     }, CLOSE_WINDOW_REQUEST_TIMEOUT_MS),
   );
-  browserWindow.webContents.send(BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL, null);
+  sendToActiveApplicationRenderer(
+    browserWindow,
+    BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
+    null,
+  );
 }
 
 function closeFocusedDetachedDevTools(): void {
@@ -642,6 +733,10 @@ function resolveInitialUrlForNewWindow(): string | null {
     resolveUrlForServerId(activeServerState.getMostRecentServerId()) ??
     currentWindowUrl
   );
+}
+
+function resolveInitialServerIdForNewWindow(): string {
+  return activeServerState?.getMostRecentServerId() ?? BUILTIN_SERVER_ID;
 }
 
 function buildMenuServerItems(): Array<{
@@ -743,40 +838,56 @@ function installCurrentApplicationMenu(): void {
     createNewWindow() {
       void createApplicationWindow({
         initialUrl: resolveInitialUrlForNewWindow(),
+        primaryServerId: resolveInitialServerIdForNewWindow(),
         stateKey: null,
       });
     },
     openNewTab() {
-      desktopWindowFactory?.sendToFocusedWindow(
-        BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
-        null,
-      );
-      desktopWindowFactory?.sendToFocusedWindow(
-        BB_DESKTOP_APP_COMMAND_CHANNEL,
-        "panel.newTab",
-      );
+      const browserWindow = getFocusedApplicationWindow();
+      if (browserWindow !== null) {
+        sendToActiveApplicationRenderer(
+          browserWindow,
+          BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+          null,
+        );
+        sendToActiveApplicationRenderer(
+          browserWindow,
+          BB_DESKTOP_APP_COMMAND_CHANNEL,
+          "panel.newTab",
+        );
+      }
     },
     openNewThread() {
-      desktopWindowFactory?.sendToFocusedWindow(
-        BB_DESKTOP_APP_COMMAND_CHANNEL,
-        "thread.new",
-      );
+      const browserWindow = getFocusedApplicationWindow();
+      if (browserWindow !== null) {
+        sendToActiveApplicationRenderer(
+          browserWindow,
+          BB_DESKTOP_APP_COMMAND_CHANNEL,
+          "thread.new",
+        );
+      }
     },
     openSettings() {
-      desktopWindowFactory?.sendToFocusedWindow(
-        BB_DESKTOP_APP_COMMAND_CHANNEL,
-        "settings.open",
-      );
+      const browserWindow = getFocusedApplicationWindow();
+      if (browserWindow !== null) {
+        sendToActiveApplicationRenderer(
+          browserWindow,
+          BB_DESKTOP_APP_COMMAND_CHANNEL,
+          "settings.open",
+        );
+      }
     },
     reloadWindow(browserWindow, ignoreCache) {
       if (!(browserWindow instanceof BrowserWindow)) {
         return;
       }
-      if (ignoreCache) {
+      if (desktopServerViewCache !== null) {
+        desktopServerViewCache.reload(browserWindow, ignoreCache);
+      } else if (ignoreCache) {
         browserWindow.webContents.reloadIgnoringCache();
-        return;
+      } else {
+        browserWindow.webContents.reload();
       }
-      browserWindow.webContents.reload();
     },
     closeWindowOrSideTab(browserWindow) {
       if (browserWindow === undefined) {
@@ -1081,14 +1192,22 @@ function startSystemConfigSync(serverUrl: string): void {
   void refreshSystemConfig({ serverUrl });
 }
 
-function registerApplicationWindow(browserWindow: DesktopBrowserWindow): void {
+function registerApplicationWindow(
+  browserWindow: DesktopBrowserWindow,
+  primaryServerId: string,
+): void {
   const webContentsId = browserWindow.webContents.id;
   applicationWindowWebContentsIds.add(webContentsId);
+  desktopServerViewCache?.registerWindow({
+    hostWindow: browserWindow as BrowserWindow,
+    primaryServerId,
+  });
+  registerApplicationRendererReloadShortcut(
+    browserWindow as BrowserWindow,
+    (browserWindow as BrowserWindow).webContents,
+  );
   if (activeServerState !== null) {
-    activeServerState.setActiveServerId(
-      browserWindow.id,
-      activeServerState.getMostRecentServerId(),
-    );
+    activeServerState.setActiveServerId(browserWindow.id, primaryServerId);
   }
   registerDesktopContextMenu({ webContents: browserWindow.webContents });
   browserWindow.on("enter-full-screen", () => {
@@ -1107,9 +1226,12 @@ async function loadUrlInApplicationWindow(args: {
   browserWindow: BrowserWindow;
   url: string;
 }): Promise<void> {
-  args.browserWindow.webContents.setZoomFactor(1);
+  const webContents =
+    desktopServerViewCache?.getActiveWebContents(args.browserWindow) ??
+    args.browserWindow.webContents;
+  webContents.setZoomFactor(1);
   try {
-    await args.browserWindow.loadURL(args.url);
+    await webContents.loadURL(args.url);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("ERR_ABORTED")) {
@@ -1208,7 +1330,11 @@ function sendServersChangedToWindow(browserWindow: {
   const servers = buildServerListEntries({
     activeServerId: activeServerState.getActiveServerId(browserWindow.id),
   });
-  browserWindow.webContents.send(BB_DESKTOP_SERVERS_CHANGED_CHANNEL, servers);
+  sendToAllApplicationRenderers(
+    browserWindow as BrowserWindow,
+    BB_DESKTOP_SERVERS_CHANGED_CHANNEL,
+    servers,
+  );
 }
 
 function sendServersChanged(): void {
@@ -1275,6 +1401,7 @@ async function setActiveServerForWindow(
   if (server === null) {
     return;
   }
+  let targetUrl: string;
 
   if (server.source === "builtin") {
     const attached = await ensureBuiltinRuntimeAttached();
@@ -1296,7 +1423,7 @@ async function setActiveServerForWindow(
       sendServersChanged();
       return;
     }
-    const url = resolveDesktopWindowUrl({
+    targetUrl = resolveDesktopWindowUrl({
       env: process.env,
       serverUrl: server.url,
     });
@@ -1313,14 +1440,7 @@ async function setActiveServerForWindow(
         popoutWindowUrl = localUrl;
       }
     }
-    currentWindowUrl = url;
-    await loadUrlInApplicationWindow({
-      browserWindow: args.browserWindow,
-      url,
-    });
-    if (shouldOpenDevTools()) {
-      args.browserWindow.webContents.openDevTools({ mode: "detach" });
-    }
+    currentWindowUrl = targetUrl;
   } else {
     // Remote servers are pure web loads. Owned local runtime keeps running.
     if (server.source === "connect") {
@@ -1376,11 +1496,39 @@ async function setActiveServerForWindow(
         return;
       }
     }
-    currentWindowUrl = server.url;
+    targetUrl = server.url;
+  }
+
+  if (desktopServerViewCache !== null) {
+    const activation = await desktopServerViewCache.activate({
+      hostWindow: args.browserWindow,
+      serverId: server.id,
+      url: targetUrl,
+    });
+    if (
+      activation.previousRendererWebContentsId !==
+      activation.rendererWebContentsId
+    ) {
+      desktopBrowserViewManager?.setRendererActive(
+        activation.previousRendererWebContentsId,
+        false,
+      );
+      desktopBrowserViewManager?.setRendererActive(
+        activation.rendererWebContentsId,
+        true,
+      );
+    }
+  } else {
     await loadUrlInApplicationWindow({
       browserWindow: args.browserWindow,
-      url: server.url,
+      url: targetUrl,
     });
+  }
+  currentWindowUrl = targetUrl;
+  if (shouldOpenDevTools()) {
+    desktopServerViewCache
+      ?.getActiveWebContents(args.browserWindow)
+      .openDevTools({ mode: "detach" });
   }
 
   activeServerState.setActiveServerId(args.browserWindow.id, server.id);
@@ -1399,7 +1547,7 @@ function registerDesktopServerIpc(): void {
     scheduleServerAttentionRefresh();
     // Soft-trigger connect sync when the last attempt is older than 60s.
     connectServerSync?.onListRequested();
-    const browserWindow = BrowserWindow.fromWebContents(event.sender);
+    const browserWindow = resolveApplicationWindow(event.sender);
     const activeServerId =
       browserWindow === null || activeServerState === null
         ? BUILTIN_SERVER_ID
@@ -1478,6 +1626,7 @@ function registerDesktopServerIpc(): void {
     }
     remoteServerStatuses.delete(parsed.data.id);
     serverAttentionStates.delete(parsed.data.id);
+    desktopServerViewCache?.removeServer(parsed.data.id);
     // Windows pointing at the removed server fall back to the builtin entry.
     for (const browserWindow of BrowserWindow.getAllWindows()) {
       if (
@@ -1538,7 +1687,7 @@ function registerDesktopServerIpc(): void {
       if (!parsed.success) {
         return;
       }
-      const browserWindow = BrowserWindow.fromWebContents(event.sender);
+      const browserWindow = resolveApplicationWindow(event.sender);
       if (browserWindow === null) {
         return;
       }
@@ -1610,7 +1759,11 @@ function registerDesktopServerIpc(): void {
 }
 
 function isApplicationWindowSender(webContents: WebContents): boolean {
-  return applicationWindowWebContentsIds.has(webContents.id);
+  return (
+    applicationWindowWebContentsIds.has(webContents.id) ||
+    (desktopServerViewCache !== null &&
+      desktopServerViewCache.getHostWindow(webContents.id) !== null)
+  );
 }
 
 function isPopoutWindowSender(webContents: WebContents): boolean {
@@ -1663,14 +1816,16 @@ async function openPopoutThreadInMain(
     return false;
   }
   const path = getDesktopThreadRoutePath(thread);
-  if (
-    desktopWindowFactory.sendToFirstWindow(
+  const firstWindow = BrowserWindow.getAllWindows().find((browserWindow) =>
+    isRegisteredApplicationWindow(browserWindow),
+  );
+  if (firstWindow !== undefined) {
+    sendToActiveApplicationRenderer(
+      firstWindow,
       BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,
-      {
-        url: path,
-      },
-    )
-  ) {
+      { url: path },
+    );
+    firstWindow.focus();
     return true;
   }
   const url = getWindowUrlForRoute(path);
@@ -1679,6 +1834,7 @@ async function openPopoutThreadInMain(
   }
   const browserWindow = await createApplicationWindow({
     initialUrl: url,
+    primaryServerId: BUILTIN_SERVER_ID,
     stateKey: null,
   });
   return browserWindow !== null;
@@ -1899,7 +2055,7 @@ async function createApplicationWindow(
     initialUrl: args.initialUrl,
     stateKey: args.stateKey,
   });
-  registerApplicationWindow(browserWindow);
+  registerApplicationWindow(browserWindow, args.primaryServerId);
   if (bbAppLoaded && shouldOpenDevTools()) {
     browserWindow.webContents.openDevTools({ mode: "detach" });
   }
@@ -1947,6 +2103,7 @@ async function finishQuit(): Promise<void> {
   desktopUpdateService?.stop();
   desktopAutoUpdateService?.stop();
   desktopBrowserViewManager?.destroyAll();
+  desktopServerViewCache?.destroyAll();
   await desktopWindowFactory?.persistOpenWindows();
   await stopOwnedRuntime();
 }
@@ -1997,7 +2154,7 @@ function registerDesktopUpdateIpc(): void {
       pendingCloseWindowRequests.delete(event.sender.id);
     }
     if (payload === false) {
-      BrowserWindow.fromWebContents(event.sender)?.close();
+      resolveApplicationWindow(event.sender)?.close();
     }
   });
   // The in-app browser tab hands off the current address to the system
@@ -2339,6 +2496,7 @@ async function runDesktopApp(): Promise<void> {
     }
     void createApplicationWindow({
       initialUrl: resolveInitialUrlForNewWindow(),
+      primaryServerId: resolveInitialServerIdForNewWindow(),
       stateKey: null,
     });
   });
@@ -2352,6 +2510,7 @@ async function runDesktopApp(): Promise<void> {
     if (desktopWindowFactory?.hasOpenWindows() === false) {
       void createApplicationWindow({
         initialUrl: resolveInitialUrlForNewWindow(),
+        primaryServerId: resolveInitialServerIdForNewWindow(),
         stateKey: null,
       });
     }
@@ -2480,6 +2639,22 @@ async function runDesktopApp(): Promise<void> {
   registerDesktopUpdateIpc();
   registerDesktopServerIpc();
   registerPopoutIpc();
+  desktopServerViewCache = createDesktopServerViewCache({
+    onRendererCreated({ hostWindow, webContents }) {
+      applicationWindowWebContentsIds.add(webContents.id);
+      registerDesktopContextMenu({ webContents });
+      registerApplicationRendererReloadShortcut(hostWindow, webContents);
+      desktopBrowserViewManager?.setRendererActive(webContents.id, false);
+    },
+    onRendererDestroyed({ webContentsId }) {
+      applicationWindowWebContentsIds.delete(webContentsId);
+      desktopBrowserViewManager?.releaseRenderer(webContentsId);
+    },
+    openExternalUrl(url) {
+      void shell.openExternal(url);
+    },
+    preloadPath,
+  });
   desktopBrowserViewManager = createDesktopBrowserViewManager({
     dispatchAppCommand({ command, hostWebContentsId }) {
       const browserWindow = BrowserWindow.getAllWindows().find(
@@ -2488,13 +2663,25 @@ async function runDesktopApp(): Promise<void> {
       if (browserWindow === undefined) {
         return;
       }
-      browserWindow.webContents.send(BB_DESKTOP_APP_COMMAND_CHANNEL, command);
+      sendToActiveApplicationRenderer(
+        browserWindow,
+        BB_DESKTOP_APP_COMMAND_CHANNEL,
+        command,
+      );
     },
     focusHostWebContents(hostWebContentsId) {
       const browserWindow = BrowserWindow.getAllWindows().find(
         (candidate) => candidate.webContents.id === hostWebContentsId,
       );
-      browserWindow?.webContents.focus();
+      if (browserWindow !== undefined) {
+        desktopServerViewCache?.getActiveWebContents(browserWindow).focus();
+      }
+    },
+    sendToRenderer(rendererWebContentsId, channel, payload) {
+      const target = electronWebContents.fromId(rendererWebContentsId);
+      if (target !== undefined && !target.isDestroyed()) {
+        target.send(channel, payload);
+      }
     },
     resolveAppCommand(input) {
       return resolveDesktopBrowserAppCommand({
@@ -2504,7 +2691,11 @@ async function runDesktopApp(): Promise<void> {
       });
     },
   });
-  registerDesktopBrowserIpc(desktopBrowserViewManager);
+  registerDesktopBrowserIpc(
+    desktopBrowserViewManager,
+    (webContentsId) =>
+      desktopServerViewCache?.getHostWindow(webContentsId) ?? null,
+  );
   desktopUpdateService.start();
   desktopAutoUpdateService.start();
 
@@ -2539,7 +2730,7 @@ async function runDesktopApp(): Promise<void> {
     initialUrl: currentWindowUrl,
   });
   for (const browserWindow of restoredWindows) {
-    registerApplicationWindow(browserWindow);
+    registerApplicationWindow(browserWindow, BUILTIN_SERVER_ID);
   }
   await initializeRuntime({ bridgePath, serverUrl, userDataPath });
 }

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -14,6 +14,8 @@ export const CLOSE_WINDOW_MENU_LABEL = "Close Window";
 export const OPEN_SETTINGS_MENU_LABEL = "Settings…";
 export const TOGGLE_DEVELOPER_TOOLS_MENU_LABEL = "Toggle Developer Tools";
 export const TOGGLE_DEVELOPER_TOOLS_ACCELERATOR = "Command+Option+I";
+export const RELOAD_ACCELERATOR = "CommandOrControl+R";
+export const FORCE_RELOAD_ACCELERATOR = "CommandOrControl+Shift+R";
 export const SERVER_MENU_LABEL = "Server";
 
 export interface ApplicationMenuServerItem {
@@ -34,10 +36,7 @@ export interface InstallApplicationMenuArgs {
   closeWindowOrSideTab(browserWindow: BaseWindow | undefined): void;
   createNewWindow(): void;
   openServerDaemonLogs(): void;
-  selectServer(
-    serverId: string,
-    browserWindow: BaseWindow | undefined,
-  ): void;
+  selectServer(serverId: string, browserWindow: BaseWindow | undefined): void;
   serverDaemonLogsMenuEnabled: boolean;
   servers: ApplicationMenuServerItem[];
 }
@@ -163,13 +162,17 @@ export function buildApplicationMenuTemplate(
       label: "View",
       submenu: [
         {
+          accelerator: RELOAD_ACCELERATOR,
           label: "Reload",
+          registerAccelerator: false,
           click(_menuItem, browserWindow) {
             args.reloadWindow(browserWindow, false);
           },
         },
         {
+          accelerator: FORCE_RELOAD_ACCELERATOR,
           label: "Force Reload",
+          registerAccelerator: false,
           click(_menuItem, browserWindow) {
             args.reloadWindow(browserWindow, true);
           },

--- a/apps/desktop/test/desktop-browser-main-ipc.test.ts
+++ b/apps/desktop/test/desktop-browser-main-ipc.test.ts
@@ -1,3 +1,4 @@
+import type { BrowserWindow } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
@@ -98,9 +99,14 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
   public readonly goForwardCalls: TabCommandCall[] = [];
   public readonly navigateCalls: NavigateCall[] = [];
   public readonly releaseWindowCalls: number[] = [];
+  public readonly releaseRendererCalls: number[] = [];
   public readonly reloadCalls: TabCommandCall[] = [];
   public readonly setBoundsCalls: SetBoundsCall[] = [];
   public readonly setVisibleCalls: SetVisibleCall[] = [];
+  public readonly setRendererActiveCalls: Array<{
+    active: boolean;
+    rendererWebContentsId: number;
+  }> = [];
   public readonly stopCalls: TabCommandCall[] = [];
 
   attach(args: AttachCall): void {
@@ -139,6 +145,10 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
     this.releaseWindowCalls.push(hostWebContentsId);
   }
 
+  releaseRenderer(rendererWebContentsId: number): void {
+    this.releaseRendererCalls.push(rendererWebContentsId);
+  }
+
   reload(args: TabCommandCall): void {
     this.reloadCalls.push(args);
   }
@@ -149,6 +159,10 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
 
   setVisible(args: SetVisibleCall): void {
     this.setVisibleCalls.push(args);
+  }
+
+  setRendererActive(rendererWebContentsId: number, active: boolean): void {
+    this.setRendererActiveCalls.push({ active, rendererWebContentsId });
   }
 
   stop(args: TabCommandCall): void {
@@ -192,6 +206,37 @@ function oversizedBrowserUrl(): string {
 }
 
 describe("registerDesktopBrowserIpc", () => {
+  it("routes commands from cached child renderers to their host window", () => {
+    const manager = new RecordingDesktopBrowserViewManager();
+    const cachedRenderer = createUntrustedSender();
+    const hostWindow = {
+      label: "cached-host-window",
+    } as unknown as BrowserWindow;
+    registerDesktopBrowserIpc(manager, (webContentsId) =>
+      webContentsId === cachedRenderer.id ? hostWindow : null,
+    );
+    const attachRequest: BbDesktopBrowserAttachRequest = {
+      tabId: "browser:cached",
+      url: "https://example.com/",
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+      visible: true,
+    };
+
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
+      payload: attachRequest,
+      sender: cachedRenderer,
+    });
+
+    expect(manager.attachCalls).toEqual([
+      {
+        hostWindow,
+        rendererWebContentsId: cachedRenderer.id,
+        request: attachRequest,
+      },
+    ]);
+  });
+
   it("dispatches valid browser commands only from BrowserWindow-owned senders", () => {
     const manager = new RecordingDesktopBrowserViewManager();
     registerDesktopBrowserIpc(manager);
@@ -231,12 +276,22 @@ describe("registerDesktopBrowserIpc", () => {
 
     expect(manager.attachCalls).toHaveLength(1);
     expect(manager.attachCalls[0]?.hostWindow).toBe(renderer.hostWindow);
+    expect(manager.attachCalls[0]?.rendererWebContentsId).toBe(
+      renderer.sender.id,
+    );
     expect(manager.attachCalls[0]?.request).toEqual(attachRequest);
     expect(manager.navigateCalls).toHaveLength(1);
     expect(manager.navigateCalls[0]?.hostWindow).toBe(renderer.hostWindow);
+    expect(manager.navigateCalls[0]?.rendererWebContentsId).toBe(
+      renderer.sender.id,
+    );
     expect(manager.navigateCalls[0]?.request).toEqual(navigateRequest);
     expect(manager.reloadCalls).toEqual([
-      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        tabId: "browser:a",
+      },
     ]);
   });
 
@@ -353,22 +408,46 @@ describe("registerDesktopBrowserIpc", () => {
     });
 
     expect(manager.setBoundsCalls).toEqual([
-      { hostWindow: renderer.hostWindow, request: boundsRequest },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        request: boundsRequest,
+      },
     ]);
     expect(manager.setVisibleCalls).toEqual([
-      { hostWindow: renderer.hostWindow, request: visibleRequest },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        request: visibleRequest,
+      },
     ]);
     expect(manager.detachCalls).toEqual([
-      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        tabId: "browser:a",
+      },
     ]);
     expect(manager.goBackCalls).toEqual([
-      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        tabId: "browser:a",
+      },
     ]);
     expect(manager.goForwardCalls).toEqual([
-      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        tabId: "browser:a",
+      },
     ]);
     expect(manager.stopCalls).toEqual([
-      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+      {
+        hostWindow: renderer.hostWindow,
+        rendererWebContentsId: renderer.sender.id,
+        tabId: "browser:a",
+      },
     ]);
   });
 });

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -360,7 +360,9 @@ const electronMock = vi.hoisted(() => {
       }
     }
 
-    emitBeforeInput(input: Partial<FakeInput> & Pick<FakeInput, "key">): boolean {
+    emitBeforeInput(
+      input: Partial<FakeInput> & Pick<FakeInput, "key">,
+    ): boolean {
       const event = new FakePreventableEventImpl();
       const resolvedInput: FakeInput = {
         alt: false,
@@ -696,11 +698,58 @@ function scopedOpenTabPushesOf(
 }
 
 describe("DesktopBrowserViewManager", () => {
+  it("isolates native browser tabs by cached server renderer", () => {
+    const sendToRenderer = vi.fn();
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+      sendToRenderer,
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 49,
+    });
+    const request = {
+      tabId: "browser:a",
+      url: "https://example.com",
+      bounds: { x: 100, y: 50, width: 500, height: 350 },
+      visible: true,
+    };
+
+    manager.attach({
+      hostWindow,
+      rendererWebContentsId: 501,
+      request,
+    });
+    manager.attach({
+      hostWindow,
+      rendererWebContentsId: 502,
+      request,
+    });
+    manager.setRendererActive(501, false);
+
+    expect(electronMock.fakeViews).toHaveLength(2);
+    expect(requireFakeView(0).visible).toBe(false);
+    expect(requireFakeView(1).visible).toBe(true);
+    expect(sendToRenderer).toHaveBeenCalledWith(
+      501,
+      expect.any(String),
+      expect.objectContaining({ tabId: "browser:a" }),
+    );
+    expect(sendToRenderer).toHaveBeenCalledWith(
+      502,
+      expect.any(String),
+      expect.objectContaining({ tabId: "browser:a" }),
+    );
+  });
+
   it("forwards resolved browser shortcuts and suppresses the untrusted page", () => {
     const dispatchAppCommand = vi.fn();
     const focusHostWebContents = vi.fn();
-    const resolveAppCommand = vi.fn((input: { key: string; metaKey: boolean }) =>
-      input.key === "l" && input.metaKey ? "browser.focusLocation" as const : null,
+    const resolveAppCommand = vi.fn(
+      (input: { key: string; metaKey: boolean }) =>
+        input.key === "l" && input.metaKey
+          ? ("browser.focusLocation" as const)
+          : null,
     );
     const manager = createDesktopBrowserViewManager({
       dispatchAppCommand,
@@ -846,9 +895,7 @@ describe("DesktopBrowserViewManager", () => {
         webContentsId: view.webContents.id,
       }),
     ).toBe(true);
-    expect(view.webContents.emitWillNavigate("http://192.168.1.1/")).toBe(
-      true,
-    );
+    expect(view.webContents.emitWillNavigate("http://192.168.1.1/")).toBe(true);
   });
 
   it("allows unattributed loopback main-frame requests with matching tabs", () => {
@@ -1409,9 +1456,11 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual({
-      action: "deny",
-    });
+    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual(
+      {
+        action: "deny",
+      },
+    );
     expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
     expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
       {

--- a/apps/desktop/test/desktop-reload-shortcut.test.ts
+++ b/apps/desktop/test/desktop-reload-shortcut.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveDesktopReloadShortcut } from "../src/desktop-reload-shortcut.js";
+
+function input(
+  overrides: Partial<Parameters<typeof resolveDesktopReloadShortcut>[0]> = {},
+): Parameters<typeof resolveDesktopReloadShortcut>[0] {
+  return {
+    alt: false,
+    control: false,
+    isAutoRepeat: false,
+    isComposing: false,
+    key: "r",
+    meta: true,
+    shift: false,
+    type: "keyDown",
+    ...overrides,
+  };
+}
+
+describe("resolveDesktopReloadShortcut", () => {
+  it("maps Cmd+R and Cmd+Shift+R to reload actions", () => {
+    expect(resolveDesktopReloadShortcut(input())).toBe("reload");
+    expect(resolveDesktopReloadShortcut(input({ shift: true }))).toBe(
+      "force-reload",
+    );
+  });
+
+  it("ignores unrelated, repeated, and composing input", () => {
+    expect(resolveDesktopReloadShortcut(input({ key: "x" }))).toBeNull();
+    expect(resolveDesktopReloadShortcut(input({ meta: false }))).toBeNull();
+    expect(resolveDesktopReloadShortcut(input({ alt: true }))).toBeNull();
+    expect(
+      resolveDesktopReloadShortcut(input({ isAutoRepeat: true })),
+    ).toBeNull();
+    expect(
+      resolveDesktopReloadShortcut(input({ isComposing: true })),
+    ).toBeNull();
+    expect(resolveDesktopReloadShortcut(input({ type: "keyUp" }))).toBeNull();
+  });
+});

--- a/apps/desktop/test/desktop-server-view-cache.test.ts
+++ b/apps/desktop/test/desktop-server-view-cache.test.ts
@@ -1,0 +1,250 @@
+import type { BrowserWindow } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDesktopServerViewCache } from "../src/desktop-server-view-cache.js";
+
+const electronMock = vi.hoisted(() => {
+  let nextWebContentsId = 100;
+
+  class FakeWebContents {
+    public closed = false;
+    public focused = false;
+    public readonly id = nextWebContentsId++;
+    public readonly loadedUrls: string[] = [];
+    public reloadCount = 0;
+    public reloadIgnoringCacheCount = 0;
+    public readonly session = {
+      setSpellCheckerEnabled: vi.fn(),
+    };
+    public zoomFactor = 0;
+
+    close(): void {
+      this.closed = true;
+    }
+
+    focus(): void {
+      this.focused = true;
+    }
+
+    getURL(): string {
+      return this.loadedUrls.at(-1) ?? "";
+    }
+
+    isDestroyed(): boolean {
+      return this.closed;
+    }
+
+    loadURL(url: string): Promise<void> {
+      this.loadedUrls.push(url);
+      return Promise.resolve();
+    }
+
+    openDevTools(): void {}
+    reload(): void {
+      this.reloadCount += 1;
+    }
+    reloadIgnoringCache(): void {
+      this.reloadIgnoringCacheCount += 1;
+    }
+    send(): void {}
+    setWindowOpenHandler(): void {}
+    setZoomFactor(factor: number): void {
+      this.zoomFactor = factor;
+    }
+  }
+
+  class FakeWebContentsView {
+    public readonly bounds: Array<{
+      height: number;
+      width: number;
+      x: number;
+      y: number;
+    }> = [];
+    public readonly webContents = new FakeWebContents();
+    public readonly visibility: boolean[] = [];
+
+    setBounds(bounds: {
+      height: number;
+      width: number;
+      x: number;
+      y: number;
+    }): void {
+      this.bounds.push(bounds);
+    }
+
+    setVisible(visible: boolean): void {
+      this.visibility.push(visible);
+    }
+  }
+
+  return {
+    FakeWebContents,
+    FakeWebContentsView,
+    reset() {
+      nextWebContentsId = 100;
+    },
+    views: [] as FakeWebContentsView[],
+  };
+});
+
+vi.mock("electron", () => ({
+  WebContentsView: class extends electronMock.FakeWebContentsView {
+    constructor() {
+      super();
+      electronMock.views.push(this);
+    }
+  },
+}));
+
+class FakeHostWindow {
+  public readonly contentView = {
+    addChildView: vi.fn(),
+    removeChildView: vi.fn(),
+  };
+  public readonly id: number;
+  public readonly webContents = new electronMock.FakeWebContents();
+  private contentBounds = { height: 700, width: 1000 };
+  private destroyed = false;
+  private readonly listeners = new Map<string, Array<() => void>>();
+
+  constructor(id: number) {
+    this.id = id;
+  }
+
+  emit(eventName: string): void {
+    for (const listener of this.listeners.get(eventName) ?? []) {
+      listener();
+    }
+  }
+
+  getContentBounds(): { height: number; width: number } {
+    return this.contentBounds;
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  on(eventName: string, listener: () => void): void {
+    const listeners = this.listeners.get(eventName) ?? [];
+    listeners.push(listener);
+    this.listeners.set(eventName, listeners);
+  }
+
+  once(eventName: string, listener: () => void): void {
+    this.on(eventName, listener);
+  }
+
+  resize(width: number, height: number): void {
+    this.contentBounds = { height, width };
+    this.emit("resize");
+  }
+}
+
+function asBrowserWindow(hostWindow: FakeHostWindow): BrowserWindow {
+  return hostWindow as unknown as BrowserWindow;
+}
+
+beforeEach(() => {
+  electronMock.reset();
+  electronMock.views.length = 0;
+});
+
+describe("DesktopServerViewCache", () => {
+  it("loads each server renderer once and restores it on later switches", async () => {
+    const created = vi.fn();
+    const destroyed = vi.fn();
+    const hostWindow = new FakeHostWindow(1);
+    const browserWindow = asBrowserWindow(hostWindow);
+    const cache = createDesktopServerViewCache({
+      onRendererCreated: created,
+      onRendererDestroyed: destroyed,
+      openExternalUrl: vi.fn(),
+      preloadPath: "/tmp/preload.cjs",
+    });
+    cache.registerWindow({
+      hostWindow: browserWindow,
+      primaryServerId: "local",
+    });
+
+    const firstRemote = await cache.activate({
+      hostWindow: browserWindow,
+      serverId: "remote",
+      url: "https://remote.example.test/",
+    });
+    await electronMock.views[0]?.webContents.loadURL(
+      "https://remote.example.test/thread/thr_123",
+    );
+    await cache.activate({
+      hostWindow: browserWindow,
+      serverId: "local",
+      url: "http://127.0.0.1:38886/",
+    });
+    const restoredRemote = await cache.activate({
+      hostWindow: browserWindow,
+      serverId: "remote",
+      url: "https://remote.example.test/",
+    });
+    cache.reload(browserWindow, false);
+    cache.reload(browserWindow, true);
+
+    expect(electronMock.views).toHaveLength(1);
+    expect(electronMock.views[0]?.webContents.loadedUrls).toEqual([
+      "https://remote.example.test/",
+      "https://remote.example.test/thread/thr_123",
+    ]);
+    expect(electronMock.views[0]?.webContents.getURL()).toBe(
+      "https://remote.example.test/thread/thr_123",
+    );
+    expect(electronMock.views[0]?.webContents.reloadCount).toBe(1);
+    expect(electronMock.views[0]?.webContents.reloadIgnoringCacheCount).toBe(1);
+    expect(restoredRemote.rendererWebContentsId).toBe(
+      firstRemote.rendererWebContentsId,
+    );
+    expect(electronMock.views[0]?.visibility).toEqual([
+      false,
+      true,
+      false,
+      true,
+    ]);
+    expect(created).toHaveBeenCalledTimes(1);
+    expect(destroyed).not.toHaveBeenCalled();
+  });
+
+  it("keeps cached views sized to the host and disposes removed servers", async () => {
+    const destroyed = vi.fn();
+    const hostWindow = new FakeHostWindow(2);
+    const browserWindow = asBrowserWindow(hostWindow);
+    const cache = createDesktopServerViewCache({
+      onRendererCreated: vi.fn(),
+      onRendererDestroyed: destroyed,
+      openExternalUrl: vi.fn(),
+      preloadPath: "/tmp/preload.cjs",
+    });
+    cache.registerWindow({
+      hostWindow: browserWindow,
+      primaryServerId: "local",
+    });
+    const activation = await cache.activate({
+      hostWindow: browserWindow,
+      serverId: "remote",
+      url: "https://remote.example.test/",
+    });
+
+    hostWindow.resize(820, 540);
+    cache.removeServer("remote");
+
+    expect(electronMock.views[0]?.bounds).toEqual([
+      { height: 700, width: 1000, x: 0, y: 0 },
+      { height: 540, width: 820, x: 0, y: 0 },
+    ]);
+    expect(electronMock.views[0]?.webContents.closed).toBe(true);
+    expect(destroyed).toHaveBeenCalledWith({
+      hostWindow: browserWindow,
+      serverId: "remote",
+      webContentsId: activation.rendererWebContentsId,
+    });
+    expect(cache.getActiveWebContents(browserWindow)).toBe(
+      hostWindow.webContents,
+    );
+  });
+});

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -32,15 +32,13 @@ function menuArgs(
     reloadWindow,
     selectServer: () => {},
     serverDaemonLogsMenuEnabled: false,
-    servers: [
-      { checked: true, id: "builtin-local", name: "This Mac" },
-    ],
+    servers: [{ checked: true, id: "builtin-local", name: "This Mac" }],
     ...overrides,
   };
 }
 
 describe("application menu", () => {
-  it("keeps reload menu actions click-only so app command chords do not collide", () => {
+  it("shows reload shortcuts without globally stealing browser commands", () => {
     const reloadWindow = vi.fn();
     const template = buildApplicationMenuTemplate(menuArgs(reloadWindow));
     const viewMenu = template.find((item) => item.label === "View");
@@ -49,8 +47,10 @@ describe("application menu", () => {
     const forceReload = submenu.find((item) => item.label === "Force Reload");
     const focusedWindow = {} as BaseWindow;
 
-    expect(reload?.accelerator).toBeUndefined();
-    expect(forceReload?.accelerator).toBeUndefined();
+    expect(reload?.accelerator).toBe("CommandOrControl+R");
+    expect(reload?.registerAccelerator).toBe(false);
+    expect(forceReload?.accelerator).toBe("CommandOrControl+Shift+R");
+    expect(forceReload?.registerAccelerator).toBe(false);
     reload?.click?.({} as never, focusedWindow, {} as never);
     forceReload?.click?.({} as never, focusedWindow, {} as never);
     expect(reloadWindow).toHaveBeenNthCalledWith(1, focusedWindow, false);


### PR DESCRIPTION
## Summary

- keep one live renderer per visited desktop server so switching preserves navigation and UI state
- scope native browser views and desktop IPC to the owning cached renderer, with cleanup when servers or windows close
- make Cmd+R reload the active server and Cmd+Shift+R force-reload it
- inherit tooltip foreground color so server URL/status text stays readable across themes

## Test plan

- `pnpm exec turbo run typecheck test --filter=@bb/app --filter=@bb/desktop --force`
- `pnpm exec turbo run build --filter=@bb/desktop`
- signed production package plus `pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force`

## Risk

Cached renderers intentionally retain their server connection and state until the server is removed or the desktop window closes.