### PR TITLE
Extend split panes to New Thread and plugin pages

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,8 +1,7 @@
 import { lazy, Suspense, useEffect } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { AppLayout } from "./components/layout/AppLayout";
 import { AuthCallbackView } from "./views/AuthCallbackView";
-import { RootComposeRoute } from "./views/RootComposeView";
 import { QuickCreateProjectProvider } from "./hooks/useQuickCreateProject";
 import { ProviderCliHealthToasts } from "./components/provider-cli/ProviderCliHealthToasts";
 import { RouteNavigationProvider } from "./components/ui/app-route-anchor";
@@ -16,20 +15,15 @@ import {
 import { usePluginFrontendBoot } from "./hooks/usePluginFrontendBoot";
 import { useWebSocket } from "./hooks/useWebSocket";
 import {
-  APP_ROOT_ROUTE_PATH,
   AUTH_CALLBACK_ROUTE_PATH,
-  LEGACY_PROJECT_COMPOSE_ROUTE_PATH,
-  PLUGIN_PANEL_ROUTE_PATH,
   POPOUT_ROUTE_PATH,
   PROJECT_ARCHIVED_ROUTE_PATH,
   PROJECTLESS_ARCHIVED_ROUTE_PATH,
-  PROJECTLESS_THREAD_DETAIL_ROUTE_PATH,
   PROJECT_SETTINGS_ROUTE_PATH,
   SETTINGS_PLUGIN_ROUTE_PATH,
   SETTINGS_PROVIDER_ROUTE_PATH,
   SETTINGS_ROUTE_PATH,
   SETTINGS_SECTION_ROUTE_PATH,
-  THREAD_DETAIL_ROUTE_PATH,
 } from "./lib/route-paths";
 import { Icon } from "@bb/shared-ui/icon";
 import { AppCommandProvider } from "./components/commands/AppCommandProvider";
@@ -38,9 +32,6 @@ import {
   POPOUT_SHADOW_MARGIN,
 } from "@bb/desktop-contract";
 
-const ThreadDetailRoute = lazy(
-  () => import("./views/thread-detail/ThreadDetailRoute"),
-);
 const SettingsView = lazy(() =>
   import("./views/SettingsView").then((m) => ({
     default: m.SettingsView,
@@ -61,11 +52,7 @@ const PopoutChatView = lazy(() =>
     default: m.PopoutChatView,
   })),
 );
-const PluginPanelView = lazy(() =>
-  import("./views/PluginPanelView").then((m) => ({
-    default: m.PluginPanelView,
-  })),
-);
+const SplitWorkspaceRoute = lazy(() => import("./views/SplitWorkspaceRoute"));
 
 function PopoutRouteFallback() {
   useEffect(() => {
@@ -98,7 +85,6 @@ function AppRoutes() {
     <AppLayout>
       <Suspense fallback={null}>
         <Routes>
-          <Route path={APP_ROOT_ROUTE_PATH} element={<RootComposeRoute />} />
           <Route path={SETTINGS_ROUTE_PATH} element={<SettingsView />} />
           <Route
             path={SETTINGS_SECTION_ROUTE_PATH}
@@ -108,10 +94,6 @@ function AppRoutes() {
           <Route
             path={SETTINGS_PROVIDER_ROUTE_PATH}
             element={<SettingsView />}
-          />
-          <Route
-            path={LEGACY_PROJECT_COMPOSE_ROUTE_PATH}
-            element={<RootComposeRoute />}
           />
           <Route
             path={PROJECT_SETTINGS_ROUTE_PATH}
@@ -125,19 +107,7 @@ function AppRoutes() {
             path={PROJECTLESS_ARCHIVED_ROUTE_PATH}
             element={<ArchivedThreadsView />}
           />
-          <Route
-            path={THREAD_DETAIL_ROUTE_PATH}
-            element={<ThreadDetailRoute />}
-          />
-          <Route
-            path={PROJECTLESS_THREAD_DETAIL_ROUTE_PATH}
-            element={<ThreadDetailRoute />}
-          />
-          <Route path={PLUGIN_PANEL_ROUTE_PATH} element={<PluginPanelView />} />
-          <Route
-            path="*"
-            element={<Navigate to={APP_ROOT_ROUTE_PATH} replace />}
-          />
+          <Route path="*" element={<SplitWorkspaceRoute />} />
         </Routes>
       </Suspense>
     </AppLayout>

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -544,7 +544,10 @@ export function AppLayout({ children }: AppLayoutProps) {
   const startWidthRef = useRef(0);
   const liveWidthRef = useRef(sidebarWidth);
   const animationFrameRef = useRef<number | null>(null);
-  const showHeader = !isThreadView && !isRootView;
+  const showHeader =
+    !isThreadView &&
+    !isRootView &&
+    !(threadSplitsEnabled && pluginPanelMatch !== null);
   const [desktopInfo] = useState(getBbDesktopInfo);
   const desktopWindowState = useDesktopWindowState();
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -5,6 +5,8 @@ import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectLi
 import { getPluginPanelRoutePath } from "@/lib/route-paths";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { cn } from "@bb/shared-ui/lib/utils";
+import type { PluginNavPanelSlot } from "@/lib/plugin-slots";
+import { usePaneContentSplitDrag } from "@/components/sidebar/usePaneContentSplitDrag";
 
 /**
  * Sidebar entries for plugin `navPanel` slots (plugin design §5.2): one row
@@ -13,7 +15,10 @@ import { cn } from "@bb/shared-ui/lib/utils";
  * while no plugin contributes a panel. Only host chrome renders here — the
  * plugin's component mounts on the route (PluginPanelView).
  */
-export function PluginNavSidebarItems(props: { onNavigate?: () => void }) {
+export function PluginNavSidebarItems(props: {
+  onNavigate?: () => void;
+  splitEnabled?: boolean;
+}) {
   const { navPanels } = usePluginSlots();
   // Router hooks live in the inner component so hosts without a Router
   // (isolated sidebar tests/stories) can render the empty state.
@@ -24,11 +29,12 @@ export function PluginNavSidebarItems(props: { onNavigate?: () => void }) {
 function PluginNavSidebarItemList({
   onNavigate,
   navPanels,
+  splitEnabled = false,
 }: {
   onNavigate?: () => void;
   navPanels: ReturnType<typeof usePluginSlots>["navPanels"];
+  splitEnabled?: boolean;
 }) {
-  const navigate = useNavigate();
   const location = useLocation();
   return (
     <div
@@ -38,36 +44,71 @@ function PluginNavSidebarItemList({
       data-testid="plugin-nav-sidebar-items"
     >
       {navPanels.map((panel) => {
-        const path = getPluginPanelRoutePath({
-          pluginId: panel.pluginId,
-          path: panel.path,
-        });
-        const isActive =
-          location.pathname === path || location.pathname.startsWith(`${path}/`);
         return (
-          <Button
+          <PluginNavSidebarItem
             key={`${panel.pluginId}/${panel.id}`}
-            type="button"
-            size="sm"
-            variant="ghost"
-            className={cn(
-              PROJECT_LIST_ACTION_BUTTON_CLASS,
-              "w-full",
-              isActive && "bg-sidebar-accent text-sidebar-foreground",
-            )}
-            aria-current={isActive ? "page" : undefined}
-            onClick={() => {
-              onNavigate?.();
-              void navigate(path);
-            }}
-          >
-            <PluginIcon pluginId={panel.pluginId} icon={panel.icon} />
-            <span className="min-w-0 flex-1 truncate text-left">
-              {panel.title}
-            </span>
-          </Button>
+            panel={panel}
+            pathname={location.pathname}
+            onNavigate={onNavigate}
+            splitEnabled={splitEnabled}
+          />
         );
       })}
     </div>
+  );
+}
+
+function PluginNavSidebarItem({
+  panel,
+  pathname,
+  onNavigate,
+  splitEnabled,
+}: {
+  panel: PluginNavPanelSlot;
+  pathname: string;
+  onNavigate?: () => void;
+  splitEnabled: boolean;
+}) {
+  const navigate = useNavigate();
+  const path = getPluginPanelRoutePath({
+    pluginId: panel.pluginId,
+    path: panel.path,
+  });
+  const isActive = pathname === path || pathname.startsWith(`${path}/`);
+  const content = {
+    kind: "plugin-panel",
+    pluginId: panel.pluginId,
+    panelPath: panel.path,
+    subPath: "",
+  } as const;
+  const { onPointerDown, openInSplit } = usePaneContentSplitDrag({
+    content,
+    enabled: splitEnabled,
+    label: panel.title,
+  });
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(
+        PROJECT_LIST_ACTION_BUTTON_CLASS,
+        "w-full",
+        isActive && "bg-sidebar-accent text-sidebar-foreground",
+      )}
+      aria-current={isActive ? "page" : undefined}
+      onPointerDown={onPointerDown}
+      onClick={(event) => {
+        onNavigate?.();
+        if (event.metaKey || event.ctrlKey) {
+          openInSplit();
+          return;
+        }
+        void navigate(path);
+      }}
+    >
+      <PluginIcon pluginId={panel.pluginId} icon={panel.icon} />
+      <span className="min-w-0 flex-1 truncate text-left">{panel.title}</span>
+    </Button>
   );
 }

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -35,6 +35,8 @@ import {
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
 import { getRootComposeRoutePath, getThreadRoutePath } from "@/lib/route-paths";
+import { useThreadSplitsEnabled } from "@/hooks/useThreadSplitsEnabled";
+import { usePaneContentSplitDrag } from "./usePaneContentSplitDrag";
 import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import {
   haveSameSidebarThreadSearchNavigationItems,
@@ -56,6 +58,8 @@ import {
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
+
+const NEW_THREAD_PANE_CONTENT = { kind: "new-thread" } as const;
 
 const BUG_REPORT_NEW_ISSUE_URL = "https://github.com/ymichael/bb/issues/new";
 const SIDEBAR_FOOTER_ACTION_CLASS = cn(
@@ -90,6 +94,12 @@ export function AppSidebar({
   const quickCreateProject = useQuickCreateProjectController();
   const { threadId: activeThreadId } = useRouteState();
   const navigate = useNavigate();
+  const threadSplitsEnabled = useThreadSplitsEnabled();
+  const newThreadSplit = usePaneContentSplitDrag({
+    content: NEW_THREAD_PANE_CONTENT,
+    enabled: threadSplitsEnabled,
+    label: "New thread",
+  });
   const closeOnMobile = useCloseMobileSidebar();
   const { isCompactViewport, setOpen, setOpenMobile } = useSidebar();
   const [desktopInfo] = useState(getBbDesktopInfo);
@@ -370,6 +380,7 @@ export function AppSidebar({
           className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
         >
           <ProjectListActionButtons
+            newThreadSplit={newThreadSplit}
             onNewChat={handleNewChat}
             threadSearch={{
               activeDescendantId: threadSearchActiveDescendantId,
@@ -382,7 +393,10 @@ export function AppSidebar({
             }}
           />
         </div>
-        <PluginNavSidebarItems onNavigate={closeOnMobile} />
+        <PluginNavSidebarItems
+          onNavigate={closeOnMobile}
+          splitEnabled={threadSplitsEnabled}
+        />
         <SidebarContent>
           <ProjectList
             onNewProject={

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -181,6 +181,10 @@ interface ProjectListProps {
 }
 
 interface ProjectListActionButtonsProps {
+  newThreadSplit?: {
+    onPointerDown?: PointerEventHandler<HTMLElement>;
+    openInSplit(): void;
+  };
   onNewChat?: () => void;
   threadSearch?: SidebarThreadSearchInputController;
 }
@@ -1027,6 +1031,7 @@ const SortableSidebarSection = memo(function SortableSidebarSection({
 });
 
 export function ProjectListActionButtons({
+  newThreadSplit,
   onNewChat,
   threadSearch,
 }: ProjectListActionButtonsProps) {
@@ -1088,7 +1093,14 @@ export function ProjectListActionButtons({
             size="sm"
             variant="ghost"
             className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "flex-1")}
-            onClick={onNewChat}
+            onPointerDown={newThreadSplit?.onPointerDown}
+            onClick={(event) => {
+              if (event.metaKey || event.ctrlKey) {
+                newThreadSplit?.openInSplit();
+                return;
+              }
+              onNewChat?.();
+            }}
             disabled={isNewChatDisabled}
             aria-label={
               newThreadShortcut

--- a/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
+++ b/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
@@ -1,0 +1,145 @@
+import { useCallback, type PointerEvent as ReactPointerEvent } from "react";
+import { useStore } from "jotai";
+import { useNavigate } from "react-router-dom";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
+  getPluginPanelRoutePath,
+  getRootComposeRoutePath,
+  getThreadRoutePath,
+} from "@/lib/route-paths";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import {
+  countPanes,
+  findPaneByContent,
+  listPanes,
+  MAX_PANES,
+  replacePaneContent,
+  setFocus,
+  splitPane,
+  type PaneContent,
+  type SplitLayout,
+} from "@/lib/split-layout";
+import {
+  beginSplitDrag,
+  decideThreadDrop,
+  shouldEngageSidebarSplitDrag,
+  type SplitDragFallbackTarget,
+} from "@/lib/split-drag";
+
+const SIDEBAR_SELECTOR = '[data-sidebar="sidebar"]';
+const MAIN_CONTENT_SELECTOR = "main";
+
+function routeForContent(content: PaneContent): string {
+  if (content.kind === "thread") return getThreadRoutePath(content);
+  if (content.kind === "new-thread") return getRootComposeRoutePath();
+  return getPluginPanelRoutePath({
+    pluginId: content.pluginId,
+    path: content.panelPath,
+    subPath: content.subPath,
+  });
+}
+
+/** Prototype drag/cmd-click source for non-thread pages. */
+export function usePaneContentSplitDrag({
+  content,
+  enabled,
+  label,
+}: {
+  content: PaneContent;
+  enabled: boolean;
+  label: string;
+}) {
+  const store = useStore();
+  const navigate = useNavigate();
+  const isCompact = useIsCompactViewport();
+
+  const openInSplit = useCallback(() => {
+    const route = routeForContent(content);
+    const layout = store.get(splitLayoutAtom);
+    if (!enabled || isCompact || layout === null) {
+      navigate(route);
+      return;
+    }
+    const existing = findPaneByContent(layout.root, content);
+    const next =
+      existing !== null
+        ? setFocus(layout, existing.paneId)
+        : countPanes(layout.root) >= MAX_PANES
+          ? replacePaneContent(layout, layout.focusedPaneId, content)
+          : splitPane(layout, layout.focusedPaneId, "right", content);
+    if (next !== layout) store.set(splitLayoutAtom, next);
+    navigate(route, existing !== null ? { replace: true } : undefined);
+  }, [content, enabled, isCompact, navigate, store]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || event.button !== 0) return;
+      const rowEl = event.currentTarget;
+      const sidebarEl = rowEl.closest(SIDEBAR_SELECTOR);
+      const sidebarRightEdge = (sidebarEl ?? rowEl).getBoundingClientRect()
+        .right;
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const startLayout = store.get(splitLayoutAtom);
+      const fallback = singlePaneFallback(startLayout);
+      beginSplitDrag(startX, startY, {
+        ghostLabel: label,
+        sourceEl: rowEl,
+        cancelSidebarReorderOnEngage: true,
+        ...(fallback ? { fallback } : {}),
+        shouldEngage: (x, y) =>
+          shouldEngageSidebarSplitDrag({
+            startX,
+            startY,
+            x,
+            y,
+            sidebarRightEdge,
+          }),
+        decide: (_paneId, zone) => {
+          const layout = store.get(splitLayoutAtom);
+          if (layout === null) return null;
+          return decideThreadDrop({
+            zone,
+            threadAlreadyOpen: findPaneByContent(layout.root, content) !== null,
+            atMaxPanes: countPanes(layout.root) >= MAX_PANES,
+          });
+        },
+        onDrop: (target) => {
+          const layout = store.get(splitLayoutAtom);
+          if (layout === null) return;
+          const existing = findPaneByContent(layout.root, content);
+          const next =
+            existing !== null
+              ? setFocus(layout, existing.paneId)
+              : target.zone === "center"
+                ? replacePaneContent(layout, target.paneId, content)
+                : splitPane(layout, target.paneId, target.zone, content);
+          if (next !== layout) store.set(splitLayoutAtom, next);
+          navigate(
+            routeForContent(content),
+            existing !== null ? { replace: true } : undefined,
+          );
+        },
+      });
+    },
+    [content, enabled, label, navigate, store],
+  );
+
+  return {
+    onPointerDown: enabled && !isCompact ? onPointerDown : undefined,
+    openInSplit,
+  };
+}
+
+function singlePaneFallback(
+  layout: SplitLayout | null,
+): SplitDragFallbackTarget | null {
+  if (layout === null) return null;
+  const panes = listPanes(layout.root);
+  const only = panes[0];
+  if (panes.length !== 1 || only === undefined) return null;
+  return {
+    paneId: only.paneId,
+    container: document.querySelector<HTMLElement>(MAIN_CONTENT_SELECTOR),
+  };
+}

--- a/apps/app/src/lib/split-layout/ops.test.ts
+++ b/apps/app/src/lib/split-layout/ops.test.ts
@@ -100,8 +100,8 @@ describe("split layout operations", () => {
 
     expect(replaced.focusedPaneId).toBe("pane-1");
     expect(findPane(swapped.root, "pane-2")?.content).toBe(replacement);
-    expect(findPane(swapped.root, "pane-1")?.content.threadId).toBe(
-      "thread-2",
+    expect(findPane(swapped.root, "pane-1")?.content).toEqual(
+      threadContent("thread-2"),
     );
     expect(swapped.focusedPaneId).toBe("pane-2");
   });

--- a/apps/app/src/lib/split-layout/ops.ts
+++ b/apps/app/src/lib/split-layout/ops.ts
@@ -56,6 +56,35 @@ export function findPaneByThread(
   );
 }
 
+/** Finds the pane representing the same routable page as `content`. Plugin
+ * subpaths belong to one panel identity, so navigating within a panel updates
+ * that pane instead of opening duplicates. The compose page is a singleton in
+ * this prototype, matching its existing shared draft/project state. */
+export function findPaneByContent(
+  root: LayoutNode,
+  content: PaneContent,
+): PaneNode | null {
+  return (
+    listPanes(root).find((pane) => {
+      const candidate = pane.content;
+      if (candidate.kind !== content.kind) return false;
+      if (content.kind === "new-thread") return true;
+      if (content.kind === "thread") {
+        return (
+          candidate.kind === "thread" &&
+          candidate.projectId === content.projectId &&
+          candidate.threadId === content.threadId
+        );
+      }
+      return (
+        candidate.kind === "plugin-panel" &&
+        candidate.pluginId === content.pluginId &&
+        candidate.panelPath === content.panelPath
+      );
+    }) ?? null
+  );
+}
+
 function replacePaneNode(
   node: LayoutNode,
   paneId: string,
@@ -184,7 +213,7 @@ function detachPane(node: LayoutNode, paneId: string): DetachResult {
       node: {
         ...node,
         children: node.children.map((candidate, childIndex) =>
-          childIndex === index ? result.node ?? candidate : candidate,
+          childIndex === index ? (result.node ?? candidate) : candidate,
         ),
       },
       detached: result.detached,
@@ -204,7 +233,8 @@ export function removePane(layout: SplitLayout, paneId: string): SplitLayout {
     return layout;
   }
   const panesAfter = listPanes(result.node);
-  const fallbackPane = panesAfter[Math.min(removedIndex, panesAfter.length - 1)];
+  const fallbackPane =
+    panesAfter[Math.min(removedIndex, panesAfter.length - 1)];
   return {
     root: result.node,
     focusedPaneId:
@@ -270,7 +300,10 @@ function equalSizes(count: number): number[] {
   return Array.from({ length: count }, () => 1 / count);
 }
 
-function normalizeSizes(sizes: readonly number[], childCount: number): number[] {
+function normalizeSizes(
+  sizes: readonly number[],
+  childCount: number,
+): number[] {
   if (
     sizes.length !== childCount ||
     sizes.some((size) => !Number.isFinite(size) || size <= 0)
@@ -391,10 +424,7 @@ export function resizeSplit(
   return root === null ? layout : { ...layout, root };
 }
 
-export function setFocus(
-  layout: SplitLayout,
-  paneId: string,
-): SplitLayout {
+export function setFocus(layout: SplitLayout, paneId: string): SplitLayout {
   if (findPane(layout.root, paneId) === null) {
     return layout;
   }
@@ -435,9 +465,10 @@ function trimToPaneLimit(root: LayoutNode): LayoutNode {
 export function normalize(layout: SplitLayout): SplitLayout {
   const root = normalizeNode(trimToPaneLimit(layout.root));
   const panes = listPanes(root);
-  const focusedPaneId =
-    panes.some((pane) => pane.paneId === layout.focusedPaneId)
-      ? layout.focusedPaneId
-      : (panes[0]?.paneId ?? layout.focusedPaneId);
+  const focusedPaneId = panes.some(
+    (pane) => pane.paneId === layout.focusedPaneId,
+  )
+    ? layout.focusedPaneId
+    : (panes[0]?.paneId ?? layout.focusedPaneId);
   return { root, focusedPaneId };
 }

--- a/apps/app/src/lib/split-layout/persistence.test.ts
+++ b/apps/app/src/lib/split-layout/persistence.test.ts
@@ -45,6 +45,36 @@ describe("split layout persistence", () => {
     expect(deserializeSplitLayout(serialized)).toEqual(layout);
   });
 
+  it("round-trips mixed new-thread and plugin panel content", () => {
+    const mixed: SplitLayout = {
+      root: {
+        type: "split",
+        dir: "row",
+        sizes: [0.5, 0.5],
+        children: [
+          {
+            type: "pane",
+            paneId: "pane-1",
+            content: { kind: "new-thread" },
+          },
+          {
+            type: "pane",
+            paneId: "pane-2",
+            content: {
+              kind: "plugin-panel",
+              pluginId: "notes",
+              panelPath: "notes",
+              subPath: "work/today.md",
+            },
+          },
+        ],
+      },
+      focusedPaneId: "pane-2",
+    };
+
+    expect(deserializeSplitLayout(serializeSplitLayout(mixed))).toEqual(mixed);
+  });
+
   it("rejects malformed JSON, unknown versions, and invalid layout invariants", () => {
     expect(deserializeSplitLayout(null)).toBeNull();
     expect(deserializeSplitLayout("not json")).toBeNull();

--- a/apps/app/src/lib/split-layout/persistence.ts
+++ b/apps/app/src/lib/split-layout/persistence.ts
@@ -5,13 +5,24 @@ import type { LayoutNode, PaneNode, SplitLayout, SplitNode } from "./types";
 export const SPLIT_LAYOUT_SCHEMA_VERSION = 1;
 export const SPLIT_LAYOUT_STORAGE_KEY = "bb.splitLayout";
 
-const paneContentSchema = z
-  .object({
-    kind: z.literal("thread"),
-    projectId: z.string().min(1),
-    threadId: z.string().min(1),
-  })
-  .strict();
+const paneContentSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("thread"),
+      projectId: z.string().min(1),
+      threadId: z.string().min(1),
+    })
+    .strict(),
+  z.object({ kind: z.literal("new-thread") }).strict(),
+  z
+    .object({
+      kind: z.literal("plugin-panel"),
+      pluginId: z.string().min(1),
+      panelPath: z.string().min(1),
+      subPath: z.string(),
+    })
+    .strict(),
+]);
 
 const paneNodeSchema: z.ZodType<PaneNode> = z
   .object({

--- a/apps/app/src/lib/split-layout/types.ts
+++ b/apps/app/src/lib/split-layout/types.ts
@@ -1,8 +1,18 @@
-export type PaneContent = {
-  kind: "thread";
-  projectId: string;
-  threadId: string;
-};
+export type PaneContent =
+  | {
+      kind: "thread";
+      projectId: string;
+      threadId: string;
+    }
+  | {
+      kind: "new-thread";
+    }
+  | {
+      kind: "plugin-panel";
+      pluginId: string;
+      panelPath: string;
+      subPath: string;
+    };
 
 export interface PaneNode {
   type: "pane";

--- a/apps/app/src/views/PluginPanelView.tsx
+++ b/apps/app/src/views/PluginPanelView.tsx
@@ -11,7 +11,8 @@ import { usePluginSlots } from "@/lib/plugin-slots";
 
 // Plugins can render `@pierre/diffs` FileDiff (the specifier is shimmed to
 // the host's copy); syntax highlighting needs a worker pool in React context.
-// Thread routes get theirs from ThreadDetailRoute — nav panels get one here.
+// Thread panes get theirs from the split workspace — standalone nav panels get
+// one here.
 const WORKER_POOL_OPTIONS = {
   workerFactory: createDiffWorker,
   poolSize: getDiffWorkerPoolSize(),
@@ -35,15 +36,22 @@ const HIGHLIGHTER_OPTIONS = {};
  * - "none": the plugin component owns the entire body region — no host
  *   padding — with only the error boundary remaining.
  */
-export function PluginPanelView() {
+interface PluginPanelViewProps {
+  pluginId?: string;
+  panelPath?: string;
+  subPath?: string;
+}
+
+export function PluginPanelView(props: PluginPanelViewProps = {}) {
   const params = useParams<{
     pluginId: string;
     panelPath: string;
     "*": string;
   }>();
-  const { pluginId, panelPath } = params;
+  const pluginId = props.pluginId ?? params.pluginId;
+  const panelPath = props.panelPath ?? params.panelPath;
   // The route's trailing splat: panel-internal location ("" at the root).
-  const subPath = params["*"] ?? "";
+  const subPath = props.subPath ?? params["*"] ?? "";
   const { navPanels } = usePluginSlots();
   const panel =
     navPanels.find(
@@ -55,8 +63,8 @@ export function PluginPanelView() {
     return (
       <PageShell contentClassName="pt-4 md:pt-5">
         <EmptyStatePanel className="rounded-lg p-6 text-sm">
-          This plugin panel is not available. The plugin may still be
-          loading, or it has been disabled or removed.
+          This plugin panel is not available. The plugin may still be loading,
+          or it has been disabled or removed.
         </EmptyStatePanel>
       </PageShell>
     );

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
+  ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS,
   ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
   RootComposeSecondaryContent,
 } from "./RootComposeSecondaryContent";
@@ -28,6 +29,7 @@ interface PanelProps {
 interface RenderRootComposeArgs {
   isCompactViewport: boolean;
   isSecondaryPanelOpen: boolean;
+  panelTogglePositionClassName?: string;
 }
 
 type TestDesktopWindow = {
@@ -154,6 +156,10 @@ function renderRootCompose(args: RenderRootComposeArgs) {
     >
       <RootComposeSecondaryContent
         isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
+        panelTogglePositionClassName={
+          renderArgs.panelTogglePositionClassName ??
+          ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS
+        }
         secondaryPanel={createSecondaryPanel(renderArgs.isSecondaryPanelOpen)}
       >
         <div data-testid="root-compose-content" />
@@ -171,6 +177,10 @@ function renderRootCompose(args: RenderRootComposeArgs) {
         >
           <RootComposeSecondaryContent
             isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
+            panelTogglePositionClassName={
+              renderArgs.panelTogglePositionClassName ??
+              ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS
+            }
             secondaryPanel={createSecondaryPanel(
               renderArgs.isSecondaryPanelOpen,
             )}
@@ -229,6 +239,22 @@ describe("RootComposeSecondaryContent desktop layout", () => {
     )) {
       expect(cutout.className).toContain(positionClass);
     }
+  });
+
+  it("moves the drag-strip cutout with the bounded-pane toggle", () => {
+    setMacosDesktopChrome();
+
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: false,
+      panelTogglePositionClassName:
+        ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS,
+    });
+
+    const cutout = screen.getByTestId("root-compose-drag-strip-toggle-cutout");
+    const cutoutClasses = cutout.className.split(" ");
+    expect(cutoutClasses).toContain("right-12");
+    expect(cutoutClasses).not.toContain("right-4");
   });
 
   it("keeps the drag strip whole while the panel is open (the panel chrome carves instead)", () => {

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -37,7 +37,8 @@ const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
 const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
 
 // Where root compose pins its right-panel toggle in the viewport corner (see
-// rootPanelToggle in RootComposeView, which shares this constant). The window
+// rootPanelToggle in RootComposeView, which passes its selected position here).
+// The window
 // drag strip below must carve this same footprint back out of the macOS drag
 // region while the panel is closed: Electron resolves app-regions in DOM order
 // (later wins), and the strip renders after the fixed toggle, so a no-drag on
@@ -46,6 +47,8 @@ const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
 // from drifting apart.
 export const ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS =
   "right-4 top-2.5";
+export const ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS =
+  "right-12 top-2.5";
 
 type RootSecondaryPanelProps = Omit<
   ComponentProps<typeof ThreadSecondaryPanel>,
@@ -63,6 +66,7 @@ interface RootComposeSecondaryContentProps {
   children: ReactNode;
   contentClassName?: string;
   isSecondaryPanelOpen: boolean;
+  panelTogglePositionClassName: string;
   secondaryPanel: RootSecondaryPanelProps;
 }
 
@@ -72,6 +76,7 @@ export function RootComposeSecondaryContent({
   children,
   contentClassName,
   isSecondaryPanelOpen,
+  panelTogglePositionClassName,
   secondaryPanel,
 }: RootComposeSecondaryContentProps) {
   const renderAsDrawer = useIsCompactViewport();
@@ -269,7 +274,7 @@ export function RootComposeSecondaryContent({
                       data-testid="root-compose-drag-strip-toggle-cutout"
                       className={cn(
                         "absolute",
-                        ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
+                        panelTogglePositionClassName,
                         COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
                         MACOS_APP_REGION_NO_DRAG_CLASS,
                       )}

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -172,6 +172,7 @@ import {
   useSetRootComposeProjectId,
 } from "@/lib/root-compose-selection";
 import {
+  ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS,
   ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
   RootComposeSecondaryContent,
 } from "./RootComposeSecondaryContent";
@@ -393,6 +394,7 @@ export function shouldStartComposingFromLocationState(state: unknown): boolean {
 
 type RootComposeViewProps =
   | {
+      isBoundedPane: boolean;
       surface: "page";
     }
   | {
@@ -834,7 +836,7 @@ export function buildRootComposeTerminalSessions({
   return undefined;
 }
 
-function LegacyProjectComposeRedirect({
+export function LegacyProjectComposeRedirect({
   projectId,
 }: LegacyProjectComposeRedirectProps) {
   const location = useLocation();
@@ -920,7 +922,7 @@ export function RootComposeRoute() {
       poolOptions={FILE_PREVIEW_WORKER_POOL_OPTIONS}
       highlighterOptions={FILE_PREVIEW_HIGHLIGHTER_OPTIONS}
     >
-      <RootComposeView surface="page" />
+      <RootComposeView isBoundedPane={false} surface="page" />
     </WorkerPoolContextProvider>
   );
 }
@@ -3128,18 +3130,23 @@ export function RootComposeView(props: RootComposeViewProps) {
     },
     [openWorkspaceFile],
   );
-  // Keep the panel toggle pinned to the viewport corner in the wide layout so it
-  // stays mounted and fixed in place across open/close (the panel reserves a
-  // matching slot via inlinePanelToggle="reserved", and the pinned button lands
-  // centered over it). The drawer layout has no pinned slot, so there the toggle
-  // only opens the drawer and its close control lives inside the drawer.
+  // Keep the panel toggle pinned to the viewport corner on the full page and to
+  // the pane corner in a split. A bounded pane shifts it left by one action slot
+  // so its close button can own the outermost position. The panel reserves a
+  // matching slot via inlinePanelToggle="reserved". The drawer layout has no
+  // pinned slot, so there the toggle only opens the drawer and its close control
+  // lives inside the drawer.
   // The shared position class keeps this footprint paired with the no-drag
   // cutout the macOS window-drag strip carves for it while the panel is closed
   // (see RootComposeSecondaryContent).
+  const isBoundedPage = props.surface === "page" && props.isBoundedPane;
+  const panelTogglePositionClassName = isBoundedPage
+    ? ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS
+    : ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS;
   const rootPanelToggle =
     !renderSecondaryPanelAsDrawer || !isSecondaryPanelOpen ? (
       <div
-        className={`fixed z-40 ${ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS}`}
+        className={`${isBoundedPage ? "absolute" : "fixed"} z-40 ${panelTogglePositionClassName}`}
       >
         <RootComposeRightPanelToggle
           isOpen={isSecondaryPanelOpen}
@@ -3541,6 +3548,7 @@ export function RootComposeView(props: RootComposeViewProps) {
             : ROOT_COMPOSE_SIDEBAR_ACTION_ALIGNED_TOP_PADDING_CLASS
         }
         isSecondaryPanelOpen={isSecondaryPanelOpen}
+        panelTogglePositionClassName={panelTogglePositionClassName}
         secondaryPanel={{
           activeTab: activeFixedSecondaryTab,
           canUseGitUi: false,

--- a/apps/app/src/views/SplitWorkspaceRoute.test.tsx
+++ b/apps/app/src/views/SplitWorkspaceRoute.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { useEffect } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PaneContent } from "@/lib/split-layout";
+import SplitWorkspaceRoute from "./SplitWorkspaceRoute";
+
+const workspaceLifecycle = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }));
+
+vi.mock("./thread-detail/SplitThreadArea", () => ({
+  SplitThreadArea: ({ routeContent }: { routeContent: PaneContent }) => {
+    useEffect(() => {
+      workspaceLifecycle.mounts += 1;
+      return () => {
+        workspaceLifecycle.unmounts += 1;
+      };
+    }, []);
+    return <output data-testid="route-content">{routeContent.kind}</output>;
+  },
+}));
+
+vi.mock("./RootComposeView", () => ({
+  LegacyProjectComposeRedirect: () => <div>legacy redirect</div>,
+}));
+
+function NavigationControls() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button onClick={() => navigate("/")}>compose</button>
+      <button onClick={() => navigate("/plugins/docs/docs/work/today.md")}>
+        plugin
+      </button>
+      <button onClick={() => navigate("/threads/thread-1")}>thread</button>
+    </>
+  );
+}
+
+describe("SplitWorkspaceRoute", () => {
+  beforeEach(() => {
+    workspaceLifecycle.mounts = 0;
+    workspaceLifecycle.unmounts = 0;
+  });
+
+  it("preserves the workspace mount across focus-driven page URL changes", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <NavigationControls />
+        <Routes>
+          <Route path="*" element={<SplitWorkspaceRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("route-content").textContent).toBe("new-thread");
+
+    fireEvent.click(screen.getByRole("button", { name: "plugin" }));
+    expect(screen.getByTestId("route-content").textContent).toBe(
+      "plugin-panel",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "thread" }));
+    expect(screen.getByTestId("route-content").textContent).toBe("thread");
+    expect(workspaceLifecycle).toEqual({ mounts: 1, unmounts: 0 });
+  });
+});

--- a/apps/app/src/views/SplitWorkspaceRoute.tsx
+++ b/apps/app/src/views/SplitWorkspaceRoute.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import { matchPath, Navigate, useLocation } from "react-router-dom";
+import {
+  APP_ROOT_ROUTE_PATH,
+  LEGACY_PROJECT_COMPOSE_ROUTE_PATH,
+  PLUGIN_PANEL_ROUTE_PATH,
+} from "@/lib/route-paths";
+import type { PaneContent } from "@/lib/split-layout";
+import { useRouteState } from "@/hooks/useRouteState";
+import { LegacyProjectComposeRedirect } from "./RootComposeView";
+import { SplitThreadArea } from "./thread-detail/SplitThreadArea";
+
+const ROOT_COMPOSE_CONTENT = { kind: "new-thread" } as const;
+
+/**
+ * Stable route owner for every page that can live in the split workspace.
+ *
+ * All supported URLs intentionally match the same outer `*` route in App.tsx.
+ * Focus-driven URL changes therefore update `routeContent` without replacing
+ * this component or remounting the split tree and its plugin/compose panes.
+ */
+export default function SplitWorkspaceRoute() {
+  const location = useLocation();
+  const { projectId, threadId, isThreadView } = useRouteState();
+  const pluginMatch = matchPath(PLUGIN_PANEL_ROUTE_PATH, location.pathname);
+  const legacyProjectMatch = matchPath(
+    LEGACY_PROJECT_COMPOSE_ROUTE_PATH,
+    location.pathname,
+  );
+  const pluginId = pluginMatch?.params.pluginId;
+  const panelPath = pluginMatch?.params.panelPath;
+  const pluginSubPath = pluginMatch?.params["*"] ?? "";
+
+  const routeContent = useMemo<PaneContent | null>(() => {
+    if (location.pathname === APP_ROOT_ROUTE_PATH) {
+      return ROOT_COMPOSE_CONTENT;
+    }
+    if (isThreadView && projectId && threadId) {
+      return { kind: "thread", projectId, threadId };
+    }
+    if (pluginId && panelPath) {
+      return {
+        kind: "plugin-panel",
+        pluginId,
+        panelPath,
+        subPath: pluginSubPath,
+      };
+    }
+    return null;
+  }, [
+    isThreadView,
+    location.pathname,
+    panelPath,
+    pluginId,
+    pluginSubPath,
+    projectId,
+    threadId,
+  ]);
+
+  const legacyProjectId = legacyProjectMatch?.params.projectId;
+  if (legacyProjectId) {
+    return <LegacyProjectComposeRedirect projectId={legacyProjectId} />;
+  }
+  if (routeContent === null) {
+    return <Navigate to={APP_ROOT_ROUTE_PATH} replace />;
+  }
+  return <SplitThreadArea routeContent={routeContent} />;
+}

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -51,16 +51,31 @@ import {
 } from "@/components/commands/AppCommandProvider";
 import { PaneContext, type PaneContextValue } from "./PaneContext";
 import { ThreadDetailView } from "./ThreadDetailView";
+import { RootComposeView } from "@/views/RootComposeView";
+import { PluginPanelView } from "@/views/PluginPanelView";
+import {
+  AppPageHeader,
+  HEADER_ICON_BUTTON_CLASS,
+} from "@/components/layout/AppPageHeader";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { usePluginSlots } from "@/lib/plugin-slots";
+import {
+  PluginPanelHeaderActions,
+  PluginPanelHeaderCenter,
+} from "@/components/plugin/PluginPanelHeader";
 import {
   getAdjacentPaneId,
   getPaneIdAtReadingIndex,
 } from "./splitPaneCommands";
 import {
   createSinglePaneLayout,
-  focusedThreadRoute,
-  reconcileLayoutForRoute,
+  focusedPaneRoute,
+  paneContentRoute,
+  reconcileLayoutForContent,
   threadPaneContent,
 } from "./splitThreadNavigation";
+import { ThreadDetailWorkerPoolProvider } from "./ThreadDetailWorkerPoolProvider";
 
 // A `pointerdown`-relative move threshold before a pane-header drag engages.
 const PANE_DRAG_ENGAGE_DISTANCE_PX = 7;
@@ -82,7 +97,19 @@ type NavigateInPane = (paneId: string, thread: ThreadRoutePathArgs) => void;
  * A single pane renders identically to the pre-split page surface (no wrapper,
  * no focus ring); compact viewports disable splits entirely.
  */
-export function SplitThreadArea() {
+interface SplitThreadAreaProps {
+  routeContent?: PaneContent;
+}
+
+export function SplitThreadArea(props: SplitThreadAreaProps = {}) {
+  return (
+    <ThreadDetailWorkerPoolProvider>
+      <SplitThreadAreaContent {...props} />
+    </ThreadDetailWorkerPoolProvider>
+  );
+}
+
+function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
   const { projectId, threadId } = useRouteState();
   const isCompact = useIsCompactViewport();
   const threadSplitsEnabled = useThreadSplitsEnabled();
@@ -94,20 +121,31 @@ export function SplitThreadArea() {
     () => (projectId && threadId ? { projectId, threadId } : null),
     [projectId, threadId],
   );
+  const currentContent = useMemo<PaneContent | null>(
+    () => routeContent ?? (routeThread ? threadPaneContent(routeThread) : null),
+    [routeContent, routeThread],
+  );
 
   // Fold external navigation (initial load, sidebar click, deep link) into the
   // layout. The reconcile is idempotent, so a URL that already matches the
   // focused pane is a no-op — no history spam, no render loop.
   useEffect(() => {
-    if (!threadSplitsEnabled || routeThread === null) {
+    if (!threadSplitsEnabled || currentContent === null) {
       return;
     }
-    setLayout((previous) => reconcileLayoutForRoute(previous, routeThread));
-  }, [routeThread, setLayout, threadSplitsEnabled]);
+    setLayout((previous) =>
+      reconcileLayoutForContent(previous, currentContent),
+    );
+  }, [currentContent, setLayout, threadSplitsEnabled]);
 
   // Effective layout for render/handlers before the effect seeds the atom.
   const layout: SplitLayout | null =
-    storedLayout ?? (routeThread ? createSinglePaneLayout(routeThread) : null);
+    storedLayout ??
+    (currentContent?.kind === "thread" && routeThread
+      ? createSinglePaneLayout(routeThread)
+      : currentContent
+        ? reconcileLayoutForContent(null, currentContent)
+        : null);
   const panes = layout === null ? [] : listPanes(layout.root);
   const isSplitActive = threadSplitsEnabled && !isCompact && panes.length > 1;
 
@@ -134,14 +172,8 @@ export function SplitThreadArea() {
       }
       const pane = findPane(layout.root, paneId);
       setLayout(setFocus(layout, paneId));
-      if (pane !== null && pane.content.kind === "thread") {
-        navigate(
-          getThreadRoutePath({
-            projectId: pane.content.projectId,
-            threadId: pane.content.threadId,
-          }),
-          { replace: true },
-        );
+      if (pane !== null) {
+        navigate(paneContentRoute(pane.content), { replace: true });
       }
     },
     [layout, navigate, setLayout],
@@ -158,9 +190,9 @@ export function SplitThreadArea() {
       }
       setLayout(next);
       if (next.focusedPaneId !== layout.focusedPaneId) {
-        const route = focusedThreadRoute(next);
+        const route = focusedPaneRoute(next);
         if (route !== null) {
-          navigate(getThreadRoutePath(route), { replace: true });
+          navigate(route, { replace: true });
         }
       }
     },
@@ -196,9 +228,9 @@ export function SplitThreadArea() {
       }
       store.set(splitLayoutAtom, next);
       if (next.focusedPaneId !== current.focusedPaneId) {
-        const route = focusedThreadRoute(next);
+        const route = focusedPaneRoute(next);
         if (route !== null) {
-          navigate(getThreadRoutePath(route), { replace: true });
+          navigate(route, { replace: true });
         }
       }
     },
@@ -244,9 +276,9 @@ export function SplitThreadArea() {
             return;
           }
           store.set(splitLayoutAtom, next);
-          const route = focusedThreadRoute(next);
+          const route = focusedPaneRoute(next);
           if (route !== null) {
-            navigate(getThreadRoutePath(route), { replace: true });
+            navigate(route, { replace: true });
           }
         },
       });
@@ -257,8 +289,15 @@ export function SplitThreadArea() {
   // A disabled experiment and compact viewports both render the route thread as
   // single page surface (byte-identical to the pre-split page). The layout atom
   // is preserved so the arrangement returns when the gate opens again.
-  if (!threadSplitsEnabled || isCompact || layout === null) {
-    return <ThreadDetailView surface="page" />;
+  if (
+    !threadSplitsEnabled ||
+    isCompact ||
+    layout === null ||
+    currentContent === null
+  ) {
+    return currentContent ? (
+      <StandalonePaneContent content={currentContent} />
+    ) : null;
   }
 
   const commandHandlers = (
@@ -280,7 +319,7 @@ export function SplitThreadArea() {
     return (
       <>
         {commandHandlers}
-        <ThreadPaneContent
+        <WorkspacePaneContent
           content={firstPane.content}
           paneId={firstPane.paneId}
           isFocused
@@ -384,7 +423,6 @@ function SplitTree(props: SplitTreeProps) {
 
   if (node.type === "pane") {
     const isFocused = node.paneId === focusedPaneId;
-    const threadId = node.content.threadId;
     return (
       <div
         onPointerDown={() => props.onFocusPane(node.paneId)}
@@ -397,11 +435,13 @@ function SplitTree(props: SplitTreeProps) {
       >
         {/* Only mounted in split mode, so single panes never pay for the extra
             thread subscription (and never prune the last pane). */}
-        <PaneStaleWatcher
-          threadId={threadId}
-          onStale={() => props.onPruneStalePane(node.paneId)}
-        />
-        <ThreadPaneContent
+        {node.content.kind === "thread" ? (
+          <PaneStaleWatcher
+            threadId={node.content.threadId}
+            onStale={() => props.onPruneStalePane(node.paneId)}
+          />
+        ) : null}
+        <WorkspacePaneContent
           content={node.content}
           paneId={node.paneId}
           isFocused={isFocused}
@@ -457,7 +497,7 @@ function SplitTree(props: SplitTreeProps) {
   );
 }
 
-interface ThreadPaneContentProps {
+interface WorkspacePaneContentProps {
   content: PaneContent;
   paneId: string;
   isFocused: boolean;
@@ -471,7 +511,7 @@ interface ThreadPaneContentProps {
   onBeginPaneDrag?: BeginPaneDrag;
 }
 
-function ThreadPaneContent({
+function WorkspacePaneContent({
   content,
   paneId,
   isFocused,
@@ -480,7 +520,7 @@ function ThreadPaneContent({
   isBoundedPane,
   onNavigateInPane,
   onBeginPaneDrag,
-}: ThreadPaneContentProps) {
+}: WorkspacePaneContentProps) {
   const navigateInPane = useCallback(
     (thread: ThreadRoutePathArgs) => onNavigateInPane(paneId, thread),
     [onNavigateInPane, paneId],
@@ -514,6 +554,17 @@ function ThreadPaneContent({
     ],
   );
 
+  if (content.kind !== "thread") {
+    return (
+      <NonThreadPaneContent
+        content={content}
+        onRequestClose={onRequestClose}
+        beginPaneDrag={beginPaneDrag}
+        isBoundedPane={isBoundedPane}
+      />
+    );
+  }
+
   return (
     <PaneContext.Provider value={value}>
       <ThreadDetailView
@@ -522,6 +573,113 @@ function ThreadPaneContent({
         threadId={content.threadId}
       />
     </PaneContext.Provider>
+  );
+}
+
+function StandalonePaneContent({ content }: { content: PaneContent }) {
+  if (content.kind === "thread") {
+    return <ThreadDetailView surface="page" />;
+  }
+  if (content.kind === "new-thread") {
+    return <RootComposeView isBoundedPane={false} surface="page" />;
+  }
+  return (
+    <PluginPanelView
+      pluginId={content.pluginId}
+      panelPath={content.panelPath}
+      subPath={content.subPath}
+    />
+  );
+}
+
+function NonThreadPaneContent({
+  content,
+  onRequestClose,
+  beginPaneDrag,
+  isBoundedPane,
+}: {
+  content: Exclude<PaneContent, { kind: "thread" }>;
+  onRequestClose: (() => void) | null;
+  beginPaneDrag?: (event: ReactPointerEvent, label: string) => void;
+  isBoundedPane: boolean;
+}) {
+  const { navPanels } = usePluginSlots();
+  const panel =
+    content.kind === "plugin-panel"
+      ? navPanels.find(
+          (candidate) =>
+            candidate.pluginId === content.pluginId &&
+            candidate.path === content.panelPath,
+        )
+      : undefined;
+  const label = panel?.title ?? "New thread";
+  const handlePointerDown = (event: ReactPointerEvent) => {
+    if (event.button === 0) beginPaneDrag?.(event, label);
+  };
+  const actions = (
+    <>
+      {panel ? (
+        <PluginPanelHeaderActions
+          panel={panel}
+          subPath={content.kind === "plugin-panel" ? content.subPath : ""}
+        />
+      ) : null}
+      {onRequestClose ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={HEADER_ICON_BUTTON_CLASS}
+          aria-label="Close pane"
+          onClick={onRequestClose}
+        >
+          <Icon name="X" />
+        </Button>
+      ) : null}
+    </>
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+        content.kind === "plugin-panel" && !isBoundedPane && "-m-4 md:-m-5",
+      )}
+    >
+      {isBoundedPane || panel ? (
+        <AppPageHeader
+          bordered={false}
+          className="border-b border-border-seam-vertical/60"
+          center={
+            <div
+              className={cn(
+                "flex min-w-0 flex-1 items-center",
+                beginPaneDrag && "cursor-grab touch-none select-none",
+              )}
+              onPointerDown={beginPaneDrag ? handlePointerDown : undefined}
+            >
+              {panel ? (
+                <PluginPanelHeaderCenter panel={panel} />
+              ) : (
+                <p className="truncate text-sm font-medium">New thread</p>
+              )}
+            </div>
+          }
+          actions={actions}
+        />
+      ) : null}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col p-4 md:p-5">
+        {content.kind === "new-thread" ? (
+          <RootComposeView isBoundedPane={isBoundedPane} surface="page" />
+        ) : (
+          <PluginPanelView
+            pluginId={content.pluginId}
+            panelPath={content.panelPath}
+            subPath={content.subPath}
+          />
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailRoute.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailRoute.tsx
@@ -1,74 +1,31 @@
-import { WorkerPoolContextProvider } from "@pierre/diffs/react";
-import type { ReactNode } from "react";
-import {
-  createDiffWorker,
-  getDiffWorkerPoolSize,
-} from "@/lib/diff-worker-pool";
-import { SplitThreadArea } from "./SplitThreadArea";
 import { ThreadDetailView } from "./ThreadDetailView";
 import type { ThreadRoutePathArgs } from "@/lib/route-paths";
+import { ThreadDetailWorkerPoolProvider } from "./ThreadDetailWorkerPoolProvider";
 
-const WORKER_POOL_OPTIONS = {
-  workerFactory: createDiffWorker,
-  poolSize: getDiffWorkerPoolSize(),
-};
-const HIGHLIGHTER_OPTIONS = {};
-
-interface ThreadDetailRoutePageProps {
-  surface?: "page";
-}
-
-interface ThreadDetailRoutePopoutProps {
+interface ThreadDetailRouteProps {
   onPopoutHide: () => void;
   onPopoutNewQuickThread: () => void;
   onPopoutOpenInMain: (thread: ThreadRoutePathArgs) => void;
   surface: "popout";
 }
 
-type ThreadDetailRouteProps =
-  | ThreadDetailRoutePageProps
-  | ThreadDetailRoutePopoutProps;
-
-interface ThreadDetailWorkerPoolProviderProps {
-  children: ReactNode;
-}
-
-export function ThreadDetailWorkerPoolProvider({
-  children,
-}: ThreadDetailWorkerPoolProviderProps) {
-  return (
-    <WorkerPoolContextProvider
-      poolOptions={WORKER_POOL_OPTIONS}
-      highlighterOptions={HIGHLIGHTER_OPTIONS}
-    >
-      {children}
-    </WorkerPoolContextProvider>
-  );
-}
-
 export function SingleThreadDetailRoute(props: ThreadDetailRouteProps) {
-  return props.surface === "popout" ? (
+  return (
     <ThreadDetailView
       surface="popout"
       onPopoutHide={props.onPopoutHide}
       onPopoutNewQuickThread={props.onPopoutNewQuickThread}
       onPopoutOpenInMain={props.onPopoutOpenInMain}
     />
-  ) : (
-    <ThreadDetailView surface="page" />
   );
 }
 
 export default function ThreadDetailRoute(props: ThreadDetailRouteProps) {
-  // Popout keeps its dedicated single-thread route. The page surface renders
-  // the split area, with one shared diff worker pool above all panes.
+  // Popout keeps its dedicated single-thread route. Page thread routes are
+  // owned by SplitWorkspaceRoute so focus changes never remount that workspace.
   return (
     <ThreadDetailWorkerPoolProvider>
-      {props.surface === "popout" ? (
-        <SingleThreadDetailRoute {...props} />
-      ) : (
-        <SplitThreadArea />
-      )}
+      <SingleThreadDetailRoute {...props} />
     </ThreadDetailWorkerPoolProvider>
   );
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailWorkerPoolProvider.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailWorkerPoolProvider.tsx
@@ -1,0 +1,30 @@
+import { WorkerPoolContextProvider } from "@pierre/diffs/react";
+import type { ReactNode } from "react";
+import {
+  createDiffWorker,
+  getDiffWorkerPoolSize,
+} from "@/lib/diff-worker-pool";
+
+const WORKER_POOL_OPTIONS = {
+  workerFactory: createDiffWorker,
+  poolSize: getDiffWorkerPoolSize(),
+};
+const HIGHLIGHTER_OPTIONS = {};
+
+export function ThreadDetailWorkerPoolProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  if (typeof Worker === "undefined") {
+    return children;
+  }
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={WORKER_POOL_OPTIONS}
+      highlighterOptions={HIGHLIGHTER_OPTIONS}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  );
+}

--- a/apps/app/src/views/thread-detail/splitThreadNavigation.test.ts
+++ b/apps/app/src/views/thread-detail/splitThreadNavigation.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { findPaneByThread, listPanes, splitPane } from "@/lib/split-layout";
+import {
+  findPaneByContent,
+  findPaneByThread,
+  listPanes,
+  splitPane,
+} from "@/lib/split-layout";
 import type { SplitLayout } from "@/lib/split-layout";
 import {
   applyThreadOpenToLayout,
   createSinglePaneLayout,
+  focusedPaneRoute,
   focusedThreadRoute,
+  reconcileLayoutForContent,
   reconcileLayoutForRoute,
 } from "./splitThreadNavigation";
 
@@ -80,6 +87,46 @@ describe("reconcileLayoutForRoute", () => {
     });
 
     expect(after).toBe(before);
+  });
+});
+
+describe("mixed page navigation", () => {
+  it("keeps New Thread as a singleton and focuses its existing pane", () => {
+    const withCompose = splitPane(twoPaneLayout(), "pane-2", "bottom", {
+      kind: "new-thread",
+    });
+
+    const after = reconcileLayoutForContent(withCompose, {
+      kind: "new-thread",
+    });
+
+    expect(listPanes(after.root)).toHaveLength(3);
+    expect(after.focusedPaneId).toBe(
+      findPaneByContent(after.root, { kind: "new-thread" })?.paneId,
+    );
+    expect(focusedPaneRoute(after)).toBe("/");
+  });
+
+  it("updates a plugin pane's subpath without duplicating the panel", () => {
+    const plugin = {
+      kind: "plugin-panel",
+      pluginId: "notes",
+      panelPath: "notes",
+      subPath: "inbox.md",
+    } as const;
+    const before = splitPane(twoPaneLayout(), "pane-1", "bottom", plugin);
+
+    const after = reconcileLayoutForContent(before, {
+      ...plugin,
+      subPath: "work/today.md",
+    });
+
+    expect(listPanes(after.root)).toHaveLength(3);
+    expect(findPaneByContent(after.root, plugin)?.content).toEqual({
+      ...plugin,
+      subPath: "work/today.md",
+    });
+    expect(focusedPaneRoute(after)).toBe("/plugins/notes/notes/work/today.md");
   });
 });
 

--- a/apps/app/src/views/thread-detail/splitThreadNavigation.ts
+++ b/apps/app/src/views/thread-detail/splitThreadNavigation.ts
@@ -3,6 +3,7 @@ import type { ThreadOpenSplit } from "@bb/server-contract";
 import {
   countPanes,
   findPane,
+  findPaneByContent,
   findPaneByThread,
   MAX_PANES,
   replacePaneContent,
@@ -11,6 +12,11 @@ import {
 } from "@/lib/split-layout";
 import { decideThreadDrop, type SplitZone } from "@/lib/split-drag";
 import type { PaneContent, SplitLayout } from "@/lib/split-layout";
+import {
+  getPluginPanelRoutePath,
+  getRootComposeRoutePath,
+  getThreadRoutePath,
+} from "@/lib/route-paths";
 
 const FIRST_PANE_ID = "pane-1";
 
@@ -33,6 +39,57 @@ export function createSinglePaneLayout(
     },
     focusedPaneId: FIRST_PANE_ID,
   };
+}
+
+export function createSinglePaneContentLayout(
+  content: PaneContent,
+): SplitLayout {
+  return {
+    root: { type: "pane", paneId: FIRST_PANE_ID, content },
+    focusedPaneId: FIRST_PANE_ID,
+  };
+}
+
+export function paneContentRoute(content: PaneContent): string {
+  if (content.kind === "thread") {
+    return getThreadRoutePath(content);
+  }
+  if (content.kind === "new-thread") {
+    return getRootComposeRoutePath();
+  }
+  return getPluginPanelRoutePath({
+    pluginId: content.pluginId,
+    path: content.panelPath,
+    subPath: content.subPath,
+  });
+}
+
+/** Reconciles any splittable page route into the focused pane. */
+export function reconcileLayoutForContent(
+  layout: SplitLayout | null,
+  content: PaneContent,
+): SplitLayout {
+  if (layout === null) {
+    return createSinglePaneContentLayout(content);
+  }
+  const existing = findPaneByContent(layout.root, content);
+  if (existing !== null) {
+    const withRouteState =
+      existing.content.kind === "plugin-panel" &&
+      content.kind === "plugin-panel" &&
+      existing.content.subPath !== content.subPath
+        ? replacePaneContent(layout, existing.paneId, content)
+        : layout;
+    return withRouteState.focusedPaneId === existing.paneId
+      ? withRouteState
+      : setFocus(withRouteState, existing.paneId);
+  }
+  return replacePaneContent(layout, layout.focusedPaneId, content);
+}
+
+export function focusedPaneRoute(layout: SplitLayout): string | null {
+  const focused = findPane(layout.root, layout.focusedPaneId);
+  return focused === null ? null : paneContentRoute(focused.content);
 }
 
 /**


### PR DESCRIPTION
## Summary

- generalize the experimental split workspace to persist and render threads, New Thread, and plugin panels
- keep the split workspace mounted across focused-pane route changes to eliminate plugin flicker
- add pane-aware header actions so New Thread panel and close controls do not overlap

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (233 files, 1,525 tests)
- `pnpm exec turbo run build --filter=@bb/app`
- live browser QA with New Thread, GitHub, and Docs panes; focus changes preserved plugin DOM nodes

## Notes

- remains gated by the existing Thread Splits experiment