### PR TITLE
Require exact SDK version for prebuilt plugin server bundles pre-1.0

### DIFF
--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -643,13 +643,24 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     );
   }
 
+  function isPrebuiltServerSdkCompatible(
+    meta: { sdkMajor: number; sdkVersion: string } | null,
+  ): boolean {
+    if (meta === null) return false;
+    if (meta.sdkMajor !== PLUGIN_SDK_MAJOR) return false;
+    if (PLUGIN_SDK_MAJOR === 0) return meta.sdkVersion === PLUGIN_SDK_VERSION;
+    return true;
+  }
+
   /**
    * The backend entry to import for this load. Managed (git:/npm:) installs
-   * prefer a fresh, SDK-major-compatible prebuilt `dist/server.js` (design
+   * prefer a fresh, SDK-compatible prebuilt `dist/server.js` (design
    * §3 loader amendment, §6 prebuilt distribution) so consumers never need
    * npm or node_modules; path installs ALWAYS load from source, so author
    * iteration via `bb plugin reload` sees edited files. A present-but-stale
-   * or meta-less dist falls back to source with one warning.
+   * or meta-less dist falls back to source with one warning. While the SDK
+   * is pre-1.0, minor bumps are breaking (semver), so compatibility requires
+   * the exact SDK version, not just a matching major.
    */
   async function resolveServerEntry(
     row: InstalledPluginRow,
@@ -670,9 +681,9 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     } catch {
       // missing sidecar → meta stays null
     }
-    if (meta?.sdkMajor !== PLUGIN_SDK_MAJOR) {
+    if (!isPrebuiltServerSdkCompatible(meta)) {
       logger.warn(
-        `plugin ${row.id}: ignoring prebuilt dist/server.js (built for SDK ${meta ? `major ${meta.sdkMajor}` : "unknown"}, running SDK major is ${PLUGIN_SDK_MAJOR}) — loading from source`,
+        `plugin ${row.id}: ignoring prebuilt dist/server.js (built with SDK ${meta?.sdkVersion ?? "unknown"}, running SDK is ${PLUGIN_SDK_VERSION}) — loading from source`,
       );
       return manifest.serverEntry;
     }

--- a/apps/server/test/services/plugins/prebuilt-server-loading.test.ts
+++ b/apps/server/test/services/plugins/prebuilt-server-loading.test.ts
@@ -41,9 +41,10 @@ function gitPersistence(url: string, requestedRef: string) {
 
 /**
  * Prebuilt backend distribution (design §3 loader amendment, §6): managed
- * (git:/npm:) installs prefer a fresh, SDK-major-compatible dist/server.js;
- * path installs always load from source. The fixture's source entry THROWS,
- * so whichever half runs is unambiguous.
+ * (git:/npm:) installs prefer a fresh, SDK-compatible dist/server.js;
+ * path installs always load from source. Pre-1.0, minor SDK bumps are
+ * breaking, so compatibility means the exact SDK version. The fixture's
+ * source entry THROWS, so whichever half runs is unambiguous.
  */
 
 const THROWING_SERVER_TS = `throw new Error("source must not load");\n`;
@@ -145,6 +146,27 @@ describe("prebuilt server bundle loading", () => {
     const entry = await service.installPath(rootDir);
     expect(entry.status).toBe("error");
     expect(entry.statusDetail).toContain("source must not load");
+  });
+
+  it("pre-1.0: falls back to source when the dist SDK version differs within major 0", async () => {
+    const rootDir = await writePrebuiltPlugin("bb-plugin-minordist", {
+      sdkMajor: PLUGIN_SDK_MAJOR,
+      sdkVersion: `${PLUGIN_SDK_MAJOR}.999.0`,
+    });
+    upsertInstalledPlugin(db, {
+      ...gitPersistence("https://github.com/acme/bb-plugin-minordist", "v1"),
+      id: "minordist",
+      source: "git:github.com/acme/bb-plugin-minordist@v1",
+      rootDir,
+      version: "0.1.0",
+      enabled: true,
+    });
+    await service.reload("minordist");
+
+    const entry = service.list().find((plugin) => plugin.id === "minordist");
+    // The throwing source ran — proof the 0.x-stale dist was NOT imported.
+    expect(entry?.status).toBe("error");
+    expect(entry?.statusDetail).toContain("source must not load");
   });
 
   it("falls back to source when the dist meta's SDK major mismatches", async () => {


### PR DESCRIPTION
## Summary

Booting bb after the Plugin SDK 0.3 bump (#716) failed to load every builtin plugin:

```
plugin automations failed to load: bb.storage.sqlite is not a function
plugin connect failed to load: rpc.register handlers must be an object
```

`resolveServerEntry` prefers a prebuilt `dist/server.js` for non-path installs, gated only on `sdkMajor`. Bundles built with SDK 0.2.0 pass that check under the 0.3.0 server (both major 0), so stale bundles left in `plugins/*/dist` by an earlier packaging run kept loading and hit renamed 0.3 APIs. The `secrets` plugin was worse: its stale bundle loaded "successfully" and silently ran 0.2 code. CI never catches this because `plugins/*/dist` is gitignored — clean checkouts always fall back to source.

## Fix

Pre-1.0, minor SDK bumps are breaking per semver, so prebuilt compatibility now requires the exact SDK version (`isPrebuiltServerSdkCompatible`). Once the SDK reaches 1.0, matching major suffices as before. Rejected bundles fall back to source with a warning naming the full built/running versions. This mirrors the frontend bundle path, which already compares full `sdkVersion` and rebuilds.

Managed-install validation (`validatePluginArtifactMeta`) and the frontend `compatible` flag keep their major-only checks — engine ranges are the documented pre-1.0 gate there.

## Testing

- New regression test: same major, different minor → source entry wins (`prebuilt-server-loading.test.ts`), alongside existing fresh-dist / path-install / major-mismatch cases; all pass.
- `turbo run typecheck --filter=@bb/server` clean.
- Verified live: deleted the stale dists, reloaded builtins on a running 0.3 server — all five now `running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)