### PR TITLE
Build bundled plugins before production start

### DIFF
--- a/scripts/start-bb.mjs
+++ b/scripts/start-bb.mjs
@@ -50,7 +50,35 @@ async function buildRuntimeArtifacts() {
   throw new Error(`Runtime build failed with exit code ${result.code ?? 1}`);
 }
 
+async function buildBundledPlugins() {
+  const child = spawn(
+    process.execPath,
+    [
+      "--conditions=source",
+      "--import",
+      "tsx",
+      resolve(repoRoot, "apps/server/scripts/copy-builtin-plugins.ts"),
+    ],
+    {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+  const result = await waitForProcess(child);
+  if (result.code === 0) {
+    return;
+  }
+  if (result.signal !== null) {
+    throw new Error(`Bundled plugin build stopped by ${result.signal}`);
+  }
+  throw new Error(
+    `Bundled plugin build failed with exit code ${result.code ?? 1}`,
+  );
+}
+
 await buildRuntimeArtifacts();
+await buildBundledPlugins();
 ensureNativeModules({ repoRoot });
 
 const { runBbApp } = await import("../packages/bb-app/src/index.ts");


### PR DESCRIPTION
## Summary
- rebuild every bundled built-in and official plugin during `pnpm start`
- copy fresh plugin artifacts into the server runtime before launching BB
- fail startup clearly when the bundled-plugin build fails

## Validation
- ran the bundled-plugin build successfully for all ten plugins
- verified the Tasks app bundle contains the inline status control
- `pnpm exec prettier scripts/start-bb.mjs --check`
- `git diff --check`

## Risk
- production startup does additional plugin compilation work before launching; this guarantees source changes cannot leave stale runtime bundles