### PR TITLE
Build plugin SDK during pnpm start

### DIFF
--- a/scripts/start-bb.mjs
+++ b/scripts/start-bb.mjs
@@ -25,6 +25,7 @@ async function buildRuntimeArtifacts() {
       turboEntrypoint,
       "run",
       "build",
+      "--filter=@bb/plugin-sdk",
       "--filter=@bb/app",
       "--filter=@bb/server",
       "--filter=@bb/host-daemon",


### PR DESCRIPTION
## Summary
- include `@bb/plugin-sdk` in the production startup build
- let bundled official plugins resolve the SDK runtime on a fresh checkout

## Validation
- installed dependencies in a clean worktree with no `packages/plugin-sdk/dist/index.js`
- ran `BB_DATA_DIR=/tmp/bb-start-plugin-sdk-validation BB_SERVER_PORT=39886 BB_HOST_DAEMON_PORT=39887 pnpm start`
- Turbo built all four selected packages, including `@bb/plugin-sdk`
- bundled plugins loaded and bb reached ready state on the isolated server and daemon ports
- stopped the isolated server and verified both ports closed
- `git diff --check`