### PR TITLE
Refine focused split pane styling

### DIFF
--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -453,17 +453,14 @@ function SplitTree(props: SplitTreeProps) {
           onNavigateInPane={props.onNavigateInPane}
           onBeginPaneDrag={props.onBeginPaneDrag}
         />
-        {/* Focus chrome lives on an overlay ABOVE the pane's content — styles
-            painted on the pane element itself get covered by children with
-            opaque backgrounds (header scrim, composer). Focused pane: an
-            unbroken inset outline. Unfocused panes: a translucent canvas
-            scrim that fades the whole pane toward the background, the
-            "inactive editor" grey-out. */}
+        {/* The inactive-pane scrim lives on an overlay ABOVE the pane's content
+            because styles painted on the pane element itself get covered by
+            children with opaque backgrounds (header scrim, composer). */}
         <div
           aria-hidden
           className={cn(
             "pointer-events-none absolute inset-0 z-20 transition-colors",
-            isFocused ? "ring-1 ring-inset ring-ring" : "bg-background/30",
+            isFocused ? "bg-transparent" : "bg-background/40",
           )}
         />
       </div>

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -67,7 +67,8 @@ export function ThreadDetailHeader({
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   // The title doubles as the pane-reorder drag handle when the layout is split;
   // beginPaneDrag is undefined on the single-pane, page, and popout surfaces.
-  const { beginPaneDrag } = usePaneContext();
+  const { beginPaneDrag, isFocused } = usePaneContext();
+  const showFocusedPaneTitlePill = beginPaneDrag !== undefined && isFocused;
   const handleTitlePointerDown = (event: ReactPointerEvent) => {
     if (!beginPaneDrag || event.button !== 0) {
       return;
@@ -86,21 +87,29 @@ export function ThreadDetailHeader({
 
   const center = (
     <>
-      <p
-        className={cn(
-          "min-w-0 truncate text-sm font-medium",
-          beginPaneDrag &&
-            cn(
-              "cursor-grab touch-none select-none",
-              // Opt the drag handle out of the macOS title-bar drag region so a
-              // pane-reorder gesture isn't swallowed as a window drag.
-              usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
-            ),
-        )}
-        onPointerDown={beginPaneDrag ? handleTitlePointerDown : undefined}
-      >
-        {threadTitle}
-      </p>
+      <div className="relative min-w-0">
+        {showFocusedPaneTitlePill ? (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -inset-x-2 -inset-y-1 rounded-md bg-state-active"
+          />
+        ) : null}
+        <p
+          className={cn(
+            "relative min-w-0 truncate text-sm font-medium",
+            beginPaneDrag &&
+              cn(
+                "cursor-grab touch-none select-none",
+                // Opt the drag handle out of the macOS title-bar drag region so a
+                // pane-reorder gesture isn't swallowed as a window drag.
+                usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+              ),
+          )}
+          onPointerDown={beginPaneDrag ? handleTitlePointerDown : undefined}
+        >
+          {threadTitle}
+        </p>
+      </div>
       {childPillLabel ? (
         <Pill variant="outline" size="sm">
           {childPillLabel}
@@ -197,7 +206,10 @@ export function ThreadDetailHeader({
       center={center}
       actions={actions}
       bordered={false}
-      className="border-b border-border-seam-vertical/60"
+      className={cn(
+        "border-b border-border-seam-vertical/60",
+        beginPaneDrag && isFocused && "bg-surface-raised",
+      )}
     />
   );
 }


### PR DESCRIPTION
## Summary
- remove the focused pane outline from split layouts
- strengthen inactive-pane dimming and raise the focused pane header
- mark the focused thread title with a layout-stable selected-state pill

## Validation
- `pnpm exec turbo run test --filter=@bb/app --force -- src/views/thread-detail/SplitThreadArea.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing warnings)
- `pnpm exec prettier --check apps/app/src/views/thread-detail/SplitThreadArea.tsx apps/app/src/views/thread-detail/ThreadDetailHeader.tsx`
- manual QA on managed dev server