### PR TITLE
Fix flaky connect-tunnel 404-retry handshake test

### DIFF
--- a/apps/host-daemon/src/connect-tunnel/connect-tunnel.test.ts
+++ b/apps/host-daemon/src/connect-tunnel/connect-tunnel.test.ts
@@ -321,8 +321,17 @@ describe("ConnectTunnelClient", () => {
     });
     client.replaceShareSet({ generation: 1, ports: [3000] });
 
-    await waitFor(() => sockets.length === 1, "successful third upgrade");
+    // Wait on the client's own connected state, not the gate accepting the
+    // socket: the server's "connection" event (sockets.length === 1) fires just
+    // before the client WebSocket "open" handler flips status to "connected",
+    // so asserting status right after the server-side wait raced with that
+    // transition and intermittently observed "reconnecting".
+    await waitFor(
+      () => client.status().state === "connected",
+      "client connected after retried handshakes",
+    );
     expect(attempts).toBe(3);
+    expect(sockets).toHaveLength(1);
     expect(client.status()).toMatchObject({
       state: "connected",
       credentialRejected: false,


### PR DESCRIPTION
## What

Deflakes `apps/host-daemon/src/connect-tunnel/connect-tunnel.test.ts` → "retries rejected 404 handshakes with backoff until the gate upgrades", which intermittently failed on CI (observed on #659) with `expected { state: 'reconnecting' } to match { state: 'connected' }`.

## Root cause

The test waited on the **gate server** accepting the upgrade (`sockets.length === 1`) and then immediately asserted the **client's** status was `connected`. The server's `connection` event fires just before the client-side WebSocket `open` handler runs and flips the client status to `connected`, so the assertion raced that transition and sometimes saw `reconnecting`.

## Fix

Wait on the client's own `state === "connected"` — the exact condition being asserted — which is deterministic. The `sockets.length` check becomes a follow-up assertion rather than the wait gate. No product code changes.

## Validation

- Ran the connect-tunnel suite 5× with `--force`: green every run.
- Full `@bb/host-daemon` typecheck + test: 40/40 files pass.

Base is `bb/connect-v2` (the connect-v2 integration branch), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)