### PR TITLE
test(plugins): consume packaged SDK exports

### DIFF
--- a/marketplace/plugins/docs/package.json
+++ b/marketplace/plugins/docs/package.json
@@ -48,6 +48,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
+    "@bb/plugin-sdk": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/marketplace/plugins/docs/tsconfig.json
+++ b/marketplace/plugins/docs/tsconfig.json
@@ -10,9 +10,7 @@
     "skipLibCheck": true,
     "types": ["node"],
     "paths": {
-      "@/*": ["./*"],
-      "@bb/plugin-sdk": ["../../../packages/plugin-sdk/src/index.ts"],
-      "@bb/plugin-sdk/*": ["../../../packages/plugin-sdk/src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": [

--- a/marketplace/plugins/docs/vitest.config.ts
+++ b/marketplace/plugins/docs/vitest.config.ts
@@ -6,10 +6,6 @@ export default defineWorkspaceTestConfig({
     // Mirror the plugin tsconfig's "@/*" paths.
     alias: {
       "@": path.resolve(import.meta.dirname, "."),
-      "@bb/plugin-sdk": path.resolve(
-        import.meta.dirname,
-        "../../../packages/plugin-sdk/src",
-      ),
     },
   },
   test: {

--- a/marketplace/plugins/github/package.json
+++ b/marketplace/plugins/github/package.json
@@ -50,6 +50,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
+    "@bb/plugin-sdk": "workspace:*",
     "@pierre/diffs": "^1.2.9",
     "@radix-ui/react-dropdown-menu": "^2.1.20",
     "@radix-ui/react-select": "^2.3.3",

--- a/marketplace/plugins/github/tsconfig.json
+++ b/marketplace/plugins/github/tsconfig.json
@@ -10,9 +10,7 @@
     "skipLibCheck": true,
     "types": ["node"],
     "paths": {
-      "@/*": ["./*"],
-      "@bb/plugin-sdk": ["../../../packages/plugin-sdk/src/index.ts"],
-      "@bb/plugin-sdk/*": ["../../../packages/plugin-sdk/src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": [

--- a/marketplace/plugins/github/vitest.config.ts
+++ b/marketplace/plugins/github/vitest.config.ts
@@ -1,15 +1,6 @@
-import path from "node:path";
 import { defineWorkspaceTestConfig } from "../../../vitest.shared.js";
 
 export default defineWorkspaceTestConfig({
-  resolve: {
-    alias: {
-      "@bb/plugin-sdk": path.resolve(
-        import.meta.dirname,
-        "../../../packages/plugin-sdk/src",
-      ),
-    },
-  },
   test: {
     silent: "passed-only",
     name: "bb-plugin-github",

--- a/marketplace/plugins/memory/package.json
+++ b/marketplace/plugins/memory/package.json
@@ -55,6 +55,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@bb/plugin-sdk": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/marketplace/plugins/memory/tsconfig.json
+++ b/marketplace/plugins/memory/tsconfig.json
@@ -10,9 +10,7 @@
     "skipLibCheck": true,
     "types": ["node", "vitest/globals"],
     "paths": {
-      "@/*": ["./*"],
-      "@bb/plugin-sdk": ["../../../packages/plugin-sdk/src/index.ts"],
-      "@bb/plugin-sdk/*": ["../../../packages/plugin-sdk/src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["*.ts", "*.tsx", "components", "lib", "skills"]

--- a/marketplace/plugins/memory/vitest.config.ts
+++ b/marketplace/plugins/memory/vitest.config.ts
@@ -5,10 +5,6 @@ export default defineWorkspaceTestConfig({
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "."),
-      "@bb/plugin-sdk": path.resolve(
-        import.meta.dirname,
-        "../../../packages/plugin-sdk/src",
-      ),
     },
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,6 +1056,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-sdk
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1114,6 +1117,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-sdk
       '@pierre/diffs':
         specifier: ^1.2.9
         version: 1.2.9(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1163,6 +1169,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-sdk
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

- remove direct Plugin SDK source aliases from all BB Official marketplace plugin typecheck and test configs
- declare the public Plugin SDK development dependency for Docs, GitHub, and Memory
- exercise package exports and bundled declarations while retaining the packed external scaffold test as the distribution boundary check

## Focused validation

- canonical Plugin SDK declaration, plugin registry, and template generator checks
- sequential build, typecheck, and test for Docs, GitHub, and Memory
- packed external scaffold backend/frontend test
- targeted live stale-name, manifest-shape, generic RPC, version, and diff checks

No package, plugin, or API version was changed.