### PR TITLE
Fix misleading desktop update status

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
@@ -57,7 +57,9 @@ function providerStatus(
     executableName,
     executablePath: installed ? `/usr/local/bin/${executableName}` : null,
     installed,
-    installSource: installed ? ("npmGlobal" as const) : ("notInstalled" as const),
+    installSource: installed
+      ? ("npmGlobal" as const)
+      : ("notInstalled" as const),
     currentVersion:
       overrides.currentVersion !== undefined
         ? overrides.currentVersion
@@ -166,6 +168,7 @@ export function WebAppUpdateAvailable() {
             }}
             desktopInfo={null}
             onRelaunchDesktop={null}
+            onRetryDesktop={null}
           />
         </UpdatesRowList>
       </SettingsSection>
@@ -181,6 +184,7 @@ export function DesktopUpdateReady() {
           <BbAppUpdateRows
             systemVersion={undefined}
             desktopInfo={{
+              downloadState: "downloaded",
               lastCheckedAt: "2026-07-19T00:00:00.000Z",
               latestVersion: "0.0.33",
               pendingVersion: "0.0.33",
@@ -190,6 +194,7 @@ export function DesktopUpdateReady() {
               version: "0.0.32",
             }}
             onRelaunchDesktop={noop}
+            onRetryDesktop={noop}
           />
         </UpdatesRowList>
       </SettingsSection>
@@ -205,6 +210,7 @@ export function DesktopDownloading() {
           <BbAppUpdateRows
             systemVersion={undefined}
             desktopInfo={{
+              downloadState: "downloading",
               lastCheckedAt: "2026-07-19T00:00:00.000Z",
               latestVersion: "0.0.33",
               pendingVersion: null,
@@ -214,6 +220,7 @@ export function DesktopDownloading() {
               version: "0.0.32",
             }}
             onRelaunchDesktop={noop}
+            onRetryDesktop={noop}
           />
         </UpdatesRowList>
       </SettingsSection>

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -190,7 +190,9 @@ function makeInventory(overrides: Partial<UpdateInventory>): UpdateInventory {
 function renderSection(): void {
   render(
     <QueryClientProvider
-      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
     >
       <UpdatesSettingsSection />
     </QueryClientProvider>,
@@ -242,6 +244,7 @@ describe("UpdatesSettingsSection", () => {
 
   it("checks for desktop updates through the desktop bridge", async () => {
     const desktopInfo: BbDesktopInfo = {
+      downloadState: "downloaded",
       lastCheckedAt: null,
       latestVersion: "0.0.6",
       pendingVersion: "0.0.6",
@@ -272,6 +275,54 @@ describe("UpdatesSettingsSection", () => {
       expect(checkForUpdates).toHaveBeenCalledTimes(1);
     });
     expect(sdk.system.version).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a legacy desktop shell is downloading an available update", () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: "0.0.6",
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: true,
+      updateDownloaded: false,
+      version: "0.0.5",
+    };
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: {} as BbDesktopApi,
+      desktopInfo,
+    });
+    useUpdateInventoryMock.mockReturnValue(makeInventory({ desktopInfo }));
+
+    renderSection();
+
+    expect(screen.getByText("Available")).toBeDefined();
+    expect(screen.queryByText("Downloading in the background…")).toBeNull();
+  });
+
+  it("retries a failed desktop download through the desktop bridge", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      downloadState: "failed",
+      lastCheckedAt: null,
+      latestVersion: "0.0.6",
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: true,
+      updateDownloaded: false,
+      version: "0.0.5",
+    };
+    const checkForUpdates = vi.fn().mockResolvedValue(desktopInfo);
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: { checkForUpdates } as unknown as BbDesktopApi,
+      desktopInfo,
+    });
+    useUpdateInventoryMock.mockReturnValue(makeInventory({ desktopInfo }));
+
+    renderSection();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(checkForUpdates).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("runs every actionable provider update across machines from Update all", () => {

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -142,15 +142,14 @@ function StateCell({
 }
 
 function ActionCell({ children }: { children?: ReactNode }) {
-  return (
-    <span className="flex min-w-14 justify-end">{children ?? null}</span>
-  );
+  return <span className="flex min-w-14 justify-end">{children ?? null}</span>;
 }
 
 export interface BbAppUpdateRowsProps {
   systemVersion: SystemVersionResponse | undefined;
   desktopInfo: BbDesktopInfo | null;
   onRelaunchDesktop: (() => void) | null;
+  onRetryDesktop: (() => void) | null;
 }
 
 /**
@@ -162,6 +161,7 @@ export function BbAppUpdateRows({
   systemVersion,
   desktopInfo,
   onRelaunchDesktop,
+  onRetryDesktop,
 }: BbAppUpdateRowsProps) {
   if (desktopInfo !== null) {
     const pendingVersion =
@@ -184,9 +184,23 @@ export function BbAppUpdateRows({
               </RowButton>
             </ActionCell>
           </>
+        ) : desktopInfo.downloadState === "downloading" ? (
+          <>
+            <StateCell tone="attention">
+              Downloading in the background…
+            </StateCell>
+            <ActionCell />
+          </>
+        ) : desktopInfo.downloadState === "failed" ? (
+          <>
+            <StateCell tone="destructive">Download failed</StateCell>
+            <ActionCell>
+              <RowButton onClick={() => onRetryDesktop?.()}>Retry</RowButton>
+            </ActionCell>
+          </>
         ) : desktopInfo.updateAvailable ? (
           <>
-            <StateCell tone="attention">Downloading in the background…</StateCell>
+            <StateCell tone="attention">Available</StateCell>
             <ActionCell />
           </>
         ) : (
@@ -508,6 +522,19 @@ export function UpdatesSettingsSection() {
                         description: updateCheckErrorDescription(error),
                       });
                     });
+                  }
+            }
+            onRetryDesktop={
+              desktopApi === null
+                ? null
+                : () => {
+                    void desktopApi
+                      .checkForUpdates()
+                      .catch((error: unknown) => {
+                        appToast.error("Update retry failed", {
+                          description: updateCheckErrorDescription(error),
+                        });
+                      });
                   }
             }
           />

--- a/apps/desktop/src/desktop-auto-update.ts
+++ b/apps/desktop/src/desktop-auto-update.ts
@@ -92,6 +92,7 @@ export interface DesktopAutoUpdateService extends DesktopUpdateService {
 
 function createBaseInfo(currentVersion: string): BbDesktopInfo {
   return {
+    downloadState: "idle",
     lastCheckedAt: null,
     latestVersion: null,
     pendingVersion: null,
@@ -128,6 +129,7 @@ function areDesktopInfoValuesEqual(
 ): boolean {
   return (
     left.lastCheckedAt === right.lastCheckedAt &&
+    left.downloadState === right.downloadState &&
     left.latestVersion === right.latestVersion &&
     left.pendingVersion === right.pendingVersion &&
     left.platform === right.platform &&
@@ -232,6 +234,7 @@ export function createDesktopAutoUpdateService(
   ): BbDesktopInfo {
     updateInfo({
       ...currentInfo,
+      downloadState: "downloaded",
       lastCheckedAt: applyArgs.checkedAt,
       latestVersion: applyArgs.version,
       pendingVersion: applyArgs.version,
@@ -246,6 +249,7 @@ export function createDesktopAutoUpdateService(
   ): BbDesktopInfo {
     updateInfo({
       ...currentInfo,
+      downloadState: "idle",
       lastCheckedAt: applyArgs.checkedAt,
       latestVersion: applyArgs.version,
       pendingVersion: null,
@@ -259,9 +263,30 @@ export function createDesktopAutoUpdateService(
     if (downloadInFlight !== null) {
       return;
     }
-    downloadInFlight = args.updater.downloadUpdate();
+    updateInfo({
+      ...currentInfo,
+      downloadState: "downloading",
+    });
+    try {
+      downloadInFlight = args.updater.downloadUpdate();
+    } catch (error: unknown) {
+      updateInfo({
+        ...currentInfo,
+        downloadState: "failed",
+      });
+      logger.error(
+        `Desktop auto-update download failed; preserving current update state: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+      return;
+    }
     void downloadInFlight
       .catch((error: unknown) => {
+        updateInfo({
+          ...currentInfo,
+          downloadState: "failed",
+        });
         logger.error(
           `Desktop auto-update download failed; preserving current update state: ${formatErrorMessage(
             error,
@@ -366,6 +391,12 @@ export function createDesktopAutoUpdateService(
           errorArgs.error,
         )}`,
       );
+      if (currentInfo.downloadState === "downloading") {
+        updateInfo({
+          ...currentInfo,
+          downloadState: "failed",
+        });
+      }
     });
   }
 

--- a/apps/desktop/src/desktop-update-info.ts
+++ b/apps/desktop/src/desktop-update-info.ts
@@ -1,0 +1,60 @@
+import type { BbDesktopInfo } from "@bb/desktop-contract";
+
+export interface MergeDesktopUpdateInfoArgs {
+  autoInfo: BbDesktopInfo | null;
+  feedInfo: BbDesktopInfo | null;
+}
+
+function latestCheckedAt(
+  left: string | null,
+  right: string | null,
+): string | null {
+  if (left === null) {
+    return right;
+  }
+  if (right === null) {
+    return left;
+  }
+  return left > right ? left : right;
+}
+
+/**
+ * The version feed can establish availability, but only electron-updater can
+ * establish native download activity. Keep those facts separate so a feed-only
+ * result never masquerades as an active download.
+ */
+export function mergeDesktopUpdateInfo(
+  args: MergeDesktopUpdateInfoArgs,
+): BbDesktopInfo | null {
+  const baseInfo = args.feedInfo ?? args.autoInfo;
+  if (baseInfo === null) {
+    return null;
+  }
+
+  const feedUpdateAvailable = args.feedInfo?.updateAvailable ?? false;
+  const autoUpdateAvailable = args.autoInfo?.updateAvailable ?? false;
+  const updateDownloaded = args.autoInfo?.updateDownloaded ?? false;
+  const pendingVersion = args.autoInfo?.pendingVersion ?? null;
+  const latestVersion =
+    pendingVersion ??
+    args.feedInfo?.latestVersion ??
+    args.autoInfo?.latestVersion ??
+    null;
+  const nativeDownloadState = args.autoInfo?.downloadState;
+
+  return {
+    ...baseInfo,
+    ...(nativeDownloadState === undefined
+      ? {}
+      : { downloadState: nativeDownloadState }),
+    lastCheckedAt: latestCheckedAt(
+      args.feedInfo?.lastCheckedAt ?? null,
+      args.autoInfo?.lastCheckedAt ?? null,
+    ),
+    latestVersion,
+    pendingVersion,
+    updateAvailable:
+      feedUpdateAvailable || autoUpdateAvailable || updateDownloaded,
+    updateDownloaded,
+  };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -96,6 +96,7 @@ import {
   type DesktopAutoUpdateLogger,
   type DesktopAutoUpdateService,
 } from "./desktop-auto-update.js";
+import { mergeDesktopUpdateInfo } from "./desktop-update-info.js";
 import {
   BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL,
   BB_DESKTOP_GET_INFO_CHANNEL,
@@ -233,11 +234,6 @@ interface ResolveDesktopUpdateFeedUrlArgs {
   env: NodeJS.ProcessEnv;
 }
 
-interface MergeDesktopUpdateInfoArgs {
-  autoInfo: BbDesktopInfo | null;
-  feedInfo: BbDesktopInfo | null;
-}
-
 interface FetchSystemConfigArgs {
   serverUrl: string;
 }
@@ -337,51 +333,6 @@ function getDesktopVersion(version: string | undefined): string {
     throw new Error("Desktop version must be injected at build time");
   }
   return version;
-}
-
-function latestCheckedAt(
-  left: string | null,
-  right: string | null,
-): string | null {
-  if (left === null) {
-    return right;
-  }
-  if (right === null) {
-    return left;
-  }
-  return left > right ? left : right;
-}
-
-function mergeDesktopUpdateInfo(
-  args: MergeDesktopUpdateInfoArgs,
-): BbDesktopInfo | null {
-  const baseInfo = args.feedInfo ?? args.autoInfo;
-  if (baseInfo === null) {
-    return null;
-  }
-
-  const feedUpdateAvailable = args.feedInfo?.updateAvailable ?? false;
-  const autoUpdateAvailable = args.autoInfo?.updateAvailable ?? false;
-  const updateDownloaded = args.autoInfo?.updateDownloaded ?? false;
-  const pendingVersion = args.autoInfo?.pendingVersion ?? null;
-  const latestVersion =
-    pendingVersion ??
-    args.feedInfo?.latestVersion ??
-    args.autoInfo?.latestVersion ??
-    null;
-
-  return {
-    ...baseInfo,
-    lastCheckedAt: latestCheckedAt(
-      args.feedInfo?.lastCheckedAt ?? null,
-      args.autoInfo?.lastCheckedAt ?? null,
-    ),
-    latestVersion,
-    pendingVersion,
-    updateAvailable:
-      feedUpdateAvailable || autoUpdateAvailable || updateDownloaded,
-    updateDownloaded,
-  };
 }
 
 function getCurrentDesktopInfo(): BbDesktopInfo | null {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -69,6 +69,7 @@ function getDesktopVersion(version: string | undefined): string {
 
 function createInitialDesktopInfo(): BbDesktopInfo {
   return {
+    downloadState: "idle",
     lastCheckedAt: null,
     latestVersion: null,
     pendingVersion: null,

--- a/apps/desktop/test/desktop-auto-update.test.ts
+++ b/apps/desktop/test/desktop-auto-update.test.ts
@@ -244,6 +244,7 @@ describe("desktop auto-update service", () => {
 
     expect(updater.downloadUpdateCalls).toBe(1);
     expect(service.getInfo()).toEqual({
+      downloadState: "downloading",
       lastCheckedAt: checkedAt,
       latestVersion: "0.0.2",
       pendingVersion: null,
@@ -256,6 +257,7 @@ describe("desktop auto-update service", () => {
     updater.emitUpdateDownloaded(createDownloadedEvent("0.0.2"));
 
     expect(service.getInfo()).toEqual({
+      downloadState: "downloaded",
       lastCheckedAt: checkedAt,
       latestVersion: "0.0.2",
       pendingVersion: "0.0.2",
@@ -322,6 +324,7 @@ describe("desktop auto-update service", () => {
     expect(messages.errors[0]).toContain("download failed");
     expect(messages.errors[0]).toContain("signature rejected");
     expect(service.getInfo()).toEqual({
+      downloadState: "failed",
       lastCheckedAt: checkedAt,
       latestVersion: "0.0.2",
       pendingVersion: null,
@@ -348,6 +351,7 @@ describe("desktop auto-update service", () => {
 
     expect(updater.checkForUpdatesCalls).toBe(1);
     expect(info).toEqual({
+      downloadState: "idle",
       lastCheckedAt: checkedAt,
       latestVersion: "0.0.2",
       pendingVersion: null,

--- a/apps/desktop/test/desktop-update-info.test.ts
+++ b/apps/desktop/test/desktop-update-info.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { BbDesktopInfo } from "@bb/desktop-contract";
+import { mergeDesktopUpdateInfo } from "../src/desktop-update-info.js";
+
+function info(overrides: Partial<BbDesktopInfo> = {}): BbDesktopInfo {
+  return {
+    lastCheckedAt: "2026-07-19T00:00:00.000Z",
+    latestVersion: "0.0.32",
+    pendingVersion: null,
+    platform: "macos",
+    updateAvailable: true,
+    updateDownloaded: false,
+    version: "0.0.31",
+    ...overrides,
+  };
+}
+
+describe("mergeDesktopUpdateInfo", () => {
+  it("does not infer native download activity from feed availability", () => {
+    const merged = mergeDesktopUpdateInfo({
+      autoInfo: info({
+        downloadState: "idle",
+        latestVersion: null,
+        updateAvailable: false,
+      }),
+      feedInfo: info(),
+    });
+
+    expect(merged).toMatchObject({
+      downloadState: "idle",
+      latestVersion: "0.0.32",
+      updateAvailable: true,
+      updateDownloaded: false,
+    });
+  });
+
+  it("preserves native updater activity when the feed also has an update", () => {
+    const merged = mergeDesktopUpdateInfo({
+      autoInfo: info({ downloadState: "downloading" }),
+      feedInfo: info(),
+    });
+
+    expect(merged).toMatchObject({
+      downloadState: "downloading",
+      updateAvailable: true,
+      updateDownloaded: false,
+    });
+  });
+
+  it("leaves download state unknown for a legacy feed-only shell", () => {
+    const merged = mergeDesktopUpdateInfo({
+      autoInfo: null,
+      feedInfo: info(),
+    });
+
+    expect(merged).not.toHaveProperty("downloadState");
+  });
+});

--- a/packages/desktop-contract/src/info.ts
+++ b/packages/desktop-contract/src/info.ts
@@ -4,7 +4,23 @@ import type { AppCommandId } from "@bb/domain";
 
 const isoUtcDateTimeSchema = z.iso.datetime();
 
+export const bbDesktopDownloadStateSchema = z.enum([
+  "idle",
+  "downloading",
+  "downloaded",
+  "failed",
+]);
+export type BbDesktopDownloadState = z.infer<
+  typeof bbDesktopDownloadStateSchema
+>;
+
 export const bbDesktopInfoSchema = z.object({
+  /**
+   * Native updater state. Older desktop shells omit this field, which means
+   * the renderer knows only that an update is available, not that a download
+   * has actually started.
+   */
+  downloadState: bbDesktopDownloadStateSchema.optional(),
   lastCheckedAt: isoUtcDateTimeSchema.nullable(),
   latestVersion: z.string().min(1).nullable(),
   pendingVersion: z.string().min(1).nullable(),

--- a/packages/desktop-contract/test/info.test.ts
+++ b/packages/desktop-contract/test/info.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { bbDesktopInfoSchema } from "../src/info.js";
+
+const baseInfo = {
+  lastCheckedAt: null,
+  latestVersion: "0.0.32",
+  pendingVersion: null,
+  platform: "macos",
+  updateAvailable: true,
+  updateDownloaded: false,
+  version: "0.0.31",
+} as const;
+
+describe("bbDesktopInfoSchema", () => {
+  it("accepts both explicit download state and legacy shell payloads", () => {
+    expect(
+      bbDesktopInfoSchema.safeParse({
+        ...baseInfo,
+        downloadState: "downloading",
+      }).success,
+    ).toBe(true);
+    expect(bbDesktopInfoSchema.safeParse(baseInfo).success).toBe(true);
+  });
+
+  it("rejects an unknown download state", () => {
+    expect(
+      bbDesktopInfoSchema.safeParse({
+        ...baseInfo,
+        downloadState: "available",
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- track native desktop downloads as idle, downloading, downloaded, or failed
- treat version-feed availability and legacy desktop shells conservatively instead of claiming a download is active
- surface download failures with a Retry action
- preserve compatibility when a newer remote UI is loaded inside an older desktop shell

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/desktop-contract --filter=@bb/desktop --filter=@bb/app`
- focused desktop updater, merge, contract, and settings UI tests
- full `@bb/app` suite: 248 files, 1,728 tests passed
- full desktop run reached 169 passing tests; three unrelated Electron-dependent suites could not start because this Linux checkout has no Electron binary