### PR TITLE
Fix machine group name truncation

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -937,17 +937,10 @@ export function TopLevelSidebarSection({
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
       >
-        <span
-          className={cn(
-            "relative z-10 flex min-w-0 flex-1 items-center gap-1 text-left",
-            actions && "pr-[7.5rem] max-md:pointer-coarse:pr-[9.75rem]",
-          )}
-        >
+        <span className="relative z-10 flex min-w-0 flex-1 items-center gap-1 text-left">
           <span className="min-w-0 truncate" title={label}>
             {label}
           </span>
-          {/* Reserve room for the compact section action cluster on the right;
-              coarse pointers need a little more. */}
           {collapseControl ? (
             <button
               type="button"
@@ -981,8 +974,11 @@ export function TopLevelSidebarSection({
           ) : null}
         </span>
         {actions ? (
+          // Keep the cluster in the flex row so labels reserve its real width.
+          // The fixed wrapper height prevents taller action buttons from
+          // changing the section-header height.
           <span
-            className="absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center"
+            className="relative z-20 inline-flex h-6 shrink-0 items-center"
             onClick={stopActionsClick}
           >
             <span

--- a/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
@@ -25,4 +25,22 @@ describe("TopLevelSidebarSection", () => {
       screen.getByRole("button", { name: "Expand Pinned section" }),
     ).not.toBeNull();
   });
+
+  it("reserves only the rendered action width beside a long section label", () => {
+    render(
+      <TopLevelSidebarSection
+        label="Sawyer's MacBook Pro"
+        actions={<button type="button">Display options</button>}
+      >
+        <div>Machine thread</div>
+      </TopLevelSidebarSection>,
+    );
+
+    const label = screen.getByTitle("Sawyer's MacBook Pro");
+    const action = screen.getByRole("button", { name: "Display options" });
+
+    expect(label.parentElement?.className).not.toContain("pr-[7.5rem]");
+    expect(action.parentElement?.className).toContain("shrink-0");
+    expect(action.parentElement?.className).not.toContain("absolute");
+  });
 });


### PR DESCRIPTION
## Summary

- size sidebar section action reservations to the rendered action cluster
- give machine group labels more usable width without changing header height
- add a regression test for long section labels with actions

## Tests

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/sidebar/ProjectListSectionHeader.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing warnings)