### PR TITLE
Fix daemon self-update npm resolution

### DIFF
--- a/apps/host-daemon/src/protocol-self-update.test.ts
+++ b/apps/host-daemon/src/protocol-self-update.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HostDaemonLogger } from "./logger.js";
@@ -27,6 +27,7 @@ async function createFixture(
     installFailure?: Error;
     now?: () => number;
     serverUrl?: string;
+    useDefaultInstaller?: boolean;
   } = {},
 ) {
   const dataDir = await mkdtemp(join(tmpdir(), "bb-self-update-test-"));
@@ -34,6 +35,7 @@ async function createFixture(
   const installTarball = vi.fn(async () => {
     if (args.installFailure) throw args.installFailure;
   });
+  const runProcess = vi.fn(async () => undefined);
   const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
     if (url.endsWith("/install/version")) {
@@ -53,15 +55,16 @@ async function createFixture(
     dataDir,
     enabled: args.enabled ?? true,
     fetchFn,
-    installTarball,
+    ...(args.useDefaultInstaller ? { runProcess } : { installTarball }),
     logger: testLogger,
     now: args.now,
     serverUrl: args.serverUrl ?? "https://server.example.test",
   });
-  return { fetchFn, installTarball, logger: testLogger, updater };
+  return { fetchFn, installTarball, logger: testLogger, runProcess, updater };
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(
     roots.splice(0).map((root) => rm(root, { recursive: true })),
   );
@@ -75,6 +78,26 @@ describe("protocol self-update", () => {
     );
     expect(test.fetchFn).toHaveBeenCalledTimes(2);
     expect(test.installTarball).toHaveBeenCalledOnce();
+  });
+
+  it("finds npm beside the running Node executable when the service PATH omits it", async () => {
+    vi.stubEnv("PATH", "/usr/bin:/bin");
+    const test = await createFixture({ useDefaultInstaller: true });
+
+    await expect(test.updater.handleProtocolMismatch()).resolves.toBe(
+      "updated",
+    );
+
+    expect(test.runProcess).toHaveBeenCalledOnce();
+    expect(test.runProcess).toHaveBeenCalledWith(
+      "npm",
+      ["install", "-g", expect.stringContaining("bb-app-update-")],
+      {
+        env: expect.objectContaining({
+          PATH: `${dirname(process.execPath)}${delimiter}/usr/bin:/bin`,
+        }),
+      },
+    );
   });
 
   it("does nothing when auto-update is disabled", async () => {

--- a/apps/host-daemon/src/protocol-self-update.ts
+++ b/apps/host-daemon/src/protocol-self-update.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import type { HostDaemonLogger } from "./logger.js";
@@ -26,6 +26,14 @@ export interface ProtocolSelfUpdateInstaller {
   (tarballPath: string): Promise<void>;
 }
 
+interface SelfUpdateProcessRunner {
+  (
+    command: string,
+    args: string[],
+    options: { env: NodeJS.ProcessEnv },
+  ): Promise<void>;
+}
+
 interface CreateProtocolSelfUpdaterOptions {
   dataDir: string;
   enabled: boolean;
@@ -33,6 +41,7 @@ interface CreateProtocolSelfUpdaterOptions {
   serverUrl: string;
   fetchFn?: FetchFn;
   installTarball?: ProtocolSelfUpdateInstaller;
+  runProcess?: SelfUpdateProcessRunner;
   now?: () => number;
 }
 
@@ -79,15 +88,39 @@ async function writeAttempt(path: string, attemptedAt: number): Promise<void> {
   await rename(temporary, path);
 }
 
-async function defaultInstallTarball(tarballPath: string): Promise<void> {
-  await execFileAsync("npm", ["install", "-g", tarballPath]);
+const defaultRunProcess: SelfUpdateProcessRunner = async (
+  command,
+  args,
+  options,
+) => {
+  await execFileAsync(command, args, options);
+};
+
+async function defaultInstallTarball(
+  tarballPath: string,
+  runProcess: SelfUpdateProcessRunner,
+): Promise<void> {
+  const executableDirectory = dirname(process.execPath);
+  const inheritedPath = process.env.PATH;
+  const path = inheritedPath
+    ? `${executableDirectory}${delimiter}${inheritedPath}`
+    : executableDirectory;
+  await runProcess("npm", ["install", "-g", tarballPath], {
+    env: { ...process.env, PATH: path },
+  });
 }
 
 export function createProtocolSelfUpdater(
   options: CreateProtocolSelfUpdaterOptions,
 ): ProtocolSelfUpdater {
   const fetchFn = options.fetchFn ?? fetch;
-  const installTarball = options.installTarball ?? defaultInstallTarball;
+  const installTarball =
+    options.installTarball ??
+    ((tarballPath) =>
+      defaultInstallTarball(
+        tarballPath,
+        options.runProcess ?? defaultRunProcess,
+      ));
   const now = options.now ?? Date.now;
   const attemptPath = join(options.dataDir, ATTEMPT_FILE_NAME);
 


### PR DESCRIPTION
## Summary

- prepend the running Node executable directory when the daemon invokes npm for protocol self-updates
- preserve the inherited service PATH while supporting launchd/systemd environments that omit the Node installation directory
- add regression coverage for the launchd PATH failure

## Validation

- `pnpm exec turbo run test --filter=@bb/host-daemon --force` (414 tests)
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run build lint --filter=@bb/host-daemon`
- `pnpm exec prettier apps/host-daemon/src/protocol-self-update.ts apps/host-daemon/src/protocol-self-update.test.ts --check`