### PR TITLE
Unify skill autocomplete catalog

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -955,6 +955,46 @@ describe("PromptBoxInternal mention triggers", () => {
       "/api/v1/plugins/github/assets/logo?h=abc",
     );
   });
+
+  it("keeps path-first mention results in keyboard navigation order", async () => {
+    const pathSuggestion: PromptMentionSuggestion = {
+      kind: "path",
+      source: "workspace",
+      entryKind: "file",
+      path: "src/app.ts",
+      name: "app.ts",
+      replacement: "src/app.ts",
+    };
+    const threadSuggestion: PromptMentionSuggestion = {
+      kind: "thread",
+      path: "thread:thr_app",
+      replacement: "thread:thr_app",
+      projectId: "proj_app",
+      projectName: "App",
+      threadId: "thr_app",
+      title: "App thread",
+    };
+    const { promptBoxRef } = renderPromptBox("@src/", {
+      mentionSuggestions: [pathSuggestion, threadSuggestion],
+    });
+
+    await focusPromptEnd(promptBoxRef);
+    const workspaceLabel = await screen.findByText("Workspace");
+    const menu = workspaceLabel.closest(".overflow-hidden");
+    if (!(menu instanceof HTMLElement)) {
+      throw new Error("Expected mention menu");
+    }
+    const [pathButton, threadButton] = within(menu).getAllByRole("button");
+    expect(pathButton.textContent).toContain("app.ts");
+    expect(threadButton.textContent).toContain("App thread");
+    expect(pathButton.className).toContain("bg-state-active");
+
+    fireEvent.keyDown(getPromptEditorElement(), { key: "ArrowDown" });
+
+    await waitFor(() =>
+      expect(threadButton.className).toContain("bg-state-active"),
+    );
+  });
 });
 
 describe("PromptBoxInternal prompt actions", () => {
@@ -1486,6 +1526,88 @@ describe("PromptBoxInternal command typeahead submit", () => {
     await act(async () => {});
 
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe("PromptBoxInternal command typeahead navigation", () => {
+  it("uses the rendered section order for Arrow keys and Enter", async () => {
+    const { changes, promptBoxRef } = renderPromptBox("/", {
+      commandSuggestions: [
+        {
+          kind: "command",
+          name: "plan",
+          source: "command",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "review",
+          source: "skill",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "compact",
+          source: "command",
+          origin: "builtin",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "interview",
+          source: "command",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "deploy",
+          source: "command",
+          origin: "project",
+          description: null,
+          argumentHint: null,
+        },
+      ],
+    });
+
+    await focusPromptEnd(promptBoxRef);
+    const sectionLabel = await screen.findByText("Commands");
+    const menu = sectionLabel.closest(".overflow-hidden");
+    if (!(menu instanceof HTMLElement)) {
+      throw new Error("Expected command menu");
+    }
+    const buttons = within(menu).getAllByRole("button");
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "compact",
+      "review",
+      "deploy",
+      "plan",
+      "interview",
+    ]);
+
+    const editor = getPromptEditorElement();
+    for (const name of ["compact", "review", "deploy", "plan", "interview"]) {
+      const button = within(menu).getByRole("button", { name });
+      await waitFor(() =>
+        expect(button.className).toContain("bg-state-active"),
+      );
+      if (name !== "interview") {
+        fireEvent.keyDown(editor, { key: "ArrowDown" });
+      }
+    }
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    await waitFor(() => expect(latestValue(changes)).toBe("/interview "));
+    expect(latestChange(changes)?.mentions[0]?.resource).toMatchObject({
+      kind: "command",
+      name: "interview",
+    });
   });
 });
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -21,15 +21,16 @@ import {
   type ReactNode,
   type Ref,
 } from "react";
-import type {
-  ActiveTrigger,
-  CommandMenuState,
-  ComposerCommandSuggestion,
-  MentionMenuState,
-  ProviderCommandSuggestion,
-  PromptMentionSuggestion,
-  TypeaheadMenuState,
-  TypeaheadTrigger,
+import {
+  orderCommandSuggestionsBySection,
+  type ActiveTrigger,
+  type CommandMenuState,
+  type ComposerCommandSuggestion,
+  type MentionMenuState,
+  type ProviderCommandSuggestion,
+  type PromptMentionSuggestion,
+  type TypeaheadMenuState,
+  type TypeaheadTrigger,
 } from "@/components/promptbox/mentions/types";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
@@ -1671,17 +1672,21 @@ export function PromptBoxInternal({
       isError: commandError,
       isLoadingMore: commandIsLoadingMore,
     });
+  const orderedCommandSuggestions = useMemo(
+    () => orderCommandSuggestionsBySection(commandSuggestions),
+    [commandSuggestions],
+  );
   // The suggestion list driving keyboard nav + Enter/Tab apply for whichever
   // trigger is active. Empty when no trigger is open. Memoized so the keyboard
   // handler's useCallback identity is stable across renders.
   const activeSuggestions = useMemo<readonly TypeaheadSuggestion[]>(
     () =>
       activeTriggerKind === "command"
-        ? commandSuggestions
+        ? orderedCommandSuggestions
         : activeTriggerKind === "mention"
           ? mentionSuggestions
           : [],
-    [activeTriggerKind, commandSuggestions, mentionSuggestions],
+    [activeTriggerKind, mentionSuggestions, orderedCommandSuggestions],
   );
 
   const activeMentionQuery =
@@ -1699,7 +1704,7 @@ export function PromptBoxInternal({
     ? { kind: "loading" }
     : commandError
       ? { kind: "error" }
-      : { kind: "results", suggestions: commandSuggestions };
+      : { kind: "results", suggestions: orderedCommandSuggestions };
 
   // Loaded-empty suppression (§6): a command trigger with zero loaded results
   // (not loading, not error) is literal text — never open the menu. Mention

--- a/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
+++ b/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
@@ -7,7 +7,6 @@ import {
   type UIEvent,
 } from "react";
 import {
-  PROVIDER_COMMAND_SECTIONS,
   providerCommandSection,
   type ProviderCommandSection,
 } from "@bb/server-contract";
@@ -59,14 +58,13 @@ interface MenuSection<TKind extends string, TItem> {
 }
 
 /**
- * Groups a flat suggestion list into ordered sections. Shared by the mention
- * and command paths so the section-building/ordering logic lives in one place;
- * each caller supplies how to map a row to its section kind plus the canonical
- * order and labels.
+ * Groups a flat suggestion list into sections without changing its section
+ * order. The same flat list drives keyboard navigation, so rendering must
+ * preserve the first occurrence of every section instead of applying a second
+ * visual-only order.
  */
 function groupSections<TKind extends string, TItem>(args: {
   suggestions: readonly TItem[];
-  order: readonly TKind[];
   sectionKind: (item: TItem) => TKind;
   sectionLabel: (kind: TKind) => string;
 }): MenuSection<TKind, TItem>[] {
@@ -86,10 +84,7 @@ function groupSections<TKind extends string, TItem>(args: {
     });
   }
 
-  return args.order.flatMap((kind) => {
-    const section = sectionsByKind.get(kind);
-    return section ? [section] : [];
-  });
+  return [...sectionsByKind.values()];
 }
 
 type PathMentionSectionKind = "workspace" | "thread-storage";
@@ -104,28 +99,6 @@ type MentionSectionKind =
   | PluginMentionSectionKind;
 type PathMentionSuggestion = Extract<PromptMentionSuggestion, { kind: "path" }>;
 type SecondaryContextKind = "path" | "project";
-
-const MENTION_SECTION_ORDER: readonly MentionSectionKind[] = [
-  "threads",
-  "projects",
-  "workspace",
-  "thread-storage",
-];
-
-/** Built-in sections first, then plugin provider sections in row order. */
-function getMentionSectionOrder(
-  suggestions: readonly PromptMentionSuggestion[],
-): MentionSectionKind[] {
-  const pluginKinds: PluginMentionSectionKind[] = [];
-  for (const item of suggestions) {
-    if (item.kind !== "plugin") continue;
-    const kind = getPluginSectionKind(item);
-    if (!pluginKinds.includes(kind)) {
-      pluginKinds.push(kind);
-    }
-  }
-  return [...MENTION_SECTION_ORDER, ...pluginKinds];
-}
 
 function getPluginSectionKind(
   item: Extract<PromptMentionSuggestion, { kind: "plugin" }>,
@@ -227,14 +200,11 @@ function getMentionKey(item: PromptMentionSuggestion, index: number): string {
   return `${item.kind}-${item.path}-${index}`;
 }
 
-// Command sections derive from the shared `PROVIDER_COMMAND_SECTIONS` order and
-// `providerCommandSection` mapping in @bb/server-contract — the SAME definition
-// the server sorts the flat response by — so the menu's visual order and the
-// keyboard-nav order can't drift. The menu only adds the human-readable labels.
+// Command sections use the shared `providerCommandSection` mapping from
+// @bb/server-contract. PromptBoxInternal orders the flat suggestions with the
+// matching section rank before that same array reaches rendering, keyboard
+// navigation, and apply; the menu only adds human-readable labels.
 type CommandSectionKind = ProviderCommandSection;
-
-const COMMAND_SECTION_ORDER: readonly CommandSectionKind[] =
-  PROVIDER_COMMAND_SECTIONS;
 
 function getCommandSectionKind(
   item: ComposerCommandSuggestion,
@@ -385,7 +355,6 @@ function MentionResults({
     const pluginSectionLabels = getPluginSectionLabels(suggestions);
     return groupSections({
       suggestions,
-      order: getMentionSectionOrder(suggestions),
       sectionKind: getMentionSectionKind,
       sectionLabel: (kind) => getMentionSectionLabel(kind, pluginSectionLabels),
     });
@@ -475,7 +444,6 @@ function CommandResults({
     () =>
       groupSections({
         suggestions,
-        order: COMMAND_SECTION_ORDER,
         sectionKind: getCommandSectionKind,
         sectionLabel: getCommandSectionLabel,
       }),

--- a/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
+++ b/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
@@ -257,8 +257,21 @@ function getCommandSectionLabel(kind: CommandSectionKind): string {
 const ROW_ICON_CLASS = "size-3.5 shrink-0 text-muted-foreground";
 
 function getCommandIcon(item: ComposerCommandSuggestion): ReactNode {
+  if (item.pluginId !== undefined) {
+    return (
+      <PluginIcon
+        pluginId={item.pluginId}
+        icon={null}
+        className={ROW_ICON_CLASS}
+      />
+    );
+  }
   return (
-    <Icon name={promptCommandIconName(item)} className={ROW_ICON_CLASS} aria-hidden />
+    <Icon
+      name={promptCommandIconName(item)}
+      className={ROW_ICON_CLASS}
+      aria-hidden
+    />
   );
 }
 
@@ -273,7 +286,11 @@ function getMentionIcon(item: PromptMentionSuggestion): ReactNode {
     );
   }
   return (
-    <Icon name={getMentionIconName(item)} className={ROW_ICON_CLASS} aria-hidden />
+    <Icon
+      name={getMentionIconName(item)}
+      className={ROW_ICON_CLASS}
+      aria-hidden
+    />
   );
 }
 

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -1,7 +1,8 @@
-import type {
-  ProviderCommand,
-  ProviderCommandOrigin,
-  ProviderCommandSource,
+import {
+  providerCommandSectionRank,
+  type ProviderCommand,
+  type ProviderCommandOrigin,
+  type ProviderCommandSource,
 } from "@bb/server-contract";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
 import type { PluginMentionTrigger } from "@/lib/plugin-mention-triggers";
@@ -100,6 +101,24 @@ export function toProviderCommandSuggestion(
 
 /** Every row the command typeahead menu can render. */
 export type ComposerCommandSuggestion = ProviderCommandSuggestion;
+
+export function compareCommandSuggestionSections(
+  left: ComposerCommandSuggestion,
+  right: ComposerCommandSuggestion,
+): number {
+  return providerCommandSectionRank(left) - providerCommandSectionRank(right);
+}
+
+/**
+ * Put the flat command list in the same section order the menu renders. The
+ * composer uses this exact array for keyboard navigation and Enter/Tab apply,
+ * so visual grouping must never be the first place section ordering happens.
+ */
+export function orderCommandSuggestionsBySection(
+  suggestions: readonly ComposerCommandSuggestion[],
+): ComposerCommandSuggestion[] {
+  return [...suggestions].sort(compareCommandSuggestionSections);
+}
 
 /**
  * A typeahead trigger the composer watches for. Mention triggers open the

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -76,6 +76,7 @@ export interface ProviderCommandSuggestion {
   origin: ProviderCommandOrigin;
   description: string | null;
   argumentHint: string | null;
+  pluginId?: string;
 }
 
 /**
@@ -93,6 +94,7 @@ export function toProviderCommandSuggestion(
     origin: command.origin,
     description: command.description,
     argumentHint: command.argumentHint,
+    ...(command.pluginId !== undefined ? { pluginId: command.pluginId } : {}),
   };
 }
 

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -148,6 +148,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
   ],
   "hooks/cache-owners/realtime-cache-registry.ts": [
     "allHostQueryKeyPrefix",
+    "allProjectCommandsQueryKeyPrefix",
     "allSystemExecutionOptionsQueryKeyPrefix",
     "allThreadStorageFilePreviewQueryKeyPrefix",
     "allThreadStorageFilesQueryKeyPrefix",

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -61,6 +61,7 @@ import {
 } from "./thread-list-cache-data";
 import {
   allHostQueryKeyPrefix,
+  allProjectCommandsQueryKeyPrefix,
   allThreadStorageFilePreviewQueryKeyPrefix,
   allThreadStorageFilesQueryKeyPrefix,
   allThreadStoragePathsQueryKeyPrefix,
@@ -301,9 +302,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
   },
   "tabs-changed": {
     flush: "immediate",
-    dirty: [
-      dirtyThreadTabsQueries,
-    ],
+    dirty: [dirtyThreadTabsQueries],
   },
   "terminals-changed": {
     flush: "debounced",
@@ -428,6 +427,7 @@ export const REALTIME_SYSTEM_CHANGE_REGISTRY = {
   "plugins-changed": {
     dirty: [
       dirtyPluginContributionQueries,
+      dirtyProjectCommandCatalogQueries,
       dirtyPluginManagementQueries,
       reconcilePluginFrontendBundles,
     ],
@@ -876,6 +876,10 @@ function dirtySystemExecutionOptionQueries(): QueryKey[] {
 
 function dirtyPluginContributionQueries(): QueryKey[] {
   return [allPluginContributionsQueryKeyPrefix()];
+}
+
+function dirtyProjectCommandCatalogQueries(): QueryKey[] {
+  return [allProjectCommandsQueryKeyPrefix()];
 }
 
 function dirtyPluginManagementQueries(): QueryKey[] {

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type {
   CommandListResponse,
   ProjectBranchesResponse,
@@ -11,7 +11,6 @@ import type { FilePreview } from "@/lib/api";
 import { useProjectDetailRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import {
   projectCommandsQueryKey,
-  projectCommandsPagesQueryKey,
   projectFilePreviewQueryKey,
   projectPathsQueryKey,
   projectPromptHistoryQueryKey,
@@ -50,9 +49,6 @@ interface UseProjectCommandsArgs {
   projectId: string | undefined;
   providerId: string | undefined;
   environmentId: string | null;
-  query: string;
-  limit: number;
-  offset: number;
 }
 
 const PROJECT_SOURCE_BRANCHES_LIMIT = 50;
@@ -237,58 +233,18 @@ export function useProjectCommands(
       args.projectId,
       args.providerId,
       args.environmentId,
-      args.query,
-      args.offset,
-      args.limit,
     ),
     queryFn: ({ signal }) =>
       api.listProjectCommands({
         projectId: requireProjectId(args.projectId, "useProjectCommands"),
         providerId: requireProviderId(args.providerId, "useProjectCommands"),
         environmentId: args.environmentId,
-        query: args.query,
-        limit: args.limit,
-        offset: args.offset,
         signal,
       }),
     enabled,
     ...TYPEAHEAD_QUERY_POLICY,
-    placeholderData: (previousData) => previousData,
-  });
-}
-
-export function useProjectCommandsPages(
-  args: Omit<UseProjectCommandsArgs, "offset">,
-  options?: QueryOptions,
-) {
-  return useInfiniteQuery({
-    queryKey: projectCommandsPagesQueryKey(
-      args.projectId,
-      args.providerId,
-      args.environmentId,
-      args.query,
-      args.limit,
-    ),
-    queryFn: ({ pageParam, signal }) =>
-      api.listProjectCommands({
-        projectId: requireProjectId(args.projectId, "useProjectCommandsPages"),
-        providerId: requireProviderId(
-          args.providerId,
-          "useProjectCommandsPages",
-        ),
-        environmentId: args.environmentId,
-        query: args.query,
-        limit: args.limit,
-        offset: pageParam,
-        signal,
-      }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
-      lastPage.truncated ? lastPageParam + args.limit : undefined,
-    enabled:
-      (options?.enabled ?? true) &&
-      Boolean(args.projectId) &&
-      Boolean(args.providerId),
-    ...TYPEAHEAD_QUERY_POLICY,
+    // Reopening the slash menu refreshes provider-native files that may have
+    // changed on disk; typing keeps the same key and still filters locally.
+    staleTime: 0,
   });
 }

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -36,7 +36,6 @@ export const THREAD_PENDING_INTERACTIONS_QUERY_KEY =
   "threadPendingInteractions";
 export const TERMINALS_QUERY_KEY = "terminals";
 export const PROJECT_COMMANDS_QUERY_KEY = "projectCommands";
-export const PROJECT_COMMANDS_PAGES_QUERY_KEY = "projectCommandsPages";
 export const THREAD_STORAGE_FILES_QUERY_KEY = "threadStorageFiles";
 export const THREAD_STORAGE_PATHS_QUERY_KEY = "threadStoragePaths";
 export const THREAD_STORAGE_FILE_PREVIEW_QUERY_KEY = "threadStorageFilePreview";
@@ -231,17 +230,9 @@ export type ProjectCommandsQueryKey = readonly [
   string | undefined,
   string | undefined,
   string | null,
-  string,
-  number,
-  number,
 ];
-export type ProjectCommandsPagesQueryKey = readonly [
-  typeof PROJECT_COMMANDS_PAGES_QUERY_KEY,
-  string | undefined,
-  string | undefined,
-  string | null,
-  string,
-  number,
+export type AllProjectCommandsQueryKeyPrefix = readonly [
+  typeof PROJECT_COMMANDS_QUERY_KEY,
 ];
 export type ThreadStorageFilesQueryKey = readonly [
   typeof THREAD_STORAGE_FILES_QUERY_KEY,
@@ -714,36 +705,12 @@ export function projectCommandsQueryKey(
   projectId: string | undefined,
   providerId: string | undefined,
   environmentId: string | null,
-  query: string,
-  offset: number,
-  limit: number,
 ): ProjectCommandsQueryKey {
-  return [
-    PROJECT_COMMANDS_QUERY_KEY,
-    projectId,
-    providerId,
-    environmentId,
-    query,
-    offset,
-    limit,
-  ];
+  return [PROJECT_COMMANDS_QUERY_KEY, projectId, providerId, environmentId];
 }
 
-export function projectCommandsPagesQueryKey(
-  projectId: string | undefined,
-  providerId: string | undefined,
-  environmentId: string | null,
-  query: string,
-  limit: number,
-): ProjectCommandsPagesQueryKey {
-  return [
-    PROJECT_COMMANDS_PAGES_QUERY_KEY,
-    projectId,
-    providerId,
-    environmentId,
-    query,
-    limit,
-  ];
+export function allProjectCommandsQueryKeyPrefix(): AllProjectCommandsQueryKeyPrefix {
+  return [PROJECT_COMMANDS_QUERY_KEY];
 }
 
 export function threadStorageFilesQueryKey(

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -15,6 +15,7 @@ import {
   environmentWorkStatusQueryKey,
   hostPathExistenceQueryKey,
   projectPathsQueryKey,
+  projectCommandsQueryKey,
   projectPromptHistoryQueryKey,
   projectSourceBranchesQueryKey,
   projectsQueryKey,
@@ -157,13 +158,19 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("invalidates the plugin contributions cache on plugins-changed", () => {
+  it("invalidates plugin contributions and command catalogs on plugins-changed", () => {
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const contributionsKey = pluginContributionsQueryKey(true);
     queryClient.setQueryData(contributionsKey, {
       threadActions: [],
       mentionProviders: [],
     });
+    const commandsKey = projectCommandsQueryKey(
+      "project-1",
+      "codex",
+      "environment-1",
+    );
+    queryClient.setQueryData(commandsKey, { commands: [] });
 
     effects.handleChanged({
       type: "changed",
@@ -176,6 +183,7 @@ describe("createRealtimeCacheEffects", () => {
     expect(queryClient.getQueryState(contributionsKey)?.isInvalidated).toBe(
       true,
     );
+    expect(queryClient.getQueryState(commandsKey)?.isInvalidated).toBe(true);
   });
 
   it.each(PROJECT_PROMPT_HISTORY_THREAD_CHANGES)(

--- a/apps/app/src/hooks/useCommandSuggestions.test.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { AUTOMATION_PROMPT_ACTION } from "@/components/promptbox/PromptBoxActionsMenu";
-import { promptActionCommandSuggestions } from "./useCommandSuggestions";
+import {
+  commandSuggestionMatchesQuery,
+  filterCommandSuggestions,
+  promptActionCommandSuggestions,
+} from "./useCommandSuggestions";
 
 const promptActions = [
   { kind: "skills", text: "/" },
@@ -61,5 +65,40 @@ describe("promptActionCommandSuggestions", () => {
         trigger: "/",
       }).map((suggestion) => suggestion.name),
     ).toEqual(["automation"]);
+  });
+});
+
+describe("commandSuggestionMatchesQuery", () => {
+  const pluginSkill = {
+    kind: "command",
+    name: "review",
+    source: "skill",
+    origin: "user",
+    description: "Review a pull request",
+    argumentHint: null,
+    pluginId: "github",
+  } as const;
+
+  it("filters the cached catalog locally by name and description", () => {
+    expect(commandSuggestionMatchesQuery(pluginSkill, "rev")).toBe(true);
+    expect(commandSuggestionMatchesQuery(pluginSkill, "pull")).toBe(true);
+    expect(commandSuggestionMatchesQuery(pluginSkill, "deploy")).toBe(false);
+  });
+
+  it("ranks a namespaced skill by its direct name without another fetch", () => {
+    const names = filterCommandSuggestions(
+      [
+        { ...pluginSkill, name: "alpha-review-notes" },
+        { ...pluginSkill, name: "ottonomous:review" },
+        { ...pluginSkill, name: "zeta-review" },
+      ],
+      "review",
+    ).map((suggestion) => suggestion.name);
+
+    expect(names).toEqual([
+      "ottonomous:review",
+      "alpha-review-notes",
+      "zeta-review",
+    ]);
   });
 });

--- a/apps/app/src/hooks/useCommandSuggestions.test.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.test.ts
@@ -101,4 +101,25 @@ describe("commandSuggestionMatchesQuery", () => {
       "zeta-review",
     ]);
   });
+
+  it("keeps menu sections primary when ranking prefix matches", () => {
+    const names = filterCommandSuggestions(
+      [
+        {
+          ...pluginSkill,
+          name: "review-helper",
+          description: "Contains deploy guidance",
+        },
+        {
+          ...pluginSkill,
+          name: "deploy",
+          source: "command",
+          origin: "user",
+        },
+      ],
+      "deploy",
+    ).map((suggestion) => suggestion.name);
+
+    expect(names).toEqual(["review-helper", "deploy"]);
+  });
 });

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
 import {
+  compareCommandSuggestionSections,
+  orderCommandSuggestionsBySection,
   toProviderCommandSuggestion,
   type ProviderCommandSuggestion,
 } from "@/components/promptbox/mentions/types";
@@ -85,6 +87,10 @@ export function filterCommandSuggestions(
       commandSuggestionMatchesQuery(suggestion, normalizedQuery),
     )
     .sort((left, right) => {
+      const bySection = compareCommandSuggestionSections(left, right);
+      if (bySection !== 0) {
+        return bySection;
+      }
       const leftPrefix = commandSuggestionSearchNames(left).some((name) =>
         name.startsWith(normalizedQuery),
       );
@@ -197,9 +203,8 @@ export function useCommandSuggestions(
       (commandsQuery.data?.commands ?? []).map(toProviderCommandSuggestion),
       trimmedQuery,
     );
-    return mergeCommandSuggestions(
-      promptActionSuggestions,
-      discoveredSuggestions,
+    return orderCommandSuggestionsBySection(
+      mergeCommandSuggestions(promptActionSuggestions, discoveredSuggestions),
     );
   }, [
     commandsQuery.data?.commands,

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -1,14 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useDebounceValue } from "usehooks-ts";
+import { useMemo } from "react";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
 import {
   toProviderCommandSuggestion,
   type ProviderCommandSuggestion,
 } from "@/components/promptbox/mentions/types";
-import { useProjectCommandsPages } from "./queries/project-queries";
-import { PATH_SUGGESTION_DEBOUNCE_MS } from "./usePathSuggestions";
-
-const COMMAND_SUGGESTION_PAGE_SIZE = 50;
+import { useProjectCommands } from "./queries/project-queries";
 
 export interface UseCommandSuggestionsArgs {
   projectId: string | undefined;
@@ -50,7 +46,7 @@ export interface CommandSuggestionPromptAction {
   };
 }
 
-function commandSuggestionMatchesQuery(
+export function commandSuggestionMatchesQuery(
   suggestion: ProviderCommandSuggestion,
   query: string,
 ): boolean {
@@ -66,6 +62,37 @@ function commandSuggestionMatchesQuery(
     .join(" ")
     .toLowerCase()
     .includes(query);
+}
+
+function commandSuggestionSearchNames(
+  suggestion: ProviderCommandSuggestion,
+): string[] {
+  const name = suggestion.name.toLowerCase();
+  if (suggestion.source !== "skill") {
+    return [name];
+  }
+  const separatorIndex = name.lastIndexOf(":");
+  return separatorIndex < 0 ? [name] : [name, name.slice(separatorIndex + 1)];
+}
+
+export function filterCommandSuggestions(
+  suggestions: readonly ProviderCommandSuggestion[],
+  query: string,
+): ProviderCommandSuggestion[] {
+  const normalizedQuery = query.toLowerCase();
+  return suggestions
+    .filter((suggestion) =>
+      commandSuggestionMatchesQuery(suggestion, normalizedQuery),
+    )
+    .sort((left, right) => {
+      const leftPrefix = commandSuggestionSearchNames(left).some((name) =>
+        name.startsWith(normalizedQuery),
+      );
+      const rightPrefix = commandSuggestionSearchNames(right).some((name) =>
+        name.startsWith(normalizedQuery),
+      );
+      return leftPrefix === rightPrefix ? 0 : leftPrefix ? -1 : 1;
+    });
 }
 
 export function promptActionCommandSuggestions({
@@ -140,15 +167,7 @@ export function useCommandSuggestions(
     trigger !== null &&
     args.query !== null;
 
-  const [debouncedNonNullQuery] = useDebounceValue(
-    args.query,
-    PATH_SUGGESTION_DEBOUNCE_MS,
-  );
-  const debouncedQuery = args.query === null ? null : debouncedNonNullQuery;
   const trimmedQuery = args.query?.trim() ?? "";
-  const debouncedTrimmedQuery = debouncedQuery?.trim() ?? "";
-  const isDebouncing = isActive && trimmedQuery !== debouncedTrimmedQuery;
-  const loadMoreInFlightRef = useRef(false);
   const promptActionSuggestions = useMemo(
     () =>
       isActive
@@ -161,23 +180,11 @@ export function useCommandSuggestions(
     [args.promptActions, isActive, trigger, trimmedQuery],
   );
 
-  useEffect(() => {
-    loadMoreInFlightRef.current = false;
-  }, [
-    args.environmentId,
-    args.projectId,
-    args.providerId,
-    trigger,
-    debouncedTrimmedQuery,
-  ]);
-
-  const commandsQuery = useProjectCommandsPages(
+  const commandsQuery = useProjectCommands(
     {
       projectId: args.projectId,
       providerId: args.providerId,
       environmentId: args.environmentId,
-      query: debouncedTrimmedQuery,
-      limit: COMMAND_SUGGESTION_PAGE_SIZE,
     },
     { enabled: isActive },
   );
@@ -186,27 +193,20 @@ export function useCommandSuggestions(
     if (!isActive) {
       return [];
     }
-    const discoveredSuggestions = (commandsQuery.data?.pages ?? [])
-      .flatMap((page) => page.commands)
-      .map(toProviderCommandSuggestion);
+    const discoveredSuggestions = filterCommandSuggestions(
+      (commandsQuery.data?.commands ?? []).map(toProviderCommandSuggestion),
+      trimmedQuery,
+    );
     return mergeCommandSuggestions(
       promptActionSuggestions,
       discoveredSuggestions,
     );
-  }, [commandsQuery.data?.pages, isActive, promptActionSuggestions]);
-
-  const hasMore = isActive && commandsQuery.hasNextPage === true;
-  const isLoadingMore = isActive && commandsQuery.isFetchingNextPage;
-  const fetchNextPage = commandsQuery.fetchNextPage;
-  const loadMore = useCallback(() => {
-    if (!hasMore || isLoadingMore || loadMoreInFlightRef.current) {
-      return;
-    }
-    loadMoreInFlightRef.current = true;
-    void fetchNextPage().finally(() => {
-      loadMoreInFlightRef.current = false;
-    });
-  }, [fetchNextPage, hasMore, isLoadingMore]);
+  }, [
+    commandsQuery.data?.commands,
+    isActive,
+    promptActionSuggestions,
+    trimmedQuery,
+  ]);
 
   // Loading flips on only before any result is available. Once the first page
   // returns, fetching additional pages leaves suggestions populated — and a
@@ -216,7 +216,7 @@ export function useCommandSuggestions(
     isActive &&
     suggestions.length === 0 &&
     commandsQuery.data === undefined &&
-    (isDebouncing || commandsQuery.isPending || commandsQuery.isFetching);
+    (commandsQuery.isPending || commandsQuery.isFetching);
   const isError = isActive && commandsQuery.isError;
 
   return {
@@ -224,8 +224,8 @@ export function useCommandSuggestions(
     suggestions,
     isLoading,
     isError,
-    hasMore,
-    isLoadingMore,
-    loadMore,
+    hasMore: false,
+    isLoadingMore: false,
+    loadMore: () => {},
   };
 }

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -704,9 +704,6 @@ interface ListProjectCommandsArgs {
   projectId: string;
   providerId: string;
   environmentId: string | null;
-  query: string;
-  limit: number;
-  offset: number;
   signal?: AbortSignal;
 }
 
@@ -729,9 +726,6 @@ export async function listProjectCommands(
         query: {
           provider: args.providerId,
           environmentId: args.environmentId ?? "",
-          ...(args.query.length > 0 ? { query: args.query } : {}),
-          limit: String(args.limit),
-          ...(args.offset > 0 ? { offset: String(args.offset) } : {}),
         },
       },
       requestOptions(args.signal),

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -295,8 +295,6 @@ export function registerProjectCommands(
       "--environment <id>",
       "Environment workspace; omit for default source",
     )
-    .option("--query <query>", "Command-name filter")
-    .option("--limit <count>", "Maximum commands")
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (id: string, opts: ProjectDiscoveryCommandOptions) => {
@@ -304,8 +302,6 @@ export function registerProjectCommands(
           projectId: id,
           provider: opts.provider ?? "",
           environmentId: opts.environment ?? null,
-          ...(opts.query ? { query: opts.query } : {}),
-          ...(opts.limit ? { limit: opts.limit } : {}),
         });
         if (outputJson(opts, result)) return;
         console.log(JSON.stringify(result, null, 2));

--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -57,9 +57,6 @@ async function discoverClaude(
     roots: await resolveProviderCommandScanRoots({
       providerId: "claude-code",
       cwd,
-      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-      additionalSkillsRootPaths: [],
-      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     }),
@@ -74,9 +71,6 @@ async function discoverCodex(
     roots: await resolveProviderCommandScanRoots({
       providerId: "codex",
       cwd,
-      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-      additionalSkillsRootPaths: [],
-      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     }),
@@ -99,7 +93,7 @@ afterEach(async () => {
 });
 
 describe("discoverProviderCommands (claude-code)", () => {
-  it("discovers project-local and globally installed bb skills", async () => {
+  it("leaves bb-managed skills to the server catalog", async () => {
     const fixture = await makeWorkspaceFixture();
     await writeFileEnsuringDir(
       path.join(fixture.cwd, ".bb", "skills", "project-bb", "SKILL.md"),
@@ -116,27 +110,9 @@ describe("discoverProviderCommands (claude-code)", () => {
 
     const commands = await discoverClaude(fixture, fixture.cwd);
 
-    expect(byName(commands, "project-bb")).toEqual({
-      name: "project-bb",
-      source: "skill",
-      origin: "project",
-      description: "Project bb skill",
-      argumentHint: null,
-    });
-    expect(byName(commands, "user-bb")).toEqual({
-      name: "user-bb",
-      source: "skill",
-      origin: "user",
-      description: "User bb skill",
-      argumentHint: null,
-    });
-    expect(byName(commands, "bb-cli")).toEqual({
-      name: "bb-cli",
-      source: "skill",
-      origin: "user",
-      description: "Built-in bb CLI skill",
-      argumentHint: null,
-    });
+    expect(byName(commands, "project-bb")).toBeUndefined();
+    expect(byName(commands, "user-bb")).toBeUndefined();
+    expect(byName(commands, "bb-cli")).toBeUndefined();
   });
 
   it("parses project skills, namespaced commands, and frontmatter", async () => {
@@ -823,7 +799,7 @@ describe("discoverProviderCommands (claude-code)", () => {
 });
 
 describe("discoverProviderCommands (codex)", () => {
-  it("discovers project-local and globally installed bb skills", async () => {
+  it("leaves bb-managed skills to the server catalog", async () => {
     const fixture = await makeWorkspaceFixture();
     await writeFileEnsuringDir(
       path.join(fixture.cwd, ".bb", "skills", "project-bb", "SKILL.md"),
@@ -840,30 +816,12 @@ describe("discoverProviderCommands (codex)", () => {
 
     const commands = await discoverCodex(fixture, fixture.cwd);
 
-    expect(byName(commands, "project-bb")).toEqual({
-      name: "project-bb",
-      source: "skill",
-      origin: "project",
-      description: "Project bb skill",
-      argumentHint: null,
-    });
-    expect(byName(commands, "user-bb")).toEqual({
-      name: "user-bb",
-      source: "skill",
-      origin: "user",
-      description: "User bb skill",
-      argumentHint: null,
-    });
-    expect(byName(commands, "bb-cli")).toEqual({
-      name: "bb-cli",
-      source: "skill",
-      origin: "user",
-      description: "Built-in bb CLI skill",
-      argumentHint: null,
-    });
+    expect(byName(commands, "project-bb")).toBeUndefined();
+    expect(byName(commands, "user-bb")).toBeUndefined();
+    expect(byName(commands, "bb-cli")).toBeUndefined();
   });
 
-  it("discovers inherited bb skills as user-origin codex skills", async () => {
+  it("does not scan inherited bb skill roots", async () => {
     const fixture = await makeWorkspaceFixture();
     const inheritedSkillsRootPath = path.join(tempRoot, "inherited-skills");
     await writeFileEnsuringDir(
@@ -875,21 +833,12 @@ describe("discoverProviderCommands (codex)", () => {
       roots: await resolveProviderCommandScanRoots({
         providerId: "codex",
         cwd: fixture.cwd,
-        builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-        additionalSkillsRootPaths: [inheritedSkillsRootPath],
-        dataDir: fixture.dataDir,
         homeDir: fixture.homeDir,
         codexHome: fixture.codexHome,
       }),
     });
 
-    expect(byName(commands, "stories")).toEqual({
-      name: "stories",
-      source: "skill",
-      origin: "user",
-      description: "Show Ladle stories",
-      argumentHint: null,
-    });
+    expect(byName(commands, "stories")).toBeUndefined();
   });
 
   it("parses project and user codex skills with correct origins", async () => {
@@ -1118,8 +1067,7 @@ describe("discoverProviderCommands (codex)", () => {
 });
 
 describe("resolveCommandScanRoots", () => {
-  it("discovers synchronized skills staged outside the daemon's normal roots", async () => {
-    const fixture = await makeWorkspaceFixture();
+  it("does not accept synchronized bb skills", async () => {
     const sourceRootPath = path.join(tempRoot, "server-skill", "synced-skill");
     const skillFilePath = path.join(sourceRootPath, "SKILL.md");
     await writeFileEnsuringDir(
@@ -1127,105 +1075,35 @@ describe("resolveCommandScanRoots", () => {
       "---\nname: synced-skill\ndescription: Synced from the primary machine\n---\n",
     );
 
-    const result = await listHostCommands(
-      {
-        type: "host.list_commands",
-        providerId: "pi",
-        cwd: null,
-        builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-        injectedSkillSources: [
-          {
-            kind: "workspace-path",
-            sourceType: "project",
-            name: "synced-skill",
-            description: "Synced from the primary machine",
-            sourceRootPath,
-            skillFilePath,
-          },
-        ],
-      },
-      { dataDir: fixture.dataDir },
-    );
-
-    expect(byName(result.commands, "synced-skill")).toEqual({
-      name: "synced-skill",
-      source: "skill",
-      origin: "project",
-      description: "Synced from the primary machine",
-      argumentHint: null,
+    const result = await listHostCommands({
+      type: "host.list_commands",
+      providerId: "pi",
+      cwd: null,
     });
+
+    expect(byName(result.commands, "synced-skill")).toBeUndefined();
   });
 
-  it("scans shared bb skill roots for pi", async () => {
+  it("returns no provider-native roots for pi", async () => {
     const fixture = await makeWorkspaceFixture();
     const roots = resolveCommandScanRoots({
       providerId: "pi",
       cwd: fixture.cwd,
-      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-      additionalSkillsRootPaths: [path.join(fixture.dataDir, "inherited")],
-      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     });
-    expect(roots).toEqual([
-      {
-        rootPath: path.join(fixture.cwd, ".bb", "skills"),
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "project",
-      },
-      {
-        rootPath: path.join(fixture.dataDir, "skills"),
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      },
-      {
-        rootPath: path.join(fixture.dataDir, "inherited"),
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      },
-      {
-        rootPath: fixture.builtinSkillsRootPath,
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      },
-    ]);
+    expect(roots).toEqual([]);
   });
 
-  it("scans shared bb skill roots for ACP providers", async () => {
+  it("returns no provider-native roots for ACP providers", async () => {
     const fixture = await makeWorkspaceFixture();
     const roots = resolveCommandScanRoots({
       providerId: "acp-cursor",
       cwd: null,
-      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-      additionalSkillsRootPaths: [],
-      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     });
-    expect(roots).toEqual([
-      {
-        rootPath: path.join(fixture.dataDir, "skills"),
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      },
-      {
-        rootPath: fixture.builtinSkillsRootPath,
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      },
-    ]);
+    expect(roots).toEqual([]);
   });
 
   it("returns no roots for an unknown provider", async () => {
@@ -1233,9 +1111,6 @@ describe("resolveCommandScanRoots", () => {
     const roots = resolveCommandScanRoots({
       providerId: "unknown-provider",
       cwd: fixture.cwd,
-      builtinSkillsRootPath: fixture.builtinSkillsRootPath,
-      additionalSkillsRootPaths: [],
-      dataDir: fixture.dataDir,
       homeDir: fixture.homeDir,
       codexHome: fixture.codexHome,
     });

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -2,7 +2,6 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveDataDirSkillsRootPath } from "@bb/config/skill-storage-paths";
 import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
 import { z } from "zod";
 import {
@@ -13,18 +12,10 @@ import {
   discoverProviderCommands,
   type CommandScanRoot,
 } from "../command-discovery.js";
-import { stageInjectedSkillSources } from "../injected-skills.js";
-import type { FetchSkillTree } from "../skill-trees.js";
 
 export interface CommandRootResolution {
   /** Resolved workspace path, or null for an unprovisioned thread. */
   cwd: string | null;
-  /** Built-in bb skills bundled with the server. */
-  builtinSkillsRootPath: string;
-  /** Additional bb skill roots inherited by managed dev app instances. */
-  additionalSkillsRootPaths: readonly string[];
-  /** bb data directory containing user-installed bb skills. */
-  dataDir: string;
   /** Claude user-home base (`os.homedir()`). */
   homeDir: string;
   /** Codex user-home base (`$CODEX_HOME` or `~/.codex`). */
@@ -1061,53 +1052,10 @@ export async function resolveProviderCommandScanRoots(
 }
 
 /**
- * Shared bb skill roots scanned for every provider that exposes slash-command
- * typeahead: project `.bb/skills`, data-dir skills, inherited roots, and
- * built-in skills. Project roots are skipped when `cwd` is null.
- */
-function pushBbSkillCommandScanRoots(
-  roots: CommandScanRoot[],
-  resolution: CommandRootResolution,
-): void {
-  if (resolution.cwd !== null) {
-    roots.push({
-      rootPath: path.join(resolution.cwd, ".bb", "skills"),
-      shape: "skill",
-      namePrefix: "",
-      source: "skill",
-      origin: "project",
-    });
-  }
-  roots.push({
-    rootPath: resolveDataDirSkillsRootPath(resolution.dataDir),
-    shape: "skill",
-    namePrefix: "",
-    source: "skill",
-    origin: "user",
-  });
-  for (const rootPath of resolution.additionalSkillsRootPaths) {
-    roots.push({
-      rootPath,
-      shape: "skill",
-      namePrefix: "",
-      source: "skill",
-      origin: "user",
-    });
-  }
-  roots.push({
-    rootPath: resolution.builtinSkillsRootPath,
-    shape: "skill",
-    namePrefix: "",
-    source: "skill",
-    origin: "user",
-  });
-}
-
-/**
  * Build the ordered set of roots to scan for a provider. Project (cwd-dependent)
  * roots are skipped when `cwd` is null; user-home roots are always included.
- * Every provider that injects bb skills also scans those roots for typeahead;
- * Claude Code and Codex add their native skill/command directories on top.
+ * The daemon owns provider-native discovery only. The server adds its canonical
+ * bb skill catalog to the final composer response.
  * Unknown provider ids yield an empty root set.
  */
 export function resolveCommandScanRoots(
@@ -1118,13 +1066,6 @@ export function resolveCommandScanRoots(
   if (resolution.providerId === "claude-code") {
     if (resolution.cwd !== null) {
       roots.push({
-        rootPath: path.join(resolution.cwd, ".bb", "skills"),
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "project",
-      });
-      roots.push({
         rootPath: path.join(resolution.cwd, ".claude", "skills"),
         shape: "skill",
         namePrefix: "",
@@ -1134,29 +1075,6 @@ export function resolveCommandScanRoots(
     }
     roots.push({
       rootPath: path.join(resolution.homeDir, ".claude", "skills"),
-      shape: "skill",
-      namePrefix: "",
-      source: "skill",
-      origin: "user",
-    });
-    roots.push({
-      rootPath: resolveDataDirSkillsRootPath(resolution.dataDir),
-      shape: "skill",
-      namePrefix: "",
-      source: "skill",
-      origin: "user",
-    });
-    for (const rootPath of resolution.additionalSkillsRootPaths) {
-      roots.push({
-        rootPath,
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      });
-    }
-    roots.push({
-      rootPath: resolution.builtinSkillsRootPath,
       shape: "skill",
       namePrefix: "",
       source: "skill",
@@ -1184,13 +1102,6 @@ export function resolveCommandScanRoots(
   if (resolution.providerId === "codex") {
     if (resolution.cwd !== null) {
       roots.push({
-        rootPath: path.join(resolution.cwd, ".bb", "skills"),
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "project",
-      });
-      roots.push({
         rootPath: path.join(resolution.cwd, ".codex", "skills"),
         shape: "skill",
         namePrefix: "",
@@ -1206,29 +1117,6 @@ export function resolveCommandScanRoots(
       origin: "user",
     });
     roots.push({
-      rootPath: resolveDataDirSkillsRootPath(resolution.dataDir),
-      shape: "skill",
-      namePrefix: "",
-      source: "skill",
-      origin: "user",
-    });
-    for (const rootPath of resolution.additionalSkillsRootPaths) {
-      roots.push({
-        rootPath,
-        shape: "skill",
-        namePrefix: "",
-        source: "skill",
-        origin: "user",
-      });
-    }
-    roots.push({
-      rootPath: resolution.builtinSkillsRootPath,
-      shape: "skill",
-      namePrefix: "",
-      source: "skill",
-      origin: "user",
-    });
-    roots.push({
       rootPath: path.join(resolution.codexHome, "skills", ".system"),
       shape: "skill",
       namePrefix: "",
@@ -1238,65 +1126,22 @@ export function resolveCommandScanRoots(
     return roots;
   }
 
-  // Pi and all ACP agents (built-in `acp-cursor` and dynamic `acp-*`) receive
-  // the shared bb skills catalog at runtime and expose the same set in
-  // slash-command typeahead. No provider-native command directories.
-  if (
-    resolution.providerId === "pi" ||
-    resolution.providerId.startsWith("acp-")
-  ) {
-    pushBbSkillCommandScanRoots(roots, resolution);
-    return roots;
-  }
-
   return roots;
 }
 
 export async function listHostCommands(
   command: CommandOf<"host.list_commands">,
-  options: { dataDir: string; fetchSkillTree?: FetchSkillTree },
 ): Promise<HostDaemonOnlineRpcResult<"host.list_commands">> {
   if (command.cwd !== null && !path.isAbsolute(command.cwd)) {
     throw new CommandDispatchError("invalid_path", "cwd must be absolute");
   }
-  if (!path.isAbsolute(command.builtinSkillsRootPath)) {
-    throw new CommandDispatchError(
-      "invalid_path",
-      "builtinSkillsRootPath must be absolute",
-    );
-  }
   const homeDir = os.homedir();
   const roots = await resolveProviderCommandScanRoots({
     cwd: command.cwd,
-    builtinSkillsRootPath: command.builtinSkillsRootPath,
-    additionalSkillsRootPaths: command.additionalSkillsRootPaths ?? [],
-    dataDir: options.dataDir,
     homeDir,
     codexHome: resolveCodexHome(homeDir),
     providerId: command.providerId,
   });
-  const staged = await stageInjectedSkillSources({
-    dataDir: options.dataDir,
-    injectedSkillSources: command.injectedSkillSources,
-    ...(options.fetchSkillTree !== undefined
-      ? { fetchSkillTree: options.fetchSkillTree }
-      : {}),
-  });
-  const stagedSkillsRootPath = staged.skillRoots.find(
-    (root): root is typeof root & { skillDirectoryRootPath: string } =>
-      "skillDirectoryRootPath" in root,
-  )?.skillDirectoryRootPath;
-  if (stagedSkillsRootPath !== undefined) {
-    for (const source of command.injectedSkillSources) {
-      roots.push({
-        rootPath: path.join(stagedSkillsRootPath, source.name),
-        shape: "skill-directory",
-        namePrefix: "",
-        source: "skill",
-        origin: source.sourceType === "project" ? "project" : "user",
-      });
-    }
-  }
   const commands = await discoverProviderCommands({ roots });
   return { commands };
 }

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -54,16 +54,11 @@ import {
   createDaemonFileContentResponse,
   remapDaemonFileRouteError,
 } from "../services/hosts/daemon-file-response.js";
-import {
-  parseBoundedPositiveOptionalInteger,
-  parseOptionalInteger,
-} from "../services/lib/validation.js";
+import { parseBoundedPositiveOptionalInteger } from "../services/lib/validation.js";
 import {
   buildCommandListResponse,
   providerHasCommandSurface,
   resolveCommandWorkspace,
-  PROVIDER_COMMAND_DEFAULT_LIMIT,
-  PROVIDER_COMMAND_LIMIT_MAX,
 } from "../services/threads/provider-command-typeahead.js";
 import {
   beginProjectDeletion,
@@ -78,11 +73,11 @@ import {
 } from "./branch-list-query.js";
 import { parseFileListLimit } from "./file-list-query.js";
 import { parseSafeRelativeRoutePath } from "./relative-route-path.js";
-import { resolveSkillCatalogSources } from "../services/skills/skill-catalog.js";
+import { resolveSkillCatalog } from "../services/skills/skill-catalog.js";
+import { resolveWorkspaceProjectSkills } from "../services/skills/workspace-skills.js";
 import {
   assertUsableHostId,
   requirePrimaryHostId,
-  resolvePrimaryHostId,
 } from "../services/hosts/primary-host.js";
 
 type ProjectResponseProjectFields = Omit<ProjectResponse, "sources">;
@@ -708,47 +703,35 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     // Providers without a skills composer action have no typeahead entries,
     // so skip the daemon roundtrip entirely.
     if (!providerHasCommandSurface(query.provider)) {
-      return context.json({ commands: [], truncated: false });
+      return context.json({ commands: [] });
     }
 
-    const limit = parseBoundedPositiveOptionalInteger({
-      defaultValue: PROVIDER_COMMAND_DEFAULT_LIMIT,
-      max: PROVIDER_COMMAND_LIMIT_MAX,
-      name: "limit",
-      value: query.limit,
-    });
-    const offset = parseOptionalInteger(query.offset, "offset") ?? 0;
     const workspace = resolveCommandWorkspace(deps, {
       environmentId: query.environmentId,
       projectId,
     });
-    const primaryHostId = resolvePrimaryHostId(deps);
-    const isRemoteHost =
-      primaryHostId !== null && workspace.hostId !== primaryHostId;
-    const result = await callHostRetryableOnlineRpc(deps, {
-      hostId: workspace.hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command: {
-        type: "host.list_commands",
-        providerId: query.provider,
-        cwd: workspace.cwd,
-        builtinSkillsRootPath: deps.config.builtinSkillsRootPath,
-        ...(deps.config.inheritedSkillsRootPaths.length > 0
-          ? { additionalSkillsRootPaths: deps.config.inheritedSkillsRootPaths }
-          : {}),
-        // These absolute roots live on the primary machine. Remote daemons
-        // receive the same content-addressed catalog used for runtime injection.
-        injectedSkillSources: isRemoteHost
-          ? resolveSkillCatalogSources(deps)
-          : [],
-      },
-    });
+    const [result, projectSkillSources] = await Promise.all([
+      callHostRetryableOnlineRpc(deps, {
+        hostId: workspace.hostId,
+        timeoutMs: COMMAND_TIMEOUT_MS,
+        command: {
+          type: "host.list_commands",
+          providerId: query.provider,
+          cwd: workspace.cwd,
+        },
+      }),
+      workspace.cwd === null
+        ? Promise.resolve([])
+        : resolveWorkspaceProjectSkills(deps, {
+            hostId: workspace.hostId,
+            workspacePath: workspace.cwd,
+          }),
+    ]);
+    const skillCatalog = resolveSkillCatalog(deps, { projectSkillSources });
     return context.json(
       buildCommandListResponse({
         commands: result.commands,
-        limit,
-        offset,
-        query: query.query,
+        skillCatalog,
       }),
     );
   });

--- a/apps/server/src/services/plugins/plugin-agent-contributions.ts
+++ b/apps/server/src/services/plugins/plugin-agent-contributions.ts
@@ -7,6 +7,7 @@ import type {
   PluginAgentToolContribution,
   PluginMentionResolveResult,
   PluginService,
+  PluginSkillRootContribution,
 } from "./plugin-service.js";
 
 /**
@@ -19,7 +20,7 @@ import type {
  */
 type PluginAgentContributions = Pick<
   PluginService,
-  | "listSkillsRootPaths"
+  | "listSkillRootContributions"
   | "listAgentTools"
   | "listInstructionContributions"
   | "findAgentTool"
@@ -36,8 +37,8 @@ export function setPluginAgentContributions(
 }
 
 /** Skills roots contributed by running plugins (the "plugin" skill tier). */
-export function getPluginSkillsRootPaths(): string[] {
-  return contributions?.listSkillsRootPaths() ?? [];
+export function getPluginSkillRootContributions(): PluginSkillRootContribution[] {
+  return contributions?.listSkillRootContributions() ?? [];
 }
 
 /** Native tools from bb.agents.registerTool, resolved live per session start. */

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -120,6 +120,11 @@ export type {
   PluginWireLookup,
 } from "./plugin-service-internal.js";
 
+export interface PluginSkillRootContribution {
+  pluginId: string;
+  rootPath: string;
+}
+
 export interface PluginService {
   /** Whether the `plugins` experiment is currently on. */
   isEnabled(): boolean;
@@ -267,7 +272,7 @@ export interface PluginService {
    * passed to resolveInjectedSkillSources per turn. Missing directories are
    * tolerated downstream; empty when the experiment is off.
    */
-  listSkillsRootPaths(): string[];
+  listSkillRootContributions(): PluginSkillRootContribution[];
   /**
    * Native tools of running plugins (bb.agents.registerTool), ordered by
    * plugin id then registration order, deduped defensively (first wins —
@@ -1397,10 +1402,15 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
       return fail(`bb ${registration.name} failed: ${outcome.error}`);
     },
 
-    listSkillsRootPaths() {
+    listSkillRootContributions() {
       return exposedLoadedEntries()
         .sort(([a], [b]) => a.localeCompare(b))
-        .flatMap(([, plugin]) => plugin.manifest.skillsRootPaths);
+        .flatMap(([pluginId, plugin]) =>
+          plugin.manifest.skillsRootPaths.map((rootPath) => ({
+            pluginId,
+            rootPath,
+          })),
+        );
     },
 
     listAgentTools() {

--- a/apps/server/src/services/skills/injected-skills.ts
+++ b/apps/server/src/services/skills/injected-skills.ts
@@ -40,10 +40,26 @@ export interface ResolveInjectedSkillSourcesArgs {
    * skills by name, and overriding built-ins by name. Earlier roots win
    * plugin-vs-plugin name collisions.
    */
-  pluginSkillsRootPaths?: readonly string[];
+  pluginSkillRoots?: readonly PluginSkillRoot[];
   projectSkillSources?: readonly ProjectInjectedSkillSource[];
   projectSkillsRootPath?: string;
   skillTreeRegistry: SkillTreeRegistry;
+}
+
+export interface PluginSkillRoot {
+  pluginId: string;
+  rootPath: string;
+}
+
+export type SkillCatalogProvenance =
+  | { kind: "builtin" }
+  | { kind: "plugin"; pluginId: string }
+  | { kind: "project" }
+  | { kind: "user" };
+
+export interface ResolvedSkillCatalogEntry {
+  provenance: SkillCatalogProvenance;
+  runtimeSource: HostDaemonInjectedSkillSource;
 }
 
 export type ProjectInjectedSkillSource = Extract<
@@ -566,10 +582,10 @@ function excludeCollisions(
  * sources remain workspace paths so the target daemon stages their full trees
  * directly from its workspace after the server enumerates their metadata.
  */
-export function resolveInjectedSkillSources(
+export function resolveSkillCatalogEntries(
   logger: ServerLogger,
   args: ResolveInjectedSkillSourcesArgs,
-): HostDaemonInjectedSkillSource[] {
+): ResolvedSkillCatalogEntry[] {
   const { skillTreeRegistry } = args;
   if (
     args.projectSkillSources !== undefined &&
@@ -627,19 +643,21 @@ export function resolveInjectedSkillSources(
   // The plugin tier (design §4.4): sources ride the "data-dir" wire label —
   // the daemon stages every sourceType identically, so the tier is purely a
   // server-side precedence concept and needs no daemon-contract change.
-  const pluginSourceGroups = (args.pluginSkillsRootPaths ?? []).map(
-    (skillsRootPath) =>
-      readSkillsRoot({
+  const pluginSourceGroups = (args.pluginSkillRoots ?? []).map(
+    ({ pluginId, rootPath }) => ({
+      pluginId,
+      sources: readSkillsRoot({
         logger,
         skillTreeRegistry,
-        skillsRootPath,
+        skillsRootPath: rootPath,
         sourceType: "data-dir",
       }),
+    }),
   );
   const pluginSources = pluginSourceGroups.reduce<
     HostDaemonInjectedSkillSource[]
   >(
-    (higherPrioritySources, lowerPrioritySources) => [
+    (higherPrioritySources, { sources: lowerPrioritySources }) => [
       ...higherPrioritySources,
       ...excludeOverriddenLowerPriorityUserSources(logger, {
         higherPrioritySources,
@@ -669,10 +687,48 @@ export function resolveInjectedSkillSources(
     activeProjectSources.map((source) => source.name),
   );
 
+  const provenanceBySource = new Map<
+    HostDaemonInjectedSkillSource,
+    SkillCatalogProvenance
+  >();
+  for (const source of projectSources) {
+    provenanceBySource.set(source, { kind: "project" });
+  }
+  for (const source of builtinSources) {
+    provenanceBySource.set(source, { kind: "builtin" });
+  }
+  for (const source of [...dataDirSources, ...inheritedSourceGroups.flat()]) {
+    provenanceBySource.set(source, { kind: "user" });
+  }
+  for (const group of pluginSourceGroups) {
+    for (const source of group.sources) {
+      provenanceBySource.set(source, {
+        kind: "plugin",
+        pluginId: group.pluginId,
+      });
+    }
+  }
+
   return [...activeProjectSources, ...globalSources]
     .filter(
       (source) =>
         source.sourceType === "project" || !projectNames.has(source.name),
     )
-    .sort((left, right) => compareStringsByCodePoint(left.name, right.name));
+    .sort((left, right) => compareStringsByCodePoint(left.name, right.name))
+    .map((runtimeSource) => {
+      const provenance = provenanceBySource.get(runtimeSource);
+      if (provenance === undefined) {
+        throw new Error(`Missing skill provenance for ${runtimeSource.name}`);
+      }
+      return { provenance, runtimeSource };
+    });
+}
+
+export function resolveInjectedSkillSources(
+  logger: ServerLogger,
+  args: ResolveInjectedSkillSourcesArgs,
+): HostDaemonInjectedSkillSource[] {
+  return resolveSkillCatalogEntries(logger, args).map(
+    (entry) => entry.runtimeSource,
+  );
 }

--- a/apps/server/src/services/skills/skill-catalog.ts
+++ b/apps/server/src/services/skills/skill-catalog.ts
@@ -1,10 +1,11 @@
 import type { HostDaemonInjectedSkillSource } from "@bb/host-daemon-contract";
 import type { LoggedWorkSessionDeps } from "../../types.js";
-import { getPluginSkillsRootPaths } from "../plugins/plugin-agent-contributions.js";
+import { getPluginSkillRootContributions } from "../plugins/plugin-agent-contributions.js";
 import { generatedSkillsRootPath } from "../plugins/plugin-commands-skill.js";
 import {
-  resolveInjectedSkillSources,
+  resolveSkillCatalogEntries,
   type ProjectInjectedSkillSource,
+  type ResolvedSkillCatalogEntry,
 } from "./injected-skills.js";
 
 interface ResolveSkillCatalogSourcesArgs {
@@ -20,14 +21,21 @@ export function resolveSkillCatalogSources(
   deps: Pick<LoggedWorkSessionDeps, "config" | "logger" | "skillTreeRegistry">,
   args: ResolveSkillCatalogSourcesArgs = {},
 ): HostDaemonInjectedSkillSource[] {
-  return resolveInjectedSkillSources(deps.logger, {
+  return resolveSkillCatalog(deps, args).map((entry) => entry.runtimeSource);
+}
+
+export function resolveSkillCatalog(
+  deps: Pick<LoggedWorkSessionDeps, "config" | "logger" | "skillTreeRegistry">,
+  args: ResolveSkillCatalogSourcesArgs = {},
+): ResolvedSkillCatalogEntry[] {
+  return resolveSkillCatalogEntries(deps.logger, {
     additionalSkillsRootPaths: [
       ...deps.config.inheritedSkillsRootPaths,
       generatedSkillsRootPath(deps.config.dataDir),
     ],
     builtinSkillsRootPath: deps.config.builtinSkillsRootPath,
     dataDir: deps.config.dataDir,
-    pluginSkillsRootPaths: getPluginSkillsRootPaths(),
+    pluginSkillRoots: getPluginSkillRootContributions(),
     ...(args.projectSkillSources !== undefined
       ? { projectSkillSources: args.projectSkillSources }
       : {}),

--- a/apps/server/src/services/threads/provider-command-typeahead.ts
+++ b/apps/server/src/services/threads/provider-command-typeahead.ts
@@ -13,19 +13,7 @@ import {
 import type { HostProviderCommand } from "@bb/host-daemon-contract";
 import type { AppDeps } from "../../types.js";
 import { requirePrimaryHostId } from "../hosts/primary-host.js";
-
-/**
- * Default `limit` applied when the route receives no `limit` query param.
- * Matches the composer mention menu cap so the command and mention menus show
- * the same number of rows.
- */
-export const PROVIDER_COMMAND_DEFAULT_LIMIT = 8;
-
-/**
- * Upper bound on the `limit` query param. Command/skill sets are small local
- * directories, so this only guards against absurd client requests.
- */
-export const PROVIDER_COMMAND_LIMIT_MAX = 50;
+import type { ResolvedSkillCatalogEntry } from "../skills/injected-skills.js";
 
 const BUILT_IN_PROVIDER_COMMANDS: ProviderCommand[] = [
   {
@@ -132,28 +120,16 @@ function toProviderCommand(command: HostProviderCommand): ProviderCommand {
   };
 }
 
-function commandSearchNames(command: ProviderCommand): string[] {
-  const name = command.name.toLowerCase();
-  if (command.source !== "skill") {
-    return [name];
-  }
-  const separatorIndex = name.lastIndexOf(":");
-  if (separatorIndex < 0 || separatorIndex === name.length - 1) {
-    return [name];
-  }
-  return [name, name.slice(separatorIndex + 1)];
-}
-
-function matchesQuery(command: ProviderCommand, query: string): boolean {
-  if (query === "") {
-    return true;
-  }
-  if (commandSearchNames(command).some((name) => name.includes(query))) {
-    return true;
-  }
-  return command.description !== null
-    ? command.description.toLowerCase().includes(query)
-    : false;
+function toSkillCommand(entry: ResolvedSkillCatalogEntry): ProviderCommand {
+  const { provenance, runtimeSource } = entry;
+  return {
+    name: runtimeSource.name,
+    source: "skill",
+    origin: provenance.kind === "project" ? "project" : "user",
+    description: runtimeSource.description,
+    argumentHint: null,
+    ...(provenance.kind === "plugin" ? { pluginId: provenance.pluginId } : {}),
+  };
 }
 
 /**
@@ -185,11 +161,7 @@ function commandOriginRank(command: ProviderCommand): number {
   }
 }
 
-function compareForQuery(
-  a: ProviderCommand,
-  b: ProviderCommand,
-  query: string,
-): number {
+function compareCommands(a: ProviderCommand, b: ProviderCommand): number {
   // Section rank is the PRIMARY key so the flat response is grouped in the
   // composer menu's visual order (skills → project commands → user commands).
   // The composer walks this flat order for keyboard nav, so deriving both from
@@ -201,17 +173,6 @@ function compareForQuery(
   if (bySection !== 0) {
     return bySection;
   }
-  if (query !== "") {
-    const aPrefix = commandSearchNames(a).some((name) =>
-      name.startsWith(query),
-    );
-    const bPrefix = commandSearchNames(b).some((name) =>
-      name.startsWith(query),
-    );
-    if (aPrefix !== bPrefix) {
-      return aPrefix ? -1 : 1;
-    }
-  }
   // Same section + same name is a true tie: section rank (the primary key) is a
   // pure function of source+origin, so two entries that reach here already share
   // a section and therefore a source. A same-named skill and legacy command land
@@ -221,35 +182,24 @@ function compareForQuery(
 
 export interface BuildCommandListResponseArgs {
   commands: HostProviderCommand[];
-  limit: number;
-  offset: number;
-  query: string | undefined;
+  skillCatalog: readonly ResolvedSkillCatalogEntry[];
 }
 
 /**
- * Server policy over the daemon's raw command set: case-insensitive filter,
- * de-dup by `(source, name)` (project wins), section-grouped
- * (skills → project commands → user commands) then prefix-then-alphabetical
- * sort, offset, and truncation to `limit`. The section grouping mirrors the
+ * Server policy over the daemon's raw command set: de-dup by `(source, name)`
+ * (project wins), then section-grouped and alphabetically sorted. The section grouping mirrors the
  * composer menu's visual order so the flat response and the rendered sections
- * stay in lockstep. `truncated` reflects whether more rows remain after this
- * page, so the client can fetch the next page while keyboard navigation
- * approaches the end.
+ * stay in lockstep. Filtering is local to the composer, so discovery runs once
+ * per project/environment/provider snapshot rather than once per keystroke.
  */
 export function buildCommandListResponse(
   args: BuildCommandListResponseArgs,
 ): CommandListResponse {
-  const query = (args.query ?? "").toLowerCase();
-  const filtered = dedupeBySourceAndName(
-    [
-      ...BUILT_IN_PROVIDER_COMMANDS,
-      ...args.commands.map(toProviderCommand),
-    ].filter((command) => matchesQuery(command, query)),
-  ).sort((a, b) => compareForQuery(a, b, query));
-  const end = args.offset + args.limit;
-
   return {
-    commands: filtered.slice(args.offset, end),
-    truncated: filtered.length > end,
+    commands: dedupeBySourceAndName([
+      ...BUILT_IN_PROVIDER_COMMANDS,
+      ...args.skillCatalog.map(toSkillCommand),
+      ...args.commands.map(toProviderCommand),
+    ]).sort(compareCommands),
   };
 }

--- a/apps/server/test/public/public-project-commands.test.ts
+++ b/apps/server/test/public/public-project-commands.test.ts
@@ -30,29 +30,30 @@ interface RegisterCommandRpcArgs {
 }
 
 /**
- * Mocks the host online-RPC boundary for `host.list_commands` only: returns the
- * supplied raw command set and records every request so tests can assert what
- * `cwd`/`providerId` the server sent. All other RPC types fail loudly so an
- * unexpected daemon call surfaces instead of silently passing.
+ * Mocks provider-native command discovery and an empty project skill root.
+ * Only list-commands requests are recorded for concise assertions.
  */
 function registerCommandRpc(
   harness: Parameters<typeof registerHostRpcResponder>[0],
   args: RegisterCommandRpcArgs,
 ): CommandRpcStub {
   const stub: CommandRpcStub = { commands: args.commands, requests: [] };
-  const responder = registerHostRpcResponder(harness, {
+  registerHostRpcResponder(harness, {
     hostId: args.hostId,
     sessionId: args.sessionId,
     handle: (request) => {
-      if (request.command.type !== "host.list_commands") {
-        throw new Error(
-          `Unexpected RPC command ${request.command.type} in command typeahead test`,
-        );
+      if (request.command.type === "host.list_files") {
+        return { ok: true, result: { files: [], truncated: false } };
       }
-      return { ok: true, result: { commands: stub.commands } };
+      if (request.command.type === "host.list_commands") {
+        stub.requests.push(request);
+        return { ok: true, result: { commands: stub.commands } };
+      }
+      throw new Error(
+        `Unexpected RPC command ${request.command.type} in command typeahead test`,
+      );
     },
   });
-  stub.requests = responder.requests;
   return stub;
 }
 
@@ -85,7 +86,7 @@ function legacyCommand(
 }
 
 describe("public project command typeahead route", () => {
-  it("sends the synchronized skill catalog when discovery targets another machine", async () => {
+  it("uses the server skill catalog when discovery targets another machine", async () => {
     await withTestHarness(async (harness) => {
       const primaryHost = seedHost(harness.deps, {
         id: "host-commands-primary",
@@ -117,7 +118,7 @@ describe("public project command typeahead route", () => {
       const stub = registerCommandRpc(harness, {
         hostId: remoteHost.id,
         sessionId: session.id,
-        commands: [skill("synced-remote", "user")],
+        commands: [],
       });
 
       const response = await harness.app.request(
@@ -125,24 +126,23 @@ describe("public project command typeahead route", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(stub.requests[0]?.command).toEqual(
-        expect.objectContaining({
-          type: "host.list_commands",
-          providerId: "codex",
-          cwd: "/tmp/remote-commands-env",
-          injectedSkillSources: expect.arrayContaining([
-            expect.objectContaining({
-              kind: "tree",
-              sourceType: "data-dir",
-              name: "synced-remote",
-            }),
-          ]),
-        }),
-      );
+      const body = commandListResponseSchema.parse(await readJson(response));
+      expect(body.commands).toContainEqual({
+        name: "synced-remote",
+        source: "skill",
+        origin: "user",
+        description: "Synced remote skill",
+        argumentHint: null,
+      });
+      expect(stub.requests[0]?.command).toEqual({
+        type: "host.list_commands",
+        providerId: "codex",
+        cwd: "/tmp/remote-commands-env",
+      });
     });
   });
 
-  it("filters, sorts, and de-dupes claude-code commands with project winning over user", async () => {
+  it("sorts and de-dupes the command catalog with project winning over user", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
         id: "host-commands-claude",
@@ -176,18 +176,31 @@ describe("public project command typeahead route", () => {
       });
 
       const response = await harness.app.request(
-        `/api/v1/projects/${project.id}/commands?provider=claude-code&environmentId=${environment.id}&query=re`,
+        `/api/v1/projects/${project.id}/commands?provider=claude-code&environmentId=${environment.id}`,
       );
 
       expect(response.status).toBe(200);
       const body = commandListResponseSchema.parse(await readJson(response));
-      // query "re": names review/refactor match; deploy does not. Section rank
-      // is primary (skills before legacy commands), then within a section the
-      // prefix-then-alphabetical order: skills `refactor` < `review`, then the
-      // `command`-source `review`. The (skill review) collision keeps the
+      // Section rank is primary (built-ins, skills, then legacy commands),
+      // with alphabetical ordering inside each section. The (skill review)
+      // collision keeps the
       // project-origin entry over the user-origin one, while the cross-source
       // (command review) is retained as a distinct invocation.
       expect(body.commands).toEqual([
+        {
+          name: "compact",
+          source: "command",
+          origin: "builtin",
+          description: "Compact context",
+          argumentHint: null,
+        },
+        {
+          name: "deploy",
+          source: "skill",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
         {
           name: "refactor",
           source: "skill",
@@ -210,7 +223,6 @@ describe("public project command typeahead route", () => {
           argumentHint: null,
         },
       ]);
-      expect(body.truncated).toBe(false);
 
       // Exactly one RPC, carrying the requested provider + resolved env cwd.
       expect(stub.requests.map((request) => request.command)).toEqual([
@@ -218,8 +230,6 @@ describe("public project command typeahead route", () => {
           type: "host.list_commands",
           providerId: "claude-code",
           cwd: "/tmp/claude-commands-env",
-          builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-          injectedSkillSources: [],
         },
       ]);
     });
@@ -259,18 +269,15 @@ describe("public project command typeahead route", () => {
         "prd",
         "skill-installer",
       ]);
-      expect(body.truncated).toBe(false);
       expect(stub.requests[0]?.command).toEqual({
         type: "host.list_commands",
         providerId: "codex",
         cwd: "/tmp/codex-commands-env",
-        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-        injectedSkillSources: [],
       });
     });
   });
 
-  it("passes inherited skills roots to command discovery", async () => {
+  it("keeps inherited bb skill roots out of provider-native discovery", async () => {
     await withTestHarness(
       {
         inheritedSkillsRootPaths: ["/tmp/bb-parent-skills"],
@@ -295,27 +302,25 @@ describe("public project command typeahead route", () => {
         });
 
         const response = await harness.app.request(
-          `/api/v1/projects/${project.id}/commands?provider=codex&environmentId=&query=stories`,
+          `/api/v1/projects/${project.id}/commands?provider=codex&environmentId=`,
         );
 
         expect(response.status).toBe(200);
         const body = commandListResponseSchema.parse(await readJson(response));
         expect(body.commands.map((command) => command.name)).toEqual([
+          "compact",
           "stories",
         ]);
         expect(stub.requests[0]?.command).toEqual({
           type: "host.list_commands",
           providerId: "codex",
           cwd: "/tmp/inherited-skills-project",
-          builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-          additionalSkillsRootPaths: ["/tmp/bb-parent-skills"],
-          injectedSkillSources: [],
         });
       },
     );
   });
 
-  it("matches namespaced skills by their direct skill name", async () => {
+  it("returns the complete snapshot for local composer filtering", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
         id: "host-commands-direct-skill",
@@ -340,15 +345,17 @@ describe("public project command typeahead route", () => {
       });
 
       const response = await harness.app.request(
-        `/api/v1/projects/${project.id}/commands?provider=codex&environmentId=${environment.id}&query=review&limit=1`,
+        `/api/v1/projects/${project.id}/commands?provider=codex&environmentId=${environment.id}`,
       );
 
       expect(response.status).toBe(200);
       const body = commandListResponseSchema.parse(await readJson(response));
       expect(body.commands.map((command) => command.name)).toEqual([
+        "compact",
+        "alpha-review-notes",
         "ottonomous:review",
+        "zeta-review",
       ]);
-      expect(body.truncated).toBe(true);
     });
   });
 
@@ -376,7 +383,7 @@ describe("public project command typeahead route", () => {
 
       expect(response.status).toBe(200);
       const body = commandListResponseSchema.parse(await readJson(response));
-      expect(body).toEqual({ commands: [], truncated: false });
+      expect(body).toEqual({ commands: [] });
       // No daemon roundtrip for a provider without a command surface.
       expect(stub.requests).toEqual([]);
     });
@@ -398,9 +405,7 @@ describe("public project command typeahead route", () => {
       const stub = registerCommandRpc(harness, {
         hostId: host.id,
         sessionId: session.id,
-        commands: [
-          skill("bb-cli", "user", { description: "Use the bb CLI" }),
-        ],
+        commands: [skill("bb-cli", "user", { description: "Use the bb CLI" })],
       });
 
       const response = await harness.app.request(
@@ -417,8 +422,6 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "pi",
         cwd: "/tmp/pi-commands-env",
-        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-        injectedSkillSources: [],
       });
     });
   });
@@ -457,8 +460,6 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: "/tmp/no-env-project",
-        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-        injectedSkillSources: [],
       });
     });
   });
@@ -503,8 +504,6 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: "/tmp/provisioning-project",
-        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-        injectedSkillSources: [],
       });
     });
   });
@@ -542,8 +541,6 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: null,
-        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-        injectedSkillSources: [],
       });
     });
   });
@@ -574,8 +571,6 @@ describe("public project command typeahead route", () => {
         type: "host.list_commands",
         providerId: "codex",
         cwd: null,
-        builtinSkillsRootPath: harness.deps.config.builtinSkillsRootPath,
-        injectedSkillSources: [],
       });
     });
   });
@@ -602,7 +597,7 @@ describe("public project command typeahead route", () => {
     });
   });
 
-  it("honors limit, offset, and reports truncation; empty query returns the full capped list", async () => {
+  it("returns the full command catalog in one snapshot", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
         id: "host-commands-limit",
@@ -627,32 +622,6 @@ describe("public project command typeahead route", () => {
         ],
       });
 
-      const limitedResponse = await harness.app.request(
-        `/api/v1/projects/${project.id}/commands?provider=claude-code&environmentId=${environment.id}&limit=2`,
-      );
-      expect(limitedResponse.status).toBe(200);
-      const limited = commandListResponseSchema.parse(
-        await readJson(limitedResponse),
-      );
-      expect(limited.commands.map((command) => command.name)).toEqual([
-        "compact",
-        "alpha",
-      ]);
-      expect(limited.truncated).toBe(true);
-
-      const nextPageResponse = await harness.app.request(
-        `/api/v1/projects/${project.id}/commands?provider=claude-code&environmentId=${environment.id}&limit=2&offset=2`,
-      );
-      expect(nextPageResponse.status).toBe(200);
-      const nextPage = commandListResponseSchema.parse(
-        await readJson(nextPageResponse),
-      );
-      expect(nextPage.commands.map((command) => command.name)).toEqual([
-        "bravo",
-        "charlie",
-      ]);
-      expect(nextPage.truncated).toBe(true);
-
       const fullResponse = await harness.app.request(
         `/api/v1/projects/${project.id}/commands?provider=claude-code&environmentId=${environment.id}`,
       );
@@ -667,7 +636,6 @@ describe("public project command typeahead route", () => {
         "charlie",
         "delta",
       ]);
-      expect(full.truncated).toBe(false);
     });
   });
 });

--- a/apps/server/test/services/plugins/heroes.test.ts
+++ b/apps/server/test/services/plugins/heroes.test.ts
@@ -139,15 +139,17 @@ describe("hero plugin: agent-enrichment", () => {
   });
 
   it("auto-imports its skills/ directory through the plugin skills tier", () => {
-    const pluginSkillsRootPaths = harness.pluginService.listSkillsRootPaths();
-    expect(pluginSkillsRootPaths).toContain(
-      join(EXAMPLES_DIR, "agent-enrichment", "skills"),
+    const pluginSkillRoots = harness.pluginService.listSkillRootContributions();
+    expect(pluginSkillRoots).toContainEqual(
+      expect.objectContaining({
+        rootPath: join(EXAMPLES_DIR, "agent-enrichment", "skills"),
+      }),
     );
     // Resolved the same way thread-runtime-config wires the plugin tier.
     const sources = resolveInjectedSkillSources(testLogger, {
       builtinSkillsRootPath: join(harness.config.dataDir, "builtin-skills"),
       dataDir: harness.config.dataDir,
-      pluginSkillsRootPaths,
+      pluginSkillRoots,
       skillTreeRegistry: harness.deps.skillTreeRegistry,
     });
     const skill = sources.find((source) => source.name === "repo-conventions");

--- a/apps/server/test/services/plugins/plugin-agent-contributions.test.ts
+++ b/apps/server/test/services/plugins/plugin-agent-contributions.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   SkillTreeRegistry,
   resolveInjectedSkillSources,
+  resolveSkillCatalogEntries,
 } from "../../../src/services/skills/injected-skills.js";
 import { buildThreadStartCommand } from "../../../src/services/threads/thread-commands.js";
 import { resolveExecutionOptions } from "../../../src/services/threads/thread-runtime-config.js";
@@ -141,13 +142,14 @@ describe("plugin skills tier", () => {
     const projectGamma = await writeSkill(projectRoot, "gamma"); // beats the plugin copy
 
     const skillTreeRegistry = new SkillTreeRegistry();
-    const sources = resolveInjectedSkillSources(testLogger, {
+    const entries = resolveSkillCatalogEntries(testLogger, {
       builtinSkillsRootPath: builtinRoot,
       dataDir,
-      pluginSkillsRootPaths: service.listSkillsRootPaths(),
+      pluginSkillRoots: service.listSkillRootContributions(),
       projectSkillsRootPath: projectRoot,
       skillTreeRegistry,
     });
+    const sources = entries.map((entry) => entry.runtimeSource);
     const byName = new Map(sources.map((source) => [source.name, source]));
 
     const alpha = byName.get("alpha");
@@ -164,6 +166,9 @@ describe("plugin skills tier", () => {
       throw new Error("Expected server-owned tree sources");
     }
     expect(alpha.sourceType).toBe("data-dir");
+    expect(
+      entries.find((entry) => entry.runtimeSource.name === "alpha")?.provenance,
+    ).toEqual({ kind: "plugin", pluginId: "skiller" });
     expect(beta.sourceType).toBe("data-dir");
     expect(byName.get("gamma")).toMatchObject({
       kind: "workspace-path",
@@ -184,17 +189,19 @@ describe("plugin skills tier", () => {
     });
     await service.installPath(rootDir);
 
-    expect(service.listSkillsRootPaths()).toEqual([join(rootDir, "custom")]);
+    expect(service.listSkillRootContributions()).toEqual([
+      { pluginId: "relocated", rootPath: join(rootDir, "custom") },
+    ]);
     const sources = resolveInjectedSkillSources(testLogger, {
       builtinSkillsRootPath: join(workDir, "no-builtins"),
       dataDir: join(workDir, "data"),
-      pluginSkillsRootPaths: service.listSkillsRootPaths(),
+      pluginSkillRoots: service.listSkillRootContributions(),
       skillTreeRegistry: new SkillTreeRegistry(),
     });
     expect(sources.map((source) => source.name)).toEqual(["relocated-skill"]);
 
     experimentOn = false;
-    expect(service.listSkillsRootPaths()).toEqual([]);
+    expect(service.listSkillRootContributions()).toEqual([]);
   });
 
   it("a skill added after install is discovered on the next resolve after reload", async () => {
@@ -208,7 +215,7 @@ describe("plugin skills tier", () => {
       resolveInjectedSkillSources(testLogger, {
         builtinSkillsRootPath: join(workDir, "no-builtins"),
         dataDir: join(workDir, "data"),
-        pluginSkillsRootPaths: service.listSkillsRootPaths(),
+        pluginSkillRoots: service.listSkillRootContributions(),
         skillTreeRegistry: new SkillTreeRegistry(),
       }).map((source) => source.name);
 

--- a/apps/server/test/services/threads/provider-command-typeahead.test.ts
+++ b/apps/server/test/services/threads/provider-command-typeahead.test.ts
@@ -27,9 +27,7 @@ describe("buildCommandListResponse", () => {
           argumentHint: "<target>",
         },
       ],
-      limit: 10,
-      offset: 0,
-      query: "compact",
+      skillCatalog: [],
     });
 
     expect(response.commands).toEqual([
@@ -43,22 +41,32 @@ describe("buildCommandListResponse", () => {
     ]);
   });
 
-  it("matches namespaced skills by their direct skill name", () => {
+  it("includes plugin provenance on canonical skill rows", () => {
     const response = buildCommandListResponse({
-      commands: [
-        skill("alpha-review-notes"),
-        skill("ottonomous:review"),
-        skill("zeta-review"),
+      commands: [],
+      skillCatalog: [
+        {
+          provenance: { kind: "plugin", pluginId: "ottonomous" },
+          runtimeSource: {
+            kind: "tree",
+            sourceType: "data-dir",
+            name: "review",
+            description: "Review the current change",
+            treeHash: "abc123",
+            entryPath: "SKILL.md",
+          },
+        },
       ],
-      limit: 1,
-      offset: 0,
-      query: "review",
     });
 
-    expect(response.commands.map((command) => command.name)).toEqual([
-      "ottonomous:review",
-    ]);
-    expect(response.truncated).toBe(true);
+    expect(response.commands).toContainEqual({
+      name: "review",
+      source: "skill",
+      origin: "user",
+      description: "Review the current change",
+      argumentHint: null,
+      pluginId: "ottonomous",
+    });
   });
 
   it("keeps the first user-origin skill when global roots provide the same name", () => {
@@ -67,12 +75,12 @@ describe("buildCommandListResponse", () => {
         skill("bb-cli", { description: "Data-dir override" }),
         skill("bb-cli", { description: "Built-in default" }),
       ],
-      limit: 10,
-      offset: 0,
-      query: "bb-cli",
+      skillCatalog: [],
     });
 
-    expect(response.commands).toEqual([
+    expect(
+      response.commands.filter((command) => command.name === "bb-cli"),
+    ).toEqual([
       {
         name: "bb-cli",
         source: "skill",

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -1554,7 +1554,7 @@ describe("thread runtime config", () => {
       }>;
     }): void {
       setPluginAgentContributions({
-        listSkillsRootPaths: () => [],
+        listSkillRootContributions: () => [],
         listAgentTools: () => args.tools ?? [],
         listInstructionContributions: () => args.instructions ?? [],
         findAgentTool: () => undefined,

--- a/docs/agent-api-cli-parity.md
+++ b/docs/agent-api-cli-parity.md
@@ -105,14 +105,14 @@ Both attachment flags are repeatable. `thread spawn` additionally supports
 
 ## Projects
 
-| SDK                                               | CLI                                                                                                 |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `bb.projects.promptHistory({ projectId, limit })` | `bb project history <id> [--limit <count>]`                                                         |
-| `bb.projects.reorder(...)`                        | `bb project reorder <id> [--after <id>] [--before <id>]`                                            |
-| `bb.projects.branches(...)`                       | `bb project branches <id> --host <id> [--query <query>] [--limit <count>]`                          |
-| `bb.projects.paths(...)`                          | `bb project paths <id> [--environment <id>] [--query <query>] [--limit <count>]`                    |
-| `bb.projects.commands(...)`                       | `bb project commands <id> --provider <id> [--environment <id>] [--query <query>] [--limit <count>]` |
-| `bb.projects.defaultExecutionOptions(...)`        | Available through the SDK; existing CLI execution flags consume these defaults.                     |
+| SDK                                               | CLI                                                                              |
+| ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `bb.projects.promptHistory({ projectId, limit })` | `bb project history <id> [--limit <count>]`                                      |
+| `bb.projects.reorder(...)`                        | `bb project reorder <id> [--after <id>] [--before <id>]`                         |
+| `bb.projects.branches(...)`                       | `bb project branches <id> --host <id> [--query <query>] [--limit <count>]`       |
+| `bb.projects.paths(...)`                          | `bb project paths <id> [--environment <id>] [--query <query>] [--limit <count>]` |
+| `bb.projects.commands(...)`                       | `bb project commands <id> --provider <id> [--environment <id>]`                  |
+| `bb.projects.defaultExecutionOptions(...)`        | Available through the SDK; existing CLI execution flags consume these defaults.  |
 
 Existing project source operations remain available under
 `bb.projects.sources` and `bb project source`.

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 53 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 54 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,
@@ -603,7 +603,7 @@ export type HostCommandOrigin = z.infer<typeof hostCommandOriginSchema>;
 
 /**
  * A discovered provider skill or legacy slash command. The daemon returns the
- * raw parsed records; server policy (filter/de-dup/sort/limit) is applied on
+ * raw parsed records; server policy (merge/de-dup/sort) is applied on
  * top. Mirrors `@bb/server-contract`'s `ProviderCommand` shape (the contract
  * packages intentionally define matching record shapes independently, like
  * `hostPathEntrySchema` / `workspacePathEntrySchema`).
@@ -619,21 +619,18 @@ export type HostProviderCommand = z.infer<typeof hostProviderCommandSchema>;
 
 /**
  * List the provider's discoverable skills / legacy slash commands. The daemon
- * resolves the user-home roots itself and scans the project roots under `cwd`
- * when provided; `cwd: null` (unprovisioned thread) skips the project roots and
- * returns only user-origin entries. Synchronized skills are supplied as the
- * same content-addressed sources used by thread runtime injection. Returns the
- * full raw set — the server owns de-dup/sort/limit, so there is no `truncated`
- * field here.
+ * resolves provider-native user-home roots itself and scans provider-native
+ * project roots under `cwd` when provided; `cwd: null` skips project roots.
+ * bb-managed skills are resolved by the server's canonical skill catalog and
+ * never cross this discovery boundary.
  */
-const hostListCommandsCommandSchema = z.object({
-  type: z.literal("host.list_commands"),
-  providerId: z.string().min(1),
-  cwd: z.string().min(1).nullable(),
-  builtinSkillsRootPath: z.string().min(1),
-  additionalSkillsRootPaths: z.array(z.string().min(1)).optional(),
-  injectedSkillSources: z.array(hostDaemonInjectedSkillSourceSchema),
-});
+const hostListCommandsCommandSchema = z
+  .object({
+    type: z.literal("host.list_commands"),
+    providerId: z.string().min(1),
+    cwd: z.string().min(1).nullable(),
+  })
+  .strict();
 
 /**
  * List a bounded page of git branches at an absolute host path. Path-only

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -678,8 +678,6 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
     "ACP permission CLI config only needs args for modes that differ from the agent default.",
   "hostDaemonOnlineRpcCommandSchema.acpLaunchSpec.permissionCli.insertAfterArgs":
     "ACP permission CLI config omits insertAfterArgs when permission args should be inserted before all configured agent args.",
-  "hostDaemonOnlineRpcCommandSchema.additionalSkillsRootPaths":
-    "host.list_commands may include inherited skill roots for source-dev app instances; ordinary app instances scan data-dir and built-in skills.",
   "hostDaemonOnlineRpcCommandSchema.query":
     "host.list_files may omit a search string to list files without filtering.",
   "hostDaemonOnlineRpcCommandSchema.path":
@@ -1226,15 +1224,11 @@ describe("host-daemon command schemas", () => {
         type: "host.list_commands",
         providerId: "claude-code",
         cwd: "/tmp/workspace",
-        builtinSkillsRootPath: "/tmp/builtin-skills",
-        injectedSkillSources: [],
       }),
     ).toMatchObject({
       type: "host.list_commands",
       providerId: "claude-code",
       cwd: "/tmp/workspace",
-      builtinSkillsRootPath: "/tmp/builtin-skills",
-      injectedSkillSources: [],
     });
 
     expect(

--- a/packages/server-contract/src/api/projects.ts
+++ b/packages/server-contract/src/api/projects.ts
@@ -257,6 +257,8 @@ export const providerCommandSchema = z.object({
   description: z.string().nullable(),
   /** `null` = no argument hint. */
   argumentHint: z.string().nullable(),
+  /** Present when this skill is contributed by a running bb plugin. */
+  pluginId: z.string().min(1).optional(),
 });
 export type ProviderCommand = z.infer<typeof providerCommandSchema>;
 
@@ -306,23 +308,17 @@ export function providerCommandSectionRank(cmd: {
 
 export const commandListResponseSchema = z.object({
   commands: z.array(providerCommandSchema),
-  truncated: z.boolean(),
 });
 export type CommandListResponse = z.infer<typeof commandListResponseSchema>;
 
-/**
- * Command typeahead query. Extends the shared project file-search query
- * (`query`/`limit`/`environmentId`, including the empty-string→null wire
- * convention) with the `provider` whose skill/command surface to discover.
- * `query` here is a case-insensitive substring filter on command name/description.
- * Namespaced skills also match on their local name after `:` (for example,
- * `review` matches `ottonomous:review`).
- */
-export const projectCommandsQuerySchema = projectFilesQuerySchema.extend({
-  /** Provider whose command/skill surface to discover (e.g. `claude-code`, `codex`). */
-  provider: z.string().min(1),
-  offset: z.string().regex(/^\d+$/).optional(),
-});
+/** Query for the complete command catalog available to a project and provider. */
+export const projectCommandsQuerySchema = projectFilesQuerySchema
+  .pick({ environmentId: true })
+  .extend({
+    /** Provider whose command/skill surface to discover (e.g. `claude-code`, `codex`). */
+    provider: z.string().min(1),
+  })
+  .strict();
 export type ProjectCommandsQuery = z.infer<typeof projectCommandsQuerySchema>;
 
 export const projectResponseSchema = projectSchema.extend({

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -1500,6 +1500,27 @@ describe("server-contract clients", () => {
     ).toEqual({ path: "/Users/me/notes/plan.md" });
   });
 
+  it("keeps project command catalog queries snapshot-only", () => {
+    expect(
+      contract.projectCommandsQuerySchema.parse({
+        provider: "codex",
+        environmentId: "",
+      }),
+    ).toEqual({ provider: "codex", environmentId: null });
+    expect(() =>
+      contract.projectCommandsQuerySchema.parse({
+        provider: "codex",
+        query: "review",
+      }),
+    ).toThrow();
+    expect(() =>
+      contract.projectCommandsQuerySchema.parse({
+        provider: "codex",
+        limit: "50",
+      }),
+    ).toThrow();
+  });
+
   it("rejects zero timeline pagination cursor sequences", () => {
     expect(() =>
       contract.timelinePaginationCursorSchema.parse({


### PR DESCRIPTION
## Summary

- make the server runtime skill catalog the canonical source for built-in, user, project, and plugin skills, including plugin provenance
- keep host-daemon discovery provider-native, then merge provider commands and skills into the same composer catalog
- replace paginated per-keystroke discovery with one cached snapshot, local ranking/filtering, and plugin lifecycle invalidation
- carry plugin identity to the menu icon and simplify the API, SDK, and CLI contracts
- make one canonical flat suggestion order drive menu sections, keyboard navigation, and Enter/Tab application

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/server-contract`
- `pnpm exec turbo run build --filter=@bb/app --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/cli --filter=@bb/sdk`
- app: 233 files, 1,529 tests passed
- host daemon: 39 files, 419 tests passed
- server contract: 4 files, 37 tests passed
- focused command and mention navigation coverage: 3 files, 59 tests passed
- focused server command and install coverage: 2 files, 13 tests passed with the preinstalled global `bb-app` removed from `PATH`
- app lint: 0 errors (107 existing warnings)
- dev-browser E2E: installed the example agent-enrichment plugin, opened `/repo`, verified `repo-conventions` appeared with the plugin icon, selected it, and observed exactly one command-catalog request while typing
- dev-browser E2E: walked all 99 kitchen-sink command rows with ArrowDown and observed zero differences between the highlighted row and DOM order; Enter applied the final highlighted command
- CLI smoke: `bb project commands` returned the full catalog with `pluginId: agent-enrichment` for `repo-conventions`