### PR TITLE
Bump host daemon protocol for RPC contract change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - The host daemon owns host-local primitives, provider translation, runtime/session management, and workspace execution.
 - If the server needs host-local data, the daemon should return raw data and the server should assemble product behavior.
 - Do not move responsibility across the server/daemon boundary unless the current change requires it.
+- **Always increment `HOST_DAEMON_PROTOCOL_VERSION` when a change can alter anything sent between the server and host daemon.** This includes adding, removing, renaming, or changing the type, requiredness, default, or meaning of fields in session payloads, WebSocket messages, host RPC commands, or host RPC results. A shared TypeScript build passing is not evidence of wire compatibility: enrolled machines can still be running an older daemon. The version mismatch is what triggers their automatic update; without a bump, an old daemon may connect successfully and then enter an `invalid-message` reconnect loop. If compatibility with the previously shipped daemon has not been deliberately preserved and tested, bump the version.
 
 ## CLI, Guide, And Skill
 

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 54 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 55 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,


### PR DESCRIPTION
## Summary

- bump the host daemon protocol after the incompatible `workspace.pull_request` result change
- document that every server/daemon wire-contract change must bump the protocol unless backward compatibility is deliberately preserved and tested
- explain the stale-daemon `invalid-message` reconnect failure this prevents

## Validation

- `pnpm exec turbo run test typecheck --filter=@bb/host-daemon-contract --force`
- 44 contract tests passed
- verified a previously stale enrolled Mac reconnects after installing the current daemon and completes the PR lookup without disconnecting