### PR TITLE
Preserve app and settings navigation state

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -81,6 +81,7 @@ import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import { findPaneByThread } from "@/lib/split-layout";
 import { applyThreadOpenToLayout } from "@/views/thread-detail/splitThreadNavigation";
 import { useThreadSplitsEnabled } from "@/hooks/useThreadSplitsEnabled";
+import { useAppSettingsRouteMemory } from "@/hooks/useAppSettingsRouteMemory";
 
 const SIDEBAR_WIDTH_KEY = "bb.sidebar.width";
 const SIDEBAR_OPEN_KEY = "bb.sidebar.open";
@@ -445,6 +446,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   useMobileVisualViewportHeight(contentShellRef, isCompactViewport);
   const location = useLocation();
   const navigate = useNavigate();
+  const { appRoutePath, settingsRoutePath } = useAppSettingsRouteMemory();
   useEffect(
     () =>
       wsManager.onThreadOpen((signal) => {
@@ -480,7 +482,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     return true;
   });
   useAppCommandHandler("settings.open", () => {
-    void navigate(SETTINGS_ROUTE_PATH);
+    void navigate(settingsRoutePath);
     return true;
   });
   // Native server rail "+" tile.
@@ -766,12 +768,14 @@ export function AppLayout({ children }: AppLayoutProps) {
               onResizeMouseDown={handleResizeMouseDown}
               isResizing={isSidebarResizing}
               showTopReserve={true}
+              appRoutePath={appRoutePath}
             />
           ) : (
             <AppSidebar
               onResizeMouseDown={handleResizeMouseDown}
               isResizing={isSidebarResizing}
               showTopReserve={true}
+              settingsRoutePath={settingsRoutePath}
             />
           )}
           <SidebarInset>

--- a/apps/app/src/components/settings/SettingsSidebar.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/lib/bb-desktop";
 import {
   SETTINGS_ROUTE_PATH,
-  getRootComposeRoutePath,
   getSettingsPluginRoutePath,
   getSettingsProviderRoutePath,
   getSettingsRoutePath,
@@ -34,6 +33,7 @@ interface SettingsSidebarProps {
   onResizeMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
   isResizing: boolean;
   showTopReserve: boolean;
+  appRoutePath: string;
 }
 
 interface SettingsSidebarRowProps {
@@ -100,6 +100,7 @@ export function SettingsSidebar({
   onResizeMouseDown,
   isResizing,
   showTopReserve,
+  appRoutePath,
 }: SettingsSidebarProps) {
   const closeOnMobile = useCloseMobileSidebar();
   const [desktopInfo] = useState(getBbDesktopInfo);
@@ -146,7 +147,7 @@ export function SettingsSidebar({
             active={false}
             label="Back to app"
             onNavigate={closeOnMobile}
-            to={getRootComposeRoutePath()}
+            to={appRoutePath}
           >
             {sectionIcon("ChevronLeft")}
           </SettingsSidebarRow>

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -71,6 +71,7 @@ interface AppSidebarProps {
   onResizeMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
   isResizing: boolean;
   showTopReserve: boolean;
+  settingsRoutePath: string;
 }
 
 export function isThreadSearchKeyboardEventTarget(
@@ -90,6 +91,7 @@ export function AppSidebar({
   onResizeMouseDown,
   isResizing,
   showTopReserve,
+  settingsRoutePath,
 }: AppSidebarProps) {
   const quickCreateProject = useQuickCreateProjectController();
   const { threadId: activeThreadId } = useRouteState();
@@ -437,7 +439,7 @@ export function AppSidebar({
                 }}
                 className={SIDEBAR_FOOTER_ACTION_CLASS}
               >
-                <Link to="/settings" onClick={closeOnMobile}>
+                <Link to={settingsRoutePath} onClick={closeOnMobile}>
                   <Icon name="Settings" />
                   <span className="sr-only">Settings</span>
                 </Link>

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Link, MemoryRouter, useLocation } from "react-router-dom";
+import { useAppSettingsRouteMemory } from "./useAppSettingsRouteMemory";
+
+function RouteMemoryTestSurface() {
+  const location = useLocation();
+  const { appRoutePath, settingsRoutePath } = useAppSettingsRouteMemory();
+
+  return (
+    <>
+      <div data-testid="location">
+        {location.pathname}
+        {location.search}
+        {location.hash}
+      </div>
+      <Link to={appRoutePath}>App</Link>
+      <Link to={settingsRoutePath}>Settings</Link>
+      <Link to="/settings/providers/codex?tab=models#preferred">
+        Codex settings
+      </Link>
+    </>
+  );
+}
+
+describe("useAppSettingsRouteMemory", () => {
+  afterEach(cleanup);
+
+  it("switches between the most recent app and settings routes", () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/projects/proj_one/threads/thr_one?message=12#event-12",
+        ]}
+      >
+        <RouteMemoryTestSurface />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
+    expect(screen.getByTestId("location").textContent).toBe("/settings");
+
+    fireEvent.click(screen.getByRole("link", { name: "Codex settings" }));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/settings/providers/codex?tab=models#preferred",
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "App" }));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/projects/proj_one/threads/thr_one?message=12#event-12",
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/settings/providers/codex?tab=models#preferred",
+    );
+  });
+});

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.ts
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+import { matchPath, useLocation } from "react-router-dom";
+import {
+  getRootComposeRoutePath,
+  SETTINGS_ROUTE_PATH,
+} from "@/lib/route-paths";
+
+interface AppSettingsRouteMemory {
+  appRoutePath: string;
+  settingsRoutePath: string;
+}
+
+function getLocationRoutePath(location: {
+  pathname: string;
+  search: string;
+  hash: string;
+}): string {
+  return `${location.pathname}${location.search}${location.hash}`;
+}
+
+function isGlobalSettingsRoute(pathname: string): boolean {
+  return matchPath(`${SETTINGS_ROUTE_PATH}/*`, pathname) !== null;
+}
+
+/**
+ * Remembers the most recently visited app and global-settings routes while the
+ * app shell is mounted. This lets the two sidebar modes switch back and forth
+ * without resetting either surface to its root route.
+ */
+export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
+  const location = useLocation();
+  const currentRoutePath = getLocationRoutePath(location);
+  const isSettingsRoute = isGlobalSettingsRoute(location.pathname);
+  const lastAppRoutePathRef = useRef(
+    isSettingsRoute ? getRootComposeRoutePath() : currentRoutePath,
+  );
+  const lastSettingsRoutePathRef = useRef(
+    isSettingsRoute ? currentRoutePath : SETTINGS_ROUTE_PATH,
+  );
+
+  useEffect(() => {
+    if (isSettingsRoute) {
+      lastSettingsRoutePathRef.current = currentRoutePath;
+      return;
+    }
+    lastAppRoutePathRef.current = currentRoutePath;
+  }, [currentRoutePath, isSettingsRoute]);
+
+  return {
+    appRoutePath: isSettingsRoute
+      ? lastAppRoutePathRef.current
+      : currentRoutePath,
+    settingsRoutePath: isSettingsRoute
+      ? currentRoutePath
+      : lastSettingsRoutePathRef.current,
+  };
+}


### PR DESCRIPTION
## Summary
- remember the latest app and global settings routes in the shared app shell
- return to the previous thread/project when leaving Settings and the previous section when reopening it
- preserve query strings and hashes and apply the same destination to the Settings keyboard command

## Testing
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run test --filter=@bb/app --force` (1,533 tests)
- `pnpm exec turbo run lint --filter=@bb/app --force` (0 errors; existing warnings only)
- live managed dev app smoke test