### PR TITLE
BB-65: Make Tasks refresh a subtle icon button

### DIFF
--- a/official-plugins/tasks/shell/data.ts
+++ b/official-plugins/tasks/shell/data.ts
@@ -83,6 +83,10 @@ export interface TasksQuery<T> {
  * Fetch-and-subscribe primitive: runs `fetcher` on mount and again whenever
  * one of `channels` fires or `deps` change. Stale responses (superseded by a
  * newer refresh) are dropped.
+ *
+ * Generation bumps (manual refresh / reconnect) report begin/end to the shared
+ * refresh provider so the header control can single-flight without a timer.
+ * Invalidation- and deps-driven refetches do not mark the shared in-flight bit.
  */
 export function useTasksQuery<T>(
   fetcher: (rpc: TasksRpc) => Promise<T>,
@@ -90,7 +94,8 @@ export function useTasksQuery<T>(
   deps: readonly unknown[] = [],
 ): TasksQuery<T> {
   const rpc = useTasksRpc();
-  const { generation } = useTasksRefresh();
+  const { generation, beginGenerationWork, endGenerationWork } =
+    useTasksRefresh();
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
   const [state, setState] = useState<{
@@ -99,10 +104,11 @@ export function useTasksQuery<T>(
     isLoading: boolean;
   }>({ data: undefined, error: null, isLoading: true });
   const seqRef = useRef(0);
+  const previousGenerationRef = useRef(generation);
   const depsKey = JSON.stringify(deps);
   const refresh = useCallback(() => {
     const seq = ++seqRef.current;
-    fetcherRef.current(rpc).then(
+    return fetcherRef.current(rpc).then(
       (data) => {
         if (seq !== seqRef.current) return;
         setState({ data, error: null, isLoading: false });
@@ -118,9 +124,21 @@ export function useTasksQuery<T>(
     );
   }, [rpc, depsKey]);
   useEffect(() => {
+    const generationBumped = previousGenerationRef.current !== generation;
+    previousGenerationRef.current = generation;
     setState((current) => ({ ...current, isLoading: true }));
-    refresh();
-  }, [refresh, generation]);
+    if (generationBumped) beginGenerationWork();
+    let settled = false;
+    const finish = () => {
+      if (!generationBumped || settled) return;
+      settled = true;
+      endGenerationWork();
+    };
+    void refresh().finally(finish);
+    return () => {
+      finish();
+    };
+  }, [refresh, generation, beginGenerationWork, endGenerationWork]);
   useInvalidation(channels, refresh);
   return { ...state, refresh };
 }

--- a/official-plugins/tasks/shell/refresh.tsx
+++ b/official-plugins/tasks/shell/refresh.tsx
@@ -12,7 +12,17 @@ import { useRealtimeConnectionState } from "@bb/plugin-sdk/app";
 
 interface TasksRefreshState {
   generation: number;
+  /**
+   * True while any mounted query still has a generation-driven fetch in
+   * flight (manual refresh or reconnect). Used by the header control for
+   * single-flight + loading UI without a second refresh channel.
+   */
+  isRefreshing: boolean;
   refresh: () => void;
+  /** Called by queries when a generation-driven fetch starts. */
+  beginGenerationWork: () => void;
+  /** Called by queries when a generation-driven fetch settles or unmounts. */
+  endGenerationWork: () => void;
 }
 
 const TasksRefreshContext = createContext<TasksRefreshState | null>(null);
@@ -29,10 +39,25 @@ export function TasksRefreshProvider({ children }: { children: ReactNode }) {
   // even if the Tasks shell happened to mount during the outage.
   const hasConnected = useRef(connectionState !== "connecting");
   const [generation, setGeneration] = useState(0);
-  const refresh = useCallback(
-    () => setGeneration((current) => current + 1),
-    [],
-  );
+  const pendingWorkRef = useRef(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const refresh = useCallback(() => {
+    // Optimistic busy so rapid pointer/keyboard activations coalesce before
+    // query effects report beginGenerationWork on the next paint.
+    setIsRefreshing(true);
+    setGeneration((current) => current + 1);
+  }, []);
+
+  const beginGenerationWork = useCallback(() => {
+    pendingWorkRef.current += 1;
+    setIsRefreshing(true);
+  }, []);
+
+  const endGenerationWork = useCallback(() => {
+    pendingWorkRef.current = Math.max(0, pendingWorkRef.current - 1);
+    if (pendingWorkRef.current === 0) setIsRefreshing(false);
+  }, []);
 
   useEffect(() => {
     const previous = previousConnectionState.current;
@@ -42,7 +67,22 @@ export function TasksRefreshProvider({ children }: { children: ReactNode }) {
     hasConnected.current = true;
   }, [connectionState, refresh]);
 
-  const value = useMemo(() => ({ generation, refresh }), [generation, refresh]);
+  const value = useMemo(
+    () => ({
+      generation,
+      isRefreshing,
+      refresh,
+      beginGenerationWork,
+      endGenerationWork,
+    }),
+    [
+      generation,
+      isRefreshing,
+      refresh,
+      beginGenerationWork,
+      endGenerationWork,
+    ],
+  );
   return (
     <TasksRefreshContext.Provider value={value}>
       {children}

--- a/official-plugins/tasks/shell/shell.test.tsx
+++ b/official-plugins/tasks/shell/shell.test.tsx
@@ -392,8 +392,215 @@ describe("tasks app shell", () => {
     await slot.findByText("Recovered list title");
 
     title = "Manually refreshed list title";
-    fireEvent.click(slot.getByRole("button", { name: "Refresh" }));
+    fireEvent.click(slot.getByRole("button", { name: "Refresh tasks" }));
     await slot.findByText("Manually refreshed list title");
+  });
+
+  it("exposes a subtle icon-only refresh control left of New task", async () => {
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc({
+          listTasks: () => ({
+            tasks: [
+              {
+                ...pagerTask("TSK-4", "todo", 1),
+                title: "Order probe",
+                description: "",
+                labelIds: [],
+              },
+            ],
+          }),
+          listLabels: () => ({ labels: [] }),
+          listAttachments: () => ({ attachments: [] }),
+          listTaskThreads: () => ({ taskThreads: [] }),
+          listComments: () => ({ comments: [] }),
+        }),
+      },
+    );
+    await slot.findByText("Order probe");
+
+    const refresh = slot.getByRole("button", { name: "Refresh tasks" });
+    const newTask = slot.getByRole("button", { name: /New task/i });
+    const sidebar = slot.getByRole("button", { name: "Collapse sidebar" });
+
+    // Icon-only: no visible "Refresh" text; accessible name remains.
+    expect(refresh.textContent?.trim() ?? "").not.toMatch(/Refresh/i);
+    expect(refresh.getAttribute("aria-label")).toBe("Refresh tasks");
+    expect(refresh.className).toMatch(/size-7/);
+
+    // DOM order: refresh → New task → sidebar toggle.
+    expect(
+      refresh.compareDocumentPosition(newTask) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      newTask.compareDocumentPosition(sidebar) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    // Tab order follows DOM order among the three controls.
+    const tabbables = [refresh, newTask, sidebar];
+    for (let i = 0; i < tabbables.length - 1; i++) {
+      expect(
+        tabbables[i]!.compareDocumentPosition(tabbables[i + 1]!) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    }
+
+    // Focus-visible path: control is a native button and can take focus.
+    refresh.focus();
+    expect(document.activeElement).toBe(refresh);
+  });
+
+  it("single-flights manual refresh and keeps icon-button geometry stable", async () => {
+    let listTasksCalls = 0;
+    let title = "Flight title A";
+    const task = {
+      ...pagerTask("TSK-4", "todo", 1),
+      title,
+      description: "",
+      labelIds: [],
+    };
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc({
+          listTasks: () => {
+            listTasksCalls += 1;
+            return { tasks: [{ ...task, title }] };
+          },
+          listLabels: () => ({ labels: [] }),
+          listAttachments: () => ({ attachments: [] }),
+          listTaskThreads: () => ({ taskThreads: [] }),
+          listComments: () => ({ comments: [] }),
+        }),
+      },
+    );
+    await slot.findByText("Flight title A");
+    const baselineCalls = listTasksCalls;
+    expect(baselineCalls).toBeGreaterThan(0);
+
+    const refresh = slot.getByRole("button", {
+      name: "Refresh tasks",
+    }) as HTMLButtonElement;
+    const idleClassName = refresh.className;
+    expect(idleClassName).toMatch(/size-7/);
+    expect(refresh.getAttribute("aria-busy")).not.toBe("true");
+    expect(refresh.disabled).toBe(false);
+
+    title = "Flight title B";
+    fireEvent.click(refresh);
+    // In-flight: disabled + busy, same icon-button box classes (no layout shift).
+    expect(refresh.disabled).toBe(true);
+    expect(refresh.getAttribute("aria-busy")).toBe("true");
+    expect(refresh.className).toBe(idleClassName);
+
+    // Rapid pointer/keyboard re-activation while in flight must not re-bump.
+    fireEvent.click(refresh);
+    fireEvent.keyDown(refresh, { key: "Enter" });
+    fireEvent.keyUp(refresh, { key: "Enter" });
+    fireEvent.keyDown(refresh, { key: " " });
+    fireEvent.keyUp(refresh, { key: " " });
+
+    await waitFor(() => expect(listTasksCalls).toBeGreaterThan(baselineCalls));
+    await slot.findByText("Flight title B");
+    const afterFirstFlight = listTasksCalls;
+
+    fireEvent.click(refresh);
+    fireEvent.click(refresh);
+    // Allow any would-be effect to flush; call count must stay flat.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(listTasksCalls).toBe(afterFirstFlight);
+
+    // After the flight window clears, a deliberate second refresh works.
+    await waitFor(
+      () => {
+        expect(
+          (
+            slot.getByRole("button", {
+              name: "Refresh tasks",
+            }) as HTMLButtonElement
+          ).disabled,
+        ).toBe(false);
+      },
+      { timeout: 1500 },
+    );
+
+    title = "Flight title C";
+    fireEvent.click(slot.getByRole("button", { name: "Refresh tasks" }));
+    await slot.findByText("Flight title C");
+    expect(listTasksCalls).toBeGreaterThan(afterFirstFlight);
+
+    // Wait for the second flight window so recovery assertions are stable.
+    await waitFor(
+      () => {
+        const button = slot.getByRole("button", {
+          name: "Refresh tasks",
+        }) as HTMLButtonElement;
+        expect(button.disabled).toBe(false);
+        expect(button.getAttribute("aria-busy")).not.toBe("true");
+      },
+      { timeout: 1500 },
+    );
+
+    const recovered = slot.getByRole("button", {
+      name: "Refresh tasks",
+    }) as HTMLButtonElement;
+    expect(recovered.className).toMatch(/size-7/);
+  });
+
+  it("retains stale list data when a manual refresh fails, then recovers", async () => {
+    let shouldFail = false;
+    let title = "Stable title";
+    const task = {
+      ...pagerTask("TSK-4", "todo", 1),
+      title,
+      description: "",
+      labelIds: [],
+    };
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc({
+          listTasks: () => {
+            if (shouldFail) throw new Error("refresh failed");
+            return { tasks: [{ ...task, title }] };
+          },
+          listLabels: () => ({ labels: [] }),
+          listAttachments: () => ({ attachments: [] }),
+          listTaskThreads: () => ({ taskThreads: [] }),
+          listComments: () => ({ comments: [] }),
+        }),
+      },
+    );
+    await slot.findByText("Stable title");
+
+    shouldFail = true;
+    fireEvent.click(slot.getByRole("button", { name: "Refresh tasks" }));
+    // Prior data stays on screen (useTasksQuery retains data on error).
+    await waitFor(() =>
+      expect(slot.getByText("Stable title")).toBeDefined(),
+    );
+    // Give the failed request a moment to settle without clearing rows.
+    await waitFor(
+      () => {
+        expect(
+          (slot.getByRole("button", { name: "Refresh tasks" }) as HTMLButtonElement)
+            .disabled,
+        ).toBe(false);
+      },
+      { timeout: 1500 },
+    );
+    expect(slot.getByText("Stable title")).toBeDefined();
+
+    shouldFail = false;
+    title = "Recovered after failure";
+    fireEvent.click(slot.getByRole("button", { name: "Refresh tasks" }));
+    await slot.findByText("Recovered after failure");
   });
 
   it("resyncs an open task detail after reconnect", async () => {

--- a/official-plugins/tasks/shell/shell.test.tsx
+++ b/official-plugins/tasks/shell/shell.test.tsx
@@ -454,9 +454,15 @@ describe("tasks app shell", () => {
     expect(document.activeElement).toBe(refresh);
   });
 
-  it("single-flights manual refresh and keeps icon-button geometry stable", async () => {
+  it("single-flights manual refresh against deferred RPCs and keeps geometry stable", async () => {
     let listTasksCalls = 0;
     let title = "Flight title A";
+    let holdListTasks = false;
+    const pendingResolvers: Array<() => void> = [];
+    const releaseAllPending = () => {
+      const resolvers = pendingResolvers.splice(0, pendingResolvers.length);
+      for (const resolve of resolvers) resolve();
+    };
     const task = {
       ...pagerTask("TSK-4", "todo", 1),
       title,
@@ -470,7 +476,16 @@ describe("tasks app shell", () => {
         rpc: seededRpc({
           listTasks: () => {
             listTasksCalls += 1;
-            return { tasks: [{ ...task, title }] };
+            if (!holdListTasks) {
+              return { tasks: [{ ...task, title }] };
+            }
+            // Generation-driven fetches stay pending until released so the
+            // shared in-flight bit tracks real request completion.
+            return new Promise((resolve) => {
+              pendingResolvers.push(() =>
+                resolve({ tasks: [{ ...task, title }] }),
+              );
+            });
           },
           listLabels: () => ({ labels: [] }),
           listAttachments: () => ({ attachments: [] }),
@@ -490,66 +505,68 @@ describe("tasks app shell", () => {
     expect(idleClassName).toMatch(/size-7/);
     expect(refresh.getAttribute("aria-busy")).not.toBe("true");
     expect(refresh.disabled).toBe(false);
+    expect(idleClassName).toMatch(/active:bg-state-active/);
 
+    // Accessible name is the stable tooltip/label contract.
+    fireEvent.pointerMove(refresh);
+    fireEvent.focus(refresh);
+    expect(refresh.getAttribute("aria-label")).toBe("Refresh tasks");
+
+    holdListTasks = true;
     title = "Flight title B";
     fireEvent.click(refresh);
-    // In-flight: disabled + busy, same icon-button box classes (no layout shift).
+    await waitFor(() => expect(listTasksCalls).toBeGreaterThan(baselineCalls));
+    // In-flight while the deferred RPC is still pending.
     expect(refresh.disabled).toBe(true);
     expect(refresh.getAttribute("aria-busy")).toBe("true");
     expect(refresh.className).toBe(idleClassName);
 
-    // Rapid pointer/keyboard re-activation while in flight must not re-bump.
-    fireEvent.click(refresh);
-    fireEvent.keyDown(refresh, { key: "Enter" });
-    fireEvent.keyUp(refresh, { key: "Enter" });
-    fireEvent.keyDown(refresh, { key: " " });
-    fireEvent.keyUp(refresh, { key: " " });
-
-    await waitFor(() => expect(listTasksCalls).toBeGreaterThan(baselineCalls));
-    await slot.findByText("Flight title B");
-    const afterFirstFlight = listTasksCalls;
-
+    const callsWhilePending = listTasksCalls;
+    // Rapid re-activation while pending must not bump generation again.
     fireEvent.click(refresh);
     fireEvent.click(refresh);
-    // Allow any would-be effect to flush; call count must stay flat.
+    // Browser keyboard activation synthesizes click; exercise that path.
+    refresh.focus();
+    fireEvent.click(refresh);
     await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(listTasksCalls).toBe(afterFirstFlight);
+    expect(listTasksCalls).toBe(callsWhilePending);
 
-    // After the flight window clears, a deliberate second refresh works.
-    await waitFor(
-      () => {
-        expect(
-          (
-            slot.getByRole("button", {
-              name: "Refresh tasks",
-            }) as HTMLButtonElement
-          ).disabled,
-        ).toBe(false);
-      },
-      { timeout: 1500 },
-    );
+    // Stay pending well past any former fixed timer; still disabled.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(refresh.disabled).toBe(true);
+    expect(listTasksCalls).toBe(callsWhilePending);
 
+    releaseAllPending();
+    await slot.findByText("Flight title B");
+    await waitFor(() => {
+      expect(
+        (
+          slot.getByRole("button", {
+            name: "Refresh tasks",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+
+    // Deliberate second refresh after completion works.
     title = "Flight title C";
     fireEvent.click(slot.getByRole("button", { name: "Refresh tasks" }));
-    await slot.findByText("Flight title C");
-    expect(listTasksCalls).toBeGreaterThan(afterFirstFlight);
-
-    // Wait for the second flight window so recovery assertions are stable.
-    await waitFor(
-      () => {
-        const button = slot.getByRole("button", {
-          name: "Refresh tasks",
-        }) as HTMLButtonElement;
-        expect(button.disabled).toBe(false);
-        expect(button.getAttribute("aria-busy")).not.toBe("true");
-      },
-      { timeout: 1500 },
+    await waitFor(() =>
+      expect(listTasksCalls).toBeGreaterThan(callsWhilePending),
     );
-
-    const recovered = slot.getByRole("button", {
-      name: "Refresh tasks",
-    }) as HTMLButtonElement;
-    expect(recovered.className).toMatch(/size-7/);
+    releaseAllPending();
+    await slot.findByText("Flight title C");
+    await waitFor(() => {
+      const button = slot.getByRole("button", {
+        name: "Refresh tasks",
+      }) as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+      expect(button.getAttribute("aria-busy")).not.toBe("true");
+    });
+    expect(
+      (slot.getByRole("button", { name: "Refresh tasks" }) as HTMLButtonElement)
+        .className,
+    ).toMatch(/size-7/);
   });
 
   it("retains stale list data when a manual refresh fails, then recovers", async () => {
@@ -582,19 +599,17 @@ describe("tasks app shell", () => {
     shouldFail = true;
     fireEvent.click(slot.getByRole("button", { name: "Refresh tasks" }));
     // Prior data stays on screen (useTasksQuery retains data on error).
-    await waitFor(() =>
-      expect(slot.getByText("Stable title")).toBeDefined(),
-    );
-    // Give the failed request a moment to settle without clearing rows.
-    await waitFor(
-      () => {
-        expect(
-          (slot.getByRole("button", { name: "Refresh tasks" }) as HTMLButtonElement)
-            .disabled,
-        ).toBe(false);
-      },
-      { timeout: 1500 },
-    );
+    await waitFor(() => expect(slot.getByText("Stable title")).toBeDefined());
+    // Failed generation work clears the shared in-flight bit.
+    await waitFor(() => {
+      expect(
+        (
+          slot.getByRole("button", {
+            name: "Refresh tasks",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
     expect(slot.getByText("Stable title")).toBeDefined();
 
     shouldFail = false;

--- a/official-plugins/tasks/shell/topbar.tsx
+++ b/official-plugins/tasks/shell/topbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Project, Task } from "../shared/contract.js";
 import { groupTasksByStatus } from "../views/list/lib.js";
 import { listAllTasks, useTasksQuery } from "./data.js";
@@ -6,7 +6,23 @@ import type { TaskViewMode, TasksRoute } from "./routes.js";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
 import { useTasksRefresh } from "./refresh.js";
+
+/** Accessible name + tooltip for the header refresh control. */
+export const REFRESH_TASKS_LABEL = "Refresh tasks";
+
+/**
+ * Coalesce rapid pointer/keyboard activations so a double-click or held key
+ * does not bump the shared refresh generation twice. Long enough to cover
+ * activation bounce; short enough that a deliberate second refresh is available.
+ */
+export const REFRESH_SINGLE_FLIGHT_MS = 500;
 
 export interface PagerPosition {
   /** 1-based position of the task within its sibling list. */
@@ -127,6 +143,63 @@ function ViewToggle({
   );
 }
 
+/**
+ * Subtle icon-only refresh control. Shares the BB-19 generation channel; does
+ * not add listeners or alternate refresh paths. In-flight state is visual only
+ * (spin + disabled) with a fixed geometry so the header does not shift.
+ */
+function RefreshTasksButton() {
+  const { refresh } = useTasksRefresh();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const flightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (flightTimerRef.current !== null) {
+        clearTimeout(flightTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    refresh();
+    if (flightTimerRef.current !== null) {
+      clearTimeout(flightTimerRef.current);
+    }
+    flightTimerRef.current = setTimeout(() => {
+      flightTimerRef.current = null;
+      setIsRefreshing(false);
+    }, REFRESH_SINGLE_FLIGHT_MS);
+  }, [isRefreshing, refresh]);
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label={REFRESH_TASKS_LABEL}
+            aria-busy={isRefreshing}
+            disabled={isRefreshing}
+            onClick={handleRefresh}
+          >
+            <Icon
+              name="RotateCcw"
+              className={cn("size-3.5", isRefreshing && "animate-spin")}
+            />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{REFRESH_TASKS_LABEL}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 export interface TasksTopbarProps {
   route: TasksRoute;
   projects: Project[] | undefined;
@@ -153,7 +226,6 @@ export function TasksTopbar({
   onNewTask,
   onBack,
 }: TasksTopbarProps) {
-  const { refresh } = useTasksRefresh();
   const project = useMemo(() => {
     if (route.kind === "project") {
       return (projects ?? []).find((p) => p.id === route.projectId) ?? null;
@@ -270,21 +342,14 @@ export function TasksTopbar({
           onChange={(view) => onNavigate({ ...route, view })}
         />
       ) : null}
+      {/* Refresh sits immediately left of the primary New task action. */}
+      <RefreshTasksButton />
       {route.kind !== "task" && route.kind !== "manage" ? (
         <Button size="sm" className="h-7 gap-1.5" onClick={onNewTask}>
           <Icon name="Plus" className="size-3.5" />
           New task
         </Button>
       ) : null}
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 gap-1.5"
-        onClick={refresh}
-      >
-        <Icon name="RotateCcw" className="size-3.5" />
-        Refresh
-      </Button>
       <Button
         variant="ghost"
         size="icon"

--- a/official-plugins/tasks/shell/topbar.tsx
+++ b/official-plugins/tasks/shell/topbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import type { Project, Task } from "../shared/contract.js";
 import { groupTasksByStatus } from "../views/list/lib.js";
 import { listAllTasks, useTasksQuery } from "./data.js";
@@ -16,13 +16,6 @@ import { useTasksRefresh } from "./refresh.js";
 
 /** Accessible name + tooltip for the header refresh control. */
 export const REFRESH_TASKS_LABEL = "Refresh tasks";
-
-/**
- * Coalesce rapid pointer/keyboard activations so a double-click or held key
- * does not bump the shared refresh generation twice. Long enough to cover
- * activation bounce; short enough that a deliberate second refresh is available.
- */
-export const REFRESH_SINGLE_FLIGHT_MS = 500;
 
 export interface PagerPosition {
   /** 1-based position of the task within its sibling list. */
@@ -145,33 +138,16 @@ function ViewToggle({
 
 /**
  * Subtle icon-only refresh control. Shares the BB-19 generation channel; does
- * not add listeners or alternate refresh paths. In-flight state is visual only
- * (spin + disabled) with a fixed geometry so the header does not shift.
+ * not add listeners or alternate refresh paths. In-flight state tracks real
+ * generation-driven query work (spin + disabled) with fixed geometry so the
+ * header does not shift.
  */
 function RefreshTasksButton() {
-  const { refresh } = useTasksRefresh();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const flightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (flightTimerRef.current !== null) {
-        clearTimeout(flightTimerRef.current);
-      }
-    };
-  }, []);
+  const { refresh, isRefreshing } = useTasksRefresh();
 
   const handleRefresh = useCallback(() => {
     if (isRefreshing) return;
-    setIsRefreshing(true);
     refresh();
-    if (flightTimerRef.current !== null) {
-      clearTimeout(flightTimerRef.current);
-    }
-    flightTimerRef.current = setTimeout(() => {
-      flightTimerRef.current = null;
-      setIsRefreshing(false);
-    }, REFRESH_SINGLE_FLIGHT_MS);
   }, [isRefreshing, refresh]);
 
   return (
@@ -182,7 +158,7 @@ function RefreshTasksButton() {
             type="button"
             variant="ghost"
             size="icon"
-            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground active:bg-state-active active:text-foreground"
             aria-label={REFRESH_TASKS_LABEL}
             aria-busy={isRefreshing}
             disabled={isRefreshing}


### PR DESCRIPTION
## Summary

- Replace the Tasks list header text **Refresh** action with a low-emphasis ghost icon-only control immediately **left** of **New task**.
- Accessible name and tooltip: **Refresh tasks**; spin + `aria-busy` + disabled while generation-driven work is in flight, without changing the button box.
- Single-flight is tied to real generation-driven query completion (not a fixed timer); reconnect still shares the BB-19 generation channel without duplicate listeners.
- Focused shell tests cover order, labeling, deferred single-flight, error retention, and reconnect naming.

## Review

- One independent review: `codex` / `gpt-5.6-sol` / medium / readonly on MacBook Pro (`thr_ebxd268vin`) returned **REQUEST CHANGES**.
- Blocking/major findings fixed: real in-flight tracking via `beginGenerationWork`/`endGenerationWork`, deferred-RPC single-flight tests, `active:` styling.
- No second review requested (per task policy).

## Validation

- `pnpm exec turbo run test --filter=bb-plugin-tasks`: **317 passed** (post-rebase)
- `pnpm exec turbo run typecheck build --filter=bb-plugin-tasks`: pass
- Live QA on isolated `bb-dev-app` (:18072): desktop/768/390, light/dark/Nord, manual refresh, offline stale retain + retry, WebSocket reconnect auto-resync after CLI title mutation
- Product review HTML + coverage ledger + screenshots attached on BB-65 comment `01KXRF1XYBS1W7Q43Q2NTRVR35`

## Risks / coordination

- **BB-60** (mobile Tasks layout) is in progress and may also touch the Tasks header; permanent icon-only refresh left of New task is compatible and saves width—coordinate merges carefully.
- No server/daemon/protocol changes.

## Test plan

- [ ] Open Tasks panel; confirm icon refresh is left of New task with tooltip/name **Refresh tasks**
- [ ] Click/keyboard activate; spin without layout shift; rapid double-activation does not storm
- [ ] Offline refresh retains rows; online retry works
- [ ] Interrupt WebSocket / go offline, mutate a task via CLI, restore → list auto-resyncs
- [ ] Check light/dark/custom palette and narrow widths for overflow