### PR TITLE
Survive daemon lock compromise instead of crashing mid-turn

### DIFF
--- a/apps/host-daemon/src/lock.test.ts
+++ b/apps/host-daemon/src/lock.test.ts
@@ -1,0 +1,150 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { acquireDaemonLock, DAEMON_LOCK_FILE_NAME } from "./lock.js";
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function createRecordingLogger() {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  return {
+    logger: {
+      warn: (_fields: Record<string, unknown>, message: string) => {
+        warnings.push(message);
+      },
+      error: (_fields: Record<string, unknown>, message: string) => {
+        errors.push(message);
+      },
+    },
+    warnings,
+    errors,
+  };
+}
+
+describe("acquireDaemonLock compromise handling", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-daemon-lock-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("re-acquires a compromised lock instead of crashing the daemon", async () => {
+    const { logger, warnings } = createRecordingLogger();
+    const onLockLost = vi.fn();
+    const release = await acquireDaemonLock(dataDir, {
+      staleMs: 2_000,
+      retryIntervalMs: 100,
+      retries: 25,
+      logger,
+      onLockLost,
+    });
+    const lockDirPath = path.join(dataDir, `${DAEMON_LOCK_FILE_NAME}.lock`);
+
+    // Simulate the refresh failing (the incident: EPERM on the periodic mtime
+    // touch): removing the lock dir makes the next refresh tick compromise.
+    await fs.rm(lockDirPath, { recursive: true, force: true });
+
+    await waitFor(
+      () => warnings.includes("Daemon lock re-acquired after compromise"),
+      10_000,
+    );
+    expect(warnings).toContain(
+      "Daemon lock compromised; re-acquiring without restarting the daemon",
+    );
+    expect(onLockLost).not.toHaveBeenCalled();
+    await expect(fs.stat(lockDirPath)).resolves.toBeDefined();
+
+    await release();
+    await expect(fs.stat(lockDirPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  }, 20_000);
+
+  it("re-acquires when the lock dir survives the compromise and must age past stale", async () => {
+    const { logger, warnings } = createRecordingLogger();
+    const onLockLost = vi.fn();
+    const release = await acquireDaemonLock(dataDir, {
+      staleMs: 2_000,
+      retryIntervalMs: 100,
+      retries: 25,
+      logger,
+      onLockLost,
+    });
+    const lockDirPath = path.join(dataDir, `${DAEMON_LOCK_FILE_NAME}.lock`);
+
+    // The incident's shape: the refresh fails but the lock dir stays on
+    // disk. A foreign fresh mtime makes the next refresh tick compromise,
+    // and re-acquisition must retry until the dir ages past the stale
+    // window before reclaiming it.
+    const foreignMtime = new Date(Date.now() + 500);
+    fsSync.utimesSync(lockDirPath, foreignMtime, foreignMtime);
+
+    await waitFor(
+      () => warnings.includes("Daemon lock re-acquired after compromise"),
+      15_000,
+    );
+    expect(onLockLost).not.toHaveBeenCalled();
+
+    await release();
+    await expect(fs.stat(lockDirPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  }, 30_000);
+
+  it("yields the data dir when another live process holds the lock", async () => {
+    const { logger } = createRecordingLogger();
+    const lockLostErrors: unknown[] = [];
+    const release = await acquireDaemonLock(dataDir, {
+      staleMs: 2_000,
+      retryIntervalMs: 100,
+      retries: 3,
+      logger,
+      onLockLost: (error) => {
+        lockLostErrors.push(error);
+      },
+    });
+    const lockPath = path.join(dataDir, DAEMON_LOCK_FILE_NAME);
+    const lockDirPath = `${lockPath}.lock`;
+
+    // A contender takes over the lock: replace the lock dir and keep its
+    // mtime fresh. Our next refresh tick sees a foreign mtime and
+    // compromises, and every re-acquire attempt stays ELOCKED because the
+    // contender's lock never goes stale.
+    await fs.rm(lockDirPath, { recursive: true, force: true });
+    await fs.mkdir(lockDirPath);
+    const keepContenderFresh = setInterval(() => {
+      const now = new Date();
+      try {
+        fsSync.utimesSync(lockDirPath, now, now);
+      } catch {
+        // The dir only disappears once the test is over.
+      }
+    }, 200);
+
+    try {
+      await waitFor(() => lockLostErrors.length > 0, 15_000);
+      expect(lockLostErrors[0]).toMatchObject({ code: "ELOCKED" });
+    } finally {
+      clearInterval(keepContenderFresh);
+      await release().catch(() => undefined);
+    }
+  }, 30_000);
+});

--- a/apps/host-daemon/src/lock.ts
+++ b/apps/host-daemon/src/lock.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import lockfile from "proper-lockfile";
 
 export const DAEMON_LOCK_FILE_NAME = "daemon.lock";
@@ -10,14 +11,48 @@ export const DAEMON_LOCK_FILE_NAME = "daemon.lock";
 const DAEMON_LOCK_STALE_MS = 10_000;
 const DAEMON_LOCK_RETRY_INTERVAL_MS = 1_000;
 const DAEMON_LOCK_ACQUIRE_RETRIES = 13;
+// Each failed re-acquire cycle spans the full acquisition retry budget
+// (~14s with defaults), so this cap bounds unlocked operation after a
+// compromise to roughly five minutes before the daemon yields for a clean
+// service-manager restart.
+const DAEMON_LOCK_REACQUIRE_MAX_CYCLES = 20;
 
-interface AcquireDaemonLockOptions {
+export interface DaemonLockLogger {
+  warn(fields: Record<string, unknown>, message: string): void;
+  error(fields: Record<string, unknown>, message: string): void;
+}
+
+export interface AcquireDaemonLockOptions {
   /** Lock is treated as stale once its mtime is older than this many ms. */
   staleMs?: number;
-  /** How many times to retry acquisition while a lock exists. */
+  /**
+   * How many times to retry acquisition while a lock exists. Together with
+   * retryIntervalMs this must span staleMs: compromise recovery relies on a
+   * still-ours lock dir aging past the stale window within the retry budget.
+   */
   retries?: number;
   /** Fixed delay between acquisition retries. */
   retryIntervalMs?: number;
+  /** Receives lock lifecycle diagnostics. Defaults to the console. */
+  logger?: DaemonLockLogger;
+  /**
+   * Called when, after a compromise, the lock is confirmed held by another
+   * live process. Two daemons must never share a data dir, so the default
+   * exits the process.
+   */
+  onLockLost?: (error: unknown) => void;
+}
+
+const consoleLockLogger: DaemonLockLogger = {
+  warn: (fields, message) => console.warn(message, fields),
+  error: (fields, message) => console.error(message, fields),
+};
+
+function isErrorWithCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
 }
 
 export async function acquireDaemonLock(
@@ -33,23 +68,118 @@ export async function acquireDaemonLock(
   // We pass lockfilePath explicitly so the exit handler below doesn't rely
   // on an undocumented default.
   const lockDirPath = `${lockPath}.lock`;
+  const staleMs = options.staleMs ?? DAEMON_LOCK_STALE_MS;
   const retryIntervalMs =
     options.retryIntervalMs ?? DAEMON_LOCK_RETRY_INTERVAL_MS;
-  const release = await lockfile.lock(lockPath, {
-    realpath: false,
-    stale: options.staleMs ?? DAEMON_LOCK_STALE_MS,
-    retries: {
-      retries: options.retries ?? DAEMON_LOCK_ACQUIRE_RETRIES,
-      factor: 1,
-      minTimeout: retryIntervalMs,
-      maxTimeout: retryIntervalMs,
-    },
-    lockfilePath: lockDirPath,
-  });
+  const retries = options.retries ?? DAEMON_LOCK_ACQUIRE_RETRIES;
+  const logger = options.logger ?? consoleLockLogger;
+  const onLockLost = options.onLockLost ?? (() => process.exit(1));
+
+  let released = false;
+  let reacquiring = false;
+  let holdsLock = false;
+  let release: (() => Promise<void>) | null = null;
+
+  // A compromised lock (the periodic mtime refresh failed — e.g. a transient
+  // EPERM/ENOENT on the lock dir after sleep or an FS hiccup) must not crash
+  // the daemon: proper-lockfile's default handler throws from a timer
+  // callback, which took down a daemon mid-turn and interrupted every active
+  // thread on the host. Instead, re-acquire in place. The acquisition retry
+  // profile spans the stale window, so a lock dir that is still ours ages out
+  // and is retaken; a lock that stays ELOCKED through every retry is being
+  // actively refreshed by another live daemon — only then yield the data dir.
+  // Observing for the stale window is the only way to tell those apart, so a
+  // genuine contender coexists with us for at most one retry budget (~13s)
+  // before we yield; that window only arises when the service manager
+  // double-launches. Persistent non-ELOCKED failures are also bounded: after
+  // DAEMON_LOCK_REACQUIRE_MAX_CYCLES the daemon yields rather than running
+  // unlocked indefinitely.
+  function handleCompromised(error: Error): void {
+    if (released || reacquiring) {
+      return;
+    }
+    reacquiring = true;
+    holdsLock = false;
+    logger.warn(
+      { err: error },
+      "Daemon lock compromised; re-acquiring without restarting the daemon",
+    );
+    void (async () => {
+      try {
+        for (let cycle = 1; !released; cycle += 1) {
+          try {
+            const reacquiredRelease = await lockDaemonLockFile();
+            if (released) {
+              await reacquiredRelease().catch(() => undefined);
+              return;
+            }
+            release = reacquiredRelease;
+            holdsLock = true;
+            logger.warn({}, "Daemon lock re-acquired after compromise");
+            return;
+          } catch (acquireError) {
+            if (released) {
+              return;
+            }
+            if (isErrorWithCode(acquireError, "ELOCKED")) {
+              logger.error(
+                { err: acquireError },
+                "Daemon lock is held by another live daemon; yielding the data dir",
+              );
+              onLockLost(acquireError);
+              return;
+            }
+            if (cycle >= DAEMON_LOCK_REACQUIRE_MAX_CYCLES) {
+              logger.error(
+                { err: acquireError, cycle },
+                "Daemon lock could not be re-acquired after repeated attempts; yielding the data dir",
+              );
+              onLockLost(acquireError);
+              return;
+            }
+            logger.error(
+              { err: acquireError, cycle },
+              "Re-acquiring the compromised daemon lock failed; retrying",
+            );
+            // Unref'd so a pending retry never keeps a shutting-down
+            // process alive.
+            await sleep(retryIntervalMs, undefined, { ref: false });
+          }
+        }
+      } finally {
+        reacquiring = false;
+      }
+    })();
+  }
+
+  function lockDaemonLockFile(): Promise<() => Promise<void>> {
+    return lockfile.lock(lockPath, {
+      realpath: false,
+      stale: staleMs,
+      retries: {
+        retries,
+        factor: 1,
+        minTimeout: retryIntervalMs,
+        maxTimeout: retryIntervalMs,
+      },
+      lockfilePath: lockDirPath,
+      onCompromised: handleCompromised,
+    });
+  }
+
+  release = await lockDaemonLockFile();
+  holdsLock = true;
 
   // Synchronous fallback: if the process exits before the async release
   // completes, remove the lock directory so the next startup isn't blocked.
+  // Only while we believe the lock is ours: after a compromise (and
+  // especially after yielding to a live contender) the dir may belong to
+  // another daemon, and deleting it would compromise that daemon in turn. A
+  // leftover dir merely ages out via the stale window.
   const onExit = () => {
+    if (!holdsLock) {
+      return;
+    }
     try {
       fsSync.rmSync(lockDirPath, { recursive: true, force: true });
     } catch {
@@ -58,13 +188,20 @@ export async function acquireDaemonLock(
   };
   process.once("exit", onExit);
 
-  let released = false;
   return async () => {
     if (released) {
       return;
     }
     released = true;
     process.removeListener("exit", onExit);
-    await release();
+    try {
+      await release?.();
+    } catch (error) {
+      // A compromised lock is already dropped by proper-lockfile.
+      if (!isErrorWithCode(error, "ERELEASED")) {
+        throw error;
+      }
+    }
+    holdsLock = false;
   };
 }

--- a/apps/host-daemon/src/proper-lockfile.d.ts
+++ b/apps/host-daemon/src/proper-lockfile.d.ts
@@ -15,6 +15,12 @@ declare module "proper-lockfile" {
     /** Interval at which the held lock's mtime is refreshed. */
     update?: number;
     lockfilePath?: string;
+    /**
+     * Called when the held lock can no longer be refreshed (mtime update
+     * failed or drifted). Default rethrows, which crashes the process from
+     * inside a timer callback.
+     */
+    onCompromised?: (error: Error) => void;
   }
 
   export type ReleaseFn = () => Promise<void>;

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -91,7 +91,37 @@ export async function startHostDaemon(
   if (dataDir === undefined) {
     throw new Error("Host daemon data directory is required");
   }
-  const releaseLock = await (options.acquireLock ?? acquireDaemonLock)(dataDir);
+  // The real logger writes into the shared data dir, so it must not exist
+  // before the lock is held (a losing daemon would mutate the winner's
+  // rolling logs). Lock diagnostics delegate to it once it is created below;
+  // until then they fall back to the console. Compromise can only fire after
+  // acquisition, so in practice the logger is already set.
+  let lockDiagnosticsLogger: HostDaemonLogger | null = null;
+  // Losing the lock to another live daemon before the app exists exits
+  // directly; once the app is running it gets a graceful shutdown first.
+  let handleDaemonLockLost: () => void = () => process.exit(1);
+  const releaseLock = await (options.acquireLock ?? acquireDaemonLock)(
+    dataDir,
+    {
+      logger: {
+        warn: (fields, message) => {
+          if (lockDiagnosticsLogger) {
+            lockDiagnosticsLogger.warn(fields, message);
+          } else {
+            console.warn(message, fields);
+          }
+        },
+        error: (fields, message) => {
+          if (lockDiagnosticsLogger) {
+            lockDiagnosticsLogger.error(fields, message);
+          } else {
+            console.error(message, fields);
+          }
+        },
+      },
+      onLockLost: () => handleDaemonLockLost(),
+    },
+  );
 
   let app: Awaited<ReturnType<typeof createHostDaemonApp>> | undefined;
   let machineAuthProxy: MachineAuthProxy | undefined;
@@ -180,6 +210,7 @@ export async function startHostDaemon(
         dataDir,
         transportMode: "worker",
       });
+    lockDiagnosticsLogger = logger;
     if (options.machineCredential !== undefined) {
       machineAuthProxy = await startMachineAuthProxy({
         machineCredential: options.machineCredential,
@@ -247,6 +278,13 @@ export async function startHostDaemon(
       createWebSocket: options.createWebSocket,
       closeMachineAuthProxy: machineAuthProxy?.close,
     });
+    const startedApp = app;
+    handleDaemonLockLost = () => {
+      void startedApp.daemon
+        .shutdown("daemon-lock-lost")
+        .catch(() => undefined)
+        .finally(() => process.exit(1));
+    };
     await app.daemon.start();
     return app.daemon;
   } catch (error) {

--- a/apps/server/src/services/threads/thread-runtime-display.ts
+++ b/apps/server/src/services/threads/thread-runtime-display.ts
@@ -27,7 +27,7 @@ import {
   type ThreadEventWithMeta,
 } from "@bb/thread-view";
 import type { ThreadResponse } from "@bb/server-contract";
-import { DAEMON_DISCONNECT_GRACE_MS } from "../../constants.js";
+import { DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS } from "../../constants.js";
 import type { NotificationHub } from "../../ws/hub.js";
 import { parseStoredEvent } from "./thread-data.js";
 import { canThreadSpawnChild } from "./thread-parent.js";
@@ -107,6 +107,12 @@ function threadStatusRuntimeState(status: ThreadStatus): ThreadRuntimeState {
   }
 }
 
+/**
+ * Only computed for `active` threads: an active turn survives a daemon
+ * disconnect until the active-work grace elapses, so that is the reconnect
+ * window the DTO advertises. The shorter DAEMON_DISCONNECT_GRACE_MS window
+ * only settles pending interactions and background tasks.
+ */
 function getDaemonDisconnectGraceExpiresAt(
   session: HostDaemonSessionRow,
 ): number | null {
@@ -119,7 +125,7 @@ function getDaemonDisconnectGraceExpiresAt(
   if (session.closedAt === null) {
     return null;
   }
-  return session.closedAt + DAEMON_DISCONNECT_GRACE_MS;
+  return session.closedAt + DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS;
 }
 
 function hasOpenDaemonSessionForHost(

--- a/apps/server/test/services/threads/thread-runtime-display.test.ts
+++ b/apps/server/test/services/threads/thread-runtime-display.test.ts
@@ -27,7 +27,7 @@ import type {
   Thread,
   ThreadRuntimeState,
 } from "@bb/domain";
-import { DAEMON_DISCONNECT_GRACE_MS } from "../../../src/constants.js";
+import { DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS } from "../../../src/constants.js";
 import {
   resolveThreadRuntimeState,
   toThreadListEntryResponses,
@@ -257,12 +257,16 @@ describe("thread runtime display", () => {
     } satisfies ThreadRuntimeState);
   });
 
-  it("shows host-reconnecting while a daemon disconnect is inside the grace period", () => {
+  it("shows host-reconnecting for the full active-work grace after a daemon disconnect", () => {
     const { db, hostId, hub } = setup();
-    const now = 10_000;
+    const now = 60_000;
     const session = openTestSession({ db, hostId });
+    // Well past the short pending-interaction grace, still inside the
+    // active-work window: the thread has not been interrupted yet, so the
+    // DTO must keep advertising the reconnect window.
+    const closedAt = now - DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS + 1_000;
     closeTestSession({
-      closedAt: now - 1_000,
+      closedAt,
       db,
       sessionId: session.id,
     });
@@ -274,16 +278,17 @@ describe("thread runtime display", () => {
       ),
     ).toEqual({
       displayStatus: "host-reconnecting",
-      hostReconnectGraceExpiresAt: now - 1_000 + DAEMON_DISCONNECT_GRACE_MS,
+      hostReconnectGraceExpiresAt:
+        closedAt + DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS,
     } satisfies ThreadRuntimeState);
   });
 
-  it("shows waiting-for-host after the daemon disconnect grace period expires", () => {
+  it("shows waiting-for-host after the active-work disconnect grace expires", () => {
     const { db, hostId, hub } = setup();
-    const now = 10_000;
+    const now = 60_000;
     const session = openTestSession({ db, hostId });
     closeTestSession({
-      closedAt: now - DAEMON_DISCONNECT_GRACE_MS - 1,
+      closedAt: now - DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS - 1,
       db,
       sessionId: session.id,
     });


### PR DESCRIPTION
## Summary

Root-caused from a production incident on an enrolled MacBook Air (thr_56awm97i28 / host_4d7ti9wyhs): proper-lockfile's periodic mtime refresh of `daemon.lock` failed with `EPERM`, and its default `onCompromised` handler throws from a timer callback — an uncaughtException that killed the daemon mid-turn. launchd relaunched it with a new `instanceId`, so the server's restart branch immediately interrupted every active thread on the host ("Thread interrupted because the host daemon disconnected"), bypassing the 30s active-work disconnect grace that covers socket-only drops.

- **`apps/host-daemon/src/lock.ts`**: handle lock compromise by re-acquiring in place. The acquisition retry profile spans the stale window, so a still-ours lock dir ages out and is retaken. The daemon yields the data dir (graceful shutdown → exit for the service manager to restart) only when the lock stays `ELOCKED` through the retry budget — i.e. another live daemon is actively refreshing it — or after a bounded number of failed re-acquire cycles (~5 min), so it never runs unlocked indefinitely. Exit-time lock-dir cleanup only fires while we believe the lock is ours, so a yielding daemon can't delete a contender's live lock; a graceful release racing re-acquisition is not misclassified as lock loss.
- **`apps/host-daemon/src/start-host-daemon.ts`**: wires `onLockLost` to a graceful `daemon.shutdown("daemon-lock-lost")`. Lock diagnostics delegate to the file logger once it exists (still created only after the lock is held, so a losing daemon never mutates the winner's logs).
- **`apps/server/.../thread-runtime-display.ts`**: `hostReconnectGraceExpiresAt` now advertises `DAEMON_ACTIVE_WORK_DISCONNECT_GRACE_MS` (30s) instead of the 5s pending-interaction grace, matching when active work is actually interrupted, so the UI shows "host-reconnecting" with a countdown for the full recovery window.

No server↔daemon wire contract changed, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

Known bounded tradeoff: while distinguishing an abandoned lock from a live one, a genuine contender (service-manager double-launch only) can coexist with the daemon for at most one retry budget (~13s) before it yields; documented in `handleCompromised`.

## Tests

- New `apps/host-daemon/src/lock.test.ts` (real proper-lockfile, tmp dirs): compromise → re-acquire without crashing; retained lock dir with foreign mtime must age past stale before reclaim (the incident's shape); live contender ⇒ `onLockLost` with `ELOCKED`.
- Updated `thread-runtime-display.test.ts` for the 30s display grace.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/server` green; full `@bb/host-daemon` suite 448/448; server display + reconciliation suites green on the rebased branch.
- Reviewed by a high-reasoning agent pass (proper-lockfile 4.1.2 semantics verified against source; no blockers; all major/minor findings addressed or documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)