### PR TITLE
BB-28: Remember task list scroll position across navigation

### DIFF
--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Label, Task } from "../../shared/contract.js";
 import { useProjects } from "../../shell/data.js";
 import { useTasksNavigation } from "../../shell/routes.js";
@@ -21,6 +21,10 @@ import {
 } from "./list-preference.js";
 import { sortTasks, type TaskSort } from "../../shared/sort.js";
 import { PriorityIcon, StatusIcon } from "./icons.js";
+import {
+  listScrollScopeKey,
+  useListScrollRestoration,
+} from "./scroll-restoration.js";
 import {
   formatDueDate,
   groupTasksByStatus,
@@ -203,6 +207,27 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   const showProject = projectId === null;
   const filtered = hasActiveFilters(filters);
 
+  // Remember/restore the list's scroll offset per distinct list+filter+sort
+  // context, so opening a task and returning (or refreshing) lands where the
+  // user left off. Restore only once the real rows have loaded.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scopeKey = listScrollScopeKey({ projectId, activeOnly, filters, sort });
+  // `useListTasks` keeps the previous scope's rows on screen while it refetches
+  // and only flips `isLoading` in a later effect, so on the first render after a
+  // filter/sort change the rows are stale but `isLoading` is still false. Treat
+  // the scope as loading until fresh data for it has settled, giving scroll
+  // restoration a synchronously-correct signal that more rows are still coming.
+  const settledScope = useRef(scopeKey);
+  const scopeChanged = settledScope.current !== scopeKey;
+  useEffect(() => {
+    if (!tasksQuery.isLoading) settledScope.current = scopeKey;
+  }, [scopeKey, tasksQuery.isLoading, tasksQuery.data]);
+  useListScrollRestoration(scrollRef, scopeKey, {
+    contentReady: tasksQuery.data !== undefined && tasksQuery.data.length > 0,
+    loading: tasksQuery.isLoading || scopeChanged,
+    revision: tasksQuery.data?.length ?? 0,
+  });
+
   let body: React.ReactNode;
   if (tasksQuery.data === undefined) {
     body = tasksQuery.error !== null ? (
@@ -324,7 +349,9 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
         labelOptions={labelOptions}
         taskCount={tasksQuery.data?.length}
       />
-      <div className="min-h-0 flex-1 overflow-y-auto">{body}</div>
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+        {body}
+      </div>
       <NewTaskDialog
         open={newTaskOpen}
         onOpenChange={setNewTaskOpen}

--- a/official-plugins/tasks/views/list/scroll-restoration.test.tsx
+++ b/official-plugins/tasks/views/list/scroll-restoration.test.tsx
@@ -45,6 +45,24 @@ describe("listScrollScopeKey", () => {
     );
   });
 
+  it("does not collide distinct label filters that share a delimiter", () => {
+    // Label names are arbitrary strings; a naive comma-join would make these
+    // two different filters share a key and restore each other's offset.
+    const withComma: ListFilterState = {
+      statuses: [],
+      priorities: [],
+      labelNames: ["a,b"],
+    };
+    const twoLabels: ListFilterState = {
+      statuses: [],
+      priorities: [],
+      labelNames: ["a", "b"],
+    };
+    expect(listScrollScopeKey({ ...base, filters: withComma })).not.toBe(
+      listScrollScopeKey({ ...base, filters: twoLabels }),
+    );
+  });
+
   it("distinguishes sort while holding the list fixed", () => {
     expect(listScrollScopeKey(base)).not.toBe(
       listScrollScopeKey({ ...base, sort: "priority" }),
@@ -66,6 +84,8 @@ describe("resolveRestoreTarget", () => {
 });
 
 describe("scroll store", () => {
+  // Storage key contract: keep in sync with STORAGE_PREFIX in the module.
+  const PREFIX = "bb-tasks:list-scroll:";
   beforeEach(() => window.sessionStorage.clear());
   afterEach(() => window.sessionStorage.clear());
 
@@ -74,6 +94,37 @@ describe("scroll store", () => {
     expect(readListScroll("all|")).toBe(124);
     writeListScroll("all|", -5);
     expect(readListScroll("all|")).toBe(0);
+  });
+
+  it("persists to sessionStorage under the scoped key", () => {
+    writeListScroll("proj:x|", 250);
+    expect(window.sessionStorage.getItem(`${PREFIX}proj:x|`)).toBe("250");
+  });
+
+  it("reads a value seeded directly in sessionStorage (survives refresh)", () => {
+    // A fresh page load starts with an empty in-memory map, so this proves the
+    // sessionStorage read path rather than the memory fallback.
+    window.sessionStorage.setItem(`${PREFIX}fresh|`, "333");
+    expect(readListScroll("fresh|")).toBe(333);
+  });
+
+  it("rejects malformed stored values instead of truncating them", () => {
+    for (const bad of ["400garbage", "-5", "12.5", "", "NaN", "1e3"]) {
+      window.sessionStorage.setItem(`${PREFIX}bad|`, bad);
+      expect(readListScroll("bad|")).toBeNull();
+    }
+  });
+
+  it("falls back to null when a read throws", () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error("blocked");
+    };
+    try {
+      expect(readListScroll("boom|")).toBeNull();
+    } finally {
+      Storage.prototype.getItem = original;
+    }
   });
 
   it("returns null for an unknown scope", () => {
@@ -216,6 +267,48 @@ describe("useListScrollRestoration", () => {
     );
     // Now the full offset is honored (1498 - 500 = 998 >= 680).
     expect(node.scrollTop).toBe(680);
+  });
+
+  it("abandons an unreached pending target once the user scrolls", () => {
+    // Regression: a target that never fit the (short) content stays pending; a
+    // later rerender must not yank the user back to it after they scroll away.
+    writeListScroll("cancel|", 900);
+    let el: HTMLDivElement | null = null;
+    const capture = (node: HTMLDivElement) => {
+      el = node;
+    };
+    const view = render(
+      <Harness
+        scopeKey="cancel|"
+        contentReady
+        loading
+        revision={1}
+        scrollHeight={1000}
+        onReady={capture}
+      />,
+    );
+    const node = el as unknown as HTMLDivElement;
+    expect(node.scrollTop).toBe(500); // clamped; 900 still pending, loading
+
+    // User scrolls elsewhere.
+    act(() => {
+      node.scrollTop = 120;
+      node.dispatchEvent(new Event("scroll"));
+    });
+
+    // A later refetch rerenders with a taller list that *could* honor 900.
+    view.rerender(
+      <Harness
+        scopeKey="cancel|"
+        contentReady
+        loading={false}
+        revision={2}
+        scrollHeight={2000}
+        onReady={capture}
+      />,
+    );
+    // The pending restore was abandoned on the user scroll — they stay put.
+    expect(node.scrollTop).toBe(120);
   });
 
   it("flushes the observed offset, not a detached container's zeroed scrollTop", () => {

--- a/official-plugins/tasks/views/list/scroll-restoration.test.tsx
+++ b/official-plugins/tasks/views/list/scroll-restoration.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EMPTY_FILTERS, type ListFilterState } from "./filter-bar.js";
+import {
+  listScrollScopeKey,
+  readListScroll,
+  resolveRestoreTarget,
+  useListScrollRestoration,
+  writeListScroll,
+} from "./scroll-restoration.js";
+
+describe("listScrollScopeKey", () => {
+  const base = {
+    projectId: null,
+    activeOnly: false,
+    filters: EMPTY_FILTERS,
+    sort: "manual" as const,
+  };
+
+  it("distinguishes the all/active/project lists", () => {
+    const all = listScrollScopeKey(base);
+    const active = listScrollScopeKey({ ...base, activeOnly: true });
+    const project = listScrollScopeKey({ ...base, projectId: "proj_1" });
+    expect(new Set([all, active, project]).size).toBe(3);
+  });
+
+  it("ignores filter member order but reflects filter content", () => {
+    const a: ListFilterState = {
+      statuses: ["todo", "done"],
+      priorities: [],
+      labelNames: ["b", "a"],
+    };
+    const b: ListFilterState = {
+      statuses: ["done", "todo"],
+      priorities: [],
+      labelNames: ["a", "b"],
+    };
+    expect(listScrollScopeKey({ ...base, filters: a })).toBe(
+      listScrollScopeKey({ ...base, filters: b }),
+    );
+    expect(listScrollScopeKey({ ...base, filters: a })).not.toBe(
+      listScrollScopeKey(base),
+    );
+  });
+
+  it("distinguishes sort while holding the list fixed", () => {
+    expect(listScrollScopeKey(base)).not.toBe(
+      listScrollScopeKey({ ...base, sort: "priority" }),
+    );
+  });
+});
+
+describe("resolveRestoreTarget", () => {
+  it("clamps a saved offset to the scrollable range", () => {
+    // Full-length list: exact offset preserved.
+    expect(resolveRestoreTarget(400, 1000, 500)).toBe(400);
+    // Shortened list: snap to the new bottom, never past it.
+    expect(resolveRestoreTarget(400, 600, 500)).toBe(100);
+    // Content now fits entirely: top.
+    expect(resolveRestoreTarget(400, 300, 500)).toBe(0);
+    // Negative/garbage saved value: top.
+    expect(resolveRestoreTarget(-50, 1000, 500)).toBe(0);
+  });
+});
+
+describe("scroll store", () => {
+  beforeEach(() => window.sessionStorage.clear());
+  afterEach(() => window.sessionStorage.clear());
+
+  it("round-trips a rounded, non-negative offset", () => {
+    writeListScroll("all|", 123.7);
+    expect(readListScroll("all|")).toBe(124);
+    writeListScroll("all|", -5);
+    expect(readListScroll("all|")).toBe(0);
+  });
+
+  it("returns null for an unknown scope", () => {
+    expect(readListScroll("never-written")).toBeNull();
+  });
+});
+
+/**
+ * A container whose layout metrics can be scripted (jsdom does no layout).
+ * scrollHeight is mutable via `el.__sh` so a test can grow the content between
+ * rerenders to model late-arriving rows.
+ */
+function scriptContainer(el: HTMLDivElement, scrollHeight: number): void {
+  (el as unknown as { __sh: number }).__sh = scrollHeight;
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => (el as unknown as { __sh: number }).__sh,
+  });
+  Object.defineProperty(el, "clientHeight", { configurable: true, value: 500 });
+  let top = 0;
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => top,
+    set: (v: number) => {
+      top = v;
+    },
+  });
+}
+
+function Harness({
+  scopeKey,
+  contentReady,
+  scrollHeight,
+  loading = false,
+  revision = 0,
+  onReady,
+}: {
+  scopeKey: string;
+  contentReady: boolean;
+  scrollHeight: number;
+  loading?: boolean;
+  revision?: number;
+  onReady: (el: HTMLDivElement) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useListScrollRestoration(ref, scopeKey, { contentReady, loading, revision });
+  return (
+    <div
+      ref={(el) => {
+        if (el && ref.current !== el) {
+          ref.current = el;
+          scriptContainer(el, scrollHeight);
+          onReady(el);
+        } else if (el) {
+          // Same element across rerenders: reflect the latest scripted height.
+          (el as unknown as { __sh: number }).__sh = scrollHeight;
+        }
+      }}
+      data-testid="scroll"
+    />
+  );
+}
+
+describe("useListScrollRestoration", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("persists on scroll and restores on remount, clamped to content", () => {
+    let el: HTMLDivElement | null = null;
+    const capture = (node: HTMLDivElement) => {
+      el = node;
+    };
+
+    // First mount: user scrolls the list down.
+    const first = render(
+      <Harness
+        scopeKey="all|"
+        contentReady
+        scrollHeight={2000}
+        onReady={capture}
+      />,
+    );
+    const firstEl = el as unknown as HTMLDivElement;
+    act(() => {
+      firstEl.scrollTop = 800;
+      firstEl.dispatchEvent(new Event("scroll"));
+    });
+    // Unmount (navigating into a task) flushes the offset.
+    first.unmount();
+    expect(readListScroll("all|")).toBe(800);
+
+    // Remount (back to the list) with a now-shorter list: offset is clamped
+    // to the new scrollable range instead of hanging past the end.
+    el = null;
+    render(
+      <Harness
+        scopeKey="all|"
+        contentReady
+        scrollHeight={1000}
+        onReady={capture}
+      />,
+    );
+    const secondEl = el as unknown as HTMLDivElement;
+    // scrollHeight 1000 - clientHeight 500 => max 500.
+    expect(secondEl.scrollTop).toBe(500);
+  });
+
+  it("re-applies the target as late-arriving rows grow the scroll height", () => {
+    // Regression: switching scope (e.g. clearing a filter) keeps the previous,
+    // shorter rows mounted for a frame while the fetch is in flight. Applying
+    // the target once would clamp it against that stale height and stick.
+    writeListScroll("grow|", 680);
+    let el: HTMLDivElement | null = null;
+    const capture = (node: HTMLDivElement) => {
+      el = node;
+    };
+    // First paint: stale/short content (height 1021 => max 521), still loading.
+    const view = render(
+      <Harness
+        scopeKey="grow|"
+        contentReady
+        loading
+        revision={29}
+        scrollHeight={1021}
+        onReady={capture}
+      />,
+    );
+    const node = el as unknown as HTMLDivElement;
+    expect(node.scrollTop).toBe(521); // clamped to the short height for now
+
+    // The real rows arrive: taller content, fetch settled.
+    view.rerender(
+      <Harness
+        scopeKey="grow|"
+        contentReady
+        loading={false}
+        revision={40}
+        scrollHeight={1498}
+        onReady={capture}
+      />,
+    );
+    // Now the full offset is honored (1498 - 500 = 998 >= 680).
+    expect(node.scrollTop).toBe(680);
+  });
+
+  it("flushes the observed offset, not a detached container's zeroed scrollTop", () => {
+    // Regression: on unmount React has already detached the list container, so
+    // reading el.scrollTop there yields 0 and would clobber the saved offset.
+    let el: HTMLDivElement | null = null;
+    const view = render(
+      <Harness
+        scopeKey="detach|"
+        contentReady
+        scrollHeight={2000}
+        onReady={(node) => {
+          el = node;
+        }}
+      />,
+    );
+    const node = el as unknown as HTMLDivElement;
+    act(() => {
+      node.scrollTop = 620;
+      node.dispatchEvent(new Event("scroll"));
+    });
+    // Simulate the browser zeroing scrollTop as the node is detached — with no
+    // scroll event, exactly what happens during an unmount transition.
+    node.scrollTop = 0;
+    view.unmount();
+    expect(readListScroll("detach|")).toBe(620);
+  });
+
+  it("does not restore a different list's offset (pins new scope to top)", () => {
+    writeListScroll("all|", 600);
+    let el: HTMLDivElement | null = null;
+    render(
+      <Harness
+        scopeKey="project:proj_1|"
+        contentReady
+        scrollHeight={2000}
+        onReady={(node) => {
+          el = node;
+        }}
+      />,
+    );
+    const target = el as unknown as HTMLDivElement;
+    expect(target.scrollTop).toBe(0);
+  });
+
+  it("stays pinned to top and saves nothing while content is loading", () => {
+    let el: HTMLDivElement | null = null;
+    render(
+      <Harness
+        scopeKey="loading|"
+        contentReady={false}
+        scrollHeight={0}
+        onReady={(node) => {
+          el = node;
+        }}
+      />,
+    );
+    const target = el as unknown as HTMLDivElement;
+    act(() => {
+      target.scrollTop = 300;
+      target.dispatchEvent(new Event("scroll"));
+    });
+    expect(readListScroll("loading|")).toBeNull();
+  });
+});

--- a/official-plugins/tasks/views/list/scroll-restoration.ts
+++ b/official-plugins/tasks/views/list/scroll-restoration.ts
@@ -1,0 +1,215 @@
+import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
+import type { ListFilterState } from "./filter-bar.js";
+import type { TaskSort } from "../../shared/sort.js";
+
+/**
+ * Remembering the task list's scroll offset so opening a task and coming back
+ * (or refreshing) lands the user where they left off. This is ephemeral,
+ * client-local view state — like the sidebar-collapsed preference it has no
+ * server/CLI/SDK surface.
+ *
+ * We use `sessionStorage` rather than `localStorage`: positions should survive
+ * a page refresh within the same tab (a listed requirement) but not linger for
+ * days across unrelated sessions, which would otherwise let per-filter keys
+ * accumulate unboundedly. An in-memory map backs storage so restoration still
+ * works when storage is unavailable (private mode, disabled cookies).
+ */
+const STORAGE_PREFIX = "bb-tasks:list-scroll:";
+
+const memoryFallback = new Map<string, number>();
+
+function storage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A stable key for a distinct list *context*. Two lists with different
+ * projects, filters, or sort are different contexts and must not restore each
+ * other's offset. Filter arrays are sorted so member order never changes the
+ * key.
+ */
+export function listScrollScopeKey(params: {
+  projectId: string | null;
+  activeOnly: boolean;
+  filters: ListFilterState;
+  sort: TaskSort;
+}): string {
+  const list =
+    params.projectId !== null
+      ? `project:${params.projectId}`
+      : params.activeOnly
+        ? "active"
+        : "all";
+  const statuses = [...params.filters.statuses].sort().join(",");
+  const priorities = [...params.filters.priorities].sort().join(",");
+  const labels = [...params.filters.labelNames].sort().join(",");
+  return `${list}|s=${statuses}|p=${priorities}|l=${labels}|sort=${params.sort}`;
+}
+
+export function readListScroll(scopeKey: string): number | null {
+  const memory = memoryFallback.get(scopeKey);
+  if (memory !== undefined) return memory;
+  const store = storage();
+  if (store === null) return null;
+  const raw = store.getItem(STORAGE_PREFIX + scopeKey);
+  if (raw === null) return null;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+export function writeListScroll(scopeKey: string, offset: number): void {
+  const rounded = Math.max(0, Math.round(offset));
+  memoryFallback.set(scopeKey, rounded);
+  const store = storage();
+  if (store === null) return;
+  try {
+    store.setItem(STORAGE_PREFIX + scopeKey, String(rounded));
+  } catch {
+    // Best-effort; the in-memory fallback still serves this session.
+  }
+}
+
+/**
+ * Clamp a remembered offset to what the container can actually scroll now. A
+ * shortened list (fewer/collapsed rows) must not leave the view scrolled past
+ * its end; a `saved` beyond range snaps to the bottom, and an empty/short list
+ * yields 0.
+ */
+export function resolveRestoreTarget(
+  saved: number,
+  scrollHeight: number,
+  clientHeight: number,
+): number {
+  const max = Math.max(0, scrollHeight - clientHeight);
+  return Math.min(Math.max(0, saved), max);
+}
+
+export interface ListScrollState {
+  /** True once real rows (not skeletons/empty state) are in the DOM. */
+  contentReady: boolean;
+  /**
+   * True while a fetch for the current scope is in flight. `useListTasks`
+   * retains the previous filter/sort's rows during a refetch, so the container
+   * can briefly be shorter than the settled list; while loading we keep
+   * re-applying the target as content grows and only finalize once it clears.
+   */
+  loading: boolean;
+  /**
+   * Changes whenever the rendered row set changes (row count is a faithful
+   * proxy since rows are fixed height). Drives the re-apply pass so a
+   * remembered offset survives late-arriving rows growing the scroll height.
+   */
+  revision: number;
+}
+
+/**
+ * Restore the list container's scroll offset for `scopeKey` once its content is
+ * laid out, and persist the offset as the user scrolls.
+ *
+ * The container is reused when switching between the All/Active/project lists
+ * (same `ListView` element), so on every scope change we re-target it: pinned
+ * to top while the new list loads, then set to the remembered (clamped) offset.
+ * This guarantees a reused container never strands a previous list's position.
+ *
+ * A remembered offset can exceed the height the container has at the instant we
+ * first apply it — when the scope changes the previous (shorter) rows are still
+ * mounted for a frame, and rows can arrive in more than one paint. We therefore
+ * hold the target as `pending` and re-clamp it against the growing scroll
+ * height on each revision, finalizing only once the offset is reached or the
+ * fetch settles. This keeps the re-apply from ever fighting the user after the
+ * list is stable.
+ */
+export function useListScrollRestoration(
+  ref: RefObject<HTMLDivElement | null>,
+  scopeKey: string,
+  state: ListScrollState,
+): void {
+  const { contentReady, loading, revision } = state;
+  // The scope we've already applied a restore for. While this differs from the
+  // active scope we neither trust the container's current offset nor persist
+  // it. Re-saving the just-restored offset (from the synthetic scroll event the
+  // programmatic write triggers) is harmless — it writes the same value back.
+  const restoredScope = useRef<string | null>(null);
+  // The remembered offset we're still trying to reach for the active scope, or
+  // null once reached / finalized. Guards the re-apply pass from disturbing a
+  // settled list on later refetches.
+  const pending = useRef<number | null>(null);
+  // The last offset observed from a real scroll event *while the container was
+  // connected*, per active scope. We flush this on unmount rather than reading
+  // `el.scrollTop` there: by the time the cleanup runs React has already
+  // detached the container (leaving to a task), and a detached element reports
+  // scrollTop 0 — which would clobber the good value the scroll writes saved.
+  const lastOffset = useRef<number | null>(null);
+
+  // Initial restore when the scope changes.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el === null) return;
+    if (restoredScope.current === scopeKey) return;
+    if (!contentReady) {
+      // New scope still loading: keep the reused container pinned to top so no
+      // stale offset flashes, but don't mark it restored yet.
+      el.scrollTop = 0;
+      return;
+    }
+    restoredScope.current = scopeKey;
+    const saved = readListScroll(scopeKey);
+    if (saved === null) {
+      el.scrollTop = 0;
+      pending.current = null;
+      return;
+    }
+    const clamped = resolveRestoreTarget(saved, el.scrollHeight, el.clientHeight);
+    el.scrollTop = clamped;
+    // Keep chasing the target only if the current height can't honor it yet and
+    // more rows may still arrive; otherwise we're done.
+    pending.current = clamped < saved && loading ? saved : null;
+  }, [ref, scopeKey, contentReady, loading]);
+
+  // Re-apply the pending target as late-arriving rows grow the scroll height,
+  // then finalize once the offset is reached or the fetch settles.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el === null) return;
+    if (restoredScope.current !== scopeKey) return;
+    if (pending.current === null) return;
+    const clamped = resolveRestoreTarget(
+      pending.current,
+      el.scrollHeight,
+      el.clientHeight,
+    );
+    el.scrollTop = clamped;
+    if (clamped >= pending.current || !loading) pending.current = null;
+  }, [ref, scopeKey, revision, loading]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el === null) return;
+    // Fresh scope: forget the previous scope's observed offset so an unmount
+    // without any scroll here can't flush a stale value under this key.
+    lastOffset.current = null;
+    let raf = 0;
+    const onScroll = () => {
+      // Don't persist until this scope has been restored, otherwise the
+      // pinned-to-top or transitional offset would clobber the saved value.
+      if (restoredScope.current !== scopeKey) return;
+      lastOffset.current = el.scrollTop;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => writeListScroll(scopeKey, el.scrollTop));
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(raf);
+      // Flush the latest connected-observed offset so an in-flight debounced
+      // write is never lost when leaving to a task.
+      if (restoredScope.current === scopeKey && lastOffset.current !== null) {
+        writeListScroll(scopeKey, lastOffset.current);
+      }
+    };
+  }, [ref, scopeKey]);
+}

--- a/official-plugins/tasks/views/list/scroll-restoration.ts
+++ b/official-plugins/tasks/views/list/scroll-restoration.ts
@@ -44,9 +44,12 @@ export function listScrollScopeKey(params: {
       : params.activeOnly
         ? "active"
         : "all";
-  const statuses = [...params.filters.statuses].sort().join(",");
-  const priorities = [...params.filters.priorities].sort().join(",");
-  const labels = [...params.filters.labelNames].sort().join(",");
+  // JSON-serialize each array (sorted for order independence). Label names are
+  // arbitrary user strings, so a delimiter join would let e.g. `["a,b"]` and
+  // `["a","b"]` collide into the same key and restore each other's offset.
+  const statuses = JSON.stringify([...params.filters.statuses].sort());
+  const priorities = JSON.stringify([...params.filters.priorities].sort());
+  const labels = JSON.stringify([...params.filters.labelNames].sort());
   return `${list}|s=${statuses}|p=${priorities}|l=${labels}|sort=${params.sort}`;
 }
 
@@ -55,10 +58,19 @@ export function readListScroll(scopeKey: string): number | null {
   if (memory !== undefined) return memory;
   const store = storage();
   if (store === null) return null;
-  const raw = store.getItem(STORAGE_PREFIX + scopeKey);
-  if (raw === null) return null;
+  let raw: string | null;
+  try {
+    // getItem itself can throw in some locked-down storage contexts, not just
+    // the initial `window.sessionStorage` access — keep the read total.
+    raw = store.getItem(STORAGE_PREFIX + scopeKey);
+  } catch {
+    return null;
+  }
+  // Only accept a complete non-negative integer; reject partials like
+  // "400garbage" that Number.parseInt would otherwise truncate to 400.
+  if (raw === null || !/^\d+$/.test(raw)) return null;
   const value = Number.parseInt(raw, 10);
-  return Number.isFinite(value) && value >= 0 ? value : null;
+  return Number.isFinite(value) ? value : null;
 }
 
 export function writeListScroll(scopeKey: string, offset: number): void {
@@ -138,6 +150,10 @@ export function useListScrollRestoration(
   // null once reached / finalized. Guards the re-apply pass from disturbing a
   // settled list on later refetches.
   const pending = useRef<number | null>(null);
+  // The offset our own programmatic writes last set. A scroll event landing on
+  // a materially different offset is the user, and cancels any pending restore
+  // so a later refetch can never yank them back to the target.
+  const lastApplied = useRef<number | null>(null);
   // The last offset observed from a real scroll event *while the container was
   // connected*, per active scope. We flush this on unmount rather than reading
   // `el.scrollTop` there: by the time the cleanup runs React has already
@@ -160,11 +176,13 @@ export function useListScrollRestoration(
     const saved = readListScroll(scopeKey);
     if (saved === null) {
       el.scrollTop = 0;
+      lastApplied.current = 0;
       pending.current = null;
       return;
     }
     const clamped = resolveRestoreTarget(saved, el.scrollHeight, el.clientHeight);
     el.scrollTop = clamped;
+    lastApplied.current = clamped;
     // Keep chasing the target only if the current height can't honor it yet and
     // more rows may still arrive; otherwise we're done.
     pending.current = clamped < saved && loading ? saved : null;
@@ -183,6 +201,7 @@ export function useListScrollRestoration(
       el.clientHeight,
     );
     el.scrollTop = clamped;
+    lastApplied.current = clamped;
     if (clamped >= pending.current || !loading) pending.current = null;
   }, [ref, scopeKey, revision, loading]);
 
@@ -197,6 +216,14 @@ export function useListScrollRestoration(
       // Don't persist until this scope has been restored, otherwise the
       // pinned-to-top or transitional offset would clobber the saved value.
       if (restoredScope.current !== scopeKey) return;
+      // A scroll to an offset we didn't programmatically apply is the user;
+      // abandon any in-flight restore so a later refetch can't override them.
+      if (
+        pending.current !== null &&
+        Math.abs(el.scrollTop - (lastApplied.current ?? el.scrollTop)) > 2
+      ) {
+        pending.current = null;
+      }
       lastOffset.current = el.scrollTop;
       cancelAnimationFrame(raf);
       raf = requestAnimationFrame(() => writeListScroll(scopeKey, el.scrollTop));


### PR DESCRIPTION
## BB-28 — Remember scroll position when navigating between task list and task

Opening a task detail unmounted the Tasks list; returning re-mounted a fresh list scrolled back to the top. This preserves the list's scroll offset across that round trip and across refreshes, keyed so it is always the *right* list's position.

### What it does
- Restores the list scroll offset on **list → task → back** (Esc, topbar Back), on **browser refresh / direct route**, and when switching between the **All / Active / project** lists.
- Offset is keyed per **list context** — list identity plus a stable filter/sort signature — so one list (or filter/sort context) never restores another's position.
- Backed by `sessionStorage` (best-effort, in-memory fallback); clamps to shortened lists; waits for the scope's own rows to lay out and re-applies as late-arriving rows grow the height; defaults to the top on first use.
- Composes with BB-35 (#760): with filters/sort now persisted per scope, filter + sort + scroll restore together.
- **No server/daemon/wire/CLI/SDK/migration surface** — purely client-local view state, like the existing sidebar-collapsed preference. No `HOST_DAEMON_PROTOCOL_VERSION` bump required.

### Files
- `official-plugins/tasks/views/list/scroll-restoration.ts` (new) — store + `useListScrollRestoration` hook + `listScrollScopeKey` + `resolveRestoreTarget`
- `official-plugins/tasks/views/list/scroll-restoration.test.tsx` (new) — 17 hook/store tests
- `official-plugins/tasks/views/list/index.tsx` — wiring on the inner scroll container

### Verification
- **266 tests pass (28 files)**, typecheck clean (`turbo`, `--filter=bb-plugin-tasks`).
- **Live product QA** against the real plugin in an isolated dev instance (40-task project) with numeric verification of the actual scroll container: core loop, topbar-Back, refresh/deep-link, list+filter+sort scope isolation, shortened-list clamp, grouped/sticky content, dark mode, two custom palettes, narrow layout, and filter+sort+scroll survival.
- **2 defects found in QA** (back-restore-to-0 from a detached-node read; filter-clear clamp against stale rows) — both fixed with regression tests.
- **1 independent review round** (GPT-5.6-Sol, readonly) returned REQUEST CHANGES; all findings (storage read hardening, scope-key delimiter collision, strict value validation, user-scroll cancels pending restore, stronger tests) were resolved and reverified. No second round per policy.

A full evidence-backed Product Review Report (HTML), coverage ledger, and screenshot archive are attached to task BB-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
