### PR TITLE
Use resolved shell PATH for worktree setup

### DIFF
--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -1077,6 +1077,34 @@ describe("RuntimeManager", () => {
     );
   });
 
+  it("passes the resolved shell PATH to managed worktree setup", async () => {
+    const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      shellEnv: {
+        PATH: "/resolved/user/bin:/usr/bin:/bin",
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      provision: {
+        workspaceProvisionType: "managed-worktree",
+        sourcePath: "/tmp/source",
+        targetPath: "/tmp/env-1",
+        branchName: "bb/env-1",
+        baseBranch: "main",
+        timeoutMs: 900000,
+      },
+    });
+
+    expect(provisionWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupPath: "/resolved/user/bin:/usr/bin:/bin",
+      }),
+    );
+  });
+
   it("passes shell PATH through to provider process env", async () => {
     const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
     const createRuntime = vi.fn(() => createFakeRuntime());

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -1038,8 +1038,12 @@ export class RuntimeManager {
       );
     }
 
+    const setupPath = this.getShellEnv().PATH;
     const workspace = await this.provisionWorkspace({
       ...provision,
+      ...(provision.workspaceProvisionType === "managed-worktree" && setupPath
+        ? { setupPath }
+        : {}),
       signal: args.provisionSignal,
     });
     const workspaceWriteRoots =

--- a/packages/host-workspace/src/provision.ts
+++ b/packages/host-workspace/src/provision.ts
@@ -91,6 +91,8 @@ export interface ManagedWorkspaceBaseOpts extends ProvisionBase {
   baseBranch: string | null;
   /** Setup script timeout in ms. Controlled by the server. */
   timeoutMs: number;
+  /** Resolved user-shell PATH for the setup script. */
+  setupPath?: string;
 }
 
 export interface ManagedWorktreeOpts extends ManagedWorkspaceBaseOpts {
@@ -684,6 +686,7 @@ async function provisionWorktree(
     branchName: opts.branchName,
     baseBranch: opts.baseBranch,
     timeoutMs: opts.timeoutMs,
+    setupPath: opts.setupPath,
     onProgress: opts.onProgress,
     pruneEmptyParent: true,
     signal: opts.signal,

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -49,6 +49,8 @@ export interface CreateWorkspaceArgs {
   baseBranch: string | null;
   /** Setup script timeout in ms. Controlled by the server. */
   timeoutMs: number;
+  /** Resolved user-shell PATH for the setup script. */
+  setupPath?: string;
   onProgress?: ProgressCallback;
   pruneEmptyParent?: boolean;
   signal?: AbortSignal;
@@ -57,6 +59,8 @@ export interface CreateWorkspaceArgs {
 export interface RunSetupScriptArgs {
   workspacePath: string;
   timeoutMs: number;
+  /** Resolved user-shell PATH. Falls back to the daemon process PATH. */
+  setupPath?: string;
   onProgress?: ProgressCallback;
   signal?: AbortSignal;
 }
@@ -388,6 +392,7 @@ export async function createWorktree(
     await runSetupScript({
       workspacePath: args.targetPath,
       timeoutMs: args.timeoutMs,
+      setupPath: args.setupPath,
       onProgress: args.onProgress,
       signal: args.signal,
     });
@@ -436,12 +441,16 @@ export async function runSetupScript(
   });
 
   const { timeoutMs } = args;
+  const env = sanitizeInheritedChildProcessEnv({ env: process.env });
+  if (args.setupPath !== undefined) {
+    env.PATH = args.setupPath;
+  }
   const child = spawnPortableOutputProcess({
     command: command.command,
     args: command.args,
     cwd: args.workspacePath,
     detached: shouldRunSetupScriptInProcessGroup(),
-    env: sanitizeInheritedChildProcessEnv({ env: process.env }),
+    env,
   });
 
   const outputChunks: string[] = [];

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -476,6 +476,28 @@ describe("workspace provisioning", () => {
     expect(result.output).toBe("missing|missing|missing|external-value\n");
   });
 
+  it("uses the resolved user-shell PATH for setup scripts", async () => {
+    const workspacePath = await makeTempDir("bb-setup-shell-path-");
+    const binPath = await makeTempDir("bb-setup-shell-bin-");
+    const executablePath = path.join(binPath, "shell-path-tool");
+    await fs.writeFile(executablePath, "#!/bin/sh\necho resolved-shell-path\n");
+    await fs.chmod(executablePath, 0o755);
+    await fs.writeFile(
+      path.join(workspacePath, DEFAULT_ENV_SETUP_SCRIPT_NAME),
+      "shell-path-tool\n",
+      "utf8",
+    );
+
+    const result = await runSetupScript({
+      workspacePath,
+      timeoutMs: 900000,
+      setupPath: `${binPath}${path.delimiter}/usr/bin:/bin`,
+    });
+
+    expect(result.ran).toBe(true);
+    expect(result.output).toBe("resolved-shell-path\n");
+  });
+
   it("builds a bash command for the supported setup script", () => {
     expect(
       buildSetupScriptCommand({


### PR DESCRIPTION
## Summary

- pass the host daemon's resolved user-shell PATH into managed worktree provisioning
- use that PATH when running `.bb-env-setup.sh` while preserving existing environment sanitization
- cover the daemon-to-workspace propagation and executable lookup with regression tests

## Testing

- `pnpm exec turbo run test --filter=@bb/host-workspace --force`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force`
- `pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-daemon`
- `git diff --check`