### PR TITLE
Ship a plugin SDK runtime bundle so packaged builtin plugins can load

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --templates --external ./start-server.js --external esbuild --external @tailwindcss/node --external @tailwindcss/oxide --copy-dir ../../packages/db/drizzle dist/drizzle --copy-dir src/assets dist/assets && node --import tsx scripts/copy-builtin-skills.ts && node ../../scripts/build-node-entry.mjs src/start-server.ts dist/start-server.js --external esbuild --external @tailwindcss/node --external @tailwindcss/oxide",
+    "build": "node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --templates --external ./start-server.js --external esbuild --external @tailwindcss/node --external @tailwindcss/oxide --copy-dir ../../packages/db/drizzle dist/drizzle --copy-dir src/assets dist/assets && node --import tsx scripts/copy-builtin-skills.ts && node ../../scripts/build-node-entry.mjs src/start-server.ts dist/start-server.js --external esbuild --external @tailwindcss/node --external @tailwindcss/oxide && node ../../scripts/build-node-entry.mjs ../../packages/plugin-sdk/src/index.ts dist/plugin-sdk-runtime.js",
     "start": "node dist/index.js",
     "start:prod": "cross-env NODE_ENV=production node dist/index.js",
     "dev": "node --conditions=source --import tsx scripts/dev-supervisor.mjs",

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -1,6 +1,7 @@
-import type { FSWatcher } from "node:fs";
+import { existsSync, type FSWatcher } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { performance } from "node:perf_hooks";
 import { createJiti } from "jiti";
 import semver from "semver";
@@ -41,6 +42,24 @@ import type {
   PluginWireLookup,
   ServiceRuntime,
 } from "./plugin-service-internal.js";
+
+/**
+ * Plugin server bundles keep `@bb/plugin-sdk` external (see @bb/plugin-build),
+ * and plugin authors never have it installed — the scaffold maps the specifier
+ * to bundled `.d.ts` files only. Source-checkout servers resolve the workspace
+ * package naturally, but built and packaged servers have no node_modules copy,
+ * so the server build ships a self-contained SDK runtime bundle next to the
+ * server bundle and the loader aliases the specifier to it.
+ */
+const pluginSdkRuntimePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "plugin-sdk-runtime.js",
+);
+const pluginSdkAlias: Record<string, string> | undefined = existsSync(
+  pluginSdkRuntimePath,
+)
+  ? { "@bb/plugin-sdk": pluginSdkRuntimePath }
+  : undefined;
 
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
 const DEFAULT_SERVICE_STOP_TIMEOUT_MS = 5_000;
@@ -888,7 +907,10 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     });
     try {
       // Fresh instance per load: guarantees re-imports see current sources.
-      const jiti = createJiti(import.meta.url, { moduleCache: false });
+      const jiti = createJiti(import.meta.url, {
+        moduleCache: false,
+        ...(pluginSdkAlias === undefined ? {} : { alias: pluginSdkAlias }),
+      });
       // Same jiti instance for source and prebuilt dist/server.js, so the
       // @bb/plugin-sdk resolution applies identically to both.
       const mod = (await jiti.import(

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -7,6 +7,19 @@ import { fileURLToPath } from "node:url";
 
 const HTTP_WAIT_TIMEOUT_MS = 60_000;
 const HTTP_WAIT_INTERVAL_MS = 250;
+const PLUGIN_LOAD_TIMEOUT_MS = 60_000;
+const PLUGIN_LOAD_INTERVAL_MS = 1_000;
+// Auto-installed, default-enabled builtins (apps/server/src/services/plugins/
+// builtin-registry.ts). Each must reach "running" in the packed tarball —
+// bundles that pass health checks can still fail to load (0.0.31 shipped with
+// every builtin unable to resolve @bb/plugin-sdk at import time).
+const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
+  "automations",
+  "connect",
+  "custom-instructions",
+  "inline-vis",
+  "secrets",
+];
 const BRIDGE_WAIT_TIMEOUT_MS = 10_000;
 const PROCESS_STOP_TIMEOUT_MS = 5_000;
 const DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST = "127.0.0.1";
@@ -493,6 +506,44 @@ async function smokeSdkPackage(tarballPath) {
   return sdkDir;
 }
 
+async function smokeBuiltinPluginsRunning({ cliEnv, tarballPath }) {
+  const deadline = Date.now() + PLUGIN_LOAD_TIMEOUT_MS;
+  let lastSummary = "no plugin list output yet";
+  // Plugins load after the HTTP server starts listening, so poll until every
+  // expected builtin settles into "running".
+  while (Date.now() <= deadline) {
+    const stdout = await runCommand({
+      args: createNpxArgs(tarballPath, "bb", ["plugin", "list", "--json"]),
+      command: "npx",
+      env: cliEnv,
+      label: "bb plugin list",
+    });
+    const plugins = JSON.parse(stdout).plugins ?? [];
+    const byId = new Map(plugins.map((plugin) => [plugin.id, plugin]));
+    const errored = plugins.filter((plugin) => plugin.status === "error");
+    if (errored.length > 0) {
+      throw new Error(
+        `Builtin plugins failed to load:\n${errored
+          .map((plugin) => `- ${plugin.id}: ${plugin.statusDetail}`)
+          .join("\n")}`,
+      );
+    }
+    const pending = EXPECTED_RUNNING_BUILTIN_PLUGINS.filter(
+      (id) => byId.get(id)?.status !== "running",
+    );
+    if (pending.length === 0) {
+      return;
+    }
+    lastSummary = pending
+      .map((id) => `${id}=${byId.get(id)?.status ?? "missing"}`)
+      .join(", ");
+    await delay(PLUGIN_LOAD_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for builtin plugins to run: ${lastSummary}`,
+  );
+}
+
 async function smokeFullStack(tarballPath, sdkDir) {
   const dataDir = join(tempRoot, "full-stack-data");
   const serverPort = await getFreePort();
@@ -525,16 +576,18 @@ async function smokeFullStack(tarballPath, sdkDir) {
       processRef: stack,
       url: `http://${DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST}:${daemonPort}/health`,
     });
+    const cliEnv = {
+      BB_DATA_DIR: dataDir,
+      BB_HOST_DAEMON_PORT: String(daemonPort),
+      BB_SERVER_URL: serverUrl,
+    };
     await runCommand({
       args: createNpxArgs(tarballPath, "bb", ["status"]),
       command: "npx",
-      env: {
-        BB_DATA_DIR: dataDir,
-        BB_HOST_DAEMON_PORT: String(daemonPort),
-        BB_SERVER_URL: serverUrl,
-      },
+      env: cliEnv,
       label: "bb cli status",
     });
+    await smokeBuiltinPluginsRunning({ cliEnv, tarballPath });
     await runCommand({
       args: [
         "--input-type=module",

--- a/packages/plugin-build/src/build-plugin-server.ts
+++ b/packages/plugin-build/src/build-plugin-server.ts
@@ -17,9 +17,11 @@ import { validatePluginBuildManifest } from "./plugin-manifest.js";
  *
  * - `dist/server.js` (+ `.map`) — single node-platform ESM file with the
  *   plugin's npm deps inlined, so git:/npm: consumers never need npm or
- *   node_modules. `@bb/plugin-sdk` stays external (the server's loader
- *   resolves it to the live in-process implementation) and so does
- *   better-sqlite3 (plugins get sqlite from the host via `bb.storage`;
+ *   node_modules. `@bb/plugin-sdk` stays external — plugin authors only ever
+ *   have its `.d.ts` types, so the specifier must survive to load time, where
+ *   the server's loader aliases it to the SDK runtime bundle shipped next to
+ *   the server (workspace resolution covers source checkouts). better-sqlite3
+ *   is also external (plugins get sqlite from the host via `bb.storage`;
  *   native deps are unsupported in plugins regardless).
  * - `dist/server.meta.json` — SDK compatibility plus authoritative plugin,
  *   artifact-format, and build-version metadata.
@@ -137,7 +139,7 @@ export async function buildPluginServer(
       target: "node22",
       sourcemap: true,
       banner: { js: NODE_ESM_REQUIRE_BANNER },
-      // The SDK resolves to the server's live in-process implementation at
+      // The server's loader aliases the SDK to its shipped runtime bundle at
       // load time; better-sqlite3 comes from the host (bb.storage). Node
       // builtins are auto-external via platform: "node".
       external: ["@bb/plugin-sdk", "better-sqlite3"],


### PR DESCRIPTION
## Problem

The published **bb-app 0.0.31 boots with every builtin plugin except `secrets` failing** — connect, automations, custom-instructions, inline-vis all report:

```
plugin connect failed to load: Cannot find module '@bb/plugin-sdk'
```

Reproduced against the real npm artifacts: 0.0.30 loads all builtins; 0.0.31 fails on both upgraded and **fresh** data dirs, so every packaged 0.0.31 install is affected (npm + desktop). Store officials (github, docs, memory, tasks) carry the same import and fail on install.

## Root cause

Three things intersect:

1. `buildPluginServer` keeps `@bb/plugin-sdk` external in plugin server bundles, per a comment claiming "the server's loader resolves it" — but the jiti loader had **no such mapping**; it relied on normal Node resolution.
2. That was accidentally fine until now: plugins only imported SDK **types**, which are erased at build. Every 0.0.30 bundle has zero runtime SDK references.
3. Plugin SDK 0.3 (#716) introduced `defineRpcContract` — the first **runtime** SDK export — and the plugins adopted it. 0.0.31 bundles carry a live `import { defineRpcContract } from "@bb/plugin-sdk"`, which resolves in source checkouts (workspace node_modules) but not in the packaged app, where `@bb/plugin-sdk` is inlined into the server bundle and never shipped as a resolvable module.

Inlining the SDK into plugin bundles at build time is not a viable fix: third-party authors never have the SDK installed (it's not on npm — the scaffold maps the specifier to bundled `.d.ts` files only), so the specifier must survive to load time and be provided by the server.

## Fix

- The server build now bundles the SDK runtime (tiny: `defineRpcContract` + one constant, zero deps) into `dist/plugin-sdk-runtime.js`.
- The plugin loader aliases `@bb/plugin-sdk` to that file when it exists next to the server bundle (packaged app, built checkout). Source checkouts have no such file and keep workspace resolution, so dev behavior is unchanged.
- This fixes builtins, store officials, and third-party plugins (bundled *and* source-loaded) in one place, matching the original design intent.
- Updated the stale comments in `build-plugin-server.ts`.

## Why CI and the publish smoke missed it

Same blind spot as #735: clean checkouts always resolve the workspace SDK, so only packed artifacts fail. The publish workflow's tarball smoke boots the full stack but only checked `/health` — plugin load failures are warn-level. The smoke now polls `bb plugin list --json` until every default-enabled builtin reaches `running` and fails on any plugin in `error`, closing this regression class for good.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/plugin-build`
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force` — packs the tarball, boots it, and all five default-enabled builtins reach `running` (the same assertion fails against the published 0.0.31, which reports `status: "error"` for four of five)
- jiti `alias` behavior verified in isolation against the shipped jiti version

Needs a 0.0.32 release to reach affected users; until then rolling back to 0.0.30 is the only workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)