### PR TITLE
Soften icon shimmer animation

### DIFF
--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -761,25 +761,25 @@ body.sidebar-resizing [data-sidebar="panel"] {
   /*
    * Icon counterpart to `.animate-shine`: `background-clip: text` only shimmers
    * glyphs, so for an SVG icon we sweep the same bright band as a mask instead
-   * (the icon dims to ~45% at the edges with a full-opacity band moving across),
-   * matching the "Thinking..." text shimmer.
+   * (the icon retains 45% opacity at the edges with a full-opacity band moving
+   * across). The longer cycle keeps this small status cue from pulling focus.
    */
   .animate-shine-icon {
     -webkit-mask-image: linear-gradient(
       90deg,
-      rgba(0, 0, 0, 0.15) 0%,
+      rgba(0, 0, 0, 0.45) 0%,
       rgba(0, 0, 0, 1) 50%,
-      rgba(0, 0, 0, 0.15) 100%
+      rgba(0, 0, 0, 0.45) 100%
     );
     mask-image: linear-gradient(
       90deg,
-      rgba(0, 0, 0, 0.15) 0%,
+      rgba(0, 0, 0, 0.45) 0%,
       rgba(0, 0, 0, 1) 50%,
-      rgba(0, 0, 0, 0.15) 100%
+      rgba(0, 0, 0, 0.45) 100%
     );
     -webkit-mask-size: 200% 100%;
     mask-size: 200% 100%;
-    animation: shine-mask 2s linear infinite;
+    animation: shine-mask 2.6s linear infinite;
   }
 
   /* Empty-state bb mark: a clean foreground-colored silhouette. Its parent

--- a/apps/web/src/components/ui/theme.css
+++ b/apps/web/src/components/ui/theme.css
@@ -756,25 +756,25 @@ body.sidebar-resizing [data-sidebar="panel"] {
   /*
    * Icon counterpart to `.animate-shine`: `background-clip: text` only shimmers
    * glyphs, so for an SVG icon we sweep the same bright band as a mask instead
-   * (the icon dims to ~45% at the edges with a full-opacity band moving across),
-   * matching the "Thinking..." text shimmer.
+   * (the icon retains 45% opacity at the edges with a full-opacity band moving
+   * across). The longer cycle keeps this small status cue from pulling focus.
    */
   .animate-shine-icon {
     -webkit-mask-image: linear-gradient(
       90deg,
-      rgba(0, 0, 0, 0.15) 0%,
+      rgba(0, 0, 0, 0.45) 0%,
       rgba(0, 0, 0, 1) 50%,
-      rgba(0, 0, 0, 0.15) 100%
+      rgba(0, 0, 0, 0.45) 100%
     );
     mask-image: linear-gradient(
       90deg,
-      rgba(0, 0, 0, 0.15) 0%,
+      rgba(0, 0, 0, 0.45) 0%,
       rgba(0, 0, 0, 1) 50%,
-      rgba(0, 0, 0, 0.15) 100%
+      rgba(0, 0, 0, 0.45) 100%
     );
     -webkit-mask-size: 200% 100%;
     mask-size: 200% 100%;
-    animation: shine-mask 2s linear infinite;
+    animation: shine-mask 2.6s linear infinite;
   }
 
   /* Empty-state bb mark: a clean foreground-colored silhouette. Its parent


### PR DESCRIPTION
## Summary

- soften the shared SVG icon shimmer by raising its minimum opacity from 15% to 45%
- slow the shimmer cycle from 2s to 2.6s
- keep app and web theme definitions aligned

## Tests

- `pnpm exec turbo run test --filter=@bb/app --filter=@bb/web --force` (1,344 tests passed)