### PR TITLE
BB-13: Scope split keyboard navigation to the focused pane

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -537,23 +537,42 @@ export function ModelReasoningPicker({
     [isPreviewing, onModelChange, onSelectedProviderChange, previewProviderId],
   );
 
-  // Scope Cmd+Shift+M to the focused split pane; standalone/single-pane
-  // surfaces have no pane context and default to focused.
-  const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
+  // Scope Cmd+Shift+M to one composer of the focused pane. Standalone/single-pane
+  // surfaces have no pane context and default to focused/non-split.
+  const paneContext = useOptionalPaneContext();
+  const isFocusedPane = paneContext?.isFocused ?? true;
+  const isSplitPane = paneContext?.isSplitPane ?? false;
   useAppCommandContext("modelPickerOpen", open && !disabled);
   useAppCommandHandler(
     "modelPicker.toggle",
     ({ target }) => {
+      const pickerComposer =
+        triggerRef.current?.closest("[data-app-composer]") ?? null;
+      const caretComposer =
+        target instanceof HTMLElement
+          ? target.closest("[data-app-composer]")
+          : null;
+      // Two composers of the same pane share its `[data-split-pane-id]` wrapper;
+      // a lone surface has none, so this stays false there.
+      const pickerPane =
+        triggerRef.current?.closest("[data-split-pane-id]") ?? null;
+      const caretPane = caretComposer?.closest("[data-split-pane-id]") ?? null;
       const action = resolveModelPickerToggle({
         open,
         disabled: disabled ?? false,
         isFocusedPane,
-        targetComposer:
-          target instanceof HTMLElement
-            ? target.closest("[data-app-composer]")
-            : null,
-        pickerComposer:
-          triggerRef.current?.closest("[data-app-composer]") ?? null,
+        isSplitPane,
+        // The main/new-thread composer is primary; a side chat marks itself
+        // secondary via data-app-composer-role.
+        isPrimaryComposer:
+          pickerComposer?.getAttribute("data-app-composer-role") !== "secondary",
+        caretInThisComposer:
+          caretComposer !== null && caretComposer === pickerComposer,
+        caretInOtherComposerOfPane:
+          caretComposer !== null &&
+          caretComposer !== pickerComposer &&
+          pickerPane !== null &&
+          caretPane === pickerPane,
       });
       if (action === "ignore") return false;
       setOpen(action === "open");

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -59,6 +59,8 @@ import {
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
+import { useOptionalPaneContext } from "@/views/thread-detail/PaneContext";
+import { resolveModelPickerToggle } from "./modelPickerToggle";
 
 interface ModelLabelParts {
   base: string;
@@ -535,22 +537,26 @@ export function ModelReasoningPicker({
     [isPreviewing, onModelChange, onSelectedProviderChange, previewProviderId],
   );
 
+  // Scope Cmd+Shift+M to the focused split pane; standalone/single-pane
+  // surfaces have no pane context and default to focused.
+  const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   useAppCommandContext("modelPickerOpen", open && !disabled);
   useAppCommandHandler(
     "modelPicker.toggle",
     ({ target }) => {
-      if (disabled) return false;
-      if (open) {
-        setOpen(false);
-        return true;
-      }
-      if (!(target instanceof HTMLElement)) return false;
-      const targetComposer = target.closest("[data-app-composer]");
-      const pickerComposer = triggerRef.current?.closest("[data-app-composer]");
-      if (targetComposer === null || targetComposer !== pickerComposer) {
-        return false;
-      }
-      setOpen(true);
+      const action = resolveModelPickerToggle({
+        open,
+        disabled: disabled ?? false,
+        isFocusedPane,
+        targetComposer:
+          target instanceof HTMLElement
+            ? target.closest("[data-app-composer]")
+            : null,
+        pickerComposer:
+          triggerRef.current?.closest("[data-app-composer]") ?? null,
+      });
+      if (action === "ignore") return false;
+      setOpen(action === "open");
       return true;
     },
     50,

--- a/apps/app/src/components/pickers/modelPickerToggle.test.ts
+++ b/apps/app/src/components/pickers/modelPickerToggle.test.ts
@@ -1,34 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { resolveModelPickerToggle } from "./modelPickerToggle";
+import {
+  resolveModelPickerToggle,
+  type ModelPickerToggleInput,
+} from "./modelPickerToggle";
 
-// Stand-ins for `[data-app-composer]` elements. Reference identity is all the
-// decision compares, so bare objects cast to Element keep the test DOM-free.
-const composerA = {} as Element;
-const composerB = {} as Element;
-
-const base = {
+// A focused, split, primary composer with the caret sitting inside it — the
+// simplest "open" case. Individual tests override just the fields they exercise.
+const base: ModelPickerToggleInput = {
   open: false,
   disabled: false,
   isFocusedPane: true,
-  targetComposer: composerA,
-  pickerComposer: composerA,
-} as const;
+  isSplitPane: true,
+  isPrimaryComposer: true,
+  caretInThisComposer: true,
+  caretInOtherComposerOfPane: false,
+};
 
 describe("resolveModelPickerToggle", () => {
-  it("opens when the focused pane's cursor sits in this picker's composer", () => {
+  it("opens when the focused pane's caret sits in this composer", () => {
     expect(resolveModelPickerToggle(base)).toBe("open");
-  });
-
-  it("closes an open picker regardless of focus or target", () => {
-    expect(
-      resolveModelPickerToggle({
-        ...base,
-        open: true,
-        isFocusedPane: false,
-        targetComposer: composerB,
-        pickerComposer: composerA,
-      }),
-    ).toBe("close");
   });
 
   it("ignores the chord entirely while disabled", () => {
@@ -43,26 +33,61 @@ describe("resolveModelPickerToggle", () => {
     );
   });
 
-  it("ignores a picker whose composer is not the one under the cursor", () => {
+  it("closes only the focused pane's open picker", () => {
+    expect(resolveModelPickerToggle({ ...base, open: true })).toBe("close");
+    // Focus is checked before close, so an unfocused pane's stale-open picker
+    // cannot swallow the chord away from the focused pane.
     expect(
-      resolveModelPickerToggle({ ...base, targetComposer: composerB }),
+      resolveModelPickerToggle({ ...base, open: true, isFocusedPane: false }),
     ).toBe("ignore");
   });
 
-  it("opens the focused pane's picker when focus is outside every composer", () => {
-    // Keyboard pane navigation leaves focus off the text field: the cursor is in
-    // no composer, so the focused pane's picker still opens.
-    expect(
-      resolveModelPickerToggle({ ...base, targetComposer: null }),
-    ).toBe("open");
-  });
-
-  it("still requires focus when the cursor is outside every composer", () => {
+  it("opens the composer under the caret regardless of split or primary", () => {
     expect(
       resolveModelPickerToggle({
         ...base,
-        targetComposer: null,
-        isFocusedPane: false,
+        isPrimaryComposer: false,
+        isSplitPane: false,
+      }),
+    ).toBe("open");
+  });
+
+  it("defers to a sibling composer the caret is actually in", () => {
+    // A side-chat caret toggles the side chat's picker, not the main one.
+    expect(
+      resolveModelPickerToggle({
+        ...base,
+        caretInThisComposer: false,
+        caretInOtherComposerOfPane: true,
+      }),
+    ).toBe("ignore");
+  });
+
+  it("opens the focused split pane's primary composer when the caret is outside every composer", () => {
+    // Keyboard pane navigation leaves the caret off the text field.
+    expect(
+      resolveModelPickerToggle({ ...base, caretInThisComposer: false }),
+    ).toBe("open");
+  });
+
+  it("does NOT open a hidden secondary (side-chat) composer on the caret-outside fallback", () => {
+    // The regression the reviewer flagged: a mounted-but-hidden side chat
+    // must not win the fallback in a focused split pane.
+    expect(
+      resolveModelPickerToggle({
+        ...base,
+        caretInThisComposer: false,
+        isPrimaryComposer: false,
+      }),
+    ).toBe("ignore");
+  });
+
+  it("does nothing on a lone surface when the caret is outside the composer (backward compatible)", () => {
+    expect(
+      resolveModelPickerToggle({
+        ...base,
+        isSplitPane: false,
+        caretInThisComposer: false,
       }),
     ).toBe("ignore");
   });

--- a/apps/app/src/components/pickers/modelPickerToggle.test.ts
+++ b/apps/app/src/components/pickers/modelPickerToggle.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelPickerToggle } from "./modelPickerToggle";
+
+// Stand-ins for `[data-app-composer]` elements. Reference identity is all the
+// decision compares, so bare objects cast to Element keep the test DOM-free.
+const composerA = {} as Element;
+const composerB = {} as Element;
+
+const base = {
+  open: false,
+  disabled: false,
+  isFocusedPane: true,
+  targetComposer: composerA,
+  pickerComposer: composerA,
+} as const;
+
+describe("resolveModelPickerToggle", () => {
+  it("opens when the focused pane's cursor sits in this picker's composer", () => {
+    expect(resolveModelPickerToggle(base)).toBe("open");
+  });
+
+  it("closes an open picker regardless of focus or target", () => {
+    expect(
+      resolveModelPickerToggle({
+        ...base,
+        open: true,
+        isFocusedPane: false,
+        targetComposer: composerB,
+        pickerComposer: composerA,
+      }),
+    ).toBe("close");
+  });
+
+  it("ignores the chord entirely while disabled", () => {
+    expect(resolveModelPickerToggle({ ...base, disabled: true })).toBe(
+      "ignore",
+    );
+  });
+
+  it("ignores panes that are not focused", () => {
+    expect(resolveModelPickerToggle({ ...base, isFocusedPane: false })).toBe(
+      "ignore",
+    );
+  });
+
+  it("ignores a picker whose composer is not the one under the cursor", () => {
+    expect(
+      resolveModelPickerToggle({ ...base, targetComposer: composerB }),
+    ).toBe("ignore");
+  });
+
+  it("opens the focused pane's picker when focus is outside every composer", () => {
+    // Keyboard pane navigation leaves focus off the text field: the cursor is in
+    // no composer, so the focused pane's picker still opens.
+    expect(
+      resolveModelPickerToggle({ ...base, targetComposer: null }),
+    ).toBe("open");
+  });
+
+  it("still requires focus when the cursor is outside every composer", () => {
+    expect(
+      resolveModelPickerToggle({
+        ...base,
+        targetComposer: null,
+        isFocusedPane: false,
+      }),
+    ).toBe("ignore");
+  });
+});

--- a/apps/app/src/components/pickers/modelPickerToggle.ts
+++ b/apps/app/src/components/pickers/modelPickerToggle.ts
@@ -1,0 +1,46 @@
+/** Outcome of a Cmd+Shift+M dispatch for a single model picker instance. */
+export type ModelPickerToggleAction = "open" | "close" | "ignore";
+
+export interface ModelPickerToggleInput {
+  /** Whether this picker is currently open. */
+  open: boolean;
+  /** Whether this picker is disabled (locked/preview surfaces). */
+  disabled: boolean;
+  /** Whether this picker's split pane is the focused one. */
+  isFocusedPane: boolean;
+  /**
+   * The `[data-app-composer]` element the keyboard event originated in, or null
+   * when focus sits outside any composer (e.g. after keyboard pane navigation).
+   */
+  targetComposer: Element | null;
+  /** The `[data-app-composer]` element this picker belongs to, if any. */
+  pickerComposer: Element | null;
+}
+
+/**
+ * Decides what a single {@link ModelReasoningPicker} should do when the
+ * `modelPicker.toggle` command (Cmd+Shift+M) fires. Every composer registers its
+ * own handler, so the decision must both scope to the focused split pane and, for
+ * panes with several composers (main + side chat), pick the composer the cursor
+ * sits in.
+ *
+ * - An already-open picker always closes, so the chord dismisses whatever popover
+ *   is showing regardless of focus.
+ * - Otherwise only the focused pane may open. When the cursor is inside a specific
+ *   composer, only that composer's picker opens; when focus is outside every
+ *   composer (keyboard pane nav, body focus), the focused pane's picker opens.
+ */
+export function resolveModelPickerToggle(
+  input: ModelPickerToggleInput,
+): ModelPickerToggleAction {
+  if (input.disabled) return "ignore";
+  if (input.open) return "close";
+  if (!input.isFocusedPane) return "ignore";
+  if (
+    input.targetComposer !== null &&
+    input.targetComposer !== input.pickerComposer
+  ) {
+    return "ignore";
+  }
+  return "open";
+}

--- a/apps/app/src/components/pickers/modelPickerToggle.ts
+++ b/apps/app/src/components/pickers/modelPickerToggle.ts
@@ -8,39 +8,47 @@ export interface ModelPickerToggleInput {
   disabled: boolean;
   /** Whether this picker's split pane is the focused one. */
   isFocusedPane: boolean;
+  /** Whether this picker lives inside a multi-pane split (not a lone surface). */
+  isSplitPane: boolean;
   /**
-   * The `[data-app-composer]` element the keyboard event originated in, or null
-   * when focus sits outside any composer (e.g. after keyboard pane navigation).
+   * Whether this composer is the pane's primary composer (the main thread /
+   * new-thread box) rather than a secondary one (a side-chat composer, which
+   * stays mounted but hidden). Only the primary composer answers the keyboard
+   * fallback when the caret is outside every composer.
    */
-  targetComposer: Element | null;
-  /** The `[data-app-composer]` element this picker belongs to, if any. */
-  pickerComposer: Element | null;
+  isPrimaryComposer: boolean;
+  /** The caret sits inside THIS picker's composer. */
+  caretInThisComposer: boolean;
+  /** The caret sits inside a DIFFERENT composer of the same focused pane. */
+  caretInOtherComposerOfPane: boolean;
 }
 
 /**
  * Decides what a single {@link ModelReasoningPicker} should do when the
- * `modelPicker.toggle` command (Cmd+Shift+M) fires. Every composer registers its
- * own handler, so the decision must both scope to the focused split pane and, for
- * panes with several composers (main + side chat), pick the composer the cursor
- * sits in.
+ * `modelPicker.toggle` command (Cmd+Shift+M) fires. Every mounted composer
+ * registers its own handler — including side-chat composers that stay mounted
+ * while hidden — so the decision must scope to the focused pane AND to a single
+ * composer within it.
  *
- * - An already-open picker always closes, so the chord dismisses whatever popover
- *   is showing regardless of focus.
- * - Otherwise only the focused pane may open. When the cursor is inside a specific
- *   composer, only that composer's picker opens; when focus is outside every
- *   composer (keyboard pane nav, body focus), the focused pane's picker opens.
+ * Precedence:
+ * 1. Disabled pickers never act.
+ * 2. Only the focused pane participates (checked before close so a stale open
+ *    picker in an unfocused pane can't swallow the chord).
+ * 3. An open picker in the focused pane toggles closed.
+ * 4. If the caret is inside a composer, only that composer's picker opens; a
+ *    sibling composer of the same pane defers to it.
+ * 5. Otherwise (caret outside every composer, e.g. after keyboard pane
+ *    navigation) only a split pane's primary composer opens — lone surfaces keep
+ *    their prior "do nothing unless the caret is in the composer" behavior.
  */
 export function resolveModelPickerToggle(
   input: ModelPickerToggleInput,
 ): ModelPickerToggleAction {
   if (input.disabled) return "ignore";
-  if (input.open) return "close";
   if (!input.isFocusedPane) return "ignore";
-  if (
-    input.targetComposer !== null &&
-    input.targetComposer !== input.pickerComposer
-  ) {
-    return "ignore";
-  }
-  return "open";
+  if (input.open) return "close";
+  if (input.caretInThisComposer) return "open";
+  if (input.caretInOtherComposerOfPane) return "ignore";
+  if (!input.isSplitPane) return "ignore";
+  return input.isPrimaryComposer ? "open" : "ignore";
 }

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -37,6 +37,7 @@ import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { ThreadTimelineScrollToBottomButton } from "@/views/thread-detail/ThreadTimelineScrollToBottomButton";
+import { useOptionalPaneContext } from "@/views/thread-detail/PaneContext";
 import { ThreadContextWindowIndicator } from "@/components/thread/timeline";
 import { THREAD_PROMPT_CONTEXT_BANNER_ROW_HEIGHT } from "@/components/promptbox/banner/ThreadPromptContextBanner";
 import {
@@ -258,8 +259,13 @@ function FollowUpPromptBoxWithComposer({
       : undefined;
   const canStopRuntime = onStopRuntime !== undefined;
   const promptBoxRef = useRef<PromptBoxHandle>(null);
+  // Scope Cmd+Shift+C to the focused split pane. Every pane mounts its own
+  // composer, so an ungated handler would let an arbitrary pane win dispatch.
+  // Standalone/single-pane surfaces have no pane context and default to focused.
+  const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   useAppCommandContext("promptAvailable", true);
   useAppCommandHandler("composer.focus", () => {
+    if (!isFocusedPane) return false;
     promptBoxRef.current?.focusEnd();
     return promptBoxRef.current !== null;
   });

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -198,6 +198,15 @@ export interface FollowUpPromptBoxProps {
    * queued message restores its text into the draft.
    */
   focusEndKey?: string | number;
+  /**
+   * Whether this is the pane's primary composer (the main thread box) rather
+   * than a secondary one such as a side-chat composer, which stays mounted but
+   * hidden. Only the primary composer answers the pane-scoped Cmd+Shift+C /
+   * Cmd+Shift+M fallback when the caret is outside every composer. Defaults to
+   * true; side chats pass false. Marks the composer shell via
+   * `data-app-composer-role` so the model picker can read the same signal.
+   */
+  isPrimaryComposer?: boolean;
 }
 
 type FollowUpPromptBoxWithComposerProps = Omit<
@@ -237,6 +246,7 @@ function FollowUpPromptBoxWithComposer({
   promptActions,
   zenModeResetKey,
   focusEndKey,
+  isPrimaryComposer = true,
 }: FollowUpPromptBoxWithComposerProps) {
   const submitMode = composer.submitMode;
   const canQueueFollowUp = submitMode.kind === "queue";
@@ -259,13 +269,15 @@ function FollowUpPromptBoxWithComposer({
       : undefined;
   const canStopRuntime = onStopRuntime !== undefined;
   const promptBoxRef = useRef<PromptBoxHandle>(null);
-  // Scope Cmd+Shift+C to the focused split pane. Every pane mounts its own
-  // composer, so an ungated handler would let an arbitrary pane win dispatch.
-  // Standalone/single-pane surfaces have no pane context and default to focused.
+  // Scope Cmd+Shift+C to the focused pane's primary composer. Every mounted
+  // composer registers this handler — including side-chat composers that stay
+  // mounted while hidden — so gating on both the focused pane and "primary"
+  // keeps a hidden side chat from stealing the chord. Standalone/single-pane
+  // surfaces have no pane context and default to focused.
   const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   useAppCommandContext("promptAvailable", true);
   useAppCommandHandler("composer.focus", () => {
-    if (!isFocusedPane) return false;
+    if (!isFocusedPane || !isPrimaryComposer) return false;
     promptBoxRef.current?.focusEnd();
     return promptBoxRef.current !== null;
   });
@@ -493,7 +505,12 @@ function FollowUpPromptBoxWithComposer({
       <ThreadTimelineScrollToBottomButton
         active={composer.threadRuntimeDisplayStatus === "active"}
       />
-      <div data-app-composer="" data-promptbox-shell="" className="space-y-2">
+      <div
+        data-app-composer=""
+        data-app-composer-role={isPrimaryComposer ? "primary" : "secondary"}
+        data-promptbox-shell=""
+        className="space-y-2"
+      >
         <div ref={stackRef} className="space-y-2">
           {stack}
         </div>

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -26,6 +26,7 @@ import {
   type TypeaheadConfig,
 } from "@/components/promptbox/PromptBoxInternal";
 import { usePromptVoice } from "@/components/promptbox/usePromptVoice";
+import { useOptionalPaneContext } from "@/views/thread-detail/PaneContext";
 import {
   BranchPicker,
   type BranchPickerMenuKind,
@@ -215,8 +216,11 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   execution,
 }: NewThreadPromptBoxUIProps) {
   const promptBoxRef = useRef<PromptBoxHandle>(null);
+  // Scope Cmd+Shift+C to the focused split pane (see FollowUpPromptBox).
+  const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   useAppCommandContext("promptAvailable", true);
   useAppCommandHandler("composer.focus", () => {
+    if (!isFocusedPane) return false;
     promptBoxRef.current?.focusEnd();
     return promptBoxRef.current !== null;
   });

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -216,7 +216,8 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   execution,
 }: NewThreadPromptBoxUIProps) {
   const promptBoxRef = useRef<PromptBoxHandle>(null);
-  // Scope Cmd+Shift+C to the focused split pane (see FollowUpPromptBox).
+  // Scope Cmd+Shift+C to the focused split pane (see FollowUpPromptBox). The
+  // new-thread composer is always a pane's primary composer.
   const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   useAppCommandContext("promptAvailable", true);
   useAppCommandHandler("composer.focus", () => {
@@ -263,7 +264,12 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
       ? "Loading models..."
       : "Submit (Enter)";
   return (
-    <div data-app-composer="" data-promptbox-shell="" className="w-full">
+    <div
+      data-app-composer=""
+      data-app-composer-role="primary"
+      data-promptbox-shell=""
+      className="w-full"
+    >
       {modeConfig.banner ? (
         <div className="mb-2">{modeConfig.banner}</div>
       ) : null}

--- a/apps/app/src/components/secondary-panel/SideChatTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/SideChatTabContent.tsx
@@ -1334,6 +1334,10 @@ export function SideChatTabContent({
           promptActions={promptActions}
           zenModeResetKey={childThreadId ?? tab.id}
           focusEndKey={composerFocusNonce}
+          // A side chat is a secondary composer: it stays mounted (often hidden)
+          // inside its pane, so it must not answer the pane-scoped Cmd+Shift+C /
+          // Cmd+Shift+M fallback unless the caret is actually inside it.
+          isPrimaryComposer={false}
         />
       </div>
     </div>

--- a/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
+++ b/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
@@ -33,6 +33,7 @@ import {
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
+import { useOptionalPaneContext } from "@/views/thread-detail/PaneContext";
 
 interface UserQuestionAnswerFormProps {
   className?: string;
@@ -411,8 +412,12 @@ export function UserQuestionAnswerForm({
     stopThread.mutate(threadId);
   };
 
+  // Scope number-key question answers to the focused split pane, so a pending
+  // question in another pane never steals the keypress. Defaults to focused on
+  // standalone/single-pane surfaces (no pane context).
+  const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   const selectChoiceAt = (index: number): boolean => {
-    if (disabled || !currentQuestion) return false;
+    if (!isFocusedPane || disabled || !currentQuestion) return false;
     const choice = resolveQuestionShortcutChoice(currentQuestion, index);
     if (choice?.kind === "option") {
       handleToggleOption(currentQuestion, choice.value);

--- a/apps/app/src/views/thread-detail/PaneContext.tsx
+++ b/apps/app/src/views/thread-detail/PaneContext.tsx
@@ -18,6 +18,12 @@ export interface PaneContextValue {
   paneId: string;
   isFocused: boolean;
   /**
+   * True only inside a multi-pane split. Lets keyboard commands scope a
+   * caret-outside-composer fallback (e.g. Cmd+Shift+M after keyboard pane
+   * navigation) to splits while leaving lone surfaces at their prior behavior.
+   */
+  isSplitPane: boolean;
+  /**
    * Window-level secondary-panel host for a multi-pane workspace. Pane views
    * publish their already-assembled panel model here while retaining ownership
    * of panel tabs, selection, commands, and product policy. Null on standalone
@@ -179,6 +185,7 @@ export function DefaultPaneContextProvider({
     () => ({
       paneId: "main",
       isFocused: true,
+      isSplitPane: false,
       secondaryPanelHost: null,
       reservesWindowPanelToggle: false,
       onRequestClose: null,

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -343,6 +343,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           content={firstPane.content}
           paneId={firstPane.paneId}
           isFocused
+          isSplitPane={false}
           secondaryPanelRegistry={null}
           reservesWindowPanelToggle={false}
           onRequestClose={null}
@@ -478,6 +479,7 @@ function SplitTree(props: SplitTreeProps) {
           content={node.content}
           paneId={node.paneId}
           isFocused={isFocused}
+          isSplitPane
           secondaryPanelRegistry={props.secondaryPanelRegistry}
           reservesWindowPanelToggle={isTopRow && isRightEdge}
           onRequestClose={() => props.onClosePane(node.paneId)}
@@ -543,6 +545,7 @@ interface WorkspacePaneContentProps {
   content: PaneContent;
   paneId: string;
   isFocused: boolean;
+  isSplitPane: boolean;
   secondaryPanelRegistry: PaneSecondaryPanelRegistry | null;
   reservesWindowPanelToggle: boolean;
   onRequestClose: (() => void) | null;
@@ -559,6 +562,7 @@ function WorkspacePaneContent({
   content,
   paneId,
   isFocused,
+  isSplitPane,
   secondaryPanelRegistry,
   reservesWindowPanelToggle,
   onRequestClose,
@@ -593,6 +597,7 @@ function WorkspacePaneContent({
     () => ({
       paneId,
       isFocused,
+      isSplitPane,
       secondaryPanelHost,
       reservesWindowPanelToggle,
       onRequestClose,
@@ -605,6 +610,7 @@ function WorkspacePaneContent({
       beginPaneDrag,
       isBoundedPane,
       isFocused,
+      isSplitPane,
       isTopRow,
       navigateInPane,
       onRequestClose,

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -218,6 +218,7 @@ function ThreadDetailTestPaneProvider({
   const value: PaneContextValue = {
     paneId: "pane-test",
     isFocused: isFocusedHosted,
+    isSplitPane: true,
     secondaryPanelHost: hostedPaneRegistration,
     reservesWindowPanelToggle: false,
     onRequestClose: noop,


### PR DESCRIPTION
## BB-13 · Keyboard navigation for splits

Makes the split-pane keyboard commands operate on the **focused pane's** correct composer. App shortcuts dispatch a chord to per-component handlers until one consumes it, and every split pane mounts its own handlers — so commands that ignored pane focus let an arbitrary pane win.

### Fixes
- **`composer.focus` (⌘⇧C)** — focuses the focused pane's **primary** composer. Previously any pane's composer could win.
- **`modelPicker.toggle` (⌘⇧M)** — new pure `resolveModelPickerToggle` decision: opens the composer under the caret when there is one, otherwise the focused split pane's primary picker (so it works after keyboard pane navigation), and toggles closed. Lone surfaces keep their prior behavior.
- **`question.select.1–9`** — number-key answers scoped to the focused pane.

### Why the extra machinery
A pane keeps its side-chat composers mounted (`display:none`) inside the focused pane, so pane focus alone doesn't disambiguate them. This PR adds `PaneContext.isSplitPane` and marks the primary composer (`isPrimaryComposer` + `data-app-composer-role`) so a hidden side chat can never steal ⌘⇧C / ⌘⇧M unless the caret is actually inside it.

### Audit (unchanged)
`panel.newTab/close/toggle`, `terminal.open`, `diff.toggle`, `file.quickOpen`, `workspace.openPreferred`, `pane.focus.*`, and `pane.close` were already focus-gated. Pane-navigation shortcuts already existed. App-global commands stay window-scoped.

Pure UI change: no server/daemon boundary, no route/command contract, no protocol bump, no new shortcuts.

### Testing
- `resolveModelPickerToggle` unit matrix (9 cases incl. hidden-side-chat fallback, sibling defer, standalone no-op, focus-before-close).
- `@bb/app` typecheck + 352 tests across pickers / promptbox / side-chat / split / thread suites.
- **Real-browser QA** on an isolated dev instance (2-pane split): ⌘⇧C focus tracking, ⌘⇧M open/close + cross-pane isolation, ⌘⇧M opening the focused pane even when the caret is in another pane's composer, ⌘1/⌘2 and ⌘⇧[ /] pane focus, ⌘⇧X close→single-pane URL follow, compact-viewport disable/restore, standalone backward-compat, zero console errors.

### Review
One reviewer (codex / gpt-5.6-sol, read-only) → REQUEST CHANGES on three side-chat / backward-compat edge cases; all fixed and reverified in the second commit. A full Product Review Report (coverage ledger + screenshots) is attached to task BB-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
