### PR TITLE
BB-35: Remember all task list filters and sort

### DIFF
--- a/official-plugins/tasks/views/list/data.ts
+++ b/official-plugins/tasks/views/list/data.ts
@@ -10,7 +10,12 @@ import type {
 export interface ListTaskFilters {
   statuses: readonly TaskStatus[];
   priorities: readonly TaskPriority[];
-  labelIds: readonly string[];
+  /**
+   * `null` means no label filter. An array (including empty) is an active
+   * label filter: empty matches nothing once the catalog is known, which is
+   * how stale/deleted label names recover without silently showing all tasks.
+   */
+  labelIds: readonly string[] | null;
 }
 
 /**
@@ -33,7 +38,7 @@ export function useListTasks(
           ...(filters.priorities.length > 0
             ? { priorities: [...filters.priorities] }
             : {}),
-          ...(filters.labelIds.length > 0
+          ...(filters.labelIds !== null
             ? { labelIds: [...filters.labelIds] }
             : {}),
           activeOnly,
@@ -46,7 +51,7 @@ export function useListTasks(
       activeOnly,
       filters.statuses.join(),
       filters.priorities.join(),
-      filters.labelIds.join(),
+      filters.labelIds === null ? "" : `active:${filters.labelIds.join()}`,
     ],
   );
 }

--- a/official-plugins/tasks/views/list/filter-bar.tsx
+++ b/official-plugins/tasks/views/list/filter-bar.tsx
@@ -153,8 +153,12 @@ export function ListFilterBar({
   taskCount: number | undefined;
 }) {
   const keepOpen = (event: Event) => event.preventDefault();
+  // Show the Label chip whenever there are options or a remembered selection
+  // (including stale names that no longer exist in the catalog).
+  const showLabelChip =
+    labelOptions.length > 0 || filters.labelNames.length > 0;
   return (
-    <div className="flex shrink-0 items-center gap-1.5 border-b border-border-hairline px-3.5 py-1.5">
+    <div className="flex shrink-0 items-center gap-1.5 overflow-x-auto border-b border-border-hairline px-3.5 py-1.5">
       <FilterChip
         icon="Circle"
         label="Status"
@@ -209,7 +213,7 @@ export function ListFilterBar({
           </DropdownMenuCheckboxItem>
         ))}
       </FilterChip>
-      {labelOptions.length > 0 ? (
+      {showLabelChip ? (
         <FilterChip
           icon="ListTodo"
           label="Label"
@@ -241,6 +245,36 @@ export function ListFilterBar({
               </span>
             </DropdownMenuCheckboxItem>
           ))}
+          {filters.labelNames
+            .filter(
+              (name) => !labelOptions.some((option) => option.name === name),
+            )
+            .map((name) => (
+              <DropdownMenuCheckboxItem
+                key={`stale:${name}`}
+                checked
+                onSelect={keepOpen}
+                onCheckedChange={(checked) =>
+                  onChange({
+                    ...filters,
+                    labelNames: toggled(
+                      filters.labelNames,
+                      name,
+                      checked === true,
+                    ),
+                  })
+                }
+              >
+                <span className="flex items-center gap-2 text-muted-foreground">
+                  <span
+                    aria-hidden
+                    className="size-2 rounded-full bg-muted-foreground/40"
+                  />
+                  {name}
+                  <span className="text-xs">(unavailable)</span>
+                </span>
+              </DropdownMenuCheckboxItem>
+            ))}
         </FilterChip>
       ) : null}
       {hasActiveFilters(filters) ? (

--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Label, Task } from "../../shared/contract.js";
 import { useProjects } from "../../shell/data.js";
 import { useTasksNavigation } from "../../shell/routes.js";
@@ -13,6 +13,12 @@ import {
   ListFilterBar,
   type ListFilterState,
 } from "./filter-bar.js";
+import {
+  listPreferenceScope,
+  loadListPreference,
+  storeListPreference,
+  type ListPreference,
+} from "./list-preference.js";
 import { sortTasks, type TaskSort } from "../../shared/sort.js";
 import { PriorityIcon, StatusIcon } from "./icons.js";
 import {
@@ -125,8 +131,31 @@ function LoadingRows() {
 export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   const navigation = useTasksNavigation();
   const projects = useProjects();
-  const [filters, setFilters] = useState<ListFilterState>(EMPTY_FILTERS);
-  const [sort, setSort] = useState<TaskSort>("manual");
+  const preferenceScope = listPreferenceScope(projectId, activeOnly);
+  const [preference, setPreference] = useState<ListPreference>(() =>
+    loadListPreference(preferenceScope),
+  );
+  // Remounts already re-read storage; this covers prop-scope changes if the
+  // same ListView instance is reused across routes.
+  useEffect(() => {
+    setPreference(loadListPreference(preferenceScope));
+  }, [preferenceScope]);
+  const filters = preference.filters;
+  const sort = preference.sort;
+  const setFilters = (next: ListFilterState) => {
+    setPreference((current) => {
+      const updated: ListPreference = { filters: next, sort: current.sort };
+      storeListPreference(preferenceScope, updated);
+      return updated;
+    });
+  };
+  const setSort = (next: TaskSort) => {
+    setPreference((current) => {
+      const updated: ListPreference = { filters: current.filters, sort: next };
+      storeListPreference(preferenceScope, updated);
+      return updated;
+    });
+  };
   const [newTaskOpen, setNewTaskOpen] = useState(false);
 
   const labelProjectIds = useMemo(
@@ -141,10 +170,15 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
     () => labelFilterOptions(labels.data ?? []),
     [labels.data],
   );
-  const labelIds = useMemo(
-    () => selectedLabelIds(labelOptions, filters.labelNames),
-    [labelOptions, filters.labelNames],
-  );
+  // null = no label filter. Once the catalog is loaded, unresolved selected
+  // names become an active empty id list so the query matches nothing (not
+  // every task). While labels are still loading, defer the filter to avoid a
+  // flash of empty results before options arrive.
+  const labelIds = useMemo((): readonly string[] | null => {
+    if (filters.labelNames.length === 0) return null;
+    if (labels.data === undefined) return null;
+    return selectedLabelIds(labelOptions, filters.labelNames);
+  }, [filters.labelNames, labelOptions, labels.data]);
 
   const tasksQuery = useListTasks(projectId, activeOnly, {
     statuses: filters.statuses,

--- a/official-plugins/tasks/views/list/list-preference.persistence.test.tsx
+++ b/official-plugins/tasks/views/list/list-preference.persistence.test.tsx
@@ -1,0 +1,507 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
+import type { Task } from "../../shared/contract.js";
+import { LIST_PREFERENCE_STORAGE_KEY } from "./list-preference.js";
+
+// Compact viewport so sort/filter menus render as clickable drawers in jsdom.
+window.matchMedia = (query: string) => ({
+  matches: query === COMPACT_VIEWPORT_QUERY,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+window.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView ??= () => {};
+
+const app = await loadPluginApp(() => import("../../app"));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const PROJECT_A = "01HZZZZZZZZZZZZZZZZZZZZZP1";
+const PROJECT_B = "01HZZZZZZZZZZZZZZZZZZZZZP2";
+
+const projectA = {
+  id: PROJECT_A,
+  name: "Alpha",
+  prefix: "ALP",
+  nextTaskNumber: 5,
+  color: "blue",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-07-15T00:00:00.000Z",
+};
+
+const projectB = {
+  id: PROJECT_B,
+  name: "Beta",
+  prefix: "BET",
+  nextTaskNumber: 5,
+  color: "green",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-07-15T00:00:00.000Z",
+};
+
+function task(
+  projectId: string,
+  number: number,
+  status: Task["status"],
+  priority: Task["priority"] = "none",
+): Task {
+  const prefix = projectId === PROJECT_A ? "ALP" : "BET";
+  return {
+    id: `01HZZZZZZZZZZZZZZZZZZZZT${projectId.slice(-2)}${number}`,
+    projectId,
+    number,
+    key: `${prefix}-${number}`,
+    title: `Task ${number}`,
+    description: "",
+    status,
+    priority,
+    dueDate: null,
+    parentTaskId: null,
+    position: number,
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+    labelIds: [],
+  };
+}
+
+const tasksA = [
+  task(PROJECT_A, 1, "todo", "none"),
+  task(PROJECT_A, 2, "todo", "urgent"),
+  task(PROJECT_A, 3, "done", "low"),
+];
+
+const tasksB = [
+  task(PROJECT_B, 1, "todo"),
+  task(PROJECT_B, 2, "in_progress"),
+];
+
+function applyListFilters(
+  tasks: Task[],
+  input: {
+    statuses?: readonly string[];
+    priorities?: readonly string[];
+  },
+): Task[] {
+  let next = tasks;
+  if (input.statuses !== undefined && input.statuses.length > 0) {
+    const allowed = new Set(input.statuses);
+    next = next.filter((item) => allowed.has(item.status));
+  }
+  if (input.priorities !== undefined && input.priorities.length > 0) {
+    const allowed = new Set(input.priorities);
+    next = next.filter((item) => allowed.has(item.priority));
+  }
+  return next;
+}
+
+const LABEL_BUG = "01HZZZZZZZZZZZZZZZZZZZZLB1";
+const LABEL_UX = "01HZZZZZZZZZZZZZZZZZZZZLB2";
+
+const labelsA = [
+  {
+    id: LABEL_BUG,
+    projectId: PROJECT_A,
+    name: "Bug",
+    color: "#ef4444",
+  },
+  {
+    id: LABEL_UX,
+    projectId: PROJECT_A,
+    name: "UX",
+    color: "#3b82f6",
+  },
+];
+
+function baseRpc(overrides: Record<string, unknown> = {}) {
+  const listTasksCalls: unknown[] = [];
+  const rpc = {
+    listProjects: () => ({ projects: [projectA, projectB] }),
+    listFolders: () => ({ folders: [] }),
+    listPresets: () => ({ presets: [] }),
+    sidebarSummary: () => ({ projects: [] }),
+    listLabels: (input: { projectId: string }) => ({
+      labels: input.projectId === PROJECT_A ? labelsA : [],
+    }),
+    listTasks: (input: {
+      projectId?: string | null;
+      activeOnly?: boolean;
+      statuses?: readonly string[];
+      priorities?: readonly string[];
+      labelIds?: readonly string[];
+    }) => {
+      listTasksCalls.push(input);
+      let tasks: Task[];
+      if (input.activeOnly) {
+        tasks = [
+          task(PROJECT_A, 9, "in_progress", "high"),
+          task(PROJECT_B, 9, "in_progress", "high"),
+        ];
+      } else if (input.projectId === PROJECT_A) {
+        tasks = tasksA.map((item, index) =>
+          index === 0
+            ? { ...item, labelIds: [LABEL_BUG] }
+            : index === 1
+              ? { ...item, labelIds: [LABEL_UX] }
+              : item,
+        );
+      } else if (input.projectId === PROJECT_B) {
+        tasks = tasksB;
+      } else {
+        tasks = [...tasksA, ...tasksB];
+      }
+      let next = applyListFilters(tasks, input);
+      if (input.labelIds !== undefined) {
+        if (input.labelIds.length === 0) next = [];
+        else {
+          const allowed = new Set(input.labelIds);
+          next = next.filter((item) =>
+            item.labelIds.some((id) => allowed.has(id)),
+          );
+        }
+      }
+      return { tasks: next };
+    },
+    listTaskThreads: () => ({ taskThreads: [] }),
+    listComments: () => ({ comments: [] }),
+    listAttachments: () => ({ attachments: [] }),
+    ...overrides,
+  };
+  return Object.assign(rpc, { listTasksCalls });
+}
+
+function renderProject(projectId: string) {
+  return renderSlot(
+    app.navPanels[0]!,
+    { subPath: projectId },
+    { rpc: baseRpc() },
+  );
+}
+
+async function selectSort(
+  slot: ReturnType<typeof renderProject>,
+  label: string,
+) {
+  fireEvent.click(slot.getByRole("button", { name: /Sort/ }));
+  const drawer = await slot.findByRole("dialog", { name: "Sort tasks" });
+  fireEvent.click(within(drawer).getByRole("menuitemcheckbox", { name: label }));
+}
+
+describe("list filter/sort preference persistence", () => {
+  it("restores sort and filters after unmount (navigation / remount)", async () => {
+    const registration = app.navPanels[0]!;
+    const slot = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await slot.findByText("ALP-1");
+
+    await selectSort(slot, "Priority");
+    await waitFor(() =>
+      expect(slot.getByRole("button", { name: /Sort/ }).textContent).toContain(
+        "Priority",
+      ),
+    );
+
+    // Filter to done only via the Status chip.
+    fireEvent.click(slot.getByRole("button", { name: /^Status/ }));
+    const doneOption = await slot.findByRole("menuitemcheckbox", {
+      name: /Done/,
+    });
+    fireEvent.click(doneOption);
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(LIST_PREFERENCE_STORAGE_KEY)).not.toBeNull();
+    });
+
+    slot.lifecycle.unmount();
+
+    const remounted = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await remounted.findByText("ALP-3");
+    expect(
+      remounted.getByRole("button", { name: /Sort/ }).textContent,
+    ).toContain("Priority");
+    // Active status filter is reflected on the chip label.
+    expect(
+      remounted.getByRole("button", { name: /^Status/ }).textContent,
+    ).toContain("Done");
+    // Only done task remains visible for project A.
+    expect(remounted.queryByText("ALP-1")).toBeNull();
+    expect(remounted.queryByText("ALP-2")).toBeNull();
+    expect(remounted.getByText("ALP-3")).toBeDefined();
+  });
+
+  it("keeps project A and project B preferences independent", async () => {
+    const registration = app.navPanels[0]!;
+    const slotA = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await slotA.findByText("ALP-1");
+    await selectSort(slotA, "Priority");
+    await waitFor(() =>
+      expect(
+        slotA.getByRole("button", { name: /Sort/ }).textContent,
+      ).toContain("Priority"),
+    );
+    slotA.lifecycle.unmount();
+
+    const slotB = renderSlot(
+      registration,
+      { subPath: PROJECT_B },
+      { rpc: baseRpc() },
+    );
+    await slotB.findByText("BET-1");
+    // Project B still defaults to manual.
+    expect(slotB.getByRole("button", { name: /Sort/ }).textContent).not.toContain(
+      "Priority",
+    );
+    await selectSort(slotB, "Due date");
+    await waitFor(() =>
+      expect(
+        slotB.getByRole("button", { name: /Sort/ }).textContent,
+      ).toContain("Due date"),
+    );
+    slotB.lifecycle.unmount();
+
+    const backToA = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await backToA.findByText("ALP-1");
+    expect(
+      backToA.getByRole("button", { name: /Sort/ }).textContent,
+    ).toContain("Priority");
+    expect(
+      backToA.getByRole("button", { name: /Sort/ }).textContent,
+    ).not.toContain("Due date");
+  });
+
+  it("remembers an explicit clear across remount", async () => {
+    const registration = app.navPanels[0]!;
+    // Seed a preference, then clear via UI.
+    window.localStorage.setItem(
+      LIST_PREFERENCE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        scopes: {
+          [`project:${PROJECT_A}`]: {
+            filters: {
+              statuses: ["done"],
+              priorities: [],
+              labelNames: [],
+            },
+            sort: "priority",
+          },
+        },
+      }),
+    );
+
+    const slot = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await slot.findByText("ALP-3");
+    fireEvent.click(slot.getByRole("button", { name: /Clear/ }));
+    await waitFor(() => {
+      expect(slot.queryByText("ALP-1")).not.toBeNull();
+    });
+    expect(slot.queryByRole("button", { name: /Clear/ })).toBeNull();
+
+    slot.lifecycle.unmount();
+    const remounted = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await remounted.findByText("ALP-1");
+    expect(remounted.queryByRole("button", { name: /Clear/ })).toBeNull();
+    expect(
+      remounted.getByRole("button", { name: /Sort/ }).textContent,
+    ).toContain("Priority");
+    // Filters cleared; sort still priority because Clear only resets filters.
+    expect(remounted.getByText("ALP-2")).toBeDefined();
+  });
+
+  it("keeps filtering usable when storage rejects writes", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is disabled", "SecurityError");
+    });
+    const slot = renderProject(PROJECT_A);
+    await slot.findByText("ALP-1");
+    await selectSort(slot, "Priority");
+    await waitFor(() =>
+      expect(slot.getByRole("button", { name: /Sort/ }).textContent).toContain(
+        "Priority",
+      ),
+    );
+    // Session still applies sort even though nothing was persisted.
+    expect(slot.getByText("ALP-2")).toBeDefined();
+  });
+
+  it("isolates All tasks preference from Active", async () => {
+    const registration = app.navPanels[0]!;
+    const allSlot = renderSlot(
+      registration,
+      { subPath: "all" },
+      { rpc: baseRpc() },
+    );
+    await allSlot.findByText("ALP-1");
+    await selectSort(allSlot, "Priority");
+    allSlot.lifecycle.unmount();
+
+    const activeSlot = renderSlot(
+      registration,
+      { subPath: "active" },
+      {
+        rpc: baseRpc({
+          listTasks: () => ({
+            tasks: [task(PROJECT_A, 9, "in_progress", "high")],
+          }),
+        }),
+      },
+    );
+    await activeSlot.findByText("ALP-9");
+    expect(
+      activeSlot.getByRole("button", { name: /Sort/ }).textContent,
+    ).not.toContain("Priority");
+  });
+
+  it("persists priority and label filters and sends resolved label ids", async () => {
+    const registration = app.navPanels[0]!;
+    const rpc = baseRpc();
+    const slot = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc },
+    );
+    await slot.findByText("ALP-1");
+
+    fireEvent.click(slot.getByRole("button", { name: /^Priority/ }));
+    fireEvent.click(
+      await slot.findByRole("menuitemcheckbox", { name: /Urgent/ }),
+    );
+    pageKeyboardEscape(slot);
+
+    fireEvent.click(slot.getByRole("button", { name: /^Label/ }));
+    fireEvent.click(await slot.findByRole("menuitemcheckbox", { name: /Bug/ }));
+    pageKeyboardEscape(slot);
+
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem(LIST_PREFERENCE_STORAGE_KEY)!,
+      );
+      expect(
+        stored.scopes[`project:${PROJECT_A}`].filters.priorities,
+      ).toEqual(["urgent"]);
+      expect(
+        stored.scopes[`project:${PROJECT_A}`].filters.labelNames,
+      ).toEqual(["Bug"]);
+    });
+
+    await waitFor(() => {
+      const withLabels = rpc.listTasksCalls.filter(
+        (call): call is { labelIds?: string[]; priorities?: string[] } =>
+          typeof call === "object" && call !== null,
+      );
+      expect(
+        withLabels.some(
+          (call) =>
+            Array.isArray(call.labelIds) &&
+            call.labelIds.includes(LABEL_BUG) &&
+            Array.isArray(call.priorities) &&
+            call.priorities.includes("urgent"),
+        ),
+      ).toBe(true);
+    });
+
+    slot.lifecycle.unmount();
+    const remounted = renderSlot(
+      registration,
+      { subPath: PROJECT_A },
+      { rpc: baseRpc() },
+    );
+    await remounted.findByRole("button", { name: /Priority/ });
+    expect(
+      remounted.getByRole("button", { name: /^Priority/ }).textContent,
+    ).toContain("Urgent");
+    expect(
+      remounted.getByRole("button", { name: /^Label/ }).textContent,
+    ).toContain("Bug");
+  });
+
+  it("matches nothing for stale label names once the catalog is loaded", async () => {
+    window.localStorage.setItem(
+      LIST_PREFERENCE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        scopes: {
+          [`project:${PROJECT_A}`]: {
+            filters: {
+              statuses: [],
+              priorities: [],
+              labelNames: ["DeletedLabel"],
+            },
+            sort: "manual",
+          },
+        },
+      }),
+    );
+    const rpc = baseRpc();
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: PROJECT_A },
+      { rpc },
+    );
+    await slot.findByRole("button", { name: /^Label/ });
+    expect(slot.getByRole("button", { name: /^Label/ }).textContent).toContain(
+      "DeletedLabel",
+    );
+    await waitFor(() => {
+      expect(
+        rpc.listTasksCalls.some(
+          (call) =>
+            typeof call === "object" &&
+            call !== null &&
+            Array.isArray((call as { labelIds?: unknown }).labelIds) &&
+            (call as { labelIds: unknown[] }).labelIds.length === 0,
+        ),
+      ).toBe(true);
+    });
+    // Empty labelIds filter yields no rows (not the full unfiltered list).
+    expect(slot.queryByText("ALP-1")).toBeNull();
+    expect(slot.queryByText("ALP-2")).toBeNull();
+  });
+});
+
+function pageKeyboardEscape(slot: ReturnType<typeof renderProject>): void {
+  fireEvent.keyDown(slot.container.ownerDocument, { key: "Escape" });
+}

--- a/official-plugins/tasks/views/list/list-preference.test.ts
+++ b/official-plugins/tasks/views/list/list-preference.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_LIST_PREFERENCE,
+  LIST_PREFERENCE_STORAGE_KEY,
+  LIST_PREFERENCE_VERSION,
+  listPreferenceScope,
+  loadListPreference,
+  sanitizeListPreference,
+  storeListPreference,
+} from "./list-preference.js";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("listPreferenceScope", () => {
+  it("maps list surfaces to independent scopes", () => {
+    expect(listPreferenceScope(null, false)).toBe("all");
+    expect(listPreferenceScope(null, true)).toBe("active");
+    expect(listPreferenceScope("01HZZZZZZZZZZZZZZZZZZZZZP1", false)).toBe(
+      "project:01HZZZZZZZZZZZZZZZZZZZZZP1",
+    );
+    // activeOnly wins over a project id (Active route is cross-project).
+    expect(listPreferenceScope("01HZZZZZZZZZZZZZZZZZZZZZP1", true)).toBe(
+      "active",
+    );
+  });
+});
+
+describe("sanitizeListPreference", () => {
+  it("returns defaults for missing or garbage input", () => {
+    expect(sanitizeListPreference(undefined)).toEqual({
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+    expect(sanitizeListPreference(null)).toEqual({
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+    expect(sanitizeListPreference("nope")).toEqual({
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+  });
+
+  it("drops invalid statuses, priorities, and sort; keeps label names", () => {
+    expect(
+      sanitizeListPreference({
+        filters: {
+          statuses: ["todo", "not-a-status", "todo", "done"],
+          priorities: ["high", 3, "high", "telepathic"],
+          labelNames: [" Bug ", "", "Bug", "Feature", 12],
+        },
+        sort: "priority-please",
+      }),
+    ).toEqual({
+      filters: {
+        statuses: ["todo", "done"],
+        priorities: ["high"],
+        labelNames: ["Bug", "Feature"],
+      },
+      sort: "manual",
+    });
+  });
+
+  it("accepts a valid preference and known sort modes", () => {
+    expect(
+      sanitizeListPreference({
+        filters: {
+          statuses: ["in_progress"],
+          priorities: ["urgent", "none"],
+          labelNames: ["infra"],
+        },
+        sort: "due",
+      }),
+    ).toEqual({
+      filters: {
+        statuses: ["in_progress"],
+        priorities: ["urgent", "none"],
+        labelNames: ["infra"],
+      },
+      sort: "due",
+    });
+  });
+});
+
+describe("loadListPreference / storeListPreference", () => {
+  it("defaults when storage is empty", () => {
+    expect(loadListPreference("all")).toEqual({
+      filters: { ...DEFAULT_LIST_PREFERENCE.filters },
+      sort: "manual",
+    });
+  });
+
+  it("round-trips a preference for one scope without touching another", () => {
+    storeListPreference("all", {
+      filters: {
+        statuses: ["todo"],
+        priorities: ["high"],
+        labelNames: ["Bug"],
+      },
+      sort: "priority",
+    });
+    storeListPreference("project:p1", {
+      filters: {
+        statuses: ["done"],
+        priorities: [],
+        labelNames: [],
+      },
+      sort: "due",
+    });
+
+    expect(loadListPreference("all")).toEqual({
+      filters: {
+        statuses: ["todo"],
+        priorities: ["high"],
+        labelNames: ["Bug"],
+      },
+      sort: "priority",
+    });
+    expect(loadListPreference("project:p1")).toEqual({
+      filters: {
+        statuses: ["done"],
+        priorities: [],
+        labelNames: [],
+      },
+      sort: "due",
+    });
+    expect(loadListPreference("active")).toEqual({
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(LIST_PREFERENCE_STORAGE_KEY)!,
+    );
+    expect(stored.version).toBe(LIST_PREFERENCE_VERSION);
+    expect(Object.keys(stored.scopes).sort()).toEqual(["all", "project:p1"]);
+  });
+
+  it("persists an explicit clear (empty filters + manual sort)", () => {
+    storeListPreference("all", {
+      filters: { statuses: ["todo"], priorities: [], labelNames: [] },
+      sort: "priority",
+    });
+    storeListPreference("all", {
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+    expect(loadListPreference("all")).toEqual({
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+  });
+
+  it("recovers from corrupt JSON and invalid document shapes", () => {
+    window.localStorage.setItem(LIST_PREFERENCE_STORAGE_KEY, "{not-json");
+    expect(loadListPreference("all").sort).toBe("manual");
+
+    window.localStorage.setItem(
+      LIST_PREFERENCE_STORAGE_KEY,
+      JSON.stringify({ version: 1, scopes: "nope" }),
+    );
+    expect(loadListPreference("all").filters.statuses).toEqual([]);
+
+    window.localStorage.setItem(
+      LIST_PREFERENCE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        scopes: {
+          all: {
+            filters: { statuses: ["bogus"], priorities: ["high"] },
+            sort: "priority",
+          },
+        },
+      }),
+    );
+    expect(loadListPreference("all")).toEqual({
+      filters: { statuses: [], priorities: ["high"], labelNames: [] },
+      sort: "priority",
+    });
+  });
+
+  it("best-effort reads scopes from an unknown future version without rewriting it", () => {
+    const future = JSON.stringify({
+      version: 99,
+      scopes: {
+        all: {
+          filters: { statuses: ["todo"], priorities: [], labelNames: [] },
+          sort: "due",
+          extraFutureField: true,
+        },
+      },
+    });
+    window.localStorage.setItem(LIST_PREFERENCE_STORAGE_KEY, future);
+    expect(loadListPreference("all")).toEqual({
+      filters: { statuses: ["todo"], priorities: [], labelNames: [] },
+      sort: "due",
+    });
+    storeListPreference("all", {
+      filters: { statuses: ["done"], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+    // Older client must not down-convert a newer document.
+    expect(window.localStorage.getItem(LIST_PREFERENCE_STORAGE_KEY)).toBe(
+      future,
+    );
+  });
+
+  it("swallows storage write failures", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is disabled", "SecurityError");
+    });
+    expect(() =>
+      storeListPreference("all", {
+        filters: { statuses: ["todo"], priorities: [], labelNames: [] },
+        sort: "manual",
+      }),
+    ).not.toThrow();
+  });
+
+  it("swallows storage read failures", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Storage is disabled", "SecurityError");
+    });
+    expect(loadListPreference("all")).toEqual({
+      filters: { statuses: [], priorities: [], labelNames: [] },
+      sort: "manual",
+    });
+  });
+});

--- a/official-plugins/tasks/views/list/list-preference.ts
+++ b/official-plugins/tasks/views/list/list-preference.ts
@@ -1,0 +1,231 @@
+import {
+  TASK_PRIORITIES,
+  TASK_STATUSES,
+  type TaskPriority,
+  type TaskStatus,
+} from "../../shared/contract.js";
+import { TASK_SORTS, type TaskSort } from "../../shared/sort.js";
+import {
+  EMPTY_FILTERS,
+  type ListFilterState,
+} from "./filter-bar.js";
+
+/**
+ * Client-local list filter/sort preferences. Stored in the browser profile so
+ * one client (or user profile) does not rewrite another client connected to
+ * the same bb server — same boundary as the Tasks sidebar preference.
+ *
+ * Preferences are scoped per list surface so All / Active / each project keep
+ * independent restored and cleared state.
+ */
+export const LIST_PREFERENCE_STORAGE_KEY = "bb-tasks:list-preferences";
+export const LIST_PREFERENCE_VERSION = 1 as const;
+
+export type ListPreferenceScope =
+  | "all"
+  | "active"
+  | `project:${string}`;
+
+export interface ListPreference {
+  filters: ListFilterState;
+  sort: TaskSort;
+}
+
+export const DEFAULT_LIST_PREFERENCE: ListPreference = {
+  filters: EMPTY_FILTERS,
+  sort: "manual",
+};
+
+interface StoredDocumentV1 {
+  version: typeof LIST_PREFERENCE_VERSION;
+  scopes: Record<string, unknown>;
+}
+
+export function listPreferenceScope(
+  projectId: string | null,
+  activeOnly: boolean,
+): ListPreferenceScope {
+  if (activeOnly) return "active";
+  if (projectId !== null) return `project:${projectId}`;
+  return "all";
+}
+
+const STATUS_SET = new Set<string>(TASK_STATUSES);
+const PRIORITY_SET = new Set<string>(TASK_PRIORITIES);
+const SORT_SET = new Set<string>(TASK_SORTS);
+
+function uniqueValidStatuses(values: unknown): TaskStatus[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<TaskStatus>();
+  const result: TaskStatus[] = [];
+  for (const value of values) {
+    if (typeof value !== "string" || !STATUS_SET.has(value)) continue;
+    const status = value as TaskStatus;
+    if (seen.has(status)) continue;
+    seen.add(status);
+    result.push(status);
+  }
+  return result;
+}
+
+function uniqueValidPriorities(values: unknown): TaskPriority[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<TaskPriority>();
+  const result: TaskPriority[] = [];
+  for (const value of values) {
+    if (typeof value !== "string" || !PRIORITY_SET.has(value)) continue;
+    const priority = value as TaskPriority;
+    if (seen.has(priority)) continue;
+    seen.add(priority);
+    result.push(priority);
+  }
+  return result;
+}
+
+/**
+ * Label selections are stored by name (matching the filter UI). Unknown or
+ * deleted names are kept so a temporary empty label catalog does not wipe the
+ * user's selection; once the catalog is loaded, unresolved names force an
+ * empty match set in the list query (see ListView).
+ */
+function uniqueLabelNames(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const name = value.trim();
+    if (name.length === 0 || seen.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
+function sanitizeSort(value: unknown): TaskSort {
+  if (typeof value === "string" && SORT_SET.has(value)) {
+    return value as TaskSort;
+  }
+  return DEFAULT_LIST_PREFERENCE.sort;
+}
+
+export function sanitizeListPreference(raw: unknown): ListPreference {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      filters: { ...EMPTY_FILTERS },
+      sort: DEFAULT_LIST_PREFERENCE.sort,
+    };
+  }
+  const record = raw as Record<string, unknown>;
+  const filtersRaw =
+    record.filters !== undefined &&
+    record.filters !== null &&
+    typeof record.filters === "object" &&
+    !Array.isArray(record.filters)
+      ? (record.filters as Record<string, unknown>)
+      : record;
+  return {
+    filters: {
+      statuses: uniqueValidStatuses(filtersRaw.statuses),
+      priorities: uniqueValidPriorities(filtersRaw.priorities),
+      labelNames: uniqueLabelNames(filtersRaw.labelNames),
+    },
+    sort: sanitizeSort(record.sort),
+  };
+}
+
+interface ParsedStorage {
+  /** Document version as stored, when a number. */
+  version: number | null;
+  scopes: Record<string, unknown>;
+  /** True when version is greater than this build understands. */
+  isFutureVersion: boolean;
+}
+
+function readStorage(): ParsedStorage | null {
+  try {
+    const raw = window.localStorage.getItem(LIST_PREFERENCE_STORAGE_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    const record = parsed as Record<string, unknown>;
+    if (
+      record.scopes === null ||
+      typeof record.scopes !== "object" ||
+      Array.isArray(record.scopes)
+    ) {
+      return null;
+    }
+    const version =
+      typeof record.version === "number" && Number.isFinite(record.version)
+        ? record.version
+        : null;
+    const isFutureVersion =
+      version !== null && version > LIST_PREFERENCE_VERSION;
+    // Only v1 (or missing version with a scopes map from early experiments)
+    // is a fully known shape. Future versions may still expose a scopes map
+    // for best-effort reads of known fields.
+    if (
+      version !== null &&
+      version < LIST_PREFERENCE_VERSION
+    ) {
+      // No older versions shipped; refuse rather than silently invent fields.
+      return null;
+    }
+    return {
+      version,
+      scopes: record.scopes as Record<string, unknown>,
+      isFutureVersion,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function loadListPreference(scope: ListPreferenceScope): ListPreference {
+  const document = readStorage();
+  if (document === null) {
+    return {
+      filters: { ...EMPTY_FILTERS },
+      sort: DEFAULT_LIST_PREFERENCE.sort,
+    };
+  }
+  return sanitizeListPreference(document.scopes[scope]);
+}
+
+/**
+ * Persist a preference for one scope. Refuses to overwrite storage written by
+ * a newer client (version > current) so older builds cannot down-convert a
+ * future document. Concurrent same-version writes merge scopes.
+ */
+export function storeListPreference(
+  scope: ListPreferenceScope,
+  preference: ListPreference,
+): void {
+  const sanitized = sanitizeListPreference(preference);
+  try {
+    const existing = readStorage();
+    if (existing?.isFutureVersion) {
+      // Leave the future document untouched; session state still updates in React.
+      return;
+    }
+    const scopes = { ...(existing?.scopes ?? {}) };
+    scopes[scope] = sanitized;
+    const document: StoredDocumentV1 = {
+      version: LIST_PREFERENCE_VERSION,
+      scopes,
+    };
+    window.localStorage.setItem(
+      LIST_PREFERENCE_STORAGE_KEY,
+      JSON.stringify(document),
+    );
+  } catch {
+    // Persistence is best-effort (private mode / storage disabled).
+  }
+}

--- a/official-plugins/tasks/views/list/sorting.test.tsx
+++ b/official-plugins/tasks/views/list/sorting.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, waitFor, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import type { Task } from "../../shared/contract.js";
@@ -30,6 +30,10 @@ Element.prototype.scrollIntoView ??= () => {};
 // loadPluginApp installs the fake SDK runtime; nothing SDK-touching may be
 // imported before it runs.
 const app = await loadPluginApp(() => import("../../app"));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
 
 afterEach(cleanup);
 


### PR DESCRIPTION
## Summary
- Persist Tasks list **Status**, **Priority**, **Label**, and **Sort** in client-local `localStorage` (same boundary as the sidebar preference) so preferences survive navigation, remount, refresh, and restart without coupling clients on a shared server.
- Scope preferences independently for **All**, **Active**, and each **project**.
- Versioned storage with sanitization of invalid enums; refuse to down-convert future documents; stale label names keep the filter active with empty match set and remain visible as unavailable.

## Test plan
- [x] `pnpm exec turbo run test --filter=bb-plugin-tasks` (249 passed)
- [x] `pnpm exec turbo run typecheck --filter=bb-plugin-tasks`
- [x] Live QA via isolated `scripts/bb-dev-app` + Product Review Report on BB-35
- [x] Codex readonly review (gpt-5.6-sol): REQUEST CHANGES → fixed P1 stale labels, future-version writes, filter-bar overflow, label/priority integration tests; re-ran suite

## Task
BB-35