### PR TITLE
Refine keyboard hints and queued message drawer

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -265,6 +265,22 @@ describe("AppCommandProvider", () => {
     vi.useRealTimers();
   });
 
+  it("does not show keyboard hints when another modifier was held first", () => {
+    vi.useFakeTimers();
+    renderProvider(<ModifierState />);
+
+    fireEvent.keyDown(window, { key: "Shift", shiftKey: true });
+    fireEvent.keyDown(window, {
+      key: "Control",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    act(() => vi.advanceTimersByTime(700));
+
+    expect(screen.getByText("released")).toBeDefined();
+    vi.useRealTimers();
+  });
+
   it("does not share primary-modifier hold state when keyboard hints are disabled", () => {
     vi.useFakeTimers();
     testState.showKeyboardHints = false;

--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -242,6 +242,29 @@ describe("AppCommandProvider", () => {
     vi.useRealTimers();
   });
 
+  it("cancels keyboard hints when the modifier becomes part of a shortcut chord", () => {
+    vi.useFakeTimers();
+    renderProvider(<ModifierState />);
+
+    fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+    act(() => vi.advanceTimersByTime(699));
+    fireEvent.keyDown(window, {
+      key: "Shift",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByText("released")).toBeDefined();
+
+    fireEvent.keyUp(window, { key: "Control" });
+    fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+    act(() => vi.advanceTimersByTime(700));
+    expect(screen.getByText("held")).toBeDefined();
+    fireEvent.keyDown(window, { key: "3", ctrlKey: true, shiftKey: true });
+    expect(screen.getByText("released")).toBeDefined();
+    vi.useRealTimers();
+  });
+
   it("does not share primary-modifier hold state when keyboard hints are disabled", () => {
     vi.useFakeTimers();
     testState.showKeyboardHints = false;

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -137,6 +137,14 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
       ) {
         return;
       }
+      const nonPrimaryModifierHeld =
+        event.shiftKey ||
+        event.altKey ||
+        (primaryModifier === "Meta" ? event.ctrlKey : event.metaKey);
+      if (nonPrimaryModifierHeld) {
+        clearModifierHold();
+        return;
+      }
       modifierHoldTimerRef.current = setTimeout(() => {
         modifierHoldTimerRef.current = null;
         primaryModifierHeldRef.current = true;

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -98,6 +98,7 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
   const modifierHoldTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const primaryModifierHeldRef = useRef(false);
   const keybindingsRef = useRef(keybindings);
   const handlersRef = useRef(
     new Map<AppCommandId, Map<symbol, AppCommandHandlerRegistration>>(),
@@ -117,17 +118,28 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
         clearTimeout(modifierHoldTimerRef.current);
         modifierHoldTimerRef.current = null;
       }
+      primaryModifierHeldRef.current = false;
       setIsPrimaryModifierHeld(false);
     };
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== primaryModifier) {
+        if (
+          modifierHoldTimerRef.current !== null ||
+          primaryModifierHeldRef.current
+        ) {
+          clearModifierHold();
+        }
+        return;
+      }
       if (
-        event.key !== primaryModifier ||
-        modifierHoldTimerRef.current !== null
+        modifierHoldTimerRef.current !== null ||
+        primaryModifierHeldRef.current
       ) {
         return;
       }
       modifierHoldTimerRef.current = setTimeout(() => {
         modifierHoldTimerRef.current = null;
+        primaryModifierHeldRef.current = true;
         setIsPrimaryModifierHeld(true);
       }, SHORTCUT_HINT_HOLD_DELAY_MS);
     };

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -534,7 +534,7 @@ const queuedMessages: readonly ThreadQueuedMessage[] = [
   makeStoryQueuedMessage("q_4", "Compare the queue in light and dark themes."),
   makeStoryQueuedMessage("q_5", "Verify keyboard reordering from each grip."),
   makeStoryQueuedMessage("q_6", "Run the prompt-box typecheck."),
-  makeStoryQueuedMessage("q_7", "Review the drawer at a narrow width."),
+  makeStoryQueuedMessage("q_7", "Review the queue at a narrow width."),
   makeStoryQueuedMessage("q_8", "Capture the final interaction states."),
 ];
 
@@ -1023,7 +1023,7 @@ export function QueuedWorkspace() {
     <StoryCard>
       <StoryRow
         label="eight queued follow-ups"
-        hint="drag the header up, reorder by the grip, then choose Edit from a row menu"
+        hint="the centered handle stays quiet; hover the header to reveal the right-aligned caret"
       >
         <Row
           submitMode={{ kind: "queue", onStop: noop }}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -414,7 +414,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="multiple messages"
-        hint="hover for the grip and row menu; drag the header up for the workspace"
+        hint="a few messages fit the drawer; the caret collapses it"
       >
         <ResponsivePromptStage>
           <ReorderableQueuedMessagesList />
@@ -422,7 +422,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="overflowing queue"
-        hint="nine messages scroll in the drawer and expand into the pull-up workspace"
+        hint="the caret expands an overflowing drawer into the pull-up workspace"
       >
         <ResponsivePromptStage>
           <QueuedMessagesList
@@ -441,7 +441,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="with attachments"
-        hint="FileAttachment icon; multiple files add a compact numeric count"
+        hint="the attachment icon and count sit directly beside the prompt text"
       >
         <ResponsivePromptStage>
           <QueuedMessagesList

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -379,6 +379,44 @@ describe("QueuedMessagesList", () => {
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
+  it("keeps an active inline editor usable when the queue is empty", async () => {
+    const { container } = render(
+      <QueuedMessagesList
+        queuedMessages={[]}
+        inlineEditor={{
+          queuedMessageId: "q_missing",
+          queuedMessageIndex: 0,
+          ready: true,
+          onComposerTargetChange: noop,
+          onDismiss: noop,
+        }}
+        sendDisabled={false}
+        actionDisabled={false}
+        processingMessageId={null}
+        processingAction={null}
+        onSendImmediately={noop}
+        onReorder={noop}
+        onSetGroupBoundary={noop}
+        onEdit={noop}
+        onDelete={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector("[data-queued-messages-mode]")
+          ?.getAttribute("data-queued-messages-mode"),
+      ).toBe("workspace");
+    });
+
+    const scrollFrame = container.querySelector(
+      "[data-queued-messages-scroll-frame]",
+    );
+    expect(scrollFrame?.hasAttribute("inert")).toBe(false);
+    expect(scrollFrame?.getAttribute("aria-hidden")).not.toBe("true");
+  });
+
   it("returns to the fitted drawer height after inline editing ends", async () => {
     const queuedMessages = Array.from({ length: 4 }, (_, index) =>
       makeQueuedMessage(`q_${index}`, `Queued message ${index + 1}`),

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -107,7 +107,7 @@ afterEach(() => {
 });
 
 describe("QueuedMessagesList", () => {
-  it("cycles from drawer to workspace to collapsed with one header control", () => {
+  it("toggles a few messages between the fitted drawer and collapsed modes", () => {
     const { container, getByRole } = renderQueuedMessages([
       makeQueuedMessage("q_one", "First queued message"),
       makeQueuedMessage("q_two", "Second queued message"),
@@ -115,28 +115,18 @@ describe("QueuedMessagesList", () => {
     const header = container.querySelector<HTMLElement>(
       "[data-queued-messages-mode]",
     );
+    const surface = container.querySelector<HTMLElement>(
+      'section[aria-label="Queued messages"]',
+    );
 
     expect(header?.getAttribute("data-queued-messages-mode")).toBe("drawer");
     expect(header?.className.split(/\s+/u)).toContain("border-b");
-    expect(header?.className.split(/\s+/u)).toContain("border-border/35");
-    expect(
-      getByRole("button", { name: "Expand queued messages" }).querySelector(
-        '[data-icon="ChevronUp"]',
-      ),
-    ).not.toBeNull();
-
-    fireEvent.click(getByRole("button", { name: "Expand queued messages" }));
-    expect(header?.getAttribute("data-queued-messages-mode")).toBe("workspace");
+    expect(surface?.style.height).toBe("123px");
     expect(
       getByRole("button", { name: "Collapse queued messages" }).querySelector(
         '[data-icon="ChevronDown"]',
       ),
     ).not.toBeNull();
-    expect(
-      container.querySelector<HTMLElement>(
-        'section[aria-label="Queued messages"]',
-      )?.style.height,
-    ).toBe("240px");
 
     fireEvent.click(getByRole("button", { name: "Collapse queued messages" }));
     expect(header?.getAttribute("data-queued-messages-mode")).toBe("collapsed");
@@ -146,16 +136,76 @@ describe("QueuedMessagesList", () => {
         '[data-icon="ChevronUp"]',
       ),
     ).not.toBeNull();
+    expect(surface?.style.height).toBe("44px");
 
     fireEvent.click(getByRole("button", { name: "Show queued messages" }));
+    expect(header?.getAttribute("data-queued-messages-mode")).toBe("drawer");
+    expect(surface?.style.height).toBe("123px");
+  });
+
+  it("toggles an overflowing queue between the workspace and collapsed modes", () => {
+    const { container, getByRole } = renderQueuedMessages(
+      Array.from({ length: 5 }, (_, index) =>
+        makeQueuedMessage(`q_${index}`, `Queued message ${index + 1}`),
+      ),
+    );
+    const header = container.querySelector<HTMLElement>(
+      "[data-queued-messages-mode]",
+    );
+
+    expect(header?.getAttribute("data-queued-messages-mode")).toBe("drawer");
+    fireEvent.click(getByRole("button", { name: "Expand queued messages" }));
+    expect(header?.getAttribute("data-queued-messages-mode")).toBe("workspace");
+    fireEvent.click(getByRole("button", { name: "Collapse queued messages" }));
+    expect(header?.getAttribute("data-queued-messages-mode")).toBe("collapsed");
+    fireEvent.click(getByRole("button", { name: "Expand queued messages" }));
+    expect(header?.getAttribute("data-queued-messages-mode")).toBe("workspace");
+  });
+
+  it("opens the fitted drawer when a queued message arrives while collapsed", async () => {
+    const sharedProps = {
+      sendDisabled: false,
+      actionDisabled: false,
+      processingMessageId: null,
+      processingAction: null,
+      onSendImmediately: noop,
+      onReorder: noop,
+      onSetGroupBoundary: noop,
+      onEdit: noop,
+      onDelete: noop,
+    } as const;
+    const firstMessage = makeQueuedMessage("q_one", "First queued message");
+    const { container, getByRole, rerender } = render(
+      <QueuedMessagesList {...sharedProps} queuedMessages={[firstMessage]} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Collapse queued messages" }));
     expect(
       container
         .querySelector("[data-queued-messages-mode]")
         ?.getAttribute("data-queued-messages-mode"),
-    ).toBe("drawer");
+    ).toBe("collapsed");
+
+    rerender(
+      <QueuedMessagesList
+        {...sharedProps}
+        queuedMessages={[
+          firstMessage,
+          makeQueuedMessage("q_two", "Second queued message"),
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector("[data-queued-messages-mode]")
+          ?.getAttribute("data-queued-messages-mode"),
+      ).toBe("drawer");
+    });
   });
 
-  it("opens the workspace when the header handle is dragged up", () => {
+  it("moves through all three modes with the header drag handle", () => {
     const { container, getByRole } = renderQueuedMessages([
       makeQueuedMessage("q_one", "First queued message"),
       makeQueuedMessage("q_two", "Second queued message"),
@@ -167,20 +217,51 @@ describe("QueuedMessagesList", () => {
       configurable: true,
       value: vi.fn(),
     });
+    expect(handle.className.split(/\s+/u)).toContain("cursor-grab");
 
     fireEvent.pointerDown(handle, {
       button: 0,
       clientY: 200,
       pointerId: 1,
     });
+    expect(handle.className.split(/\s+/u)).toContain("cursor-grabbing");
     fireEvent.pointerMove(handle, { clientY: 100, pointerId: 1 });
     fireEvent.pointerUp(handle, { clientY: 100, pointerId: 1 });
+    expect(handle.className.split(/\s+/u)).toContain("cursor-grab");
 
     expect(
       container
         .querySelector("[data-queued-messages-mode]")
         ?.getAttribute("data-queued-messages-mode"),
     ).toBe("workspace");
+
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      clientY: 100,
+      pointerId: 2,
+    });
+    fireEvent.pointerMove(handle, { clientY: 200, pointerId: 2 });
+    fireEvent.pointerUp(handle, { clientY: 200, pointerId: 2 });
+
+    expect(
+      container
+        .querySelector("[data-queued-messages-mode]")
+        ?.getAttribute("data-queued-messages-mode"),
+    ).toBe("drawer");
+
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      clientY: 100,
+      pointerId: 3,
+    });
+    fireEvent.pointerMove(handle, { clientY: 200, pointerId: 3 });
+    fireEvent.pointerUp(handle, { clientY: 200, pointerId: 3 });
+
+    expect(
+      container
+        .querySelector("[data-queued-messages-mode]")
+        ?.getAttribute("data-queued-messages-mode"),
+    ).toBe("collapsed");
   });
 
   it("uses hover-revealed icon actions on desktop and an overflow menu on mobile widths", () => {
@@ -298,7 +379,7 @@ describe("QueuedMessagesList", () => {
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
-  it("returns to the drawer height after inline editing ends", async () => {
+  it("returns to the fitted drawer height after inline editing ends", async () => {
     const queuedMessages = Array.from({ length: 4 }, (_, index) =>
       makeQueuedMessage(`q_${index}`, `Queued message ${index + 1}`),
     );
@@ -488,6 +569,11 @@ describe("QueuedMessagesList", () => {
     expect(
       container.querySelector('[data-icon="FileAttachment"]'),
     ).not.toBeNull();
+    expect(
+      container
+        .querySelector('[title="Review the attached screenshot"]')
+        ?.classList.contains("fade-clip-right"),
+    ).toBe(false);
     expect(container.textContent).not.toContain("1 attachment");
   });
 

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -969,6 +969,7 @@ export function QueuedMessagesList({
   );
   const [surfaceDragging, setSurfaceDragging] = useState(false);
   const [surfaceDragOffset, setSurfaceDragOffset] = useState(0);
+  const inlineEditorActive = inlineEditor !== undefined;
   const surfaceDragStartYRef = useRef(0);
   const surfaceDragOffsetRef = useRef(0);
   const surfaceDraggingRef = useRef(false);
@@ -1112,6 +1113,9 @@ export function QueuedMessagesList({
   useEffect(() => {
     const previousMessageCount = previousMessageCountRef.current;
     previousMessageCountRef.current = queuedMessages.length;
+    if (inlineEditorActive) {
+      return;
+    }
     if (
       queuedMessages.length !== 0 &&
       queuedMessages.length <= previousMessageCount
@@ -1133,7 +1137,7 @@ export function QueuedMessagesList({
     return () => {
       cancelled = true;
     };
-  }, [queuedMessages.length]);
+  }, [inlineEditorActive, queuedMessages.length]);
 
   const openWorkspace = useCallback(() => {
     setMode("workspace");

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -132,8 +132,9 @@ interface QueuedMessageRowProps {
 }
 
 const GROUP_DIVIDER_ID = "__queued_message_group_divider__";
-const COLLAPSED_HEIGHT = 56;
+const COLLAPSED_HEIGHT = 44;
 const DRAWER_HEIGHT = 174;
+const DRAWER_MAX_VISIBLE_MESSAGES = 3;
 const WORKSPACE_MIN_HEIGHT = 240;
 const WORKSPACE_MAX_HEIGHT = 360;
 const WORKSPACE_CHROME_HEIGHT = 56;
@@ -561,10 +562,12 @@ function buildQueuedMessagePreviewText(
 
 function QueuedMessagePreview({
   compact,
+  hasAttachments,
   queuedMessage,
   resolveMentionLink,
 }: {
   compact: boolean;
+  hasAttachments: boolean;
   queuedMessage: ThreadQueuedMessage;
   resolveMentionLink?: PromptMentionLinkResolver;
 }) {
@@ -582,7 +585,10 @@ function QueuedMessagePreview({
 
   return (
     <div
-      className="fade-clip-right min-w-0 flex-1 overflow-hidden text-foreground"
+      className={cn(
+        "min-w-0 overflow-hidden text-foreground",
+        !hasAttachments && "fade-clip-right",
+      )}
       title={preview}
     >
       {markdownPreview.text.length > 0 ? (
@@ -684,6 +690,7 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
           >
             <QueuedMessagePreview
               compact={compact}
+              hasAttachments={attachmentCount > 0}
               queuedMessage={queuedMessage}
               resolveMentionLink={resolveMentionLink}
             />
@@ -957,7 +964,9 @@ export function QueuedMessagesList({
       coordinateGetter: sortableKeyboardCoordinates,
     }),
   );
-  const [mode, setMode] = useState<QueueSurfaceMode>("drawer");
+  const [mode, setMode] = useState<QueueSurfaceMode>(
+    queuedMessages.length > 0 ? "drawer" : "collapsed",
+  );
   const [surfaceDragging, setSurfaceDragging] = useState(false);
   const [surfaceDragOffset, setSurfaceDragOffset] = useState(0);
   const surfaceDragStartYRef = useRef(0);
@@ -965,6 +974,7 @@ export function QueuedMessagesList({
   const surfaceDraggingRef = useRef(false);
   const wasInlineEditingRef = useRef(false);
   const inlineEditorDismissModeRef = useRef<QueueSurfaceMode | null>(null);
+  const previousMessageCountRef = useRef(queuedMessages.length);
   const {
     aboveOverflow,
     belowOverflow,
@@ -1098,6 +1108,32 @@ export function QueuedMessagesList({
     }
     wasInlineEditingRef.current = inlineEditor !== undefined;
   }, [inlineEditor]);
+
+  useEffect(() => {
+    const previousMessageCount = previousMessageCountRef.current;
+    previousMessageCountRef.current = queuedMessages.length;
+    if (
+      queuedMessages.length !== 0 &&
+      queuedMessages.length <= previousMessageCount
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      if (queuedMessages.length === 0) {
+        setMode("collapsed");
+        return;
+      }
+      setMode((currentMode) =>
+        currentMode === "collapsed" ? "drawer" : currentMode,
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [queuedMessages.length]);
 
   const openWorkspace = useCallback(() => {
     setMode("workspace");
@@ -1270,6 +1306,24 @@ export function QueuedMessagesList({
 
   if (queuedMessages.length === 0 && !inlineEditor) return null;
 
+  const queueFitsDrawer = queuedMessages.length <= DRAWER_MAX_VISIBLE_MESSAGES;
+  const caretWillCollapse =
+    mode === "workspace" || (mode === "drawer" && queueFitsDrawer);
+  const caretLabel = caretWillCollapse
+    ? "Collapse queued messages"
+    : mode === "collapsed" && queueFitsDrawer
+      ? "Show queued messages"
+      : "Expand queued messages";
+  const handleCaretClick = () => {
+    if (caretWillCollapse) {
+      collapseDrawer();
+    } else if (mode === "drawer" || !queueFitsDrawer) {
+      openWorkspace();
+    } else {
+      showDrawer();
+    }
+  };
+
   return (
     <PromptStackCard
       ariaLabel="Queued messages"
@@ -1285,12 +1339,12 @@ export function QueuedMessagesList({
     >
       <header
         className={cn(
-          "flex h-9 shrink-0 items-center gap-2 px-2",
+          "group/queue-header flex h-8 shrink-0 items-center gap-2 px-2",
           mode !== "collapsed" && "border-b border-border/35",
         )}
         data-queued-messages-mode={mode}
       >
-        <div className="flex min-w-20 items-baseline gap-1.5 pl-1">
+        <div className="flex min-w-16 items-baseline gap-1.5 pl-1">
           <span className="text-xs font-medium text-foreground">Queued</span>
           <span className="text-2xs text-subtle-foreground">
             {queuedMessages.length}
@@ -1299,8 +1353,8 @@ export function QueuedMessagesList({
         <button
           type="button"
           className={cn(
-            "group/handle flex h-full min-w-24 flex-1 touch-none cursor-ns-resize select-none items-center justify-center focus-visible:rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-            surfaceDragging && "cursor-grabbing",
+            "group/handle flex h-full min-w-16 flex-1 touch-none select-none items-center justify-center focus-visible:rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            surfaceDragging ? "cursor-grabbing" : "cursor-grab",
           )}
           aria-label={
             mode === "workspace"
@@ -1313,36 +1367,31 @@ export function QueuedMessagesList({
           onPointerCancel={finishSurfaceDrag}
           onKeyDown={handleSurfaceKeyDown}
         >
-          <span className="h-1 w-10 rounded-full bg-border transition-colors group-hover/handle:bg-muted-foreground/45" />
+          <span className="h-px w-7 rounded-full bg-muted-foreground opacity-30 transition-opacity group-hover/handle:opacity-50 group-focus-visible/handle:opacity-50" />
         </button>
-        <div className="flex min-w-20 items-center justify-end">
-          <Button
-            type="button"
-            size="icon"
-            variant="ghost"
-            className="size-7 text-muted-foreground"
-            onClick={
-              mode === "workspace"
-                ? collapseDrawer
-                : mode === "drawer"
-                  ? openWorkspace
-                  : showDrawer
-            }
-            aria-label={
-              mode === "workspace"
-                ? "Collapse queued messages"
-                : mode === "drawer"
-                  ? "Expand queued messages"
-                  : "Show queued messages"
-            }
-            aria-expanded={mode !== "collapsed"}
-          >
-            <Icon
-              name={mode === "workspace" ? "ChevronDown" : "ChevronUp"}
-              className="size-4 text-subtle-foreground opacity-60"
-              aria-hidden
-            />
-          </Button>
+        <div className="flex min-w-16 items-center justify-end">
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="size-6 text-muted-foreground hover:bg-surface-recessed"
+                  onClick={handleCaretClick}
+                  aria-label={caretLabel}
+                  aria-expanded={mode !== "collapsed"}
+                >
+                  <Icon
+                    name={caretWillCollapse ? "ChevronDown" : "ChevronUp"}
+                    className="size-3.5 text-muted-foreground opacity-0 transition-opacity group-hover/queue-header:opacity-65 group-focus-within/queue-header:opacity-65 [@media(hover:none)]:opacity-45"
+                    aria-hidden
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{caretLabel}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </header>
       <div

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -11,7 +11,14 @@ import type { ThreadListEntry } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { ProjectRow, type ProjectThreadListState } from "./ProjectRow";
+import { Provider, createStore } from "jotai";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  ChronologicalSectionThreadSections,
+  ProjectRow,
+  type ProjectThreadListState,
+} from "./ProjectRow";
+import { buildSidebarEntitySectionId } from "./sidebarSectionOrder";
 
 const mockUpdateEnvironment = vi.hoisted(() => ({
   mutate: vi.fn(),
@@ -190,6 +197,53 @@ describe("ProjectRow interactions", () => {
     expect(screen.getByLabelText("Agent working")).not.toBeNull();
     expect(screen.queryByLabelText("Workflow running")).toBeNull();
     expect(screen.queryByLabelText("Thread working")).toBeNull();
+  });
+
+  it("shows active thread status when a top-level section is collapsed", () => {
+    const store = createStore();
+    const queryClient = new QueryClient();
+    const sectionId = "sec_active";
+    const activeThread = makeThread({
+      id: "thr_section_active",
+      sectionId,
+      status: "active",
+      runtime: {
+        displayStatus: "active",
+        hostReconnectGraceExpiresAt: null,
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ChronologicalSectionThreadSections
+              threadListState={{ status: "ready", threads: [activeThread] }}
+              compareThreads={() => 0}
+              sections={[{ id: sectionId, name: "Active work" }]}
+              collapsedThreadIds={new Set()}
+              collapsedEnvironmentIds={new Set()}
+              onToggleThreadCollapsed={vi.fn()}
+              onToggleEnvironmentCollapsed={vi.fn()}
+              topLevelSectionOrder={[
+                buildSidebarEntitySectionId("section", sectionId),
+              ]}
+              onTopLevelSectionOrderChange={vi.fn()}
+              pinnedReorderPending={false}
+              pinnedThreads={[]}
+              onReorderPinnedThread={vi.fn()}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </Provider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse Active work section" }),
+    );
+
+    expect(screen.queryByText("Test thread")).toBeNull();
+    expect(screen.getByLabelText("Agent working")).not.toBeNull();
   });
 
   it("closes the worktree actions menu after selecting rename", async () => {

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1385,7 +1385,19 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
   if (variant === "section" && depthOffset === 0) {
     const externalHeaderActions = renderTopLevelSectionHeaderActions?.(section);
     const hasMenuActions = Boolean(onRenameSection || onRemoveSection);
-    const topLevelActions = (
+    const hasTopLevelActions = Boolean(
+      externalHeaderActions?.actions ||
+      hasMenuActions ||
+      onCreateThreadInSection,
+    );
+    const topLevelActionsOpen =
+      isTopLevelActionsOpen || externalHeaderActions?.actionsOpen === true;
+    const showRollupGlyph =
+      isCollapsed &&
+      (section.activity.pending ||
+        section.activity.working ||
+        section.activity.unread);
+    const topLevelActionControls = (
       <>
         {externalHeaderActions?.actions}
         {hasMenuActions ? (
@@ -1446,14 +1458,66 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
         ) : null}
       </>
     );
+    const topLevelActions = (
+      <span
+        className={cn(
+          "relative z-10 inline-flex shrink-0 items-center",
+          showRollupGlyph &&
+            !hasTopLevelActions &&
+            COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+        )}
+      >
+        {showRollupGlyph ? (
+          <span
+            data-sidebar-hover-actions-open={
+              topLevelActionsOpen ? "true" : undefined
+            }
+            className={cn(
+              hasTopLevelActions && SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+              "pointer-events-none absolute inset-0 flex items-center justify-end text-subtle-foreground",
+              hasTopLevelActions && "max-md:pointer-coarse:hidden",
+            )}
+          >
+            <CollapsedThreadStatusGlyph
+              activity={section.activity}
+              isBusy={section.activity.working}
+            />
+          </span>
+        ) : null}
+        {showRollupGlyph && hasTopLevelActions ? (
+          <span className="hidden shrink-0 items-center justify-center text-subtle-foreground max-md:pointer-coarse:inline-flex">
+            <CollapsedThreadStatusGlyph
+              activity={section.activity}
+              isBusy={section.activity.working}
+            />
+          </span>
+        ) : null}
+        {hasTopLevelActions ? (
+          <span
+            data-sidebar-hover-actions-open={
+              topLevelActionsOpen ? "true" : undefined
+            }
+            data-sidebar-hover-actions-mobile={
+              SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+            }
+            className={cn(
+              SIDEBAR_HOVER_ACTIONS_CLASS,
+              "relative z-10 inline-flex shrink-0 items-center",
+              SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
+            )}
+          >
+            {topLevelActionControls}
+          </span>
+        ) : null}
+      </span>
+    );
 
     return (
       <TopLevelSidebarSection
         label={section.name}
         actions={topLevelActions}
-        actionsOpen={
-          isTopLevelActionsOpen || externalHeaderActions?.actionsOpen === true
-        }
+        actionsAlwaysVisible
+        actionsOpen={topLevelActionsOpen}
         actionsMobileAlways
         collapseControl={{
           isCollapsed,


### PR DESCRIPTION
## Summary

- cancel modifier-hold shortcut hints as soon as the modifier becomes part of a shortcut chord, preventing screenshot shortcuts from flashing the overlay
- make the queued-message drawer more compact and adapt caret behavior to the number of queued messages
- automatically reopen the fitted drawer when a message is queued while collapsed
- align attachment metadata with prompt text and quiet the drag divider/caret treatment
- reveal the caret on header hover or keyboard focus and use grab/grabbing cursors for the drag divider
- update Ladle stories and interaction coverage for the revised states

## Why

Keyboard hints were appearing during screenshot shortcuts, and the queued-message drawer used too much chrome while forcing small and overflowing queues through the same disclosure behavior. This keeps shortcut hints intentional and makes the queue surface denser, calmer, and more predictable.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/commands/AppCommandProvider.test.tsx src/components/promptbox/banner/QueuedMessagesList.test.tsx` — 41 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed
- ESLint on all six changed files — 0 errors (5 existing warnings in `QueuedMessagesList.tsx`)
- visually verified drawer, workspace, collapsed, caret-hover, and drag-cursor states in Ladle
