### PR TITLE
Extract @bb/tunnel-client from the connect plugin

### DIFF
--- a/packages/tunnel-client/package.json
+++ b/packages/tunnel-client/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@bb/tunnel-client",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@bb/tunnel-contract": "workspace:*",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@bb/tsconfig": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/tunnel-client/src/headers.ts
+++ b/packages/tunnel-client/src/headers.ts
@@ -1,0 +1,37 @@
+import type { HeaderPair } from "@bb/tunnel-contract";
+
+const SKIP_REQUEST_HEADERS = new Set([
+  "host",
+  "content-length",
+  "connection",
+  "accept-encoding",
+]);
+
+export interface LoopbackHeaderRewrite {
+  publicOrigin: string;
+  loopbackOrigin: string;
+  /**
+   * When set, inject a Host header (share streams). When omitted, Host is
+   * dropped — bare-handle behavior, byte-identical to pre-share.
+   */
+  host?: string;
+}
+
+export function headersForLoopbackRequest(
+  headers: HeaderPair[],
+  rewrite: LoopbackHeaderRewrite,
+): Record<string, string> {
+  const forwarded: Record<string, string> = {};
+  for (const [name, value] of headers) {
+    const lowerName = name.toLowerCase();
+    if (SKIP_REQUEST_HEADERS.has(lowerName)) continue;
+    forwarded[name] =
+      lowerName === "origin" && value === rewrite.publicOrigin
+        ? rewrite.loopbackOrigin
+        : value;
+  }
+  if (rewrite.host !== undefined) {
+    forwarded.Host = rewrite.host;
+  }
+  return forwarded;
+}

--- a/packages/tunnel-client/src/humanize.ts
+++ b/packages/tunnel-client/src/humanize.ts
@@ -1,0 +1,20 @@
+/**
+ * Turn a raw socket error into a human line for the reconnecting card:
+ * "can't reach getbb.app — connection refused". Falls back to the raw
+ * message for unrecognized failures rather than inventing a cause.
+ */
+export function humanizeTransportError(error: Error, host: string): string {
+  const code = (error as NodeJS.ErrnoException).code;
+  let reason: string;
+  if (code === "ECONNREFUSED") reason = "connection refused";
+  else if (code === "ENOTFOUND" || code === "EAI_AGAIN")
+    reason = "host not found";
+  else if (
+    code === "ETIMEDOUT" ||
+    /timed out|timeout|ETIMEDOUT/i.test(error.message)
+  )
+    reason = "timed out";
+  else if (code === "ECONNRESET") reason = "connection reset";
+  else reason = error.message;
+  return `can't reach ${host} — ${reason}`;
+}

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -1,0 +1,20 @@
+export type { TunnelClientLogger } from "./logger.js";
+export {
+  headersForLoopbackRequest,
+  type LoopbackHeaderRewrite,
+} from "./headers.js";
+export { humanizeTransportError } from "./humanize.js";
+export {
+  DEFAULT_MAX_RECONNECT_DELAY_MS,
+  DEFAULT_RECONNECT_BASE_DELAY_MS,
+  DEFAULT_STABLE_CONNECTION_MS,
+  ReconnectBackoff,
+  type ReconnectBackoffOptions,
+} from "./reconnect.js";
+export {
+  isBareBbRealtimeWs,
+  TunnelSession,
+  type ResolvedStreamOrigin,
+  type StreamOriginResult,
+  type TunnelSessionOptions,
+} from "./session.js";

--- a/packages/tunnel-client/src/logger.ts
+++ b/packages/tunnel-client/src/logger.ts
@@ -1,0 +1,15 @@
+/**
+ * Minimal logger surface used by the tunnel client.
+ *
+ * Declares the same method names as PluginLogger so existing plugin call
+ * sites and tests can pass their logger through without adapting. Only
+ * `warn` is required; the session currently uses that alone. Callers
+ * adapt their own logger rather than depending on plugin-sdk from this
+ * package.
+ */
+export interface TunnelClientLogger {
+  debug?(message: string): void;
+  info?(message: string): void;
+  warn(message: string): void;
+  error?(message: string): void;
+}

--- a/packages/tunnel-client/src/reconnect.ts
+++ b/packages/tunnel-client/src/reconnect.ts
@@ -1,0 +1,49 @@
+/** Default base delay before the first reconnect attempt (1s). */
+export const DEFAULT_RECONNECT_BASE_DELAY_MS = 1_000;
+/** Cap on exponential reconnect delay (30s). */
+export const DEFAULT_MAX_RECONNECT_DELAY_MS = 30_000;
+/**
+ * A connection that stayed open at least this long resets the attempt
+ * counter (so a brief blip after a stable session does not jump to long delays).
+ */
+export const DEFAULT_STABLE_CONNECTION_MS = 10_000;
+
+export interface ReconnectBackoffOptions {
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  stableConnectionMs?: number;
+}
+
+/**
+ * Capped exponential backoff for tunnel reconnects.
+ *
+ * Matches the historical ConnectTunnel schedule: delay = min(base * 2^attempt,
+ * max), with attempt reset after a connection that was open longer than the
+ * stable threshold.
+ */
+export class ReconnectBackoff {
+  private attempt = 0;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly stableConnectionMs: number;
+
+  constructor(options: ReconnectBackoffOptions = {}) {
+    this.baseDelayMs = options.baseDelayMs ?? DEFAULT_RECONNECT_BASE_DELAY_MS;
+    this.maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS;
+    this.stableConnectionMs =
+      options.stableConnectionMs ?? DEFAULT_STABLE_CONNECTION_MS;
+  }
+
+  reset(): void {
+    this.attempt = 0;
+  }
+
+  /**
+   * Record a socket close after `stableMs` of uptime and return the delay
+   * (ms) before the next dial.
+   */
+  nextDelayAfterClose(stableMs: number): number {
+    this.attempt = stableMs > this.stableConnectionMs ? 0 : this.attempt + 1;
+    return Math.min(this.baseDelayMs * 2 ** this.attempt, this.maxDelayMs);
+  }
+}

--- a/packages/tunnel-client/src/reconnect.ts
+++ b/packages/tunnel-client/src/reconnect.ts
@@ -3,8 +3,9 @@ export const DEFAULT_RECONNECT_BASE_DELAY_MS = 1_000;
 /** Cap on exponential reconnect delay (30s). */
 export const DEFAULT_MAX_RECONNECT_DELAY_MS = 30_000;
 /**
- * A connection that stayed open at least this long resets the attempt
+ * A connection that stayed open more than this long resets the attempt
  * counter (so a brief blip after a stable session does not jump to long delays).
+ * Equality with the threshold does not reset — the comparison is strict `>`.
  */
 export const DEFAULT_STABLE_CONNECTION_MS = 10_000;
 

--- a/packages/tunnel-client/src/session.ts
+++ b/packages/tunnel-client/src/session.ts
@@ -1,0 +1,370 @@
+// Transport-generic tunnel client session: proxies relayed HTTP/WS streams
+// from one live tunnel socket to per-stream loopback origins.
+import { WebSocket as NodeWebSocket } from "ws";
+import {
+  HEARTBEAT_REQUEST,
+  HEARTBEAT_RESPONSE,
+  chunkBody,
+  decodeFrame,
+  encodeFrame,
+  type Frame,
+  type HeaderPair,
+  type OpenHttpFrame,
+  type OpenWsFrame,
+} from "@bb/tunnel-contract";
+import { headersForLoopbackRequest } from "./headers.js";
+import type { TunnelClientLogger } from "./logger.js";
+
+const HEARTBEAT_INTERVAL_MS = 20_000;
+const HEARTBEAT_DEADLINE_MS = 60_000;
+
+const UNREGISTERED_PORT_BODY = "this port is not shared";
+const textEncoder = new TextEncoder();
+
+/** True when this open-ws is the bb app's realtime socket via the bare handle. */
+export function isBareBbRealtimeWs(
+  path: string,
+  target: string | undefined,
+): boolean {
+  if (target !== undefined) return false;
+  // Spec: path starts with `/ws` and has no target.
+  return path === "/ws" || path.startsWith("/ws?") || path.startsWith("/ws/");
+}
+
+interface HttpStream {
+  meta: OpenHttpFrame;
+  chunks: Buffer[];
+  abort: AbortController;
+}
+interface WsStream {
+  socket: NodeWebSocket;
+  buffered: Frame[];
+  open: boolean;
+  /** Counted toward remoteClients (bare-handle /ws). */
+  countsAsRemoteClient: boolean;
+}
+
+export interface ResolvedStreamOrigin {
+  /** Fetch/WS base, e.g. `http://127.0.0.1:38886` or a share port. */
+  origin: string;
+  publicOrigin: string;
+  /** Injected Host for share streams; omitted for bare-handle. */
+  host?: string;
+}
+
+export type StreamOriginResult =
+  | { kind: "ok"; resolved: ResolvedStreamOrigin }
+  | { kind: "unregistered" };
+
+export interface TunnelSessionOptions {
+  tunnel: NodeWebSocket;
+  log: TunnelClientLogger;
+  /**
+   * Resolve a frame's optional `target` (decimal port string) to a local
+   * origin. Called for every open-http / open-ws.
+   */
+  resolveOrigin: (target: string | undefined) => StreamOriginResult;
+  /** Fired when remoteClients transitions 0↔nonzero. */
+  onRemoteClientsChange?: (remoteClients: number) => void;
+  /** Fired on every relayed frame (any type). */
+  onActivity?: (at: number) => void;
+}
+
+/** Proxies one live tunnel socket's frames to per-stream loopback origins. */
+export class TunnelSession {
+  private readonly httpStreams = new Map<number, HttpStream>();
+  private readonly wsStreams = new Map<number, WsStream>();
+  private lastAck = Date.now();
+  private heartbeat: ReturnType<typeof setInterval> | undefined;
+  private remoteClientCount = 0;
+  lastRemoteActivityAt: number | null = null;
+
+  constructor(private readonly options: TunnelSessionOptions) {}
+
+  get remoteClients(): number {
+    return this.remoteClientCount;
+  }
+
+  start(): void {
+    const { tunnel } = this.options;
+    this.heartbeat = setInterval(() => {
+      if (Date.now() - this.lastAck > HEARTBEAT_DEADLINE_MS) {
+        this.options.log.warn("tunnel heartbeat missed; reconnecting");
+        tunnel.terminate();
+        return;
+      }
+      tunnel.send(HEARTBEAT_REQUEST);
+    }, HEARTBEAT_INTERVAL_MS);
+
+    tunnel.on("message", (data: Buffer, isBinary: boolean) => {
+      if (!isBinary) {
+        if (data.toString() === HEARTBEAT_RESPONSE) this.lastAck = Date.now();
+        return;
+      }
+      try {
+        this.onFrame(decodeFrame(data));
+      } catch (e) {
+        this.options.log.warn(`tunnel bad frame: ${String(e)}`);
+      }
+    });
+    tunnel.on("close", () => this.dispose());
+  }
+
+  dispose(): void {
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    for (const s of this.httpStreams.values()) s.abort.abort();
+    for (const s of this.wsStreams.values())
+      s.socket.close(1001, "tunnel closed");
+    this.httpStreams.clear();
+    this.wsStreams.clear();
+    this.setRemoteClients(0);
+  }
+
+  private noteActivity(): void {
+    const at = Date.now();
+    this.lastRemoteActivityAt = at;
+    this.options.onActivity?.(at);
+  }
+
+  private setRemoteClients(next: number): void {
+    const prev = this.remoteClientCount;
+    this.remoteClientCount = next;
+    if ((prev === 0) !== (next === 0)) {
+      this.options.onRemoteClientsChange?.(next);
+    }
+  }
+
+  private adjustRemoteClients(delta: number): void {
+    this.setRemoteClients(Math.max(0, this.remoteClientCount + delta));
+  }
+
+  private send(frame: Frame): void {
+    if (this.options.tunnel.readyState === NodeWebSocket.OPEN) {
+      this.options.tunnel.send(encodeFrame(frame));
+    }
+  }
+
+  private onFrame(frame: Frame): void {
+    this.noteActivity();
+    switch (frame.type) {
+      case "open-http": {
+        const stream: HttpStream = {
+          meta: frame,
+          chunks: [],
+          abort: new AbortController(),
+        };
+        this.httpStreams.set(frame.streamId, stream);
+        if (!frame.hasBody) void this.executeHttp(frame.streamId, stream);
+        return;
+      }
+      case "body-chunk":
+        this.httpStreams
+          .get(frame.streamId)
+          ?.chunks.push(Buffer.from(frame.data));
+        return;
+      case "body-end": {
+        const s = this.httpStreams.get(frame.streamId);
+        if (s) void this.executeHttp(frame.streamId, s);
+        return;
+      }
+      case "open-ws":
+        this.openOriginWs(frame);
+        return;
+      case "ws-data": {
+        const s = this.wsStreams.get(frame.streamId);
+        if (!s) return;
+        if (!s.open) {
+          s.buffered.push(frame);
+          return;
+        }
+        s.socket.send(
+          frame.isBinary ? frame.data : Buffer.from(frame.data).toString(),
+        );
+        return;
+      }
+      case "close-stream": {
+        const h = this.httpStreams.get(frame.streamId);
+        if (h) {
+          h.abort.abort();
+          this.httpStreams.delete(frame.streamId);
+          return;
+        }
+        const w = this.wsStreams.get(frame.streamId);
+        if (w) {
+          w.socket.close(frame.code, frame.reason);
+          this.forgetWsStream(frame.streamId, w);
+        }
+        return;
+      }
+      case "resp-head":
+      case "ws-open-ack":
+        return;
+    }
+  }
+
+  private forgetWsStream(streamId: number, stream: WsStream): void {
+    if (!this.wsStreams.delete(streamId)) return;
+    if (stream.countsAsRemoteClient) this.adjustRemoteClients(-1);
+  }
+
+  private rejectUnregisteredHttp(streamId: number): void {
+    const body = textEncoder.encode(UNREGISTERED_PORT_BODY);
+    this.send({
+      type: "resp-head",
+      streamId,
+      status: 404,
+      headers: [["content-type", "text/plain; charset=utf-8"]],
+    });
+    for (const c of chunkBody(streamId, body)) this.send(c);
+    this.send({ type: "body-end", streamId });
+  }
+
+  private async executeHttp(
+    streamId: number,
+    stream: HttpStream,
+  ): Promise<void> {
+    const { meta } = stream;
+    const originResult = this.options.resolveOrigin(meta.target);
+    if (originResult.kind === "unregistered") {
+      this.rejectUnregisteredHttp(streamId);
+      this.httpStreams.delete(streamId);
+      return;
+    }
+    const { resolved } = originResult;
+    const headers = headersForLoopbackRequest(meta.headers, {
+      publicOrigin: resolved.publicOrigin,
+      loopbackOrigin: new URL(resolved.origin).origin,
+      ...(resolved.host !== undefined ? { host: resolved.host } : {}),
+    });
+    try {
+      const body = meta.hasBody ? Buffer.concat(stream.chunks) : undefined;
+      const res = await fetch(`${resolved.origin}${meta.path}`, {
+        method: meta.method,
+        headers,
+        body,
+        redirect: "manual",
+        signal: stream.abort.signal,
+      });
+      const respHeaders: HeaderPair[] = [];
+      // fetch transparently decompresses a compressed origin body, so when
+      // content-encoding is present the origin's content-length describes
+      // compressed bytes we are not forwarding — relaying it would corrupt
+      // the response framing at the relay. Drop both.
+      const decompressed = res.headers.get("content-encoding") !== null;
+      res.headers.forEach((v, n) => {
+        const lower = n.toLowerCase();
+        if (lower === "content-encoding") return;
+        if (decompressed && lower === "content-length") return;
+        respHeaders.push([n, v]);
+      });
+      this.send({
+        type: "resp-head",
+        streamId,
+        status: res.status,
+        headers: respHeaders,
+      });
+      if (res.body) {
+        const reader = res.body.getReader();
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          for (const c of chunkBody(streamId, value)) this.send(c);
+        }
+      }
+      this.send({ type: "body-end", streamId });
+    } catch (e) {
+      // Unreachable share ports and other fetch failures: clean close-stream,
+      // not a crash. Aborted streams are silent.
+      if (!stream.abort.signal.aborted) {
+        this.send({
+          type: "close-stream",
+          streamId,
+          code: 1011,
+          reason: String(e),
+        });
+      }
+    } finally {
+      this.httpStreams.delete(streamId);
+    }
+  }
+
+  private openOriginWs(frame: OpenWsFrame): void {
+    const originResult = this.options.resolveOrigin(frame.target);
+    if (originResult.kind === "unregistered") {
+      this.send({
+        type: "close-stream",
+        streamId: frame.streamId,
+        code: 1008,
+        reason: UNREGISTERED_PORT_BODY,
+      });
+      return;
+    }
+    const { resolved } = originResult;
+    const wsOrigin = resolved.origin.replace(/^http/, "ws");
+    const headers = headersForLoopbackRequest(frame.headers, {
+      publicOrigin: resolved.publicOrigin,
+      loopbackOrigin: new URL(resolved.origin).origin,
+      ...(resolved.host !== undefined ? { host: resolved.host } : {}),
+    });
+    const countsAsRemoteClient = isBareBbRealtimeWs(frame.path, frame.target);
+    let socket: NodeWebSocket;
+    try {
+      socket = new NodeWebSocket(`${wsOrigin}${frame.path}`, frame.protocols, {
+        headers,
+      });
+    } catch (e) {
+      this.send({
+        type: "close-stream",
+        streamId: frame.streamId,
+        code: 1011,
+        reason: String(e),
+      });
+      return;
+    }
+    const stream: WsStream = {
+      socket,
+      buffered: [],
+      open: false,
+      countsAsRemoteClient,
+    };
+    this.wsStreams.set(frame.streamId, stream);
+    if (countsAsRemoteClient) this.adjustRemoteClients(1);
+
+    socket.on("open", () => {
+      stream.open = true;
+      this.send({
+        type: "ws-open-ack",
+        streamId: frame.streamId,
+        protocol: socket.protocol || null,
+      });
+      for (const b of stream.buffered) this.onFrame(b);
+      stream.buffered = [];
+    });
+    socket.on("message", (data: Buffer, isBinary: boolean) => {
+      this.send({
+        type: "ws-data",
+        streamId: frame.streamId,
+        isBinary,
+        data: isBinary
+          ? new Uint8Array(data)
+          : new Uint8Array(Buffer.from(data.toString())),
+      });
+    });
+    socket.on("close", (code: number, reason: Buffer) => {
+      if (this.wsStreams.has(frame.streamId)) {
+        this.forgetWsStream(frame.streamId, stream);
+        this.send({
+          type: "close-stream",
+          streamId: frame.streamId,
+          code: code === 1000 || (code >= 3000 && code <= 4999) ? code : 1000,
+          reason: reason.toString(),
+        });
+      }
+    });
+    socket.on("error", (e: Error) => {
+      // Dead share ports surface as socket errors; the subsequent 'close'
+      // sends close-stream. Log only — do not throw.
+      this.options.log.warn(`origin ws error on ${frame.path}: ${e.message}`);
+    });
+  }
+}

--- a/packages/tunnel-client/test/reconnect.test.ts
+++ b/packages/tunnel-client/test/reconnect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_RECONNECT_DELAY_MS,
+  DEFAULT_RECONNECT_BASE_DELAY_MS,
+  ReconnectBackoff,
+} from "../src/reconnect.js";
+import { humanizeTransportError } from "../src/humanize.js";
+
+describe("ReconnectBackoff", () => {
+  it("grows exponentially and caps at max", () => {
+    const backoff = new ReconnectBackoff();
+    // First close before stable → attempt 1 → 2s
+    expect(backoff.nextDelayAfterClose(0)).toBe(
+      DEFAULT_RECONNECT_BASE_DELAY_MS * 2,
+    );
+    expect(backoff.nextDelayAfterClose(0)).toBe(
+      DEFAULT_RECONNECT_BASE_DELAY_MS * 4,
+    );
+    expect(backoff.nextDelayAfterClose(0)).toBe(
+      DEFAULT_RECONNECT_BASE_DELAY_MS * 8,
+    );
+    // Keep going until the cap binds.
+    let delay = 0;
+    for (let i = 0; i < 20; i++) {
+      delay = backoff.nextDelayAfterClose(0);
+    }
+    expect(delay).toBe(DEFAULT_MAX_RECONNECT_DELAY_MS);
+  });
+
+  it("resets attempt after a stable connection", () => {
+    const backoff = new ReconnectBackoff({ stableConnectionMs: 10_000 });
+    expect(backoff.nextDelayAfterClose(0)).toBe(2_000);
+    // Stable session: attempt resets to 0 → delay = base * 2^0 = 1s.
+    expect(backoff.nextDelayAfterClose(10_001)).toBe(1_000);
+  });
+
+  it("reset() clears the attempt counter", () => {
+    const backoff = new ReconnectBackoff();
+    backoff.nextDelayAfterClose(0);
+    backoff.nextDelayAfterClose(0);
+    backoff.reset();
+    expect(backoff.nextDelayAfterClose(0)).toBe(2_000);
+  });
+});
+
+describe("humanizeTransportError", () => {
+  it("maps known errno codes to short reasons", () => {
+    const refused = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    expect(humanizeTransportError(refused, "getbb.app")).toBe(
+      "can't reach getbb.app — connection refused",
+    );
+  });
+
+  it("falls back to the raw message for unknown failures", () => {
+    expect(humanizeTransportError(new Error("boom"), "host.example")).toBe(
+      "can't reach host.example — boom",
+    );
+  });
+});

--- a/packages/tunnel-client/test/reconnect.test.ts
+++ b/packages/tunnel-client/test/reconnect.test.ts
@@ -34,6 +34,14 @@ describe("ReconnectBackoff", () => {
     expect(backoff.nextDelayAfterClose(10_001)).toBe(1_000);
   });
 
+  it("does not reset at exactly the stable threshold", () => {
+    const backoff = new ReconnectBackoff({ stableConnectionMs: 10_000 });
+    // First unstable close → attempt 1 → 2s
+    expect(backoff.nextDelayAfterClose(0)).toBe(2_000);
+    // Exactly 10_000ms is not more than the threshold, so attempt advances.
+    expect(backoff.nextDelayAfterClose(10_000)).toBe(4_000);
+  });
+
   it("reset() clears the attempt counter", () => {
     const backoff = new ReconnectBackoff();
     backoff.nextDelayAfterClose(0);

--- a/packages/tunnel-client/tsconfig.json
+++ b/packages/tunnel-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "@bb/tsconfig/base.json",
+    "@bb/tsconfig/typecheck-overrides.json"
+  ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/tunnel-client/vitest.config.ts
+++ b/packages/tunnel-client/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/plugins/connect/package.json
+++ b/plugins/connect/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@bb/shared-ui": "workspace:*",
+    "@bb/tunnel-client": "workspace:*",
     "@bb/tunnel-contract": "workspace:*",
     "@radix-ui/react-slot": "^1.3.0",
     "qrcode": "^1.5.4",

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -7,12 +7,12 @@ import {
   type FakePluginHost,
 } from "@bb/plugin-sdk/testing";
 import { decodeFrame, encodeFrame, type Frame } from "@bb/tunnel-contract";
-import { deriveConnectBaseUrl, serverUrlForHandle } from "./redeem.js";
 import {
   headersForLoopbackRequest,
   isBareBbRealtimeWs,
   TunnelSession,
-} from "./tunnel.js";
+} from "@bb/tunnel-client";
+import { deriveConnectBaseUrl, serverUrlForHandle } from "./redeem.js";
 import {
   parseSharePort,
   SharePortError,

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -3,20 +3,20 @@
 // proxies relayed HTTP/WS streams to the server's own loopback base URL
 // (which serves the SPA + /api + /ws), or to a registered share port when
 // the relay stamps `target` on the open frame.
+//
+// Transport-generic session machinery lives in @bb/tunnel-client; this file
+// owns pairing, credentials, shares, and status.
 import { WebSocket as NodeWebSocket } from "ws";
 import {
-  HEARTBEAT_REQUEST,
-  HEARTBEAT_RESPONSE,
   PROTOCOL_VERSION,
   TUNNEL_PROTOCOL_QUERY_PARAM,
-  chunkBody,
-  decodeFrame,
-  encodeFrame,
-  type Frame,
-  type HeaderPair,
-  type OpenHttpFrame,
-  type OpenWsFrame,
 } from "@bb/tunnel-contract";
+import {
+  humanizeTransportError,
+  ReconnectBackoff,
+  TunnelSession,
+  type StreamOriginResult,
+} from "@bb/tunnel-client";
 import type { PluginLogger } from "@bb/plugin-sdk";
 import type { ConnectCredential, CredentialStore } from "./credential.js";
 import { fetchMachineCode, MachineCodeError } from "./machine-code.js";
@@ -42,434 +42,6 @@ import {
   sharePublicUrl,
 } from "./shares.js";
 import type { ConnectStateName, ConnectStatus } from "./types.js";
-
-const HEARTBEAT_INTERVAL_MS = 20_000;
-const HEARTBEAT_DEADLINE_MS = 60_000;
-const MAX_RECONNECT_DELAY_MS = 30_000;
-const SKIP_REQUEST_HEADERS = new Set([
-  "host",
-  "content-length",
-  "connection",
-  "accept-encoding",
-]);
-
-const UNREGISTERED_PORT_BODY = "this port is not shared";
-const textEncoder = new TextEncoder();
-
-export interface LoopbackHeaderRewrite {
-  publicOrigin: string;
-  loopbackOrigin: string;
-  /**
-   * When set, inject a Host header (share streams). When omitted, Host is
-   * dropped — bare-handle behavior, byte-identical to pre-share.
-   */
-  host?: string;
-}
-
-export function headersForLoopbackRequest(
-  headers: HeaderPair[],
-  rewrite: LoopbackHeaderRewrite,
-): Record<string, string> {
-  const forwarded: Record<string, string> = {};
-  for (const [name, value] of headers) {
-    const lowerName = name.toLowerCase();
-    if (SKIP_REQUEST_HEADERS.has(lowerName)) continue;
-    forwarded[name] =
-      lowerName === "origin" && value === rewrite.publicOrigin
-        ? rewrite.loopbackOrigin
-        : value;
-  }
-  if (rewrite.host !== undefined) {
-    forwarded.Host = rewrite.host;
-  }
-  return forwarded;
-}
-
-/** Host shown in transport errors — the connect apex, e.g. "getbb.app". */
-function connectApexHost(serverUrl: string): string {
-  try {
-    return new URL(deriveConnectBaseUrl(serverUrl)).host;
-  } catch {
-    return "getbb.app";
-  }
-}
-
-/**
- * Turn a raw socket error into a human line for the reconnecting card:
- * "can't reach getbb.app — connection refused". Falls back to the raw
- * message for unrecognized failures rather than inventing a cause.
- */
-export function humanizeTransportError(error: Error, host: string): string {
-  const code = (error as NodeJS.ErrnoException).code;
-  let reason: string;
-  if (code === "ECONNREFUSED") reason = "connection refused";
-  else if (code === "ENOTFOUND" || code === "EAI_AGAIN")
-    reason = "host not found";
-  else if (
-    code === "ETIMEDOUT" ||
-    /timed out|timeout|ETIMEDOUT/i.test(error.message)
-  )
-    reason = "timed out";
-  else if (code === "ECONNRESET") reason = "connection reset";
-  else reason = error.message;
-  return `can't reach ${host} — ${reason}`;
-}
-
-function tunnelUrlForServer(serverUrl: string): string {
-  const base =
-    serverUrl.replace(/^http/, "ws").replace(/\/$/, "") + "/__tunnel";
-  const url = new URL(base);
-  url.searchParams.set(TUNNEL_PROTOCOL_QUERY_PARAM, String(PROTOCOL_VERSION));
-  return url.toString();
-}
-
-/** True when this open-ws is the bb app's realtime socket via the bare handle. */
-export function isBareBbRealtimeWs(
-  path: string,
-  target: string | undefined,
-): boolean {
-  if (target !== undefined) return false;
-  // Spec: path starts with `/ws` and has no target.
-  return path === "/ws" || path.startsWith("/ws?") || path.startsWith("/ws/");
-}
-
-interface HttpStream {
-  meta: OpenHttpFrame;
-  chunks: Buffer[];
-  abort: AbortController;
-}
-interface WsStream {
-  socket: NodeWebSocket;
-  buffered: Frame[];
-  open: boolean;
-  /** Counted toward remoteClients (bare-handle /ws). */
-  countsAsRemoteClient: boolean;
-}
-
-export interface ResolvedStreamOrigin {
-  /** Fetch/WS base, e.g. `http://127.0.0.1:38886` or a share port. */
-  origin: string;
-  publicOrigin: string;
-  /** Injected Host for share streams; omitted for bare-handle. */
-  host?: string;
-}
-
-export type StreamOriginResult =
-  | { kind: "ok"; resolved: ResolvedStreamOrigin }
-  | { kind: "unregistered" };
-
-export interface TunnelSessionOptions {
-  tunnel: NodeWebSocket;
-  log: PluginLogger;
-  /**
-   * Resolve a frame's optional `target` (decimal port string) to a local
-   * origin. Called for every open-http / open-ws.
-   */
-  resolveOrigin: (target: string | undefined) => StreamOriginResult;
-  /** Fired when remoteClients transitions 0↔nonzero. */
-  onRemoteClientsChange?: (remoteClients: number) => void;
-  /** Fired on every relayed frame (any type). */
-  onActivity?: (at: number) => void;
-}
-
-/** Proxies one live tunnel socket's frames to per-stream loopback origins. */
-export class TunnelSession {
-  private readonly httpStreams = new Map<number, HttpStream>();
-  private readonly wsStreams = new Map<number, WsStream>();
-  private lastAck = Date.now();
-  private heartbeat: ReturnType<typeof setInterval> | undefined;
-  private remoteClientCount = 0;
-  lastRemoteActivityAt: number | null = null;
-
-  constructor(private readonly options: TunnelSessionOptions) {}
-
-  get remoteClients(): number {
-    return this.remoteClientCount;
-  }
-
-  start(): void {
-    const { tunnel } = this.options;
-    this.heartbeat = setInterval(() => {
-      if (Date.now() - this.lastAck > HEARTBEAT_DEADLINE_MS) {
-        this.options.log.warn("tunnel heartbeat missed; reconnecting");
-        tunnel.terminate();
-        return;
-      }
-      tunnel.send(HEARTBEAT_REQUEST);
-    }, HEARTBEAT_INTERVAL_MS);
-
-    tunnel.on("message", (data: Buffer, isBinary: boolean) => {
-      if (!isBinary) {
-        if (data.toString() === HEARTBEAT_RESPONSE) this.lastAck = Date.now();
-        return;
-      }
-      try {
-        this.onFrame(decodeFrame(data));
-      } catch (e) {
-        this.options.log.warn(`tunnel bad frame: ${String(e)}`);
-      }
-    });
-    tunnel.on("close", () => this.dispose());
-  }
-
-  dispose(): void {
-    if (this.heartbeat) clearInterval(this.heartbeat);
-    for (const s of this.httpStreams.values()) s.abort.abort();
-    for (const s of this.wsStreams.values())
-      s.socket.close(1001, "tunnel closed");
-    this.httpStreams.clear();
-    this.wsStreams.clear();
-    this.setRemoteClients(0);
-  }
-
-  private noteActivity(): void {
-    const at = Date.now();
-    this.lastRemoteActivityAt = at;
-    this.options.onActivity?.(at);
-  }
-
-  private setRemoteClients(next: number): void {
-    const prev = this.remoteClientCount;
-    this.remoteClientCount = next;
-    if ((prev === 0) !== (next === 0)) {
-      this.options.onRemoteClientsChange?.(next);
-    }
-  }
-
-  private adjustRemoteClients(delta: number): void {
-    this.setRemoteClients(Math.max(0, this.remoteClientCount + delta));
-  }
-
-  private send(frame: Frame): void {
-    if (this.options.tunnel.readyState === NodeWebSocket.OPEN) {
-      this.options.tunnel.send(encodeFrame(frame));
-    }
-  }
-
-  private onFrame(frame: Frame): void {
-    this.noteActivity();
-    switch (frame.type) {
-      case "open-http": {
-        const stream: HttpStream = {
-          meta: frame,
-          chunks: [],
-          abort: new AbortController(),
-        };
-        this.httpStreams.set(frame.streamId, stream);
-        if (!frame.hasBody) void this.executeHttp(frame.streamId, stream);
-        return;
-      }
-      case "body-chunk":
-        this.httpStreams
-          .get(frame.streamId)
-          ?.chunks.push(Buffer.from(frame.data));
-        return;
-      case "body-end": {
-        const s = this.httpStreams.get(frame.streamId);
-        if (s) void this.executeHttp(frame.streamId, s);
-        return;
-      }
-      case "open-ws":
-        this.openOriginWs(frame);
-        return;
-      case "ws-data": {
-        const s = this.wsStreams.get(frame.streamId);
-        if (!s) return;
-        if (!s.open) {
-          s.buffered.push(frame);
-          return;
-        }
-        s.socket.send(
-          frame.isBinary ? frame.data : Buffer.from(frame.data).toString(),
-        );
-        return;
-      }
-      case "close-stream": {
-        const h = this.httpStreams.get(frame.streamId);
-        if (h) {
-          h.abort.abort();
-          this.httpStreams.delete(frame.streamId);
-          return;
-        }
-        const w = this.wsStreams.get(frame.streamId);
-        if (w) {
-          w.socket.close(frame.code, frame.reason);
-          this.forgetWsStream(frame.streamId, w);
-        }
-        return;
-      }
-      case "resp-head":
-      case "ws-open-ack":
-        return;
-    }
-  }
-
-  private forgetWsStream(streamId: number, stream: WsStream): void {
-    if (!this.wsStreams.delete(streamId)) return;
-    if (stream.countsAsRemoteClient) this.adjustRemoteClients(-1);
-  }
-
-  private rejectUnregisteredHttp(streamId: number): void {
-    const body = textEncoder.encode(UNREGISTERED_PORT_BODY);
-    this.send({
-      type: "resp-head",
-      streamId,
-      status: 404,
-      headers: [["content-type", "text/plain; charset=utf-8"]],
-    });
-    for (const c of chunkBody(streamId, body)) this.send(c);
-    this.send({ type: "body-end", streamId });
-  }
-
-  private async executeHttp(
-    streamId: number,
-    stream: HttpStream,
-  ): Promise<void> {
-    const { meta } = stream;
-    const originResult = this.options.resolveOrigin(meta.target);
-    if (originResult.kind === "unregistered") {
-      this.rejectUnregisteredHttp(streamId);
-      this.httpStreams.delete(streamId);
-      return;
-    }
-    const { resolved } = originResult;
-    const headers = headersForLoopbackRequest(meta.headers, {
-      publicOrigin: resolved.publicOrigin,
-      loopbackOrigin: new URL(resolved.origin).origin,
-      ...(resolved.host !== undefined ? { host: resolved.host } : {}),
-    });
-    try {
-      const body = meta.hasBody ? Buffer.concat(stream.chunks) : undefined;
-      const res = await fetch(`${resolved.origin}${meta.path}`, {
-        method: meta.method,
-        headers,
-        body,
-        redirect: "manual",
-        signal: stream.abort.signal,
-      });
-      const respHeaders: HeaderPair[] = [];
-      // fetch transparently decompresses a compressed origin body, so when
-      // content-encoding is present the origin's content-length describes
-      // compressed bytes we are not forwarding — relaying it would corrupt
-      // the response framing at the relay. Drop both.
-      const decompressed = res.headers.get("content-encoding") !== null;
-      res.headers.forEach((v, n) => {
-        const lower = n.toLowerCase();
-        if (lower === "content-encoding") return;
-        if (decompressed && lower === "content-length") return;
-        respHeaders.push([n, v]);
-      });
-      this.send({
-        type: "resp-head",
-        streamId,
-        status: res.status,
-        headers: respHeaders,
-      });
-      if (res.body) {
-        const reader = res.body.getReader();
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          for (const c of chunkBody(streamId, value)) this.send(c);
-        }
-      }
-      this.send({ type: "body-end", streamId });
-    } catch (e) {
-      // Unreachable share ports and other fetch failures: clean close-stream,
-      // not a crash. Aborted streams are silent.
-      if (!stream.abort.signal.aborted) {
-        this.send({
-          type: "close-stream",
-          streamId,
-          code: 1011,
-          reason: String(e),
-        });
-      }
-    } finally {
-      this.httpStreams.delete(streamId);
-    }
-  }
-
-  private openOriginWs(frame: OpenWsFrame): void {
-    const originResult = this.options.resolveOrigin(frame.target);
-    if (originResult.kind === "unregistered") {
-      this.send({
-        type: "close-stream",
-        streamId: frame.streamId,
-        code: 1008,
-        reason: UNREGISTERED_PORT_BODY,
-      });
-      return;
-    }
-    const { resolved } = originResult;
-    const wsOrigin = resolved.origin.replace(/^http/, "ws");
-    const headers = headersForLoopbackRequest(frame.headers, {
-      publicOrigin: resolved.publicOrigin,
-      loopbackOrigin: new URL(resolved.origin).origin,
-      ...(resolved.host !== undefined ? { host: resolved.host } : {}),
-    });
-    const countsAsRemoteClient = isBareBbRealtimeWs(frame.path, frame.target);
-    let socket: NodeWebSocket;
-    try {
-      socket = new NodeWebSocket(`${wsOrigin}${frame.path}`, frame.protocols, {
-        headers,
-      });
-    } catch (e) {
-      this.send({
-        type: "close-stream",
-        streamId: frame.streamId,
-        code: 1011,
-        reason: String(e),
-      });
-      return;
-    }
-    const stream: WsStream = {
-      socket,
-      buffered: [],
-      open: false,
-      countsAsRemoteClient,
-    };
-    this.wsStreams.set(frame.streamId, stream);
-    if (countsAsRemoteClient) this.adjustRemoteClients(1);
-
-    socket.on("open", () => {
-      stream.open = true;
-      this.send({
-        type: "ws-open-ack",
-        streamId: frame.streamId,
-        protocol: socket.protocol || null,
-      });
-      for (const b of stream.buffered) this.onFrame(b);
-      stream.buffered = [];
-    });
-    socket.on("message", (data: Buffer, isBinary: boolean) => {
-      this.send({
-        type: "ws-data",
-        streamId: frame.streamId,
-        isBinary,
-        data: isBinary
-          ? new Uint8Array(data)
-          : new Uint8Array(Buffer.from(data.toString())),
-      });
-    });
-    socket.on("close", (code: number, reason: Buffer) => {
-      if (this.wsStreams.has(frame.streamId)) {
-        this.forgetWsStream(frame.streamId, stream);
-        this.send({
-          type: "close-stream",
-          streamId: frame.streamId,
-          code: code === 1000 || (code >= 3000 && code <= 4999) ? code : 1000,
-          reason: reason.toString(),
-        });
-      }
-    });
-    socket.on("error", (e: Error) => {
-      // Dead share ports surface as socket errors; the subsequent 'close'
-      // sends close-stream. Log only — do not throw.
-      this.options.log.warn(`origin ws error on ${frame.path}: ${e.message}`);
-    });
-  }
-}
 
 export interface ConnectTunnelOptions {
   store: CredentialStore;
@@ -499,7 +71,7 @@ export class ConnectTunnel {
   private pairing = false;
   private lastError: string | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
-  private attempt = 0;
+  private readonly backoff = new ReconnectBackoff();
   private stopped = false;
   private lastState: ConnectStateName = "disconnected";
   private stateSince = Date.now();
@@ -704,7 +276,7 @@ export class ConnectTunnel {
     this.tunnel?.terminate();
     this.tunnel = undefined;
     this.connected = false;
-    this.attempt = 0;
+    this.backoff.reset();
     this.nextRetryAt = null;
   }
 
@@ -837,8 +409,7 @@ export class ConnectTunnel {
       this.remoteClients = 0;
       if (this.stopped || this.tunnel !== tunnel) return;
       const stable = connectedAt ? Date.now() - connectedAt : 0;
-      this.attempt = stable > 10_000 ? 0 : this.attempt + 1;
-      const delay = Math.min(1000 * 2 ** this.attempt, MAX_RECONNECT_DELAY_MS);
+      const delay = this.backoff.nextDelayAfterClose(stable);
       // A clean close with no prior socket error still leaves the card empty;
       // give it an honest line so the reconnecting state is never blank.
       if (this.lastError === null) {
@@ -852,4 +423,21 @@ export class ConnectTunnel {
       this.publish();
     });
   }
+}
+
+/** Host shown in transport errors — the connect apex, e.g. "getbb.app". */
+function connectApexHost(serverUrl: string): string {
+  try {
+    return new URL(deriveConnectBaseUrl(serverUrl)).host;
+  } catch {
+    return "getbb.app";
+  }
+}
+
+function tunnelUrlForServer(serverUrl: string): string {
+  const base =
+    serverUrl.replace(/^http/, "ws").replace(/\/$/, "") + "/__tunnel";
+  const url = new URL(base);
+  url.searchParams.set(TUNNEL_PROTOCOL_QUERY_PARAM, String(PROTOCOL_VERSION));
+  return url.toString();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2202,6 +2202,34 @@ importers:
 
   packages/tsconfig: {}
 
+  packages/tunnel-client:
+    dependencies:
+      '@bb/tunnel-contract':
+        specifier: workspace:*
+        version: link:../tunnel-contract
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
+    devDependencies:
+      '@bb/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.10)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/tunnel-contract:
     devDependencies:
       '@bb/tsconfig':
@@ -2277,6 +2305,9 @@ importers:
       '@bb/shared-ui':
         specifier: workspace:*
         version: link:../../packages/shared-ui
+      '@bb/tunnel-client':
+        specifier: workspace:*
+        version: link:../../packages/tunnel-client
       '@bb/tunnel-contract':
         specifier: workspace:*
         version: link:../../packages/tunnel-contract
@@ -16028,6 +16059,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@3.2.6(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@6.4.1(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2)
+      vite: 6.4.1(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/mocker@3.2.6(msw@2.12.14(@types/node@24.12.4)(@typescript/typescript6@6.0.2))(vite@6.4.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.6
@@ -21175,7 +21215,7 @@ snapshots:
   unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   until-async@3.0.2: {}
@@ -21269,6 +21309,27 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  vite-node@3.2.4(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-node@3.2.4(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -21388,6 +21449,49 @@ snapshots:
     optionalDependencies:
       vite: 8.0.12(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.10)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@6.4.1(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.19.10
+      jsdom: 29.0.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vitest@3.2.6(@types/debug@4.1.12)(@types/node@24.12.4)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.4)(@typescript/typescript6@6.0.2))(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
@@ -21403,11 +21507,11 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21215,7 +21215,7 @@ snapshots:
   unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.5
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   until-async@3.0.2: {}
@@ -21464,11 +21464,11 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.5
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@22.19.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -21507,11 +21507,11 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.5
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)


### PR DESCRIPTION
## Summary

- Move transport-generic tunnel client machinery (`TunnelSession`, loopback header rewrite, heartbeat, humanized transport errors, capped exponential reconnect backoff) out of `plugins/connect` into a new shared package `@bb/tunnel-client`.
- Keep pairing, credentials, shares, and status in the connect plugin; adapt `PluginLogger` via a minimal `TunnelClientLogger` so plugin-sdk does not leak into the shared package.
- Pure refactor for connect-v2 phase 1 (machine-direct tunnels): zero behavior change, `@bb/tunnel-contract` untouched, connect RPC/CLI surfaces unchanged.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/tunnel-client --filter=bb-plugin-connect` — pass
- `pnpm exec turbo run test --filter=@bb/tunnel-client --filter=bb-plugin-connect` — pass (`@bb/tunnel-client` 5 tests; `bb-plugin-connect` 47 tests)
- `pnpm exec turbo run build --filter=@bb/tunnel-client --filter=bb-plugin-connect` — no build tasks (source-export packages, same as `@bb/tunnel-contract`)

## Notes

- `ReconnectBackoff` is extracted so the daemon tunnel client (phase 3) can reuse the same schedule without depending on the plugin.
- Connect tests only change import paths for moved symbols.