### PR TITLE
Docs plugin: default sidebar to collapsed in narrow panes

### DIFF
--- a/marketplace/plugins/docs/app.test.tsx
+++ b/marketplace/plugins/docs/app.test.tsx
@@ -163,6 +163,49 @@ describe("Docs nav panel", () => {
     expect(releasePointerCapture).toHaveBeenCalledWith(7);
   });
 
+  it("defaults the sidebar to collapsed in a narrow pane but allows expanding", async () => {
+    class FakeResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+    const clientWidth = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "clientWidth",
+    );
+    Object.defineProperty(Element.prototype, "clientWidth", {
+      configurable: true,
+      get: () => 400,
+    });
+    try {
+      const slot = renderSlot(
+        app.navPanels[0]!,
+        { subPath: "personal" },
+        {
+          rpc: {
+            listNotes: () =>
+              listNotesResult([
+                { path: "note.md", title: "Note", preview: "", modifiedAtMs: 1 },
+              ]),
+          },
+        },
+      );
+
+      const expand = await slot.findByLabelText("Expand notes sidebar");
+      expect(slot.container.querySelector("aside")?.style.width).toBe("40px");
+
+      fireEvent.click(expand);
+      expect(slot.getByLabelText("Collapse notes sidebar")).toBeTruthy();
+      expect(slot.container.querySelector("aside")?.style.width).toBe("288px");
+    } finally {
+      if (clientWidth) {
+        Object.defineProperty(Element.prototype, "clientWidth", clientWidth);
+      }
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("only shows host status when the selected vault is unavailable", async () => {
     const available = listNotesResult([]);
     const unavailable = {

--- a/marketplace/plugins/docs/app.tsx
+++ b/marketplace/plugins/docs/app.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -1232,6 +1233,8 @@ function orderEntries(entries: VaultEntry[]): VaultEntry[] {
   return ordered;
 }
 
+const SIDEBAR_AUTO_COLLAPSE_PANE_WIDTH = 640;
+
 function Tree({
   data,
   selectedPath,
@@ -1252,8 +1255,29 @@ function Tree({
   const [query, setQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  // null = follow the responsive default (collapsed in narrow panes) until
+  // the user toggles the sidebar explicitly.
+  const [sidebarUserCollapsed, setSidebarUserCollapsed] = useState<
+    boolean | null
+  >(null);
+  const [paneNarrow, setPaneNarrow] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(288);
+  const asideRef = useRef<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    const pane = asideRef.current?.parentElement;
+    if (!pane || typeof ResizeObserver === "undefined") return;
+    const update = () => {
+      const width = pane.clientWidth;
+      // Width 0 means the pane is hidden or not yet laid out — keep the
+      // wide-pane default rather than collapsing.
+      setPaneNarrow(width > 0 && width < SIDEBAR_AUTO_COLLAPSE_PANE_WIDTH);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(pane);
+    return () => observer.disconnect();
+  }, []);
+  const sidebarCollapsed = sidebarUserCollapsed ?? paneNarrow;
   const resizeCleanupRef = useRef<(() => void) | null>(null);
   useEffect(
     () => () => {
@@ -1340,6 +1364,7 @@ function Tree({
   if (sidebarCollapsed) {
     return (
       <aside
+        ref={asideRef}
         className="order-2 flex w-10 shrink-0 flex-col items-center border-l border-border bg-muted/20 py-2"
         style={{ width: 40 }}
       >
@@ -1348,7 +1373,7 @@ function Tree({
           size="icon"
           variant="ghost"
           aria-label="Expand notes sidebar"
-          onClick={() => setSidebarCollapsed(false)}
+          onClick={() => setSidebarUserCollapsed(false)}
         >
           <HugeiconsIcon icon={SidebarRightIcon} />
         </Button>
@@ -1358,6 +1383,7 @@ function Tree({
 
   return (
     <aside
+      ref={asideRef}
       className="relative order-2 flex shrink-0 flex-col border-l border-border bg-muted/20"
       style={{ width: sidebarWidth }}
     >
@@ -1432,7 +1458,7 @@ function Tree({
           size="icon"
           variant="ghost"
           aria-label="Collapse notes sidebar"
-          onClick={() => setSidebarCollapsed(true)}
+          onClick={() => setSidebarUserCollapsed(true)}
         >
           <HugeiconsIcon icon={SidebarRightIcon} />
         </Button>


### PR DESCRIPTION
## Summary

When the Docs panel opens in a narrow viewport (e.g. the lower-right pane of a multi-pane split), the 288px notes sidebar overwhelmed the content. The sidebar's default is now responsive:

- **Collapsed** when the plugin pane is narrower than **640px**; **open** (unchanged) otherwise.
- Width is measured with a `ResizeObserver` on the panel's own container — plugin apps render inline, so window-level media queries would see the whole app window rather than the split pane.
- The user's explicit expand/collapse always overrides the default (stored as `boolean | null`, where `null` means "follow the responsive default"); resizing tracks the breakpoint only until the user toggles. Reopening the panel re-derives the default.
- Zero/unmeasurable width (hidden pane, jsdom) keeps the wide-pane default; the observer is skipped when `ResizeObserver` is unavailable.

## Tests

- New test simulating a 400px pane: sidebar renders collapsed by default and manual expand still works.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-simple-notes --force`: 19/19 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)