### PR TITLE
Allow secret requests to write outside workspaces

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -364,7 +364,9 @@ For review or fix pipelines, get the environment ID from
   needed. Batch known names and add `--purpose <text>` plus one
   `--describe <NAME> <text>` per variable.
 - The user enters values in a secure plugin form; values are written directly
-  to the workspace dotenv file and never returned in CLI output or chat.
+  to the dotenv file and never returned in CLI output or chat. Relative paths
+  resolve from the CLI working directory; absolute paths may point anywhere on
+  the thread's host.
 - Treat the returned path and added/updated/unchanged counts as verification.
   Do not inspect the completed file with `cat`, `sed`, `env`, or similar tools.
 

--- a/plugins/secrets/package.json
+++ b/plugins/secrets/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Securely request credentials from a user and reconcile them into workspace dotenv files.",
+  "description": "Securely request credentials from a user and reconcile them into dotenv files.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Secrets",
-    "description": "Securely request credentials from a user and reconcile them into workspace dotenv files.",
+    "description": "Securely request credentials from a user and reconcile them into dotenv files.",
     "branding": {
       "icon": "Lock"
     },

--- a/plugins/secrets/skills/secrets/SKILL.md
+++ b/plugins/secrets/skills/secrets/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: secrets
-description: Securely request API keys, access tokens, passwords, webhook secrets, or other credentials from the user and write them to a workspace dotenv file without exposing their values to the agent.
+description: Securely request API keys, access tokens, passwords, webhook secrets, or other credentials from the user and write them to a dotenv file without exposing their values to the agent.
 ---
 
-# Request workspace secrets securely
+# Request secrets securely
 
 Use `bb secret request` whenever work needs a credential. Do not ask the user to paste a secret into chat.
 
@@ -17,7 +17,7 @@ bb secret request OPENAI_API_KEY RESEND_API_KEY \
   --write-env .env.local
 ```
 
-Always provide the exact `--write-env` destination, a concise purpose, and one short plain-language description per variable. Never place secret values in argv, prompts, comments, logs, or follow-up messages.
+Always provide the exact `--write-env` destination, a concise purpose, and one short plain-language description per variable. Relative destinations resolve from the CLI working directory; absolute destinations may point anywhere on the thread's host. Never place secret values in argv, prompts, comments, logs, or follow-up messages.
 
 After success, trust the command's path and added/updated/unchanged counts. Never verify by running `cat`, `sed`, `env`, or another command that would reveal the completed file.
 

--- a/plugins/secrets/src/server-harness.test.ts
+++ b/plugins/secrets/src/server-harness.test.ts
@@ -11,7 +11,6 @@ describe("secrets plugin server", () => {
         threads: {
           async get() {
             return {
-              environment: { path: "/workspace" },
               host: { id: "host-test" },
             };
           },
@@ -46,7 +45,7 @@ describe("secrets plugin server", () => {
         "API_KEY",
         "Primary API key",
       ],
-      { threadId: "thr-test", cwd: "/workspace" },
+      { threadId: "thr-test", cwd: "/outside/workspace/plugin" },
     );
     await vi.waitFor(() =>
       expect(host.harness.pendingInteractions).toHaveLength(1),
@@ -54,6 +53,10 @@ describe("secrets plugin server", () => {
     const pending = host.harness.pendingInteractions[0]!;
     expect(pending.payload).toMatchObject({
       purpose: "Configure the app",
+      destination: {
+        kind: "dotenv",
+        path: "/outside/workspace/plugin/.env.local",
+      },
       fields: [{ name: "API_KEY" }, { name: "TOKEN" }],
     });
     host.harness.submitInteraction(pending.id, {
@@ -66,10 +69,58 @@ describe("secrets plugin server", () => {
     expect(result.stdout).not.toContain("secret-two");
     expect(writtenContent).toContain("API_KEY='secret-one'");
     expect(writtenContent).toContain("TOKEN='secret-two'");
-    expect(host.harness.sdk.callsTo("files.write")[0]?.[0]).toMatchObject({
+    const writeArgs = host.harness.sdk.callsTo("files.write")[0]?.[0];
+    expect(writeArgs).toMatchObject({
+      hostId: "host-test",
+      path: "/outside/workspace/plugin/.env.local",
       expectedSha256: "before",
       mode: 0o600,
     });
+    expect(writeArgs).not.toHaveProperty("rootPath");
+    expect(JSON.parse(result.stdout ?? "")).toMatchObject({
+      path: "/outside/workspace/plugin/.env.local",
+    });
+  });
+
+  it("preserves an absolute dotenv destination outside the CLI working directory", async () => {
+    const host = createFakePluginHost({
+      pluginId: "secrets",
+      sdk: {
+        threads: {
+          async get() {
+            return { host: { id: "host-test" } };
+          },
+        },
+        files: {
+          async read() {
+            return {
+              content: "",
+              contentEncoding: "utf8",
+              sha256: "before",
+            };
+          },
+        },
+      },
+    });
+    plugin(host.bb as unknown as Parameters<typeof plugin>[0]);
+
+    const command = host.harness.runCli(
+      ["request", "API_KEY", "--write-env", "/var/plugin/.env"],
+      { threadId: "thr-test", cwd: "/workspace" },
+    );
+    await vi.waitFor(() =>
+      expect(host.harness.pendingInteractions).toHaveLength(1),
+    );
+
+    expect(host.harness.pendingInteractions[0]?.payload).toMatchObject({
+      destination: { kind: "dotenv", path: "/var/plugin/.env" },
+    });
+    expect(host.harness.sdk.callsTo("files.read")[0]?.[0]).toEqual({
+      hostId: "host-test",
+      path: "/var/plugin/.env",
+    });
+    host.harness.cancelInteraction(host.harness.pendingInteractions[0]!.id);
+    await command;
   });
 
   it.each([

--- a/plugins/secrets/src/server.ts
+++ b/plugins/secrets/src/server.ts
@@ -25,8 +25,7 @@ const fileReadResultSchema = z.object({
   contentEncoding: z.enum(["utf8", "base64"]),
   sha256: z.string(),
 });
-const threadWorkspaceSchema = z.object({
-  environment: z.object({ path: z.string().nullable() }).nullable().optional(),
+const threadHostSchema = z.object({
   host: z.object({ id: z.string() }).nullable().optional(),
 });
 const fileWriteResultSchema = z.discriminatedUnion("outcome", [
@@ -119,19 +118,12 @@ function parseRequest(argv: string[]): ParsedRequest {
   return { names, purpose, descriptions, writeEnv };
 }
 
-function requireContained(
-  root: string,
-  candidate: string,
-  label: string,
-): void {
-  const relative = path.relative(root, candidate);
-  if (
-    relative === ".." ||
-    relative.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relative)
-  ) {
-    throw new Error(`${label} must be inside the thread workspace.`);
-  }
+function resolveHostPath(cwd: string, candidate: string): string {
+  if (path.posix.isAbsolute(candidate)) return path.posix.normalize(candidate);
+  if (path.win32.isAbsolute(candidate)) return path.win32.normalize(candidate);
+  return path.posix.isAbsolute(cwd)
+    ? path.posix.resolve(cwd, candidate)
+    : path.win32.resolve(cwd, candidate);
 }
 
 function httpStatus(error: unknown): number | null {
@@ -143,7 +135,7 @@ function httpStatus(error: unknown): number | null {
 
 async function readSnapshot(
   bb: BbPluginApi,
-  args: { hostId: string; rootPath: string; path: string },
+  args: { hostId: string; path: string },
 ): Promise<FileSnapshot> {
   try {
     const result = fileReadResultSchema.parse(await bb.sdk.files.read(args));
@@ -166,24 +158,18 @@ async function runRequest(
     throw new Error("bb secret request must run from a bb thread.");
   if (!ctx.cwd)
     throw new Error(
-      "bb secret request requires the invoking workspace directory.",
+      "bb secret request requires the invoking working directory.",
     );
-  const thread = threadWorkspaceSchema.parse(
+  const thread = threadHostSchema.parse(
     await bb.sdk.threads.get({
       threadId: ctx.threadId,
-      include: "environment,host",
+      include: "host",
     }),
   );
-  const environment = thread.environment;
   const host = thread.host;
-  if (!environment?.path || !host?.id)
-    throw new Error("The thread needs a live workspace and host.");
-  const rootPath = path.resolve(environment.path);
-  const cwd = path.resolve(ctx.cwd);
-  requireContained(rootPath, cwd, "CLI working directory");
-  const destinationPath = path.resolve(cwd, parsed.writeEnv);
-  requireContained(rootPath, destinationPath, "Dotenv destination");
-  const fileArgs = { hostId: host.id, rootPath, path: destinationPath };
+  if (!host?.id) throw new Error("The thread needs a live host.");
+  const destinationPath = resolveHostPath(ctx.cwd, parsed.writeEnv);
+  const fileArgs = { hostId: host.id, path: destinationPath };
   let snapshot = await readSnapshot(bb, fileArgs);
   assertNoDuplicateAssignments(snapshot.content, parsed.names);
 
@@ -191,12 +177,12 @@ async function runRequest(
     {
       threadId: ctx.threadId,
       rendererId: "secret-request",
-      title: `Add secrets to ${path.relative(rootPath, destinationPath)}`,
+      title: `Add secrets to ${destinationPath}`,
       payload: {
         purpose: parsed.purpose,
         destination: {
           kind: "dotenv",
-          path: path.relative(rootPath, destinationPath),
+          path: destinationPath,
         },
         fields: parsed.names.map((name) => ({
           name,
@@ -235,7 +221,7 @@ async function runRequest(
     if (write.outcome === "written") {
       return {
         exitCode: 0,
-        stdout: `${JSON.stringify({ path: path.relative(rootPath, destinationPath), names: parsed.names, added: reconciled.added, updated: reconciled.updated, unchanged: reconciled.unchanged })}\n`,
+        stdout: `${JSON.stringify({ path: destinationPath, names: parsed.names, added: reconciled.added, updated: reconciled.updated, unchanged: reconciled.unchanged })}\n`,
       };
     }
     if (attempt === 1)
@@ -251,8 +237,7 @@ async function runRequest(
 export default function plugin(bb: BbPluginApi) {
   bb.cli.register({
     name: "secret",
-    summary:
-      "Securely request credentials and write them to a workspace dotenv file.",
+    summary: "Securely request credentials and write them to a dotenv file.",
     commands: [
       {
         name: "request",


### PR DESCRIPTION
## Summary

- allow bb secret request destinations anywhere on the thread host
- resolve relative destinations from the invoking CLI working directory and preserve absolute host paths
- show the resolved absolute destination in the secure form and command result
- retain dotenv reconciliation, conflict handling, and 0600 permissions for newly created files
- update agent-facing guidance and plugin descriptions

## Tests

- pnpm exec turbo run test typecheck --filter=bb-plugin-secrets --force
- pnpm exec prettier --check on changed plugin files
- git diff --check

## Risk

This intentionally removes workspace root confinement. The secure form displays the resolved absolute destination before the user submits secret values.