### PR TITLE
Pause animations in collapsed height transitions

### DIFF
--- a/apps/app/src/components/ui/height-transition.test.tsx
+++ b/apps/app/src/components/ui/height-transition.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { HeightTransition } from "./height-transition";
+
+afterEach(cleanup);
+
+describe("HeightTransition", () => {
+  it("pauses descendant animations while preserving collapsed content state", () => {
+    const view = render(
+      <HeightTransition visible={false}>
+        <span data-testid="animated-child">Working...</span>
+      </HeightTransition>,
+    );
+
+    const child = view.getByTestId("animated-child");
+    const wrapper = child.parentElement?.parentElement;
+    expect(wrapper?.className).toContain(
+      "[&_*]:![animation-play-state:paused]",
+    );
+
+    view.rerender(
+      <HeightTransition visible>
+        <span data-testid="animated-child">Working...</span>
+      </HeightTransition>,
+    );
+
+    expect(view.getByTestId("animated-child")).toBe(child);
+    expect(wrapper?.className).not.toContain(
+      "[&_*]:![animation-play-state:paused]",
+    );
+  });
+});

--- a/apps/app/src/components/ui/height-transition.tsx
+++ b/apps/app/src/components/ui/height-transition.tsx
@@ -1,11 +1,14 @@
 import { useStore } from "jotai";
 import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { cn } from "@bb/shared-ui/lib/utils";
 import { layoutAnimationInFlightCountAtom } from "./layoutAnimationAtoms.js";
 
 // Shared animation tokens for height transitions across the timeline.
 const HEIGHT_TRANSITION_DURATION_MS = 180;
 // Cubic-bezier ease-out-expo: fast initial expansion, gentle settle.
 const HEIGHT_TRANSITION_EASE_CSS = "cubic-bezier(0.16, 1, 0.3, 1)";
+const PAUSE_COLLAPSED_DESCENDANT_ANIMATIONS_CLASS =
+  "[&_*]:![animation-play-state:paused]";
 
 // While content is reflowing (window/panel resize, sidebar collapse, font
 // load), the wrapper's height changes every frame. Letting the CSS height
@@ -205,7 +208,10 @@ export function HeightTransition({
   return (
     <div
       ref={wrapperRef}
-      className={className}
+      className={cn(
+        className,
+        !visible && PAUSE_COLLAPSED_DESCENDANT_ANIMATIONS_CLASS,
+      )}
       style={{
         // Clip vertically (so intermediate heights during the animation
         // don't leak content past the wrapper) without turning the wrapper


### PR DESCRIPTION
## Summary

- pause descendant CSS animations while `HeightTransition` content is collapsed
- preserve mounted child state and resume animations automatically when visible
- add regression coverage for the collapsed and restored states

## Root cause

After refreshing the affected workspace, the page was back at 60 FPS with no mutation loop, but two `Working...` shimmer animations continued running inside `height: 0`, `opacity: 0`, overflow-clipped wrappers. The indicators were not visible or hit-testable, but Chromium continued advancing and painting their `background-position` animations.

Browser profiling measured about 0.73 seconds of renderer task time per five seconds with the hidden shimmers running versus 0.027 seconds with them paused. The production build now emits the descendant `animation-play-state: paused` selector for collapsed transitions.

## Validation

- browser bounding-rect, clipping, and hit-test inspection of the hidden indicators
- reversible runtime pause profiling on the live page
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/ui/height-transition.test.tsx src/components/thread/timeline/GeneratedConversationMessage.test.tsx`
- `pnpm exec turbo run typecheck build --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (242 files, 1,602 tests)
