### PR TITLE
Restrict desktop window drag to top split row

### DIFF
--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -29,6 +29,11 @@ interface AppPageHeaderProps {
   actions?: ReactNode;
   bordered?: boolean;
   className?: string;
+  /**
+   * Whether this header occupies the native title-bar row and may drag the
+   * desktop window. Split panes below the workspace's top edge disable this.
+   */
+  isWindowDragRegion?: boolean;
 }
 
 export function AppPageHeader({
@@ -36,6 +41,7 @@ export function AppPageHeader({
   actions,
   bordered = true,
   className,
+  isWindowDragRegion = true,
 }: AppPageHeaderProps) {
   const isSidebarShowing = useIsSidebarShowing();
   const isCompactViewport = useIsCompactViewport();
@@ -52,7 +58,7 @@ export function AppPageHeader({
       className={cn(
         CHROME_ROW_HEIGHT_CLASS,
         "relative shrink-0 bg-surface-scrim px-4 backdrop-blur-sm",
-        usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
+        usesDesktopChrome && isWindowDragRegion && MACOS_WINDOW_DRAG_CLASS,
         bordered && "border-b border-border-seam",
         className,
       )}

--- a/apps/app/src/views/thread-detail/PaneContext.tsx
+++ b/apps/app/src/views/thread-detail/PaneContext.tsx
@@ -35,6 +35,11 @@ export interface PaneContextValue {
    * full-bleed page layout.
    */
   isBoundedPane: boolean;
+  /**
+   * Whether this pane touches the workspace's top edge, where its header
+   * occupies the native desktop title-bar row.
+   */
+  isTopRow: boolean;
   navigateInPane: (thread: ThreadRoutePathArgs) => void;
   /**
    * Starts a pane-reorder drag from the pane header via the shared split-drag
@@ -76,6 +81,7 @@ export function DefaultPaneContextProvider({
       canShowSecondaryPanel: true,
       onRequestClose: null,
       isBoundedPane: false,
+      isTopRow: true,
       navigateInPane,
     }),
     [navigateInPane],

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -138,6 +138,62 @@ const docsContent: PaneContent = {
   subPath: "",
 };
 
+function pluginContent(panelPath: string): PaneContent {
+  return {
+    kind: "plugin-panel",
+    pluginId: "test-plugin",
+    panelPath,
+    subPath: "",
+  };
+}
+
+function fourPanePluginLayout(): SplitLayout {
+  return {
+    root: {
+      type: "split",
+      dir: "row",
+      sizes: [0.5, 0.5],
+      children: [
+        {
+          type: "split",
+          dir: "col",
+          sizes: [0.5, 0.5],
+          children: [
+            {
+              type: "pane",
+              paneId: "pane-top-left",
+              content: pluginContent("top-left"),
+            },
+            {
+              type: "pane",
+              paneId: "pane-bottom-left",
+              content: pluginContent("bottom-left"),
+            },
+          ],
+        },
+        {
+          type: "split",
+          dir: "col",
+          sizes: [0.5, 0.5],
+          children: [
+            {
+              type: "pane",
+              paneId: "pane-top-right",
+              content: pluginContent("top-right"),
+            },
+            {
+              type: "pane",
+              paneId: "pane-bottom-right",
+              content: pluginContent("bottom-right"),
+            },
+          ],
+        },
+      ],
+    },
+    focusedPaneId: "pane-bottom-right",
+  };
+}
+
 function pluginSplitLayout(): SplitLayout {
   return {
     root: {
@@ -324,6 +380,55 @@ describe("SplitThreadArea", () => {
     expect(dragHandle?.className).toContain("cursor-grab");
     expect(dragHandle?.className).toContain("[app-region:no-drag]");
     expect(dragHandle?.className).toContain("[-webkit-app-region:no-drag]");
+  });
+
+  it("makes only top-row split headers desktop window-drag regions", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: null,
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: false,
+      updateDownloaded: false,
+      version: "0.0.0-test",
+    };
+    window.bbDesktop = createBbDesktopApi(desktopInfo);
+    setPluginSlotRegistrations("test-plugin", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: ["top-left", "bottom-left", "top-right", "bottom-right"].map(
+        (path) => ({
+          id: path,
+          title: path,
+          icon: "FileText",
+          path,
+          component: () => <div>{path} panel</div>,
+        }),
+      ),
+      threadPanelActions: [],
+      composerAccessories: [],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+
+    renderSplitArea({
+      path: "/plugins/test-plugin/bottom-right",
+      layout: fourPanePluginLayout(),
+      routeContent: pluginContent("bottom-right"),
+    });
+
+    for (const path of ["top-left", "top-right"]) {
+      const header = (await screen.findByText(path)).closest("header");
+      expect(header?.className).toContain("[app-region:drag]");
+      expect(header?.className).toContain("[-webkit-app-region:drag]");
+    }
+    for (const path of ["bottom-left", "bottom-right"]) {
+      const header = (await screen.findByText(path)).closest("header");
+      expect(header?.className).not.toContain("[app-region:drag]");
+      expect(header?.className).not.toContain("[-webkit-app-region:drag]");
+    }
   });
 
   it("places plugin header actions before the pane close button", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -332,6 +332,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           canShowSecondaryPanel
           onRequestClose={null}
           isBoundedPane={false}
+          isTopRow
           onNavigateInPane={navigateInPane}
         />
       </>
@@ -350,6 +351,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
         <SplitTree
           node={layout.root}
           path={EMPTY_PATH}
+          isTopRow
           focusedPaneId={layout.focusedPaneId}
           paneCount={panes.length}
           onFocusPane={focusPane}
@@ -410,6 +412,8 @@ function SplitPaneCommandHandlers({
 interface SplitTreeProps {
   node: LayoutNode;
   path: SplitPath;
+  /** Whether this subtree touches the workspace's top edge. */
+  isTopRow: boolean;
   focusedPaneId: string;
   paneCount: number;
   onFocusPane: (paneId: string) => void;
@@ -425,7 +429,7 @@ interface SplitTreeProps {
 }
 
 function SplitTree(props: SplitTreeProps) {
-  const { node, path, focusedPaneId, paneCount } = props;
+  const { node, path, isTopRow, focusedPaneId, paneCount } = props;
 
   if (node.type === "pane") {
     const isFocused = node.paneId === focusedPaneId;
@@ -456,6 +460,7 @@ function SplitTree(props: SplitTreeProps) {
           canShowSecondaryPanel={paneCount < 3 || isFocused}
           onRequestClose={() => props.onClosePane(node.paneId)}
           isBoundedPane
+          isTopRow={isTopRow}
           onNavigateInPane={props.onNavigateInPane}
           onBeginPaneDrag={props.onBeginPaneDrag}
         />
@@ -492,7 +497,15 @@ function SplitTree(props: SplitTreeProps) {
             className="flex min-h-0 min-w-0"
             style={{ flex: `${node.sizes[index] ?? 1} 1 0` }}
           >
-            <SplitTree {...props} node={child} path={[...path, index]} />
+            <SplitTree
+              {...props}
+              node={child}
+              path={[...path, index]}
+              // Horizontal siblings all remain on the same top row. In a
+              // vertical stack, only the first child can inherit the parent
+              // subtree's contact with the workspace top edge.
+              isTopRow={isTopRow && (node.dir === "row" || index === 0)}
+            />
           </div>
         </Fragment>
       ))}
@@ -509,6 +522,7 @@ interface WorkspacePaneContentProps {
   // True inside multi-pane split cards; suppresses the page-bleed margins so
   // content fills the card exactly (see PaneContextValue.isBoundedPane).
   isBoundedPane: boolean;
+  isTopRow: boolean;
   onNavigateInPane: NavigateInPane;
   // Absent for the single-pane surface — a lone pane has nothing to reorder.
   onBeginPaneDrag?: BeginPaneDrag;
@@ -521,6 +535,7 @@ function WorkspacePaneContent({
   canShowSecondaryPanel,
   onRequestClose,
   isBoundedPane,
+  isTopRow,
   onNavigateInPane,
   onBeginPaneDrag,
 }: WorkspacePaneContentProps) {
@@ -543,6 +558,7 @@ function WorkspacePaneContent({
       canShowSecondaryPanel,
       onRequestClose,
       isBoundedPane,
+      isTopRow,
       navigateInPane,
       beginPaneDrag,
     }),
@@ -551,6 +567,7 @@ function WorkspacePaneContent({
       canShowSecondaryPanel,
       isBoundedPane,
       isFocused,
+      isTopRow,
       navigateInPane,
       onRequestClose,
       paneId,
@@ -564,6 +581,7 @@ function WorkspacePaneContent({
         onRequestClose={onRequestClose}
         beginPaneDrag={beginPaneDrag}
         isBoundedPane={isBoundedPane}
+        isTopRow={isTopRow}
       />
     );
   }
@@ -600,11 +618,13 @@ function NonThreadPaneContent({
   onRequestClose,
   beginPaneDrag,
   isBoundedPane,
+  isTopRow,
 }: {
   content: Exclude<PaneContent, { kind: "thread" }>;
   onRequestClose: (() => void) | null;
   beginPaneDrag?: (event: ReactPointerEvent, label: string) => void;
   isBoundedPane: boolean;
+  isTopRow: boolean;
 }) {
   const { navPanels } = usePluginSlots();
   const [desktopInfo] = useState(getBbDesktopInfo);
@@ -654,6 +674,7 @@ function NonThreadPaneContent({
       {isBoundedPane || panel ? (
         <AppPageHeader
           bordered={false}
+          isWindowDragRegion={isTopRow}
           className="border-b border-border-seam-vertical/60"
           center={
             <div

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -67,7 +67,7 @@ export function ThreadDetailHeader({
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   // The title doubles as the pane-reorder drag handle when the layout is split;
   // beginPaneDrag is undefined on the single-pane and page surfaces.
-  const { beginPaneDrag, isFocused } = usePaneContext();
+  const { beginPaneDrag, isFocused, isTopRow } = usePaneContext();
   const showFocusedPaneTitlePill = beginPaneDrag !== undefined && isFocused;
   const handleTitlePointerDown = (event: ReactPointerEvent) => {
     if (!beginPaneDrag || event.button !== 0) {
@@ -206,6 +206,7 @@ export function ThreadDetailHeader({
       center={center}
       actions={actions}
       bordered={false}
+      isWindowDragRegion={isTopRow}
       className={cn(
         "border-b border-border-seam-vertical/60",
         beginPaneDrag && isFocused && "bg-surface-raised",


### PR DESCRIPTION
## Summary

- track whether each split pane touches the workspace top edge
- enable the macOS window-drag region only for top-row headers
- cover a nested 2x2 split so lower-row headers cannot drag the window

## Tests

- pnpm exec turbo run test --filter=@bb/app --force -- src/views/thread-detail/SplitThreadArea.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (0 errors; existing warnings only)