### PR TITLE
Fix collapsed preview overflow render loop

### DIFF
--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import type { TimelineTitleLink } from "@bb/thread-view";
@@ -67,6 +73,7 @@ function renderChildCompleted() {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 // An agent-generated body that carries an offset-based `path` mention and a
@@ -135,6 +142,40 @@ function mockInnerPreviewTextOverflow(text: string): void {
   );
 }
 
+function mockContinuationSensitiveOverflow(): () => void {
+  const resizeCallbacks: Array<() => void> = [];
+
+  class ResizeObserverMock {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallbacks.push(() =>
+        callback([], this as unknown as ResizeObserver),
+      );
+    }
+
+    observe(): void {}
+    disconnect(): void {}
+  }
+
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(20);
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(20);
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
+    function clientWidth(this: HTMLElement) {
+      const continuation = Array.from(this.parentElement?.children ?? []).find(
+        (child) => child.textContent === "...",
+      );
+      return continuation ? 90 : 100;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(100);
+
+  return () => {
+    act(() => {
+      for (const callback of resizeCallbacks) callback();
+    });
+  };
+}
+
 describe("GeneratedConversationMessage markdown body", () => {
   it("keeps the agent body on the offset renderer (no markdown, no <br>) and renders its path mention", () => {
     renderAgentMessage();
@@ -151,7 +192,7 @@ describe("GeneratedConversationMessage markdown body", () => {
 
     const toggle = screen.getByRole("button", { name: /Message from Worker/u });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.queryByText("...")).toBeNull();
+    expect(screen.getByText("...").className).toContain("invisible");
 
     fireEvent.click(toggle);
 
@@ -176,6 +217,20 @@ describe("GeneratedConversationMessage markdown body", () => {
 });
 
 describe("GeneratedConversationMessage markdown body (system)", () => {
+  it("keeps the continuation width stable when it makes the preview overflow", () => {
+    const notifyResize = mockContinuationSensitiveOverflow();
+    renderChildCompleted();
+
+    const continuation = screen.getByText("...");
+    expect(continuation.className).toContain("invisible");
+
+    notifyResize();
+    notifyResize();
+
+    expect(screen.getByText("...")).toBe(continuation);
+    expect(continuation.className).toContain("invisible");
+  });
+
   it("shows a first-line preview and reveals the rest when expanded", () => {
     renderChildCompleted();
 

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -444,8 +444,14 @@ export const GeneratedConversationMessage = memo(
       (hasExpandedOnlyContent ||
         hasAdditionalBodyLines ||
         collapsedPreviewOverflowMeasurement === "overflowing");
-    const showManualContinuation =
-      expandable && collapsedPreviewOverflowMeasurement !== "overflowing";
+    // Keep the continuation marker mounted once the row is expandable. If we
+    // remove it when the preview overflows, its reclaimed width can make the
+    // preview fit again; ResizeObserver then adds it back and creates a
+    // fit/overflow render loop. `invisible` preserves the measured width while
+    // native truncation supplies the visible continuation affordance.
+    const renderManualContinuation = expandable;
+    const hideManualContinuation =
+      collapsedPreviewOverflowMeasurement === "overflowing";
     const collapsedPreviewBody = clipMentionTextToVisibleRange({
       mentions: messageMentions,
       rangeStart: 0,
@@ -489,8 +495,15 @@ export const GeneratedConversationMessage = memo(
               })}
             </span>
           )}
-          {showManualContinuation ? (
-            <span className="shrink-0 text-muted-foreground">...</span>
+          {renderManualContinuation ? (
+            <span
+              className={cn(
+                "shrink-0 text-muted-foreground",
+                hideManualContinuation && "invisible",
+              )}
+            >
+              ...
+            </span>
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- keep expandable collapsed-preview continuation markers mounted so their width remains stable
- hide the manual marker when native truncation is active instead of removing it from layout
- add regression coverage for the ResizeObserver fit/overflow feedback loop

## Root cause

A collapsed child-thread preview could fit without its manual `...` marker but overflow after the marker was mounted. The overflow measurement then removed the marker, which made the preview fit again and caused an infinite ResizeObserver/render loop.

Browser profiling on the affected workspace measured 364 DOM mutations and 4.62 seconds of style recalculation over five seconds at roughly 18 FPS. Reserving the marker width reduced that sample to zero mutations, 0.033 seconds of style recalculation, and 60 FPS.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/timeline/GeneratedConversationMessage.test.tsx`
- `pnpm exec turbo run test --filter=@bb/app --force` (241 files, 1,601 tests)
- local managed-app browser smoke test with no console or page errors
