### PR TITLE
Keep a maximized split pane from covering the open secondary panel

### DIFF
--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -245,8 +245,13 @@ export function SplitWorkspaceSecondaryPanelHost({
             )}
           >
             {/* Panel renders a plain block; the split tree sizes itself with
-              flex-1, so restore a full-height flex context for it. */}
-            <div className="flex h-full min-h-0 min-w-0">{children}</div>
+              flex-1, so restore a full-height flex context for it. `relative`
+              makes this the containing block for a maximized pane's
+              `absolute inset-0`, so fullscreening a pane fills the main panel
+              without covering the open secondary panel to its right. */}
+            <div className="relative flex h-full min-h-0 min-w-0">
+              {children}
+            </div>
           </Panel>
           {model === null ? (
             <>


### PR DESCRIPTION
## Summary

Fullscreening a split pane overlaid the right (secondary) panel. The maximized pane is styled `absolute inset-0 z-30`, and its nearest positioned ancestor was the secondary-panel host's `relative` wrapper — which encloses both the split tree and the panel — so the pane stretched across the whole host, covering the panel and the chrome that hosts the panel toggle.

Fix: make the main `Panel`'s inner wrapper (the div directly containing the split tree) `relative`, so it becomes the maximized pane's containing block. A fullscreened pane now fills only the split area; an open right panel stays visible beside it. With the panel closed, the main panel spans the full width, so behavior is unchanged. The window-toggle corner reservation already matches this geometry (`ThreadDetailHeader` only reserves the corner when the panel is closed).

## Tests

- `turbo run typecheck --filter=@bb/app`
- SplitThreadArea suites, PaneMaximizeButton, secondary-panel suites, SplitWorkspaceRoute: 164 tests pass
- Manual QA via `scripts/bb-dev-app` on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)