### PR TITLE
Prevent host daemon crashes on PartySocket timeouts

### DIFF
--- a/apps/host-daemon/package.json
+++ b/apps/host-daemon/package.json
@@ -43,7 +43,7 @@
     "mime-types": "^3.0.2",
     "node-pty": "1.1.0",
     "p-retry": "^6.2.1",
-    "partysocket": "^1.1.16",
+    "partysocket": "^1.3.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "pino-roll": "^4.0.0",

--- a/apps/host-daemon/src/partysocket.test.ts
+++ b/apps/host-daemon/src/partysocket.test.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("PartySocket", () => {
+  it("absorbs a late error after timing out a connecting WebSocket", async () => {
+    const script = `
+      import { EventEmitter } from "node:events";
+      import PartySocket from "partysocket/ws";
+
+      let closeCount = 0;
+
+      class ConnectingWebSocket extends EventEmitter {
+        readyState = 0;
+        binaryType = "blob";
+
+        addEventListener(type, listener) {
+          this.on(type, listener);
+        }
+
+        removeEventListener(type, listener) {
+          this.off(type, listener);
+        }
+
+        close() {
+          closeCount += 1;
+          process.nextTick(() => {
+            this.emit(
+              "error",
+              new Error("WebSocket was closed before the connection was established"),
+            );
+          });
+        }
+      }
+
+      new PartySocket("ws://unreachable.test", [], {
+        WebSocket: ConnectingWebSocket,
+        connectionTimeout: 1,
+        maxRetries: 0,
+        minReconnectionDelay: 0,
+      });
+
+      setTimeout(() => {
+        if (closeCount !== 1) {
+          throw new Error(\`Expected one timed-out connection, received \${closeCount}\`);
+        }
+        process.stdout.write("survived late WebSocket error");
+      }, 25);
+    `;
+
+    const result = await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "--eval", script],
+      { cwd: import.meta.dirname },
+    );
+
+    expect(result).toMatchObject({
+      stdout: "survived late WebSocket error",
+      stderr: "",
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,8 +646,8 @@ importers:
         specifier: ^6.2.1
         version: 6.2.1
       partysocket:
-        specifier: ^1.1.16
-        version: 1.1.16(react@19.2.4)
+        specifier: ^1.3.0
+        version: 1.3.0(react@19.2.4)
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -10098,6 +10098,14 @@ packages:
 
   partysocket@1.1.16:
     resolution: {integrity: sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==}
+    peerDependencies:
+      react: '>=17'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  partysocket@1.3.0:
+    resolution: {integrity: sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA==}
     peerDependencies:
       react: '>=17'
     peerDependenciesMeta:
@@ -20044,6 +20052,12 @@ snapshots:
   partial-json@0.1.7: {}
 
   partysocket@1.1.16(react@19.2.4):
+    dependencies:
+      event-target-polyfill: 0.0.4
+    optionalDependencies:
+      react: 19.2.4
+
+  partysocket@1.3.0(react@19.2.4):
     dependencies:
       event-target-polyfill: 0.0.4
     optionalDependencies:


### PR DESCRIPTION
## Summary

Prevents host-daemon restarts when a timed-out `CONNECTING` WebSocket emits its expected late error.

- Upgrades PartySocket from 1.1.16 to 1.3.0, which absorbs errors emitted after it detaches a socket.
- Adds a child-process regression test covering the real timeout and disconnect lifecycle.

## Root cause

PartySocket 1.1.16 removed its error listener before closing a still-connecting Node `ws` socket. The socket then emitted `WebSocket was closed before the connection was established` on the next tick with no remaining error listener, terminating the host-daemon process and interrupting active threads.

## Validation

- The regression scenario exits with an unhandled error on PartySocket 1.1.16 and survives on 1.3.0.
- Focused and related tests: 9 passed.
- Host-daemon Turbo typecheck passed.
- Host-daemon production build passed.
- Prettier and `git diff --check` passed.

The complete host-daemon suite was attempted twice. The new regression passed in both runs, while unrelated Git and filesystem tests exceeded their existing 15-second timeout under concurrent host load. There were no non-timeout assertion failures.
