### PR TITLE
Fix remote slash command autocomplete

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -716,6 +716,11 @@ export async function createHostDaemonApp(
         source: "fetchProjectAttachment",
         request: () => serverClient.fetchProjectAttachment(args),
       }),
+    fetchSkillTree: (treeHash) =>
+      runSessionRequest({
+        source: "fetchSkillTree",
+        request: () => serverClient.fetchSkillTree(treeHash),
+      }),
     runtimeManager,
     terminalManager,
     listModels: async (args) => {

--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { HostProviderCommand } from "@bb/host-daemon-contract";
 import { discoverProviderCommands } from "./command-discovery.js";
 import {
+  listHostCommands,
   resolveCommandScanRoots,
   resolveProviderCommandScanRoots,
 } from "./command-handlers/list-commands.js";
@@ -1117,6 +1118,44 @@ describe("discoverProviderCommands (codex)", () => {
 });
 
 describe("resolveCommandScanRoots", () => {
+  it("discovers synchronized skills staged outside the daemon's normal roots", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const sourceRootPath = path.join(tempRoot, "server-skill", "synced-skill");
+    const skillFilePath = path.join(sourceRootPath, "SKILL.md");
+    await writeFileEnsuringDir(
+      skillFilePath,
+      "---\nname: synced-skill\ndescription: Synced from the primary machine\n---\n",
+    );
+
+    const result = await listHostCommands(
+      {
+        type: "host.list_commands",
+        providerId: "pi",
+        cwd: null,
+        builtinSkillsRootPath: fixture.builtinSkillsRootPath,
+        injectedSkillSources: [
+          {
+            kind: "workspace-path",
+            sourceType: "project",
+            name: "synced-skill",
+            description: "Synced from the primary machine",
+            sourceRootPath,
+            skillFilePath,
+          },
+        ],
+      },
+      { dataDir: fixture.dataDir },
+    );
+
+    expect(byName(result.commands, "synced-skill")).toEqual({
+      name: "synced-skill",
+      source: "skill",
+      origin: "project",
+      description: "Synced from the primary machine",
+      argumentHint: null,
+    });
+  });
+
   it("scans shared bb skill roots for pi", async () => {
     const fixture = await makeWorkspaceFixture();
     const roots = resolveCommandScanRoots({

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -19,6 +19,7 @@ import type { InteractiveResolveCommandInput } from "./interactive-request-regis
 import { RuntimeManager, type RuntimeEntry } from "./runtime-manager.js";
 import type { TerminalManager } from "./terminals/terminal-manager.js";
 import type { FetchProjectAttachment } from "./project-attachments.js";
+import type { FetchSkillTree } from "./skill-trees.js";
 import type { CaffeinateManager } from "./command-handlers/caffeinate.js";
 
 type DispatchCommand = HostDaemonCommand | HostDaemonOnlineRpcCommand;
@@ -41,6 +42,7 @@ export const noopEventSink: EventSink = {
 export interface CommandDispatchOptions {
   dataDir: string;
   fetchProjectAttachment: FetchProjectAttachment;
+  fetchSkillTree?: FetchSkillTree;
   runtimeManager: RuntimeManager;
   terminalManager?: Pick<TerminalManager, "closeEnvironmentTerminals">;
   eventSink: EventSink;

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -13,6 +13,8 @@ import {
   discoverProviderCommands,
   type CommandScanRoot,
 } from "../command-discovery.js";
+import { stageInjectedSkillSources } from "../injected-skills.js";
+import type { FetchSkillTree } from "../skill-trees.js";
 
 export interface CommandRootResolution {
   /** Resolved workspace path, or null for an unprovisioned thread. */
@@ -1252,7 +1254,7 @@ export function resolveCommandScanRoots(
 
 export async function listHostCommands(
   command: CommandOf<"host.list_commands">,
-  options: { dataDir: string },
+  options: { dataDir: string; fetchSkillTree?: FetchSkillTree },
 ): Promise<HostDaemonOnlineRpcResult<"host.list_commands">> {
   if (command.cwd !== null && !path.isAbsolute(command.cwd)) {
     throw new CommandDispatchError("invalid_path", "cwd must be absolute");
@@ -1273,6 +1275,28 @@ export async function listHostCommands(
     codexHome: resolveCodexHome(homeDir),
     providerId: command.providerId,
   });
+  const staged = await stageInjectedSkillSources({
+    dataDir: options.dataDir,
+    injectedSkillSources: command.injectedSkillSources,
+    ...(options.fetchSkillTree !== undefined
+      ? { fetchSkillTree: options.fetchSkillTree }
+      : {}),
+  });
+  const stagedSkillsRootPath = staged.skillRoots.find(
+    (root): root is typeof root & { skillDirectoryRootPath: string } =>
+      "skillDirectoryRootPath" in root,
+  )?.skillDirectoryRootPath;
+  if (stagedSkillsRootPath !== undefined) {
+    for (const source of command.injectedSkillSources) {
+      roots.push({
+        rootPath: path.join(stagedSkillsRootPath, source.name),
+        shape: "skill-directory",
+        namePrefix: "",
+        source: "skill",
+        origin: source.sourceType === "project" ? "project" : "user",
+      });
+    }
+  }
   const commands = await discoverProviderCommands({ roots });
   return { commands };
 }

--- a/apps/host-daemon/src/command-router.ts
+++ b/apps/host-daemon/src/command-router.ts
@@ -104,6 +104,7 @@ type CommandRouterTask = Promise<HostDaemonCommandResultForCommand>;
 export interface CommandRouterOptions {
   dataDir: CommandDispatchOptions["dataDir"];
   fetchProjectAttachment: CommandDispatchOptions["fetchProjectAttachment"];
+  fetchSkillTree?: CommandDispatchOptions["fetchSkillTree"];
   runtimeManager: RuntimeManager;
   terminalManager?: CommandDispatchOptions["terminalManager"];
   eventSink: CommandDispatchOptions["eventSink"];
@@ -294,6 +295,7 @@ export class CommandRouter {
   private createDispatchOptions(): CommandDispatchOptions {
     return {
       fetchProjectAttachment: this.options.fetchProjectAttachment,
+      fetchSkillTree: this.options.fetchSkillTree,
       runtimeManager: this.options.runtimeManager,
       terminalManager: this.options.terminalManager,
       dataDir: this.options.dataDir,

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -78,9 +78,11 @@ import {
 } from "./branch-list-query.js";
 import { parseFileListLimit } from "./file-list-query.js";
 import { parseSafeRelativeRoutePath } from "./relative-route-path.js";
+import { resolveSkillCatalogSources } from "../services/skills/skill-catalog.js";
 import {
   assertUsableHostId,
   requirePrimaryHostId,
+  resolvePrimaryHostId,
 } from "../services/hosts/primary-host.js";
 
 type ProjectResponseProjectFields = Omit<ProjectResponse, "sources">;
@@ -720,6 +722,9 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       environmentId: query.environmentId,
       projectId,
     });
+    const primaryHostId = resolvePrimaryHostId(deps);
+    const isRemoteHost =
+      primaryHostId !== null && workspace.hostId !== primaryHostId;
     const result = await callHostRetryableOnlineRpc(deps, {
       hostId: workspace.hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
@@ -731,6 +736,11 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
         ...(deps.config.inheritedSkillsRootPaths.length > 0
           ? { additionalSkillsRootPaths: deps.config.inheritedSkillsRootPaths }
           : {}),
+        // These absolute roots live on the primary machine. Remote daemons
+        // receive the same content-addressed catalog used for runtime injection.
+        injectedSkillSources: isRemoteHost
+          ? resolveSkillCatalogSources(deps)
+          : [],
       },
     });
     return context.json(

--- a/apps/server/src/services/skills/skill-catalog.ts
+++ b/apps/server/src/services/skills/skill-catalog.ts
@@ -1,0 +1,36 @@
+import type { HostDaemonInjectedSkillSource } from "@bb/host-daemon-contract";
+import type { LoggedWorkSessionDeps } from "../../types.js";
+import { getPluginSkillsRootPaths } from "../plugins/plugin-agent-contributions.js";
+import { generatedSkillsRootPath } from "../plugins/plugin-commands-skill.js";
+import {
+  resolveInjectedSkillSources,
+  type ProjectInjectedSkillSource,
+} from "./injected-skills.js";
+
+interface ResolveSkillCatalogSourcesArgs {
+  projectSkillSources?: readonly ProjectInjectedSkillSource[];
+}
+
+/**
+ * Resolve the server-owned skill catalog shared by runtime injection and
+ * slash-command discovery. Project sources are supplied by callers that have
+ * a concrete workspace; global, plugin, and built-in tiers are always present.
+ */
+export function resolveSkillCatalogSources(
+  deps: Pick<LoggedWorkSessionDeps, "config" | "logger" | "skillTreeRegistry">,
+  args: ResolveSkillCatalogSourcesArgs = {},
+): HostDaemonInjectedSkillSource[] {
+  return resolveInjectedSkillSources(deps.logger, {
+    additionalSkillsRootPaths: [
+      ...deps.config.inheritedSkillsRootPaths,
+      generatedSkillsRootPath(deps.config.dataDir),
+    ],
+    builtinSkillsRootPath: deps.config.builtinSkillsRootPath,
+    dataDir: deps.config.dataDir,
+    pluginSkillsRootPaths: getPluginSkillsRootPaths(),
+    ...(args.projectSkillSources !== undefined
+      ? { projectSkillSources: args.projectSkillSources }
+      : {}),
+    skillTreeRegistry: deps.skillTreeRegistry,
+  });
+}

--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -23,12 +23,10 @@ import {
   resolveExistingThreadExecutionPlan,
 } from "./thread-execution-plan.js";
 import {
-  getPluginSkillsRootPaths,
   listPluginAgentTools,
   listPluginInstructionContributions,
 } from "../plugins/plugin-agent-contributions.js";
-import { generatedSkillsRootPath } from "../plugins/plugin-commands-skill.js";
-import { resolveInjectedSkillSources } from "../skills/injected-skills.js";
+import { resolveSkillCatalogSources } from "../skills/skill-catalog.js";
 import { resolveWorkspaceProjectSkills } from "../skills/workspace-skills.js";
 import { UPDATE_ENVIRONMENT_DIRECTORY_TOOL } from "./thread-environment-directory.js";
 import { isSideChatThread } from "./side-chat-thread.js";
@@ -181,22 +179,8 @@ export async function resolveThreadRuntimeCommandConfig(
       workspacePath,
     }),
   ]);
-  const injectedSkillSources = resolveInjectedSkillSources(deps.logger, {
-    // The server-generated skills root (plugin-commands) rides the data-dir
-    // tier; the plugin service only materializes it while the plugins
-    // experiment is on and a plugin registers a CLI command, and a missing
-    // root resolves to no skills.
-    additionalSkillsRootPaths: [
-      ...deps.config.inheritedSkillsRootPaths,
-      generatedSkillsRootPath(deps.config.dataDir),
-    ],
-    builtinSkillsRootPath: deps.config.builtinSkillsRootPath,
-    dataDir: deps.config.dataDir,
-    // Skills roots of running plugins — resolved live each turn, so a
-    // reloaded plugin's skills apply on the next turn without a restart.
-    pluginSkillsRootPaths: getPluginSkillsRootPaths(),
+  const injectedSkillSources = resolveSkillCatalogSources(deps, {
     projectSkillSources,
-    skillTreeRegistry: deps.skillTreeRegistry,
   });
   const dataDirAgentInstructions = readDataDirAgentInstructions(
     deps.logger,

--- a/apps/server/test/public/public-project-commands.test.ts
+++ b/apps/server/test/public/public-project-commands.test.ts
@@ -1,4 +1,6 @@
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 import type {
   HostProviderCommand,
   HostDaemonOnlineRpcRequestMessage,
@@ -83,6 +85,63 @@ function legacyCommand(
 }
 
 describe("public project command typeahead route", () => {
+  it("sends the synchronized skill catalog when discovery targets another machine", async () => {
+    await withTestHarness(async (harness) => {
+      const primaryHost = seedHost(harness.deps, {
+        id: "host-commands-primary",
+      });
+      seedPrimaryHost(harness.deps, primaryHost.id);
+      const { host: remoteHost, session } = seedHostSession(harness.deps, {
+        id: "host-commands-remote",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: primaryHost.id,
+        path: "/tmp/remote-commands-project",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: remoteHost.id,
+        projectId: project.id,
+        path: "/tmp/remote-commands-env",
+      });
+      const skillRoot = path.join(
+        harness.deps.config.dataDir,
+        "skills",
+        "synced-remote",
+      );
+      await mkdir(skillRoot, { recursive: true });
+      await writeFile(
+        path.join(skillRoot, "SKILL.md"),
+        "---\nname: synced-remote\ndescription: Synced remote skill\n---\n",
+        "utf8",
+      );
+      const stub = registerCommandRpc(harness, {
+        hostId: remoteHost.id,
+        sessionId: session.id,
+        commands: [skill("synced-remote", "user")],
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/projects/${project.id}/commands?provider=codex&environmentId=${environment.id}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(stub.requests[0]?.command).toEqual(
+        expect.objectContaining({
+          type: "host.list_commands",
+          providerId: "codex",
+          cwd: "/tmp/remote-commands-env",
+          injectedSkillSources: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "tree",
+              sourceType: "data-dir",
+              name: "synced-remote",
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
   it("filters, sorts, and de-dupes claude-code commands with project winning over user", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
@@ -160,6 +219,7 @@ describe("public project command typeahead route", () => {
           providerId: "claude-code",
           cwd: "/tmp/claude-commands-env",
           builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+          injectedSkillSources: [],
         },
       ]);
     });
@@ -205,6 +265,7 @@ describe("public project command typeahead route", () => {
         providerId: "codex",
         cwd: "/tmp/codex-commands-env",
         builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+        injectedSkillSources: [],
       });
     });
   });
@@ -248,6 +309,7 @@ describe("public project command typeahead route", () => {
           cwd: "/tmp/inherited-skills-project",
           builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
           additionalSkillsRootPaths: ["/tmp/bb-parent-skills"],
+          injectedSkillSources: [],
         });
       },
     );
@@ -356,6 +418,7 @@ describe("public project command typeahead route", () => {
         providerId: "pi",
         cwd: "/tmp/pi-commands-env",
         builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+        injectedSkillSources: [],
       });
     });
   });
@@ -395,6 +458,7 @@ describe("public project command typeahead route", () => {
         providerId: "claude-code",
         cwd: "/tmp/no-env-project",
         builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+        injectedSkillSources: [],
       });
     });
   });
@@ -440,6 +504,7 @@ describe("public project command typeahead route", () => {
         providerId: "claude-code",
         cwd: "/tmp/provisioning-project",
         builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+        injectedSkillSources: [],
       });
     });
   });
@@ -478,6 +543,7 @@ describe("public project command typeahead route", () => {
         providerId: "claude-code",
         cwd: null,
         builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+        injectedSkillSources: [],
       });
     });
   });
@@ -509,6 +575,7 @@ describe("public project command typeahead route", () => {
         providerId: "codex",
         cwd: null,
         builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
+        injectedSkillSources: [],
       });
     });
   });

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 52 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 53 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,
@@ -621,8 +621,10 @@ export type HostProviderCommand = z.infer<typeof hostProviderCommandSchema>;
  * List the provider's discoverable skills / legacy slash commands. The daemon
  * resolves the user-home roots itself and scans the project roots under `cwd`
  * when provided; `cwd: null` (unprovisioned thread) skips the project roots and
- * returns only user-origin entries. Returns the full raw set — the server owns
- * de-dup/sort/limit, so there is no `truncated` field here.
+ * returns only user-origin entries. Synchronized skills are supplied as the
+ * same content-addressed sources used by thread runtime injection. Returns the
+ * full raw set — the server owns de-dup/sort/limit, so there is no `truncated`
+ * field here.
  */
 const hostListCommandsCommandSchema = z.object({
   type: z.literal("host.list_commands"),
@@ -630,6 +632,7 @@ const hostListCommandsCommandSchema = z.object({
   cwd: z.string().min(1).nullable(),
   builtinSkillsRootPath: z.string().min(1),
   additionalSkillsRootPaths: z.array(z.string().min(1)).optional(),
+  injectedSkillSources: z.array(hostDaemonInjectedSkillSourceSchema),
 });
 
 /**

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1227,12 +1227,14 @@ describe("host-daemon command schemas", () => {
         providerId: "claude-code",
         cwd: "/tmp/workspace",
         builtinSkillsRootPath: "/tmp/builtin-skills",
+        injectedSkillSources: [],
       }),
     ).toMatchObject({
       type: "host.list_commands",
       providerId: "claude-code",
       cwd: "/tmp/workspace",
       builtinSkillsRootPath: "/tmp/builtin-skills",
+      injectedSkillSources: [],
     });
 
     expect(


### PR DESCRIPTION
## Summary
- send the synchronized global skill catalog to remote command discovery
- stage synchronized skills on the target daemon before slash-command scanning
- share server-owned skill catalog policy with runtime injection and bump the daemon protocol

## Tests
- pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/server --filter=@bb/host-daemon-contract
- pnpm exec turbo run test --filter=@bb/host-daemon-contract -- --run test/contract.test.ts
- pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/command-discovery.test.ts
- pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-project-commands.test.ts
- pnpm exec turbo run test --filter=@bb/server -- --run test/threads/thread-runtime-config.test.ts

## Risk
- daemon protocol changes from 52 to 53 so connected daemons update before accepting the new command contract