### PR TITLE
BB-18: inline task embeds in chat via ::task directives

### DIFF
--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -862,6 +862,52 @@ describe("Tasks RPC domain API", () => {
     await harness.dispose();
   });
 
+  it("resolves task keys case-insensitively and degrades bad keys to null", async () => {
+    const { bb, harness } = createFakePluginHost({ pluginId: "tasks" });
+    const store = createStore(bb);
+    registerTasksApi(bb, store);
+    const project = store.tasks.createProject({
+      name: "Plugin",
+      prefix: "PLUG",
+      color: "blue",
+    });
+    const label = store.tasks.createLabel({
+      projectId: project.id,
+      name: "Backend",
+      color: "green",
+    });
+    const task = store.tasks.createTask({
+      projectId: project.id,
+      title: "Ship task embeds",
+    });
+    store.tasks.addTaskLabel(task.id, label.id);
+
+    const found = tasksRpcContract.getTaskByKey.output.parse(
+      await harness.callRpc("getTaskByKey", { taskKey: task.key }),
+    );
+    expect(found.task).toMatchObject({
+      id: task.id,
+      key: task.key,
+      labelIds: [label.id],
+    });
+
+    const caseInsensitive = tasksRpcContract.getTaskByKey.output.parse(
+      await harness.callRpc("getTaskByKey", {
+        taskKey: task.key.toLowerCase(),
+      }),
+    );
+    expect(caseInsensitive.task?.id).toBe(task.id);
+
+    // Unknown number, unknown prefix, and malformed keys all degrade to null
+    // (the chat card's not-found state), never an RPC error.
+    for (const taskKey of ["PLUG-999", "NOPE-1", "not a key", "PLUG-"]) {
+      const missing = tasksRpcContract.getTaskByKey.output.parse(
+        await harness.callRpc("getTaskByKey", { taskKey }),
+      );
+      expect(missing.task).toBeNull();
+    }
+  });
+
   it("returns a typed error when a task would exceed one sub-task level", async () => {
     const { bb, harness } = createFakePluginHost({ pluginId: "tasks" });
     registerTasksApi(bb, createStore(bb));

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -696,6 +696,10 @@ export function registerHandlers(
       const task = store.tasks.getTask(input.taskId);
       return { task: task ? apiTask(store, task) : null };
     },
+    getTaskByKey(input) {
+      const task = store.tasks.getTaskByKey(input.taskKey);
+      return { task: task ? apiTask(store, task) : null };
+    },
     updateTask(input) {
       try {
         const current = store.tasks.getTask(input.taskId);

--- a/official-plugins/tasks/app.tsx
+++ b/official-plugins/tasks/app.tsx
@@ -1,5 +1,6 @@
 import { definePluginApp } from "@bb/plugin-sdk/app";
 import { TasksAppShell } from "./shell/app-shell.js";
+import { TaskDirectiveCard, TaskEmbedPanel } from "./views/embed/index.js";
 
 export default definePluginApp((app) => {
   app.slots.navPanel({
@@ -9,4 +10,11 @@ export default definePluginApp((app) => {
     path: "tasks",
     component: TasksAppShell,
   });
+  app.slots.threadPanelAction({
+    id: "task",
+    title: "Task",
+    icon: "ListTodo",
+    component: TaskEmbedPanel,
+  });
+  app.slots.messageDirective({ id: "task", component: TaskDirectiveCard });
 });

--- a/official-plugins/tasks/db/store.ts
+++ b/official-plugins/tasks/db/store.ts
@@ -604,6 +604,20 @@ export function createTasksStore(db: PluginDatabase) {
     return row ? taskFromRow(row) : undefined;
   }
 
+  const getTaskByKeyRow = db.prepare<[string, number], TaskRow>(
+    `${taskSelect} WHERE p.prefix = ? COLLATE NOCASE AND t.number = ?`,
+  );
+
+  /** Resolve a task key like "TSK-4" (prefix matched case-insensitively). */
+  function getTaskByKey(key: string): Task | undefined {
+    const match = /^([A-Za-z][A-Za-z0-9]{0,9})-(\d+)$/.exec(key.trim());
+    if (!match) return undefined;
+    const [, prefix, number] = match;
+    if (prefix === undefined || number === undefined) return undefined;
+    const row = getTaskByKeyRow.get(prefix, Number(number));
+    return row ? taskFromRow(row) : undefined;
+  }
+
   function requireTask(id: string): Task {
     const task = getTask(id);
     if (!task) throw new Error(`Task not found: ${id}`);
@@ -1545,6 +1559,7 @@ export function createTasksStore(db: PluginDatabase) {
     deleteProject,
     createTask,
     getTask,
+    getTaskByKey,
     listTasks,
     listSubtasks,
     getSubtaskDoneCounts,

--- a/official-plugins/tasks/shared/contract.ts
+++ b/official-plugins/tasks/shared/contract.ts
@@ -444,6 +444,15 @@ export const tasksRpcContract = defineRpcContract({
     input: z.object({ taskId: idSchema }).strict(),
     output: z.object({ task: taskSchema.nullable() }).strict(),
   },
+  /**
+   * Resolve a task key like "TSK-4" with one targeted query. The prefix is
+   * matched case-insensitively; a malformed key resolves to null rather than
+   * erroring so stale chat references degrade to the card's not-found state.
+   */
+  getTaskByKey: {
+    input: z.object({ taskKey: nonBlankStringSchema }).strict(),
+    output: z.object({ task: taskSchema.nullable() }).strict(),
+  },
   updateTask: {
     input: updateTaskInputSchema,
     output: taskMutationResultSchema,

--- a/official-plugins/tasks/shell/shell.test.tsx
+++ b/official-plugins/tasks/shell/shell.test.tsx
@@ -61,6 +61,7 @@ function seededRpc(overrides: Record<string, unknown> = {}) {
       projects: [{ projectId: PROJECT_ID, taskCount: 3, activeAgentCount: 1 }],
     }),
     listTasks: () => ({ tasks: [] }),
+    getTaskByKey: () => ({ task: null }),
     ...overrides,
   };
 }
@@ -312,7 +313,7 @@ describe("tasks app shell", () => {
       { subPath: "task/TSK-4" },
       { rpc: seededRpc() },
     );
-    // Seeded listTasks is empty, so the real detail view lands on not-found.
+    // Seeded getTaskByKey is null, so the real detail view lands on not-found.
     await taskSlot.findByText(/Task TSK-4 was not found/);
     // Esc returns to the previous list/board (default: all tasks).
     fireEvent.keyDown(window, { key: "Escape" });

--- a/official-plugins/tasks/skills/tasks/SKILL.md
+++ b/official-plugins/tasks/skills/tasks/SKILL.md
@@ -68,6 +68,22 @@ not already exist. Dispatch requires an existing preset.
    bb tasks attach ABC-12
    ```
 
+## Link tasks in responses
+
+When your answer refers the user to a task — including a task you just
+created — emit this leaf directive on its own line instead of writing the
+key as plain text:
+
+```md
+::task{key="ABC-12"}
+```
+
+`key` is required. Optionally add `title="…"` as a display fallback shown
+while the card loads and when the key no longer resolves. The rendered card
+shows the live status, title, and priority, opens the task in the thread
+side panel, and links to the full Tasks app. Emit one directive per line;
+each renders its own card.
+
 ## Invariants
 
 - Valid task statuses are `backlog`, `todo`, `in_progress`, `in_review`,

--- a/official-plugins/tasks/views/detail/index.tsx
+++ b/official-plugins/tasks/views/detail/index.tsx
@@ -7,7 +7,6 @@ import {
   useMentionItems,
   useTasksQuery,
   useTasksRpc,
-  type TasksRpc,
 } from "../../shell/data.js";
 import { useTasksNavigation } from "../../shell/routes.js";
 import { TasksEditor } from "../../editor/tasks-editor.js";
@@ -495,18 +494,9 @@ function TaskDetail({ task }: { task: Task }) {
   );
 }
 
-async function fetchTaskByKey(
-  rpc: TasksRpc,
-  taskKey: string,
-): Promise<Task | null> {
-  const { tasks } = await rpc.call("listTasks", {});
-  const wanted = taskKey.toUpperCase();
-  return tasks.find((task) => task.key.toUpperCase() === wanted) ?? null;
-}
-
 export function DetailView({ taskKey }: DetailViewProps) {
   const query = useTasksQuery(
-    (rpc) => fetchTaskByKey(rpc, taskKey),
+    async (rpc) => (await rpc.call("getTaskByKey", { taskKey })).task,
     ["tasks:changed"],
     [taskKey],
   );

--- a/official-plugins/tasks/views/detail/rail.test.tsx
+++ b/official-plugins/tasks/views/detail/rail.test.tsx
@@ -67,6 +67,7 @@ function detailRpc(
     sidebarSummary: () => ({ projects: [] }),
     listTasks: (input: { parentTaskId?: string } | null) =>
       input?.parentTaskId ? { tasks: [] } : { tasks: [task] },
+    getTaskByKey: () => ({ task }),
     listLabels: () => ({ labels: [] }),
     listAttachments: () => ({ attachments: [] }),
     listTaskThreads: () => ({ taskThreads: [] }),

--- a/official-plugins/tasks/views/detail/threads.test.tsx
+++ b/official-plugins/tasks/views/detail/threads.test.tsx
@@ -77,6 +77,7 @@ function detailRpc(overrides: Record<string, unknown> = {}) {
     listFolders: () => ({ folders: [] }),
     listPresets: () => ({ presets: [] }),
     sidebarSummary: () => ({ projects: [] }),
+    getTaskByKey: () => ({ task }),
     listTasks: (input: { parentTaskId?: string } | null) =>
       input?.parentTaskId ? { tasks: [] } : { tasks: [task] },
     listLabels: () => ({ labels: [] }),

--- a/official-plugins/tasks/views/embed/embed.test.tsx
+++ b/official-plugins/tasks/views/embed/embed.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+
+// jsdom lacks matchMedia; the vendored Dialog's responsive root needs it.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+const app = await loadPluginApp(() => import("../../app"));
+
+afterEach(cleanup);
+
+const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
+const TASK_ID = "01HZZZZZZZZZZZZZZZZZZZZZT1";
+
+const task = {
+  id: TASK_ID,
+  projectId: PROJECT_ID,
+  number: 4,
+  key: "TSK-4",
+  title: "Ship task embeds",
+  description: "",
+  status: "in_progress",
+  priority: "high",
+  dueDate: null,
+  parentTaskId: null,
+  position: 100,
+  createdAt: "2026-07-15T00:00:00.000Z",
+  updatedAt: "2026-07-15T00:00:00.000Z",
+  labelIds: [],
+};
+
+function directiveProps(attributes: Record<string, string>) {
+  return {
+    attributes,
+    source: `::task{key="${attributes.key ?? ""}"}`,
+    message: {
+      id: "msg_1",
+      threadId: "thr_1",
+      turnId: "turn_1",
+      projectId: null,
+    },
+    openWorkspaceFile: null,
+    openThreadPanel: null,
+  };
+}
+
+describe("Tasks app slots", () => {
+  it("registers the task directive card and thread panel action", () => {
+    expect(app.messageDirectives).toHaveLength(1);
+    expect(app.messageDirectives[0]?.id).toBe("task");
+    expect(app.threadPanelActions[0]).toMatchObject({
+      id: "task",
+      title: "Task",
+    });
+  });
+});
+
+describe("Task directive card", () => {
+  it("renders live task data with a complete accessible name", async () => {
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-4" }), {
+      rpc: { getTaskByKey: () => ({ task }) },
+    });
+
+    const main = await slot.findByRole("button", {
+      name: "TSK-4 — Ship task embeds, in progress, high priority — open in side panel",
+    });
+    expect(main).toBeTruthy();
+    expect(slot.rpcCalls).toContainEqual({
+      method: "getTaskByKey",
+      input: { taskKey: "TSK-4" },
+    });
+    // Visible key/title/glyphs are duplicated by the accessible name and
+    // must stay hidden from the accessibility tree.
+    expect(slot.getByText("TSK-4").closest("[aria-hidden]")).toBeTruthy();
+  });
+
+  it("omits the priority glyph and spoken priority when priority is none", async () => {
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-4" }), {
+      rpc: { getTaskByKey: () => ({ task: { ...task, priority: "none" } }) },
+    });
+    const main = await slot.findByRole("button", {
+      name: "TSK-4 — Ship task embeds, in progress — open in side panel",
+    });
+    expect(main.querySelectorAll("svg")).toHaveLength(1);
+  });
+
+  it("opens the side panel on primary click and the Tasks app from the arrow", async () => {
+    const openThreadPanel = vi.fn(() => true);
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      { ...directiveProps({ key: "TSK-4" }), openThreadPanel },
+      { rpc: { getTaskByKey: () => ({ task }) } },
+    );
+
+    fireEvent.click(await slot.findByText("Ship task embeds"));
+    expect(openThreadPanel).toHaveBeenCalledWith({
+      actionId: "task",
+      title: "TSK-4",
+      params: { taskKey: "TSK-4" },
+    });
+
+    fireEvent.click(slot.getByRole("button", { name: "Open TSK-4 in Tasks" }));
+    expect(slot.navigateCalls).toContainEqual({
+      method: "toPluginPanel",
+      path: "tasks",
+      options: { subPath: "task/TSK-4" },
+    });
+  });
+
+  it("falls back to the Tasks app when no side panel is available", async () => {
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-4" }), {
+      rpc: { getTaskByKey: () => ({ task }) },
+    });
+    fireEvent.click(await slot.findByText("Ship task embeds"));
+    expect(slot.navigateCalls).toContainEqual({
+      method: "toPluginPanel",
+      path: "tasks",
+      options: { subPath: "task/TSK-4" },
+    });
+  });
+
+  it("shows the title fallback while loading and keeps it when not found", async () => {
+    let resolveFetch: (value: { task: null }) => void;
+    const pending = new Promise<{ task: null }>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      directiveProps({ key: "TSK-9", title: "Old embed work" }),
+      { rpc: { getTaskByKey: () => pending } },
+    );
+
+    const loading = slot.getByRole("status", { name: "Loading task TSK-9" });
+    expect(loading.textContent).toContain("Old embed work");
+
+    resolveFetch!({ task: null });
+    await slot.findByText("Old embed work · not found");
+    fireEvent.click(slot.getByRole("button", { name: "Open Tasks" }));
+    expect(slot.navigateCalls).toContainEqual({
+      method: "toPluginPanel",
+      path: "tasks",
+      options: {},
+    });
+  });
+
+  it("renders the generic not-found copy without a title fallback", async () => {
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-9" }), {
+      rpc: { getTaskByKey: () => ({ task: null }) },
+    });
+    await slot.findByText("Task not found — deleted, or its key changed");
+  });
+
+  it("rejects malformed keys without calling the backend", () => {
+    for (const attributes of [{}, { key: "  " }, { key: "not a key" }]) {
+      const slot = renderSlot(app.messageDirectives[0]!, directiveProps(attributes), {
+        rpc: {},
+      });
+      slot.getByText("Invalid task link. Expected a task key like TSK-4.");
+      expect(slot.rpcCalls).toHaveLength(0);
+      cleanup();
+    }
+  });
+
+  it("offers a retry that refetches after a transport error", async () => {
+    let fail = true;
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-4" }), {
+      rpc: {
+        getTaskByKey: () => {
+          if (fail) throw new Error("boom");
+          return { task };
+        },
+      },
+    });
+    const retry = await slot.findByRole("button", { name: "Retry" });
+    fail = false;
+    fireEvent.click(retry);
+    await slot.findByText("Ship task embeds");
+  });
+
+  it("refetches on matching realtime payloads and ignores unrelated ones", async () => {
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-4" }), {
+      rpc: { getTaskByKey: () => ({ task }) },
+    });
+    await slot.findByText("Ship task embeds");
+    const calls = () =>
+      slot.rpcCalls.filter((call) => call.method === "getTaskByKey").length;
+    const baseline = calls();
+
+    await slot.emitRealtime("tasks:changed", {
+      taskId: "01HZZZZZZZZZZZZZZZZZZZZZT9",
+      projectId: PROJECT_ID,
+    });
+    await slot.emitRealtime("projects:changed", {
+      projectId: "01HZZZZZZZZZZZZZZZZZZZZZP9",
+    });
+    expect(calls()).toBe(baseline);
+
+    await slot.emitRealtime("tasks:changed", {
+      taskId: TASK_ID,
+      projectId: PROJECT_ID,
+    });
+    await waitFor(() => expect(calls()).toBe(baseline + 1));
+
+    await slot.emitRealtime("projects:changed", { projectId: PROJECT_ID });
+    await waitFor(() => expect(calls()).toBe(baseline + 2));
+  });
+
+  it("refetches an unresolved card on any tasks event so new tasks appear", async () => {
+    let created = false;
+    const slot = renderSlot(app.messageDirectives[0]!, directiveProps({ key: "TSK-4" }), {
+      rpc: { getTaskByKey: () => ({ task: created ? task : null }) },
+    });
+    await slot.findByText("Task not found — deleted, or its key changed");
+    created = true;
+    await slot.emitRealtime("tasks:changed", {
+      taskId: TASK_ID,
+      projectId: PROJECT_ID,
+    });
+    await slot.findByText("Ship task embeds");
+  });
+});
+
+describe("Task embed panel", () => {
+  it("renders the task detail for the panel params and links to the app", async () => {
+    const slot = renderSlot(
+      app.threadPanelActions[0]!,
+      { threadId: "thr_1", params: { taskKey: "TSK-4" } },
+      {
+        rpc: {
+          getTaskByKey: () => ({ task }),
+          listProjects: () => ({ projects: [] }),
+          getTask: () => ({ task: null }),
+          listTasks: () => ({ tasks: [] }),
+          listLabels: () => ({ labels: [] }),
+          listAttachments: () => ({ attachments: [] }),
+          listTaskThreads: () => ({ taskThreads: [] }),
+          listPresets: () => ({ presets: [] }),
+          listComments: () => ({ comments: [] }),
+          searchThreads: () => ({ threads: [] }),
+        },
+      },
+    );
+    await slot.findByRole("textbox", { name: "Task title" });
+    fireEvent.click(slot.getByRole("button", { name: "Open TSK-4 in Tasks" }));
+    expect(slot.navigateCalls).toContainEqual({
+      method: "toPluginPanel",
+      path: "tasks",
+      options: { subPath: "task/TSK-4" },
+    });
+  });
+
+  it("shows a hint when opened without a task key", () => {
+    const slot = renderSlot(
+      app.threadPanelActions[0]!,
+      { threadId: "thr_1", params: null },
+      { rpc: {} },
+    );
+    slot.getByText("Open a task card from a message to view it here.");
+  });
+});

--- a/official-plugins/tasks/views/embed/index.tsx
+++ b/official-plugins/tasks/views/embed/index.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  PluginMessageDirectiveProps,
+  PluginThreadPanelProps,
+} from "@bb/plugin-sdk";
+import { useBbNavigate, useRealtime } from "@bb/plugin-sdk/app";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { Skeleton } from "@bb/shared-ui/skeleton";
+import type { Task } from "../../shared/contract.js";
+import { useTasksRpc } from "../../shell/data.js";
+import { PANEL_PATH, tasksRouteToSubPath } from "../../shell/routes.js";
+import { DetailView } from "../detail/index.js";
+import { PRIORITY_LABELS, STATUS_LABELS } from "../detail/meta.js";
+import { PriorityIcon, StatusIcon } from "../list/icons.js";
+
+/**
+ * `::task{key="TSK-4"}` chat embeds: a single quiet row (status glyph, key,
+ * title, priority glyph, open arrow). Primary click opens the task in the
+ * thread side panel; the arrow opens the full Tasks app. Everything richer —
+ * due date, labels, comments, threads, editing — lives in those surfaces.
+ */
+
+const TASK_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9]{0,9}-\d+$/;
+
+type TaskEmbedState =
+  | { kind: "loading" }
+  | { kind: "found"; task: Task }
+  | { kind: "not_found" }
+  | { kind: "error" };
+
+/**
+ * Fetch a task by key and keep it fresh. Unlike `useTasksQuery`, realtime
+ * refetches are payload-filtered: a resolved card refetches only for events
+ * about its own task or project, so one mutation does not refetch every
+ * embed mounted in a long thread. While unresolved (loading / not found /
+ * error) any event refetches — the task may have just been created or
+ * renamed into existence.
+ */
+export function useTaskEmbed(taskKey: string): {
+  state: TaskEmbedState;
+  retry: () => void;
+} {
+  const rpc = useTasksRpc();
+  const [state, setState] = useState<TaskEmbedState>({ kind: "loading" });
+  const seqRef = useRef(0);
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const refresh = useCallback(() => {
+    // Blank key ⇒ the caller is rendering the invalid-attributes notice and
+    // this hook only runs to satisfy the rules of hooks; never fetch.
+    if (taskKey === "") return;
+    const seq = ++seqRef.current;
+    rpc.call("getTaskByKey", { taskKey }).then(
+      ({ task }) => {
+        if (seq !== seqRef.current) return;
+        setState(task ? { kind: "found", task } : { kind: "not_found" });
+      },
+      () => {
+        if (seq !== seqRef.current) return;
+        setState({ kind: "error" });
+      },
+    );
+  }, [rpc, taskKey]);
+
+  useEffect(() => {
+    setState({ kind: "loading" });
+    refresh();
+  }, [refresh]);
+
+  const onEvent = useCallback(
+    (matches: (task: Task) => boolean) => {
+      const current = stateRef.current;
+      if (current.kind !== "found" || matches(current.task)) refresh();
+    },
+    [refresh],
+  );
+  useRealtime("tasks:changed", (payload) => {
+    const taskId = isRecord(payload) ? payload.taskId : undefined;
+    onEvent((task) => typeof taskId !== "string" || taskId === task.id);
+  });
+  useRealtime("projects:changed", (payload) => {
+    const projectId = isRecord(payload) ? payload.projectId : undefined;
+    onEvent(
+      (task) => typeof projectId !== "string" || projectId === task.projectId,
+    );
+  });
+
+  return { state, retry: refresh };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function taskDetailSubPath(taskKey: string): string {
+  return tasksRouteToSubPath({ kind: "task", taskKey });
+}
+
+function OpenInTasksButton({
+  label,
+  subPath,
+}: {
+  label: string;
+  subPath?: string;
+}) {
+  const navigate = useBbNavigate();
+  return (
+    <Button
+      className="size-8 shrink-0"
+      size="icon"
+      variant="ghost"
+      aria-label={label}
+      onClick={() =>
+        navigate.toPluginPanel(PANEL_PATH, subPath === undefined ? {} : { subPath })
+      }
+    >
+      <Icon name="ArrowUpRight" className="size-4" />
+    </Button>
+  );
+}
+
+function CardShell({
+  dashed = false,
+  children,
+}: {
+  dashed?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={
+        dashed
+          ? "my-3 flex h-11 items-center gap-1 rounded-lg border border-dashed border-border bg-surface-recessed-solid px-2"
+          : "my-3 flex h-11 items-center gap-1 rounded-lg border border-border bg-card px-2 shadow-sm transition-colors hover:bg-state-hover"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function embedAriaLabel(task: Task): string {
+  const parts = [
+    `${task.key} — ${task.title}`,
+    STATUS_LABELS[task.status].toLowerCase(),
+  ];
+  if (task.priority !== "none") {
+    parts.push(`${PRIORITY_LABELS[task.priority].toLowerCase()} priority`);
+  }
+  return `${parts.join(", ")} — open in side panel`;
+}
+
+export function TaskDirectiveCard({
+  attributes,
+  openThreadPanel,
+}: PluginMessageDirectiveProps) {
+  const navigate = useBbNavigate();
+  const taskKey = attributes.key?.trim() ?? "";
+  const fallbackTitle = attributes.title?.trim() || null;
+  const validKey = TASK_KEY_PATTERN.test(taskKey);
+  const { state, retry } = useTaskEmbed(validKey ? taskKey : "");
+
+  if (!validKey) {
+    return (
+      <div className="my-3 rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+        Invalid task link. Expected a task key like TSK-4.
+      </div>
+    );
+  }
+
+  if (state.kind === "loading") {
+    return (
+      <CardShell>
+        <div
+          role="status"
+          aria-label={`Loading task ${taskKey}`}
+          className="flex min-w-0 flex-1 items-center gap-2 px-1"
+        >
+          <Skeleton className="size-3.5 shrink-0 rounded-full" />
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">
+            {taskKey}
+          </span>
+          {fallbackTitle ? (
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-muted-foreground">
+              {fallbackTitle}
+            </span>
+          ) : (
+            <Skeleton className="h-3.5 w-1/2" />
+          )}
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (state.kind === "not_found") {
+    return (
+      <CardShell dashed>
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-1">
+          <StatusIcon status="backlog" />
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">
+            {taskKey}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+            {fallbackTitle
+              ? `${fallbackTitle} · not found`
+              : "Task not found — deleted, or its key changed"}
+          </span>
+        </div>
+        <OpenInTasksButton label="Open Tasks" />
+      </CardShell>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <CardShell dashed>
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-1">
+          <Icon
+            name="AlertCircle"
+            className="size-3.5 shrink-0 text-muted-foreground"
+          />
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">
+            {taskKey}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+            Couldn't load this task
+          </span>
+        </div>
+        <Button variant="ghost" size="sm" className="shrink-0" onClick={retry}>
+          Retry
+        </Button>
+      </CardShell>
+    );
+  }
+
+  const { task } = state;
+  const openInSidePanel = () => {
+    const opened =
+      openThreadPanel?.({
+        actionId: "task",
+        title: task.key,
+        params: { taskKey: task.key },
+      }) ?? false;
+    if (!opened) {
+      navigate.toPluginPanel(PANEL_PATH, {
+        subPath: taskDetailSubPath(task.key),
+      });
+    }
+  };
+
+  return (
+    <CardShell>
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-1 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        aria-label={embedAriaLabel(task)}
+        onClick={openInSidePanel}
+      >
+        <span aria-hidden>
+          <StatusIcon status={task.status} />
+        </span>
+        <span
+          aria-hidden
+          className="shrink-0 font-mono text-xs text-muted-foreground"
+        >
+          {task.key}
+        </span>
+        <span
+          aria-hidden
+          className="min-w-0 flex-1 truncate text-sm font-medium"
+        >
+          {task.title}
+        </span>
+        {task.priority !== "none" ? (
+          <span aria-hidden className="shrink-0">
+            <PriorityIcon priority={task.priority} />
+          </span>
+        ) : null}
+      </button>
+      <OpenInTasksButton
+        label={`Open ${task.key} in Tasks`}
+        subPath={taskDetailSubPath(task.key)}
+      />
+    </CardShell>
+  );
+}
+
+/**
+ * Thread side-panel tab opened by the directive card: the full task-detail
+ * composition (editing, comments, attachments, delegation) rendered
+ * panel-sized — TaskDetail's own container queries adapt the layout.
+ */
+export function TaskEmbedPanel({ params }: PluginThreadPanelProps) {
+  const taskKey =
+    isRecord(params) && typeof params.taskKey === "string"
+      ? params.taskKey
+      : null;
+  if (taskKey === null || !TASK_KEY_PATTERN.test(taskKey.trim())) {
+    return (
+      <div className="p-3 text-sm text-muted-foreground">
+        Open a task card from a message to view it here.
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border pb-2">
+        <div className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+          {taskKey.trim()}
+        </div>
+        <OpenInTasksButton
+          label={`Open ${taskKey.trim()} in Tasks`}
+          subPath={taskDetailSubPath(taskKey.trim())}
+        />
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <DetailView taskKey={taskKey.trim()} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Agents can now reference tasks in assistant messages with `::task{key="TSK-4"}` leaf directives; the Tasks plugin renders them as a single quiet row — status glyph, key, live title, priority glyph (omitted for priority `none`), and an open arrow — through the existing message-directive pipeline (no host changes). This PR started as a design deliverable (interactive mock + spec, reviewed and approved on BB-18); per Sawyer's direction the branch now ships the production implementation and the design artifacts are not checked in (they live as BB-18 attachments).

- **Card behavior**: primary click opens the task in a persistent thread side-panel tab (new `threadPanelAction` `task` reusing the full task-detail composition — editing, comments, attachments, delegation); the arrow (and the fallback when no side panel exists) opens the Tasks app at `task/<key>`, matching the Docs card's interaction grammar. The chat card itself is read-only.
- **Data**: new `getTaskByKey` RPC resolves `PREFIX-number` keys case-insensitively with one targeted `WHERE` query. Malformed/unknown keys degrade to `null` → a calm dashed not-found card (the directive's `title` attribute renders as a muted fallback there and during loading); transport errors get a Retry card; invalid attributes get the destructive notice, like Docs.
- **Realtime**: cards refresh on `tasks:changed`/`projects:changed` with payload `taskId`/`projectId` filtering, so one mutation doesn't refetch every embed in a long thread; unresolved cards refetch on any event so newly created keys appear.
- **Accessibility**: the primary region carries a complete accessible name ("EMB-1 — Ship inline task embeds, in progress, high priority — open in side panel"); the visual glyph/key/title strip is `aria-hidden`; the loading row is `role="status"`.
- **Cleanup**: `DetailView`'s key lookup switches from a listTasks scan-and-filter to the same targeted RPC.
- **Agent surface**: the tasks SKILL.md documents the directive so agents emit it when referring to or creating tasks (`bb tasks show` already covers data access; no new CLI surface).

## Validation

- `turbo typecheck`, `turbo build`, and the full plugin suite via `turbo test` — 176/176 passing, including new tests for the RPC (found / case-insensitive / degraded keys), card states + accessible names, side-panel and fallback navigation, title fallback, retry, payload-filtered realtime refresh (matching payloads refetch, unrelated ones don't), and the panel tab.
- End-to-end in the real app via `scripts/bb-dev-app`: installed the tasks plugin in a fresh dev instance, spawned a codex thread that replied with `::task{key="EMB-1"}` and a bogus `::task{key="EMB-99" title="Old embed work"}` — the found card rendered with live status/priority, the bogus one rendered the dashed not-found fallback; clicking the card opened the EMB-1 side-panel tab with full editing; `bb tasks update EMB-1 --status done --priority none` updated the mounted card live (green done glyph, priority glyph removed, accessible name updated) without reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)