### PR TITLE
Keep Claude child threads active while subagents run

### DIFF
--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -2147,6 +2147,54 @@ describe("claude-code provider adapter", () => {
     ]);
   });
 
+  it("keeps an open turn for synthetic no-response messages while an agent is running", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const context = { threadId: "bb-thread-1" };
+    adapter.translateEvent(loadFixture("task-started-subagent.json"), context);
+
+    const events = adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "No response requested." }],
+          model: "<synthetic>",
+          stop_reason: "stop_sequence",
+          stop_sequence: "",
+          usage: {
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+        session_id: "claude-session-1",
+      },
+      context,
+    );
+
+    expect(events).toEqual([]);
+    adapter.translateEvent(
+      loadFixture("task-notification-subagent.json"),
+      context,
+    );
+    const finalEvents = adapter.translateEvent(
+      {
+        type: "result",
+        subtype: "end_turn",
+        session_id: "claude-session-1",
+      },
+      context,
+    );
+    expect(finalEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      }),
+    );
+  });
+
   it("translateEvent keeps assistant message ids distinct within one turn", () => {
     const adapter = createClaudeCodeProviderAdapter();
 
@@ -3463,6 +3511,214 @@ describe("claude-code provider adapter", () => {
         type: "turn/completed",
         scope: turnScope("turn-1"),
         status: "completed",
+      }),
+    );
+  });
+
+  it("keeps one logical turn open across Claude background-agent reinvocations", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const context = { threadId: "bb-thread-1" };
+
+    adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "I will wait for the agent." }],
+        },
+        session_id: "sess-1",
+      },
+      context,
+    );
+    adapter.translateEvent(loadFixture("task-started-subagent.json"), context);
+
+    const intermediateResult = adapter.translateEvent(
+      {
+        type: "result",
+        subtype: "end_turn",
+        session_id: "sess-1",
+      },
+      context,
+    );
+    expect(intermediateResult).not.toContainEqual(
+      expect.objectContaining({ type: "turn/completed" }),
+    );
+
+    adapter.translateEvent(
+      loadFixture("task-notification-subagent.json"),
+      context,
+    );
+    const resumed = adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "The agent finished." }],
+        },
+        session_id: "sess-1",
+      },
+      context,
+    );
+    expect(resumed).not.toContainEqual(
+      expect.objectContaining({ type: "turn/started" }),
+    );
+    expect(resumed).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        scope: turnScope("turn-1"),
+        item: expect.objectContaining({
+          type: "agentMessage",
+          text: "The agent finished.",
+        }),
+      }),
+    );
+
+    const finalResult = adapter.translateEvent(
+      {
+        type: "result",
+        subtype: "end_turn",
+        session_id: "sess-1",
+      },
+      context,
+    );
+    expect(finalResult).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      }),
+    );
+  });
+
+  it("treats workflows and legacy subagents as completion-blocking", () => {
+    const blockingTasks = [
+      loadFixture("task-started-workflow.json"),
+      {
+        type: "system",
+        subtype: "task_started",
+        task_id: "subagent-1",
+        tool_use_id: "tool-subagent-1",
+        description: "Legacy subagent",
+        task_type: "local_subagent",
+        subagent_type: "Explore",
+        uuid: "uuid-subagent-1",
+        session_id: "sess-1",
+      },
+    ];
+
+    for (const [index, task] of blockingTasks.entries()) {
+      const adapter = createClaudeCodeProviderAdapter();
+      const context = { threadId: `bb-thread-${index}` };
+      adapter.translateEvent(
+        {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "waiting" }],
+          },
+          session_id: "sess-1",
+        },
+        context,
+      );
+      adapter.translateEvent(task, context);
+
+      const events = adapter.translateEvent(
+        {
+          type: "result",
+          subtype: "end_turn",
+          session_id: "sess-1",
+        },
+        context,
+      );
+      expect(events).not.toContainEqual(
+        expect.objectContaining({ type: "turn/completed" }),
+      );
+    }
+  });
+
+  it("does not let detached or ambient tasks block turn completion", () => {
+    for (const task of [
+      {
+        task_id: "bash-1",
+        task_type: "local_bash",
+        description: "Run a detached server",
+      },
+      {
+        task_id: "ambient-agent-1",
+        task_type: "local_agent",
+        description: "Ambient agent",
+        skip_transcript: true,
+      },
+    ]) {
+      const adapter = createClaudeCodeProviderAdapter();
+      const context = { threadId: `bb-thread-${task.task_id}` };
+      adapter.translateEvent(
+        {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+          },
+          session_id: "sess-1",
+        },
+        context,
+      );
+      adapter.translateEvent(
+        {
+          type: "system",
+          subtype: "task_started",
+          tool_use_id: `tool-${task.task_id}`,
+          uuid: `uuid-${task.task_id}`,
+          session_id: "sess-1",
+          ...task,
+        },
+        context,
+      );
+
+      const events = adapter.translateEvent(
+        {
+          type: "result",
+          subtype: "end_turn",
+          session_id: "sess-1",
+        },
+        context,
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn/completed",
+          scope: turnScope("turn-1"),
+          status: "completed",
+        }),
+      );
+    }
+  });
+
+  it("closes a failed result even while a background agent is open", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const context = { threadId: "bb-thread-1" };
+    adapter.translateEvent(
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "x" }] },
+        session_id: "sess-1",
+      },
+      context,
+    );
+    adapter.translateEvent(loadFixture("task-started-subagent.json"), context);
+
+    const events = adapter.translateEvent(
+      {
+        type: "result",
+        subtype: "error",
+        session_id: "sess-1",
+      },
+      context,
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        status: "failed",
       }),
     );
   });

--- a/packages/agent-runtime/src/claude-code/task-translation.ts
+++ b/packages/agent-runtime/src/claude-code/task-translation.ts
@@ -84,6 +84,31 @@ export function hasOpenClaudeBackgroundTasks(tasks: ClaudeTaskMap): boolean {
   return false;
 }
 
+/**
+ * Whether Claude still has bounded agent work that will reinvoke the parent
+ * model when it settles. A successful SDK result while one of these tasks is
+ * open ends only the current SDK loop segment, not the logical bb turn.
+ *
+ * Backgrounded shell commands are deliberately excluded: they are detached
+ * work and may be long-lived (for example, a dev server). Ambient tasks are
+ * excluded for the same reason.
+ */
+export function hasCompletionBlockingClaudeTasks(
+  tasks: ClaudeTaskMap,
+): boolean {
+  for (const task of tasks.values()) {
+    if (
+      !task.terminal &&
+      !task.skipTranscript &&
+      (isBackgroundAgentTaskType(task.taskType) ||
+        task.taskType === LOCAL_WORKFLOW_TASK_TYPE)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function buildClaudeTaskItemId(taskId: string, generation: number): string {
   return generation > 1 ? `task:${taskId}#${generation}` : `task:${taskId}`;
 }

--- a/packages/agent-runtime/src/claude-code/translate-message.ts
+++ b/packages/agent-runtime/src/claude-code/translate-message.ts
@@ -39,6 +39,7 @@ import {
 } from "./schemas.js";
 import { buildClaudeProviderErrorInfo } from "./error-info.js";
 import {
+  hasCompletionBlockingClaudeTasks,
   translateClaudeTaskMessage,
   type ClaudeTaskMap,
 } from "./task-translation.js";
@@ -277,14 +278,15 @@ function buildClaudeRateLimitEventDetail(
   return details.join("; ");
 }
 
-function isHardClaudeRateLimitRejection(message: ClaudeRateLimitEvent): boolean {
+function isHardClaudeRateLimitRejection(
+  message: ClaudeRateLimitEvent,
+): boolean {
   const info = message.rate_limit_info;
   if (info.status !== "rejected") {
     return false;
   }
   return (
-    info.overageStatus !== "allowed" &&
-    info.overageStatus !== "allowed_warning"
+    info.overageStatus !== "allowed" && info.overageStatus !== "allowed_warning"
   );
 }
 
@@ -463,6 +465,9 @@ export function translateClaudeSdkMessage(
             : undefined);
         if (!turnId) {
           return [];
+        }
+        if (hasCompletionBlockingClaudeTasks(state.tasksById)) {
+          return events;
         }
         events.push({
           type: "turn/completed",
@@ -697,7 +702,8 @@ export function translateClaudeSdkMessage(
             tokenUsage,
           });
         }
-        if (isClaudeResultFailure(message)) {
+        const failed = isClaudeResultFailure(message);
+        if (failed) {
           events.push(
             buildClaudeProviderErrorEvent({
               detail: getClaudeResultErrorDetail(message),
@@ -710,15 +716,21 @@ export function translateClaudeSdkMessage(
             }),
           );
         }
+        // Claude emits a successful result at the end of each SDK loop
+        // segment. Background agents and workflows notify the CLI when they
+        // settle, which reinvokes the parent model. Keep the logical bb turn
+        // open across those segments so idle status, waiters, queued messages,
+        // pruning, and parent completion notifications only observe the final
+        // result. Failures still close immediately.
+        if (!failed && hasCompletionBlockingClaudeTasks(state.tasksById)) {
+          break;
+        }
         events.push({
           type: "turn/completed",
           threadId,
           providerThreadId: "",
           scope: turnScope(state.currentTurnId),
-          status:
-            message.is_error || message.subtype.startsWith("error")
-              ? "failed"
-              : "completed",
+          status: failed ? "failed" : "completed",
         });
         args.turnState.finishTurn({ state, threadId: stateKey });
       }


### PR DESCRIPTION
## Summary

- keep a logical Claude turn open across successful SDK-loop results while bounded background agents or workflows are still running
- leave detached shell commands and ambient tasks non-blocking, and preserve immediate failure completion
- cover native agents, legacy subagents, workflows, synthetic no-response messages, and reinvocation ordering

## Tests

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test typecheck --filter=@bb/agent-runtime`