### PR TITLE
BB-67: Restore workflow hierarchy and phase shimmer

### DIFF
--- a/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.test.tsx
+++ b/apps/app/src/components/thread/timeline/WorkflowWorkRowBody.test.tsx
@@ -57,6 +57,17 @@ describe("WorkflowWorkRowBody", () => {
     fireEvent.click(screen.getByRole("button", { name: /Discover1\/1/ }));
     expect(screen.getByText("Inspect implementation")).toBeTruthy();
     expect(screen.getByText("Adversarial review")).toBeTruthy();
+
+    // The active phase title carries the calm shimmer; settled phase titles
+    // and worker rows stay static, and worker rows indent under their phase.
+    expect(screen.getByText("Review").className).toContain("animate-shine");
+    expect(screen.getByText("Discover").className).not.toContain(
+      "animate-shine",
+    );
+    expect(screen.getByText("Adversarial review").className).not.toContain(
+      "animate-shine",
+    );
+    expect(screen.getByText("Adversarial review").closest(".pl-5")).toBeTruthy();
   });
 
   it("auto-collapses completed phases live while manual toggles survive", () => {
@@ -90,6 +101,14 @@ describe("WorkflowWorkRowBody", () => {
     expect(screen.getByText("Straggler scan")).toBeTruthy();
     expect(screen.getByText("Adversarial review")).toBeTruthy();
     expect(screen.getByText("not started")).toBeTruthy();
+
+    // A declared-but-empty phase renders as an upcoming stage row: inset a
+    // step beyond the worker rows and static (no shimmer).
+    const stageRow = screen.getByText("Verify").closest(".pl-16");
+    expect(stageRow).toBeTruthy();
+    expect(screen.getByText("Verify").className).not.toContain(
+      "animate-shine",
+    );
 
     // Manually collapse the running Review phase to prove overrides survive
     // later default flips.

--- a/packages/shared-ui/src/components/ui/workflow-progress.tsx
+++ b/packages/shared-ui/src/components/ui/workflow-progress.tsx
@@ -61,9 +61,15 @@ interface WorkflowPhaseGroup {
 const ACTIVE_PHASE_SCROLL_OFFSET = 12;
 const PROMPT_STACK_ACTIVE_ROW_CLASS = "shadow-none ring-0";
 const PROMPT_STACK_ACTIVE_ICON_CLASS = "text-foreground";
-// Inside the phase tree the shine shimmer is reserved for the card's top-level
-// header; running rows already carry a spinner, so their text stays static.
+// Inside the phase tree only the active phase title shimmers; running worker
+// rows already carry a spinner, so their text stays static.
 const PROMPT_STACK_ACTIVE_TEXT_CLASS = "font-medium text-foreground";
+// The collapsible tree indents one step per level so the hierarchy reads
+// spatially: phase header flush, worker rows inset beneath it, and a
+// declared-but-empty phase (an upcoming pipeline stage) inset a further step
+// so it reads as pending work nested under the workers above it.
+const PHASE_TREE_WORKER_INDENT_CLASS = "pl-5";
+const PHASE_TREE_STAGE_INDENT_CLASS = "pl-16";
 
 function isSettledAgentState(state: WorkflowProgressAgentState): boolean {
   return (
@@ -567,7 +573,10 @@ function CollapsiblePhaseSection({
   ));
   if (!group.phase) {
     return (
-      <div ref={ref} className="flex min-w-0 flex-col">
+      <div
+        ref={ref}
+        className={cn("flex min-w-0 flex-col", PHASE_TREE_WORKER_INDENT_CLASS)}
+      >
         {agentLines}
       </div>
     );
@@ -584,12 +593,11 @@ function CollapsiblePhaseSection({
     return (
       <div
         ref={ref}
-        className={cn(
-          "flex items-center gap-1.5",
-          promptStackActivityRowClass(activityState),
+        className={promptStackActivityRowClass(
+          activityState,
+          cn("flex items-center gap-1.5", PHASE_TREE_STAGE_INDENT_CLASS),
         )}
       >
-        <span className="size-3 shrink-0" aria-hidden="true" />
         <span
           className={promptStackActivityTextClass(
             activityState,
@@ -632,7 +640,7 @@ function CollapsiblePhaseSection({
           aria-hidden="true"
         />
         <span
-          className={promptStackActivityTextClass(
+          className={activityTextClass(
             activityState,
             "text-xs font-medium no-underline",
           )}
@@ -650,7 +658,14 @@ function CollapsiblePhaseSection({
         <PhaseCompletedBadge visible={activityState === "completed"} />
       </button>
       {expanded ? (
-        <div className="mt-1 flex min-w-0 flex-col">{agentLines}</div>
+        <div
+          className={cn(
+            "mt-1 flex min-w-0 flex-col",
+            PHASE_TREE_WORKER_INDENT_CLASS,
+          )}
+        >
+          {agentLines}
+        </div>
       ) : null}
     </div>
   );

--- a/plugins/workflows/src/app.test.tsx
+++ b/plugins/workflows/src/app.test.tsx
@@ -73,6 +73,11 @@ const run: WorkflowRunView = {
         },
       ],
     },
+    {
+      title: "Verify",
+      detail: "Verify the integrated result.",
+      calls: [],
+    },
   ],
   unphasedCalls: [],
   resultAvailable: false,
@@ -138,9 +143,11 @@ describe("workflow-preview directive", () => {
     expect(slot.getByText("Discover")).toBeTruthy();
     expect(slot.getAllByText("Review")).toHaveLength(1);
     expect(slot.getByText("Adversarial review")).toBeTruthy();
+    expect(slot.getByText("Verify")).toBeTruthy();
     expect(slot.getByText("claude · opus-4-6 · high")).toBeTruthy();
-    // A live run has no "Running" pill, and only the top-level header
-    // shimmers — phase and agent rows stay static (agents have spinners).
+    // A live run has no "Running" pill. The top-level header and the active
+    // phase title carry the calm shimmer; settled phase titles and worker
+    // rows stay static (running workers already have spinners).
     expect(slot.queryByText("Running")).toBeNull();
     expect(
       slot.getByText("Review the release").className.includes("animate-shine"),
@@ -149,10 +156,18 @@ describe("workflow-preview directive", () => {
       slot.getByText("Adversarial review").className.includes("animate-shine"),
     ).toBe(false);
     expect(
-      slot
-        .getAllByText("Review")[0]!
-        .className.includes("animate-shine"),
-    ).toBe(false);
+      slot.getAllByText("Review")[0]!.className.includes("animate-shine"),
+    ).toBe(true);
+    expect(slot.getByText("Discover").className.includes("animate-shine")).toBe(
+      false,
+    );
+    // Worker rows indent one step beneath their phase header so the
+    // phase → worker hierarchy reads spatially.
+    expect(slot.getByText("Adversarial review").closest(".pl-5")).toBeTruthy();
+    expect(slot.getByText("Verify").closest(".pl-16")).toBeTruthy();
+    expect(slot.getByText("Verify").className.includes("animate-shine")).toBe(
+      false,
+    );
 
     const workflowToggle = slot.getByRole("button", {
       name: "Workflow: Review the release",
@@ -434,6 +449,17 @@ describe("workflow thread panel", () => {
     // The settled Discover phase starts collapsed; the active phase is open.
     expect(slot.queryByText("Inspect implementation")).toBeNull();
     expect(slot.getByText("Adversarial review")).toBeTruthy();
+    // The panel consumes the same shared tree and must preserve the exact
+    // phase → worker → stage hierarchy and active-only shimmer.
+    expect(slot.getAllByText("Review")[0]!.className).toContain(
+      "animate-shine",
+    );
+    expect(slot.getByText("Adversarial review").className).not.toContain(
+      "animate-shine",
+    );
+    expect(slot.getByText("Adversarial review").closest(".pl-5")).toBeTruthy();
+    expect(slot.getByText("Verify").className).not.toContain("animate-shine");
+    expect(slot.getByText("Verify").closest(".pl-16")).toBeTruthy();
     fireEvent.click(slot.getByRole("button", { name: /Discover1\/1/ }));
     expect(slot.getByText("Inspect implementation")).toBeTruthy();
     fireEvent.click(slot.getByRole("button", { name: /adversarial review/i }));


### PR DESCRIPTION
## Summary
- restore explicit phase → worker → upcoming-stage indentation in the shared workflow-progress tree
- shimmer only the current phase title while keeping worker and stage rows static
- preserve the removed Running pill, completed-phase auto-collapse, manual overrides, and reduced-motion behavior
- add focused parity regression coverage for the native component, inline workflow card, and right sidebar

## Validation
- `pnpm exec turbo run test --filter=@bb/app --filter=bb-plugin-workflows --force`
- `pnpm exec turbo run typecheck --filter=@bb/shared-ui --filter=@bb/app --filter=bb-plugin-workflows --force`
- `pnpm exec turbo run build --filter=@bb/app --force`
- isolated real-product QA across live workflow transitions, sidebar parity, failure/cancel/reload, light/dark/custom palettes, narrow width, keyboard/a11y, and reduced motion
- independent readonly `codex/gpt-5.6-sol` medium review: APPROVE

## Evidence
The self-contained HTML review, coverage ledger, evidence archive, and key screenshots are attached to the Product QA milestone comment on BB-67.