### PR TITLE
Optimize multi-machine payload transfers

### DIFF
--- a/apps/host-daemon/src/server-client.test.ts
+++ b/apps/host-daemon/src/server-client.test.ts
@@ -231,8 +231,24 @@ describe("createServerClient", () => {
   });
 
   it("returns accepted event mappings when posting events", async () => {
-    const fetchFn = vi.fn<FetchFn>(async (input) => {
+    const fetchFn = vi.fn<FetchFn>(async (input, init) => {
       expect(String(input)).toContain("/internal/session/events");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        sessionId: "session-1",
+        eventGroups: [
+          {
+            threadId: "thr_123",
+            events: [
+              {
+                type: "turn/started",
+                threadId: "thr_123",
+                providerThreadId: "provider-thread",
+                scope: { kind: "turn", turnId: "turn-1" },
+              },
+            ],
+          },
+        ],
+      });
       return new Response(
         JSON.stringify({
           acceptedEvents: [

--- a/apps/host-daemon/src/server-client.ts
+++ b/apps/host-daemon/src/server-client.ts
@@ -12,6 +12,7 @@ import {
   type HostDaemonActiveThread,
   type HostDaemonEventBatchRequest,
   type HostDaemonEventEnvelope,
+  groupHostDaemonEvents,
   type HostDaemonInteractiveInterruptRequest,
   type HostDaemonInteractiveRequest,
   type HostDaemonLoadedEnvironment,
@@ -425,7 +426,7 @@ export function createServerClient(
     ): Promise<EventPostResult> {
       const payload: HostDaemonEventBatchRequest = {
         sessionId: requireSessionId(),
-        events,
+        eventGroups: groupHostDaemonEvents(events),
       };
       const response = await fetchFn(buildInternalUrl("/session/events"), {
         method: "POST",

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -15,6 +15,7 @@ import type {
 } from "@bb/db";
 import {
   hostDaemonEventBatchRequestSchema,
+  ungroupHostDaemonEvents,
   typedRoutes,
   type HostDaemonEventBatchResponse,
   type HostDaemonEventEnvelope,
@@ -851,11 +852,12 @@ export function registerInternalEventRoutes(app: Hono, deps: AppDeps): void {
         }
         throw error;
       }
+      const events = ungroupHostDaemonEvents(payload.eventGroups);
       const { entries, rejectedEvents } = resolvePostableEventBatchEntries(
         deps,
         {
           hostId: session.hostId,
-          events: payload.events,
+          events,
         },
       );
       if (rejectedEvents.length > 0) {

--- a/apps/server/src/ws/watch-interests.ts
+++ b/apps/server/src/ws/watch-interests.ts
@@ -72,6 +72,7 @@ export class WatchInterestCoordinator {
   >();
   private readonly targetsByInterest = new Map<string, RealtimeSubscriptionTarget>();
   private readonly generationByHost = new Map<string, number>();
+  private readonly lastWatchTargetFingerprintByHost = new Map<string, string>();
   private readonly lastResolvedHostIdsByInterest = new Map<string, Set<string>>();
 
   constructor(private readonly deps: WatchInterestCoordinatorDeps) {
@@ -202,10 +203,19 @@ export class WatchInterestCoordinator {
   private sendSnapshotsForHosts(hostIds: ReadonlySet<string>): void {
     for (const hostId of hostIds) {
       const generation = (this.generationByHost.get(hostId) ?? 0) + 1;
+      const watchSet = this.resolveWatchSetForHost({ generation, hostId });
+      const fingerprint = JSON.stringify({
+        workspaceTargets: watchSet.workspaceTargets,
+        threadStorageTargets: watchSet.threadStorageTargets,
+      });
+      if (this.lastWatchTargetFingerprintByHost.get(hostId) === fingerprint) {
+        continue;
+      }
+      this.lastWatchTargetFingerprintByHost.set(hostId, fingerprint);
       this.generationByHost.set(hostId, generation);
       this.deps.hub.sendDaemonMessage(hostId, {
         type: "watch-set.replace",
-        ...this.resolveWatchSetForHost({ generation, hostId }),
+        ...watchSet,
       });
     }
   }

--- a/apps/server/test/app/watch-interests.test.ts
+++ b/apps/server/test/app/watch-interests.test.ts
@@ -68,6 +68,7 @@ describe("WatchInterestCoordinator", () => {
       kind: "environment-detail",
       environmentId: environment.id,
     });
+    expect(daemonSocket.messages).toHaveLength(1);
 
     expect(lastDaemonMessage(daemonSocket)).toMatchObject({
       type: "watch-set.replace",
@@ -87,6 +88,7 @@ describe("WatchInterestCoordinator", () => {
       kind: "environment-detail",
       environmentId: environment.id,
     });
+    expect(daemonSocket.messages).toHaveLength(1);
     expect(lastDaemonMessage(daemonSocket)).toMatchObject({
       type: "watch-set.replace",
       workspaceTargets: [
@@ -100,6 +102,7 @@ describe("WatchInterestCoordinator", () => {
       kind: "environment-detail",
       environmentId: environment.id,
     });
+    expect(daemonSocket.messages).toHaveLength(2);
     expect(lastDaemonMessage(daemonSocket)).toMatchObject({
       type: "watch-set.replace",
       workspaceTargets: [],
@@ -252,6 +255,23 @@ describe("WatchInterestCoordinator", () => {
     const snapshotCount = daemonSocket.messages.length;
 
     hub.notifyEnvironment(environment.id, ["work-status-changed"]);
+
+    expect(daemonSocket.messages).toHaveLength(snapshotCount);
+  });
+
+  it("does not replace a watch set when a relevant invalidation resolves identically", () => {
+    const { environment, host, hub, watchInterests } = setup();
+    const daemonSocket = createMockHubSocket();
+    const socket = createMockHubSocket();
+    hub.registerDaemon("session-1", host.id, daemonSocket);
+
+    watchInterests.subscribe(socket, {
+      kind: "environment-detail",
+      environmentId: environment.id,
+    });
+    const snapshotCount = daemonSocket.messages.length;
+
+    hub.notifyEnvironment(environment.id, ["metadata-changed"]);
 
     expect(daemonSocket.messages).toHaveLength(snapshotCount);
   });

--- a/apps/server/test/internal/internal-event-append-ownership.test.ts
+++ b/apps/server/test/internal/internal-event-append-ownership.test.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { events, getThread } from "@bb/db";
 import { threadScope, turnScope } from "@bb/domain";
 import {
+  groupHostDaemonEvents,
   hostDaemonEventBatchResponseSchema,
   type HostDaemonEventEnvelope,
 } from "@bb/host-daemon-contract";
@@ -38,7 +39,7 @@ async function postEventBatch(args: PostEventBatchArgs): Promise<Response> {
     headers: internalAuthHeaders(args.harness),
     body: JSON.stringify({
       sessionId: args.sessionId,
-      events: args.events,
+      eventGroups: groupHostDaemonEvents(args.events),
     }),
   });
 }

--- a/apps/server/test/internal/internal-event-envelope-threadid-regression.test.ts
+++ b/apps/server/test/internal/internal-event-envelope-threadid-regression.test.ts
@@ -1,5 +1,6 @@
 import { createThread, getThread } from "@bb/db";
 import { threadScope } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { describe, expect, it } from "vitest";
 import {
   createTestDaemonEventEnvelope,
@@ -50,7 +51,7 @@ describe("internal event envelope threadId regression", () => {
         headers: internalAuthHeaders(harness, { hostId: hostA.host.id }),
         body: JSON.stringify({
           sessionId: hostA.session.id,
-          events: [
+          eventGroups: groupHostDaemonEvents([
             createTestDaemonEventEnvelope({
               threadId: threadA.id,
               event: {
@@ -61,7 +62,7 @@ describe("internal event envelope threadId regression", () => {
                 threadName: "hacked",
               },
             }),
-          ],
+          ]),
         }),
       });
 
@@ -97,7 +98,7 @@ describe("internal event envelope threadId regression", () => {
         headers: internalAuthHeaders(harness, { hostId: host.id }),
         body: JSON.stringify({
           sessionId: session.id,
-          events: [
+          eventGroups: groupHostDaemonEvents([
             createTestDaemonEventEnvelope({
               threadId: thread.id,
               event: {
@@ -108,7 +109,7 @@ describe("internal event envelope threadId regression", () => {
                 threadName: "Provider supplied name",
               },
             }),
-          ],
+          ]),
         }),
       });
 

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -10,7 +10,10 @@ import {
   threads,
 } from "@bb/db";
 import { threadScope, turnScope } from "@bb/domain";
-import type { HostDaemonEventEnvelope } from "@bb/host-daemon-contract";
+import {
+  groupHostDaemonEvents,
+  type HostDaemonEventEnvelope,
+} from "@bb/host-daemon-contract";
 import { describe, expect, it, vi } from "vitest";
 import {
   internalAuthHeaders,
@@ -40,7 +43,7 @@ async function postEventBatch(args: {
     headers: internalAuthHeaders(args.harness),
     body: JSON.stringify({
       sessionId: args.sessionId,
-      events: args.events,
+      eventGroups: groupHostDaemonEvents(args.events),
     }),
   });
 }

--- a/apps/server/test/public/public-thread-timeline-delta.test.ts
+++ b/apps/server/test/public/public-thread-timeline-delta.test.ts
@@ -187,6 +187,7 @@ describe("GET /threads/:id/timeline?afterSequence (row-patch delta)", () => {
       const delta = await getTimeline(harness, thread.id, before.maxSeq);
       expect(delta.delta).toBeDefined();
       expect(delta.delta!.upsertRows).toHaveLength(0);
+      expect(delta.delta!.rowOrder).toBeUndefined();
       expect(applyTimelineDelta(before.rows, delta.delta!)).toEqual(
         before.rows,
       );

--- a/apps/server/test/system/event-pruning.test.ts
+++ b/apps/server/test/system/event-pruning.test.ts
@@ -1,5 +1,6 @@
 import { getThread, listEvents } from "@bb/db";
 import { turnScope } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { describe, expect, it, vi } from "vitest";
 import { applyTurnCompletedEvent } from "../../src/internal/turn-completed-events.js";
 import {
@@ -546,7 +547,7 @@ describe("thread event pruning", () => {
         headers: internalAuthHeaders(harness),
         body: JSON.stringify({
           sessionId: session.id,
-          events: [
+          eventGroups: groupHostDaemonEvents([
             createTestDaemonEventEnvelope({
               event: {
                 type: "thread/tokenUsage/updated",
@@ -572,7 +573,7 @@ describe("thread event pruning", () => {
                 },
               },
             }),
-          ],
+          ]),
         }),
       });
 

--- a/apps/server/test/threads/generated-branch-names.test.ts
+++ b/apps/server/test/threads/generated-branch-names.test.ts
@@ -5,6 +5,7 @@ import {
   threadSchema,
   turnScope,
 } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   internalAuthHeaders,
@@ -857,7 +858,7 @@ describe("generated managed branch names", () => {
           headers: internalAuthHeaders(harness),
           body: JSON.stringify({
             sessionId: session.id,
-            events: [
+            eventGroups: groupHostDaemonEvents([
               {
                 threadId: thread.id,
                 event: {
@@ -877,7 +878,7 @@ describe("generated managed branch names", () => {
                   status: "completed",
                 },
               },
-            ],
+            ]),
           }),
         },
       );

--- a/apps/server/test/threads/thread-live-start-handoff.test.ts
+++ b/apps/server/test/threads/thread-live-start-handoff.test.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedThreadExecutionOptions,
   type Thread,
 } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { describe, expect, it } from "vitest";
 import {
   hasLiveThreadStartInFlight,
@@ -174,11 +175,15 @@ describe("live thread start handoff", () => {
           environmentId: fixture.environment.id,
           threadId: fixture.thread.id,
         });
+        expect(getThread(harness.db, fixture.thread.id)?.archivedAt).toEqual(
+          expect.any(Number),
+        );
         expect(
-          getThread(harness.db, fixture.thread.id)?.archivedAt,
-        ).toEqual(expect.any(Number));
-        expect(
-          listQueuedThreadCommands(harness, "thread.archive", fixture.thread.id),
+          listQueuedThreadCommands(
+            harness,
+            "thread.archive",
+            fixture.thread.id,
+          ),
         ).toEqual([]);
         await reportQueuedCommandSuccess(harness, stopCommand, {});
       } finally {
@@ -323,7 +328,7 @@ describe("live thread start handoff", () => {
           headers: internalAuthHeaders(harness),
           body: JSON.stringify({
             sessionId,
-            events: [
+            eventGroups: groupHostDaemonEvents([
               createTestDaemonEventEnvelope({
                 event: {
                   type: "thread/identity",
@@ -349,7 +354,7 @@ describe("live thread start handoff", () => {
                   status: "completed",
                 },
               }),
-            ],
+            ]),
           }),
         },
       );

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 51 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 52 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -170,13 +170,68 @@ export type HostDaemonEventEnvelope = z.infer<
   typeof hostDaemonEventEnvelopeSchema
 >;
 
-export const hostDaemonEventBatchRequestSchema = z.object({
-  sessionId: z.string().min(1),
-  events: z.array(hostDaemonEventEnvelopeSchema),
-});
+const hostDaemonWireEventSchema = z
+  .unknown()
+  .superRefine((value, context) => {
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      Object.hasOwn(value, "sequence")
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Daemon events must not provide a server-owned sequence",
+        path: ["sequence"],
+      });
+    }
+  })
+  .pipe(threadEventSchema);
+
+export const hostDaemonEventGroupSchema = z
+  .object({
+    threadId: z.string().min(1),
+    events: z.array(hostDaemonWireEventSchema).min(1),
+  })
+  .strict();
+export type HostDaemonEventGroup = z.infer<typeof hostDaemonEventGroupSchema>;
+
+export const hostDaemonEventBatchRequestSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    eventGroups: z.array(hostDaemonEventGroupSchema),
+  })
+  .strict();
 export type HostDaemonEventBatchRequest = z.infer<
   typeof hostDaemonEventBatchRequestSchema
 >;
+
+/**
+ * Compact consecutive events for the same thread without changing global
+ * event ordering. Keeping separate groups when a thread recurs later preserves
+ * response event indexes exactly.
+ */
+export function groupHostDaemonEvents(
+  envelopes: readonly HostDaemonEventEnvelope[],
+): HostDaemonEventGroup[] {
+  const groups: HostDaemonEventGroup[] = [];
+  for (const envelope of envelopes) {
+    const last = groups.at(-1);
+    if (last?.threadId === envelope.threadId) {
+      last.events.push(envelope.event);
+    } else {
+      groups.push({ threadId: envelope.threadId, events: [envelope.event] });
+    }
+  }
+  return groups;
+}
+
+export function ungroupHostDaemonEvents(
+  groups: readonly HostDaemonEventGroup[],
+): HostDaemonEventEnvelope[] {
+  return groups.flatMap((group) =>
+    group.events.map((event) => ({ threadId: group.threadId, event })),
+  );
+}
 
 export const hostDaemonEventRejectionReasonSchema = z.enum([
   "thread_not_owned_by_host",

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -2594,21 +2594,23 @@ describe("host-daemon session schemas", () => {
     expect(
       hostDaemonEventBatchRequestSchema.parse({
         sessionId: "session_123",
-        events: [
+        eventGroups: [
           {
             threadId: "thr_123",
-            event: {
-              type: "system/error",
-              threadId: "thr_123",
-              scope: threadScope(),
-              message: "boom",
-            },
+            events: [
+              {
+                type: "system/error",
+                threadId: "thr_123",
+                scope: threadScope(),
+                message: "boom",
+              },
+            ],
           },
         ],
       }),
     ).toMatchObject({
       sessionId: "session_123",
-      events: [
+      eventGroups: [
         {
           threadId: "thr_123",
         },
@@ -2671,16 +2673,18 @@ describe("host-daemon session schemas", () => {
     expect(() =>
       hostDaemonEventBatchRequestSchema.parse({
         sessionId: "session_123",
-        events: [
+        eventGroups: [
           {
             threadId: "thr_123",
-            sequence: 1,
-            event: {
-              type: "system/error",
-              threadId: "thr_123",
-              scope: threadScope(),
-              message: "boom",
-            },
+            events: [
+              {
+                type: "system/error",
+                threadId: "thr_123",
+                scope: threadScope(),
+                message: "boom",
+                sequence: 1,
+              },
+            ],
           },
         ],
       }),

--- a/packages/host-daemon-contract/test/payload-size.test.ts
+++ b/packages/host-daemon-contract/test/payload-size.test.ts
@@ -1,0 +1,141 @@
+import { gzipSync } from "node:zlib";
+import { turnScope, type ThreadEvent } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import {
+  groupHostDaemonEvents,
+  type HostDaemonEventEnvelope,
+  ungroupHostDaemonEvents,
+} from "../src/session.js";
+
+interface PayloadSize {
+  gzipBytes: number;
+  jsonBytes: number;
+}
+
+function payloadSize(value: unknown): PayloadSize {
+  const json = JSON.stringify(value);
+  return {
+    gzipBytes: gzipSync(json).byteLength,
+    jsonBytes: Buffer.byteLength(json),
+  };
+}
+
+function event(index: number): ThreadEvent {
+  return {
+    type: "item/agentMessage/delta",
+    threadId: "thr_payload_measurement_123456789",
+    providerThreadId: "provider_payload_measurement_123456789",
+    scope: turnScope("turn_payload_measurement_123456789"),
+    itemId: "item_payload_measurement_123456789",
+    delta: `streamed token chunk ${index} `,
+  };
+}
+
+describe("daemon-to-server event payload sizes", () => {
+  it("preserves event order when a thread recurs after another thread", () => {
+    const envelopes: HostDaemonEventEnvelope[] = [
+      { threadId: "thr_a", event: event(1) },
+      { threadId: "thr_b", event: event(2) },
+      { threadId: "thr_a", event: event(3) },
+    ];
+
+    const groups = groupHostDaemonEvents(envelopes);
+
+    expect(groups.map((group) => group.threadId)).toEqual([
+      "thr_a",
+      "thr_b",
+      "thr_a",
+    ]);
+    expect(ungroupHostDaemonEvents(groups)).toEqual(envelopes);
+  });
+
+  it("records legacy-envelope and grouped sizes across representative batches", () => {
+    const measurements = [1, 10, 50].map((eventCount) => {
+      const events: HostDaemonEventEnvelope[] = Array.from(
+        { length: eventCount },
+        (_, index) => ({
+          threadId: "thr_payload_measurement_123456789",
+          event: event(index),
+        }),
+      );
+      const legacyPayload = {
+        sessionId: "session_payload_measurement_123456789",
+        events,
+      };
+      const groupedPayload = {
+        sessionId: "session_payload_measurement_123456789",
+        eventGroups: groupHostDaemonEvents(events),
+      };
+      return {
+        eventCount,
+        legacyEnvelope: payloadSize(legacyPayload),
+        grouped: payloadSize(groupedPayload),
+      };
+    });
+
+    expect(measurements).toEqual([
+      {
+        eventCount: 1,
+        legacyEnvelope: { gzipBytes: 194, jsonBytes: 413 },
+        grouped: { gzipBytes: 198, jsonBytes: 421 },
+      },
+      {
+        eventCount: 10,
+        legacyEnvelope: { gzipBytes: 246, jsonBytes: 3_554 },
+        grouped: { gzipBytes: 247, jsonBytes: 3_049 },
+      },
+      {
+        eventCount: 50,
+        legacyEnvelope: { gzipBytes: 406, jsonBytes: 17_554 },
+        grouped: { gzipBytes: 407, jsonBytes: 14_769 },
+      },
+    ]);
+
+    for (const measurement of measurements.slice(1)) {
+      expect(measurement.grouped.jsonBytes).toBeLessThan(
+        measurement.legacyEnvelope.jsonBytes,
+      );
+    }
+  });
+});
+
+describe("server-to-daemon watch payload sizes", () => {
+  it("records replacement snapshot sizes across representative target counts", () => {
+    const measurements = [1, 10, 50].map((targetCount) => {
+      const payload = {
+        type: "watch-set.replace",
+        generation: 42,
+        workspaceTargets: Array.from({ length: targetCount }, (_, index) => ({
+          environmentId: `env_payload_measurement_${index}`,
+          workspaceContext: {
+            workspacePath: `/Users/example/worktrees/payload-measurement-${index}`,
+            workspaceProvisionType: "managed-worktree",
+          },
+        })),
+        threadStorageTargets: Array.from(
+          { length: targetCount },
+          (_, index) => ({
+            environmentId: `env_payload_measurement_${index}`,
+            threadId: `thr_payload_measurement_${index}`,
+          }),
+        ),
+      };
+      return { targetCount, replacement: payloadSize(payload) };
+    });
+
+    expect(measurements).toEqual([
+      {
+        targetCount: 1,
+        replacement: { gzipBytes: 201, jsonBytes: 351 },
+      },
+      {
+        targetCount: 10,
+        replacement: { gzipBytes: 315, jsonBytes: 2_700 },
+      },
+      {
+        targetCount: 50,
+        replacement: { gzipBytes: 765, jsonBytes: 13_300 },
+      },
+    ]);
+  });
+});

--- a/packages/server-contract/src/thread-timeline.ts
+++ b/packages/server-contract/src/thread-timeline.ts
@@ -522,14 +522,14 @@ export type TimelineToolArgs = JsonObject | null;
  * are preserved) and diffing it against the rows the client last received.
  *
  * `upsertRows` carries the full body of every row that was added or changed.
- * `rowOrder` is the complete, ordered id list of the current window, so the
- * client reconstructs the exact row order and membership without guessing —
- * any id present in `rowOrder` but absent from `upsertRows` is an unchanged row
- * the client already holds. See {@link applyTimelineDelta}.
+ * `rowOrder`, when present, is the complete, ordered id list of the current
+ * window, so the client reconstructs exact ordering and membership. It is
+ * omitted when both are unchanged, which avoids repeatedly sending every row
+ * id while an active row is merely streaming new content.
  */
 export const timelineDeltaSchema = z.object({
   upsertRows: z.array(timelineRowSchema),
-  rowOrder: z.array(z.string()),
+  rowOrder: z.array(z.string()).optional(),
 });
 export type TimelineDelta = z.infer<typeof timelineDeltaSchema>;
 
@@ -547,13 +547,17 @@ export function computeTimelineRowDelta(
   }
   const upsertRows: TimelineRow[] = [];
   const rowOrder: string[] = [];
+  let orderChanged = prevRows.length !== currentRows.length;
   for (const row of currentRows) {
     rowOrder.push(row.id);
+    if (prevRows[rowOrder.length - 1]?.id !== row.id) {
+      orderChanged = true;
+    }
     if (prevById.get(row.id) !== JSON.stringify(row)) {
       upsertRows.push(row);
     }
   }
-  return { upsertRows, rowOrder };
+  return orderChanged ? { upsertRows, rowOrder } : { upsertRows };
 }
 
 /**
@@ -574,7 +578,8 @@ export function applyTimelineDelta(
     byId.set(row.id, row);
   }
   const result: TimelineRow[] = [];
-  for (const id of delta.rowOrder) {
+  const rowOrder = delta.rowOrder ?? prevRows.map((row) => row.id);
+  for (const id of rowOrder) {
     const row = byId.get(id);
     if (row === undefined) {
       return null;

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -224,8 +224,11 @@ const OPTIONAL_SERVER_FIELD_GROUPS: readonly OptionalServerFieldGroup[] = [
   },
   {
     reason:
-      "Timeline responses carry a row-patch delta only when the request supplied a usable afterSequence; a full window omits it.",
-    fields: ["threadTimelineResponseSchema.delta"],
+      "Timeline responses carry a row-patch delta only for a usable afterSequence, and that delta carries rowOrder only when membership or ordering changed.",
+    fields: [
+      "threadTimelineResponseSchema.delta",
+      "threadTimelineResponseSchema.delta.rowOrder",
+    ],
   },
   {
     reason:

--- a/packages/server-contract/test/payload-size.test.ts
+++ b/packages/server-contract/test/payload-size.test.ts
@@ -1,0 +1,92 @@
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+  computeTimelineRowDelta,
+  type TimelineRow,
+} from "../src/thread-timeline.js";
+
+interface PayloadSize {
+  gzipBytes: number;
+  jsonBytes: number;
+}
+
+function payloadSize(value: unknown): PayloadSize {
+  const json = JSON.stringify(value);
+  return {
+    gzipBytes: gzipSync(json).byteLength,
+    jsonBytes: Buffer.byteLength(json),
+  };
+}
+
+function row(index: number, detail = "stable"): TimelineRow {
+  return {
+    id: `timeline-row-${String(index).padStart(4, "0")}`,
+    kind: "system",
+    threadId: "thr_payload_measurement_123456789",
+    turnId: "turn_payload_measurement_123456789",
+    sourceSeqStart: index + 1,
+    sourceSeqEnd: index + 1,
+    startedAt: 1_750_000_000_000 + index,
+    createdAt: 1_750_000_000_000 + index,
+    systemKind: "debug",
+    title: `Timeline measurement row ${index}`,
+    detail,
+    status: null,
+  };
+}
+
+describe("server-to-browser timeline payload sizes", () => {
+  it("records full and single-row delta sizes across representative windows", () => {
+    const measurements = [1, 20, 100].map((rowCount) => {
+      const previous = Array.from({ length: rowCount }, (_, index) =>
+        row(index),
+      );
+      const current = previous.map((item, index) =>
+        index === rowCount - 1
+          ? row(index, "streamed update ".repeat(20))
+          : item,
+      );
+      const compactDelta = computeTimelineRowDelta(previous, current);
+      const legacyDelta = {
+        ...compactDelta,
+        rowOrder: current.map((item) => item.id),
+      };
+      return {
+        rowCount,
+        full: payloadSize(current),
+        legacyDelta: payloadSize(legacyDelta),
+        compactDelta: payloadSize(compactDelta),
+      };
+    });
+
+    expect(measurements).toEqual([
+      {
+        rowCount: 1,
+        full: { gzipBytes: 216, jsonBytes: 629 },
+        legacyDelta: { gzipBytes: 239, jsonBytes: 677 },
+        compactDelta: { gzipBytes: 227, jsonBytes: 644 },
+      },
+      {
+        rowCount: 20,
+        full: { gzipBytes: 552, jsonBytes: 6_627 },
+        legacyDelta: { gzipBytes: 297, jsonBytes: 1_060 },
+        compactDelta: { gzipBytes: 230, jsonBytes: 647 },
+      },
+      {
+        rowCount: 100,
+        full: { gzipBytes: 1_868, jsonBytes: 31_989 },
+        legacyDelta: { gzipBytes: 471, jsonBytes: 2_662 },
+        compactDelta: { gzipBytes: 230, jsonBytes: 649 },
+      },
+    ]);
+
+    for (const measurement of measurements) {
+      expect(measurement.compactDelta.jsonBytes).toBeLessThanOrEqual(
+        measurement.legacyDelta.jsonBytes,
+      );
+      expect(measurement.compactDelta.gzipBytes).toBeLessThanOrEqual(
+        measurement.legacyDelta.gzipBytes,
+      );
+    }
+  });
+});

--- a/packages/server-contract/test/thread-timeline-delta.test.ts
+++ b/packages/server-contract/test/thread-timeline-delta.test.ts
@@ -50,6 +50,16 @@ describe("timeline delta", () => {
     expect(merged?.[0]).toBe(a);
   });
 
+  it("omits row order when membership and ordering are unchanged", () => {
+    const prev = [row("a", 1), row("b", 2)];
+    const current = [row("a", 1), row("b", 2, "changed")];
+
+    const delta = computeTimelineRowDelta(prev, current);
+
+    expect(delta.rowOrder).toBeUndefined();
+    expect(applyTimelineDelta(prev, delta)).toEqual(current);
+  });
+
   it("returns null when the base is stale (id neither held nor sent)", () => {
     expect(
       applyTimelineDelta([row("a", 1)], {


### PR DESCRIPTION
## Summary
- omit unchanged timeline row ordering from server-to-browser deltas
- group consecutive daemon events by thread and bump the daemon protocol to 52
- suppress semantically identical server-to-daemon watch-set replacements
- add repeatable raw JSON and gzip payload-size measurements

## Measurements
- 100-row browser delta: 2,662 B to 649 B raw; 471 B to 230 B gzip
- 50-event daemon batch: 17,554 B to 14,769 B raw
- unchanged 50-target watch update: 13,300 B to 0 B

## Validation
- full @bb/server test suite: 1,036 tests passed
- full @bb/host-daemon test suite: 413 tests passed
- server/host-daemon contract suites passed
- targeted watch-interest and timeline-delta tests passed after rebase
- build, typecheck, and lint passed for app, server, host daemon, and both contracts

## Rollout note
This bumps the host-daemon protocol from 51 to 52, so server and daemon artifacts must ship together. Auto-updating remote daemons recover through the existing protocol mismatch update path; daemons with auto-update disabled require a manual update/restart.