### PR TITLE
Fix mobile sidebar safe-area coverage

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -2,15 +2,21 @@
 <html lang="en" class="bb-app-shell-root">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#ffffff" id="theme-color" />
     <!-- iOS ignores the manifest's display mode, so these opt the home-screen
-         app into standalone (chrome-less) launch. Status-bar style is left at
-         the default (opaque, non-overlapping) on purpose: black-translucent
-         renders content under the status bar, which needs viewport-fit=cover
-         plus top safe-area-inset padding the app does not yet have. -->
+         app into standalone (chrome-less) launch. The translucent status bar
+         and viewport-fit=cover let app surfaces paint edge-to-edge; layout
+         chrome and overlays apply safe-area padding to their content. -->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
     <meta name="apple-mobile-web-app-title" content="bb" />
     <title>bb</title>
     <link

--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -33,12 +33,6 @@
     padding-bottom: 0.5rem;
   }
 
-  @media (display-mode: standalone) {
-    .chat-prompt-box {
-      padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
-    }
-  }
-
   * {
     scrollbar-width: thin;
     scrollbar-color: color-mix(in oklab, var(--foreground) 20%, transparent)

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -251,7 +251,7 @@ function SidebarTriggerOverlay({
     <div
       data-testid="app-sidebar-trigger-overlay"
       className={cn(
-        "fixed left-0 top-0 z-50",
+        "fixed top-[env(safe-area-inset-top)] left-[env(safe-area-inset-left)] z-50",
         CHROME_ROW_CLASS,
         BROWSER_SIDEBAR_TRIGGER_INSET_CLASS,
       )}
@@ -782,7 +782,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             <div
               ref={contentShellRef}
               data-testid="app-layout-content-shell"
-              className="relative flex h-[100dvh] min-w-0 w-full flex-col"
+              className="relative flex h-[100dvh] min-w-0 w-full flex-col pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]"
             >
               {showHeader ? (
                 <AppHeader

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -590,7 +590,7 @@ const Sidebar = React.forwardRef<
                 suppressMobileOpenAnimation ? "true" : undefined
               }
               className={cn(
-                "group fixed inset-y-0 z-40 flex h-svh w-(--sidebar-width-mobile) flex-col bg-sidebar text-sidebar-foreground outline-none",
+                "group fixed inset-y-0 z-40 flex h-dvh w-(--sidebar-width-mobile) flex-col bg-sidebar text-sidebar-foreground outline-none",
                 "[&[data-sidebar-suppress-open-animation=true][data-state=open]]:![animation:none]",
                 side === "left" ? "left-0" : "right-0",
                 variant === "floating" || variant === "inset"
@@ -615,7 +615,7 @@ const Sidebar = React.forwardRef<
               </DrawerPrimitive.Description>
               <div
                 data-sidebar="sidebar"
-                className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+                className="flex h-full w-full flex-col bg-sidebar pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
               >
                 {children}
               </div>


### PR DESCRIPTION
## Summary
- enable edge-to-edge viewport rendering for the mobile web app
- make the compact sidebar and backdrop fill the dynamic viewport
- keep sidebar controls, the global trigger, and main app content within device safe areas
- avoid double-applying the bottom safe-area inset to the prompt box

## Validation
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (1,539 tests)
- `pnpm exec turbo run build --filter=@bb/app`
- mobile browser QA at 390×844 (drawer and backdrop span 0–844px)