### PR TITLE
Fix file preview refresh

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -125,6 +125,46 @@ describe("FilePreview", () => {
     vi.useRealTimers();
   });
 
+  it("offers a manual file refresh action", () => {
+    const onRefresh = vi.fn();
+
+    render(
+      <FilePreview
+        path="README.md"
+        onRefresh={onRefresh}
+        state={{
+          kind: "ready",
+          file: { name: "README.md", contents: "# Preview" },
+          lineRange: null,
+          textPreviewKind: "markdown",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh file" }));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("disables the manual refresh action while a refresh is running", () => {
+    render(
+      <FilePreview
+        path="README.md"
+        onRefresh={() => undefined}
+        isRefreshing
+        state={{ kind: "loading" }}
+      />,
+    );
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Refreshing file",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
   it("rerenders the code view when the Pierre worker pool advances", async () => {
     render(
       <FilePreview

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -87,6 +87,8 @@ export interface FilePreviewProps {
   headerMode?: FilePreviewHeaderMode;
   onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
   markdownLinkRouting?: MarkdownLinkRouting;
   statusLabel?: WorkspaceFilePreviewStatusLabel | null;
 }
@@ -112,6 +114,8 @@ interface FilePreviewHeaderProps {
   copyPath: string | null;
   rawContents: string | null;
   onOpenInEditor?: (path: string) => void;
+  onRefresh?: () => void;
+  isRefreshing: boolean;
   statusLabel: WorkspaceFilePreviewStatusLabel | null;
   toggleKind: FilePreviewToggleKind | null;
   showLineOverflowToggle: boolean;
@@ -430,6 +434,8 @@ export function FilePreview({
   headerMode = "file",
   onSelectionAddToChat,
   onOpenInEditor,
+  onRefresh,
+  isRefreshing = false,
   markdownLinkRouting,
   statusLabel = null,
 }: FilePreviewProps) {
@@ -503,6 +509,8 @@ export function FilePreview({
           copyPath={copyPath}
           rawContents={rawContents}
           onOpenInEditor={onOpenInEditor}
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
           statusLabel={statusLabel}
           toggleKind={toggleKind}
           showLineOverflowToggle={showLineOverflowToggle}
@@ -608,6 +616,8 @@ function FilePreviewHeader({
   copyPath,
   rawContents,
   onOpenInEditor,
+  onRefresh,
+  isRefreshing,
   statusLabel,
   toggleKind,
   showLineOverflowToggle,
@@ -643,6 +653,35 @@ function FilePreviewHeader({
             </span>
           )}
           <TooltipProvider delayDuration={300}>
+            {onRefresh ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
+                      "shrink-0 text-muted-foreground hover:bg-state-hover hover:text-foreground",
+                    )}
+                    onClick={onRefresh}
+                    disabled={isRefreshing}
+                    aria-label={
+                      isRefreshing ? "Refreshing file" : "Refresh file"
+                    }
+                  >
+                    <Icon
+                      name={isRefreshing ? "Spinner" : "RotateCcw"}
+                      className={cn(isRefreshing && "animate-spin")}
+                      aria-hidden
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {isRefreshing ? "Refreshing file" : "Refresh file"}
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
             {rawContents === null ? null : (
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -318,7 +318,9 @@ export function WorkspaceFilePreviewTabContent({
   const {
     data: workspaceFilePreview,
     error: workspaceFilePreviewError,
+    isFetching: isWorkspaceFilePreviewFetching,
     isLoading: isWorkspaceFilePreviewLoading,
+    refetch: refetchWorkspaceFilePreview,
   } = useEnvironmentFilePreview(environmentId, activePath, source);
 
   return (
@@ -333,10 +335,12 @@ export function WorkspaceFilePreviewTabContent({
           : null
       }
       isLoading={isWorkspaceFilePreviewLoading}
+      isRefreshing={isWorkspaceFilePreviewFetching}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
+      onRefresh={() => void refetchWorkspaceFilePreview()}
       statusLabel={statusLabel}
     />
   );
@@ -353,7 +357,9 @@ export function ProjectFilePreviewTabContent({
   const {
     data: projectFilePreview,
     error: projectFilePreviewError,
+    isFetching: isProjectFilePreviewFetching,
     isLoading: isProjectFilePreviewLoading,
+    refetch: refetchProjectFilePreview,
   } = useProjectFilePreview(projectId, activePath);
 
   return (
@@ -363,9 +369,11 @@ export function ProjectFilePreviewTabContent({
       error={projectFilePreviewError}
       filePreview={projectFilePreview}
       isLoading={isProjectFilePreviewLoading}
+      isRefreshing={isProjectFilePreviewFetching}
       lineRange={lineRange}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
+      onRefresh={() => void refetchProjectFilePreview()}
       statusLabel={null}
     />
   );
@@ -384,7 +392,9 @@ export function HostFilePreviewTabContent({
   const {
     data: hostFilePreview,
     error: hostFilePreviewError,
+    isFetching: isHostFilePreviewFetching,
     isLoading: isHostFilePreviewLoading,
+    refetch: refetchHostFilePreview,
   } = useThreadHostFilePreview(threadId, environmentId, activePath);
 
   return (
@@ -395,10 +405,12 @@ export function HostFilePreviewTabContent({
       filePreview={hostFilePreview}
       htmlPreviewUrl={buildRawFilesystemHtmlContentUrl(threadId, activePath)}
       isLoading={isHostFilePreviewLoading}
+      isRefreshing={isHostFilePreviewFetching}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
+      onRefresh={() => void refetchHostFilePreview()}
       statusLabel={null}
     />
   );
@@ -416,7 +428,9 @@ export function ThreadStorageFilePreviewTabContent({
   const {
     data: threadStorageFilePreview,
     error: threadStorageFilePreviewError,
+    isFetching: isThreadStorageFilePreviewFetching,
     isLoading: isThreadStorageFilePreviewLoading,
+    refetch: refetchThreadStorageFilePreview,
   } = useThreadStorageFilePreview(threadId, activePath);
 
   return (
@@ -426,10 +440,12 @@ export function ThreadStorageFilePreviewTabContent({
       error={threadStorageFilePreviewError}
       filePreview={threadStorageFilePreview}
       isLoading={isThreadStorageFilePreviewLoading}
+      isRefreshing={isThreadStorageFilePreviewFetching}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
+      onRefresh={() => void refetchThreadStorageFilePreview()}
       threadId={threadId}
     />
   );

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -29,10 +29,12 @@ interface FilePreviewBaseProps {
   error?: Error | null;
   filePreview: FilePreview | undefined;
   isLoading: boolean;
+  isRefreshing?: boolean;
   lineRange?: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
   onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
+  onRefresh?: () => void;
 }
 
 interface ThreadStorageFilePreviewProps extends FilePreviewBaseProps {
@@ -103,10 +105,12 @@ export function SecondaryPanelFilePreview({
   filePreview,
   htmlPreviewUrl = null,
   isLoading,
+  isRefreshing = false,
   lineRange = null,
   markdownLinkRouting,
   onSelectionAddToChat,
   onOpenInEditor,
+  onRefresh,
   statusLabel = null,
 }: SecondaryPanelFilePreviewProps) {
   if (error) {
@@ -117,6 +121,8 @@ export function SecondaryPanelFilePreview({
         copyPath={copyPath}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
         statusLabel={statusLabel}
         state={{ kind: isNotFound ? "not-found" : "error" }}
       />
@@ -130,6 +136,8 @@ export function SecondaryPanelFilePreview({
         copyPath={copyPath}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
         statusLabel={statusLabel}
         state={{ kind: "loading" }}
       />
@@ -144,6 +152,8 @@ export function SecondaryPanelFilePreview({
           copyPath={copyPath}
           onSelectionAddToChat={onSelectionAddToChat}
           onOpenInEditor={onOpenInEditor}
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
           statusLabel={statusLabel}
           state={{
             kind: "iframe",
@@ -161,6 +171,8 @@ export function SecondaryPanelFilePreview({
         copyPath={copyPath}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
         statusLabel={statusLabel}
         state={{
           kind: "html",
@@ -184,6 +196,8 @@ export function SecondaryPanelFilePreview({
           copyPath={copyPath}
           onSelectionAddToChat={onSelectionAddToChat}
           onOpenInEditor={onOpenInEditor}
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
           statusLabel={statusLabel}
           state={{ kind: "empty" }}
         />
@@ -195,6 +209,8 @@ export function SecondaryPanelFilePreview({
         copyPath={copyPath}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
         markdownLinkRouting={markdownLinkRouting}
         statusLabel={statusLabel}
         state={{
@@ -214,6 +230,8 @@ export function SecondaryPanelFilePreview({
         copyPath={copyPath}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
         statusLabel={statusLabel}
         state={{ kind: "image", url: filePreview.url }}
       />
@@ -227,6 +245,8 @@ export function SecondaryPanelFilePreview({
         copyPath={copyPath}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
         statusLabel={statusLabel}
         state={{ kind: "video", url: filePreview.url }}
       />
@@ -239,6 +259,8 @@ export function SecondaryPanelFilePreview({
       copyPath={copyPath}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
+      onRefresh={onRefresh}
+      isRefreshing={isRefreshing}
       statusLabel={statusLabel}
       state={{
         kind: "error",
@@ -254,10 +276,12 @@ export function ThreadStorageFilePreview({
   error,
   filePreview,
   isLoading,
+  isRefreshing,
   lineRange,
   markdownLinkRouting,
   onSelectionAddToChat,
   onOpenInEditor,
+  onRefresh,
   threadId,
 }: ThreadStorageFilePreviewProps) {
   return (
@@ -268,10 +292,12 @@ export function ThreadStorageFilePreview({
       filePreview={filePreview}
       htmlPreviewUrl={buildThreadStorageRawContentUrl(threadId, activePath)}
       isLoading={isLoading}
+      isRefreshing={isRefreshing}
       lineRange={lineRange}
       markdownLinkRouting={markdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
+      onRefresh={onRefresh}
     />
   );
 }

--- a/apps/host-daemon/src/watch-manager.test.ts
+++ b/apps/host-daemon/src/watch-manager.test.ts
@@ -216,7 +216,7 @@ describe("WatchManager", () => {
     expect(stopWatchingStatus).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses workspace change notifications when the local fingerprint is unchanged", async () => {
+  it("reports workspace content changes when the local fingerprint is unchanged", async () => {
     let watchWorkspaceArgs: WatchWorkspaceArgs | undefined;
     const workspace = createFakeWorkspace("/tmp/env-watch");
     const { hostWatcher } = createFakeHostWatcher({
@@ -249,6 +249,51 @@ describe("WatchManager", () => {
     watchWorkspaceArgs?.onChange({
       changedPaths: ["/tmp/env-watch/README.md"],
       changeKinds: ["workspace-content-changed"],
+      kind: "workspace-status-changed",
+      environmentId: "env-watch",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onWorkspaceStatusChanged).toHaveBeenCalledWith({
+      changeKinds: ["work-status-changed"],
+      environmentId: "env-watch",
+    });
+  });
+
+  it("suppresses git metadata notifications when the local fingerprint is unchanged", async () => {
+    let watchWorkspaceArgs: WatchWorkspaceArgs | undefined;
+    const workspace = createFakeWorkspace("/tmp/env-watch");
+    const { hostWatcher } = createFakeHostWatcher({
+      watchWorkspaceImplementation: (args) => {
+        watchWorkspaceArgs = args;
+        return () => undefined;
+      },
+    });
+    const onWorkspaceStatusChanged = vi.fn();
+    const manager = new WatchManager({
+      hostWatcher,
+      provisionWorkspace: vi.fn(async () => workspace),
+      onWorkspaceStatusChanged,
+    });
+
+    await manager.replaceWatchSet({
+      generation: 1,
+      workspaceTargets: [
+        {
+          environmentId: "env-watch",
+          workspaceContext: {
+            workspacePath: "/tmp/env-watch",
+            workspaceProvisionType: "unmanaged",
+          },
+        },
+      ],
+      threadStorageTargets: [],
+    });
+
+    watchWorkspaceArgs?.onChange({
+      changedPaths: ["/tmp/env-watch/.git/index"],
+      changeKinds: ["workspace-git-changed"],
       kind: "workspace-status-changed",
       environmentId: "env-watch",
     });

--- a/apps/host-daemon/src/watch-manager.ts
+++ b/apps/host-daemon/src/watch-manager.ts
@@ -334,7 +334,15 @@ export class WatchManager {
       if (workspaceWatchKindsIncludeLocalState(pendingKinds)) {
         const nextLocalFingerprint =
           await args.workspace.getLocalStateFingerprint();
+        // A real workspace file event must reach live content consumers even
+        // when the git-status summary is unchanged. For example, replacing one
+        // line with another repeatedly produces the same path/status/numstat
+        // fingerprint, but open file previews and diffs still need to refetch.
+        const workspaceContentChanged = pendingKinds.includes(
+          "workspace-content-changed",
+        );
         if (
+          workspaceContentChanged ||
           args.workspaceWatchState.lastLocalFingerprint !== nextLocalFingerprint
         ) {
           args.workspaceWatchState.lastLocalFingerprint = nextLocalFingerprint;


### PR DESCRIPTION
## Summary
- emit workspace change notifications for content edits even when Git status fingerprints are unchanged
- add a manual refresh button with loading state to file preview headers
- support manual refresh for workspace, project, host, and thread-storage previews

## Tests
- `pnpm exec turbo run test --filter=@bb/host-daemon --force`
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/secondary-panel/FilePreview.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`

Closes #615