### PR TITLE
Show queued message send/edit/delete as icon buttons on desktop

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -183,23 +183,40 @@ describe("QueuedMessagesList", () => {
     ).toBe("workspace");
   });
 
-  it("uses one hover-revealed overflow action and a grip-only drag handle", () => {
+  it("uses hover-revealed icon actions on desktop and an overflow menu on mobile widths", () => {
     const { container, getByRole } = renderQueuedMessages([
       makeQueuedMessage("q_one", "First queued message"),
     ]);
 
-    expect(
-      getByRole("button", { name: "Queued message 1 actions" }).className,
-    ).toContain("opacity-0");
+    const sendButton = getByRole("button", {
+      name: "Send queued message 1 now",
+    });
+    const editButton = getByRole("button", {
+      name: "Edit queued message 1",
+    });
+    const deleteButton = getByRole("button", {
+      name: "Delete queued message 1",
+    });
+    const overflowButton = getByRole("button", {
+      name: "Queued message 1 actions",
+    });
+
+    expect(sendButton.closest("div")?.className).toContain("opacity-0");
+    expect(sendButton.closest("div")?.className).toContain("md:flex");
+    expect(sendButton.closest("div")?.className).toContain("hidden");
+    expect(editButton).toBeTruthy();
+    expect(deleteButton).toBeTruthy();
+    expect(overflowButton.className).toContain("md:hidden");
+    expect(overflowButton.className).toContain("opacity-0");
+    expect(container.querySelector('[data-icon="Sent"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="Edit"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="Trash2"]')).not.toBeNull();
     expect(
       container.querySelector('[data-icon="MoreHorizontal"]'),
     ).not.toBeNull();
     expect(
       container.querySelector('[data-icon="DragDropVertical"]'),
     ).not.toBeNull();
-    expect(
-      container.querySelector('[data-icon="ArrowTurnForward"]'),
-    ).toBeNull();
   });
 
   it("replaces the edited row with the real-composer target", () => {

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -708,51 +708,115 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
             {processingLabel}
           </span>
         ) : (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+          <>
+            <div
+              className={cn(
+                "pointer-events-none hidden shrink-0 items-center gap-0.5 opacity-0 transition-opacity md:flex",
+                "group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+                "group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100",
+              )}
+            >
               <Button
                 type="button"
                 size="icon"
                 variant="ghost"
                 className={cn(
-                  "pointer-events-none shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/row:pointer-events-auto group-hover/row:opacity-100 group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100 data-[state=open]:pointer-events-auto data-[state=open]:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
+                  "shrink-0 text-muted-foreground",
+                  compact ? "size-7" : "size-8",
+                )}
+                disabled={actionDisabled || sendDisabled}
+                onClick={() => onSendImmediately(queuedMessage.id)}
+                aria-label={`Send queued message ${index + 1} now`}
+                title="Send now"
+              >
+                <Icon name="Sent" className="size-4" aria-hidden />
+              </Button>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className={cn(
+                  "shrink-0 text-muted-foreground",
                   compact ? "size-7" : "size-8",
                 )}
                 disabled={actionDisabled}
-                aria-label={`Queued message ${index + 1} actions`}
-              >
-                <Icon name="MoreHorizontal" className="size-4" aria-hidden />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-[7rem]">
-              <DropdownMenuItem
-                disabled={sendDisabled}
-                onSelect={() => onSendImmediately(queuedMessage.id)}
-              >
-                <Icon name="Sent" aria-hidden />
-                Send now
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() =>
+                onClick={() =>
                   onEdit({
                     queuedMessageId: queuedMessage.id,
                     queuedMessageIndex: index,
                   })
                 }
+                aria-label={`Edit queued message ${index + 1}`}
+                title="Edit"
               >
-                <Icon name="Edit" aria-hidden />
-                Edit
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => onDelete(queuedMessage.id)}
+                <Icon name="Edit" className="size-4" aria-hidden />
+              </Button>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className={cn(
+                  "shrink-0 text-muted-foreground hover:text-destructive",
+                  compact ? "size-7" : "size-8",
+                )}
+                disabled={actionDisabled}
+                onClick={() => onDelete(queuedMessage.id)}
+                aria-label={`Delete queued message ${index + 1}`}
+                title="Delete"
               >
-                <Icon name="Trash2" aria-hidden />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <Icon name="Trash2" className="size-4" aria-hidden />
+              </Button>
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className={cn(
+                    "pointer-events-none shrink-0 text-muted-foreground opacity-0 transition-opacity md:hidden",
+                    "group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+                    "group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100",
+                    "data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
+                    "[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
+                    compact ? "size-7" : "size-8",
+                  )}
+                  disabled={actionDisabled}
+                  aria-label={`Queued message ${index + 1} actions`}
+                >
+                  <Icon name="MoreHorizontal" className="size-4" aria-hidden />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[7rem]">
+                <DropdownMenuItem
+                  disabled={sendDisabled}
+                  onSelect={() => onSendImmediately(queuedMessage.id)}
+                >
+                  <Icon name="Sent" aria-hidden />
+                  Send now
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() =>
+                    onEdit({
+                      queuedMessageId: queuedMessage.id,
+                      queuedMessageIndex: index,
+                    })
+                  }
+                >
+                  <Icon name="Edit" aria-hidden />
+                  Edit
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => onDelete(queuedMessage.id)}
+                >
+                  <Icon name="Trash2" aria-hidden />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
         )}
       </div>
     </li>

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -727,7 +727,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                 disabled={actionDisabled || sendDisabled}
                 onClick={() => onSendImmediately(queuedMessage.id)}
                 aria-label={`Send queued message ${index + 1} now`}
-                title="Send now"
               >
                 <Icon name="Sent" className="size-4" aria-hidden />
               </Button>
@@ -747,7 +746,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                   })
                 }
                 aria-label={`Edit queued message ${index + 1}`}
-                title="Edit"
               >
                 <Icon name="Edit" className="size-4" aria-hidden />
               </Button>
@@ -762,7 +760,6 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                 disabled={actionDisabled}
                 onClick={() => onDelete(queuedMessage.id)}
                 aria-label={`Delete queued message ${index + 1}`}
-                title="Delete"
               >
                 <Icon name="Trash2" className="size-4" aria-hidden />
               </Button>


### PR DESCRIPTION
## Summary

- On desktop widths (`md+`), queued message rows reveal send, edit, and delete as direct icon buttons instead of burying them in a kebab menu.
- On mobile widths, keep the existing `...` overflow menu so the row stays compact.
- Hover/focus reveal behavior is preserved; touch devices still show the mobile overflow control.

## Test plan

- [x] `QueuedMessagesList` unit tests (30) pass
- [ ] Desktop: hover a queued message row and confirm send/edit/delete icon buttons appear and work
- [ ] Mobile width: confirm the `...` menu remains and still exposes Send now / Edit / Delete
- [ ] Runtime-busy state: send is disabled while edit/delete remain available