### PR TITLE
Split view: lighten inactive-pane scrim (40% → 30%)

### DIFF
--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -463,7 +463,7 @@ function SplitTree(props: SplitTreeProps) {
           aria-hidden
           className={cn(
             "pointer-events-none absolute inset-0 z-20 transition-colors",
-            isFocused ? "ring-1 ring-inset ring-ring" : "bg-background/40",
+            isFocused ? "ring-1 ring-inset ring-ring" : "bg-background/30",
           )}
         />
       </div>


### PR DESCRIPTION
## What

In split mode, the non-focused pane was dimmed with a `bg-background/40` scrim overlay, which read as quite dark. This lowers it to `bg-background/30` so the inactive pane is visibly brighter while still clearly distinguishable from the focused pane (which also keeps its inset `ring-ring` outline).

Single-line change in `apps/app/src/views/thread-detail/SplitThreadArea.tsx:466`.

## Before / after

- Inactive pane scrim opacity: `40%` → `30%`
- Focused pane: unchanged (inset ring, no scrim)
- Interaction behavior unchanged — overlay stays `pointer-events-none aria-hidden`

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/app` → passes
- Verified live in the local dev app (split panes render with the lighter scrim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)