### PR TITLE
Fix attachments when switching projects

### DIFF
--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -79,6 +79,7 @@ import type {
   TimelineTurnSummaryDetailsRequest,
   TimelineTurnSummaryDetailsResponse,
   CloseTerminalRequest,
+  CopyProjectAttachmentsRequest,
   ResolvePendingInteractionRequest,
   UpdateEnvironmentRequest,
   UpdateThreadFolderRequest,
@@ -757,6 +758,18 @@ export async function uploadPromptAttachment(
   return postMultipart<UploadedPromptAttachment>(
     apiClient.projects[":id"].attachments.$url({ param: { id: projectId } }),
     file,
+  );
+}
+
+export async function copyPromptAttachments(
+  targetProjectId: string,
+  requestBody: CopyProjectAttachmentsRequest,
+): Promise<void> {
+  await request(
+    apiClient.projects[":id"].attachments.copy.$post({
+      param: { id: targetProjectId },
+      json: requestBody,
+    }),
   );
 }
 

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -17,6 +17,7 @@ import {
   buildRootComposeTerminalSessions,
   buildMobileRecentThreads,
   canCreateRootComposeTerminal,
+  getProjectStoredPromptAttachmentPaths,
   hasPromptBranchSelectionChanged,
   hasPromptOptionValueChanged,
   hasSingleUseRootComposeTargetState,
@@ -340,6 +341,46 @@ describe("mergeMissingPromptDraftAttachments", () => {
         ],
       ),
     ).toBeNull();
+  });
+});
+
+describe("getProjectStoredPromptAttachmentPaths", () => {
+  it("selects only server-managed relative attachment paths", () => {
+    expect(
+      getProjectStoredPromptAttachmentPaths([
+        {
+          type: "localImage",
+          path: "image-uploaded.png",
+          name: "image.png",
+          mimeType: "image/png",
+          sizeBytes: 64,
+        },
+        {
+          type: "localFile",
+          path: "image-uploaded.png",
+          name: "duplicate.png",
+          sizeBytes: 64,
+        },
+        {
+          type: "localFile",
+          path: "/tmp/report.pdf",
+          name: "report.pdf",
+          sizeBytes: 32,
+        },
+        {
+          type: "localImage",
+          path: "C:\\Users\\sawyer\\screenshot.png",
+          name: "screenshot.png",
+          sizeBytes: 32,
+        },
+        {
+          type: "localFile",
+          path: "https://example.test/report.pdf",
+          name: "remote.pdf",
+          sizeBytes: 32,
+        },
+      ]),
+    ).toEqual(["image-uploaded.png"]);
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -103,6 +103,7 @@ import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { useLocalOpenTargets } from "@/hooks/useLocalOpenTargets";
 import { selectPrimaryHost, useHosts } from "@/hooks/queries/host-queries";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
+import { copyPromptAttachments } from "@/lib/api";
 import { subscribeComposerFocusRequests } from "@/lib/composer-focus-requests";
 import { usePromptMentions } from "@/hooks/usePromptMentions";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
@@ -274,6 +275,23 @@ export function mergeMissingPromptDraftAttachments(
     return null;
   }
   return [...currentAttachments, ...missingAttachments];
+}
+
+export function getProjectStoredPromptAttachmentPaths(
+  attachments: readonly PromptDraftAttachment[],
+): string[] {
+  return [
+    ...new Set(
+      attachments.flatMap((attachment) => {
+        const path = attachment.path;
+        const isRuntimeReadable =
+          /^[\\/]/u.test(path) ||
+          /^[a-zA-Z]:[\\/]/u.test(path) ||
+          /^[a-zA-Z][a-zA-Z0-9+.-]*:/u.test(path);
+        return isRuntimeReadable ? [] : [path];
+      }),
+    ),
+  ];
 }
 
 export function restorePromptDraftAfterOptionChange({
@@ -1019,6 +1037,8 @@ export function RootComposeView(props: RootComposeViewProps) {
   const { data: projectPromptHistory = [] } =
     useProjectPromptHistory(projectId);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [isCopyingPromptAttachments, setIsCopyingPromptAttachments] =
+    useState(false);
   const prompt = promptDraft.text;
   const promptInput = useMemo(
     () =>
@@ -1645,14 +1665,51 @@ export function RootComposeView(props: RootComposeViewProps) {
 
   const selectedThreadModel = activeModel?.model ?? selectedModel;
   const handleProjectChange = useCallback<ProjectSelectionChangeHandler>(
-    (nextProjectId) => {
+    async (nextProjectId) => {
       const nextRootComposeProjectId = nextProjectId ?? PERSONAL_PROJECT_ID;
-      if (nextRootComposeProjectId === projectId) return;
+      if (
+        nextRootComposeProjectId === projectId ||
+        isCopyingPromptAttachments
+      ) {
+        return;
+      }
+
+      const attachmentPaths = getProjectStoredPromptAttachmentPaths(
+        promptDraft.getCurrent().attachments,
+      );
+      if (attachmentPaths.length > 0) {
+        setAttachmentError(null);
+        setIsCopyingPromptAttachments(true);
+        try {
+          await copyPromptAttachments(nextRootComposeProjectId, {
+            sourceProjectId: projectId,
+            paths: attachmentPaths,
+          });
+        } catch (error) {
+          setAttachmentError(
+            getMutationErrorMessage({
+              error,
+              fallbackMessage:
+                "Attachments could not be moved to the selected project",
+            }),
+          );
+          return;
+        } finally {
+          setIsCopyingPromptAttachments(false);
+        }
+      }
+
       snapshotPromptDraftBeforeOptionChange();
       setForkSeed(null);
       setRootComposeProjectId(nextRootComposeProjectId);
     },
-    [projectId, setRootComposeProjectId, snapshotPromptDraftBeforeOptionChange],
+    [
+      isCopyingPromptAttachments,
+      projectId,
+      promptDraft,
+      setRootComposeProjectId,
+      snapshotPromptDraftBeforeOptionChange,
+    ],
   );
   const shouldFocusPrompt =
     typeof location.state === "object" &&
@@ -1821,6 +1878,7 @@ export function RootComposeView(props: RootComposeViewProps) {
     isCodexCliVersionBlocked ||
     !selectedThreadModel ||
     createThread.isPending ||
+    isCopyingPromptAttachments ||
     promptInput.length === 0 ||
     (forkSeed === null && !selectedEnvironment) ||
     managedWorktreeAvailabilityPending ||
@@ -3092,7 +3150,8 @@ export function RootComposeView(props: RootComposeViewProps) {
       projectId: projectId ?? "",
       onAttachFiles: handleAttachFiles,
       onRemove: promptDraft.removeAttachment,
-      isAttaching: uploadPromptAttachment.isPending,
+      isAttaching:
+        uploadPromptAttachment.isPending || isCopyingPromptAttachments,
       error: attachmentError,
     }),
     [
@@ -3101,6 +3160,7 @@ export function RootComposeView(props: RootComposeViewProps) {
       projectId,
       promptDraft.attachments,
       promptDraft.removeAttachment,
+      isCopyingPromptAttachments,
       uploadPromptAttachment.isPending,
     ],
   );
@@ -3451,7 +3511,7 @@ export function RootComposeView(props: RootComposeViewProps) {
             !quickCreateProject.isAvailable || quickCreateProject.isCreating,
           isCreating: quickCreateProject.isCreating,
         },
-        disabled: isForkDraft,
+        disabled: isForkDraft || isCopyingPromptAttachments,
       }}
       execution={executionConfig}
     />

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -34,6 +34,7 @@ import type { AppDeps } from "../types.js";
 import { COMMAND_TIMEOUT_MS } from "../constants.js";
 import { ApiError } from "../errors.js";
 import {
+  copyProjectAttachments,
   readAttachment,
   storeAttachment,
 } from "../services/projects/attachments.js";
@@ -774,6 +775,20 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       await storeAttachment(deps.config.dataDir, context.req.param("id"), file),
       201,
     );
+  });
+
+  post(routes.copyAttachments, async (context) => {
+    const targetProjectId = context.req.param("id");
+    requirePublicProject(deps.db, targetProjectId);
+    const request = await context.req.json();
+    requirePublicProject(deps.db, request.sourceProjectId);
+    await copyProjectAttachments(
+      deps.config.dataDir,
+      request.sourceProjectId,
+      targetProjectId,
+      request.paths,
+    );
+    return context.json({ ok: true as const });
   });
 
   get(routes.attachmentContent, async (context, query) => {

--- a/apps/server/src/services/projects/attachments.test.ts
+++ b/apps/server/src/services/projects/attachments.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  copyProjectAttachments,
   readAttachment,
   validatePromptAttachmentReferences,
 } from "./attachments.js";
@@ -34,6 +35,42 @@ describe("project attachments", () => {
 
     expect(result.content.toString("utf8")).toBe("hello");
     expect(result.mimeType).toBe("text/plain");
+  });
+
+  it("copies project-scoped attachments without changing their draft paths", async () => {
+    const dataDir = await makeTempDir();
+    const sourceDir = join(dataDir, "attachments", "proj_source");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "image-uploaded.png"), "image bytes");
+
+    await copyProjectAttachments(dataDir, "proj_source", "proj_target", [
+      "image-uploaded.png",
+    ]);
+
+    const copied = await readAttachment(
+      dataDir,
+      "proj_target",
+      "image-uploaded.png",
+    );
+    expect(copied.content.toString("utf8")).toBe("image bytes");
+  });
+
+  it("does not partially copy when one source attachment is missing", async () => {
+    const dataDir = await makeTempDir();
+    const sourceDir = join(dataDir, "attachments", "proj_source");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "present.txt"), "present");
+
+    await expect(
+      copyProjectAttachments(dataDir, "proj_source", "proj_target", [
+        "present.txt",
+        "missing.txt",
+      ]),
+    ).rejects.toMatchObject({ status: 404 });
+
+    await expect(
+      readAttachment(dataDir, "proj_target", "present.txt"),
+    ).rejects.toMatchObject({ status: 404 });
   });
 
   it("accepts prompt attachment references to uploaded project files", async () => {

--- a/apps/server/src/services/projects/attachments.ts
+++ b/apps/server/src/services/projects/attachments.ts
@@ -4,6 +4,7 @@
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import {
   basename,
+  dirname,
   extname,
   isAbsolute,
   join,
@@ -185,6 +186,34 @@ export async function readAttachment(
     content: await readFile(resolved),
     mimeType: mimeTypes.lookup(resolved) || undefined,
   };
+}
+
+export async function copyProjectAttachments(
+  dataDir: string,
+  sourceProjectId: string,
+  targetProjectId: string,
+  attachmentPaths: readonly string[],
+): Promise<void> {
+  if (sourceProjectId === targetProjectId || attachmentPaths.length === 0) {
+    return;
+  }
+
+  const uniquePaths = [...new Set(attachmentPaths)];
+  const targetDir = projectAttachmentDir(dataDir, targetProjectId);
+  const attachments = await Promise.all(
+    uniquePaths.map(async (attachmentPath) => ({
+      content: (await readAttachment(dataDir, sourceProjectId, attachmentPath))
+        .content,
+      targetPath: resolveAttachmentPath(targetDir, attachmentPath),
+    })),
+  );
+
+  await Promise.all(
+    attachments.map(async ({ content, targetPath }) => {
+      await mkdir(dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, content);
+    }),
+  );
 }
 
 export async function deleteProjectAttachments(

--- a/packages/server-contract/src/api/projects.ts
+++ b/packages/server-contract/src/api/projects.ts
@@ -360,3 +360,13 @@ export const uploadedPromptAttachmentSchema = z.object({
 export type UploadedPromptAttachment = z.infer<
   typeof uploadedPromptAttachmentSchema
 >;
+
+export const copyProjectAttachmentsRequestSchema = z
+  .object({
+    sourceProjectId: z.string().min(1),
+    paths: z.array(z.string().min(1)).min(1).max(100),
+  })
+  .strict();
+export type CopyProjectAttachmentsRequest = z.infer<
+  typeof copyProjectAttachmentsRequestSchema
+>;

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -46,6 +46,7 @@ import type {
 import type {
   CloseTerminalRequest,
   CommandListResponse,
+  CopyProjectAttachmentsRequest,
   CreateHostJoinCodeRequest,
   CreateHostJoinCodeResponse,
   CreateTerminalRequest,
@@ -191,6 +192,7 @@ import type {
 import { updateThreadTabsRequestSchema } from "./api/thread-tabs.js";
 import {
   closeTerminalRequestSchema,
+  copyProjectAttachmentsRequestSchema,
   createFilePreviewRequestSchema,
   createThreadFolderRequestSchema,
   deleteThreadFolderRequestSchema,
@@ -409,6 +411,14 @@ export const publicApiRoutes = {
       method: "post",
       request: formRequest<PathProjectId, ProjectAttachmentUploadForm>(),
       response: jsonResponse<UploadedPromptAttachment>({ status: 201 }),
+    }),
+    copyAttachments: defineRoute({
+      path: "/projects/:id/attachments/copy",
+      method: "post",
+      request: jsonRequest<PathProjectId, CopyProjectAttachmentsRequest>(
+        copyProjectAttachmentsRequestSchema,
+      ),
+      response: jsonResponse<{ ok: true }>(),
     }),
     attachmentContent: defineRoute({
       path: "/projects/:id/attachments/content",


### PR DESCRIPTION
## Summary

- copy project-scoped prompt attachments before changing the root composer project
- preserve stored attachment paths so previews and submitted drafts continue to resolve
- leave runtime-readable absolute and URL attachments untouched

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/server-contract`
- `pnpm exec turbo run test --filter=@bb/app -- src/views/RootComposeView.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- src/services/projects/attachments.test.ts`
- `pnpm exec turbo run test --filter=@bb/server-contract`
- browser QA: uploaded an image, switched from a standard project to Personal, and confirmed the new project URL remained fully decoded (`naturalWidth: 785`)

## Risk

Low. The project selector waits for server-side copies to complete and leaves the current project selected if copying fails.