### PR TITLE
Fix split resize jank

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -24,10 +24,50 @@ const workspaceLinkRouting = {
 afterEach(() => {
   cleanup();
   window.localStorage.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
 describe("MarkdownPreview", () => {
+  it("observes content width only when the preview renders a table", () => {
+    const observed: Element[] = [];
+    class ResizeObserverMock {
+      constructor(_callback: ResizeObserverCallback) {}
+      observe(target: Element) {
+        observed.push(target);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 320,
+      top: 0,
+      width: 320,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    const plain = render(<MarkdownPreview content="Plain paragraph" />);
+    expect(observed).toHaveLength(0);
+    plain.unmount();
+
+    const { container } = render(
+      <MarkdownPreview content={"| A |\n| - |\n| B |"} />,
+    );
+    const table = container.querySelector("table");
+    const breakout = table?.parentElement?.parentElement;
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.hasAttribute("data-markdown-preview")).toBe(true);
+    expect(breakout?.style.getPropertyValue("--md-content-w")).toBe("320px");
+  });
+
   it("HTML-escapes fenced code so it cannot inject markup", () => {
     const { container } = render(
       <MarkdownPreview

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -886,8 +886,11 @@ function MarkdownBlockquote({ children }: MarkdownBlockquoteProps) {
 }
 
 function MarkdownTable({ children }: MarkdownTableProps) {
+  const breakoutRef = useMarkdownTableContentWidthVariable();
+
   return (
     <div
+      ref={breakoutRef}
       className="my-2 flex justify-center"
       style={{
         width: MARKDOWN_TABLE_BREAKOUT_WIDTH,
@@ -1094,18 +1097,19 @@ function setMarkdownContentWidthVariable({
   element.style.setProperty(MARKDOWN_CONTENT_WIDTH_VARIABLE, `${width}px`);
 }
 
-function useMarkdownContentWidthVariable() {
-  const contentRef = useRef<HTMLDivElement>(null);
+function useMarkdownTableContentWidthVariable() {
+  const breakoutRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    const element = contentRef.current;
-    if (!element) {
+    const breakout = breakoutRef.current;
+    const content = breakout?.closest<HTMLElement>("[data-markdown-preview]");
+    if (!breakout || !content) {
       return;
     }
 
     setMarkdownContentWidthVariable({
-      element,
-      width: element.getBoundingClientRect().width,
+      element: breakout,
+      width: content.getBoundingClientRect().width,
     });
 
     if (typeof ResizeObserver === "undefined") {
@@ -1118,15 +1122,15 @@ function useMarkdownContentWidthVariable() {
         return;
       }
       setMarkdownContentWidthVariable({
-        element,
+        element: breakout,
         width: entry.contentRect.width,
       });
     });
-    observer.observe(element);
+    observer.observe(content);
     return () => observer.disconnect();
   }, []);
 
-  return contentRef;
+  return breakoutRef;
 }
 
 const FRONTMATTER_PATTERN =
@@ -1205,7 +1209,6 @@ function MarkdownPreviewComponent({
 }: MarkdownPreviewProps) {
   const preferredTheme = usePreferredTheme();
   const [rewriteLocalhostLinks] = useRewriteLocalhostLinksPreference();
-  const contentRef = useMarkdownContentWidthVariable();
   const [expandedImageUrl, setExpandedImageUrl] = useState<string | null>(null);
   const localFileRouting = linkRouting?.localFile;
   const localImageRouting = linkRouting?.localImage;
@@ -1356,7 +1359,7 @@ function MarkdownPreviewComponent({
   return (
     <>
       <div
-        ref={contentRef}
+        data-markdown-preview=""
         className={cn(
           "max-w-none break-words text-sm leading-relaxed text-foreground",
           className,

--- a/apps/app/src/lib/split-layout/ops.ts
+++ b/apps/app/src/lib/split-layout/ops.ts
@@ -14,6 +14,10 @@ const MIN_SIZE = 0.15;
 const MAX_SIZE = 0.85;
 const SIZE_EPSILON = 1e-12;
 
+export function clampSplitPairFraction(fraction: number): number {
+  return Math.min(MAX_SIZE, Math.max(MIN_SIZE, fraction));
+}
+
 export function listPanes(root: LayoutNode): PaneNode[] {
   if (root.type === "pane") {
     return [root];
@@ -444,7 +448,7 @@ export function resizeSplit(
       return null;
     }
     const pairTotal = first + second;
-    const pairFraction = Math.min(MAX_SIZE, Math.max(MIN_SIZE, fraction));
+    const pairFraction = clampSplitPairFraction(fraction);
     const nextSizes = [...sizes];
     nextSizes[childIndex] = pairTotal * pairFraction;
     nextSizes[childIndex + 1] = pairTotal * (1 - pairFraction);

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -366,6 +366,103 @@ afterEach(() => {
 });
 
 describe("SplitThreadArea", () => {
+  it("keeps drag updates local and persists the resized pair once on release", () => {
+    const store = renderSplitArea({
+      path: threadPath("thr-a"),
+      layout: twoPaneLayout("pane-1"),
+    });
+    const separator = screen.getByRole("separator");
+    const previous = separator.previousElementSibling;
+    const next = separator.nextElementSibling;
+    if (!(previous instanceof HTMLElement) || !(next instanceof HTMLElement)) {
+      throw new Error("Expected adjacent split flex items");
+    }
+
+    Object.defineProperty(separator, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(previous, "getBoundingClientRect").mockReturnValue({
+      bottom: 300,
+      height: 300,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(next, "getBoundingClientRect").mockReturnValue({
+      bottom: 300,
+      height: 300,
+      left: 406,
+      right: 806,
+      top: 0,
+      width: 400,
+      x: 406,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    const scrollViewport = document.createElement("div");
+    scrollViewport.style.overflowY = "auto";
+    Object.defineProperties(scrollViewport, {
+      clientHeight: { configurable: true, value: 300 },
+      scrollHeight: { configurable: true, value: 1_000 },
+    });
+    vi.spyOn(scrollViewport, "getBoundingClientRect").mockReturnValue({
+      bottom: 300,
+      height: 300,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    const offscreenRow = document.createElement("div");
+    offscreenRow.dataset.timelineRowId = "offscreen-row";
+    vi.spyOn(offscreenRow, "getBoundingClientRect").mockReturnValue({
+      bottom: -450,
+      height: 50,
+      left: 0,
+      right: 400,
+      top: -500,
+      width: 400,
+      x: 0,
+      y: -500,
+      toJSON: () => ({}),
+    });
+    scrollViewport.appendChild(offscreenRow);
+    previous.appendChild(scrollViewport);
+
+    const splitSizes = () => {
+      const root = store.get(splitLayoutAtom)?.root;
+      if (root?.type !== "split") {
+        throw new Error("Expected split layout");
+      }
+      return root.sizes;
+    };
+
+    fireEvent.pointerDown(separator, { clientX: 403, pointerId: 1 });
+    fireEvent.pointerMove(separator, { clientX: 564.2, pointerId: 1 });
+
+    expect(splitSizes()).toEqual([0.5, 0.5]);
+    expect(offscreenRow.style.contentVisibility).toBe("hidden");
+    expect(offscreenRow.style.containIntrinsicBlockSize).toBe("50px");
+    expect(Number.parseFloat(previous.style.flexGrow)).toBeCloseTo(0.7, 5);
+    expect(Number.parseFloat(next.style.flexGrow)).toBeCloseTo(0.3, 5);
+
+    fireEvent.pointerUp(separator, { clientX: 564.2, pointerId: 1 });
+
+    expect(splitSizes()[0]).toBeCloseTo(0.7, 5);
+    expect(splitSizes()[1]).toBeCloseTo(0.3, 5);
+    expect(offscreenRow.style.contentVisibility).toBe("");
+    expect(offscreenRow.style.containIntrinsicBlockSize).toBe("");
+  });
+
   it("keeps the merged toggle absolute and places a visible shortcut hint below pane actions", async () => {
     commandPresentationState.isModifierHeld = true;
     commandPresentationState.shortcut = {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -24,6 +24,7 @@ import { useThread } from "@/hooks/queries/thread-queries";
 import { useThreadSplitsEnabled } from "@/hooks/useThreadSplitsEnabled";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import {
+  clampSplitPairFraction,
   countPanes,
   findPane,
   listPanes,
@@ -776,6 +777,81 @@ interface SplitDividerProps {
   onResize: (fraction: number) => void;
 }
 
+interface FrozenTimelineRow {
+  containIntrinsicBlockSize: string;
+  contentVisibility: string;
+  element: HTMLElement;
+  height: string;
+}
+
+function findVerticalScrollViewport(element: HTMLElement): HTMLElement | null {
+  let candidate = element.parentElement;
+  while (candidate !== null) {
+    const overflowY = window.getComputedStyle(candidate).overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      candidate.scrollHeight > candidate.clientHeight
+    ) {
+      return candidate;
+    }
+    candidate = candidate.parentElement;
+  }
+  return null;
+}
+
+function freezeOffscreenTimelineRows(
+  previous: HTMLElement,
+  next: HTMLElement,
+): () => void {
+  const rows = [
+    ...previous.querySelectorAll<HTMLElement>("[data-timeline-row-id]"),
+    ...next.querySelectorAll<HTMLElement>("[data-timeline-row-id]"),
+  ];
+  const frozenRows: FrozenTimelineRow[] = [];
+  const viewportRects = new Map<HTMLElement, DOMRect>();
+
+  // Batch every geometry read before writing styles so this setup incurs at
+  // most one layout pass. Keep one viewport of overscan on each side; only
+  // rows far outside the clipped pane are skipped during the drag.
+  for (const row of rows) {
+    const viewport = findVerticalScrollViewport(row);
+    if (viewport === null) continue;
+    const rowRect = row.getBoundingClientRect();
+    let viewportRect = viewportRects.get(viewport);
+    if (viewportRect === undefined) {
+      viewportRect = viewport.getBoundingClientRect();
+      viewportRects.set(viewport, viewportRect);
+    }
+    const overscan = viewportRect.height;
+    const isOffscreen =
+      rowRect.bottom < viewportRect.top - overscan ||
+      rowRect.top > viewportRect.bottom + overscan;
+    if (!isOffscreen || rowRect.height <= 0) continue;
+    frozenRows.push({
+      containIntrinsicBlockSize: row.style.containIntrinsicBlockSize,
+      contentVisibility: row.style.contentVisibility,
+      element: row,
+      height: `${rowRect.height}px`,
+    });
+  }
+
+  for (const { element, height } of frozenRows) {
+    element.style.containIntrinsicBlockSize = height;
+    element.style.contentVisibility = "hidden";
+  }
+
+  return () => {
+    for (const {
+      containIntrinsicBlockSize,
+      contentVisibility,
+      element,
+    } of frozenRows) {
+      element.style.containIntrinsicBlockSize = containIntrinsicBlockSize;
+      element.style.contentVisibility = contentVisibility;
+    }
+  };
+}
+
 function SplitDivider({ dir, onResize }: SplitDividerProps) {
   const horizontal = dir === "row";
 
@@ -791,30 +867,71 @@ function SplitDivider({ dir, onResize }: SplitDividerProps) {
       ) {
         return;
       }
+      // The adjacent pair's outer bounds do not move during this drag. Read
+      // them once instead of forcing layout twice for every pointer event.
+      const previousRect = previous.getBoundingClientRect();
+      const nextRect = next.getBoundingClientRect();
+      const start = horizontal ? previousRect.left : previousRect.top;
+      const end = horizontal ? nextRect.right : nextRect.bottom;
+      const span = end - start;
+      if (span <= 0) {
+        return;
+      }
+
       divider.setPointerCapture(event.pointerId);
       divider.dataset.dragging = "true";
 
+      const previousGrow = Number.parseFloat(
+        window.getComputedStyle(previous).flexGrow,
+      );
+      const nextGrow = Number.parseFloat(
+        window.getComputedStyle(next).flexGrow,
+      );
+      const pairTotal =
+        Number.isFinite(previousGrow) &&
+        Number.isFinite(nextGrow) &&
+        previousGrow + nextGrow > 0
+          ? previousGrow + nextGrow
+          : 1;
+      const previousFlex = previous.style.flex;
+      const nextFlex = next.style.flex;
+      const restoreTimelineRows = freezeOffscreenTimelineRows(previous, next);
+      let pendingFraction: number | null = null;
+      let finished = false;
+
       const onMove = (moveEvent: PointerEvent) => {
-        const previousRect = previous.getBoundingClientRect();
-        const nextRect = next.getBoundingClientRect();
-        const start = horizontal ? previousRect.left : previousRect.top;
-        const end = horizontal ? nextRect.right : nextRect.bottom;
-        const span = end - start;
-        if (span <= 0) {
-          return;
-        }
         const pointer = horizontal ? moveEvent.clientX : moveEvent.clientY;
-        // Fraction of the adjacent pair claimed by the first child; resizeSplit
-        // clamps it into [0.15, 0.85].
-        onResize((pointer - start) / span);
+        const fraction = clampSplitPairFraction((pointer - start) / span);
+        pendingFraction = fraction;
+
+        // Keep high-frequency drag state local to the two flex items. Writing
+        // the persisted split-layout atom here would rerender every pane and
+        // sidebar split indicator, and serialize localStorage, on every move.
+        previous.style.flex = `${pairTotal * fraction} 1 0px`;
+        next.style.flex = `${pairTotal * (1 - fraction)} 1 0px`;
       };
-      const onUp = () => {
+      const finish = (commit: boolean) => {
+        if (finished) return;
+        finished = true;
         delete divider.dataset.dragging;
         divider.removeEventListener("pointermove", onMove);
         divider.removeEventListener("pointerup", onUp);
+        divider.removeEventListener("pointercancel", onCancel);
+        restoreTimelineRows();
+        if (commit && pendingFraction !== null) {
+          // Commit once so the imperative flex values above become the
+          // canonical persisted layout without a visual jump.
+          onResize(pendingFraction);
+          return;
+        }
+        previous.style.flex = previousFlex;
+        next.style.flex = nextFlex;
       };
+      const onUp = () => finish(true);
+      const onCancel = () => finish(false);
       divider.addEventListener("pointermove", onMove);
       divider.addEventListener("pointerup", onUp);
+      divider.addEventListener("pointercancel", onCancel);
     },
     [horizontal, onResize],
   );


### PR DESCRIPTION
## Summary

- keep high-frequency divider movement local to the adjacent flex items and persist the split layout once on pointer release
- temporarily freeze far-offscreen timeline rows at their exact current heights during a drag, preserving scroll geometry while avoiding needless reflow
- attach Markdown width observers only to rendered tables instead of every Markdown message

## Live performance

Measured with the same 32-step drag on a three-pane, 112-row production thread:

| Metric | Before | After |
| --- | ---: | ---: |
| p95 frame time | 49.4 ms | 9.1 ms |
| long tasks | 10 | 0 |
| style recalculation | 1.514 s | 0.239 s |
| total task duration | 2.181 s | 0.657 s |

Both affected timeline scroll heights and bottom positions were identical before and after the drag.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/views/thread-detail/SplitThreadArea.test.tsx src/components/ui/markdown-preview.test.tsx` (30 passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run build --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (existing warnings only)
- full app suite reached 1,602/1,603 on the final run; the unrelated existing `inserts automation mode as a command pill` test timed out under full parallel load and passed immediately when rerun alone