### PR TITLE
Move prompt attachments into the actions menu

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PromptBoxActionsMenu } from "./PromptBoxActionsMenu";
 
 afterEach(cleanup);
@@ -11,5 +11,33 @@ describe("PromptBoxActionsMenu", () => {
     render(<PromptBoxActionsMenu onAction={() => {}} />);
 
     expect(screen.queryByRole("button", { name: "Prompt actions" })).toBeNull();
+  });
+
+  it("offers file attachments even when no provider actions are available", async () => {
+    const onAttach = vi.fn();
+    render(<PromptBoxActionsMenu onAction={() => {}} onAttach={onAttach} />);
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Prompt actions" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Attach files" }),
+    );
+
+    expect(onAttach).toHaveBeenCalledOnce();
+  });
+
+  it("keeps attachment upload progress visible on the menu trigger", () => {
+    render(
+      <PromptBoxActionsMenu
+        isAttaching
+        onAction={() => {}}
+        onAttach={() => {}}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Prompt actions" });
+    expect(trigger.querySelector('[data-icon="Spinner"]')).not.toBeNull();
   });
 });

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
@@ -23,6 +24,8 @@ export interface PromptBoxAction {
 
 interface PromptBoxActionsMenuProps {
   actions?: readonly PromptBoxAction[];
+  isAttaching?: boolean;
+  onAttach?: () => void;
   onAction: (action: PromptBoxAction) => void;
 }
 
@@ -81,15 +84,17 @@ function orderedPromptActions(
 
 export function PromptBoxActionsMenu({
   actions = [],
+  isAttaching = false,
+  onAttach,
   onAction,
 }: PromptBoxActionsMenuProps) {
-  const selectedActionRef = useRef(false);
+  const selectedItemRef = useRef(false);
   const visibleActions = orderedPromptActions(actions).filter(
     (action) => action.text.length > 0,
   );
   const clearSelectedActionAfterClose = useCallback(() => {
     const clear = () => {
-      selectedActionRef.current = false;
+      selectedItemRef.current = false;
     };
     if (typeof requestAnimationFrame === "function") {
       requestAnimationFrame(clear);
@@ -98,7 +103,7 @@ export function PromptBoxActionsMenu({
     setTimeout(clear, 0);
   }, []);
 
-  if (visibleActions.length === 0) {
+  if (visibleActions.length === 0 && !onAttach) {
     return null;
   }
 
@@ -124,7 +129,10 @@ export function PromptBoxActionsMenu({
             "-ml-1.5",
           )}
         >
-          <Icon name="Plus" className="size-4" />
+          <Icon
+            name={isAttaching ? "Spinner" : "Plus"}
+            className={cn("size-4", isAttaching && "animate-spin")}
+          />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -135,11 +143,33 @@ export function PromptBoxActionsMenu({
         className="w-36"
         mobileTitle="Prompt actions"
         onCloseAutoFocus={(event) => {
-          if (selectedActionRef.current) {
+          if (selectedItemRef.current) {
             event.preventDefault();
           }
         }}
       >
+        {onAttach ? (
+          <>
+            <DropdownMenuItem
+              disabled={isAttaching}
+              onSelect={() => {
+                selectedItemRef.current = true;
+                onAttach();
+              }}
+            >
+              <Icon
+                name={isAttaching ? "Spinner" : "Paperclip"}
+                className={cn(
+                  "size-4 text-muted-foreground",
+                  isAttaching && "animate-spin",
+                )}
+                aria-hidden
+              />
+              Attach files
+            </DropdownMenuItem>
+            {visibleActions.length > 0 ? <DropdownMenuSeparator /> : null}
+          </>
+        ) : null}
         {visibleActions.map((action) => {
           const presentation = PROMPT_ACTION_PRESENTATION[action.kind];
           return (
@@ -147,7 +177,7 @@ export function PromptBoxActionsMenu({
               key={action.kind}
               disabled={action.disabled}
               onSelect={() => {
-                selectedActionRef.current = true;
+                selectedItemRef.current = true;
                 onAction(action);
               }}
             >

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -656,6 +656,7 @@ describe("PromptBoxInternal zen mode layout", () => {
             { length: 40 },
             (_, index) => `Line ${index + 1}`,
           ).join("\n"),
+          promptActions,
           zenMode: { storageKey },
         })}
       />,
@@ -679,7 +680,7 @@ describe("PromptBoxInternal zen mode layout", () => {
       );
     });
 
-    const footerRow = screen.getByRole("button", { name: "Attach files" })
+    const footerRow = screen.getByRole("button", { name: "Prompt actions" })
       .parentElement?.parentElement;
     expect(footerRow?.classList.contains("shrink-0")).toBe(true);
 
@@ -808,7 +809,9 @@ describe("PromptBoxInternal minimized layout", () => {
     render(
       <PromptBoxInternal
         {...createPromptBoxProps({
+          attachments: { onAttachFiles: vi.fn() },
           minimized: { isMinimized: false, onToggle: vi.fn() },
+          promptActions,
         })}
       />,
     );
@@ -819,7 +822,7 @@ describe("PromptBoxInternal minimized layout", () => {
     expect(
       screen.queryByRole("button", { name: "Make prompt box larger" }),
     ).toBeNull();
-    expect(screen.getByRole("button", { name: "Attach files" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Prompt actions" })).toBeTruthy();
   });
 
   it("uses one contextual size control for compact and normal on mobile", () => {
@@ -1014,18 +1017,30 @@ describe("PromptBoxInternal prompt actions", () => {
     expect(getPromptEditorElement().querySelector("blockquote")).not.toBeNull();
   });
 
-  it("places prompt actions before the right-side action cluster", () => {
-    renderPromptBox("");
+  it("opens the file picker from the prompt actions menu", async () => {
+    const onAttachFiles = vi.fn();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          attachments: { onAttachFiles },
+          promptActions,
+        })}
+      />,
+    );
 
-    const promptActionsButton = screen.getByRole("button", {
-      name: "Prompt actions",
-    });
-    const attachButton = screen.getByRole("button", { name: "Attach files" });
+    const attachmentInput = document.querySelector('input[type="file"]');
+    if (!(attachmentInput instanceof HTMLInputElement)) {
+      throw new Error("Attachment input was not rendered");
+    }
+    const clickFileInput = vi.fn();
+    attachmentInput.addEventListener("click", clickFileInput);
 
-    expect(
-      promptActionsButton.compareDocumentPosition(attachButton) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).not.toBe(0);
+    await selectPromptAction("Attach files");
+
+    expect(clickFileInput).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(screen.queryByRole("menu", { name: "Prompt actions" })).toBeNull(),
+    );
   });
 
   it("inserts the skills trigger with no trailing space", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1032,8 +1032,9 @@ describe("PromptBoxInternal prompt actions", () => {
     if (!(attachmentInput instanceof HTMLInputElement)) {
       throw new Error("Attachment input was not rendered");
     }
-    const clickFileInput = vi.fn();
-    attachmentInput.addEventListener("click", clickFileInput);
+    const clickFileInput = vi
+      .spyOn(attachmentInput, "click")
+      .mockImplementation(() => {});
 
     await selectPromptAction("Attach files");
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2780,6 +2780,12 @@ export function PromptBoxInternal({
               >
                 <PromptBoxActionsMenu
                   actions={promptActions}
+                  isAttaching={isAttaching}
+                  onAttach={
+                    onAttachFiles
+                      ? () => attachmentInputRef.current?.click()
+                      : undefined
+                  }
                   onAction={applyPromptAction}
                 />
                 {footerStart}
@@ -2804,21 +2810,6 @@ export function PromptBoxInternal({
               ) : null}
               {!showMinimizedLayout ? (
                 <>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label="Attach files"
-                    disabled={!onAttachFiles || isAttaching}
-                    onClick={() => attachmentInputRef.current?.click()}
-                    className={COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS}
-                  >
-                    {isAttaching ? (
-                      <Icon name="Spinner" className="size-4 animate-spin" />
-                    ) : (
-                      <Icon name="Paperclip" className="size-4" />
-                    )}
-                  </Button>
                   {voice && !showVoiceActionGroup ? (
                     <Button
                       type="button"


### PR DESCRIPTION
## Summary
- move the standalone prompt attachment button into the promptbox + menu
- keep attachment upload progress visible on the menu trigger
- preserve file-picker behavior across new-thread, follow-up, and side-chat composers

## Tests
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/promptbox/PromptBoxActionsMenu.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`