### PR TITLE
Ignore Codex turn moderation metadata

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -2653,6 +2653,26 @@ describe("codex provider adapter", () => {
     );
   });
 
+  it("translateEvent ignores Codex turn moderation metadata", () => {
+    const adapter = createCodexProviderAdapter();
+    const events = adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "turn/moderationMetadata",
+      params: {
+        threadId: "t1",
+        turnId: "turn-1",
+        metadata: {
+          prompt: {},
+          generation: {},
+          tool_call: {},
+          tool_response: {},
+        },
+      },
+    });
+
+    expect(events).toEqual([]);
+  });
+
   it("translateEvent item/mcpToolCall/progress maps to shared tool progress", () => {
     const adapter = createCodexProviderAdapter();
     const events = adapter.translateEvent(

--- a/packages/agent-runtime/src/codex/visibility.ts
+++ b/packages/agent-runtime/src/codex/visibility.ts
@@ -183,7 +183,8 @@ const CODEX_NOTIFICATION_COVERAGE = {
   "thread/unarchived": "noise",
   "turn/completed": "normalized",
   "turn/diff/updated": "normalized",
-  "turn/moderationMetadata": "unknown",
+  // Internal moderation accounting is not actionable thread output.
+  "turn/moderationMetadata": "noise",
   "turn/plan/updated": "normalized",
   "turn/started": "normalized",
   warning: "unknown",

--- a/packages/agent-runtime/src/provider-visibility.test.ts
+++ b/packages/agent-runtime/src/provider-visibility.test.ts
@@ -147,4 +147,26 @@ describe("provider visibility raw events", () => {
       coverage: "noise",
     });
   });
+
+  it("classifies Codex turn moderation metadata as noise", () => {
+    expect(
+      codexVisibilityMetadata.describeRawEvent({
+        jsonrpc: "2.0",
+        method: "turn/moderationMetadata",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          metadata: {
+            prompt: {},
+            generation: {},
+            tool_call: {},
+            tool_response: {},
+          },
+        },
+      }),
+    ).toEqual({
+      kind: "turn/moderationMetadata",
+      coverage: "noise",
+    });
+  });
 });

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 59 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 60 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,


### PR DESCRIPTION
## Summary

- classify Codex turn moderation metadata notifications as provider noise
- prevent them from rendering as unhandled timeline errors
- bump the host daemon protocol version for the changed event stream

## Tests

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon-contract`
- `git diff --check`