### PR TITLE
Fix stale pending steer projection

### DIFF
--- a/apps/server/test/services/threads/timeline-parented-pagination.test.ts
+++ b/apps/server/test/services/threads/timeline-parented-pagination.test.ts
@@ -33,7 +33,7 @@ interface SetupResult {
   thread: Thread;
 }
 
-function setup(): SetupResult {
+function setup(status: Thread["status"] = "starting"): SetupResult {
   const db = createConnection(":memory:");
   migrate(db);
   const host = upsertHost(db, noopNotifier, {
@@ -47,6 +47,7 @@ function setup(): SetupResult {
   const thread = createThread(db, noopNotifier, {
     projectId: project.id,
     providerId: "claude-code",
+    status,
   });
   return { db, thread };
 }
@@ -285,6 +286,166 @@ function insertCrossWindowSubagentEvents(
   ]);
 }
 
+function insertSplitPagePendingSteerEvents(
+  db: DbConnection,
+  thread: Thread,
+): void {
+  const targetRequestId = requestId(10);
+  const steerRequestId = requestId(11);
+  const fallbackRequestId = requestId(12);
+  const activeRequestId = requestId(13);
+  insertEvents(db, noopNotifier, [
+    {
+      threadId: thread.id,
+      sequence: 1,
+      type: "client/turn/requested",
+      scope: threadScope(),
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({
+        direction: "outbound",
+        source: "tell",
+        initiator: "user",
+        request: { method: "turn/start", params: {} },
+        requestId: targetRequestId,
+        senderThreadId: null,
+        input: [{ type: "text", text: "Start target turn.", mentions: [] }],
+        target: { kind: "new-turn" },
+        execution,
+      }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 2,
+      type: "turn/started",
+      scope: turnScope("target-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({}),
+    },
+    {
+      threadId: thread.id,
+      sequence: 3,
+      type: "turn/input/accepted",
+      scope: turnScope("target-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({ clientRequestId: targetRequestId }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 4,
+      type: "client/turn/requested",
+      scope: threadScope(),
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({
+        direction: "outbound",
+        source: "tell",
+        initiator: "user",
+        request: { method: "turn/start", params: {} },
+        requestId: steerRequestId,
+        senderThreadId: null,
+        input: [
+          { type: "text", text: "STALE_PENDING_STEER", mentions: [] },
+        ],
+        target: { kind: "steer", expectedTurnId: "target-turn" },
+        execution,
+      }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 10,
+      type: "client/turn/requested",
+      scope: threadScope(),
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({
+        direction: "outbound",
+        source: "tell",
+        initiator: "user",
+        request: { method: "turn/start", params: {} },
+        requestId: fallbackRequestId,
+        senderThreadId: null,
+        input: [{ type: "text", text: "Fallback turn.", mentions: [] }],
+        target: { kind: "new-turn" },
+        execution,
+      }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 11,
+      type: "turn/started",
+      scope: turnScope("fallback-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({}),
+    },
+    {
+      threadId: thread.id,
+      sequence: 12,
+      type: "turn/input/accepted",
+      scope: turnScope("fallback-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({ clientRequestId: fallbackRequestId }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 20,
+      type: "client/turn/requested",
+      scope: threadScope(),
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({
+        direction: "outbound",
+        source: "tell",
+        initiator: "user",
+        request: { method: "turn/start", params: {} },
+        requestId: activeRequestId,
+        senderThreadId: null,
+        input: [{ type: "text", text: "Active turn.", mentions: [] }],
+        target: { kind: "new-turn" },
+        execution,
+      }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 21,
+      type: "turn/started",
+      scope: turnScope("active-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({}),
+    },
+    {
+      threadId: thread.id,
+      sequence: 22,
+      type: "turn/input/accepted",
+      scope: turnScope("active-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({ clientRequestId: activeRequestId }),
+    },
+    {
+      threadId: thread.id,
+      sequence: 23,
+      type: "turn/completed",
+      scope: turnScope("target-turn"),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      data: JSON.stringify({ status: "completed" }),
+    },
+  ]);
+}
+
 function nestedRows(row: TimelineRow): readonly TimelineRow[] {
   if (row.kind === "turn") {
     return row.children ?? [];
@@ -360,5 +521,37 @@ describe("thread timeline parented pagination", () => {
     expect(rowTexts(delegation?.childRows ?? [])).toContain(
       "SECOND_SUBAGENT_OUTPUT",
     );
+  });
+
+  it("does not resurrect a pending steer on an older split page", () => {
+    const { db, thread } = setup("active");
+    insertSplitPagePendingSteerEvents(db, thread);
+
+    const timeline = buildThreadTimeline(db, thread, {
+      includeProviderUnhandledOperations: false,
+      includeNestedRows: true,
+      maxSeq: 23,
+      page: {
+        kind: "older",
+        beforeCursor: {
+          anchorId: `${thread.id}:user-seed:10`,
+          anchorSeq: 10,
+        },
+        segmentLimit: 1,
+      },
+    });
+    const rows = flattenRows(timeline.rows);
+
+    expect(rowTexts(rows)).toContain("Start target turn.");
+    expect(rowTexts(rows)).not.toContain("STALE_PENDING_STEER");
+    expect(
+      rows.some(
+        (row) =>
+          row.kind === "conversation" &&
+          row.role === "user" &&
+          row.turnRequest.kind === "steer" &&
+          row.turnRequest.status === "pending",
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -15,6 +15,7 @@ import type {
   TimelineWorkflowWorkRow,
 } from "@bb/server-contract";
 import {
+  getThreadEventScopeTurnId,
   isBackgroundAgentTaskType,
   readTerminalOutputLines,
   type ActiveThinking,
@@ -822,7 +823,22 @@ function buildPendingSteerRowsFromEvents(
   events: ThreadEventWithMeta[],
   options: ThreadTimelineFromEventsBaseOptions,
 ): TimelineUserConversationRow[] {
+  // Pending steers describe current tail state. Historical pages must not
+  // resurrect a request whose settlement is outside their event window.
+  if (!options.isLatestPage) {
+    return [];
+  }
+
   const orderedEvents = getOrderedThreadEvents(events);
+  const completedTurnIds = new Set(
+    orderedEvents.flatMap(({ event }) => {
+      if (event.type !== "turn/completed") {
+        return [];
+      }
+      const turnId = getThreadEventScopeTurnId(event.scope);
+      return turnId ? [turnId] : [];
+    }),
+  );
   const acceptedClientRequestById = buildAcceptedClientRequestById({
     context: acceptedClientRequestContext,
     events: orderedEvents,
@@ -830,6 +846,14 @@ function buildPendingSteerRowsFromEvents(
   const pendingSteerRows: TimelineUserConversationRow[] = [];
 
   for (const { event, meta } of orderedEvents) {
+    if (
+      event.type === "client/turn/requested" &&
+      (event.target.kind === "auto" || event.target.kind === "steer") &&
+      event.target.expectedTurnId !== null &&
+      completedTurnIds.has(event.target.expectedTurnId)
+    ) {
+      continue;
+    }
     const pendingSteers = parsePendingSteersFromClientRequest({
       acceptedClientRequest:
         event.type === "client/turn/requested"

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -675,6 +675,7 @@ function buildTimelineRows(
   events: ThreadEventWithMeta[],
   threadStatus: BuildTimelineRowsThreadStatus = "idle",
   workspaceRoot: string | null = null,
+  isLatestPage = true,
 ): TimelineRow[] {
   return buildThreadTimelineFromEvents({
     acceptedClientRequestContext: EMPTY_ACCEPTED_CLIENT_REQUEST_CONTEXT,
@@ -684,7 +685,7 @@ function buildTimelineRows(
       includeDebugRawEvents: false,
       includeNestedRows: true,
       includeProviderUnhandledOperations: false,
-      isLatestPage: true,
+      isLatestPage,
       threadStatus,
       threadName: "",
       turnMessageDetail: "full",
@@ -1355,6 +1356,69 @@ describe("buildThreadTimelineFromEvents", () => {
     expect(
       rows.filter((row) => row.kind === "conversation" && row.role === "user"),
     ).toHaveLength(0);
+  });
+
+  it("does not resurrect an unaccepted steer on a historical page", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const targetTurnStarted = event.turnStarted({ turnId: "turn-target" });
+    const steerRequest = event.clientTurnRequested({
+      target: { kind: "steer", expectedTurnId: "turn-target" },
+      text: "Please account for the restart",
+    });
+
+    const rows = buildTimelineRows(
+      fromRows([targetTurnStarted, steerRequest]),
+      "active",
+      null,
+      false,
+    );
+
+    expect(
+      rows.filter((row) => row.kind === "conversation" && row.role === "user"),
+    ).toHaveLength(0);
+  });
+
+  it("drops an unaccepted steer after its target turn completes while another turn remains active", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const text = "also a source: WAI-ARIA APG";
+    const activeTurnStarted = event.turnStarted({ turnId: "turn-active" });
+    const targetTurnStarted = event.turnStarted({ turnId: "turn-target" });
+    const steerRequest = event.clientTurnRequested({
+      target: { kind: "steer", expectedTurnId: "turn-target" },
+      text,
+    });
+    const fallbackRequest = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text,
+    });
+    const targetTurnCompleted = event.turnCompleted({
+      turnId: "turn-target",
+    });
+
+    const rows = buildTimelineRows(
+      fromRows([
+        activeTurnStarted,
+        targetTurnStarted,
+        steerRequest,
+        fallbackRequest,
+        targetTurnCompleted,
+      ]),
+      "active",
+    );
+    const userRows = rows.filter(
+      (row) => row.kind === "conversation" && row.role === "user",
+    );
+
+    expect(userRows).toEqual([
+      expect.objectContaining({
+        sourceSeqStart: fallbackRequest.seq,
+        text,
+        turnRequest: {
+          kind: "message",
+          status: "pending",
+        },
+      }),
+    ]);
   });
 
   it("uses accepted context to classify stale steers as messages when the accepted turn is visible", () => {

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -479,7 +479,7 @@ describe("timeline CLI rendering snapshots", () => {
     );
   });
 
-  it("shows an unacknowledged active-turn steer from the client request", () => {
+  it("shows an unacknowledged steer while its target turn remains active", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const timeline = renderActiveTimeline([
       event.turnStarted(),
@@ -496,7 +496,6 @@ describe("timeline CLI rendering snapshots", () => {
         command: "sqlite3 ~/.bb-dev/bb.db '.tables'",
       }),
       event.assistantCompleted({ itemId: "assistant-1", text: "Done." }),
-      event.turnCompleted(),
     ]);
 
     expect(messageKinds(timeline.messages)).toEqual([
@@ -504,11 +503,7 @@ describe("timeline CLI rendering snapshots", () => {
       "command",
       "assistant-text",
     ]);
-    expect(timeline.turnRows).toHaveLength(1);
-    expect(timeline.turnRows[0]).toMatchObject({
-      kind: "turn",
-      status: "completed",
-    });
+    expect(timeline.turnRows).toHaveLength(0);
     expect(
       timeline.rows.some(
         (row) => row.kind === "conversation" && row.role === "user",
@@ -531,12 +526,11 @@ describe("timeline CLI rendering snapshots", () => {
       status: "pending",
     });
     expect(timeline.text).toMatchInlineSnapshot(`
-      "── Worked for (5ms) ────────────────────────────────────────
-        ── Ran 2 commands
-          ── Ran pnpm test
-            $ pnpm test
-          ── Ran sqlite3 ~/.bb-dev/bb.db '.tables'
-            $ sqlite3 ~/.bb-dev/bb.db '.tables'
+      "── Ran 2 commands ──────────────────────────────────────────
+        ── Ran pnpm test
+          $ pnpm test
+        ── Ran sqlite3 ~/.bb-dev/bb.db '.tables'
+          $ sqlite3 ~/.bb-dev/bb.db '.tables'
 
       ── Assistant ───────────────────────────────────────────────
       Done.


### PR DESCRIPTION
## Summary

- stop projecting unaccepted steers after their target turn completes
- treat pending steers as latest-page tail state so historical pages cannot resurrect stale requests
- add unit, CLI-rendering, and database-backed pagination regressions

## Root cause

The timeline treated any unaccepted steer as pending whenever the overall thread remained active. It did not distinguish thread activity from the lifecycle of the steer’s expected target turn. After durable request-settlement state was removed, a completed target with later unrelated active work could leave the old steer visible indefinitely.

## Validation

- `pnpm exec turbo run test --filter=@bb/thread-view --force` — 343 tests passed
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/threads/timeline-parented-pagination.test.ts` — 3 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --force`
- `pnpm exec turbo run typecheck --filter=@bb/server --force`
- staged review loop completed with no remaining P0/P1 findings
