### PR TITLE
BB-22 Notify the latest responding task agent

### DIFF
--- a/official-plugins/tasks/README.md
+++ b/official-plugins/tasks/README.md
@@ -48,9 +48,11 @@ at the CLI boundary. You can also delegate from a task's **Delegate** menu,
 choose or create presets under **Manage → Presets**, and type `@` in the bb
 composer to send a task mention to an agent.
 
-When a task has working agents, its comment composer shows a **Notify working
-agents** switch. Leave it on to steer the new comment to those threads, or turn
-it off to record the comment without interrupting them. The CLI equivalent is
+The comment composer shows a **Notify last responding agent** switch. When the
+task has an agent reply, leave it on to send the new comment to the thread that
+authored the latest reply, resuming that thread when it is idle. Turn it off to
+keep the comment in Tasks only. If no agent has replied, the disabled control
+says so explicitly. Agents and scripts can use the same behavior with
 `bb tasks comment PROD-1 --body "New context" --notify`.
 
 ## CLI reference
@@ -58,23 +60,23 @@ it off to record the comment without interrupting them. The CLI equivalent is
 Run `bb tasks --help` or `bb tasks <command> --help` for exact options. Add
 `--json` to commands when another command or agent will consume the output.
 
-| Command | Purpose |
-| --- | --- |
-| `bb tasks status` | Show the installed Tasks plugin name and version. |
-| `bb tasks project create\|list\|show\|update` | Manage tracker projects, folders, colors, prefixes, and bb-project links. |
-| `bb tasks folder create\|list\|update` | Organize tracker projects into nested folders. |
-| `bb tasks create` | Create a task with description, priority, labels, due date, optional parent, and file attachments (repeatable `--attach <path>`). |
-| `bb tasks list` | Filter tasks by project, status, priority, label, active agents, or search text; `--sort priority\|due` orders the results. |
-| `bb tasks show <key-or-id>` | Show the complete task record, including comments, attachments, subtasks, and attached threads. |
-| `bb tasks update <key-or-id>` | Update status, priority, title, description, due date, or labels. |
-| `bb tasks comment <key-or-id>` | Add a Markdown comment from inline text or a file; optionally notify mentioned threads. |
-| `bb tasks attachment add\|get\|list` | Add a task/comment artifact, fetch it to a path, or list a task's attachments. |
-| `bb tasks preset list\|create\|update\|delete` | Manage reusable agent execution presets. |
-| `bb tasks delegate <key>` | Start and attach a new agent thread using a preset. |
-| `bb tasks attach <key-or-id>` | Attach the current bb thread to a task when it was not delegated from Tasks. |
-| `bb tasks threads <key>` | List the bb threads attached to a task. |
-| `bb tasks label create\|list\|delete` | Manage project-scoped labels. |
-| `bb tasks seed-demo --yes` | Create sample folders, projects, labels, tasks, and comments for evaluation. |
+| Command                                        | Purpose                                                                                                                           |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `bb tasks status`                              | Show the installed Tasks plugin name and version.                                                                                 |
+| `bb tasks project create\|list\|show\|update`  | Manage tracker projects, folders, colors, prefixes, and bb-project links.                                                         |
+| `bb tasks folder create\|list\|update`         | Organize tracker projects into nested folders.                                                                                    |
+| `bb tasks create`                              | Create a task with description, priority, labels, due date, optional parent, and file attachments (repeatable `--attach <path>`). |
+| `bb tasks list`                                | Filter tasks by project, status, priority, label, active agents, or search text; `--sort priority\|due` orders the results.       |
+| `bb tasks show <key-or-id>`                    | Show the complete task record, including comments, attachments, subtasks, and attached threads.                                   |
+| `bb tasks update <key-or-id>`                  | Update status, priority, title, description, due date, or labels.                                                                 |
+| `bb tasks comment <key-or-id>`                 | Add a Markdown comment from inline text or a file; optionally notify mentioned threads.                                           |
+| `bb tasks attachment add\|get\|list`           | Add a task/comment artifact, fetch it to a path, or list a task's attachments.                                                    |
+| `bb tasks preset list\|create\|update\|delete` | Manage reusable agent execution presets.                                                                                          |
+| `bb tasks delegate <key>`                      | Start and attach a new agent thread using a preset.                                                                               |
+| `bb tasks attach <key-or-id>`                  | Attach the current bb thread to a task when it was not delegated from Tasks.                                                      |
+| `bb tasks threads <key>`                       | List the bb threads attached to a task.                                                                                           |
+| `bb tasks label create\|list\|delete`          | Manage project-scoped labels.                                                                                                     |
+| `bb tasks seed-demo --yes`                     | Create sample folders, projects, labels, tasks, and comments for evaluation.                                                      |
 
 Statuses are `backlog`, `todo`, `in_progress`, `in_review`, `done`, and
 `canceled`. Priorities are `urgent`, `high`, `medium`, `low`, and `none`.

--- a/official-plugins/tasks/README.md
+++ b/official-plugins/tasks/README.md
@@ -54,6 +54,9 @@ authored the latest reply, resuming that thread when it is idle. Turn it off to
 keep the comment in Tasks only. If no agent has replied, the disabled control
 says so explicitly. Agents and scripts can use the same behavior with
 `bb tasks comment PROD-1 --body "New context" --notify`.
+When run from a thread, the CLI preserves that agent thread and any explicit
+`--author`; notification still targets the prior latest responder rather than
+the newly recorded agent comment itself.
 
 ## CLI reference
 
@@ -69,7 +72,7 @@ Run `bb tasks --help` or `bb tasks <command> --help` for exact options. Add
 | `bb tasks list`                                | Filter tasks by project, status, priority, label, active agents, or search text; `--sort priority\|due` orders the results.       |
 | `bb tasks show <key-or-id>`                    | Show the complete task record, including comments, attachments, subtasks, and attached threads.                                   |
 | `bb tasks update <key-or-id>`                  | Update status, priority, title, description, due date, or labels.                                                                 |
-| `bb tasks comment <key-or-id>`                 | Add a Markdown comment from inline text or a file; optionally notify mentioned threads.                                           |
+| `bb tasks comment <key-or-id>`                 | Add a Markdown comment from inline text or a file; optionally notify the latest responding task agent.                            |
 | `bb tasks attachment add\|get\|list`           | Add a task/comment artifact, fetch it to a path, or list a task's attachments.                                                    |
 | `bb tasks preset list\|create\|update\|delete` | Manage reusable agent execution presets.                                                                                          |
 | `bb tasks delegate <key>`                      | Start and attach a new agent thread using a preset.                                                                               |

--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -446,7 +446,7 @@ describe("Tasks RPC domain API", () => {
     await harness.dispose();
   });
 
-  it("does not send for notify=false or agent comments", async () => {
+  it("does not send for notify=false or when no prior agent has replied", async () => {
     const { bb, harness } = createFakePluginHost({
       pluginId: "tasks",
       sdk: { threads: { send: async () => undefined } },
@@ -481,6 +481,8 @@ describe("Tasks RPC domain API", () => {
       taskId: task.id,
       kind: "agent",
       authorName: "Worker",
+      presetName: null,
+      threadId: "thr_worker",
       body: "Reporting progress.",
       notify: true,
     });
@@ -1065,11 +1067,8 @@ describe("Tasks RPC domain API", () => {
           },
         },
         environments: {
-          pullRequest: async ({
-            environmentId,
-          }: {
-            environmentId: string;
-          }) => pullRequestsByEnvironment[environmentId]!,
+          pullRequest: async ({ environmentId }: { environmentId: string }) =>
+            pullRequestsByEnvironment[environmentId]!,
         },
       },
     });
@@ -1246,7 +1245,11 @@ describe("Tasks RPC domain API", () => {
       title: "Ship it",
     });
     // Two threads share env_a; a third uses env_b.
-    for (const threadId of ["thr_alpha0000", "thr_alpha0001", "thr_beta00000"]) {
+    for (const threadId of [
+      "thr_alpha0000",
+      "thr_alpha0001",
+      "thr_beta00000",
+    ]) {
       store.tasks.upsertTaskThread({
         taskId: task.id,
         threadId,
@@ -1325,11 +1328,8 @@ describe("Tasks RPC domain API", () => {
             }),
         },
         environments: {
-          pullRequest: async ({
-            environmentId,
-          }: {
-            environmentId: string;
-          }) => lookupByEnvironment[environmentId]!,
+          pullRequest: async ({ environmentId }: { environmentId: string }) =>
+            lookupByEnvironment[environmentId]!,
         },
       },
     });

--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -10,7 +10,7 @@ import { tasksRpcContract } from "../shared/contract";
 import { createComment, createStore, registerTasksApi } from ".";
 
 describe("Tasks RPC domain API", () => {
-  it("persists successful comment steers and skips completed threads", async () => {
+  it("persists one successful notification to the latest replying agent", async () => {
     const { bb, harness } = createFakePluginHost({
       pluginId: "tasks",
       sdk: {
@@ -45,6 +45,20 @@ describe("Tasks RPC domain API", () => {
         liveStatus,
       });
     }
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "First agent",
+      threadId: "thr_one",
+      body: "First reply",
+    });
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Second agent",
+      threadId: "thr_two",
+      body: "Latest reply",
+    });
 
     const result = tasksRpcContract.createComment.output.parse(
       await harness.callRpc("createComment", {
@@ -54,12 +68,14 @@ describe("Tasks RPC domain API", () => {
       }),
     );
 
-    expect(result.comment.notifiedCount).toBe(2);
-    expect(store.tasks.getComment(result.comment.id)?.notifiedCount).toBe(2);
-    expect(harness.sdk.callsTo("threads.send")).toHaveLength(2);
+    expect(result.comment.notifiedCount).toBe(1);
+    expect(store.tasks.getComment(result.comment.id)?.notifiedCount).toBe(1);
+    expect(harness.sdk.callsTo("threads.send")).toEqual([
+      [expect.objectContaining({ threadId: "thr_two" })],
+    ]);
     expect(harness.realtimeSignals.at(-1)).toEqual({
       channel: "comments:changed",
-      payload: { taskId: task.id, notifiedCount: 2 },
+      payload: { taskId: task.id, notifiedCount: 1 },
     });
     await harness.dispose();
   });
@@ -525,7 +541,7 @@ describe("Tasks RPC domain API", () => {
     await harness.dispose();
   });
 
-  it("keeps the comment and persists only successful steer deliveries", async () => {
+  it("keeps the comment when delivery to the latest responder fails", async () => {
     const { bb, harness } = createFakePluginHost({
       pluginId: "tasks",
       sdk: {
@@ -560,6 +576,20 @@ describe("Tasks RPC domain API", () => {
         liveStatus: "working",
       });
     }
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Earlier agent",
+      threadId: "thr_success",
+      body: "Earlier reply",
+    });
+    store.tasks.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Latest agent",
+      threadId: "thr_failing",
+      body: "Latest reply",
+    });
 
     const result = tasksRpcContract.createComment.output.parse(
       await harness.callRpc("createComment", {
@@ -569,11 +599,12 @@ describe("Tasks RPC domain API", () => {
       }),
     );
 
-    expect(result.comment.notifiedCount).toBe(1);
+    expect(result.comment.notifiedCount).toBe(0);
     expect(store.tasks.getComment(result.comment.id)).toMatchObject({
       body: "This comment must survive delivery failures.",
-      notifiedCount: 1,
+      notifiedCount: 0,
     });
+    expect(harness.sdk.callsTo("threads.send")).toHaveLength(1);
     expect(harness.logEntries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -7,7 +7,7 @@ import {
   type TasksStore,
 } from "../db";
 import { removeAttachmentBlobs } from "../attachments";
-import { deliverCommentToAgents } from "../steer";
+import { deliverCommentToLatestAgent } from "../steer";
 import {
   tasksRpcContract,
   type Attachment as AttachmentMetadata,
@@ -418,7 +418,7 @@ export async function createComment(
   );
 
   if (input.notify && comment.kind === "user") {
-    const delivery = await deliverCommentToAgents(bb, store.tasks, {
+    const delivery = await deliverCommentToLatestAgent(bb, store.tasks, {
       taskId: comment.taskId,
       commentId: comment.id,
       body: comment.body,

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -398,6 +398,8 @@ interface CreateCommentInput {
   taskId: string;
   kind: StoredComment["kind"];
   authorName: string;
+  presetName: string | null;
+  threadId: string | null;
   body: string;
   notify: boolean;
 }
@@ -412,12 +414,14 @@ export async function createComment(
       taskId: input.taskId,
       kind: input.kind,
       authorName: input.authorName,
+      presetName: input.presetName,
+      threadId: input.threadId,
       body: input.body,
       notifiedCount: 0,
     }),
   );
 
-  if (input.notify && comment.kind === "user") {
+  if (input.notify) {
     const delivery = await deliverCommentToLatestAgent(bb, store.tasks, {
       taskId: comment.taskId,
       commentId: comment.id,
@@ -841,6 +845,8 @@ export function registerHandlers(
         taskId: input.taskId,
         kind: "user",
         authorName: "You",
+        presetName: null,
+        threadId: null,
         body: input.body,
         notify: input.notify,
       });

--- a/official-plugins/tasks/cli/cli.test.ts
+++ b/official-plugins/tasks/cli/cli.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
 import { describe, expect, it, vi } from "vitest";
 
+import { createStore } from "../api";
 import plugin from "../server";
 
 // Passthrough mock with one injectable failure: files named boom.bin fail at
@@ -195,8 +196,14 @@ describe("bb tasks CLI", () => {
     );
     const seed = [
       { title: "No priority", args: [] },
-      { title: "High later", args: ["--priority", "high", "--due", "2026-08-01"] },
-      { title: "High soon", args: ["--priority", "high", "--due", "2026-07-20"] },
+      {
+        title: "High later",
+        args: ["--priority", "high", "--due", "2026-08-01"],
+      },
+      {
+        title: "High soon",
+        args: ["--priority", "high", "--due", "2026-07-20"],
+      },
       { title: "Urgent undated", args: ["--priority", "urgent"] },
     ];
     for (const task of seed) {
@@ -215,19 +222,30 @@ describe("bb tasks CLI", () => {
 
     const byPriority = JSON.parse(
       stdout(
-        await harness.runCli(["list", "--project", "SRT", "--sort", "priority", "--json"]),
+        await harness.runCli([
+          "list",
+          "--project",
+          "SRT",
+          "--sort",
+          "priority",
+          "--json",
+        ]),
       ),
     );
-    expect(byPriority.tasks.map((task: { title: string }) => task.title)).toEqual([
-      "Urgent undated",
-      "High soon",
-      "High later",
-      "No priority",
-    ]);
+    expect(
+      byPriority.tasks.map((task: { title: string }) => task.title),
+    ).toEqual(["Urgent undated", "High soon", "High later", "No priority"]);
 
     const byDue = JSON.parse(
       stdout(
-        await harness.runCli(["list", "--project", "SRT", "--sort", "due", "--json"]),
+        await harness.runCli([
+          "list",
+          "--project",
+          "SRT",
+          "--sort",
+          "due",
+          "--json",
+        ]),
       ),
     );
     expect(byDue.tasks.map((task: { title: string }) => task.title)).toEqual([
@@ -600,6 +618,13 @@ describe("bb tasks CLI", () => {
         presetName: "Attached",
       }),
     ]);
+    createStore(bb).tasks.createComment({
+      taskId: threads.task.id,
+      kind: "agent",
+      authorName: "CLI worker",
+      threadId: "thr_cli_self",
+      body: "Prior reply from this agent.",
+    });
 
     const notified = JSON.parse(
       stdout(
@@ -621,7 +646,7 @@ describe("bb tasks CLI", () => {
       [
         expect.objectContaining({
           threadId: "thr_cli_self",
-          mode: "steer",
+          mode: "steer-if-active",
         }),
       ],
     ]);
@@ -732,9 +757,7 @@ describe("bb tasks CLI", () => {
           outputPath,
         ]),
       );
-      expect(await readFile(outputPath, "utf8")).toBe(
-        "attach me at create\n",
-      );
+      expect(await readFile(outputPath, "utf8")).toBe("attach me at create\n");
     } finally {
       await rm(directory, { recursive: true, force: true });
       await harness.dispose();
@@ -784,8 +807,8 @@ describe("bb tasks CLI", () => {
       const payload = JSON.parse(mixed.stdout);
       expect(payload.task).toMatchObject({ key: "MIX-1" });
       expect(
-        payload.attachments.map((attachment: { fileName: string }) =>
-          attachment.fileName,
+        payload.attachments.map(
+          (attachment: { fileName: string }) => attachment.fileName,
         ),
       ).toEqual(["first.txt", "last.txt"]);
       expect(payload.failedAttachments).toEqual([
@@ -793,9 +816,7 @@ describe("bb tasks CLI", () => {
       ]);
       // Both successes really persisted on the created task.
       const listed = JSON.parse(
-        stdout(
-          await harness.runCli(["attachment", "list", "MIX-1", "--json"]),
-        ),
+        stdout(await harness.runCli(["attachment", "list", "MIX-1", "--json"])),
       );
       expect(listed.attachments).toHaveLength(2);
 

--- a/official-plugins/tasks/cli/cli.test.ts
+++ b/official-plugins/tasks/cli/cli.test.ts
@@ -618,34 +618,50 @@ describe("bb tasks CLI", () => {
         presetName: "Attached",
       }),
     ]);
-    createStore(bb).tasks.createComment({
+    const taskStore = createStore(bb).tasks;
+    taskStore.createComment({
       taskId: threads.task.id,
       kind: "agent",
-      authorName: "CLI worker",
-      threadId: "thr_cli_self",
-      body: "Prior reply from this agent.",
+      authorName: "Prior worker",
+      threadId: "thr_prior_worker",
+      body: "Prior reply from another agent.",
     });
 
     const notified = JSON.parse(
       stdout(
-        await harness.runCli([
-          "comment",
-          "ATT-1",
-          "--body",
-          "Include the new edge case.",
-          "--notify",
-          "--json",
-        ]),
+        await harness.runCli(
+          [
+            "comment",
+            "ATT-1",
+            "--body",
+            "Include the new edge case.",
+            "--author",
+            "Custom CLI agent",
+            "--notify",
+            "--json",
+          ],
+          { threadId: "thr_cli_sender", projectId: "proj_bb" },
+        ),
       ),
     ).comment;
     expect(notified).toMatchObject({
       taskId: threads.task.id,
+      kind: "agent",
+      authorName: "Custom CLI agent",
+      threadId: "thr_cli_sender",
+      body: "Include the new edge case.",
+      notifiedCount: 1,
+    });
+    expect(taskStore.getComment(notified.id)).toMatchObject({
+      kind: "agent",
+      authorName: "Custom CLI agent",
+      threadId: "thr_cli_sender",
       notifiedCount: 1,
     });
     expect(harness.sdk.callsTo("threads.send")).toEqual([
       [
         expect.objectContaining({
-          threadId: "thr_cli_self",
+          threadId: "thr_prior_worker",
           mode: "steer-if-active",
         }),
       ],
@@ -900,10 +916,23 @@ describe("bb tasks CLI", () => {
     });
     await plugin(bb);
     stdout(
-      await harness.runCli(["project", "create", "--name", "PRs", "--prefix", "PRS"]),
+      await harness.runCli([
+        "project",
+        "create",
+        "--name",
+        "PRs",
+        "--prefix",
+        "PRS",
+      ]),
     );
     stdout(
-      await harness.runCli(["create", "--project", "PRS", "--title", "Ship the pill"]),
+      await harness.runCli([
+        "create",
+        "--project",
+        "PRS",
+        "--title",
+        "Ship the pill",
+      ]),
     );
     stdout(
       await harness.runCli(["attach", "PRS-1", "--thread", "thr_pr_worker"]),
@@ -964,12 +993,27 @@ describe("bb tasks CLI", () => {
     });
     await plugin(bb);
     stdout(
-      await harness.runCli(["project", "create", "--name", "PRs", "--prefix", "PRS"]),
+      await harness.runCli([
+        "project",
+        "create",
+        "--name",
+        "PRs",
+        "--prefix",
+        "PRS",
+      ]),
     );
     stdout(
-      await harness.runCli(["create", "--project", "PRS", "--title", "Ship the pill"]),
+      await harness.runCli([
+        "create",
+        "--project",
+        "PRS",
+        "--title",
+        "Ship the pill",
+      ]),
     );
-    stdout(await harness.runCli(["attach", "PRS-1", "--thread", "thr_down_0000"]));
+    stdout(
+      await harness.runCli(["attach", "PRS-1", "--thread", "thr_down_0000"]),
+    );
 
     const shown = stdout(await harness.runCli(["show", "PRS-1"]));
     expect(shown).toContain("PR lookup unavailable for: thr_down_0000");

--- a/official-plugins/tasks/cli/index.ts
+++ b/official-plugins/tasks/cli/index.ts
@@ -9,7 +9,7 @@ import type {
 import { z } from "zod";
 
 import {
-  publishCommentsChanged,
+  createComment,
   publishProjectsChanged,
   registerHandlers,
   type TasksApiStore,
@@ -825,7 +825,9 @@ async function runList(
   const sortOption = option(args, "sort") ?? "manual";
   const sort = TASK_SORTS.find((candidate) => candidate === sortOption);
   if (sort === undefined) {
-    throw new CliError(`invalid sort: ${sortOption} (${TASK_SORTS.join(", ")})`);
+    throw new CliError(
+      `invalid sort: ${sortOption} (${TASK_SORTS.join(", ")})`,
+    );
   }
   const project = await selectedProject(
     domain,
@@ -1122,25 +1124,15 @@ async function runComment(
   if (body === undefined)
     throw new CliError("missing required --body or --body-file");
   if (!body.trim()) throw new CliError("comment body must not be blank");
-  const comment = args.flags.has("notify")
-    ? tasksRpcContract.createComment.output.parse(
-        await domain.createComment(
-          tasksRpcContract.createComment.input.parse({
-            taskId: task.id,
-            body,
-            notify: true,
-          }),
-        ),
-      ).comment
-    : store.tasks.createComment({
-        taskId: task.id,
-        kind: ctx.threadId ? "agent" : "user",
-        authorName: option(args, "author") ?? taskAuthor(ctx),
-        threadId: ctx.threadId ?? null,
-        body,
-        notifiedCount: 0,
-      });
-  if (!args.flags.has("notify")) publishCommentsChanged(bb, task.id);
+  const comment = await createComment(bb, store, {
+    taskId: task.id,
+    kind: ctx.threadId ? "agent" : "user",
+    authorName: option(args, "author") ?? taskAuthor(ctx),
+    presetName: null,
+    threadId: ctx.threadId ?? null,
+    body,
+    notify: args.flags.has("notify"),
+  });
   return args.flags.has("json")
     ? json({ comment })
     : `Commented on ${task.key}  ${comment.id}`;

--- a/official-plugins/tasks/db.test.ts
+++ b/official-plugins/tasks/db.test.ts
@@ -328,9 +328,51 @@ describe("tasks storage", () => {
       setCreatedAt.run("2026-07-15T10:00:00.000Z", older.id);
       setCreatedAt.run("2026-07-15T11:00:00.000Z", latest.id);
 
-      expect(store.getLatestAgentComment(task.id)).toMatchObject({
+      expect(store.getLatestAgentComment(task.id, null)).toMatchObject({
         id: latest.id,
         threadId: "thr_latest",
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("uses insertion order when agent replies share a timestamp", async () => {
+    const { db, harness, store } = setup();
+    try {
+      const project = createProject(store, "TIE");
+      const task = store.createTask({ projectId: project.id, title: "Task" });
+      const earlier = store.createComment({
+        id: "01H00000000000000000000002",
+        taskId: task.id,
+        kind: "agent",
+        authorName: "Earlier responder",
+        threadId: "thr_earlier",
+        body: "Earlier reply",
+      });
+      const later = store.createComment({
+        // Deliberately lexicographically smaller than the earlier ID.
+        id: "01H00000000000000000000001",
+        taskId: task.id,
+        kind: "agent",
+        authorName: "Later responder",
+        threadId: "thr_later",
+        body: "Later reply",
+      });
+      const setCreatedAt = db.prepare<[string, string]>(
+        "UPDATE comments SET created_at = ? WHERE id = ?",
+      );
+      const sharedTime = "2026-07-15T10:00:00.000Z";
+      setCreatedAt.run(sharedTime, earlier.id);
+      setCreatedAt.run(sharedTime, later.id);
+
+      expect(store.listComments(task.id).map((comment) => comment.id)).toEqual([
+        earlier.id,
+        later.id,
+      ]);
+      expect(store.getLatestAgentComment(task.id, null)).toMatchObject({
+        id: later.id,
+        threadId: "thr_later",
       });
     } finally {
       await harness.dispose();

--- a/official-plugins/tasks/db.test.ts
+++ b/official-plugins/tasks/db.test.ts
@@ -297,6 +297,46 @@ describe("tasks storage", () => {
     }
   });
 
+  it("finds the latest agent comment by reply time and ignores other activity", async () => {
+    const { db, harness, store } = setup();
+    try {
+      const project = createProject(store, "LAR");
+      const task = store.createTask({ projectId: project.id, title: "Task" });
+      const latest = store.createComment({
+        taskId: task.id,
+        kind: "agent",
+        authorName: "Latest responder",
+        threadId: "thr_latest",
+        body: "Latest agent reply",
+      });
+      const older = store.createComment({
+        taskId: task.id,
+        kind: "agent",
+        authorName: "Older responder",
+        threadId: "thr_older",
+        body: "Older agent reply",
+      });
+      store.createComment({
+        taskId: task.id,
+        kind: "user",
+        authorName: "Sawyer",
+        body: "Newer user activity",
+      });
+      const setCreatedAt = db.prepare<[string, string]>(
+        "UPDATE comments SET created_at = ? WHERE id = ?",
+      );
+      setCreatedAt.run("2026-07-15T10:00:00.000Z", older.id);
+      setCreatedAt.run("2026-07-15T11:00:00.000Z", latest.id);
+
+      expect(store.getLatestAgentComment(task.id)).toMatchObject({
+        id: latest.id,
+        threadId: "thr_latest",
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
   it("rejects duplicate preset names", async () => {
     const { harness, store } = setup();
     try {

--- a/official-plugins/tasks/db/store.ts
+++ b/official-plugins/tasks/db/store.ts
@@ -1169,6 +1169,20 @@ export function createTasksStore(db: PluginDatabase) {
       .map(commentFromRow);
   }
 
+  function getLatestAgentComment(taskId: string): Comment | undefined {
+    const row = db
+      .prepare<[string], CommentRow>(
+        `
+        SELECT * FROM comments
+        WHERE task_id = ? AND kind = 'agent'
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      `,
+      )
+      .get(taskId);
+    return row ? commentFromRow(row) : undefined;
+  }
+
   function updateComment(id: string, input: UpdateCommentInput): Comment {
     const current = requireComment(id);
     db.prepare<[string, number, string]>(
@@ -1578,6 +1592,7 @@ export function createTasksStore(db: PluginDatabase) {
     createComment,
     getComment,
     listComments,
+    getLatestAgentComment,
     updateComment,
     deleteComment,
     createAttachment,

--- a/official-plugins/tasks/db/store.ts
+++ b/official-plugins/tasks/db/store.ts
@@ -1162,24 +1162,29 @@ export function createTasksStore(db: PluginDatabase) {
     return db
       .prepare<[string], CommentRow>(
         `
-        SELECT * FROM comments WHERE task_id = ? ORDER BY created_at, id
+        SELECT * FROM comments WHERE task_id = ? ORDER BY created_at, rowid
       `,
       )
       .all(taskId)
       .map(commentFromRow);
   }
 
-  function getLatestAgentComment(taskId: string): Comment | undefined {
+  function getLatestAgentComment(
+    taskId: string,
+    excludeCommentId: string | null,
+  ): Comment | undefined {
     const row = db
-      .prepare<[string], CommentRow>(
+      .prepare<[string, string | null, string | null], CommentRow>(
         `
         SELECT * FROM comments
-        WHERE task_id = ? AND kind = 'agent'
-        ORDER BY created_at DESC, id DESC
+        WHERE task_id = ?
+          AND kind = 'agent'
+          AND (? IS NULL OR id <> ?)
+        ORDER BY created_at DESC, rowid DESC
         LIMIT 1
       `,
       )
-      .get(taskId);
+      .get(taskId, excludeCommentId, excludeCommentId);
     return row ? commentFromRow(row) : undefined;
   }
 

--- a/official-plugins/tasks/skills/tasks/SKILL.md
+++ b/official-plugins/tasks/skills/tasks/SKILL.md
@@ -43,7 +43,9 @@ not already exist. Dispatch requires an existing preset.
    Add `--notify` only when the new comment should be delivered to the thread
    that authored the task's most recent agent reply. This resumes an idle
    recipient; with no prior agent reply, the comment is recorded without
-   targeting an unrelated thread.
+   targeting an unrelated thread. In agent context, the new comment keeps the
+   current thread identity and an explicit `--author`, while delivery still
+   targets the prior latest responder rather than the new comment itself.
 
 4. Attach result artifacts that belong with the task, such as reports,
    screenshots, patches, or generated files:

--- a/official-plugins/tasks/skills/tasks/SKILL.md
+++ b/official-plugins/tasks/skills/tasks/SKILL.md
@@ -40,6 +40,11 @@ not already exist. Dispatch requires an existing preset.
    bb tasks comment ABC-12 --body "Implemented the change; focused validation now passes."
    ```
 
+   Add `--notify` only when the new comment should be delivered to the thread
+   that authored the task's most recent agent reply. This resumes an idle
+   recipient; with no prior agent reply, the comment is recorded without
+   targeting an unrelated thread.
+
 4. Attach result artifacts that belong with the task, such as reports,
    screenshots, patches, or generated files:
 

--- a/official-plugins/tasks/steer/index.ts
+++ b/official-plugins/tasks/steer/index.ts
@@ -42,7 +42,12 @@ export async function deliverCommentToLatestAgent(
   const task = store.getTask(input.taskId);
   if (!task) throw new Error(`Task not found: ${input.taskId}`);
 
-  const latestReply = store.getLatestAgentComment(input.taskId);
+  // The CLI can explicitly notify while preserving an agent-authored comment.
+  // Exclude the comment being delivered so it cannot select its own thread.
+  const latestReply = store.getLatestAgentComment(
+    input.taskId,
+    input.commentId,
+  );
   if (!latestReply) return { notifiedCount: 0, outcomes: [] };
   if (latestReply.threadId === null) {
     return {

--- a/official-plugins/tasks/steer/index.ts
+++ b/official-plugins/tasks/steer/index.ts
@@ -10,7 +10,7 @@ export interface DeliverCommentInput {
 
 export type CommentDeliveryOutcome =
   | { threadId: string; status: "delivered" }
-  | { threadId: string; status: "skipped"; reason: string }
+  | { threadId: string | null; status: "skipped"; reason: string }
   | { threadId: string; status: "failed"; reason: string };
 
 export interface CommentDeliveryResult {
@@ -25,7 +25,7 @@ function steerPrompt(
 ): string {
   return (
     `New comment on task ${taskKey} from ${authorName}: ${body}\n\n` +
-    "This is a steer — fold it into your current work on this task; " +
+    "Treat this as updated context for your work on this task; " +
     `reply via bb tasks comment ${taskKey} when relevant.`
   );
 }
@@ -34,7 +34,7 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export async function deliverCommentToAgents(
+export async function deliverCommentToLatestAgent(
   bb: BbPluginApi,
   store: TasksStore,
   input: DeliverCommentInput,
@@ -42,56 +42,53 @@ export async function deliverCommentToAgents(
   const task = store.getTask(input.taskId);
   if (!task) throw new Error(`Task not found: ${input.taskId}`);
 
-  const activeThreads = store
-    .listTaskThreads(input.taskId)
-    .filter(
-      (thread) =>
-        thread.liveStatus === "starting" || thread.liveStatus === "working",
-    );
-  const prompt = steerPrompt(task.key, input.authorName, input.body);
-  const outcomes = await Promise.all(
-    activeThreads.map(async (thread): Promise<CommentDeliveryOutcome> => {
-      try {
-        const current = await bb.sdk.threads.get({
-          threadId: thread.threadId,
-        });
-        if (current.status !== "active") {
-          return {
-            threadId: thread.threadId,
-            status: "skipped",
-            reason: `thread is ${current.status}`,
-          };
-        }
+  const latestReply = store.getLatestAgentComment(input.taskId);
+  if (!latestReply) return { notifiedCount: 0, outcomes: [] };
+  if (latestReply.threadId === null) {
+    return {
+      notifiedCount: 0,
+      outcomes: [
+        {
+          threadId: null,
+          status: "skipped",
+          reason: "latest agent reply has no thread",
+        },
+      ],
+    };
+  }
 
-        // The status can change after this read. The SDK does not yet expose
-        // an atomic active-only send, so send-time 409s remain possible and
-        // are recorded below as non-deliveries.
-        await bb.sdk.threads.send({
-          threadId: thread.threadId,
-          input: [{ type: "text", text: prompt, mentions: [] }],
-          mode: "steer",
-        });
-        return { threadId: thread.threadId, status: "delivered" };
-      } catch (error) {
-        const reason = errorMessage(error);
-        bb.log.warn(
-          `failed to steer comment ${input.commentId} to thread ${thread.threadId}: ${reason}`,
-        );
-        return {
-          threadId: thread.threadId,
-          status: "failed",
-          reason,
-        };
-      }
-    }),
-  );
-  // Deterministic output order: task_threads rows attached within the same
-  // millisecond have no stable DB order, which made this array (and the
-  // tests asserting it) order-flaky.
-  outcomes.sort((a, b) => a.threadId.localeCompare(b.threadId));
+  const threadId = latestReply.threadId;
+  const prompt = steerPrompt(task.key, input.authorName, input.body);
+  let outcome: CommentDeliveryOutcome;
+  try {
+    const thread = await bb.sdk.threads.get({ threadId });
+    if (
+      thread.originKind === "side-chat" ||
+      thread.childOrigin === "side-chat"
+    ) {
+      outcome = {
+        threadId,
+        status: "skipped",
+        reason: "latest agent reply belongs to a side chat",
+      };
+    } else {
+      await bb.sdk.threads.send({
+        threadId,
+        input: [{ type: "text", text: prompt, mentions: [] }],
+        mode: "steer-if-active",
+      });
+      outcome = { threadId, status: "delivered" };
+    }
+  } catch (error) {
+    const reason = errorMessage(error);
+    bb.log.warn(
+      `failed to deliver comment ${input.commentId} to thread ${threadId}: ${reason}`,
+    );
+    outcome = { threadId, status: "failed", reason };
+  }
+
   return {
-    notifiedCount: outcomes.filter((outcome) => outcome.status === "delivered")
-      .length,
-    outcomes,
+    notifiedCount: outcome.status === "delivered" ? 1 : 0,
+    outcomes: [outcome],
   };
 }

--- a/official-plugins/tasks/steer/steer.test.ts
+++ b/official-plugins/tasks/steer/steer.test.ts
@@ -4,152 +4,240 @@ import {
 } from "@bb/plugin-sdk/testing";
 import { describe, expect, it } from "vitest";
 import { createTasksStore } from "../db";
-import { deliverCommentToAgents } from ".";
+import { deliverCommentToLatestAgent } from ".";
 
-function taskWithThreads() {
+function setup(
+  getThread: (threadId: string) => ReturnType<typeof makeThreadResponse> = (
+    threadId,
+  ) => makeThreadResponse({ id: threadId, status: "active" }),
+) {
   const host = createFakePluginHost({
     pluginId: "tasks",
     sdk: {
       threads: {
-        get: async ({ threadId }) =>
-          makeThreadResponse({ id: threadId, status: "active" }),
+        get: async ({ threadId }) => getThread(threadId),
         send: async () => undefined,
       },
     },
   });
-  const store = createTasksStore(host.bb.storage.database());
+  const db = host.bb.storage.database();
+  const store = createTasksStore(db);
   const project = store.createProject({
     name: "Plugin",
     prefix: "PLUG",
     color: "blue",
   });
   const task = store.createTask({ projectId: project.id, title: "Steer work" });
-  for (const [threadId, liveStatus] of [
-    ["thr_starting", "starting"],
-    ["thr_working", "working"],
-    ["thr_completed", "completed"],
-  ] as const) {
-    store.upsertTaskThread({
-      taskId: task.id,
-      threadId,
-      presetName: "Default",
-      title: threadId,
-      liveStatus,
-    });
-  }
-  return { ...host, store, task };
+  return { ...host, db, store, task };
 }
 
-describe("comment steer delivery", () => {
-  it("steers starting and working threads without waking completed threads", async () => {
-    const { bb, harness, store, task } = taskWithThreads();
+const input = {
+  commentId: "01J00000000000000000000000",
+  authorName: "Sawyer",
+  body: "Please include the regression test.",
+};
+
+describe("comment notification delivery", () => {
+  it("notifies only the latest replying agent despite newer unrelated task activity", async () => {
+    const { bb, db, harness, store, task } = setup();
+    const older = store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "First agent",
+      threadId: "thr_first",
+      body: "First reply",
+    });
+    const latest = store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Second agent",
+      threadId: "thr_second",
+      body: "Latest reply",
+    });
+    store.upsertTaskThread({
+      taskId: task.id,
+      threadId: "thr_second",
+      presetName: "Default",
+      title: "Second agent",
+      liveStatus: "working",
+    });
+    const unrelated = store.upsertTaskThread({
+      taskId: task.id,
+      threadId: "thr_first",
+      presetName: "Default",
+      title: "First agent",
+      liveStatus: "working",
+    });
+    db.prepare("UPDATE comments SET created_at = ? WHERE id = ?").run(
+      "2026-07-16T10:00:00.000Z",
+      older.id,
+    );
+    db.prepare("UPDATE comments SET created_at = ? WHERE id = ?").run(
+      "2026-07-16T11:00:00.000Z",
+      latest.id,
+    );
+    db.prepare("UPDATE task_threads SET updated_at = ? WHERE id = ?").run(
+      "2026-07-16T12:00:00.000Z",
+      unrelated.id,
+    );
 
     await expect(
-      deliverCommentToAgents(bb, store, {
-        taskId: task.id,
-        commentId: "01J00000000000000000000000",
-        authorName: "Sawyer",
-        body: "Please include the regression test.",
-      }),
+      deliverCommentToLatestAgent(bb, store, { taskId: task.id, ...input }),
     ).resolves.toEqual({
-      notifiedCount: 2,
-      outcomes: [
-        { threadId: "thr_starting", status: "delivered" },
-        { threadId: "thr_working", status: "delivered" },
-      ],
+      notifiedCount: 1,
+      outcomes: [{ threadId: "thr_second", status: "delivered" }],
     });
-
     expect(harness.sdk.callsTo("threads.send")).toEqual([
       [
         {
-          threadId: "thr_starting",
+          threadId: "thr_second",
           input: [
             {
               type: "text",
               text:
                 "New comment on task PLUG-1 from Sawyer: Please include the regression test.\n\n" +
-                "This is a steer — fold it into your current work on this task; reply via bb tasks comment PLUG-1 when relevant.",
+                "Treat this as updated context for your work on this task; reply via bb tasks comment PLUG-1 when relevant.",
               mentions: [],
             },
           ],
-          mode: "steer",
+          mode: "steer-if-active",
         },
       ],
+    ]);
+  });
+
+  it("uses resume-capable delivery for an idle latest responder", async () => {
+    const { bb, harness, store, task } = setup((threadId) =>
+      makeThreadResponse({ id: threadId, status: "idle" }),
+    );
+    store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Idle agent",
+      threadId: "thr_idle",
+      body: "Ready for more context",
+    });
+
+    await expect(
+      deliverCommentToLatestAgent(bb, store, { taskId: task.id, ...input }),
+    ).resolves.toEqual({
+      notifiedCount: 1,
+      outcomes: [{ threadId: "thr_idle", status: "delivered" }],
+    });
+    expect(harness.sdk.callsTo("threads.send")).toEqual([
       [
         expect.objectContaining({
-          threadId: "thr_working",
-          mode: "steer",
+          threadId: "thr_idle",
+          mode: "steer-if-active",
         }),
       ],
     ]);
   });
 
-  it("skips an idle thread even when the task row still says working", async () => {
-    const { bb, harness, store, task } = taskWithThreads();
-    harness.sdk.stub("threads.get", async (input: never) => {
-      const { threadId } = input as { threadId: string };
-      return makeThreadResponse({
+  it("does nothing when no agent has replied", async () => {
+    const { bb, harness, store, task } = setup();
+
+    await expect(
+      deliverCommentToLatestAgent(bb, store, { taskId: task.id, ...input }),
+    ).resolves.toEqual({ notifiedCount: 0, outcomes: [] });
+    expect(harness.sdk.callsTo("threads.get")).toEqual([]);
+    expect(harness.sdk.callsTo("threads.send")).toEqual([]);
+  });
+
+  it("does not fall back when the latest agent reply has no thread", async () => {
+    const { bb, harness, store, task } = setup();
+    store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Older linked agent",
+      threadId: "thr_older",
+      body: "Older reply",
+    });
+    store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Legacy agent",
+      body: "Latest unlinked reply",
+    });
+
+    await expect(
+      deliverCommentToLatestAgent(bb, store, { taskId: task.id, ...input }),
+    ).resolves.toEqual({
+      notifiedCount: 0,
+      outcomes: [
+        {
+          threadId: null,
+          status: "skipped",
+          reason: "latest agent reply has no thread",
+        },
+      ],
+    });
+    expect(harness.sdk.callsTo("threads.send")).toEqual([]);
+  });
+
+  it("preserves side-chat privacy and does not fall back", async () => {
+    const { bb, harness, store, task } = setup((threadId) =>
+      makeThreadResponse({
         id: threadId,
-        status: threadId === "thr_working" ? "idle" : "active",
+        status: "idle",
+        originKind: "side-chat",
+      }),
+    );
+    store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Side chat",
+      threadId: "thr_side_chat",
+      body: "Private reply",
+    });
+
+    await expect(
+      deliverCommentToLatestAgent(bb, store, { taskId: task.id, ...input }),
+    ).resolves.toEqual({
+      notifiedCount: 0,
+      outcomes: [
+        {
+          threadId: "thr_side_chat",
+          status: "skipped",
+          reason: "latest agent reply belongs to a side chat",
+        },
+      ],
+    });
+    expect(harness.sdk.callsTo("threads.send")).toEqual([]);
+  });
+
+  it("records delivery failure without trying another agent", async () => {
+    const { bb, harness, store, task } = setup();
+    store.createComment({
+      taskId: task.id,
+      kind: "agent",
+      authorName: "Latest agent",
+      threadId: "thr_latest",
+      body: "Latest reply",
+    });
+    harness.sdk.stub("threads.send", async () => {
+      throw Object.assign(new Error("thread awaiting interaction"), {
+        status: 409,
       });
     });
 
     await expect(
-      deliverCommentToAgents(bb, store, {
-        taskId: task.id,
-        commentId: "01J00000000000000000000000",
-        authorName: "Sawyer",
-        body: "Do not wake the idle worker.",
-      }),
+      deliverCommentToLatestAgent(bb, store, { taskId: task.id, ...input }),
     ).resolves.toEqual({
-      notifiedCount: 1,
-      outcomes: [
-        { threadId: "thr_starting", status: "delivered" },
-        {
-          threadId: "thr_working",
-          status: "skipped",
-          reason: "thread is idle",
-        },
-      ],
-    });
-    expect(harness.sdk.callsTo("threads.send")).toEqual([
-      [expect.objectContaining({ threadId: "thr_starting" })],
-    ]);
-  });
-
-  it("records a send-time 409 as a non-delivery", async () => {
-    const { bb, harness, store, task } = taskWithThreads();
-    harness.sdk.stub("threads.send", async (input: never) => {
-      const request = input as { threadId: string };
-      if (request.threadId === "thr_starting") {
-        throw Object.assign(new Error("thread awaiting interaction"), {
-          status: 409,
-        });
-      }
-    });
-
-    await expect(
-      deliverCommentToAgents(bb, store, {
-        taskId: task.id,
-        commentId: "01J00000000000000000000000",
-        authorName: "Sawyer",
-        body: "Please retry safely.",
-      }),
-    ).resolves.toEqual({
-      notifiedCount: 1,
+      notifiedCount: 0,
       outcomes: [
         {
-          threadId: "thr_starting",
+          threadId: "thr_latest",
           status: "failed",
           reason: "thread awaiting interaction",
         },
-        { threadId: "thr_working", status: "delivered" },
       ],
     });
+    expect(harness.sdk.callsTo("threads.send")).toHaveLength(1);
     expect(harness.logEntries).toContainEqual({
       level: "warn",
       message:
-        "failed to steer comment 01J00000000000000000000000 to thread thr_starting: thread awaiting interaction",
+        "failed to deliver comment 01J00000000000000000000000 to thread thr_latest: thread awaiting interaction",
     });
   });
 });

--- a/official-plugins/tasks/views/activity/task-activity.test.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DisplayComment } from "../../shared/contract.js";
+import {
+  AgentNotificationControl,
+  agentNotificationTarget,
+} from "./task-activity.js";
+
+afterEach(cleanup);
+
+function comment(
+  kind: DisplayComment["kind"],
+  threadId: string | null = null,
+  threadTitle: string | null = null,
+): DisplayComment {
+  return {
+    id: `01HZZZZZZZZZZZZZZZZZZZZZ${kind === "agent" ? "A" : "U"}`,
+    taskId: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+    kind,
+    authorName: kind === "agent" ? "Agent" : "You",
+    presetName: null,
+    threadId,
+    threadTitle,
+    body: "Reply",
+    notifiedCount: 0,
+    createdAt: "2026-07-15T00:00:00.000Z",
+  };
+}
+
+describe("agent notification target", () => {
+  it("uses the last agent reply rather than the last activity entry", () => {
+    expect(
+      agentNotificationTarget([
+        comment("agent", "thr_first", "First agent"),
+        comment("agent", "thr_latest", "Latest agent"),
+        comment("user"),
+      ]),
+    ).toEqual({ kind: "ready", title: "Latest agent" });
+  });
+
+  it("distinguishes no prior reply from an unavailable latest responder", () => {
+    expect(agentNotificationTarget([comment("user")])).toEqual({
+      kind: "none",
+    });
+    expect(
+      agentNotificationTarget([comment("agent", "thr_private", null)]),
+    ).toEqual({ kind: "unavailable" });
+  });
+});
+
+describe("AgentNotificationControl", () => {
+  it("exposes an enabled accessible opt-in for the latest responder", () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <AgentNotificationControl
+        target={{ kind: "ready", title: "Fix the login bug" }}
+        checked
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", {
+      name: "Notify last responding agent",
+    });
+    expect(toggle.hasAttribute("disabled")).toBe(false);
+    expect(screen.getByText("Notify Fix the login bug")).toBeTruthy();
+    fireEvent.click(toggle);
+    expect(onCheckedChange).toHaveBeenCalledWith(false);
+  });
+
+  it("clearly disables notification when no agent has replied", () => {
+    render(
+      <AgentNotificationControl
+        target={{ kind: "none" }}
+        checked
+        onCheckedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No prior agent reply to notify")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("switch", { name: "Notify last responding agent" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("does not expose a private or missing latest thread as a target", () => {
+    render(
+      <AgentNotificationControl
+        target={{ kind: "unavailable" }}
+        checked
+        onCheckedChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Latest responding agent can’t be notified"),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("switch", { name: "Notify last responding agent" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+});

--- a/official-plugins/tasks/views/activity/task-activity.test.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.test.tsx
@@ -1,13 +1,53 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  createFakePluginHost,
+  makeThreadResponse,
+} from "@bb/plugin-sdk/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createComment, createStore } from "../../api/index.js";
 import type { DisplayComment } from "../../shared/contract.js";
 import {
   AgentNotificationControl,
   agentNotificationTarget,
+  CommentComposer,
 } from "./task-activity.js";
 
-afterEach(cleanup);
+const { rpcCall } = vi.hoisted(() => ({ rpcCall: vi.fn() }));
+
+vi.mock("../../shell/data.js", () => ({
+  useMentionItems: () => [],
+  useTasksQuery: () => ({ data: [] }),
+  useTasksRpc: () => ({ call: rpcCall }),
+}));
+
+vi.mock("@bb/plugin-sdk/app", () => ({
+  useBbNavigate: () => ({ toThread: vi.fn() }),
+}));
+
+vi.mock("../../editor/tasks-editor.js", () => ({
+  TasksEditor: (props: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="Comment body"
+      value={props.value}
+      onChange={(event) => props.onChange(event.currentTarget.value)}
+    />
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  rpcCall.mockReset();
+});
 
 function comment(
   kind: DisplayComment["kind"],
@@ -61,7 +101,7 @@ describe("AgentNotificationControl", () => {
     );
 
     const toggle = screen.getByRole("switch", {
-      name: "Notify last responding agent",
+      name: "Notify Fix the login bug",
     });
     expect(toggle.hasAttribute("disabled")).toBe(false);
     expect(screen.getByText("Notify Fix the login bug")).toBeTruthy();
@@ -81,7 +121,7 @@ describe("AgentNotificationControl", () => {
     expect(screen.getByText("No prior agent reply to notify")).toBeTruthy();
     expect(
       screen
-        .getByRole("switch", { name: "Notify last responding agent" })
+        .getByRole("switch", { name: "No prior agent reply to notify" })
         .hasAttribute("disabled"),
     ).toBe(true);
   });
@@ -100,8 +140,104 @@ describe("AgentNotificationControl", () => {
     ).toBeTruthy();
     expect(
       screen
-        .getByRole("switch", { name: "Notify last responding agent" })
+        .getByRole("switch", {
+          name: "Latest responding agent can’t be notified",
+        })
         .hasAttribute("disabled"),
     ).toBe(true);
+  });
+});
+
+describe("CommentComposer", () => {
+  it("single-flights rapid submit activation into one comment and send", async () => {
+    let releaseSend!: () => void;
+    const sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    const { bb, harness } = createFakePluginHost({
+      pluginId: "tasks",
+      sdk: {
+        threads: {
+          get: async ({ threadId }) =>
+            makeThreadResponse({ id: threadId, status: "active" }),
+          send: async () => sendGate,
+        },
+      },
+    });
+    try {
+      const store = createStore(bb);
+      const project = store.tasks.createProject({
+        name: "Composer",
+        prefix: "CMP",
+        color: "blue",
+      });
+      const task = store.tasks.createTask({
+        projectId: project.id,
+        title: "Submit once",
+      });
+      store.tasks.createComment({
+        taskId: task.id,
+        kind: "agent",
+        authorName: "Worker",
+        threadId: "thr_worker",
+        body: "Ready for input",
+      });
+      rpcCall.mockImplementation(async (method, input) => {
+        if (method !== "createComment") {
+          throw new Error(`Unexpected RPC method: ${String(method)}`);
+        }
+        const request = input as {
+          taskId: string;
+          body: string;
+          notify: boolean;
+        };
+        return {
+          comment: await createComment(bb, store, {
+            taskId: request.taskId,
+            kind: "user",
+            authorName: "You",
+            presetName: null,
+            threadId: null,
+            body: request.body,
+            notify: request.notify,
+          }),
+        };
+      });
+
+      render(
+        <CommentComposer
+          taskId={task.id}
+          notificationTarget={{ kind: "ready", title: "Worker" }}
+        />,
+      );
+      fireEvent.change(screen.getByRole("textbox", { name: "Comment body" }), {
+        target: { value: "Only once" },
+      });
+      const submit = screen.getByRole("button", { name: "Comment" });
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+
+      await waitFor(() => expect(rpcCall).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(harness.sdk.callsTo("threads.send")).toHaveLength(1),
+      );
+      expect(
+        store.tasks
+          .listComments(task.id)
+          .filter((entry) => entry.body === "Only once"),
+      ).toHaveLength(1);
+
+      releaseSend();
+      await waitFor(() =>
+        expect(
+          store.tasks
+            .listComments(task.id)
+            .find((entry) => entry.body === "Only once")?.notifiedCount,
+        ).toBe(1),
+      );
+    } finally {
+      releaseSend();
+      await harness.dispose();
+    }
   });
 });

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowUp02Icon,
@@ -246,7 +246,7 @@ interface ComposerProps {
   notificationTarget: AgentNotificationTarget;
 }
 
-function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
+export function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
   const rpc = useTasksRpc();
   const navigate = useBbNavigate();
   const mentionItems = useMentionItems();
@@ -256,6 +256,7 @@ function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const sendingRef = useRef(false);
 
   const staged = pendingFiles.filter((entry) => entry.status === "staged");
   const canSend = !sending && (body.trim().length > 0 || staged.length > 0);
@@ -293,13 +294,13 @@ function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
   };
 
   const send = async () => {
-    if (!canSend) return;
+    if (!canSend || sendingRef.current) return;
+    sendingRef.current = true;
     setSending(true);
     setError(null);
     const text = body.trim();
-    let comment: Comment;
     try {
-      comment = (
+      const comment: Comment = (
         await rpc.call("createComment", {
           taskId,
           body: text,
@@ -307,45 +308,45 @@ function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
           allowEmptyBody: text.length === 0,
         })
       ).comment;
+      // The comment is now posted — clear the text so a later upload failure
+      // can't double-post it. Failed uploads stay behind as retryable chips.
+      setBody("");
+      const failed: StagedAttachment[] = [];
+      for (const entry of staged) {
+        try {
+          await uploadAttachment(entry.file, { commentId: comment.id });
+        } catch (cause) {
+          failed.push({
+            ...entry,
+            status: "failed",
+            owner: { commentId: comment.id },
+            error: cause instanceof Error ? cause.message : String(cause),
+          });
+        }
+      }
+      // Sent entries leave the tray (failures come back as retryable chips);
+      // anything staged after send started is untouched.
+      setPendingFiles((files) =>
+        files.flatMap((entry) => {
+          const failure = failed.find((candidate) => candidate.id === entry.id);
+          if (failure) return [failure];
+          return staged.some((candidate) => candidate.id === entry.id)
+            ? []
+            : [entry];
+        }),
+      );
+      if (failed.length > 0) {
+        setError(
+          `The comment posted, but ${failed.length} attachment${failed.length > 1 ? "s" : ""} failed to upload — retry below.`,
+        );
+      }
     } catch (cause) {
       // Nothing posted: keep the draft and chips for another attempt.
       setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      sendingRef.current = false;
       setSending(false);
-      return;
     }
-    // The comment is now posted — clear the text so a later upload failure
-    // can't double-post it. Failed uploads stay behind as retryable chips.
-    setBody("");
-    const failed: StagedAttachment[] = [];
-    for (const entry of staged) {
-      try {
-        await uploadAttachment(entry.file, { commentId: comment.id });
-      } catch (cause) {
-        failed.push({
-          ...entry,
-          status: "failed",
-          owner: { commentId: comment.id },
-          error: cause instanceof Error ? cause.message : String(cause),
-        });
-      }
-    }
-    // Sent entries leave the tray (failures come back as retryable chips);
-    // anything staged after send started is untouched.
-    setPendingFiles((files) =>
-      files.flatMap((entry) => {
-        const failure = failed.find((candidate) => candidate.id === entry.id);
-        if (failure) return [failure];
-        return staged.some((candidate) => candidate.id === entry.id)
-          ? []
-          : [entry];
-      }),
-    );
-    if (failed.length > 0) {
-      setError(
-        `The comment posted, but ${failed.length} attachment${failed.length > 1 ? "s" : ""} failed to upload — retry below.`,
-      );
-    }
-    setSending(false);
   };
 
   return (
@@ -430,6 +431,7 @@ export function AgentNotificationControl({
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
 }) {
+  const labelId = useId();
   const enabled = target.kind === "ready";
   const label =
     target.kind === "ready"
@@ -444,9 +446,9 @@ export function AgentNotificationControl({
         checked={enabled && checked}
         disabled={!enabled}
         onCheckedChange={onCheckedChange}
-        aria-label="Notify last responding agent"
+        aria-labelledby={labelId}
       />
-      {label}
+      <span id={labelId}>{label}</span>
     </label>
   );
 }

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -31,7 +31,6 @@ import type {
   Attachment,
   Comment,
   DisplayComment,
-  TaskThread,
 } from "../../shared/contract.js";
 import {
   formatFileSize,
@@ -70,8 +69,27 @@ function useActivityFeed(taskId: string) {
   );
 }
 
-function isRunning(thread: TaskThread): boolean {
-  return thread.liveStatus === "starting" || thread.liveStatus === "working";
+export type AgentNotificationTarget =
+  | { kind: "ready"; title: string }
+  | { kind: "none" }
+  | { kind: "unavailable" };
+
+export function agentNotificationTarget(
+  comments: readonly DisplayComment[],
+): AgentNotificationTarget {
+  let latest: DisplayComment | undefined;
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    if (comment?.kind === "agent") {
+      latest = comment;
+      break;
+    }
+  }
+  if (!latest) return { kind: "none" };
+  if (latest.threadId === null || latest.threadTitle === null) {
+    return { kind: "unavailable" };
+  }
+  return { kind: "ready", title: latest.threadTitle };
 }
 
 function UserAvatar({ name }: { name: string }) {
@@ -171,13 +189,7 @@ function SystemEvent({ comment, nowMs }: { comment: Comment; nowMs: number }) {
   );
 }
 
-function CommentCard({
-  entry,
-  nowMs,
-}: {
-  entry: FeedEntry;
-  nowMs: number;
-}) {
+function CommentCard({ entry, nowMs }: { entry: FeedEntry; nowMs: number }) {
   const { comment, attachments } = entry;
   const agent = comment.kind === "agent";
   const navigate = useBbNavigate();
@@ -221,8 +233,7 @@ function CommentCard({
         {comment.kind === "user" && comment.notifiedCount > 0 ? (
           <div className="mt-1 flex items-center gap-1 text-2xs font-medium text-success">
             <HugeiconsIcon icon={Notification02Icon} className="size-2.5" />
-            notified {comment.notifiedCount} working agent
-            {comment.notifiedCount > 1 ? "s" : ""}
+            notified the last responding agent
           </div>
         ) : null}
       </div>
@@ -232,10 +243,10 @@ function CommentCard({
 
 interface ComposerProps {
   taskId: string;
-  runningCount: number;
+  notificationTarget: AgentNotificationTarget;
 }
 
-function CommentComposer({ taskId, runningCount }: ComposerProps) {
+function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
   const rpc = useTasksRpc();
   const navigate = useBbNavigate();
   const mentionItems = useMentionItems();
@@ -292,7 +303,7 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
         await rpc.call("createComment", {
           taskId,
           body: text,
-          notify: notify && runningCount > 0,
+          notify: notify && notificationTarget.kind === "ready",
           allowEmptyBody: text.length === 0,
         })
       ).comment;
@@ -368,19 +379,11 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
         <div className="mt-2 text-xs text-destructive">{error}</div>
       ) : null}
       <div className="mt-2 flex items-center gap-1.5">
-        {runningCount > 0 ? (
-          <label className="mr-auto flex items-center gap-2 text-xs text-muted-foreground">
-            <HugeiconsIcon icon={Notification02Icon} className="size-3" />
-            <Switch
-              checked={notify}
-              onCheckedChange={setNotify}
-              aria-label="Notify working agents"
-            />
-            Notify {runningCount} working agent{runningCount > 1 ? "s" : ""}
-          </label>
-        ) : (
-          <span className="mr-auto" />
-        )}
+        <AgentNotificationControl
+          target={notificationTarget}
+          checked={notify}
+          onCheckedChange={setNotify}
+        />
         <input
           ref={fileInputRef}
           type="file"
@@ -418,6 +421,36 @@ function CommentComposer({ taskId, runningCount }: ComposerProps) {
   );
 }
 
+export function AgentNotificationControl({
+  target,
+  checked,
+  onCheckedChange,
+}: {
+  target: AgentNotificationTarget;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  const enabled = target.kind === "ready";
+  const label =
+    target.kind === "ready"
+      ? `Notify ${target.title}`
+      : target.kind === "none"
+        ? "No prior agent reply to notify"
+        : "Latest responding agent can’t be notified";
+  return (
+    <label className="mr-auto flex items-center gap-2 text-xs text-muted-foreground">
+      <HugeiconsIcon icon={Notification02Icon} className="size-3" />
+      <Switch
+        checked={enabled && checked}
+        disabled={!enabled}
+        onCheckedChange={onCheckedChange}
+        aria-label="Notify last responding agent"
+      />
+      {label}
+    </label>
+  );
+}
+
 export interface TaskActivityProps {
   taskId: string;
   /** Task key like TSK-4; reserved for deep links from feed entries. */
@@ -427,17 +460,12 @@ export interface TaskActivityProps {
 /** Activity feed + comment composer for the task detail page. */
 export function TaskActivity({ taskId }: TaskActivityProps) {
   const feed = useActivityFeed(taskId);
-  const threads = useTasksQuery(
-    async (rpc) => (await rpc.call("listTaskThreads", { taskId })).taskThreads,
-    ["threads:changed"],
-    [taskId],
-  );
   const nowMs = useNowTick();
-  const runningCount = useMemo(
-    () => (threads.data ?? []).filter(isRunning).length,
-    [threads.data],
-  );
   const entries = feed.data ?? [];
+  const notificationTarget = useMemo(
+    () => agentNotificationTarget(entries.map((entry) => entry.comment)),
+    [entries],
+  );
 
   return (
     <section aria-label="Activity">
@@ -468,7 +496,10 @@ export function TaskActivity({ taskId }: TaskActivityProps) {
           ),
         )}
       </div>
-      <CommentComposer taskId={taskId} runningCount={runningCount} />
+      <CommentComposer
+        taskId={taskId}
+        notificationTarget={notificationTarget}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- route opt-in task comments to exactly the agent thread that authored the latest agent reply, including idle threads
- keep disabled and no-prior-reply paths explicit and safe, preserve side-chat privacy, and avoid fallback or duplicate delivery
- expose the same behavior through the Tasks CLI while preserving agent authorship and custom author values
- make reply ordering insertion-safe for equal timestamps and expose the dynamic notification target accessibly

## Validation
- Turbo focused notification suite: 57/57
- Turbo full Tasks suite: 190/190
- Turbo Tasks typecheck and build
- isolated real-product E2E: active, idle resume, multiple-agent ordering, disabled, no prior reply, failure durability, accessibility, persistence/reconnect, CLI authorship, and rapid duplicate submit

## Review
Exactly one GPT-5.6 Sol Medium read-only review returned REQUEST CHANGES. All five findings were addressed; no second review round was run. The refreshed test catalog and screenshots are attached to BB-22.