### PR TITLE
BB-21 Remove task attachments safely

### DIFF
--- a/official-plugins/tasks/README.md
+++ b/official-plugins/tasks/README.md
@@ -73,7 +73,7 @@ Run `bb tasks --help` or `bb tasks <command> --help` for exact options. Add
 | `bb tasks show <key-or-id>`                    | Show the complete task record, including comments, attachments, subtasks, and attached threads.                                   |
 | `bb tasks update <key-or-id>`                  | Update status, priority, title, description, due date, or labels.                                                                 |
 | `bb tasks comment <key-or-id>`                 | Add a Markdown comment from inline text or a file; optionally notify the latest responding task agent.                            |
-| `bb tasks attachment add\|get\|list`           | Add a task/comment artifact, fetch it to a path, or list a task's attachments.                                                    |
+| `bb tasks attachment add\|get\|list\|remove`  | Add a task/comment artifact, fetch it to a path, list a task's attachments, or remove one by id. Removal is rejected while the saved task description references the attachment. |
 | `bb tasks preset list\|create\|update\|delete` | Manage reusable agent execution presets.                                                                                          |
 | `bb tasks delegate <key>`                      | Start and attach a new agent thread using a preset.                                                                               |
 | `bb tasks attach <key-or-id>`                  | Attach the current bb thread to a task when it was not delegated from Tasks.                                                      |

--- a/official-plugins/tasks/README.md
+++ b/official-plugins/tasks/README.md
@@ -73,7 +73,7 @@ Run `bb tasks --help` or `bb tasks <command> --help` for exact options. Add
 | `bb tasks show <key-or-id>`                    | Show the complete task record, including comments, attachments, subtasks, and attached threads.                                   |
 | `bb tasks update <key-or-id>`                  | Update status, priority, title, description, due date, or labels.                                                                 |
 | `bb tasks comment <key-or-id>`                 | Add a Markdown comment from inline text or a file; optionally notify the latest responding task agent.                            |
-| `bb tasks attachment add\|get\|list\|remove`  | Add a task/comment artifact, fetch it to a path, list a task's attachments, or remove one by id. Removal is rejected while the saved task description references the attachment. |
+| `bb tasks attachment add\|get\|list\|remove`  | Add, fetch, list, or remove attachments. Referenced attachments require `remove --remove-references`.                            |
 | `bb tasks preset list\|create\|update\|delete` | Manage reusable agent execution presets.                                                                                          |
 | `bb tasks delegate <key>`                      | Start and attach a new agent thread using a preset.                                                                               |
 | `bb tasks attach <key-or-id>`                  | Attach the current bb thread to a task when it was not delegated from Tasks.                                                      |

--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -51,9 +51,11 @@ describe("Tasks RPC domain API", () => {
     expect(store.tasks.getAttachment(attachmentId)).toBeDefined();
     expect(harness.realtimeSignals).toHaveLength(signalsBeforeConflict);
 
-    store.tasks.updateTask(task.id, { description: "Reference removed." });
     const deleted = tasksRpcContract.deleteAttachment.output.parse(
-      await harness.callRpc("deleteAttachment", { attachmentId }),
+      await harness.callRpc("deleteAttachment", {
+        attachmentId,
+        removeDescriptionReferences: true,
+      }),
     );
     expect(deleted).toMatchObject({
       ok: true,
@@ -61,6 +63,7 @@ describe("Tasks RPC domain API", () => {
       attachment: { id: attachmentId },
     });
     expect(store.tasks.getAttachment(attachmentId)).toBeUndefined();
+    expect(store.tasks.getTask(task.id)?.description).toBe("");
     expect(harness.realtimeSignals.at(-1)).toEqual({
       channel: "tasks:changed",
       payload: { taskId: task.id, projectId: project.id },

--- a/official-plugins/tasks/api/api.test.ts
+++ b/official-plugins/tasks/api/api.test.ts
@@ -5,11 +5,73 @@ import {
   makeThreadResponse,
 } from "@bb/plugin-sdk/testing";
 import { describe, expect, it, vi } from "vitest";
-import { registerAttachments } from "../attachments";
+import { buildAttachmentUrl, registerAttachments } from "../attachments";
 import { tasksRpcContract } from "../shared/contract";
 import { createComment, createStore, registerTasksApi } from ".";
 
 describe("Tasks RPC domain API", () => {
+  it("deletes through the typed RPC policy and rejects saved-description references", async () => {
+    const { bb, harness } = createFakePluginHost({ pluginId: "tasks" });
+    const store = createStore(bb);
+    registerAttachments(bb, store.tasks);
+    registerTasksApi(bb, store);
+    const project = store.tasks.createProject({
+      name: "Attachments",
+      prefix: "ATT",
+      color: "blue",
+    });
+    const task = store.tasks.createTask({
+      projectId: project.id,
+      title: "Referenced image",
+    });
+    const uploaded = await harness.fetchHttp(
+      "POST",
+      `/attachments/upload?taskId=${task.id}&fileName=diagram.png&mime=image%2Fpng`,
+      { body: "image", headers: { "content-type": "image/png" } },
+    );
+    const { attachmentId } = (await uploaded.json()) as {
+      attachmentId: string;
+    };
+    store.tasks.updateTask(task.id, {
+      description: `![diagram](${buildAttachmentUrl(attachmentId)})`,
+    });
+    const signalsBeforeConflict = harness.realtimeSignals.length;
+
+    const conflict = tasksRpcContract.deleteAttachment.output.parse(
+      await harness.callRpc("deleteAttachment", { attachmentId }),
+    );
+    expect(conflict).toEqual({
+      ok: false,
+      error: {
+        code: "attachment_referenced",
+        message:
+          'Attachment "diagram.png" is used in the task description. Remove it from the description before deleting the attachment.',
+      },
+    });
+    expect(store.tasks.getAttachment(attachmentId)).toBeDefined();
+    expect(harness.realtimeSignals).toHaveLength(signalsBeforeConflict);
+
+    store.tasks.updateTask(task.id, { description: "Reference removed." });
+    const deleted = tasksRpcContract.deleteAttachment.output.parse(
+      await harness.callRpc("deleteAttachment", { attachmentId }),
+    );
+    expect(deleted).toMatchObject({
+      ok: true,
+      deleted: true,
+      attachment: { id: attachmentId },
+    });
+    expect(store.tasks.getAttachment(attachmentId)).toBeUndefined();
+    expect(harness.realtimeSignals.at(-1)).toEqual({
+      channel: "tasks:changed",
+      payload: { taskId: task.id, projectId: project.id },
+    });
+
+    await expect(
+      harness.callRpc("deleteAttachment", { attachmentId }),
+    ).resolves.toEqual({ ok: true, deleted: false, attachment: null });
+    await harness.dispose();
+  });
+
   it("persists one successful notification to the latest replying agent", async () => {
     const { bb, harness } = createFakePluginHost({
       pluginId: "tasks",

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -6,7 +6,11 @@ import {
   type Task as StoredTask,
   type TasksStore,
 } from "../db";
-import { removeAttachmentBlobs } from "../attachments";
+import {
+  AttachmentReferencedError,
+  deleteAttachmentById,
+  removeAttachmentBlobs,
+} from "../attachments";
 import { deliverCommentToLatestAgent } from "../steer";
 import {
   tasksRpcContract,
@@ -873,6 +877,33 @@ export function registerHandlers(
       return {
         attachments: attachments.map(attachmentMetadata),
       };
+    },
+    async deleteAttachment(input) {
+      try {
+        const attachment = await deleteAttachmentById(
+          bb,
+          store.tasks,
+          input.attachmentId,
+        );
+        return attachment
+          ? {
+              ok: true,
+              deleted: true,
+              attachment: attachmentMetadata(attachment),
+            }
+          : { ok: true, deleted: false, attachment: null };
+      } catch (error) {
+        if (error instanceof AttachmentReferencedError) {
+          return {
+            ok: false,
+            error: {
+              code: "attachment_referenced",
+              message: error.message,
+            },
+          };
+        }
+        throw error;
+      }
     },
     listTaskThreads(input) {
       return { taskThreads: store.tasks.listTaskThreads(input.taskId) };

--- a/official-plugins/tasks/api/index.ts
+++ b/official-plugins/tasks/api/index.ts
@@ -884,6 +884,9 @@ export function registerHandlers(
           bb,
           store.tasks,
           input.attachmentId,
+          {
+            removeDescriptionReferences: input.removeDescriptionReferences,
+          },
         );
         return attachment
           ? {

--- a/official-plugins/tasks/attachments/attachments.test.ts
+++ b/official-plugins/tasks/attachments/attachments.test.ts
@@ -5,11 +5,12 @@ import { describe, expect, it } from "vitest";
 import { createTasksStore } from "../db";
 import {
   buildAttachmentUrl,
+  deleteAttachmentById,
   MAX_ATTACHMENT_SIZE_BYTES,
   registerAttachments,
 } from ".";
 
-function setup() {
+function setup(options?: Parameters<typeof registerAttachments>[2]) {
   const { bb, harness } = createFakePluginHost({ pluginId: "tasks" });
   const db = bb.storage.database();
   const store = createTasksStore(db);
@@ -22,13 +23,13 @@ function setup() {
     projectId: project.id,
     title: "Attachment owner",
   });
-  registerAttachments(bb, store);
+  registerAttachments(bb, store, options);
   const database = db
     .prepare<[], { name: string; file: string }>("PRAGMA database_list")
     .all()
     .find((entry) => entry.name === "main");
   if (!database) throw new Error("test database path is missing");
-  return { harness, store, task, root: dirname(database.file) };
+  return { bb, harness, store, task, root: dirname(database.file) };
 }
 
 async function upload(
@@ -235,6 +236,121 @@ describe("task attachments", () => {
           payload: { taskId: task.id, projectId: task.projectId },
         },
       ]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("deleteAttachmentById removes the row and blob and returns the attachment", async () => {
+    const { bb, harness, root, store, task } = setup();
+    try {
+      const uploaded = await upload(
+        harness,
+        task.id,
+        "document",
+        "note.txt",
+        "text/plain",
+      );
+      const { attachmentId } = (await uploaded.json()) as {
+        attachmentId: string;
+      };
+      const attachment = store.getAttachment(attachmentId);
+      if (!attachment) throw new Error("attachment row was not created");
+      const blobDirectory = dirname(join(root, attachment.blobPath));
+
+      const deleted = await deleteAttachmentById(bb, store, attachmentId);
+      expect(deleted).toMatchObject({ id: attachmentId });
+      expect(store.getAttachment(attachmentId)).toBeUndefined();
+      await expect(stat(blobDirectory)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("keeps the row and blob reachable and publishes nothing when cleanup fails", async () => {
+    const { harness, root, store, task } = setup({
+      removeBlobs: async () => {
+        throw new Error("simulated rm failure");
+      },
+    });
+    try {
+      const uploaded = await upload(
+        harness,
+        task.id,
+        "document",
+        "note.txt",
+        "text/plain",
+      );
+      const { attachmentId } = (await uploaded.json()) as {
+        attachmentId: string;
+      };
+      const attachment = store.getAttachment(attachmentId);
+      if (!attachment) throw new Error("attachment row was not created");
+      const signalsBeforeDelete = harness.realtimeSignals.length;
+
+      const response = await harness.fetchHttp(
+        "DELETE",
+        `/attachments/delete?attachmentId=${attachmentId}`,
+        { headers: { "content-type": "application/json" } },
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "Failed to remove attachment blob: note.txt",
+      });
+      expect(store.getAttachment(attachmentId)).toEqual(attachment);
+      await expect(
+        readFile(join(root, attachment.blobPath), "utf8"),
+      ).resolves.toBe("document");
+      expect(harness.realtimeSignals).toHaveLength(signalsBeforeDelete);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("rejects deletion when the saved task description references the attachment", async () => {
+    const { harness, root, store, task } = setup();
+    try {
+      const uploaded = await upload(harness, task.id, "image");
+      const { attachmentId } = (await uploaded.json()) as {
+        attachmentId: string;
+      };
+      const attachment = store.getAttachment(attachmentId);
+      if (!attachment) throw new Error("attachment row was not created");
+      store.updateTask(task.id, {
+        description: `![diagram](${buildAttachmentUrl(attachmentId)})`,
+      });
+      const signalsBeforeDelete = harness.realtimeSignals.length;
+
+      const response = await harness.fetchHttp(
+        "DELETE",
+        `/attachments/delete?attachmentId=${attachmentId}`,
+        { headers: { "content-type": "application/json" } },
+      );
+
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toEqual({
+        error:
+          'Attachment "image.png" is used in the task description. Remove it from the description before deleting the attachment.',
+      });
+      expect(store.getAttachment(attachmentId)).toEqual(attachment);
+      await expect(
+        readFile(join(root, attachment.blobPath), "utf8"),
+      ).resolves.toBe("image");
+      expect(harness.realtimeSignals).toHaveLength(signalsBeforeDelete);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it("deleteAttachmentById is a safe no-op for an unknown id", async () => {
+    const { bb, harness, store } = setup();
+    try {
+      await expect(
+        deleteAttachmentById(bb, store, "01JZZZZZZZZZZZZZZZZZZZZZZZ"),
+      ).resolves.toBeNull();
     } finally {
       await harness.dispose();
     }

--- a/official-plugins/tasks/attachments/attachments.test.ts
+++ b/official-plugins/tasks/attachments/attachments.test.ts
@@ -276,34 +276,31 @@ describe("task attachments", () => {
       },
     });
     try {
-      const uploaded = await upload(
-        harness,
-        task.id,
-        "document",
-        "note.txt",
-        "text/plain",
-      );
+      const uploaded = await upload(harness, task.id, "image");
       const { attachmentId } = (await uploaded.json()) as {
         attachmentId: string;
       };
       const attachment = store.getAttachment(attachmentId);
       if (!attachment) throw new Error("attachment row was not created");
+      const description = `![diagram](${buildAttachmentUrl(attachmentId)})`;
+      store.updateTask(task.id, { description });
       const signalsBeforeDelete = harness.realtimeSignals.length;
 
       const response = await harness.fetchHttp(
         "DELETE",
-        `/attachments/delete?attachmentId=${attachmentId}`,
+        `/attachments/delete?attachmentId=${attachmentId}&removeDescriptionReferences=true`,
         { headers: { "content-type": "application/json" } },
       );
 
       expect(response.status).toBe(500);
       await expect(response.json()).resolves.toEqual({
-        error: "Failed to remove attachment blob: note.txt",
+        error: "Failed to remove attachment blob: image.png",
       });
       expect(store.getAttachment(attachmentId)).toEqual(attachment);
+      expect(store.getTask(task.id)?.description).toBe(description);
       await expect(
         readFile(join(root, attachment.blobPath), "utf8"),
-      ).resolves.toBe("document");
+      ).resolves.toBe("image");
       expect(harness.realtimeSignals).toHaveLength(signalsBeforeDelete);
     } finally {
       await harness.dispose();
@@ -340,6 +337,19 @@ describe("task attachments", () => {
         readFile(join(root, attachment.blobPath), "utf8"),
       ).resolves.toBe("image");
       expect(harness.realtimeSignals).toHaveLength(signalsBeforeDelete);
+
+      const confirmed = await harness.fetchHttp(
+        "DELETE",
+        `/attachments/delete?attachmentId=${attachmentId}&removeDescriptionReferences=true`,
+        { headers: { "content-type": "application/json" } },
+      );
+      expect(confirmed.status).toBe(200);
+      expect(store.getAttachment(attachmentId)).toBeUndefined();
+      expect(store.getTask(task.id)?.description).toBe("");
+      await expect(
+        stat(dirname(join(root, attachment.blobPath))),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      expect(harness.realtimeSignals).toHaveLength(signalsBeforeDelete + 1);
     } finally {
       await harness.dispose();
     }

--- a/official-plugins/tasks/attachments/index.ts
+++ b/official-plugins/tasks/attachments/index.ts
@@ -83,6 +83,18 @@ export class AttachmentCleanupError extends Error {
   }
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function removeAttachmentDescriptionReferences(
+  markdown: string,
+  attachmentId: string,
+): string {
+  const url = escapeRegExp(buildAttachmentUrl(attachmentId));
+  return markdown.replace(new RegExp(`!\\[[^\\]]*\\]\\(${url}\\)`, "g"), "");
+}
+
 function pluginDataDirectory(bb: BbPluginApi): string {
   const main = bb.storage
     .database()
@@ -411,16 +423,20 @@ function errorResponse(context: PluginHttpContext, error: unknown): Response {
 
 /**
  * Removes an attachment end to end using one shared policy for HTTP, RPC, and
- * CLI callers. Saved-description references are rejected, blob cleanup must
- * succeed before the row is removed, and realtime is published only after
- * both mutations succeed. A cleanup failure therefore leaves the row and blob
- * reachable for a later retry instead of reporting a false success.
+ * CLI callers. Saved-description references are rejected unless the caller
+ * explicitly opts into removing them, blob cleanup must succeed before the
+ * row is removed, and realtime is published only after every mutation
+ * succeeds. A cleanup failure therefore leaves the row and blob reachable for
+ * a later retry instead of reporting a false success.
  */
 export async function deleteAttachmentById(
   bb: BbPluginApi,
   store: TasksStore,
   attachmentId: string,
-  removeBlobs: typeof removeAttachmentBlobs = removeAttachmentBlobs,
+  options: {
+    removeBlobs?: typeof removeAttachmentBlobs;
+    removeDescriptionReferences?: boolean;
+  } = {},
 ): Promise<Attachment | null> {
   const attachment = store.getAttachment(attachmentId);
   if (!attachment) return null;
@@ -431,14 +447,29 @@ export async function deleteAttachmentById(
       ? store.getComment(attachment.commentId)?.taskId
       : undefined);
   const ownerTask = taskId ? store.getTask(taskId) : undefined;
+  let nextDescription: string | undefined;
   if (ownerTask?.description.includes(buildAttachmentUrl(attachment.id))) {
-    throw new AttachmentReferencedError(attachment);
+    if (!options.removeDescriptionReferences) {
+      throw new AttachmentReferencedError(attachment);
+    }
+    nextDescription = removeAttachmentDescriptionReferences(
+      ownerTask.description,
+      attachment.id,
+    );
+    if (nextDescription === ownerTask.description) {
+      throw new AttachmentReferencedError(attachment);
+    }
   }
 
   try {
-    await removeBlobs(bb, store, [attachment]);
+    await (options.removeBlobs ?? removeAttachmentBlobs)(bb, store, [
+      attachment,
+    ]);
   } catch (error) {
     throw new AttachmentCleanupError(attachment, error);
+  }
+  if (ownerTask && nextDescription !== undefined) {
+    store.updateTask(ownerTask.id, { description: nextDescription });
   }
   if (!store.deleteAttachment(attachment.id)) return null;
   publishAttachmentChanged(bb, store, attachment);
@@ -550,7 +581,11 @@ export function registerAttachments(
             bb,
             store,
             attachmentId,
-            options.removeBlobs,
+            {
+              removeBlobs: options.removeBlobs,
+              removeDescriptionReferences:
+                context.req.query("removeDescriptionReferences") === "true",
+            },
           )
         : null;
       if (!attachment)

--- a/official-plugins/tasks/attachments/index.ts
+++ b/official-plugins/tasks/attachments/index.ts
@@ -64,6 +64,25 @@ class AttachmentRequestError extends Error {
   }
 }
 
+export class AttachmentReferencedError extends Error {
+  constructor(readonly attachment: Attachment) {
+    super(
+      `Attachment "${attachment.fileName}" is used in the task description. Remove it from the description before deleting the attachment.`,
+    );
+    this.name = "AttachmentReferencedError";
+  }
+}
+
+export class AttachmentCleanupError extends Error {
+  constructor(
+    readonly attachment: Attachment,
+    readonly cleanupCause: unknown,
+  ) {
+    super(`Failed to remove attachment blob: ${attachment.fileName}`);
+    this.name = "AttachmentCleanupError";
+  }
+}
+
 function pluginDataDirectory(bb: BbPluginApi): string {
   const main = bb.storage
     .database()
@@ -104,27 +123,28 @@ export async function removeAttachmentBlobs(
   attachments: readonly Pick<Attachment, "id" | "blobPath">[],
 ): Promise<void> {
   if (attachments.length === 0) return;
-  let root: string;
-  try {
-    root = requireStoreRoot(store);
-  } catch (error) {
-    bb.log.warn(
-      `failed to resolve attachment blob storage: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-  await Promise.all(
+  const root = requireStoreRoot(store);
+  const removals = await Promise.allSettled(
     attachments.map(async (attachment) => {
-      try {
-        const absolutePath = pathInside(root, attachment.blobPath);
-        await rm(dirname(absolutePath), { recursive: true, force: true });
-      } catch (error) {
-        bb.log.warn(
-          `failed to remove attachment blob ${attachment.id}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
+      const absolutePath = pathInside(root, attachment.blobPath);
+      await rm(dirname(absolutePath), { recursive: true, force: true });
     }),
   );
+  const failures = removals.flatMap((result, index) => {
+    if (result.status === "fulfilled") return [];
+    const attachment = attachments[index];
+    const message =
+      result.reason instanceof Error
+        ? result.reason.message
+        : String(result.reason);
+    bb.log.warn(
+      `failed to remove attachment blob ${attachment?.id ?? "unknown"}: ${message}`,
+    );
+    return [result.reason];
+  });
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Failed to remove attachment blobs");
+  }
 }
 
 function sanitizeFileName(fileName: string): string {
@@ -380,7 +400,49 @@ function errorResponse(context: PluginHttpContext, error: unknown): Response {
   if (error instanceof AttachmentRequestError) {
     return context.json({ error: error.message }, error.status);
   }
+  if (error instanceof AttachmentReferencedError) {
+    return context.json({ error: error.message }, 409);
+  }
+  if (error instanceof AttachmentCleanupError) {
+    return context.json({ error: error.message }, 500);
+  }
   throw error;
+}
+
+/**
+ * Removes an attachment end to end using one shared policy for HTTP, RPC, and
+ * CLI callers. Saved-description references are rejected, blob cleanup must
+ * succeed before the row is removed, and realtime is published only after
+ * both mutations succeed. A cleanup failure therefore leaves the row and blob
+ * reachable for a later retry instead of reporting a false success.
+ */
+export async function deleteAttachmentById(
+  bb: BbPluginApi,
+  store: TasksStore,
+  attachmentId: string,
+  removeBlobs: typeof removeAttachmentBlobs = removeAttachmentBlobs,
+): Promise<Attachment | null> {
+  const attachment = store.getAttachment(attachmentId);
+  if (!attachment) return null;
+
+  const taskId =
+    attachment.taskId ??
+    (attachment.commentId
+      ? store.getComment(attachment.commentId)?.taskId
+      : undefined);
+  const ownerTask = taskId ? store.getTask(taskId) : undefined;
+  if (ownerTask?.description.includes(buildAttachmentUrl(attachment.id))) {
+    throw new AttachmentReferencedError(attachment);
+  }
+
+  try {
+    await removeBlobs(bb, store, [attachment]);
+  } catch (error) {
+    throw new AttachmentCleanupError(attachment, error);
+  }
+  if (!store.deleteAttachment(attachment.id)) return null;
+  publishAttachmentChanged(bb, store, attachment);
+  return attachment;
 }
 
 export function publishAttachmentChanged(
@@ -409,7 +471,13 @@ export function publishAttachmentChanged(
  * and therefore uses token auth; metadata may be supplied through query
  * parameters or x-task-id/x-comment-id/x-file-name/x-mime-type headers.
  */
-export function registerAttachments(bb: BbPluginApi, store: TasksStore): void {
+export function registerAttachments(
+  bb: BbPluginApi,
+  store: TasksStore,
+  options: {
+    removeBlobs?: typeof removeAttachmentBlobs;
+  } = {},
+): void {
   const root = pluginDataDirectory(bb);
   storeRoots.set(store, root);
 
@@ -476,15 +544,20 @@ export function registerAttachments(bb: BbPluginApi, store: TasksStore): void {
 
   bb.http.route("DELETE", DELETE_PATH, async (context) => {
     const attachmentId = context.req.query("attachmentId")?.trim();
-    const attachment = attachmentId
-      ? store.getAttachment(attachmentId)
-      : undefined;
-    if (!attachment)
-      return context.json({ error: "attachment not found" }, 404);
-
-    store.deleteAttachment(attachment.id);
-    await removeAttachmentBlobs(bb, store, [attachment]);
-    publishAttachmentChanged(bb, store, attachment);
-    return context.json({ deleted: true });
+    try {
+      const attachment = attachmentId
+        ? await deleteAttachmentById(
+            bb,
+            store,
+            attachmentId,
+            options.removeBlobs,
+          )
+        : null;
+      if (!attachment)
+        return context.json({ error: "attachment not found" }, 404);
+      return context.json({ deleted: true });
+    } catch (error) {
+      return errorResponse(context, error);
+    }
   });
 }

--- a/official-plugins/tasks/cli/args.ts
+++ b/official-plugins/tasks/cli/args.ts
@@ -19,6 +19,7 @@ const VALUELESS_FLAGS = new Set([
   "no-folder",
   "no-parent",
   "notify",
+  "remove-references",
   "unlink-bb-project",
   "yes",
 ]);

--- a/official-plugins/tasks/cli/cli.test.ts
+++ b/official-plugins/tasks/cli/cli.test.ts
@@ -1105,6 +1105,28 @@ describe("bb tasks CLI", () => {
         },
       ]);
 
+      stdout(
+        await harness.runCli([
+          "update",
+          "FILE-1",
+          "--description",
+          `![pixel](/api/v1/plugins/tasks/http/attachments/download?attachmentId=${pngAttachment.id})`,
+        ]),
+      );
+      const signalsBeforeReferencedRemove = harness.realtimeSignals.length;
+      const referencedRemove = await harness.runCli([
+        "attachment",
+        "remove",
+        pngAttachment.id,
+      ]);
+      expect(referencedRemove.exitCode).toBe(1);
+      expect(referencedRemove.stderr).toContain(
+        "is used in the task description",
+      );
+      expect(harness.realtimeSignals).toHaveLength(
+        signalsBeforeReferencedRemove,
+      );
+
       const listed = JSON.parse(
         stdout(
           await harness.runCli(["attachment", "list", "FILE-1", "--json"]),
@@ -1168,6 +1190,38 @@ describe("bb tasks CLI", () => {
       expect(await readFile(outputPath, "utf8")).toBe(
         "attachment bytes from CLI\n",
       );
+
+      const removed = JSON.parse(
+        stdout(
+          await harness.runCli([
+            "attachment",
+            "remove",
+            attachment.id,
+            "--json",
+          ]),
+        ),
+      );
+      expect(removed).toMatchObject({
+        deleted: true,
+        attachment: { id: attachment.id },
+      });
+      const afterRemove = JSON.parse(
+        stdout(
+          await harness.runCli(["attachment", "list", "FILE-1", "--json"]),
+        ),
+      );
+      expect(
+        afterRemove.attachments.map((entry: { id: string }) => entry.id),
+      ).not.toContain(attachment.id);
+
+      // Removing an already-gone id is an explicit CLI error, not a silent 0.
+      const removeMissing = await harness.runCli([
+        "attachment",
+        "remove",
+        attachment.id,
+      ]);
+      expect(removeMissing.exitCode).toBe(1);
+      expect(removeMissing.stderr).toContain("attachment not found");
     } finally {
       await harness.dispose();
       await rm(directory, { recursive: true, force: true });

--- a/official-plugins/tasks/cli/cli.test.ts
+++ b/official-plugins/tasks/cli/cli.test.ts
@@ -1222,6 +1222,28 @@ describe("bb tasks CLI", () => {
       ]);
       expect(removeMissing.exitCode).toBe(1);
       expect(removeMissing.stderr).toContain("attachment not found");
+
+      const removedReferenced = JSON.parse(
+        stdout(
+          await harness.runCli([
+            "attachment",
+            "remove",
+            pngAttachment.id,
+            "--remove-references",
+            "--json",
+          ]),
+        ),
+      );
+      expect(removedReferenced).toMatchObject({
+        deleted: true,
+        attachment: { id: pngAttachment.id },
+      });
+      const shownAfterReferencedRemove = JSON.parse(
+        stdout(await harness.runCli(["show", "FILE-1", "--json"])),
+      );
+      expect(shownAfterReferencedRemove.task.description).not.toContain(
+        pngAttachment.id,
+      );
     } finally {
       await harness.dispose();
       await rm(directory, { recursive: true, force: true });

--- a/official-plugins/tasks/cli/index.ts
+++ b/official-plugins/tasks/cli/index.ts
@@ -104,7 +104,7 @@ const ATTACHMENT_HELP = `Usage:
   bb tasks attachment add <key-or-comment-id> --file <path> [--name <name>] [--json]
   bb tasks attachment get <attachment-id> --out <path> [--json]
   bb tasks attachment list <key> [--json]
-  bb tasks attachment remove <attachment-id> [--json]`;
+  bb tasks attachment remove <attachment-id> [--remove-references] [--json]`;
 const PRESET_HELP = `Usage:
   bb tasks preset list [--json]
   bb tasks preset show <name-or-id> [--json]
@@ -1325,16 +1325,17 @@ async function runAttachment(
   }
 
   if (action === "remove") {
-    assertAllowed(args, []);
+    assertAllowed(args, [], ["remove-references"]);
     const [attachmentId] = requirePositionals(
       args,
       1,
-      "bb tasks attachment remove <attachment-id> [--json]",
+      "bb tasks attachment remove <attachment-id> [--remove-references] [--json]",
     );
     const result = tasksRpcContract.deleteAttachment.output.parse(
       await domain.deleteAttachment(
         tasksRpcContract.deleteAttachment.input.parse({
           attachmentId: attachmentId!.trim(),
+          removeDescriptionReferences: args.flags.has("remove-references"),
         }),
       ),
     );

--- a/official-plugins/tasks/cli/index.ts
+++ b/official-plugins/tasks/cli/index.ts
@@ -67,7 +67,7 @@ Commands:
   update                         Update a task
   comment                        Add a task comment
   label create|list|delete
-  attachment add|get|list
+  attachment add|get|list|remove
   preset list|show|create|update|delete
   dispatch                       Dispatch a task to a new agent thread
   attach                         Attach an agent thread to a task
@@ -103,7 +103,8 @@ const LABEL_HELP = `Usage:
 const ATTACHMENT_HELP = `Usage:
   bb tasks attachment add <key-or-comment-id> --file <path> [--name <name>] [--json]
   bb tasks attachment get <attachment-id> --out <path> [--json]
-  bb tasks attachment list <key> [--json]`;
+  bb tasks attachment list <key> [--json]
+  bb tasks attachment remove <attachment-id> [--json]`;
 const PRESET_HELP = `Usage:
   bb tasks preset list [--json]
   bb tasks preset show <name-or-id> [--json]
@@ -1323,6 +1324,29 @@ async function runAttachment(
         );
   }
 
+  if (action === "remove") {
+    assertAllowed(args, []);
+    const [attachmentId] = requirePositionals(
+      args,
+      1,
+      "bb tasks attachment remove <attachment-id> [--json]",
+    );
+    const result = tasksRpcContract.deleteAttachment.output.parse(
+      await domain.deleteAttachment(
+        tasksRpcContract.deleteAttachment.input.parse({
+          attachmentId: attachmentId!.trim(),
+        }),
+      ),
+    );
+    if (!result.ok) throw new CliError(result.error.message);
+    if (!result.deleted) {
+      throw new CliError(`attachment not found: ${attachmentId}`);
+    }
+    return args.flags.has("json")
+      ? json({ deleted: true, attachment: result.attachment })
+      : `Removed attachment ${result.attachment.fileName}  ${result.attachment.id}`;
+  }
+
   throw new CliError(`unknown attachment subcommand: ${action}`);
 }
 
@@ -1692,7 +1716,7 @@ export function registerTasksCli(
       },
       {
         name: "attachment",
-        summary: "Add, download, or list task attachments",
+        summary: "Add, download, list, or remove task attachments",
         usage: ATTACHMENT_HELP,
       },
       {

--- a/official-plugins/tasks/editor/editor.test.tsx
+++ b/official-plugins/tasks/editor/editor.test.tsx
@@ -396,4 +396,25 @@ describe("TasksEditor component", () => {
     // Echoing our own onChange output back must not reset the document.
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("stays editable when the description is only a single image", async () => {
+    // A lone block image gives no text caret on its own; the fix relies on a
+    // trailing gap cursor so the user can still add text. Placing the caret at
+    // the end and typing must keep the image and add a paragraph, not replace
+    // or select the image node.
+    let editor: Editor | null = null;
+    render(
+      <TasksEditor
+        value={"![shot](https://example.com/a.png)"}
+        onChange={() => undefined}
+        onEditorReady={(ready) => (editor = ready)}
+      />,
+    );
+    editor!.chain().focus("end").insertContent("caption").run();
+    await waitFor(() => {
+      const markdown = editor!.storage.markdown.getMarkdown() as string;
+      expect(markdown).toContain("![shot](https://example.com/a.png)");
+      expect(markdown).toContain("caption");
+    });
+  });
 });

--- a/official-plugins/tasks/editor/extensions.ts
+++ b/official-plugins/tasks/editor/extensions.ts
@@ -6,7 +6,7 @@ import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Markdown } from "tiptap-markdown";
-import { PluginKey } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { DOMOutputSpec } from "@tiptap/pm/model";
 import { Suggestion, type SuggestionProps } from "@tiptap/suggestion";
 import type { IconSvgElement } from "@hugeicons/react";
@@ -232,6 +232,35 @@ export const ThreadMention = Node.create({
   },
 });
 
+// Keeps a trailing empty paragraph after a terminal leaf block (a block image
+// or horizontal rule). Such a leaf offers no place for a text caret after it,
+// so a description whose only content is an image would otherwise be
+// impossible to focus or extend. The empty paragraph adds no characters when
+// the document is serialized back to markdown for an image-terminal document.
+// Runs only on transactions (not initial construction) and only while the
+// editor is editable; the host seeds the initial document separately.
+export const TrailingParagraph = Extension.create({
+  name: "trailingParagraph",
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    return [
+      new Plugin({
+        key: new PluginKey("trailingParagraph"),
+        appendTransaction: (_transactions, _oldState, newState) => {
+          if (!editor.isEditable) return null;
+          const last = newState.doc.lastChild;
+          const paragraph = newState.schema.nodes.paragraph;
+          if (!paragraph || !last || !last.type.isLeaf) return null;
+          return newState.tr.insert(
+            newState.doc.content.size,
+            paragraph.create(),
+          );
+        },
+      }),
+    ];
+  },
+});
+
 export interface MentionSuggestionHandle {
   getItems(query: string): Promise<MentionItem[]>;
   onChange(props: SuggestionProps<MentionItem, MentionItem>): void;
@@ -299,6 +328,7 @@ export function createEditorExtensions(options?: {
     MarkdownTaskInput,
     TaskMention,
     ThreadMention,
+    TrailingParagraph,
     MentionSuggestion.configure({
       handle: options?.mentionHandle ?? null,
     }),

--- a/official-plugins/tasks/editor/tasks-editor.tsx
+++ b/official-plugins/tasks/editor/tasks-editor.tsx
@@ -35,6 +35,13 @@ const EDITOR_CSS = `
   overflow-wrap: break-word; -webkit-font-smoothing: antialiased;
 }
 .bb-tasks-editor[data-variant="comment"] .tiptap { font-size: 13px; line-height: 1.55; }
+/* Doc variant: let the ProseMirror surface fill the wrapper's min-height so
+   the whole area is editable. Otherwise a short document (e.g. a single block
+   image) leaves a non-editable dead zone below it that swallows clicks, and a
+   lone image atom offers no text caret — the description looks unfocusable. */
+.bb-tasks-editor[data-variant="doc"] { display: flex; flex-direction: column; }
+.bb-tasks-editor[data-variant="doc"] .bb-tasks-editor-surface { display: flex; flex: 1 1 auto; flex-direction: column; }
+.bb-tasks-editor[data-variant="doc"] .bb-tasks-editor-surface .tiptap { flex: 1 1 auto; }
 .bb-tasks-editor .tiptap > :first-child,
 .bb-tasks-editor .tiptap li > :first-child,
 .bb-tasks-editor .tiptap blockquote > :first-child { margin-top: 0; }
@@ -216,6 +223,7 @@ export function TasksEditor({
   className,
 }: TasksEditorProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<Editor | null>(null);
   const lastMarkdownRef = useRef(value);
@@ -355,6 +363,22 @@ export function TasksEditor({
       },
     });
     editorRef.current = editor;
+    // The trailing-paragraph plugin only fires on transactions, so the initial
+    // constructor document is not covered. Seed it once here — before the
+    // update listener is attached — so a description that loads as a single
+    // image starts with a caret target without registering as a user edit.
+    if (!readOnly) {
+      const last = editor.state.doc.lastChild;
+      const paragraph = editor.state.schema.nodes.paragraph;
+      if (paragraph && last && last.type.isLeaf) {
+        editor.view.dispatch(
+          editor.state.tr.insert(
+            editor.state.doc.content.size,
+            paragraph.create(),
+          ),
+        );
+      }
+    }
     if (variant === "doc" && !readOnly && bubbleRef.current) {
       editor.registerPlugin(
         BubbleMenuPlugin({
@@ -458,10 +482,27 @@ export function TasksEditor({
     </button>
   );
 
+  // Clicks that land on the wrapper padding or the empty surface container
+  // (rather than on real content) place the caret at the end of the document.
+  // With StarterKit's gapcursor this yields a usable caret even when the only
+  // node is a block image, so the description stays editable.
+  const focusOnEmptyMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (readOnly) return;
+    if (
+      event.target === wrapperRef.current ||
+      event.target === rootRef.current
+    ) {
+      event.preventDefault();
+      editorRef.current?.commands.focus("end");
+    }
+  };
+
   return (
     <div
+      ref={wrapperRef}
       className={cn("bb-tasks-editor relative min-w-0", className)}
       data-variant={variant}
+      onMouseDown={variant === "doc" ? focusOnEmptyMouseDown : undefined}
     >
       {/* Floating selection menu (doc variant only); BubbleMenuPlugin moves
           this element into a tippy popper positioned above the selection. */}
@@ -499,7 +540,7 @@ export function TasksEditor({
           ))}
         </div>
       ) : null}
-      <div ref={rootRef} className="min-w-0" />
+      <div ref={rootRef} className="bb-tasks-editor-surface min-w-0" />
       {mention && mention.items.length > 0 ? (
         <div
           role="listbox"

--- a/official-plugins/tasks/shared/contract.ts
+++ b/official-plugins/tasks/shared/contract.ts
@@ -225,6 +225,7 @@ export const tasksDomainErrorSchema = z
       "label_project_mismatch",
       "project_not_empty",
       "project_prefix_conflict",
+      "attachment_referenced",
     ]),
     message: z.string(),
   })
@@ -242,6 +243,24 @@ const projectMutationResultSchema = z.discriminatedUnion("ok", [
 
 const projectDeleteResultSchema = z.discriminatedUnion("ok", [
   z.object({ ok: z.literal(true), deleted: z.boolean() }).strict(),
+  z.object({ ok: z.literal(false), error: tasksDomainErrorSchema }).strict(),
+]);
+
+const attachmentDeleteResultSchema = z.union([
+  z
+    .object({
+      ok: z.literal(true),
+      deleted: z.literal(true),
+      attachment: attachmentSchema,
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(true),
+      deleted: z.literal(false),
+      attachment: z.null(),
+    })
+    .strict(),
   z.object({ ok: z.literal(false), error: tasksDomainErrorSchema }).strict(),
 ]);
 
@@ -536,6 +555,10 @@ export const tasksRpcContract = defineRpcContract({
       z.object({ commentId: idSchema }).strict(),
     ]),
     output: z.object({ attachments: z.array(attachmentSchema) }).strict(),
+  },
+  deleteAttachment: {
+    input: z.object({ attachmentId: idSchema }).strict(),
+    output: attachmentDeleteResultSchema,
   },
   listTaskThreads: {
     input: z.object({ taskId: idSchema }).strict(),

--- a/official-plugins/tasks/shared/contract.ts
+++ b/official-plugins/tasks/shared/contract.ts
@@ -557,7 +557,12 @@ export const tasksRpcContract = defineRpcContract({
     output: z.object({ attachments: z.array(attachmentSchema) }).strict(),
   },
   deleteAttachment: {
-    input: z.object({ attachmentId: idSchema }).strict(),
+    input: z
+      .object({
+        attachmentId: idSchema,
+        removeDescriptionReferences: z.boolean().default(false),
+      })
+      .strict(),
     output: attachmentDeleteResultSchema,
   },
   listTaskThreads: {

--- a/official-plugins/tasks/skills/tasks/SKILL.md
+++ b/official-plugins/tasks/skills/tasks/SKILL.md
@@ -56,7 +56,11 @@ not already exist. Dispatch requires an existing preset.
 
    Use `--json` when capturing the returned attachment metadata. When creating
    a task that should start with files, pass repeatable `--attach <path>` to
-   `bb tasks create` instead of attaching afterwards.
+   `bb tasks create` instead of attaching afterwards. Remove an attachment by
+   id with `bb tasks attachment remove <attachment-id>` (row and blob are
+   deleted together); reuse the ids from `bb tasks attachment list <key>`.
+   Remove any saved task-description reference first; referenced attachments
+   are rejected so the command cannot leave broken description content.
 
 5. When the work is ready for review, update the task:
 

--- a/official-plugins/tasks/skills/tasks/SKILL.md
+++ b/official-plugins/tasks/skills/tasks/SKILL.md
@@ -59,8 +59,9 @@ not already exist. Dispatch requires an existing preset.
    `bb tasks create` instead of attaching afterwards. Remove an attachment by
    id with `bb tasks attachment remove <attachment-id>` (row and blob are
    deleted together); reuse the ids from `bb tasks attachment list <key>`.
-   Remove any saved task-description reference first; referenced attachments
-   are rejected so the command cannot leave broken description content.
+   Referenced attachments are rejected unless the caller explicitly confirms
+   content cleanup with `--remove-references`; that flag removes the saved
+   description image reference together with the row and blob.
 
 5. When the work is ready for review, update the task:
 

--- a/official-plugins/tasks/views/detail/attachments.test.tsx
+++ b/official-plugins/tasks/views/detail/attachments.test.tsx
@@ -62,16 +62,16 @@ describe("AttachmentsGrid removal", () => {
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps image removal visible when hover is unavailable", () => {
+  it("uses the composer's always-visible image removal treatment", () => {
     const screen = render(
       <AttachmentsGrid
         attachments={[imageAttachment()]}
         onRemove={vi.fn().mockResolvedValue(undefined)}
       />,
     );
-    expect(screen.getByLabelText("Remove diagram.png").className).toContain(
-      "[@media(hover:none)]:opacity-100",
-    );
+    const remove = screen.getByLabelText("Remove diagram.png");
+    expect(remove.className).toContain("rounded-full bg-black/55");
+    expect(remove.className).not.toContain("opacity-0");
   });
 
   it("shows no remove affordance without an onRemove handler", () => {

--- a/official-plugins/tasks/views/detail/attachments.test.tsx
+++ b/official-plugins/tasks/views/detail/attachments.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Attachment } from "../../shared/contract.js";
+import { AttachmentsGrid } from "./attachments.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function imageAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    id: "01JIMAGE0000000000000000AA",
+    taskId: "01JTASK00000000000000000AA",
+    commentId: null,
+    fileName: "diagram.png",
+    mime: "image/png",
+    sizeBytes: 1024,
+    isImage: true,
+    createdAt: "2026-07-16T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("AttachmentsGrid removal", () => {
+  it("calls the typed removal callback after confirmation", async () => {
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const attachment = imageAttachment();
+
+    const screen = render(
+      <AttachmentsGrid
+        attachments={[attachment]}
+        onRemove={onRemove}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Remove diagram.png"));
+    fireEvent.click(await screen.findByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(onRemove).toHaveBeenCalledWith(attachment));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server error and does not report a removal on failure", async () => {
+    const onRemove = vi.fn().mockRejectedValue(new Error("blob is busy"));
+    const onError = vi.fn();
+
+    const screen = render(
+      <AttachmentsGrid
+        attachments={[imageAttachment()]}
+        onRemove={onRemove}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Remove diagram.png"));
+    fireEvent.click(await screen.findByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith("blob is busy"));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps image removal visible when hover is unavailable", () => {
+    const screen = render(
+      <AttachmentsGrid
+        attachments={[imageAttachment()]}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    expect(screen.getByLabelText("Remove diagram.png").className).toContain(
+      "[@media(hover:none)]:opacity-100",
+    );
+  });
+
+  it("shows no remove affordance without an onRemove handler", () => {
+    const screen = render(
+      <AttachmentsGrid attachments={[imageAttachment()]} />,
+    );
+    expect(screen.queryByLabelText("Remove diagram.png")).toBeNull();
+  });
+});

--- a/official-plugins/tasks/views/detail/attachments.tsx
+++ b/official-plugins/tasks/views/detail/attachments.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Attachment } from "../../shared/contract.js";
 import { formatBytes } from "./meta.js";
+import { ConfirmDialog } from "../../components/confirm-dialog.js";
 import { Icon } from "@bb/shared-ui/icon";
 
 /** Frontend twin of attachments/index.ts `buildAttachmentUrl`. */
@@ -124,63 +125,158 @@ export function Lightbox({
   );
 }
 
+/** Small circular spinner used while a removal request is in flight. */
+function RemovalSpinner() {
+  return (
+    <span
+      role="status"
+      aria-label="Removing"
+      className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+    />
+  );
+}
+
 export function AttachmentsGrid({
   attachments,
+  onRemove,
+  onError,
 }: {
   attachments: Attachment[];
+  /** When provided, each attachment gains a remove affordance. */
+  onRemove?: (attachment: Attachment) => Promise<void>;
+  onError?: (message: string) => void;
 }) {
   const [lightbox, setLightbox] = useState<Attachment | null>(null);
+  // Snapshot of the attachment awaiting confirmation, kept independent of the
+  // live `attachments` prop so a concurrent realtime refresh can't drop it.
+  const [confirm, setConfirm] = useState<Attachment | null>(null);
+  // Ids with a delete request in flight, keyed so refreshes don't reset them.
+  const [pending, setPending] = useState<ReadonlySet<string>>(new Set());
+  const removable = onRemove !== undefined;
+
+  const requestRemove = (attachment: Attachment) => setConfirm(attachment);
+
+  const performRemove = async (attachment: Attachment) => {
+    setConfirm(null);
+    setLightbox((current) => (current?.id === attachment.id ? null : current));
+    setPending((current) => new Set(current).add(attachment.id));
+    try {
+      await onRemove?.(attachment);
+    } catch (error) {
+      onError?.(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPending((current) => {
+        const next = new Set(current);
+        next.delete(attachment.id);
+        return next;
+      });
+    }
+  };
+
   if (attachments.length === 0) return null;
+
+  const removeButton = (attachment: Attachment, variant: "image" | "file") => {
+    if (!removable) return null;
+    const busy = pending.has(attachment.id);
+    const base =
+      variant === "image"
+        ? "absolute right-1 top-1 flex size-6 items-center justify-center rounded-md bg-popover/90 text-popover-foreground opacity-0 shadow-md transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-popover disabled:opacity-100 [@media(hover:none)]:opacity-100"
+        : "flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground";
+    return (
+      <button
+        type="button"
+        aria-label={`Remove ${attachment.fileName}`}
+        disabled={busy}
+        className={base}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!busy) requestRemove(attachment);
+        }}
+      >
+        {busy ? <RemovalSpinner /> : <Icon name="X" className="size-3.5" />}
+      </button>
+    );
+  };
+
   return (
     <div className="flex flex-wrap gap-2">
       {attachments.map((attachment) =>
         attachment.isImage ? (
-          <button
+          <div
             key={attachment.id}
-            type="button"
             className="group relative overflow-hidden rounded-md border border-border shadow-2xs"
-            title={`${attachment.fileName} · ${formatBytes(attachment.sizeBytes)}`}
-            onClick={() => setLightbox(attachment)}
           >
-            <img
-              src={attachmentDownloadUrl(attachment.id)}
-              alt={attachment.fileName}
-              className="block h-24 w-36 object-cover transition-opacity group-hover:opacity-90"
-            />
-            <span
-              className="absolute inset-x-0 bottom-0 truncate px-1.5 py-0.5 text-left text-2xs opacity-0 transition-opacity group-hover:opacity-100"
-              style={{
-                background: "color-mix(in oklab, var(--ink) 55%, transparent)",
-                color: "var(--canvas)",
-              }}
+            <button
+              type="button"
+              className="block"
+              title={`${attachment.fileName} · ${formatBytes(attachment.sizeBytes)}`}
+              onClick={() => setLightbox(attachment)}
             >
-              {attachment.fileName}
-            </span>
-          </button>
-        ) : (
-          <a
-            key={attachment.id}
-            href={attachmentDownloadUrl(attachment.id)}
-            download={attachment.fileName}
-            className="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm shadow-2xs hover:bg-state-hover"
-          >
-            <span className="flex size-6 shrink-0 items-center justify-center rounded-sm bg-secondary text-muted-foreground">
-              <Icon name="File" className="size-3.5" />
-            </span>
-            <span className="min-w-0">
-              <span className="block max-w-48 truncate">
+              <img
+                src={attachmentDownloadUrl(attachment.id)}
+                alt={attachment.fileName}
+                className="block h-24 w-36 object-cover transition-opacity group-hover:opacity-90"
+              />
+              <span
+                className="absolute inset-x-0 bottom-0 truncate px-1.5 py-0.5 text-left text-2xs opacity-0 transition-opacity group-hover:opacity-100"
+                style={{
+                  background:
+                    "color-mix(in oklab, var(--ink) 55%, transparent)",
+                  color: "var(--canvas)",
+                }}
+              >
                 {attachment.fileName}
               </span>
-              <span className="block text-2xs text-muted-foreground">
-                {formatBytes(attachment.sizeBytes)}
+            </button>
+            {removeButton(attachment, "image")}
+          </div>
+        ) : (
+          <div
+            key={attachment.id}
+            className="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm shadow-2xs"
+          >
+            <a
+              href={attachmentDownloadUrl(attachment.id)}
+              download={attachment.fileName}
+              className="flex min-w-0 items-center gap-2 rounded-sm hover:bg-state-hover"
+            >
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-sm bg-secondary text-muted-foreground">
+                <Icon name="File" className="size-3.5" />
               </span>
-            </span>
-          </a>
+              <span className="min-w-0">
+                <span className="block max-w-48 truncate">
+                  {attachment.fileName}
+                </span>
+                <span className="block text-2xs text-muted-foreground">
+                  {formatBytes(attachment.sizeBytes)}
+                </span>
+              </span>
+            </a>
+            {removeButton(attachment, "file")}
+          </div>
         ),
       )}
       {lightbox ? (
         <Lightbox attachment={lightbox} onClose={() => setLightbox(null)} />
       ) : null}
+      <ConfirmDialog
+        open={confirm !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        title="Remove attachment?"
+        description={
+          confirm
+            ? `"${confirm.fileName}" will be permanently removed from this task. This cannot be undone.`
+            : ""
+        }
+        confirmLabel="Remove"
+        destructive
+        onConfirm={() => {
+          if (confirm) void performRemove(confirm);
+        }}
+      />
     </div>
   );
 }

--- a/official-plugins/tasks/views/detail/attachments.tsx
+++ b/official-plugins/tasks/views/detail/attachments.tsx
@@ -180,8 +180,8 @@ export function AttachmentsGrid({
     const busy = pending.has(attachment.id);
     const base =
       variant === "image"
-        ? "absolute right-1 top-1 flex size-6 items-center justify-center rounded-md bg-popover/90 text-popover-foreground opacity-0 shadow-md transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-popover disabled:opacity-100 [@media(hover:none)]:opacity-100"
-        : "flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground";
+        ? "absolute right-1 top-1 z-10 rounded-full bg-black/55 p-0.5 text-white transition-colors hover:bg-black/70 disabled:opacity-70"
+        : "shrink-0 rounded p-0.5 text-muted-foreground hover:bg-state-hover hover:text-foreground disabled:opacity-70";
     return (
       <button
         type="button"
@@ -194,7 +194,7 @@ export function AttachmentsGrid({
           if (!busy) requestRemove(attachment);
         }}
       >
-        {busy ? <RemovalSpinner /> : <Icon name="X" className="size-3.5" />}
+        {busy ? <RemovalSpinner /> : <Icon name="X" className="size-3" />}
       </button>
     );
   };
@@ -268,7 +268,7 @@ export function AttachmentsGrid({
         title="Remove attachment?"
         description={
           confirm
-            ? `"${confirm.fileName}" will be permanently removed from this task. This cannot be undone.`
+            ? `"${confirm.fileName}" will be permanently removed. Any references in the task description will be removed too. This cannot be undone.`
             : ""
         }
         confirmLabel="Remove"

--- a/official-plugins/tasks/views/detail/index.tsx
+++ b/official-plugins/tasks/views/detail/index.tsx
@@ -448,7 +448,17 @@ function TaskDetail({ task }: { task: Task }) {
             />
           </div>
 
-          <AttachmentsGrid attachments={attachments.data ?? []} />
+          <AttachmentsGrid
+            attachments={attachments.data ?? []}
+            onRemove={async (attachment) => {
+              const result = await rpc.call("deleteAttachment", {
+                attachmentId: attachment.id,
+              });
+              if (!result.ok) throw new Error(result.error.message);
+              attachments.refresh();
+            }}
+            onError={(message) => push("error", message)}
+          />
 
           <SubTasksSection
             ref={subtasksRef}

--- a/official-plugins/tasks/views/detail/index.tsx
+++ b/official-plugins/tasks/views/detail/index.tsx
@@ -453,6 +453,7 @@ function TaskDetail({ task }: { task: Task }) {
             onRemove={async (attachment) => {
               const result = await rpc.call("deleteAttachment", {
                 attachmentId: attachment.id,
+                removeDescriptionReferences: true,
               });
               if (!result.ok) throw new Error(result.error.message);
               attachments.refresh();

--- a/official-plugins/tasks/vitest.setup.ts
+++ b/official-plugins/tasks/vitest.setup.ts
@@ -12,3 +12,23 @@ if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
     value: () => {},
   });
 }
+
+// The shared-ui Dialog resolves a responsive layout via matchMedia, which
+// jsdom does not implement. Default to the non-compact (desktop) branch.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string): MediaQueryList =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  });
+}


### PR DESCRIPTION
## Summary

- add end-to-end task attachment removal in the Tasks UI and CLI
- keep single-image task descriptions focusable with a trailing caret target
- centralize deletion in a typed `deleteAttachment` RPC/domain policy shared by UI, HTTP, and CLI
- match the bb composer's always-visible image X treatment
- after UI confirmation, remove exact saved-description image references together with the attachment
- preserve row/blob/description reachability and suppress success realtime when filesystem cleanup fails

## Authorized review fixes

This branch received the task's one authorized GPT-5.6 Sol review, which returned `REQUEST CHANGES`. No second review was run.

- cleanup invariant: blob cleanup precedes description/row mutation; forced-rm coverage asserts HTTP 500, unchanged description/row/blob, and no realtime success
- referenced image: deletion conflicts safely by default; explicit RPC/HTTP/CLI opt-in removes saved references, while the confirmed UI path opts in automatically
- SDK parity: added typed `deleteAttachment` RPC contract and handler; CLI and UI use the shared domain policy
- discoverability: image removal uses the bb composer's always-visible dark circular X, including touch/non-hover input

## Validation

- post-rebase `pnpm exec turbo run typecheck test build --filter=bb-plugin-tasks --force`
- 218/218 tests across 24 files
- real dev-server E2E: X visible at rest with composer classes and computed opacity 1
- real dev-server E2E: confirmed referenced-image deletion produced no conflict/error toast, removed the editor image and attachment, persisted an empty description, and removed the blob
- prior real filesystem cleanup denial/recovery and touch/coarse-pointer evidence preserved

The original QA evidence and manually updated review-fix catalog are attached to BB-21. The `testing-catalog` skill was unavailable, so its structured catalog was maintained manually.
