### PR TITLE
BB-27: Remember the Tasks sidebar collapsed state

### DIFF
--- a/official-plugins/tasks/shell/app-shell.tsx
+++ b/official-plugins/tasks/shell/app-shell.tsx
@@ -13,6 +13,10 @@ import {
   type TasksRoute,
 } from "./routes.js";
 import { TasksSidebar } from "./sidebar.js";
+import {
+  loadSidebarCollapsed,
+  storeSidebarCollapsed,
+} from "./sidebar-preference.js";
 import { TasksTopbar } from "./topbar.js";
 import { ListView } from "../views/list/index.js";
 import { BoardView } from "../views/board/index.js";
@@ -93,14 +97,16 @@ function RouteOutlet({ route }: { route: TasksRoute }) {
 export function TasksAppShell({ subPath }: PluginNavPanelProps) {
   const route = parseTasksRoute(subPath);
   const navigation = useTasksNavigation();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] =
+    useState(loadSidebarCollapsed);
   const [newTaskOpen, setNewTaskOpen] = useState(false);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
 
   // Auto-collapse in narrow containers (the plugin can live in a split pane,
   // so the panel's own width is what matters — never the window's). A manual
-  // toggle while narrow sticks until the next threshold crossing; growing
-  // wide again restores the user's pre-collapse choice.
+  // toggle while narrow sticks until the next threshold crossing. Automatic
+  // narrow collapse is transient; an explicit toggle updates the user's
+  // client-local preference.
   const rootRef = useRef<HTMLDivElement>(null);
   const [narrow, setNarrow] = useState(false);
   const [narrowOverride, setNarrowOverride] = useState<boolean | null>(null);
@@ -124,8 +130,10 @@ export function TasksAppShell({ subPath }: PluginNavPanelProps) {
     ? (narrowOverride ?? true)
     : sidebarCollapsed;
   const toggleSidebar = () => {
-    if (narrow) setNarrowOverride(!effectiveSidebarCollapsed);
-    else setSidebarCollapsed((value) => !value);
+    const next = !effectiveSidebarCollapsed;
+    if (narrow) setNarrowOverride(next);
+    setSidebarCollapsed(next);
+    storeSidebarCollapsed(next);
   };
 
   const folders = useFolders();

--- a/official-plugins/tasks/shell/shell.test.tsx
+++ b/official-plugins/tasks/shell/shell.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
 
 // jsdom lacks matchMedia; the vendored Dialog's responsive root needs it.
@@ -22,8 +22,14 @@ if (!window.matchMedia) {
 const app = await loadPluginApp(() => import("../app"));
 const { parseTasksRoute, tasksRouteToSubPath } = await import("./routes.js");
 const { pagerPosition } = await import("./topbar.js");
+const { SIDEBAR_COLLAPSED_STORAGE_KEY } =
+  await import("./sidebar-preference.js");
 
-afterEach(cleanup);
+beforeEach(() => window.localStorage.clear());
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
 const FOLDER_ID = "01HZZZZZZZZZZZZZZZZZZZZZF1";
@@ -164,6 +170,121 @@ describe("task pager", () => {
 });
 
 describe("tasks app shell", () => {
+  it("keeps the first-use sidebar expanded without writing a preference", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc(),
+      },
+    );
+    await slot.findByText("Tasks Plugin");
+
+    expect(
+      slot
+        .getByRole("button", { name: "Collapse sidebar" })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(
+      window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY),
+    ).toBeNull();
+  });
+
+  it("persists collapsed state across route changes and remounts", async () => {
+    const registration = app.navPanels[0]!;
+    const slot = renderSlot(
+      registration,
+      { subPath: "all" },
+      {
+        rpc: seededRpc(),
+      },
+    );
+    await slot.findByText("Tasks Plugin");
+
+    fireEvent.click(slot.getByRole("button", { name: "Collapse sidebar" }));
+    expect(slot.queryByRole("button", { name: "Manage" })).toBeNull();
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe(
+      "true",
+    );
+
+    const Shell = registration.component;
+    slot.lifecycle.rerender(<Shell subPath={`${PROJECT_ID}?view=board`} />);
+    await slot.findByText("Backlog");
+    expect(
+      slot
+        .getByRole("button", { name: "Expand sidebar" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+
+    slot.lifecycle.unmount();
+    const remounted = renderSlot(
+      registration,
+      { subPath: "all" },
+      {
+        rpc: seededRpc(),
+      },
+    );
+    await remounted.findByText("All tasks");
+    expect(remounted.queryByRole("button", { name: "Manage" })).toBeNull();
+    expect(
+      remounted.getByRole("button", { name: "Expand sidebar" }),
+    ).toBeDefined();
+  });
+
+  it("persists expanded state after restoring a collapsed preference", async () => {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, "true");
+    const registration = app.navPanels[0]!;
+    const slot = renderSlot(
+      registration,
+      { subPath: "all" },
+      {
+        rpc: seededRpc(),
+      },
+    );
+    await slot.findByText("All tasks");
+    fireEvent.click(slot.getByRole("button", { name: "Expand sidebar" }));
+
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe(
+      "false",
+    );
+    await slot.findByRole("button", { name: "Manage" });
+
+    slot.lifecycle.unmount();
+    const remounted = renderSlot(
+      registration,
+      { subPath: "manage" },
+      {
+        rpc: seededRpc({ listLabels: () => ({ labels: [] }) }),
+      },
+    );
+    await remounted.findByText("Labels, agent presets, and folders.");
+    expect(
+      remounted.getByRole("button", { name: "Collapse sidebar" }),
+    ).toBeDefined();
+    expect(remounted.getByRole("button", { name: "Manage" })).toBeDefined();
+  });
+
+  it("keeps toggling usable when client storage rejects writes", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is disabled", "SecurityError");
+    });
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc(),
+      },
+    );
+    await slot.findByText("Tasks Plugin");
+
+    fireEvent.click(slot.getByRole("button", { name: "Collapse sidebar" }));
+    expect(
+      slot
+        .getByRole("button", { name: "Expand sidebar" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
   it("shows the empty state and opens the New project dialog", async () => {
     const slot = renderSlot(app.navPanels[0]!, { subPath: "" }, {
       rpc: emptyRpc,

--- a/official-plugins/tasks/shell/sidebar-preference.ts
+++ b/official-plugins/tasks/shell/sidebar-preference.ts
@@ -1,0 +1,28 @@
+export const SIDEBAR_COLLAPSED_STORAGE_KEY = "bb-tasks:sidebar-collapsed";
+
+/**
+ * The Tasks sidebar is a client-local layout preference. Keeping it in the
+ * browser profile avoids changing another client connected to the same bb
+ * server. Missing, invalid, or unavailable storage preserves the existing
+ * first-use default: expanded.
+ */
+export function loadSidebarCollapsed(): boolean {
+  try {
+    return (
+      window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function storeSidebarCollapsed(collapsed: boolean): void {
+  try {
+    window.localStorage.setItem(
+      SIDEBAR_COLLAPSED_STORAGE_KEY,
+      String(collapsed),
+    );
+  } catch {
+    // Persistence is best-effort (for example, storage-disabled browsers).
+  }
+}


### PR DESCRIPTION
## Summary
- persist the Tasks internal sidebar collapsed state in client-local browser storage
- preserve the expanded first-use default and transient narrow-pane auto-collapse
- restore both values across navigation, remount, refresh, and restart

## Validation
- Tasks plugin tests: 174/174 passed before rebase
- post-rebase focused Tasks shell tests: 14/14 passed
- post-rebase Tasks plugin typecheck and build passed
- isolated real-product E2E covered first use, both states, navigation/remount, refresh, two dev-server restarts, narrow panes, keyboard/ARIA, and storage denial
- independent readonly Codex gpt-5.6-sol review: APPROVE

## Evidence
Testing catalog and seven screenshots are attached to BB-27.