### PR TITLE
Split workspace: window-level right panel with stable visibility

### DIFF
--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
@@ -144,6 +144,17 @@ function callIndex(
   return calls.findIndex(predicate);
 }
 
+function lastCallIndex(
+  calls: readonly BrowserCall[],
+  predicate: (call: BrowserCall) => boolean,
+): number {
+  for (let index = calls.length - 1; index >= 0; index -= 1) {
+    const call = calls[index];
+    if (call !== undefined && predicate(call)) return index;
+  }
+  return -1;
+}
+
 describe("BrowserTabDeck native browser first-show ordering", () => {
   const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
   const originalMatchMedia = window.matchMedia;
@@ -215,8 +226,7 @@ describe("BrowserTabDeck native browser first-show ordering", () => {
     const attachIndex = callIndex(calls, (call) => call.type === "attach");
     const boundsIndex = callIndex(
       calls,
-      (call) =>
-        call.type === "setBounds" && call.request.tabId === "tab-url",
+      (call) => call.type === "setBounds" && call.request.tabId === "tab-url",
     );
     const showIndex = callIndex(
       calls,
@@ -234,6 +244,61 @@ describe("BrowserTabDeck native browser first-show ordering", () => {
       bounds: { x: 12, y: 24, width: 420, height: 260 },
     });
     expect(visibility.at(-1)).toEqual({ tabId: "tab-url", visible: true });
+
+    // Focus leaving the owning pane drives readiness false. Returning focus
+    // must recompute bounds before exposing the retained native view again.
+    view.rerender(
+      <BrowserTabDeck
+        browserTabs={[makeBrowserTab("tab-url", "https://example.com")]}
+        activeBrowserTabId="tab-url"
+        environmentId="env-1"
+        canShowNativeBrowserView={false}
+        threadId="thread-1"
+        onUpdate={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(visibility.at(-1)).toEqual({
+        tabId: "tab-url",
+        visible: false,
+      });
+    });
+    const hideIndex = lastCallIndex(
+      calls,
+      (call) =>
+        call.type === "setVisible" &&
+        call.request.tabId === "tab-url" &&
+        !call.request.visible,
+    );
+
+    view.rerender(
+      <BrowserTabDeck
+        browserTabs={[makeBrowserTab("tab-url", "https://example.com")]}
+        activeBrowserTabId="tab-url"
+        environmentId="env-1"
+        canShowNativeBrowserView={true}
+        threadId="thread-1"
+        onUpdate={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      const visibleShows = visibility.filter((request) => request.visible);
+      expect(visibleShows).toHaveLength(2);
+    });
+    const restoredBoundsIndex = lastCallIndex(
+      calls,
+      (call) => call.type === "setBounds" && call.request.tabId === "tab-url",
+    );
+    const restoredShowIndex = lastCallIndex(
+      calls,
+      (call) =>
+        call.type === "setVisible" &&
+        call.request.tabId === "tab-url" &&
+        call.request.visible,
+    );
+    expect(hideIndex).toBeGreaterThan(showIndex);
+    expect(restoredBoundsIndex).toBeGreaterThan(hideIndex);
+    expect(restoredShowIndex).toBeGreaterThan(restoredBoundsIndex);
   });
 
   it("focuses the address bar when an empty browser tab requests focus", () => {

--- a/apps/app/src/components/secondary-panel/SecondaryPanelHostLayoutContext.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelHostLayoutContext.ts
@@ -1,0 +1,21 @@
+import { createContext } from "react";
+
+/**
+ * Provided by a window-level secondary-panel host (the split workspace) around
+ * the whole workspace it lays out. Carries the window's panel visibility for
+ * two consumers:
+ * - A pane's ThreadSecondaryPanel mounting into the host's PanelGroup sizes
+ *   itself to the window state. The pane's own persisted open state can lag
+ *   one commit behind (the host aligns it right after a focus or thread
+ *   switch), and a defaultSize computed from that stale value would make the
+ *   group collapse the freshly mounted panel and misreport a user close.
+ * - The right-edge pane headers reserve the window toggle's corner footprint
+ *   only while the panel is closed; open, the toggle overlays the panel's own
+ *   chrome and the pane actions sit flush at the pane edge.
+ */
+export interface SecondaryPanelHostLayout {
+  isOpen: boolean;
+}
+
+export const SecondaryPanelHostLayoutContext =
+  createContext<SecondaryPanelHostLayout | null>(null);

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -3,7 +3,9 @@ import {
   type FocusEvent,
   type ReactNode,
   useCallback,
+  useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useAtomValue } from "jotai";
@@ -24,6 +26,7 @@ import {
 } from "./panelTransitionTokens";
 import { SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS } from "./panelChromeClasses";
 import { resolveConversationCollapseControl } from "./panelToggleControlState";
+import { SecondaryPanelHostLayoutContext } from "./SecondaryPanelHostLayoutContext";
 import { SecondaryPanelTabStrip } from "./SecondaryPanelTabStrip";
 import type {
   SecondaryPanelFileTab,
@@ -64,9 +67,7 @@ import {
 } from "@/lib/bb-desktop";
 import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import type { SecondaryFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
-import {
-  useAppCommandShortcut,
-} from "@/components/commands/AppCommandProvider";
+import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 export type {
@@ -75,8 +76,10 @@ export type {
 } from "./GitDiffToolbar";
 export type { SecondaryPanelFileTab } from "./secondaryPanelFileTab";
 
-const THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT = 24;
-const THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT = 70;
+// Shared with the split-workspace host's empty-state panel, which must resize
+// within the same bounds as the real panel it stands in for.
+export const THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT = 24;
+export const THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT = 70;
 // While the conversation is collapsed the panel fills the content area, so its
 // size/max are lifted to the full width of the horizontal group.
 const CONVERSATION_COLLAPSED_PANEL_SIZE_PERCENT = 100;
@@ -164,6 +167,15 @@ export interface ThreadSecondaryPanelProps {
    * The drawer layout always renders the button (it carries its own close).
    */
   inlinePanelToggle?: "button" | "reserved" | "hidden";
+  /**
+   * Unique id for this panel's resizable Panel within its PanelGroup. The
+   * split-workspace host swaps different panes' panels through one group, and
+   * react-resizable-panels keys layout state by panel id — a shared id would
+   * make a newly focused pane's panel adopt the previous pane's layout entry
+   * and then "collapse" to its own defaultSize, misreporting a user close.
+   * Defaults to the standalone surface's stable id.
+   */
+  resizablePanelId?: string;
   onPanelFocus: () => void;
   onPanelChange: (panel: ThreadSecondaryPanelTab) => void;
   onCollapse: () => void;
@@ -239,6 +251,7 @@ export function ThreadSecondaryPanel({
   showInfoTab = true,
   showNewTabButton = true,
   inlinePanelToggle = "button",
+  resizablePanelId = "thread-detail-secondary-panel",
   onPanelFocus,
   onPanelChange,
   onCollapse,
@@ -265,11 +278,11 @@ export function ThreadSecondaryPanel({
   // layout fills the screen and cannot collapse the conversation.
   const conversationCollapseControl =
     renderAsDrawer || !showConversationCollapseControl
-    ? null
-    : resolveConversationCollapseControl({
-        isConversationCollapsed,
-        onToggleConversationCollapse,
-      });
+      ? null
+      : resolveConversationCollapseControl({
+          isConversationCollapsed,
+          onToggleConversationCollapse,
+        });
   const {
     gitDiffDisplayMode,
     handleGitDiffDisplayModeChange,
@@ -296,6 +309,34 @@ export function ThreadSecondaryPanel({
       },
       [handleResizeDragging, handleSecondaryPanelResizeStart],
     );
+  // A Panel that registers with its group already collapsed (a closed panel
+  // mounting, or the split-workspace host swapping panes' panels) reports a
+  // collapse no user performed — and it can land after a programmatic open,
+  // silently closing it again. Only a collapse from a layout this Panel
+  // instance actually held expanded may close the persisted panel.
+  const hasPanelExpandedRef = useRef(false);
+  const handlePanelResize = useCallback(
+    (size: number) => {
+      if (size > 0) {
+        hasPanelExpandedRef.current = true;
+      }
+      handleSecondaryPanelResize(size);
+    },
+    [handleSecondaryPanelResize],
+  );
+  const handlePanelCollapse = useCallback(() => {
+    if (!hasPanelExpandedRef.current) {
+      return;
+    }
+    hasPanelExpandedRef.current = false;
+    onCollapse();
+  }, [onCollapse]);
+  // Inside a window-level host, the Panel's mount size must follow the
+  // window's panel visibility: this pane's own persisted state can lag one
+  // commit behind the host's alignment, and the group re-applies defaultSize
+  // after mount — a stale-closed value would collapse the just-opened panel.
+  const hostLayout = useContext(SecondaryPanelHostLayoutContext);
+  const isLayoutOpen = hostLayout?.isOpen ?? isOpen;
   const activeFixedPanel =
     resolveActiveFixedPanel({ activeTab, canUseGitUi }) ?? "thread-info";
   const isDiffPanelActive = activeFixedPanel === "git-diff";
@@ -415,7 +456,9 @@ export function ThreadSecondaryPanel({
       // below) so the content is always exactly the panel's current width.
       style={
         !renderAsDrawer && !isSecondaryPanelResizing
-          ? { width: `var(--secondary-swipe-width, ${persistedWidthPercent}cqw)` }
+          ? {
+              width: `var(--secondary-swipe-width, ${persistedWidthPercent}cqw)`,
+            }
           : undefined
       }
       className={cn(
@@ -424,7 +467,11 @@ export function ThreadSecondaryPanel({
         // content the panel clips into view (or fills the panel while resizing).
         renderAsDrawer && "min-w-0 flex-1",
         !renderAsDrawer && [
-          "absolute inset-y-0 left-0 border-l border-border-seam-vertical",
+          "absolute inset-y-0 left-0",
+          // Inside the split-workspace host, the 6px gutter handle is the
+          // visible seam; elsewhere the panel carries its own hairline border
+          // (it slides with the panel through the open/close animation).
+          hostLayout === null && "border-l border-border-seam-vertical",
           isSecondaryPanelResizing && "right-0",
           !isOpen && "pointer-events-none",
         ],
@@ -572,7 +619,9 @@ export function ThreadSecondaryPanel({
             selectionValue={gitDiffSelectValue}
             selectionOptions={gitDiffSelectOptions}
             onSelectionChange={onGitDiffSelectionChange}
-            isSelectorDisabled={isDiffFilesLoading || gitDiffTarget === undefined}
+            isSelectorDisabled={
+              isDiffFilesLoading || gitDiffTarget === undefined
+            }
             stats={gitDiffStats}
             areAllFilesCollapsed={areAllCollapsed}
             isCollapseAllDisabled={!hasFiles || isDiffFilesLoading}
@@ -638,15 +687,16 @@ export function ThreadSecondaryPanel({
       <SecondaryPanelResizeHandle
         isOpen={isOpen}
         isConversationCollapsed={isConversationCollapsed}
+        matchesSplitDividers={hostLayout !== null}
         onDragging={handleSecondaryPanelDragging}
       />
       <Panel
         ref={resizablePanelRef}
-        id="thread-detail-secondary-panel"
+        id={resizablePanelId}
         collapsible
         collapsedSize={0}
         defaultSize={
-          isOpen
+          isLayoutOpen
             ? isConversationCollapsed
               ? CONVERSATION_COLLAPSED_PANEL_SIZE_PERCENT
               : persistedWidthPercent
@@ -658,8 +708,8 @@ export function ThreadSecondaryPanel({
             ? CONVERSATION_COLLAPSED_PANEL_SIZE_PERCENT
             : THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT
         }
-        onCollapse={onCollapse}
-        onResize={handleSecondaryPanelResize}
+        onCollapse={handlePanelCollapse}
+        onResize={handlePanelResize}
         order={2}
         style={SECONDARY_RESIZABLE_PANEL_STYLE}
         className={cn(
@@ -719,12 +769,19 @@ function NewTabButton({
 interface SecondaryPanelResizeHandleProps {
   isOpen: boolean;
   isConversationCollapsed: boolean;
+  /**
+   * True inside the split-workspace host, where the panel sits beside split
+   * dividers: the handle renders as the same visible 6px gutter so the grab
+   * target reads (and grabs) like its neighbors instead of an invisible seam.
+   */
+  matchesSplitDividers: boolean;
   onDragging: SecondaryPanelDraggingHandler;
 }
 
 function SecondaryPanelResizeHandle({
   isOpen,
   isConversationCollapsed,
+  matchesSplitDividers,
   onDragging,
 }: SecondaryPanelResizeHandleProps) {
   const isResizing = useAtomValue(threadSecondaryPanelResizingAtom);
@@ -738,42 +795,60 @@ function SecondaryPanelResizeHandle({
       onDragging={onDragging}
       hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
       className={cn(
-        "group relative shrink-0 overflow-visible bg-transparent transition-[width,opacity,background-color] before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
+        "group relative shrink-0 overflow-visible transition-[width,opacity,background-color] before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
         PANEL_COLLAPSE_TRANSITION_CLASS,
         isConversationCollapsed ? "cursor-default" : "cursor-col-resize",
-        // Zero-width: the visible panel border lives on the content (aside
-        // border-l), so this handle is purely the drag hit area + hover seam and
-        // sits exactly on that border instead of in a 1px slot to its left (which
-        // left the hit area and hover highlight a pixel off the border). Hidden +
-        // non-interactive when closed or while the conversation is collapsed.
-        isOpen && !isConversationCollapsed
-          ? "w-0 opacity-100"
-          : "pointer-events-none w-0 opacity-0",
-        isResizing && "bg-accent/20",
+        matchesSplitDividers
+          ? [
+              // Match SplitDivider: a recessed 6px gutter that warms on
+              // hover/drag, so the panel seam looks and grabs exactly like the
+              // split gutters beside it. Collapses away with the panel.
+              "z-[5] bg-muted/60 hover:bg-ring/40",
+              isOpen && !isConversationCollapsed
+                ? "w-1.5 opacity-100"
+                : "pointer-events-none w-0 opacity-0",
+              isResizing && "bg-ring/40",
+            ]
+          : [
+              // Zero-width: the visible panel border lives on the content
+              // (aside border-l), so this handle is purely the drag hit area +
+              // hover seam and sits exactly on that border instead of in a 1px
+              // slot to its left (which left the hit area and hover highlight
+              // a pixel off the border). Hidden + non-interactive when closed
+              // or while the conversation is collapsed.
+              "bg-transparent",
+              isOpen && !isConversationCollapsed
+                ? "w-0 opacity-100"
+                : "pointer-events-none w-0 opacity-0",
+              isResizing && "bg-accent/20",
+            ],
       )}
       aria-label="Resize thread and right panel"
     >
-      {/*
-        The panel's persistent left border lives on the content (aside
-        `border-l`) so it slides with the panel on open/close. This seam is only
-        the resize affordance — transparent at rest (so it doesn't double the
-        content border), brightening on hover/drag.
-      */}
-      <span
-        // Sit on the handle's right edge (`left-full`), which is the panel's left
-        // edge where the content border-l lives, so the hover/drag highlight lands
-        // exactly on the border instead of a pixel to its left at the handle's
-        // center.
-        className={cn(
-          // z-10 so the highlight paints over the adjacent content's border-l
-          // (the content renders after the handle) instead of being hidden behind
-          // it — otherwise the hover/drag highlight is invisible.
-          "pointer-events-none absolute inset-y-0 left-full z-10 w-px transition-colors",
-          isResizing
-            ? "bg-accent-foreground/50"
-            : "bg-transparent group-hover:bg-accent-foreground/35",
-        )}
-      />
+      {matchesSplitDividers ? null : (
+        /*
+          The panel's persistent left border lives on the content (aside
+          `border-l`) so it slides with the panel on open/close. This seam is
+          only the resize affordance — transparent at rest (so it doesn't
+          double the content border), brightening on hover/drag.
+        */
+        <span
+          // Sit on the handle's right edge (`left-full`), which is the panel's
+          // left edge where the content border-l lives, so the hover/drag
+          // highlight lands exactly on the border instead of a pixel to its
+          // left at the handle's center.
+          className={cn(
+            // z-10 so the highlight paints over the adjacent content's
+            // border-l (the content renders after the handle) instead of being
+            // hidden behind it — otherwise the hover/drag highlight is
+            // invisible.
+            "pointer-events-none absolute inset-y-0 left-full z-10 w-px transition-colors",
+            isResizing
+              ? "bg-accent-foreground/50"
+              : "bg-transparent group-hover:bg-accent-foreground/35",
+          )}
+        />
+      )}
     </PanelResizeHandle>
   );
 }

--- a/apps/app/src/views/RootComposePanelCommandHandlers.test.tsx
+++ b/apps/app/src/views/RootComposePanelCommandHandlers.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BbDesktopCloseWindowRequestHandler } from "@bb/desktop-contract";
+import { AppCommandProvider } from "@/components/commands/AppCommandProvider";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+import { RootComposePanelCommandHandlers } from "./RootComposePanelCommandHandlers";
+
+const commandFixture = vi.hoisted(() => ({
+  keybindings: [
+    {
+      command: "panel.toggle" as const,
+      desktopOnly: false,
+      shortcut: {
+        key: "p",
+        mod: true,
+        meta: false,
+        control: false,
+        alt: false,
+        shift: false,
+      },
+      when: { all: ["mainSurface" as const], none: [] },
+    },
+    {
+      command: "panel.close" as const,
+      desktopOnly: false,
+      shortcut: {
+        key: "w",
+        mod: true,
+        meta: false,
+        control: false,
+        alt: false,
+        shift: false,
+      },
+      when: { all: ["mainSurface" as const], none: [] },
+    },
+  ],
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: {
+      generalSettings: {
+        showKeyboardHints: false,
+      },
+      keybindings: commandFixture.keybindings,
+    },
+  }),
+}));
+
+const desktopInfo = {
+  lastCheckedAt: null,
+  latestVersion: null,
+  pendingVersion: null,
+  platform: "macos" as const,
+  updateAvailable: false,
+  updateDownloaded: false,
+  version: "0.0.0-test",
+};
+
+function dispatchControlShortcut(key: string): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    key,
+  });
+  fireEvent(window, event);
+  return event;
+}
+
+afterEach(() => {
+  cleanup();
+  delete window.bbDesktop;
+});
+
+describe("RootComposePanelCommandHandlers", () => {
+  it("routes panel shortcuts and desktop close requests only to the focused New Thread pane", async () => {
+    const firstToggle = vi.fn();
+    const firstClose = vi.fn(() => true);
+    const secondToggle = vi.fn();
+    const secondClose = vi.fn(() => true);
+    const desktopCloseHandlers = new Set<BbDesktopCloseWindowRequestHandler>();
+    window.bbDesktop = {
+      ...createBbDesktopApi(desktopInfo),
+      onCloseWindowRequest(listener) {
+        desktopCloseHandlers.add(listener);
+        return () => desktopCloseHandlers.delete(listener);
+      },
+    };
+
+    const view = render(
+      <AppCommandProvider>
+        <RootComposePanelCommandHandlers
+          isFocused
+          onClose={firstClose}
+          onToggle={firstToggle}
+        />
+        <RootComposePanelCommandHandlers
+          isFocused={false}
+          onClose={secondClose}
+          onToggle={secondToggle}
+        />
+      </AppCommandProvider>,
+    );
+
+    await act(async () => undefined);
+    expect(desktopCloseHandlers.size).toBe(1);
+    expect(dispatchControlShortcut("p").defaultPrevented).toBe(true);
+    expect(firstToggle).toHaveBeenCalledTimes(1);
+    expect(secondToggle).not.toHaveBeenCalled();
+    expect(dispatchControlShortcut("w").defaultPrevented).toBe(true);
+    expect(firstClose).toHaveBeenCalledTimes(1);
+    expect(secondClose).not.toHaveBeenCalled();
+    for (const handler of desktopCloseHandlers) {
+      expect(handler()).toBe(true);
+    }
+    expect(firstClose).toHaveBeenCalledTimes(2);
+
+    view.rerender(
+      <AppCommandProvider>
+        <RootComposePanelCommandHandlers
+          isFocused={false}
+          onClose={firstClose}
+          onToggle={firstToggle}
+        />
+        <RootComposePanelCommandHandlers
+          isFocused
+          onClose={secondClose}
+          onToggle={secondToggle}
+        />
+      </AppCommandProvider>,
+    );
+    await act(async () => undefined);
+
+    expect(desktopCloseHandlers.size).toBe(1);
+    dispatchControlShortcut("p");
+    dispatchControlShortcut("w");
+    expect(firstToggle).toHaveBeenCalledTimes(1);
+    expect(firstClose).toHaveBeenCalledTimes(2);
+    expect(secondToggle).toHaveBeenCalledTimes(1);
+    expect(secondClose).toHaveBeenCalledTimes(1);
+    for (const handler of desktopCloseHandlers) handler();
+    expect(secondClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/app/src/views/RootComposePanelCommandHandlers.tsx
+++ b/apps/app/src/views/RootComposePanelCommandHandlers.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useAppCommandHandler } from "@/components/commands/AppCommandProvider";
+import { getBbDesktopInfo } from "@/lib/bb-desktop";
+
+interface RootComposePanelCommandHandlersProps {
+  isFocused: boolean;
+  onClose: () => boolean;
+  onToggle: () => void;
+}
+
+/** Focus-scoped command bridge for a New Thread pane's secondary panel. */
+export function RootComposePanelCommandHandlers({
+  isFocused,
+  onClose,
+  onToggle,
+}: RootComposePanelCommandHandlersProps) {
+  useAppCommandHandler("panel.toggle", () => {
+    if (!isFocused) return false;
+    onToggle();
+    return true;
+  });
+  useAppCommandHandler("panel.close", () => {
+    if (!isFocused) return false;
+    return onClose();
+  });
+  useEffect(() => {
+    if (!isFocused) return;
+    const desktopInfo = getBbDesktopInfo();
+    if (desktopInfo?.onCloseWindowRequest === undefined) return;
+    return desktopInfo.onCloseWindowRequest(onClose);
+  }, [isFocused, onClose]);
+  return null;
+}

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -5,7 +5,6 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
-  ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS,
   ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
   RootComposeSecondaryContent,
 } from "./RootComposeSecondaryContent";
@@ -156,6 +155,7 @@ function renderRootCompose(args: RenderRootComposeArgs) {
     >
       <RootComposeSecondaryContent
         isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
+        onToggleSecondaryPanel={() => undefined}
         panelTogglePositionClassName={
           renderArgs.panelTogglePositionClassName ??
           ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS
@@ -177,6 +177,7 @@ function renderRootCompose(args: RenderRootComposeArgs) {
         >
           <RootComposeSecondaryContent
             isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
+            onToggleSecondaryPanel={() => undefined}
             panelTogglePositionClassName={
               renderArgs.panelTogglePositionClassName ??
               ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS
@@ -239,22 +240,6 @@ describe("RootComposeSecondaryContent desktop layout", () => {
     )) {
       expect(cutout.className).toContain(positionClass);
     }
-  });
-
-  it("moves the drag-strip cutout with the bounded-pane toggle", () => {
-    setMacosDesktopChrome();
-
-    renderRootCompose({
-      isCompactViewport: false,
-      isSecondaryPanelOpen: false,
-      panelTogglePositionClassName:
-        ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS,
-    });
-
-    const cutout = screen.getByTestId("root-compose-drag-strip-toggle-cutout");
-    const cutoutClasses = cutout.className.split(" ");
-    expect(cutoutClasses).toContain("right-12");
-    expect(cutoutClasses).not.toContain("right-4");
   });
 
   it("keeps the drag strip whole while the panel is open (the panel chrome carves instead)", () => {

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -210,22 +210,33 @@ export function RootComposeSecondaryContent({
       secondaryWidth,
     ]);
   }, [isSecondaryPanelOpen, renderAsDrawer]);
-  const inlineSecondaryPanelContent = !renderAsDrawer ? (
-    <ThreadSecondaryPanel
-      {...threadSecondaryPanelProps}
-      browserDeck={browserDeck}
-      renderAsDrawer={false}
-      isConversationCollapsed={false}
-      onToggleConversationCollapse={noopToggleConversationCollapse}
-      // In the split-workspace host, panes' panels share one PanelGroup, so
-      // each pane's Panel needs its own layout identity (see the prop doc).
-      resizablePanelId={
-        secondaryPanelHost === null || paneContext === null
-          ? undefined
-          : `thread-detail-secondary-panel-${paneContext.paneId}`
-      }
-    />
-  ) : null;
+  const inlineSecondaryPanelContent = useMemo(
+    () =>
+      !renderAsDrawer ? (
+        <ThreadSecondaryPanel
+          {...threadSecondaryPanelProps}
+          browserDeck={browserDeck}
+          renderAsDrawer={false}
+          isConversationCollapsed={false}
+          onToggleConversationCollapse={noopToggleConversationCollapse}
+          // In the split-workspace host, panes' panels share one PanelGroup,
+          // so each pane's Panel needs its own layout identity (see the prop
+          // doc).
+          resizablePanelId={
+            secondaryPanelHost === null || paneContext === null
+              ? undefined
+              : `thread-detail-secondary-panel-${paneContext.paneId}`
+          }
+        />
+      ) : null,
+    [
+      browserDeck,
+      paneContext,
+      renderAsDrawer,
+      secondaryPanelHost,
+      threadSecondaryPanelProps,
+    ],
+  );
   const drawerSecondaryPanelContent = renderAsDrawer ? (
     <ThreadSecondaryPanel
       {...threadSecondaryPanelProps}

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -31,6 +31,11 @@ import {
 } from "@/lib/bb-desktop";
 import { PluginHomepageSections } from "@/components/plugin/PluginHomepageSections";
 import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  useOptionalPaneContext,
+  usePaneSecondaryPanelRegistration,
+  type PaneSecondaryPanelViewModel,
+} from "./thread-detail/PaneContext";
 
 const CLOSED_MAIN_PANEL_SIZE_PERCENT = 100;
 const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
@@ -47,8 +52,6 @@ const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
 // from drifting apart.
 export const ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS =
   "right-4 top-2.5";
-export const ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS =
-  "right-12 top-2.5";
 
 type RootSecondaryPanelProps = Omit<
   ComponentProps<typeof ThreadSecondaryPanel>,
@@ -66,6 +69,7 @@ interface RootComposeSecondaryContentProps {
   children: ReactNode;
   contentClassName?: string;
   isSecondaryPanelOpen: boolean;
+  onToggleSecondaryPanel: () => void;
   panelTogglePositionClassName: string;
   secondaryPanel: RootSecondaryPanelProps;
 }
@@ -76,9 +80,12 @@ export function RootComposeSecondaryContent({
   children,
   contentClassName,
   isSecondaryPanelOpen,
+  onToggleSecondaryPanel,
   panelTogglePositionClassName,
   secondaryPanel,
 }: RootComposeSecondaryContentProps) {
+  const paneContext = useOptionalPaneContext();
+  const secondaryPanelHost = paneContext?.secondaryPanelHost ?? null;
   const renderAsDrawer = useIsCompactViewport();
   const persistedSecondaryWidthPercent = useAtomValue(
     secondaryPanelWidthPercentAtom,
@@ -179,7 +186,8 @@ export function RootComposeSecondaryContent({
 
   const canShowNativeBrowserView = renderAsDrawer
     ? isSecondaryPanelOpen && isCompactDrawerContentSettled
-    : isSecondaryPanelOpen;
+    : isSecondaryPanelOpen &&
+      (secondaryPanelHost === null || paneContext?.isFocused === true);
   const { renderBrowserDeck, ...threadSecondaryPanelProps } = secondaryPanel;
   const browserDeck = useMemo(
     () => renderBrowserDeck?.({ canShowNativeBrowserView }),
@@ -209,6 +217,13 @@ export function RootComposeSecondaryContent({
       renderAsDrawer={false}
       isConversationCollapsed={false}
       onToggleConversationCollapse={noopToggleConversationCollapse}
+      // In the split-workspace host, panes' panels share one PanelGroup, so
+      // each pane's Panel needs its own layout identity (see the prop doc).
+      resizablePanelId={
+        secondaryPanelHost === null || paneContext === null
+          ? undefined
+          : `thread-detail-secondary-panel-${paneContext.paneId}`
+      }
     />
   ) : null;
   const drawerSecondaryPanelContent = renderAsDrawer ? (
@@ -220,6 +235,67 @@ export function RootComposeSecondaryContent({
       onToggleConversationCollapse={noopToggleConversationCollapse}
     />
   ) : null;
+  const hostedPanelModel = useMemo<PaneSecondaryPanelViewModel>(
+    () => ({
+      collapsedRail: null,
+      contentKey: "new-thread",
+      isMainCollapsed: false,
+      isOpen: isSecondaryPanelOpen,
+      panel: inlineSecondaryPanelContent,
+      onToggle: onToggleSecondaryPanel,
+    }),
+    [inlineSecondaryPanelContent, isSecondaryPanelOpen, onToggleSecondaryPanel],
+  );
+  usePaneSecondaryPanelRegistration(secondaryPanelHost, hostedPanelModel);
+
+  const mainContent = (
+    <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+      {usesDesktopChrome ? (
+        <div
+          data-testid="root-compose-main-window-drag-strip"
+          aria-hidden="true"
+          className={cn(
+            "absolute inset-x-0 top-0 z-10 shrink-0",
+            CHROME_ROW_HEIGHT_CLASS,
+            MACOS_WINDOW_DRAG_CLASS,
+          )}
+        >
+          {!isSecondaryPanelOpen && secondaryPanelHost === null ? (
+            <div
+              data-testid="root-compose-drag-strip-toggle-cutout"
+              className={cn(
+                "absolute",
+                panelTogglePositionClassName,
+                COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
+                MACOS_APP_REGION_NO_DRAG_CLASS,
+              )}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      <div className="@container/page min-h-0 flex-1 overflow-y-auto">
+        <div
+          className={cn(
+            "mx-auto flex w-full flex-col px-4 pb-4 pt-2",
+            ROOT_COMPOSE_MAX_WIDTH_CLASS,
+            contentClassName,
+          )}
+          style={PAGE_SHELL_CONTENT_STYLE}
+        >
+          {children}
+          <PluginHomepageSections />
+        </div>
+      </div>
+    </div>
+  );
+
+  if (secondaryPanelHost !== null) {
+    return (
+      <div className="-mx-4 -mb-4 -mt-4 flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip md:-mx-5 md:-mb-5 md:-mt-5">
+        {mainContent}
+      </div>
+    );
+  }
 
   return (
     <div className="-mx-4 -mb-4 -mt-4 flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip md:-mx-5 md:-mb-5 md:-mt-5">
@@ -251,51 +327,7 @@ export function RootComposeSecondaryContent({
               PANEL_COLLAPSE_TRANSITION_CLASS,
             )}
           >
-            <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-              {usesDesktopChrome ? (
-                <div
-                  data-testid="root-compose-main-window-drag-strip"
-                  aria-hidden="true"
-                  className={cn(
-                    "absolute inset-x-0 top-0 z-10 shrink-0",
-                    CHROME_ROW_HEIGHT_CLASS,
-                    MACOS_WINDOW_DRAG_CLASS,
-                  )}
-                >
-                  {/* While the panel is closed the main panel spans the full
-                      width and the pinned right-panel toggle overlays this
-                      strip, so carve its footprint out of the drag region — as
-                      a child of the strip it resolves after the strip's own
-                      drag rect and wins. Open, the toggle sits over the panel
-                      chrome instead (whose reserved slot does the carving), so
-                      the strip stays fully draggable. */}
-                  {!isSecondaryPanelOpen ? (
-                    <div
-                      data-testid="root-compose-drag-strip-toggle-cutout"
-                      className={cn(
-                        "absolute",
-                        panelTogglePositionClassName,
-                        COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
-                        MACOS_APP_REGION_NO_DRAG_CLASS,
-                      )}
-                    />
-                  ) : null}
-                </div>
-              ) : null}
-              <div className="@container/page min-h-0 flex-1 overflow-y-auto">
-                <div
-                  className={cn(
-                    "mx-auto flex w-full flex-col px-4 pb-4 pt-2",
-                    ROOT_COMPOSE_MAX_WIDTH_CLASS,
-                    contentClassName,
-                  )}
-                  style={PAGE_SHELL_CONTENT_STYLE}
-                >
-                  {children}
-                  <PluginHomepageSections />
-                </div>
-              </div>
-            </div>
+            {mainContent}
           </Panel>
           {inlineSecondaryPanelContent}
         </PanelGroup>

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -141,7 +141,6 @@ import {
 import { resolveAbsoluteFilePath } from "@/lib/absolute-file-path";
 import { getBrowserUrlHost } from "@/lib/browser-url";
 import {
-  getBbDesktopInfo,
   getDesktopBrowserApi,
   isDesktopBrowserAvailable,
 } from "@/lib/bb-desktop";
@@ -171,7 +170,6 @@ import {
   useSetRootComposeProjectId,
 } from "@/lib/root-compose-selection";
 import {
-  ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS,
   ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
   RootComposeSecondaryContent,
 } from "./RootComposeSecondaryContent";
@@ -224,6 +222,8 @@ import {
   useAppCommandHandler,
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
+import { useOptionalPaneContext } from "./thread-detail/PaneContext";
+import { RootComposePanelCommandHandlers } from "./RootComposePanelCommandHandlers";
 
 const ROOT_COMPOSE_ZEN_MODE_STORAGE_KEY = "bb.promptbox.zen-mode.root-compose";
 const ROOT_COMPOSE_SIDEBAR_ACTION_ALIGNED_TOP_PADDING_CLASS = "pt-14";
@@ -406,10 +406,6 @@ export function shouldStartComposingFromLocationState(state: unknown): boolean {
     return false;
   }
   return "focusPrompt" in state && state.focusPrompt === true;
-}
-
-interface RootComposeViewProps {
-  isBoundedPane: boolean;
 }
 
 interface BuildMobileRecentThreadsArgs {
@@ -956,12 +952,14 @@ export function RootComposeRoute() {
       poolOptions={FILE_PREVIEW_WORKER_POOL_OPTIONS}
       highlighterOptions={FILE_PREVIEW_HIGHLIGHTER_OPTIONS}
     >
-      <RootComposeView isBoundedPane={false} />
+      <RootComposeView />
     </WorkerPoolContextProvider>
   );
 }
 
-export function RootComposeView(props: RootComposeViewProps) {
+export function RootComposeView() {
+  const paneContext = useOptionalPaneContext();
+  const isFocusedPane = paneContext?.isFocused ?? true;
   const [rootComposeProjectId, setRootComposeProjectId] =
     useRootComposeProjectId();
   const location = useLocation();
@@ -2524,10 +2522,12 @@ export function RootComposeView(props: RootComposeViewProps) {
     setNewTabFocusRequest((current) => current + 1);
   }, [openCompactDrawer, openTab]);
   useAppCommandHandler("panel.newTab", () => {
+    if (!isFocusedPane) return false;
     handleOpenNewTab();
     return true;
   });
   useAppCommandHandler("file.quickOpen", () => {
+    if (!isFocusedPane) return false;
     handleOpenNewTab();
     return true;
   });
@@ -2592,6 +2592,7 @@ export function RootComposeView(props: RootComposeViewProps) {
   ]);
   useAppCommandHandler("terminal.open", () => {
     if (
+      !isFocusedPane ||
       !canCreateRootTerminal ||
       rootPanelTerminalTarget === null ||
       createEnvironmentTerminalMutation.isPending ||
@@ -2683,23 +2684,6 @@ export function RootComposeView(props: RootComposeViewProps) {
     handleCloseTerminalTab,
     isSecondaryPanelOpen,
   ]);
-  useAppCommandHandler("panel.toggle", () => {
-    handleToggleSecondaryPanel();
-    return true;
-  });
-  useAppCommandHandler("panel.close", () => {
-    return handleCloseWindowRequest();
-  });
-  useEffect(() => {
-    const desktopInfo = getBbDesktopInfo();
-    if (
-      desktopInfo === null ||
-      desktopInfo.onCloseWindowRequest === undefined
-    ) {
-      return;
-    }
-    return desktopInfo.onCloseWindowRequest(handleCloseWindowRequest);
-  }, [handleCloseWindowRequest]);
   const fileTabs = (() => {
     const filenameOf = (path: string) => path.split("/").at(-1) ?? path;
     const tabs = syncedOrderedSecondaryFileTabs.map(
@@ -3004,6 +2988,7 @@ export function RootComposeView(props: RootComposeViewProps) {
       }
     : undefined;
   useAppCommandHandler("workspace.openPreferred", () => {
+    if (!isFocusedPane) return false;
     if (
       activeWorkspaceFilePath !== null &&
       activeWorkspaceFileEnvironmentId !== null &&
@@ -3190,24 +3175,18 @@ export function RootComposeView(props: RootComposeViewProps) {
     },
     [openWorkspaceFile],
   );
-  // Keep the panel toggle pinned to the viewport corner on the full page and to
-  // the pane corner in a split. A bounded pane shifts it left by one action slot
-  // so its close button can own the outermost position. The panel reserves a
-  // matching slot via inlinePanelToggle="reserved". The drawer layout has no
-  // pinned slot, so there the toggle only opens the drawer and its close control
-  // lives inside the drawer.
+  // Standalone compose keeps its panel toggle pinned to the viewport corner.
+  // Multi-pane compose publishes its panel model to SplitThreadArea instead,
+  // which owns the one stable window-level toggle.
   // The shared position class keeps this footprint paired with the no-drag
   // cutout the macOS window-drag strip carves for it while the panel is closed
   // (see RootComposeSecondaryContent).
-  const isBoundedPage = props.isBoundedPane;
-  const panelTogglePositionClassName = isBoundedPage
-    ? ROOT_COMPOSE_BOUNDED_PANEL_TOGGLE_POSITION_CLASS
-    : ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS;
+  const panelTogglePositionClassName =
+    ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS;
   const rootPanelToggle =
-    !renderSecondaryPanelAsDrawer || !isSecondaryPanelOpen ? (
-      <div
-        className={`${isBoundedPage ? "absolute" : "fixed"} z-40 ${panelTogglePositionClassName}`}
-      >
+    (paneContext?.secondaryPanelHost ?? null) === null &&
+    (!renderSecondaryPanelAsDrawer || !isSecondaryPanelOpen) ? (
+      <div className={`fixed z-40 ${panelTogglePositionClassName}`}>
         <RootComposeRightPanelToggle
           isOpen={isSecondaryPanelOpen}
           onToggle={handleToggleSecondaryPanel}
@@ -3591,6 +3570,11 @@ export function RootComposeView(props: RootComposeViewProps) {
 
   return (
     <>
+      <RootComposePanelCommandHandlers
+        isFocused={isFocusedPane}
+        onClose={handleCloseWindowRequest}
+        onToggle={handleToggleSecondaryPanel}
+      />
       {providerCliInstallLogDialog}
       {machineSetupDialog}
       {rootPanelToggle}
@@ -3601,6 +3585,7 @@ export function RootComposeView(props: RootComposeViewProps) {
             : ROOT_COMPOSE_SIDEBAR_ACTION_ALIGNED_TOP_PADDING_CLASS
         }
         isSecondaryPanelOpen={isSecondaryPanelOpen}
+        onToggleSecondaryPanel={handleToggleSecondaryPanel}
         panelTogglePositionClassName={panelTogglePositionClassName}
         secondaryPanel={{
           activeTab: activeFixedSecondaryTab,

--- a/apps/app/src/views/thread-detail/PaneContext.tsx
+++ b/apps/app/src/views/thread-detail/PaneContext.tsx
@@ -2,7 +2,9 @@ import {
   createContext,
   useCallback,
   useContext,
+  useLayoutEffect,
   useMemo,
+  useSyncExternalStore,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
@@ -16,11 +18,14 @@ export interface PaneContextValue {
   paneId: string;
   isFocused: boolean;
   /**
-   * Whether this pane may show its secondary panel. Always true for the page
-   * surface; false for unfocused panes once the split reaches ≥3
-   * panes (no room for two secondary panels).
+   * Window-level secondary-panel host for a multi-pane workspace. Pane views
+   * publish their already-assembled panel model here while retaining ownership
+   * of panel tabs, selection, commands, and product policy. Null on standalone
+   * and single-pane surfaces, which keep their existing inline/drawer layout.
    */
-  canShowSecondaryPanel: boolean;
+  secondaryPanelHost: PaneSecondaryPanelRegistration | null;
+  /** Whether this pane owns the window's top-right control footprint. */
+  reservesWindowPanelToggle: boolean;
   /**
    * Closes this pane, or null when closing isn't available (single pane or
    * page). Bridges the pane close affordance and archive/delete-when-split.
@@ -50,6 +55,98 @@ export interface PaneContextValue {
   beginPaneDrag?: (event: ReactPointerEvent, label: string) => void;
 }
 
+export interface PaneSecondaryPanelViewModel {
+  collapsedRail: ReactNode | null;
+  /**
+   * Identity of the content backing this panel (threadId, or a surface name
+   * for non-thread panes). The workspace host uses it to tell "the focused
+   * pane now shows different content" apart from "the same content opened or
+   * closed its panel": only the latter may change the window-level panel
+   * visibility.
+   */
+  contentKey: string;
+  isMainCollapsed: boolean;
+  isOpen: boolean;
+  panel: ReactNode;
+  onToggle: () => void;
+}
+
+export interface PaneSecondaryPanelRegistration {
+  clear: () => void;
+  publish: (model: PaneSecondaryPanelViewModel) => void;
+}
+
+type PaneSecondaryPanelRegistryListener = () => void;
+
+export interface PaneSecondaryPanelRegistry {
+  clear: (paneId: string) => void;
+  getSnapshot: (paneId: string) => PaneSecondaryPanelViewModel | null;
+  publish: (paneId: string, model: PaneSecondaryPanelViewModel) => void;
+  subscribe: (
+    paneId: string,
+    listener: PaneSecondaryPanelRegistryListener,
+  ) => () => void;
+}
+
+export function createPaneSecondaryPanelRegistry(): PaneSecondaryPanelRegistry {
+  const models = new Map<string, PaneSecondaryPanelViewModel>();
+  const listeners = new Map<string, Set<PaneSecondaryPanelRegistryListener>>();
+  const notify = (paneId: string) => {
+    listeners.get(paneId)?.forEach((listener) => listener());
+  };
+
+  return {
+    clear: (paneId) => {
+      if (!models.delete(paneId)) return;
+      notify(paneId);
+    },
+    getSnapshot: (paneId) => models.get(paneId) ?? null,
+    publish: (paneId, model) => {
+      models.set(paneId, model);
+      notify(paneId);
+    },
+    subscribe: (paneId, listener) => {
+      const paneListeners = listeners.get(paneId) ?? new Set();
+      paneListeners.add(listener);
+      listeners.set(paneId, paneListeners);
+      return () => {
+        paneListeners.delete(listener);
+        if (paneListeners.size === 0) listeners.delete(paneId);
+      };
+    },
+  };
+}
+
+export function usePaneSecondaryPanelModel(
+  registry: PaneSecondaryPanelRegistry,
+  paneId: string,
+): PaneSecondaryPanelViewModel | null {
+  const subscribe = useCallback(
+    (listener: PaneSecondaryPanelRegistryListener) =>
+      registry.subscribe(paneId, listener),
+    [paneId, registry],
+  );
+  const getSnapshot = useCallback(
+    () => registry.getSnapshot(paneId),
+    [paneId, registry],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function usePaneSecondaryPanelRegistration(
+  registration: PaneSecondaryPanelRegistration | null,
+  model: PaneSecondaryPanelViewModel,
+): void {
+  useLayoutEffect(() => {
+    if (registration === null) return;
+    registration.publish(model);
+  }, [model, registration]);
+  useLayoutEffect(
+    () => (registration === null ? undefined : registration.clear),
+    [registration],
+  );
+}
+
 export const PaneContext = createContext<PaneContextValue | null>(null);
 
 export function usePaneContext(): PaneContextValue {
@@ -58,6 +155,10 @@ export function usePaneContext(): PaneContextValue {
     throw new Error("usePaneContext must be used within a <PaneContext>");
   }
   return context;
+}
+
+export function useOptionalPaneContext(): PaneContextValue | null {
+  return useContext(PaneContext);
 }
 
 interface DefaultPaneContextProviderProps {
@@ -78,7 +179,8 @@ export function DefaultPaneContextProvider({
     () => ({
       paneId: "main",
       isFocused: true,
-      canShowSecondaryPanel: true,
+      secondaryPanelHost: null,
+      reservesWindowPanelToggle: false,
       onRequestClose: null,
       isBoundedPane: false,
       isTopRow: true,

--- a/apps/app/src/views/thread-detail/SplitThreadArea.archive.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.archive.test.tsx
@@ -69,7 +69,9 @@ vi.mock("@/lib/api", async (importOriginal) => {
 vi.mock("@/components/commands/AppCommandProvider", () => ({
   useAppCommandContext: () => undefined,
   useAppCommandHandler: () => undefined,
+  useAppCommandShortcut: () => null,
   useIndexedAppCommandHandlers: () => undefined,
+  useIsAppCommandModifierHeld: () => false,
 }));
 
 vi.mock("./ThreadDetailView", () => ({

--- a/apps/app/src/views/thread-detail/SplitThreadArea.parity.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.parity.test.tsx
@@ -32,7 +32,9 @@ vi.mock("./ThreadDetailView", () => ({
 vi.mock("@/components/commands/AppCommandProvider", () => ({
   useAppCommandContext: () => undefined,
   useAppCommandHandler: () => undefined,
+  useAppCommandShortcut: () => null,
   useIndexedAppCommandHandlers: () => undefined,
+  useIsAppCommandModifierHeld: () => false,
 }));
 
 // Split panes mount a PaneStaleWatcher that reads the thread query; keep it in a

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { createStore, Provider as JotaiProvider } from "jotai";
-import { useContext } from "react";
+import { useContext, useMemo, useState, type ReactNode } from "react";
 import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
@@ -24,7 +24,7 @@ import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
-import { PaneContext } from "./PaneContext";
+import { PaneContext, usePaneSecondaryPanelRegistration } from "./PaneContext";
 import { SplitThreadArea } from "./SplitThreadArea";
 
 // Per-thread archived/deleted state consulted by the mocked useThread, driving
@@ -34,6 +34,16 @@ const threadStore = vi.hoisted(
     new Map<string, { archivedAt: number | null; deletedAt: number | null }>(),
 );
 const experimentState = vi.hoisted(() => ({ enabled: true }));
+interface ShortcutPresentationFixture {
+  ariaKeyshortcuts: string;
+  label: string;
+}
+const commandPresentationState = vi.hoisted(
+  (): {
+    isModifierHeld: boolean;
+    shortcut: ShortcutPresentationFixture | null;
+  } => ({ isModifierHeld: false, shortcut: null }),
+);
 
 vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
   useThreadSplitsEnabled: () => experimentState.enabled,
@@ -57,8 +67,36 @@ vi.mock("@/hooks/queries/thread-queries", () => ({
 vi.mock("@/components/commands/AppCommandProvider", () => ({
   useAppCommandContext: () => undefined,
   useAppCommandHandler: () => undefined,
+  useAppCommandShortcut: () => commandPresentationState.shortcut,
+  useIsAppCommandModifierHeld: () => commandPresentationState.isModifierHeld,
   useIndexedAppCommandHandlers: () => undefined,
 }));
+
+vi.mock("react-resizable-panels", async () => {
+  const React = await import("react");
+  const PanelGroup = React.forwardRef<
+    {
+      getLayout: () => number[];
+      setLayout: (layout: number[]) => void;
+    },
+    { children?: ReactNode }
+  >(({ children }, ref) => {
+    React.useImperativeHandle(
+      ref,
+      () => ({ getLayout: () => [100, 0], setLayout: () => undefined }),
+      [],
+    );
+    return <div data-testid="workspace-panel-group">{children}</div>;
+  });
+  PanelGroup.displayName = "MockPanelGroup";
+  const Panel = ({ children }: { children?: ReactNode }) => (
+    <div data-testid="workspace-panel">{children}</div>
+  );
+  const PanelResizeHandle = () => (
+    <div data-testid="workspace-panel-resize-handle" />
+  );
+  return { Panel, PanelGroup, PanelResizeHandle };
+});
 
 vi.mock("@/components/ui/sidebar.js", () => ({
   useIsSidebarShowing: () => true,
@@ -76,6 +114,22 @@ vi.mock("./ThreadDetailView", () => ({
     threadId: string;
   }) => {
     const pane = useContext(PaneContext);
+    const [isPanelOpen, setIsPanelOpen] = useState(threadId === "thr-a");
+    const panelModel = useMemo(
+      () => ({
+        collapsedRail: null,
+        contentKey: threadId,
+        isMainCollapsed: false,
+        isOpen: isPanelOpen,
+        panel: <div data-testid={`hosted-panel-${threadId}`} />,
+        onToggle: () => setIsPanelOpen((open) => !open),
+      }),
+      [isPanelOpen, threadId],
+    );
+    usePaneSecondaryPanelRegistration(
+      pane?.secondaryPanelHost ?? null,
+      panelModel,
+    );
     const draft = usePromptDraftStorage({
       kind: "thread",
       projectId,
@@ -231,11 +285,23 @@ function ExternalNav({ to }: { to: string }) {
   );
 }
 
+function RouteAwareSplitArea() {
+  const location = useLocation();
+  return (
+    <SplitThreadArea
+      routeContent={
+        location.pathname.startsWith("/plugins/") ? docsContent : undefined
+      }
+    />
+  );
+}
+
 function renderSplitArea(options: {
   path: string;
   layout?: SplitLayout;
   externalTo?: string;
   routeContent?: PaneContent;
+  routeAwareContent?: boolean;
 }) {
   const store = createStore();
   if (options.layout !== undefined) {
@@ -245,7 +311,11 @@ function renderSplitArea(options: {
     <JotaiProvider store={store}>
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[options.path]}>
-          <SplitThreadArea routeContent={options.routeContent} />
+          {options.routeAwareContent ? (
+            <RouteAwareSplitArea />
+          ) : (
+            <SplitThreadArea routeContent={options.routeContent} />
+          )}
           <LocationProbe />
           {options.externalTo !== undefined ? (
             <ExternalNav to={options.externalTo} />
@@ -259,6 +329,8 @@ function renderSplitArea(options: {
 
 beforeEach(() => {
   experimentState.enabled = true;
+  commandPresentationState.isModifierHeld = false;
+  commandPresentationState.shortcut = null;
   threadStore.set("thr-a", { archivedAt: null, deletedAt: null });
   threadStore.set("thr-b", { archivedAt: null, deletedAt: null });
 });
@@ -272,6 +344,128 @@ afterEach(() => {
 });
 
 describe("SplitThreadArea", () => {
+  it("keeps the merged toggle absolute and places a visible shortcut hint below pane actions", async () => {
+    commandPresentationState.isModifierHeld = true;
+    commandPresentationState.shortcut = {
+      ariaKeyshortcuts: "Control+Shift+P",
+      label: "Ctrl Shift P",
+    };
+    renderSplitArea({
+      path: threadPath("thr-a"),
+      layout: twoPaneLayout("pane-1"),
+    });
+
+    const toggle = await screen.findByTestId("split-workspace-panel-toggle");
+    expect(toggle.classList).toContain("absolute");
+    expect(toggle.classList).not.toContain("relative");
+    expect(toggle.classList).toContain("right-2.5");
+    expect(toggle.classList).toContain("top-2.5");
+    const hint = screen.getByText("Ctrl Shift P");
+    expect(hint.classList).toContain("absolute");
+    expect(hint.classList).toContain("right-0");
+    expect(hint.classList).toContain("top-full");
+  });
+
+  it("hosts one panel whose visibility survives focus changes between panes", async () => {
+    renderSplitArea({
+      path: threadPath("thr-a"),
+      layout: twoPaneLayout("pane-1"),
+    });
+
+    const toggle = await screen.findByTestId("split-workspace-panel-toggle");
+    expect(
+      screen.queryAllByTestId("split-workspace-panel-toggle"),
+    ).toHaveLength(1);
+    expect(screen.getByTestId("hosted-panel-thr-a")).toBeTruthy();
+    expect(screen.queryByTestId("hosted-panel-thr-b")).toBeNull();
+    expect(toggle.querySelector("button")?.getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+
+    // thr-b's own persisted panel state is closed, but refocusing must swap
+    // the panel's content without closing the window-level panel.
+    fireEvent.pointerDown(screen.getByTestId("pane-thr-b"));
+    await screen.findByTestId("hosted-panel-thr-b");
+    expect(screen.queryByTestId("hosted-panel-thr-a")).toBeNull();
+    expect(
+      screen
+        .getByTestId("split-workspace-panel-toggle")
+        .querySelector("button")
+        ?.getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    // An explicit toggle closes it, and the closed state also survives
+    // refocusing the pane whose panel was originally open.
+    fireEvent.click(screen.getByRole("button", { name: "Hide right panel" }));
+    expect(
+      screen
+        .getByTestId("split-workspace-panel-toggle")
+        .querySelector("button")
+        ?.getAttribute("aria-pressed"),
+    ).toBe("false");
+
+    fireEvent.pointerDown(screen.getByTestId("pane-thr-a"));
+    await screen.findByTestId("hosted-panel-thr-a");
+    expect(
+      screen
+        .getByTestId("split-workspace-panel-toggle")
+        .querySelector("button")
+        ?.getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("keeps the open panel as an empty state on a pane with no panel support", async () => {
+    const layout = pluginSplitLayout();
+    layout.focusedPaneId = "pane-1";
+    renderSplitArea({
+      path: threadPath("thr-a"),
+      layout,
+      routeAwareContent: true,
+    });
+
+    const toggle = await screen.findByTestId("split-workspace-panel-toggle");
+    expect(toggle.querySelector("button")?.getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(
+      screen.queryByTestId("split-workspace-empty-panel-state"),
+    ).toBeNull();
+    const pluginPane = document.querySelector('[data-split-pane-id="pane-2"]');
+    if (!(pluginPane instanceof HTMLElement)) {
+      throw new Error("Expected plugin split pane");
+    }
+
+    // Focusing the plugin pane keeps the panel open, swapping its content for
+    // the empty state; the toggle stays put and stays pressed.
+    fireEvent.pointerDown(pluginPane);
+    await screen.findByTestId("split-workspace-empty-panel-state");
+    expect(
+      screen
+        .getByTestId("split-workspace-panel-toggle")
+        .querySelector("button")
+        ?.getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    // The toggle closes the window panel from the plugin pane, and the closed
+    // state survives refocusing the thread pane (imposed on its persisted
+    // state).
+    fireEvent.click(screen.getByRole("button", { name: "Hide right panel" }));
+    expect(
+      screen
+        .getByTestId("split-workspace-panel-toggle")
+        .querySelector("button")
+        ?.getAttribute("aria-pressed"),
+    ).toBe("false");
+    fireEvent.pointerDown(screen.getByTestId("pane-thr-a"));
+    const restoredClosedToggle = await screen.findByRole("button", {
+      name: "Show right panel",
+    });
+    expect(restoredClosedToggle.getAttribute("aria-pressed")).toBe("false");
+    expect(
+      screen.queryByTestId("split-workspace-empty-panel-state"),
+    ).toBeNull();
+  });
+
   it("mounts both panes with independent, threadId-keyed drafts", async () => {
     renderSplitArea({
       path: threadPath("thr-b"),

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -5,6 +5,7 @@ import { useAtom, useStore } from "jotai";
 import {
   Fragment,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -50,7 +51,14 @@ import {
   useAppCommandHandler,
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
-import { PaneContext, type PaneContextValue } from "./PaneContext";
+import {
+  PaneContext,
+  createPaneSecondaryPanelRegistry,
+  useOptionalPaneContext,
+  type PaneContextValue,
+  type PaneSecondaryPanelRegistration,
+  type PaneSecondaryPanelRegistry,
+} from "./PaneContext";
 import { ThreadDetailView } from "./ThreadDetailView";
 import { RootComposeView } from "@/views/RootComposeView";
 import { PluginPanelView } from "@/views/PluginPanelView";
@@ -82,6 +90,8 @@ import {
   MACOS_WINDOW_NO_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
+import { SplitWorkspaceSecondaryPanelHost } from "./SplitWorkspaceSecondaryPanelHost";
+import { SecondaryPanelHostLayoutContext } from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
 
 // A `pointerdown`-relative move threshold before a pane-header drag engages.
 const PANE_DRAG_ENGAGE_DISTANCE_PX = 7;
@@ -122,6 +132,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
   const navigate = useNavigate();
   const store = useStore();
   const [storedLayout, setLayout] = useAtom(splitLayoutAtom);
+  const secondaryPanelRegistry = useMemo(createPaneSecondaryPanelRegistry, []);
 
   const routeThread = useMemo<ThreadRoutePathArgs | null>(
     () => (projectId && threadId ? { projectId, threadId } : null),
@@ -329,7 +340,8 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           content={firstPane.content}
           paneId={firstPane.paneId}
           isFocused
-          canShowSecondaryPanel
+          secondaryPanelRegistry={null}
+          reservesWindowPanelToggle={false}
           onRequestClose={null}
           isBoundedPane={false}
           isTopRow
@@ -348,19 +360,25 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           windows from scrolling the whole split when stacked panes hit their
           min content height. */}
       <div className="-m-4 flex min-h-0 min-w-0 flex-1 overflow-hidden md:-m-5">
-        <SplitTree
-          node={layout.root}
-          path={EMPTY_PATH}
-          isTopRow
+        <SplitWorkspaceSecondaryPanelHost
           focusedPaneId={layout.focusedPaneId}
-          paneCount={panes.length}
-          onFocusPane={focusPane}
-          onClosePane={closePane}
-          onResize={resize}
-          onNavigateInPane={navigateInPane}
-          onBeginPaneDrag={beginPaneDrag}
-          onPruneStalePane={pruneStalePane}
-        />
+          registry={secondaryPanelRegistry}
+        >
+          <SplitTree
+            node={layout.root}
+            path={EMPTY_PATH}
+            isTopRow
+            isRightEdge
+            focusedPaneId={layout.focusedPaneId}
+            secondaryPanelRegistry={secondaryPanelRegistry}
+            onFocusPane={focusPane}
+            onClosePane={closePane}
+            onResize={resize}
+            onNavigateInPane={navigateInPane}
+            onBeginPaneDrag={beginPaneDrag}
+            onPruneStalePane={pruneStalePane}
+          />
+        </SplitWorkspaceSecondaryPanelHost>
       </div>
     </>
   );
@@ -414,8 +432,10 @@ interface SplitTreeProps {
   path: SplitPath;
   /** Whether this subtree touches the workspace's top edge. */
   isTopRow: boolean;
+  /** Whether this subtree touches the workspace's right edge. */
+  isRightEdge: boolean;
   focusedPaneId: string;
-  paneCount: number;
+  secondaryPanelRegistry: PaneSecondaryPanelRegistry;
   onFocusPane: (paneId: string) => void;
   onClosePane: (paneId: string) => void;
   onResize: (
@@ -429,7 +449,7 @@ interface SplitTreeProps {
 }
 
 function SplitTree(props: SplitTreeProps) {
-  const { node, path, isTopRow, focusedPaneId, paneCount } = props;
+  const { node, path, isTopRow, isRightEdge, focusedPaneId } = props;
 
   if (node.type === "pane") {
     const isFocused = node.paneId === focusedPaneId;
@@ -455,9 +475,8 @@ function SplitTree(props: SplitTreeProps) {
           content={node.content}
           paneId={node.paneId}
           isFocused={isFocused}
-          // ≥3 panes have no room for two secondary panels: only the focused
-          // pane may show its own; ≤2 panes keep per-pane panels.
-          canShowSecondaryPanel={paneCount < 3 || isFocused}
+          secondaryPanelRegistry={props.secondaryPanelRegistry}
+          reservesWindowPanelToggle={isTopRow && isRightEdge}
           onRequestClose={() => props.onClosePane(node.paneId)}
           isBoundedPane
           isTopRow={isTopRow}
@@ -505,6 +524,10 @@ function SplitTree(props: SplitTreeProps) {
               // vertical stack, only the first child can inherit the parent
               // subtree's contact with the workspace top edge.
               isTopRow={isTopRow && (node.dir === "row" || index === 0)}
+              isRightEdge={
+                isRightEdge &&
+                (node.dir === "col" || index === node.children.length - 1)
+              }
             />
           </div>
         </Fragment>
@@ -517,7 +540,8 @@ interface WorkspacePaneContentProps {
   content: PaneContent;
   paneId: string;
   isFocused: boolean;
-  canShowSecondaryPanel: boolean;
+  secondaryPanelRegistry: PaneSecondaryPanelRegistry | null;
+  reservesWindowPanelToggle: boolean;
   onRequestClose: (() => void) | null;
   // True inside multi-pane split cards; suppresses the page-bleed margins so
   // content fills the card exactly (see PaneContextValue.isBoundedPane).
@@ -532,7 +556,8 @@ function WorkspacePaneContent({
   content,
   paneId,
   isFocused,
-  canShowSecondaryPanel,
+  secondaryPanelRegistry,
+  reservesWindowPanelToggle,
   onRequestClose,
   isBoundedPane,
   isTopRow,
@@ -551,11 +576,22 @@ function WorkspacePaneContent({
         : undefined,
     [onBeginPaneDrag, paneId],
   );
+  const secondaryPanelHost = useMemo<PaneSecondaryPanelRegistration | null>(
+    () =>
+      secondaryPanelRegistry === null
+        ? null
+        : {
+            publish: (model) => secondaryPanelRegistry.publish(paneId, model),
+            clear: () => secondaryPanelRegistry.clear(paneId),
+          },
+    [paneId, secondaryPanelRegistry],
+  );
   const value = useMemo<PaneContextValue>(
     () => ({
       paneId,
       isFocused,
-      canShowSecondaryPanel,
+      secondaryPanelHost,
+      reservesWindowPanelToggle,
       onRequestClose,
       isBoundedPane,
       isTopRow,
@@ -564,25 +600,28 @@ function WorkspacePaneContent({
     }),
     [
       beginPaneDrag,
-      canShowSecondaryPanel,
       isBoundedPane,
       isFocused,
       isTopRow,
       navigateInPane,
       onRequestClose,
       paneId,
+      reservesWindowPanelToggle,
+      secondaryPanelHost,
     ],
   );
 
   if (content.kind !== "thread") {
     return (
-      <NonThreadPaneContent
-        content={content}
-        onRequestClose={onRequestClose}
-        beginPaneDrag={beginPaneDrag}
-        isBoundedPane={isBoundedPane}
-        isTopRow={isTopRow}
-      />
+      <PaneContext.Provider value={value}>
+        <NonThreadPaneContent
+          content={content}
+          onRequestClose={onRequestClose}
+          beginPaneDrag={beginPaneDrag}
+          isBoundedPane={isBoundedPane}
+          isTopRow={isTopRow}
+        />
+      </PaneContext.Provider>
     );
   }
 
@@ -602,7 +641,7 @@ function StandalonePaneContent({ content }: { content: PaneContent }) {
     return <ThreadDetailView surface="page" />;
   }
   if (content.kind === "new-thread") {
-    return <RootComposeView isBoundedPane={false} />;
+    return <RootComposeView />;
   }
   return (
     <PluginPanelView
@@ -627,6 +666,11 @@ function NonThreadPaneContent({
   isTopRow: boolean;
 }) {
   const { navPanels } = usePluginSlots();
+  const { reservesWindowPanelToggle } = useOptionalPaneContext() ?? {
+    reservesWindowPanelToggle: false,
+  };
+  const isWindowPanelOpen =
+    useContext(SecondaryPanelHostLayoutContext)?.isOpen === true;
   const [desktopInfo] = useState(getBbDesktopInfo);
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   const panel =
@@ -660,6 +704,13 @@ function NonThreadPaneContent({
         >
           <Icon name="X" />
         </Button>
+      ) : null}
+      {reservesWindowPanelToggle && !isWindowPanelOpen ? (
+        // The host's shortcut hint drops below the chrome row; reserve only
+        // its stable 28px corner button beside these pane actions. With the
+        // window panel open, the toggle overlays the panel's own chrome
+        // instead, so the pane actions sit flush at the pane edge.
+        <span aria-hidden className={HEADER_ICON_BUTTON_CLASS} />
       ) : null}
     </>
   );
@@ -704,7 +755,7 @@ function NonThreadPaneContent({
       ) : null}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col p-4 md:p-5">
         {content.kind === "new-thread" ? (
-          <RootComposeView isBoundedPane={isBoundedPane} />
+          <RootComposeView />
         ) : (
           <PluginPanelView
             pluginId={content.pluginId}

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -132,7 +132,10 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
   const navigate = useNavigate();
   const store = useStore();
   const [storedLayout, setLayout] = useAtom(splitLayoutAtom);
-  const secondaryPanelRegistry = useMemo(createPaneSecondaryPanelRegistry, []);
+  const secondaryPanelRegistry = useMemo(
+    () => createPaneSecondaryPanelRegistry(),
+    [],
+  );
 
   const routeThread = useMemo<ThreadRoutePathArgs | null>(
     () => (projectId && threadId ? { projectId, threadId } : null),

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -1,0 +1,304 @@
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+  type ImperativePanelGroupHandle,
+} from "react-resizable-panels";
+import { Button } from "@bb/shared-ui/button";
+import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { HEADER_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
+import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
+import {
+  useAppCommandHandler,
+  useAppCommandShortcut,
+} from "@/components/commands/AppCommandProvider";
+import { secondaryPanelWidthPercentAtom } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
+import {
+  THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT,
+  THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT,
+} from "@/components/secondary-panel/ThreadSecondaryPanel";
+import {
+  SecondaryPanelHostLayoutContext,
+  type SecondaryPanelHostLayout,
+} from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
+import {
+  PANEL_COLLAPSE_TRANSITION_CLASS,
+  PANEL_RESIZE_HIT_AREA_MARGINS,
+} from "@/components/secondary-panel/panelTransitionTokens";
+import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
+import {
+  type PaneSecondaryPanelRegistry,
+  usePaneSecondaryPanelModel,
+} from "./PaneContext";
+
+const MAIN_PANEL_OPEN_SIZE_PERCENT = 100;
+const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
+
+interface SplitWorkspaceSecondaryPanelHostProps {
+  children: ReactNode;
+  focusedPaneId: string;
+  registry: PaneSecondaryPanelRegistry;
+}
+
+export function SplitWorkspaceSecondaryPanelHost({
+  children,
+  focusedPaneId,
+  registry,
+}: SplitWorkspaceSecondaryPanelHostProps) {
+  const model = usePaneSecondaryPanelModel(registry, focusedPaneId);
+  const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
+  const panelWidthPercent = useAtomValue(secondaryPanelWidthPercentAtom);
+  const shortcut = useAppCommandShortcut("panel.toggle");
+
+  // The window has ONE panel visibility: refocusing another pane or switching
+  // a pane's thread swaps the panel's content but never opens or closes it.
+  // Null until the first pane publishes, so entering a split adopts the
+  // focused content's persisted state.
+  const [isPanelVisible, setIsPanelVisible] = useState<boolean | null>(null);
+  const isOpen = isPanelVisible ?? model?.isOpen ?? false;
+  const lastTargetRef = useRef<{
+    paneId: string;
+    contentKey: string;
+    isOpen: boolean;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (model === null) {
+      // A pane with no secondary panel (plugin pane) keeps the window
+      // visibility — the panel stays put showing its empty state — and
+      // focusing back to a publishing pane re-aligns below.
+      lastTargetRef.current = null;
+      return;
+    }
+    const previousTarget = lastTargetRef.current;
+    lastTargetRef.current = {
+      paneId: focusedPaneId,
+      contentKey: model.contentKey,
+      isOpen: model.isOpen,
+    };
+    if (isPanelVisible === null) {
+      setIsPanelVisible(model.isOpen);
+      return;
+    }
+    if (
+      previousTarget !== null &&
+      previousTarget.paneId === focusedPaneId &&
+      previousTarget.contentKey === model.contentKey
+    ) {
+      // Only an actual open/close transition on the same target is an
+      // intentional change (toggle button, shortcut, "open diff") that moves
+      // the window visibility with it. Republished models with an unchanged
+      // isOpen — including the stale render that races the imposed toggle
+      // below — must not.
+      if (model.isOpen !== previousTarget.isOpen) {
+        setIsPanelVisible(model.isOpen);
+      }
+      return;
+    }
+    // Focus moved or the pane switched threads: impose the window visibility
+    // on the new target instead of following its persisted state.
+    if (model.isOpen !== isPanelVisible) model.onToggle();
+  }, [focusedPaneId, isPanelVisible, model]);
+
+  // A passive effect on purpose: on a pane switch the group applies the
+  // freshly mounted panel's defaultSize in react-resizable-panels' own
+  // (child) passive effect, and this reassertion must run after it — a layout
+  // effect would win the paint but then lose the final layout to it.
+  useEffect(() => {
+    const group = panelGroupRef.current;
+    if (group === null) return;
+    // Both panels register with the group asynchronously on mount; until they
+    // have, setLayout throws and defaultSize already encodes this state.
+    if (group.getLayout().length !== 2) return;
+    if (!isOpen) {
+      group.setLayout([MAIN_PANEL_OPEN_SIZE_PERCENT, 0]);
+      return;
+    }
+    if (model?.isMainCollapsed) {
+      group.setLayout([0, MAIN_PANEL_OPEN_SIZE_PERCENT]);
+      return;
+    }
+    group.setLayout([
+      MAIN_PANEL_OPEN_SIZE_PERCENT - panelWidthPercent,
+      panelWidthPercent,
+    ]);
+  }, [focusedPaneId, isOpen, model?.isMainCollapsed, panelWidthPercent]);
+
+  // Panes without a secondary panel (plugin panes) leave the window panel in
+  // place with an empty state; their toggle drives the window visibility
+  // directly, and refocusing a publishing pane re-aligns through the effect
+  // above.
+  const toggleWindowPanel = () => {
+    if (model !== null) {
+      model.onToggle();
+      return;
+    }
+    setIsPanelVisible((current) => !(current ?? false));
+  };
+  useAppCommandHandler("panel.toggle", () => {
+    if (model !== null) return false;
+    toggleWindowPanel();
+    return true;
+  });
+
+  // Resizing the empty-state panel mirrors the real panel's persistence: the
+  // shared width atom updates on drag end, so the size carries to whichever
+  // pane's panel shows next. Dragging it collapsed closes the window panel.
+  const setPanelWidthPercent = useSetAtom(secondaryPanelWidthPercentAtom);
+  const lastEmptyPanelSizeRef = useRef(0);
+  const handleEmptyPanelResize = (size: number) => {
+    if (size > 0) lastEmptyPanelSizeRef.current = size;
+  };
+  const handleEmptyPanelDragging = (isDragging: boolean) => {
+    if (isDragging || lastEmptyPanelSizeRef.current <= 0) return;
+    setPanelWidthPercent(lastEmptyPanelSizeRef.current);
+  };
+  const handleEmptyPanelCollapse = () => {
+    setIsPanelVisible(false);
+  };
+
+  const toggleLabel = isOpen ? "Hide right panel" : "Show right panel";
+  const hostLayout = useMemo<SecondaryPanelHostLayout>(
+    () => ({ isOpen }),
+    [isOpen],
+  );
+
+  return (
+    // The layout context serves two consumers: a freshly mounted pane panel
+    // sizes its resizable Panel to the window visibility (its own persisted
+    // state lags one commit behind the alignment above, and a stale-closed
+    // defaultSize would collapse the group's panel and misreport a user
+    // close), and the right-edge pane headers drop their reserved corner slot
+    // while the open panel's chrome hosts the window toggle instead.
+    <SecondaryPanelHostLayoutContext.Provider value={hostLayout}>
+      <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        <div
+          data-testid="split-workspace-panel-toggle"
+          className={cn(
+            "absolute right-2.5 top-2.5 z-40",
+            // This overlay already owns positioning and stacking. Use only the
+            // raw app-region token: MACOS_WINDOW_NO_DRAG_CLASS adds `relative
+            // z-50`, which tailwind-merge would resolve against `absolute` and
+            // move the control back into document flow.
+            MACOS_APP_REGION_NO_DRAG_CLASS,
+          )}
+        >
+          <AppCommandShortcutHint
+            shortcut={shortcut}
+            // Keep the modifier-held hint out of the top chrome row. The
+            // reserved header slot is exactly the 28px button footprint; a
+            // side-by-side hint would extend left over Close pane or plugin
+            // actions. Dropping it below preserves both the stable corner and
+            // the action row's hit targets.
+            className="absolute right-0 top-full mt-1"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={HEADER_ICON_BUTTON_CLASS}
+            aria-label={
+              shortcut ? `${toggleLabel} (${shortcut.label})` : toggleLabel
+            }
+            aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
+            aria-pressed={isOpen}
+            onClick={toggleWindowPanel}
+          >
+            <Icon name="PanelRight" />
+          </Button>
+        </div>
+        {model?.collapsedRail}
+        <PanelGroup
+          ref={panelGroupRef}
+          direction="horizontal"
+          className="@container h-full min-w-0 flex-1"
+          style={{ overflow: "clip" }}
+        >
+          <Panel
+            id="split-workspace-main-panel"
+            collapsible
+            collapsedSize={0}
+            defaultSize={
+              model?.isMainCollapsed
+                ? 0
+                : isOpen
+                  ? MAIN_PANEL_OPEN_SIZE_PERCENT - panelWidthPercent
+                  : MAIN_PANEL_OPEN_SIZE_PERCENT
+            }
+            minSize={MAIN_PANEL_MIN_SIZE_PERCENT}
+            order={1}
+            className={cn(
+              "min-w-0 overflow-clip transition-[flex-grow,flex-basis]",
+              PANEL_COLLAPSE_TRANSITION_CLASS,
+            )}
+          >
+            {/* Panel renders a plain block; the split tree sizes itself with
+              flex-1, so restore a full-height flex context for it. */}
+            <div className="flex h-full min-h-0 min-w-0">{children}</div>
+          </Panel>
+          {model === null ? (
+            <>
+              {/* Working twin of the panel's gutter-style resize handle: the
+                  seam keeps the split dividers' 6px body and the window panel
+                  stays resizable even while showing the empty state. */}
+              <PanelResizeHandle
+                id="split-workspace-empty-secondary-panel-handle"
+                disabled={!isOpen}
+                onDragging={handleEmptyPanelDragging}
+                hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
+                className={cn(
+                  "relative z-[5] shrink-0 overflow-visible bg-muted/60 transition-[width,opacity,background-color] before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-[''] hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
+                  PANEL_COLLAPSE_TRANSITION_CLASS,
+                  isOpen
+                    ? "w-1.5 cursor-col-resize opacity-100"
+                    : "pointer-events-none w-0 opacity-0",
+                )}
+                aria-label="Resize right panel"
+              />
+              <Panel
+                id="split-workspace-empty-secondary-panel"
+                collapsible
+                collapsedSize={0}
+                defaultSize={isOpen ? panelWidthPercent : 0}
+                minSize={THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT}
+                maxSize={THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT}
+                onCollapse={handleEmptyPanelCollapse}
+                onResize={handleEmptyPanelResize}
+                order={2}
+                className={cn(
+                  "min-w-0 overflow-clip transition-[flex-grow,flex-basis]",
+                  PANEL_COLLAPSE_TRANSITION_CLASS,
+                )}
+              >
+                <div
+                  data-testid="split-workspace-empty-panel-state"
+                  // pt-12 keeps the placeholder clear of the floating window
+                  // toggle, which occupies the panel's top chrome corner.
+                  className="flex h-full min-h-0 flex-col overflow-hidden bg-background p-4 pt-12"
+                >
+                  <EmptyStatePanel className="flex-1 rounded-lg">
+                    This pane has no right panel.
+                  </EmptyStatePanel>
+                </div>
+              </Panel>
+            </>
+          ) : (
+            <Fragment key={focusedPaneId}>{model.panel}</Fragment>
+          )}
+        </PanelGroup>
+      </div>
+    </SecondaryPanelHostLayoutContext.Provider>
+  );
+}

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -1,4 +1,5 @@
 import {
+  useContext,
   useState,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
@@ -22,6 +23,7 @@ import {
 import { cn } from "@bb/shared-ui/lib/utils";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
+import { SecondaryPanelHostLayoutContext } from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
 import { usePaneContext } from "./PaneContext";
 
 const THREAD_HEADER_ACTION_BUTTON_CLASS =
@@ -67,7 +69,15 @@ export function ThreadDetailHeader({
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   // The title doubles as the pane-reorder drag handle when the layout is split;
   // beginPaneDrag is undefined on the single-pane and page surfaces.
-  const { beginPaneDrag, isFocused, isTopRow } = usePaneContext();
+  const {
+    beginPaneDrag,
+    isFocused,
+    isTopRow,
+    reservesWindowPanelToggle,
+    secondaryPanelHost,
+  } = usePaneContext();
+  const isWindowPanelOpen =
+    useContext(SecondaryPanelHostLayoutContext)?.isOpen === true;
   const showFocusedPaneTitlePill = beginPaneDrag !== undefined && isFocused;
   const handleTitlePointerDown = (event: ReactPointerEvent) => {
     if (!beginPaneDrag || event.button !== 0) {
@@ -79,11 +89,12 @@ export function ThreadDetailHeader({
     ? "Hide right panel"
     : "Show right panel";
   const rightPanelIconName = renderAsDrawer ? "PanelBottom" : "PanelRight";
-  // The header is a full-width bar, so the toggle holds a stable position at the
-  // window edge — keep it mounted across open/close on wide layouts (the panel no
-  // longer renders its own inline hide control). The drawer still hides it while
-  // open, since the drawer carries its own close affordance.
-  const showRightPanelToggle = !renderAsDrawer || !isSecondaryPanelOpen;
+  // Standalone thread pages keep their header toggle mounted across open/close
+  // on wide layouts. Split panes publish to the one workspace-level toggle, so
+  // no pane header renders its own copy. The drawer still hides the standalone
+  // toggle while open because the drawer carries its own close affordance.
+  const showRightPanelToggle =
+    secondaryPanelHost === null && (!renderAsDrawer || !isSecondaryPanelOpen);
 
   const center = (
     <>
@@ -195,6 +206,14 @@ export function ThreadDetailHeader({
         >
           <Icon name="X" />
         </Button>
+      ) : null}
+      {reservesWindowPanelToggle && !isWindowPanelOpen ? (
+        // Reserve only the fixed 28px corner button. Its modifier-held hint is
+        // positioned below the chrome row by the workspace host, so it never
+        // consumes or covers this pane-action row. With the window panel open,
+        // the toggle overlays the panel's own chrome instead, so the pane
+        // actions sit flush at the pane edge.
+        <span aria-hidden className={HEADER_ICON_BUTTON_CLASS} />
       ) : null}
     </>
   );

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -6,6 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
 import { ThreadDetailSecondaryContent } from "./ThreadDetailSecondaryContent";
+import {
+  DefaultPaneContextProvider,
+  PaneContext,
+  type PaneContextValue,
+} from "./PaneContext";
+import { MemoryRouter } from "react-router-dom";
 
 type ThreadDetailSecondaryContentProps = ComponentProps<
   typeof ThreadDetailSecondaryContent
@@ -181,6 +187,7 @@ interface QueuedAnimationFrames {
 }
 
 interface RenderThreadDetailArgs {
+  isFocusedHosted?: boolean;
   isCompactViewport: boolean;
   isSecondaryPanelOpen: boolean;
   renderBrowserDeck: RenderBrowserDeck;
@@ -188,6 +195,38 @@ interface RenderThreadDetailArgs {
 }
 
 const noop = () => {};
+
+const hostedPaneRegistration = {
+  clear: noop,
+  publish: noop,
+};
+
+function ThreadDetailTestPaneProvider({
+  children,
+  isFocusedHosted,
+}: {
+  children: ReactNode;
+  isFocusedHosted: boolean | undefined;
+}) {
+  if (isFocusedHosted === undefined) {
+    return (
+      <MemoryRouter>
+        <DefaultPaneContextProvider>{children}</DefaultPaneContextProvider>
+      </MemoryRouter>
+    );
+  }
+  const value: PaneContextValue = {
+    paneId: "pane-test",
+    isFocused: isFocusedHosted,
+    secondaryPanelHost: hostedPaneRegistration,
+    reservesWindowPanelToggle: false,
+    onRequestClose: noop,
+    isBoundedPane: true,
+    isTopRow: true,
+    navigateInPane: noop,
+  };
+  return <PaneContext.Provider value={value}>{children}</PaneContext.Provider>;
+}
 
 function installAnimationFrameQueue(order?: string[]): QueuedAnimationFrames {
   const callbacks = new Map<number, FrameRequestCallback>();
@@ -307,6 +346,8 @@ function createProps({
       workspaceStatusError: null,
     } as ThreadDetailSecondaryContentProps["metadata"],
     onToggleConversationCollapse: noop,
+    onToggleSecondaryPanel: noop,
+    renderHostedPanel: (panel) => panel,
     secondaryPanel: {
       activeTab: null,
       canUseGitUi: false,
@@ -348,13 +389,17 @@ function renderThreadDetail(args: RenderThreadDetailArgs) {
     <CompactViewportOverrideProvider
       isCompactViewport={renderArgs.isCompactViewport}
     >
-      <ThreadDetailSecondaryContent
-        {...createProps({
-          isSecondaryPanelOpen: renderArgs.isSecondaryPanelOpen,
-          renderBrowserDeck: renderArgs.renderBrowserDeck,
-          threadId: renderArgs.threadId,
-        })}
-      />
+      <ThreadDetailTestPaneProvider
+        isFocusedHosted={renderArgs.isFocusedHosted}
+      >
+        <ThreadDetailSecondaryContent
+          {...createProps({
+            isSecondaryPanelOpen: renderArgs.isSecondaryPanelOpen,
+            renderBrowserDeck: renderArgs.renderBrowserDeck,
+            threadId: renderArgs.threadId,
+          })}
+        />
+      </ThreadDetailTestPaneProvider>
     </CompactViewportOverrideProvider>,
   );
 
@@ -366,13 +411,17 @@ function renderThreadDetail(args: RenderThreadDetailArgs) {
         <CompactViewportOverrideProvider
           isCompactViewport={renderArgs.isCompactViewport}
         >
-          <ThreadDetailSecondaryContent
-            {...createProps({
-              isSecondaryPanelOpen: renderArgs.isSecondaryPanelOpen,
-              renderBrowserDeck: renderArgs.renderBrowserDeck,
-              threadId: renderArgs.threadId,
-            })}
-          />
+          <ThreadDetailTestPaneProvider
+            isFocusedHosted={renderArgs.isFocusedHosted}
+          >
+            <ThreadDetailSecondaryContent
+              {...createProps({
+                isSecondaryPanelOpen: renderArgs.isSecondaryPanelOpen,
+                renderBrowserDeck: renderArgs.renderBrowserDeck,
+                threadId: renderArgs.threadId,
+              })}
+            />
+          </ThreadDetailTestPaneProvider>
         </CompactViewportOverrideProvider>,
       );
     },
@@ -409,6 +458,35 @@ beforeEach(() => {
 });
 
 describe("ThreadDetailSecondaryContent compact drawer settling", () => {
+  it("hides and restores native browser readiness as hosted pane focus changes", () => {
+    const order: string[] = [];
+    const renderBrowserDeck = createBrowserDeckRenderer(order);
+    const view = renderThreadDetail({
+      isCompactViewport: false,
+      isFocusedHosted: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck,
+      threadId: "thread-1",
+    });
+
+    expect(renderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: true,
+    });
+    view.rerenderWith({ isFocusedHosted: false });
+    expect(renderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: false,
+    });
+    view.rerenderWith({ isFocusedHosted: true });
+    expect(renderBrowserDeck).toHaveBeenLastCalledWith({
+      canShowNativeBrowserView: true,
+    });
+    expect(order.filter((entry) => entry.startsWith("render:"))).toEqual([
+      "render:true",
+      "render:false",
+      "render:true",
+    ]);
+  });
+
   it("orders open-animation completion, rAF, bounds sync, and drawer settled true", () => {
     const order: string[] = [];
     const frames = installAnimationFrameQueue(order);

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -267,27 +267,42 @@ export function ThreadDetailSecondaryContent({
       ),
     [hasForks, isMetadataLoading, stableMetadata],
   );
-  const inlineSecondaryPanelContent = !renderAsDrawer ? (
-    <ThreadSecondaryPanel
-      {...threadSecondaryPanelProps}
-      browserDeck={browserDeck}
-      renderAsDrawer={false}
-      isConversationCollapsed={isConversationCollapsedActive}
-      onToggleConversationCollapse={onToggleConversationCollapse}
-      // The full-width header bar owns the (stable) right-panel toggle, so the
-      // panel drops its own inline hide control entirely — no reserved slot, so
-      // the trailing expand control sits flush at the edge.
-      inlinePanelToggle={secondaryPanelHost === null ? "hidden" : "reserved"}
-      // In the split-workspace host, panes' panels share one PanelGroup, so
-      // each pane's Panel needs its own layout identity (see the prop doc).
-      resizablePanelId={
-        secondaryPanelHost === null
-          ? undefined
-          : `thread-detail-secondary-panel-${paneId}`
-      }
-      metadataContent={metadataContent}
-    />
-  ) : null;
+  const inlineSecondaryPanelContent = useMemo(
+    () =>
+      !renderAsDrawer ? (
+        <ThreadSecondaryPanel
+          {...threadSecondaryPanelProps}
+          browserDeck={browserDeck}
+          renderAsDrawer={false}
+          isConversationCollapsed={isConversationCollapsedActive}
+          onToggleConversationCollapse={onToggleConversationCollapse}
+          // The full-width header bar owns the (stable) right-panel toggle, so
+          // the panel drops its own inline hide control entirely — no reserved
+          // slot, so the trailing expand control sits flush at the edge.
+          inlinePanelToggle={
+            secondaryPanelHost === null ? "hidden" : "reserved"
+          }
+          // In the split-workspace host, panes' panels share one PanelGroup, so
+          // each pane's Panel needs its own layout identity (see the prop doc).
+          resizablePanelId={
+            secondaryPanelHost === null
+              ? undefined
+              : `thread-detail-secondary-panel-${paneId}`
+          }
+          metadataContent={metadataContent}
+        />
+      ) : null,
+    [
+      browserDeck,
+      isConversationCollapsedActive,
+      metadataContent,
+      onToggleConversationCollapse,
+      paneId,
+      renderAsDrawer,
+      secondaryPanelHost,
+      threadSecondaryPanelProps,
+    ],
+  );
   const drawerSecondaryPanelContent = renderAsDrawer ? (
     <ThreadSecondaryPanel
       {...threadSecondaryPanelProps}
@@ -298,13 +313,20 @@ export function ThreadDetailSecondaryContent({
       metadataContent={metadataContent}
     />
   ) : null;
-  const hostedCollapsedRail = (
-    <ConversationCollapsedRail
-      collapsed={isConversationCollapsedActive}
-      isWorking={isConversationWorking}
-      reserveTopForDesktopTrafficLights={false}
-      onExpand={onToggleConversationCollapse}
-    />
+  const hostedCollapsedRail = useMemo(
+    () => (
+      <ConversationCollapsedRail
+        collapsed={isConversationCollapsedActive}
+        isWorking={isConversationWorking}
+        reserveTopForDesktopTrafficLights={false}
+        onExpand={onToggleConversationCollapse}
+      />
+    ),
+    [
+      isConversationCollapsedActive,
+      isConversationWorking,
+      onToggleConversationCollapse,
+    ],
   );
   const hostedPanelModel = useMemo<PaneSecondaryPanelViewModel>(
     () => ({

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -33,6 +33,11 @@ import { ThreadTimelinePane } from "./ThreadTimelinePane";
 import { ConversationCollapsedRail } from "@/components/secondary-panel/ConversationCollapsedRail";
 import { PANEL_COLLAPSE_TRANSITION_CLASS } from "@/components/secondary-panel/panelTransitionTokens";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import {
+  usePaneContext,
+  usePaneSecondaryPanelRegistration,
+  type PaneSecondaryPanelViewModel,
+} from "./PaneContext";
 
 const CLOSED_TIMELINE_PANEL_SIZE_PERCENT = 100;
 const COLLAPSED_TIMELINE_PANEL_SIZE_PERCENT = 0;
@@ -69,7 +74,9 @@ interface ThreadDetailSecondaryContentProps {
    * without stretching it).
    */
   isBoundedPane: boolean;
+  onToggleSecondaryPanel: () => void;
   onToggleConversationCollapse: () => void;
+  renderHostedPanel: (panel: ReactNode) => ReactNode;
   metadata: ThreadMetadataContentProps;
   secondaryPanel: ThreadSecondaryPanelProps;
   timeline: ThreadTimelinePaneProps;
@@ -82,11 +89,14 @@ export function ThreadDetailSecondaryContent({
   isSecondaryPanelOpen,
   isConversationCollapsed,
   isBoundedPane,
+  onToggleSecondaryPanel,
   onToggleConversationCollapse,
+  renderHostedPanel,
   metadata,
   secondaryPanel,
   timeline,
 }: ThreadDetailSecondaryContentProps) {
+  const { isFocused, paneId, secondaryPanelHost } = usePaneContext();
   const stableMetadata = metadata;
   const stableSecondaryPanel = secondaryPanel;
   const stableTimeline = timeline;
@@ -193,7 +203,7 @@ export function ThreadDetailSecondaryContent({
   );
   const canShowNativeBrowserView = renderAsDrawer
     ? isSecondaryPanelOpen && isCompactDrawerContentSettled
-    : isSecondaryPanelOpen;
+    : isSecondaryPanelOpen && (secondaryPanelHost === null || isFocused);
   const { renderBrowserDeck, ...threadSecondaryPanelProps } =
     stableSecondaryPanel;
   const browserDeck = useMemo(
@@ -267,7 +277,14 @@ export function ThreadDetailSecondaryContent({
       // The full-width header bar owns the (stable) right-panel toggle, so the
       // panel drops its own inline hide control entirely — no reserved slot, so
       // the trailing expand control sits flush at the edge.
-      inlinePanelToggle="hidden"
+      inlinePanelToggle={secondaryPanelHost === null ? "hidden" : "reserved"}
+      // In the split-workspace host, panes' panels share one PanelGroup, so
+      // each pane's Panel needs its own layout identity (see the prop doc).
+      resizablePanelId={
+        secondaryPanelHost === null
+          ? undefined
+          : `thread-detail-secondary-panel-${paneId}`
+      }
       metadataContent={metadataContent}
     />
   ) : null;
@@ -281,6 +298,53 @@ export function ThreadDetailSecondaryContent({
       metadataContent={metadataContent}
     />
   ) : null;
+  const hostedCollapsedRail = (
+    <ConversationCollapsedRail
+      collapsed={isConversationCollapsedActive}
+      isWorking={isConversationWorking}
+      reserveTopForDesktopTrafficLights={false}
+      onExpand={onToggleConversationCollapse}
+    />
+  );
+  const hostedPanelModel = useMemo<PaneSecondaryPanelViewModel>(
+    () => ({
+      collapsedRail: hostedCollapsedRail,
+      contentKey: stableTimeline.threadId,
+      isMainCollapsed: isConversationCollapsedActive,
+      isOpen: isSecondaryPanelOpen,
+      panel: renderHostedPanel(inlineSecondaryPanelContent),
+      onToggle: onToggleSecondaryPanel,
+    }),
+    [
+      hostedCollapsedRail,
+      inlineSecondaryPanelContent,
+      isConversationCollapsedActive,
+      isSecondaryPanelOpen,
+      onToggleSecondaryPanel,
+      renderHostedPanel,
+      stableTimeline.threadId,
+    ],
+  );
+  usePaneSecondaryPanelRegistration(secondaryPanelHost, hostedPanelModel);
+
+  if (secondaryPanelHost !== null) {
+    return (
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip">
+        {header}
+        <div
+          data-conversation-collapsed={isConversationCollapsedActive}
+          inert={isConversationCollapsedActive}
+          className={cn(
+            "flex min-h-0 min-w-0 flex-1 flex-col transition-opacity",
+            PANEL_COLLAPSE_TRANSITION_CLASS,
+            isConversationCollapsedActive && "opacity-0",
+          )}
+        >
+          <ThreadTimelinePane {...stableTimeline} footer={footer} />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -456,29 +456,22 @@ export function ThreadDetailView(props: ThreadDetailViewProps) {
 
 function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   const { projectId, threadId } = props;
-  const {
-    isFocused,
-    navigateInPane,
-    canShowSecondaryPanel,
-    onRequestClose,
-    isBoundedPane,
-  } = usePaneContext();
+  const { isFocused, navigateInPane, onRequestClose, isBoundedPane } =
+    usePaneContext();
   const navigate = useNavigate();
   useFixedPanelTabsStorageMaintenance(threadId);
   const fixedPanelTabsState = useFixedPanelTabsState(threadId, threadId);
   const isPersistedSecondaryPanelOpen = fixedPanelTabsState.secondary.isOpen;
-  const isPersistedSecondaryPanelOpenForSurface =
-    isPersistedSecondaryPanelOpen && canShowSecondaryPanel;
   const activeFixedSecondaryTab = getActiveFixedSecondaryTab({
     fixedPanelTabsState,
   });
   const openFixedSecondaryTab = getOpenFixedSecondaryTab({
     activeFixedSecondaryTab,
-    isSecondaryPanelOpen: isPersistedSecondaryPanelOpenForSurface,
+    isSecondaryPanelOpen: isPersistedSecondaryPanelOpen,
   });
   const retainedTerminalId = getRetainedTerminalTabId({
     activeTab: activeFixedSecondaryTab,
-    isPanelOpen: isPersistedSecondaryPanelOpenForSurface,
+    isPanelOpen: isPersistedSecondaryPanelOpen,
   });
   const activeFixedSecondaryTabId = activeFixedSecondaryTab?.id ?? null;
   const renderSecondaryPanelAsDrawer = useIsCompactViewport();
@@ -966,7 +959,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     togglePanel: toggleSecondaryPanel,
   } = useThreadSecondaryPanelVisibility({
     closePersistedPanel: closeThreadSecondaryPanel,
-    isPersistedOpen: isPersistedSecondaryPanelOpenForSurface,
+    isPersistedOpen: isPersistedSecondaryPanelOpen,
     isCompactViewport: renderSecondaryPanelAsDrawer,
     openPersistedCommitDiff,
     openPersistedDiffFile,
@@ -2519,7 +2512,21 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
           isSecondaryPanelOpen={isSecondaryPanelOpen}
           isConversationCollapsed={isConversationCollapsed}
           isBoundedPane={isBoundedPane}
+          onToggleSecondaryPanel={toggleSecondaryPanel}
           onToggleConversationCollapse={toggleConversationCollapse}
+          renderHostedPanel={(panel) => (
+            <MarkdownLocalFileContextMenuContext.Provider
+              value={getLocalFileContextMenuItems}
+            >
+              <UrlOpenRoutingProvider
+                openInAppBrowser={
+                  canOpenUrlsInAppBrowser ? openBrowserTabAndReveal : null
+                }
+              >
+                {panel}
+              </UrlOpenRoutingProvider>
+            </MarkdownLocalFileContextMenuContext.Provider>
+          )}
           metadata={{
             thread,
             projectId,


### PR DESCRIPTION
## Summary

The split workspace now hosts **one** right panel at the window level instead of per-pane panels. Panes publish their assembled panel view-model to a pane registry (`PaneContext`); `SplitWorkspaceSecondaryPanelHost` renders the focused pane's panel beside the split tree and owns the single top-right toggle.

- **Visibility survives focus/thread changes.** The host keeps one window visibility and aligns a newly targeted pane's persisted panel state to it (instead of following it). Only a real open/close on the same target — toggle, shortcut, "open diff" — moves the window state.
- **No phantom closes.** Panes' panels get unique resizable-Panel ids plus a collapse gate, so a freshly mounted panel adopting stale group layout can't misreport a user close; hosted panels compute `defaultSize` from the window visibility via `SecondaryPanelHostLayoutContext` (the pane's own state lags one commit behind the alignment).
- **Panel-less panes get an empty state.** Focusing a pane with no right panel (plugin panes) keeps the panel open with a placeholder, a working resize gutter, and the window toggle (with a `panel.toggle` fallback handler in the host).
- **Seams match the splits.** Inside the workspace the panel's resize handle renders as the same 6px gutter as the split dividers (same hover/drag treatment, shared persisted width), fixing finicky drag targets next to splits.
- **Flush pane chrome.** The right-edge pane's close button only reserves the corner-toggle footprint while the panel is closed; open, the toggle overlays the panel's own chrome.
- Root compose panes publish through the same contract; its `panel.toggle`/`panel.close`/window-close handlers move to `RootComposePanelCommandHandlers` with pane-focus gating.

Everything is gated behind the `threadSplits` experiment: with it off, `SplitThreadArea` returns the standalone page surface before any of this mounts. The only change reaching non-experiment users is the collapse gate, which strictly suppresses calls that were already no-ops.

## Tests

- `turbo run typecheck --filter=@bb/app`
- All secondary-panel / split / thread-detail / root-compose vitest suites (197–204 tests across iterations), including a rewritten visibility-survival test and a new empty-state test.
- Manual QA in the dev app via browser automation: focus switches with panel open/closed in both directions, thread↔compose↔plugin pane switches, gutter drag-resize (width persists across panes), drag-to-collapse, empty-state resize, and pixel checks that the panel gutter matches the split dividers.

## Risks

- The host↔pane alignment relies on react-resizable-panels callback ordering; the collapse gate + unique panel ids + context-driven defaultSize each guard a distinct race we reproduced live (details in code comments).
- `PromptBoxInternal.test.tsx` shows 2 pre-existing flakes under the full parallel run (pass in isolation, with and without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)