### PR TITLE
Rename sidebar organization option to Manually

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -562,12 +562,12 @@ function ProjectListThreadsSectionActions({
   );
 }
 
-// "In one list" is the user-facing name for chronological/drag-ordered mode;
+// "Manually" is the user-facing name for chronological/drag-ordered mode;
 // the stored atom value stays "chronological".
 const SIDEBAR_ORGANIZE_OPTIONS = [
   { label: "By project", mode: "project" },
   { label: "By machine", mode: "machine" },
-  { label: "In one list", mode: "chronological" },
+  { label: "Manually", mode: "chronological" },
 ] as const satisfies readonly {
   label: string;
   mode: SidebarOrganizationMode;

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.stories.tsx
@@ -59,7 +59,7 @@ export function Overview() {
     <StoryCard>
       <StoryRow
         label="interactive"
-        hint="open the menu · toggle By project/In one list · pick a fixed-order sort field"
+        hint="open the menu · toggle By project/Manually · pick a fixed-order sort field"
       >
         <InteractiveMenu />
       </StoryRow>

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.test.tsx
@@ -79,14 +79,14 @@ describe("sidebar display options menu", () => {
       "menuitemcheckbox",
       { name: "By project" },
     );
-    const inOneListOption = within(organizeGroup).getByRole(
+    const manuallyOption = within(organizeGroup).getByRole(
       "menuitemcheckbox",
-      { name: "In one list" },
+      { name: "Manually" },
     );
 
     expect(byProjectOption.getAttribute("aria-checked")).toBe("true");
-    expect(inOneListOption.getAttribute("aria-checked")).toBe("false");
-    fireEvent.click(inOneListOption);
+    expect(manuallyOption.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(manuallyOption);
 
     expect(screen.getByTestId("organization-mode").textContent).toBe(
       "chronological",
@@ -96,7 +96,7 @@ describe("sidebar display options menu", () => {
     fireEvent.click(trigger);
     expect(
       (
-        await screen.findByRole("menuitemcheckbox", { name: "In one list" })
+        await screen.findByRole("menuitemcheckbox", { name: "Manually" })
       ).getAttribute("aria-checked"),
     ).toBe("true");
   });


### PR DESCRIPTION
## Summary
- rename the sidebar organization label from “In one list” to “Manually”
- update the sidebar story and interaction test to match
- preserve the stored `chronological` organization mode

## Tests
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/sidebar/SidebarViewOptionsMenu.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`