### PR TITLE
Allow removing orphaned builtin plugins

### DIFF
--- a/apps/app/src/components/settings/PluginsSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/PluginsSettingsSection.test.tsx
@@ -176,6 +176,7 @@ function rowPlugin(status: string, logoUrl: string | null = null) {
     logoDarkUrl: null,
     hasSettings: true,
     provenance: "builtin" as const,
+    isOrphanedBuiltin: false,
     marketplaceName: null,
     sourceDisplay: "builtin",
     updateState: EMPTY_PLUGIN_UPDATE_STATE,
@@ -189,9 +190,12 @@ describe("PluginSettingsDetail settings gating", () => {
       vi.fn(() => Promise.resolve(jsonOk(SETTINGS_VIEW))),
     );
     const { wrapper } = createQueryClientTestHarness();
-    render(<PluginSettingsDetail plugin={rowPlugin("needs-configuration")} />, {
-      wrapper,
-    });
+    render(
+      <MemoryRouter>
+        <PluginSettingsDetail plugin={rowPlugin("needs-configuration")} />
+      </MemoryRouter>,
+      { wrapper },
+    );
     expect(await screen.findByLabelText("Greeting")).toBeTruthy();
   });
 
@@ -199,9 +203,51 @@ describe("PluginSettingsDetail settings gating", () => {
     const fetchSpy = vi.fn(() => Promise.resolve(jsonOk(SETTINGS_VIEW)));
     vi.stubGlobal("fetch", fetchSpy);
     const { wrapper } = createQueryClientTestHarness();
-    render(<PluginSettingsDetail plugin={rowPlugin("error")} />, { wrapper });
+    render(
+      <MemoryRouter>
+        <PluginSettingsDetail plugin={rowPlugin("error")} />
+      </MemoryRouter>,
+      { wrapper },
+    );
     expect(screen.queryByLabelText("Greeting")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("removes a stale builtin plugin from its detail page", async () => {
+    const requests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({ url, init });
+        return jsonOk({ ok: true });
+      }),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter>
+        <PluginSettingsDetail
+          plugin={{
+            ...rowPlugin("disabled"),
+            isOrphanedBuiltin: true,
+          }}
+        />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(
+      screen.getByText(/BB remembers the removal so the plugin stays hidden/),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Remove plugin" }));
+
+    await vi.waitFor(() => {
+      expect(requests).toContainEqual({
+        url: "/api/v1/plugins/linear",
+        init: { method: "DELETE" },
+      });
+    });
   });
 
   it("renders a slot-only settings page while the plugins experiment is off", async () => {
@@ -248,6 +294,7 @@ describe("PluginSettingsDetail settings gating", () => {
                 logoDarkUrl: null,
                 hasSettings: false,
                 provenance: "builtin",
+                isOrphanedBuiltin: false,
                 sourceDisplay: "builtin",
                 updateState: {},
               },
@@ -259,7 +306,12 @@ describe("PluginSettingsDetail settings gating", () => {
     );
 
     const { wrapper } = createQueryClientTestHarness();
-    render(<PluginSettingsDetailSection pluginId="connect" />, { wrapper });
+    render(
+      <MemoryRouter>
+        <PluginSettingsDetailSection pluginId="connect" />
+      </MemoryRouter>,
+      { wrapper },
+    );
 
     expect(await screen.findByText("Remote access")).toBeDefined();
     expect(screen.getByText("Custom connect settings")).toBeDefined();

--- a/apps/app/src/components/settings/PluginsSettingsSection.tsx
+++ b/apps/app/src/components/settings/PluginsSettingsSection.tsx
@@ -497,15 +497,16 @@ export function PluginsSettingsSection() {
 }
 
 /**
- * Uninstall control on a plugin's detail page. Builtins can't be uninstalled
- * (they're managed by bb — disable them instead), so this only renders for
- * direct/marketplace installs. A path source keeps its local files; managed
- * (git/npm) sources have their downloaded files deleted.
+ * Uninstall control on a plugin's detail page. Orphaned builtins can be
+ * cleaned up by recording a tombstone while leaving any bundled files alone.
+ * A path source likewise keeps its local files; managed (git/npm) sources
+ * have their downloaded files deleted.
  */
 function RemovePluginSection({ plugin }: { plugin: PluginListItem }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const isBuiltin = plugin.provenance === "builtin";
   const isPathSource = plugin.sourceDisplay.toLowerCase().startsWith("path");
   const name = plugin.displayName ?? plugin.id;
   const remove = useMutation({
@@ -527,7 +528,9 @@ function RemovePluginSection({ plugin }: { plugin: PluginListItem }) {
       <div className="min-w-0">
         <p className="text-sm font-medium text-foreground">Remove plugin</p>
         <p className="mt-0.5 text-xs text-muted-foreground">
-          {isPathSource
+          {isBuiltin
+            ? "Removes the plugin from BB. Its bundled files are left in place."
+            : isPathSource
             ? "Uninstalls the plugin. Its local source files are left in place."
             : "Uninstalls the plugin and deletes its downloaded files."}
         </p>
@@ -546,7 +549,9 @@ function RemovePluginSection({ plugin }: { plugin: PluginListItem }) {
           <DialogHeader>
             <DialogTitle>Remove {name}?</DialogTitle>
             <DialogDescription>
-              {isPathSource
+              {isBuiltin
+                ? "This removes the plugin and its stored settings. BB remembers the removal so the plugin stays hidden after restart; its bundled files remain in place."
+                : isPathSource
                 ? "This uninstalls the plugin and removes its stored settings. Its local source files stay on disk, so you can reinstall it."
                 : "This uninstalls the plugin, deletes its downloaded files, and removes its stored settings."}
             </DialogDescription>
@@ -677,7 +682,7 @@ export function PluginSettingsDetail({ plugin }: { plugin: PluginListItem }) {
       {settingsAvailable ? (
         <PluginSettingsSections pluginId={plugin.id} />
       ) : null}
-      {plugin.provenance !== "builtin" ? (
+      {plugin.provenance !== "builtin" || plugin.isOrphanedBuiltin ? (
         <RemovePluginSection plugin={plugin} />
       ) : null}
     </div>

--- a/apps/app/src/components/settings/plugins/PluginUpdatesCard.test.tsx
+++ b/apps/app/src/components/settings/plugins/PluginUpdatesCard.test.tsx
@@ -38,6 +38,7 @@ function plugin(overrides: Partial<PluginListItem> = {}): PluginListItem {
     logoDarkUrl: null,
     hasSettings: false,
     provenance: "direct",
+    isOrphanedBuiltin: false,
     marketplaceName: null,
     sourceDisplay: "npm · @bb-plugins/linear · pinned",
     updateState: EMPTY_PLUGIN_UPDATE_STATE,

--- a/apps/app/src/components/settings/plugins/UpdatePluginDialog.test.tsx
+++ b/apps/app/src/components/settings/plugins/UpdatePluginDialog.test.tsx
@@ -24,6 +24,7 @@ function plugin(updateState: Partial<PluginUpdateState>): PluginListItem {
     logoDarkUrl: null,
     hasSettings: false,
     provenance: "marketplace",
+    isOrphanedBuiltin: false,
     marketplaceName: "bb-official",
     sourceDisplay: "npm · @bb-plugins/linear · tracks compatible",
     updateState: { ...EMPTY_PLUGIN_UPDATE_STATE, ...updateState },

--- a/apps/app/src/components/settings/plugins/plugin-update-signals.test.ts
+++ b/apps/app/src/components/settings/plugins/plugin-update-signals.test.ts
@@ -23,6 +23,7 @@ function plugin(
     logoDarkUrl: null,
     hasSettings: false,
     provenance: "marketplace",
+    isOrphanedBuiltin: false,
     marketplaceName: "bb-official",
     sourceDisplay: "npm · @bb-plugins/linear · tracks compatible",
     updateState: { ...EMPTY_PLUGIN_UPDATE_STATE, ...updateState },

--- a/apps/app/src/components/settings/settings-nav.test.tsx
+++ b/apps/app/src/components/settings/settings-nav.test.tsx
@@ -150,6 +150,7 @@ describe("useSettingsNavState", () => {
               logoDarkUrl: null,
               hasSettings: false,
               provenance: "builtin",
+              isOrphanedBuiltin: false,
               sourceDisplay: "builtin",
               updateState: {},
             },

--- a/apps/app/src/hooks/queries/plugin-settings-queries.test.ts
+++ b/apps/app/src/hooks/queries/plugin-settings-queries.test.ts
@@ -16,6 +16,7 @@ const ROW = {
   status: "running",
   statusDetail: null,
   provenance: "direct",
+  isOrphanedBuiltin: false,
   sourceDisplay: "npm · @bb-plugins/linear · pinned",
   updateState: {
     availableVersion: "1.7.0",
@@ -56,10 +57,17 @@ describe("fetchPluginList envelope", () => {
     const { updateState, ...noUpdateState } = ROW;
     const { provenance, ...noProvenance } = ROW;
     const { sourceDisplay, ...noSourceDisplay } = ROW;
+    const { isOrphanedBuiltin, ...noOrphanedBuiltin } = ROW;
     const result = await fetchPluginList(
       fetchReturning({
         enabled: true,
-        plugins: [noUpdateState, noProvenance, noSourceDisplay, ROW],
+        plugins: [
+          noUpdateState,
+          noProvenance,
+          noSourceDisplay,
+          noOrphanedBuiltin,
+          ROW,
+        ],
       }),
     );
     expect(result.plugins.map((plugin) => plugin.id)).toEqual(["linear"]);

--- a/apps/app/src/hooks/queries/plugin-settings-queries.ts
+++ b/apps/app/src/hooks/queries/plugin-settings-queries.ts
@@ -62,6 +62,8 @@ export interface PluginListItem {
   /** True when the loaded plugin declared settings; drives its nav entry. */
   hasSettings: boolean;
   provenance: PluginProvenance;
+  /** Persisted builtin registration whose bundle is no longer shipped by BB. */
+  isOrphanedBuiltin: boolean;
   /** Marketplace display name when provenance is "marketplace". */
   marketplaceName: string | null;
   /** Human source line ("npm · @bb-plugins/linear · pinned"). */
@@ -127,6 +129,7 @@ const pluginListItemSchema = z.object({
   logoDarkUrl: z.string().nullish(),
   hasSettings: z.boolean().optional(),
   provenance: z.enum(["builtin", "direct", "marketplace"]),
+  isOrphanedBuiltin: z.boolean(),
   marketplaceName: z.string().nullish(),
   sourceDisplay: z.string(),
   updateState: updateStateSchema,
@@ -150,6 +153,7 @@ function parsePluginListItem(value: unknown): PluginListItem | null {
     logoDarkUrl: item.logoDarkUrl ?? null,
     hasSettings: item.hasSettings === true,
     provenance: item.provenance,
+    isOrphanedBuiltin: item.isOrphanedBuiltin,
     marketplaceName: item.marketplaceName ?? null,
     sourceDisplay: item.sourceDisplay,
     updateState: {

--- a/apps/server/src/services/plugins/plugin-service-internal.ts
+++ b/apps/server/src/services/plugins/plugin-service-internal.ts
@@ -69,6 +69,8 @@ export interface PluginListEntry {
   rootDir: string;
   version: string;
   provenance: "builtin" | "direct" | "marketplace";
+  /** True when a persisted builtin registration no longer exists in BB's builtin registry. */
+  isOrphanedBuiltin: boolean;
   marketplaceName?: string;
   sourceDisplay: string;
   updateState: {

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -856,6 +856,11 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
           rootDir: row.rootDir,
           version: row.version,
           provenance: row.provenance,
+          isOrphanedBuiltin:
+            row.sourceKind === "builtin" &&
+            !builtinPlugins.some(
+              (builtin) => builtin.name === row.sourceBuiltinName,
+            ),
           ...(row.marketplaceId === null
             ? {}
             : {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -129,6 +129,7 @@ function createService(args: {
   defaultEnabled?: boolean;
   isEnabled?: () => boolean;
   isConnectEnabled?: () => boolean;
+  includeBuiltin?: boolean;
   rootDir?: string;
   watchBuiltinPluginSources?: boolean;
 }): PluginService {
@@ -144,13 +145,16 @@ function createService(args: {
     appVersion: "0.9.0",
     isEnabled: args.isEnabled ?? (() => false),
     isConnectEnabled: args.isConnectEnabled ?? (() => false),
-    builtinPlugins: [
-      {
-        name: args.builtinName ?? "fixture",
-        rootDir: args.rootDir ?? fixtureRoot,
-        defaultEnabled: args.defaultEnabled ?? true,
-      },
-    ],
+    builtinPlugins:
+      args.includeBuiltin === false
+        ? []
+        : [
+            {
+              name: args.builtinName ?? "fixture",
+              rootDir: args.rootDir ?? fixtureRoot,
+              defaultEnabled: args.defaultEnabled ?? true,
+            },
+          ],
     watchBuiltinPluginSources: args.watchBuiltinPluginSources,
     loadTimeoutMs: 2000,
   });
@@ -210,6 +214,7 @@ describe("builtin plugin reconciliation", () => {
         source: "builtin:fixture",
         version: "0.1.0",
         provenance: "builtin",
+        isOrphanedBuiltin: false,
         sourceDisplay: "builtin · builtin-fixture",
         updateState: {},
         icon: "EditFile",
@@ -226,6 +231,24 @@ describe("builtin plugin reconciliation", () => {
         normalizationVersion: 1,
       },
     );
+  });
+
+  it("marks a persisted builtin as orphaned after it leaves the registry", async () => {
+    service = createService({ db, dataDir: join(workDir, "data") });
+    await service.start();
+    expect(service.list()[0]?.isOrphanedBuiltin).toBe(false);
+    await service.stop();
+
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      includeBuiltin: false,
+    });
+    await service.start();
+
+    expect(service.list()).toMatchObject([
+      { id: "builtin-fixture", isOrphanedBuiltin: true },
+    ]);
   });
 
   it("backfills every legacy source form once while preserving registration state", async () => {


### PR DESCRIPTION
## Summary

- identify persisted builtin plugin registrations that no longer exist in the current builtin registry
- expose the existing removal flow only for those orphaned builtins while keeping active builtins non-removable in Settings
- cover server classification, client boundary parsing, and the removal UI

## Tests

- pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server
- focused @bb/app plugin settings tests (17 passed)
- focused @bb/server builtin plugin tests (16 passed)
- pnpm exec turbo run lint --filter=@bb/app --filter=@bb/server (no errors; existing warnings only)