### PR TITLE
BB-46: Reserve macOS traffic-light safe area for the collapsed split panel

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getReservedInlinePanelToggleClassName } from "./ThreadSecondaryPanel";
+import {
+  getReservedInlinePanelToggleClassName,
+  resolveCollapsedPanelTrafficLightReserveClassName,
+} from "./ThreadSecondaryPanel";
+import { MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS } from "@/lib/bb-desktop";
 
 // The reserved inline-toggle slot sits under root compose's pinned right-panel
 // toggle. On macOS desktop the top chrome is an [app-region:drag] window-drag
@@ -21,5 +25,81 @@ describe("getReservedInlinePanelToggleClassName", () => {
     const className = getReservedInlinePanelToggleClassName(false);
 
     expect(className).not.toContain("app-region");
+  });
+});
+
+// BB-46: while the conversation is collapsed inside the split-workspace host and
+// the main sidebar is collapsed, the panel is the window's flush top-left
+// surface, so its leading toolbar shares the title-bar row with the macOS
+// traffic lights and the pinned sidebar trigger. Without the reserve the
+// leading Info/tab controls render under the lights and directly over the
+// sidebar trigger (BB-46's collapsed-left / expanded-right conflict).
+describe("resolveCollapsedPanelTrafficLightReserveClassName", () => {
+  const base = {
+    isConversationCollapsed: true,
+    renderAsDrawer: false,
+    isInSplitHost: true,
+    isSidebarShowing: false as boolean | null,
+    reserveMacosTrafficLights: true,
+  };
+
+  it("reserves the safe area for the collapsed-left / expanded-right split host case", () => {
+    expect(resolveCollapsedPanelTrafficLightReserveClassName(base)).toBe(
+      MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS,
+    );
+  });
+
+  it("does not reserve when the main sidebar is showing (it hosts the lights)", () => {
+    expect(
+      resolveCollapsedPanelTrafficLightReserveClassName({
+        ...base,
+        isSidebarShowing: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reserve inline (non-host) thread detail, which keeps a header on the lights' row", () => {
+    expect(
+      resolveCollapsedPanelTrafficLightReserveClassName({
+        ...base,
+        isInSplitHost: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reserve when the conversation is expanded (panel sits on the right)", () => {
+    expect(
+      resolveCollapsedPanelTrafficLightReserveClassName({
+        ...base,
+        isConversationCollapsed: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reserve in the compact drawer layout", () => {
+    expect(
+      resolveCollapsedPanelTrafficLightReserveClassName({
+        ...base,
+        renderAsDrawer: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reserve off macOS chrome or in fullscreen (no visible lights)", () => {
+    expect(
+      resolveCollapsedPanelTrafficLightReserveClassName({
+        ...base,
+        reserveMacosTrafficLights: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats an absent sidebar context (null) as showing, so it does not reserve", () => {
+    expect(
+      resolveCollapsedPanelTrafficLightReserveClassName({
+        ...base,
+        isSidebarShowing: null,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -61,10 +61,14 @@ import {
   CHROME_ROW_CLASS,
   getBbDesktopInfo,
   MACOS_APP_REGION_NO_DRAG_CLASS,
+  MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS,
   MACOS_WINDOW_DRAG_CLASS,
   MACOS_WINDOW_NO_DRAG_CLASS,
+  shouldReserveMacosTrafficLights,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
+import { useDesktopWindowState } from "@/hooks/useDesktopWindowState";
+import { useOptionalIsSidebarShowing } from "@/components/ui/sidebar.js";
 import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import type { SecondaryFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
@@ -110,6 +114,57 @@ export function getReservedInlinePanelToggleClassName(
     SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS,
     usesDesktopChrome && MACOS_APP_REGION_NO_DRAG_CLASS,
   );
+}
+
+interface CollapsedPanelTrafficLightReserveArgs {
+  /** The conversation is collapsed, so this panel fills the content area. */
+  isConversationCollapsed: boolean;
+  /** The compact drawer layout (never the window's top-left surface). */
+  renderAsDrawer: boolean;
+  /**
+   * True inside the split-workspace host — the only surface where the panel
+   * itself owns the window's flush top-left corner while the conversation is
+   * collapsed. Inline (non-split) thread detail keeps a full-width header on the
+   * traffic-light row above the panel, so it needs no reserve here.
+   */
+  isInSplitHost: boolean;
+  /**
+   * Whether the main app sidebar is showing. `null` when the sidebar context is
+   * absent (e.g. tests) — treated as showing, so no reserve is applied. The
+   * sidebar hosts the traffic lights in its own top strip while open.
+   */
+  isSidebarShowing: boolean | null;
+  /**
+   * Whether macOS traffic lights are visible (macOS desktop chrome, not
+   * fullscreen). False on the web build and in fullscreen, where the lights are
+   * hidden.
+   */
+  reserveMacosTrafficLights: boolean;
+}
+
+/**
+ * Left-padding class that clears the macOS traffic-light safe area for the
+ * secondary panel's leading top-chrome toolbar, or `false` when no reserve is
+ * needed. The reserve applies only when the panel is the window's flush
+ * top-left surface (split host, conversation collapsed) while the main sidebar
+ * is collapsed and the lights are visible — the collapsed-left / expanded-right
+ * case from BB-46. See {@link MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS}
+ * for the geometry.
+ */
+export function resolveCollapsedPanelTrafficLightReserveClassName({
+  isConversationCollapsed,
+  renderAsDrawer,
+  isInSplitHost,
+  isSidebarShowing,
+  reserveMacosTrafficLights,
+}: CollapsedPanelTrafficLightReserveArgs): string | false {
+  const reserves =
+    isConversationCollapsed &&
+    !renderAsDrawer &&
+    isInSplitHost &&
+    isSidebarShowing === false &&
+    reserveMacosTrafficLights;
+  return reserves && MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS;
 }
 
 interface ResolveActiveFixedPanelArgs {
@@ -403,6 +458,23 @@ export function ThreadSecondaryPanel({
   const [gitDiffLineOverflowMode, setGitDiffLineOverflowMode] =
     useState<CodeOverflowMode>(DEFAULT_CODE_OVERFLOW_MODE);
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
+  const desktopWindowState = useDesktopWindowState();
+  const isSidebarShowing = useOptionalIsSidebarShowing();
+  // The panel reserves the traffic-light safe area only when it is the window's
+  // flush top-left surface (split-workspace host, conversation collapsed) with
+  // the main sidebar collapsed and the lights visible. See
+  // resolveCollapsedPanelTrafficLightReserveClassName.
+  const collapsedPanelTrafficLightReserveClassName =
+    resolveCollapsedPanelTrafficLightReserveClassName({
+      isConversationCollapsed,
+      renderAsDrawer,
+      isInSplitHost: hostLayout !== null,
+      isSidebarShowing,
+      reserveMacosTrafficLights: shouldReserveMacosTrafficLights({
+        desktopInfo,
+        windowState: desktopWindowState,
+      }),
+    });
   const preferredTheme = usePreferredTheme();
   const gitDiffViewOptions = useMemo(
     () => ({
@@ -491,7 +563,23 @@ export function ThreadSecondaryPanel({
           )}
         >
           <div
-            className="flex min-w-0 flex-1 items-center gap-1"
+            className={cn(
+              "flex min-w-0 flex-1 items-center gap-1",
+              // When this panel owns the window's top-left (split host, sidebar
+              // collapsed, conversation collapsed), reserve the traffic-light
+              // safe area so the leading controls clear the lights and the
+              // pinned sidebar trigger. The padding must animate on the SAME
+              // timing/easing as the panel's collapse slide
+              // (PANEL_COLLAPSE_TRANSITION_CLASS): the panel's left edge starts
+              // well right of 120px and both ease to their endpoints together,
+              // so the combined inset (panel-left + px-4 + padding) decreases
+              // monotonically to exactly 120px and never dips below it
+              // mid-animation. A faster/looser padding transition would let the
+              // panel reach the left edge before the padding fills, briefly
+              // sliding the leading controls back under the lights/trigger.
+              `transition-[padding] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
+              collapsedPanelTrafficLightReserveClassName,
+            )}
             // A toolbar, not a tablist: the Info/Diff controls and file tabs are
             // toggle buttons (`aria-pressed`) rather than `role="tab"` widgets
             // backed by tabpanels, so `role="tablist"` would be malformed. Toolbar

--- a/apps/app/src/lib/bb-desktop.test.ts
+++ b/apps/app/src/lib/bb-desktop.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { BbDesktopInfo } from "@bb/desktop-contract";
 import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
-import { shouldReserveMacosTrafficLights } from "./bb-desktop";
+import {
+  MACOS_COLLAPSED_HEADER_RESERVE_CLASS,
+  MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS,
+  MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
+  shouldReserveMacosTrafficLights,
+} from "./bb-desktop";
 
 const desktopInfo: BbDesktopInfo = {
   lastCheckedAt: null,
@@ -35,5 +40,39 @@ describe("desktop chrome geometry", () => {
         windowState: { isFullScreen: false },
       }),
     ).toBe(false);
+  });
+
+  // The traffic-light reserves are paired px geometry, not typography. Both the
+  // page header and the collapsed split-workspace panel must land their leading
+  // content at the SAME absolute x (just right of the pinned sidebar trigger)
+  // despite starting from different base insets — the header from its `px-4`
+  // (16px) and the panel from behind the 36px conversation rail plus its own
+  // `px-4` (52px). A silent drift here reintroduces BB-46's overlap, so lock the
+  // shared target.
+  it("lands both collapsed reserves at the same traffic-light-clearing target", () => {
+    const px = (className: string): number => {
+      const match = /\[(\d+)px\]/.exec(className);
+      if (match === null) {
+        throw new Error(`no px token in "${className}"`);
+      }
+      return Number(match[1]);
+    };
+
+    const TRIGGER_OFFSET = px(MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS); // 84
+    const TRIGGER_BUTTON = 28;
+    const TRIGGER_GAP = 8;
+    // Where the pinned sidebar trigger ends: leading content must clear it.
+    const TARGET = TRIGGER_OFFSET + TRIGGER_BUTTON + TRIGGER_GAP; // 120
+
+    const HEADER_BASE_INSET = 16; // header px-4
+    const RAIL_WIDTH = 36; // ConversationCollapsedRail (w-9)
+    const PANEL_BASE_INSET = RAIL_WIDTH + 16; // rail + panel top-chrome px-4
+
+    expect(HEADER_BASE_INSET + px(MACOS_COLLAPSED_HEADER_RESERVE_CLASS)).toBe(
+      TARGET,
+    );
+    expect(
+      PANEL_BASE_INSET + px(MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS),
+    ).toBe(TARGET);
   });
 });

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -6,28 +6,31 @@ import type {
 
 // The macOS traffic-light cluster sits in a fixed strip on the left of the
 // frameless window. In-flow chrome clears it with left padding; the pinned
-// sidebar trigger clears it with a matching left offset. These are fixed px
-// geometry values because they are paired with Electron/macOS window-control
-// coordinates, not app typography.
+// sidebar trigger clears it with a matching left offset (`left: 84px`). These
+// are fixed px geometry values because they are paired with Electron/macOS
+// window-control coordinates, not app typography.
 //
-// Two reserve steps, one target — the leading content lands just right of the
-// pinned sidebar trigger (`left: 84px`), not merely past the lights:
-//  - RESERVE (`padding-left: 84px`): the full reserve, applied directly by a surface whose
-//    left padding replaces its base inset. The secondary-panel header uses it —
-//    it sits right of the 36px conversation rail, so the trigger overhangs the
-//    header's left edge and the leading tab has to clear the trigger, not just
-//    the lights.
-//  - COLLAPSED_HEADER_RESERVE (`padding-left: 104px`): the page header folds the
-//    whole pinned-trigger footprint into a single left padding: the 84px
-//    clear-the-lights step less the header's own `px-4` (84 − 16 = 68) lands at
-//    the trigger's left edge, plus the trigger's own width (28px) and the
-//    `gap-2` after it (8px) = 104px, so the leading content sits just right of
-//    the trigger. It is one padding rather than padding + a spacer element so it
-//    can transition in lockstep with the sidebar slide — otherwise it snaps on
-//    and off instantly while the inset animates and the header jumps on toggle.
-export const MACOS_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[84px]";
+// One shared target: when the main sidebar is collapsed the pinned sidebar
+// trigger (84px + a 28px button + an 8px gap = the strip ends at 120px) is the
+// last thing on the title-bar row, so a surface that owns the window's
+// top-left must land its leading content at x = 120px — just right of the
+// trigger, not merely past the lights. Two reserves reach that same 120px from
+// different base insets, each folded into a single left padding (rather than
+// padding + a spacer element) so it can transition in lockstep with the sidebar
+// slide instead of snapping on/off while the inset animates:
+//  - COLLAPSED_HEADER_RESERVE (`padding-left: 104px`): the page header content
+//    starts at its own `px-4` (16px); 16 + 104 = 120.
+//  - COLLAPSED_PANEL_RESERVE (`padding-left: 68px`): the split-workspace
+//    secondary panel, while the conversation is collapsed, is flush at the
+//    window top-left behind the 36px conversation rail, and its top chrome adds
+//    `px-4` (16px), so its leading toolbar starts at 36 + 16 = 52px; 52 + 68 =
+//    120. (This is the only surface where the panel itself owns the window's
+//    top-left — inline non-split thread detail keeps a full-width header on the
+//    lights' row above the panel, and root compose keeps the panel on the right
+//    of the main content.)
 export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[84px]";
 export const MACOS_COLLAPSED_HEADER_RESERVE_CLASS = "pl-[104px]";
+export const MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS = "pl-[68px]";
 
 // Browser-chrome analogs of the macOS reserve above. The web build has no
 // traffic lights, so it pins the sidebar toggle flush at the app's top-left with

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -38,6 +38,12 @@ import {
   usePaneSecondaryPanelRegistration,
   type PaneSecondaryPanelViewModel,
 } from "./PaneContext";
+import { useOptionalIsSidebarShowing } from "@/components/ui/sidebar.js";
+import {
+  getBbDesktopInfo,
+  shouldReserveMacosTrafficLights,
+} from "@/lib/bb-desktop";
+import { useDesktopWindowState } from "@/hooks/useDesktopWindowState";
 
 const CLOSED_TIMELINE_PANEL_SIZE_PERCENT = 100;
 const COLLAPSED_TIMELINE_PANEL_SIZE_PERCENT = 0;
@@ -104,6 +110,24 @@ export function ThreadDetailSecondaryContent({
   const persistedSecondaryWidthPercent = useAtomValue(
     secondaryPanelWidthPercentAtom,
   );
+  // The hosted (split-workspace) collapsed rail is the window's top-left-most
+  // surface while the main sidebar is collapsed on macOS desktop: it must
+  // reserve a title-bar-height strip so the traffic lights sit on clean window
+  // chrome instead of on the rail's glyph/working indicator. When the sidebar
+  // is open it hosts the lights itself and the rail sits to its right; the
+  // inline (non-host) rail always sits below a full-width header on the lights'
+  // row, so neither needs the reserve there.
+  // `null` (no sidebar context, e.g. tests) is treated as showing, so no
+  // reserve is applied.
+  const isSidebarShowing = useOptionalIsSidebarShowing();
+  const [desktopInfo] = useState(getBbDesktopInfo);
+  const desktopWindowState = useDesktopWindowState();
+  const hostedRailReservesTrafficLights =
+    isSidebarShowing === false &&
+    shouldReserveMacosTrafficLights({
+      desktopInfo,
+      windowState: desktopWindowState,
+    });
   // Collapsing the conversation only makes sense on a wide viewport with the
   // secondary panel open — there is otherwise nothing to expand into.
   const canCollapseConversation = isSecondaryPanelOpen && !renderAsDrawer;
@@ -318,11 +342,12 @@ export function ThreadDetailSecondaryContent({
       <ConversationCollapsedRail
         collapsed={isConversationCollapsedActive}
         isWorking={isConversationWorking}
-        reserveTopForDesktopTrafficLights={false}
+        reserveTopForDesktopTrafficLights={hostedRailReservesTrafficLights}
         onExpand={onToggleConversationCollapse}
       />
     ),
     [
+      hostedRailReservesTrafficLights,
       isConversationCollapsedActive,
       isConversationWorking,
       onToggleConversationCollapse,
@@ -394,6 +419,9 @@ export function ThreadDetailSecondaryContent({
         <ConversationCollapsedRail
           collapsed={isConversationCollapsedActive}
           isWorking={isConversationWorking}
+          // The inline (non-split) surface keeps a full-width thread header on
+          // the traffic-light row above this rail, so the lights never reach the
+          // rail's glyph — only the hosted split rail owns the window top-left.
           reserveTopForDesktopTrafficLights={false}
           onExpand={onToggleConversationCollapse}
         />


### PR DESCRIPTION
## BB-46 — Prevent sidebar controls from conflicting with macOS traffic lights

### Bug
In the macOS desktop app, collapsing the left sidebar while the split-workspace secondary panel is expanded and the conversation is collapsed makes the panel the window's flush top-left surface. Neither the 36px collapsed-conversation rail nor the panel's leading top-chrome toolbar reserved the traffic-light safe area, so:

- the rail's chat glyph / working spinner rendered **under the traffic lights**, and
- the panel's leading Info/Diff/＋/tab controls rendered under the lights **and directly on top of the pinned sidebar trigger** (New tab button and trigger both at `left:84px`).

This matches the reported screenshot.

### Fix
A single traffic-light safe-area target (x = 120px, just right of the pinned trigger) that surfaces owning the window top-left land on:

- **`ThreadDetailSecondaryContent`** — the hosted (split) collapsed rail now reserves the title-bar strip when the sidebar is collapsed and macOS lights are visible (was hardcoded `false` at both call sites), lifting its glyph/spinner below the lights. The inline (non-split) rail stays `false` — it sits below a full-width header on the lights' row.
- **`ThreadSecondaryPanel`** — new pure helper `resolveCollapsedPanelTrafficLightReserveClassName` adds a left reserve (`pl-[68px]`) to the leading toolbar only when the panel owns the window's flush top-left (split host + conversation collapsed + sidebar collapsed + lights visible). Padding animates on the shared `PANEL_COLLAPSE_TRANSITION_CLASS`, so the combined inset stays ≥ 120px throughout the collapse (no transient overlap).
- **`bb-desktop.ts`** — removed the exported-but-unused `MACOS_TRAFFIC_LIGHT_RESERVE_CLASS` (whose doc falsely claimed the secondary-panel header used it); added `MACOS_COLLAPSED_PANEL_TRAFFIC_LIGHT_RESERVE_CLASS` with the shared-target derivation.

All other sidebar/window states are untouched (sidebar-open hosts the lights itself; inline non-split keeps its header band; root compose keeps the panel on the right; drawer/fullscreen/non-macOS never reserve).

### Validation
- Reproduced and fixed in the **real Electron desktop shell** (CDP-driven, `platform=macos`). Before: rail glyph y=16 (over red light), Info @x=52 (over green light), New tab @x=84 (== sidebar trigger). After: glyph y=64 (below lights), Info @x=120, New tab @x=152; reserve toggles correctly with sidebar state; leading toolbar computed `transition: padding 0.22s cubic-bezier(0.32,0.72,0,1)`.
- `turbo run typecheck test build --filter=@bb/app` all green (241 test files). 20 targeted unit tests: 7-case reserve decision matrix + shared 120px geometry-contract test.
- No server/host-daemon wire contract touched — `HOST_DAEMON_PROTOCOL_VERSION` unchanged (confirmed by review).

### Review
One independent review (codex · gpt-5.6-sol · medium · read-only) → REQUEST CHANGES on one P2 (reserve transition timing mismatch causing a transient mid-collapse overlap). Fixed by matching the panel-slide timing; re-ran affected automated + live QA. No second review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
