### PR TITLE
Fix Docs paths with spaces

### DIFF
--- a/official-plugins/docs/app.test.tsx
+++ b/official-plugins/docs/app.test.tsx
@@ -266,6 +266,37 @@ describe("Docs nav panel", () => {
     }
   });
 
+  it("passes note paths with spaces to host navigation without pre-encoding", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "personal" },
+      {
+        rpc: {
+          listNotes: () =>
+            listNotesResult([
+              {
+                path: "Tasks follow up apis.md",
+                title: "Tasks follow up apis",
+                preview: "",
+                modifiedAtMs: 1,
+              },
+            ]),
+        },
+      },
+    );
+
+    fireEvent.click(await slot.findByText("Tasks follow up apis"));
+
+    expect(slot.navigateCalls).toContainEqual({
+      method: "toPluginPanel",
+      path: "docs",
+      options: {
+        subPath: "personal/Tasks follow up apis.md",
+        replace: false,
+      },
+    });
+  });
+
   it("only shows host status when the selected vault is unavailable", async () => {
     const available = listNotesResult([]);
     const unavailable = {

--- a/official-plugins/docs/app.tsx
+++ b/official-plugins/docs/app.tsx
@@ -693,7 +693,7 @@ function DocsDirectiveCard({
   }
   const openInDocs = () =>
     navigate.toPluginPanel("docs", {
-      subPath: `${encodeURIComponent(document.vaultId)}/${encodePath(document.path)}`,
+      subPath: `${document.vaultId}/${document.path}`,
     });
   const openPreview = () => {
     const opened =
@@ -800,7 +800,7 @@ function DocumentPanel({ params }: PluginThreadPanelProps) {
           aria-label="Open in Docs"
           onClick={() =>
             navigate.toPluginPanel("docs", {
-              subPath: `${encodeURIComponent(document.vaultId)}/${encodePath(document.path)}`,
+              subPath: `${document.vaultId}/${document.path}`,
             })
           }
         >
@@ -1939,7 +1939,7 @@ function NotesPanel({ subPath }: PluginNavPanelProps) {
     (path: string, replace = false) => {
       if (!activeVaultId) return;
       navigate.toPluginPanel("docs", {
-        subPath: `${encodeURIComponent(activeVaultId)}/${encodePath(path)}`,
+        subPath: `${activeVaultId}/${path}`,
         replace,
       });
     },
@@ -1999,7 +1999,7 @@ function NotesPanel({ subPath }: PluginNavPanelProps) {
       setVaultDialogOpen(false);
       setVaultId(value.id);
       navigate.toPluginPanel("docs", {
-        subPath: encodeURIComponent(value.id),
+        subPath: value.id,
       });
     } catch (error) {
       setVaultError(error instanceof Error ? error.message : String(error));
@@ -2015,7 +2015,7 @@ function NotesPanel({ subPath }: PluginNavPanelProps) {
       refresh();
       if (filePath === path) {
         navigate.toPluginPanel("docs", {
-          subPath: encodeURIComponent(activeVaultId),
+          subPath: activeVaultId,
           replace: true,
         });
       }
@@ -2107,7 +2107,7 @@ function NotesPanel({ subPath }: PluginNavPanelProps) {
           onVaultChange={(value) => {
             setVaultId(value);
             navigate.toPluginPanel("docs", {
-              subPath: encodeURIComponent(value),
+              subPath: value,
             });
           }}
           onAddVault={() => setVaultDialogOpen(true)}


### PR DESCRIPTION
## Summary

- pass raw Docs subpaths to the host navigation API
- avoid double-encoding spaces and other URL-sensitive filename characters
- add regression coverage for opening `Tasks follow up apis.md`

## Tests

- `pnpm exec turbo run test --filter=bb-plugin-simple-notes --force`
- `pnpm exec turbo run typecheck --filter=bb-plugin-simple-notes`