### PR TITLE
Stabilize compact composer transitions

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -369,6 +369,9 @@
   }
 
   [data-follow-up-composer] [data-promptbox-action-row] {
+    /* The submit group owns the edge inset in this mode. Neutralize the
+     * compact React layout's matching right inset so the two do not stack. */
+    right: 0;
     padding-right: 3rem;
   }
 
@@ -384,6 +387,14 @@
     height: 2rem;
     margin-left: 0;
     padding: 0;
+  }
+
+  [data-follow-up-composer] [data-follow-up-composer-footer] {
+    min-height: 0;
+    max-height: 0;
+    margin-top: 0;
+    opacity: 0;
+    pointer-events: none;
   }
 
   [data-follow-up-composer]:not([data-follow-up-composer-expanded])

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -552,7 +552,7 @@ function FollowUpPromptBoxWithComposer({
           {!isMobilePromptBoxCompact ? (
             <div
               data-follow-up-composer-footer=""
-              className="mt-1 flex min-h-6 items-center justify-between gap-2 pl-[15px] pr-3.5"
+              className="mt-1 flex min-h-6 max-h-6 items-center justify-between gap-2 overflow-hidden pl-[15px] pr-3.5 opacity-100 transition-[max-height,min-height,margin-top,opacity] duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
             >
               <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
                 {environmentSummary}

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -822,6 +822,8 @@ describe("PromptBoxInternal compact layout", () => {
     expect(submitButton.classList.contains("size-8")).toBe(true);
     expect(submitButton.classList.contains("p-0")).toBe(true);
     expect(submitButton.classList.contains("ml-1")).toBe(false);
+    expect(submitButton.classList.contains("transition-colors")).toBe(true);
+    expect(submitButton.classList.contains("transition-all")).toBe(false);
     expect(screen.queryByRole("button", { name: "Prompt actions" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Model selector" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Attach files" })).toBeNull();

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2888,6 +2888,11 @@ export function PromptBoxInternal({
                       showCompactLayout
                         ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
                         : ["ml-1", COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS],
+                      // Container-driven compact layouts change the button's
+                      // width, padding, and margin at the breakpoint. Keep
+                      // those geometry changes instantaneous so the action
+                      // stays pinned while the prompt height animates.
+                      "transition-colors",
                     )}
                   >
                     {isSubmitting ? (


### PR DESCRIPTION
## Summary

- keep the stop/submit action pinned while a short split crosses the compact breakpoint
- animate the environment and permission footer out of compact short panes
- prevent layout properties from inheriting the submit button's color transition

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/promptbox/FollowUpPromptBox.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- live browser verification across both sides of the short-pane breakpoint