### PR TITLE
Fix Codex resumed subagent turn tracking

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -27,6 +27,7 @@ import type {
   ProviderExecutionContext,
   TurnStartAdapterCommand,
 } from "../provider-adapter.js";
+import { RuntimeTurnState } from "../runtime-turn-state.js";
 
 // ---------------------------------------------------------------------------
 // Helpers to build typed CodexEvent fixtures
@@ -311,6 +312,53 @@ function codexTurn(args: CodexTurnArgs): Turn {
   };
 }
 
+function codexSubAgentActivity(args: {
+  id: string;
+  kind: "interacted" | "started";
+}) {
+  return {
+    jsonrpc: "2.0" as const,
+    method: "item/completed",
+    params: {
+      threadId: "root-provider-thread",
+      turnId: "parent-turn",
+      item: {
+        type: "subAgentActivity",
+        id: args.id,
+        kind: args.kind,
+        agentThreadId: "agent-thread-1",
+        agentPath: "/root/audit",
+      },
+    },
+  };
+}
+
+function completeInitialCodexSubAgentTurn(adapter: CodexProviderAdapter): void {
+  adapter.translateEvent(
+    codexSubAgentActivity({ id: "spawn-call", kind: "started" }),
+  );
+  adapter.translateEvent(
+    codexEvent("turn/started", {
+      threadId: "root-provider-thread",
+      turn: codexTurn({
+        id: "first-child-turn",
+        status: "inProgress",
+        error: null,
+      }),
+    }),
+  );
+  adapter.translateEvent(
+    codexEvent("turn/completed", {
+      threadId: "root-provider-thread",
+      turn: codexTurn({
+        id: "first-child-turn",
+        status: "completed",
+        error: null,
+      }),
+    }),
+  );
+}
+
 describe("codex provider adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -417,7 +465,7 @@ describe("codex provider adapter", () => {
     ]);
   });
 
-  it("emits input accepted when a queued turn starts and suppresses later user-message echoes", () => {
+  it("emits input accepted from the correlated Codex user-message echo", () => {
     const adapter = createCodexProviderAdapter();
 
     prepareTurnStart(adapter, {
@@ -443,6 +491,23 @@ describe("codex provider adapter", () => {
         providerThreadId: "provider-thread-1",
         scope: turnScope("turn-1"),
       },
+    ]);
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("item/started", {
+          threadId: "provider-thread-1",
+          turnId: "turn-1",
+          startedAtMs: 0,
+          item: {
+            type: "userMessage",
+            id: "provider-user-1",
+            clientId: "creq_23456789ag",
+            content: [{ type: "text", text: "normal turn", text_elements: [] }],
+          },
+        }),
+      ),
+    ).toEqual([
       {
         type: "turn/input/accepted",
         threadId: "provider-thread-1",
@@ -460,7 +525,7 @@ describe("codex provider adapter", () => {
         item: {
           type: "userMessage",
           id: "provider-user-1",
-          clientId: null,
+          clientId: "creq_23456789ag",
           content: [{ type: "text", text: "normal turn", text_elements: [] }],
         },
       }),
@@ -1949,6 +2014,7 @@ describe("codex provider adapter", () => {
       method: "turn/start",
       params: {
         threadId: "codex-1",
+        clientUserMessageId: "creq_222222228x",
         input: [{ type: "text", text: "do it" }],
         approvalPolicy: "never",
       },
@@ -3884,6 +3950,880 @@ describe("codex provider adapter", () => {
         }),
       }),
     ]);
+  });
+
+  it("keeps the foreground turn active when an idle Codex subagent resumes", () => {
+    const adapter = createCodexProviderAdapter();
+    const turnState = new RuntimeTurnState();
+    const foregroundTurnId = "019f7894-7ce8-76f0-8fd8-ca7d43bb8d29";
+    const resumedChildTurnId = "019f7894-dbf8-7bc1-a48d-3bd637892133";
+    for (const event of adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: foregroundTurnId,
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    )) {
+      turnState.observe(event);
+    }
+    completeInitialCodexSubAgentTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("rawResponseItem/completed", {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "function_call",
+            name: "followup_task",
+            arguments: '{"target":"agent-thread-1","message":"Continue"}',
+            call_id: "followup-call",
+          },
+        }),
+      ),
+    ).toEqual([]);
+
+    expect(
+      adapter.translateEvent(
+        codexSubAgentActivity({
+          id: "followup-call",
+          kind: "interacted",
+        }),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "item/started",
+        scope: turnScope("parent-turn"),
+        item: expect.objectContaining({
+          id: "followup-call",
+          type: "toolCall",
+          tool: "resumeAgent",
+          status: "pending",
+        }),
+      }),
+    ]);
+
+    const resumedChildEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: resumedChildTurnId,
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope(resumedChildTurnId),
+        parentToolCallId: "followup-call",
+      }),
+    );
+    for (const event of resumedChildEvents) {
+      turnState.observe(event);
+    }
+    expect(turnState.getActiveTurnId("root-provider-thread")).toBe(
+      foregroundTurnId,
+    );
+  });
+
+  it("does not resume an idle Codex subagent for send_message", () => {
+    const adapter = createCodexProviderAdapter();
+    completeInitialCodexSubAgentTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("rawResponseItem/completed", {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "function_call",
+            name: "send_message",
+            arguments: '{"target":"agent-thread-1","message":"FYI"}',
+            call_id: "message-call",
+          },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      adapter.translateEvent(
+        codexSubAgentActivity({
+          id: "message-call",
+          kind: "interacted",
+        }),
+      ),
+    ).toEqual([]);
+
+    const [nextForegroundTurn] = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "next-foreground-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(nextForegroundTurn).toMatchObject({
+      type: "turn/started",
+      scope: turnScope("next-foreground-turn"),
+    });
+    expect(nextForegroundTurn).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("ignores a replayed Codex followup interaction after its child completes", () => {
+    const adapter = createCodexProviderAdapter();
+    completeInitialCodexSubAgentTurn(adapter);
+
+    adapter.translateEvent(
+      codexEvent("rawResponseItem/completed", {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "function_call",
+          name: "followup_task",
+          arguments: '{"target":"agent-thread-1","message":"Continue"}',
+          call_id: "followup-call",
+        },
+      }),
+    );
+    adapter.translateEvent(
+      codexSubAgentActivity({
+        id: "followup-call",
+        kind: "interacted",
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "resumed-child-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "resumed-child-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+
+    adapter.translateEvent(
+      codexEvent("rawResponseItem/completed", {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "function_call",
+          name: "followup_task",
+          arguments: '{"target":"agent-thread-1","message":"Continue"}',
+          call_id: "followup-call",
+        },
+      }),
+    );
+    expect(
+      adapter.translateEvent(
+        codexSubAgentActivity({
+          id: "followup-call",
+          kind: "interacted",
+        }),
+      ),
+    ).toEqual([]);
+
+    const [nextForegroundTurn] = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "next-foreground-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(nextForegroundTurn).toMatchObject({
+      type: "turn/started",
+      scope: turnScope("next-foreground-turn"),
+    });
+    expect(nextForegroundTurn).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("links a rawless idle Codex interaction when its child turn starts", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        codexSubAgentActivity({
+          id: "rawless-interaction",
+          kind: "interacted",
+        }),
+      ),
+    ).toEqual([]);
+
+    const resumedChildEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "rawless-child-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        scope: turnScope("parent-turn"),
+        item: expect.objectContaining({
+          id: "rawless-interaction",
+          tool: "resumeAgent",
+          status: "pending",
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("rawless-child-turn"),
+        parentToolCallId: "rawless-interaction",
+      }),
+    );
+  });
+
+  it("links a rawless idle Codex interaction after its parent completes", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        codexSubAgentActivity({
+          id: "late-rawless-interaction",
+          kind: "interacted",
+        }),
+      ),
+    ).toEqual([]);
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+
+    const resumedChildEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "late-rawless-child-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        scope: turnScope("parent-turn"),
+        item: expect.objectContaining({
+          id: "late-rawless-interaction",
+          tool: "resumeAgent",
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("late-rawless-child-turn"),
+        parentToolCallId: "late-rawless-interaction",
+      }),
+    );
+  });
+
+  it("does not link a rawless message interaction to a native turn", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+    adapter.translateEvent(
+      codexSubAgentActivity({
+        id: "rawless-message",
+        kind: "interacted",
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId: "root-provider-thread",
+      clientRequestId: "creq_23456789ai",
+      input: [promptTextInput({ text: "next foreground turn" })],
+      options: fullProviderExecutionContext,
+    });
+
+    const nextForegroundEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "next-foreground-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(nextForegroundEvents).toEqual([]);
+
+    const acceptedForegroundEvents = adapter.translateEvent(
+      codexEvent("item/started", {
+        threadId: "root-provider-thread",
+        turnId: "next-foreground-turn",
+        startedAtMs: 0,
+        item: {
+          type: "userMessage",
+          id: "next-foreground-user-message",
+          clientId: "creq_23456789ai",
+          content: [
+            {
+              type: "text",
+              text: "next foreground turn",
+              text_elements: [],
+            },
+          ],
+        },
+      }),
+    );
+    expect(acceptedForegroundEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("next-foreground-turn"),
+      }),
+    );
+    expect(acceptedForegroundEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/input/accepted",
+        clientRequestId: "creq_23456789ai",
+      }),
+    );
+    expect(acceptedForegroundEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({ tool: "resumeAgent" }),
+      }),
+    );
+    expect(
+      acceptedForegroundEvents.find((event) => event.type === "turn/started"),
+    ).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("keeps a queued native turn correlated when a rawless child starts first", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+    adapter.translateEvent(
+      codexSubAgentActivity({
+        id: "delayed-followup",
+        kind: "interacted",
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId: "root-provider-thread",
+      clientRequestId: "creq_23456789aj",
+      input: [promptTextInput({ text: "queued foreground turn" })],
+      options: fullProviderExecutionContext,
+    });
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "delayed-child-turn",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toEqual([]);
+    const delayedChildEvents = adapter.translateEvent(
+      codexEvent("item/started", {
+        threadId: "root-provider-thread",
+        turnId: "delayed-child-turn",
+        startedAtMs: 0,
+        item: {
+          type: "userMessage",
+          id: "delayed-child-user-message",
+          clientId: null,
+          content: [{ type: "text", text: "Continue", text_elements: [] }],
+        },
+      }),
+    );
+    expect(delayedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({
+          id: "delayed-followup",
+          tool: "resumeAgent",
+        }),
+      }),
+    );
+    expect(delayedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("delayed-child-turn"),
+        parentToolCallId: "delayed-followup",
+      }),
+    );
+
+    const foregroundStartedEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "queued-foreground-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(foregroundStartedEvents).toEqual([
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("queued-foreground-turn"),
+      }),
+    ]);
+    expect(
+      adapter.translateEvent(
+        codexEvent("item/started", {
+          threadId: "root-provider-thread",
+          turnId: "queued-foreground-turn",
+          startedAtMs: 0,
+          item: {
+            type: "userMessage",
+            id: "queued-foreground-user-message",
+            clientId: "creq_23456789aj",
+            content: [
+              {
+                type: "text",
+                text: "queued foreground turn",
+                text_elements: [],
+              },
+            ],
+          },
+        }),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "turn/input/accepted",
+        scope: turnScope("queued-foreground-turn"),
+        clientRequestId: "creq_23456789aj",
+      }),
+    ]);
+  });
+
+  it("correlates interleaved rawless child and native starts by turn id", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+    adapter.translateEvent(
+      codexSubAgentActivity({
+        id: "interleaved-followup",
+        kind: "interacted",
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId: "root-provider-thread",
+      clientRequestId: "creq_23456789ak",
+      input: [promptTextInput({ text: "foreground first" })],
+      options: fullProviderExecutionContext,
+    });
+
+    for (const turnId of [
+      "interleaved-foreground-turn",
+      "interleaved-child-turn",
+    ]) {
+      expect(
+        adapter.translateEvent(
+          codexEvent("turn/started", {
+            threadId: "root-provider-thread",
+            turn: codexTurn({
+              id: turnId,
+              status: "inProgress",
+              error: null,
+            }),
+          }),
+        ),
+      ).toEqual([]);
+    }
+
+    const childEvents = adapter.translateEvent(
+      codexEvent("item/started", {
+        threadId: "root-provider-thread",
+        turnId: "interleaved-child-turn",
+        startedAtMs: 0,
+        item: {
+          type: "userMessage",
+          id: "interleaved-child-user-message",
+          clientId: null,
+          content: [{ type: "text", text: "Continue", text_elements: [] }],
+        },
+      }),
+    );
+    expect(childEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("interleaved-child-turn"),
+        parentToolCallId: "interleaved-followup",
+      }),
+    );
+    expect(childEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("interleaved-foreground-turn"),
+      }),
+    );
+
+    const foregroundEvents = adapter.translateEvent(
+      codexEvent("item/started", {
+        threadId: "root-provider-thread",
+        turnId: "interleaved-foreground-turn",
+        startedAtMs: 0,
+        item: {
+          type: "userMessage",
+          id: "interleaved-foreground-user-message",
+          clientId: "creq_23456789ak",
+          content: [
+            { type: "text", text: "foreground first", text_elements: [] },
+          ],
+        },
+      }),
+    );
+    expect(foregroundEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("interleaved-foreground-turn"),
+      }),
+    );
+    expect(
+      foregroundEvents.find((event) => event.type === "turn/started"),
+    ).not.toHaveProperty("parentToolCallId");
+    expect(foregroundEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/input/accepted",
+        clientRequestId: "creq_23456789ak",
+      }),
+    );
+  });
+
+  it("retains a rawless followup when the native turn identifies first", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+    adapter.translateEvent(
+      codexSubAgentActivity({
+        id: "later-child-followup",
+        kind: "interacted",
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId: "root-provider-thread",
+      clientRequestId: "creq_23456789am",
+      input: [promptTextInput({ text: "native identifies first" })],
+      options: fullProviderExecutionContext,
+    });
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "identified-native-turn",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toEqual([]);
+    const nativeEvents = adapter.translateEvent(
+      codexEvent("item/started", {
+        threadId: "root-provider-thread",
+        turnId: "identified-native-turn",
+        startedAtMs: 0,
+        item: {
+          type: "userMessage",
+          id: "identified-native-user-message",
+          clientId: "creq_23456789am",
+          content: [
+            {
+              type: "text",
+              text: "native identifies first",
+              text_elements: [],
+            },
+          ],
+        },
+      }),
+    );
+    expect(nativeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("identified-native-turn"),
+      }),
+    );
+    expect(nativeEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({ tool: "resumeAgent" }),
+      }),
+    );
+
+    const delayedChildEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "later-child-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(delayedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({
+          id: "later-child-followup",
+          tool: "resumeAgent",
+        }),
+      }),
+    );
+    expect(delayedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("later-child-turn"),
+        parentToolCallId: "later-child-followup",
+      }),
+    );
+  });
+
+  it("links a rawless child to the most recent idle interaction", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+    adapter.translateEvent(
+      codexSubAgentActivity({ id: "message-call", kind: "interacted" }),
+    );
+    adapter.translateEvent(
+      codexSubAgentActivity({ id: "followup-call", kind: "interacted" }),
+    );
+
+    const resumedChildEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "rawless-child-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({
+          id: "followup-call",
+          tool: "resumeAgent",
+        }),
+      }),
+    );
+    expect(resumedChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        parentToolCallId: "followup-call",
+      }),
+    );
+    expect(resumedChildEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({ id: "message-call" }),
+      }),
+    );
+  });
+
+  it("does not let a rawless interaction steal a pending spawn child turn", () => {
+    const adapter = createCodexProviderAdapter();
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "parent-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    completeInitialCodexSubAgentTurn(adapter);
+    adapter.translateEvent(
+      codexSubAgentActivity({
+        id: "rawless-message",
+        kind: "interacted",
+      }),
+    );
+    adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "second-spawn-call",
+          kind: "started",
+          agentThreadId: "agent-thread-2",
+          agentPath: "/root/review",
+        },
+      },
+    });
+
+    const spawnChildEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "spawn-child-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(spawnChildEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({ tool: "resumeAgent" }),
+      }),
+    );
+    expect(spawnChildEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("spawn-child-turn"),
+        parentToolCallId: "second-spawn-call",
+      }),
+    );
   });
 
   it("links concurrent Codex subagents to child turns in activity order", () => {

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -15,7 +15,6 @@ import {
   getThreadEventScopeTurnId,
   jsonValueSchema,
   requireThreadEventScopeTurnId,
-  turnScope,
 } from "@bb/domain";
 import type {
   ClientTurnRequestId,
@@ -76,6 +75,7 @@ import {
   buildCodexSubAgentCompletedEvent,
   buildCodexSubAgentStartedEvent,
   parseCodexSubAgentActivityEvent,
+  type CodexSubAgentActivityEvent,
   type CodexTrackedSubAgent,
 } from "./subagent-activity-translation.js";
 
@@ -863,6 +863,16 @@ interface CodexPendingDelegationTurnLink {
   parentTurnId: string;
 }
 
+interface CodexInteractionClassification {
+  kind: "followup" | "message";
+  turnId: string;
+}
+
+interface CodexDeferredTurnStart {
+  event: ThreadEvent;
+  pendingEvents: ThreadEvent[];
+}
+
 function collectStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
@@ -1107,6 +1117,22 @@ export function createCodexProviderAdapter(
     string,
     CodexRawCommandOutputState
   >();
+  const interactionClassificationsByProviderThreadId = new Map<
+    string,
+    Map<string, CodexInteractionClassification>
+  >();
+  const unclassifiedInteractionsByProviderThreadId = new Map<
+    string,
+    CodexSubAgentActivityEvent[]
+  >();
+  const deferredTurnStartsByProviderThreadId = new Map<
+    string,
+    Map<string, CodexDeferredTurnStart>
+  >();
+  const seenInteractionTurnIdsByCallIdByProviderThreadId = new Map<
+    string,
+    Map<string, string>
+  >();
   const delegationParentToolCallIdsByProviderThreadId = new Map<
     string,
     string
@@ -1241,6 +1267,19 @@ export function createCodexProviderAdapter(
       return;
     }
     rawCommandOutputStateByProviderThreadId.delete(paramsResult.data.threadId);
+    nativeTurnStartClientRequestIdsByProviderThreadId.delete(
+      paramsResult.data.threadId,
+    );
+    interactionClassificationsByProviderThreadId.delete(
+      paramsResult.data.threadId,
+    );
+    unclassifiedInteractionsByProviderThreadId.delete(
+      paramsResult.data.threadId,
+    );
+    deferredTurnStartsByProviderThreadId.delete(paramsResult.data.threadId);
+    seenInteractionTurnIdsByCallIdByProviderThreadId.delete(
+      paramsResult.data.threadId,
+    );
     clearCodexDelegationParentState(paramsResult.data.threadId);
     clearGitWritableRootsByProviderThreadId({
       providerThreadId: paramsResult.data.threadId,
@@ -1294,88 +1333,35 @@ export function createCodexProviderAdapter(
   function removeNativeTurnStartClientRequestId(args: {
     clientRequestId: ClientTurnRequestId;
     providerThreadId: string;
-  }): void {
+  }): boolean {
     const sequences = nativeTurnStartClientRequestIdsByProviderThreadId.get(
       args.providerThreadId,
     );
     if (!sequences || sequences.length === 0) {
-      return;
+      return false;
     }
     const nextSequences = [...sequences];
     const sequenceIndex = nextSequences.indexOf(args.clientRequestId);
     if (sequenceIndex === -1) {
-      return;
+      return false;
     }
     nextSequences.splice(sequenceIndex, 1);
     if (nextSequences.length === 0) {
       nativeTurnStartClientRequestIdsByProviderThreadId.delete(
         args.providerThreadId,
       );
-      return;
+      return true;
     }
     nativeTurnStartClientRequestIdsByProviderThreadId.set(
       args.providerThreadId,
       nextSequences,
     );
-  }
-
-  function shiftNativeTurnStartClientRequestId(
-    providerThreadId: string,
-  ): ClientTurnRequestId | undefined {
-    const sequences =
-      nativeTurnStartClientRequestIdsByProviderThreadId.get(providerThreadId);
-    if (!sequences || sequences.length === 0) {
-      return undefined;
-    }
-    const [clientRequestId, ...remainingSequences] = sequences;
-    if (remainingSequences.length === 0) {
-      nativeTurnStartClientRequestIdsByProviderThreadId.delete(
-        providerThreadId,
-      );
-    } else {
-      nativeTurnStartClientRequestIdsByProviderThreadId.set(
-        providerThreadId,
-        remainingSequences,
-      );
-    }
-    return clientRequestId;
+    return true;
   }
 
   function attachAcceptedUserMessageCorrelation(
     event: ThreadEvent,
   ): ThreadEvent[] {
-    if (event.type === "turn/completed") {
-      if (event.providerThreadId !== null) {
-        nativeTurnStartClientRequestIdsByProviderThreadId.delete(
-          event.providerThreadId,
-        );
-      }
-      return [event];
-    }
-
-    if (event.type === "turn/started") {
-      const clientRequestId = shiftNativeTurnStartClientRequestId(
-        event.providerThreadId,
-      );
-      if (clientRequestId === undefined) {
-        return [event];
-      }
-      const turnId = requireThreadEventScopeTurnId({
-        type: event.type,
-        scope: event.scope,
-      });
-      return [
-        event,
-        {
-          type: "turn/input/accepted",
-          threadId: event.threadId,
-          providerThreadId: event.providerThreadId,
-          scope: turnScope(turnId),
-          clientRequestId,
-        },
-      ];
-    }
-
     if (
       (event.type !== "item/started" && event.type !== "item/completed") ||
       event.item.type !== "userMessage"
@@ -1383,7 +1369,26 @@ export function createCodexProviderAdapter(
       return [event];
     }
 
-    return [];
+    const clientRequestId = event.item.clientRequestId;
+    if (
+      clientRequestId === undefined ||
+      event.providerThreadId === null ||
+      !removeNativeTurnStartClientRequestId({
+        clientRequestId,
+        providerThreadId: event.providerThreadId,
+      })
+    ) {
+      return [];
+    }
+    return buildAcceptedUserMessageEvent({
+      clientRequestId,
+      providerThreadId: event.providerThreadId,
+      threadId: event.threadId,
+      turnId: requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      }),
+    });
   }
 
   function enqueuePendingDelegationTurnLink(args: {
@@ -1593,6 +1598,100 @@ export function createCodexProviderAdapter(
     return buildCodexSubAgentCompletedEvent(args);
   }
 
+  function beginCodexTrackedSubAgent(args: {
+    activity: CodexSubAgentActivityEvent;
+    tool: CodexTrackedSubAgent["tool"];
+  }): ThreadEvent[] {
+    const tracked: CodexTrackedSubAgent = {
+      agentPath: args.activity.item.agentPath,
+      agentThreadId: args.activity.item.agentThreadId,
+      callId: args.activity.item.id,
+      parentProviderThreadId: args.activity.providerThreadId,
+      parentTurnId: args.activity.turnId,
+      terminal: false,
+      tool: args.tool,
+    };
+    trackedSubAgentsByCallId.set(tracked.callId, tracked);
+    trackedSubAgentCallIdsByAgentThreadId.set(
+      tracked.agentThreadId,
+      tracked.callId,
+    );
+
+    const [startedEvent] = attachCodexDelegationParentLinks([
+      buildCodexSubAgentStartedEvent(tracked),
+    ]);
+    if (
+      startedEvent?.type === "item/started" &&
+      startedEvent.item.type === "toolCall"
+    ) {
+      tracked.parentToolCallId = startedEvent.item.parentToolCallId;
+    }
+    // Codex currently multiplexes child turns onto the root provider
+    // thread, even though the activity includes a distinct agent thread
+    // id. Queue a FIFO fallback in addition to the explicit id mapping.
+    enqueuePendingDelegationTurnLink({
+      callId: tracked.callId,
+      parentTurnId: tracked.parentTurnId,
+      providerThreadId: tracked.parentProviderThreadId,
+    });
+    return startedEvent ? [startedEvent] : [];
+  }
+
+  function consumeCodexInteractionClassification(args: {
+    callId: string;
+    providerThreadId: string;
+  }): CodexInteractionClassification["kind"] | undefined {
+    const classifications = interactionClassificationsByProviderThreadId.get(
+      args.providerThreadId,
+    );
+    if (!classifications) {
+      return undefined;
+    }
+    const classification = classifications.get(args.callId);
+    if (!classification) {
+      return undefined;
+    }
+    classifications.delete(args.callId);
+    if (classifications.size === 0) {
+      interactionClassificationsByProviderThreadId.delete(
+        args.providerThreadId,
+      );
+    }
+    return classification.kind;
+  }
+
+  function recordCodexInteraction(
+    activity: CodexSubAgentActivityEvent,
+  ): boolean {
+    const seenInteractions =
+      seenInteractionTurnIdsByCallIdByProviderThreadId.get(
+        activity.providerThreadId,
+      ) ?? new Map<string, string>();
+    if (seenInteractions.has(activity.item.id)) {
+      return false;
+    }
+    seenInteractions.set(activity.item.id, activity.turnId);
+    seenInteractionTurnIdsByCallIdByProviderThreadId.set(
+      activity.providerThreadId,
+      seenInteractions,
+    );
+    return true;
+  }
+
+  function queueUnclassifiedCodexInteraction(
+    activity: CodexSubAgentActivityEvent,
+  ): void {
+    const pendingInteractions =
+      unclassifiedInteractionsByProviderThreadId.get(
+        activity.providerThreadId,
+      ) ?? [];
+    pendingInteractions.push(activity);
+    unclassifiedInteractionsByProviderThreadId.set(
+      activity.providerThreadId,
+      pendingInteractions,
+    );
+  }
+
   function translateCodexSubAgentActivity(
     event: ProviderRuntimeEvent,
   ): ThreadEvent[] | null {
@@ -1606,43 +1705,45 @@ export function createCodexProviderAdapter(
         if (trackedSubAgentsByCallId.has(activity.item.id)) {
           return [];
         }
-        const tracked: CodexTrackedSubAgent = {
-          agentPath: activity.item.agentPath,
-          agentThreadId: activity.item.agentThreadId,
-          callId: activity.item.id,
-          parentProviderThreadId: activity.providerThreadId,
-          parentTurnId: activity.turnId,
-          terminal: false,
-        };
-        trackedSubAgentsByCallId.set(tracked.callId, tracked);
-        trackedSubAgentCallIdsByAgentThreadId.set(
-          tracked.agentThreadId,
-          tracked.callId,
-        );
-
-        const [startedEvent] = attachCodexDelegationParentLinks([
-          buildCodexSubAgentStartedEvent(tracked),
-        ]);
-        if (
-          startedEvent?.type === "item/started" &&
-          startedEvent.item.type === "toolCall"
-        ) {
-          tracked.parentToolCallId = startedEvent.item.parentToolCallId;
-        }
-        // Codex currently multiplexes child turns onto the root provider
-        // thread, even though the activity includes a distinct agent thread
-        // id. Queue a FIFO fallback in addition to the explicit id mapping.
-        enqueuePendingDelegationTurnLink({
-          callId: tracked.callId,
-          parentTurnId: tracked.parentTurnId,
-          providerThreadId: tracked.parentProviderThreadId,
+        return beginCodexTrackedSubAgent({
+          activity,
+          tool: "spawnAgent",
         });
-        return startedEvent ? [startedEvent] : [];
       }
-      case "interacted":
-        // Messaging an existing agent is activity within the original
-        // delegation, not a new timeline row.
+      case "interacted": {
+        const classification = consumeCodexInteractionClassification({
+          callId: activity.item.id,
+          providerThreadId: activity.providerThreadId,
+        });
+        if (!recordCodexInteraction(activity)) {
+          return [];
+        }
+        if (trackedSubAgentsByCallId.has(activity.item.id)) {
+          return [];
+        }
+        const activeCallId = trackedSubAgentCallIdsByAgentThreadId.get(
+          activity.item.agentThreadId,
+        );
+        const activeTracked = activeCallId
+          ? trackedSubAgentsByCallId.get(activeCallId)
+          : undefined;
+        if (activeTracked && !activeTracked.terminal) {
+          // A message delivered into an already-running child stays within
+          // that delegation and does not create a second timeline row.
+          return [];
+        }
+        if (classification === "message") {
+          return [];
+        }
+        if (classification === "followup") {
+          return beginCodexTrackedSubAgent({
+            activity,
+            tool: "resumeAgent",
+          });
+        }
+        queueUnclassifiedCodexInteraction(activity);
         return [];
+      }
       case "interrupted": {
         const callId = trackedSubAgentCallIdsByAgentThreadId.get(
           activity.item.agentThreadId,
@@ -1660,6 +1761,171 @@ export function createCodexProviderAdapter(
         return completed ? [completed] : [];
       }
     }
+  }
+
+  function materializeUnclassifiedCodexInteraction(
+    event: ThreadEvent,
+  ): ThreadEvent[] {
+    if (event.type !== "turn/started" || event.providerThreadId === null) {
+      return [];
+    }
+    const turnId = requireThreadEventScopeTurnId({
+      type: event.type,
+      scope: event.scope,
+    });
+    const pendingDelegationLinks =
+      pendingDelegationTurnLinksByProviderThreadId.get(event.providerThreadId);
+    if (
+      pendingDelegationLinks?.some(
+        (pendingLink) => pendingLink.parentTurnId !== turnId,
+      )
+    ) {
+      return [];
+    }
+
+    const pendingInteractions = unclassifiedInteractionsByProviderThreadId.get(
+      event.providerThreadId,
+    );
+    if (!pendingInteractions) {
+      return [];
+    }
+
+    let interactionIndex = pendingInteractions.length - 1;
+    while (
+      interactionIndex >= 0 &&
+      pendingInteractions[interactionIndex]?.turnId === turnId
+    ) {
+      interactionIndex -= 1;
+    }
+    if (interactionIndex === -1) {
+      return [];
+    }
+    const [activity] = pendingInteractions.splice(interactionIndex, 1);
+    if (!activity) {
+      return [];
+    }
+
+    if (pendingInteractions.length === 0) {
+      unclassifiedInteractionsByProviderThreadId.delete(event.providerThreadId);
+    }
+    return beginCodexTrackedSubAgent({
+      activity,
+      tool: "resumeAgent",
+    });
+  }
+
+  function materializeUnclassifiedCodexInteractions(
+    events: ThreadEvent[],
+  ): ThreadEvent[] {
+    const materializedEvents: ThreadEvent[] = [];
+    for (const event of events) {
+      const providerThreadId = getCodexEventProviderThreadId(event);
+      const turnId = getThreadEventScopeTurnId(event.scope);
+      const deferredTurnStarts = providerThreadId
+        ? deferredTurnStartsByProviderThreadId.get(providerThreadId)
+        : undefined;
+      const deferredTurnStart = turnId
+        ? deferredTurnStarts?.get(turnId)
+        : undefined;
+      if (
+        providerThreadId &&
+        turnId &&
+        deferredTurnStarts &&
+        deferredTurnStart
+      ) {
+        if (event.type === "turn/started") {
+          continue;
+        }
+        const clientRequestId =
+          (event.type === "item/started" || event.type === "item/completed") &&
+          event.item.type === "userMessage"
+            ? event.item.clientRequestId
+            : undefined;
+        const pendingNativeTurnStarts =
+          nativeTurnStartClientRequestIdsByProviderThreadId.get(
+            providerThreadId,
+          );
+        const isNativeUserMessage =
+          clientRequestId !== undefined &&
+          pendingNativeTurnStarts?.includes(clientRequestId);
+        const isChildUserMessage =
+          (event.type === "item/started" || event.type === "item/completed") &&
+          event.item.type === "userMessage" &&
+          !isNativeUserMessage;
+        if (
+          !isNativeUserMessage &&
+          !isChildUserMessage &&
+          event.type !== "turn/completed"
+        ) {
+          deferredTurnStart.pendingEvents.push(event);
+          continue;
+        }
+
+        deferredTurnStarts.delete(turnId);
+        if (deferredTurnStarts.size === 0) {
+          deferredTurnStartsByProviderThreadId.delete(providerThreadId);
+        }
+        if (isNativeUserMessage) {
+          materializedEvents.push(
+            deferredTurnStart.event,
+            ...deferredTurnStart.pendingEvents,
+          );
+        } else {
+          materializedEvents.push(
+            ...materializeUnclassifiedCodexInteraction(deferredTurnStart.event),
+            deferredTurnStart.event,
+            ...deferredTurnStart.pendingEvents,
+          );
+        }
+        materializedEvents.push(event);
+        continue;
+      }
+
+      if (event.type === "turn/started" && event.providerThreadId !== null) {
+        const startedTurnId = requireThreadEventScopeTurnId({
+          type: event.type,
+          scope: event.scope,
+        });
+        const pendingInteractions =
+          unclassifiedInteractionsByProviderThreadId.get(
+            event.providerThreadId,
+          );
+        const pendingNativeTurnStarts =
+          nativeTurnStartClientRequestIdsByProviderThreadId.get(
+            event.providerThreadId,
+          );
+        const pendingDelegationLinks =
+          pendingDelegationTurnLinksByProviderThreadId.get(
+            event.providerThreadId,
+          );
+        const hasKnownDelegation = pendingDelegationLinks?.some(
+          (pendingLink) => pendingLink.parentTurnId !== startedTurnId,
+        );
+        if (
+          pendingInteractions?.length &&
+          pendingNativeTurnStarts?.length &&
+          !hasKnownDelegation
+        ) {
+          const nextDeferredTurnStarts =
+            deferredTurnStartsByProviderThreadId.get(event.providerThreadId) ??
+            new Map<string, CodexDeferredTurnStart>();
+          nextDeferredTurnStarts.set(startedTurnId, {
+            event,
+            pendingEvents: [],
+          });
+          deferredTurnStartsByProviderThreadId.set(
+            event.providerThreadId,
+            nextDeferredTurnStarts,
+          );
+          continue;
+        }
+        materializedEvents.push(
+          ...materializeUnclassifiedCodexInteraction(event),
+        );
+      }
+      materializedEvents.push(event);
+    }
+    return materializedEvents;
   }
 
   function completeFinishedCodexSubAgentTurns(
@@ -1704,9 +1970,23 @@ export function createCodexProviderAdapter(
       return true;
     }
 
-    const { threadId: providerThreadId, item } = paramsResult.data;
+    const { threadId: providerThreadId, turnId, item } = paramsResult.data;
 
     if (item.type === "function_call") {
+      if (item.name === "followup_task" || item.name === "send_message") {
+        const classifications =
+          interactionClassificationsByProviderThreadId.get(providerThreadId) ??
+          new Map<string, CodexInteractionClassification>();
+        classifications.set(item.call_id, {
+          kind: item.name === "followup_task" ? "followup" : "message",
+          turnId,
+        });
+        interactionClassificationsByProviderThreadId.set(
+          providerThreadId,
+          classifications,
+        );
+        return true;
+      }
       if (!CODEX_SHELL_TOOL_NAMES.has(item.name)) {
         return true;
       }
@@ -1758,11 +2038,57 @@ export function createCodexProviderAdapter(
     return true;
   }
 
-  function reconcileRawCommandOutputLifecycle(events: ThreadEvent[]): void {
+  function reconcileCodexTurnLifecycle(events: ThreadEvent[]): void {
     for (const event of events) {
-      if (event.type === "turn/completed") {
-        if (event.providerThreadId !== null) {
-          rawCommandOutputStateByProviderThreadId.delete(
+      if (
+        (event.type !== "turn/started" && event.type !== "turn/completed") ||
+        event.providerThreadId === null
+      ) {
+        continue;
+      }
+      const turnId = requireThreadEventScopeTurnId({
+        type: event.type,
+        scope: event.scope,
+      });
+      if (event.type === "turn/started") {
+        continue;
+      }
+
+      rawCommandOutputStateByProviderThreadId.delete(event.providerThreadId);
+
+      const classifications = interactionClassificationsByProviderThreadId.get(
+        event.providerThreadId,
+      );
+      if (classifications) {
+        for (const [callId, classification] of classifications) {
+          if (classification.turnId === turnId) {
+            classifications.delete(callId);
+          }
+        }
+        if (classifications.size === 0) {
+          interactionClassificationsByProviderThreadId.delete(
+            event.providerThreadId,
+          );
+        }
+      }
+
+      const seenInteractions =
+        seenInteractionTurnIdsByCallIdByProviderThreadId.get(
+          event.providerThreadId,
+        );
+      if (seenInteractions) {
+        const pendingCallIds = new Set(
+          unclassifiedInteractionsByProviderThreadId
+            .get(event.providerThreadId)
+            ?.map((activity) => activity.item.id) ?? [],
+        );
+        for (const [callId, parentTurnId] of seenInteractions) {
+          if (parentTurnId === turnId && !pendingCallIds.has(callId)) {
+            seenInteractions.delete(callId);
+          }
+        }
+        if (seenInteractions.size === 0) {
+          seenInteractionTurnIdsByCallIdByProviderThreadId.delete(
             event.providerThreadId,
           );
         }
@@ -1991,6 +2317,7 @@ export function createCodexProviderAdapter(
             method: "turn/start",
             params: {
               threadId: command.providerThreadId,
+              clientUserMessageId: command.clientRequestId,
               input: toCodexUserInput(input),
               approvalPolicy: permissionSettings.approvalPolicy,
               approvalsReviewer: permissionSettings.approvalsReviewer,
@@ -2076,18 +2403,23 @@ export function createCodexProviderAdapter(
 
       const subAgentActivityEvents = translateCodexSubAgentActivity(event);
       if (subAgentActivityEvents !== null) {
-        reconcileRawCommandOutputLifecycle(subAgentActivityEvents);
+        reconcileCodexTurnLifecycle(subAgentActivityEvents);
         return applyRecoveredCommandOutput(subAgentActivityEvents);
       }
 
-      const translatedEvents = translateCodexEvent(event).flatMap(
-        attachAcceptedUserMessageCorrelation,
+      const translatedEvents = translateCodexEvent(event);
+      const eventsWithMaterializedInteractions =
+        materializeUnclassifiedCodexInteractions(translatedEvents);
+      const eventsWithAcceptedUserMessages =
+        eventsWithMaterializedInteractions.flatMap(
+          attachAcceptedUserMessageCorrelation,
+        );
+      const parentLinkedEvents = attachCodexDelegationParentLinks(
+        eventsWithAcceptedUserMessages,
       );
-      const parentLinkedEvents =
-        attachCodexDelegationParentLinks(translatedEvents);
       const completedSubAgentEvents =
         completeFinishedCodexSubAgentTurns(parentLinkedEvents);
-      reconcileRawCommandOutputLifecycle(completedSubAgentEvents);
+      reconcileCodexTurnLifecycle(completedSubAgentEvents);
       return applyRecoveredCommandOutput(completedSubAgentEvents);
     },
 

--- a/packages/agent-runtime/src/codex/event-translation.ts
+++ b/packages/agent-runtime/src/codex/event-translation.ts
@@ -11,7 +11,7 @@ import type {
   ThreadEventTurnStatus,
   ThreadEventUserContent,
 } from "@bb/domain";
-import { threadScope, turnScope } from "@bb/domain";
+import { clientTurnRequestIdSchema, threadScope, turnScope } from "@bb/domain";
 import { toOptionalRecord } from "../shared/adapter-utils.js";
 import { createUnhandledProviderEvent } from "../shared/provider-unhandled-event.js";
 import { UNSTAMPED_THREAD_ID } from "../shared/unstamped-thread-id.js";
@@ -430,9 +430,19 @@ function translateCodexItem(
       const content = parsedItem.content
         .map((entry) => translateCodexUserContent(entry))
         .filter((entry) => entry.type !== "text" || entry.text.length > 0);
+      const clientRequestId = clientTurnRequestIdSchema.safeParse(
+        parsedItem.clientId,
+      );
       return {
         kind: "translated",
-        item: { type: "userMessage", id: parsedItem.id, content },
+        item: {
+          type: "userMessage",
+          id: parsedItem.id,
+          content,
+          ...(clientRequestId.success
+            ? { clientRequestId: clientRequestId.data }
+            : {}),
+        },
       };
     }
     case "commandExecution":

--- a/packages/agent-runtime/src/codex/schemas.ts
+++ b/packages/agent-runtime/src/codex/schemas.ts
@@ -358,6 +358,7 @@ export const codexHandledThreadItemSchema = z.discriminatedUnion("type", [
     .object({
       type: z.literal("userMessage"),
       id: z.string(),
+      clientId: z.string().nullable().optional(),
       content: z.array(codexUserInputSchema),
     })
     .passthrough(),

--- a/packages/agent-runtime/src/codex/subagent-activity-translation.ts
+++ b/packages/agent-runtime/src/codex/subagent-activity-translation.ts
@@ -25,6 +25,7 @@ export interface CodexTrackedSubAgent {
   parentToolCallId?: string;
   parentTurnId: string;
   terminal: boolean;
+  tool: "resumeAgent" | "spawnAgent";
 }
 
 export function parseCodexSubAgentActivityEvent(
@@ -62,7 +63,7 @@ function buildSubAgentToolCallItem(
   return {
     type: "toolCall",
     id: tracked.callId,
-    tool: "spawnAgent",
+    tool: tracked.tool,
     arguments: {
       senderThreadId: tracked.parentProviderThreadId,
       receiverThreadIds: [tracked.agentThreadId],

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 59 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 60 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,


### PR DESCRIPTION
## Summary

Fix Codex resumed subagent turns being mistaken for the thread's foreground turn. That stale active-turn state caused the next prompt/steer to fail even though Codex was still correctly running the original foreground turn.

## Exact reproduction

Use the pre-fix base commit `b6b0799eb4f9cefedbda41cbe66b0ab001f96662` with a Codex-backed BB thread.

1. Create a new Codex thread in BB.
2. Paste this prompt:

   ```text
   Spawn a child agent and ask it to inspect packages/agent-runtime/package.json and return the package name. Wait until that child finishes and becomes idle. Then use followup_task to resume the same child and ask it to run the @bb/agent-runtime test suite. Immediately after followup_task returns, post exactly "RESUMED — send status now" in commentary, keep this parent turn open, and wait for the child to finish.
   ```

3. When `RESUMED — send status now` appears, immediately submit `status?` in the same BB thread while the resumed child is still running.
4. Before this fix, the submission fails with the active-turn mismatch from the report:

   ```text
   Command turn.submit failed
   expected active turn id `019f7894-dbf8-7bc1-a48d-3bd637892133` but found `019f7894-7ce8-76f0-8fd8-ca7d43bb8d29`
   ```

The UUID ending in `dbf8` is the resumed child turn that BB incorrectly promoted to foreground. The UUID ending in `7ce8` is the actual foreground turn still owned by Codex/the host daemon.

### Automated regression breadcrumb

From a disposable worktree, copy this PR's regression test onto the pre-fix commit and run only that scenario:

```bash
git fetch origin pull/807/head:pr-807-repro
git switch --detach b6b0799eb4f9cefedbda41cbe66b0ab001f96662
git checkout pr-807-repro -- packages/agent-runtime/src/codex/adapter.test.ts
pnpm install --frozen-lockfile
pnpm exec turbo run test --filter=@bb/agent-runtime -- src/codex/adapter.test.ts -t 'keeps the foreground turn active when an idle Codex subagent resumes'
```

The test fails on the pre-fix implementation because the `interacted` activity is not translated into a `resumeAgent` delegation, so the resumed child's `turn/started` has no `parentToolCallId`. Switching to the PR head and rerunning the same command passes:

```bash
git switch pr-807-repro
pnpm exec turbo run test --filter=@bb/agent-runtime -- src/codex/adapter.test.ts -t 'keeps the foreground turn active when an idle Codex subagent resumes'
```

## Root cause

Codex emits `subAgentActivity(kind: "interacted")` when `followup_task` resumes an idle child, then multiplexes the resumed child's `turn/started` onto the root provider thread. The adapter ignored `interacted`, so it emitted that child start without delegation metadata. `RuntimeTurnState` therefore treated the child as a new foreground turn and replaced the real foreground ID.

| Event | Before | After |
| --- | --- | --- |
| Foreground turn `7ce8` starts | Active turn is `7ce8` | Active turn is `7ce8` |
| Idle child resumes as `dbf8` | `dbf8` looks unparented and replaces the active turn | `dbf8` is parented to `resumeAgent`; active turn stays `7ce8` |
| User submits `status?` | BB expects `dbf8`, daemon/Codex has `7ce8`, submission fails | BB and daemon both target `7ce8`, submission succeeds |

## What changed

- Classify raw Codex function-call metadata so `followup_task` is distinguished from `send_message`; only a true idle-child follow-up creates a new `resumeAgent` delegation.
- Translate the matching `interacted` activity into a `resumeAgent` tool call and attach its call ID as `parentToolCallId` on the resumed child turn and child items.
- Send BB's client request ID as Codex `clientUserMessageId` and read it back from user-message echoes, allowing real foreground turns to be correlated even when child/native events interleave.
- Add deferred, replay-safe correlation for sessions where raw response events are unavailable.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 59 to 60 because the daemon event behavior changed.

## Verification

- Exact reported UUID regression: passing.
- Focused regression command above: 1/1 passing.
- Codex adapter suite: 165/165 passing.
- Agent runtime suite: 789/789 passing.
- Host daemon contract suite: 47/47 passing.
- Agent runtime and host daemon contract typechecks: passing.
- Prettier and `git diff --check`: passing.
- Independent architecture and test-review gates: clean.
