### PR TITLE
Add /changelog page to the marketing site

### DIFF
--- a/apps/web/src/landing/changelog.css
+++ b/apps/web/src/landing/changelog.css
@@ -1,0 +1,274 @@
+/* bb changelog — loads alongside landing.css and reuses its tokens (--ink,
+   --border-soft, …) plus the hero mock's sidebar classes (.side-label, .trow,
+   .thread-kids, .tstatus, .trun) for the release visuals. Layout follows the
+   Cursor-changelog shape: a sticky version rail beside each release body. */
+
+/* ── Page header ─────────────────────────────────────────────────── */
+
+.page-head {
+  padding: 72px 0 40px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.page-head h1 {
+  font-size: clamp(34px, 5vw, 46px);
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  color: oklch(0.21 0 0);
+}
+
+.page-head .sub {
+  margin-top: 14px;
+  color: var(--dim);
+  font-size: 17px;
+  max-width: 540px;
+}
+
+.page-head .meta-row {
+  margin-top: 22px;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  font-size: 13.5px;
+}
+
+.meta-row a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--dim);
+}
+
+.meta-row a:hover {
+  color: var(--ink);
+}
+
+.meta-row .ri {
+  width: 15px;
+  height: 15px;
+}
+
+/* Current-page link in the shared nav. */
+.nav-links .nav-current {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+/* ── Releases ────────────────────────────────────────────────────── */
+
+.release {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  gap: 48px;
+  padding: 64px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+/* The subscribe strip below draws its own border-top. */
+.release:last-of-type {
+  border-bottom: none;
+}
+
+/* Left rail: version + date stay pinned while the entry scrolls. */
+.rail-sticky {
+  position: sticky;
+  top: 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.version {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.version:hover {
+  border-color: color-mix(in oklab, var(--ink) 28%, var(--bg));
+}
+
+.release-date {
+  font-size: 13.5px;
+  color: var(--subtle);
+}
+
+/* Right column: entry body. */
+.release-body h2 {
+  font-size: clamp(24px, 3.2vw, 32px);
+  line-height: 1.12;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+  color: oklch(0.21 0 0);
+}
+
+.release-body .lede {
+  margin-top: 14px;
+  color: var(--dim);
+  font-size: 16.5px;
+  max-width: 38em;
+}
+
+.release-body h3 {
+  margin-top: 40px;
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  color: oklch(0.24 0 0);
+}
+
+.release-body h3 + p,
+.release-body ul + p {
+  margin-top: 12px;
+  color: var(--dim);
+  font-size: 15px;
+  max-width: 44em;
+}
+
+.release-body ul {
+  margin-top: 12px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.release-body li {
+  position: relative;
+  padding-left: 20px;
+  color: var(--dim);
+  font-size: 15px;
+  max-width: 44em;
+}
+
+/* Small square tick — quieter than a round bullet, matching the app's
+   utilitarian feel. */
+.release-body li::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 0.62em;
+  width: 6px;
+  height: 6px;
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--ink) 26%, var(--bg));
+}
+
+/* "Beta" chip next to the Experiments section heading. */
+.h-chip {
+  display: inline-block;
+  vertical-align: 2px;
+  margin-left: 9px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--spark);
+  border: 1px solid color-mix(in oklab, var(--spark) 35%, var(--bg));
+  background: color-mix(in oklab, var(--spark) 7%, var(--bg));
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.release-body code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--surface-recessed);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+/* ── Feature media: sidebar recreation on a dot-grid stage ───────── */
+
+.feature-media {
+  margin-top: 28px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--surface);
+  box-shadow:
+    0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent),
+    0 24px 54px -30px color-mix(in oklab, var(--ink) 30%, transparent);
+}
+
+.media-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  background-image: radial-gradient(
+    circle,
+    color-mix(in oklab, var(--ink) 12%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 22px 22px;
+}
+
+/* The media card holds app-mock markup, not prose — undo the release-body
+   list styling so .threads/.trow render exactly as they do in landing.css. */
+.release-body .feature-media ul {
+  margin-top: 0;
+  display: block;
+  gap: 0;
+}
+
+.release-body .feature-media li {
+  padding-left: 0;
+  max-width: none;
+  font-size: inherit;
+  color: inherit;
+}
+
+.release-body .feature-media li::before {
+  content: none;
+}
+
+/* A floating slice of the app sidebar. Row styles come from landing.css. */
+.sidebar-card {
+  width: min(320px, 100%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 8px 8px 10px;
+  overflow: hidden;
+  box-shadow:
+    0 1px 0 color-mix(in oklab, var(--ink) 4%, transparent),
+    0 22px 44px -24px color-mix(in oklab, var(--ink) 32%, transparent);
+}
+
+.sidebar-card .side-label:first-child {
+  padding-top: 5px;
+}
+
+/* Rows are decorative here, not clickable like the hero mock's. */
+.sidebar-card .trow {
+  cursor: default;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────── */
+
+@media (max-width: 720px) {
+  .release {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    padding: 48px 0;
+  }
+
+  .rail-sticky {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .media-stage {
+    padding: 28px 16px;
+  }
+}

--- a/apps/web/src/landing/changelog.test.ts
+++ b/apps/web/src/landing/changelog.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { parseChangelog } from "./changelog";
+
+const SAMPLE = `# Changelog
+
+## 0.0.30
+
+This release introduces multi-machine workflows.
+It also adds more ways to customize bb.
+
+### Work across machines
+
+- Multi-machine support lets you add computers to bb.
+- bb Connect lets you securely access bb from other devices
+  and share previews from any enrolled machine.
+
+### Fixes and polish
+
+- Fixed microphone input in signed macOS desktop builds.
+
+## 0.0.29
+
+This release expands agent and model support.
+
+### Experiments
+
+New experiment to let you connect to bb from other computers.
+`;
+
+describe("parseChangelog", () => {
+  it("splits releases and keeps section structure", () => {
+    const releases = parseChangelog(SAMPLE);
+    expect(releases.map((release) => release.version)).toEqual([
+      "0.0.30",
+      "0.0.29",
+    ]);
+
+    const [latest, prior] = releases;
+    expect(latest.lede).toEqual([
+      {
+        kind: "paragraph",
+        text: "This release introduces multi-machine workflows. It also adds more ways to customize bb.",
+      },
+    ]);
+    expect(latest.sections.map((section) => section.title)).toEqual([
+      "Work across machines",
+      "Fixes and polish",
+    ]);
+    expect(prior.sections).toHaveLength(1);
+  });
+
+  it("joins indented bullet continuation lines", () => {
+    const [latest] = parseChangelog(SAMPLE);
+    const [firstSection] = latest.sections;
+    expect(firstSection.blocks).toEqual([
+      {
+        kind: "list",
+        items: [
+          "Multi-machine support lets you add computers to bb.",
+          "bb Connect lets you securely access bb from other devices and share previews from any enrolled machine.",
+        ],
+      },
+    ]);
+  });
+
+  it("keeps a bare paragraph inside a section (0.0.29 Experiments shape)", () => {
+    const [, prior] = parseChangelog(SAMPLE);
+    expect(prior.sections[0].blocks).toEqual([
+      {
+        kind: "paragraph",
+        text: "New experiment to let you connect to bb from other computers.",
+      },
+    ]);
+  });
+});

--- a/apps/web/src/landing/changelog.ts
+++ b/apps/web/src/landing/changelog.ts
@@ -1,0 +1,119 @@
+/* Parses the repo-root CHANGELOG.md (the single source of truth for release
+ * notes) into structured releases for the /changelog page. The changelog's
+ * shape is deliberately simple — `## <version>` per release, optional intro
+ * paragraphs, `### <section>` groups of paragraphs and `- ` bullets — and the
+ * parser supports exactly that shape. */
+
+export type ReleaseBlock =
+  | { kind: "paragraph"; text: string }
+  | { kind: "list"; items: string[] };
+
+export type ReleaseSection = {
+  title: string;
+  blocks: ReleaseBlock[];
+};
+
+export type Release = {
+  version: string;
+  /** Intro blocks between the `##` heading and the first `###` section. */
+  lede: ReleaseBlock[];
+  sections: ReleaseSection[];
+};
+
+/** Presentation extras that don't belong in CHANGELOG.md itself. */
+export type ReleaseMeta = {
+  /** Human-readable ship date, e.g. "July 14, 2026". */
+  date: string;
+  /** Marketing headline shown instead of the bare version number. */
+  headline: string;
+};
+
+export const RELEASE_META: Record<string, ReleaseMeta> = {
+  "0.0.30": {
+    date: "July 14, 2026",
+    headline: "Multi-machine workflows and bb Connect",
+  },
+  "0.0.29": {
+    date: "July 9, 2026",
+    headline: "More agents, more models, redesigned Settings",
+  },
+};
+
+export function parseChangelog(markdown: string): Release[] {
+  const releases: Release[] = [];
+  let release: Release | null = null;
+  let section: ReleaseSection | null = null;
+  let paragraph: string[] = [];
+
+  const blocksInScope = (): ReleaseBlock[] | null => {
+    if (!release) {
+      return null;
+    }
+    return section ? section.blocks : release.lede;
+  };
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) {
+      return;
+    }
+    const text = paragraph.join(" ").trim();
+    paragraph = [];
+    const blocks = blocksInScope();
+    if (text && blocks) {
+      blocks.push({ kind: "paragraph", text });
+    }
+  };
+
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.trimEnd();
+
+    if (line.startsWith("## ") && !line.startsWith("### ")) {
+      flushParagraph();
+      section = null;
+      release = { version: line.slice(3).trim(), lede: [], sections: [] };
+      releases.push(release);
+      continue;
+    }
+    if (!release) {
+      // Preamble (the `# Changelog` title) — nothing to collect.
+      continue;
+    }
+    if (line.startsWith("### ")) {
+      flushParagraph();
+      section = { title: line.slice(4).trim(), blocks: [] };
+      release.sections.push(section);
+      continue;
+    }
+    if (line.startsWith("- ")) {
+      flushParagraph();
+      const blocks = blocksInScope();
+      if (!blocks) {
+        continue;
+      }
+      const last = blocks.at(-1);
+      let list = last?.kind === "list" ? last : null;
+      if (!list) {
+        list = { kind: "list", items: [] };
+        blocks.push(list);
+      }
+      list.items.push(line.slice(2).trim());
+      continue;
+    }
+    if (line.startsWith("  ") && line.trim()) {
+      // Indented continuation of the previous bullet.
+      const last = blocksInScope()?.at(-1);
+      if (last?.kind === "list" && last.items.length > 0) {
+        last.items[last.items.length - 1] += ` ${line.trim()}`;
+        continue;
+      }
+    }
+    if (!line.trim()) {
+      flushParagraph();
+      continue;
+    }
+    paragraph.push(line.trim());
+  }
+  flushParagraph();
+
+  return releases;
+}

--- a/apps/web/src/landing/cta.tsx
+++ b/apps/web/src/landing/cta.tsx
@@ -1,0 +1,136 @@
+import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import type { FormEvent, ReactNode } from "react";
+
+import { trackLandingEvent } from "./analytics";
+import type { CtaPlacement } from "./site";
+import { GITHUB_URL, SUBSCRIBE_PATH, downloadMacosHref } from "./site";
+
+/* Marketing CTAs shared by the landing page and the changelog. */
+
+type CtaLinkProps = {
+  placement: CtaPlacement;
+  /** Omit for a plain inline link (nav/footer); set for button-styled CTAs. */
+  className?: string;
+  children: ReactNode;
+};
+
+export function DownloadLink({ placement, className, children }: CtaLinkProps) {
+  return (
+    <a className={className} href={downloadMacosHref(placement)}>
+      {children}
+    </a>
+  );
+}
+
+export function GitHubLink({ placement, className, children }: CtaLinkProps) {
+  return (
+    <a
+      className={className}
+      href={GITHUB_URL}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() =>
+        trackLandingEvent({
+          name: "landing_github_clicked",
+          properties: { placement },
+        })
+      }
+    >
+      {children}
+    </a>
+  );
+}
+
+/* ── Email signup ─────────────────────────────────────────────────── */
+
+type SubscribeStatus = "idle" | "submitting" | "success" | "error";
+
+// Email capture that POSTs to the first-party /api/subscribe Worker route,
+// which adds the address to the bb marketing audience in Resend. JS-enhanced:
+// it submits inline and swaps to a confirmation rather than navigating.
+export function EmailSignup({ placement }: { placement: CtaPlacement }) {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<SubscribeStatus>("idle");
+  const [error, setError] = useState("");
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (status === "submitting") {
+      return;
+    }
+    setStatus("submitting");
+    setError("");
+    try {
+      const response = await fetch(SUBSCRIBE_PATH, {
+        body: JSON.stringify({ email }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setError(body.error ?? "Something went wrong. Try again.");
+        setStatus("error");
+        return;
+      }
+      trackLandingEvent({
+        name: "landing_email_subscribed",
+        properties: { placement },
+      });
+      setStatus("success");
+    } catch {
+      setError("Could not reach the server. Try again.");
+      setStatus("error");
+    }
+  };
+
+  if (status === "success") {
+    return (
+      <p className="subscribe-done" role="status">
+        <HugeiconsIcon
+          icon={CheckmarkCircle02Icon}
+          className="subscribe-done-ic"
+        />
+        You&rsquo;re on the list. We&rsquo;ll be in touch.
+      </p>
+    );
+  }
+
+  return (
+    <form className="subscribe-form" onSubmit={submit} noValidate>
+      <input
+        className="subscribe-input"
+        type="email"
+        name="email"
+        inputMode="email"
+        autoComplete="email"
+        required
+        placeholder="you@example.com"
+        aria-label="Email address"
+        aria-invalid={status === "error"}
+        value={email}
+        onChange={(event) => {
+          setEmail(event.target.value);
+          if (status === "error") {
+            setStatus("idle");
+          }
+        }}
+      />
+      <button
+        type="submit"
+        className="btn btn-primary subscribe-btn"
+        disabled={status === "submitting"}
+      >
+        {status === "submitting" ? "Subscribing…" : "Subscribe"}
+      </button>
+      {status === "error" ? (
+        <span className="subscribe-error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DownloadMacosRouteImport } from './routes/download.macos'
 import { Route as ApiSubscribeRouteImport } from './routes/api.subscribe'
@@ -22,6 +23,11 @@ import { Route as ApiAuthSplatRouteImport } from './routes/api.auth.$'
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChangelogRoute = ChangelogRouteImport.update({
+  id: '/changelog',
+  path: '/changelog',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -67,6 +73,7 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
   '/api/subscribe': typeof ApiSubscribeRoute
   '/download/macos': typeof DownloadMacosRoute
@@ -78,6 +85,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
   '/api/subscribe': typeof ApiSubscribeRoute
   '/download/macos': typeof DownloadMacosRoute
@@ -90,6 +98,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
   '/api/subscribe': typeof ApiSubscribeRoute
   '/download/macos': typeof DownloadMacosRoute
@@ -103,6 +112,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/changelog'
     | '/dashboard'
     | '/api/subscribe'
     | '/download/macos'
@@ -114,6 +124,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/changelog'
     | '/dashboard'
     | '/api/subscribe'
     | '/download/macos'
@@ -125,6 +136,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/changelog'
     | '/dashboard'
     | '/api/subscribe'
     | '/download/macos'
@@ -137,6 +149,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ChangelogRoute: typeof ChangelogRoute
   DashboardRoute: typeof DashboardRoute
   ApiSubscribeRoute: typeof ApiSubscribeRoute
   DownloadMacosRoute: typeof DownloadMacosRoute
@@ -154,6 +167,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard'
       fullPath: '/dashboard'
       preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/changelog': {
+      id: '/changelog'
+      path: '/changelog'
+      fullPath: '/changelog'
+      preLoaderRoute: typeof ChangelogRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -217,6 +237,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ChangelogRoute: ChangelogRoute,
   DashboardRoute: DashboardRoute,
   ApiSubscribeRoute: ApiSubscribeRoute,
   DownloadMacosRoute: DownloadMacosRoute,

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -1,0 +1,238 @@
+import { Loading03Icon, Mail01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { createFileRoute } from "@tanstack/react-router";
+import { Fragment, useEffect } from "react";
+import type { ReactNode } from "react";
+
+import changelogMd from "../../../../CHANGELOG.md?raw";
+import bbIcon from "../assets/bb-icon.png";
+import { initAnalytics } from "../landing/analytics";
+import type { Release, ReleaseBlock } from "../landing/changelog";
+import { RELEASE_META, parseChangelog } from "../landing/changelog";
+import { DownloadLink, EmailSignup, GitHubLink } from "../landing/cta";
+import { DASHBOARD_PATH } from "../lib/connect-return-to";
+import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import landingCss from "../landing/landing.css?url";
+import changelogCss from "../landing/changelog.css?url";
+
+const PAGE_TITLE = "Changelog — bb";
+const PAGE_DESCRIPTION =
+  "New features, improvements, and fixes in every bb release.";
+
+export const Route = createFileRoute("/changelog")({
+  head: () => ({
+    meta: [
+      { title: PAGE_TITLE },
+      { name: "description", content: PAGE_DESCRIPTION },
+      { property: "og:title", content: PAGE_TITLE },
+      { property: "og:description", content: PAGE_DESCRIPTION },
+      { property: "og:type", content: "website" },
+      { name: "theme-color", content: "#ffffff" },
+    ],
+    links: [
+      {
+        rel: "preload",
+        href: interWoff2,
+        as: "font",
+        type: "font/woff2",
+        crossOrigin: "anonymous",
+      },
+      { rel: "stylesheet", href: landingCss },
+      { rel: "stylesheet", href: changelogCss },
+    ],
+  }),
+  component: ChangelogRoute,
+});
+
+function ChangelogRoute() {
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+  return <ChangelogPage />;
+}
+
+const RELEASES = parseChangelog(changelogMd);
+
+/** "0.0.30" → "0-0-30", a fragment id that survives URL parsing. */
+function anchorId(version: string): string {
+  return version.replaceAll(".", "-");
+}
+
+/** Render a changelog line, turning `backtick` spans into <code>. */
+function inline(text: string): ReactNode {
+  const parts = text.split("`");
+  if (parts.length === 1) {
+    return text;
+  }
+  return parts.map((part, index) =>
+    index % 2 === 1 ? <code key={index}>{part}</code> : <Fragment key={index}>{part}</Fragment>,
+  );
+}
+
+/* ── Release media ────────────────────────────────────────────────────
+   A hand-built visual per marquee release, in place of a screenshot: a
+   floating slice of the app sidebar, reusing the hero mock's classes from
+   landing.css so it matches the real app (and the homepage) exactly. */
+
+function ByMachineSidebar() {
+  return (
+    <div className="feature-media">
+      <div className="media-stage">
+        <div
+          className="sidebar-card"
+          role="img"
+          aria-label="bb sidebar grouped by machine, with threads running on two computers"
+        >
+          <div className="side-label">Sawyer&rsquo;s MacBook Air</div>
+          <ul className="threads">
+            <li>
+              <div className="trow">
+                <span className="trow-title">Special Case Handling</span>
+                <span className="tstatus" aria-hidden>
+                  <HugeiconsIcon icon={Loading03Icon} className="trun" />
+                </span>
+              </div>
+            </li>
+            <li>
+              <div className="trow">
+                <span className="trow-title">Desloppify High-Priority Worker</span>
+              </div>
+              <ul className="threads thread-kids">
+                <li>
+                  <div className="trow trow-kid">
+                    <span className="trow-title">
+                      First-principles codebase simplification
+                    </span>
+                  </div>
+                </li>
+              </ul>
+            </li>
+          </ul>
+          <div className="side-label">Sawyer&rsquo;s MacBook Pro</div>
+          <ul className="threads">
+            <li>
+              <div className="trow active">
+                <span className="trow-title">Design Changelog Page</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const RELEASE_MEDIA: Record<string, ReactNode> = {
+  "0.0.30": <ByMachineSidebar />,
+};
+
+/* ── Page ─────────────────────────────────────────────────────────── */
+
+function Blocks({ blocks }: { blocks: ReleaseBlock[] }) {
+  return (
+    <>
+      {blocks.map((block, index) =>
+        block.kind === "list" ? (
+          <ul key={index}>
+            {block.items.map((item) => (
+              <li key={item}>{inline(item)}</li>
+            ))}
+          </ul>
+        ) : (
+          <p key={index}>{inline(block.text)}</p>
+        ),
+      )}
+    </>
+  );
+}
+
+function ReleaseEntry({ release }: { release: Release }) {
+  const meta = RELEASE_META[release.version];
+  const anchor = anchorId(release.version);
+  return (
+    <article className="release" id={anchor}>
+      <div className="release-rail">
+        <div className="rail-sticky">
+          <a className="version" href={`#${anchor}`}>
+            {release.version}
+          </a>
+          {meta ? <span className="release-date">{meta.date}</span> : null}
+        </div>
+      </div>
+      <div className="release-body">
+        <h2>{meta?.headline ?? release.version}</h2>
+        {release.lede.map((block, index) =>
+          block.kind === "paragraph" ? (
+            <p key={index} className="lede">
+              {inline(block.text)}
+            </p>
+          ) : null,
+        )}
+        {RELEASE_MEDIA[release.version]}
+        {release.sections.map((section) => (
+          <Fragment key={section.title}>
+            <h3>
+              {section.title}
+              {section.title === "Experiments" ? (
+                <span className="h-chip">Beta</span>
+              ) : null}
+            </h3>
+            <Blocks blocks={section.blocks} />
+          </Fragment>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function ChangelogPage() {
+  return (
+    <div className="wrap">
+      <nav className="nav">
+        <a className="logo" href="/">
+          <img src={bbIcon} alt="bb" width={36} height={36} />
+        </a>
+        <div className="nav-links">
+          <a className="nav-current" href="/changelog">
+            Changelog
+          </a>
+          <GitHubLink placement="nav">GitHub</GitHubLink>
+          <a href={DASHBOARD_PATH}>Sign in</a>
+          <DownloadLink placement="nav" className="btn btn-primary btn-sm">
+            Download for macOS
+          </DownloadLink>
+        </div>
+      </nav>
+
+      <header className="page-head">
+        <h1>Changelog</h1>
+        <p className="sub">{PAGE_DESCRIPTION}</p>
+        <div className="meta-row">
+          <a href="#subscribe">
+            <HugeiconsIcon icon={Mail01Icon} className="ri" />
+            Get release notes by email
+          </a>
+        </div>
+      </header>
+
+      {RELEASES.map((release) => (
+        <ReleaseEntry key={release.version} release={release} />
+      ))}
+
+      <section className="subscribe" id="subscribe">
+        <h2 className="subscribe-title">Stay in the loop.</h2>
+        <p>Get release notes in your inbox. No spam.</p>
+        <EmailSignup placement="footer" />
+      </section>
+
+      <footer className="footer">
+        <span>bb is free and open source (MIT)</span>
+        <span>
+          <GitHubLink placement="footer">GitHub</GitHubLink>
+          {" · "}
+          <DownloadLink placement="footer">Download</DownloadLink>
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -27,12 +27,13 @@ import {
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { CSSProperties, FormEvent, ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { initAnalytics, trackLandingEvent } from "../landing/analytics";
 import bbIcon from "../assets/bb-icon.png";
 import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
+import { DownloadLink, EmailSignup, GitHubLink } from "../landing/cta";
 import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import {
   ClaudeIcon,
@@ -45,14 +46,7 @@ import {
   PiIcon,
 } from "../landing/icons";
 import type { CtaPlacement } from "../landing/site";
-import {
-  CLI_COMMAND,
-  GITHUB_URL,
-  SITE_DESCRIPTION,
-  SITE_TITLE,
-  SUBSCRIBE_PATH,
-  downloadMacosHref,
-} from "../landing/site";
+import { CLI_COMMAND, SITE_DESCRIPTION, SITE_TITLE } from "../landing/site";
 import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
 import landingCss from "../landing/landing.css?url";
 
@@ -110,40 +104,6 @@ const AppleSolidIcon: IconSvgElement = [
 ];
 
 /* ── CTAs ─────────────────────────────────────────────────────────── */
-
-type CtaLinkProps = {
-  placement: CtaPlacement;
-  /** Omit for a plain inline link (nav/footer); set for button-styled CTAs. */
-  className?: string;
-  children: ReactNode;
-};
-
-function DownloadLink({ placement, className, children }: CtaLinkProps) {
-  return (
-    <a className={className} href={downloadMacosHref(placement)}>
-      {children}
-    </a>
-  );
-}
-
-function GitHubLink({ placement, className, children }: CtaLinkProps) {
-  return (
-    <a
-      className={className}
-      href={GITHUB_URL}
-      target="_blank"
-      rel="noreferrer"
-      onClick={() =>
-        trackLandingEvent({
-          name: "landing_github_clicked",
-          properties: { placement },
-        })
-      }
-    >
-      {children}
-    </a>
-  );
-}
 
 // The browser install path, rendered as an outline button whose body is the
 // run command. Clicking anywhere copies it (there's no hosted URL to open —
@@ -209,92 +169,6 @@ function InstallOptions({ placement }: { placement: CtaPlacement }) {
         </span>
       </div>
     </div>
-  );
-}
-
-/* ── Email signup ─────────────────────────────────────────────────── */
-
-type SubscribeStatus = "idle" | "submitting" | "success" | "error";
-
-// Email capture that POSTs to the first-party /api/subscribe Worker route,
-// which adds the address to the bb marketing audience in Resend. JS-enhanced:
-// it submits inline and swaps to a confirmation rather than navigating.
-function EmailSignup({ placement }: { placement: CtaPlacement }) {
-  const [email, setEmail] = useState("");
-  const [status, setStatus] = useState<SubscribeStatus>("idle");
-  const [error, setError] = useState("");
-
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (status === "submitting") {
-      return;
-    }
-    setStatus("submitting");
-    setError("");
-    try {
-      const response = await fetch(SUBSCRIBE_PATH, {
-        body: JSON.stringify({ email }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
-      if (!response.ok) {
-        const body = (await response.json().catch(() => ({}))) as {
-          error?: string;
-        };
-        setError(body.error ?? "Something went wrong. Try again.");
-        setStatus("error");
-        return;
-      }
-      trackLandingEvent({ name: "landing_email_subscribed", properties: { placement } });
-      setStatus("success");
-    } catch {
-      setError("Could not reach the server. Try again.");
-      setStatus("error");
-    }
-  };
-
-  if (status === "success") {
-    return (
-      <p className="subscribe-done" role="status">
-        <HugeiconsIcon icon={CheckmarkCircle02Icon} className="subscribe-done-ic" />
-        You&rsquo;re on the list. We&rsquo;ll be in touch.
-      </p>
-    );
-  }
-
-  return (
-    <form className="subscribe-form" onSubmit={submit} noValidate>
-      <input
-        className="subscribe-input"
-        type="email"
-        name="email"
-        inputMode="email"
-        autoComplete="email"
-        required
-        placeholder="you@example.com"
-        aria-label="Email address"
-        aria-invalid={status === "error"}
-        value={email}
-        onChange={(event) => {
-          setEmail(event.target.value);
-          if (status === "error") {
-            setStatus("idle");
-          }
-        }}
-      />
-      <button
-        type="submit"
-        className="btn btn-primary subscribe-btn"
-        disabled={status === "submitting"}
-      >
-        {status === "submitting" ? "Subscribing…" : "Subscribe"}
-      </button>
-      {status === "error" ? (
-        <span className="subscribe-error" role="alert">
-          {error}
-        </span>
-      ) : null}
-    </form>
   );
 }
 
@@ -1733,6 +1607,7 @@ function LandingPage() {
           <img src={bbIcon} alt="bb" width={36} height={36} />
         </a>
         <div className="nav-links">
+          <a href="/changelog">Changelog</a>
           <GitHubLink placement="nav">GitHub</GitHubLink>
           <a href={DASHBOARD_PATH}>Sign in</a>
           <DownloadLink placement="nav" className="btn btn-primary btn-sm">
@@ -1836,6 +1711,8 @@ function LandingPage() {
       <footer className="footer">
         <span>bb is free and open source (MIT)</span>
         <span>
+          <a href="/changelog">Changelog</a>
+          {" · "}
           <GitHubLink placement="footer">GitHub</GitHubLink>
           {" · "}
           <DownloadLink placement="footer">Download</DownloadLink>

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -78,9 +78,16 @@ If any input is unclear, ask before bumping the version.
    `apps/desktop/package.json`. Do not run `npm version` directly in
    `packages/bb-app`; CI enforces these versions in lockstep.
 
-4. Make any release documentation updates requested by the user.
+4. Update the release notes. Add the new version's section to the repo-root
+   `CHANGELOG.md`, and add its entry (ship date and headline) to
+   `RELEASE_META` in `apps/web/src/landing/changelog.ts`. The marketing site's
+   `/changelog` page renders `CHANGELOG.md` at build time, so both must land
+   before the release is published — redeploy `@bb/web` after the release
+   commit lands so the site shows the new version.
 
-5. Run validation.
+5. Make any release documentation updates requested by the user.
+
+6. Run validation.
 
    ```bash
    node .github/workflows/check-version-lockstep.mjs
@@ -89,7 +96,7 @@ If any input is unclear, ask before bumping the version.
    git diff --check
    ```
 
-6. Commit the release change.
+7. Commit the release change.
 
    ```bash
    git add README.md docs packages/bb-app/package.json packages/bb-app/README.md apps/desktop/package.json


### PR DESCRIPTION
## Summary

- Adds a Cursor-style `/changelog` page to the marketing site: each release renders with a sticky version-pill/date rail beside the release body, linkable per-version anchors (`/changelog#0-0-30`), and the landing page's visual language throughout.
- `CHANGELOG.md` at the repo root stays the single source of truth: the route imports it at build time (`?raw`) and a small parser turns `## version` / `### section` / bullets (plus bare paragraphs and wrapped bullet lines) into structured releases. Ship dates and marketing headlines live in a tiny `RELEASE_META` map since they don't exist in the markdown.
- The 0.0.30 entry leads with an HTML recreation of the by-machine sidebar (two machines, live spinner, nested subagent thread) reusing the homepage hero mock's classes from `landing.css` and the app's real Hugeicons spinner, so it matches the app pixel-for-pixel.
- Extracts shared marketing CTAs (`GitHubLink`, `DownloadLink`, `EmailSignup`) from `routes/index.tsx` into `landing/cta.tsx`; both pages now use one implementation. Landing nav and footer link to `/changelog`.
- Updates `docs/bb-release-process.md` with a step to update `CHANGELOG.md` and the site's `RELEASE_META` before publishing a release.

## Testing

- `pnpm exec turbo run build typecheck test --filter=@bb/web` — all green, including 3 new parser tests (release/section splitting, indented bullet continuation, bare-paragraph sections).
- Click-tested in a real browser at desktop and 390px mobile widths: entries, sticky rail, anchors, subscribe form wiring, and the landing page nav/hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)