### PR TITLE
Prepare bb-app 0.0.32

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bb/desktop",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "private": true,
   "description": "macOS Electron shell for bb",
   "main": "dist/main.js",

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-app",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "bb app launcher for npx",
   "keywords": [
     "bb",


### PR DESCRIPTION
## Summary

- bump `bb-app` and the desktop app from `0.0.31` to `0.0.32` in lockstep
- leave the changelog and web release metadata unchanged for this hotfix

## Validation

- `node .github/workflows/check-version-lockstep.mjs`
- `pnpm exec turbo run typecheck test --filter=@bb/config --filter=@bb/server --filter=bb-app`
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force`
- `git diff --check`