### PR TITLE
Release Docs plugin 0.1.1

### DIFF
--- a/apps/server/src/services/marketplaces/official-marketplace.ts
+++ b/apps/server/src/services/marketplaces/official-marketplace.ts
@@ -47,7 +47,7 @@ export const OFFICIAL_MARKETPLACE_CATALOG = {
         githubRelease: {
           repository: "ymichael/bb",
           package: "bb-plugin-simple-notes",
-          range: "^0.1.0",
+          range: "^0.1.1",
           tagTemplate: "plugin-docs-v{version}",
           assetTemplate: "bb-plugin-simple-notes-{version}.tgz",
         },

--- a/marketplace.json
+++ b/marketplace.json
@@ -35,7 +35,7 @@
         "githubRelease": {
           "repository": "ymichael/bb",
           "package": "bb-plugin-simple-notes",
-          "range": "^0.1.0",
+          "range": "^0.1.1",
           "tagTemplate": "plugin-docs-v{version}",
           "assetTemplate": "bb-plugin-simple-notes-{version}.tgz"
         }

--- a/marketplace/plugins/docs/package.json
+++ b/marketplace/plugins/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-plugin-simple-notes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create and edit Markdown documents across local and connected-host vaults.",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `bb-plugin-simple-notes` to `0.1.1`
- advance both BB Official catalog ranges to `^0.1.1`
- prepare the Docs sidebar resize fix from #657 for release

## Validation

- `pnpm exec turbo run typecheck --filter=bb-plugin-github --filter=bb-plugin-simple-notes --filter=bb-plugin-memory --filter=@bb/server --filter=@bb/templates`
- `pnpm exec turbo run test --filter=bb-plugin-simple-notes --filter=bb-plugin-memory --filter=@bb/server --filter=@bb/templates --force`
- `pnpm exec turbo run build --filter=bb-plugin-github --filter=bb-plugin-simple-notes --filter=bb-plugin-memory --force`
- `npm pack --dry-run --json` for github/docs/memory; required artifacts present
- `git diff --check`