### PR TITLE
Stabilize prompt action autofocus test

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -290,6 +290,12 @@ function dispatchThroughEditorTarget({
 }
 
 async function selectPromptAction(label: string) {
+  // The prompt schedules passive autofocus on its first animation frame. Let
+  // that settle before opening the portaled menu so the frame cannot move
+  // focus back to the editor while the menu item is being selected.
+  await waitFor(() =>
+    expect(document.activeElement).toBe(getPromptEditorElement()),
+  );
   const trigger = screen.getByRole("button", { name: "Prompt actions" });
   fireEvent.pointerDown(trigger, { button: 0 });
   const menu = await screen.findByRole("menu", { name: "Prompt actions" });


### PR DESCRIPTION
## Summary

- wait for the composer passive autofocus frame before opening its portaled actions menu in tests
- remove the recurring race where autofocus closes the menu before the Skills action is selected

## Validation

- focused PromptBoxInternal suite: 20 consecutive forced runs, 47 tests each
- full app suite: 209 files, 1394 tests
- pnpm exec turbo run typecheck --filter=@bb/app
- git diff --check