### PR TITLE
Fix plugin pane dragging on macOS

### DIFF
--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -12,12 +12,18 @@ import { useContext } from "react";
 import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import type { BbDesktopInfo } from "@bb/desktop-contract";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import { SPLIT_LAYOUT_STORAGE_KEY } from "@/lib/split-layout";
-import type { SplitLayout } from "@/lib/split-layout";
+import type { PaneContent, SplitLayout } from "@/lib/split-layout";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
 import { PaneContext } from "./PaneContext";
 import { SplitThreadArea } from "./SplitThreadArea";
 
@@ -52,6 +58,10 @@ vi.mock("@/components/commands/AppCommandProvider", () => ({
   useAppCommandContext: () => undefined,
   useAppCommandHandler: () => undefined,
   useIndexedAppCommandHandlers: () => undefined,
+}));
+
+vi.mock("@/components/ui/sidebar.js", () => ({
+  useIsSidebarShowing: () => true,
 }));
 
 // Lightweight stand-in for the heavyweight thread view. It surfaces the pane's
@@ -121,6 +131,28 @@ function twoPaneLayout(focusedPaneId: "pane-1" | "pane-2"): SplitLayout {
   };
 }
 
+const docsContent: PaneContent = {
+  kind: "plugin-panel",
+  pluginId: "docs",
+  panelPath: "docs",
+  subPath: "",
+};
+
+function pluginSplitLayout(): SplitLayout {
+  return {
+    root: {
+      type: "split",
+      dir: "row",
+      sizes: [0.5, 0.5],
+      children: [
+        { type: "pane", paneId: "pane-1", content: threadContent("thr-a") },
+        { type: "pane", paneId: "pane-2", content: docsContent },
+      ],
+    },
+    focusedPaneId: "pane-2",
+  };
+}
+
 function threadPath(threadId: string): string {
   return `/threads/${threadId}`;
 }
@@ -147,6 +179,7 @@ function renderSplitArea(options: {
   path: string;
   layout?: SplitLayout;
   externalTo?: string;
+  routeContent?: PaneContent;
 }) {
   const store = createStore();
   if (options.layout !== undefined) {
@@ -156,7 +189,7 @@ function renderSplitArea(options: {
     <JotaiProvider store={store}>
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[options.path]}>
-          <SplitThreadArea />
+          <SplitThreadArea routeContent={options.routeContent} />
           <LocationProbe />
           {options.externalTo !== undefined ? (
             <ExternalNav to={options.externalTo} />
@@ -177,6 +210,8 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   threadStore.clear();
+  resetPluginSlotStoreForTest();
+  delete window.bbDesktop;
   window.localStorage.clear();
 });
 
@@ -245,6 +280,50 @@ describe("SplitThreadArea", () => {
 
     expect(await screen.findByTestId("pane-thr-a")).toBeTruthy();
     expect(screen.getByTestId("pane-thr-b")).toBeTruthy();
+  });
+
+  it("carves a plugin pane drag handle out of the macOS window-drag region", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: null,
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: false,
+      updateDownloaded: false,
+      version: "0.0.0-test",
+    };
+    window.bbDesktop = createBbDesktopApi(desktopInfo);
+    setPluginSlotRegistrations("docs", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [
+        {
+          id: "docs",
+          title: "Docs",
+          icon: "FileText",
+          path: "docs",
+          component: () => <div>Docs panel</div>,
+        },
+      ],
+      threadPanelActions: [],
+      composerAccessories: [],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+
+    renderSplitArea({
+      path: "/plugins/docs/docs",
+      layout: pluginSplitLayout(),
+      routeContent: docsContent,
+    });
+
+    const title = await screen.findByText("Docs");
+    const dragHandle = title.parentElement?.parentElement;
+    expect(dragHandle?.className).toContain("cursor-grab");
+    expect(dragHandle?.className).toContain("[app-region:no-drag]");
+    expect(dragHandle?.className).toContain("[-webkit-app-region:no-drag]");
   });
 
   it("falls back to a single pane from the route when persisted state is malformed", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useNavigate } from "react-router-dom";
@@ -76,6 +77,11 @@ import {
   threadPaneContent,
 } from "./splitThreadNavigation";
 import { ThreadDetailWorkerPoolProvider } from "./ThreadDetailWorkerPoolProvider";
+import {
+  getBbDesktopInfo,
+  MACOS_WINDOW_NO_DRAG_CLASS,
+  shouldUseMacosDesktopChrome,
+} from "@/lib/bb-desktop";
 
 // A `pointerdown`-relative move threshold before a pane-header drag engages.
 const PANE_DRAG_ENGAGE_DISTANCE_PX = 7;
@@ -601,6 +607,8 @@ function NonThreadPaneContent({
   isBoundedPane: boolean;
 }) {
   const { navPanels } = usePluginSlots();
+  const [desktopInfo] = useState(getBbDesktopInfo);
+  const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   const panel =
     content.kind === "plugin-panel"
       ? navPanels.find(
@@ -651,7 +659,15 @@ function NonThreadPaneContent({
             <div
               className={cn(
                 "flex min-w-0 flex-1 items-center",
-                beginPaneDrag && "cursor-grab touch-none select-none",
+                beginPaneDrag &&
+                  cn(
+                    "cursor-grab touch-none select-none",
+                    // AppPageHeader is an OS window-drag region on macOS.
+                    // Carve this pane-reorder handle out so Electron routes
+                    // the pointer gesture to the split drag layer, matching
+                    // the thread-title handle in ThreadDetailHeader.
+                    usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+                  ),
               )}
               onPointerDown={beginPaneDrag ? handlePointerDown : undefined}
             >


### PR DESCRIPTION
## Summary

- carve plugin and new-thread split-pane drag handles out of the macOS window drag region
- preserve the existing host-owned split drag behavior for plugin panels
- add regression coverage for a plugin pane rendered in desktop chrome

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/views/thread-detail/SplitThreadArea.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- packaged desktop smoke test and local code-signature verification