### PR TITLE
Docs plugin: remove 'Add to chat' and 'Mention in chat' actions

### DIFF
--- a/marketplace/plugins/docs/app.test.tsx
+++ b/marketplace/plugins/docs/app.test.tsx
@@ -423,17 +423,8 @@ describe("Docs nav panel", () => {
     expect(slot.getByRole("textbox").getAttribute("contenteditable")).toBe(
       "true",
     );
-    fireEvent.click(slot.getByRole("button", { name: "Add to chat" }));
-    fireEvent.click(slot.getByRole("button", { name: "Mention in chat" }));
-    expect(slot.composer.quotes).toEqual(["# Release plan\n\nShip it."]);
-    expect(slot.composer.mentions).toEqual([
-      {
-        provider: "note",
-        id: "personal:plans/release.md",
-        label: "Release plan",
-      },
-    ]);
-    expect(slot.composer.focusCount).toBe(2);
+    expect(slot.queryByRole("button", { name: "Add to chat" })).toBeNull();
+    expect(slot.queryByRole("button", { name: "Mention in chat" })).toBeNull();
     fireEvent.click(slot.getByRole("button", { name: "Open in Docs" }));
     expect(slot.navigateCalls).toContainEqual({
       method: "toPluginPanel",

--- a/marketplace/plugins/docs/app.tsx
+++ b/marketplace/plugins/docs/app.tsx
@@ -10,7 +10,6 @@ import {
 import {
   definePluginApp,
   useBbNavigate,
-  useComposer,
   useRpc,
   useRealtime,
   type PluginFileOpenerProps,
@@ -782,48 +781,8 @@ function DocumentPanel({ params }: PluginThreadPanelProps) {
           onChanged={() => undefined}
           onRenamed={() => undefined}
           renameToTitle={false}
-          composerDocument={document}
         />
       )}
-    </div>
-  );
-}
-
-function DocumentComposerActions({
-  document,
-  getMarkdown,
-}: {
-  document: DocumentRef;
-  getMarkdown(): string;
-}) {
-  const composer = useComposer();
-  return (
-    <div className="flex shrink-0 items-center justify-end gap-2 border-b border-border px-3 py-1.5">
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={() => {
-          const selection = window.getSelection()?.toString().trim();
-          composer.addQuote(selection || getMarkdown());
-          composer.focus();
-        }}
-      >
-        Add to chat
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={() => {
-          composer.insertMention({
-            provider: "note",
-            id: `${document.vaultId}:${document.path}`,
-            label: document.title,
-          });
-          composer.focus();
-        }}
-      >
-        Mention in chat
-      </Button>
     </div>
   );
 }
@@ -834,14 +793,12 @@ function NotePane({
   onChanged,
   onRenamed,
   renameToTitle = true,
-  composerDocument,
 }: {
   vaultId: string;
   notePath: string;
   onChanged(): void;
   onRenamed(path: string): void;
   renameToTitle?: boolean;
-  composerDocument?: DocumentRef;
 }) {
   const rpc = useRpc();
   const [state, setState] = useState<
@@ -962,12 +919,6 @@ function NotePane({
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      {composerDocument ? (
-        <DocumentComposerActions
-          document={composerDocument}
-          getMarkdown={() => markdownRef.current}
-        />
-      ) : null}
       {conflict ? (
         <div className="flex items-center gap-2 border-b border-border bg-muted px-4 py-2 text-xs">
           Changed on disk.


### PR DESCRIPTION
## Summary
Removes the two Docs plugin composer action buttons — **Add to chat** and **Mention in chat** — from the Docs thread panel.

- Deleted the `DocumentComposerActions` component (both buttons and their `addQuote` / `insertMention` / `focus` handlers).
- Removed the render block in `NotePane` that showed it, plus the now-dead `composerDocument` prop from `NotePane`'s signature/type and the `composerDocument={document}` pass in `DocumentPanel`.
- Removed the now-unused `useComposer` import.
- Updated tests to assert both buttons are absent.

No other Docs functionality is affected (mention provider in `server.ts`, "Open in Docs", note editing, and HTML preview are untouched).

## Tests
`pnpm exec turbo run typecheck test build --filter=bb-plugin-simple-notes` — all 4 tasks pass (typecheck clean, 19 tests pass, build succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)