### PR TITLE
Promote official plugins to SDK 0.3

### DIFF
--- a/apps/server/src/services/marketplaces/official-marketplace.ts
+++ b/apps/server/src/services/marketplaces/official-marketplace.ts
@@ -27,13 +27,13 @@ export const OFFICIAL_MARKETPLACE_CATALOG = {
         githubRelease: {
           repository: "ymichael/bb",
           package: "bb-plugin-github",
-          range: "^0.1.0",
+          range: "^0.2.0",
           tagTemplate: "plugin-github-v{version}",
           assetTemplate: "bb-plugin-github-{version}.tgz",
         },
       },
       installation: {
-        engines: { bb: ">=0.0", bbPluginSdk: "^0.2.0" },
+        engines: { bb: ">=0.0", bbPluginSdk: "^0.3.0" },
       },
     },
     {
@@ -47,13 +47,13 @@ export const OFFICIAL_MARKETPLACE_CATALOG = {
         githubRelease: {
           repository: "ymichael/bb",
           package: "bb-plugin-simple-notes",
-          range: "^0.1.1",
+          range: "^0.2.0",
           tagTemplate: "plugin-docs-v{version}",
           assetTemplate: "bb-plugin-simple-notes-{version}.tgz",
         },
       },
       installation: {
-        engines: { bb: ">=0.0", bbPluginSdk: "^0.2.0" },
+        engines: { bb: ">=0.0", bbPluginSdk: "^0.3.0" },
       },
     },
     {
@@ -67,13 +67,13 @@ export const OFFICIAL_MARKETPLACE_CATALOG = {
         githubRelease: {
           repository: "ymichael/bb",
           package: "bb-plugin-memory",
-          range: "^0.1.0",
+          range: "^0.2.0",
           tagTemplate: "plugin-memory-v{version}",
           assetTemplate: "bb-plugin-memory-{version}.tgz",
         },
       },
       installation: {
-        engines: { bb: ">=0.0", bbPluginSdk: "^0.2.0" },
+        engines: { bb: ">=0.0", bbPluginSdk: "^0.3.0" },
       },
     },
   ],

--- a/marketplace.json
+++ b/marketplace.json
@@ -13,7 +13,7 @@
         "githubRelease": {
           "repository": "ymichael/bb",
           "package": "bb-plugin-github",
-          "range": "^0.1.0",
+          "range": "^0.2.0",
           "tagTemplate": "plugin-github-v{version}",
           "assetTemplate": "bb-plugin-github-{version}.tgz"
         }
@@ -21,7 +21,7 @@
       "installation": {
         "engines": {
           "bb": ">=0.0",
-          "bbPluginSdk": "^0.2.0"
+          "bbPluginSdk": "^0.3.0"
         }
       }
     },
@@ -35,7 +35,7 @@
         "githubRelease": {
           "repository": "ymichael/bb",
           "package": "bb-plugin-simple-notes",
-          "range": "^0.1.1",
+          "range": "^0.2.0",
           "tagTemplate": "plugin-docs-v{version}",
           "assetTemplate": "bb-plugin-simple-notes-{version}.tgz"
         }
@@ -43,7 +43,7 @@
       "installation": {
         "engines": {
           "bb": ">=0.0",
-          "bbPluginSdk": "^0.2.0"
+          "bbPluginSdk": "^0.3.0"
         }
       }
     },
@@ -57,7 +57,7 @@
         "githubRelease": {
           "repository": "ymichael/bb",
           "package": "bb-plugin-memory",
-          "range": "^0.1.0",
+          "range": "^0.2.0",
           "tagTemplate": "plugin-memory-v{version}",
           "assetTemplate": "bb-plugin-memory-{version}.tgz"
         }
@@ -65,7 +65,7 @@
       "installation": {
         "engines": {
           "bb": ">=0.0",
-          "bbPluginSdk": "^0.2.0"
+          "bbPluginSdk": "^0.3.0"
         }
       }
     }


### PR DESCRIPTION
## Summary

- promote GitHub, Docs, and Memory to their published `0.2.x` release lines
- require the host plugin SDK `^0.3.0` in both the public and bundled official catalogs
- keep both catalog copies in lockstep

Published releases:

- `plugin-github-v0.2.0`
- `plugin-docs-v0.2.0`
- `plugin-memory-v0.2.0`

All three target merged commit `e83d58fba4ec860baf0dd1158480ae0cd2594824` and expose verified SHA-256 digests.

## Validation

- official plugin publication dry run: passed
- official plugin publication workflow: passed
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server --force` (1,149 tests)
- `git diff --check`