### PR TITLE
Refresh Connect and release messaging

### DIFF
--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -311,7 +311,7 @@ code,
 /* ── Hero ───────────────────────────────────────────────────────── */
 
 .hero {
-  padding: 96px 0 48px;
+  padding: 56px 0 48px;
   text-align: center;
   position: relative;
 }
@@ -417,6 +417,48 @@ code,
 
 .hero > :nth-child(6) {
   animation-delay: 0.57s;
+}
+
+.updates-callout {
+  width: fit-content;
+  max-width: min(100%, 680px);
+  margin: -32px auto 56px;
+  padding: 6px 12px 6px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--bg) 82%, transparent);
+  color: var(--dim);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.35;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.updates-callout:hover {
+  background: var(--state-hover);
+  border-color: color-mix(in oklab, var(--ink) 22%, var(--bg));
+  transform: translateY(-1px);
+}
+
+.updates-label {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: var(--ink);
+  color: var(--bg);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.updates-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Scroll reveal: sections start hidden only once JS marks them pending,
@@ -2539,6 +2581,10 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 
   .nav-links .btn-sm {
     padding: 8px 12px;
+  }
+
+  .updates-label {
+    display: none;
   }
 }
 

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -351,8 +351,7 @@ function SignInView({ returnTo }: { returnTo: string | undefined }) {
           Continue with GitHub
         </Button>
         <p className="mt-3 text-center text-xs text-subtle-foreground">
-          Free while in beta · up to {MAX_SERVERS_PER_ACCOUNT} servers per
-          account
+          Up to {MAX_SERVERS_PER_ACCOUNT} servers per account
         </p>
       </WebCard>
     </Shell>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -29,10 +29,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
+import changelogMd from "../../../../CHANGELOG.md?raw";
 import { initAnalytics, trackLandingEvent } from "../landing/analytics";
 import bbIcon from "../assets/bb-icon.png";
 import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
+import { RELEASE_META, parseChangelog } from "../landing/changelog";
 import { DownloadLink, EmailSignup, GitHubLink } from "../landing/cta";
 import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import {
@@ -49,6 +51,18 @@ import type { CtaPlacement } from "../landing/site";
 import { CLI_COMMAND, SITE_DESCRIPTION, SITE_TITLE } from "../landing/site";
 import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
 import landingCss from "../landing/landing.css?url";
+
+const [LATEST_RELEASE] = parseChangelog(changelogMd);
+if (!LATEST_RELEASE) {
+  throw new Error("CHANGELOG.md must contain at least one release");
+}
+const LATEST_RELEASE_META = RELEASE_META[LATEST_RELEASE.version];
+if (!LATEST_RELEASE_META) {
+  throw new Error(
+    `Latest release ${LATEST_RELEASE.version} must have presentation metadata`,
+  );
+}
+const LATEST_RELEASE_URL = `/changelog#${LATEST_RELEASE.version.replaceAll(".", "-")}`;
 
 export const Route = createFileRoute("/")({
   head: () => ({
@@ -1617,6 +1631,11 @@ function LandingPage() {
       </nav>
 
       <header className="hero">
+        <a className="updates-callout" href={LATEST_RELEASE_URL}>
+          <span className="updates-label">New</span>
+          <span className="updates-title">{LATEST_RELEASE_META.headline}</span>
+          <span aria-hidden="true">→</span>
+        </a>
         <h1>
           The First LDE<span className="lde-star">*</span>
         </h1>


### PR DESCRIPTION
## Summary
- remove the beta-free claim from the Connect sign-in screen
- add a compact homepage callout for the latest changelog headline
- derive the callout target and copy from the newest changelog release metadata

## Testing
- `pnpm exec turbo run typecheck --filter=@bb/web`
- `pnpm exec turbo run test --filter=@bb/web --force`
- `pnpm exec turbo run build --filter=@bb/web`