### PR TITLE
BB-64: Two-track attachment layout for task comments

### DIFF
--- a/official-plugins/tasks/views/activity/task-activity.test.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.test.tsx
@@ -12,9 +12,10 @@ import {
 } from "@bb/plugin-sdk/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createComment, createStore } from "../../api/index.js";
-import type { DisplayComment } from "../../shared/contract.js";
+import type { Attachment, DisplayComment } from "../../shared/contract.js";
 import {
   AgentNotificationControl,
+  AttachmentTracks,
   agentNotificationTarget,
   CommentComposer,
 } from "./task-activity.js";
@@ -77,6 +78,53 @@ function comment(
     createdAt: "2026-07-15T00:00:00.000Z",
   };
 }
+
+describe("AttachmentTracks", () => {
+  const attachment = (
+    id: string,
+    fileName: string,
+    isImage: boolean,
+  ): Attachment => ({
+    id,
+    taskId: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+    commentId: "01HZZZZZZZZZZZZZZZZZZZZZC1",
+    fileName,
+    mime: isImage ? "image/png" : "text/plain",
+    sizeBytes: 1024,
+    isImage,
+    createdAt: "2026-07-15T00:00:00.000Z",
+  });
+
+  it("renders file cards before images regardless of input order", () => {
+    const screen = render(
+      <AttachmentTracks
+        attachments={[
+          attachment("01HZZZZZZZZZZZZZZZZZZZZ1I1", "shot-a.png", true),
+          attachment("01HZZZZZZZZZZZZZZZZZZZZ1F1", "notes.md", false),
+          attachment("01HZZZZZZZZZZZZZZZZZZZZ1I2", "shot-b.png", true),
+        ]}
+        onOpenImage={() => {}}
+      />,
+    );
+    const file = screen.getByText("notes.md");
+    const image = screen.getByAltText("shot-a.png");
+    expect(
+      file.compareDocumentPosition(image) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("keeps each caption inside its own image figure", () => {
+    const screen = render(
+      <AttachmentTracks
+        attachments={[attachment("01HZZZZZZZZZZZZZZZZZZZZ1I1", "shot.png", true)]}
+        onOpenImage={() => {}}
+      />,
+    );
+    const figure = screen.getByRole("figure");
+    expect(figure.contains(screen.getByAltText("shot.png"))).toBe(true);
+    expect(figure.contains(screen.getByText("shot.png"))).toBe(true);
+  });
+});
 
 describe("agent notification target", () => {
   it("uses the last agent reply rather than the last activity entry", () => {

--- a/official-plugins/tasks/views/activity/task-activity.tsx
+++ b/official-plugins/tasks/views/activity/task-activity.tsx
@@ -110,41 +110,15 @@ function UserAvatar({ name }: { name: string }) {
   );
 }
 
-function AttachmentPreview({
-  attachment,
-  onOpenImage,
-}: {
-  attachment: Attachment;
-  onOpenImage: (attachment: Attachment) => void;
-}) {
-  const url = attachmentDownloadUrl(attachment.id);
-  if (attachment.isImage) {
-    return (
-      <figure className="m-0 flex flex-col">
-        <button
-          type="button"
-          aria-label={`View ${attachment.fileName}`}
-          onClick={() => onOpenImage(attachment)}
-        >
-          <img
-            src={url}
-            alt={attachment.fileName}
-            className="h-24 w-[150px] cursor-zoom-in rounded-md border border-border bg-muted object-cover hover:border-input"
-          />
-        </button>
-        <figcaption className="mt-0.5 max-w-[150px] truncate text-2xs text-muted-foreground">
-          {attachment.fileName}
-        </figcaption>
-      </figure>
-    );
-  }
+function FileAttachmentCard({ attachment }: { attachment: Attachment }) {
   return (
     <a
-      href={url}
+      href={attachmentDownloadUrl(attachment.id)}
       download={attachment.fileName}
-      className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-xs shadow-2xs hover:border-input"
+      title={`${attachment.fileName} · ${formatFileSize(attachment.sizeBytes)}`}
+      className="inline-flex min-w-0 max-w-60 items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-xs shadow-2xs hover:border-input hover:bg-state-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
     >
-      <span className="flex size-6 items-center justify-center rounded-sm bg-secondary text-muted-foreground">
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-sm bg-secondary text-muted-foreground">
         <HugeiconsIcon icon={File01Icon} className="size-3.5" />
       </span>
       <span className="min-w-0">
@@ -154,6 +128,93 @@ function AttachmentPreview({
         </small>
       </span>
     </a>
+  );
+}
+
+/**
+ * Gallery thumbnail: shares the track's row height and keeps its natural
+ * aspect ratio, center-cropping past a 0.62×–2.2× width clamp so panoramas
+ * and tall phone shots stay on the shared row. The width cap sits on the
+ * button (not just the img) because a percentage max-width is ignored during
+ * intrinsic sizing — the figure must shrink-wrap the *cropped* width for the
+ * centered caption to stay aligned with the visible image.
+ */
+function ImageAttachmentFigure({
+  attachment,
+  onOpenImage,
+}: {
+  attachment: Attachment;
+  onOpenImage: (attachment: Attachment) => void;
+}) {
+  return (
+    <figure className="relative m-0 flex min-w-0 max-w-full flex-col">
+      <button
+        type="button"
+        aria-label={`View ${attachment.fileName}`}
+        title={attachment.fileName}
+        className="block max-w-[211px] rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring @2xl:max-w-[282px]"
+        onClick={() => onOpenImage(attachment)}
+      >
+        <img
+          src={attachmentDownloadUrl(attachment.id)}
+          alt={attachment.fileName}
+          className="h-24 w-auto min-w-15 max-w-full cursor-zoom-in rounded-md border border-border bg-muted object-cover hover:border-input @2xl:h-32 @2xl:min-w-20"
+        />
+      </button>
+      {/* w-0 + min-w-full: the caption never inflates the figure, so it
+          truncates and centers at the image's own width. */}
+      <figcaption
+        title={attachment.fileName}
+        className="mt-0.5 w-0 min-w-full truncate px-1 text-center text-2xs text-muted-foreground"
+      >
+        {attachment.fileName}
+      </figcaption>
+    </figure>
+  );
+}
+
+/**
+ * Two-track attachment layout: compact file cards first, then an image
+ * gallery. Grouping by kind keeps file cards out of image wrap rows (a
+ * single wrap's `align-items: stretch` is what inflated them to image
+ * height); DOM order matches the rendered order, so keyboard and screen
+ * reader traversal follow the visual reading order.
+ */
+export function AttachmentTracks({
+  attachments,
+  onOpenImage,
+}: {
+  attachments: Attachment[];
+  onOpenImage: (attachment: Attachment) => void;
+}) {
+  const files = attachments.filter((attachment) => !attachment.isImage);
+  const images = attachments.filter((attachment) => attachment.isImage);
+  return (
+    <div className="mt-1.5">
+      {files.length > 0 ? (
+        <div className="flex flex-wrap items-start gap-1.5">
+          {files.map((attachment) => (
+            <FileAttachmentCard key={attachment.id} attachment={attachment} />
+          ))}
+        </div>
+      ) : null}
+      {images.length > 0 ? (
+        <div
+          className={cn(
+            "flex flex-wrap items-start gap-x-2.5 gap-y-2",
+            files.length > 0 && "mt-2",
+          )}
+        >
+          {images.map((attachment) => (
+            <ImageAttachmentFigure
+              key={attachment.id}
+              attachment={attachment}
+              onOpenImage={onOpenImage}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -216,15 +277,7 @@ function CommentCard({ entry, nowMs }: { entry: FeedEntry; nowMs: number }) {
           onOpenThread={(threadId) => navigate.toThread(threadId)}
         />
         {attachments.length > 0 ? (
-          <div className="mt-1.5 flex flex-wrap gap-2">
-            {attachments.map((attachment) => (
-              <AttachmentPreview
-                key={attachment.id}
-                attachment={attachment}
-                onOpenImage={setLightbox}
-              />
-            ))}
-          </div>
+          <AttachmentTracks attachments={attachments} onOpenImage={setLightbox} />
         ) : null}
         {lightbox ? (
           <Lightbox attachment={lightbox} onClose={() => setLightbox(null)} />

--- a/official-plugins/tasks/views/detail/attachments.test.tsx
+++ b/official-plugins/tasks/views/detail/attachments.test.tsx
@@ -22,6 +22,31 @@ function imageAttachment(overrides: Partial<Attachment> = {}): Attachment {
   };
 }
 
+describe("AttachmentsGrid layout", () => {
+  it("groups file cards before image previews regardless of input order", () => {
+    const screen = render(
+      <AttachmentsGrid
+        attachments={[
+          imageAttachment({ id: "01JIMAGE0000000000000000A1" }),
+          imageAttachment({
+            id: "01JFILE00000000000000000A1",
+            fileName: "notes.md",
+            mime: "text/markdown",
+            isImage: false,
+          }),
+          imageAttachment({ id: "01JIMAGE0000000000000000A2" }),
+        ]}
+      />,
+    );
+    const fileCard = screen.getByText("notes.md");
+    const image = screen.getAllByAltText("diagram.png")[0]!;
+    expect(
+      fileCard.compareDocumentPosition(image) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});
+
 describe("AttachmentsGrid removal", () => {
   it("calls the typed removal callback after confirmation", async () => {
     const onRemove = vi.fn().mockResolvedValue(undefined);

--- a/official-plugins/tasks/views/detail/attachments.tsx
+++ b/official-plugins/tasks/views/detail/attachments.tsx
@@ -175,6 +175,12 @@ export function AttachmentsGrid({
 
   if (attachments.length === 0) return null;
 
+  // Files render before images, each group in upload order. A single mixed
+  // wrap lets `align-items: stretch` inflate compact file cards to image
+  // height; separate tracks keep every card at its natural height.
+  const files = attachments.filter((attachment) => !attachment.isImage);
+  const images = attachments.filter((attachment) => attachment.isImage);
+
   const removeButton = (attachment: Attachment, variant: "image" | "file") => {
     if (!removable) return null;
     const busy = pending.has(attachment.id);
@@ -199,64 +205,72 @@ export function AttachmentsGrid({
     );
   };
 
+  const fileCard = (attachment: Attachment) => (
+    <div
+      key={attachment.id}
+      className="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm shadow-2xs"
+    >
+      <a
+        href={attachmentDownloadUrl(attachment.id)}
+        download={attachment.fileName}
+        className="flex min-w-0 items-center gap-2 rounded-sm hover:bg-state-hover"
+      >
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-sm bg-secondary text-muted-foreground">
+          <Icon name="File" className="size-3.5" />
+        </span>
+        <span className="min-w-0">
+          <span className="block max-w-48 truncate">{attachment.fileName}</span>
+          <span className="block text-2xs text-muted-foreground">
+            {formatBytes(attachment.sizeBytes)}
+          </span>
+        </span>
+      </a>
+      {removeButton(attachment, "file")}
+    </div>
+  );
+
+  const imageTile = (attachment: Attachment) => (
+    <div
+      key={attachment.id}
+      className="group relative overflow-hidden rounded-md border border-border shadow-2xs"
+    >
+      <button
+        type="button"
+        className="block"
+        title={`${attachment.fileName} · ${formatBytes(attachment.sizeBytes)}`}
+        onClick={() => setLightbox(attachment)}
+      >
+        <img
+          src={attachmentDownloadUrl(attachment.id)}
+          alt={attachment.fileName}
+          className="block h-24 w-36 object-cover transition-opacity group-hover:opacity-90"
+        />
+        <span
+          className="absolute inset-x-0 bottom-0 truncate px-1.5 py-0.5 text-left text-2xs opacity-0 transition-opacity group-hover:opacity-100"
+          style={{
+            background: "color-mix(in oklab, var(--ink) 55%, transparent)",
+            color: "var(--canvas)",
+          }}
+        >
+          {attachment.fileName}
+        </span>
+      </button>
+      {removeButton(attachment, "image")}
+    </div>
+  );
+
   return (
-    <div className="flex flex-wrap gap-2">
-      {attachments.map((attachment) =>
-        attachment.isImage ? (
-          <div
-            key={attachment.id}
-            className="group relative overflow-hidden rounded-md border border-border shadow-2xs"
-          >
-            <button
-              type="button"
-              className="block"
-              title={`${attachment.fileName} · ${formatBytes(attachment.sizeBytes)}`}
-              onClick={() => setLightbox(attachment)}
-            >
-              <img
-                src={attachmentDownloadUrl(attachment.id)}
-                alt={attachment.fileName}
-                className="block h-24 w-36 object-cover transition-opacity group-hover:opacity-90"
-              />
-              <span
-                className="absolute inset-x-0 bottom-0 truncate px-1.5 py-0.5 text-left text-2xs opacity-0 transition-opacity group-hover:opacity-100"
-                style={{
-                  background:
-                    "color-mix(in oklab, var(--ink) 55%, transparent)",
-                  color: "var(--canvas)",
-                }}
-              >
-                {attachment.fileName}
-              </span>
-            </button>
-            {removeButton(attachment, "image")}
-          </div>
-        ) : (
-          <div
-            key={attachment.id}
-            className="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm shadow-2xs"
-          >
-            <a
-              href={attachmentDownloadUrl(attachment.id)}
-              download={attachment.fileName}
-              className="flex min-w-0 items-center gap-2 rounded-sm hover:bg-state-hover"
-            >
-              <span className="flex size-6 shrink-0 items-center justify-center rounded-sm bg-secondary text-muted-foreground">
-                <Icon name="File" className="size-3.5" />
-              </span>
-              <span className="min-w-0">
-                <span className="block max-w-48 truncate">
-                  {attachment.fileName}
-                </span>
-                <span className="block text-2xs text-muted-foreground">
-                  {formatBytes(attachment.sizeBytes)}
-                </span>
-              </span>
-            </a>
-            {removeButton(attachment, "file")}
-          </div>
-        ),
-      )}
+    <div className="flex flex-col gap-2">
+      {files.length > 0 ? (
+        <div className="flex flex-wrap items-start gap-2">
+          {files.map(fileCard)}
+        </div>
+      ) : null}
+      {images.length > 0 ? (
+        <div className="flex flex-wrap items-start gap-2">
+          {images.map(imageTile)}
+        </div>
+      ) : null}
       {lightbox ? (
         <Lightbox attachment={lightbox} onClose={() => setLightbox(null)} />
       ) : null}


### PR DESCRIPTION
## Problem

Task comments mixing image and non-image attachments rendered everything in one `flex flex-wrap`, whose default `align-items: stretch` inflated compact file cards to the height of image figures sharing a wrap row. Image captions were left-aligned and truncated at a fixed 150px regardless of the preview's width.

## Change

**Comment feed (`task-activity.tsx`)** now renders a two-track layout:
- **File track first**: compact cards at natural height (~44px), wrap with `items-start`, 240px max width, one-line truncation with a full-name `title` tooltip, hover + `focus-visible:ring` affordances.
- **Image gallery second**: thumbnails share a row height (96px, 128px in `@2xl` containers) and keep their natural aspect ratio inside a 0.62×–2.2× width clamp — panoramas center-crop at the ceiling, tall phone shots at the floor, so rows stay rectangular. The clamp lives on the figure's button (a non-percentage `max-width`) because percentage max-widths are ignored during intrinsic sizing; this keeps the figure shrink-wrapped to the *cropped* width.
- **Captions** center directly beneath each preview (`w-0 min-w-full` so a long caption can't inflate its figure) and truncate at the image's own width.
- Grouping preserves upload order within each kind; DOM order matches visual order, so keyboard and screen-reader traversal follow the reading order.

**Detail grid (`attachments.tsx`)** gets the same files-before-images grouping with top-aligned tracks (fixing the identical stretch there), keeping its existing tile affordances (hover name overlay, remove, lightbox).

Design spec and mockup are attached to BB-64.

## Verification

- `turbo run typecheck --filter=bb-plugin-tasks` clean; all 316 plugin tests pass including new grouping/caption-association tests.
- Live QA on a dev instance (`scripts/bb-dev-app`) with a seeded 8-attachment mixed comment (4 files uploaded interleaved + 4 images across 4 aspect ratios): file cards measured 44px in every case, image rows uniform 128px desktop / 96px narrow with the panorama clamped at 282px and the portrait at the 80px floor, caption centers at 0px offset, files grouped before images despite a file uploading last, lightbox open/Esc-close intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)