### PR TITLE
Remove ellipses from remote access actions

### DIFF
--- a/plugins/connect/app.test.tsx
+++ b/plugins/connect/app.test.tsx
@@ -243,7 +243,7 @@ describe("connect settings section", () => {
     );
 
     await slot.findByText("Connected");
-    fireEvent.click(slot.getByRole("button", { name: "Disconnect…" }));
+    fireEvent.click(slot.getByRole("button", { name: "Disconnect" }));
 
     // The dialog names the concrete URL that will die.
     await slot.findByText("Disconnect remote access?");

--- a/plugins/connect/app.tsx
+++ b/plugins/connect/app.tsx
@@ -827,7 +827,7 @@ function ConnectedContent({
           className="text-muted-foreground"
           onClick={() => setRepairOpen((open) => !open)}
         >
-          Re-pair…
+          Re-pair
         </Button>
       </div>
 
@@ -878,7 +878,7 @@ function ConnectedContent({
           className={DANGER_QUIET_CLASS}
           onClick={() => setConfirmOpen(true)}
         >
-          Disconnect…
+          Disconnect
         </Button>
       </div>
       {disconnectError !== null ? (
@@ -970,7 +970,7 @@ function ReconnectingContent({
           className={DANGER_QUIET_CLASS}
           onClick={() => setConfirmOpen(true)}
         >
-          Disconnect…
+          Disconnect
         </Button>
       </div>
       {disconnectError !== null ? (


### PR DESCRIPTION
## Summary

- remove trailing ellipses from the Re-pair action
- remove trailing ellipses from Disconnect actions in connected and reconnecting states
- retain ellipses for ongoing progress states

## Tests

- pnpm exec turbo run test --filter=bb-plugin-connect --force
- pnpm exec turbo run typecheck --filter=bb-plugin-connect