### PR TITLE
Add sidebar "By machine" organization mode

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -45,7 +45,7 @@ import {
   isHostPathMissing,
   useHostPathExistence,
 } from "@/hooks/queries/host-path-queries";
-import { usePrimaryHost } from "@/hooks/queries/host-queries";
+import { useHosts, usePrimaryHost } from "@/hooks/queries/host-queries";
 import { useDialogState } from "@/hooks/useDialogState";
 import {
   getFolderArchivedRoutePath,
@@ -119,6 +119,7 @@ import {
   DEFAULT_SIDEBAR_SECTION_ORDER,
   sidebarChronologicalSortAtom,
   sidebarCollapsedFoldersAtom,
+  sidebarCollapsedMachinesAtom,
   sidebarOrganizationModeAtom,
   sidebarSectionOrderAtom,
   type SidebarChronologicalSort,
@@ -127,6 +128,10 @@ import {
   type SidebarSectionId,
 } from "./sidebarCollapsedAtoms";
 import { folderKeyForThreadFolder } from "./folderKeys";
+import {
+  buildMachineThreadGroups,
+  NO_MACHINE_GROUP_KEY,
+} from "./machineThreadGroups";
 import { CHRONOLOGICAL_CONTAINER_ID } from "./projectThreadGroups";
 import {
   DropdownMenu,
@@ -267,13 +272,14 @@ interface ToggleCollapsedIdListArgs {
 }
 
 interface SelectedThreadSidebarExpansionArgs {
-  isFolderOrganizationMode: boolean;
+  organizationMode: SidebarOrganizationMode;
   isPinned: boolean;
   selectedThread: ThreadListEntry;
 }
 
 interface SelectedThreadSidebarExpansion {
   folderKey?: string;
+  machineKey?: string;
   projectId?: string;
   sidebarSectionId?: CollapsibleSidebarSectionId;
 }
@@ -286,6 +292,7 @@ type OpenSidebarMenu =
   | "projectsDisplayOptions"
   | "threadsDisplayOptions"
   | "allThreadsOverflow"
+  | `machineDisplayOptions:${string}`
   | null;
 
 interface TopLevelSidebarSectionProps {
@@ -341,7 +348,7 @@ function removeCollapsedIds<T extends string>(
 }
 
 export function getSelectedThreadSidebarExpansion({
-  isFolderOrganizationMode,
+  organizationMode,
   isPinned,
   selectedThread,
 }: SelectedThreadSidebarExpansionArgs): SelectedThreadSidebarExpansion {
@@ -349,7 +356,13 @@ export function getSelectedThreadSidebarExpansion({
     return { sidebarSectionId: "pinned" };
   }
 
-  if (isFolderOrganizationMode) {
+  if (organizationMode === "machine") {
+    return {
+      machineKey: selectedThread.environmentHostId ?? NO_MACHINE_GROUP_KEY,
+    };
+  }
+
+  if (organizationMode === "chronological") {
     const folderKey = folderKeyForThreadFolder(
       CHRONOLOGICAL_CONTAINER_ID,
       selectedThread.folderId,
@@ -616,6 +629,7 @@ function ProjectListThreadsSectionActions({
 // the stored atom value stays "chronological".
 const SIDEBAR_ORGANIZE_OPTIONS = [
   { label: "By project", mode: "project" },
+  { label: "By machine", mode: "machine" },
   { label: "In one list", mode: "chronological" },
 ] as const satisfies readonly {
   label: string;
@@ -1187,6 +1201,7 @@ function ProjectListComponent({
     ),
   });
   const primaryHost = usePrimaryHost();
+  const { data: hosts } = useHosts();
   const workHostId =
     primaryHost?.status === "connected" ? primaryHost.id : null;
   const { threadId: selectedThreadId } = useRouteState();
@@ -1438,6 +1453,9 @@ function ProjectListComponent({
   const [collapsedEnvironmentIdList, setCollapsedEnvironmentIdList] = useAtom(
     collapsedEnvironmentIdsAtom,
   );
+  const [collapsedMachineKeyList, setCollapsedMachineKeyList] = useAtom(
+    sidebarCollapsedMachinesAtom,
+  );
   const [collapsedSidebarSectionIdList, setCollapsedSidebarSectionIdList] =
     useAtom(collapsedSidebarSectionIdsAtom);
   const [sidebarSectionOrderList, setSidebarSectionOrderList] = useAtom(
@@ -1474,6 +1492,7 @@ function ProjectListComponent({
     sidebarChronologicalSortAtom,
   );
   const isFolderOrganizationMode = organizationMode === "chronological";
+  const isMachineOrganizationMode = organizationMode === "machine";
   const setCollapsedFolderList = useSetAtom(sidebarCollapsedFoldersAtom);
   const sidebarThreadComparator = useMemo<ThreadComparator>(
     () => getSidebarThreadComparator(chronologicalSort),
@@ -1490,6 +1509,10 @@ function ProjectListComponent({
   const collapsedEnvironmentIds = useMemo(
     () => new Set(collapsedEnvironmentIdList),
     [collapsedEnvironmentIdList],
+  );
+  const collapsedMachineKeys = useMemo(
+    () => new Set(collapsedMachineKeyList),
+    [collapsedMachineKeyList],
   );
   const sidebarSectionOrder = useMemo(
     () => normalizeSidebarSectionOrder(sidebarSectionOrderList),
@@ -1592,10 +1615,16 @@ function ProjectListComponent({
     const isPinned =
       pinnedSidebarState.effectivePinnedThreadIds.has(selectedThreadId);
     const expansion = getSelectedThreadSidebarExpansion({
-      isFolderOrganizationMode,
+      organizationMode,
       isPinned,
       selectedThread,
     });
+    if (expansion.machineKey) {
+      const machineKey = expansion.machineKey;
+      setCollapsedMachineKeyList((current) =>
+        removeCollapsedIds(current, new Set([machineKey])),
+      );
+    }
     if (expansion.folderKey) {
       const folderKey = expansion.folderKey;
       setCollapsedFolderList((current) =>
@@ -1615,11 +1644,12 @@ function ProjectListComponent({
       );
     }
   }, [
-    isFolderOrganizationMode,
+    organizationMode,
     pinnedSidebarState.effectivePinnedThreadIds,
     selectedThreadId,
     setCollapsedEnvironmentIdList,
     setCollapsedFolderList,
+    setCollapsedMachineKeyList,
     setCollapsedProjectIdList,
     setCollapsedSidebarSectionIdList,
     setCollapsedThreadIdList,
@@ -1723,6 +1753,15 @@ function ProjectListComponent({
     [setCollapsedEnvironmentIdList],
   );
 
+  const toggleMachineCollapsed = useCallback<ToggleCollapsedId>(
+    (machineKey) => {
+      setCollapsedMachineKeyList((current) => {
+        return toggleCollapsedIdList({ current, id: machineKey });
+      });
+    },
+    [setCollapsedMachineKeyList],
+  );
+
   const toggleSidebarSectionCollapsed =
     useCallback<ToggleCollapsedSidebarSectionId>(
       (sectionId) => {
@@ -1789,6 +1828,21 @@ function ProjectListComponent({
     status: projectsState.status,
     threads: nonPinnedThreads,
   });
+
+  // Machine mode buckets every non-pinned thread by its environment's host,
+  // one top-level section per machine.
+  const machineSections = useMemo(
+    () =>
+      buildMachineThreadGroups(nonPinnedThreads, hosts ?? []).map((group) => ({
+        key: group.key,
+        label: group.label,
+        threadListState: {
+          status: "ready",
+          threads: group.threads,
+        } satisfies ProjectThreadListState,
+      })),
+    [hosts, nonPinnedThreads],
+  );
 
   const pinnedSectionContent = (
     <PinnedThreadTree
@@ -2015,6 +2069,84 @@ function ProjectListComponent({
     return (
       <ProjectListShell>
         <ProjectListNavigationLoadingState />
+      </ProjectListShell>
+    );
+  }
+
+  if (isMachineOrganizationMode) {
+    return (
+      <ProjectListShell>
+        <div className="space-y-4">
+          {hasPinnedSection ? (
+            <TopLevelSidebarSection
+              label="Pinned"
+              collapseControl={{
+                isCollapsed: collapsedSidebarSectionIds.has("pinned"),
+                onToggleCollapsed: () =>
+                  toggleSidebarSectionCollapsed("pinned"),
+              }}
+            >
+              {pinnedSectionContent}
+            </TopLevelSidebarSection>
+          ) : null}
+          {machineSections.length === 0 ? (
+            <TopLevelSidebarSection
+              label="Threads"
+              actions={threadsSectionActions}
+              actionsOpen={threadsDisplayOptionsMenuOpen}
+              actionsMobileAlways
+            >
+              <ProjectThreadTree
+                threadListState={allThreadsListState}
+                compareThreads={sidebarThreadComparator}
+                variant="section"
+                selectedThreadId={selectedThreadId}
+                collapsedThreadIds={collapsedThreadIds}
+                collapsedEnvironmentIds={collapsedEnvironmentIds}
+                onProjectSelect={onProjectSelect}
+                onToggleThreadCollapsed={toggleThreadCollapsed}
+                onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+              />
+            </TopLevelSidebarSection>
+          ) : (
+            machineSections.map((section) => {
+              const machineMenuId =
+                `machineDisplayOptions:${section.key}` as const;
+              return (
+                <TopLevelSidebarSection
+                  key={section.key}
+                  label={section.label}
+                  actions={
+                    <SidebarDisplayOptionsMenu
+                      open={openSidebarMenu === machineMenuId}
+                      onOpenChange={(open) =>
+                        setSidebarMenuOpen(machineMenuId, open)
+                      }
+                    />
+                  }
+                  actionsOpen={openSidebarMenu === machineMenuId}
+                  actionsMobileAlways
+                  collapseControl={{
+                    isCollapsed: collapsedMachineKeys.has(section.key),
+                    onToggleCollapsed: () => toggleMachineCollapsed(section.key),
+                  }}
+                >
+                  <ProjectThreadTree
+                    threadListState={section.threadListState}
+                    compareThreads={sidebarThreadComparator}
+                    variant="section"
+                    selectedThreadId={selectedThreadId}
+                    collapsedThreadIds={collapsedThreadIds}
+                    collapsedEnvironmentIds={collapsedEnvironmentIds}
+                    onProjectSelect={onProjectSelect}
+                    onToggleThreadCollapsed={toggleThreadCollapsed}
+                    onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                  />
+                </TopLevelSidebarSection>
+              );
+            })
+          )}
+        </div>
       </ProjectListShell>
     );
   }

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -155,7 +155,9 @@ export interface ProjectRowProps {
 }
 
 interface ProjectThreadTreeProps {
-  projectId: string;
+  // Route every row to this project; omit to derive each row's project from
+  // its own thread (cross-project views such as By machine).
+  projectId?: string;
   threadListState: ProjectThreadListState;
   compareThreads: ThreadComparator;
   selectedThreadId?: string;

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
@@ -101,6 +101,18 @@ describe("sidebar display options menu", () => {
     ).toBe("true");
   });
 
+  it("switches to machine organization", async () => {
+    renderMobileViewOptions(<ControlledDisplayOptionsMenu />);
+
+    fireEvent.click(
+      await screen.findByRole("menuitemcheckbox", { name: "By machine" }),
+    );
+
+    expect(screen.getByTestId("organization-mode").textContent).toBe(
+      "machine",
+    );
+  });
+
   it("selects one fixed-direction sort field and closes", async () => {
     renderMobileViewOptions(<ControlledDisplayOptionsMenu />);
 

--- a/apps/app/src/components/sidebar/machineThreadGroups.test.ts
+++ b/apps/app/src/components/sidebar/machineThreadGroups.test.ts
@@ -1,0 +1,115 @@
+import type { Host, ThreadListEntry } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import {
+  buildMachineThreadGroups,
+  NO_MACHINE_GROUP_KEY,
+} from "./machineThreadGroups";
+
+function createThread(overrides: Partial<ThreadListEntry>): ThreadListEntry {
+  return {
+    id: "thr_1",
+    projectId: "proj_1",
+    environmentId: null,
+    providerId: "codex",
+    title: "Thread",
+    titleFallback: "Thread",
+    folderId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    childOrigin: null,
+    archivedAt: null,
+    pinnedAt: null,
+    pinSortKey: null,
+    deletedAt: null,
+    lastReadAt: 0,
+    latestAttentionAt: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    activity: {
+      activeWorkflowCount: 0,
+      activeBackgroundAgentCount: 0,
+      activeBackgroundCommandCount: 0,
+      activePlanModeCount: 0,
+      activeGoalCount: 0,
+    },
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+    ...overrides,
+  };
+}
+
+function createHost(overrides: Partial<Host> & Pick<Host, "id" | "name">): Host {
+  return {
+    type: "persistent",
+    status: "connected",
+    lastSeenAt: null,
+    lastRejectedProtocolVersion: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("buildMachineThreadGroups", () => {
+  it("orders known hosts by server order, then unknown hosts, then no-machine", () => {
+    const hosts = [
+      createHost({ id: "host_a", name: "Laptop" }),
+      createHost({ id: "host_b", name: "Desktop" }),
+    ];
+    const threads = [
+      createThread({ id: "thr_1", environmentHostId: "host_b" }),
+      createThread({ id: "thr_2", environmentHostId: null }),
+      createThread({ id: "thr_3", environmentHostId: "host_gone" }),
+      createThread({ id: "thr_4", environmentHostId: "host_a" }),
+      createThread({ id: "thr_5", environmentHostId: "host_b" }),
+    ];
+
+    const groups = buildMachineThreadGroups(threads, hosts);
+
+    expect(
+      groups.map((group) => ({
+        key: group.key,
+        label: group.label,
+        threadIds: group.threads.map((thread) => thread.id),
+      })),
+    ).toEqual([
+      { key: "host_a", label: "Laptop", threadIds: ["thr_4"] },
+      { key: "host_b", label: "Desktop", threadIds: ["thr_1", "thr_5"] },
+      { key: "host_gone", label: "Unknown machine", threadIds: ["thr_3"] },
+      { key: NO_MACHINE_GROUP_KEY, label: "No machine", threadIds: ["thr_2"] },
+    ]);
+  });
+
+  it("skips machines that have no threads and omits the no-machine group when empty", () => {
+    const hosts = [
+      createHost({ id: "host_a", name: "Laptop" }),
+      createHost({ id: "host_b", name: "Desktop" }),
+    ];
+    const threads = [createThread({ id: "thr_1", environmentHostId: "host_b" })];
+
+    const groups = buildMachineThreadGroups(threads, hosts);
+
+    expect(groups.map((group) => group.key)).toEqual(["host_b"]);
+  });
+
+  it("falls back to id-ordered unknown groups when the host list is empty", () => {
+    const threads = [
+      createThread({ id: "thr_1", environmentHostId: "host_b" }),
+      createThread({ id: "thr_2", environmentHostId: "host_a" }),
+    ];
+
+    const groups = buildMachineThreadGroups(threads, []);
+
+    expect(groups.map((group) => group.key)).toEqual(["host_a", "host_b"]);
+  });
+});

--- a/apps/app/src/components/sidebar/machineThreadGroups.ts
+++ b/apps/app/src/components/sidebar/machineThreadGroups.ts
@@ -1,0 +1,68 @@
+import type { Host, ThreadListEntry } from "@bb/domain";
+
+// Group key for threads whose environment has no host (plain chats). Host ids
+// are prefixed (e.g. "host_…"), so the sentinel cannot collide with one.
+export const NO_MACHINE_GROUP_KEY = "no-machine";
+
+export interface MachineThreadGroup {
+  /** Host id, or {@link NO_MACHINE_GROUP_KEY}. */
+  key: string;
+  label: string;
+  threads: ThreadListEntry[];
+}
+
+/**
+ * Buckets threads by the host their environment runs on, for the sidebar's
+ * "By machine" view. Groups follow server host order; hosts the server no
+ * longer lists keep a stable id-ordered section; machineless threads land in
+ * a trailing "No machine" group. Machines without threads get no group.
+ */
+export function buildMachineThreadGroups(
+  threads: readonly ThreadListEntry[],
+  hosts: readonly Host[],
+): MachineThreadGroup[] {
+  const threadsByKey = new Map<string, ThreadListEntry[]>();
+  for (const thread of threads) {
+    const key = thread.environmentHostId ?? NO_MACHINE_GROUP_KEY;
+    const existing = threadsByKey.get(key);
+    if (existing) {
+      existing.push(thread);
+    } else {
+      threadsByKey.set(key, [thread]);
+    }
+  }
+
+  const groups: MachineThreadGroup[] = [];
+  for (const host of hosts) {
+    const hostThreads = threadsByKey.get(host.id);
+    if (!hostThreads) {
+      continue;
+    }
+    threadsByKey.delete(host.id);
+    groups.push({ key: host.id, label: host.name, threads: hostThreads });
+  }
+
+  const noMachineThreads = threadsByKey.get(NO_MACHINE_GROUP_KEY);
+  threadsByKey.delete(NO_MACHINE_GROUP_KEY);
+
+  const unknownHostIds = Array.from(threadsByKey.keys()).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  for (const hostId of unknownHostIds) {
+    groups.push({
+      key: hostId,
+      label: "Unknown machine",
+      threads: threadsByKey.get(hostId) ?? [],
+    });
+  }
+
+  if (noMachineThreads) {
+    groups.push({
+      key: NO_MACHINE_GROUP_KEY,
+      label: "No machine",
+      threads: noMachineThreads,
+    });
+  }
+
+  return groups;
+}

--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -9,6 +9,7 @@ const SIDEBAR_SECTION_ORDER_STORAGE_KEY = "bb.sidebar.sectionOrder";
 const ORGANIZATION_MODE_STORAGE_KEY = "bb.sidebar.organizationMode";
 const CHRONOLOGICAL_SORT_STORAGE_KEY = "bb.sidebar.chronologicalSort";
 const COLLAPSED_FOLDERS_STORAGE_KEY = "bb.sidebar.collapsedFolders";
+const COLLAPSED_MACHINES_STORAGE_KEY = "bb.sidebar.collapsedMachines";
 
 export type SidebarSectionId = "pinned" | "projects" | "threads";
 export type CollapsibleSidebarSectionId =
@@ -18,8 +19,9 @@ export type CollapsibleSidebarSectionId =
   | "threads";
 
 // "project" keeps the per-project grouping; "chronological" is the persisted
-// value for the cross-project Folders view that replaced the old None view.
-export type SidebarOrganizationMode = "project" | "chronological";
+// value for the cross-project Folders view that replaced the old None view;
+// "machine" groups threads by the host their environment runs on.
+export type SidebarOrganizationMode = "project" | "chronological" | "machine";
 // Controls thread ordering in both grouped and ungrouped sidebar views. Time
 // sorts show newest first and alphabetical sorts A→Z. "none" is a legacy value
 // that the runtime normalizes back to "updated".
@@ -88,6 +90,15 @@ export const sidebarChronologicalSortAtom =
 // matching collapsedThreadIds / collapsedProjectIds.
 export const sidebarCollapsedFoldersAtom = atomWithStorage<string[]>(
   COLLAPSED_FOLDERS_STORAGE_KEY,
+  [],
+  createJsonLocalStorage<string[]>(),
+  { getOnInit: true },
+);
+
+// Collapsed machine-mode group keys (host ids plus the no-machine sentinel;
+// see machineThreadGroups.ts).
+export const sidebarCollapsedMachinesAtom = atomWithStorage<string[]>(
+  COLLAPSED_MACHINES_STORAGE_KEY,
   [],
   createJsonLocalStorage<string[]>(),
   { getOnInit: true },

--- a/apps/app/src/components/sidebar/sortComparator.test.ts
+++ b/apps/app/src/components/sidebar/sortComparator.test.ts
@@ -119,7 +119,7 @@ describe("getSelectedThreadSidebarExpansion", () => {
   it("expands the personal threads section in project mode", () => {
     expect(
       getSelectedThreadSidebarExpansion({
-        isFolderOrganizationMode: false,
+        organizationMode: "project",
         isPinned: false,
         selectedThread: thread({ projectId: PERSONAL_PROJECT_ID }),
       }),
@@ -129,7 +129,7 @@ describe("getSelectedThreadSidebarExpansion", () => {
   it("expands the owning project in project mode", () => {
     expect(
       getSelectedThreadSidebarExpansion({
-        isFolderOrganizationMode: false,
+        organizationMode: "project",
         isPinned: false,
         selectedThread: thread({ projectId: "proj_app" }),
       }),
@@ -139,7 +139,7 @@ describe("getSelectedThreadSidebarExpansion", () => {
   it("expands the threads section for unfiled project threads in folders mode", () => {
     expect(
       getSelectedThreadSidebarExpansion({
-        isFolderOrganizationMode: true,
+        organizationMode: "chronological",
         isPinned: false,
         selectedThread: thread({ folderId: null, projectId: "proj_app" }),
       }),
@@ -149,7 +149,7 @@ describe("getSelectedThreadSidebarExpansion", () => {
   it("expands the containing folder for foldered threads in folders mode", () => {
     expect(
       getSelectedThreadSidebarExpansion({
-        isFolderOrganizationMode: true,
+        organizationMode: "chronological",
         isPinned: false,
         selectedThread: thread({ folderId: "fld_work", projectId: "proj_app" }),
       }),
@@ -159,10 +159,30 @@ describe("getSelectedThreadSidebarExpansion", () => {
     });
   });
 
+  it("expands the owning machine group in machine mode", () => {
+    expect(
+      getSelectedThreadSidebarExpansion({
+        organizationMode: "machine",
+        isPinned: false,
+        selectedThread: thread({
+          projectId: "proj_app",
+          environmentHostId: "host_a",
+        }),
+      }),
+    ).toEqual({ machineKey: "host_a" });
+    expect(
+      getSelectedThreadSidebarExpansion({
+        organizationMode: "machine",
+        isPinned: false,
+        selectedThread: thread({ projectId: "proj_app" }),
+      }),
+    ).toEqual({ machineKey: "no-machine" });
+  });
+
   it("expands the pinned section for pinned threads", () => {
     expect(
       getSelectedThreadSidebarExpansion({
-        isFolderOrganizationMode: true,
+        organizationMode: "chronological",
         isPinned: true,
         selectedThread: thread({ folderId: null, projectId: "proj_app" }),
       }),


### PR DESCRIPTION
## Summary
- Adds a **By machine** option to the sidebar's Organize menu (alongside By project / In one list)
- Machine mode buckets every non-pinned thread into one top-level section per machine, keyed by the thread's `environmentHostId`; sections follow server host order
- Threads without an environment fall into a trailing **No machine** group; threads pointing at hosts the server no longer lists get a stable id-ordered **Unknown machine** group
- Machine sections collapse independently (persisted in `bb.sidebar.collapsedMachines`), each header carries the display-options menu, and selecting a thread auto-expands its machine group; Pinned and Sort by behave as in other modes
- `ProjectThreadTree.projectId` is now optional so cross-project machine groups route each row via its own thread's project

## Testing
- `pnpm exec turbo run typecheck --filter=@bb/app`
- All 84 sidebar vitest tests pass, including new unit tests for `buildMachineThreadGroups` (host ordering, unknown hosts, no-machine bucket) and the menu/expansion helpers
- Manual QA in the dev app: switched modes via the menu, verified grouping under the live host, per-section menu, and collapse persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)