### PR TITLE
BB-47: Enter submits task comments

### DIFF
--- a/official-plugins/tasks/editor/editor.test.tsx
+++ b/official-plugins/tasks/editor/editor.test.tsx
@@ -2,10 +2,36 @@
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
+import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { createEditorExtensions } from "./extensions.js";
 import { TasksEditor } from "./tasks-editor.js";
 
 afterEach(cleanup);
+
+function mockPointerCoarse(matches: boolean): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === POINTER_COARSE_QUERY ? matches : false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
+function getEditorSurface(container: HTMLElement): HTMLElement {
+  const surface = container.querySelector(".tiptap");
+  if (!(surface instanceof HTMLElement)) {
+    throw new Error("Expected TipTap surface");
+  }
+  return surface;
+}
 
 function roundTrip(markdown: string): string {
   const editor = new Editor({
@@ -416,5 +442,205 @@ describe("TasksEditor component", () => {
       expect(markdown).toContain("![shot](https://example.com/a.png)");
       expect(markdown).toContain("caption");
     });
+  });
+});
+
+describe("TasksEditor submit-on-Enter", () => {
+  function callHandleKeyDown(editor: Editor, event: KeyboardEvent): boolean {
+    const { handleKeyDown } = editor.options.editorProps;
+    return Boolean(handleKeyDown?.call(editor.view, editor.view, event));
+  }
+
+  it("submits on bare Enter when onSubmit is provided", () => {
+    const onSubmit = vi.fn();
+    let editor: Editor | null = null;
+    const screen = render(
+      <TasksEditor
+        value="Draft"
+        onChange={() => undefined}
+        onSubmit={onSubmit}
+        variant="comment"
+        onEditorReady={(ready) => {
+          editor = ready;
+        }}
+      />,
+    );
+    editor!.commands.focus("end");
+    const surface = getEditorSurface(screen.container);
+    expect(surface.getAttribute("enterkeyhint")).toBe("send");
+
+    expect(
+      callHandleKeyDown(
+        editor!,
+        new KeyboardEvent("keydown", { key: "Enter", cancelable: true }),
+      ),
+    ).toBe(true);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("inserts a newline on Shift+Enter instead of submitting", () => {
+    const onSubmit = vi.fn();
+    let editor: Editor | null = null;
+    render(
+      <TasksEditor
+        value="Line"
+        onChange={() => undefined}
+        onSubmit={onSubmit}
+        variant="comment"
+        onEditorReady={(ready) => {
+          editor = ready;
+        }}
+      />,
+    );
+    editor!.commands.focus("end");
+    // Returning false lets TipTap's default Enter keymap insert a hard break /
+    // new paragraph.
+    expect(
+      callHandleKeyDown(
+        editor!,
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          shiftKey: true,
+          cancelable: true,
+        }),
+      ),
+    ).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit during IME composition", () => {
+    const onSubmit = vi.fn();
+    let editor: Editor | null = null;
+    render(
+      <TasksEditor
+        value="候補"
+        onChange={() => undefined}
+        onSubmit={onSubmit}
+        variant="comment"
+        onEditorReady={(ready) => {
+          editor = ready;
+        }}
+      />,
+    );
+    editor!.commands.focus("end");
+    const composing = new KeyboardEvent("keydown", {
+      key: "Enter",
+      cancelable: true,
+      isComposing: true,
+    });
+    expect(callHandleKeyDown(editor!, composing)).toBe(false);
+
+    // Legacy IME signal: some browsers still report keyCode 229 while composing.
+    const keyCode229 = new KeyboardEvent("keydown", {
+      key: "Enter",
+      cancelable: true,
+    });
+    Object.defineProperty(keyCode229, "keyCode", {
+      get: () => 229,
+    });
+    expect(callHandleKeyDown(editor!, keyCode229)).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on Cmd/Ctrl+Enter even when pointer is coarse", () => {
+    const restore = mockPointerCoarse(true);
+    try {
+      const onSubmit = vi.fn();
+      let editor: Editor | null = null;
+      const screen = render(
+        <TasksEditor
+          value="Touch draft"
+          onChange={() => undefined}
+          onSubmit={onSubmit}
+          variant="comment"
+          onEditorReady={(ready) => {
+            editor = ready;
+          }}
+        />,
+      );
+      editor!.commands.focus("end");
+      const surface = getEditorSurface(screen.container);
+      expect(surface.getAttribute("enterkeyhint")).toBe("enter");
+
+      // Bare Enter must remain a newline on touch devices.
+      expect(
+        callHandleKeyDown(
+          editor!,
+          new KeyboardEvent("keydown", { key: "Enter", cancelable: true }),
+        ),
+      ).toBe(false);
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      expect(
+        callHandleKeyDown(
+          editor!,
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            metaKey: true,
+            cancelable: true,
+          }),
+        ),
+      ).toBe(true);
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not claim Enter when onSubmit is omitted", () => {
+    let editor: Editor | null = null;
+    render(
+      <TasksEditor
+        value="Description"
+        onChange={() => undefined}
+        variant="comment"
+        onEditorReady={(ready) => {
+          editor = ready;
+        }}
+      />,
+    );
+    editor!.commands.focus("end");
+    expect(
+      callHandleKeyDown(
+        editor!,
+        new KeyboardEvent("keydown", { key: "Enter", cancelable: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("lets the mention popover own Enter while open", async () => {
+    const onSubmit = vi.fn();
+    let editor: Editor | null = null;
+    const screen = render(
+      <TasksEditor
+        value=""
+        onChange={() => undefined}
+        onSubmit={onSubmit}
+        variant="comment"
+        mentionItems={() =>
+          Promise.resolve([
+            {
+              type: "task" as const,
+              id: "1",
+              key: "TSK-1",
+              title: "Pick me",
+            },
+          ])
+        }
+        onEditorReady={(ready) => {
+          editor = ready;
+        }}
+      />,
+    );
+    editor!.chain().focus().insertContent("@").run();
+    await screen.findByText("Pick me");
+    // Enter selects the mention instead of submitting the comment.
+    fireEvent.keyDown(getEditorSurface(screen.container), { key: "Enter" });
+    await waitFor(() =>
+      expect(
+        screen.container.querySelector('[data-task-mention="TSK-1"]'),
+      ).toBeTruthy(),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/official-plugins/tasks/editor/tasks-editor.tsx
+++ b/official-plugins/tasks/editor/tasks-editor.tsx
@@ -20,12 +20,18 @@ import {
 } from "@hugeicons/core-free-icons";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import { Button } from "@bb/shared-ui/button";
+import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   createEditorExtensions,
   type MentionItem,
   type MentionSuggestionHandle,
 } from "./extensions.js";
+
+/** True while an IME is composing (e.g. Japanese candidate selection). */
+function isImeComposing(event: KeyboardEvent): boolean {
+  return event.isComposing || event.keyCode === 229;
+}
 
 const STYLE_MARKER = "data-bb-tasks-editor-styles";
 const EDITOR_CSS = `
@@ -204,6 +210,13 @@ export interface TasksEditorProps {
   mentionItems?: (query: string) => Promise<MentionItem[]>;
   /** Invoked when a thread-mention pill is clicked (edit and read-only). */
   onOpenThread?: (threadId: string) => void;
+  /**
+   * When set, bare Enter (and Cmd/Ctrl+Enter) invoke this instead of inserting
+   * a newline. Shift+Enter still inserts a newline. Used by the task comment
+   * composer. On coarse-pointer devices bare Enter stays a newline; Cmd/Ctrl+Enter
+   * still submits. Hosts should no-op when send is disabled or in-flight.
+   */
+  onSubmit?: () => void;
   onEditorReady?: (editor: Editor) => void;
   className?: string;
 }
@@ -219,6 +232,7 @@ export function TasksEditor({
   onAttachFiles,
   mentionItems,
   onOpenThread,
+  onSubmit,
   onEditorReady,
   className,
 }: TasksEditorProps) {
@@ -239,10 +253,23 @@ export function TasksEditor({
   mentionItemsRef.current = mentionItems;
   const openThreadRef = useRef(onOpenThread);
   openThreadRef.current = onOpenThread;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
   const readyRef = useRef(onEditorReady);
   readyRef.current = onEditorReady;
   const initialValueRef = useRef(value);
   const autofocusRef = useRef(autofocus);
+  // Coarse pointer (touch) keeps bare Enter as newline; soft keyboards use
+  // enterkeyhint="enter" rather than "send" so the key doesn't look like submit.
+  const isPointerCoarse = usePointerCoarse();
+  const canSubmitWithEnterKey = Boolean(onSubmit) && !isPointerCoarse;
+  const canSubmitWithEnterRef = useRef(canSubmitWithEnterKey);
+  canSubmitWithEnterRef.current = canSubmitWithEnterKey;
+  const editorEnterKeyHint = onSubmit
+    ? isPointerCoarse
+      ? "enter"
+      : "send"
+    : undefined;
 
   const [, setRevision] = useState(0);
   const [mention, setMentionState] = useState<MentionPopoverState | null>(
@@ -328,6 +355,39 @@ export function TasksEditor({
       content: initialValueRef.current,
       autofocus: autofocusRef.current && !readOnly ? "end" : false,
       editorProps: {
+        handleKeyDown(_view, event) {
+          // Submit-on-Enter is opt-in via onSubmit (comment composer). Without
+          // it, Enter keeps the default TipTap newline/list behavior.
+          if (!onSubmitRef.current || readOnly) return false;
+          if (event.key !== "Enter") return false;
+          // Never steal Enter while an IME is composing a candidate.
+          if (isImeComposing(event)) return false;
+          // Mention popover owns Enter/Tab while open.
+          const openMention = mentionRef.current;
+          if (openMention && openMention.items.length > 0) return false;
+
+          const withPrimaryMod =
+            (event.metaKey || event.ctrlKey) &&
+            !event.altKey &&
+            !event.shiftKey;
+          const plainEnter =
+            !event.shiftKey &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey;
+
+          // Shift+Enter (and other modifier combos we don't claim) insert a
+          // newline via the default editor keymap.
+          if (event.shiftKey && !withPrimaryMod) return false;
+          if (!withPrimaryMod && !plainEnter) return false;
+          // Touch devices: bare Enter stays a newline; Cmd/Ctrl+Enter still
+          // submits so a hardware keyboard can force send.
+          if (plainEnter && !canSubmitWithEnterRef.current) return false;
+
+          event.preventDefault();
+          onSubmitRef.current();
+          return true;
+        },
         handlePaste(_view, event) {
           const files = [...(event.clipboardData?.files ?? [])];
           if (attachFilesRef.current) {
@@ -441,6 +501,17 @@ export function TasksEditor({
     lastMarkdownRef.current = value;
     editor.commands.setContent(value, false);
   }, [value]);
+
+  // Soft-keyboard enterkeyhint tracks coarse-pointer without recreating the editor.
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || editor.isDestroyed) return;
+    if (editorEnterKeyHint) {
+      editor.view.dom.setAttribute("enterkeyhint", editorEnterKeyHint);
+    } else {
+      editor.view.dom.removeAttribute("enterkeyhint");
+    }
+  }, [editorEnterKeyHint]);
 
   const editor = editorRef.current;
   const mentionRect = mention?.clientRect?.() ?? null;

--- a/official-plugins/tasks/views/activity/task-activity.test.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.test.tsx
@@ -35,11 +35,21 @@ vi.mock("../../editor/tasks-editor.js", () => ({
   TasksEditor: (props: {
     value: string;
     onChange: (value: string) => void;
+    onSubmit?: () => void;
   }) => (
     <textarea
       aria-label="Comment body"
       value={props.value}
       onChange={(event) => props.onChange(event.currentTarget.value)}
+      onKeyDown={(event) => {
+        // Mirror the real TasksEditor submit-on-Enter contract for unit tests.
+        if (event.key !== "Enter" || !props.onSubmit) return;
+        if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+        if (event.shiftKey || event.altKey) return;
+        // Bare Enter or Cmd/Ctrl+Enter submits.
+        event.preventDefault();
+        props.onSubmit();
+      }}
     />
   ),
 }));
@@ -188,71 +198,89 @@ describe("AgentNotificationControl", () => {
   });
 });
 
+async function renderComposerWithTask(options?: {
+  body?: string;
+  holdSend?: boolean;
+}) {
+  let releaseSend!: () => void;
+  const sendGate = options?.holdSend
+    ? new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      })
+    : Promise.resolve();
+  if (!options?.holdSend) {
+    releaseSend = () => {};
+  }
+  const { bb, harness } = createFakePluginHost({
+    pluginId: "tasks",
+    sdk: {
+      threads: {
+        get: async ({ threadId }) =>
+          makeThreadResponse({ id: threadId, status: "active" }),
+        send: async () => sendGate,
+      },
+    },
+  });
+  const store = createStore(bb);
+  const project = store.tasks.createProject({
+    name: "Composer",
+    prefix: "CMP",
+    color: "blue",
+  });
+  const task = store.tasks.createTask({
+    projectId: project.id,
+    title: "Submit once",
+  });
+  store.tasks.createComment({
+    taskId: task.id,
+    kind: "agent",
+    authorName: "Worker",
+    threadId: "thr_worker",
+    body: "Ready for input",
+  });
+  rpcCall.mockImplementation(async (method, input) => {
+    if (method !== "createComment") {
+      throw new Error(`Unexpected RPC method: ${String(method)}`);
+    }
+    const request = input as {
+      taskId: string;
+      body: string;
+      notify: boolean;
+    };
+    return {
+      comment: await createComment(bb, store, {
+        taskId: request.taskId,
+        kind: "user",
+        authorName: "You",
+        presetName: null,
+        threadId: null,
+        body: request.body,
+        notify: request.notify,
+      }),
+    };
+  });
+
+  render(
+    <CommentComposer
+      taskId={task.id}
+      notificationTarget={{ kind: "ready", title: "Worker" }}
+    />,
+  );
+  if (options?.body !== undefined) {
+    fireEvent.change(screen.getByRole("textbox", { name: "Comment body" }), {
+      target: { value: options.body },
+    });
+  }
+  return { store, task, harness, releaseSend };
+}
+
 describe("CommentComposer", () => {
   it("single-flights rapid submit activation into one comment and send", async () => {
-    let releaseSend!: () => void;
-    const sendGate = new Promise<void>((resolve) => {
-      releaseSend = resolve;
-    });
-    const { bb, harness } = createFakePluginHost({
-      pluginId: "tasks",
-      sdk: {
-        threads: {
-          get: async ({ threadId }) =>
-            makeThreadResponse({ id: threadId, status: "active" }),
-          send: async () => sendGate,
-        },
-      },
+    const { store, task, harness, releaseSend } = await renderComposerWithTask({
+      body: "Only once",
+      holdSend: true,
     });
     try {
-      const store = createStore(bb);
-      const project = store.tasks.createProject({
-        name: "Composer",
-        prefix: "CMP",
-        color: "blue",
-      });
-      const task = store.tasks.createTask({
-        projectId: project.id,
-        title: "Submit once",
-      });
-      store.tasks.createComment({
-        taskId: task.id,
-        kind: "agent",
-        authorName: "Worker",
-        threadId: "thr_worker",
-        body: "Ready for input",
-      });
-      rpcCall.mockImplementation(async (method, input) => {
-        if (method !== "createComment") {
-          throw new Error(`Unexpected RPC method: ${String(method)}`);
-        }
-        const request = input as {
-          taskId: string;
-          body: string;
-          notify: boolean;
-        };
-        return {
-          comment: await createComment(bb, store, {
-            taskId: request.taskId,
-            kind: "user",
-            authorName: "You",
-            presetName: null,
-            threadId: null,
-            body: request.body,
-            notify: request.notify,
-          }),
-        };
-      });
-
-      render(
-        <CommentComposer
-          taskId={task.id}
-          notificationTarget={{ kind: "ready", title: "Worker" }}
-        />,
-      );
-      fireEvent.change(screen.getByRole("textbox", { name: "Comment body" }), {
-        target: { value: "Only once" },
-      });
       const submit = screen.getByRole("button", { name: "Comment" });
       fireEvent.click(submit);
       fireEvent.click(submit);
@@ -275,6 +303,104 @@ describe("CommentComposer", () => {
             .find((entry) => entry.body === "Only once")?.notifiedCount,
         ).toBe(1),
       );
+    } finally {
+      releaseSend();
+      await harness.dispose();
+    }
+  });
+
+  it("submits on Enter and single-flights rapid Enter presses", async () => {
+    const { store, task, harness, releaseSend } = await renderComposerWithTask({
+      body: "From keyboard",
+      holdSend: true,
+    });
+    try {
+      const body = screen.getByRole("textbox", { name: "Comment body" });
+      fireEvent.keyDown(body, { key: "Enter" });
+      fireEvent.keyDown(body, { key: "Enter" });
+
+      await waitFor(() => expect(rpcCall).toHaveBeenCalledTimes(1));
+      expect(
+        store.tasks
+          .listComments(task.id)
+          .filter((entry) => entry.body === "From keyboard"),
+      ).toHaveLength(1);
+      releaseSend();
+    } finally {
+      releaseSend();
+      await harness.dispose();
+    }
+  });
+
+  it("does not submit on Shift+Enter", async () => {
+    const { harness, releaseSend } = await renderComposerWithTask({
+      body: "Keep drafting",
+    });
+    try {
+      fireEvent.keyDown(screen.getByRole("textbox", { name: "Comment body" }), {
+        key: "Enter",
+        shiftKey: true,
+      });
+      expect(rpcCall).not.toHaveBeenCalled();
+    } finally {
+      releaseSend();
+      await harness.dispose();
+    }
+  });
+
+  it("does not submit during IME composition", async () => {
+    const { harness, releaseSend } = await renderComposerWithTask({
+      body: "候補",
+    });
+    try {
+      fireEvent.keyDown(screen.getByRole("textbox", { name: "Comment body" }), {
+        key: "Enter",
+        isComposing: true,
+      });
+      fireEvent.keyDown(screen.getByRole("textbox", { name: "Comment body" }), {
+        key: "Enter",
+        keyCode: 229,
+      });
+      expect(rpcCall).not.toHaveBeenCalled();
+    } finally {
+      releaseSend();
+      await harness.dispose();
+    }
+  });
+
+  it("does not submit when the comment is empty", async () => {
+    const { harness, releaseSend } = await renderComposerWithTask({ body: "" });
+    try {
+      fireEvent.keyDown(screen.getByRole("textbox", { name: "Comment body" }), {
+        key: "Enter",
+      });
+      expect(rpcCall).not.toHaveBeenCalled();
+      expect(
+        (
+          screen.getByRole("button", { name: "Comment" }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true);
+    } finally {
+      releaseSend();
+      await harness.dispose();
+    }
+  });
+
+  it("submits on Cmd+Enter", async () => {
+    const { store, task, harness, releaseSend } = await renderComposerWithTask({
+      body: "Mod submit",
+    });
+    try {
+      fireEvent.keyDown(screen.getByRole("textbox", { name: "Comment body" }), {
+        key: "Enter",
+        metaKey: true,
+      });
+      await waitFor(() => expect(rpcCall).toHaveBeenCalledTimes(1));
+      expect(
+        store.tasks
+          .listComments(task.id)
+          .some((entry) => entry.body === "Mod submit"),
+      ).toBe(true);
     } finally {
       releaseSend();
       await harness.dispose();

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -358,6 +358,7 @@ export function CommentComposer({ taskId, notificationTarget }: ComposerProps) {
         className="min-h-11"
         mentionItems={mentionItems}
         onOpenThread={(threadId) => navigate.toThread(threadId)}
+        onSubmit={() => void send()}
       />
       {pendingFiles.length > 0 ? (
         <div className="mt-2 flex flex-wrap gap-1.5">


### PR DESCRIPTION
## Summary
- Tasks detail comment composer submits on bare **Enter** (and Cmd/Ctrl+Enter); **Shift+Enter** inserts a newline.
- Optional `TasksEditor` `onSubmit` preserves IME composition, @-mention Enter ownership, coarse-pointer newline behavior (`enterkeyhint`), and existing single-flight / empty / disabled send guards.
- Focused keyboard tests cover Enter/Shift+Enter/IME/mention/coarse-pointer paths; live browser QA on isolated `bb-dev-app` posted comments verified via CLI.

## Test plan
- [x] `pnpm exec turbo run test --filter=bb-plugin-tasks` (308 passed)
- [x] `pnpm exec turbo run typecheck build --filter=bb-plugin-tasks`
- [x] Live Tasks detail: Enter submit, Shift+Enter newline, double-Enter single-flight, Cmd+Enter, button path
- [x] CLI `bb tasks show` corroboration of UI-posted comments
- [x] Independent review: provider codex / gpt-5.6-sol / medium / readonly → **APPROVE**

## Task
BB-47