### PR TITLE
Fix machine join: always install server build, per-server data dirs

### DIFF
--- a/apps/server/src/assets/install-machine.sh
+++ b/apps/server/src/assets/install-machine.sh
@@ -50,89 +50,83 @@ case "$(uname -s)" in
     ;;
 esac
 
-bb_app=
-installed_version=
-server_version=
-if command -v bb-app >/dev/null 2>&1; then
-  bb_app=$(command -v bb-app)
-  if command -v node >/dev/null 2>&1; then
-    installed_version=$(node -e '
-      const fs = require("node:fs");
-      const path = require("node:path");
-      let current = path.dirname(fs.realpathSync(process.argv[1]));
-      while (current !== path.dirname(current)) {
-        try {
-          const pkg = JSON.parse(fs.readFileSync(path.join(current, "package.json"), "utf8"));
-          if (pkg.name === "bb-app" && typeof pkg.version === "string") {
-            process.stdout.write(pkg.version);
-            process.exit(0);
-          }
-        } catch {}
-        current = path.dirname(current);
-      }
-      process.exit(2);
-    ' "$bb_app" 2>/dev/null || true)
-  fi
-  version_response=$(curl -fsSL --connect-timeout 5 --max-time 10 "${server_url%/}/install/version" 2>/dev/null || true)
-  if [ -n "$version_response" ] && command -v node >/dev/null 2>&1; then
-    server_version=$(printf '%s' "$version_response" | node -e '
-      let input = "";
-      process.stdin.on("data", (chunk) => { input += chunk; });
-      process.stdin.on("end", () => {
-        const body = JSON.parse(input);
-        if (typeof body.version !== "string") process.exit(2);
-        process.stdout.write(body.version);
-      });
-    ' 2>/dev/null || true)
-  fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "bb-app requires Node.js 20.19 or newer (Node.js 22 LTS is recommended), but node is not on PATH." >&2
+  exit 1
 fi
+node_version=$(node -p 'process.versions.node')
+node_supported=$(node -e '
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  process.exit(major > 20 || (major === 20 && minor >= 19) ? 0 : 1);
+' && echo yes || echo no)
+if [ "$node_supported" != yes ]; then
+  echo "Node.js $node_version is too old; bb-app requires Node.js 20.19 or newer (Node.js 22 LTS is recommended)." >&2
+  exit 1
+fi
+node_bin=$(command -v node)
 
-if [ -n "$bb_app" ] && { [ -z "$server_version" ] || [ "$installed_version" = "$server_version" ]; }; then
-  echo "Using bb-app at $bb_app"
-else
-  if ! command -v node >/dev/null 2>&1; then
-    echo "bb-app installation requires Node.js 20.19 or newer (Node.js 22 LTS is recommended)." >&2
-    exit 1
-  fi
-  node_version=$(node -p 'process.versions.node')
-  node_supported=$(node -e '
-    const [major, minor] = process.versions.node.split(".").map(Number);
-    process.exit(major > 20 || (major === 20 && minor >= 19) ? 0 : 1);
-  ' && echo yes || echo no)
-  if [ "$node_supported" != yes ]; then
-    echo "Node.js $node_version is too old; bb-app requires Node.js 20.19 or newer (Node.js 22 LTS is recommended)." >&2
-    exit 1
-  fi
+require_npm() {
   if ! command -v npm >/dev/null 2>&1; then
     echo "bb-app installation requires npm." >&2
     exit 1
   fi
-  package_url="${server_url%/}/install/bb-app.tgz"
-  package_dir=$(mktemp -d "${TMPDIR:-/tmp}/bb-app.XXXXXX")
-  package_file="$package_dir/bb-app.tgz"
-  package_status=$(curl -sS -L -o "$package_file" -w '%{http_code}' "$package_url") || {
-    rm -rf "$package_dir"
-    echo "Could not download the server's bb-app package from $package_url." >&2
-    exit 1
-  }
-  if [ "$package_status" = 404 ]; then
-    rm -rf "$package_dir"
-    echo "The server does not provide its bb-app package; falling back to the npm registry..."
-    install_source=bb-app
-  elif [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ]; then
-    install_source=$package_file
-    echo "Installing bb-app $server_version from the server..."
-  else
-    rm -rf "$package_dir"
-    echo "Could not download the server's bb-app package (HTTP $package_status)." >&2
-    exit 1
-  fi
-  if ! npm install -g "$install_source"; then
+}
+
+server_host=$(node -e '
+  const url = new URL(process.argv[1]);
+  process.stdout.write(url.host.replace(/[^a-zA-Z0-9.-]/gu, "-"));
+' "$server_url") || {
+  echo "Could not parse the server URL $server_url." >&2
+  exit 1
+}
+service_slug=$(printf '%s' "$server_host" | tr '.' '-')
+
+# Each server gets its own data dir and daemon instance, so one machine can
+# serve several bb servers and a full local bb install keeps ~/.bb to itself.
+data_dir=${BB_DATA_DIR:-"$HOME/.bb-machines/$server_host"}
+mkdir -p "$data_dir"
+mkdir -p "$data_dir/logs"
+
+# The server's own build is always installed when it offers one: version
+# strings cannot distinguish unpublished builds, so an existing bb-app is
+# trusted only when the server provides no package (404) or is unreachable.
+package_url="${server_url%/}/install/bb-app.tgz"
+package_dir=$(mktemp -d "${TMPDIR:-/tmp}/bb-app.XXXXXX")
+package_file="$package_dir/bb-app.tgz"
+package_status=$(curl -sS -L -o "$package_file" -w '%{http_code}' "$package_url" 2>/dev/null) || package_status=000
+
+bb_app=
+if [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ]; then
+  require_npm
+  echo "Installing the server's bb-app build..."
+  if ! npm install -g "$package_file"; then
     rm -rf "$package_dir"
     echo "Could not install bb-app globally. Fix npm global-install permissions, then rerun this command." >&2
     exit 1
   fi
+elif command -v bb-app >/dev/null 2>&1; then
+  bb_app=$(command -v bb-app)
+  if [ "$package_status" = 404 ]; then
+    echo "The server does not provide its bb-app package; using bb-app at $bb_app"
+  else
+    echo "Warning: could not download the server's bb-app package (HTTP $package_status); using bb-app at $bb_app" >&2
+  fi
+elif [ "$package_status" = 404 ]; then
+  require_npm
+  echo "The server does not provide its bb-app package; installing bb-app from the npm registry..."
+  if ! npm install -g bb-app; then
+    rm -rf "$package_dir"
+    echo "Could not install bb-app globally. Fix npm global-install permissions, then rerun this command." >&2
+    exit 1
+  fi
+else
   rm -rf "$package_dir"
+  echo "Could not download the server's bb-app package from $package_url (HTTP $package_status)." >&2
+  exit 1
+fi
+rm -rf "$package_dir"
+
+if [ -z "$bb_app" ]; then
   if ! command -v bb-app >/dev/null 2>&1; then
     echo "npm installed bb-app, but its global bin directory is not on PATH." >&2
     echo "Add npm's global bin directory to PATH, then rerun this command." >&2
@@ -140,16 +134,6 @@ else
   fi
   bb_app=$(command -v bb-app)
 fi
-
-if ! command -v node >/dev/null 2>&1; then
-  echo "bb-app requires Node.js, but node is not on PATH." >&2
-  exit 1
-fi
-node_bin=$(command -v node)
-
-data_dir=${BB_DATA_DIR:-"$HOME/.bb"}
-mkdir -p "$data_dir"
-mkdir -p "$data_dir/logs"
 
 if [ -n "$machine_code" ]; then
   connect_apex=$(node -e '
@@ -206,19 +190,29 @@ if [ -n "$machine_code" ]; then
   }
 fi
 
-already_joined=no
-if [ -f "$data_dir/auth.json" ] && [ -f "$data_dir/config.json" ]; then
-  if node -e '
+auth_matches_host() {
+  node -e '
     const fs = require("node:fs");
-    const [dataDir, expectedServer, expectedHost] = process.argv.slice(1);
+    const [dataDir, expectedHost] = process.argv.slice(1);
     const auth = JSON.parse(fs.readFileSync(`${dataDir}/auth.json`, "utf8"));
+    process.exit(auth.hostId === expectedHost ? 0 : 1);
+  ' "$data_dir" "$host_id" 2>/dev/null
+}
+
+already_joined=no
+if [ -f "$data_dir/auth.json" ]; then
+  if ! auth_matches_host; then
+    echo "$data_dir already holds credentials for a different host, not $host_id." >&2
+    echo "If this machine was removed from the server, delete $data_dir and rerun this command." >&2
+    exit 1
+  fi
+  if [ -f "$data_dir/config.json" ] && node -e '
+    const fs = require("node:fs");
+    const [dataDir, expectedServer] = process.argv.slice(1);
     const config = JSON.parse(fs.readFileSync(`${dataDir}/config.json`, "utf8"));
     const normalize = (value) => String(value).replace(/\/+$/, "");
-    process.exit(
-      auth.hostId === expectedHost &&
-      normalize(config.serverUrl) === normalize(expectedServer) ? 0 : 1
-    );
-  ' "$data_dir" "$server_url" "$host_id" 2>/dev/null; then
+    process.exit(normalize(config.serverUrl) === normalize(expectedServer) ? 0 : 1);
+  ' "$data_dir" "$server_url" 2>/dev/null; then
     already_joined=yes
     echo "This machine is already joined to $server_url as $host_id."
   fi
@@ -239,7 +233,7 @@ if [ "$already_joined" = no ]; then
   joined=no
   attempts=0
   while [ "$attempts" -lt 60 ]; do
-    if [ -f "$data_dir/auth.json" ]; then
+    if [ -f "$data_dir/auth.json" ] && auth_matches_host; then
       joined=yes
       break
     fi
@@ -292,7 +286,8 @@ systemd_escape() {
 
 if [ "$platform" = darwin ]; then
   service_dir="$HOME/Library/LaunchAgents"
-  service_file="$service_dir/app.getbb.host-daemon.plist"
+  service_label="app.getbb.host-daemon.$service_slug"
+  service_file="$service_dir/$service_label.plist"
   mkdir -p "$service_dir"
   escaped_node_bin=$(xml_escape "$node_bin")
   escaped_bb_app=$(xml_escape "$bb_app")
@@ -303,7 +298,7 @@ if [ "$platform" = darwin ]; then
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key><string>app.getbb.host-daemon</string>
+  <key>Label</key><string>$service_label</string>
   <key>ProgramArguments</key>
   <array>
     <string>$escaped_node_bin</string>
@@ -324,12 +319,13 @@ if [ "$platform" = darwin ]; then
 EOF
   launchctl bootout "gui/$(id -u)" "$service_file" >/dev/null 2>&1 || true
   launchctl bootstrap "gui/$(id -u)" "$service_file"
-  launchctl kickstart -k "gui/$(id -u)/app.getbb.host-daemon"
+  launchctl kickstart -k "gui/$(id -u)/$service_label"
   echo "Installed and started launch agent: $service_file"
   echo "Uninstall: launchctl bootout gui/$(id -u) '$service_file' && rm '$service_file'"
 else
   service_dir="$HOME/.config/systemd/user"
-  service_file="$service_dir/bb-host-daemon.service"
+  service_name="bb-host-daemon-$service_slug"
+  service_file="$service_dir/$service_name.service"
   mkdir -p "$service_dir"
   escaped_node_bin=$(systemd_escape "$node_bin")
   escaped_bb_app=$(systemd_escape "$bb_app")
@@ -337,7 +333,7 @@ else
   escaped_data_dir=$(systemd_escape "$data_dir")
   cat >"$service_file" <<EOF
 [Unit]
-Description=bb host daemon
+Description=bb host daemon for $server_host
 After=network-online.target
 Wants=network-online.target
 
@@ -351,8 +347,8 @@ RestartSec=2
 WantedBy=default.target
 EOF
   systemctl --user daemon-reload
-  systemctl --user enable --now bb-host-daemon.service
+  systemctl --user enable --now "$service_name.service"
   echo "Installed and started systemd user service: $service_file"
   echo "It starts with your systemd user session."
-  echo "Uninstall: systemctl --user disable --now bb-host-daemon.service && rm '$service_file' && systemctl --user daemon-reload"
+  echo "Uninstall: systemctl --user disable --now $service_name.service && rm '$service_file' && systemctl --user daemon-reload"
 fi

--- a/apps/server/test/app/install-machine-script.test.ts
+++ b/apps/server/test/app/install-machine-script.test.ts
@@ -34,7 +34,11 @@ function writeExecutable(path: string, contents: string): void {
   chmodSync(path, 0o755);
 }
 
-function runScript(args: string[], fixture: ReturnType<typeof createFixture>) {
+function runScript(
+  args: string[],
+  fixture: ReturnType<typeof createFixture>,
+  env: Record<string, string> = {},
+) {
   return spawnSync("sh", [SCRIPT_PATH.pathname, ...args], {
     encoding: "utf8",
     env: {
@@ -42,9 +46,19 @@ function runScript(args: string[], fixture: ReturnType<typeof createFixture>) {
       BB_DATA_DIR: fixture.dataDir,
       HOME: fixture.homeDir,
       PATH: `${fixture.binDir}${delimiter}${process.env.PATH ?? ""}`,
+      ...env,
     },
   });
 }
+
+const JOIN_ARGS = [
+  "--join-code",
+  "join-secret",
+  "--host-id",
+  "host-test",
+  "--server",
+  "https://machine.getbb.app",
+];
 
 function writeJoinedState(
   fixture: ReturnType<typeof createFixture>,
@@ -61,6 +75,9 @@ function writeJoinedState(
   );
 }
 
+// Mocks curl to serve the redeem endpoint and answer the bb-app tarball
+// download with the given status; npm records invocations and fabricates a
+// bb-app that enrolls into whatever BB_DATA_DIR the script hands it.
 function writeServerInstallTools(
   fixture: ReturnType<typeof createFixture>,
   artifactStatus: 200 | 404,
@@ -71,7 +88,7 @@ function writeServerInstallTools(
     join(fixture.binDir, "curl"),
     `#!/bin/sh
 case "$*" in
-  *install/version*) printf '%s' '{"version":"9.9.9","protocolVersion":2}' ;;
+  *redeem-machine*) printf '%s' '{"credential":"bbcm_durable","machineId":"machine-1"}' ;;
   *)
     output=
     while [ "$#" -gt 0 ]; do
@@ -83,15 +100,53 @@ case "$*" in
 esac
 `,
   );
+  const bbAppTemplatePath = join(fixture.dataDir, "bb-app-template");
+  writeExecutable(
+    bbAppTemplatePath,
+    `#!/bin/sh
+printf '%s\\n' '{"hostId":"host-test","hostKey":"secret","hostType":"persistent"}' >"$BB_DATA_DIR/auth.json"
+printf '%s\\n' '{"serverUrl":"https://machine.getbb.app"}' >"$BB_DATA_DIR/config.json"
+while :; do sleep 1; done
+`,
+  );
   writeExecutable(
     join(fixture.binDir, "npm"),
     `#!/bin/sh
 printf '%s\n' "$*" >>"${npmLog}"
-printf '%s\n' '#!/bin/sh' \
-  'printf '\''%s\\n'\'' '\''{"hostId":"host-test","hostKey":"secret","hostType":"persistent"}'\'' >"$BB_DATA_DIR/auth.json"' \
-  'printf '\''%s\\n'\'' '\''{"serverUrl":"https://machine.getbb.app"}'\'' >"$BB_DATA_DIR/config.json"' \
-  'while :; do sleep 1; done' >"${bbAppPath}"
+cp "${bbAppTemplatePath}" "${bbAppPath}"
 chmod +x "${bbAppPath}"
+`,
+  );
+}
+
+function writeEnrollingBbApp(
+  fixture: ReturnType<typeof createFixture>,
+  invocationPath: string,
+  hostId = "host-test",
+): void {
+  writeExecutable(
+    join(fixture.binDir, "bb-app"),
+    `#!/bin/sh
+printf '%s\n' "$@" >"${invocationPath}"
+printf '%s\n' '{"hostId":"${hostId}","hostKey":"secret","hostType":"persistent"}' >"$BB_DATA_DIR/auth.json"
+while :; do sleep 1; done
+`,
+  );
+}
+
+function writeCurlArtifactMock(
+  fixture: ReturnType<typeof createFixture>,
+  artifactStatus: number,
+): void {
+  writeExecutable(
+    join(fixture.binDir, "curl"),
+    `#!/bin/sh
+output=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then output=$2; shift 2; else shift; fi
+done
+[ -z "$output" ] || printf '%s' 'fixture-tarball' >"$output"
+printf '%s' '${artifactStatus}'
 `,
   );
 }
@@ -116,37 +171,11 @@ describe("machine install script", () => {
   it("uses bb-app from PATH and passes the launcher join flags verbatim", () => {
     const fixture = createFixture();
     const invocationPath = join(fixture.dataDir, "invocation");
-    writeExecutable(
-      join(fixture.binDir, "bb-app"),
-      `#!/bin/sh
-printf '%s\n' "$@" >"${invocationPath}"
-printf '%s\n' '{"hostId":"host-test","hostKey":"secret","hostType":"persistent"}' >"$BB_DATA_DIR/auth.json"
-printf '%s\n' '{"serverUrl":"https://machine.getbb.app"}' >"$BB_DATA_DIR/config.json"
-while :; do sleep 1; done
-`,
-    );
-    const result = spawnSync(
-      "sh",
-      [
-        SCRIPT_PATH.pathname,
-        "--join-code",
-        "join-secret",
-        "--host-id",
-        "host-test",
-        "--server",
-        "https://machine.getbb.app",
-      ],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          BB_DATA_DIR: fixture.dataDir,
-          BB_INSTALL_SKIP_SERVICE: "1",
-          HOME: fixture.homeDir,
-          PATH: `${fixture.binDir}${delimiter}${process.env.PATH ?? ""}`,
-        },
-      },
-    );
+    writeCurlArtifactMock(fixture, 404);
+    writeEnrollingBbApp(fixture, invocationPath);
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
 
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(invocationPath, "utf8").trim().split("\n")).toEqual([
@@ -166,31 +195,34 @@ while :; do sleep 1; done
     process.kill(daemonPid, "SIGTERM");
   });
 
+  it("installs the server tarball even when a same-version bb-app is on PATH", () => {
+    const fixture = createFixture();
+    writeServerInstallTools(fixture, 200);
+    // A stale build with the same version string must not be reused.
+    writeExecutable(join(fixture.binDir, "bb-app"), "#!/bin/sh\nexit 99\n");
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const npmInvocation = readFileSync(
+      join(fixture.dataDir, "npm.log"),
+      "utf8",
+    );
+    expect(npmInvocation).toMatch(/^install -g \/.*bb-app\..*\.tgz$/mu);
+    const daemonPid = Number(
+      readFileSync(join(fixture.dataDir, "install-daemon.pid"), "utf8"),
+    );
+    process.kill(daemonPid, "SIGTERM");
+  });
+
   it("prefers the server-matched tarball when bb-app is absent", () => {
     const fixture = createFixture();
     writeServerInstallTools(fixture, 200);
-    const result = spawnSync(
-      "sh",
-      [
-        SCRIPT_PATH.pathname,
-        "--join-code",
-        "join-secret",
-        "--host-id",
-        "host-test",
-        "--server",
-        "https://machine.getbb.app",
-      ],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          BB_DATA_DIR: fixture.dataDir,
-          BB_INSTALL_SKIP_SERVICE: "1",
-          HOME: fixture.homeDir,
-          PATH: `${fixture.binDir}${delimiter}${process.env.PATH ?? ""}`,
-        },
-      },
-    );
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
     expect(result.status, result.stderr).toBe(0);
     const npmInvocation = readFileSync(
       join(fixture.dataDir, "npm.log"),
@@ -207,28 +239,10 @@ while :; do sleep 1; done
   it("falls back to npm only when the server artifact returns 404", () => {
     const fixture = createFixture();
     writeServerInstallTools(fixture, 404);
-    const result = spawnSync(
-      "sh",
-      [
-        SCRIPT_PATH.pathname,
-        "--join-code",
-        "join-secret",
-        "--host-id",
-        "host-test",
-        "--server",
-        "https://machine.getbb.app",
-      ],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          BB_DATA_DIR: fixture.dataDir,
-          BB_INSTALL_SKIP_SERVICE: "1",
-          HOME: fixture.homeDir,
-          PATH: `${fixture.binDir}${delimiter}${process.env.PATH ?? ""}`,
-        },
-      },
-    );
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(join(fixture.dataDir, "npm.log"), "utf8")).toBe(
       "install -g bb-app\n",
@@ -239,25 +253,49 @@ while :; do sleep 1; done
     process.kill(daemonPid, "SIGTERM");
   });
 
+  it("defaults the data dir to a per-server directory under ~/.bb-machines", () => {
+    const fixture = createFixture();
+    writeServerInstallTools(fixture, 200);
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_DATA_DIR: "",
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const defaultDataDir = join(
+      fixture.homeDir,
+      ".bb-machines/machine.getbb.app",
+    );
+    expect(
+      JSON.parse(readFileSync(join(defaultDataDir, "auth.json"), "utf8")),
+    ).toMatchObject({ hostId: "host-test" });
+    const daemonPid = Number(
+      readFileSync(join(defaultDataDir, "install-daemon.pid"), "utf8"),
+    );
+    process.kill(daemonPid, "SIGTERM");
+  });
+
+  it("refuses a data dir enrolled for a different host instead of faking success", () => {
+    const fixture = createFixture();
+    writeCurlArtifactMock(fixture, 404);
+    writeExecutable(join(fixture.binDir, "bb-app"), "#!/bin/sh\nexit 99\n");
+    writeJoinedState(fixture, "https://machine.getbb.app", "host-other");
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("credentials for a different host");
+    expect(result.stdout).not.toContain("Joined successfully");
+  });
+
   it("redeems and persists a connect machine code before joining through the tunnel", () => {
     const fixture = createFixture();
     const invocationPath = join(fixture.dataDir, "invocation");
-    writeExecutable(
-      join(fixture.binDir, "curl"),
-      '#!/bin/sh\nprintf \'%s\' \'{"credential":"bbcm_durable","machineId":"machine-1"}\'\n',
-    );
-    writeExecutable(
-      join(fixture.binDir, "bb-app"),
-      `#!/bin/sh
-printf '%s\n' "$@" >"${invocationPath}"
-printf '%s\n' '{"hostId":"host-test","hostKey":"secret","hostType":"persistent"}' >"$BB_DATA_DIR/auth.json"
-while :; do sleep 1; done
-`,
-    );
-    const result = spawnSync(
-      "sh",
+    writeServerInstallTools(fixture, 404);
+    writeEnrollingBbApp(fixture, invocationPath);
+    const result = runScript(
       [
-        SCRIPT_PATH.pathname,
         "--join-code",
         "join-secret",
         "--host-id",
@@ -267,26 +305,18 @@ while :; do sleep 1; done
         "--machine-code",
         "MACH-INE1",
       ],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          BB_DATA_DIR: fixture.dataDir,
-          BB_INSTALL_SKIP_SERVICE: "1",
-          HOME: fixture.homeDir,
-          PATH: `${fixture.binDir}${delimiter}${process.env.PATH ?? ""}`,
-        },
-      },
+      fixture,
+      { BB_INSTALL_SKIP_SERVICE: "1" },
     );
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(invocationPath, "utf8")).not.toContain("bbcm_durable");
     expect(readFileSync(invocationPath, "utf8")).not.toContain(
       "--machine-credential",
     );
     expect(
       JSON.parse(readFileSync(join(fixture.dataDir, "config.json"), "utf8")),
-    ).toEqual({
+    ).toMatchObject({
       connectMachineId: "machine-1",
       machineCredential: "bbcm_durable",
       serverUrl: "https://sawyer.getbb.app",
@@ -300,6 +330,7 @@ while :; do sleep 1; done
   it("installs an idempotent macOS launch agent for joined state", () => {
     const fixture = createFixture();
     writeJoinedState(fixture);
+    writeCurlArtifactMock(fixture, 404);
     writeExecutable(join(fixture.binDir, "bb-app"), "#!/bin/sh\nexit 99\n");
     writeExecutable(join(fixture.binDir, "uname"), "#!/bin/sh\necho Darwin\n");
     writeExecutable(
@@ -321,11 +352,17 @@ printf '%s\n' "$*" >>"${join(fixture.dataDir, "launchctl.log")}"
       fixture,
     );
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("already joined");
     const plist = readFileSync(
-      join(fixture.homeDir, "Library/LaunchAgents/app.getbb.host-daemon.plist"),
+      join(
+        fixture.homeDir,
+        "Library/LaunchAgents/app.getbb.host-daemon.machine-getbb-app.plist",
+      ),
       "utf8",
+    );
+    expect(plist).toContain(
+      "<string>app.getbb.host-daemon.machine-getbb-app</string>",
     );
     expect(plist).toContain("<string>host-daemon</string>");
     expect(plist).toContain("<string>--auto-update</string>");
@@ -338,6 +375,7 @@ printf '%s\n' "$*" >>"${join(fixture.dataDir, "launchctl.log")}"
   it("installs an idempotent Linux systemd user unit for joined state", () => {
     const fixture = createFixture();
     writeJoinedState(fixture);
+    writeCurlArtifactMock(fixture, 404);
     writeExecutable(join(fixture.binDir, "bb-app"), "#!/bin/sh\nexit 99\n");
     writeExecutable(join(fixture.binDir, "uname"), "#!/bin/sh\necho Linux\n");
     writeExecutable(
@@ -359,17 +397,20 @@ printf '%s\n' "$*" >>"${join(fixture.dataDir, "systemctl.log")}"
       fixture,
     );
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("already joined");
     const unit = readFileSync(
-      join(fixture.homeDir, ".config/systemd/user/bb-host-daemon.service"),
+      join(
+        fixture.homeDir,
+        ".config/systemd/user/bb-host-daemon-machine-getbb-app.service",
+      ),
       "utf8",
     );
     expect(unit).toContain(
       'host-daemon --auto-update --server-url "https://machine.getbb.app"',
     );
     expect(readFileSync(join(fixture.dataDir, "systemctl.log"), "utf8")).toBe(
-      "--user daemon-reload\n--user enable --now bb-host-daemon.service\n",
+      "--user daemon-reload\n--user enable --now bb-host-daemon-machine-getbb-app.service\n",
     );
   });
 });

--- a/docs/multiple-devices.md
+++ b/docs/multiple-devices.md
@@ -54,13 +54,22 @@ execute work. It installs and enrolls a host daemon; when bb connect is paired,
 the installer also configures the machine credential used to reach the server
 through the account gate.
 
-The installer prefers the exact `bb-app` package exposed by that server at
-`/install/bb-app.tgz`; it falls back to the npm registry only when an older
-server returns 404. This keeps remote machines aligned with development and
-pre-release servers whose build may not exist on npm. The package route is
-public like `/install.sh`: `bb-app` is public software, and exposing an
-unpublished build slightly early through a paired tunnel is an accepted
-tradeoff.
+The installer always installs the exact `bb-app` package exposed by that
+server at `/install/bb-app.tgz`; a `bb-app` already on PATH is reused, and the
+npm registry consulted, only when the server provides no package. Version
+strings cannot distinguish unpublished builds, so this keeps remote machines
+aligned with development and pre-release servers whose build may not exist on
+npm. The package route is public like `/install.sh`: `bb-app` is public
+software, and exposing an unpublished build slightly early through a paired
+tunnel is an accepted tradeoff.
+
+Each joined server gets its own daemon instance, data directory
+(`~/.bb-machines/<server-host>`, override with `BB_DATA_DIR` when running the
+installer), and launchd/systemd service. One machine can therefore serve
+several bb servers at once, and joining never touches a full local bb
+install's `~/.bb`. Each instance self-updates against its own server, but
+instances currently share the global `bb-app` binary, so servers running
+different bb versions on one machine can still fight over it.
 
 The installed launchd/systemd service enables `--auto-update`. If session open
 reports a newer server protocol, the daemon downloads and globally installs the
@@ -68,8 +77,9 @@ server artifact, then exits so the service manager restarts it. Failed attempts
 fall back to normal reconnect behavior and attempts are limited to once per 15
 minutes. A daemon never downgrades itself to an older server protocol. To opt
 out, remove `--auto-update` from
-`~/Library/LaunchAgents/app.getbb.host-daemon.plist` or
-`~/.config/systemd/user/bb-host-daemon.service`, then reload the service.
+`~/Library/LaunchAgents/app.getbb.host-daemon.<server>.plist` or
+`~/.config/systemd/user/bb-host-daemon-<server>.service`, then reload the
+service.
 
 After it connects:
 


### PR DESCRIPTION
## Summary

Joining an execution machine reported "Joined successfully" but the machine never appeared in Settings → Machines. Three stacked bugs in `install-machine.sh`:

- **Stale bb-app reused on version-string match.** Unpublished builds all share one version string, so a stale global `bb-app` (predating `--auto-update`) was kept and crash-looped under launchd; enrollment never reached the server. The script now **always installs the server's own `/install/bb-app.tgz` when offered** — an existing `bb-app` on PATH or the npm registry is only the 404 fallback. This matches what `docs/multiple-devices.md` already documented.
- **Fake join success.** The enrollment wait loop only checked that `auth.json` *exists*, so a machine already running its own bb out of `~/.bb` passed instantly with its local server's credentials. The loop now verifies the enrolled `hostId`, and a data dir enrolled for a different host errors with instructions instead.
- **`~/.bb` collision.** Machine joins shared the data dir with any full local bb install (the daemon hard-rejects a mismatched `auth.json` hostId, so such machines could never join — and the connect redeem step polluted the local server's `config.json`). Joins now default to a per-server data dir `~/.bb-machines/<server-host>` with per-server launchd/systemd service names, so one machine can serve several bb servers and never touches a local server's `~/.bb`.

The stricter wait loop exposed a latent test-mock bug: TypeScript's `\'` escape collapsed the shell `'\''` idiom into `'''`, silently unquoting the fabricated `bb-app` so it always wrote unparseable `auth.json` (unnoticed under the old existence-only check). The npm mock now copies a plainly-written template file instead of nesting quotes.

## Tests

- `turbo run test --filter=@bb/server -- install-machine-script` — 10/10 pass, including new coverage: server tarball wins over a same-version PATH binary; mismatched-host data dir refuses instead of faking success; default per-server data dir.
- `turbo run typecheck --filter=@bb/server` — clean.
- Verified end to end on real hardware: a machine running its own full bb install joined a real server through a bb connect tunnel with the fixed script — enrolled under `~/.bb-machines/<server-host>`, per-server launch agent running, machine shows **connected** in the Machines list and `bb machine list`.

## Notes / risks

- Per-server daemon instances currently share the global `bb-app` binary; two servers running *different* bb versions on one machine could still fight during self-update. Follow-up if it matters: per-instance binary copies.
- Servers must be restarted onto this build before UI-generated join commands serve the fixed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)