### PR TITLE
Center picker menu icons on their label line

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -447,7 +447,9 @@ function BranchPickerUnavailableRow({
       <Icon
         name={icon}
         className={cn(
-          "mt-0.5 text-muted-foreground",
+          // Center the 14px icon on the label's 16px first line; on coarse
+          // pointers icon and line are both 20px, so no offset.
+          "mt-px text-muted-foreground max-md:pointer-coarse:mt-0",
           COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
         )}
       />

--- a/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
@@ -1,7 +1,11 @@
 import type { ProjectSource } from "@bb/domain";
 import { EnvironmentPickerUI } from "./EnvironmentPicker";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
-import { HOST_IDS, makeHost } from "../../../.ladle/story-fixtures";
+import {
+  HOST_IDS,
+  HOST_NAMES,
+  makeHost,
+} from "../../../.ladle/story-fixtures";
 
 const localHost = makeHost({ id: HOST_IDS.local });
 const remoteHost = makeHost({ id: HOST_IDS.local, name: "studio-mac-mini" });
@@ -144,6 +148,42 @@ export function Overview() {
           sources={localProjectSources}
           host={localHost}
           isLocal
+          defaultOpen
+          modal={false}
+        />
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+const machineHosts = [
+  makeHost({ id: HOST_IDS.local }),
+  makeHost({ id: HOST_IDS.remote, name: HOST_NAMES.remote }),
+];
+
+const multiMachineSources: readonly ProjectSource[] = [
+  makeSource("src_local", HOST_IDS.local, "/Users/michael/Projects/bb"),
+  makeSource("src_remote", HOST_IDS.remote, "/home/michael/bb"),
+];
+
+export function MachineMenu() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="machine-grouped menu"
+        hint="two hosts viewed from another device (no local daemon) — checkout rows carry a path hint, 'Existing worktree' selected"
+      >
+        <EnvironmentPickerUI
+          value="reuse"
+          onChange={noop}
+          sources={multiMachineSources}
+          host={machineHosts[0] ?? null}
+          isLocal={false}
+          machines={{
+            hosts: machineHosts,
+            localDaemonHostId: null,
+            primaryHostId: HOST_IDS.local,
+          }}
           defaultOpen
           modal={false}
         />

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -581,7 +581,9 @@ function EnvironmentMenuItem({
         <Icon
           name={icon}
           className={cn(
-            "mt-0.5",
+            // Center the 14px icon on the label's 16px first line; on coarse
+            // pointers icon and line are both 20px, so no offset.
+            "mt-px max-md:pointer-coarse:mt-0",
             "text-muted-foreground",
             COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
           )}
@@ -598,7 +600,7 @@ function EnvironmentMenuItem({
         </span>
       </span>
       {hint ? (
-        <span className="mt-0.5 max-w-32 truncate text-xs text-muted-foreground">
+        <span className="max-w-32 truncate text-xs text-muted-foreground">
           {hint}
         </span>
       ) : null}

--- a/apps/app/src/components/pickers/OptionPicker.tsx
+++ b/apps/app/src/components/pickers/OptionPicker.tsx
@@ -256,8 +256,10 @@ export function OptionPicker<T extends string>({
                   option.tone === "warning" && "text-warning-text",
                 )}
               >
+                {/* 16px icon matches the label's 16px first line; coarse
+                    pointers keep size-4 while the line grows to 20px. */}
                 {OptionIcon ? (
-                  <OptionIcon className="mt-0.5 size-4 shrink-0" />
+                  <OptionIcon className="size-4 shrink-0 max-md:pointer-coarse:mt-0.5" />
                 ) : null}
                 <span className="min-w-0 flex-1">
                   <span


### PR DESCRIPTION
## Summary

Icons in the environment/branch/option picker dropdown menus sat 1–2px below the text centerline, and the checkout-path hint in the multi-machine menu sat 2px below the label baseline.

Menu item labels render at `text-xs` (16px line-height; 20px on coarse pointers), but the leading icons carried a blanket `mt-0.5` copied between components regardless of icon size:

- `EnvironmentPicker` (`EnvironmentMenuItem`): 14px icon on a 16px line needs `mt-px`, not `mt-0.5`; on coarse pointers icon and line are both 20px, so no offset. Also removed the stray `mt-0.5` on the path hint.
- `OptionPicker`: 16px icon on a 16px line needs no offset (kept `mt-0.5` only under coarse pointers, where the line grows to 20px but the icon stays 16px).
- `BranchPicker` (`BranchPickerUnavailableRow`): same fix as EnvironmentMenuItem.

Also adds a `MachineMenu` story for the machine-grouped environment menu, which previously had no story.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- Verified visually in Ladle (`pickers--environment-picker--machine-menu` and `--overview`): icons center on their label line and the path hint shares the label baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)