### PR TITLE
Keep model reasoning picker open after selection

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -41,6 +41,7 @@ const manyCodexModels: readonly PickerOption<string>[] = [
 
 const reasoningOptions: readonly PickerOption<ReasoningLevel>[] = [
   { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
 ];
 
 function availableModel({
@@ -83,12 +84,14 @@ function executionOptions({
 function renderPicker({
   onSelectedProviderChange = vi.fn(),
   onModelChange = vi.fn(),
+  onReasoningChange = vi.fn(),
   modelOptions = codexModels,
   moreModelOptions = [],
   providerRouting,
 }: {
   onSelectedProviderChange?: (value: string) => void;
   onModelChange?: (value: string) => void;
+  onReasoningChange?: (value: ReasoningLevel) => void;
   modelOptions?: readonly PickerOption<string>[];
   moreModelOptions?: readonly PickerOption<string>[];
   providerRouting?: SystemProvidersQuery;
@@ -124,7 +127,7 @@ function renderPicker({
       onModelChange={onModelChange}
       reasoningValue="medium"
       reasoningOptions={reasoningOptions}
-      onReasoningChange={vi.fn()}
+      onReasoningChange={onReasoningChange}
       fastModeEnabled={false}
       onFastModeChange={vi.fn()}
       showFastModeToggle={false}
@@ -133,7 +136,7 @@ function renderPicker({
     { wrapper },
   );
 
-  return { onSelectedProviderChange, onModelChange };
+  return { onSelectedProviderChange, onModelChange, onReasoningChange };
 }
 
 afterEach(() => {
@@ -142,6 +145,28 @@ afterEach(() => {
 });
 
 describe("ModelReasoningPicker", () => {
+  it("stays open while changing both the model and reasoning effort", () => {
+    const { onModelChange, onReasoningChange } = renderPicker({
+      modelOptions: [
+        ...codexModels,
+        { value: "gpt-5.2", label: "GPT-5.2" },
+      ],
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    fireEvent.click(screen.getByText("5.2"));
+
+    expect(onModelChange).toHaveBeenCalledWith("gpt-5.2");
+    expect(screen.getByRole("dialog")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("High"));
+
+    expect(onReasoningChange).toHaveBeenCalledWith("high");
+    expect(screen.getByRole("dialog")).not.toBeNull();
+  });
+
   it("marks the portaled picker as native no-drag content", () => {
     renderPicker();
 

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -531,7 +531,6 @@ export function ModelReasoningPicker({
       }
       onModelChange(model);
       setMoreModelsOpen(false);
-      setOpen(false);
       setPreviewProviderId(null);
     },
     [isPreviewing, onModelChange, onSelectedProviderChange, previewProviderId],
@@ -590,9 +589,8 @@ export function ModelReasoningPicker({
         onModelChange(previewDefaultModel.model);
       }
       onReasoningChange(level);
-      // Match the standalone Reasoning OptionPicker's behaviour: picking a
-      // value commits and closes.
-      setOpen(false);
+      // Keep the combined picker open so the model and reasoning effort can be
+      // changed together without reopening it between selections.
       setPreviewProviderId(null);
       setMoreModelsOpen(false);
     },


### PR DESCRIPTION
## Summary

- keep the combined model/reasoning picker open after selecting a model
- keep it open after selecting a reasoning effort so both values can be changed together
- add regression coverage for changing both values in one open picker

## Tests

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/pickers/ModelReasoningPicker.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`