### PR TITLE
Polish sidebar split indicators

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRowMiniMap.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRowMiniMap.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThreadRowMiniMap } from "./ThreadRowMiniMap";
+
+afterEach(cleanup);
+
+function visibleBounds(rect: SVGElement) {
+  const strokeWidth = Number(rect.getAttribute("stroke-width"));
+  const x = Number(rect.getAttribute("x")) - strokeWidth / 2;
+  const y = Number(rect.getAttribute("y")) - strokeWidth / 2;
+  return {
+    x,
+    y,
+    width: Number(rect.getAttribute("width")) + strokeWidth,
+    height: Number(rect.getAttribute("height")) + strokeWidth,
+  };
+}
+
+describe("ThreadRowMiniMap", () => {
+  it("keeps filled and outlined slots the same size with square corners", () => {
+    render(
+      <ThreadRowMiniMap
+        label="Two-pane split"
+        slots={[
+          {
+            paneId: "pane-left",
+            rect: { x: 0, y: 0, w: 0.5, h: 1 },
+            isMe: false,
+            isFocused: false,
+          },
+          {
+            paneId: "pane-right",
+            rect: { x: 0.5, y: 0, w: 0.5, h: 1 },
+            isMe: true,
+            isFocused: true,
+          },
+        ]}
+      />,
+    );
+
+    const miniMap = screen.getByRole("img", { name: "Two-pane split" });
+    const [outlined, filled] = miniMap.querySelectorAll("rect");
+    if (outlined === undefined || filled === undefined) {
+      throw new Error("Expected two mini-map slots");
+    }
+
+    expect(visibleBounds(outlined)).toEqual({
+      x: 1,
+      y: 1,
+      width: 6,
+      height: 12,
+    });
+    expect(visibleBounds(filled)).toEqual({
+      x: 7,
+      y: 1,
+      width: 6,
+      height: 12,
+    });
+    expect(outlined.hasAttribute("rx")).toBe(false);
+    expect(filled.hasAttribute("rx")).toBe(false);
+    expect(miniMap.getAttribute("shape-rendering")).toBe("crispEdges");
+  });
+});

--- a/apps/app/src/components/sidebar/ThreadRowMiniMap.tsx
+++ b/apps/app/src/components/sidebar/ThreadRowMiniMap.tsx
@@ -4,6 +4,7 @@ import type { MiniMapSlot } from "./threadSplitIndicator";
 const GLYPH_SIZE = 14;
 const GLYPH_PADDING = 1;
 const INNER = GLYPH_SIZE - 2 * GLYPH_PADDING;
+const OUTLINE_WIDTH = 1;
 
 interface ThreadRowMiniMapProps {
   slots: MiniMapSlot[];
@@ -17,6 +18,12 @@ function offset(value: number): number {
 
 function extent(value: number): number {
   return value * INNER;
+}
+
+// SVG strokes are centered on a rect's edge. Inset outlined slots by half the
+// stroke so their visible bounds match the filled slot bounds exactly.
+function outlineInset(isFilled: boolean): number {
+  return isFilled ? 0 : OUTLINE_WIDTH / 2;
 }
 
 /**
@@ -33,27 +40,30 @@ export function ThreadRowMiniMap({ slots, label }: ThreadRowMiniMapProps) {
       height={GLYPH_SIZE}
       viewBox={`0 0 ${GLYPH_SIZE} ${GLYPH_SIZE}`}
       className="pointer-events-none ml-0.5 shrink-0"
+      shapeRendering="crispEdges"
       role="img"
       aria-label={label}
     >
-      {slots.map((slot) => (
-        <rect
-          key={slot.paneId}
-          x={offset(slot.rect.x)}
-          y={offset(slot.rect.y)}
-          width={Math.max(extent(slot.rect.w), 0)}
-          height={Math.max(extent(slot.rect.h), 0)}
-          rx={1.5}
-          strokeWidth={slot.isMe ? 0 : 1}
-          className={cn(
-            slot.isMe
-              ? slot.isFocused
-                ? "fill-primary/70 stroke-none"
-                : "fill-muted-foreground/45 stroke-none"
-              : "fill-none stroke-muted-foreground/30",
-          )}
-        />
-      ))}
+      {slots.map((slot) => {
+        const inset = outlineInset(slot.isMe);
+        return (
+          <rect
+            key={slot.paneId}
+            x={offset(slot.rect.x) + inset}
+            y={offset(slot.rect.y) + inset}
+            width={Math.max(extent(slot.rect.w) - 2 * inset, 0)}
+            height={Math.max(extent(slot.rect.h) - 2 * inset, 0)}
+            strokeWidth={slot.isMe ? 0 : OUTLINE_WIDTH}
+            className={cn(
+              slot.isMe
+                ? slot.isFocused
+                  ? "fill-primary/70 stroke-none"
+                  : "fill-muted-foreground/45 stroke-none"
+                : "fill-none stroke-muted-foreground/30",
+            )}
+          />
+        );
+      })}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

- align the visible bounds of filled and outlined sidebar split slots
- use square, crisp edges for the mini-map rectangles
- add regression coverage for slot geometry and corners

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/sidebar/ThreadRowMiniMap.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app --force` (passes with existing warnings)
- `pnpm exec prettier --check apps/app/src/components/sidebar/ThreadRowMiniMap.tsx apps/app/src/components/sidebar/ThreadRowMiniMap.test.tsx`