### PR TITLE
Isolate provider process groups to prevent cross-thread termination

### DIFF
--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -266,21 +266,7 @@ export class RuntimeProviderProcessManager {
     const shutdownPromises: Promise<void>[] = [];
 
     for (const [processKey, providerProcess] of this.processes) {
-      shutdownPromises.push(
-        new Promise<void>((resolve) => {
-          const timer = setTimeout(() => {
-            providerProcess.child.kill("SIGKILL");
-            resolve();
-          }, 5000);
-
-          providerProcess.child.on("exit", () => {
-            clearTimeout(timer);
-            resolve();
-          });
-
-          providerProcess.child.kill("SIGTERM");
-        }),
-      );
+      shutdownPromises.push(this.terminateProviderProcess({ providerProcess }));
       for (const [, pending] of providerProcess.pending) {
         pending.reject(new Error("Runtime shutting down"));
       }
@@ -331,6 +317,7 @@ export class RuntimeProviderProcessManager {
       command: processConfig.command,
       args: processConfig.args,
       cwd: this.args.workspacePath,
+      detached: process.platform !== "win32",
       env,
     });
 
@@ -417,7 +404,7 @@ export class RuntimeProviderProcessManager {
       const timeoutMs = args.timeoutMs ?? 5000;
       const softTimer = setTimeout(() => {
         if (!hasChildProcessExited(args.providerProcess.child)) {
-          args.providerProcess.child.kill("SIGKILL");
+          signalProviderProcessGroup(args.providerProcess.child, "SIGKILL");
         }
       }, timeoutMs);
       const hardTimer = setTimeout(resolve, timeoutMs + 1000);
@@ -428,7 +415,7 @@ export class RuntimeProviderProcessManager {
         resolve();
       });
 
-      args.providerProcess.child.kill("SIGTERM");
+      signalProviderProcessGroup(args.providerProcess.child, "SIGTERM");
     });
   }
 
@@ -515,6 +502,28 @@ export class RuntimeProviderProcessManager {
  */
 export function hasChildProcessExited(child: ChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
+}
+
+function signalProviderProcessGroup(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+): void {
+  if (process.platform !== "win32" && child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !("code" in error) ||
+        error.code !== "ESRCH"
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  child.kill(signal);
 }
 
 function getChildProcessExitStatus(

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   rmSync,
 } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,6 +43,26 @@ interface ProviderAccountErrorParams {
   providerThreadId: string;
   threadId: string;
   turnId: string;
+}
+
+const unixIt = process.platform === "win32" ? it.skip : it;
+
+function readProcessGroupId(pid: number): number {
+  return Number.parseInt(
+    execFileSync("ps", ["-o", "pgid=", "-p", String(pid)], {
+      encoding: "utf8",
+    }).trim(),
+    10,
+  );
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 describe("createAgentRuntime process lifecycle", () => {
@@ -395,6 +416,80 @@ rl.on("line", (line) => {
   });
 
   // ---- Process lifecycle ----
+
+  unixIt("isolates each provider in its own process group", async () => {
+    const manager = createProviderProcessManager({
+      onProcessExit: vi.fn(),
+      scriptPath,
+      workspacePath: tmpDir,
+    });
+
+    try {
+      await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+      const providerProcess = manager.requireProviderProcess({
+        processKey: "fake",
+        providerId: "fake",
+      });
+      const providerPid = providerProcess.child.pid;
+
+      expect(providerPid).toBeTypeOf("number");
+      expect(readProcessGroupId(providerPid!)).toBe(providerPid);
+    } finally {
+      await manager.shutdown();
+    }
+  });
+
+  unixIt("force kills the provider's entire process group", async () => {
+    const grandchildPidPath = join(tmpDir, "grandchild.pid");
+    const processTreeScript = join(tmpDir, "process-tree-provider.cjs");
+    writeFileSync(
+      processTreeScript,
+      `const { spawn } = require("node:child_process");
+      const { writeFileSync } = require("node:fs");
+      const grandchild = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"], {
+        stdio: "ignore",
+      });
+      writeFileSync(process.env.GRANDCHILD_PID_PATH, String(grandchild.pid));
+      process.on("SIGTERM", () => {});
+      setInterval(() => {}, 1000);`,
+    );
+    const manager = createProviderProcessManager({
+      adapterProcessEnv: { GRANDCHILD_PID_PATH: grandchildPidPath },
+      onProcessExit: vi.fn(),
+      scriptPath: processTreeScript,
+      workspacePath: tmpDir,
+    });
+    let grandchildPid: number | undefined;
+
+    try {
+      await manager.ensureProvider({
+        processKey: "fake",
+        providerId: "fake",
+      });
+      await waitForRuntimeState({
+        label: "provider grandchild pid",
+        predicate: () => existsSync(grandchildPidPath),
+      });
+      grandchildPid = Number.parseInt(readFileSync(grandchildPidPath, "utf8"));
+
+      await manager.shutdownProvider({
+        processKey: "fake",
+        providerId: "fake",
+        timeoutMs: 50,
+      });
+      await waitForRuntimeState({
+        label: "provider grandchild exit",
+        predicate: () => !isProcessAlive(grandchildPid!),
+      });
+
+      expect(isProcessAlive(grandchildPid)).toBe(false);
+    } finally {
+      if (grandchildPid !== undefined && isProcessAlive(grandchildPid)) {
+        process.kill(grandchildPid, "SIGKILL");
+      }
+      await manager.shutdown();
+    }
+  });
 
   it("fires onProcessExit when provider crashes", async () => {
     const exitInfo = vi.fn();


### PR DESCRIPTION
This prevents one provider/tool cleanup from terminating unrelated bb provider sessions by giving every Unix provider process its own process group and signaling that full group during shutdown.

## Impact

Multiple independent Codex threads could fail together with either:

- `Provider "codex" exited unexpectedly with code 0`
- `Provider "codex" exited unexpectedly with signal SIGKILL`

The stderr displayed in the incident cards predated the exits by 6–21 minutes. It was retained process stderr, not the terminating cause.

## Deterministic repro

The PR includes regression tests that reproduce the old lifecycle boundary without invoking `pkill` against a real bb process tree.

From this PR branch, temporarily restore only the implementation file from `main` while keeping the new tests:

```bash
git checkout origin/main -- packages/agent-runtime/src/runtime-provider-process.ts
pnpm exec turbo run test --filter=@bb/agent-runtime -- src/runtime.process-lifecycle.test.ts -t 'isolates each provider|force kills the provider'
git checkout HEAD -- packages/agent-runtime/src/runtime-provider-process.ts
```

Expected pre-fix result: both selected tests fail.

1. `isolates each provider in its own process group` reports that the provider PGID is the test runner's PGID instead of the provider PID. During the original red run, this was `expected 34078`, `received 33581`.
2. `force kills the provider's entire process group` times out waiting for the SIGTERM-resistant grandchild to exit. Pre-fix shutdown kills only the provider wrapper; its descendant remains alive.

Then run the same test command with this PR's implementation restored:

```bash
pnpm exec turbo run test --filter=@bb/agent-runtime -- src/runtime.process-lifecycle.test.ts -t 'isolates each provider|force kills the provider'
```

Expected post-fix result:

```text
Test Files  1 passed (1)
Tests       2 passed | 20 skipped (22)
```

## Production incident breadcrumbs

Observed on macOS on 2026-07-19. bb host-daemon logs showed independent per-thread Codex processes exiting in two synchronized batches:

| Local time | UTC | bb result | Correlated macOS event |
| --- | --- | --- | --- |
| 12:01:05 PDT | 19:01:05Z | Three Codex providers exited with code 0 within ~360 ms | Computer Use service received SIGTERM from `pkill[36568]` at 12:01:05.283 |
| 12:08:09 PDT | 19:08:09Z | Two Codex providers exited with SIGKILL within ~140 ms | Computer Use service received SIGKILL from `pkill[46125]` at 12:08:09.244 |

To inspect the same evidence on an affected Mac:

```bash
rg -n -C 3 'pkill\[(36568|46125)\]' \
  /var/log/com.apple.xpc.launchd/launchd.log \
  /var/log/com.apple.xpc.launchd/launchd.log.1

rg -n 'provider process exited|exited unexpectedly' ~/.bb/logs/host-daemon*.log
```

The relevant launchd lines are:

```text
2026-07-19 12:01:05.283848 ... exited due to SIGTERM | sent by pkill[36568]
2026-07-19 12:08:09.244558 ... exited due to SIGKILL | sent by pkill[46125]
```

Because Codex providers are unmanaged child processes, launchd does not attribute their signals directly. The attribution is a correlation across the synchronized bb exits and the launchd events; the process-group defect itself is reproduced deterministically by the tests above.

A live pre-fix process table showed every production provider sharing the daemon's PGID:

```bash
ps -axo pid,ppid,pgid,sess,command \
  | rg 'host-daemon|codex.*app-server'
```

Pre-fix shape:

```text
PID    PPID(host daemon)  PGID(host daemon)  node .../codex app-server
child  PID                PGID(host daemon)  .../bin/codex app-server
```

Post-fix expectation on Unix:

```text
PID    PPID(host daemon)  PID                node .../codex app-server
child  PID                PID                .../bin/codex app-server
```

## Root cause

`RuntimeProviderProcessManager` spawned every provider without `detached`, so Unix inherited the bb host daemon's process group. That removed the isolation boundary between per-thread providers and allowed broad external cleanup to have a cross-thread blast radius.

Shutdown also signaled only the wrapper `ChildProcess`. Once providers are isolated, shutdown must signal the negative provider PID so SIGTERM and timeout SIGKILL reach the wrapper and all descendants.

## Fix

- Spawn provider processes with `detached: true` on Unix, making each provider the leader of a new process group.
- Route graceful SIGTERM and forced SIGKILL through `process.kill(-providerPid, signal)`.
- Keep the existing `child.kill(signal)` behavior on Windows and as the Unix `ESRCH` fallback.
- Reuse the same tree-aware termination path for provider shutdown, runtime shutdown, and failed startup cleanup.

## Validation

```bash
pnpm exec turbo run test --filter=@bb/agent-runtime -- src/runtime.process-lifecycle.test.ts -t 'isolates each provider|force kills the provider'
pnpm exec turbo run typecheck --filter=@bb/agent-runtime
pnpm exec turbo run test typecheck --filter=@bb/agent-runtime
pnpm exec prettier --check packages/agent-runtime/src/runtime-provider-process.ts packages/agent-runtime/src/runtime.process-lifecycle.test.ts
```

Results:

- New process-group regressions: 2/2 passed.
- Full `@bb/agent-runtime` suite: 38 files, 782 tests passed.
- `@bb/agent-runtime` typecheck passed.
- Prettier and `git diff --check` passed.

The process-group tests are Unix-only; Windows retains its prior direct-child termination behavior.
