### PR TITLE
Render plugin icons in mention pills

### DIFF
--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -214,6 +214,7 @@ describe("useComposer", () => {
         resource: {
           kind: "plugin",
           pluginId: "demo",
+          icon: null,
           itemId: "notes:work/ideas.md",
           label: "ideas.md",
         },

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -909,6 +909,26 @@ describe("PromptBoxInternal mention triggers", () => {
     expect(row.querySelector('[data-icon="FileText"]')).not.toBeNull();
   });
 
+  it("keeps a plugin mention's named icon hint in the inserted pill", async () => {
+    setPluginLogoUrls(new Map());
+    const suggestion = { ...githubIssueSuggestion, icon: "FileText" };
+    const { promptBoxRef } = renderPromptBox("@fix", {
+      mentionSuggestions: [suggestion],
+    });
+
+    await focusPromptEnd(promptBoxRef);
+    fireEvent.mouseDown(
+      await screen.findByRole("button", { name: /Fix login bug/u }),
+      { button: 0 },
+    );
+
+    await waitFor(() =>
+      expect(
+        getPromptEditorElement().querySelector('[data-icon="FileText"]'),
+      ).not.toBeNull(),
+    );
+  });
+
   it("reports hash mention queries with the active trigger", async () => {
     const { onMentionQueryChange, promptBoxRef } = renderPromptBox("#42", {
       mentionTriggers: ["@", "#"],
@@ -968,6 +988,7 @@ describe("PromptBoxInternal mention triggers", () => {
         resource: {
           kind: "plugin",
           pluginId: "github",
+          icon: null,
           itemId: "issue:owner/repo#42",
           label: "#42 Fix login bug",
         },

--- a/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-serialization.ts
@@ -1064,6 +1064,7 @@ export function promptMentionResourceFromSuggestion(
     return {
       kind: "plugin",
       pluginId: suggestion.pluginId,
+      icon: suggestion.icon,
       itemId: suggestion.itemId,
       label: suggestion.title.trim() || suggestion.itemId,
     };

--- a/apps/app/src/components/promptbox/mentions/PromptMentionIcon.tsx
+++ b/apps/app/src/components/promptbox/mentions/PromptMentionIcon.tsx
@@ -14,7 +14,7 @@ export function PromptMentionIcon({
     return (
       <PluginIcon
         pluginId={resource.pluginId}
-        icon={resource.icon}
+        icon={resource.icon ?? null}
         className={className}
       />
     );

--- a/apps/app/src/components/promptbox/mentions/PromptMentionIcon.tsx
+++ b/apps/app/src/components/promptbox/mentions/PromptMentionIcon.tsx
@@ -14,7 +14,7 @@ export function PromptMentionIcon({
     return (
       <PluginIcon
         pluginId={resource.pluginId}
-        icon={null}
+        icon={resource.icon}
         className={className}
       />
     );

--- a/apps/app/src/components/promptbox/mentions/prompt-mention-clipboard.test.ts
+++ b/apps/app/src/components/promptbox/mentions/prompt-mention-clipboard.test.ts
@@ -36,6 +36,7 @@ describe("parsePromptMentionClipboardElement", () => {
     const resource = {
       kind: "plugin" as const,
       pluginId: "github",
+      icon: null,
       itemId: "issue:owner/repo#42",
       label: "#42 Fix login bug",
     };
@@ -61,6 +62,7 @@ describe("parsePromptMentionClipboardElement", () => {
         resource: {
           kind: "plugin",
           pluginId: "github",
+          icon: null,
           itemId: "issue:owner/repo#42",
           label: "#42 Fix login bug",
         },

--- a/apps/app/src/lib/plugin-sdk-hooks.ts
+++ b/apps/app/src/lib/plugin-sdk-hooks.ts
@@ -278,6 +278,7 @@ export function useComposer(): PluginComposerApi {
             resource: {
               kind: "plugin",
               pluginId,
+              icon: null,
               itemId: `${provider}:${mention.id}`,
               label,
             },

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -188,8 +188,11 @@ export const promptMentionResourceSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("plugin"),
     pluginId: z.string(),
-    /** Named shared-UI icon hint supplied by the plugin mention item. */
-    icon: z.string().nullable().default(null),
+    /**
+     * Named shared-UI icon hint supplied by the plugin mention item. Omitted
+     * by mentions persisted before icon hints were stored.
+     */
+    icon: z.string().nullable().optional(),
     /**
      * Opaque item reference minted by the server's mention search
      * (`<providerId>:<provider item id>`); resolved back through the same

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -188,6 +188,8 @@ export const promptMentionResourceSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("plugin"),
     pluginId: z.string(),
+    /** Named shared-UI icon hint supplied by the plugin mention item. */
+    icon: z.string().nullable().default(null),
     /**
      * Opaque item reference minted by the server's mention search
      * (`<providerId>:<provider item id>`); resolved back through the same

--- a/packages/domain/test/shared-types.test.ts
+++ b/packages/domain/test/shared-types.test.ts
@@ -30,7 +30,7 @@ describe("prompt mention command triggers", () => {
     ).toBe(true);
   });
 
-  it("accepts plugin mention resources and requires all fields", () => {
+  it("defaults old plugin mention icons and requires identity fields", () => {
     const resource = {
       kind: "plugin",
       pluginId: "linear",
@@ -40,7 +40,7 @@ describe("prompt mention command triggers", () => {
     const parsed = promptMentionResourceSchema.safeParse(resource);
     expect(parsed.success).toBe(true);
     if (parsed.success) {
-      expect(parsed.data).toEqual(resource);
+      expect(parsed.data).toEqual({ ...resource, icon: null });
     }
     expect(
       promptMentionResourceSchema.safeParse({

--- a/packages/domain/test/shared-types.test.ts
+++ b/packages/domain/test/shared-types.test.ts
@@ -30,7 +30,7 @@ describe("prompt mention command triggers", () => {
     ).toBe(true);
   });
 
-  it("defaults old plugin mention icons and requires identity fields", () => {
+  it("accepts old plugin mentions without icons and requires identity fields", () => {
     const resource = {
       kind: "plugin",
       pluginId: "linear",
@@ -40,7 +40,7 @@ describe("prompt mention command triggers", () => {
     const parsed = promptMentionResourceSchema.safeParse(resource);
     expect(parsed.success).toBe(true);
     if (parsed.success) {
-      expect(parsed.data).toEqual({ ...resource, icon: null });
+      expect(parsed.data).toEqual(resource);
     }
     expect(
       promptMentionResourceSchema.safeParse({


### PR DESCRIPTION
## Summary
- preserve plugin-provided icon hints when mention suggestions become persisted prompt resources
- render the preserved icon in composer pills while keeping plugin logos preferred
- default older saved mentions to the generic plugin icon

## Tests
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/domain --force`
- `pnpm exec turbo run typecheck --filter=@bb/domain`