### PR TITLE
Prepare bb-app 0.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,15 @@
 
 ## 0.0.31
 
-Splits headline this release: split views graduate out of experiments for everyone, with twice the pane capacity, per-pane maximize, and a smarter side panel.
+This release brings split views to everyone and redesigns queued messages in the composer.
 
-### Splits, out of experiments
+### Features
 
-- Split views are now on for everyone: arrange up to eight chats side by side, drag threads in from the sidebar, and move between panes with keyboard shortcuts.
-- Maximize a single pane and restore the layout with Mod+Shift+E or the pane header control.
-- The right panel (diffs, previews, terminals) now follows the focused pane and stays open as you switch panes and threads.
-- Sidebar actions show a split preview, so you can see where a thread will open before you click.
-- Lots of polish: smoother resizing, better divider hit testing, and correct macOS traffic-light spacing.
+- Split views are now available: arrange up to eight chats side by side, drag threads in from the sidebar, and move between panes with keyboard shortcuts.
+- Queued messages in the composer got a redesign: a compact drawer that scales to long queues, with fullscreen editing.
 
 ### Improvements
 
-- Queued messages in the composer got a redesign: a compact drawer that scales to long queues, with fullscreen editing.
 - New compact composer on mobile.
 - Sidebar sections are unified and drag-reorderable, with drag-to-pin; archived threads moved into Settings.
 - Usage limits now show which account email each provider is signed in with, and Cursor usage limits are now supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ This release brings split views to everyone and redesigns queued messages in the
 - Sidebar sections are unified and drag-reorderable, with drag-to-pin; archived threads moved into Settings.
 - Usage limits now show which account email each provider is signed in with, and Cursor usage limits are now supported.
 
+### Experiments
+
+- New Tasks plugin: Linear-style task tracking with agent dispatch — assign agents to tasks, follow their progress in comments, and attach files and GitHub PRs.
+- Official plugins are now bundled with the app and update alongside it.
+- New Workflows plugin renders live multi-agent workflow runs in chat, across providers.
+- Docs gained table editing, easier file management, and a pull/push-based CLI.
+
 ### Fixes and polish
 
 - Fixed Claude model fallbacks not being surfaced immediately.
@@ -24,13 +31,6 @@ This release brings split views to everyone and redesigns queued messages in the
 - Fixed a performance issue with animations.
 - Improved bb Connect reliability.
 - Worktree setup now runs with your resolved shell PATH.
-
-### Experiments
-
-- New Tasks plugin: Linear-style task tracking with agent dispatch — assign agents to tasks, follow their progress in comments, and attach files and GitHub PRs.
-- Official plugins are now bundled with the app and update alongside it.
-- New Workflows plugin renders live multi-agent workflow runs in chat, across providers.
-- Docs gained table editing, easier file management, and a pull/push-based CLI.
 
 ## 0.0.30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.0.31
+
+Splits headline this release: split views graduate out of experiments for everyone, with twice the pane capacity, per-pane maximize, and a smarter side panel. Queued messages, sidebar organization, and model-fallback visibility also got significant upgrades.
+
+### Splits, out of experiments
+
+- Split views are now on for everyone — no experiment toggle needed. Arrange multiple chats side by side by dragging threads from the sidebar, then resize, rearrange, and move between panes with keyboard shortcuts.
+- Splits now hold up to eight panes, up from four, with focus shortcuts for panes 5–8 and smarter layout balancing as you add panes.
+- Maximize a single pane and restore the full layout with Mod+Shift+E, the pane header control, or `bb thread pane maximize|restore|toggle` from the CLI and SDK.
+- The right panel (diffs, previews, terminals) now lives at the window level: it follows the focused pane and stays open as you move between panes and threads.
+- Sidebar actions show a split preview, so you can see where a thread or new chat will open before you click.
+- Keyboard commands like focus composer and toggle model picker now act on the focused pane instead of an arbitrary one.
+- Polish throughout: precise divider hit testing, smoother resizing, no more stuck sidebar state after dragging a thread into a split, window dragging confined to the top row, correct macOS traffic-light spacing, and refined pane header and focused-pane styling.
+
+### Queued messages and the composer
+
+- Queued follow-ups now live in a compact drawer that scales to long queues, with drag-to-resize and a fullscreen editing mode; editing a queued message keeps its position, grouping, and execution options.
+- Queued message actions — send now, edit, delete — are now icon buttons on desktop.
+- Agent messages have a consistent action row: Copy, Add to chat, Reply in side chat, and Fork, with Add to chat inserting the response into your current draft.
+- Thread mentions render as live pills that follow renames across timelines, thread headers, and the sidebar.
+- Prompt attachments are preserved when switching projects.
+
+### Sidebar and navigation
+
+- Top-level sidebar sections (Pinned, your sections, Threads) are unified and drag-reorderable, and you can now pin or unpin a thread by dragging it.
+- Archived threads moved out of the sidebar into Settings.
+- The Threads sidebar header is unified across organization modes, and the manual sort option is now called Manually.
+
+### Models and providers
+
+- When Claude falls back to another model, bb shows it immediately with a dismissible banner above the composer and updates the model picker to the active model.
+- Usage limits now show which account email each provider is signed in with, and Cursor usage limits are now supported.
+- Thread creation no longer fails on providers that are slow to start.
+
+### Other improvements
+
+- `bb secret request` can now write credentials to any destination on the thread's host, and the secure form shows the resolved absolute path before you approve.
+- The SDK now includes the personal project in project listings and emits a curated `thread.active` lifecycle event.
+- The bb website has a new changelog page, with the latest release highlighted on the homepage.
+
+### Fixes and polish
+
+- Fixed desktop light/dark switching when following the system theme.
+- Fixed scrolling of long agent questions and sidebar safe-area coverage on mobile.
+- Fixed a render loop in collapsed thread previews and paused animations during collapse transitions for smoother sidebars.
+- Worktree setup now runs with your resolved shell PATH.
+- Development builds no longer send telemetry.
+- bb Connect no longer proxies requests through a dead tunnel socket.
+- Removed the popout chat experiment, superseded by splits.
+
 ## 0.0.30
 
 This release introduces multi-machine workflows and bb Connect, adds more ways to customize how bb works, and gives you clearer visibility into what agents are doing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,53 +2,32 @@
 
 ## 0.0.31
 
-Splits headline this release: split views graduate out of experiments for everyone, with twice the pane capacity, per-pane maximize, and a smarter side panel. Queued messages, sidebar organization, and model-fallback visibility also got significant upgrades.
+Splits headline this release: split views graduate out of experiments for everyone, with twice the pane capacity, per-pane maximize, and a smarter side panel.
 
 ### Splits, out of experiments
 
-- Split views are now on for everyone — no experiment toggle needed. Arrange multiple chats side by side by dragging threads from the sidebar, then resize, rearrange, and move between panes with keyboard shortcuts.
-- Splits now hold up to eight panes, up from four, with focus shortcuts for panes 5–8 and smarter layout balancing as you add panes.
-- Maximize a single pane and restore the full layout with Mod+Shift+E, the pane header control, or `bb thread pane maximize|restore|toggle` from the CLI and SDK.
-- The right panel (diffs, previews, terminals) now lives at the window level: it follows the focused pane and stays open as you move between panes and threads.
-- Sidebar actions show a split preview, so you can see where a thread or new chat will open before you click.
-- Keyboard commands like focus composer and toggle model picker now act on the focused pane instead of an arbitrary one.
-- Polish throughout: precise divider hit testing, smoother resizing, no more stuck sidebar state after dragging a thread into a split, window dragging confined to the top row, correct macOS traffic-light spacing, and refined pane header and focused-pane styling.
+- Split views are now on for everyone: arrange up to eight chats side by side, drag threads in from the sidebar, and move between panes with keyboard shortcuts.
+- Maximize a single pane and restore the layout with Mod+Shift+E or the pane header control.
+- The right panel (diffs, previews, terminals) now follows the focused pane and stays open as you switch panes and threads.
+- Sidebar actions show a split preview, so you can see where a thread will open before you click.
+- Lots of polish: smoother resizing, better divider hit testing, and correct macOS traffic-light spacing.
 
-### Queued messages and the composer
+### Improvements
 
-- Queued follow-ups now live in a compact drawer that scales to long queues, with drag-to-resize and a fullscreen editing mode; editing a queued message keeps its position, grouping, and execution options.
-- Queued message actions — send now, edit, delete — are now icon buttons on desktop.
-- Agent messages have a consistent action row: Copy, Add to chat, Reply in side chat, and Fork, with Add to chat inserting the response into your current draft.
-- Thread mentions render as live pills that follow renames across timelines, thread headers, and the sidebar.
-- Prompt attachments are preserved when switching projects.
-
-### Sidebar and navigation
-
-- Top-level sidebar sections (Pinned, your sections, Threads) are unified and drag-reorderable, and you can now pin or unpin a thread by dragging it.
-- Archived threads moved out of the sidebar into Settings.
-- The Threads sidebar header is unified across organization modes, and the manual sort option is now called Manually.
-
-### Models and providers
-
-- When Claude falls back to another model, bb shows it immediately with a dismissible banner above the composer and updates the model picker to the active model.
+- Queued messages in the composer got a redesign: a compact drawer that scales to long queues, with fullscreen editing.
+- New compact composer on mobile.
+- Sidebar sections are unified and drag-reorderable, with drag-to-pin; archived threads moved into Settings.
 - Usage limits now show which account email each provider is signed in with, and Cursor usage limits are now supported.
-- Thread creation no longer fails on providers that are slow to start.
-
-### Other improvements
-
-- `bb secret request` can now write credentials to any destination on the thread's host, and the secure form shows the resolved absolute path before you approve.
-- The SDK now includes the personal project in project listings and emits a curated `thread.active` lifecycle event.
-- The bb website has a new changelog page, with the latest release highlighted on the homepage.
 
 ### Fixes and polish
 
+- Fixed Claude model fallbacks not being surfaced immediately.
+- Fixed `bb secret request` destinations in multi-machine setups.
 - Fixed desktop light/dark switching when following the system theme.
 - Fixed scrolling of long agent questions and sidebar safe-area coverage on mobile.
-- Fixed a render loop in collapsed thread previews and paused animations during collapse transitions for smoother sidebars.
+- Fixed a performance issue with animations.
+- Improved bb Connect reliability.
 - Worktree setup now runs with your resolved shell PATH.
-- Development builds no longer send telemetry.
-- bb Connect no longer proxies requests through a dead tunnel socket.
-- Removed the popout chat experiment, superseded by splits.
 
 ## 0.0.30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ This release brings split views to everyone and redesigns queued messages in the
 - Improved bb Connect reliability.
 - Worktree setup now runs with your resolved shell PATH.
 
+### Experiments
+
+- New Tasks plugin: Linear-style task tracking with agent dispatch — assign agents to tasks, follow their progress in comments, and attach files and GitHub PRs.
+- Official plugins are now bundled with the app and update alongside it.
+- New Workflows plugin renders live multi-agent workflow runs in chat, across providers.
+- Docs gained table editing, easier file management, and a pull/push-based CLI.
+
 ## 0.0.30
 
 This release introduces multi-machine workflows and bb Connect, adds more ways to customize how bb works, and gives you clearer visibility into what agents are doing.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bb/desktop",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": true,
   "description": "macOS Electron shell for bb",
   "main": "dist/main.js",

--- a/apps/web/src/landing/changelog.ts
+++ b/apps/web/src/landing/changelog.ts
@@ -29,6 +29,10 @@ export type ReleaseMeta = {
 };
 
 export const RELEASE_META: Record<string, ReleaseMeta> = {
+  "0.0.31": {
+    date: "July 17, 2026",
+    headline: "Splits for everyone",
+  },
   "0.0.30": {
     date: "July 14, 2026",
     headline: "Multi-machine workflows and bb Connect",

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-app",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "bb app launcher for npx",
   "keywords": [
     "bb",


### PR DESCRIPTION
## Summary
- bump `bb-app` and `@bb/desktop` to 0.0.31 in lockstep
- add the 0.0.31 changelog entry (Features / Improvements / Experiments / Fixes) and its website release meta

## Validation
- `node .github/workflows/check-version-lockstep.mjs`
- `pnpm exec turbo run typecheck test --filter=@bb/config --filter=@bb/server --filter=bb-app` (one env-dependent install-script test fails only when a global bb-app is on PATH; passes with it removed)
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force`
- `pnpm exec turbo run test typecheck --filter=@bb/web`
- packaged, signed, and installed the 0.0.31 desktop app locally
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)