### PR TITLE
BB-61: Scope macOS header reserve to the structural top-left pane

### DIFF
--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -46,6 +46,12 @@ interface AppPageHeaderProps {
    * desktop window. Split panes below the workspace's top edge disable this.
    */
   isWindowDragRegion?: boolean;
+  /**
+   * Whether this header owns the window's top-left chrome footprint. A split
+   * may have several top-row drag regions, but only its structural top-left
+   * leaf may clear the pinned sidebar trigger and macOS traffic lights.
+   */
+  ownsWindowTopLeft?: boolean;
 }
 
 export function AppPageHeader({
@@ -54,6 +60,7 @@ export function AppPageHeader({
   bordered = true,
   className,
   isWindowDragRegion = true,
+  ownsWindowTopLeft = true,
 }: AppPageHeaderProps) {
   const isSidebarShowing = useIsSidebarShowing();
   const isCompactViewport = useIsCompactViewport();
@@ -64,7 +71,8 @@ export function AppPageHeader({
     desktopInfo,
     windowState: desktopWindowState,
   });
-  const shouldReserveSidebarTrigger = isCompactViewport || !isSidebarShowing;
+  const shouldReserveSidebarTrigger =
+    ownsWindowTopLeft && (isCompactViewport || !isSidebarShowing);
   return (
     <header
       className={cn(

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -168,6 +168,7 @@ function withPaneContext(
     onToggleMaximize: noop,
     isBoundedPane: true,
     isTopRow,
+    ownsWindowTopLeft: isTopRow,
     navigateInPane: noop,
   };
   return <PaneContext.Provider value={value}>{children}</PaneContext.Provider>;

--- a/apps/app/src/views/thread-detail/PaneContext.tsx
+++ b/apps/app/src/views/thread-detail/PaneContext.tsx
@@ -55,6 +55,12 @@ export interface PaneContextValue {
    * occupies the native desktop title-bar row.
    */
   isTopRow: boolean;
+  /**
+   * Whether this pane owns the window's top-left chrome footprint. This is
+   * stricter than {@link isTopRow}: horizontal siblings can all be title-bar
+   * drag regions, but only one leaf may reserve traffic-light/sidebar space.
+   */
+  ownsWindowTopLeft: boolean;
   navigateInPane: (thread: ThreadRoutePathArgs) => void;
   /**
    * Starts a pane-reorder drag from the pane header via the shared split-drag
@@ -197,6 +203,7 @@ export function DefaultPaneContextProvider({
       onToggleMaximize: null,
       isBoundedPane: false,
       isTopRow: true,
+      ownsWindowTopLeft: true,
       navigateInPane,
     }),
     [navigateInPane],

--- a/apps/app/src/views/thread-detail/PaneMaximizeButton.test.tsx
+++ b/apps/app/src/views/thread-detail/PaneMaximizeButton.test.tsx
@@ -31,6 +31,7 @@ function renderButton(
     onToggleMaximize,
     isBoundedPane: true,
     isTopRow: true,
+    ownsWindowTopLeft: true,
     navigateInPane: noop,
   };
   return render(
@@ -86,6 +87,7 @@ describe("PaneMaximizeButton", () => {
       onToggleMaximize: null,
       isBoundedPane: false,
       isTopRow: true,
+      ownsWindowTopLeft: true,
       navigateInPane: noop,
     };
     render(

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -41,6 +41,7 @@ const threadStore = vi.hoisted(
 );
 const experimentState = vi.hoisted(() => ({ enabled: true }));
 const viewportState = vi.hoisted(() => ({ compact: false }));
+const sidebarState = vi.hoisted(() => ({ showing: true }));
 const commandHandlers = vi.hoisted(() => new Map<string, () => boolean>());
 interface ShortcutPresentationFixture {
   ariaKeyshortcuts: string;
@@ -113,7 +114,7 @@ vi.mock("react-resizable-panels", async () => {
 });
 
 vi.mock("@/components/ui/sidebar.js", () => ({
-  useIsSidebarShowing: () => true,
+  useIsSidebarShowing: () => sidebarState.showing,
 }));
 
 // Lightweight stand-in for the heavyweight thread view. It surfaces the pane's
@@ -153,6 +154,7 @@ vi.mock("./ThreadDetailView", () => ({
       <div
         data-testid={`pane-${threadId}`}
         data-focused={pane?.isFocused ? "true" : "false"}
+        data-window-top-left-owner={pane?.ownsWindowTopLeft ? "true" : "false"}
       >
         <div
           data-testid={`drag-${threadId}`}
@@ -387,6 +389,7 @@ function renderSplitArea(options: {
 beforeEach(() => {
   experimentState.enabled = true;
   viewportState.compact = false;
+  sidebarState.showing = true;
   commandHandlers.clear();
   commandPresentationState.isModifierHeld = false;
   commandPresentationState.shortcut = null;
@@ -920,12 +923,27 @@ describe("SplitThreadArea", () => {
     });
     await screen.findByTestId("pane-thr-b");
 
+    expect(
+      screen
+        .getAllByTestId(/^pane-thr-/)
+        .filter(
+          (pane) => pane.getAttribute("data-window-top-left-owner") === "true",
+        ),
+    ).toEqual([screen.getByTestId("pane-thr-a")]);
+
     fireEvent.click(screen.getByTestId("external-nav"));
 
     // Focused pane (thr-b) now shows thr-c; the unfocused pane (thr-a) survives.
     expect(await screen.findByTestId("pane-thr-c")).toBeTruthy();
     expect(screen.getByTestId("pane-thr-a")).toBeTruthy();
     expect(screen.queryByTestId("pane-thr-b")).toBeNull();
+    expect(
+      screen
+        .getAllByTestId(/^pane-thr-/)
+        .filter(
+          (pane) => pane.getAttribute("data-window-top-left-owner") === "true",
+        ),
+    ).toEqual([screen.getByTestId("pane-thr-a")]);
   });
 
   it("focuses an already-open pane instead of duplicating on external navigation", async () => {
@@ -1086,6 +1104,113 @@ describe("SplitThreadArea", () => {
       expect(header?.className).not.toContain("[app-region:drag]");
       expect(header?.className).not.toContain("[-webkit-app-region:drag]");
     }
+  });
+
+  it("reserves collapsed window-left chrome only for the structural top-left pane", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: null,
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: false,
+      updateDownloaded: false,
+      version: "0.0.0-test",
+    };
+    window.bbDesktop = createBbDesktopApi(desktopInfo);
+    sidebarState.showing = false;
+    setPluginSlotRegistrations("test-plugin", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: ["top-left", "bottom-left", "top-right", "bottom-right"].map(
+        (path) => ({
+          id: path,
+          title: path,
+          icon: "FileText",
+          path,
+          component: () => <div>{path} panel</div>,
+        }),
+      ),
+      threadPanelActions: [],
+      composerAccessories: [],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+
+    renderSplitArea({
+      path: "/plugins/test-plugin/bottom-right",
+      layout: fourPanePluginLayout(),
+      routeContent: pluginContent("bottom-right"),
+    });
+
+    const contentRow = async (path: string) =>
+      (await screen.findByText(path))
+        .closest("header")
+        ?.querySelector('[data-testid="app-page-header-content-row"]');
+    expect((await contentRow("top-left"))?.className).toContain("pl-[104px]");
+    for (const path of ["top-right", "bottom-left", "bottom-right"]) {
+      expect((await contentRow(path))?.className).not.toContain("pl-[104px]");
+    }
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /Maximize pane/ })[3]!,
+    );
+    await waitFor(() =>
+      expect(contentRow("bottom-right")).resolves.toHaveProperty(
+        "className",
+        expect.stringContaining("pl-[104px]"),
+      ),
+    );
+    expect((await contentRow("top-left"))?.className).not.toContain(
+      "pl-[104px]",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Restore pane/ }));
+    await waitFor(() =>
+      expect(contentRow("top-left")).resolves.toHaveProperty(
+        "className",
+        expect.stringContaining("pl-[104px]"),
+      ),
+    );
+  });
+
+  it("assigns exactly one top-left owner through eight-pane structural changes", async () => {
+    for (const threadId of [
+      "thr-c",
+      "thr-d",
+      "thr-e",
+      "thr-f",
+      "thr-g",
+      "thr-h",
+    ]) {
+      threadStore.set(threadId, { archivedAt: null, deletedAt: null });
+    }
+    const initialLayout = eightPaneThreadLayout();
+    const store = renderSplitArea({
+      path: threadPath("thr-h"),
+      layout: initialLayout,
+    });
+    await screen.findByTestId("pane-thr-h");
+
+    const owners = () =>
+      screen
+        .getAllByTestId(/^pane-thr-/)
+        .filter(
+          (pane) => pane.getAttribute("data-window-top-left-owner") === "true",
+        );
+    expect(owners()).toHaveLength(1);
+    expect(owners()[0]?.getAttribute("data-testid")).toBe("pane-thr-a");
+
+    const moved = movePane(initialLayout, "pane-8", "pane-1", "left");
+    store.set(splitLayoutAtom, moved);
+    await waitFor(() => expect(owners()).toHaveLength(1));
+    expect(owners()[0]?.getAttribute("data-testid")).toBe("pane-thr-h");
+
+    fireEvent.click(screen.getByTestId("close-thr-h"));
+    await waitFor(() => expect(screen.queryByTestId("pane-thr-h")).toBeNull());
+    expect(owners()).toHaveLength(1);
+    expect(owners()[0]?.getAttribute("data-testid")).toBe("pane-thr-a");
   });
 
   it("places plugin header actions before the pane close button", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -565,6 +565,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           onToggleMaximize={null}
           isBoundedPane={false}
           isTopRow
+          ownsWindowTopLeft
           onNavigateInPane={navigateInPane}
         />
       </>
@@ -591,6 +592,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
             node={layout.root}
             path={EMPTY_PATH}
             isTopRow
+            isLeftEdge
             isRightEdge
             focusedPaneId={effectiveMaximizedPaneId ?? layout.focusedPaneId}
             maximizedPaneId={effectiveMaximizedPaneId}
@@ -666,6 +668,8 @@ interface SplitTreeProps {
   path: SplitPath;
   /** Whether this subtree touches the workspace's top edge. */
   isTopRow: boolean;
+  /** Whether this subtree touches the workspace's left edge. */
+  isLeftEdge: boolean;
   /** Whether this subtree touches the workspace's right edge. */
   isRightEdge: boolean;
   focusedPaneId: string;
@@ -685,7 +689,8 @@ interface SplitTreeProps {
 }
 
 function SplitTree(props: SplitTreeProps) {
-  const { node, path, isTopRow, isRightEdge, focusedPaneId } = props;
+  const { node, path, isTopRow, isLeftEdge, isRightEdge, focusedPaneId } =
+    props;
 
   if (node.type === "pane") {
     const isFocused = node.paneId === focusedPaneId;
@@ -733,6 +738,11 @@ function SplitTree(props: SplitTreeProps) {
           onToggleMaximize={() => props.onToggleMaximizePane(node.paneId)}
           isBoundedPane
           isTopRow={isMaximized || isTopRow}
+          ownsWindowTopLeft={
+            props.maximizedPaneId !== null
+              ? isMaximized
+              : isTopRow && isLeftEdge
+          }
           onNavigateInPane={props.onNavigateInPane}
           onBeginPaneDrag={props.onBeginPaneDrag}
         />
@@ -778,6 +788,9 @@ function SplitTree(props: SplitTreeProps) {
               // vertical stack, only the first child can inherit the parent
               // subtree's contact with the workspace top edge.
               isTopRow={isTopRow && (node.dir === "row" || index === 0)}
+              // Vertical siblings share the parent's left edge. In a
+              // horizontal row, only the first child can inherit it.
+              isLeftEdge={isLeftEdge && (node.dir === "col" || index === 0)}
               isRightEdge={
                 isRightEdge &&
                 (node.dir === "col" || index === node.children.length - 1)
@@ -804,6 +817,7 @@ interface WorkspacePaneContentProps {
   // content fills the card exactly (see PaneContextValue.isBoundedPane).
   isBoundedPane: boolean;
   isTopRow: boolean;
+  ownsWindowTopLeft: boolean;
   onNavigateInPane: NavigateInPane;
   // Absent for the single-pane surface — a lone pane has nothing to reorder.
   onBeginPaneDrag?: BeginPaneDrag;
@@ -821,6 +835,7 @@ function WorkspacePaneContent({
   onToggleMaximize,
   isBoundedPane,
   isTopRow,
+  ownsWindowTopLeft,
   onNavigateInPane,
   onBeginPaneDrag,
 }: WorkspacePaneContentProps) {
@@ -858,6 +873,7 @@ function WorkspacePaneContent({
       onToggleMaximize,
       isBoundedPane,
       isTopRow,
+      ownsWindowTopLeft,
       navigateInPane,
       beginPaneDrag,
     }),
@@ -867,6 +883,7 @@ function WorkspacePaneContent({
       isFocused,
       isSplitPane,
       isTopRow,
+      ownsWindowTopLeft,
       navigateInPane,
       onRequestClose,
       isMaximized,
@@ -886,6 +903,7 @@ function WorkspacePaneContent({
           beginPaneDrag={beginPaneDrag}
           isBoundedPane={isBoundedPane}
           isTopRow={isTopRow}
+          ownsWindowTopLeft={ownsWindowTopLeft}
         />
       </PaneContext.Provider>
     );
@@ -924,12 +942,14 @@ function NonThreadPaneContent({
   beginPaneDrag,
   isBoundedPane,
   isTopRow,
+  ownsWindowTopLeft,
 }: {
   content: Exclude<PaneContent, { kind: "thread" }>;
   onRequestClose: (() => void) | null;
   beginPaneDrag?: (event: ReactPointerEvent, label: string) => void;
   isBoundedPane: boolean;
   isTopRow: boolean;
+  ownsWindowTopLeft: boolean;
 }) {
   const { navPanels } = usePluginSlots();
   const { reservesWindowPanelToggle } = useOptionalPaneContext() ?? {
@@ -993,6 +1013,7 @@ function NonThreadPaneContent({
         <AppPageHeader
           bordered={false}
           isWindowDragRegion={isTopRow}
+          ownsWindowTopLeft={ownsWindowTopLeft}
           className="border-b border-border-seam-vertical/60"
           center={
             <div

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -37,6 +37,7 @@ const PANE_CONTEXT: PaneContextValue = {
   onToggleMaximize: null,
   isBoundedPane: false,
   isTopRow: true,
+  ownsWindowTopLeft: true,
   navigateInPane: vi.fn(),
 };
 

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -75,6 +75,7 @@ export function ThreadDetailHeader({
     beginPaneDrag,
     isFocused,
     isTopRow,
+    ownsWindowTopLeft,
     reservesWindowPanelToggle,
     secondaryPanelHost,
   } = usePaneContext();
@@ -229,6 +230,7 @@ export function ThreadDetailHeader({
       actions={actions}
       bordered={false}
       isWindowDragRegion={isTopRow}
+      ownsWindowTopLeft={ownsWindowTopLeft}
       className={cn(
         "border-b border-border-seam-vertical/60",
         beginPaneDrag && isFocused && "bg-surface-raised",

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -226,6 +226,7 @@ function ThreadDetailTestPaneProvider({
     onToggleMaximize: noop,
     isBoundedPane: true,
     isTopRow: true,
+    ownsWindowTopLeft: true,
     navigateInPane: noop,
   };
   return <PaneContext.Provider value={value}>{children}</PaneContext.Provider>;


### PR DESCRIPTION
## Summary

- assign collapsed-sidebar/macOS traffic-light clearance to the split tree’s structural top-left leaf only
- transfer ownership during maximize/restore and structural pane changes
- preserve independent top-row titlebar drag eligibility

## Validation

- focused split regression: 26/26
- full `@bb/app` suite: 247 files, 1,710 tests
- Turbo `@bb/app` typecheck and build
- real Electron QA across 1–8/nested panes, sidebar, maximize/restore, panel, themes, narrow/fullscreen, DPR 1 and Retina DPR 2 evidence
- existing keyboard and CLI pane surfaces
- independent readonly `codex/gpt-5.6-sol` medium review: APPROVE

## Protocol

Renderer-only change; no server↔host-daemon wire behavior changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

Task: BB-61