### PR TITLE
Show account emails in provider usage limits

### DIFF
--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx
@@ -42,6 +42,7 @@ describe("UsageLimitsSettingsSectionContent", () => {
       usage: {
         cursor: {
           status: "ok",
+          accountEmail: "cursor@example.com",
           planLabel: "Pro",
           windows: [
             { label: "Plan usage", usedPercent: 50, resetsAt: null },
@@ -61,6 +62,7 @@ describe("UsageLimitsSettingsSectionContent", () => {
     });
 
     expect(screen.getByRole("heading", { name: "Cursor" })).toBeDefined();
+    expect(screen.getByText("cursor@example.com")).toBeDefined();
     expect(screen.getByText("Plan usage")).toBeDefined();
     expect(screen.getByText("50% used")).toBeDefined();
     expect(screen.getByText("On-demand spend")).toBeDefined();

--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
@@ -221,11 +221,19 @@ function ProviderUsageBlock({
   isError,
 }: ProviderUsageBlockProps) {
   const planLabel = usage?.status === "ok" ? usage.planLabel : null;
+  const accountEmail = usage?.status === "ok" ? usage.accountEmail : null;
 
   return (
     <div className="space-y-3.5">
-      <div className="flex items-center justify-between gap-2">
-        <h3 className="text-sm font-normal text-foreground">{config.name}</h3>
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-sm font-normal text-foreground">{config.name}</h3>
+          {accountEmail ? (
+            <p className="truncate text-xs text-muted-foreground">
+              {accountEmail}
+            </p>
+          ) : null}
+        </div>
         {planLabel ? (
           <span className="text-xs text-muted-foreground">{planLabel}</span>
         ) : null}

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -95,6 +95,7 @@ const usageFixture: {
 } = {
   codex: {
     status: "ok",
+    accountEmail: "sawyer@example.com",
     planLabel: "Pro",
     windows: [
       {
@@ -111,6 +112,7 @@ const usageFixture: {
   },
   claudeCode: {
     status: "ok",
+    accountEmail: "sawyer@example.com",
     planLabel: "Max (20x)",
     windows: [
       {
@@ -127,6 +129,7 @@ const usageFixture: {
   },
   cursor: {
     status: "ok",
+    accountEmail: "sawyer@example.com",
     planLabel: "Pro",
     windows: [
       {

--- a/apps/host-daemon/src/codex-auth.ts
+++ b/apps/host-daemon/src/codex-auth.ts
@@ -23,6 +23,7 @@ export interface CodexChatGptAuthCredentials {
   type: "chatgpt";
   accessToken: string;
   accountId: string;
+  accountEmail: string | null;
   isFedrampAccount: boolean;
 }
 
@@ -98,6 +99,15 @@ function getChatGptAuthClaims(token: string): JsonObject | null {
 function getAccountIdFromToken(token: string): string | null {
   const auth = getChatGptAuthClaims(token);
   return auth ? optionalString(auth.chatgpt_account_id) : null;
+}
+
+function getAccountEmailFromToken(token: string): string | null {
+  const payload = decodeJwtPayload(token);
+  if (!payload) {
+    return null;
+  }
+  const profile = toJsonObject(payload["https://api.openai.com/profile"]);
+  return optionalString(payload.email) ?? optionalString(profile?.email);
 }
 
 function isFedrampToken(token: string): boolean {
@@ -222,6 +232,11 @@ function buildChatGptCredentials(
       accessToken: auth.accessToken,
       tokens: auth.tokens,
     }),
+    accountEmail:
+      getAccountEmailFromToken(auth.accessToken) ??
+      (typeof auth.tokens.id_token === "string"
+        ? getAccountEmailFromToken(auth.tokens.id_token)
+        : null),
     isFedrampAccount: resolveFedrampAccount({
       accessToken: auth.accessToken,
       tokens: auth.tokens,

--- a/apps/host-daemon/src/provider-usage.test.ts
+++ b/apps/host-daemon/src/provider-usage.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { __testing } from "./provider-usage.js";
 
@@ -7,32 +11,37 @@ const {
   normalizeCursorUsage,
   codexPlanLabel,
   claudePlanLabel,
+  readCursorAccountEmailFromDatabase,
 } = __testing;
 
 describe("normalizeCodexUsage", () => {
   it("maps primary/secondary windows and plan to the unified shape", () => {
     const primaryReset = 1_780_000_000;
     const secondaryReset = 1_780_500_000;
-    const result = normalizeCodexUsage({
-      plan_type: "pro",
-      rate_limit: {
-        primary_window: {
-          used_percent: 12,
-          reset_at: primaryReset,
-          limit_window_seconds: 18_000,
+    const result = normalizeCodexUsage(
+      {
+        plan_type: "pro",
+        rate_limit: {
+          primary_window: {
+            used_percent: 12,
+            reset_at: primaryReset,
+            limit_window_seconds: 18_000,
+          },
+          secondary_window: {
+            used_percent: 18,
+            reset_at: secondaryReset,
+            limit_window_seconds: 604_800,
+          },
         },
-        secondary_window: {
-          used_percent: 18,
-          reset_at: secondaryReset,
-          limit_window_seconds: 604_800,
-        },
+        // Unknown sibling fields must be ignored, not fatal.
+        credits: { has_credits: false, unlimited: false, balance: null },
       },
-      // Unknown sibling fields must be ignored, not fatal.
-      credits: { has_credits: false, unlimited: false, balance: null },
-    });
+      "codex@example.com",
+    );
 
     expect(result).toEqual({
       status: "ok",
+      accountEmail: "codex@example.com",
       planLabel: "Pro",
       windows: [
         {
@@ -60,6 +69,7 @@ describe("normalizeCodexUsage", () => {
 
     expect(result).toEqual({
       status: "ok",
+      accountEmail: null,
       planLabel: "Team",
       windows: [
         { label: "Current session", usedPercent: 100, resetsAt: null },
@@ -71,6 +81,7 @@ describe("normalizeCodexUsage", () => {
   it("returns ok with no windows when rate limits are absent", () => {
     expect(normalizeCodexUsage({ plan_type: "plus" })).toEqual({
       status: "ok",
+      accountEmail: null,
       planLabel: "Plus",
       windows: [],
     });
@@ -100,10 +111,12 @@ describe("normalizeClaudeUsage", () => {
         seven_day_sonnet: { utilization: 0, resets_at: null },
       },
       credentials,
+      "claude@example.com",
     );
 
     expect(result).toEqual({
       status: "ok",
+      accountEmail: "claude@example.com",
       planLabel: "Max (20x)",
       windows: [
         {
@@ -131,6 +144,7 @@ describe("normalizeClaudeUsage", () => {
 
     expect(result).toEqual({
       status: "ok",
+      accountEmail: null,
       planLabel: null,
       windows: [{ label: "Current session", usedPercent: 7, resetsAt: null }],
     });
@@ -138,6 +152,34 @@ describe("normalizeClaudeUsage", () => {
 });
 
 describe("normalizeCursorUsage", () => {
+  it("reads and validates Cursor's cached authenticated email", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-cursor-email-"),
+    );
+    const databasePath = path.join(directory, "state.vscdb");
+    const database = new Database(databasePath);
+    try {
+      database.exec(
+        "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)",
+      );
+      database
+        .prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)")
+        .run("cursorAuth/cachedEmail", "cursor@example.com");
+
+      expect(readCursorAccountEmailFromDatabase(databasePath)).toBe(
+        "cursor@example.com",
+      );
+
+      database
+        .prepare("UPDATE ItemTable SET value = ? WHERE key = ?")
+        .run("not-an-email", "cursorAuth/cachedEmail");
+      expect(readCursorAccountEmailFromDatabase(databasePath)).toBeNull();
+    } finally {
+      database.close();
+      await fs.rm(directory, { force: true, recursive: true });
+    }
+  });
+
   it("uses Cursor's explicit plan percentage instead of its spend ratio", () => {
     const billingCycleEnd = 1_784_391_684_000;
     const result = normalizeCursorUsage(
@@ -163,10 +205,12 @@ describe("normalizeCursorUsage", () => {
           includedAmountCents: 2_000,
         },
       },
+      "cursor@example.com",
     );
 
     expect(result).toEqual({
       status: "ok",
+      accountEmail: "cursor@example.com",
       planLabel: "Pro",
       windows: [
         {
@@ -198,6 +242,7 @@ describe("normalizeCursorUsage", () => {
 
     expect(result).toEqual({
       status: "ok",
+      accountEmail: null,
       planLabel: null,
       windows: [
         {

--- a/apps/host-daemon/src/provider-usage.ts
+++ b/apps/host-daemon/src/provider-usage.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import Database from "better-sqlite3";
 import type {
   ProviderUsage,
   ProviderUsageResponse,
@@ -145,7 +146,10 @@ async function fetchChatGptUsage(headers: Headers): Promise<Response> {
   return response;
 }
 
-function normalizeCodexUsage(raw: unknown): ProviderUsage {
+function normalizeCodexUsage(
+  raw: unknown,
+  accountEmail: string | null = null,
+): ProviderUsage {
   const parsed = codexUsageResponseSchema.safeParse(raw);
   if (!parsed.success) {
     return { status: "error", message: "Codex usage response was malformed." };
@@ -158,6 +162,7 @@ function normalizeCodexUsage(raw: unknown): ProviderUsage {
 
   return {
     status: "ok",
+    accountEmail,
     planLabel: codexPlanLabel(parsed.data.plan_type),
     windows,
   };
@@ -209,7 +214,7 @@ async function fetchCodexUsage(): Promise<ProviderUsage> {
     };
   }
 
-  return normalizeCodexUsage(await response.json());
+  return normalizeCodexUsage(await response.json(), credentials.accountEmail);
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +239,12 @@ const claudeCredentialsSchema = z.object({
 type ClaudeCredentials = z.infer<
   typeof claudeCredentialsSchema
 >["claudeAiOauth"];
+
+const claudeAccountSchema = z.object({
+  oauthAccount: z
+    .object({ emailAddress: z.string().email().nullish() })
+    .nullish(),
+});
 
 const claudeUsageWindowSchema = z.object({
   utilization: z.number().nullish(),
@@ -306,6 +317,21 @@ async function readClaudeCredentials(): Promise<ClaudeCredentials | null> {
   return parsed.success ? parsed.data.claudeAiOauth : null;
 }
 
+async function readClaudeAccountEmail(): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(
+      path.join(os.homedir(), ".claude.json"),
+      "utf8",
+    );
+    const parsed = claudeAccountSchema.safeParse(JSON.parse(raw));
+    return parsed.success
+      ? (parsed.data.oauthAccount?.emailAddress ?? null)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function claudePlanLabel(credentials: ClaudeCredentials): string | null {
   const tier = credentials.rateLimitTier ?? "";
   const maxMatch = tier.match(/max_(\d+)x/u);
@@ -336,6 +362,7 @@ function claudeWindow(
 function normalizeClaudeUsage(
   raw: unknown,
   credentials: ClaudeCredentials,
+  accountEmail: string | null = null,
 ): ProviderUsage {
   const parsed = claudeUsageResponseSchema.safeParse(raw);
   if (!parsed.success) {
@@ -349,13 +376,17 @@ function normalizeClaudeUsage(
 
   return {
     status: "ok",
+    accountEmail,
     planLabel: claudePlanLabel(credentials),
     windows,
   };
 }
 
 async function fetchClaudeUsage(): Promise<ProviderUsage> {
-  const credentials = await readClaudeCredentials();
+  const [credentials, accountEmail] = await Promise.all([
+    readClaudeCredentials(),
+    readClaudeAccountEmail(),
+  ]);
   if (!credentials) {
     return { status: "unauthenticated" };
   }
@@ -393,7 +424,7 @@ async function fetchClaudeUsage(): Promise<ProviderUsage> {
     };
   }
 
-  return normalizeClaudeUsage(await response.json(), credentials);
+  return normalizeClaudeUsage(await response.json(), credentials, accountEmail);
 }
 
 // ---------------------------------------------------------------------------
@@ -447,6 +478,8 @@ const cursorPlanInfoSchema = z
 const cursorFileCredentialsSchema = z.object({
   accessToken: z.string().min(1).nullish(),
 });
+
+const cursorCachedEmailSchema = z.string().email();
 
 function cursorAuthFilePath(): string {
   if (process.platform === "win32") {
@@ -509,6 +542,63 @@ async function readCursorAccessToken(): Promise<string | null> {
   );
 }
 
+function cursorStateDatabasePath(): string {
+  if (process.platform === "win32") {
+    const appData =
+      process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "Cursor", "User", "globalStorage", "state.vscdb");
+  }
+  if (process.platform === "darwin") {
+    return path.join(
+      os.homedir(),
+      "Library",
+      "Application Support",
+      "Cursor",
+      "User",
+      "globalStorage",
+      "state.vscdb",
+    );
+  }
+  const configHome =
+    process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), ".config");
+  return path.join(
+    configHome,
+    "Cursor",
+    "User",
+    "globalStorage",
+    "state.vscdb",
+  );
+}
+
+function readCursorAccountEmailFromDatabase(
+  databasePath: string,
+): string | null {
+  let database: Database.Database | null = null;
+  try {
+    database = new Database(databasePath, {
+      fileMustExist: true,
+      readonly: true,
+    });
+    const row = database
+      .prepare("SELECT value FROM ItemTable WHERE key = ?")
+      .get("cursorAuth/cachedEmail");
+    const parsed = z.object({ value: z.string() }).safeParse(row);
+    if (!parsed.success) {
+      return null;
+    }
+    const email = cursorCachedEmailSchema.safeParse(parsed.data.value);
+    return email.success ? email.data : null;
+  } catch {
+    return null;
+  } finally {
+    database?.close();
+  }
+}
+
+function readCursorAccountEmail(): string | null {
+  return readCursorAccountEmailFromDatabase(cursorStateDatabasePath());
+}
+
 interface CursorSpendUsageWindowArgs {
   label: string;
   used: number | null | undefined;
@@ -550,6 +640,7 @@ function cursorPlanUsageWindow(
 function normalizeCursorUsage(
   rawUsage: unknown,
   rawPlan: unknown,
+  accountEmail: string | null = null,
 ): ProviderUsage {
   const usage = cursorCurrentPeriodUsageSchema.safeParse(rawUsage);
   if (!usage.success) {
@@ -581,6 +672,7 @@ function normalizeCursorUsage(
 
   return {
     status: "ok",
+    accountEmail,
     planLabel: plan.success ? (plan.data.planInfo?.planName ?? null) : null,
     windows,
   };
@@ -635,7 +727,11 @@ async function fetchCursorUsage(): Promise<ProviderUsage> {
   }
 
   const rawPlan: unknown = planResponse.ok ? await planResponse.json() : {};
-  return normalizeCursorUsage(await usageResponse.json(), rawPlan);
+  return normalizeCursorUsage(
+    await usageResponse.json(),
+    rawPlan,
+    readCursorAccountEmail(),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -678,4 +774,5 @@ export const __testing = {
   normalizeCursorUsage,
   codexPlanLabel,
   claudePlanLabel,
+  readCursorAccountEmailFromDatabase,
 };

--- a/apps/server/test/public/public-system-usage-limits.test.ts
+++ b/apps/server/test/public/public-system-usage-limits.test.ts
@@ -8,6 +8,7 @@ import { withTestHarness } from "../helpers/test-app.js";
 const USAGE_RESPONSE: ProviderUsageResponse = {
   codex: {
     status: "ok",
+    accountEmail: "codex@example.com",
     planLabel: "Plus",
     windows: [{ label: "5-hour", usedPercent: 42, resetsAt: null }],
   },

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 55 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 56 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,
@@ -1141,7 +1141,9 @@ export type ProviderUsageWindow = z.infer<typeof providerUsageWindowSchema>;
  * UI can render the windows, prompt the user to sign in, or surface an error
  * without inventing placeholder numbers.
  *
- * - `ok` — usage was read; `windows` may be empty if the plan exposes none.
+ * - `ok` — usage was read; `accountEmail` is null when the provider's local
+ *   auth state does not expose it, and `windows` may be empty if the plan
+ *   exposes none.
  * - `not_installed` — the provider CLI is not installed on this host.
  * - `unauthenticated` — no local credentials (the CLI is not logged in).
  * - `expired` — credentials exist but the token expired; the CLI must refresh
@@ -1151,6 +1153,7 @@ export type ProviderUsageWindow = z.infer<typeof providerUsageWindowSchema>;
 export const providerUsageSchema = z.discriminatedUnion("status", [
   z.object({
     status: z.literal("ok"),
+    accountEmail: z.string().email().nullable(),
     planLabel: z.string().min(1).nullable(),
     windows: z.array(providerUsageWindowSchema),
   }),

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -314,6 +314,7 @@ const ONLINE_RPC_RESPONSE_RESULT_FIXTURES: OnlineRpcResponseResultFixtures = {
   "provider.usage": {
     codex: {
       status: "ok",
+      accountEmail: "codex@example.com",
       planLabel: "Pro",
       windows: [
         {


### PR DESCRIPTION
## Summary
- include the authenticated account email in provider usage responses
- source Codex, Claude Code, and Cursor emails from their provider-owned local auth state
- render the email beneath each provider name and bump the daemon protocol

## Tests
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/provider-usage.test.ts`
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/settings/UsageLimitsSettingsSection.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/app --filter=@bb/server --filter=@bb/host-daemon-contract`
- live provider usage smoke test for all three account-email sources