### PR TITLE
Render local images in assistant Markdown

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { RouteNavigationProvider } from "@/components/ui/app-route-anchor";
+import { ConversationMessageContent } from "./ConversationMessageContent";
+
+afterEach(cleanup);
+
+describe("ConversationMessageContent assistant images", () => {
+  it("serves local Markdown images through the thread host-file route", () => {
+    render(
+      <MemoryRouter>
+        <RouteNavigationProvider>
+          <ConversationMessageContent
+            role="assistant"
+            attachments={null}
+            id="msg_image"
+            threadId="thr_image"
+            turnId="turn_image"
+            sourceSeqStart={1}
+            sourceSeqEnd={2}
+            showActions={false}
+            mobileActionDisplay="overflow"
+            text="![Generated diagram](/workspace/output/diagram.png)"
+            turnRequest={null}
+          />
+        </RouteNavigationProvider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen
+        .getByRole("img", { name: "Generated diagram" })
+        .getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_image/host-files/content?path=%2Fworkspace%2Foutput%2Fdiagram.png",
+    );
+  });
+});

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -55,6 +55,7 @@ import {
   type MessageProseSelection,
 } from "./SelectableMessageProse.js";
 import type { PromptDraftAttachment } from "@/lib/prompt-draft";
+import { buildThreadHostFileContentUrl } from "@/lib/file-content-urls";
 
 interface ConversationMessageContentBaseProps {
   attachments: TimelineConversationAttachments | null;
@@ -502,12 +503,22 @@ function AssistantConversationMessage({
   turnId,
   workspaceRootPath,
 }: AssistantConversationMessageProps) {
-  const linkRouting = useMemo<MarkdownLinkRouting | undefined>(() => {
-    if (!onOpenLink && !onOpenLocalFileLink) {
-      return undefined;
+  const linkRouting = useMemo<MarkdownLinkRouting>(() => {
+    const localImage: NonNullable<MarkdownLinkRouting["localImage"]> = {
+      absolutePaths: {
+        kind: "trusted-host",
+      },
+      resolveSrc: ({ path }) => buildThreadHostFileContentUrl(threadId, path),
+    };
+    const routing: MarkdownLinkRouting = {
+      localImage,
+    };
+    if (workspaceRootPath !== undefined) {
+      localImage.relativePaths = {
+        baseDir: workspaceRootPath,
+        rootPath: workspaceRootPath,
+      };
     }
-
-    const routing: MarkdownLinkRouting = {};
     if (onOpenLink) {
       routing.onOpenLink = onOpenLink;
     }
@@ -526,7 +537,7 @@ function AssistantConversationMessage({
       }
     }
     return routing;
-  }, [onOpenLink, onOpenLocalFileLink, workspaceRootPath]);
+  }, [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath]);
 
   // Registry is subscribed once at the timeline root and provided via context;
   // only assistant (and nested delegation) bodies activate plugin directives.

--- a/apps/app/src/components/ui/markdown-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-link-routing.ts
@@ -57,7 +57,14 @@ export interface MarkdownLocalFileLinkRouting {
   relativeLinks?: MarkdownRelativeLocalFileLinkRouting;
 }
 
+export interface MarkdownLocalImageRouting {
+  absolutePaths: MarkdownAbsoluteLocalFileLinkRouting;
+  relativePaths?: MarkdownRelativeLocalFileLinkRouting;
+  resolveSrc: (image: MarkdownPreviewLocalFileLink) => string;
+}
+
 export interface MarkdownLinkRouting {
   localFile?: MarkdownLocalFileLinkRouting;
+  localImage?: MarkdownLocalImageRouting;
   onOpenLink?: MarkdownPreviewLinkHandler;
 }

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -132,6 +132,43 @@ describe("MarkdownPreview", () => {
     expect(screen.getByText("README.md").tagName).toBe("CODE");
   });
 
+  it("routes local Markdown images through the configured content resolver", () => {
+    const resolveSrc = vi.fn(
+      ({ path }: { path: string }) =>
+        `/api/files/content?path=${encodeURIComponent(path)}`,
+    );
+    const { container } = render(
+      <MarkdownPreview
+        content={[
+          "![absolute](/workspace/generated.png)",
+          "![relative](art/chart.png)",
+          "![remote](https://example.com/image.png)",
+        ].join("\n\n")}
+        linkRouting={{
+          localImage: {
+            absolutePaths: { kind: "trusted-host" },
+            relativePaths: {
+              baseDir: "/workspace",
+              rootPath: "/workspace",
+            },
+            resolveSrc,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      container.querySelector('img[alt="absolute"]')?.getAttribute("src"),
+    ).toBe("/api/files/content?path=%2Fworkspace%2Fgenerated.png");
+    expect(
+      container.querySelector('img[alt="relative"]')?.getAttribute("src"),
+    ).toBe("/api/files/content?path=%2Fworkspace%2Fart%2Fchart.png");
+    expect(
+      container.querySelector('img[alt="remote"]')?.getAttribute("src"),
+    ).toBe("https://example.com/image.png");
+    expect(resolveSrc).toHaveBeenCalledTimes(2);
+  });
+
   it("lets link routing open absolute app-origin URLs", () => {
     const onOpenLink = vi.fn(() => true);
     const href = `${window.location.origin}/threads/thr_localhost`;

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -50,6 +50,7 @@ import {
   parseLocalFileHref,
   resolveRelativeLocalFileHref,
   type MarkdownAbsoluteLocalFileLinkRouting,
+  type MarkdownPreviewLocalFileLink,
   type MarkdownRelativeLocalFileLinkRouting,
 } from "./markdown-local-file-link.js";
 import {
@@ -57,6 +58,7 @@ import {
   type MarkdownLinkRouting,
   type MarkdownLocalFileContextMenuItem,
   type MarkdownLocalFileLinkRouting,
+  type MarkdownLocalImageRouting,
 } from "./markdown-link-routing.js";
 import {
   buildThreadMentionComponent,
@@ -171,9 +173,10 @@ interface ResolvedPromptMentions {
   resolveMentionLink?: PromptMentionLinkResolver;
 }
 
-interface BuildLocalFileAwareUrlTransformArgs {
+interface BuildLocalAwareUrlTransformArgs {
   fallbackUrlTransform: UrlTransform | undefined;
-  localFileRouting: MarkdownLocalFileLinkRouting;
+  localFileRouting: MarkdownLocalFileLinkRouting | undefined;
+  localImageRouting: MarkdownLocalImageRouting | undefined;
 }
 
 interface MarkdownImageRendererArgs {
@@ -201,6 +204,11 @@ interface AreMarkdownRelativeLocalFileLinkRoutingsEqualArgs {
 interface AreMarkdownLocalFileLinkRoutingsEqualArgs {
   next: MarkdownLocalFileLinkRouting | undefined;
   previous: MarkdownLocalFileLinkRouting | undefined;
+}
+
+interface AreMarkdownLocalImageRoutingsEqualArgs {
+  next: MarkdownLocalImageRouting | undefined;
+  previous: MarkdownLocalImageRouting | undefined;
 }
 
 interface AreMarkdownLinkRoutingsEqualArgs {
@@ -330,6 +338,25 @@ function areMarkdownLocalFileLinkRoutingsEqual({
   );
 }
 
+function areMarkdownLocalImageRoutingsEqual({
+  next,
+  previous,
+}: AreMarkdownLocalImageRoutingsEqualArgs): boolean {
+  if (previous === next) return true;
+  if (previous === undefined || next === undefined) return false;
+  return (
+    previous.resolveSrc === next.resolveSrc &&
+    areMarkdownAbsoluteLocalFileLinkRoutingsEqual({
+      next: next.absolutePaths,
+      previous: previous.absolutePaths,
+    }) &&
+    areMarkdownRelativeLocalFileLinkRoutingsEqual({
+      next: next.relativePaths,
+      previous: previous.relativePaths,
+    })
+  );
+}
+
 function areMarkdownLinkRoutingsEqual({
   next,
   previous,
@@ -341,6 +368,10 @@ function areMarkdownLinkRoutingsEqual({
     areMarkdownLocalFileLinkRoutingsEqual({
       next: next.localFile,
       previous: previous.localFile,
+    }) &&
+    areMarkdownLocalImageRoutingsEqual({
+      next: next.localImage,
+      previous: previous.localImage,
     })
   );
 }
@@ -429,12 +460,38 @@ function isMarkdownAppRouteHref({ href }: IsMarkdownAppRouteHrefArgs): boolean {
   );
 }
 
-function buildLocalFileAwareUrlTransform({
+function resolveMarkdownLocalPath(
+  value: string,
+  absolutePaths: MarkdownAbsoluteLocalFileLinkRouting,
+  relativePaths: MarkdownRelativeLocalFileLinkRouting | undefined,
+): MarkdownPreviewLocalFileLink | null {
+  const absolutePath = parseLocalFileHref({
+    absoluteLinks: absolutePaths,
+    href: value,
+  });
+  if (absolutePath !== null || relativePaths === undefined) {
+    return absolutePath;
+  }
+
+  const resolvedHref = resolveRelativeLocalFileHref({
+    href: value,
+    ...relativePaths,
+  });
+  return resolvedHref === null
+    ? null
+    : parseLocalFileHref({
+        absoluteLinks: absolutePaths,
+        href: resolvedHref,
+      });
+}
+
+function buildLocalAwareUrlTransform({
   fallbackUrlTransform,
   localFileRouting,
-}: BuildLocalFileAwareUrlTransformArgs): UrlTransform {
+  localImageRouting,
+}: BuildLocalAwareUrlTransformArgs): UrlTransform {
   return (value, key, node) => {
-    if (key === "href") {
+    if (key === "href" && localFileRouting !== undefined) {
       if (
         parseLocalFileHref({
           absoluteLinks: localFileRouting.absoluteLinks,
@@ -458,6 +515,17 @@ function buildLocalFileAwareUrlTransform({
         ) {
           return resolvedHref;
         }
+      }
+    }
+
+    if (key === "src" && localImageRouting !== undefined) {
+      const localImage = resolveMarkdownLocalPath(
+        value,
+        localImageRouting.absolutePaths,
+        localImageRouting.relativePaths,
+      );
+      if (localImage !== null) {
+        return localImageRouting.resolveSrc(localImage);
       }
     }
 
@@ -1140,7 +1208,9 @@ function MarkdownPreviewComponent({
   const contentRef = useMarkdownContentWidthVariable();
   const [expandedImageUrl, setExpandedImageUrl] = useState<string | null>(null);
   const localFileRouting = linkRouting?.localFile;
-  const normalizeLocalFileLinks = localFileRouting !== undefined;
+  const localImageRouting = linkRouting?.localImage;
+  const normalizeLocalFileLinks =
+    localFileRouting !== undefined || localImageRouting !== undefined;
   // Substitute prompt-mention spans for inert sentinels first (offsets index
   // into the raw `content`), so the sentinels are present before frontmatter
   // splitting and link normalization run. `resolvedPromptMentions` carries the
@@ -1273,13 +1343,14 @@ function MarkdownPreviewComponent({
   }, [threadMentions, promptMentions, messageDirectiveMounts]);
   const resolvedUrlTransform = useMemo(
     () =>
-      localFileRouting
-        ? buildLocalFileAwareUrlTransform({
+      localFileRouting || localImageRouting
+        ? buildLocalAwareUrlTransform({
             fallbackUrlTransform: urlTransform,
             localFileRouting,
+            localImageRouting,
           })
         : urlTransform,
-    [localFileRouting, urlTransform],
+    [localFileRouting, localImageRouting, urlTransform],
   );
 
   return (


### PR DESCRIPTION
## Summary
- route absolute and workspace-relative Markdown image paths through the thread host-file content endpoint
- preserve normal remote image URLs and existing local-file link behavior
- add Markdown renderer and assistant-message regression coverage

## Validation
- pnpm exec turbo run test --filter=@bb/app (217 files, 1,440 tests)
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (passes with existing warnings)
- git diff --check