### PR TITLE
Show canonical plugin icons across app surfaces

### DIFF
--- a/apps/app/src/components/plugin/PluginIcon.test.tsx
+++ b/apps/app/src/components/plugin/PluginIcon.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import {
   resetPluginLogoStoreForTest,
@@ -35,4 +35,26 @@ it("uses the plugin's canonical app icon on surfaces without an icon hint", () =
   const view = render(<PluginIcon pluginId="docs" icon={null} />);
   expect(view.container.querySelector("[data-icon=FileText]")).toBeTruthy();
   expect(view.container.querySelector("[data-icon=Zap]")).toBeNull();
+});
+
+it("falls back to the canonical app icon when the plugin logo fails", () => {
+  setPluginLogoUrls(
+    new Map([
+      [
+        "github",
+        {
+          icon: "Github",
+          logoUrl: "/api/v1/plugins/github/assets/logo?h=abc",
+          logoDarkUrl: null,
+        },
+      ],
+    ]),
+  );
+
+  const view = render(<PluginIcon pluginId="github" icon="Layers" />);
+  const logo = view.getByTestId("plugin-logo-github");
+  fireEvent.error(logo);
+
+  expect(view.container.querySelector("[data-icon=Github]")).toBeTruthy();
+  expect(view.container.querySelector("[data-icon=Layers]")).toBeNull();
 });

--- a/apps/app/src/components/plugin/PluginIcon.tsx
+++ b/apps/app/src/components/plugin/PluginIcon.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Icon, ICON_NAMES, type IconName } from "@bb/shared-ui/icon";
 import { usePluginIconHint, usePluginLogoUrl } from "@/lib/plugin-logos";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -30,7 +31,8 @@ export function PluginIcon({
 }) {
   const logoUrl = usePluginLogoUrl(pluginId);
   const pluginIcon = usePluginIconHint(pluginId);
-  if (logoUrl !== null) {
+  const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null);
+  if (logoUrl !== null && logoUrl !== failedLogoUrl) {
     return (
       <img
         src={logoUrl}
@@ -38,6 +40,7 @@ export function PluginIcon({
         aria-hidden="true"
         data-testid={`plugin-logo-${pluginId}`}
         className={cn("size-4 shrink-0 rounded-sm object-contain", className)}
+        onError={() => setFailedLogoUrl(logoUrl)}
       />
     );
   }

--- a/apps/app/src/components/plugin/PluginSidebarFooterActions.test.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterActions.test.tsx
@@ -9,6 +9,10 @@ import {
   setPluginSlotRegistrations,
   type PluginRegistrationSet,
 } from "@/lib/plugin-slots";
+import {
+  resetPluginLogoStoreForTest,
+  setPluginLogoUrls,
+} from "@/lib/plugin-logos";
 import { PluginSidebarFooterActions } from "./PluginSidebarFooterActions";
 
 function registrationSet(
@@ -38,10 +42,44 @@ function renderWithProviders(ui: ReactNode) {
 afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
+  resetPluginLogoStoreForTest();
   vi.restoreAllMocks();
 });
 
 describe("PluginSidebarFooterActions", () => {
+  it("prefers the plugin's canonical logo over the contribution icon", () => {
+    setPluginLogoUrls(
+      new Map([
+        [
+          "remote",
+          {
+            icon: "Plug",
+            logoUrl: "/api/v1/plugins/remote/assets/logo?h=abc",
+            logoDarkUrl: null,
+          },
+        ],
+      ]),
+    );
+    setPluginSlotRegistrations(
+      "remote",
+      registrationSet({
+        sidebarFooterActions: [
+          {
+            id: "open",
+            title: "Remote",
+            icon: "Smartphone",
+            run: () => {},
+          },
+        ],
+      }),
+    );
+
+    renderWithProviders(<PluginSidebarFooterActions />);
+
+    expect(screen.getByTestId("plugin-logo-remote")).toBeTruthy();
+    expect(document.querySelector('[data-icon="Smartphone"]')).toBeNull();
+  });
+
   it("contains a throwing run without breaking the sidebar", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     setPluginSlotRegistrations(

--- a/apps/app/src/components/plugin/PluginSidebarFooterActions.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterActions.tsx
@@ -1,12 +1,8 @@
 import { useNavigate } from "react-router-dom";
-import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
-import {
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from "@/components/ui/sidebar.js";
-import { pluginIconName } from "@/components/plugin/PluginIcon";
+import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar.js";
+import { PluginIcon } from "@/components/plugin/PluginIcon";
 import {
   usePluginSlots,
   type PluginSidebarFooterActionSlot,
@@ -24,9 +20,7 @@ const SIDEBAR_FOOTER_ACTION_CLASS = cn(
  * one runs the plugin's `run` with `{ openSettings }` — throws/rejections
  * are logged and never break the sidebar.
  */
-export function PluginSidebarFooterActions(props: {
-  onNavigate?: () => void;
-}) {
+export function PluginSidebarFooterActions(props: { onNavigate?: () => void }) {
   const { sidebarFooterActions } = usePluginSlots();
   if (sidebarFooterActions.length === 0) return null;
   return (
@@ -66,7 +60,7 @@ function PluginSidebarFooterActionList({
               runSidebarFooterAction({ action, navigate });
             }}
           >
-            <Icon name={pluginIconName(action.icon)} />
+            <PluginIcon pluginId={action.pluginId} icon={action.icon} />
             <span className="sr-only">{action.title}</span>
           </SidebarMenuButton>
         </SidebarMenuItem>

--- a/apps/app/src/components/settings/plugins/AddPluginDialog.test.tsx
+++ b/apps/app/src/components/settings/plugins/AddPluginDialog.test.tsx
@@ -44,7 +44,9 @@ function stubFetch(
   return requests;
 }
 
-function renderDialog(initial?: Parameters<typeof AddPluginDialog>[0]["initial"]) {
+function renderDialog(
+  initial?: Parameters<typeof AddPluginDialog>[0]["initial"],
+) {
   const { wrapper } = createQueryClientTestHarness();
   return render(
     <AddPluginDialog open onOpenChange={() => {}} initial={initial} />,
@@ -89,7 +91,11 @@ describe("AddPluginDialog", () => {
       marketplaceName: "bb-official",
       entryId: "linear",
       displayName: "Linear",
+      icon: "Github",
     });
+
+    expect(document.querySelector('[data-icon="Github"]')).not.toBeNull();
+    expect(document.querySelector('[data-icon="Zap"]')).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /install linear/i }));
 

--- a/apps/app/src/components/settings/plugins/AddPluginDialog.tsx
+++ b/apps/app/src/components/settings/plugins/AddPluginDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@bb/shared-ui/dialog";
 import { Icon } from "@bb/shared-ui/icon";
 import { Input } from "@bb/shared-ui/input";
+import { pluginIconName } from "@/components/plugin/PluginIcon";
 import { appToast } from "@/components/ui/app-toast.js";
 import {
   invalidateMarketplaces,
@@ -32,6 +33,7 @@ export type AddPluginInitial = {
   marketplaceName: string;
   entryId: string;
   displayName: string;
+  icon: string | null;
 };
 
 export interface AddPluginDialogProps {
@@ -124,7 +126,10 @@ function AddPluginDialogContent({
       <div className="space-y-3">
         {initial !== null ? (
           <div className="flex items-center gap-2.5 rounded-md border border-border bg-muted/30 px-3 py-2">
-            <PlaceholderBadge className="size-6" />
+            <PlaceholderBadge
+              className="size-6"
+              iconName={pluginIconName(initial.icon)}
+            />
             <span className="text-sm font-medium text-foreground">
               {initial.displayName}
             </span>
@@ -151,7 +156,11 @@ function AddPluginDialogContent({
         <FullTrustWarning />
       </div>
       <DialogFooter>
-        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => onOpenChange(false)}
+        >
           Cancel
         </Button>
         <Button

--- a/apps/app/src/components/settings/plugins/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/settings/plugins/BrowsePluginsTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { BrowsePluginsTab } from "./BrowsePluginsTab";
@@ -59,8 +59,9 @@ describe("BrowsePluginsTab", () => {
       }),
     );
 
+    const onInstall = vi.fn();
     const { wrapper } = createQueryClientTestHarness();
-    render(<BrowsePluginsTab onInstall={() => {}} />, { wrapper });
+    render(<BrowsePluginsTab onInstall={onInstall} />, { wrapper });
 
     const card = await screen.findByTestId("browse-card-memory");
     expect(card.querySelector('[data-icon="Brain"]')).not.toBeNull();
@@ -69,5 +70,10 @@ describe("BrowsePluginsTab", () => {
     expect(sourceLine.classList.contains("truncate")).toBe(true);
     expect(sourceLine.getAttribute("title")).toBe(`BB Official · ${source}`);
     expect(sourceLine.textContent).toBe(`BB Official · ${source}`);
+
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    expect(onInstall).toHaveBeenCalledWith(
+      expect.objectContaining({ icon: "Brain" }),
+    );
   });
 });

--- a/apps/app/src/components/settings/plugins/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/settings/plugins/BrowsePluginsTab.tsx
@@ -44,7 +44,10 @@ export function BrowsePluginsTab({
 
   const marketplaces = marketplacesQuery.data ?? [];
   const marketplaceNames = new Map(
-    marketplaces.map((marketplace) => [marketplace.id, marketplace.displayName]),
+    marketplaces.map((marketplace) => [
+      marketplace.id,
+      marketplace.displayName,
+    ]),
   );
   const entries = (searchQuery.data ?? []).filter(
     (entry) =>
@@ -221,6 +224,7 @@ function BrowseCard({
               marketplaceName,
               entryId: entry.entryId,
               displayName: entry.displayName,
+              icon: entry.icon,
             })
           }
         >


### PR DESCRIPTION
## Summary
- carry marketplace icon metadata into the install confirmation
- use the canonical plugin logo/icon for sidebar footer actions
- fall back to the canonical manifest icon when a logo asset fails to load

## Tests
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/plugin/PluginIcon.test.tsx src/components/plugin/PluginSidebarFooterActions.test.tsx src/components/settings/plugins/AddPluginDialog.test.tsx src/components/settings/plugins/BrowsePluginsTab.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `git diff --check`