### PR TITLE
Fix desktop system theme switching

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -81,7 +81,7 @@ export function App() {
   // Show a separate toast when the Electron shell reports a desktop update.
   useDesktopUpdateAvailableToast();
   // Keep the Electron window chrome (traffic lights, inactive title bar)
-  // in sync with bb's resolved theme.
+  // in sync with bb's theme preference.
   useDesktopThemeSync();
   // Apply the server-stored app palette (built-in or custom CSS) app-wide.
   useAppTheme();

--- a/apps/app/src/hooks/useDesktopThemeSync.test.tsx
+++ b/apps/app/src/hooks/useDesktopThemeSync.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BbDesktopInfo, BbDesktopTheme } from "@bb/desktop-contract";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+
+const desktopInfo: BbDesktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos",
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.0-test",
+};
+
+function installColorSchemeMediaQuery(initialDark: boolean): {
+  setDark(dark: boolean): void;
+} {
+  let dark = initialDark;
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  const mediaQuery: MediaQueryList = {
+    get matches() {
+      return dark;
+    },
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener(
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
+      listeners.add(listener);
+    },
+    removeEventListener(
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
+      listeners.delete(listener);
+    },
+    dispatchEvent(event) {
+      for (const listener of listeners) {
+        if (typeof listener === "function") {
+          listener.call(mediaQuery, event);
+        } else {
+          listener.handleEvent(event);
+        }
+      }
+      return true;
+    },
+  };
+
+  window.matchMedia = vi.fn(() => mediaQuery);
+  return {
+    setDark(nextDark) {
+      dark = nextDark;
+      mediaQuery.dispatchEvent(new Event("change"));
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  delete window.bbDesktop;
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("desktop theme synchronization", () => {
+  it("keeps Electron on system while the resolved theme follows OS changes", async () => {
+    const colorScheme = installColorSchemeMediaQuery(true);
+    const setThemeCalls: BbDesktopTheme[] = [];
+    const desktopApi = createBbDesktopApi(desktopInfo);
+    desktopApi.setTheme = (theme) => setThemeCalls.push(theme);
+    window.bbDesktop = desktopApi;
+
+    const { useDesktopThemeSync } = await import("./useDesktopThemeSync");
+    const { usePreferredTheme } = await import("./useTheme");
+    const { result } = renderHook(() => {
+      useDesktopThemeSync();
+      return usePreferredTheme();
+    });
+
+    expect(result.current).toBe("dark");
+    expect(setThemeCalls).toEqual(["system"]);
+
+    act(() => colorScheme.setDark(false));
+
+    expect(result.current).toBe("light");
+    expect(setThemeCalls).toEqual(["system"]);
+  });
+});

--- a/apps/app/src/hooks/useDesktopThemeSync.ts
+++ b/apps/app/src/hooks/useDesktopThemeSync.ts
@@ -1,17 +1,17 @@
 import { useEffect } from "react";
 import { getBbDesktopInfo } from "@/lib/bb-desktop";
-import { usePreferredTheme } from "./useTheme";
+import { useThemePreference } from "./useTheme";
 
 /**
- * Push the renderer-resolved theme to the Electron main process so the
- * NSWindow chrome (traffic lights + inactive title-bar) follows bb's theme
- * rather than the OS appearance. Mounts once at the app root; safely no-ops
- * in the web build where `window.bbDesktop` is undefined.
+ * Push the renderer's theme preference to the Electron main process so the
+ * NSWindow chrome (traffic lights + inactive title-bar) follows bb's explicit
+ * theme or the OS when set to system. Mounts once at the app root; safely
+ * no-ops in the web build where `window.bbDesktop` is undefined.
  */
 export function useDesktopThemeSync(): void {
-  const theme = usePreferredTheme();
+  const themePreference = useThemePreference();
   useEffect(() => {
     const desktopApi = getBbDesktopInfo();
-    desktopApi?.setTheme(theme);
-  }, [theme]);
+    desktopApi?.setTheme(themePreference);
+  }, [themePreference]);
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1377,10 +1377,10 @@ function registerDesktopUpdateIpc(): void {
     await finishQuit();
     desktopAutoUpdateService.installUpdate();
   });
-  // Renderer pushes the resolved bb theme so the NSWindow appearance —
-  // traffic lights and inactive title-bar chrome — follows bb's theme
-  // rather than the OS appearance. `themeSource` is app-global so a single
-  // assignment covers every BrowserWindow, including the log viewer.
+  // Renderer pushes the bb theme preference so the NSWindow appearance —
+  // traffic lights and inactive title-bar chrome — follows an explicit bb
+  // theme or the OS when set to system. `themeSource` is app-global so a
+  // single assignment covers every BrowserWindow, including the log viewer.
   ipcMain.on(BB_DESKTOP_SET_THEME_CHANNEL, (_event, payload: unknown) => {
     const parsed = bbDesktopThemeSchema.safeParse(payload);
     if (!parsed.success) {

--- a/packages/desktop-contract/src/info.ts
+++ b/packages/desktop-contract/src/info.ts
@@ -22,7 +22,7 @@ export const bbDesktopWindowStateSchema = z
   .strict();
 export type BbDesktopWindowState = z.infer<typeof bbDesktopWindowStateSchema>;
 
-export const bbDesktopThemeSchema = z.enum(["light", "dark"]);
+export const bbDesktopThemeSchema = z.enum(["system", "light", "dark"]);
 export type BbDesktopTheme = z.infer<typeof bbDesktopThemeSchema>;
 
 export type BbDesktopInfoChangeHandler = (info: BbDesktopInfo) => void;
@@ -83,10 +83,10 @@ export interface BbDesktopApi extends BbDesktopInfo {
    */
   openExternalUrl(url: string): void;
   /**
-   * Push the renderer-resolved theme to the Electron main process so the
+   * Push the renderer's theme preference to the Electron main process so the
    * NSWindow appearance — traffic lights and inactive title-bar chrome —
-   * follows bb's theme rather than the OS appearance. No-op on the web build
-   * where `window.bbDesktop` is undefined.
+   * follows bb's explicit theme or the OS when set to system. No-op on the web
+   * build where `window.bbDesktop` is undefined.
    */
   setTheme(theme: BbDesktopTheme): void;
 }

--- a/packages/desktop-contract/test/version-feed.test.ts
+++ b/packages/desktop-contract/test/version-feed.test.ts
@@ -26,7 +26,7 @@ describe("desktop info schema", () => {
   it("accepts the desktop theme values", () => {
     expect(bbDesktopThemeSchema.safeParse("dark").success).toBe(true);
     expect(bbDesktopThemeSchema.safeParse("light").success).toBe(true);
-    expect(bbDesktopThemeSchema.safeParse("system").success).toBe(false);
+    expect(bbDesktopThemeSchema.safeParse("system").success).toBe(true);
     expect(
       bbDesktopThemeSchema.safeParse({
         canvasColor: "oklch(0.195 0 0)",


### PR DESCRIPTION
## Summary

- preserve the three-state appearance preference across the desktop IPC boundary
- let Electron use its system theme source when appearance is set to System
- cover macOS light/dark transitions with a renderer regression test

## Validation

- pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/desktop --filter=@bb/desktop-contract
- pnpm exec turbo run test --filter=@bb/desktop
- pnpm exec turbo run test --filter=@bb/app -- src/hooks/useDesktopThemeSync.test.tsx
- pnpm exec turbo run test --filter=@bb/desktop-contract -- test/version-feed.test.ts
- manual desktop QA: System follows macOS light/dark changes