### PR TITLE
Simplify connect-v2: single share-listing pipeline, legacy-share normalization, drop defensive guards

### DIFF
--- a/apps/connect/src/machine-label.ts
+++ b/apps/connect/src/machine-label.ts
@@ -46,21 +46,24 @@ function labelWithSuffix(base: string, ordinal: number): string {
   return `${stem}${suffix}`;
 }
 
-function affectedRows(result: unknown): number | null {
-  if (typeof result !== "object" || result === null) return null;
-  if ("changes" in result && typeof result.changes === "number") {
-    return result.changes;
+/** Affected-row count from either driver shape: better-sqlite3 `{changes}` or
+ * D1 `{meta: {changes}}`. Anything else is a broken driver — fail fast. */
+function affectedRows(result: unknown): number {
+  if (typeof result === "object" && result !== null) {
+    if ("changes" in result && typeof result.changes === "number") {
+      return result.changes;
+    }
+    if (
+      "meta" in result &&
+      typeof result.meta === "object" &&
+      result.meta !== null &&
+      "changes" in result.meta &&
+      typeof result.meta.changes === "number"
+    ) {
+      return result.meta.changes;
+    }
   }
-  if (
-    "meta" in result &&
-    typeof result.meta === "object" &&
-    result.meta !== null &&
-    "changes" in result.meta &&
-    typeof result.meta.changes === "number"
-  ) {
-    return result.meta.changes;
-  }
-  return null;
+  throw new Error("machine label update did not report affected rows");
 }
 
 export interface MachineLabelAssignmentHooks {
@@ -114,29 +117,15 @@ export async function assignMachineLabel(
       if (isLabelCollision(error)) continue;
       throw error;
     }
-    const changes = affectedRows(updateResult);
-    if (changes === 1) return candidate;
+    if (affectedRows(updateResult) === 1) return candidate;
 
     const current = await db
       .select({ subdomain: machine.subdomain, revokedAt: machine.revokedAt })
       .from(machine)
       .where(eq(machine.id, machineId))
       .get();
-    // Some drivers do not report affected-row counts. The exact attached row
-    // is authoritative and must retain the claim in that case.
-    if (
-      changes === null &&
-      current?.revokedAt === null &&
-      current.subdomain === candidate
-    ) {
-      return candidate;
-    }
-
     if (!current || current.revokedAt !== null) return null;
     if (current.subdomain !== null) return current.subdomain;
-    if (changes === null) {
-      throw new Error("machine label update did not report affected rows");
-    }
   }
 }
 

--- a/apps/host-daemon/src/connect-tunnel/index.ts
+++ b/apps/host-daemon/src/connect-tunnel/index.ts
@@ -105,8 +105,7 @@ export class ConnectTunnelClient {
   private readonly fetchFn: ConnectTunnelFetch;
   private readonly backoff: ReconnectBackoff;
   private readonly machineCredential: string | undefined;
-  private shares: HostDaemonConnectShares = { generation: 0, ports: [] };
-  private latestGeneration = -1;
+  private generation = -1;
   private ports = new Set<number>();
   private identity: HostDaemonConnectTunnelIdentity | undefined;
   private identityPromise: Promise<HostDaemonConnectTunnelIdentity> | undefined;
@@ -138,14 +137,14 @@ export class ConnectTunnelClient {
       state: this.state,
       lastError: this.lastError,
       credentialRejected: this.credentialRejected,
-      generation: this.shares.generation,
+      generation: Math.max(this.generation, 0),
       ports: [...this.ports].sort((a, b) => a - b),
     };
   }
 
   /** Apply a pushed replacement only when it advances the host generation. */
   replaceShareSet(shares: HostDaemonConnectShares): boolean {
-    if (shares.generation <= this.latestGeneration) {
+    if (shares.generation <= this.generation) {
       return false;
     }
     this.applyShareSet(shares);
@@ -244,11 +243,7 @@ export class ConnectTunnelClient {
 
   private applyShareSet(shares: HostDaemonConnectShares): void {
     const previousPorts = this.ports;
-    this.latestGeneration = shares.generation;
-    this.shares = {
-      generation: shares.generation,
-      ports: [...shares.ports],
-    };
+    this.generation = shares.generation;
     this.ports = new Set(shares.ports);
 
     if (!this.hasConnectIntent()) {

--- a/apps/server/src/services/plugins/plugin-api.ts
+++ b/apps/server/src/services/plugins/plugin-api.ts
@@ -1131,11 +1131,6 @@ export function createPluginApi(options: {
     },
     declareSharedPorts(hostId, ports) {
       assertLive();
-      if (arguments.length !== 2) {
-        throw new Error(
-          "bb.hosts.declareSharedPorts accepts only hostId and ports; tunnel identity is daemon-owned",
-        );
-      }
       declareSharedPorts(hostId, ports);
     },
   };

--- a/apps/server/test/services/plugins/plugin-sdk.test.ts
+++ b/apps/server/test/services/plugins/plugin-sdk.test.ts
@@ -136,16 +136,6 @@ describe("plugin bb.sdk bind gate", () => {
       label: "sawyer-air",
       baseDomain: "getbb.app",
     });
-    expect(() =>
-      (api.hosts.declareSharedPorts as unknown as (...args: unknown[]) => void)(
-        "host-1",
-        [3000],
-        {
-          label: "stolen",
-          baseDomain: "attacker.example",
-        },
-      ),
-    ).toThrow(/tunnel identity is daemon-owned/);
     api.hosts.declareSharedPorts("host-1", [8080, 3000]);
 
     expect(ensureSharedPortTunnel).toHaveBeenCalledWith("host-1");

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -70,16 +70,6 @@ describe("host control plane", () => {
       label: "sawyer-air",
       baseDomain: "getbb.app",
     });
-    expect(() =>
-      (bb.hosts.declareSharedPorts as unknown as (...args: unknown[]) => void)(
-        "host-1",
-        [3000],
-        {
-          label: "stolen",
-          baseDomain: "attacker.example",
-        },
-      ),
-    ).toThrow(/tunnel identity is daemon-owned/);
     bb.hosts.declareSharedPorts("host-1", [8080, 3000, 8080]);
     bb.hosts.declareSharedPorts("host-2", [4173]);
     bb.hosts.declareSharedPorts("host-1", [3000]);

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -1198,11 +1198,6 @@ export function createFakePluginHost(
     },
     declareSharedPorts(hostId, ports) {
       assertLive();
-      if (arguments.length !== 2) {
-        throw new Error(
-          "bb.hosts.declareSharedPorts accepts only hostId and ports; tunnel identity is daemon-owned",
-        );
-      }
       if (hostId.trim().length === 0) {
         throw new Error("shared-port hostId must be non-empty");
       }

--- a/plugins/connect/src/cli.ts
+++ b/plugins/connect/src/cli.ts
@@ -223,14 +223,7 @@ export function registerConnectCli(args: {
             targetHost,
           );
           if (parsed.flags.has("json")) {
-            return {
-              exitCode: 0,
-              stdout: asJson({
-                removed: result.removed,
-                hostId: result.hostId,
-                port: result.port,
-              }),
-            };
+            return { exitCode: 0, stdout: asJson(result) };
           }
           if (!result.removed) {
             return {

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -311,6 +311,54 @@ describe("ShareRegistry", () => {
     await fakeHost.harness.dispose();
   });
 
+  it("normalizes legacy entries to the server host id at activation", async () => {
+    const kv = new Map<string, unknown>([
+      [SHARES_KV_KEY, { "3000": { port: 3000, createdAt: 123 } }],
+    ]);
+    const fakeHost = createConnectFakeHost();
+    const pluginBb = fakeHost.bb as unknown as Parameters<typeof plugin>[0];
+    const registry = new ShareRegistry({
+      kv: {
+        async get<T>(key: string) {
+          return kv.get(key) as T | undefined;
+        },
+        async set(key: string, value: unknown) {
+          kv.set(key, value);
+        },
+        async delete(key: string) {
+          kv.delete(key);
+        },
+      },
+      hosts: pluginBb.hosts,
+      hostResolver: new ShareHostResolver(() => pluginBb.sdk),
+      getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+      getCredential: () => ({
+        serverUrl: "https://sawyer.getbb.app",
+        handle: "sawyer",
+        credential: "bbcred_x",
+      }),
+      log: pluginBb.log,
+    });
+
+    await registry.load();
+    expect(registry.hasServerPort(3000)).toBe(true);
+    await registry.declareMachineShares(() => true);
+    // The stored entry gains the concrete server host id and canonical key.
+    expect(kv.get(SHARES_KV_KEY)).toEqual({
+      [`${SERVER_HOST_ID}:3000`]: {
+        hostId: SERVER_HOST_ID,
+        port: 3000,
+        createdAt: 123,
+      },
+    });
+    expect(registry.hasServerPort(3000)).toBe(true);
+    expect(await registry.remove(3000, SERVER_HOST_ID)).toMatchObject({
+      removed: true,
+      hostId: SERVER_HOST_ID,
+    });
+    await fakeHost.harness.dispose();
+  });
+
   it("loads valid entries when another kv entry is malformed", async () => {
     const kv = new Map<string, unknown>([
       [
@@ -1251,6 +1299,7 @@ describe("connect plugin", () => {
       hostName: SERVER_HOST_NAME,
       port: 8000,
       url: shareUrl,
+      createdAt: expect.any(Number),
     });
 
     const listed = (await harness.callRpc("listShares")) as Array<{
@@ -1263,6 +1312,7 @@ describe("connect plugin", () => {
         hostName: SERVER_HOST_NAME,
         port: 8000,
         url: shareUrl,
+        createdAt: expect.any(Number),
       },
     ]);
 
@@ -1273,6 +1323,7 @@ describe("connect plugin", () => {
         hostName: SERVER_HOST_NAME,
         port: 8000,
         url: shareUrl,
+        createdAt: expect.any(Number),
       },
     ]);
 
@@ -1283,6 +1334,7 @@ describe("connect plugin", () => {
     expect(removed).toEqual({
       removed: true,
       hostId: SERVER_HOST_ID,
+      hostName: SERVER_HOST_NAME,
       port: 8000,
     });
     expect(await harness.callRpc("listShares")).toEqual([]);
@@ -1330,6 +1382,7 @@ describe("connect plugin", () => {
     ).resolves.toEqual({
       removed: true,
       hostId: "host-deleted",
+      hostName: "removed host",
       port: 3000,
     });
     expect(await harness.callRpc("listShares")).toEqual(
@@ -1339,6 +1392,7 @@ describe("connect plugin", () => {
           hostName: SERVER_HOST_NAME,
           port: 8000,
           url: "http://127.0.0.1:8000",
+          createdAt: 1,
         },
         expect.objectContaining({
           hostId: "host-deleted",
@@ -1398,6 +1452,7 @@ describe("connect plugin", () => {
     ).resolves.toEqual({
       removed: true,
       hostId: REMOTE_HOST_ID,
+      hostName: REMOTE_HOST_NAME,
       port: 3000,
     });
     expect(declarations).toHaveBeenCalledWith(REMOTE_HOST_ID, []);
@@ -1448,6 +1503,7 @@ describe("connect plugin", () => {
       hostName: REMOTE_HOST_NAME,
       port: 3000,
       url: "https://sawyer-air--3000.getbb.app",
+      createdAt: expect.any(Number),
     });
     expect(host.harness.sharedPortDeclarations).toEqual([
       { hostId: REMOTE_HOST_ID, ports: [3000] },
@@ -1571,7 +1627,7 @@ describe("connect plugin", () => {
     expect(message).not.toMatch(/Enroll|remove and re-add/);
   });
 
-  it("empties machine declarations when the plugin service stops", async () => {
+  it("empties machine declarations when the pairing is disconnected", async () => {
     host = createConnectFakeHost({
       remoteIdentity: { label: "sawyer-air", baseDomain: "getbb.app" },
     });
@@ -1599,10 +1655,13 @@ describe("connect plugin", () => {
       { hostId: REMOTE_HOST_ID, ports: [5173] },
     ]);
 
-    await stopTunnel(host);
+    // Unpairing must drop the daemon's desired ports; a plain service stop
+    // relies on plugin dispose (load-scoped server-side clearing) instead.
+    await host.harness.callRpc("disconnect");
     expect(host.harness.sharedPortDeclarations).toEqual([
       { hostId: REMOTE_HOST_ID, ports: [] },
     ]);
+    await stopTunnel(host);
     await host.harness.dispose();
     host = undefined;
   });
@@ -2118,6 +2177,7 @@ describe("connect CLI", () => {
           hostName: REMOTE_HOST_NAME,
           port: 3000,
           url: "https://sawyer-air--3000.getbb.app",
+          createdAt: expect.any(Number),
         },
       ],
     });

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -311,6 +311,115 @@ describe("ShareRegistry", () => {
     await fakeHost.harness.dispose();
   });
 
+  it("lists persisted shares in the sync snapshot before any resolution, including unpaired", async () => {
+    const kv = new Map<string, unknown>([
+      [
+        SHARES_KV_KEY,
+        {
+          "3000": { port: 3000, createdAt: 1 },
+          [`${REMOTE_HOST_ID}:4000`]: {
+            hostId: REMOTE_HOST_ID,
+            port: 4000,
+            createdAt: 2,
+          },
+        },
+      ],
+    ]);
+    const fakeHost = createConnectFakeHost();
+    const pluginBb = fakeHost.bb as unknown as Parameters<typeof plugin>[0];
+    const registry = new ShareRegistry({
+      kv: {
+        async get<T>(key: string) {
+          return kv.get(key) as T | undefined;
+        },
+        async set(key: string, value: unknown) {
+          kv.set(key, value);
+        },
+        async delete(key: string) {
+          kv.delete(key);
+        },
+      },
+      hosts: pluginBb.hosts,
+      hostResolver: new ShareHostResolver(() => pluginBb.sdk),
+      getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+      getCredential: () => null,
+      log: pluginBb.log,
+    });
+
+    await registry.load();
+    expect(registry.snapshot()).toEqual([
+      {
+        hostId: REMOTE_HOST_ID,
+        hostName: REMOTE_HOST_ID,
+        port: 4000,
+        createdAt: 2,
+        url: "",
+        unavailableReason: "Share URL has not been resolved yet.",
+      },
+      {
+        hostId: "server",
+        hostName: "server host",
+        port: 3000,
+        createdAt: 1,
+        url: "",
+        unavailableReason: "Share URL has not been resolved yet.",
+      },
+    ]);
+    await fakeHost.harness.dispose();
+  });
+
+  it("collapses the placeholder snapshot row when a legacy share resolves", async () => {
+    const kv = new Map<string, unknown>([
+      [SHARES_KV_KEY, { "3000": { port: 3000, createdAt: 123 } }],
+    ]);
+    const fakeHost = createConnectFakeHost();
+    const pluginBb = fakeHost.bb as unknown as Parameters<typeof plugin>[0];
+    const registry = new ShareRegistry({
+      kv: {
+        async get<T>(key: string) {
+          return kv.get(key) as T | undefined;
+        },
+        async set(key: string, value: unknown) {
+          kv.set(key, value);
+        },
+        async delete(key: string) {
+          kv.delete(key);
+        },
+      },
+      hosts: pluginBb.hosts,
+      hostResolver: new ShareHostResolver(() => pluginBb.sdk),
+      getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+      getCredential: () => ({
+        serverUrl: "https://sawyer.getbb.app",
+        handle: "sawyer",
+        credential: "bbcred_x",
+      }),
+      log: pluginBb.log,
+    });
+
+    await registry.load();
+    expect(registry.snapshot()).toEqual([
+      expect.objectContaining({ hostId: "server", port: 3000 }),
+    ]);
+    // Idempotent re-expose after the server host resolves must replace the
+    // placeholder row, not sit beside it.
+    await registry.add(3000, {
+      id: SERVER_HOST_ID,
+      name: SERVER_HOST_NAME,
+      isServer: true,
+    });
+    expect(registry.snapshot()).toEqual([
+      {
+        hostId: SERVER_HOST_ID,
+        hostName: SERVER_HOST_NAME,
+        port: 3000,
+        createdAt: 123,
+        url: "https://sawyer--3000.getbb.app",
+      },
+    ]);
+    await fakeHost.harness.dispose();
+  });
+
   it("normalizes legacy entries to the server host id at activation", async () => {
     const kv = new Map<string, unknown>([
       [SHARES_KV_KEY, { "3000": { port: 3000, createdAt: 123 } }],
@@ -586,6 +695,72 @@ describe("ConnectTunnel share activation", () => {
         (declaration) => declaration.ports.length > 0,
       ),
     ).toEqual([]);
+    await fakeHost.harness.dispose();
+  });
+
+  it("keeps persisted shares visible in status after an unpaired restart", async () => {
+    const fakeHost = createConnectFakeHost();
+    const pluginBb = fakeHost.bb as unknown as Parameters<typeof plugin>[0];
+    const kv = new Map<string, unknown>([
+      [
+        SHARES_KV_KEY,
+        {
+          "3000": { port: 3000, createdAt: 1 },
+          [`${REMOTE_HOST_ID}:4000`]: {
+            hostId: REMOTE_HOST_ID,
+            port: 4000,
+            createdAt: 2,
+          },
+        },
+      ],
+    ]);
+    const shares = new ShareRegistry({
+      kv: {
+        async get<T>(key: string) {
+          return kv.get(key) as T | undefined;
+        },
+        async set(key: string, value: unknown) {
+          kv.set(key, value);
+        },
+        async delete(key: string) {
+          kv.delete(key);
+        },
+      },
+      hosts: pluginBb.hosts,
+      hostResolver: new ShareHostResolver(() => pluginBb.sdk),
+      getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+      // disconnect() cleared the pairing but kept the share kv.
+      getCredential: () => null,
+      log: pluginBb.log,
+    });
+    const tunnel = new ConnectTunnel({
+      store: {
+        read: async () => null,
+        write: async () => {},
+        clear: async () => {},
+      },
+      shares,
+      getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+      log: pluginBb.log,
+    });
+
+    await tunnel.start();
+    await waitFor(() => tunnel.status().shares.length === 2);
+    expect(tunnel.status().shares).toEqual([
+      expect.objectContaining({
+        hostId: REMOTE_HOST_ID,
+        port: 4000,
+        url: "",
+        unavailableReason: "Share URL has not been resolved yet.",
+      }),
+      expect.objectContaining({
+        hostId: "server",
+        port: 3000,
+        url: "",
+        unavailableReason: "Share URL has not been resolved yet.",
+      }),
+    ]);
+    tunnel.stop();
     await fakeHost.harness.dispose();
   });
 });

--- a/plugins/connect/src/rpc.ts
+++ b/plugins/connect/src/rpc.ts
@@ -7,6 +7,7 @@ import type { ListAccountServersResult } from "./list-servers.js";
 import type { DesktopSession } from "./desktop-session.js";
 import { MachineCodeError, type MachineCode } from "./machine-code.js";
 import type { ShareHostResolver } from "./hosts.js";
+import type { ShareListing, ShareRemoval } from "./shares.js";
 
 // Panel-facing rpc surface. `server` is optional: the dashboard command
 // carries both --code and --server, but the panel's paste-a-code field only
@@ -31,26 +32,9 @@ export type ConnectRpcHandlers = {
   pair(input: unknown): Promise<ConnectStatus>;
   status(): Promise<ConnectStatus>;
   disconnect(): Promise<ConnectStatus>;
-  expose(input: unknown): Promise<{
-    hostId: string;
-    hostName: string;
-    port: number;
-    url: string;
-  }>;
-  unexpose(input: unknown): Promise<{
-    removed: boolean;
-    hostId: string;
-    port: number;
-  }>;
-  listShares(): Promise<
-    Array<{
-      hostId: string;
-      hostName: string;
-      port: number;
-      url: string;
-      unavailableReason?: string;
-    }>
-  >;
+  expose(input: unknown): Promise<ShareListing>;
+  unexpose(input: unknown): Promise<ShareRemoval & { port: number }>;
+  listShares(): Promise<ShareListing[]>;
   listAccountServers(): Promise<ListAccountServersResult>;
   createDesktopSession(): Promise<DesktopSession>;
   createMachineCode(): Promise<MachineCode>;
@@ -95,15 +79,10 @@ export function createRpcHandlers(
     },
     async unexpose(input: unknown) {
       const args = portInputSchema.parse(input);
-      const result = await tunnel.unexpose(
+      return tunnel.unexpose(
         args.port,
         args.hostId ?? (await hostResolver.serverHostId()),
       );
-      return {
-        removed: result.removed,
-        hostId: result.hostId,
-        port: result.port,
-      };
     },
     async listShares() {
       return tunnel.listShares();

--- a/plugins/connect/src/shares.ts
+++ b/plugins/connect/src/shares.ts
@@ -16,14 +16,11 @@ import { deriveConnectBaseUrl } from "./redeem.js";
 
 export const SHARES_KV_KEY = "shares";
 
-export interface Share {
+export interface ShareListing {
   hostId: string;
+  hostName: string;
   port: number;
   createdAt: number;
-}
-
-export interface ShareListing extends Share {
-  hostName: string;
   /** Empty only when unavailableReason explains why no public URL exists. */
   url: string;
   unavailableReason?: string;
@@ -41,16 +38,11 @@ const persistedShareSchema = z
 const sharesContainerSchema = z.record(z.string(), z.unknown());
 
 interface RestoredShare {
-  /** Preserve legacy keys until a user mutation naturally rewrites the map. */
-  storageKey: string;
-  /** Null means a legacy entry whose omitted hostId denotes the server host. */
+  /** Null means a legacy entry whose omitted hostId denotes the server host;
+   * normalized to the real server host id once activation resolves it. */
   hostId: string | null;
   port: number;
   createdAt: number;
-  host?: ShareHost;
-  machineUrl?: string;
-  unavailableHostName?: string;
-  unavailableReason?: string;
 }
 
 export interface ShareRemoval {
@@ -97,21 +89,7 @@ export function machineSharePublicUrl(
   identity: { label: string; baseDomain: string },
   port: number,
 ): string {
-  const expectedHost = `${identity.label}--${port}.${identity.baseDomain}`;
-  const origin = new URL(`https://${expectedHost}`);
-  if (
-    origin.host !== expectedHost ||
-    origin.username ||
-    origin.password ||
-    origin.pathname !== "/" ||
-    origin.search ||
-    origin.hash
-  ) {
-    throw new SharePortError(
-      "the host returned an invalid connect tunnel identity",
-    );
-  }
-  return origin.origin;
+  return `https://${identity.label}--${port}.${identity.baseDomain}`;
 }
 
 export function shareLoopbackOrigin(port: number): string {
@@ -146,6 +124,18 @@ function restoredShareKey(hostId: string | null, port: number): string {
   return hostId === null ? `legacy-server:${port}` : shareKey(hostId, port);
 }
 
+/** Listing hostId for a legacy share before the real server host id is known.
+ * remove() round-trips it, so it can never strand a share un-removable. */
+const UNRESOLVED_SERVER_HOST_ID = "server";
+
+function compareListings(a: ShareListing, b: ShareListing): number {
+  return (
+    a.hostName.localeCompare(b.hostName) ||
+    a.hostId.localeCompare(b.hostId) ||
+    a.port - b.port
+  );
+}
+
 function sharedPortErrorCode(error: unknown): string | undefined {
   if (typeof error !== "object" || error === null) return undefined;
   if ("code" in error && typeof error.code === "string") return error.code;
@@ -170,6 +160,8 @@ export class ShareRegistry {
   private loaded = false;
   private loading: Promise<void> | null = null;
   private serverHostId: string | null = null;
+  /** Latest resolved listings, replaced wholesale; snapshot() reads it. */
+  private lastListings: ShareListing[] = [];
   private readonly declaredMachineHostIds = new Set<string>();
 
   constructor(private readonly options: ShareRegistryOptions) {}
@@ -211,7 +203,6 @@ export class ShareRegistry {
         }
         const hostId = parsed.data.hostId ?? null;
         const share: RestoredShare = {
-          storageKey,
           hostId,
           port: parsed.data.port,
           createdAt: parsed.data.createdAt,
@@ -229,8 +220,7 @@ export class ShareRegistry {
   hasServerPort(port: number): boolean {
     for (const share of this.shares.values()) {
       if (share.port !== port) continue;
-      if (share.hostId === null || share.host?.isServer === true) return true;
-      if (this.serverHostId !== null && share.hostId === this.serverHostId) {
+      if (share.hostId === null || share.hostId === this.serverHostId) {
         return true;
       }
     }
@@ -243,30 +233,17 @@ export class ShareRegistry {
     const listings = await Promise.all(
       [...this.shares.values()].map((share) => this.resolveListing(share)),
     );
-    const filtered = listings.filter(
-      (share) => hostId === undefined || share.hostId === hostId,
-    );
-    filtered.sort(
-      (a, b) =>
-        a.hostName.localeCompare(b.hostName) ||
-        a.hostId.localeCompare(b.hostId) ||
-        a.port - b.port,
-    );
-    return filtered;
+    listings.sort(compareListings);
+    this.lastListings = listings;
+    return hostId === undefined
+      ? listings
+      : listings.filter((share) => share.hostId === hostId);
   }
 
-  /** Synchronous cached view for realtime/status paths that cannot await. */
+  /** Synchronous cached view for realtime/status paths that cannot await.
+   * Refreshed wholesale by list() and incrementally by add()/remove(). */
   snapshot(): ShareListing[] {
-    const listings = [...this.shares.values()].map((share) =>
-      this.snapshotListing(share),
-    );
-    listings.sort(
-      (a, b) =>
-        a.hostName.localeCompare(b.hostName) ||
-        a.hostId.localeCompare(b.hostId) ||
-        a.port - b.port,
-    );
-    return listings;
+    return this.lastListings;
   }
 
   async add(port: number, host: ShareHost): Promise<ShareListing> {
@@ -293,19 +270,17 @@ export class ShareRegistry {
         (share.hostId === host.id || (share.hostId === null && host.isServer)),
     );
     if (existing) {
-      existing.host = host;
-      return this.resolveListing(existing);
+      const listing = await this.resolveListing(existing, host);
+      this.updateSnapshot(listing);
+      return listing;
     }
 
     const url = await this.urlFor(host, validated);
     const key = shareKey(host.id, validated);
     const share: RestoredShare = {
-      storageKey: key,
       hostId: host.id,
-      host,
       port: validated,
       createdAt: Date.now(),
-      ...(host.isServer ? {} : { machineUrl: url }),
     };
     this.shares.set(key, share);
     try {
@@ -316,14 +291,16 @@ export class ShareRegistry {
       if (!host.isServer) this.restoreDeclaration(host.id);
       throw error;
     }
-    this.options.onChange?.();
-    return {
+    const listing: ShareListing = {
       hostId: host.id,
       hostName: host.name,
       port: validated,
       createdAt: share.createdAt,
       url,
     };
+    this.updateSnapshot(listing);
+    this.options.onChange?.();
+    return listing;
   }
 
   async remove(port: number, hostSelector: string): Promise<ShareRemoval> {
@@ -338,13 +315,11 @@ export class ShareRegistry {
       return { removed: false, hostId: selector, hostName: selector };
     }
     const { key, share } = resolved;
-    let host = share.host;
-    if (!host) {
-      try {
-        host = await this.resolveHost(share);
-      } catch {
-        // A deleted host must remain prunable by its durable id.
-      }
+    let host: ShareHost | undefined;
+    try {
+      host = await this.resolveHost(share);
+    } catch {
+      // A deleted host must remain prunable by its durable id.
     }
     const publicHostId = host?.id ?? share.hostId ?? selector;
     const hostName = host?.name ?? "removed host";
@@ -373,6 +348,15 @@ export class ShareRegistry {
         );
       }
     }
+    const removedListingIds = new Set([publicHostId]);
+    if (share.hostId === null) {
+      removedListingIds.add(UNRESOLVED_SERVER_HOST_ID);
+      if (this.serverHostId !== null) removedListingIds.add(this.serverHostId);
+    }
+    this.lastListings = this.lastListings.filter(
+      (entry) =>
+        !(entry.port === validated && removedListingIds.has(entry.hostId)),
+    );
     this.options.onChange?.();
     return { removed: true, hostId: publicHostId, hostName };
   }
@@ -399,6 +383,7 @@ export class ShareRegistry {
     const serverHostId = await this.options.hostResolver.serverHostId();
     if (!isActivationCurrent()) return;
     this.serverHostId = serverHostId;
+    await this.normalizeLegacyShares(serverHostId);
     let firstError: unknown;
     for (const hostId of this.machineHostIds()) {
       if (!isActivationCurrent()) return;
@@ -414,64 +399,87 @@ export class ShareRegistry {
     if (firstError !== undefined) throw firstError;
   }
 
-  private async resolveListing(share: RestoredShare): Promise<ShareListing> {
+  /** Rewrite legacy hostId-less entries to the resolved server host id. */
+  private async normalizeLegacyShares(serverHostId: string): Promise<void> {
+    let changed = false;
+    for (const [key, share] of [...this.shares]) {
+      if (share.hostId !== null) continue;
+      this.shares.delete(key);
+      const canonicalKey = shareKey(serverHostId, share.port);
+      if (!this.shares.has(canonicalKey)) {
+        this.shares.set(canonicalKey, { ...share, hostId: serverHostId });
+      }
+      changed = true;
+    }
+    if (!changed) return;
     try {
-      const host = await this.resolveHost(share);
-      share.host = host;
+      await this.persist();
+    } catch (error) {
+      // In-memory state is already normalized; the next successful persist
+      // (any add/remove, or the next activation) rewrites the stored map.
+      this.options.log.warn(
+        `failed to persist normalized legacy shares: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  private updateSnapshot(listing: ShareListing): void {
+    const next = this.lastListings.filter(
+      (entry) =>
+        !(entry.port === listing.port && entry.hostId === listing.hostId),
+    );
+    next.push(listing);
+    next.sort(compareListings);
+    this.lastListings = next;
+  }
+
+  private async resolveListing(
+    share: RestoredShare,
+    knownHost?: ShareHost,
+  ): Promise<ShareListing> {
+    let host = knownHost;
+    try {
+      host ??= await this.resolveHost(share);
       if (host.isServer) this.serverHostId = host.id;
-      const url = host.isServer
-        ? this.serverUrl(share.port)
-        : (share.machineUrl ?? (await this.urlFor(host, share.port)));
-      if (!host.isServer) share.machineUrl = url;
-      share.unavailableHostName = undefined;
-      share.unavailableReason = undefined;
       return {
         hostId: host.id,
         hostName: host.name,
         port: share.port,
         createdAt: share.createdAt,
-        url,
+        url: await this.urlFor(host, share.port),
       };
     } catch (error) {
-      const reason = this.unavailableReason(share, error);
-      share.unavailableHostName =
-        error instanceof ShareHostNotFoundError ? "removed host" : undefined;
-      share.unavailableReason = reason;
-      return this.snapshotListing(share);
+      return this.unavailableListing(share, error, host);
     }
   }
 
   private async resolveHost(share: RestoredShare): Promise<ShareHost> {
-    if (share.host) return share.host;
     return share.hostId === null
       ? this.options.hostResolver.serverHost()
       : this.options.hostResolver.byId(share.hostId);
   }
 
-  private snapshotListing(share: RestoredShare): ShareListing {
-    const hostId =
-      share.host?.id ?? share.hostId ?? this.serverHostId ?? "server";
-    const hostName =
-      share.host?.name ??
-      share.unavailableHostName ??
-      (share.hostId === null ? "server host" : share.hostId);
-    let url = "";
-    if (share.host?.isServer === true) {
-      url = this.serverUrl(share.port);
-    } else if (share.machineUrl !== undefined) {
-      url = share.machineUrl;
-    }
-    const unavailableReason =
-      url === ""
-        ? (share.unavailableReason ?? "Share URL has not been resolved yet.")
-        : undefined;
+  /** `host` is set when resolution succeeded and only the URL failed. */
+  private unavailableListing(
+    share: RestoredShare,
+    error: unknown,
+    host?: ShareHost,
+  ): ShareListing {
     return {
-      hostId,
-      hostName,
+      hostId:
+        host?.id ??
+        share.hostId ??
+        this.serverHostId ??
+        UNRESOLVED_SERVER_HOST_ID,
+      hostName:
+        host?.name ??
+        (error instanceof ShareHostNotFoundError
+          ? "removed host"
+          : (share.hostId ?? "server host")),
       port: share.port,
       createdAt: share.createdAt,
-      url,
-      ...(unavailableReason === undefined ? {} : { unavailableReason }),
+      url: "",
+      unavailableReason: this.unavailableReason(share, error),
     };
   }
 
@@ -531,7 +539,15 @@ export class ShareRegistry {
     selector: string,
   ): Promise<{ key: string; share: RestoredShare } | undefined> {
     for (const [key, share] of this.shares) {
-      if (share.port === port && share.hostId === selector) {
+      if (share.port !== port) continue;
+      if (share.hostId === selector) return { key, share };
+      // Round-trip the ids a legacy share may have been listed under before
+      // its host resolved, so a placeholder can never strand a share.
+      if (
+        share.hostId === null &&
+        (selector === this.serverHostId ||
+          selector === UNRESOLVED_SERVER_HOST_ID)
+      ) {
         return { key, share };
       }
     }
@@ -540,7 +556,6 @@ export class ShareRegistry {
       if (share.port !== port) continue;
       try {
         const host = await this.resolveHost(share);
-        share.host = host;
         if (
           host.id === selector ||
           host.name.toLocaleLowerCase() === selector.toLocaleLowerCase()
@@ -589,7 +604,11 @@ export class ShareRegistry {
     }
     const map: Record<string, unknown> = {};
     for (const share of this.shares.values()) {
-      map[share.storageKey] = {
+      const storageKey =
+        share.hostId === null
+          ? String(share.port)
+          : shareKey(share.hostId, share.port);
+      map[storageKey] = {
         ...(share.hostId === null ? {} : { hostId: share.hostId }),
         port: share.port,
         createdAt: share.createdAt,

--- a/plugins/connect/src/shares.ts
+++ b/plugins/connect/src/shares.ts
@@ -215,6 +215,23 @@ export class ShareRegistry {
       }
     }
     this.shares = next;
+    // Seed the sync snapshot so restored shares are visible in status and
+    // realtime immediately — including unpaired, where no resolution runs.
+    this.lastListings = [...next.values()]
+      .map((share) => this.seededListing(share))
+      .sort(compareListings);
+  }
+
+  /** Pre-resolution listing built from persisted state alone (no RPCs). */
+  private seededListing(share: RestoredShare): ShareListing {
+    return {
+      hostId: share.hostId ?? this.serverHostId ?? UNRESOLVED_SERVER_HOST_ID,
+      hostName: share.hostId ?? "server host",
+      port: share.port,
+      createdAt: share.createdAt,
+      url: "",
+      unavailableReason: "Share URL has not been resolved yet.",
+    };
   }
 
   hasServerPort(port: number): boolean {
@@ -271,7 +288,7 @@ export class ShareRegistry {
     );
     if (existing) {
       const listing = await this.resolveListing(existing, host);
-      this.updateSnapshot(listing);
+      this.updateSnapshot(listing, existing.hostId === null);
       return listing;
     }
 
@@ -298,7 +315,7 @@ export class ShareRegistry {
       createdAt: share.createdAt,
       url,
     };
-    this.updateSnapshot(listing);
+    this.updateSnapshot(listing, false);
     this.options.onChange?.();
     return listing;
   }
@@ -348,11 +365,10 @@ export class ShareRegistry {
         );
       }
     }
-    const removedListingIds = new Set([publicHostId]);
-    if (share.hostId === null) {
-      removedListingIds.add(UNRESOLVED_SERVER_HOST_ID);
-      if (this.serverHostId !== null) removedListingIds.add(this.serverHostId);
-    }
+    const removedListingIds = this.snapshotAliases(
+      publicHostId,
+      share.hostId === null,
+    );
     this.lastListings = this.lastListings.filter(
       (entry) =>
         !(entry.port === validated && removedListingIds.has(entry.hostId)),
@@ -423,10 +439,24 @@ export class ShareRegistry {
     }
   }
 
-  private updateSnapshot(listing: ShareListing): void {
+  /**
+   * All snapshot hostIds this share may currently be listed under. A legacy
+   * or server-host share may have a pre-resolution placeholder row, so every
+   * snapshot mutation must clear the aliases, not just the concrete id.
+   */
+  private snapshotAliases(hostId: string, wasLegacy: boolean): Set<string> {
+    const aliases = new Set([hostId]);
+    if (wasLegacy || hostId === this.serverHostId) {
+      aliases.add(UNRESOLVED_SERVER_HOST_ID);
+      if (this.serverHostId !== null) aliases.add(this.serverHostId);
+    }
+    return aliases;
+  }
+
+  private updateSnapshot(listing: ShareListing, wasLegacy: boolean): void {
+    const aliases = this.snapshotAliases(listing.hostId, wasLegacy);
     const next = this.lastListings.filter(
-      (entry) =>
-        !(entry.port === listing.port && entry.hostId === listing.hostId),
+      (entry) => !(entry.port === listing.port && aliases.has(entry.hostId)),
     );
     next.push(listing);
     next.sort(compareListings);

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -40,6 +40,8 @@ import {
   shareLoopbackHost,
   shareLoopbackOrigin,
   sharePublicUrl,
+  type ShareListing,
+  type ShareRemoval,
 } from "./shares.js";
 import type { ShareHost } from "./hosts.js";
 import type { ConnectStateName, ConnectStatus } from "./types.js";
@@ -161,58 +163,24 @@ export class ConnectTunnel {
     return this.status();
   }
 
-  async expose(
-    port: number,
-    host: ShareHost,
-  ): Promise<{
-    hostId: string;
-    hostName: string;
-    port: number;
-    url: string;
-  }> {
+  async expose(port: number, host: ShareHost): Promise<ShareListing> {
     const listing = await this.options.shares.add(port, host);
     // shares.onChange already publishes; ensure status is fresh if it didn't.
     this.publish();
-    return {
-      hostId: listing.hostId,
-      hostName: listing.hostName,
-      port: listing.port,
-      url: listing.url,
-    };
+    return listing;
   }
 
   async unexpose(
     port: number,
     hostSelector: string,
-  ): Promise<{
-    removed: boolean;
-    hostId: string;
-    hostName: string;
-    port: number;
-  }> {
+  ): Promise<ShareRemoval & { port: number }> {
     const result = await this.options.shares.remove(port, hostSelector);
     this.publish();
     return { ...result, port };
   }
 
-  async listShares(hostId?: string): Promise<
-    Array<{
-      hostId: string;
-      hostName: string;
-      port: number;
-      url: string;
-      unavailableReason?: string;
-    }>
-  > {
-    return (await this.options.shares.list(hostId)).map(
-      ({ hostId: id, hostName, port, url, unavailableReason }) => ({
-        hostId: id,
-        hostName,
-        port,
-        url,
-        ...(unavailableReason === undefined ? {} : { unavailableReason }),
-      }),
-    );
+  async listShares(hostId?: string): Promise<ShareListing[]> {
+    return this.options.shares.list(hostId);
   }
 
   /**
@@ -256,17 +224,7 @@ export class ConnectTunnel {
   }
 
   status(): ConnectStatus {
-    return this.statusWithShares(
-      this.options.shares
-        .snapshot()
-        .map(({ hostId, hostName, port, url, unavailableReason }) => ({
-          hostId,
-          hostName,
-          port,
-          url,
-          ...(unavailableReason === undefined ? {} : { unavailableReason }),
-        })),
-    );
+    return this.statusWithShares(this.options.shares.snapshot());
   }
 
   async refreshStatus(): Promise<ConnectStatus> {
@@ -299,10 +257,10 @@ export class ConnectTunnel {
     return `${base.replace(/\/$/, "")}/dashboard`;
   }
 
-  /** Stop the tunnel without clearing the credential (service abort). */
+  /** Stop the tunnel without clearing the credential (service abort). Plugin
+   * dispose clears server-side declarations via the load-scoped hook. */
   stop(): void {
     this.teardown();
-    this.options.shares.clearMachineDeclarations();
     this.publish();
   }
 
@@ -374,6 +332,13 @@ export class ConnectTunnel {
         this.isShareActivationCurrent(epoch),
       );
       if (!this.isShareActivationCurrent(epoch)) return;
+      if (this.credential !== null) {
+        // Warm the sync status snapshot so realtime consumers see persisted
+        // shares without waiting for a status rpc. list() never rejects on an
+        // unavailable host — it lists that share as unavailable instead.
+        await this.options.shares.list();
+        if (!this.isShareActivationCurrent(epoch)) return;
+      }
       this.publish();
     } catch (error) {
       this.options.log.warn(


### PR DESCRIPTION
Applies the safe subset of the connect-v2 simplification analysis (base: `bb/connect-v2`). Net **-70 source lines** (169+/239-) with behavior preserved; all KEEP-list guards untouched (label_claim triggers, generation-keyed routing, revoke ordering + retry sweep, fresh-resolve tunnel dials, two-layer requireEnrolledHost, add/remove ordering asymmetry, tolerant hydration, ensureConnected finally re-entry).

## What changed

**Share registry — one listing pipeline (`plugins/connect/src/shares.ts`, `tunnel.ts`, `rpc.ts`, `cli.ts`)**
- Replaced the dual `list()`/`snapshot()` pipelines and per-share mutable caches (`host`, `machineUrl`, `unavailableHostName`, `unavailableReason`, `storageKey`) with a single `lastListings` array: `list()` replaces it wholesale, `add()`/`remove()` update it incrementally, `snapshot()` just returns it. `snapshotListing`, the duplicated sort comparator, and the tunnel/rpc field-copy re-mapping layers are gone — `ShareListing` flows through directly. Share rows in rpc/CLI/status output now additionally carry `createdAt`, and unexpose results carry `hostName` (additive; matches what docs/configuration.md already claimed).
- Share activation warms the listings once after declaring machine shares, so realtime status consumers still see persisted shares without a status rpc.
- When host resolution succeeds but URL resolution fails, the listing keeps the resolved host name (same as before).

**Legacy share normalization**
- Legacy hostId-less kv entries are rewritten to the concrete server host id (and canonical `<hostId>:<port>` key) once `declareMachineShares` resolves it; persisted immediately, with in-memory fallback if the write fails. `hasServerPort` keeps its strictly-no-RPC behavior at load time.
- The `"server"` placeholder id a legacy share may be listed under before resolution now round-trips through `remove()`, so a placeholder can never leak into `unexpose(hostId)` and strand a share.

**Dropped defensive code for impossible cases**
- `machineSharePublicUrl` no longer re-validates the tunnel identity with a URL roundtrip — it is already schema-validated at the daemon and server boundaries (`hostDaemonConnectTunnelIdentitySchema`).
- Removed the `arguments.length !== 2` guards on `declareSharedPorts` (server plugin-api + fake plugin host): extra JS args are ignored by the language; the parameter not existing is the contract.
- `affectedRows()` in the gate's machine-label assignment now fails fast when neither real driver shape (better-sqlite3 `{changes}` / D1 `{meta:{changes}}`) is present, deleting the confirm-by-reselect branch for a driver that doesn't exist.

**Redundant state/calls**
- `ConnectTunnelClient` keeps one `{generation, ports: Set}` instead of three copies (`shares`, `latestGeneration`, `ports`); status reporting unchanged.
- `tunnel.stop()` no longer clears machine declarations — every stop path is followed by plugin dispose, whose load-scoped `clearDeclarationsForOwner` clears them server-side. `disconnect()` (unpair without dispose) still clears explicitly, and the test now covers that path.
- Unexported the unused `Share` interface.

## Tests
- Updated shape expectations (`createdAt` on listings, `hostName` on removals), removed the two `arguments.length` assertions, repurposed the service-stop declarations test to cover `disconnect()`, and added a new test for legacy-entry normalization at activation.

## Validation
- `pnpm exec turbo run typecheck` repo-wide: 47/47 pass
- Tests: `bb-plugin-connect` 62/62, `@bb/connect` 79/79, `@bb/plugin-sdk` 30/30, `@bb/host-daemon` 428/428, `@bb/server` 1109/1110 — the one failure is the known macOS-local `install-machine-script` npm-fallback test (passes on CI)
- Prettier clean on all changed files

Deferred per review scope: connect-tunnel.identity push-channel removal (contract change), daemon status-surface shrink, host-name matcher dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)