### PR TITLE
Add Simple Notes composer mentions

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -894,8 +894,20 @@ describe("PromptBoxInternal mention triggers", () => {
     providerLabel: "GitHub issues",
     title: "#42 Fix login bug",
     subtitle: "owner/repo",
+    icon: null,
     replacement: "#42 Fix login bug",
   };
+
+  it("renders a plugin mention's named icon hint", async () => {
+    const suggestion = { ...githubIssueSuggestion, icon: "FileText" };
+    const { promptBoxRef } = renderPromptBox("@fix", {
+      mentionSuggestions: [suggestion],
+    });
+
+    await focusPromptEnd(promptBoxRef);
+    const row = await screen.findByRole("button", { name: /Fix login bug/u });
+    expect(row.querySelector('[data-icon="FileText"]')).not.toBeNull();
+  });
 
   it("reports hash mention queries with the active trigger", async () => {
     const { onMentionQueryChange, promptBoxRef } = renderPromptBox("#42", {

--- a/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
+++ b/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
@@ -267,7 +267,7 @@ function getMentionIcon(item: PromptMentionSuggestion): ReactNode {
     return (
       <PluginIcon
         pluginId={item.pluginId}
-        icon={null}
+        icon={item.icon}
         className={ROW_ICON_CLASS}
       />
     );

--- a/apps/app/src/components/promptbox/mentions/Mentions.stories.tsx
+++ b/apps/app/src/components/promptbox/mentions/Mentions.stories.tsx
@@ -192,6 +192,7 @@ const pluginMentionSuggestions: PromptMentionSuggestion[] = [
     providerLabel: "Linear issues",
     title: "Fix login bug",
     subtitle: "In progress",
+    icon: null,
     replacement: "Fix login bug",
   },
   {
@@ -202,6 +203,7 @@ const pluginMentionSuggestions: PromptMentionSuggestion[] = [
     providerLabel: "Linear issues",
     title: "Ship mention providers end-to-end",
     subtitle: "Todo",
+    icon: null,
     replacement: "Ship mention providers end-to-end",
   },
   {
@@ -212,6 +214,7 @@ const pluginMentionSuggestions: PromptMentionSuggestion[] = [
     providerLabel: "Linear docs",
     title: "Onboarding guide",
     subtitle: null,
+    icon: null,
     replacement: "Onboarding guide",
   },
   // A DIFFERENT plugin whose provider label collides with linear's "Linear
@@ -225,6 +228,7 @@ const pluginMentionSuggestions: PromptMentionSuggestion[] = [
     providerLabel: "Linear issues",
     title: "Mirrored triage sweep",
     subtitle: "Mirror",
+    icon: null,
     replacement: "Mirrored triage sweep",
   },
 ];

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -57,6 +57,8 @@ export type PromptMentionSuggestion =
       providerLabel: string;
       title: string;
       subtitle: string | null;
+      /** Named shared-UI icon hint supplied by the plugin item. */
+      icon: string | null;
       replacement: string;
     };
 

--- a/apps/app/src/hooks/pluginMentionSuggestions.test.ts
+++ b/apps/app/src/hooks/pluginMentionSuggestions.test.ts
@@ -12,7 +12,7 @@ const GROUPS: PluginMentionSearchGroup[] = [
         itemId: "issues:ISS-42",
         title: "Fix login bug",
         subtitle: "In progress",
-        icon: null,
+        icon: "FileText",
       },
       {
         itemId: "issues:ISS-43",
@@ -48,6 +48,7 @@ describe("buildPluginMentionSuggestions", () => {
         providerLabel: "Linear issues",
         title: "Fix login bug",
         subtitle: "In progress",
+        icon: "FileText",
         replacement: "Fix login bug",
       },
       {
@@ -58,6 +59,7 @@ describe("buildPluginMentionSuggestions", () => {
         providerLabel: "Linear issues",
         title: "Ship mention providers",
         subtitle: null,
+        icon: null,
         replacement: "Ship mention providers",
       },
       {
@@ -68,6 +70,7 @@ describe("buildPluginMentionSuggestions", () => {
         providerLabel: "Docs",
         title: "Onboarding",
         subtitle: null,
+        icon: null,
         replacement: "Onboarding",
       },
     ]);

--- a/apps/app/src/hooks/pluginMentionSuggestions.ts
+++ b/apps/app/src/hooks/pluginMentionSuggestions.ts
@@ -24,6 +24,7 @@ export function buildPluginMentionSuggestions(
         providerLabel: group.label,
         title,
         subtitle: item.subtitle,
+        icon: item.icon,
         replacement: title,
       });
     }

--- a/examples/plugins/simple-notes/README.md
+++ b/examples/plugins/simple-notes/README.md
@@ -16,6 +16,9 @@ from the installed notes plugin used in bb.
   version of the first markdown line.
 - **Markdown todos**: typing `[ ]`, `[x]`, or `- [ ]` creates task-list
   checkboxes in the rich editor.
+- **Chat mentions**: typing `@` in the composer searches note titles,
+  previews, and filenames. The selected note resolves to its latest content
+  when the message is sent.
 
 Install from a bb checkout:
 

--- a/examples/plugins/simple-notes/server.test.ts
+++ b/examples/plugins/simple-notes/server.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import simpleNotes from "./server";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function loadNotebook(notes: Record<string, string>) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "bb-simple-notes-"));
+  temporaryDirectories.push(directory);
+  await Promise.all(
+    Object.entries(notes).map(([name, content]) =>
+      writeFile(path.join(directory, name), content),
+    ),
+  );
+  const host = createFakePluginHost({
+    pluginId: "simple-notes",
+    settings: { directory },
+    sdk: {
+      files: {
+        read: async ({ path: filePath }) => ({
+          content: await readFile(filePath, "utf8"),
+          sha256: "test-sha",
+        }),
+      },
+    },
+  });
+  await simpleNotes(host.bb);
+  return host;
+}
+
+describe("simple notes mention provider", () => {
+  it("searches note titles, previews, and filenames", async () => {
+    const { harness } = await loadNotebook({
+      "roadmap.md": "# Product Roadmap\n\nQuarterly priorities",
+      "meeting-notes.md": "# Standup\n\nLaunch checklist",
+    });
+    const provider = harness.registrations.mentionProviders[0]!;
+
+    expect(provider).toMatchObject({
+      id: "note",
+      label: "Simple Notes",
+      triggers: ["@"],
+    });
+    await expect(
+      provider.search({
+        trigger: "@",
+        query: "launch",
+        projectId: null,
+        threadId: null,
+      }),
+    ).resolves.toEqual([
+      {
+        id: "meeting-notes.md",
+        title: "Standup",
+        subtitle: "Launch checklist",
+        icon: "FileText",
+      },
+    ]);
+  });
+
+  it("resolves the note's current content at send time", async () => {
+    const { harness } = await loadNotebook({
+      "ideas.md": "# Fresh Ideas\n\nBuild the mention flow.",
+    });
+    const provider = harness.registrations.mentionProviders[0]!;
+
+    await expect(provider.resolve("ideas.md")).resolves.toEqual({
+      context:
+        'Simple Note "Fresh Ideas" (ideas.md):\n\n# Fresh Ideas\n\nBuild the mention flow.',
+    });
+    expect(harness.sdk.callsTo("files.read")).toEqual([
+      [
+        {
+          path: path.join(temporaryDirectories[0]!, "ideas.md"),
+          rootPath: temporaryDirectories[0],
+        },
+      ],
+    ]);
+  });
+});

--- a/examples/plugins/simple-notes/server.ts
+++ b/examples/plugins/simple-notes/server.ts
@@ -126,6 +126,46 @@ export default async function plugin(bb: BbPluginApi) {
     );
   }
 
+  async function listNoteSummaries(): Promise<{
+    root: string;
+    notes: NoteSummary[];
+    error: string | null;
+  }> {
+    const root = await getRoot();
+    let entries;
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch (error) {
+      return {
+        root,
+        notes: [],
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    const notes: NoteSummary[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !/\.md$/i.test(entry.name)) continue;
+      const full = path.join(root, entry.name);
+      try {
+        const [info, content] = await Promise.all([
+          stat(full),
+          readFile(full, "utf8"),
+        ]);
+        const title = deriveTitle(content, entry.name.replace(/\.md$/i, ""));
+        notes.push({
+          path: entry.name,
+          title,
+          preview: derivePreview(content, title),
+          modifiedAtMs: info.mtimeMs,
+        });
+      } catch {
+        // Skip files that vanish or can't be read mid-listing.
+      }
+    }
+    notes.sort((a, b) => b.modifiedAtMs - a.modifiedAtMs);
+    return { root, notes, error: null };
+  }
+
   // --- rpc ------------------------------------------------------------------
 
   bb.rpc.register({
@@ -134,39 +174,7 @@ export default async function plugin(bb: BbPluginApi) {
       notes: NoteSummary[];
       error: string | null;
     }> {
-      const root = await getRoot();
-      let entries;
-      try {
-        entries = await readdir(root, { withFileTypes: true });
-      } catch (error) {
-        return {
-          root,
-          notes: [],
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-      const notes: NoteSummary[] = [];
-      for (const entry of entries) {
-        if (!entry.isFile() || !/\.md$/i.test(entry.name)) continue;
-        const full = path.join(root, entry.name);
-        try {
-          const [info, content] = await Promise.all([
-            stat(full),
-            readFile(full, "utf8"),
-          ]);
-          const title = deriveTitle(content, entry.name.replace(/\.md$/i, ""));
-          notes.push({
-            path: entry.name,
-            title,
-            preview: derivePreview(content, title),
-            modifiedAtMs: info.mtimeMs,
-          });
-        } catch {
-          // Skip files that vanish or can't be read mid-listing.
-        }
-      }
-      notes.sort((a, b) => b.modifiedAtMs - a.modifiedAtMs);
-      return { root, notes, error: null };
+      return listNoteSummaries();
     },
 
     async readNote(input: { path?: unknown }) {
@@ -271,6 +279,44 @@ export default async function plugin(bb: BbPluginApi) {
       }
       await rename(path.join(root, name), path.join(root, desired));
       return { path: desired };
+    },
+  });
+
+  // --- @ mentions -----------------------------------------------------------
+
+  bb.ui.registerMentionProvider({
+    id: "note",
+    label: "Simple Notes",
+    async search({ query }) {
+      const needle = query.trim().toLowerCase();
+      const { notes } = await listNoteSummaries();
+      return notes
+        .filter(
+          (note) =>
+            needle.length === 0 ||
+            note.title.toLowerCase().includes(needle) ||
+            note.preview.toLowerCase().includes(needle) ||
+            note.path.toLowerCase().includes(needle),
+        )
+        .slice(0, 25)
+        .map((note) => ({
+          id: note.path,
+          title: note.title,
+          subtitle: note.preview || note.path,
+          icon: "FileText",
+        }));
+    },
+    async resolve(itemId) {
+      const root = await getRoot();
+      const name = requireNoteName(itemId);
+      const file = await bb.sdk.files.read({
+        path: path.join(root, name),
+        rootPath: root,
+      });
+      const title = deriveTitle(file.content, name.replace(/\.md$/i, ""));
+      return {
+        context: `Simple Note "${title}" (${name}):\n\n${file.content}`,
+      };
     },
   });
 }


### PR DESCRIPTION
## Summary
- register Simple Notes as an @ mention provider
- search note titles, previews, and filenames, resolving fresh content at send time
- preserve plugin-provided icon hints so note results use the existing FileText UI icon

## Testing
- pnpm exec turbo run test typecheck --filter=@bb/app --filter=bb-plugin-simple-notes --force
- verified the locally reinstalled provider returns FileText and no plugin logo