### PR TITLE
Connect v2 phase 5: visual polish (panel grouping, machine offline copy, dashboard labels)

### DIFF
--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -1041,6 +1041,25 @@ describe("gate offline page", () => {
     expect(html).not.toContain("Last seen");
   });
 
+  it("names the machine and its last-seen when a machine share host is offline", async () => {
+    mockResolveLabel.mockResolvedValue(
+      resolvedMachine({ lastSeenAt: new Date(Date.now() - 5 * 60_000) }),
+    );
+    const { env, ctx } = makeEnv(offlineDoResponse);
+    const res = await worker.fetch(
+      visitorRequest("sawyer-air--3000.getbb.app", "/", {
+        headers: { accept: "text/html" },
+      }),
+      env as never,
+      ctx,
+    );
+    expect(res.status).toBe(503);
+    const html = await res.text();
+    expect(html).toContain("This machine is offline");
+    expect(html).toContain("This machine was last seen 5 minutes ago");
+    expect(html).not.toContain("Your bb is offline");
+  });
+
   it("keeps the plain 503 for non-navigation requests (API/assets/fetch)", async () => {
     mockResolveLabel.mockResolvedValue(resolvedServer());
     const { env, ctx } = makeEnv(offlineDoResponse);
@@ -1109,7 +1128,7 @@ describe("gate page helpers", () => {
   });
 
   it("offlinePage is a self-retrying styled 503", async () => {
-    const res = offlinePage(null);
+    const res = offlinePage(null, "server");
     expect(res.status).toBe(503);
     expect(res.headers.get("content-type")).toContain("text/html");
     expect(await res.text()).toContain("Retry now");

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -166,13 +166,28 @@ function signInPage(label: string, appUrl: string, returnTo: string): Response {
  * navigations; the last-seen timestamp comes from the row the gate already
  * resolved (fresh enough to be truthful) and the page self-retries.
  */
-export function offlinePage(lastSeenAt: Date | null): Response {
-  const lastSeen = lastSeenAt ? `Last seen ${relativeTime(lastSeenAt)}. ` : "";
+export function offlinePage(
+  lastSeenAt: Date | null,
+  kind: "server" | "machine",
+): Response {
+  // A machine label fronts a daemon's port shares, not a bb app — the copy
+  // names the machine so "your bb" never claims a laptop that only shares.
+  const heading =
+    kind === "machine" ? "This machine is offline" : "Your bb is offline";
+  const lastSeen = lastSeenAt
+    ? kind === "machine"
+      ? `This machine was last seen ${relativeTime(lastSeenAt)}. `
+      : `Last seen ${relativeTime(lastSeenAt)}. `
+    : "";
+  const note =
+    kind === "machine"
+      ? "Usually this means the machine is asleep or bb isn't running on it."
+      : "Usually this means the machine is asleep or bb isn't running.";
   return gatePage(
     `<div class="glyph"><svg viewBox="0 0 16 16" fill="none" stroke-width="1.5"><path d="M1.5 6.2a9.5 9.5 0 0 1 13 0M3.8 8.7a6 6 0 0 1 8.4 0M6.1 11.2a2.6 2.6 0 0 1 3.8 0" stroke-linecap="round"/><path d="M2 2l12 12" stroke-linecap="round"/><circle cx="8" cy="13.6" r="0.9" fill="currentColor" stroke="none"/></svg></div>
-     <h1>Your bb is offline</h1>
+     <h1>${heading}</h1>
      <p>${lastSeen}This page retries automatically when it comes back.</p>
-     <p class="note">Usually this means the machine is asleep or bb isn't running.</p>
+     <p class="note">${note}</p>
      <button class="btn" onclick="location.reload()">Retry now</button>`,
     503,
     10,
@@ -440,6 +455,7 @@ export default {
         resolved.kind === "server"
           ? resolved.server.lastSeenAt
           : resolved.machine.lastSeenAt,
+        resolved.kind,
       );
     }
     return response;

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1100,25 +1100,61 @@ function AccountDashboard({ state }: { state: ServerState }) {
             Add machines from bb Settings → Machines.
           </p>
         ) : (
-          state.machines.map((machine: MachineSummary) => (
-            <div
-              key={machine.id}
-              className="flex items-center gap-3 rounded-lg px-3 py-2.5"
-            >
-              <StatusDot
-                state={machine.lastSeenAt === null ? "new" : "online"}
-              />
-              <span className="min-w-0 flex-1 truncate text-sm">
-                {machine.name ?? `Machine ${machine.id.slice(0, 8)}`}
-              </span>
-              <button
-                className="text-xs text-destructive-text hover:underline"
-                onClick={() => void revoke(machine)}
+          state.machines.map((machine: MachineSummary) => {
+            const machineName =
+              machine.name ?? `Machine ${machine.id.slice(0, 8)}`;
+            return (
+              <div
+                key={machine.id}
+                className="flex items-center gap-3 rounded-lg px-3 py-2.5"
               >
-                Revoke
-              </button>
-            </div>
-          ))
+                <StatusDot
+                  state={
+                    machine.lastSeenAt === null
+                      ? "new"
+                      : machine.online
+                        ? "online"
+                        : "offline"
+                  }
+                />
+                <span className="min-w-0 flex-1">
+                  {machine.subdomain !== null ? (
+                    <span className="block truncate font-mono text-sm font-medium leading-tight">
+                      {machine.subdomain}
+                      <span className="font-normal text-subtle-foreground">
+                        .{state.baseDomain}
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="block truncate text-sm font-medium leading-tight">
+                      {machineName}
+                    </span>
+                  )}
+                  <span className="mt-px block truncate text-xs text-muted-foreground">
+                    {machine.online ? (
+                      "Online"
+                    ) : machine.lastSeenAt !== null ? (
+                      <>
+                        <span className="text-warning-text">Offline</span>
+                        {` · last seen ${relativeTime(machine.lastSeenAt)}`}
+                      </>
+                    ) : (
+                      "Never connected"
+                    )}
+                    {machine.subdomain !== null && machine.name !== null
+                      ? ` · ${machine.name}`
+                      : ""}
+                  </span>
+                </span>
+                <button
+                  className="text-xs text-destructive-text hover:underline"
+                  onClick={() => void revoke(machine)}
+                >
+                  Revoke
+                </button>
+              </div>
+            );
+          })
         )}
       </div>
       {dialog}

--- a/apps/web/src/server/api.test.ts
+++ b/apps/web/src/server/api.test.ts
@@ -580,6 +580,8 @@ describe("dashboard machine recovery", () => {
       {
         id: "machine-owner",
         name: "lost laptop",
+        subdomain: "lost-laptop",
+        online: true,
         lastSeenAt: now.getTime(),
         createdAt: now.getTime(),
       },
@@ -601,6 +603,45 @@ describe("dashboard machine recovery", () => {
       db.select().from(machine).where(eq(machine.id, "machine-other")).get()
         ?.revokedAt,
     ).toBeNull();
+  });
+
+  it("marks a machine online only when freshly seen, offline when stale", async () => {
+    seedUser("u1");
+    const now = new Date();
+    const stale = new Date(now.getTime() - 10 * 60_000);
+    db.insert(machine)
+      .values([
+        {
+          id: "machine-fresh",
+          userId: "u1",
+          subdomain: "fresh-machine",
+          credentialHash: "hash-fresh",
+          lastSeenAt: now,
+          createdAt: new Date(now.getTime() - 2000),
+        },
+        {
+          id: "machine-stale",
+          userId: "u1",
+          subdomain: "stale-machine",
+          credentialHash: "hash-stale",
+          lastSeenAt: stale,
+          createdAt: new Date(now.getTime() - 1000),
+        },
+        {
+          id: "machine-unlabeled",
+          userId: "u1",
+          credentialHash: "hash-unlabeled",
+          createdAt: now,
+        },
+      ])
+      .run();
+
+    const machines = (await getAccountState(deps, "u1")).machines;
+    expect(machines.map((m) => [m.id, m.subdomain, m.online])).toEqual([
+      ["machine-fresh", "fresh-machine", true],
+      ["machine-stale", "stale-machine", false],
+      ["machine-unlabeled", null, false],
+    ]);
   });
 
   it("keeps a revoked label pinned when tunnel close fails", async () => {

--- a/apps/web/src/server/api.ts
+++ b/apps/web/src/server/api.ts
@@ -90,6 +90,10 @@ export interface AccountState {
 export interface MachineSummary {
   id: string;
   name: string | null;
+  /** Routing label (`<subdomain>.<baseDomain>`); null until first expose. */
+  subdomain: string | null;
+  /** Heartbeated within the same offline window servers use. */
+  online: boolean;
   lastSeenAt: number | null;
   createdAt: number;
 }
@@ -186,6 +190,7 @@ export async function getAccountState(
     .select({
       id: machine.id,
       name: machine.name,
+      subdomain: machine.subdomain,
       lastSeenAt: machine.lastSeenAt,
       createdAt: machine.createdAt,
     })
@@ -193,12 +198,17 @@ export async function getAccountState(
     .where(and(eq(machine.userId, userId), isNull(machine.revokedAt)))
     .all();
   const machines = machineRows
-    .map((row) => ({
-      id: row.id,
-      name: row.name,
-      lastSeenAt: row.lastSeenAt?.getTime() ?? null,
-      createdAt: row.createdAt.getTime(),
-    }))
+    .map((row) => {
+      const lastSeenMs = row.lastSeenAt?.getTime() ?? null;
+      return {
+        id: row.id,
+        name: row.name,
+        subdomain: row.subdomain,
+        online: lastSeenMs != null && now - lastSeenMs < SERVER_OFFLINE_AFTER_MS,
+        lastSeenAt: lastSeenMs,
+        createdAt: row.createdAt.getTime(),
+      };
+    })
     .sort((left, right) => left.createdAt - right.createdAt);
 
   if (!prof) {

--- a/plugins/connect/app.test.tsx
+++ b/plugins/connect/app.test.tsx
@@ -235,6 +235,71 @@ describe("connect settings section", () => {
     );
   });
 
+  it("groups shares by host and degrades an unreachable host's group", async () => {
+    const reason = "sawyer-air is not connected right now.";
+    const slot = renderSlot(
+      app.settingsSections[0]!,
+      {},
+      {
+        rpc: {
+          status: () =>
+            connected({
+              shares: [
+                {
+                  hostId: "host-air",
+                  hostName: "Sawyer Air",
+                  port: 5173,
+                  url: "",
+                  unavailableReason: reason,
+                },
+                {
+                  hostId: "host-server",
+                  hostName: "Workstation",
+                  port: 3000,
+                  url: "https://workstation--3000.getbb.app",
+                },
+                {
+                  hostId: "host-server",
+                  hostName: "Workstation",
+                  port: 8080,
+                  url: "https://workstation--8080.getbb.app",
+                },
+              ],
+            }),
+          unexpose: () => ({ removed: true, port: 5173 }),
+        },
+      },
+    );
+
+    // One header per host, even with two shares on the same host.
+    await slot.findByText("Sawyer Air");
+    expect(slot.getAllByText("Workstation")).toHaveLength(1);
+
+    // Live shares stay clickable links; the unreachable host's share shows
+    // its reason with no link and no copy affordance.
+    expect(
+      slot
+        .getByText("workstation--3000.getbb.app")
+        .closest("a")
+        ?.getAttribute("href"),
+    ).toBe("https://workstation--3000.getbb.app");
+    slot.getByText(`Unavailable — ${reason}`);
+    expect(
+      slot.queryByRole("button", { name: "Copy share URL for port 5173" }),
+    ).toBeNull();
+
+    // Revoke still works while the host is unreachable (removal is local).
+    const revokeButtons = slot.getAllByRole("button", { name: "Revoke" });
+    expect(revokeButtons).toHaveLength(3);
+    fireEvent.click(revokeButtons[0]!);
+    await waitFor(() =>
+      expect(slot.rpcCalls).toContainEqual({
+        method: "unexpose",
+        input: { hostId: "host-air", port: 5173 },
+      }),
+    );
+  });
+
   it("exposes a port through the disclosure form and surfaces errors", async () => {
     const slot = renderSlot(
       app.settingsSections[0]!,

--- a/plugins/connect/app.tsx
+++ b/plugins/connect/app.tsx
@@ -506,6 +506,28 @@ function PairForm({
 // Shared ports subsection (restyled into the section grammar).
 // ---------------------------------------------------------------------------
 
+interface ShareHostGroup {
+  hostId: string;
+  hostName: string;
+  shares: ConnectStatus["shares"];
+}
+
+/** Group shares under their host, preserving the backend's host/port order. */
+function groupSharesByHost(shares: ConnectStatus["shares"]): ShareHostGroup[] {
+  const groups: ShareHostGroup[] = [];
+  const byHostId = new Map<string, ShareHostGroup>();
+  for (const share of shares) {
+    let group = byHostId.get(share.hostId);
+    if (group === undefined) {
+      group = { hostId: share.hostId, hostName: share.hostName, shares: [] };
+      byHostId.set(share.hostId, group);
+      groups.push(group);
+    }
+    group.shares.push(share);
+  }
+  return groups;
+}
+
 function SharedPortsSection({
   shares,
   dimmed,
@@ -587,54 +609,85 @@ function SharedPortsSection({
       </div>
 
       {shares.length > 0 ? (
-        <ul className="space-y-1">
-          {shares.map((share) => (
-            <li
-              key={`${share.hostId}:${share.port}`}
-              className="flex items-center gap-2"
-            >
-              <span className="shrink-0 font-mono text-xs tabular-nums text-foreground">
-                :{share.port}
-              </span>
-              {share.url ? (
-                <>
-                  <a
-                    href={share.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground underline-offset-2 hover:underline"
+        <div className="space-y-2.5">
+          {groupSharesByHost(shares).map((group) => {
+            // A host whose shares all lack a URL is unreachable right now
+            // (offline daemon, removed host, …) — the whole group reads
+            // degraded, but Revoke stays live since removal works offline.
+            const hostDown = group.shares.every((share) => share.url === "");
+            return (
+              <div key={group.hostId} className="space-y-1">
+                <div className="flex items-center gap-1.5">
+                  <StatusDot tone={hostDown ? "muted" : "ok"} />
+                  <span
+                    className={cn(
+                      "min-w-0 truncate text-xs font-medium",
+                      hostDown ? "text-muted-foreground" : "text-foreground",
+                    )}
                   >
-                    {hostOf(share.url)}
-                  </a>
-                  <QuietCopyButton
-                    url={share.url}
-                    label={`Copy share URL for port ${share.port}`}
-                  />
-                </>
-              ) : (
-                <span
-                  className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
-                  title={share.unavailableReason}
-                >
-                  Unavailable — {share.unavailableReason ?? "unknown reason"}
-                </span>
-              )}
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className={DANGER_QUIET_CLASS}
-                disabled={revokingShare === `${share.hostId}:${share.port}`}
-                onClick={() => unexpose(share.hostId, share.port)}
-              >
-                {revokingShare === `${share.hostId}:${share.port}` ? (
-                  <Icon name="Spinner" className="size-4 animate-spin" />
-                ) : null}
-                Revoke
-              </Button>
-            </li>
-          ))}
-        </ul>
+                    {group.hostName}
+                  </span>
+                </div>
+                <ul className="space-y-1 pl-3.5">
+                  {group.shares.map((share) => (
+                    <li
+                      key={`${share.hostId}:${share.port}`}
+                      className="flex items-center gap-2"
+                    >
+                      <span
+                        className={cn(
+                          "shrink-0 font-mono text-xs tabular-nums",
+                          share.url ? "text-foreground" : "text-muted-foreground",
+                        )}
+                      >
+                        :{share.port}
+                      </span>
+                      {share.url ? (
+                        <>
+                          <a
+                            href={share.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground underline-offset-2 hover:underline"
+                          >
+                            {hostOf(share.url)}
+                          </a>
+                          <QuietCopyButton
+                            url={share.url}
+                            label={`Copy share URL for port ${share.port}`}
+                          />
+                        </>
+                      ) : (
+                        <span
+                          className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+                          title={share.unavailableReason}
+                        >
+                          Unavailable —{" "}
+                          {share.unavailableReason ?? "unknown reason"}
+                        </span>
+                      )}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className={DANGER_QUIET_CLASS}
+                        disabled={
+                          revokingShare === `${share.hostId}:${share.port}`
+                        }
+                        onClick={() => unexpose(share.hostId, share.port)}
+                      >
+                        {revokingShare === `${share.hostId}:${share.port}` ? (
+                          <Icon name="Spinner" className="size-4 animate-spin" />
+                        ) : null}
+                        Revoke
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
       ) : null}
 
       {formOpen ? (


### PR DESCRIPTION
Final presentation-only phase of connect-v2 (plan phase 5). No backend or security behavior changes; data plumbing landed in phases 1–4.

## 1. Connect panel — shares grouped by host
`plugins/connect/app.tsx`: the Shared ports section now renders one group per host: a small header row (StatusDot + host name) with that host's shares indented beneath, `:port` + clickable share URL + quiet Copy. A host whose shares all have an empty `url` renders degraded — muted dot/header/port, each row showing its `unavailableReason`, no link or copy — while **Revoke stays enabled** (removal works offline). Driven by the existing realtime `connect` channel snapshots. The status payload carries no per-host tunnel status field today, so host state is derived from share availability; if a per-host status field lands later the header dot is the slot for it.

## 2. Gate offline page — accurate machine copy
`apps/connect/src/worker.ts`: `offlinePage` now takes the resolved label kind. A machine-label share host renders "This machine is offline" / "This machine was last seen 5 minutes ago." (and "…bb isn't running **on it**"), instead of claiming "Your bb is offline" for a laptop that only shares ports. Server copy, shell, tokens, and self-retry are unchanged — same `gatePage` template.

## 3. Dashboard — machines with labels next to servers
`apps/web`: `MachineSummary` gains `subdomain` + `online` (staleness via the same `SERVER_OFFLINE_AFTER_MS` window servers use) in the dashboard loader. Machine rows now mirror server rows: mono `sawyer-air.getbb.app` label (name as the fallback for unlabeled machines), status dot, and "Online" / "Offline · last seen 5m ago" / "Never connected" secondary line. Read-only presentation; existing Revoke untouched.

## Tests
- `app.test.tsx`: one header per host, live URL stays a link, degraded share shows reason with no copy affordance, Revoke still fires for the unreachable host.
- `worker.test.ts`: machine share host offline → machine copy + last-seen; server tests unchanged.
- `api.test.ts`: machine summaries carry subdomain, and `online` is true only when freshly seen (fresh/stale/unlabeled matrix).

## Validation
- `turbo run typecheck test --filter=bb-plugin-connect --filter=@bb/web --filter=@bb/connect` — all green (61 + 79 + 40 tests).
- Repo-wide `turbo run typecheck` — 46/46 green.
- `theme.css` untouched; only existing tokens/utility classes used (no new oklch literals, no arbitrary text sizes).

No screenshots: the plugin panel has no standalone Playwright harness in-repo; changes are described above. Do not merge or deploy — manager owns integration on `bb/connect-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)