### PR TITLE
BB-60: Fix the Tasks list layout on mobile

### DIFF
--- a/official-plugins/tasks/shell/app-shell.tsx
+++ b/official-plugins/tasks/shell/app-shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { PluginNavPanelProps } from "@bb/plugin-sdk/app";
 import {
   useActiveTasks,
@@ -59,6 +59,73 @@ function hasOpenOverlay(): boolean {
     document.querySelector(
       '[role="dialog"], [role="menu"], [role="listbox"]',
     ) !== null
+  );
+}
+
+/**
+ * Accessible shell for the narrow-container sidebar drawer: dialog semantics,
+ * focus moved in on open and restored on close, a Tab cycle kept inside, and
+ * Escape closing the drawer. `preventDefault` on Escape keeps the shell's
+ * task-back handler from also firing; the `role="dialog"` node additionally
+ * makes `hasOpenOverlay` treat the drawer like every other overlay.
+ */
+function SidebarDrawer({
+  onClose,
+  children,
+}: {
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const previous =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    ref.current?.focus();
+    return () => previous?.focus();
+  }, []);
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key !== "Tab" || !ref.current) return;
+    const focusables = ref.current.querySelectorAll<HTMLElement>(
+      'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (first === undefined || last === undefined) return;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Tasks sidebar"
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      className="absolute inset-0 z-30 focus-visible:outline-none"
+    >
+      <button
+        type="button"
+        aria-label="Close sidebar"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+      />
+      <div className="absolute inset-y-0 right-0 flex max-w-[85%]">
+        {children}
+      </div>
+    </div>
   );
 }
 
@@ -125,21 +192,29 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
   // narrow collapse is transient; an explicit toggle updates the user's
   // client-local preference.
   const rootRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLElement>(null);
   const [narrow, setNarrow] = useState(false);
   const [boardUsable, setBoardUsable] = useState(true);
   const [narrowOverride, setNarrowOverride] = useState<boolean | null>(null);
   useEffect(() => {
     const root = rootRef.current;
-    if (!root || typeof ResizeObserver === "undefined") return;
+    const main = mainRef.current;
+    if (!root || !main || typeof ResizeObserver === "undefined") return;
     const update = () => {
       const width = root.clientWidth;
       // Width 0 means hidden or not yet laid out — keep the wide default.
       setNarrow(width > 0 && width < SIDEBAR_AUTO_COLLAPSE_WIDTH);
-      setBoardUsable(!(width > 0 && width < BOARD_MIN_WIDTH));
+      // Board usability must track the same box the topbar's @md container
+      // rule measures — the main pane, after the desktop sidebar's width —
+      // or a wide sidebar could hide the toggle while the board still
+      // renders.
+      const mainWidth = main.clientWidth;
+      setBoardUsable(!(mainWidth > 0 && mainWidth < BOARD_MIN_WIDTH));
     };
     update();
     const observer = new ResizeObserver(update);
     observer.observe(root);
+    observer.observe(main);
     return () => observer.disconnect();
   }, []);
   useEffect(() => {
@@ -237,22 +312,12 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
     >
       {!effectiveSidebarCollapsed ? (
         sidebarOverlay ? (
-          <div className="absolute inset-0 z-30">
-            <button
-              type="button"
-              aria-label="Close sidebar"
-              onClick={toggleSidebar}
-              className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
-            />
-            <div className="absolute inset-y-0 right-0 flex max-w-[85%]">
-              {sidebar}
-            </div>
-          </div>
+          <SidebarDrawer onClose={toggleSidebar}>{sidebar}</SidebarDrawer>
         ) : (
           sidebar
         )
       ) : null}
-      <main className="@container flex min-w-0 flex-1 flex-col">
+      <main ref={mainRef} className="@container flex min-w-0 flex-1 flex-col">
         <TasksTopbar
           route={route}
           projects={projects.data}

--- a/official-plugins/tasks/shell/app-shell.tsx
+++ b/official-plugins/tasks/shell/app-shell.tsx
@@ -34,6 +34,12 @@ import { TasksRefreshProvider } from "./refresh.js";
     auto-collapses. */
 const SIDEBAR_AUTO_COLLAPSE_WIDTH = 720;
 
+/** Below this container width the board is unusable (columns get crushed), so
+    project routes render the list and the topbar hides the List/Board toggle.
+    Matches the rows' two-line breakpoint (@md, 448px) so the whole surface
+    flips to its phone layout at one width. */
+const BOARD_MIN_WIDTH = 448;
+
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   return (
@@ -77,7 +83,16 @@ function NoProjectsEmptyState({ onNewProject }: { onNewProject: () => void }) {
   );
 }
 
-function RouteOutlet({ route }: { route: TasksRoute }) {
+function RouteOutlet({
+  route,
+  boardUsable,
+}: {
+  route: TasksRoute;
+  /** False in phone-width containers: board routes fall back to the list
+      (deep links/rotation would otherwise strand a crushed board with the
+      toggle hidden). The URL keeps the board view for when width returns. */
+  boardUsable: boolean;
+}) {
   switch (route.kind) {
     case "all":
       return <ListView projectId={null} />;
@@ -88,7 +103,7 @@ function RouteOutlet({ route }: { route: TasksRoute }) {
     case "task":
       return <DetailView taskKey={route.taskKey} />;
     case "project":
-      return route.view === "board" ? (
+      return route.view === "board" && boardUsable ? (
         <BoardView projectId={route.projectId} />
       ) : (
         <ListView projectId={route.projectId} />
@@ -111,6 +126,7 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
   // client-local preference.
   const rootRef = useRef<HTMLDivElement>(null);
   const [narrow, setNarrow] = useState(false);
+  const [boardUsable, setBoardUsable] = useState(true);
   const [narrowOverride, setNarrowOverride] = useState<boolean | null>(null);
   useEffect(() => {
     const root = rootRef.current;
@@ -119,6 +135,7 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
       const width = root.clientWidth;
       // Width 0 means hidden or not yet laid out — keep the wide default.
       setNarrow(width > 0 && width < SIDEBAR_AUTO_COLLAPSE_WIDTH);
+      setBoardUsable(!(width > 0 && width < BOARD_MIN_WIDTH));
     };
     update();
     const observer = new ResizeObserver(update);
@@ -261,7 +278,7 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
               onNewProject={() => setNewProjectOpen(true)}
             />
           ) : (
-            <RouteOutlet route={route} />
+            <RouteOutlet route={route} boardUsable={boardUsable} />
           )}
         </div>
       </main>

--- a/official-plugins/tasks/shell/app-shell.tsx
+++ b/official-plugins/tasks/shell/app-shell.tsx
@@ -50,8 +50,9 @@ function isEditableTarget(target: EventTarget | null): boolean {
  */
 function hasOpenOverlay(): boolean {
   return (
-    document.querySelector('[role="dialog"], [role="menu"], [role="listbox"]') !==
-    null
+    document.querySelector(
+      '[role="dialog"], [role="menu"], [role="listbox"]',
+    ) !== null
   );
 }
 
@@ -187,25 +188,54 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
+  // In narrow containers the sidebar can't share the row (208px of a 320px
+  // viewport would crush the list), so it opens as an overlay drawer instead.
+  // Navigating from the drawer closes it — the destination is what the user
+  // came for, and the transient narrow override resets to its collapsed
+  // default rather than persisting a preference.
+  const sidebarOverlay = narrow && !effectiveSidebarCollapsed;
+  const navigateFromSidebar = (target: TasksRoute) => {
+    if (sidebarOverlay) setNarrowOverride(null);
+    navigation.go(target);
+  };
+  const sidebar = (
+    <TasksSidebar
+      route={route}
+      folders={folders.data}
+      projects={projects.data}
+      summaries={summaries.data}
+      presets={presets.data}
+      activeTasks={activeTasks.data}
+      isLoading={projects.isLoading || summaries.isLoading}
+      overlay={sidebarOverlay}
+      onNavigate={navigateFromSidebar}
+      onNewProject={() => setNewProjectOpen(true)}
+    />
+  );
+
   return (
     <div
       ref={rootRef}
-      className="flex h-full min-h-0 flex-row-reverse bg-background text-foreground"
+      className="relative flex h-full min-h-0 flex-row-reverse bg-background text-foreground"
     >
       {!effectiveSidebarCollapsed ? (
-        <TasksSidebar
-          route={route}
-          folders={folders.data}
-          projects={projects.data}
-          summaries={summaries.data}
-          presets={presets.data}
-          activeTasks={activeTasks.data}
-          isLoading={projects.isLoading || summaries.isLoading}
-          onNavigate={navigation.go}
-          onNewProject={() => setNewProjectOpen(true)}
-        />
+        sidebarOverlay ? (
+          <div className="absolute inset-0 z-30">
+            <button
+              type="button"
+              aria-label="Close sidebar"
+              onClick={toggleSidebar}
+              className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+            />
+            <div className="absolute inset-y-0 right-0 flex max-w-[85%]">
+              {sidebar}
+            </div>
+          </div>
+        ) : (
+          sidebar
+        )
       ) : null}
-      <main className="flex min-w-0 flex-1 flex-col">
+      <main className="@container flex min-w-0 flex-1 flex-col">
         <TasksTopbar
           route={route}
           projects={projects.data}
@@ -227,7 +257,9 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
         />
         <div className="min-h-0 flex-1 overflow-auto">
           {noProjects && route.kind !== "task" && route.kind !== "manage" ? (
-            <NoProjectsEmptyState onNewProject={() => setNewProjectOpen(true)} />
+            <NoProjectsEmptyState
+              onNewProject={() => setNewProjectOpen(true)}
+            />
           ) : (
             <RouteOutlet route={route} />
           )}

--- a/official-plugins/tasks/shell/sidebar.tsx
+++ b/official-plugins/tasks/shell/sidebar.tsx
@@ -64,7 +64,7 @@ function SidebarRow({ active, onClick, children, title }: SidebarRowProps) {
       onClick={onClick}
       title={title}
       className={cn(
-        "flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring max-md:pointer-coarse:h-9",
         onClick ? "cursor-pointer" : "cursor-default",
         active
           ? "bg-sidebar-accent font-medium text-foreground"
@@ -91,7 +91,10 @@ function SectionHeader({
       {onToggle ? (
         <Icon
           name="ChevronDown"
-          className={cn("size-3 transition-transform", collapsed && "-rotate-90")}
+          className={cn(
+            "size-3 transition-transform",
+            collapsed && "-rotate-90",
+          )}
         />
       ) : null}
       {label}
@@ -187,6 +190,12 @@ export interface TasksSidebarProps {
   presets: Preset[] | undefined;
   activeTasks: Task[] | undefined;
   isLoading: boolean;
+  /**
+   * Rendered as an overlay drawer over the list (narrow containers). Uses a
+   * fixed drawer width and hides the resize handle; the stored desktop width
+   * is left untouched.
+   */
+  overlay?: boolean;
   onNavigate: (route: TasksRoute) => void;
   onNewProject: () => void;
 }
@@ -199,6 +208,7 @@ export function TasksSidebar({
   presets,
   activeTasks,
   isLoading,
+  overlay = false,
   onNavigate,
   onNewProject,
 }: TasksSidebarProps) {
@@ -275,9 +285,7 @@ export function TasksSidebar({
     const folderProjects = (projects ?? []).filter(
       (p) => p.folderId === folder.id,
     );
-    const children = childFolders.filter(
-      (f) => f.parentFolderId === folder.id,
-    );
+    const children = childFolders.filter((f) => f.parentFolderId === folder.id);
     return (
       <div key={folder.id} className={cn(indent && "pl-3")}>
         <SectionHeader
@@ -297,7 +305,9 @@ export function TasksSidebar({
               />
             ))}
             {/* Folders nest one level; children only render under roots. */}
-            {!indent ? children.map((child) => renderFolder(child, true)) : null}
+            {!indent
+              ? children.map((child) => renderFolder(child, true))
+              : null}
           </div>
         ) : null}
       </div>
@@ -307,27 +317,30 @@ export function TasksSidebar({
   return (
     <aside
       ref={asideRef}
-      style={{ width }}
+      style={overlay ? undefined : { width }}
       className={cn(
         "relative flex h-full shrink-0 flex-col border-l border-border-seam-vertical bg-sidebar",
+        overlay && "w-72 min-w-0 max-w-full shrink shadow-lg",
         resizing && "select-none",
       )}
     >
-      <div
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize sidebar"
-        title="Drag to resize · double-click to reset"
-        className={cn(
-          "absolute inset-y-0 -left-px z-10 w-1 cursor-col-resize transition-colors",
-          resizing ? "bg-primary/50" : "hover:bg-primary/30",
-        )}
-        onPointerDown={startResize}
-        onPointerMove={moveResize}
-        onPointerUp={endResize}
-        onPointerCancel={endResize}
-        onDoubleClick={resetWidth}
-      />
+      {!overlay ? (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          title="Drag to resize · double-click to reset"
+          className={cn(
+            "absolute inset-y-0 -left-px z-10 w-1 cursor-col-resize transition-colors",
+            resizing ? "bg-primary/50" : "hover:bg-primary/30",
+          )}
+          onPointerDown={startResize}
+          onPointerMove={moveResize}
+          onPointerUp={endResize}
+          onPointerCancel={endResize}
+          onDoubleClick={resetWidth}
+        />
+      ) : null}
       <nav className="min-h-0 flex-1 overflow-y-auto px-2 pb-4 pt-2">
         <div className="space-y-px">
           <SidebarRow

--- a/official-plugins/tasks/shell/topbar.tsx
+++ b/official-plugins/tasks/shell/topbar.tsx
@@ -78,14 +78,19 @@ function TaskPager({
     if (key !== null) onNavigate({ kind: "task", taskKey: key });
   };
   return (
-    <div className="flex shrink-0 items-center gap-0.5 text-xs tabular-nums text-muted-foreground">
-      <span className="px-1">
+    // The pager yields entirely below @sm so the task key — the row's
+    // identity — keeps the width; the in-page task content carries its own
+    // navigation on the smallest phones.
+    <div className="hidden shrink-0 items-center gap-0.5 text-xs tabular-nums text-muted-foreground @sm:flex">
+      {/* The position readout yields to the task key in narrow containers;
+          the step buttons remain. */}
+      <span className="hidden px-1 @md:inline">
         {position.index} / {position.total}
       </span>
       <Button
         variant="ghost"
         size="icon"
-        className="size-6"
+        className="size-6 max-md:pointer-coarse:size-9"
         aria-label="Previous task"
         disabled={position.prevKey === null}
         onClick={() => step(position.prevKey)}
@@ -95,7 +100,7 @@ function TaskPager({
       <Button
         variant="ghost"
         size="icon"
-        className="size-6"
+        className="size-6 max-md:pointer-coarse:size-9"
         aria-label="Next task"
         disabled={position.nextKey === null}
         onClick={() => step(position.nextKey)}
@@ -119,7 +124,7 @@ function ViewToggle({
       onClick={() => onChange(mode)}
       aria-pressed={view === mode}
       className={cn(
-        "rounded-sm px-2.5 py-0.5 text-xs",
+        "rounded-sm px-2.5 py-0.5 text-xs max-md:pointer-coarse:py-1.5",
         view === mode
           ? "bg-background text-foreground shadow-2xs"
           : "text-muted-foreground hover:text-foreground",
@@ -158,7 +163,7 @@ function RefreshTasksButton() {
             type="button"
             variant="ghost"
             size="icon"
-            className="size-7 shrink-0 text-muted-foreground hover:text-foreground active:bg-state-active active:text-foreground"
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground active:bg-state-active active:text-foreground max-md:pointer-coarse:size-9"
             aria-label={REFRESH_TASKS_LABEL}
             aria-busy={isRefreshing}
             disabled={isRefreshing}
@@ -217,12 +222,14 @@ export function TasksTopbar({
   const breadcrumb = (() => {
     switch (route.kind) {
       case "all":
-        return <span className="font-semibold">All tasks</span>;
+        return (
+          <span className="whitespace-nowrap font-semibold">All tasks</span>
+        );
       case "active":
         return (
           <span className="flex items-center gap-2">
-            <span className="font-semibold">Active</span>
-            <span className="text-xs font-normal text-muted-foreground">
+            <span className="whitespace-nowrap font-semibold">Active</span>
+            <span className="hidden text-xs font-normal text-muted-foreground @md:inline">
               agents working now
             </span>
           </span>
@@ -230,8 +237,8 @@ export function TasksTopbar({
       case "manage":
         return (
           <span className="flex items-center gap-2">
-            <span className="font-semibold">Manage</span>
-            <span className="text-xs font-normal text-muted-foreground">
+            <span className="whitespace-nowrap font-semibold">Manage</span>
+            <span className="hidden text-xs font-normal text-muted-foreground @md:inline">
               labels, presets, folders
             </span>
           </span>
@@ -257,16 +264,18 @@ export function TasksTopbar({
             <Button
               variant="ghost"
               size="icon"
-              className="size-6 shrink-0"
+              className="size-6 shrink-0 max-md:pointer-coarse:size-9"
               aria-label="Back (Esc)"
               onClick={onBack}
             >
               <Icon name="ChevronLeft" className="size-4" />
             </Button>
+            {/* In narrow containers the project crumb yields the row to the
+                task key — the back button already returns to the project. */}
             {project ? (
               <button
                 type="button"
-                className="flex min-w-0 items-center gap-2 text-muted-foreground hover:text-foreground"
+                className="hidden min-w-0 items-center gap-2 text-muted-foreground hover:text-foreground @md:flex"
                 onClick={() =>
                   onNavigate({
                     kind: "project",
@@ -286,10 +295,10 @@ export function TasksTopbar({
             {project ? (
               <Icon
                 name="ChevronRight"
-                className="size-3 shrink-0 text-muted-foreground"
+                className="hidden size-3 shrink-0 text-muted-foreground @md:block"
               />
             ) : null}
-            <span className="shrink-0 font-medium text-muted-foreground">
+            <span className="min-w-0 truncate font-medium text-muted-foreground">
               {route.taskKey}
             </span>
           </span>
@@ -298,8 +307,16 @@ export function TasksTopbar({
   })();
 
   return (
-    <header className="flex h-11 shrink-0 items-center gap-2.5 border-b border-border-hairline bg-background px-3.5 text-sm">
-      <div className="min-w-0 flex-1">{breadcrumb}</div>
+    // On compact viewports the host renders no pane header above this bar, so
+    // the host's fixed sidebar toggle (pinned at the window's top-left, see the
+    // app's SidebarTriggerOverlay) shares this row. Reserve its footprint as
+    // left padding — 12px inset + 28px trigger + 8px gap (36px touch trigger on
+    // coarse pointers) — and match the 48px chrome-row height so the toggle and
+    // this bar's controls sit on one axis. The reserve keys off the viewport
+    // (`max-md:`), not the container, because the toggle is viewport-fixed and
+    // wide windows always place a host pane header above this bar instead.
+    <header className="flex h-11 shrink-0 items-center gap-2.5 border-b border-border-hairline bg-background px-3.5 text-sm max-md:h-12 max-md:pl-12 max-md:pointer-coarse:pl-14">
+      <div className="min-w-0 flex-1 overflow-hidden">{breadcrumb}</div>
       {route.kind === "task" &&
       (pagerScope !== null || projects !== undefined) ? (
         <TaskPager
@@ -321,15 +338,22 @@ export function TasksTopbar({
       {/* Refresh sits immediately left of the primary New task action. */}
       <RefreshTasksButton />
       {route.kind !== "task" && route.kind !== "manage" ? (
-        <Button size="sm" className="h-7 gap-1.5" onClick={onNewTask}>
+        <Button
+          size="sm"
+          className="h-7 gap-1.5 max-md:pointer-coarse:h-9"
+          aria-label="New task"
+          onClick={onNewTask}
+        >
           <Icon name="Plus" className="size-3.5" />
-          New task
+          {/* Icon-only in narrow containers so the breadcrumb (project name,
+              view toggle) keeps readable width. */}
+          <span className="hidden @lg:inline">New task</span>
         </Button>
       ) : null}
       <Button
         variant="ghost"
         size="icon"
-        className="size-7"
+        className="size-7 max-md:pointer-coarse:size-9"
         aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
         aria-expanded={!sidebarCollapsed}
         onClick={onToggleSidebar}

--- a/official-plugins/tasks/shell/topbar.tsx
+++ b/official-plugins/tasks/shell/topbar.tsx
@@ -330,10 +330,14 @@ export function TasksTopbar({
         />
       ) : null}
       {route.kind === "project" ? (
-        <ViewToggle
-          view={route.view}
-          onChange={(view) => onNavigate({ ...route, view })}
-        />
+        // Hidden in phone-width containers, where the board is unusable and
+        // the shell renders the list regardless (see BOARD_MIN_WIDTH).
+        <span className="hidden @md:block">
+          <ViewToggle
+            view={route.view}
+            onChange={(view) => onNavigate({ ...route, view })}
+          />
+        </span>
       ) : null}
       {/* Refresh sits immediately left of the primary New task action. */}
       <RefreshTasksButton />

--- a/official-plugins/tasks/views/list/filter-bar.tsx
+++ b/official-plugins/tasks/views/list/filter-bar.tsx
@@ -45,7 +45,7 @@ function FilterChip({
         <button
           type="button"
           className={cn(
-            "flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs",
+            "flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs max-md:pointer-coarse:h-8",
             active
               ? "border-border bg-secondary text-foreground"
               : "border-dashed border-border text-muted-foreground hover:border-input hover:text-foreground",
@@ -54,7 +54,7 @@ function FilterChip({
           <Icon name={icon} className="size-3" />
           {label}
           {active ? (
-            <span className="max-w-48 truncate font-medium">
+            <span className="max-w-48 truncate font-medium @max-md:max-w-24">
               {selectedNames.join(", ")}
             </span>
           ) : null}
@@ -81,7 +81,7 @@ function SortChip({
         <button
           type="button"
           className={cn(
-            "flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs",
+            "flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs max-md:pointer-coarse:h-8",
             active
               ? "border-border bg-secondary text-foreground"
               : "border-dashed border-border text-muted-foreground hover:border-input hover:text-foreground",
@@ -158,142 +158,149 @@ export function ListFilterBar({
   const showLabelChip =
     labelOptions.length > 0 || filters.labelNames.length > 0;
   return (
-    <div className="flex shrink-0 items-center gap-1.5 overflow-x-auto border-b border-border-hairline px-3.5 py-1.5">
-      <FilterChip
-        icon="Circle"
-        label="Status"
-        selectedNames={filters.statuses.map((status) => STATUS_LABELS[status])}
-      >
-        {TASK_STATUSES.map((status) => (
-          <DropdownMenuCheckboxItem
-            key={status}
-            checked={filters.statuses.includes(status)}
-            onSelect={keepOpen}
-            onCheckedChange={(checked) =>
-              onChange({
-                ...filters,
-                statuses: toggled(filters.statuses, status, checked === true),
-              })
-            }
-          >
-            <span className="flex items-center gap-2">
-              <StatusIcon status={status} className="size-3" />
-              {STATUS_LABELS[status]}
-            </span>
-          </DropdownMenuCheckboxItem>
-        ))}
-      </FilterChip>
-      <FilterChip
-        icon="ArrowUpDown"
-        label="Priority"
-        selectedNames={filters.priorities.map(
-          (priority) => PRIORITY_LABELS[priority],
-        )}
-      >
-        {TASK_PRIORITIES.map((priority) => (
-          <DropdownMenuCheckboxItem
-            key={priority}
-            checked={filters.priorities.includes(priority)}
-            onSelect={keepOpen}
-            onCheckedChange={(checked) =>
-              onChange({
-                ...filters,
-                priorities: toggled(
-                  filters.priorities,
-                  priority,
-                  checked === true,
-                ),
-              })
-            }
-          >
-            <span className="flex items-center gap-2">
-              <PriorityIcon priority={priority} className="size-3" />
-              {PRIORITY_LABELS[priority]}
-            </span>
-          </DropdownMenuCheckboxItem>
-        ))}
-      </FilterChip>
-      {showLabelChip ? (
+    // The chips live in their own horizontal scroller while the task count is
+    // pinned outside it, so the count never wraps and stays visible however
+    // many chips overflow a narrow container.
+    <div className="flex shrink-0 items-center gap-1.5 border-b border-border-hairline px-3.5 py-1.5">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto">
         <FilterChip
-          icon="ListTodo"
-          label="Label"
-          selectedNames={filters.labelNames}
+          icon="Circle"
+          label="Status"
+          selectedNames={filters.statuses.map(
+            (status) => STATUS_LABELS[status],
+          )}
         >
-          {labelOptions.map((option) => (
+          {TASK_STATUSES.map((status) => (
             <DropdownMenuCheckboxItem
-              key={option.name}
-              checked={filters.labelNames.includes(option.name)}
+              key={status}
+              checked={filters.statuses.includes(status)}
               onSelect={keepOpen}
               onCheckedChange={(checked) =>
                 onChange({
                   ...filters,
-                  labelNames: toggled(
-                    filters.labelNames,
-                    option.name,
+                  statuses: toggled(filters.statuses, status, checked === true),
+                })
+              }
+            >
+              <span className="flex items-center gap-2">
+                <StatusIcon status={status} className="size-3" />
+                {STATUS_LABELS[status]}
+              </span>
+            </DropdownMenuCheckboxItem>
+          ))}
+        </FilterChip>
+        <FilterChip
+          icon="ArrowUpDown"
+          label="Priority"
+          selectedNames={filters.priorities.map(
+            (priority) => PRIORITY_LABELS[priority],
+          )}
+        >
+          {TASK_PRIORITIES.map((priority) => (
+            <DropdownMenuCheckboxItem
+              key={priority}
+              checked={filters.priorities.includes(priority)}
+              onSelect={keepOpen}
+              onCheckedChange={(checked) =>
+                onChange({
+                  ...filters,
+                  priorities: toggled(
+                    filters.priorities,
+                    priority,
                     checked === true,
                   ),
                 })
               }
             >
               <span className="flex items-center gap-2">
-                <span
-                  aria-hidden
-                  className="size-2 rounded-full"
-                  style={{ backgroundColor: option.color }}
-                />
-                {option.name}
+                <PriorityIcon priority={priority} className="size-3" />
+                {PRIORITY_LABELS[priority]}
               </span>
             </DropdownMenuCheckboxItem>
           ))}
-          {filters.labelNames
-            .filter(
-              (name) => !labelOptions.some((option) => option.name === name),
-            )
-            .map((name) => (
+        </FilterChip>
+        {showLabelChip ? (
+          <FilterChip
+            icon="ListTodo"
+            label="Label"
+            selectedNames={filters.labelNames}
+          >
+            {labelOptions.map((option) => (
               <DropdownMenuCheckboxItem
-                key={`stale:${name}`}
-                checked
+                key={option.name}
+                checked={filters.labelNames.includes(option.name)}
                 onSelect={keepOpen}
                 onCheckedChange={(checked) =>
                   onChange({
                     ...filters,
                     labelNames: toggled(
                       filters.labelNames,
-                      name,
+                      option.name,
                       checked === true,
                     ),
                   })
                 }
               >
-                <span className="flex items-center gap-2 text-muted-foreground">
+                <span className="flex items-center gap-2">
                   <span
                     aria-hidden
-                    className="size-2 rounded-full bg-muted-foreground/40"
+                    className="size-2 rounded-full"
+                    style={{ backgroundColor: option.color }}
                   />
-                  {name}
-                  <span className="text-xs">(unavailable)</span>
+                  {option.name}
                 </span>
               </DropdownMenuCheckboxItem>
             ))}
-        </FilterChip>
-      ) : null}
-      {hasActiveFilters(filters) ? (
-        <button
-          type="button"
-          onClick={() => onChange(EMPTY_FILTERS)}
-          className="flex h-6 shrink-0 items-center gap-1 rounded-md border border-dashed border-border px-2.5 text-xs text-muted-foreground hover:border-input hover:text-foreground"
-        >
-          <Icon name="X" className="size-3" />
-          Clear
-        </button>
-      ) : null}
-      <span className="ml-auto flex items-center gap-2">
-        <SortChip sort={sort} onChange={onSortChange} />
-        <span className="text-xs tabular-nums text-subtle-foreground">
-          {taskCount === undefined
-            ? ""
-            : `${taskCount} ${taskCount === 1 ? "task" : "tasks"}`}
-        </span>
+            {filters.labelNames
+              .filter(
+                (name) => !labelOptions.some((option) => option.name === name),
+              )
+              .map((name) => (
+                <DropdownMenuCheckboxItem
+                  key={`stale:${name}`}
+                  checked
+                  onSelect={keepOpen}
+                  onCheckedChange={(checked) =>
+                    onChange({
+                      ...filters,
+                      labelNames: toggled(
+                        filters.labelNames,
+                        name,
+                        checked === true,
+                      ),
+                    })
+                  }
+                >
+                  <span className="flex items-center gap-2 text-muted-foreground">
+                    <span
+                      aria-hidden
+                      className="size-2 rounded-full bg-muted-foreground/40"
+                    />
+                    {name}
+                    <span className="text-xs">(unavailable)</span>
+                  </span>
+                </DropdownMenuCheckboxItem>
+              ))}
+          </FilterChip>
+        ) : null}
+        {hasActiveFilters(filters) ? (
+          <button
+            type="button"
+            onClick={() => onChange(EMPTY_FILTERS)}
+            className="flex h-6 shrink-0 items-center gap-1 rounded-md border border-dashed border-border px-2.5 text-xs text-muted-foreground hover:border-input hover:text-foreground max-md:pointer-coarse:h-8"
+          >
+            <Icon name="X" className="size-3" />
+            Clear
+          </button>
+        ) : null}
+      </div>
+      {/* Sort and the count sit outside the scroller so they stay visible and
+          aligned however far the filter chips overflow. */}
+      <SortChip sort={sort} onChange={onSortChange} />
+      <span className="shrink-0 whitespace-nowrap text-xs tabular-nums text-subtle-foreground">
+        {taskCount === undefined
+          ? ""
+          : `${taskCount} ${taskCount === 1 ? "task" : "tasks"}`}
       </span>
     </div>
   );

--- a/official-plugins/tasks/views/list/index.tsx
+++ b/official-plugins/tasks/views/list/index.tsx
@@ -166,7 +166,8 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
     return map;
   }, [labels.data]);
   const projectsById = useMemo(
-    () => new Map((projects.data ?? []).map((project) => [project.id, project])),
+    () =>
+      new Map((projects.data ?? []).map((project) => [project.id, project])),
     [projects.data],
   );
 
@@ -177,7 +178,12 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   const displayTasks = useMemo(() => {
     if (tasksQuery.data === undefined) return undefined;
     return editedTasks(tasksQuery.data, edits.entries).filter((task) =>
-      matchesFilters(task, filters.statuses, filters.priorities, labelIds ?? []),
+      matchesFilters(
+        task,
+        filters.statuses,
+        filters.priorities,
+        labelIds ?? [],
+      ),
     );
   }, [
     tasksQuery.data,
@@ -217,11 +223,16 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
 
   let body: React.ReactNode;
   if (tasksQuery.data === undefined || displayTasks === undefined) {
-    body = tasksQuery.error !== null ? (
-      <EmptyState icon="AlertCircle" title="Couldn't load tasks" description={tasksQuery.error} />
-    ) : (
-      <LoadingRows />
-    );
+    body =
+      tasksQuery.error !== null ? (
+        <EmptyState
+          icon="AlertCircle"
+          title="Couldn't load tasks"
+          description={tasksQuery.error}
+        />
+      ) : (
+        <LoadingRows />
+      );
   } else if (displayTasks.length === 0) {
     if (filtered) {
       body = (

--- a/official-plugins/tasks/views/list/mobile-layout.test.tsx
+++ b/official-plugins/tasks/views/list/mobile-layout.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { cleanup, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import type { Label, Task, TaskThread } from "../../shared/contract.js";
+
+// jsdom lacks matchMedia/ResizeObserver; the list shell touches both.
+window.matchMedia ??= (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+window.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView ??= () => {};
+
+const app = await loadPluginApp(() => import("../../app"));
+
+afterEach(cleanup);
+
+const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
+
+const project = {
+  id: PROJECT_ID,
+  name: "Tasks Plugin",
+  prefix: "TSK",
+  nextTaskNumber: 9,
+  color: "blue",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-07-15T00:00:00.000Z",
+};
+
+const labels: Label[] = ["bug", "frontend", "needs-design"].map(
+  (name, index) => ({
+    id: `01HZZZZZZZZZZZZZZZZZZZZZL${index}`,
+    projectId: PROJECT_ID,
+    name,
+    color: "#5e6ad2",
+  }),
+);
+
+const busyTask: Task = {
+  id: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+  projectId: PROJECT_ID,
+  number: 1,
+  key: "TSK-1",
+  title: "A task carrying every piece of row metadata at once",
+  description: "",
+  status: "todo",
+  priority: "high",
+  dueDate: "2026-07-20",
+  parentTaskId: null,
+  position: 1,
+  createdAt: "2026-07-15T00:00:00.000Z",
+  updatedAt: "2026-07-15T00:00:00.000Z",
+  labelIds: labels.map((label) => label.id),
+};
+
+const workerThread: TaskThread = {
+  id: "01HZZZZZZZZZZZZZZZZZZZZZH1",
+  taskId: busyTask.id,
+  threadId: "thr_W1",
+  presetName: "Worker",
+  title: "Worker",
+  liveStatus: "working",
+  attachedAt: "2026-07-15T00:00:00.000Z",
+  updatedAt: "2026-07-15T00:00:00.000Z",
+};
+
+function renderList() {
+  return renderSlot(
+    app.navPanels[0]!,
+    { subPath: PROJECT_ID },
+    {
+      rpc: {
+        listProjects: () => ({ projects: [project] }),
+        listFolders: () => ({ folders: [] }),
+        listPresets: () => ({ presets: [] }),
+        sidebarSummary: () => ({ projects: [] }),
+        listLabels: () => ({ labels }),
+        listTasks: () => ({ tasks: [busyTask] }),
+        listTaskThreads: () => ({ taskThreads: [workerThread] }),
+        listComments: () => ({ comments: [] }),
+        listAttachments: () => ({ attachments: [] }),
+      },
+    },
+  );
+}
+
+describe("responsive list structure", () => {
+  it("pins the task count outside the filter-chip scroller so it cannot wrap or scroll away", async () => {
+    const slot = renderList();
+    const count = await slot.findByText("1 task");
+    // Non-wrapping, and never a descendant of the horizontal chip scroller —
+    // otherwise a crowded mobile filter bar wraps the count to two lines
+    // (BB-60) or scrolls it out of view.
+    expect(count.className).toContain("whitespace-nowrap");
+    expect(count.closest(".overflow-x-auto")).toBeNull();
+    // Sort is pinned beside the count, outside the scroller, while the
+    // filter chips scroll.
+    const sortChip = slot.getByRole("button", { name: /Sort/ });
+    expect(sortChip.closest(".overflow-x-auto")).toBeNull();
+    const statusChip = slot.getByRole("button", {
+      name: "Status",
+      exact: true,
+    });
+    expect(statusChip.closest(".overflow-x-auto")).not.toBeNull();
+  });
+
+  it("renders exactly one status and one priority editor per row with full metadata", async () => {
+    // The two-line mobile layout repositions the same editor elements via
+    // container queries. A regression that renders per-breakpoint duplicates
+    // would double the interactive controls (and their accessible names).
+    const slot = renderList();
+    await slot.findByText("TSK-1");
+    const row = slot.container.querySelector('[data-task-key="TSK-1"]')!;
+    expect(
+      within(row as HTMLElement).getAllByRole("button", {
+        name: /Change status, currently/,
+      }),
+    ).toHaveLength(1);
+    expect(
+      within(row as HTMLElement).getAllByRole("button", {
+        name: /Set priority, currently/,
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/official-plugins/tasks/views/list/property-menus.tsx
+++ b/official-plugins/tasks/views/list/property-menus.tsx
@@ -27,6 +27,7 @@ import {
   ContextMenuTrigger,
 } from "@bb/shared-ui/context-menu";
 import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
 import type { TaskEdit } from "./optimistic.js";
 import { PriorityIcon, StatusIcon } from "./icons.js";
 import { formatDueDate, PRIORITY_LABELS, STATUS_LABELS } from "./lib.js";
@@ -72,9 +73,7 @@ export function isBareKey(event: {
   altKey: boolean;
   shiftKey: boolean;
 }): boolean {
-  return (
-    !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
-  );
+  return !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
 }
 
 function localIsoDate(daysFromNow: number): string {
@@ -147,7 +146,7 @@ function PickerOption({
 }
 
 const TRIGGER_CLASS =
-  "relative z-10 inline-flex size-5 shrink-0 items-center justify-center rounded-sm hover:bg-state-active focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-state-active";
+  "relative z-10 inline-flex size-5 shrink-0 items-center justify-center rounded-sm hover:bg-state-active focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-state-active max-md:pointer-coarse:size-8";
 
 /** Inline status picker: the row's status glyph, click/S to open the menu. */
 export function StatusEditor({
@@ -156,12 +155,15 @@ export function StatusEditor({
   open,
   onOpenChange,
   triggerRef,
+  className,
 }: {
   task: Task;
   onEdit: EditFn;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   triggerRef?: Ref<HTMLButtonElement>;
+  /** Extra classes for the trigger button (e.g. grid placement in list rows). */
+  className?: string;
 }) {
   const select = (status: TaskStatus) => {
     if (status !== task.status) onEdit(task, { status });
@@ -173,7 +175,7 @@ export function StatusEditor({
           ref={triggerRef}
           type="button"
           aria-label={`Change status, currently ${STATUS_LABELS[task.status]}`}
-          className={TRIGGER_CLASS}
+          className={cn(TRIGGER_CLASS, className)}
         >
           <StatusIcon status={task.status} />
         </button>
@@ -218,12 +220,15 @@ export function PriorityEditor({
   open,
   onOpenChange,
   triggerRef,
+  className,
 }: {
   task: Task;
   onEdit: EditFn;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   triggerRef?: Ref<HTMLButtonElement>;
+  /** Extra classes for the trigger button (e.g. grid placement in list rows). */
+  className?: string;
 }) {
   const select = (priority: TaskPriority) => {
     if (priority !== task.priority) onEdit(task, { priority });
@@ -235,7 +240,7 @@ export function PriorityEditor({
           ref={triggerRef}
           type="button"
           aria-label={`Set priority, currently ${PRIORITY_LABELS[task.priority]}`}
-          className={TRIGGER_CLASS}
+          className={cn(TRIGGER_CLASS, className)}
         >
           <PriorityIcon priority={task.priority} />
         </button>
@@ -384,7 +389,9 @@ export function TaskContextMenu({
             {task.dueDate !== null ? (
               <>
                 <ContextMenuSeparator />
-                <ContextMenuItem onSelect={() => onEdit(task, { dueDate: null })}>
+                <ContextMenuItem
+                  onSelect={() => onEdit(task, { dueDate: null })}
+                >
                   <Icon name="X" className="size-3.5" />
                   <span>No due date</span>
                 </ContextMenuItem>

--- a/official-plugins/tasks/views/list/row.tsx
+++ b/official-plugins/tasks/views/list/row.tsx
@@ -151,7 +151,13 @@ export function TaskRow({
         data-task-key={task.key}
         aria-busy={pending || undefined}
         className={cn(
-          "relative flex h-[34px] w-full items-center gap-2 border-b border-border-hairline px-3.5 text-left transition-opacity hover:bg-state-hover",
+          // Narrow containers get a two-line hierarchy: status + full-width
+          // title on top, then priority, key, and the metadata rail below.
+          // From @md up the same children lay out as the classic single flex
+          // row (the grid placement classes are inert in flex), so desktop
+          // keeps its exact 34px rows.
+          "relative grid w-full grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-x-2 gap-y-1 border-b border-border-hairline px-3.5 py-1.5 text-left transition-opacity hover:bg-state-hover",
+          "@md:flex @md:h-[34px] @md:py-0",
           pending && "opacity-70",
         )}
       >
@@ -177,8 +183,9 @@ export function TaskRow({
           onEdit={onEdit}
           open={openMenu === "priority"}
           onOpenChange={(next) => setOpenMenu(next ? "priority" : null)}
+          className="col-start-1 row-start-2"
         />
-        <span className="w-14 shrink-0 truncate text-xs tabular-nums text-subtle-foreground">
+        <span className="col-start-2 row-start-2 min-w-0 truncate text-xs tabular-nums text-subtle-foreground @max-md:max-w-32 @md:w-14 @md:shrink-0">
           {task.key}
         </span>
         <StatusEditor
@@ -186,9 +193,12 @@ export function TaskRow({
           onEdit={onEdit}
           open={openMenu === "status"}
           onOpenChange={(next) => setOpenMenu(next ? "status" : null)}
+          className="col-start-1 row-start-1"
         />
-        <span className="min-w-0 flex-1 truncate text-sm">{task.title}</span>
-        <span className="flex shrink-0 items-center gap-1.5 text-xs text-subtle-foreground">
+        <span className="col-start-2 col-span-2 row-start-1 min-w-0 truncate text-sm @md:flex-1">
+          {task.title}
+        </span>
+        <span className="col-start-3 row-start-2 flex min-w-0 items-center gap-1.5 justify-self-end text-xs text-subtle-foreground @max-md:overflow-hidden @md:shrink-0">
           {meta ? <ActiveChip threads={meta.activeThreads} /> : null}
           <LabelChips task={task} labelsById={labelsById} />
           {task.dueDate !== null ? (


### PR DESCRIPTION
## Summary

The Tasks plugin list was broken at phone widths: the host's fixed sidebar toggle overlapped the "All tasks" title, the task count wrapped, and single-line rows crammed the full desktop column set into 390px, truncating titles to a few words (see BB-60's iPhone screenshot).

- **Topbar** reserves the host toggle's footprint on compact viewports only (48px fine / 56px coarse pointer, 48px chrome-row height — matching the host's own reserve geometry; wide viewports get a host pane header instead so no reserve applies). New task/Refresh go icon-only in narrow containers with `aria-label`s; breadcrumbs truncate instead of wrapping or colliding with the pager; touch targets grow via `max-md:pointer-coarse:` variants.
- **Rows** become a two-line grid below a 448px *container* width — status + full-width title, then priority, key, Active chip, labels (1 + "+N"), due date, project dot — and the same DOM renders the exact previous 34px flex row at `@md`+ (grid placement classes are inert in flex). Container queries, not viewport breakpoints, so narrow split panes reflow like phones.
- **Filter bar**: chips keep every filter in a horizontal scroller; Sort and the count are pinned outside it so the count can never wrap or scroll away.
- **Plugin sidebar** opens as an overlay drawer with scrim in narrow containers (previously a 208px static column ate most of a 320px viewport), with dialog semantics, focus management, Tab cycling, and Escape-to-close; desktop keeps the resizable column.
- **Board on mobile** (follow-up feedback): the List/Board toggle hides below the same 448px container breakpoint and board routes render the list there, so deep links/rotation can't strand a crushed board. Board usability is measured on the main pane — the same box the toggle's `@md` rule measures.

UI-only inside `official-plugins/tasks`; no server/daemon wire changes.

## Review

Single independent review (codex / gpt-5.6-sol / medium / readonly): REQUEST CHANGES with two findings — drawer keyboard accessibility (P1) and board-usability measured against the wrong container (P2). Both fixed in a02a40e8d and verified live (dialog role + focus restore + Escape behavior; 760px window with 340px sidebar now falls back to the list with the toggle hidden).

## Validation

- `turbo run build test typecheck --filter=bb-plugin-tasks` green (315 tests, incl. new responsive-structure tests).
- Live QA on an isolated dev instance with seeded edge cases (54 tasks, 0/1/4 labels, long titles/keys, due dates, real codex worker for the Active chip): 320/375/390/430 portrait + 667/932 landscape, light/dark/Nord, WebKit iPhone 14 Pro profile (0 console errors), keyboard shortcuts, scroll restoration, filter persistence, `scrollWidth === clientWidth` at every width, desktop 1440/900 regression.
- Full evidence: Product Review Report, 41-row coverage ledger, and 44-screenshot archive attached to BB-60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)