### PR TITLE
Fix Docs sidebar resize over HTML artifacts

### DIFF
--- a/marketplace/plugins/docs/app.test.tsx
+++ b/marketplace/plugins/docs/app.test.tsx
@@ -150,10 +150,17 @@ describe("Docs nav panel", () => {
     const resizeHandle = slot.getByRole("separator", {
       name: "Resize notes sidebar",
     });
-    fireEvent.pointerDown(resizeHandle, { clientX: 288 });
-    fireEvent.pointerMove(window, { clientX: 176 });
+    const setPointerCapture = vi.fn();
+    const releasePointerCapture = vi.fn();
+    resizeHandle.setPointerCapture = setPointerCapture;
+    resizeHandle.hasPointerCapture = () => true;
+    resizeHandle.releasePointerCapture = releasePointerCapture;
+    fireEvent.pointerDown(resizeHandle, { clientX: 288, pointerId: 7 });
+    expect(setPointerCapture).toHaveBeenCalledWith(7);
+    fireEvent.pointerMove(resizeHandle, { clientX: 176, pointerId: 7 });
     expect(slot.container.querySelector("aside")?.style.width).toBe("400px");
-    fireEvent.pointerUp(window);
+    fireEvent.pointerUp(resizeHandle, { pointerId: 7 });
+    expect(releasePointerCapture).toHaveBeenCalledWith(7);
   });
 
   it("only shows host status when the selected vault is unavailable", async () => {

--- a/marketplace/plugins/docs/app.tsx
+++ b/marketplace/plugins/docs/app.tsx
@@ -1307,6 +1307,8 @@ function Tree({
   const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     resizeCleanupRef.current?.();
+    const handle = event.currentTarget;
+    const pointerId = event.pointerId;
     const startX = event.clientX;
     const startWidth = sidebarWidth;
     const move = (moveEvent: PointerEvent) => {
@@ -1315,13 +1317,24 @@ function Tree({
       );
     };
     const cleanup = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", cleanup);
+      if (resizeCleanupRef.current !== cleanup) return;
+      handle.removeEventListener("pointermove", move);
+      handle.removeEventListener("pointerup", cleanup);
+      handle.removeEventListener("pointercancel", cleanup);
+      handle.removeEventListener("lostpointercapture", cleanup);
+      window.removeEventListener("blur", cleanup);
       resizeCleanupRef.current = null;
+      if (handle.hasPointerCapture(pointerId)) {
+        handle.releasePointerCapture(pointerId);
+      }
     };
     resizeCleanupRef.current = cleanup;
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", cleanup);
+    handle.setPointerCapture(pointerId);
+    handle.addEventListener("pointermove", move);
+    handle.addEventListener("pointerup", cleanup);
+    handle.addEventListener("pointercancel", cleanup);
+    handle.addEventListener("lostpointercapture", cleanup);
+    window.addEventListener("blur", cleanup);
   };
 
   if (sidebarCollapsed) {


### PR DESCRIPTION
## Summary

- capture the Docs sidebar resize pointer on drag start
- keep resize events flowing when the pointer crosses an HTML artifact iframe
- clean up capture on pointer up, cancellation, capture loss, blur, and unmount

## Validation

- `pnpm exec turbo run test --filter=bb-plugin-simple-notes --force` (18 tests)
- `pnpm exec turbo run typecheck --filter=bb-plugin-simple-notes`
- `pnpm exec turbo run build --filter=bb-plugin-simple-notes`
- `pnpm exec prettier --check marketplace/plugins/docs/app.tsx marketplace/plugins/docs/app.test.tsx`
- dev-browser: resized the live Docs sidebar from 288px to 440px while the pointer crossed the visible HTML iframe