### PR TITLE
BB-56: Inline workflow view polish — calmer shimmer, no Running pill, phase auto-collapse

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadWorkflowCard.tsx
@@ -12,10 +12,7 @@ import {
 } from "@/components/ui/activity-row-styles";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-import {
-  WorkflowPhaseStrip,
-  WorkflowStatusPill,
-} from "@bb/shared-ui/workflow-progress";
+import { WorkflowPhaseStrip } from "@bb/shared-ui/workflow-progress";
 
 const WORKFLOW_CARD_ROW_HEIGHT = 32;
 const BODY_ID = "thread-workflow-card-body";
@@ -130,7 +127,6 @@ export function ThreadWorkflowCard({
               <WorkflowDuration startedAt={workflow.startedAt} />
             </span>
           </span>
-          <WorkflowStatusPill state="running" />
           <Icon
             name="ChevronDown"
             className={cn(

--- a/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.test.tsx
+++ b/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.test.tsx
@@ -59,6 +59,59 @@ describe("WorkflowWorkRowBody", () => {
     expect(screen.getByText("Adversarial review")).toBeTruthy();
   });
 
+  it("auto-collapses completed phases and keeps concurrent phases open", () => {
+    const pipelined = {
+      phases: [
+        { index: 1, title: "Discover" },
+        { index: 2, title: "Review" },
+        { index: 3, title: "Verify" },
+      ],
+      agents: [
+        { ...progress.agents[0]!, index: 1, label: "Settled scan" },
+        {
+          ...progress.agents[1]!,
+          index: 2,
+          label: "Straggler scan",
+          phaseIndex: 1,
+        },
+        { ...progress.agents[1]!, index: 3, label: "Adversarial review" },
+      ],
+    };
+    render(
+      <WorkflowWorkRowBody
+        row={workflowRow({ status: "pending", workflow: pipelined })}
+        size="base"
+        collapsiblePhases
+      />,
+    );
+
+    // Discover still has a running agent, so it stays open alongside the
+    // Review phase even though Review is the pipeline's newest phase.
+    expect(screen.getByText("Straggler scan")).toBeTruthy();
+    expect(screen.getByText("Adversarial review")).toBeTruthy();
+    expect(screen.getByText("not started")).toBeTruthy();
+
+    // Once Discover's agents all settle it folds away on the next render.
+    cleanup();
+    const settledDiscover = {
+      ...pipelined,
+      agents: pipelined.agents.map((agent) =>
+        agent.phaseIndex === 1 ? { ...agent, state: "done" as const } : agent,
+      ),
+    };
+    render(
+      <WorkflowWorkRowBody
+        row={workflowRow({ status: "pending", workflow: settledDiscover })}
+        size="base"
+        collapsiblePhases
+      />,
+    );
+    expect(screen.queryByText("Straggler scan")).toBeNull();
+    expect(screen.getByText("Adversarial review")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Discover2\/2/ }));
+    expect(screen.getByText("Straggler scan")).toBeTruthy();
+  });
+
   it("still derives stopped agents when a workflow settles mid-flight", () => {
     render(
       <WorkflowWorkRowBody

--- a/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.test.tsx
+++ b/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.test.tsx
@@ -59,7 +59,7 @@ describe("WorkflowWorkRowBody", () => {
     expect(screen.getByText("Adversarial review")).toBeTruthy();
   });
 
-  it("auto-collapses completed phases and keeps concurrent phases open", () => {
+  it("auto-collapses completed phases live while manual toggles survive", () => {
     const pipelined = {
       phases: [
         { index: 1, title: "Discover" },
@@ -77,7 +77,7 @@ describe("WorkflowWorkRowBody", () => {
         { ...progress.agents[1]!, index: 3, label: "Adversarial review" },
       ],
     };
-    render(
+    const { rerender } = render(
       <WorkflowWorkRowBody
         row={workflowRow({ status: "pending", workflow: pipelined })}
         size="base"
@@ -91,15 +91,20 @@ describe("WorkflowWorkRowBody", () => {
     expect(screen.getByText("Adversarial review")).toBeTruthy();
     expect(screen.getByText("not started")).toBeTruthy();
 
-    // Once Discover's agents all settle it folds away on the next render.
-    cleanup();
+    // Manually collapse the running Review phase to prove overrides survive
+    // later default flips.
+    fireEvent.click(screen.getByRole("button", { name: /Review0\/1/ }));
+    expect(screen.queryByText("Adversarial review")).toBeNull();
+
+    // Discover's straggler settles mid-run: the live component folds it
+    // automatically, while Review keeps its manual override.
     const settledDiscover = {
       ...pipelined,
       agents: pipelined.agents.map((agent) =>
         agent.phaseIndex === 1 ? { ...agent, state: "done" as const } : agent,
       ),
     };
-    render(
+    rerender(
       <WorkflowWorkRowBody
         row={workflowRow({ status: "pending", workflow: settledDiscover })}
         size="base"
@@ -107,9 +112,43 @@ describe("WorkflowWorkRowBody", () => {
       />,
     );
     expect(screen.queryByText("Straggler scan")).toBeNull();
-    expect(screen.getByText("Adversarial review")).toBeTruthy();
+    expect(screen.queryByText("Adversarial review")).toBeNull();
+
+    // Manual reopen still wins over the collapsed default.
     fireEvent.click(screen.getByRole("button", { name: /Discover2\/2/ }));
     expect(screen.getByText("Straggler scan")).toBeTruthy();
+  });
+
+  it("keeps a phase with a failed agent open while the workflow runs", () => {
+    const withFailure = {
+      phases: [
+        { index: 1, title: "Discover" },
+        { index: 2, title: "Review" },
+      ],
+      agents: [
+        { ...progress.agents[0]!, index: 1, label: "Settled scan" },
+        {
+          ...progress.agents[0]!,
+          index: 2,
+          label: "Broken scan",
+          state: "failed" as const,
+          phaseIndex: 1,
+        },
+        { ...progress.agents[1]!, index: 3, label: "Adversarial review" },
+      ],
+    };
+    render(
+      <WorkflowWorkRowBody
+        row={workflowRow({ status: "pending", workflow: withFailure })}
+        size="base"
+        collapsiblePhases
+      />,
+    );
+
+    // Discover's agents are all settled, but the failure keeps it open so the
+    // problem stays visible while the rest of the run continues.
+    expect(screen.getByText("Broken scan")).toBeTruthy();
+    expect(screen.getByText("Adversarial review")).toBeTruthy();
   });
 
   it("still derives stopped agents when a workflow settles mid-flight", () => {

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -791,6 +791,22 @@ body.sidebar-resizing [data-sidebar="panel"] {
     mask: url(/bb-mark.svg) center / contain no-repeat;
     background-color: var(--foreground);
   }
+
+  /* Reduced motion: drop the shimmer sweep and render the active cue as plain
+     full-strength foreground text/glyph instead of a frozen gradient/mask. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-shine {
+      animation: none;
+      background: none;
+      -webkit-text-fill-color: currentColor;
+    }
+
+    .animate-shine-icon {
+      animation: none;
+      -webkit-mask-image: none;
+      mask-image: none;
+    }
+  }
 }
 
 @keyframes shine {

--- a/apps/web/src/components/ui/theme.css
+++ b/apps/web/src/components/ui/theme.css
@@ -786,6 +786,22 @@ body.sidebar-resizing [data-sidebar="panel"] {
     mask: url(/bb-mark.svg) center / contain no-repeat;
     background-color: var(--foreground);
   }
+
+  /* Reduced motion: drop the shimmer sweep and render the active cue as plain
+     full-strength foreground text/glyph instead of a frozen gradient/mask. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-shine {
+      animation: none;
+      background: none;
+      -webkit-text-fill-color: currentColor;
+    }
+
+    .animate-shine-icon {
+      animation: none;
+      -webkit-mask-image: none;
+      mask-image: none;
+    }
+  }
 }
 
 @keyframes shine {

--- a/packages/shared-ui/src/components/ui/workflow-progress.tsx
+++ b/packages/shared-ui/src/components/ui/workflow-progress.tsx
@@ -61,6 +61,9 @@ interface WorkflowPhaseGroup {
 const ACTIVE_PHASE_SCROLL_OFFSET = 12;
 const PROMPT_STACK_ACTIVE_ROW_CLASS = "shadow-none ring-0";
 const PROMPT_STACK_ACTIVE_ICON_CLASS = "text-foreground";
+// Inside the phase tree the shine shimmer is reserved for the card's top-level
+// header; running rows already carry a spinner, so their text stays static.
+const PROMPT_STACK_ACTIVE_TEXT_CLASS = "font-medium text-foreground";
 
 function isSettledAgentState(state: WorkflowProgressAgentState): boolean {
   return (
@@ -268,6 +271,16 @@ function promptStackActivityIconClass(
   return activityIconClass(state, className);
 }
 
+function promptStackActivityTextClass(
+  state: ActivityRowState,
+  className?: string,
+): string {
+  if (state === "active") {
+    return cn(PROMPT_STACK_ACTIVE_TEXT_CLASS, className);
+  }
+  return activityTextClass(state, className);
+}
+
 function WorkflowAgentLine({
   agent,
   onActivate,
@@ -297,7 +310,7 @@ function WorkflowAgentLine({
       <span
         className={
           promptStack
-            ? activityTextClass(
+            ? promptStackActivityTextClass(
                 activityState,
                 "min-w-0 truncate text-xs no-underline",
               )
@@ -578,7 +591,7 @@ function CollapsiblePhaseSection({
       >
         <span className="size-3 shrink-0" aria-hidden="true" />
         <span
-          className={activityTextClass(
+          className={promptStackActivityTextClass(
             activityState,
             "text-xs font-medium no-underline",
           )}
@@ -619,7 +632,7 @@ function CollapsiblePhaseSection({
           aria-hidden="true"
         />
         <span
-          className={activityTextClass(
+          className={promptStackActivityTextClass(
             activityState,
             "text-xs font-medium no-underline",
           )}
@@ -660,15 +673,20 @@ function CollapsiblePhaseGroups({
   const [overrides, setOverrides] = useState<ReadonlyMap<string, boolean>>(
     () => new Map(),
   );
-  // While running, follow the active phase. Once the workflow settles,
-  // cleanly-finished phases collapse; phases holding failed, cancelled, or
-  // stopped-mid-flight agents stay open so the reason is visible.
+  // While running, phases auto-collapse as they complete: any phase with
+  // in-flight or failed agents stays open (pipelines can run several phases at
+  // once), a cleanly-finished phase folds away. Once the workflow settles,
+  // phases holding failed, cancelled, or stopped-mid-flight agents stay open
+  // so the reason is visible.
   const defaultExpanded = (key: string, group: WorkflowPhaseGroup): boolean =>
     workflowSettled
       ? group.agents.some(
           (agent) => agent.state !== "done" && agent.state !== "skipped",
         )
-      : key === activeKey;
+      : group.agents.some(
+          (agent) =>
+            !isSettledAgentState(agent.state) || agent.state === "failed",
+        );
   const isExpanded = (key: string, group: WorkflowPhaseGroup): boolean =>
     overrides.get(key) ?? defaultExpanded(key, group);
   const toggle = (key: string, group: WorkflowPhaseGroup) =>
@@ -748,14 +766,12 @@ export function WorkflowProgress({
 
 export type WorkflowStatusPillState =
   | "queued"
-  | "running"
   | "completed"
   | "failed"
   | "cancelled";
 
 const STATUS_PILL_LABEL: Record<WorkflowStatusPillState, string> = {
   queued: "Queued",
-  running: "Running",
   completed: "Complete",
   failed: "Failed",
   cancelled: "Cancelled",
@@ -764,7 +780,8 @@ const STATUS_PILL_LABEL: Record<WorkflowStatusPillState, string> = {
 /**
  * Compact status chip shown in the same top-right slot of every workflow
  * surface (inline card header and right panel header), so status always reads
- * from the same place.
+ * from the same place. There is deliberately no "running" pill: a live run
+ * already reads as active from the header shimmer, phase strip, and spinners.
  */
 export function WorkflowStatusPill({
   state,
@@ -776,18 +793,6 @@ export function WorkflowStatusPill({
   const base =
     "inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-2 py-0.5 text-2xs font-medium";
   switch (state) {
-    case "running":
-      return (
-        <span
-          className={cn(base, "bg-surface-recessed text-foreground", className)}
-        >
-          <span
-            className="size-1.5 shrink-0 animate-pulse rounded-full bg-success"
-            aria-hidden="true"
-          />
-          {STATUS_PILL_LABEL[state]}
-        </span>
-      );
     case "queued":
       return (
         <span

--- a/plugins/workflows/src/app.test.tsx
+++ b/plugins/workflows/src/app.test.tsx
@@ -139,6 +139,20 @@ describe("workflow-preview directive", () => {
     expect(slot.getAllByText("Review")).toHaveLength(1);
     expect(slot.getByText("Adversarial review")).toBeTruthy();
     expect(slot.getByText("claude · opus-4-6 · high")).toBeTruthy();
+    // A live run has no "Running" pill, and only the top-level header
+    // shimmers — phase and agent rows stay static (agents have spinners).
+    expect(slot.queryByText("Running")).toBeNull();
+    expect(
+      slot.getByText("Review the release").className.includes("animate-shine"),
+    ).toBe(true);
+    expect(
+      slot.getByText("Adversarial review").className.includes("animate-shine"),
+    ).toBe(false);
+    expect(
+      slot
+        .getAllByText("Review")[0]!
+        .className.includes("animate-shine"),
+    ).toBe(false);
 
     const workflowToggle = slot.getByRole("button", {
       name: "Workflow: Review the release",
@@ -246,13 +260,14 @@ describe("workflow-preview directive", () => {
     expect(slot.getByRole("alert").textContent).toMatch(/initial outage/i);
 
     await act(async () => vi.advanceTimersByTimeAsync(1_000));
-    expect(slot.getByText("Running")).toBeTruthy();
+    expect(slot.getByText("Review the release")).toBeTruthy();
+    expect(slot.queryByText("Complete")).toBeNull();
 
     await act(async () => vi.advanceTimersByTimeAsync(1_000));
     expect(slot.getByRole("status").textContent).toMatch(
       /poll outage.*retrying/i,
     );
-    expect(slot.getByText("Running")).toBeTruthy();
+    expect(slot.getByText("Review the release")).toBeTruthy();
 
     await act(async () => vi.advanceTimersByTimeAsync(1_000));
     expect(slot.getByText("Complete")).toBeTruthy();
@@ -308,7 +323,8 @@ describe("workflow-preview directive", () => {
     );
 
     await act(async () => Promise.resolve());
-    expect(slot.getByText("Running")).toBeTruthy();
+    expect(slot.getByText("Review the release")).toBeTruthy();
+    expect(slot.queryByText("Complete")).toBeNull();
 
     await act(async () => vi.advanceTimersByTimeAsync(1_000));
     expect(attempt).toBe(2);

--- a/plugins/workflows/src/app.tsx
+++ b/plugins/workflows/src/app.tsx
@@ -110,14 +110,16 @@ function settledAgentCount(agents: readonly WorkflowProgressAgent[]): number {
   ).length;
 }
 
+// A running workflow shows no pill: the shimmering header, phase strip, and
+// per-agent spinners already say it is live.
 function runPillState(
   status: WorkflowRunView["status"],
-): WorkflowStatusPillState {
+): WorkflowStatusPillState | null {
   switch (status) {
     case "queued":
       return "queued";
     case "running":
-      return "running";
+      return null;
     case "succeeded":
       return "completed";
     case "failed":
@@ -365,6 +367,7 @@ function WorkflowPreviewLoaded({
   const run = state.run;
   const shared = buildSharedWorkflowView(run);
   const activityState = runActivityState(run);
+  const pillState = runPillState(run.status);
   const duration = formatDuration(run.startedAt, run.finishedAt);
   const settledAgents = settledAgentCount(shared.progress.agents);
   return (
@@ -421,7 +424,7 @@ function WorkflowPreviewLoaded({
             </span>
           )}
         </span>
-        <WorkflowStatusPill state={runPillState(run.status)} />
+        {pillState === null ? null : <WorkflowStatusPill state={pillState} />}
         <Icon
           name="ChevronDown"
           className={cn(
@@ -535,6 +538,7 @@ function WorkflowRunPanelLoaded({
       <EmptyOrError>No workflow runs were found for this thread.</EmptyOrError>
     );
   }
+  const pillState = runPillState(run.status);
   const duration = formatDuration(run.startedAt, run.finishedAt);
   const settledAgents = settledAgentCount(shared.progress.agents);
   const completedCalls = shared.progress.agents.filter(
@@ -570,7 +574,9 @@ function WorkflowRunPanelLoaded({
               {run.description}
             </p>
           </div>
-          <WorkflowStatusPill state={runPillState(run.status)} />
+          {pillState === null ? null : (
+            <WorkflowStatusPill state={pillState} />
+          )}
         </div>
         <div className="mt-2 flex items-center gap-2 text-2xs tabular-nums text-subtle-foreground">
           <span>


### PR DESCRIPTION
Closes BB-56 (Tasks plugin).

## What changed

All three workflow surfaces share one renderer (`@bb/shared-ui/workflow-progress`), so these land once and apply to the workflows-plugin inline chat card, its right panel, and the built-in Claude Code prompt-stack card:

- **Shimmer only at the top.** `animate-shine` is now reserved for the card's top-level header; phase titles and agent rows in the collapsible tree render static emphasis (running agents already carry spinners).
- **Running pill removed.** `WorkflowStatusPill` drops its `running` state everywhere — a live run reads from the header shimmer, the pulsing phase-strip segment, and per-agent spinners. Queued/Complete/Failed/Cancelled pills remain.
- **Phases auto-collapse as they complete.** While running, a phase's default expansion is now "has unsettled or failed agents" instead of "is the single active phase": completed phases fold immediately, concurrent pipeline phases stay open, failed phases stay open, and manual toggles always override.
- **Reduced motion respected** (found during QA, pre-existing): `.animate-shine`/`.animate-shine-icon` now stop under `prefers-reduced-motion: reduce` in both app and web theme.css.

## Validation

- Turbo typecheck + tests green for `@bb/shared-ui`, `@bb/app` (1609 tests), `bb-plugin-workflows`, `@bb/web`; new tests pin the pill removal, shimmer scoping, live auto-collapse transition (rerender, override retention), and failed-phase-stays-open behavior.
- Live Product Review Report QA in an isolated `bb-dev-app` instance: four real workflow runs (succeeded ×2, failed, cancelled) driven through the actual agent → `bb_workflow_run` → directive loop; realtime auto-collapse observed without reload; reload/deep-link reconciliation; right-panel parity + Stop; CLI parity; keyboard/ARIA audit; light/dark/Nord themes; 560px narrow; reduced-motion reverified after the fix. Full report, coverage ledger, and evidence archive attached to BB-56.
- Single independent review (codex `gpt-5.6-sol`, medium, readonly): one P2 (test exercised remount instead of a live transition) — fixed in the final commit; no P0/P1.

## Risk

UI-only; no server/daemon wire changes (no protocol bump needed). Main behavioral risk is the new expansion default in `CollapsiblePhaseGroups`, which is covered by the new live-transition tests and was observed against real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)