### PR TITLE
Delay keyboard shortcut hints

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -212,20 +212,20 @@ afterEach(() => {
 });
 
 describe("AppCommandProvider", () => {
-  it("shares primary-modifier hold state after 300ms and clears it on release or blur", () => {
+  it("shares primary-modifier hold state after 700ms and clears it on release or blur", () => {
     vi.useFakeTimers();
     renderProvider(<ModifierState />);
 
     expect(screen.getByText("released")).toBeDefined();
     fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
-    act(() => vi.advanceTimersByTime(299));
+    act(() => vi.advanceTimersByTime(699));
     expect(screen.getByText("released")).toBeDefined();
     act(() => vi.advanceTimersByTime(1));
     expect(screen.getByText("held")).toBeDefined();
     fireEvent.keyUp(window, { key: "Control" });
     expect(screen.getByText("released")).toBeDefined();
     fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(700));
     expect(screen.getByText("held")).toBeDefined();
     fireEvent.blur(window);
     expect(screen.getByText("released")).toBeDefined();

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -61,7 +61,7 @@ const AppCommandContextValue = createContext<AppCommandProviderValue | null>(
 const AppCommandModifierHeldContext = createContext(false);
 
 const EMPTY_KEYBINDINGS: AppKeybindings = [];
-const SHORTCUT_HINT_HOLD_DELAY_MS = 300;
+const SHORTCUT_HINT_HOLD_DELAY_MS = 700;
 
 const EMPTY_CONTEXT: AppCommandContext = {
   mainSurface: false,


### PR DESCRIPTION
## Summary

- increase the modifier hold delay for keyboard shortcut hints from 300 ms to 700 ms
- apply the same delay to sidebar thread-switch hints through the shared modifier-held state

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`