### PR TITLE
BB-62: Opaque Tasks list sticky status headers

### DIFF
--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -273,10 +273,12 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
           titles paint on top while scrolling and read as a transparent bar.
           bg-background maps to --canvas via the host theme (same family as
           card); do not use surface-scrim or hardcoded colors here.
+          Hairline bottom border separates the pin band from scrolling rows
+          (same token family as the filter bar and row dividers).
         */}
         <div
           data-status-group-header={group.status}
-          className="sticky top-0 z-20 isolate flex items-center gap-2 bg-background px-3.5 pb-1.5 pt-2.5 text-sm font-semibold"
+          className="sticky top-0 z-20 isolate flex items-center gap-2 border-b border-border-hairline bg-background px-3.5 pb-1.5 pt-2.5 text-sm font-semibold"
         >
           <StatusIcon status={group.status} />
           {STATUS_LABELS[group.status]}

--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -265,7 +265,19 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   } else {
     body = groups.map((group) => (
       <section key={group.status}>
-        <div className="sticky top-0 z-10 flex items-center gap-2 bg-background px-3.5 pb-1.5 pt-2.5 text-sm font-semibold">
+        {/*
+          Opaque canvas fill + stacking above row chrome: task rows keep
+          relative z-10 property editors so they stay clickable above the
+          stretched open overlay. The stuck status header must sit higher
+          (z-20) with an opaque theme canvas token or those controls and
+          titles paint on top while scrolling and read as a transparent bar.
+          bg-background maps to --canvas via the host theme (same family as
+          card); do not use surface-scrim or hardcoded colors here.
+        */}
+        <div
+          data-status-group-header={group.status}
+          className="sticky top-0 z-20 isolate flex items-center gap-2 bg-background px-3.5 pb-1.5 pt-2.5 text-sm font-semibold"
+        >
           <StatusIcon status={group.status} />
           {STATUS_LABELS[group.status]}
           <span className="text-xs font-normal tabular-nums text-subtle-foreground">

--- a/official-plugins/tasks/views/list/sticky-header.test.tsx
+++ b/official-plugins/tasks/views/list/sticky-header.test.tsx
@@ -117,6 +117,9 @@ describe("status-group sticky headers", () => {
       expect(header.className).toMatch(/\bbg-background\b/);
       expect(header.className).toMatch(/\bz-20\b/);
       expect(header.className).toMatch(/\bisolate\b/);
+      // Edge separates the pin band from scrolling rows (theme hairline).
+      expect(header.className).toMatch(/\bborder-b\b/);
+      expect(header.className).toMatch(/\bborder-border-hairline\b/);
       // Guard against reintroducing translucent chrome tokens.
       expect(header.className).not.toMatch(/bg-surface-scrim|bg-background\//);
     }

--- a/official-plugins/tasks/views/list/sticky-header.test.tsx
+++ b/official-plugins/tasks/views/list/sticky-header.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
+import type { Task } from "../../shared/contract.js";
+
+// jsdom lacks matchMedia/ResizeObserver; mirror other list render tests so
+// the compact filter chrome stays out of the way of the assertions.
+window.matchMedia = (query: string) => ({
+  matches: query === COMPACT_VIEWPORT_QUERY,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+window.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView ??= () => {};
+
+const app = await loadPluginApp(() => import("../../app"));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
+
+const project = {
+  id: PROJECT_ID,
+  name: "Tasks Plugin",
+  prefix: "TSK",
+  nextTaskNumber: 5,
+  color: "blue",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-07-15T00:00:00.000Z",
+};
+
+function task(
+  number: number,
+  status: Task["status"],
+): Task {
+  return {
+    id: `01HZZZZZZZZZZZZZZZZZZZZZT${number}`,
+    projectId: PROJECT_ID,
+    number,
+    key: `TSK-${number}`,
+    title: `Task ${number}`,
+    description: "",
+    status,
+    priority: "none",
+    dueDate: null,
+    parentTaskId: null,
+    position: number,
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+    labelIds: [],
+  };
+}
+
+// Two status groups so stacked sticky headers are present in the DOM.
+const tasks = [
+  task(1, "todo"),
+  task(2, "todo"),
+  task(3, "done"),
+  task(4, "done"),
+];
+
+function renderList() {
+  return renderSlot(
+    app.navPanels[0]!,
+    { subPath: PROJECT_ID },
+    {
+      rpc: {
+        listProjects: () => ({ projects: [project] }),
+        listFolders: () => ({ folders: [] }),
+        listPresets: () => ({ presets: [] }),
+        sidebarSummary: () => ({ projects: [] }),
+        listLabels: () => ({ labels: [] }),
+        listTasks: () => ({ tasks }),
+        listTaskThreads: () => ({ taskThreads: [] }),
+        listComments: () => ({ comments: [] }),
+        listAttachments: () => ({ attachments: [] }),
+      },
+    },
+  );
+}
+
+describe("status-group sticky headers", () => {
+  it("pins each group with an opaque theme canvas fill above row chrome", async () => {
+    const slot = renderList();
+    await slot.findByText("TSK-1");
+
+    const headers = Array.from(
+      slot.container.querySelectorAll<HTMLElement>("[data-status-group-header]"),
+    );
+    expect(headers.map((header) => header.dataset.statusGroupHeader)).toEqual([
+      "todo",
+      "done",
+    ]);
+
+    for (const header of headers) {
+      // Sticky positioning and an opaque host-theme canvas token so rows that
+      // scroll under the bar never paint through. z-20 isolates the bar above
+      // the row's z-10 status/priority editors (see TaskRow / property-menus).
+      expect(header.className).toMatch(/\bsticky\b/);
+      expect(header.className).toMatch(/\btop-0\b/);
+      expect(header.className).toMatch(/\bbg-background\b/);
+      expect(header.className).toMatch(/\bz-20\b/);
+      expect(header.className).toMatch(/\bisolate\b/);
+      // Guard against reintroducing translucent chrome tokens.
+      expect(header.className).not.toMatch(/bg-surface-scrim|bg-background\//);
+    }
+
+    // Count + label remain visible for each group.
+    expect(slot.getByText("Todo")).toBeTruthy();
+    expect(slot.getByText("Done")).toBeTruthy();
+    expect(
+      headers.map((header) =>
+        header.querySelector(".tabular-nums")?.textContent,
+      ),
+    ).toEqual(["2", "2"]);
+
+    // Row interactive chrome stays at z-10 so the sticky bar's z-20 wins.
+    const priorityOrStatus = slot.container.querySelector(
+      '[data-task-key="TSK-1"] [class*="z-10"]',
+    );
+    expect(priorityOrStatus?.className).toMatch(/\bz-10\b/);
+  });
+});


### PR DESCRIPTION
## Summary

- Raise Tasks list status-group sticky headers to `z-20 isolate` while keeping the theme-derived opaque `bg-background` (canvas/card family) so row titles and `z-10` property editors no longer paint through while scrolling.
- Add `data-status-group-header` and a focused render contract test for sticky positioning, opaque token, stacking, labels, and counts.
- Narrow UI-only change; no server↔daemon wire/protocol updates; leaves BB-60 mobile list layout work untouched.

## Validation

- `pnpm exec turbo run typecheck test --filter=bb-plugin-tasks` — **314/314 pass**
- Live product QA on worktree build (`scripts/bb-dev-app`): desktop + narrow, light/dark/custom Nord anchors, multi-group scroll probes (`topElIsHeader`, `underTask=null`, opacity 1)
- Independent readonly review on MacBook Pro (`thr_y4azjkuus4`, codex / gpt-5.6-sol / medium) — **APPROVE**
- Product review HTML + evidence archive attached to BB-62 task comments

## Test plan

- [ ] Open Tasks with a long status group; scroll so rows pass under the group header — titles/controls must not show through
- [ ] Scroll across stacked groups (Backlog → Todo → In Progress) — each header stays opaque and readable
- [ ] Repeat in dark mode and a custom theme (e.g. Nord)
- [ ] Narrow viewport (~390px) scroll
- [ ] Filters/Sort/New task still work; open a task and back (scroll restoration)

## Risks

- Parallel BB-60 mobile list layout work may touch the same list files — this patch only changes sticky header classes
- Electron desktop not separately launched; sticky CSS is shared with the verified web plugin bundle