### PR TITLE
BB-16: Show agent thread title and chat link in task comments

### DIFF
--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -64,6 +64,104 @@ describe("Tasks RPC domain API", () => {
     await harness.dispose();
   });
 
+  it("resolves the live thread title for agent comments and falls back otherwise", async () => {
+    const { bb, harness } = createFakePluginHost({
+      pluginId: "tasks",
+      sdk: {
+        threads: {
+          get: async ({ threadId }: { threadId: string }) => {
+            if (threadId === "thr_titled") {
+              return makeThreadResponse({
+                id: threadId,
+                title: "Fix the login bug",
+              });
+            }
+            if (threadId === "thr_fallback_only") {
+              return makeThreadResponse({
+                id: threadId,
+                title: null,
+                titleFallback: "Untitled work",
+              });
+            }
+            // Deleted / hidden / inaccessible threads reject.
+            throw new Error("thread_not_found");
+          },
+        },
+      },
+    });
+    const store = createStore(bb);
+    registerTasksApi(bb, store);
+    const project = store.tasks.createProject({
+      name: "Notifications",
+      prefix: "NTF",
+      color: "blue",
+    });
+    const task = store.tasks.createTask({
+      projectId: project.id,
+      title: "Wire up comments",
+    });
+    // Agent comment whose thread has a human title.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (thr_titled)",
+      threadId: "thr_titled",
+      body: "Titled",
+      notifiedCount: 0,
+    });
+    // Agent comment whose thread only has a fallback title.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (thr_fallback_only)",
+      threadId: "thr_fallback_only",
+      body: "Fallback title",
+      notifiedCount: 0,
+    });
+    // Agent comment whose thread is gone/inaccessible.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (thr_missing)",
+      threadId: "thr_missing",
+      body: "Missing thread",
+      notifiedCount: 0,
+    });
+    // Legacy agent comment with no thread id.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (legacy)",
+      threadId: null,
+      body: "Legacy",
+      notifiedCount: 0,
+    });
+    // User comment never resolves a thread title.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "user",
+      authorName: "You",
+      threadId: null,
+      body: "Human note",
+      notifiedCount: 0,
+    });
+
+    const result = tasksRpcContract.listComments.output.parse(
+      await harness.callRpc("listComments", { taskId: task.id }),
+    );
+    const titleByBody = new Map(
+      result.comments.map((comment) => [comment.body, comment.threadTitle]),
+    );
+    expect(titleByBody.get("Titled")).toBe("Fix the login bug");
+    expect(titleByBody.get("Fallback title")).toBe("Untitled work");
+    expect(titleByBody.get("Missing thread")).toBeNull();
+    expect(titleByBody.get("Legacy")).toBeNull();
+    expect(titleByBody.get("Human note")).toBeNull();
+    // Each distinct agent thread is resolved once, not per comment.
+    expect(harness.sdk.callsTo("threads.get")).toHaveLength(3);
+    await harness.dispose();
+  });
+
   it("lists bb workspace projects as id/name options", async () => {
     const { bb, harness } = createFakePluginHost({
       pluginId: "tasks",

--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -83,6 +83,29 @@ describe("Tasks RPC domain API", () => {
                 titleFallback: "Untitled work",
               });
             }
+            if (threadId === "thr_blank_title") {
+              // A whitespace primary title must not suppress a useful fallback.
+              return makeThreadResponse({
+                id: threadId,
+                title: "   ",
+                titleFallback: "Recovered fallback",
+              });
+            }
+            if (threadId === "thr_side_chat") {
+              return makeThreadResponse({
+                id: threadId,
+                title: "Internal side chat",
+                originKind: "side-chat",
+              });
+            }
+            if (threadId === "thr_side_chat_legacy") {
+              return makeThreadResponse({
+                id: threadId,
+                title: "Legacy side chat",
+                originKind: null,
+                childOrigin: "side-chat",
+              });
+            }
             // Deleted / hidden / inaccessible threads reject.
             throw new Error("thread_not_found");
           },
@@ -116,6 +139,33 @@ describe("Tasks RPC domain API", () => {
       authorName: "agent (thr_fallback_only)",
       threadId: "thr_fallback_only",
       body: "Fallback title",
+      notifiedCount: 0,
+    });
+    // Agent comment whose thread has only a whitespace primary title.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (thr_blank_title)",
+      threadId: "thr_blank_title",
+      body: "Blank title",
+      notifiedCount: 0,
+    });
+    // Agent comment authored by a side chat (must not leak title/link).
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (thr_side_chat)",
+      threadId: "thr_side_chat",
+      body: "Side chat",
+      notifiedCount: 0,
+    });
+    // Agent comment authored by a legacy childOrigin side chat.
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "agent (thr_side_chat_legacy)",
+      threadId: "thr_side_chat_legacy",
+      body: "Legacy side chat",
       notifiedCount: 0,
     });
     // Agent comment whose thread is gone/inaccessible.
@@ -154,11 +204,14 @@ describe("Tasks RPC domain API", () => {
     );
     expect(titleByBody.get("Titled")).toBe("Fix the login bug");
     expect(titleByBody.get("Fallback title")).toBe("Untitled work");
+    expect(titleByBody.get("Blank title")).toBe("Recovered fallback");
+    expect(titleByBody.get("Side chat")).toBeNull();
+    expect(titleByBody.get("Legacy side chat")).toBeNull();
     expect(titleByBody.get("Missing thread")).toBeNull();
     expect(titleByBody.get("Legacy")).toBeNull();
     expect(titleByBody.get("Human note")).toBeNull();
     // Each distinct agent thread is resolved once, not per comment.
-    expect(harness.sdk.callsTo("threads.get")).toHaveLength(3);
+    expect(harness.sdk.callsTo("threads.get")).toHaveLength(6);
     await harness.dispose();
   });
 

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -352,9 +352,11 @@ function attachmentsForTasks(
 /**
  * Resolve the current human title of each distinct agent thread that authored
  * one of `comments`, keyed by thread id. Titles come from the live thread so
- * renames are reflected. Threads that are deleted, hidden, or otherwise
- * inaccessible resolve to no entry, so callers fall back to `authorName`
- * without leaking a thread the viewer cannot open.
+ * renames are reflected. A thread contributes no entry — so callers fall back
+ * to `authorName` and expose no link — when it is:
+ *   - deleted, hidden, or otherwise inaccessible (the SDK read rejects), or
+ *   - a side chat (originKind/legacy childOrigin === "side-chat"), which is an
+ *     internal conversation that must not surface through an ordinary comment.
  */
 async function resolveAgentThreadTitles(
   bb: BbPluginApi,
@@ -371,8 +373,18 @@ async function resolveAgentThreadTitles(
     [...threadIds].map(async (threadId) => {
       try {
         const thread = await bb.sdk.threads.get({ threadId });
-        const title = thread.title ?? thread.titleFallback ?? "";
-        if (title.trim() !== "") titles.set(threadId, title);
+        if (
+          thread.originKind === "side-chat" ||
+          thread.childOrigin === "side-chat"
+        ) {
+          return;
+        }
+        // Prefer the first non-blank candidate: a whitespace-only primary
+        // title must not suppress a useful fallback.
+        const title = [thread.title, thread.titleFallback].find(
+          (candidate) => candidate !== null && candidate.trim() !== "",
+        );
+        if (title !== null && title !== undefined) titles.set(threadId, title);
       } catch {
         // Deleted, hidden, or inaccessible threads leave no title.
       }

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -349,6 +349,38 @@ function attachmentsForTasks(
   ]);
 }
 
+/**
+ * Resolve the current human title of each distinct agent thread that authored
+ * one of `comments`, keyed by thread id. Titles come from the live thread so
+ * renames are reflected. Threads that are deleted, hidden, or otherwise
+ * inaccessible resolve to no entry, so callers fall back to `authorName`
+ * without leaking a thread the viewer cannot open.
+ */
+async function resolveAgentThreadTitles(
+  bb: BbPluginApi,
+  comments: readonly StoredComment[],
+): Promise<Map<string, string>> {
+  const threadIds = new Set<string>();
+  for (const comment of comments) {
+    if (comment.kind === "agent" && comment.threadId !== null) {
+      threadIds.add(comment.threadId);
+    }
+  }
+  const titles = new Map<string, string>();
+  await Promise.all(
+    [...threadIds].map(async (threadId) => {
+      try {
+        const thread = await bb.sdk.threads.get({ threadId });
+        const title = thread.title ?? thread.titleFallback ?? "";
+        if (title.trim() !== "") titles.set(threadId, title);
+      } catch {
+        // Deleted, hidden, or inaccessible threads leave no title.
+      }
+    }),
+  );
+  return titles;
+}
+
 interface CreateCommentInput {
   taskId: string;
   kind: StoredComment["kind"];
@@ -651,8 +683,18 @@ export function registerHandlers(
       });
       return { comment };
     },
-    listComments(input) {
-      return { comments: store.tasks.listComments(input.taskId) };
+    async listComments(input) {
+      const comments = store.tasks.listComments(input.taskId);
+      const threadTitles = await resolveAgentThreadTitles(bb, comments);
+      return {
+        comments: comments.map((comment) => ({
+          ...comment,
+          threadTitle:
+            comment.kind === "agent" && comment.threadId !== null
+              ? (threadTitles.get(comment.threadId) ?? null)
+              : null,
+        })),
+      };
     },
     listAttachments(input) {
       const attachments =

--- a/official-plugins/tasks/cli/index.ts
+++ b/official-plugins/tasks/cli/index.ts
@@ -931,7 +931,9 @@ async function runShow(domain: TasksDomain, argv: string[]): Promise<string> {
       comments.map((comment) => [
         comment.createdAt,
         comment.kind,
-        comment.authorName,
+        // Agent comments show the authoring thread's human title when it
+        // resolves; otherwise the stored author name (which carries the id).
+        comment.threadTitle ?? comment.authorName,
         comment.body,
       ]),
       "(none)",

--- a/official-plugins/tasks/shared/contract.ts
+++ b/official-plugins/tasks/shared/contract.ts
@@ -141,6 +141,19 @@ export const commentSchema = z
   })
   .strict();
 
+/**
+ * A comment enriched for display with the current human title of the agent
+ * thread that authored it. `threadTitle` is resolved at read time against the
+ * live thread and is null for user/system comments, legacy agent comments that
+ * carry no `threadId`, and threads that are deleted, hidden, or otherwise
+ * inaccessible — callers fall back to `authorName` and render no link.
+ */
+export const displayCommentSchema = commentSchema
+  .extend({
+    threadTitle: z.string().nullable(),
+  })
+  .strict();
+
 export const attachmentSchema = z
   .object({
     id: idSchema,
@@ -487,7 +500,7 @@ export const tasksRpcContract = defineRpcContract({
   },
   listComments: {
     input: z.object({ taskId: idSchema }).strict(),
-    output: z.object({ comments: z.array(commentSchema) }).strict(),
+    output: z.object({ comments: z.array(displayCommentSchema) }).strict(),
   },
   listAttachments: {
     input: z.union([
@@ -648,6 +661,7 @@ export type TaskStatus = (typeof TASK_STATUSES)[number];
 export type TaskPriority = (typeof TASK_PRIORITIES)[number];
 export type Label = z.infer<typeof labelSchema>;
 export type Comment = z.infer<typeof commentSchema>;
+export type DisplayComment = z.infer<typeof displayCommentSchema>;
 export type Attachment = z.infer<typeof attachmentSchema>;
 export type TaskThread = z.infer<typeof taskThreadSchema>;
 export type Preset = z.infer<typeof presetSchema>;

--- a/official-plugins/tasks/views/activity/activity.test.ts
+++ b/official-plugins/tasks/views/activity/activity.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { DisplayComment } from "../../shared/contract.js";
 import {
+  commentByline,
   formatFileSize,
   formatRelativeTime,
   splitSystemBody,
@@ -44,6 +46,53 @@ describe("splitSystemBody", () => {
     expect(splitSystemBody("You changed the status", "You")).toEqual([
       { text: "You changed the status", bold: false },
     ]);
+  });
+});
+
+describe("commentByline", () => {
+  const base: DisplayComment = {
+    id: "01HZZZZZZZZZZZZZZZZZZZZZC1",
+    taskId: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+    kind: "agent",
+    authorName: "agent (thr_worker)",
+    presetName: null,
+    threadId: "thr_worker",
+    threadTitle: "Fix the login bug",
+    body: "Done",
+    notifiedCount: 0,
+    createdAt: "2026-07-15T00:00:00.000Z",
+  };
+
+  it("links an agent comment to its thread by the resolved human title", () => {
+    expect(commentByline(base)).toEqual({
+      kind: "thread-link",
+      threadId: "thr_worker",
+      title: "Fix the login bug",
+    });
+  });
+
+  it("falls back to the author name when the thread title is unresolved", () => {
+    expect(commentByline({ ...base, threadTitle: null })).toEqual({
+      kind: "text",
+      name: "agent (thr_worker)",
+    });
+  });
+
+  it("falls back to the author name for legacy agent comments with no thread", () => {
+    expect(
+      commentByline({ ...base, threadId: null, threadTitle: null }),
+    ).toEqual({ kind: "text", name: "agent (thr_worker)" });
+  });
+
+  it("never links user comments even if a thread id is present", () => {
+    expect(
+      commentByline({
+        ...base,
+        kind: "user",
+        authorName: "You",
+        threadTitle: "Should be ignored",
+      }),
+    ).toEqual({ kind: "text", name: "You" });
   });
 });
 

--- a/official-plugins/tasks/views/activity/comment-author.test.tsx
+++ b/official-plugins/tasks/views/activity/comment-author.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DisplayComment } from "../../shared/contract.js";
+import { CommentAuthor } from "./comment-author.js";
+
+afterEach(cleanup);
+
+const base: DisplayComment = {
+  id: "01HZZZZZZZZZZZZZZZZZZZZZC1",
+  taskId: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+  kind: "agent",
+  authorName: "agent (thr_worker)",
+  presetName: null,
+  threadId: "thr_worker",
+  threadTitle: "Fix the login bug",
+  body: "Done",
+  notifiedCount: 0,
+  createdAt: "2026-07-15T00:00:00.000Z",
+};
+
+describe("CommentAuthor", () => {
+  it("renders an agent thread title as a link that opens the chat", () => {
+    const onOpenThread = vi.fn();
+    render(<CommentAuthor comment={base} onOpenThread={onOpenThread} />);
+
+    const link = screen.getByRole("button", { name: "Fix the login bug" });
+    fireEvent.click(link);
+
+    expect(onOpenThread).toHaveBeenCalledTimes(1);
+    expect(onOpenThread).toHaveBeenCalledWith("thr_worker");
+  });
+
+  it("renders the author name as plain text when the title is unresolved", () => {
+    const onOpenThread = vi.fn();
+    render(
+      <CommentAuthor
+        comment={{ ...base, threadTitle: null }}
+        onOpenThread={onOpenThread}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("agent (thr_worker)")).toBeTruthy();
+    expect(onOpenThread).not.toHaveBeenCalled();
+  });
+
+  it("never links a user comment even when a thread id and title are present", () => {
+    render(
+      <CommentAuthor
+        comment={{
+          ...base,
+          kind: "user",
+          authorName: "You",
+          threadTitle: "Should be ignored",
+        }}
+        onOpenThread={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("You")).toBeTruthy();
+  });
+});

--- a/official-plugins/tasks/views/activity/comment-author.tsx
+++ b/official-plugins/tasks/views/activity/comment-author.tsx
@@ -1,0 +1,35 @@
+import type { DisplayComment } from "../../shared/contract.js";
+import { commentByline } from "./time.js";
+
+/**
+ * Comment byline. Agent comments whose thread is still resolvable render the
+ * thread's human title as a link that opens the chat; everything else (users,
+ * legacy agent comments with no thread, deleted/hidden/side-chat threads)
+ * falls back to the stored author name so the byline is never blank and no
+ * unresolved thread is exposed.
+ *
+ * Kept SDK-free (navigation is injected via `onOpenThread`) so it renders in a
+ * plain jsdom test without the plugin app runtime.
+ */
+export function CommentAuthor({
+  comment,
+  onOpenThread,
+}: {
+  comment: DisplayComment;
+  onOpenThread: (threadId: string) => void;
+}) {
+  const byline = commentByline(comment);
+  if (byline.kind === "thread-link") {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenThread(byline.threadId)}
+        className="truncate font-semibold text-primary hover:underline"
+        title={byline.title}
+      >
+        {byline.title}
+      </button>
+    );
+  }
+  return <span className="font-semibold">{byline.name}</span>;
+}

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -19,8 +19,14 @@ import {
   useTasksRpc,
 } from "../../shell/data.js";
 import { Lightbox } from "../detail/attachments.js";
-import type { Attachment, Comment, TaskThread } from "../../shared/contract.js";
+import type {
+  Attachment,
+  Comment,
+  DisplayComment,
+  TaskThread,
+} from "../../shared/contract.js";
 import {
+  commentByline,
   formatFileSize,
   formatRelativeTime,
   splitSystemBody,
@@ -92,7 +98,7 @@ function attachmentDownloadUrl(attachmentId: string): string {
 }
 
 interface FeedEntry {
-  comment: Comment;
+  comment: DisplayComment;
   attachments: Attachment[];
 }
 
@@ -221,6 +227,35 @@ function SystemEvent({ comment, nowMs }: { comment: Comment; nowMs: number }) {
   );
 }
 
+/**
+ * Comment byline. Agent comments whose thread is still resolvable render the
+ * thread's human title as a link that opens the chat; everything else (users,
+ * legacy agent comments with no thread, deleted/hidden threads) falls back to
+ * the stored author name so the byline is never blank.
+ */
+function CommentAuthor({
+  comment,
+  onOpenThread,
+}: {
+  comment: DisplayComment;
+  onOpenThread: (threadId: string) => void;
+}) {
+  const byline = commentByline(comment);
+  if (byline.kind === "thread-link") {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenThread(byline.threadId)}
+        className="truncate font-semibold text-primary hover:underline"
+        title={byline.title}
+      >
+        {byline.title}
+      </button>
+    );
+  }
+  return <span className="font-semibold">{byline.name}</span>;
+}
+
 function CommentCard({
   entry,
   nowMs,
@@ -237,7 +272,7 @@ function CommentCard({
       {agent ? <AgentAvatar /> : <UserAvatar name={comment.authorName} />}
       <div className="min-w-0 flex-1">
         <div className="mb-0.5 flex items-baseline gap-1.5 text-xs">
-          <span className="font-semibold">{comment.authorName}</span>
+          <CommentAuthor comment={comment} onOpenThread={navigate.toThread} />
           {agent && comment.presetName ? (
             <span className="rounded-sm bg-secondary px-1 py-px text-2xs font-semibold text-muted-foreground">
               {comment.presetName}

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -26,12 +26,12 @@ import type {
   TaskThread,
 } from "../../shared/contract.js";
 import {
-  commentByline,
   formatFileSize,
   formatRelativeTime,
   splitSystemBody,
   useNowTick,
 } from "./time.js";
+import { CommentAuthor } from "./comment-author.js";
 
 const PLUGIN_HTTP_BASE = "/api/v1/plugins/tasks/http";
 const TOKEN_URL = "/api/v1/plugins/tasks/token";
@@ -225,35 +225,6 @@ function SystemEvent({ comment, nowMs }: { comment: Comment; nowMs: number }) {
       </span>
     </div>
   );
-}
-
-/**
- * Comment byline. Agent comments whose thread is still resolvable render the
- * thread's human title as a link that opens the chat; everything else (users,
- * legacy agent comments with no thread, deleted/hidden threads) falls back to
- * the stored author name so the byline is never blank.
- */
-function CommentAuthor({
-  comment,
-  onOpenThread,
-}: {
-  comment: DisplayComment;
-  onOpenThread: (threadId: string) => void;
-}) {
-  const byline = commentByline(comment);
-  if (byline.kind === "thread-link") {
-    return (
-      <button
-        type="button"
-        onClick={() => onOpenThread(byline.threadId)}
-        className="truncate font-semibold text-primary hover:underline"
-        title={byline.title}
-      >
-        {byline.title}
-      </button>
-    );
-  }
-  return <span className="font-semibold">{byline.name}</span>;
 }
 
 function CommentCard({

--- a/official-plugins/tasks/views/activity/time.ts
+++ b/official-plugins/tasks/views/activity/time.ts
@@ -1,4 +1,31 @@
 import { useEffect, useState } from "react";
+import type { DisplayComment } from "../../shared/contract.js";
+
+export type CommentByline =
+  | { kind: "thread-link"; threadId: string; title: string }
+  | { kind: "text"; name: string };
+
+/**
+ * How a comment's byline should render. Agent comments whose authoring thread
+ * is still resolvable link to that chat by its human title; every other case
+ * (users, system events, legacy agent comments with no thread, and deleted,
+ * hidden, or inaccessible threads) falls back to the stored author name so the
+ * byline is never blank and no unresolved thread is exposed.
+ */
+export function commentByline(comment: DisplayComment): CommentByline {
+  if (
+    comment.kind === "agent" &&
+    comment.threadId !== null &&
+    comment.threadTitle !== null
+  ) {
+    return {
+      kind: "thread-link",
+      threadId: comment.threadId,
+      title: comment.threadTitle,
+    };
+  }
+  return { kind: "text", name: comment.authorName };
+}
 
 /** "just now" / "4m ago" / "3h ago" / "2d ago" — matches the mock's cadence. */
 export function formatRelativeTime(iso: string, nowMs: number): string {


### PR DESCRIPTION
## Summary

Agent-authored task comments used to render the raw thread id (`agent (thr_...)`) with no way to open the chat. They now show the authoring thread's **current human title as a link** that opens the chat, with safe fallbacks.

## Changes
- **Contract** (`shared/contract.ts`): new `displayCommentSchema` extends `commentSchema` with `threadTitle: string | null`, used for the `listComments` output only. The stored comment shape is unchanged; `threadId` was already persisted.
- **Server** (`api/index.ts`): `listComments` resolves the title at read time via `bb.sdk.threads.get`, deduped per thread id. A thread contributes no title (callers fall back to `authorName`, no link) when it is deleted/hidden/inaccessible **or a side chat** (`originKind`/legacy `childOrigin === "side-chat"`). Picks the first non-blank of `title`/`titleFallback` so a whitespace-only primary title can't suppress a useful fallback.
- **UI** (`views/activity/comment-author.tsx`, `time.ts`, `task-activity.tsx`): `commentByline` decides link vs. text; `CommentAuthor` (SDK-free) renders the title as a `navigate.toThread(threadId)` link only when a title resolves. System/user comment rendering is unchanged.
- **CLI parity** (`cli/index.ts`): `bb tasks show --json` includes `threadTitle` per comment; the human-readable Comments table shows the resolved title.

## Design decisions (task was underspecified)
- Title is resolved **live** (not from a snapshot) so renames are reflected.
- Hidden/side-chat/deleted/inaccessible threads never leak a title or link — matching the "don't expose hidden threads" requirement and the plugin's existing authorization boundary (`bb.sdk.threads.get`).
- Legacy agent comments with no `threadId`, plus user/system comments, fall back to the stored `authorName`.

## Tests
- `api/api.test.ts`: live title, fallback-only, **blank primary title → fallback**, **side chat (originKind) → null**, **legacy childOrigin side chat → null**, missing thread → null, legacy no-thread → null, user → null, and one `threads.get` per distinct thread.
- `views/activity/comment-author.test.tsx`: rendered jsdom test — linked button name, exact `navigate.toThread("thr_worker")` on click, and user/unresolved non-link fallbacks.
- `views/activity/activity.test.ts`: `commentByline` branch coverage.

## Validation
- `turbo run typecheck build test --filter=bb-plugin-tasks` — all green; **153 tests passed**.

## Known tradeoff (non-blocking)
`listComments` fans out one `bb.sdk.threads.get` per distinct agent thread on each read (deduped). The count equals the number of distinct agent threads on a task — typically a small handful — so no bounded-concurrency/cache layer was added; a short-lived cache would risk stale titles after a rename. Revisit if tasks accrue many distinct agent threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)