### PR TITLE
Unify Threads sidebar header

### DIFF
--- a/apps/app/src/components/sidebar/FolderGrouping.stories.tsx
+++ b/apps/app/src/components/sidebar/FolderGrouping.stories.tsx
@@ -130,7 +130,7 @@ export function ChronologicalFolders() {
   return (
     <StoryCard>
       <StoryRow
-        label="all threads"
+        label="threads"
         hint="stored folderId groups matching threads across projects"
       >
         <SidebarStage>
@@ -153,7 +153,6 @@ export function ChronologicalFolders() {
             pinnedThreads={[]}
             onReorderPinnedThread={noop}
             renderPinnedSection={() => null}
-            renderAllThreadsSection={(content) => content}
             renderThreadsSection={(content) => content}
           />
         </SidebarStage>

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -118,7 +118,6 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -269,9 +268,7 @@ type ToggleCollapsedSidebarSectionId = (
   id: CollapsibleSidebarSectionId,
 ) => void;
 type OpenSidebarMenu =
-  | "projectsDisplayOptions"
   | "threadsDisplayOptions"
-  | "allThreadsOverflow"
   | `displayOptions:${string}`
   | null;
 
@@ -521,7 +518,9 @@ function ProjectListProjectsSectionActions({
       ariaLabel="New project"
       title="New project"
       disabled={isCreatingProject}
-      icon={<Icon name="FolderPlus" className={COARSE_POINTER_ICON_SIZE_CLASS} />}
+      icon={
+        <Icon name="FolderPlus" className={COARSE_POINTER_ICON_SIZE_CLASS} />
+      }
       onClick={onNewProject}
     />
   );
@@ -539,7 +538,12 @@ function ProjectListThreadsSectionActions({
           ariaLabel="New section"
           title="New section"
           disabled={isCreatingFolder}
-          icon={<Icon name="SectionAdd" className={COARSE_POINTER_ICON_SIZE_CLASS} />}
+          icon={
+            <Icon
+              name="SectionAdd"
+              className={COARSE_POINTER_ICON_SIZE_CLASS}
+            />
+          }
           onClick={onNewFolder}
         />
       ) : null}
@@ -547,7 +551,10 @@ function ProjectListThreadsSectionActions({
         ariaLabel="New thread"
         title="New thread"
         icon={
-          <Icon name="MessageSquarePlus" className={COARSE_POINTER_ICON_SIZE_CLASS} />
+          <Icon
+            name="MessageSquarePlus"
+            className={COARSE_POINTER_ICON_SIZE_CLASS}
+          />
         }
         onClick={onNewThread}
       />
@@ -691,18 +698,9 @@ interface SidebarThreadsSectionActionsProps {
   onNewThread: () => void;
 }
 
-interface SidebarAllThreadsOverflowMenuProps {
-  isCreatingFolder: boolean;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onNewFolder: () => void;
-}
-
-// The complete Threads-section header cluster (display options + new thread).
-// One component drives the Threads header in both project mode and
-// the folders view, so they can never drift apart. It carries the same combined
-// display-options menu as the primary header, so in manual mode the menu is
-// reachable above both the Folders and Threads sections.
+// The complete Threads-section header cluster. Every organization mode and
+// every folder state renders this same component so the label-adjacent actions
+// cannot drift apart.
 function SidebarThreadsSectionActions({
   displayOptionsOpen,
   onDisplayOptionsOpenChange,
@@ -730,33 +728,6 @@ function SidebarThreadsSectionActions({
         onNewThread={onNewThread}
       />
     </>
-  );
-}
-
-function SidebarAllThreadsOverflowMenu({
-  isCreatingFolder,
-  open,
-  onOpenChange,
-  onNewFolder,
-}: SidebarAllThreadsOverflowMenuProps) {
-  return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
-      <SidebarDisplayMenuTrigger
-        ariaLabel="All Threads actions"
-        iconName="MoreHorizontal"
-        tooltip="More actions"
-      />
-      <DropdownMenuContent
-        align="end"
-        mobileTitle="All Threads actions"
-        className="min-w-0"
-      >
-        <DropdownMenuItem disabled={isCreatingFolder} onSelect={onNewFolder}>
-          <Icon name="SectionAdd" aria-hidden="true" />
-          New section
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }
 
@@ -1163,7 +1134,6 @@ function ProjectModeSections({
 }
 
 interface FolderModeSectionsProps extends BuiltInSectionRenderState {
-  allThreadsSection: Omit<BuiltInSidebarSectionOptions, "content">;
   collapsedEnvironmentIds: Set<string>;
   collapsedThreadIds: Set<string>;
   compareThreads: ThreadComparator;
@@ -1193,7 +1163,6 @@ interface FolderModeSectionsProps extends BuiltInSectionRenderState {
 }
 
 function FolderModeSections({
-  allThreadsSection,
   collapsedEnvironmentIds,
   collapsedSectionIds,
   collapsedThreadIds,
@@ -1262,7 +1231,6 @@ function FolderModeSections({
       builtInSections={{
         pinned: pinnedSection,
         threads: threadsSection,
-        allThreads: allThreadsSection,
         collapsedSectionIds,
         onToggleCollapsed,
       }}
@@ -1680,23 +1648,12 @@ function ProjectListComponent({
     },
     [],
   );
-  const handleProjectsDisplayOptionsMenuOpenChange = useCallback(
-    (open: boolean) => setSidebarMenuOpen("projectsDisplayOptions", open),
-    [setSidebarMenuOpen],
-  );
   const handleThreadsDisplayOptionsMenuOpenChange = useCallback(
     (open: boolean) => setSidebarMenuOpen("threadsDisplayOptions", open),
     [setSidebarMenuOpen],
   );
-  const handleAllThreadsOverflowMenuOpenChange = useCallback(
-    (open: boolean) => setSidebarMenuOpen("allThreadsOverflow", open),
-    [setSidebarMenuOpen],
-  );
-  const projectsDisplayOptionsMenuOpen =
-    openSidebarMenu === "projectsDisplayOptions";
   const threadsDisplayOptionsMenuOpen =
     openSidebarMenu === "threadsDisplayOptions";
-  const allThreadsOverflowMenuOpen = openSidebarMenu === "allThreadsOverflow";
   const renderSectionDisplayOptions = (sectionId: SidebarSectionId) => {
     const menuId = `displayOptions:${sectionId}` as const;
     return (
@@ -1892,33 +1849,7 @@ function ProjectListComponent({
       onReorderPinnedRoot={handleReorderPinnedRoot}
     />
   );
-  // When there are no folders, the catch-all header owns the global controls
-  // that previously lived on the removed aggregate Folders header.
-  const allThreadsSectionActions = (
-    <>
-      <SidebarDisplayOptionsMenu
-        open={projectsDisplayOptionsMenuOpen}
-        onOpenChange={handleProjectsDisplayOptionsMenuOpenChange}
-      />
-      <SidebarAllThreadsOverflowMenu
-        isCreatingFolder={isCreateThreadFolderPending}
-        open={allThreadsOverflowMenuOpen}
-        onOpenChange={handleAllThreadsOverflowMenuOpenChange}
-        onNewFolder={handleOpenCreateFolderDialog}
-      />
-      {onNewProject ? (
-        <ProjectListProjectsSectionActions
-          isCreatingProject={isCreatingProject}
-          onNewProject={onNewProject}
-        />
-      ) : null}
-      <ProjectListThreadsSectionActions
-        isCreatingFolder={isCreateThreadFolderPending}
-        onNewThread={handleCreateProjectlessThread}
-      />
-    </>
-  );
-  // One Threads-header cluster shared by project mode and the folders view.
+  // One Threads-header cluster shared by every organization and folder state.
   const threadsSectionActions = (
     <SidebarThreadsSectionActions
       displayOptionsOpen={threadsDisplayOptionsMenuOpen}
@@ -1942,11 +1873,6 @@ function ProjectListComponent({
     label: "Threads",
     actions: threadsSectionActions,
     actionsOpen: threadsDisplayOptionsMenuOpen,
-  } satisfies Omit<BuiltInSidebarSectionOptions, "content">;
-  const allThreadsSection = {
-    label: "All Threads",
-    actions: allThreadsSectionActions,
-    actionsOpen: projectsDisplayOptionsMenuOpen || allThreadsOverflowMenuOpen,
   } satisfies Omit<BuiltInSidebarSectionOptions, "content">;
   const folderCreateDialog = (
     <ThreadFolderCreateDialog
@@ -2055,7 +1981,6 @@ function ProjectListComponent({
               pinnedThreads={pinnedRootThreads}
               onReorderPinnedThread={handleReorderPinnedRoot}
               threadsSection={threadsSection}
-              allThreadsSection={allThreadsSection}
               selectedThreadId={selectedThreadId}
               collapsedSectionIds={collapsedSidebarSectionIds}
               collapsedThreadIds={collapsedThreadIds}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -203,7 +203,6 @@ interface TopLevelFolderHeaderActions {
 }
 
 interface ChronologicalBuiltInSidebarSections {
-  allThreads: Omit<BuiltInSidebarSectionOptions, "content">;
   collapsedSectionIds: ReadonlySet<CollapsibleSidebarSectionId>;
   onToggleCollapsed: (id: CollapsibleSidebarSectionId) => void;
   pinned: BuiltInSidebarSectionOptions;
@@ -221,10 +220,6 @@ interface ChronologicalFolderThreadSectionsProps extends FolderThreadTreeProps {
     callbacks: { onSettled: () => void },
   ) => void;
   renderPinnedSection?: (
-    consumeClickSuppression?: ConsumeDragClickSuppression,
-  ) => ReactNode;
-  renderAllThreadsSection?: (
-    content: ReactNode,
     consumeClickSuppression?: ConsumeDragClickSuppression,
   ) => ReactNode;
   renderThreadsSection?: (
@@ -1801,7 +1796,6 @@ export const ChronologicalFolderThreadSections = memo(
     pinnedThreads,
     onReorderPinnedThread,
     renderPinnedSection,
-    renderAllThreadsSection,
     renderThreadsSection,
   }: ChronologicalFolderThreadSectionsProps) {
     const threads =
@@ -1890,7 +1884,6 @@ export const ChronologicalFolderThreadSections = memo(
     const folderItems = renderedRootItems.filter(
       (item) => item.kind === "folder",
     );
-    const hasFolders = folderItems.length > 0;
     const looseItems = renderedRootItems.filter(
       (item) => item.kind !== "folder",
     );
@@ -1998,18 +1991,14 @@ export const ChronologicalFolderThreadSections = memo(
               renderedFolderDnd?.dragOverParentKey === PINNED_THREAD_PARENT_KEY,
           },
           threads: {
-            ...(hasFolders
-              ? builtInSections.threads
-              : builtInSections.allThreads),
+            ...builtInSections.threads,
             content: threadsContent,
           },
         }
       : undefined;
     const legacyBuiltInSectionNodes: BuiltInSidebarSectionNodes = {
       pinned: renderPinnedSection?.(consumeClickSuppression),
-      threads: hasFolders
-        ? renderThreadsSection?.(threadsContent, consumeClickSuppression)
-        : renderAllThreadsSection?.(threadsContent, consumeClickSuppression),
+      threads: renderThreadsSection?.(threadsContent, consumeClickSuppression),
     };
     const sections = (
       <SidebarSectionOrderList order={topLevelSectionOrder}>

--- a/apps/app/src/components/sidebar/projectThreadGroups.ts
+++ b/apps/app/src/components/sidebar/projectThreadGroups.ts
@@ -371,7 +371,7 @@ function buildThreadTreeItems(
   return buildSortedItems(rootNodes, compareThreads, groupEnvironmentThreads);
 }
 
-// Chronological "All Threads" bucket: root threads are globally ordered by the
+// Chronological Threads bucket: root threads are globally ordered by the
 // chosen comparator and descendants stay nested under their parent. Worktree
 // grouping stays off. Side chats are excluded to match buildProjectThreadGroups.
 export function buildChronologicalThreadList(


### PR DESCRIPTION
## Summary
- always label the chronological catch-all section Threads
- render the same display, project, section, and new-thread actions whether sections exist or not
- remove the duplicate All Threads header and overflow-menu state

## Validation
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm --dir apps/app exec vitest run --config vitest.config.ts src/components/sidebar/ProjectList.modes.test.tsx src/components/sidebar/ProjectListSectionHeader.test.tsx src/components/sidebar/SidebarViewOptionsMenu.test.tsx
- pnpm exec turbo run lint --filter=@bb/app
- pnpm exec turbo run build --filter=@bb/app
- pnpm exec prettier --check on changed files
- git diff --check