### PR TITLE
Fix stuck sidebar state after split drag

### DIFF
--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
@@ -42,4 +42,31 @@ describe("useSidebarReorderDnd", () => {
     unmount();
     expect(document.body.dataset.sidebarDragging).toBeUndefined();
   });
+
+  it("clears app-owned drag state when Escape preempts dnd-kit cancellation", () => {
+    const onDragCancel = vi.fn();
+    const { result } = renderHook(() =>
+      useSidebarReorderDnd({ onDragEnd: vi.fn(), onDragCancel }),
+    );
+
+    act(() => result.current.dndContextProps.onDragStart?.(DRAG_START_EVENT));
+    expect(document.body.dataset.sidebarDragging).toBe("true");
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          code: "Escape",
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(document.body.dataset.sidebarDragging).toBeUndefined();
+    expect(onDragCancel).toHaveBeenCalledTimes(1);
+
+    // A late public callback from dnd-kit must not run owner cleanup twice.
+    act(() => result.current.dndContextProps.onDragCancel?.(DRAG_CANCEL_EVENT));
+    expect(onDragCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, type MouseEventHandler } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type MouseEventHandler,
+} from "react";
 import {
   closestCenter,
   KeyboardSensor,
@@ -110,6 +116,7 @@ export function useSidebarReorderDnd({
     clearDragClickSuppressionSoon,
     consumeDragClickSuppression,
   } = useDragClickSuppression();
+  const isDraggingRef = useRef(false);
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
     useSensor(TouchSensor, {
@@ -121,6 +128,7 @@ export function useSidebarReorderDnd({
   );
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
+      isDraggingRef.current = true;
       setSidebarDraggingCursor(true);
       beginDragClickSuppression();
       onDragStart?.(event);
@@ -128,24 +136,41 @@ export function useSidebarReorderDnd({
     [beginDragClickSuppression, onDragStart],
   );
   const handleDragCancel = useCallback(() => {
+    if (!isDraggingRef.current) {
+      return;
+    }
+    isDraggingRef.current = false;
     setSidebarDraggingCursor(false);
     clearDragClickSuppressionSoon();
     onDragCancel?.();
   }, [clearDragClickSuppressionSoon, onDragCancel]);
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      isDraggingRef.current = false;
       setSidebarDraggingCursor(false);
       clearDragClickSuppressionSoon();
       onDragEnd(event);
     },
     [clearDragClickSuppressionSoon, onDragEnd],
   );
-  useEffect(
-    () => () => {
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.code === "Escape") {
+        // Split tear-out hands the gesture off by dispatching Escape. dnd-kit
+        // can consume that while its drag is still initializing without
+        // invoking DndContext's public onDragCancel callback, so clear the
+        // sidebar-owned cursor and projected-drag state directly as well.
+        handleDragCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      isDraggingRef.current = false;
       setSidebarDraggingCursor(false);
-    },
-    [],
-  );
+    };
+  }, [handleDragCancel]);
   const onClickCapture = useCallback<MouseEventHandler<HTMLElement>>(
     (event) => {
       if (!consumeDragClickSuppression()) {


### PR DESCRIPTION
## Summary

- clear sidebar-owned drag state directly when Escape hands a reorder gesture to split drag
- guard cleanup so a later dnd-kit cancel callback cannot run twice
- add regression coverage for the initialization race where dnd-kit omits `onDragCancel`

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/sidebar/useSidebarReorderDnd.test.tsx src/lib/split-drag/splitDragSession.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings remain elsewhere in the app)
- `git diff --check`

## Risk

Low. The direct Escape cleanup runs only while this sidebar reorder hook has an active drag, and duplicate cleanup is idempotently suppressed.