### PR TITLE
Prevent development builds from sending telemetry

### DIFF
--- a/apps/server/src/services/system/telemetry.ts
+++ b/apps/server/src/services/system/telemetry.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { DEFAULTS } from "@bb/config/defaults";
 import { readOrCreateSecretFile } from "@bb/secret-storage";
 import type { AppSurface } from "@bb/config/app-surface";
 import type { ServerLogger } from "../../types.js";
@@ -15,11 +16,12 @@ import type { ServerLogger } from "../../types.js";
  * workflow state, so lost sends (offline, PostHog outage, process exit
  * mid-flight) are dropped without retry or persistence.
  *
- * A default public write-only PostHog key ships in @bb/config, but the caller
- * only enables telemetry for production server runs (the bb-app launcher and
- * desktop app set NODE_ENV=production; dev/source runs never send). Disabled
- * telemetry creates nothing, not even the install-id file. Opt out any run
- * with BB_TELEMETRY=false; override the key with BB_POSTHOG_API_KEY.
+ * A default public write-only PostHog key ships in @bb/config. Telemetry only
+ * activates for production server runs with a resolved release version (the
+ * bb-app launcher and desktop app set NODE_ENV=production). Dev/source runs
+ * never send, even if a test starts them in production mode.
+ * Disabled telemetry creates nothing, not even the install-id file. Opt out
+ * any run with BB_TELEMETRY=false; override the key with BB_POSTHOG_API_KEY.
  */
 
 const POSTHOG_INGESTION_URL = "https://us.i.posthog.com/capture/";
@@ -77,7 +79,11 @@ export function runWithTelemetryAppSurface<T>(
 export async function createTelemetryService(
   args: CreateTelemetryServiceArgs,
 ): Promise<TelemetryService> {
-  if (!args.enabled || args.apiKey.length === 0) {
+  if (
+    !args.enabled ||
+    args.apiKey.length === 0 ||
+    args.appVersion === DEFAULTS.appVersion
+  ) {
     return noopTelemetryService;
   }
   const distinctId = await readOrCreateSecretFile({
@@ -93,7 +99,8 @@ export async function createTelemetryService(
   };
   return {
     capture(event: TelemetryEvent): void {
-      const appSurface = telemetryAppSurfaceStorage.getStore() ?? args.appSurface;
+      const appSurface =
+        telemetryAppSurfaceStorage.getStore() ?? args.appSurface;
       const eventProperties = "properties" in event ? event.properties : {};
       const body = JSON.stringify({
         api_key: args.apiKey,

--- a/apps/server/test/services/telemetry.test.ts
+++ b/apps/server/test/services/telemetry.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULTS } from "@bb/config/defaults";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTelemetryService,
@@ -129,13 +130,29 @@ describe("telemetry service", () => {
   });
 
   it.each([
-    { apiKey: "", enabled: true, label: "no API key" },
-    { apiKey: "phc_test", enabled: false, label: "opted out" },
-  ])("is fully inert when $label", async ({ apiKey, enabled }) => {
+    {
+      apiKey: "",
+      appVersion: "1.2.3",
+      enabled: true,
+      label: "there is no API key",
+    },
+    {
+      apiKey: "phc_test",
+      appVersion: "1.2.3",
+      enabled: false,
+      label: "the user opted out",
+    },
+    {
+      apiKey: "phc_test",
+      appVersion: DEFAULTS.appVersion,
+      enabled: true,
+      label: "the release version is unresolved",
+    },
+  ])("is fully inert when $label", async ({ apiKey, appVersion, enabled }) => {
     const telemetry = await createTelemetryService({
       apiKey,
       appSurface: "web",
-      appVersion: "1.2.3",
+      appVersion,
       dataDir,
       enabled,
       logger: createTestLogger(),

--- a/packages/config/src/defaults.ts
+++ b/packages/config/src/defaults.ts
@@ -6,6 +6,7 @@
  * tooling entrypoints that only need the raw values.
  */
 export const DEFAULTS = {
+  appVersion: "0.0.0-dev",
   logLevel: { prod: "info", dev: "debug" },
   secretToken: { dev: "dev-secret" },
   inferenceModel: "codex/gpt-5.4-mini",

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -309,7 +309,7 @@ export const BB_HOST_TYPE_ENV = defineEnvVar<HostType | undefined>({
   parse: parseHostTypeValue,
 });
 
-export const DEFAULT_BB_APP_VERSION = "0.0.0-dev";
+export const DEFAULT_BB_APP_VERSION = DEFAULTS.appVersion;
 export const DEFAULT_BB_APP_SURFACE = DEFAULT_APP_SURFACE;
 export const DEFAULT_BB_APP_URL = "";
 export const DEFAULT_BB_EXTERNAL_URL = "";


### PR DESCRIPTION
## Summary

- centralize the unresolved `0.0.0-dev` app version sentinel in shared config defaults
- make telemetry fully inert when the runtime still has that unresolved development version
- cover the guard alongside the existing disabled/no-key telemetry cases

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/config --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/telemetry.test.ts`
- `pnpm exec turbo run build --filter=@bb/server`
- targeted Prettier check and `git diff --check`

## Notes

The broader server suite passed 1,146 of 1,147 tests locally. The sole failure was the unrelated `install-machine-script` npm-fallback case, whose mocked host daemon exited during enrollment and reproduced unchanged in isolation.