### PR TITLE
Make follow-up composer responsive in narrow splits

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -185,6 +185,12 @@
     min-width: 0;
   }
 
+  [data-promptbox-editor-content]
+    .ProseMirror
+    p.is-editor-empty:first-child::before {
+    content: attr(data-placeholder);
+  }
+
   /*
    * Light up the `ultracode` keyword in the prompt editor with animated purple
    * sparkles (mirrors Claude Code). The wrapping span is added as a ProseMirror
@@ -324,7 +330,202 @@
       display: none !important;
     }
   }
+}
 
+/*
+ * A split can make a thread narrow without making the browser viewport
+ * compact. Reuse the follow-up composer's one-line presentation at the
+ * prompt's existing compact-control breakpoint, then let focus expand it.
+ * This is intentionally unlayered so it can override the prompt's utility
+ * classes. The mobile path still owns its React state so software-keyboard
+ * expansion remains synchronized with visualViewport changes.
+ */
+@container promptbox-shell (max-width: 30rem) {
+  [data-follow-up-composer] [data-promptbox-layout] {
+    height: 100%;
+  }
+
+  [data-follow-up-composer] [data-promptbox-main] {
+    position: static;
+  }
+
+  [data-follow-up-composer] [data-promptbox-action-row] {
+    padding-right: 3rem;
+  }
+
+  [data-follow-up-composer] [data-promptbox-submit-group] {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    z-index: 1;
+  }
+
+  [data-follow-up-composer] [data-promptbox-submit-action] {
+    width: 2rem;
+    height: 2rem;
+    margin-left: 0;
+    padding: 0;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    ) {
+    overflow: hidden;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-main] {
+    height: 3rem;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-expanded-only] {
+    display: none !important;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-scroll] {
+    height: 3rem !important;
+    min-height: 3rem !important;
+    max-height: 3rem !important;
+    overflow: hidden;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-right: 3.5rem;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content] {
+    display: flex;
+    align-items: center;
+    height: 100%;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable] {
+    width: 100%;
+    min-height: 0 !important;
+    max-height: 1.7em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap !important;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    > *,
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    :where(blockquote, h1, h2, h3, h4, h5, h6, li, ol, p, ul) {
+    display: inline;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    list-style: none;
+    white-space: inherit;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    > *
+    + *::before,
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    :where(blockquote, li)
+    > *
+    + *::before,
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    :where(ol, ul)
+    > li
+    + li::before {
+    content: " ";
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    br {
+    display: inline;
+    content: " ";
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror[contenteditable]
+    br::after {
+    content: " ";
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .prompt-mention-pill
+    > span:last-child {
+    min-width: 0;
+  }
+
+  [data-follow-up-composer]:not([data-follow-up-composer-expanded])
+    [data-promptbox]:not([data-promptbox-zen]):not(
+      [data-promptbox-voice-active]
+    )
+    [data-promptbox-editor-content]
+    .ProseMirror
+    p.is-editor-empty:first-child::before {
+    content: var(--promptbox-container-compact-placeholder);
+  }
+}
+
+@layer base {
   /*
    * Sonner clips collapsed native toasts on the toast node. Our custom card
    * lives inside that node, so clip it there too when it is behind the front

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
     onSubmit,
     submission,
     zenMode,
+    heightAnimationKey,
   }: {
     footerStart?: ReactNode;
     compact?: {
@@ -59,11 +60,13 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
     onSubmit: () => void;
     submission?: { onModifierSubmit?: () => void };
     zenMode?: { resetKey: string | number };
+    heightAnimationKey?: string | number;
   }) => (
     <div
       data-testid="prompt-box"
       data-compact={compact?.isCompact}
       data-zen-reset-key={zenMode?.resetKey}
+      data-height-animation-key={heightAnimationKey}
     >
       {footerStart}
       <input aria-label="Follow-up prompt" />
@@ -466,6 +469,44 @@ describe("FollowUpPromptBox", () => {
       null,
     );
     expect(screen.getByText("Local environment")).toBeTruthy();
+  });
+
+  it("exposes focus state so narrow prompt containers can expand", () => {
+    render(
+      <>
+        <FollowUpPromptBox
+          {...createFollowUpPromptBoxProps({ kind: "ready" })}
+        />
+        <button type="button">Outside composer</button>
+      </>,
+    );
+    const composer = document.querySelector("[data-follow-up-composer]");
+    const input = screen.getByRole("textbox", { name: "Follow-up prompt" });
+
+    expect(composer?.hasAttribute("data-follow-up-composer-expanded")).toBe(
+      false,
+    );
+    expect(screen.getByTestId("prompt-box").dataset.heightAnimationKey).toBe(
+      "compact",
+    );
+
+    fireEvent.focus(input);
+    expect(composer?.hasAttribute("data-follow-up-composer-expanded")).toBe(
+      true,
+    );
+    expect(screen.getByTestId("prompt-box").dataset.heightAnimationKey).toBe(
+      "expanded",
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Outside composer" }),
+    );
+    expect(composer?.hasAttribute("data-follow-up-composer-expanded")).toBe(
+      false,
+    );
+    expect(screen.getByTestId("prompt-box").dataset.heightAnimationKey).toBe(
+      "compact",
+    );
   });
 
   it("keeps the composer mounted across compact breakpoint changes", () => {

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -285,17 +285,12 @@ function FollowUpPromptBoxWithComposer({
       isMobilePromptBoxCompact,
     ],
   );
-  const setInteractionExpanded = useCallback(
-    (nextExpanded: boolean) => {
-      if (interactionExpandedRef.current === nextExpanded) return;
-      interactionExpandedRef.current = nextExpanded;
-      if (isCompactViewport) {
-        promptBoxRef.current?.captureHeightForLayoutChange();
-      }
-      setIsInteractionExpanded(nextExpanded);
-    },
-    [isCompactViewport],
-  );
+  const setInteractionExpanded = useCallback((nextExpanded: boolean) => {
+    if (interactionExpandedRef.current === nextExpanded) return;
+    interactionExpandedRef.current = nextExpanded;
+    promptBoxRef.current?.captureHeightForLayoutChange();
+    setIsInteractionExpanded(nextExpanded);
+  }, []);
   const cancelPendingFocusExpansion = useCallback(() => {
     pendingFocusExpansionCleanupRef.current?.();
     pendingFocusExpansionCleanupRef.current = null;
@@ -496,7 +491,14 @@ function FollowUpPromptBoxWithComposer({
         <div ref={stackRef} className="space-y-2">
           {stack}
         </div>
-        <div ref={composerInteractionRef} onFocusCapture={handleComposerFocus}>
+        <div
+          ref={composerInteractionRef}
+          data-follow-up-composer=""
+          data-follow-up-composer-expanded={
+            isInteractionExpanded ? "" : undefined
+          }
+          onFocusCapture={handleComposerFocus}
+        >
           <PromptBoxWithScrollAnchor
             id={id}
             promptBoxRef={promptBoxRef}
@@ -510,6 +512,8 @@ function FollowUpPromptBoxWithComposer({
             history={composer.history}
             focusEndKey={focusEndKey}
             placeholder={composer.promptPlaceholder}
+            containerCompactPlaceholder={composer.compactPromptPlaceholder}
+            heightAnimationKey={isInteractionExpanded ? "expanded" : "compact"}
             mentionMenuPlacement="top"
             submission={{
               onStop: onStopRuntime,
@@ -546,7 +550,10 @@ function FollowUpPromptBoxWithComposer({
             footerStart={footerStart}
           />
           {!isMobilePromptBoxCompact ? (
-            <div className="mt-1 flex min-h-6 items-center justify-between gap-2 pl-[15px] pr-3.5">
+            <div
+              data-follow-up-composer-footer=""
+              className="mt-1 flex min-h-6 items-center justify-between gap-2 pl-[15px] pr-3.5"
+            >
               <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
                 {environmentSummary}
               </div>

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -679,6 +679,29 @@ describe("PromptBoxInternal zen mode layout", () => {
 });
 
 describe("PromptBoxInternal compact layout", () => {
+  it("publishes the container-compact placeholder for CSS", () => {
+    const baseProps = createPromptBoxProps();
+    const view = render(
+      <PromptBoxInternal
+        {...baseProps}
+        containerCompactPlaceholder="Reconnecting..."
+      />,
+    );
+    const form = document.querySelector("[data-promptbox]");
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error("Prompt box form was not rendered");
+    }
+
+    expect(
+      form.style.getPropertyValue("--promptbox-container-compact-placeholder"),
+    ).toBe('"Reconnecting..."');
+
+    view.rerender(<PromptBoxInternal {...baseProps} />);
+    expect(
+      form.style.getPropertyValue("--promptbox-container-compact-placeholder"),
+    ).toBe("");
+  });
+
   it("animates between compact and full layouts", async () => {
     const promptBoxRef = createRef<PromptBoxHandle>();
     const baseProps = createPromptBoxProps({ promptBoxRef });
@@ -708,8 +731,60 @@ describe("PromptBoxInternal compact layout", () => {
     await waitFor(() => {
       expect(form.style.transition).toContain("height 240ms");
       expect(form.style.height).toBe("144px");
+      expect(form.style.overflow).toBe("hidden");
     });
     fireEvent.transitionEnd(form, { propertyName: "height" });
+    expect(form.style.overflow).toBe("");
+  });
+
+  it("animates an externally driven layout change", async () => {
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    const baseProps = createPromptBoxProps({ promptBoxRef });
+    const view = render(
+      <PromptBoxInternal {...baseProps} heightAnimationKey="compact" />,
+    );
+    const form = document.querySelector("[data-promptbox]");
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error("Prompt box form was not rendered");
+    }
+    vi.spyOn(form, "getBoundingClientRect")
+      .mockReturnValueOnce(new DOMRect(0, 0, 320, 48))
+      .mockReturnValueOnce(new DOMRect(0, 0, 320, 144))
+      .mockReturnValue(new DOMRect(0, 0, 320, 144));
+
+    act(() => promptBoxRef.current?.captureHeightForLayoutChange());
+    view.rerender(
+      <PromptBoxInternal {...baseProps} heightAnimationKey="expanded" />,
+    );
+
+    await waitFor(() => {
+      expect(form.style.transition).toContain("height 240ms");
+      expect(form.style.height).toBe("144px");
+    });
+    fireEvent.transitionEnd(form, { propertyName: "height" });
+  });
+
+  it("skips an external layout animation when the height did not change", () => {
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    const baseProps = createPromptBoxProps({ promptBoxRef });
+    const view = render(
+      <PromptBoxInternal {...baseProps} heightAnimationKey="compact" />,
+    );
+    const form = document.querySelector("[data-promptbox]");
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error("Prompt box form was not rendered");
+    }
+    vi.spyOn(form, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(0, 0, 320, 144),
+    );
+
+    act(() => promptBoxRef.current?.captureHeightForLayoutChange());
+    view.rerender(
+      <PromptBoxInternal {...baseProps} heightAnimationKey="expanded" />,
+    );
+
+    expect(form.style.transition).toBe("");
+    expect(form.style.height).toBe("");
   });
 
   it("keeps only the one-line editor and primary action", () => {
@@ -818,6 +893,30 @@ describe("PromptBoxInternal compact layout", () => {
     expect(editor.querySelector("br")).toBeTruthy();
     expect(editor.children.length).toBeGreaterThan(1);
     expect(editor.textContent).toContain("A hidden paragraph after the quote");
+  });
+
+  it("anchors only the primary action during a container-driven reveal", () => {
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          voice: {
+            state: "idle",
+            isSupported: true,
+            stream: null,
+            start: vi.fn(),
+            stop: vi.fn(),
+            cancel: vi.fn(),
+          },
+        })}
+      />,
+    );
+
+    const submitGroup = document.querySelector("[data-promptbox-submit-group]");
+    const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+    const voice = screen.getByRole("button", { name: "Start voice input" });
+
+    expect(submitGroup?.contains(submit)).toBe(true);
+    expect(submitGroup?.contains(voice)).toBe(false);
   });
 
   it("does not expose zen controls in the full mobile layout", () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -342,6 +342,13 @@ export interface PromptBoxInternalProps {
   zenMode?: PromptBoxZenModeConfig;
   /** Optional one-line presentation for unfocused mobile follow-up composers. */
   compact?: PromptBoxCompactConfig;
+  /** Compact placeholder used when a follow-up composer is narrowed by its container. */
+  containerCompactPlaceholder?: string;
+  /**
+   * Changing this after captureHeightForLayoutChange() animates a layout
+   * change that is driven outside this component, such as a container query.
+   */
+  heightAnimationKey?: string | number;
   history?: HistoryConfig;
   /** When omitted, the mic button is hidden. Wrappers wire this via usePromptVoice. */
   voice?: PromptVoiceConfig;
@@ -1024,6 +1031,8 @@ export function PromptBoxInternal({
   promptActions,
   zenMode = {},
   compact,
+  containerCompactPlaceholder,
+  heightAnimationKey,
   history,
   voice,
   promptBoxRef,
@@ -1079,6 +1088,20 @@ export function PromptBoxInternal({
     heightAnimationFromRef.current =
       formElement?.getBoundingClientRect().height ?? null;
   }, []);
+  useLayoutEffect(() => {
+    const formElement = formRef.current;
+    if (!formElement) return;
+    if (containerCompactPlaceholder === undefined) {
+      formElement.style.removeProperty(
+        "--promptbox-container-compact-placeholder",
+      );
+      return;
+    }
+    formElement.style.setProperty(
+      "--promptbox-container-compact-placeholder",
+      JSON.stringify(containerCompactPlaceholder),
+    );
+  }, [containerCompactPlaceholder]);
   const editorRef = useRef<Editor | null>(null);
   const editorScrollContainerRef = useRef<HTMLDivElement>(null);
   const revealSelectionFrameRef = useRef<number | null>(null);
@@ -1625,12 +1648,21 @@ export function PromptBoxInternal({
 
     const previousTransition = formElement.style.transition;
     const previousWillChange = formElement.style.willChange;
+    const previousOverflow = formElement.style.overflow;
 
     formElement.style.transition = "none";
     formElement.style.height = "";
     const toHeight = formElement.getBoundingClientRect().height;
+    if (Math.abs(toHeight - fromHeight) < 0.5) {
+      formElement.style.transition = previousTransition;
+      return;
+    }
     formElement.style.height = `${fromHeight}px`;
     formElement.getBoundingClientRect();
+    // The next layout is already mounted while the card still has its old
+    // height. Clip it for the whole tween so footer controls are revealed by
+    // the moving border instead of briefly painting outside the card.
+    formElement.style.overflow = "hidden";
     formElement.style.willChange = "height";
     formElement.style.transition =
       "height 240ms cubic-bezier(0.22, 1, 0.36, 1)";
@@ -1642,6 +1674,7 @@ export function PromptBoxInternal({
       isCleanedUp = true;
       formElement.style.transition = previousTransition;
       formElement.style.willChange = previousWillChange;
+      formElement.style.overflow = previousOverflow;
       formElement.style.height = "";
       formElement.removeEventListener("transitionend", handleTransitionEnd);
       window.clearTimeout(fallbackTimeout);
@@ -1654,7 +1687,7 @@ export function PromptBoxInternal({
     formElement.addEventListener("transitionend", handleTransitionEnd);
 
     return cleanup;
-  }, [isZenMode, showCompactLayout, zenModeLayout]);
+  }, [heightAnimationKey, isZenMode, showCompactLayout, zenModeLayout]);
 
   const trimmedValue = value.trim();
   const hasAttachments = attachments.length > 0;
@@ -2524,6 +2557,8 @@ export function PromptBoxInternal({
       ref={formRef}
       data-promptbox=""
       data-promptbox-compact={showCompactLayout ? "" : undefined}
+      data-promptbox-zen={showZenLayout ? "" : undefined}
+      data-promptbox-voice-active={showVoiceActionGroup ? "" : undefined}
       onSubmit={handleSubmit}
       onMouseDown={handlePromptBoxMouseDown}
       onDragOver={(event) => {
@@ -2558,10 +2593,12 @@ export function PromptBoxInternal({
         onChange={handleAttachmentInputChange}
       />
       <div
+        data-promptbox-layout=""
         className={cn(COLLAPSING_GRID_CLASS, showZenLayout && "min-h-0 flex-1")}
         style={{ gridTemplateRows: showVoiceActionGroup ? "0fr" : "1fr" }}
       >
         <div
+          data-promptbox-main=""
           className={cn(
             "min-h-0 overflow-hidden transition-opacity duration-[180ms] motion-reduce:transition-none",
             isZenMode && "flex flex-col",
@@ -2575,7 +2612,10 @@ export function PromptBoxInternal({
             // shifts from px-4 to px-6 when entering zen). Right padding leaves
             // room for the zen-mode toggle button in the top-right corner. Zen
             // mode also gets more top room since the card fills the viewport.
-            <div className={cn("pl-4 pr-14 pt-3", compact && "pr-14")}>
+            <div
+              data-promptbox-expanded-only=""
+              className={cn("pl-4 pr-14 pt-3", compact && "pr-14")}
+            >
               {header}
             </div>
           ) : null}
@@ -2587,11 +2627,16 @@ export function PromptBoxInternal({
           >
             {!showCompactLayout ? (
               <>
-                <AppCommandShortcutHint
-                  shortcut={focusComposerShortcut}
-                  className="absolute right-10 top-2 z-20 group-focus-within/promptbox:hidden"
-                />
-                <div className="absolute right-2 top-2 z-20 flex items-center gap-0.5">
+                <div data-promptbox-expanded-only="">
+                  <AppCommandShortcutHint
+                    shortcut={focusComposerShortcut}
+                    className="absolute right-10 top-2 z-20 group-focus-within/promptbox:hidden"
+                  />
+                </div>
+                <div
+                  data-promptbox-expanded-only=""
+                  className="absolute right-2 top-2 z-20 flex items-center gap-0.5"
+                >
                   {isZenMode ? (
                     <Button
                       type="button"
@@ -2672,6 +2717,7 @@ export function PromptBoxInternal({
               >
                 <EditorContent
                   editor={editor}
+                  data-promptbox-editor-content=""
                   data-promptbox-compact-content={
                     showCompactLayout ? "" : undefined
                   }
@@ -2696,7 +2742,6 @@ export function PromptBoxInternal({
                     "[&_.ProseMirror_p.is-editor-empty:first-child::before]:text-subtle-foreground",
                     "[&_.ProseMirror_p.is-editor-empty:first-child::before]:font-light",
                     "[&_.ProseMirror_p.is-editor-empty:first-child::before]:opacity-70",
-                    "[&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]",
                   )}
                 />
               </PromptMentionLinkContext.Provider>
@@ -2735,23 +2780,26 @@ export function PromptBoxInternal({
 
           {!showCompactLayout ? (
             <>
-              <AttachmentPreview
-                attachments={attachments}
-                attachmentProjectId={attachmentProjectId}
-                expandedImageIndex={expandedImageIndex}
-                onExpandedImageIndexChange={setExpandedImageIndex}
-                onRemoveAttachment={onRemoveAttachment}
-              />
+              <div data-promptbox-expanded-only="">
+                <AttachmentPreview
+                  attachments={attachments}
+                  attachmentProjectId={attachmentProjectId}
+                  expandedImageIndex={expandedImageIndex}
+                  onExpandedImageIndexChange={setExpandedImageIndex}
+                  onRemoveAttachment={onRemoveAttachment}
+                />
 
-              {attachmentError ? (
-                <div className="mx-3 mb-1 mt-1 text-xs text-destructive">
-                  {attachmentError}
-                </div>
-              ) : null}
+                {attachmentError ? (
+                  <div className="mx-3 mb-1 mt-1 text-xs text-destructive">
+                    {attachmentError}
+                  </div>
+                ) : null}
+              </div>
             </>
           ) : null}
 
           <div
+            data-promptbox-action-row=""
             className={cn(
               "flex shrink-0 flex-row items-center gap-3 pb-2 pl-3.5 pr-2 pt-1.5",
               showCompactLayout && "absolute inset-y-0 right-2 gap-0 p-0",
@@ -2759,6 +2807,7 @@ export function PromptBoxInternal({
           >
             {!showCompactLayout ? (
               <div
+                data-promptbox-expanded-only=""
                 className="flex min-w-0 flex-1 flex-row items-center gap-1"
                 aria-live="polite"
               >
@@ -2781,6 +2830,7 @@ export function PromptBoxInternal({
                 <>
                   {voice && !showVoiceActionGroup ? (
                     <Button
+                      data-promptbox-expanded-only=""
                       type="button"
                       size="icon"
                       variant="ghost"
@@ -2798,46 +2848,53 @@ export function PromptBoxInternal({
                   ) : null}
                 </>
               ) : null}
-              {showStop ? (
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="secondary"
-                  aria-label="Stop run"
-                  onClick={onStop}
-                  className={
-                    showCompactLayout
-                      ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
-                      : COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS
-                  }
-                >
-                  <Icon
-                    name="Square"
-                    className="size-3.5 fill-current [&_*]:stroke-0"
-                  />
-                </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  size={showCompactLayout ? "icon" : "sm"}
-                  variant="default"
-                  aria-label={effectiveSubmitTitle}
-                  disabled={!canSubmit}
-                  className={cn(
-                    showCompactLayout
-                      ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
-                      : ["ml-1", COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS],
-                  )}
-                >
-                  {isSubmitting ? (
-                    <Icon name="Spinner" className="size-4 animate-spin" />
-                  ) : isZenMode ? (
-                    <Icon name="ArrowUp" className="size-4" />
-                  ) : (
-                    <Icon name="CornerDownLeft" className="size-4" />
-                  )}
-                </Button>
-              )}
+              <div
+                data-promptbox-submit-group=""
+                className="flex shrink-0 flex-row items-center"
+              >
+                {showStop ? (
+                  <Button
+                    data-promptbox-submit-action=""
+                    type="button"
+                    size="icon"
+                    variant="secondary"
+                    aria-label="Stop run"
+                    onClick={onStop}
+                    className={
+                      showCompactLayout
+                        ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
+                        : COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS
+                    }
+                  >
+                    <Icon
+                      name="Square"
+                      className="size-3.5 fill-current [&_*]:stroke-0"
+                    />
+                  </Button>
+                ) : (
+                  <Button
+                    data-promptbox-submit-action=""
+                    type="submit"
+                    size={showCompactLayout ? "icon" : "sm"}
+                    variant="default"
+                    aria-label={effectiveSubmitTitle}
+                    disabled={!canSubmit}
+                    className={cn(
+                      showCompactLayout
+                        ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
+                        : ["ml-1", COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS],
+                    )}
+                  >
+                    {isSubmitting ? (
+                      <Icon name="Spinner" className="size-4 animate-spin" />
+                    ) : isZenMode ? (
+                      <Icon name="ArrowUp" className="size-4" />
+                    ) : (
+                      <Icon name="CornerDownLeft" className="size-4" />
+                    )}
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- compact the follow-up composer based on its split container width
- animate compact/full transitions while clipping footer controls behind the card border
- keep the submit control at an invariant 32x32 position through open and close
- preserve the existing mobile keyboard-aware expansion path

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/FollowUpPromptBox.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run test --filter=@bb/app --force` (1,525 tests)
- frame-by-frame browser QA at a 208px composer width for both animation directions