### PR TITLE
BB-17: paste images and attach files during task creation

### DIFF
--- a/official-plugins/tasks/README.md
+++ b/official-plugins/tasks/README.md
@@ -63,7 +63,7 @@ Run `bb tasks --help` or `bb tasks <command> --help` for exact options. Add
 | `bb tasks status` | Show the installed Tasks plugin name and version. |
 | `bb tasks project create\|list\|show\|update` | Manage tracker projects, folders, colors, prefixes, and bb-project links. |
 | `bb tasks folder create\|list\|update` | Organize tracker projects into nested folders. |
-| `bb tasks create` | Create a task with description, priority, labels, due date, and optional parent. |
+| `bb tasks create` | Create a task with description, priority, labels, due date, optional parent, and file attachments (repeatable `--attach <path>`). |
 | `bb tasks list` | Filter tasks by project, status, priority, label, active agents, or search text; `--sort priority\|due` orders the results. |
 | `bb tasks show <key-or-id>` | Show the complete task record, including comments, attachments, subtasks, and attached threads. |
 | `bb tasks update <key-or-id>` | Update status, priority, title, description, due date, or labels. |

--- a/official-plugins/tasks/cli/cli.test.ts
+++ b/official-plugins/tasks/cli/cli.test.ts
@@ -611,6 +611,100 @@ describe("bb tasks CLI", () => {
     await harness.dispose();
   });
 
+  it("creates a task with --attach files after validating every source path", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "bb-tasks-cli-"));
+    const notesPath = join(directory, "notes.txt");
+    const pngPath = join(directory, "pixel.png");
+    await writeFile(notesPath, "attach me at create\n", "utf8");
+    await writeFile(
+      pngPath,
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    const { bb, harness } = createFakePluginHost({ pluginId: "tasks" });
+    await plugin(bb);
+
+    try {
+      stdout(
+        await harness.runCli([
+          "project",
+          "create",
+          "--name",
+          "Attach",
+          "--prefix",
+          "ATT",
+        ]),
+      );
+
+      // A bad path fails before anything is created — no half-built task.
+      const missing = await harness.runCli([
+        "create",
+        "--project",
+        "att",
+        "--title",
+        "Broken attach",
+        "--attach",
+        join(directory, "missing.bin"),
+      ]);
+      expect(missing.exitCode).toBe(1);
+      expect(missing.stderr).toContain("attachment source is not a file");
+      expect(
+        JSON.parse(
+          stdout(await harness.runCli(["list", "--project", "att", "--json"])),
+        ).tasks,
+      ).toEqual([]);
+
+      const created = JSON.parse(
+        stdout(
+          await harness.runCli([
+            "create",
+            "--project",
+            "att",
+            "--title",
+            "Starts with files",
+            "--attach",
+            notesPath,
+            "--attach",
+            pngPath,
+            "--json",
+          ]),
+        ),
+      );
+      expect(created.task).toMatchObject({ key: "ATT-1" });
+      expect(created.attachments).toEqual([
+        expect.objectContaining({
+          taskId: created.task.id,
+          commentId: null,
+          fileName: "notes.txt",
+          isImage: false,
+        }),
+        expect.objectContaining({
+          taskId: created.task.id,
+          commentId: null,
+          fileName: "pixel.png",
+          mime: "image/png",
+          isImage: true,
+        }),
+      ]);
+
+      const outputPath = join(directory, "roundtrip.txt");
+      stdout(
+        await harness.runCli([
+          "attachment",
+          "get",
+          created.attachments[0].id,
+          "--out",
+          outputPath,
+        ]),
+      );
+      expect(await readFile(outputPath, "utf8")).toBe(
+        "attach me at create\n",
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+      await harness.dispose();
+    }
+  });
+
   it("adds and downloads an attachment with an exact file round-trip", async () => {
     const directory = await mkdtemp(join(tmpdir(), "bb-tasks-cli-"));
     const inputPath = join(directory, "input.txt");

--- a/official-plugins/tasks/cli/cli.test.ts
+++ b/official-plugins/tasks/cli/cli.test.ts
@@ -1,10 +1,28 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, truncate, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import plugin from "../server";
+
+// Passthrough mock with one injectable failure: files named boom.bin fail at
+// blob-write time, simulating a post-preflight persistence error so the
+// create --attach partial-failure path is deterministic.
+vi.mock("../attachments", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../attachments")>();
+  const saveAttachmentFromPath: typeof actual.saveAttachmentFromPath = async (
+    store,
+    sourcePath,
+    options,
+  ) => {
+    if (sourcePath.endsWith("boom.bin")) {
+      throw new Error("simulated blob write failure");
+    }
+    return actual.saveAttachmentFromPath(store, sourcePath, options);
+  };
+  return { ...actual, saveAttachmentFromPath };
+});
 
 function stdout(result: {
   exitCode: number;
@@ -647,6 +665,23 @@ describe("bb tasks CLI", () => {
       ]);
       expect(missing.exitCode).toBe(1);
       expect(missing.stderr).toContain("attachment source is not a file");
+
+      // Preflight also enforces the shared 25 MB upload limit.
+      const hugePath = join(directory, "huge.bin");
+      await writeFile(hugePath, "");
+      await truncate(hugePath, 25 * 1024 * 1024 + 1);
+      const oversized = await harness.runCli([
+        "create",
+        "--project",
+        "att",
+        "--title",
+        "Oversized attach",
+        "--attach",
+        hugePath,
+      ]);
+      expect(oversized.exitCode).toBe(1);
+      expect(oversized.stderr).toContain("exceeds the 25 MB limit");
+
       expect(
         JSON.parse(
           stdout(await harness.runCli(["list", "--project", "att", "--json"])),
@@ -670,6 +705,7 @@ describe("bb tasks CLI", () => {
         ),
       );
       expect(created.task).toMatchObject({ key: "ATT-1" });
+      expect(created.failedAttachments).toEqual([]);
       expect(created.attachments).toEqual([
         expect.objectContaining({
           taskId: created.task.id,
@@ -698,6 +734,91 @@ describe("bb tasks CLI", () => {
       );
       expect(await readFile(outputPath, "utf8")).toBe(
         "attach me at create\n",
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+      await harness.dispose();
+    }
+  });
+
+  it("attempts every --attach file after create and reports failures truthfully", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "bb-tasks-cli-"));
+    const firstPath = join(directory, "first.txt");
+    const boomPath = join(directory, "boom.bin");
+    const lastPath = join(directory, "last.txt");
+    await writeFile(firstPath, "first", "utf8");
+    await writeFile(boomPath, "will fail at blob write", "utf8");
+    await writeFile(lastPath, "last", "utf8");
+    const { bb, harness } = createFakePluginHost({ pluginId: "tasks" });
+    await plugin(bb);
+
+    try {
+      stdout(
+        await harness.runCli([
+          "project",
+          "create",
+          "--name",
+          "Mixed",
+          "--prefix",
+          "MIX",
+        ]),
+      );
+
+      // JSON mode: middle file fails, both neighbors are still attempted.
+      const mixed = await harness.runCli([
+        "create",
+        "--project",
+        "mix",
+        "--title",
+        "Mixed outcome",
+        "--attach",
+        firstPath,
+        "--attach",
+        boomPath,
+        "--attach",
+        lastPath,
+        "--json",
+      ]);
+      expect(mixed.exitCode).toBe(1);
+      expect(mixed.stderr).toContain("1 of 3 attachments failed");
+      const payload = JSON.parse(mixed.stdout);
+      expect(payload.task).toMatchObject({ key: "MIX-1" });
+      expect(
+        payload.attachments.map((attachment: { fileName: string }) =>
+          attachment.fileName,
+        ),
+      ).toEqual(["first.txt", "last.txt"]);
+      expect(payload.failedAttachments).toEqual([
+        { path: boomPath, error: "simulated blob write failure" },
+      ]);
+      // Both successes really persisted on the created task.
+      const listed = JSON.parse(
+        stdout(
+          await harness.runCli(["attachment", "list", "MIX-1", "--json"]),
+        ),
+      );
+      expect(listed.attachments).toHaveLength(2);
+
+      // Human mode reports the same outcome with a per-file recovery command.
+      const human = await harness.runCli([
+        "create",
+        "--project",
+        "mix",
+        "--title",
+        "Mixed outcome again",
+        "--attach",
+        firstPath,
+        "--attach",
+        boomPath,
+      ]);
+      expect(human.exitCode).toBe(1);
+      expect(human.stdout).toContain("Created MIX-2");
+      expect(human.stdout).toContain("Attached first.txt");
+      expect(human.stdout).toContain(
+        `Failed to attach ${boomPath}: simulated blob write failure`,
+      );
+      expect(human.stdout).toContain(
+        `Retry with: bb tasks attachment add MIX-2 --file ${boomPath}`,
       );
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/official-plugins/tasks/cli/index.ts
+++ b/official-plugins/tasks/cli/index.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { stat } from "node:fs/promises";
+import { constants, readFileSync } from "node:fs";
+import { access, stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import type {
   BbPluginApi,
@@ -16,6 +16,7 @@ import {
 } from "../api";
 import {
   buildAttachmentUrl,
+  MAX_ATTACHMENT_SIZE_BYTES,
   publishAttachmentChanged,
   readAttachmentToPath,
   saveAttachmentFromPath,
@@ -690,7 +691,7 @@ async function runCreate(
   domain: TasksDomain,
   ctx: PluginCliContext,
   argv: string[],
-): Promise<string> {
+): Promise<string | PluginCliResult> {
   const args = parseArgs(argv);
   if (args.flags.has("help")) return CREATE_HELP;
   assertAllowed(args, [
@@ -705,8 +706,8 @@ async function runCreate(
     "attach",
   ]);
   requirePositionals(args, 0, CREATE_HELP);
-  // Validate attachment sources before creating anything so a typo'd path
-  // cannot leave behind a half-built task.
+  // Validate attachment sources against every upload constraint before
+  // creating anything, so a bad path cannot leave behind a half-built task.
   const attachPaths = options(args, "attach").map((path) =>
     resolve(ctx.cwd ?? process.cwd(), path),
   );
@@ -716,6 +717,12 @@ async function runCreate(
       if (!source?.isFile()) {
         throw new CliError(`attachment source is not a file: ${path}`);
       }
+      if (source.size > MAX_ATTACHMENT_SIZE_BYTES) {
+        throw new CliError(`attachment exceeds the 25 MB limit: ${path}`);
+      }
+      await access(path, constants.R_OK).catch(() => {
+        throw new CliError(`attachment source is not readable: ${path}`);
+      });
     }),
   );
   const project = await selectedProject(
@@ -746,7 +753,10 @@ async function runCreate(
   const task = unwrapTask(
     tasksRpcContract.createTask.output.parse(await domain.createTask(input)),
   );
+  // The task exists now, so every file gets attempted and truthfully
+  // reported; stopping at the first failure would hide the rest.
   const attachments: Attachment[] = [];
+  const failedAttachments: Array<{ path: string; error: string }> = [];
   for (const sourcePath of attachPaths) {
     try {
       const attachment = await saveAttachmentFromPath(store.tasks, sourcePath, {
@@ -755,22 +765,35 @@ async function runCreate(
       publishAttachmentChanged(bb, store.tasks, attachment);
       attachments.push(attachment);
     } catch (error) {
-      throw new CliError(
-        `created ${task.key}, but attaching ${sourcePath} failed: ${
-          error instanceof Error ? error.message : String(error)
-        }. Retry with: bb tasks attachment add ${task.key} --file <path>`,
-      );
+      failedAttachments.push({
+        path: sourcePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
-  return args.flags.has("json")
-    ? json({ task, attachments })
+  const stdout = args.flags.has("json")
+    ? json({ task, attachments, failedAttachments })
     : [
         `Created ${task.key}  ${task.title}`,
         ...attachments.map(
-          (attachment) =>
-            `Attached ${attachment.fileName}  ${attachment.id}`,
+          (attachment) => `Attached ${attachment.fileName}  ${attachment.id}`,
         ),
+        ...failedAttachments.map(
+          (failure) => `Failed to attach ${failure.path}: ${failure.error}`,
+        ),
+        ...(failedAttachments.length > 0
+          ? failedAttachments.map(
+              (failure) =>
+                `Retry with: bb tasks attachment add ${task.key} --file ${failure.path}`,
+            )
+          : []),
       ].join("\n");
+  if (failedAttachments.length === 0) return stdout;
+  return {
+    exitCode: 1,
+    stdout,
+    stderr: `created ${task.key}, but ${failedAttachments.length} of ${attachPaths.length} attachments failed; see stdout for per-file recovery commands`,
+  };
 }
 
 async function labelsForTaskList(
@@ -1707,9 +1730,14 @@ export function registerTasksCli(
           case "folder":
             stdout = await runFolder(bb, store, domain, rest);
             break;
-          case "create":
-            stdout = await runCreate(bb, store, domain, ctx, rest);
+          case "create": {
+            const result = await runCreate(bb, store, domain, ctx, rest);
+            // Partial attachment failure returns a full result: truthful
+            // stdout (task + per-file outcomes) with a non-zero exit.
+            if (typeof result !== "string") return result;
+            stdout = result;
             break;
+          }
           case "list":
             stdout = await runList(domain, ctx, rest);
             break;

--- a/official-plugins/tasks/cli/index.ts
+++ b/official-plugins/tasks/cli/index.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import type {
   BbPluginApi,
@@ -86,7 +87,7 @@ const FOLDER_HELP = `Usage:
   bb tasks folder update <id-or-name> [--name <name>] [--parent <id-or-name> | --no-parent] [--json]`;
 
 const CREATE_HELP =
-  "Usage: bb tasks create [--project <prefix-or-id>] --title <title> [--description <markdown> | --description-file <path>] [--priority <priority>] [--label <name>]... [--due YYYY-MM-DD] [--parent <key-or-id>] [--json]";
+  "Usage: bb tasks create [--project <prefix-or-id>] --title <title> [--description <markdown> | --description-file <path>] [--priority <priority>] [--label <name>]... [--due YYYY-MM-DD] [--parent <key-or-id>] [--attach <path>]... [--json]";
 const LIST_HELP =
   "Usage: bb tasks list [--project <prefix-or-id>] [--status <status>]... [--priority <priority>]... [--label <name>]... [--active] [--search <query>] [--sort manual|priority|due] [--json]";
 const SHOW_HELP = "Usage: bb tasks show <key-or-id> [--json]";
@@ -684,6 +685,8 @@ async function runFolder(
 }
 
 async function runCreate(
+  bb: BbPluginApi,
+  store: TasksApiStore,
   domain: TasksDomain,
   ctx: PluginCliContext,
   argv: string[],
@@ -699,8 +702,22 @@ async function runCreate(
     "label",
     "due",
     "parent",
+    "attach",
   ]);
   requirePositionals(args, 0, CREATE_HELP);
+  // Validate attachment sources before creating anything so a typo'd path
+  // cannot leave behind a half-built task.
+  const attachPaths = options(args, "attach").map((path) =>
+    resolve(ctx.cwd ?? process.cwd(), path),
+  );
+  await Promise.all(
+    attachPaths.map(async (path) => {
+      const source = await stat(path).catch(() => null);
+      if (!source?.isFile()) {
+        throw new CliError(`attachment source is not a file: ${path}`);
+      }
+    }),
+  );
   const project = await selectedProject(
     domain,
     ctx,
@@ -729,9 +746,31 @@ async function runCreate(
   const task = unwrapTask(
     tasksRpcContract.createTask.output.parse(await domain.createTask(input)),
   );
+  const attachments: Attachment[] = [];
+  for (const sourcePath of attachPaths) {
+    try {
+      const attachment = await saveAttachmentFromPath(store.tasks, sourcePath, {
+        taskId: task.id,
+      });
+      publishAttachmentChanged(bb, store.tasks, attachment);
+      attachments.push(attachment);
+    } catch (error) {
+      throw new CliError(
+        `created ${task.key}, but attaching ${sourcePath} failed: ${
+          error instanceof Error ? error.message : String(error)
+        }. Retry with: bb tasks attachment add ${task.key} --file <path>`,
+      );
+    }
+  }
   return args.flags.has("json")
-    ? json({ task })
-    : `Created ${task.key}  ${task.title}`;
+    ? json({ task, attachments })
+    : [
+        `Created ${task.key}  ${task.title}`,
+        ...attachments.map(
+          (attachment) =>
+            `Attached ${attachment.fileName}  ${attachment.id}`,
+        ),
+      ].join("\n");
 }
 
 async function labelsForTaskList(
@@ -1669,7 +1708,7 @@ export function registerTasksCli(
             stdout = await runFolder(bb, store, domain, rest);
             break;
           case "create":
-            stdout = await runCreate(domain, ctx, rest);
+            stdout = await runCreate(bb, store, domain, ctx, rest);
             break;
           case "list":
             stdout = await runList(domain, ctx, rest);

--- a/official-plugins/tasks/components/staged-attachments.tsx
+++ b/official-plugins/tasks/components/staged-attachments.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon, File01Icon } from "@hugeicons/core-free-icons";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { formatFileSize } from "../views/activity/time.js";
+import type { AttachmentOwnerRef } from "../views/detail/attachments.js";
+
+/** Frontend mirror of attachments/index.ts `MAX_ATTACHMENT_SIZE_BYTES`. */
+export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+export interface StagedAttachment {
+  id: number;
+  file: File;
+  /**
+   * staged: waiting for send · oversized: rejected at pick time, never sent ·
+   * failed: the owner was created but this upload failed; retry targets owner.
+   */
+  status: "staged" | "oversized" | "failed";
+  owner?: AttachmentOwnerRef;
+  error?: string;
+}
+
+let nextStagedId = 0;
+
+/** Size-validates picked files: oversized ones become rejected chips. */
+export function stageFiles(files: readonly File[]): StagedAttachment[] {
+  return files.map((file) =>
+    file.size > MAX_ATTACHMENT_BYTES
+      ? {
+          id: nextStagedId++,
+          file,
+          status: "oversized" as const,
+          error: `Over the 25 MB attachment limit (${formatFileSize(file.size)})`,
+        }
+      : { id: nextStagedId++, file, status: "staged" as const },
+  );
+}
+
+function ChipThumbnail({ file }: { file: File }) {
+  // jsdom has no URL.createObjectURL; fall back to the generic file icon.
+  const previewUrl = useMemo(
+    () =>
+      file.type.startsWith("image/") &&
+      typeof URL.createObjectURL === "function"
+        ? URL.createObjectURL(file)
+        : null,
+    [file],
+  );
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+  if (!previewUrl) return null;
+  return (
+    <img
+      src={previewUrl}
+      alt=""
+      aria-hidden
+      className="size-5 shrink-0 rounded-sm border border-border object-cover"
+    />
+  );
+}
+
+export function AttachmentChip({
+  entry,
+  onRemove,
+  onRetry,
+}: {
+  entry: StagedAttachment;
+  onRemove: () => void;
+  onRetry?: () => void;
+}) {
+  const broken = entry.status !== "staged";
+  const image = entry.file.type.startsWith("image/");
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs",
+        broken
+          ? "border-destructive/50 bg-destructive/10 text-destructive"
+          : "border-border bg-background",
+      )}
+      title={entry.error}
+    >
+      {!broken && image ? (
+        <ChipThumbnail file={entry.file} />
+      ) : (
+        <HugeiconsIcon
+          icon={File01Icon}
+          className={cn("size-3", broken ? undefined : "text-muted-foreground")}
+        />
+      )}
+      <span className="max-w-40 truncate">{entry.file.name}</span>
+      <span
+        className={cn(
+          "text-2xs",
+          broken ? "text-destructive/80" : "text-muted-foreground",
+        )}
+      >
+        {formatFileSize(entry.file.size)}
+      </span>
+      {entry.status === "failed" && onRetry ? (
+        <button
+          type="button"
+          aria-label={`Retry upload of ${entry.file.name}`}
+          className="font-medium underline underline-offset-2"
+          onClick={onRetry}
+        >
+          Retry
+        </button>
+      ) : null}
+      <button
+        type="button"
+        aria-label={`Remove ${entry.file.name}`}
+        className={cn(!broken && "text-muted-foreground hover:text-foreground")}
+        onClick={onRemove}
+      >
+        <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+      </button>
+    </span>
+  );
+}

--- a/official-plugins/tasks/components/staged-attachments.tsx
+++ b/official-plugins/tasks/components/staged-attachments.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Cancel01Icon, File01Icon } from "@hugeicons/core-free-icons";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -18,6 +18,8 @@ export interface StagedAttachment {
   status: "staged" | "oversized" | "failed";
   owner?: AttachmentOwnerRef;
   error?: string;
+  /** A retry for this entry is in flight; the chip disables its Retry button. */
+  busy?: boolean;
 }
 
 let nextStagedId = 0;
@@ -37,20 +39,21 @@ export function stageFiles(files: readonly File[]): StagedAttachment[] {
 }
 
 function ChipThumbnail({ file }: { file: File }) {
+  // Created inside an effect so abandoned renders never leak object URLs.
   // jsdom has no URL.createObjectURL; fall back to the generic file icon.
-  const previewUrl = useMemo(
-    () =>
-      file.type.startsWith("image/") &&
-      typeof URL.createObjectURL === "function"
-        ? URL.createObjectURL(file)
-        : null,
-    [file],
-  );
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-    };
-  }, [previewUrl]);
+    if (
+      !file.type.startsWith("image/") ||
+      typeof URL.createObjectURL !== "function"
+    ) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
   if (!previewUrl) return null;
   return (
     <img
@@ -66,10 +69,13 @@ export function AttachmentChip({
   entry,
   onRemove,
   onRetry,
+  disabled = false,
 }: {
   entry: StagedAttachment;
   onRemove: () => void;
   onRetry?: () => void;
+  /** Locks remove/retry, e.g. while the owning form is submitting. */
+  disabled?: boolean;
 }) {
   const broken = entry.status !== "staged";
   const image = entry.file.type.startsWith("image/");
@@ -100,20 +106,27 @@ export function AttachmentChip({
       >
         {formatFileSize(entry.file.size)}
       </span>
+      {entry.error ? <span className="sr-only">{entry.error}</span> : null}
       {entry.status === "failed" && onRetry ? (
         <button
           type="button"
           aria-label={`Retry upload of ${entry.file.name}`}
-          className="font-medium underline underline-offset-2"
+          aria-busy={entry.busy === true}
+          disabled={disabled || entry.busy === true}
+          className="font-medium underline underline-offset-2 disabled:opacity-60"
           onClick={onRetry}
         >
-          Retry
+          {entry.busy ? "Retrying…" : "Retry"}
         </button>
       ) : null}
       <button
         type="button"
         aria-label={`Remove ${entry.file.name}`}
-        className={cn(!broken && "text-muted-foreground hover:text-foreground")}
+        disabled={disabled || entry.busy === true}
+        className={cn(
+          "disabled:opacity-60",
+          !broken && "text-muted-foreground hover:text-foreground",
+        )}
         onClick={onRemove}
       >
         <HugeiconsIcon icon={Cancel01Icon} className="size-3" />

--- a/official-plugins/tasks/editor/editor.test.tsx
+++ b/official-plugins/tasks/editor/editor.test.tsx
@@ -335,6 +335,57 @@ describe("TasksEditor component", () => {
     ).toBeTruthy();
   });
 
+  it("routes pasted and dropped files to onAttachFiles instead of inline upload", () => {
+    const onAttachFiles = vi.fn();
+    const onUploadImage = vi.fn();
+    let editor: Editor | null = null;
+    render(
+      <TasksEditor
+        value=""
+        onChange={() => undefined}
+        onAttachFiles={onAttachFiles}
+        onUploadImage={onUploadImage}
+        onEditorReady={(ready) => (editor = ready)}
+      />,
+    );
+    const { handlePaste, handleDrop } = editor!.options.editorProps;
+    const file = new File(["png"], "shot.png", { type: "image/png" });
+
+    const pasteEvent = {
+      clipboardData: { files: [file] },
+    } as unknown as ClipboardEvent;
+    expect(
+      handlePaste!.call(editor!.view, editor!.view, pasteEvent, null as never),
+    ).toBe(true);
+    expect(onAttachFiles).toHaveBeenCalledWith([file]);
+    expect(onUploadImage).not.toHaveBeenCalled();
+
+    // A files-free (text) paste falls through so ProseMirror inserts it.
+    const textPaste = {
+      clipboardData: { files: [] },
+    } as unknown as ClipboardEvent;
+    expect(
+      handlePaste!.call(editor!.view, editor!.view, textPaste, null as never),
+    ).toBe(false);
+
+    const preventDefault = vi.fn();
+    const dropEvent = {
+      dataTransfer: { files: [file] },
+      preventDefault,
+    } as unknown as DragEvent;
+    expect(
+      handleDrop!.call(
+        editor!.view,
+        editor!.view,
+        dropEvent,
+        null as never,
+        false,
+      ),
+    ).toBe(true);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onAttachFiles).toHaveBeenCalledTimes(2);
+  });
+
   it("replaces the document when the value prop changes externally", async () => {
     const onChange = vi.fn();
     const screen = render(

--- a/official-plugins/tasks/editor/tasks-editor.tsx
+++ b/official-plugins/tasks/editor/tasks-editor.tsx
@@ -188,6 +188,12 @@ export interface TasksEditorProps {
   onUploadImage?: (
     file: File,
   ) => Promise<{ url: string; attachmentId: string }>;
+  /**
+   * Stages pasted/dropped files instead of uploading them inline; takes
+   * precedence over onUploadImage and accepts any file type. Used where the
+   * attachment owner does not exist yet (e.g. the new-task dialog).
+   */
+  onAttachFiles?: (files: File[]) => void;
   mentionItems?: (query: string) => Promise<MentionItem[]>;
   /** Invoked when a thread-mention pill is clicked (edit and read-only). */
   onOpenThread?: (threadId: string) => void;
@@ -203,6 +209,7 @@ export function TasksEditor({
   autofocus = false,
   variant = "doc",
   onUploadImage,
+  onAttachFiles,
   mentionItems,
   onOpenThread,
   onEditorReady,
@@ -218,6 +225,8 @@ export function TasksEditor({
   placeholderRef.current = placeholder;
   const uploadRef = useRef(onUploadImage);
   uploadRef.current = onUploadImage;
+  const attachFilesRef = useRef(onAttachFiles);
+  attachFilesRef.current = onAttachFiles;
   const mentionItemsRef = useRef(mentionItems);
   mentionItemsRef.current = mentionItems;
   const openThreadRef = useRef(onOpenThread);
@@ -312,18 +321,31 @@ export function TasksEditor({
       autofocus: autofocusRef.current && !readOnly ? "end" : false,
       editorProps: {
         handlePaste(_view, event) {
+          const files = [...(event.clipboardData?.files ?? [])];
+          if (attachFilesRef.current) {
+            if (files.length === 0) return false;
+            attachFilesRef.current(files);
+            return true;
+          }
           if (!uploadRef.current) return false;
-          const file = [...(event.clipboardData?.files ?? [])].find(
-            (candidate) => candidate.type.startsWith("image/"),
+          const file = files.find((candidate) =>
+            candidate.type.startsWith("image/"),
           );
           if (!file) return false;
           void upload(file);
           return true;
         },
         handleDrop(_view, event) {
+          const files = [...(event.dataTransfer?.files ?? [])];
+          if (attachFilesRef.current) {
+            if (files.length === 0) return false;
+            event.preventDefault();
+            attachFilesRef.current(files);
+            return true;
+          }
           if (!uploadRef.current) return false;
-          const file = [...(event.dataTransfer?.files ?? [])].find(
-            (candidate) => candidate.type.startsWith("image/"),
+          const file = files.find((candidate) =>
+            candidate.type.startsWith("image/"),
           );
           if (!file) return false;
           event.preventDefault();

--- a/official-plugins/tasks/skills/tasks/SKILL.md
+++ b/official-plugins/tasks/skills/tasks/SKILL.md
@@ -45,7 +45,9 @@ not already exist. Dispatch requires an existing preset.
    bb tasks attachment add ABC-12 --file <path>
    ```
 
-   Use `--json` when capturing the returned attachment metadata.
+   Use `--json` when capturing the returned attachment metadata. When creating
+   a task that should start with files, pass repeatable `--attach <path>` to
+   `bb tasks create` instead of attaching afterwards.
 
 5. When the work is ready for review, update the task:
 

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -4,7 +4,6 @@ import {
   ArrowUp02Icon,
   AttachmentIcon,
   BotIcon,
-  Cancel01Icon,
   File01Icon,
   Notification02Icon,
 } from "@hugeicons/core-free-icons";
@@ -18,7 +17,16 @@ import {
   useTasksQuery,
   useTasksRpc,
 } from "../../shell/data.js";
-import { Lightbox } from "../detail/attachments.js";
+import {
+  attachmentDownloadUrl,
+  Lightbox,
+  uploadAttachment,
+} from "../detail/attachments.js";
+import {
+  AttachmentChip,
+  stageFiles,
+  type StagedAttachment,
+} from "../../components/staged-attachments.js";
 import type {
   Attachment,
   Comment,
@@ -32,70 +40,6 @@ import {
   useNowTick,
 } from "./time.js";
 import { CommentAuthor } from "./comment-author.js";
-
-const PLUGIN_HTTP_BASE = "/api/v1/plugins/tasks/http";
-const TOKEN_URL = "/api/v1/plugins/tasks/token";
-
-// The plugin HTTP token is stable across requests (rotation is an explicit
-// admin action), so one fetch per page load is enough.
-let tokenPromise: Promise<string> | null = null;
-
-async function fetchPluginToken(): Promise<string> {
-  const response = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: "{}",
-  });
-  if (!response.ok) {
-    throw new Error(`token request failed with status ${response.status}`);
-  }
-  const payload: unknown = await response.json();
-  if (
-    typeof payload !== "object" ||
-    payload === null ||
-    !("token" in payload) ||
-    typeof payload.token !== "string"
-  ) {
-    throw new Error("token request returned an unexpected payload");
-  }
-  return payload.token;
-}
-
-function pluginToken(): Promise<string> {
-  tokenPromise ??= fetchPluginToken().catch((error: unknown) => {
-    tokenPromise = null;
-    throw error;
-  });
-  return tokenPromise;
-}
-
-async function uploadCommentAttachment(
-  commentId: string,
-  file: File,
-): Promise<void> {
-  const token = await pluginToken();
-  const mime = file.type || "application/octet-stream";
-  const query = new URLSearchParams({
-    commentId,
-    fileName: file.name,
-    mime,
-  });
-  const response = await fetch(
-    `${PLUGIN_HTTP_BASE}/attachments/upload?${query.toString()}`,
-    {
-      method: "POST",
-      headers: { "x-bb-plugin-token": token, "Content-Type": mime },
-      body: file,
-    },
-  );
-  if (!response.ok) {
-    throw new Error(`upload of ${file.name} failed (${response.status})`);
-  }
-}
-
-function attachmentDownloadUrl(attachmentId: string): string {
-  return `${PLUGIN_HTTP_BASE}/attachments/download?attachmentId=${encodeURIComponent(attachmentId)}`;
-}
 
 interface FeedEntry {
   comment: DisplayComment;
@@ -291,93 +235,6 @@ interface ComposerProps {
   runningCount: number;
 }
 
-export const MAX_COMMENT_ATTACHMENT_BYTES = 25 * 1024 * 1024;
-
-interface StagedAttachment {
-  id: number;
-  file: File;
-  /**
-   * staged: waiting for send · oversized: rejected at pick time, never sent ·
-   * failed: the comment posted but this upload failed; retry targets commentId.
-   */
-  status: "staged" | "oversized" | "failed";
-  commentId?: string;
-  error?: string;
-}
-
-let nextStagedId = 0;
-
-/** Size-validates picked files: oversized ones become rejected chips. */
-export function stageFiles(files: readonly File[]): StagedAttachment[] {
-  return files.map((file) =>
-    file.size > MAX_COMMENT_ATTACHMENT_BYTES
-      ? {
-          id: nextStagedId++,
-          file,
-          status: "oversized" as const,
-          error: `Over the 25 MB attachment limit (${formatFileSize(file.size)})`,
-        }
-      : { id: nextStagedId++, file, status: "staged" as const },
-  );
-}
-
-function AttachmentChip({
-  entry,
-  onRemove,
-  onRetry,
-}: {
-  entry: StagedAttachment;
-  onRemove: () => void;
-  onRetry?: () => void;
-}) {
-  const broken = entry.status !== "staged";
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs",
-        broken
-          ? "border-destructive/50 bg-destructive/10 text-destructive"
-          : "border-border bg-background",
-      )}
-      title={entry.error}
-    >
-      <HugeiconsIcon
-        icon={File01Icon}
-        className={cn("size-3", broken ? undefined : "text-muted-foreground")}
-      />
-      <span className="max-w-40 truncate">{entry.file.name}</span>
-      <span
-        className={cn(
-          "text-2xs",
-          broken ? "text-destructive/80" : "text-muted-foreground",
-        )}
-      >
-        {formatFileSize(entry.file.size)}
-      </span>
-      {entry.status === "failed" && onRetry ? (
-        <button
-          type="button"
-          aria-label={`Retry upload of ${entry.file.name}`}
-          className="font-medium underline underline-offset-2"
-          onClick={onRetry}
-        >
-          Retry
-        </button>
-      ) : null}
-      <button
-        type="button"
-        aria-label={`Remove ${entry.file.name}`}
-        className={cn(
-          !broken && "text-muted-foreground hover:text-foreground",
-        )}
-        onClick={onRemove}
-      >
-        <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
-      </button>
-    </span>
-  );
-}
-
 function CommentComposer({ taskId, runningCount }: ComposerProps) {
   const rpc = useTasksRpc();
   const navigate = useBbNavigate();
@@ -396,9 +253,9 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
     setPendingFiles((files) => files.filter((entry) => entry.id !== id));
 
   const retryUpload = async (entry: StagedAttachment) => {
-    if (entry.commentId === undefined) return;
+    if (entry.owner === undefined) return;
     try {
-      await uploadCommentAttachment(entry.commentId, entry.file);
+      await uploadAttachment(entry.file, entry.owner);
       removeFile(entry.id);
       setError(null);
     } catch (cause) {
@@ -440,12 +297,12 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
     const failed: StagedAttachment[] = [];
     for (const entry of staged) {
       try {
-        await uploadCommentAttachment(comment.id, entry.file);
+        await uploadAttachment(entry.file, { commentId: comment.id });
       } catch (cause) {
         failed.push({
           ...entry,
           status: "failed",
-          commentId: comment.id,
+          owner: { commentId: comment.id },
           error: cause instanceof Error ? cause.message : String(cause),
         });
       }

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -252,8 +252,17 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
   const removeFile = (id: number) =>
     setPendingFiles((files) => files.filter((entry) => entry.id !== id));
 
+  // Synchronous single-flight guard: double-activating Retry before React
+  // re-renders must not upload (and attach) the same file twice.
+  const retryingRef = useRef(new Set<number>());
   const retryUpload = async (entry: StagedAttachment) => {
-    if (entry.owner === undefined) return;
+    if (entry.owner === undefined || retryingRef.current.has(entry.id)) return;
+    retryingRef.current.add(entry.id);
+    setPendingFiles((files) =>
+      files.map((candidate) =>
+        candidate.id === entry.id ? { ...candidate, busy: true } : candidate,
+      ),
+    );
     try {
       await uploadAttachment(entry.file, entry.owner);
       removeFile(entry.id);
@@ -263,10 +272,12 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
       setPendingFiles((files) =>
         files.map((candidate) =>
           candidate.id === entry.id
-            ? { ...candidate, error: message }
+            ? { ...candidate, busy: false, error: message }
             : candidate,
         ),
       );
+    } finally {
+      retryingRef.current.delete(entry.id);
     }
   };
 

--- a/official-plugins/tasks/views/detail/attachments.tsx
+++ b/official-plugins/tasks/views/detail/attachments.tsx
@@ -38,13 +38,16 @@ function pluginToken(): Promise<string> {
   return tokenPromise;
 }
 
+/** Client-side twin of attachments/index.ts `AttachmentOwner`. */
+export type AttachmentOwnerRef = { taskId: string } | { commentId: string };
+
 export async function uploadAttachment(
   file: File,
-  taskId: string,
+  owner: AttachmentOwnerRef,
 ): Promise<{ attachmentId: string; url: string }> {
   const token = await pluginToken();
   const query = new URLSearchParams({
-    taskId,
+    ...owner,
     fileName: file.name || "attachment",
     mime: file.type || "application/octet-stream",
   });

--- a/official-plugins/tasks/views/detail/index.tsx
+++ b/official-plugins/tasks/views/detail/index.tsx
@@ -286,7 +286,7 @@ function TaskDetail({ task }: { task: Task }) {
   }, [task.id]);
 
   const uploadForTask = async (file: File) => {
-    const result = await uploadAttachment(file, task.id);
+    const result = await uploadAttachment(file, { taskId: task.id });
     attachments.refresh();
     return result;
   };
@@ -294,7 +294,7 @@ function TaskDetail({ task }: { task: Task }) {
   const onPickFiles = async (files: FileList | null) => {
     for (const file of files ?? []) {
       try {
-        await uploadAttachment(file, task.id);
+        await uploadAttachment(file, { taskId: task.id });
       } catch (error) {
         push(
           "error",

--- a/official-plugins/tasks/views/manage/manage.test.tsx
+++ b/official-plugins/tasks/views/manage/manage.test.tsx
@@ -247,11 +247,14 @@ describe("NewTaskDialog", () => {
 describe("NewTaskDialog attachments", () => {
   const fetchCalls: string[] = [];
   const failFileNames = new Set<string>();
+  /** When set, uploads of this fileName stall until the promise resolves. */
+  let uploadGate: { fileName: string; promise: Promise<void> } | null = null;
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     fetchCalls.length = 0;
     failFileNames.clear();
+    uploadGate = null;
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/plugins/tasks/token")) {
@@ -262,6 +265,9 @@ describe("NewTaskDialog attachments", () => {
       if (url.includes("/attachments/upload")) {
         fetchCalls.push(url);
         const query = new URL(url, "http://bb.test").searchParams;
+        if (uploadGate && query.get("fileName") === uploadGate.fileName) {
+          await uploadGate.promise;
+        }
         return failFileNames.has(query.get("fileName") ?? "")
           ? new Response(JSON.stringify({ error: "disk full" }), {
               status: 500,
@@ -387,7 +393,7 @@ describe("NewTaskDialog attachments", () => {
     expect(retryQuery.get("fileName")).toBe("bad.bin");
   });
 
-  it("rejects oversized files at pick time and never uploads them", async () => {
+  it("blocks creation while an oversized file is staged, until it is removed", async () => {
     const slot = renderSlot(
       app.navPanels[0]!,
       { subPath: PROJECT_ID },
@@ -402,6 +408,16 @@ describe("NewTaskDialog attachments", () => {
       "Over the 25 MB attachment limit",
     );
 
+    // The rejected chip blocks creation instead of being silently dropped.
+    await slot.findByText(/Remove attachments over the 25 MB limit/);
+    const createButton = slot.getByRole("button", {
+      name: "Create task",
+    }) as HTMLButtonElement;
+    expect(createButton.disabled).toBe(true);
+    fireEvent.click(createButton);
+    expect(slot.navigateCalls).toEqual([]);
+
+    fireEvent.click(slot.getByRole("button", { name: "Remove big.bin" }));
     fireEvent.click(slot.getByRole("button", { name: "Create task" }));
     await waitFor(() =>
       expect(slot.navigateCalls).toContainEqual({
@@ -411,6 +427,119 @@ describe("NewTaskDialog attachments", () => {
       }),
     );
     expect(fetchCalls).toEqual([]);
+  });
+
+  it("freezes the attachment tray while create and uploads are in flight", async () => {
+    let release!: () => void;
+    uploadGate = {
+      fileName: "slow.png",
+      promise: new Promise((resolve) => (release = resolve)),
+    };
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_ID },
+      { rpc: dialogRpc() },
+    );
+    const titleInput = await openDialogWithTitle(slot, "In flight");
+    pasteFile(titleInput, new File(["x"], "slow.png", { type: "image/png" }));
+    await slot.findByText("slow.png");
+
+    fireEvent.click(slot.getByRole("button", { name: "Create task" }));
+    await waitFor(() => expect(fetchCalls).toHaveLength(1));
+
+    // The submit pass snapshots the tray: staging and removal are locked.
+    pasteFile(titleInput, new File(["y"], "late.txt", { type: "text/plain" }));
+    expect(slot.queryByText("late.txt")).toBeNull();
+    const removeButton = slot.getByRole("button", {
+      name: "Remove slow.png",
+    }) as HTMLButtonElement;
+    expect(removeButton.disabled).toBe(true);
+    fireEvent.click(removeButton);
+    expect(slot.getByText("slow.png")).toBeDefined();
+
+    release();
+    await waitFor(() =>
+      expect(slot.navigateCalls).toContainEqual({
+        method: "toPluginPanel",
+        path: "tasks",
+        options: { subPath: "task/TSK-5" },
+      }),
+    );
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it("blocks accidental dismissal during recovery until skipped explicitly", async () => {
+    failFileNames.add("bad.bin");
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_ID },
+      { rpc: dialogRpc() },
+    );
+    const titleInput = await openDialogWithTitle(slot, "Sticky recovery");
+    pasteFile(
+      titleInput,
+      new File(["nope"], "bad.bin", { type: "application/zip" }),
+    );
+    await slot.findByText("bad.bin");
+    fireEvent.click(slot.getByRole("button", { name: "Create task" }));
+    await slot.findByRole("alert");
+
+    // Escape (and any other onOpenChange-driven dismissal) is swallowed while
+    // failed chips remain; only the explicit skip action leaves.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(slot.getByRole("alert")).toBeDefined();
+    expect(slot.navigateCalls).toEqual([]);
+
+    fireEvent.click(
+      slot.getByRole("button", { name: "Skip attachments and open task" }),
+    );
+    await waitFor(() =>
+      expect(slot.navigateCalls).toContainEqual({
+        method: "toPluginPanel",
+        path: "tasks",
+        options: { subPath: "task/TSK-5" },
+      }),
+    );
+  });
+
+  it("runs retry single-flight so double activation uploads exactly once", async () => {
+    failFileNames.add("bad.bin");
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_ID },
+      { rpc: dialogRpc() },
+    );
+    const titleInput = await openDialogWithTitle(slot, "Retry once");
+    pasteFile(
+      titleInput,
+      new File(["nope"], "bad.bin", { type: "application/zip" }),
+    );
+    await slot.findByText("bad.bin");
+    fireEvent.click(slot.getByRole("button", { name: "Create task" }));
+    await slot.findByRole("alert");
+    const attemptsBeforeRetry = fetchCalls.length;
+
+    failFileNames.clear();
+    let release!: () => void;
+    uploadGate = {
+      fileName: "bad.bin",
+      promise: new Promise((resolve) => (release = resolve)),
+    };
+    const retryButton = slot.getByRole("button", {
+      name: "Retry upload of bad.bin",
+    });
+    fireEvent.click(retryButton);
+    fireEvent.click(retryButton);
+    await slot.findByText("Retrying…");
+    release();
+    await waitFor(() =>
+      expect(slot.navigateCalls).toContainEqual({
+        method: "toPluginPanel",
+        path: "tasks",
+        options: { subPath: "task/TSK-5" },
+      }),
+    );
+    expect(fetchCalls.length - attemptsBeforeRetry).toBe(1);
   });
 });
 

--- a/official-plugins/tasks/views/manage/manage.test.tsx
+++ b/official-plugins/tasks/views/manage/manage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
 import type { Task } from "../../shared/contract.js";
 
@@ -241,6 +241,176 @@ describe("NewTaskDialog", () => {
     fireEvent.click(createBtn);
     await waitFor(() => expect(createLabelCalls).toHaveLength(1));
     expect(createLabelCalls[0]).toMatchObject({ projectId: PROJECT_ID, name: "dank" });
+  });
+});
+
+describe("NewTaskDialog attachments", () => {
+  const fetchCalls: string[] = [];
+  const failFileNames = new Set<string>();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    failFileNames.clear();
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/plugins/tasks/token")) {
+        return new Response(JSON.stringify({ token: "test-token" }), {
+          status: 200,
+        });
+      }
+      if (url.includes("/attachments/upload")) {
+        fetchCalls.push(url);
+        const query = new URL(url, "http://bb.test").searchParams;
+        return failFileNames.has(query.get("fileName") ?? "")
+          ? new Response(JSON.stringify({ error: "disk full" }), {
+              status: 500,
+            })
+          : new Response(
+              JSON.stringify({ attachmentId: "att-1", url: "/download" }),
+              { status: 201 },
+            );
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const dialogRpc = () => ({
+    listProjects: () => ({ projects: [project] }),
+    listFolders: () => ({ folders: [] }),
+    listPresets: () => ({ presets: [] }),
+    sidebarSummary: () => ({ projects: [] }),
+    listTasks: () => ({ tasks: [] }),
+    listLabels: () => ({ labels: [] }),
+    createTask: (input: Record<string, unknown>) => ({
+      ok: true,
+      task: createdTask(input),
+    }),
+  });
+
+  const openDialogWithTitle = async (
+    slot: ReturnType<typeof renderSlot>,
+    title: string,
+  ) => {
+    fireEvent.click(await slot.findByRole("button", { name: /New task/ }));
+    const titleInput = await slot.findByLabelText("Task title");
+    fireEvent.change(titleInput, { target: { value: title } });
+    return titleInput;
+  };
+
+  const pasteFile = (target: Element, file: File) =>
+    fireEvent.paste(target, { clipboardData: { files: [file], types: [] } });
+
+  it("uploads staged files to the created task and navigates on success", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_ID },
+      { rpc: dialogRpc() },
+    );
+    const titleInput = await openDialogWithTitle(slot, "With files");
+    pasteFile(
+      titleInput,
+      new File(["png"], "shot.png", { type: "image/png" }),
+    );
+    await slot.findByText("shot.png");
+
+    // Picker path: stage a second file, then remove it before creating.
+    const picker = document.querySelector<HTMLInputElement>(
+      'input[type="file"]',
+    )!;
+    fireEvent.change(picker, {
+      target: {
+        files: [new File(["doc"], "notes.txt", { type: "text/plain" })],
+      },
+    });
+    await slot.findByText("notes.txt");
+    fireEvent.click(slot.getByRole("button", { name: "Remove notes.txt" }));
+    expect(slot.queryByText("notes.txt")).toBeNull();
+
+    fireEvent.click(slot.getByRole("button", { name: "Create task" }));
+    await waitFor(() =>
+      expect(slot.navigateCalls).toContainEqual({
+        method: "toPluginPanel",
+        path: "tasks",
+        options: { subPath: "task/TSK-5" },
+      }),
+    );
+    // Only the still-staged file uploaded, to the freshly created task.
+    expect(fetchCalls).toHaveLength(1);
+    const query = new URL(fetchCalls[0]!, "http://bb.test").searchParams;
+    expect(query.get("taskId")).toBe(TASK_ID);
+    expect(query.get("fileName")).toBe("shot.png");
+  });
+
+  it("recovers from a failed upload with a retryable chip bound to the created task", async () => {
+    failFileNames.add("bad.bin");
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_ID },
+      { rpc: dialogRpc() },
+    );
+    const titleInput = await openDialogWithTitle(slot, "Partial failure");
+    pasteFile(titleInput, new File(["ok"], "good.png", { type: "image/png" }));
+    pasteFile(
+      titleInput,
+      new File(["nope"], "bad.bin", { type: "application/zip" }),
+    );
+    await slot.findByText("bad.bin");
+
+    fireEvent.click(slot.getByRole("button", { name: "Create task" }));
+    const alert = await slot.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "was created, but 1 attachment failed to upload",
+    );
+    // The task exists but the dialog stays open; nothing navigated away and
+    // the successful chip left the tray.
+    expect(slot.navigateCalls).toEqual([]);
+    expect(slot.queryByText("good.png")).toBeNull();
+
+    failFileNames.clear();
+    fireEvent.click(
+      slot.getByRole("button", { name: "Retry upload of bad.bin" }),
+    );
+    await waitFor(() =>
+      expect(slot.navigateCalls).toContainEqual({
+        method: "toPluginPanel",
+        path: "tasks",
+        options: { subPath: "task/TSK-5" },
+      }),
+    );
+    const retryQuery = new URL(fetchCalls.at(-1)!, "http://bb.test")
+      .searchParams;
+    expect(retryQuery.get("taskId")).toBe(TASK_ID);
+    expect(retryQuery.get("fileName")).toBe("bad.bin");
+  });
+
+  it("rejects oversized files at pick time and never uploads them", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_ID },
+      { rpc: dialogRpc() },
+    );
+    const titleInput = await openDialogWithTitle(slot, "Too big");
+    const big = new File(["x"], "big.bin", { type: "application/zip" });
+    Object.defineProperty(big, "size", { value: 25 * 1024 * 1024 + 1 });
+    pasteFile(titleInput, big);
+    const chip = await slot.findByText("big.bin");
+    expect(chip.closest("span")?.parentElement?.getAttribute("title")).toContain(
+      "Over the 25 MB attachment limit",
+    );
+
+    fireEvent.click(slot.getByRole("button", { name: "Create task" }));
+    await waitFor(() =>
+      expect(slot.navigateCalls).toContainEqual({
+        method: "toPluginPanel",
+        path: "tasks",
+        options: { subPath: "task/TSK-5" },
+      }),
+    );
+    expect(fetchCalls).toEqual([]);
   });
 });
 

--- a/official-plugins/tasks/views/manage/new-task-dialog.tsx
+++ b/official-plugins/tasks/views/manage/new-task-dialog.tsx
@@ -2,9 +2,16 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   TASK_PRIORITIES,
   TASK_STATUSES,
+  type Task,
   type TaskPriority,
   type TaskStatus,
 } from "../../shared/contract.js";
+import { uploadAttachment } from "../detail/attachments.js";
+import {
+  AttachmentChip,
+  stageFiles,
+  type StagedAttachment,
+} from "../../components/staged-attachments.js";
 import { useProjects, useTasksQuery, useTasksRpc } from "../../shell/data.js";
 import { useTasksNavigation } from "../../shell/routes.js";
 import { TasksEditor } from "../../editor/tasks-editor.js";
@@ -102,7 +109,12 @@ export function NewTaskDialog({
   const [error, setError] = useState<string | null>(null);
   const [labelQuery, setLabelQuery] = useState("");
   const [creatingLabel, setCreatingLabel] = useState(false);
+  const [pendingFiles, setPendingFiles] = useState<StagedAttachment[]>([]);
+  // Set once createTask succeeded but some attachment uploads failed: the
+  // dialog switches to a recovery view so nothing is double-created or lost.
+  const [createdTask, setCreatedTask] = useState<Task | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Each open starts a fresh draft seeded from the invoking context.
   useEffect(() => {
@@ -116,6 +128,8 @@ export function NewTaskDialog({
     setDueDate("");
     setParentTaskId(defaultParentTaskId ?? null);
     setLabelQuery("");
+    setPendingFiles([]);
+    setCreatedTask(null);
     setError(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -192,8 +206,48 @@ export function NewTaskDialog({
     }
   };
 
+  const stageMore = (files: File[]) => {
+    if (files.length === 0) return;
+    setPendingFiles((current) => [...current, ...stageFiles(files)]);
+  };
+
+  const removeFile = (id: number) =>
+    setPendingFiles((files) => files.filter((entry) => entry.id !== id));
+
+  const retryUpload = async (entry: StagedAttachment) => {
+    if (entry.owner === undefined) return;
+    try {
+      await uploadAttachment(entry.file, entry.owner);
+      removeFile(entry.id);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      setPendingFiles((files) =>
+        files.map((candidate) =>
+          candidate.id === entry.id
+            ? { ...candidate, error: message }
+            : candidate,
+        ),
+      );
+    }
+  };
+
+  const finish = (task: Task) => {
+    onOpenChange(false);
+    navigation.go({ kind: "task", taskKey: task.key });
+  };
+
+  // Recovery resolves itself: once every failed upload was retried or
+  // explicitly removed, the created task opens like a normal success.
+  useEffect(() => {
+    if (createdTask && pendingFiles.length === 0) finish(createdTask);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [createdTask, pendingFiles.length]);
+
   const canSubmit =
-    effectiveProjectId !== null && title.trim().length > 0 && !submitting;
+    effectiveProjectId !== null &&
+    title.trim().length > 0 &&
+    !submitting &&
+    createdTask === null;
 
   const submit = async () => {
     if (!canSubmit || effectiveProjectId === null) return;
@@ -214,15 +268,48 @@ export function NewTaskDialog({
         setError(result.error.message);
         return;
       }
+      // The task now exists; upload the staged files to it. Failures become
+      // retryable chips bound to the created task instead of vanishing.
+      const staged = pendingFiles.filter((entry) => entry.status === "staged");
+      const failed: StagedAttachment[] = [];
+      for (const entry of staged) {
+        try {
+          await uploadAttachment(entry.file, { taskId: result.task.id });
+        } catch (cause) {
+          failed.push({
+            ...entry,
+            status: "failed",
+            owner: { taskId: result.task.id },
+            error: cause instanceof Error ? cause.message : String(cause),
+          });
+        }
+      }
+      if (failed.length > 0) {
+        // Uploaded entries leave the tray; failures come back as retryable
+        // chips. Oversized (never-sendable) chips stay visible for removal.
+        setPendingFiles((files) =>
+          files.flatMap((entry) => {
+            const failure = failed.find(
+              (candidate) => candidate.id === entry.id,
+            );
+            if (failure) return [failure];
+            return staged.some((candidate) => candidate.id === entry.id)
+              ? []
+              : [entry];
+          }),
+        );
+        setCreatedTask(result.task);
+        return;
+      }
       if (createMore) {
         setTitle("");
         setDescription("");
         setLabelIds([]);
         setDueDate("");
+        setPendingFiles([]);
         titleRef.current?.focus();
       } else {
-        onOpenChange(false);
-        navigation.go({ kind: "task", taskKey: result.task.key });
+        finish(result.task);
       }
     } catch (submitError) {
       setError(
@@ -239,6 +326,9 @@ export function NewTaskDialog({
     () => (labels.data ?? []).filter((label) => labelIds.includes(label.id)),
     [labels.data, labelIds],
   );
+  const failedCount = pendingFiles.filter(
+    (entry) => entry.status === "failed",
+  ).length;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -249,6 +339,15 @@ export function NewTaskDialog({
             event.preventDefault();
             void submit();
           }
+        }}
+        onPaste={(event) => {
+          // The description editor stages files itself (and prevents the
+          // default); this catches pastes everywhere else in the dialog.
+          if (event.defaultPrevented || createdTask !== null) return;
+          const files = [...(event.clipboardData?.files ?? [])];
+          if (files.length === 0) return;
+          event.preventDefault();
+          stageMore(files);
         }}
       >
         <DialogTitle className="flex items-center gap-2 px-4 pt-4 text-xs font-normal text-muted-foreground">
@@ -263,9 +362,35 @@ export function NewTaskDialog({
           {project ? ` · ${project.name}` : ""}
         </DialogTitle>
         <DialogDescription className="sr-only">
-          Create a task with a title, description, and attributes.
+          Create a task with a title, description, attributes, and attachments.
         </DialogDescription>
-        <div className="px-4 pt-2">
+        {createdTask ? (
+          <div className="px-4 pt-2">
+            <p role="alert" className="text-sm">
+              Task <span className="font-medium">{createdTask.key}</span> was
+              created, but {failedCount} attachment
+              {failedCount === 1 ? "" : "s"} failed to upload.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Retry the uploads below, or remove a file to skip it.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {pendingFiles.map((entry) => (
+                <AttachmentChip
+                  key={entry.id}
+                  entry={entry}
+                  onRemove={() => removeFile(entry.id)}
+                  onRetry={
+                    entry.status === "failed"
+                      ? () => void retryUpload(entry)
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+        <div className={cn("px-4 pt-2", createdTask && "hidden")}>
           <input
             ref={titleRef}
             autoFocus
@@ -289,9 +414,26 @@ export function NewTaskDialog({
             onChange={setDescription}
             placeholder="Description — rich text, round-trips as markdown for agents"
             className="mt-2 min-h-16"
+            onAttachFiles={stageMore}
           />
+          {pendingFiles.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {pendingFiles.map((entry) => (
+                <AttachmentChip
+                  key={entry.id}
+                  entry={entry}
+                  onRemove={() => removeFile(entry.id)}
+                />
+              ))}
+            </div>
+          ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-1.5 px-4 pt-3">
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-1.5 px-4 pt-3",
+            createdTask && "hidden",
+          )}
+        >
           {!subtaskMode ? (
             <Select
               value={effectiveProjectId ?? undefined}
@@ -483,6 +625,28 @@ export function NewTaskDialog({
               </PopoverContent>
             </Popover>
           ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Attach files"
+            className={cn(CHIP_TRIGGER, "border-input font-normal")}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Icon name="Paperclip" className="size-3" />
+            Attach
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            aria-hidden
+            tabIndex={-1}
+            className="hidden"
+            onChange={(event) => {
+              stageMore([...(event.target.files ?? [])]);
+              event.target.value = "";
+            }}
+          />
         </div>
         {error ? (
           <p role="alert" className="px-4 pt-2 text-xs text-destructive">
@@ -490,14 +654,29 @@ export function NewTaskDialog({
           </p>
         ) : null}
         <DialogFooter className="mt-4 flex-row items-center border-t border-border-hairline px-4 py-3 sm:justify-between">
-          <CheckboxField
-            checked={createMore}
-            onCheckedChange={setCreateMore}
-            label="Create more"
-          />
-          <Button size="sm" disabled={!canSubmit} onClick={() => void submit()}>
-            {subtaskMode ? "Create sub-task" : "Create task"}
-          </Button>
+          {createdTask ? (
+            <>
+              <span />
+              <Button size="sm" onClick={() => finish(createdTask)}>
+                Open task
+              </Button>
+            </>
+          ) : (
+            <>
+              <CheckboxField
+                checked={createMore}
+                onCheckedChange={setCreateMore}
+                label="Create more"
+              />
+              <Button
+                size="sm"
+                disabled={!canSubmit}
+                onClick={() => void submit()}
+              >
+                {subtaskMode ? "Create sub-task" : "Create task"}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/official-plugins/tasks/views/manage/new-task-dialog.tsx
+++ b/official-plugins/tasks/views/manage/new-task-dialog.tsx
@@ -206,34 +206,58 @@ export function NewTaskDialog({
     }
   };
 
+  // The submit flow snapshots pendingFiles, so the tray is frozen while a
+  // create/upload pass runs: nothing may be staged or removed mid-flight.
   const stageMore = (files: File[]) => {
-    if (files.length === 0) return;
+    if (files.length === 0 || submitting || createdTask !== null) return;
     setPendingFiles((current) => [...current, ...stageFiles(files)]);
   };
 
-  const removeFile = (id: number) =>
+  const removeFile = (id: number) => {
+    if (submitting) return;
     setPendingFiles((files) => files.filter((entry) => entry.id !== id));
+  };
 
+  // Synchronous single-flight guard: double-activating Retry before React
+  // re-renders must not upload (and attach) the same file twice.
+  const retryingRef = useRef(new Set<number>());
   const retryUpload = async (entry: StagedAttachment) => {
-    if (entry.owner === undefined) return;
+    if (entry.owner === undefined || retryingRef.current.has(entry.id)) return;
+    retryingRef.current.add(entry.id);
+    setPendingFiles((files) =>
+      files.map((candidate) =>
+        candidate.id === entry.id ? { ...candidate, busy: true } : candidate,
+      ),
+    );
     try {
       await uploadAttachment(entry.file, entry.owner);
-      removeFile(entry.id);
+      setPendingFiles((files) =>
+        files.filter((candidate) => candidate.id !== entry.id),
+      );
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : String(cause);
       setPendingFiles((files) =>
         files.map((candidate) =>
           candidate.id === entry.id
-            ? { ...candidate, error: message }
+            ? { ...candidate, busy: false, error: message }
             : candidate,
         ),
       );
+    } finally {
+      retryingRef.current.delete(entry.id);
     }
   };
 
   const finish = (task: Task) => {
     onOpenChange(false);
     navigation.go({ kind: "task", taskKey: task.key });
+  };
+
+  // While recovery chips are pending, Escape/overlay/close must not discard
+  // them silently — leaving requires the explicit skip action below.
+  const requestClose = (next: boolean) => {
+    if (!next && createdTask !== null && pendingFiles.length > 0) return;
+    onOpenChange(next);
   };
 
   // Recovery resolves itself: once every failed upload was retried or
@@ -243,10 +267,16 @@ export function NewTaskDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [createdTask, pendingFiles.length]);
 
+  // Oversized chips must be removed first — creating around them would
+  // silently drop files the user staged.
+  const hasOversized = pendingFiles.some(
+    (entry) => entry.status === "oversized",
+  );
   const canSubmit =
     effectiveProjectId !== null &&
     title.trim().length > 0 &&
     !submitting &&
+    !hasOversized &&
     createdTask === null;
 
   const submit = async () => {
@@ -331,7 +361,7 @@ export function NewTaskDialog({
   ).length;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={requestClose}>
       <DialogContent
         className="max-w-xl gap-0 p-0"
         onKeyDown={(event) => {
@@ -343,7 +373,8 @@ export function NewTaskDialog({
         onPaste={(event) => {
           // The description editor stages files itself (and prevents the
           // default); this catches pastes everywhere else in the dialog.
-          if (event.defaultPrevented || createdTask !== null) return;
+          if (event.defaultPrevented || submitting || createdTask !== null)
+            return;
           const files = [...(event.clipboardData?.files ?? [])];
           if (files.length === 0) return;
           event.preventDefault();
@@ -372,7 +403,8 @@ export function NewTaskDialog({
               {failedCount === 1 ? "" : "s"} failed to upload.
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Retry the uploads below, or remove a file to skip it.
+              Retry the uploads below, remove a file to skip it, or skip them
+              all and open the task.
             </p>
             <div className="mt-3 flex flex-wrap gap-1.5">
               {pendingFiles.map((entry) => (
@@ -422,10 +454,17 @@ export function NewTaskDialog({
                 <AttachmentChip
                   key={entry.id}
                   entry={entry}
+                  disabled={submitting}
                   onRemove={() => removeFile(entry.id)}
                 />
               ))}
             </div>
+          ) : null}
+          {hasOversized ? (
+            <p className="mt-2 text-xs text-destructive">
+              Remove attachments over the 25 MB limit before creating the
+              task.
+            </p>
           ) : null}
         </div>
         <div
@@ -629,6 +668,7 @@ export function NewTaskDialog({
             variant="outline"
             size="sm"
             aria-label="Attach files"
+            disabled={submitting}
             className={cn(CHIP_TRIGGER, "border-input font-normal")}
             onClick={() => fileInputRef.current?.click()}
           >
@@ -658,7 +698,7 @@ export function NewTaskDialog({
             <>
               <span />
               <Button size="sm" onClick={() => finish(createdTask)}>
-                Open task
+                Skip attachments and open task
               </Button>
             </>
           ) : (

--- a/official-plugins/tasks/views/manage/new-task-dialog.tsx
+++ b/official-plugins/tasks/views/manage/new-task-dialog.tsx
@@ -664,17 +664,17 @@ export function NewTaskDialog({
               </PopoverContent>
             </Popover>
           ) : null}
-          <Button
-            variant="outline"
-            size="sm"
+          {/* Same muted icon-only affordance as the detail page's editor. */}
+          <button
+            type="button"
+            title="Attach files"
             aria-label="Attach files"
             disabled={submitting}
-            className={cn(CHIP_TRIGGER, "border-input font-normal")}
+            className="flex size-6.5 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground disabled:opacity-50"
             onClick={() => fileInputRef.current?.click()}
           >
-            <Icon name="Paperclip" className="size-3" />
-            Attach
-          </Button>
+            <Icon name="Paperclip" className="size-4" />
+          </button>
           <input
             ref={fileInputRef}
             type="file"

--- a/official-plugins/tasks/views/manage/new-task-dialog.tsx
+++ b/official-plugins/tasks/views/manage/new-task-dialog.tsx
@@ -664,29 +664,6 @@ export function NewTaskDialog({
               </PopoverContent>
             </Popover>
           ) : null}
-          {/* Same muted icon-only affordance as the detail page's editor. */}
-          <button
-            type="button"
-            title="Attach files"
-            aria-label="Attach files"
-            disabled={submitting}
-            className="flex size-6.5 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground disabled:opacity-50"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <Icon name="Paperclip" className="size-4" />
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            aria-hidden
-            tabIndex={-1}
-            className="hidden"
-            onChange={(event) => {
-              stageMore([...(event.target.files ?? [])]);
-              event.target.value = "";
-            }}
-          />
         </div>
         {error ? (
           <p role="alert" className="px-4 pt-2 text-xs text-destructive">
@@ -708,13 +685,40 @@ export function NewTaskDialog({
                 onCheckedChange={setCreateMore}
                 label="Create more"
               />
-              <Button
-                size="sm"
-                disabled={!canSubmit}
-                onClick={() => void submit()}
-              >
-                {subtaskMode ? "Create sub-task" : "Create task"}
-              </Button>
+              <div className="flex items-center gap-1.5">
+                {/* Same muted icon-only affordance as the detail editor and
+                    comment composer; lives beside the primary action so the
+                    chip row never wraps just for it. */}
+                <button
+                  type="button"
+                  title="Attach files"
+                  aria-label="Attach files"
+                  disabled={submitting}
+                  className="flex size-6.5 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground disabled:opacity-50"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Icon name="Paperclip" className="size-4" />
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  aria-hidden
+                  tabIndex={-1}
+                  className="hidden"
+                  onChange={(event) => {
+                    stageMore([...(event.target.files ?? [])]);
+                    event.target.value = "";
+                  }}
+                />
+                <Button
+                  size="sm"
+                  disabled={!canSubmit}
+                  onClick={() => void submit()}
+                >
+                  {subtaskMode ? "Create sub-task" : "Create task"}
+                </Button>
+              </div>
             </>
           )}
         </DialogFooter>


### PR DESCRIPTION
## Summary

Task creation (the New-task dialog) now supports pasting images and attaching files before submit, plus CLI parity via `bb tasks create --attach <path>` (repeatable).

**Product decisions** (also recorded as BB-17 task comments):
- Attachments require an existing owner at the contract level, so the dialog stages files locally and uploads after `createTask` succeeds — the same lifecycle the comment composer already used. That staging UI is extracted into `components/staged-attachments.tsx` (now with image thumbnail previews) and reused; no parallel upload system.
- Pasted images become task attachments rendered by the existing `AttachmentsGrid` on the detail page — no inline blob-URL markdown, since rewriting the description post-create risks broken links on partial failure. Inline insertion remains where a task already exists (detail editor).
- The two duplicated frontend upload helpers are consolidated into one `uploadAttachment(file, {taskId}|{commentId})`.

**Staging lifecycle:**
- Paste anywhere in the dialog (title, editor, chrome) or use the Attach chip/file picker; chips show name/size/thumbnail and are removable before create; files over the server's 25 MB limit are rejected at pick time and block creation until removed (no silent loss).
- The tray freezes while create/uploads are in flight, so the upload snapshot cannot drift from what the user sees.
- Partial failure flips the dialog into a recovery view bound to the created task: per-file single-flight Retry (busy state, accessible label) and Remove; Escape/overlay/close are swallowed while failed chips remain — leaving requires the explicit "Skip attachments and open task" action. Resolving the last chip auto-opens the task.

**CLI:**
- `--attach` preflights every source (exists, is a file, readable, ≤ 25 MB) *before* creating the task, so a bad path cannot leave a half-built task.
- After create, every file is attempted and truthfully reported: JSON output is `{task, attachments, failedAttachments}`, human output lists per-file outcomes plus exact `bb tasks attachment add` recovery commands, and partial failure exits 1 with the report still on stdout.
- README, tasks skill, and help text updated.

## Review

One GPT-5.6 Sol medium review round completed; all six blocking findings (in-flight tray mutation, dismissible recovery, non-single-flight retry, silent oversized loss, incomplete CLI preflight, untruthful CLI partial-failure reporting) and the non-blocking findings (effect-backed object URLs, accessibility, added coverage for editor paste/drop, in-flight mutation, retry reentrancy, dismissal) are addressed in the second commit.

## Validation

- `turbo run typecheck build test --filter=bb-plugin-tasks`: green, 154 tests / 17 files.
- 9 new/updated tests: dialog staging→upload→navigate, partial-failure recovery + retry, oversized-blocks-create, in-flight tray freeze, recovery dismissal guard + explicit skip, retry single-flight, editor paste/drop routing, CLI `--attach` happy path + missing/oversized preflight, CLI three-file middle-failure in JSON and human modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)