### PR TITLE
BB-44: redesign task-list row metadata

### DIFF
--- a/official-plugins/tasks/views/list/data.ts
+++ b/official-plugins/tasks/views/list/data.ts
@@ -75,15 +75,16 @@ export function useLabels(projectIds: readonly string[]) {
 }
 
 export interface TaskRowMeta {
+  /** Threads currently starting or working. Historical attachments (idle,
+   * completed, failed) are excluded — list rows only surface live activity. */
   activeThreads: TaskThread[];
-  commentCount: number;
-  attachmentCount: number;
 }
 
 /**
- * Row metadata (working agents, comment/attachment counts). The contract has
- * no bulk endpoint for these, so this fans out per task — fine at current
- * scale; a batched RPC is the follow-up if lists grow large.
+ * Live-activity metadata for list rows. Comments and attachments are detail-
+ * view concerns and are deliberately not fetched here. The contract has no
+ * bulk endpoint, so this fans out per task — fine at current scale; a batched
+ * RPC is the follow-up if lists grow large.
  */
 export function useTaskListMeta(tasks: readonly Task[] | undefined) {
   const taskIds = (tasks ?? []).map((task) => task.id);
@@ -91,28 +92,20 @@ export function useTaskListMeta(tasks: readonly Task[] | undefined) {
     async (rpc) => {
       const entries = await Promise.all(
         taskIds.map(async (taskId) => {
-          const [threads, comments, attachments] = await Promise.all([
-            rpc.call("listTaskThreads", { taskId }),
-            rpc.call("listComments", { taskId }),
-            rpc.call("listAttachments", { taskId }),
-          ]);
+          const threads = await rpc.call("listTaskThreads", { taskId });
           const meta: TaskRowMeta = {
             activeThreads: threads.taskThreads.filter(
               (thread) =>
                 thread.liveStatus === "starting" ||
                 thread.liveStatus === "working",
             ),
-            commentCount: comments.comments.filter(
-              (comment) => comment.kind !== "system",
-            ).length,
-            attachmentCount: attachments.attachments.length,
           };
           return [taskId, meta] as const;
         }),
       );
       return new Map(entries);
     },
-    ["threads:changed", "comments:changed", "tasks:changed"],
+    ["threads:changed", "tasks:changed"],
     [taskIds.join()],
   );
 }

--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -43,33 +43,34 @@ export interface ListViewProps {
 }
 
 /**
- * Live-activity dot, anchored to the end of the row title so it always sits
- * next to the content it describes instead of floating in the metadata rail.
- * Renders only while an agent is actively starting/working; historical
- * attachments show nothing. The name is accessible-only (status role + title
- * tooltip) — no visible text.
+ * Every trailing-rail element shares this pill treatment (Linear-style), so
+ * the rail reads as one aligned system rather than mixed chips and bare text.
  */
-function ActiveAgentDot({ threads }: { threads: readonly TaskThread[] }) {
+const RAIL_CHIP_CLASS =
+  "flex items-center gap-1 rounded-md border border-border px-1.5 py-px text-xs text-muted-foreground";
+
+/**
+ * Live-activity chip: a green dot plus an "Active" pill, styled like the
+ * label chips so the rail stays uniform. Renders only while an agent is
+ * actively starting/working; historical attachments show nothing. The
+ * tooltip carries the specific state (starting vs working, agent count).
+ */
+function ActiveChip({ threads }: { threads: readonly TaskThread[] }) {
   if (threads.length === 0) return null;
-  const label = activeWorkLabel(threads);
   return (
-    <span
-      role="status"
-      aria-label={label}
-      title={label}
-      className="flex size-4 shrink-0 items-center justify-center"
-    >
+    <span title={activeWorkLabel(threads)} className={RAIL_CHIP_CLASS}>
       <span
         aria-hidden
-        className="size-2 animate-pulse rounded-full bg-success"
+        className="size-1.5 shrink-0 animate-pulse rounded-full bg-success"
       />
+      {threads.length === 1 ? "Active" : `${threads.length} active`}
     </span>
   );
 }
 
 function LabelChip({ label }: { label: Label }) {
   return (
-    <span className="flex max-w-32 items-center gap-1 rounded-md border border-border px-1.5 py-px text-xs text-muted-foreground">
+    <span className={`${RAIL_CHIP_CLASS} max-w-32`}>
       <span
         aria-hidden
         className="size-1.5 shrink-0 rounded-full"
@@ -96,7 +97,7 @@ function LabelChipRow({
       {hidden.length > 0 ? (
         <span
           title={hidden.map((label) => label.name).join(", ")}
-          className="flex items-center rounded-md border border-border px-1.5 py-px text-xs tabular-nums text-muted-foreground"
+          className={`${RAIL_CHIP_CLASS} tabular-nums`}
         >
           +{hidden.length}
         </span>
@@ -348,16 +349,17 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
                 {task.key}
               </span>
               <StatusIcon status={task.status} />
-              <span className="flex min-w-0 flex-1 items-center gap-1.5">
-                <span className="min-w-0 truncate text-sm">{task.title}</span>
-                {taskMeta ? (
-                  <ActiveAgentDot threads={taskMeta.activeThreads} />
-                ) : null}
+              <span className="min-w-0 flex-1 truncate text-sm">
+                {task.title}
               </span>
-              <span className="flex shrink-0 items-center gap-2 text-xs text-subtle-foreground">
+              <span className="flex shrink-0 items-center gap-1.5 text-xs text-subtle-foreground">
+                {taskMeta ? (
+                  <ActiveChip threads={taskMeta.activeThreads} />
+                ) : null}
                 <LabelChips task={task} labelsById={labelsById} />
                 {task.dueDate !== null ? (
-                  <span className="shrink-0 tabular-nums">
+                  <span className={`${RAIL_CHIP_CLASS} shrink-0 tabular-nums`}>
+                    <Icon name="Clock" className="size-3 shrink-0" />
                     {formatDueDate(task.dueDate)}
                   </span>
                 ) : null}

--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Label, Task } from "../../shared/contract.js";
+import type { Label, Task, TaskThread } from "../../shared/contract.js";
 import { useProjects } from "../../shell/data.js";
 import { useTasksNavigation } from "../../shell/routes.js";
 import { NewTaskDialog } from "../manage/index.js";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { Skeleton } from "@bb/shared-ui/skeleton";
-import { useLabels, useListTasks, useTaskListMeta, type TaskRowMeta } from "./data.js";
+import { useLabels, useListTasks, useTaskListMeta } from "./data.js";
 import {
   EMPTY_FILTERS,
   hasActiveFilters,
@@ -26,10 +26,11 @@ import {
   useListScrollRestoration,
 } from "./scroll-restoration.js";
 import {
+  activeWorkLabel,
   formatDueDate,
   groupTasksByStatus,
   labelFilterOptions,
-  presetShortName,
+  partitionLabels,
   selectedLabelIds,
   STATUS_LABELS,
 } from "./lib.js";
@@ -41,24 +42,75 @@ export interface ListViewProps {
   activeOnly?: boolean;
 }
 
-function WorkingAgentsChip({ meta }: { meta: TaskRowMeta }) {
-  const threads = meta.activeThreads;
+/**
+ * Live-activity dot, anchored to the end of the row title so it always sits
+ * next to the content it describes instead of floating in the metadata rail.
+ * Renders only while an agent is actively starting/working; historical
+ * attachments show nothing. The name is accessible-only (status role + title
+ * tooltip) — no visible text.
+ */
+function ActiveAgentDot({ threads }: { threads: readonly TaskThread[] }) {
   if (threads.length === 0) return null;
-  const text =
-    threads.length === 1 && threads[0] !== undefined
-      ? presetShortName(threads[0].presetName)
-      : `${threads.length} agents`;
+  const label = activeWorkLabel(threads);
   return (
-    <span className="flex items-center gap-1.5 font-medium text-success">
+    <span
+      role="status"
+      aria-label={label}
+      title={label}
+      className="flex size-4 shrink-0 items-center justify-center"
+    >
       <span
         aria-hidden
-        className="size-1.5 shrink-0 animate-pulse rounded-full bg-success"
+        className="size-2 animate-pulse rounded-full bg-success"
       />
-      {text}
     </span>
   );
 }
 
+function LabelChip({ label }: { label: Label }) {
+  return (
+    <span className="flex max-w-32 items-center gap-1 rounded-md border border-border px-1.5 py-px text-xs text-muted-foreground">
+      <span
+        aria-hidden
+        className="size-1.5 shrink-0 rounded-full"
+        style={{ backgroundColor: label.color }}
+      />
+      <span className="truncate">{label.name}</span>
+    </span>
+  );
+}
+
+function LabelChipRow({
+  labels,
+  maxVisible,
+}: {
+  labels: readonly Label[];
+  maxVisible: number;
+}) {
+  const { visible, hidden } = partitionLabels(labels, maxVisible);
+  return (
+    <>
+      {visible.map((label) => (
+        <LabelChip key={label.id} label={label} />
+      ))}
+      {hidden.length > 0 ? (
+        <span
+          title={hidden.map((label) => label.name).join(", ")}
+          className="flex items-center rounded-md border border-border px-1.5 py-px text-xs tabular-nums text-muted-foreground"
+        >
+          +{hidden.length}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Row label chips, capped so rows keep a bounded metadata width: two chips in
+ * regular containers, one in narrow ones (both variants render; container
+ * queries on the list body pick which is displayed). Overflow collapses into
+ * a "+N" chip whose tooltip lists the hidden names.
+ */
 function LabelChips({
   task,
   labelsById,
@@ -67,21 +119,15 @@ function LabelChips({
   labelsById: Map<string, Label>;
 }) {
   const labels = task.labelIds.flatMap((id) => labelsById.get(id) ?? []);
+  if (labels.length === 0) return null;
   return (
     <>
-      {labels.map((label) => (
-        <span
-          key={label.id}
-          className="flex items-center gap-1 rounded-md border border-border px-1.5 py-px text-xs text-muted-foreground"
-        >
-          <span
-            aria-hidden
-            className="size-1.5 rounded-full"
-            style={{ backgroundColor: label.color }}
-          />
-          {label.name}
-        </span>
-      ))}
+      <span className="hidden items-center gap-1.5 @xl:flex">
+        <LabelChipRow labels={labels} maxVisible={2} />
+      </span>
+      <span className="flex items-center gap-1.5 @xl:hidden">
+        <LabelChipRow labels={labels} maxVisible={1} />
+      </span>
     </>
   );
 }
@@ -302,26 +348,18 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
                 {task.key}
               </span>
               <StatusIcon status={task.status} />
-              <span className="min-w-0 flex-1 truncate text-sm">
-                {task.title}
+              <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                <span className="min-w-0 truncate text-sm">{task.title}</span>
+                {taskMeta ? (
+                  <ActiveAgentDot threads={taskMeta.activeThreads} />
+                ) : null}
               </span>
               <span className="flex shrink-0 items-center gap-2 text-xs text-subtle-foreground">
-                {taskMeta ? <WorkingAgentsChip meta={taskMeta} /> : null}
                 <LabelChips task={task} labelsById={labelsById} />
-                {taskMeta !== undefined && taskMeta.attachmentCount > 0 ? (
-                  <span className="flex items-center gap-0.5" title="Attachments">
-                    <Icon name="Paperclip" className="size-3" />
-                    {taskMeta.attachmentCount}
-                  </span>
-                ) : null}
-                {taskMeta !== undefined && taskMeta.commentCount > 0 ? (
-                  <span className="flex items-center gap-0.5" title="Comments">
-                    <Icon name="MessageSquare" className="size-3" />
-                    {taskMeta.commentCount}
-                  </span>
-                ) : null}
                 {task.dueDate !== null ? (
-                  <span>{formatDueDate(task.dueDate)}</span>
+                  <span className="shrink-0 tabular-nums">
+                    {formatDueDate(task.dueDate)}
+                  </span>
                 ) : null}
                 {showProject && project !== undefined ? (
                   <span
@@ -349,7 +387,10 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
         labelOptions={labelOptions}
         taskCount={tasksQuery.data?.length}
       />
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-y-auto @container"
+      >
         {body}
       </div>
       <NewTaskDialog

--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -52,8 +52,9 @@ const RAIL_CHIP_CLASS =
 /**
  * Live-activity chip: a green dot plus an "Active" pill, styled like the
  * label chips so the rail stays uniform. Renders only while an agent is
- * actively starting/working; historical attachments show nothing. The
- * tooltip carries the specific state (starting vs working, agent count).
+ * actively starting/working; historical attachments show nothing. The pill
+ * text stays constant; the tooltip carries the specific state (starting vs
+ * working, agent count).
  */
 function ActiveChip({ threads }: { threads: readonly TaskThread[] }) {
   if (threads.length === 0) return null;
@@ -63,7 +64,7 @@ function ActiveChip({ threads }: { threads: readonly TaskThread[] }) {
         aria-hidden
         className="size-1.5 shrink-0 animate-pulse rounded-full bg-success"
       />
-      {threads.length === 1 ? "Active" : `${threads.length} active`}
+      Active
     </span>
   );
 }

--- a/official-plugins/tasks/views/list/lib.test.ts
+++ b/official-plugins/tasks/views/list/lib.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Label, Task } from "../../shared/contract.js";
 import {
+  activeWorkLabel,
   formatDueDate,
   groupTasksByStatus,
   labelFilterOptions,
-  presetShortName,
+  partitionLabels,
   selectedLabelIds,
 } from "./lib.js";
 
@@ -74,9 +75,43 @@ describe("formatDueDate", () => {
   });
 });
 
-describe("presetShortName", () => {
-  it("takes the part before the separator", () => {
-    expect(presetShortName("Sonnet · high")).toBe("Sonnet");
-    expect(presetShortName("Auto")).toBe("Auto");
+describe("activeWorkLabel", () => {
+  it("distinguishes starting from working for a single agent", () => {
+    expect(activeWorkLabel([{ liveStatus: "starting" }])).toBe(
+      "Agent starting",
+    );
+    expect(activeWorkLabel([{ liveStatus: "working" }])).toBe("Agent working");
+  });
+
+  it("counts multiple live agents", () => {
+    expect(
+      activeWorkLabel([{ liveStatus: "working" }, { liveStatus: "starting" }]),
+    ).toBe("2 agents working");
+  });
+});
+
+describe("partitionLabels", () => {
+  const label = (name: string): Label => ({
+    id: name,
+    projectId: ULID_A,
+    name,
+    color: "#5e6ad2",
+  });
+
+  it("keeps everything visible at or under the cap", () => {
+    const labels = [label("a"), label("b")];
+    expect(partitionLabels(labels, 2)).toEqual({
+      visible: labels,
+      hidden: [],
+    });
+    expect(partitionLabels([], 2)).toEqual({ visible: [], hidden: [] });
+  });
+
+  it("moves the tail into hidden above the cap", () => {
+    const labels = [label("a"), label("b"), label("c")];
+    expect(partitionLabels(labels, 1)).toEqual({
+      visible: [labels[0]],
+      hidden: [labels[1], labels[2]],
+    });
   });
 });

--- a/official-plugins/tasks/views/list/lib.ts
+++ b/official-plugins/tasks/views/list/lib.ts
@@ -103,8 +103,39 @@ export function formatDueDate(dueDate: string, today = new Date()): string {
   });
 }
 
-/** "Sonnet · high" → "Sonnet"; presets without a "·" keep their full name. */
-export function presetShortName(presetName: string): string {
-  const head = presetName.split("·")[0]?.trim();
-  return head !== undefined && head.length > 0 ? head : presetName;
+/**
+ * Accessible name for the list-row activity dot. Callers only render the dot
+ * when at least one thread is live, so the input is never empty.
+ */
+export function activeWorkLabel(
+  threads: readonly { liveStatus: string }[],
+): string {
+  if (threads.length === 1) {
+    return threads[0]?.liveStatus === "starting"
+      ? "Agent starting"
+      : "Agent working";
+  }
+  return `${threads.length} agents working`;
+}
+
+export interface LabelOverflow {
+  visible: Label[];
+  hidden: Label[];
+}
+
+/**
+ * Splits row labels into visible chips and a "+N" overflow so rows stay a
+ * bounded width no matter how many labels a task carries.
+ */
+export function partitionLabels(
+  labels: readonly Label[],
+  maxVisible: number,
+): LabelOverflow {
+  if (labels.length <= maxVisible) {
+    return { visible: [...labels], hidden: [] };
+  }
+  return {
+    visible: labels.slice(0, maxVisible),
+    hidden: labels.slice(maxVisible),
+  };
 }

--- a/official-plugins/tasks/views/list/row-metadata.test.tsx
+++ b/official-plugins/tasks/views/list/row-metadata.test.tsx
@@ -159,7 +159,7 @@ describe("list-row Active chip", () => {
     expect(slot.queryByText(/Attached/)).toBeNull();
   });
 
-  it("aggregates multiple live agents into one chip with a count", async () => {
+  it("aggregates multiple live agents into one constant-text chip", async () => {
     const busy = task(1);
     const { slot } = renderList({
       tasks: [busy],
@@ -175,7 +175,7 @@ describe("list-row Active chip", () => {
     await waitFor(() => {
       expect(slot.getByTitle("2 agents working")).toBeTruthy();
     });
-    expect(slot.getByTitle("2 agents working").textContent).toBe("2 active");
+    expect(slot.getByTitle("2 agents working").textContent).toBe("Active");
   });
 });
 

--- a/official-plugins/tasks/views/list/row-metadata.test.tsx
+++ b/official-plugins/tasks/views/list/row-metadata.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { cleanup, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import type { Label, Task, TaskThread } from "../../shared/contract.js";
+
+// jsdom lacks matchMedia/ResizeObserver; the list shell touches both.
+window.matchMedia ??= (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+window.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView ??= () => {};
+
+// loadPluginApp installs the fake SDK runtime; nothing SDK-touching may be
+// imported before it runs.
+const app = await loadPluginApp(() => import("../../app"));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
+
+const project = {
+  id: PROJECT_ID,
+  name: "Tasks Plugin",
+  prefix: "TSK",
+  nextTaskNumber: 9,
+  color: "blue",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-07-15T00:00:00.000Z",
+};
+
+function task(number: number, labelIds: string[] = []): Task {
+  return {
+    id: `01HZZZZZZZZZZZZZZZZZZZZZT${number}`,
+    projectId: PROJECT_ID,
+    number,
+    key: `TSK-${number}`,
+    title: `Task ${number}`,
+    description: "",
+    status: "todo",
+    priority: "none",
+    dueDate: null,
+    parentTaskId: null,
+    position: number,
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+    labelIds,
+  };
+}
+
+function thread(
+  taskId: string,
+  liveStatus: TaskThread["liveStatus"],
+  suffix: string,
+): TaskThread {
+  return {
+    id: `01HZZZZZZZZZZZZZZZZZZZZZH${suffix}`,
+    taskId,
+    threadId: `thr_${suffix}`,
+    presetName: "Sonnet · high",
+    title: "Worker",
+    liveStatus,
+    attachedAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+  };
+}
+
+function label(suffix: string, name: string): Label {
+  return {
+    id: `01HZZZZZZZZZZZZZZZZZZZZZL${suffix}`,
+    projectId: PROJECT_ID,
+    name,
+    color: "#5e6ad2",
+  };
+}
+
+interface ListFixture {
+  tasks: Task[];
+  labels?: Label[];
+  threadsByTask?: Record<string, TaskThread[]>;
+}
+
+function renderList(fixture: ListFixture) {
+  const calls = { listComments: 0, listAttachments: 0 };
+  const slot = renderSlot(
+    app.navPanels[0]!,
+    { subPath: PROJECT_ID },
+    {
+      rpc: {
+        listProjects: () => ({ projects: [project] }),
+        listFolders: () => ({ folders: [] }),
+        listPresets: () => ({ presets: [] }),
+        sidebarSummary: () => ({ projects: [] }),
+        listLabels: () => ({ labels: fixture.labels ?? [] }),
+        listTasks: () => ({ tasks: fixture.tasks }),
+        listTaskThreads: ({ taskId }: { taskId: string }) => ({
+          taskThreads: fixture.threadsByTask?.[taskId] ?? [],
+        }),
+        listComments: () => {
+          calls.listComments += 1;
+          return { comments: [] };
+        },
+        listAttachments: () => {
+          calls.listAttachments += 1;
+          return { attachments: [] };
+        },
+      },
+    },
+  );
+  return { slot, calls };
+}
+
+describe("list-row activity dot", () => {
+  it("shows an accessible dot only for actively starting/working agents", async () => {
+    const working = task(1);
+    const starting = task(2);
+    const historical = task(3);
+    const bare = task(4);
+    const { slot } = renderList({
+      tasks: [working, starting, historical, bare],
+      threadsByTask: {
+        [working.id]: [thread(working.id, "working", "W1")],
+        [starting.id]: [thread(starting.id, "starting", "S1")],
+        // Historical attachments in every non-live state stay silent.
+        [historical.id]: [
+          thread(historical.id, "idle", "I1"),
+          thread(historical.id, "completed", "C1"),
+          thread(historical.id, "failed", "F1"),
+        ],
+      },
+    });
+    await slot.findByText("TSK-1");
+    await waitFor(() => {
+      expect(slot.getByRole("status", { name: "Agent working" })).toBeTruthy();
+    });
+    expect(slot.getByRole("status", { name: "Agent starting" })).toBeTruthy();
+    // Exactly the two live rows carry a status; historical/bare rows do not.
+    expect(slot.getAllByRole("status")).toHaveLength(2);
+    expect(slot.queryByText(/Attached/)).toBeNull();
+  });
+
+  it("aggregates multiple live agents into one dot", async () => {
+    const busy = task(1);
+    const { slot } = renderList({
+      tasks: [busy],
+      threadsByTask: {
+        [busy.id]: [
+          thread(busy.id, "working", "W1"),
+          thread(busy.id, "working", "W2"),
+          thread(busy.id, "idle", "I1"),
+        ],
+      },
+    });
+    await slot.findByText("TSK-1");
+    await waitFor(() => {
+      expect(
+        slot.getByRole("status", { name: "2 agents working" }),
+      ).toBeTruthy();
+    });
+  });
+});
+
+describe("list-row metadata rail", () => {
+  it("fetches no comment/attachment data and renders no counts", async () => {
+    const { slot, calls } = renderList({ tasks: [task(1), task(2)] });
+    await slot.findByText("TSK-1");
+    // Give the meta query a tick to settle before asserting on RPC traffic.
+    await waitFor(() => expect(slot.getAllByRole("button").length > 0).toBe(true));
+    expect(calls.listComments).toBe(0);
+    expect(calls.listAttachments).toBe(0);
+    expect(slot.queryByTitle("Comments")).toBeNull();
+    expect(slot.queryByTitle("Attachments")).toBeNull();
+  });
+
+  it("renders zero, one, and many labels with a bounded chip count", async () => {
+    const labels = [
+      label("A", "bug"),
+      label("B", "frontend"),
+      label("C", "needs-design"),
+      label("D", "very-long-label-name-that-truncates"),
+    ];
+    const { slot } = renderList({
+      tasks: [
+        task(1),
+        task(2, [labels[0]!.id]),
+        task(3, labels.map((entry) => entry.id)),
+      ],
+      labels,
+    });
+    await slot.findByText("TSK-1");
+
+    // One label renders its chip in both width variants, no overflow chip.
+    expect(slot.getAllByText("bug").length).toBeGreaterThan(0);
+
+    // Four labels: the regular variant shows 2 chips + "+2", the narrow
+    // variant 1 chip + "+3". Hidden names live in the overflow tooltip.
+    await waitFor(() => expect(slot.getByText("+2")).toBeTruthy());
+    expect(slot.getByText("+3")).toBeTruthy();
+    expect(slot.getByText("+2").getAttribute("title")).toBe(
+      "needs-design, very-long-label-name-that-truncates",
+    );
+    expect(slot.getByText("+3").getAttribute("title")).toBe(
+      "frontend, needs-design, very-long-label-name-that-truncates",
+    );
+    // Overflowed labels never render as visible chips.
+    expect(slot.queryByText("needs-design")).toBeNull();
+  });
+});

--- a/official-plugins/tasks/views/list/row-metadata.test.tsx
+++ b/official-plugins/tasks/views/list/row-metadata.test.tsx
@@ -126,8 +126,8 @@ function renderList(fixture: ListFixture) {
   return { slot, calls };
 }
 
-describe("list-row activity dot", () => {
-  it("shows an accessible dot only for actively starting/working agents", async () => {
+describe("list-row Active chip", () => {
+  it("shows the chip only for actively starting/working agents", async () => {
     const working = task(1);
     const starting = task(2);
     const historical = task(3);
@@ -146,16 +146,20 @@ describe("list-row activity dot", () => {
       },
     });
     await slot.findByText("TSK-1");
+    // Tooltips carry the specific state; the visible pill text is "Active".
     await waitFor(() => {
-      expect(slot.getByRole("status", { name: "Agent working" })).toBeTruthy();
+      expect(slot.getByTitle("Agent working")).toBeTruthy();
     });
-    expect(slot.getByRole("status", { name: "Agent starting" })).toBeTruthy();
-    // Exactly the two live rows carry a status; historical/bare rows do not.
-    expect(slot.getAllByRole("status")).toHaveLength(2);
+    expect(slot.getByTitle("Agent working").textContent).toBe("Active");
+    expect(slot.getByTitle("Agent starting").textContent).toBe("Active");
+    // Exactly the two live rows carry a chip; historical/bare rows do not.
+    expect(
+      slot.getAllByText("Active", { selector: "span[title]" }),
+    ).toHaveLength(2);
     expect(slot.queryByText(/Attached/)).toBeNull();
   });
 
-  it("aggregates multiple live agents into one dot", async () => {
+  it("aggregates multiple live agents into one chip with a count", async () => {
     const busy = task(1);
     const { slot } = renderList({
       tasks: [busy],
@@ -169,10 +173,9 @@ describe("list-row activity dot", () => {
     });
     await slot.findByText("TSK-1");
     await waitFor(() => {
-      expect(
-        slot.getByRole("status", { name: "2 agents working" }),
-      ).toBeTruthy();
+      expect(slot.getByTitle("2 agents working")).toBeTruthy();
     });
+    expect(slot.getByTitle("2 agents working").textContent).toBe("2 active");
   });
 });
 


### PR DESCRIPTION
## Summary

Full replacement of the previous implementation on this branch (the earlier commit was reset away; this is a from-scratch redesign against current main).

- **Linear-style chip rail.** Everything trailing the title is a uniform pill sharing one chip treatment: an **Active chip** (green pulsing dot + a constant `Active` label; the agent count and starting/working detail live in the tooltip) → label chips → a clock-glyph **due-date chip** → project swatch. No bare text in the rail, so nothing reads as misaligned.
- **Active chip only for live work.** It appears only while an attached thread is actively `starting`/`working`; idle, completed, and failed historical attachments render nothing. The visible `Attached` text is gone; the chip's tooltip carries the specific state (`Agent starting` / `Agent working` / `N agents working`).
- **Bounded chips.** Label chips are capped (2 in regular containers, 1 in narrow ones via a container query on the list body) with a `+N` overflow chip whose tooltip lists the hidden label names; individual chips truncate at a max width instead of crowding the right edge.
- **No comment/attachment indicators in list rows.** Counts and icons are removed from the list only; detail view, CLI, and API expose comments, attachments, and attached threads unchanged. The list meta query no longer fans out `listComments`/`listAttachments` per row.

## Test plan
- [x] Unit: `activeWorkLabel` (starting/working/multi), `partitionLabels` overflow split
- [x] UI: Active chip shows only for starting/working (constant visible text `Active`, tooltip detail incl. agent count); idle/completed/failed/no-attachment rows have no chip; no `Attached` text
- [x] UI: no comment/attachment titles in list and zero `listComments`/`listAttachments` RPC calls from the list
- [x] UI: zero/one/many/long labels; chip cap + `+N` tooltip contents in both width variants
- [x] `pnpm exec turbo run test typecheck build --filter=bb-plugin-tasks` (256 tests)
- [x] Live QA in an isolated dev instance with the real Tasks plugin: seeded active/starting/multi-agent/idle/failed/no-attachment rows, 0/1/4 labels incl. a very long one, due dates, comments+attachments; screenshots at desktop + 480px narrow, light, dark, and Nord; hover/focus states; empty console; CLI corroboration of live statuses and preserved detail data

## Risks
- Board cards keep their existing working-agent text and paperclip (list rows only were in scope).
- The Active chip depends on task-thread `liveStatus` reconciliation; brief lag after attach/idle transitions is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
