### PR TITLE
Add agent automation update targets

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -405,6 +405,12 @@ add <key-or-comment-id> --file <path>` (task key = task-level; comment ID
 - Use `bb automation list`, `bb automation show <id>`, and
   `bb automation runs <id>` to inspect; `--output <run-id>` prints a script
   run's captured stdout.
+- Update an existing agent automation in place with `bb automation update <id>
+  --project <id> --prompt "..."`, `--permission-mode
+  accept-edits|auto|full`, or exactly one target option:
+  `--target-thread <id>`, `--environment <id-or-path>`, or
+  `--new-environment worktree [--base-branch <branch>]`. Omitted execution
+  fields are preserved; target options are mutually exclusive.
 - Use `bb automation pause <id>` / `bb automation resume <id>` to toggle,
   `bb automation run <id>` to trigger now, and `bb automation delete <id> --yes`
   to remove.

--- a/plugins/automations/skills/automations/SKILL.md
+++ b/plugins/automations/skills/automations/SKILL.md
@@ -79,7 +79,7 @@ Managing:
 ```bash
 bb plugin run automations list --project <id>
 bb plugin run automations show <automationId> --project <id>
-bb plugin run automations update <automationId> --project <id> [--name <name>] [schedule flags]
+bb plugin run automations update <automationId> --project <id> [--name <name>] [schedule flags] [agent update flags]
 bb plugin run automations pause <automationId> --project <id>
 bb plugin run automations resume <automationId> --project <id>
 bb plugin run automations run <automationId> --project <id> [--idempotency-key <key>]
@@ -88,3 +88,21 @@ bb plugin run automations delete <automationId> --project <id> --yes
 ```
 
 Every command supports `--json`.
+
+Updating an agent automation preserves every omitted execution field and edits
+the existing automation in place. Use any combination of `--prompt` and
+`--permission-mode accept-edits|auto|full`, then choose at most one
+execution target:
+
+```bash
+bb plugin run automations update <automationId> --project <id> \
+  --environment <environment-id-or-path>
+bb plugin run automations update <automationId> --project <id> \
+  --target-thread <thread-id>
+bb plugin run automations update <automationId> --project <id> \
+  --new-environment worktree [--base-branch <branch>]
+```
+
+`--target-thread`, `--environment`, and `--new-environment` are mutually
+exclusive. These flags apply only to agent automations; script automations have
+no execution environment.

--- a/plugins/automations/src/cli.ts
+++ b/plugins/automations/src/cli.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { AutomationService } from "./service.js";
 import type {
   AgentEnvironment,
+  AgentExecutionUpdate,
   AutomationResponse,
   AutomationRunResponse,
   AutomationScriptInterpreter,
@@ -164,6 +165,24 @@ async function resolvePermissionMode(
   throw new Error(`Provider ${providerId} has no supported default permission mode.`);
 }
 
+function validateAgentTargetOptions(args: ParsedArgs): void {
+  const targetOptionNames = ["target-thread", "environment", "new-environment"] as const;
+  const providedTargetOptions = targetOptionNames.filter((name) => args.flags.has(name));
+  for (const name of providedTargetOptions) {
+    if (!flag(args, name)) {
+      throw new Error(`Missing required option --${name} <value>.`);
+    }
+  }
+  if (providedTargetOptions.length > 1) {
+    throw new Error(
+      "Cannot combine target options: --target-thread, --environment, and --new-environment.",
+    );
+  }
+  if (args.flags.has("base-branch") && !args.flags.has("new-environment")) {
+    throw new Error("--base-branch requires --new-environment worktree.");
+  }
+}
+
 function parseScriptInterpreter(
   value: string | undefined,
 ): AutomationScriptInterpreter | undefined {
@@ -264,6 +283,7 @@ async function buildCreateExecution(
     if (!provider || !model) {
       throw new Error("Agent automations require --provider and --model alongside --prompt.");
     }
+    validateAgentTargetOptions(args);
     return {
       mode: "agent",
       prompt,
@@ -278,7 +298,12 @@ async function buildCreateExecution(
       ...(flag(args, "target-thread") ? { targetThreadId: flag(args, "target-thread") } : {}),
     };
   }
-  if (args.flags.has("environment") || args.flags.has("new-environment") || args.flags.has("base-branch")) {
+  if (
+    args.flags.has("target-thread") ||
+    args.flags.has("environment") ||
+    args.flags.has("new-environment") ||
+    args.flags.has("base-branch")
+  ) {
     throw new Error("Script automations do not accept environment flags.");
   }
   if (script !== undefined && scriptFile !== undefined) {
@@ -299,7 +324,44 @@ async function buildCreateExecution(
   };
 }
 
-function buildUpdateRequest(args: ParsedArgs): UpdateAutomationInput {
+async function buildAgentExecutionUpdate(
+  bb: Pick<BbPluginApi, "sdk">,
+  args: ParsedArgs,
+): Promise<AgentExecutionUpdate | undefined> {
+  const agentOptionNames = [
+    "prompt",
+    "permission-mode",
+    "target-thread",
+    "environment",
+    "new-environment",
+    "base-branch",
+  ] as const;
+  if (!agentOptionNames.some((name) => args.flags.has(name))) return undefined;
+
+  validateAgentTargetOptions(args);
+  const update: AgentExecutionUpdate = {};
+  if (args.flags.has("prompt")) update.prompt = requireFlag(args, "prompt");
+  if (args.flags.has("permission-mode")) {
+    update.permissionMode = parsePermissionMode(requireFlag(args, "permission-mode"));
+  }
+  if (args.flags.has("target-thread")) {
+    update.target = {
+      type: "target-thread",
+      threadId: requireFlag(args, "target-thread"),
+    };
+  } else if (args.flags.has("environment") || args.flags.has("new-environment")) {
+    update.target = {
+      type: "environment",
+      environment: await buildAgentEnvironment(bb, args),
+    };
+  }
+  return update;
+}
+
+async function buildUpdateRequest(
+  bb: Pick<BbPluginApi, "sdk">,
+  args: ParsedArgs,
+): Promise<UpdateAutomationInput> {
   const projectId = requireFlag(args, "project");
   const automationId = args.positionals[0];
   if (!automationId) throw new Error("Missing automationId.");
@@ -309,8 +371,12 @@ function buildUpdateRequest(args: ParsedArgs): UpdateAutomationInput {
   if (flag(args, "cron") !== undefined || flag(args, "timezone") !== undefined || flag(args, "at") !== undefined || flag(args, "in") !== undefined) {
     request.trigger = buildTrigger(args);
   }
-  if (request.name === undefined && request.trigger === undefined) {
-    throw new Error("No changes requested. Provide --name, --cron + --timezone, --at, or --in.");
+  const agentUpdate = await buildAgentExecutionUpdate(bb, args);
+  if (agentUpdate !== undefined) request.agent = agentUpdate;
+  if (request.name === undefined && request.trigger === undefined && request.agent === undefined) {
+    throw new Error(
+      "No changes requested. Provide --name, schedule flags, --prompt, --permission-mode, or one target option.",
+    );
   }
   return request;
 }
@@ -387,7 +453,7 @@ function helpText(): string {
 bb automation list --project <id>
 bb automation create --project <id> --name <name> (--cron <expr> --timezone <tz> | --at <datetime> | --in <duration>) (--prompt <text> --provider <id> --model <model> | --script <inline> | --script-file <path>)
 bb automation show <automationId> --project <id>
-bb automation update <automationId> --project <id> [--name <name>] [--cron <expr> --timezone <tz> | --at <datetime> | --in <duration>]
+bb automation update <automationId> --project <id> [--name <name>] [schedule flags] [--prompt <text>] [--permission-mode <accept-edits|auto|full>] [--target-thread <id> | --environment <id-or-path> | --new-environment worktree [--base-branch <branch>]]
 bb automation pause <automationId> --project <id>
 bb automation resume <automationId> --project <id>
 bb automation run <automationId> --project <id> [--idempotency-key <key>]
@@ -457,7 +523,7 @@ export function registerAutomationCli(args: {
           return { exitCode: 0, stdout: json ?? printAutomation(found) };
         }
         if (command === "update") {
-          const updated = await service.update(buildUpdateRequest(parsed));
+          const updated = await service.update(await buildUpdateRequest(bb, parsed));
           const json = optionalJson(parsed, updated);
           return { exitCode: 0, stdout: json ?? `Automation ${updated.id} updated\n${printAutomation(updated)}` };
         }

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -171,6 +171,38 @@ function requireExactlyOneScriptSource(
 export const automationExecutionRequestSchema =
   automationExecutionSchema.superRefine(requireExactlyOneScriptSource);
 
+export const agentExecutionTargetSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("target-thread"),
+      threadId: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("environment"),
+      environment: agentEnvironmentSchema,
+    })
+    .strict(),
+]);
+export type AgentExecutionTarget = z.infer<typeof agentExecutionTargetSchema>;
+
+export const agentExecutionUpdateSchema = z
+  .object({
+    prompt: z.string().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH).optional(),
+    permissionMode: permissionModeSchema.optional(),
+    target: agentExecutionTargetSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.prompt !== undefined ||
+      value.permissionMode !== undefined ||
+      value.target !== undefined,
+    { message: "at least one agent execution field is required" },
+  );
+export type AgentExecutionUpdate = z.infer<typeof agentExecutionUpdateSchema>;
+
 export const automationResponseSchema = z
   .object({
     id: z.string(),
@@ -248,14 +280,20 @@ export const updateAutomationInputSchema = z
     name: z.string().min(1).max(AUTOMATION_NAME_MAX_LENGTH).optional(),
     trigger: automationTriggerSchema.optional(),
     execution: automationExecutionRequestSchema.optional(),
+    agent: agentExecutionUpdateSchema.optional(),
   })
   .strict()
   .refine(
     (value) =>
       value.name !== undefined ||
       value.trigger !== undefined ||
-      value.execution !== undefined,
+      value.execution !== undefined ||
+      value.agent !== undefined,
     { message: "at least one field is required" },
+  )
+  .refine(
+    (value) => value.execution === undefined || value.agent === undefined,
+    { message: "execution and agent updates cannot be combined" },
   );
 export type UpdateAutomationInput = z.infer<typeof updateAutomationInputSchema>;
 

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -352,6 +352,184 @@ describe("automations server plugin harness", () => {
     await harness.dispose();
   });
 
+  it("updates agent execution in place through the CLI without resetting omitted fields", async () => {
+    const { harness } = await bootAutomationsPlugin();
+    const created = await createAgentAutomation(harness, {
+      name: "Keep this identity",
+      trigger: { triggerType: "schedule", cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const environmentUpdate = await harness.runCli([
+      "update",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--prompt",
+      "use the new workspace",
+      "--permission-mode",
+      "auto",
+      "--environment",
+      "/tmp/design-doctrine",
+      "--json",
+    ]);
+    expect(environmentUpdate.exitCode).toBe(0);
+    const environmentTargeted = automationResponseSchema.parse(
+      JSON.parse(environmentUpdate.stdout ?? ""),
+    );
+    expect(environmentTargeted).toMatchObject({
+      id: created.id,
+      name: "Keep this identity",
+      trigger: { triggerType: "schedule", cron: "0 9 * * *", timezone: "UTC" },
+      execution: {
+        mode: "agent",
+        prompt: "use the new workspace",
+        providerId: "codex",
+        model: "gpt-5",
+        permissionMode: "auto",
+        environment: {
+          type: "host",
+          hostId: "host_test",
+          workspace: { type: "unmanaged", path: "/tmp/design-doctrine" },
+        },
+      },
+    });
+    expect(environmentTargeted.execution).not.toHaveProperty("targetThreadId");
+
+    const threadTargetUpdate = await harness.runCli([
+      "update",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--target-thread",
+      THREAD_ID,
+      "--json",
+    ]);
+    expect(threadTargetUpdate.exitCode).toBe(0);
+    const threadTargeted = automationResponseSchema.parse(
+      JSON.parse(threadTargetUpdate.stdout ?? ""),
+    );
+    expect(threadTargeted.execution).toMatchObject({
+      mode: "agent",
+      targetThreadId: THREAD_ID,
+      environment: {
+        type: "host",
+        hostId: "host_test",
+        workspace: { type: "unmanaged", path: "/tmp/design-doctrine" },
+      },
+    });
+
+    const worktreeUpdate = await harness.runCli([
+      "update",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--new-environment",
+      "worktree",
+      "--base-branch",
+      "release",
+      "--json",
+    ]);
+    expect(worktreeUpdate.exitCode).toBe(0);
+    const worktreeTargeted = automationResponseSchema.parse(
+      JSON.parse(worktreeUpdate.stdout ?? ""),
+    );
+    expect(worktreeTargeted.execution).toMatchObject({
+      mode: "agent",
+      providerId: "codex",
+      model: "gpt-5",
+      prompt: "use the new workspace",
+      permissionMode: "auto",
+      environment: {
+        type: "host",
+        hostId: "host_test",
+        workspace: {
+          type: "managed-worktree",
+          baseBranch: { kind: "named", name: "release" },
+        },
+      },
+    });
+    expect(worktreeTargeted.execution).not.toHaveProperty("targetThreadId");
+    expect(
+      automationListResponseSchema.parse(
+        await harness.callRpc("automations_list", { projectId: PROJECT_ID }),
+      ),
+    ).toHaveLength(1);
+
+    await harness.dispose();
+  });
+
+  it("rejects conflicting targets and invalid permission modes before updating", async () => {
+    const { harness } = await bootAutomationsPlugin();
+    const created = await createAgentAutomation(harness);
+
+    const conflictingTargets = await harness.runCli([
+      "update",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--target-thread",
+      THREAD_ID,
+      "--environment",
+      "/tmp/design-doctrine",
+    ]);
+    expect(conflictingTargets.exitCode).toBe(1);
+    expect(conflictingTargets.stderr).toContain("Cannot combine target options");
+
+    const invalidPermissionMode = await harness.runCli([
+      "update",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--permission-mode",
+      "write",
+    ]);
+    expect(invalidPermissionMode.exitCode).toBe(1);
+    expect(invalidPermissionMode.stderr).toContain(
+      "Expected accept-edits, auto, or full",
+    );
+
+    await harness.dispose();
+  });
+
+  it("patches agent execution through RPC while preserving its environment", async () => {
+    const { harness } = await bootAutomationsPlugin();
+    const created = await createAgentAutomation(harness);
+
+    const updated = automationResponseSchema.parse(
+      await harness.callRpc("automations_update", {
+        projectId: PROJECT_ID,
+        automationId: created.id,
+        agent: {
+          prompt: "updated by RPC",
+          permissionMode: "full",
+          target: { type: "target-thread", threadId: THREAD_ID },
+        },
+      }),
+    );
+    expect(updated).toMatchObject({
+      id: created.id,
+      execution: {
+        mode: "agent",
+        prompt: "updated by RPC",
+        providerId: "codex",
+        model: "gpt-5",
+        permissionMode: "full",
+        environment: { type: "project-default" },
+        targetThreadId: THREAD_ID,
+      },
+    });
+
+    await expect(
+      harness.callRpc("automations_update", {
+        projectId: PROJECT_ID,
+        automationId: created.id,
+        agent: { permissionMode: "write" },
+      }),
+    ).rejects.toThrow();
+
+    await harness.dispose();
+  });
+
   it("dedupes manual runs through RPC idempotency keys", async () => {
     const { harness } = await bootAutomationsPlugin();
     const automation = await createAgentAutomation(harness);

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -25,6 +25,7 @@ import {
   AUTOMATION_RUNS_LIMIT_MAX,
   automationRunListResponseSchema,
   automationsOverviewResponseSchema,
+  type AgentExecutionUpdate,
   type AutomationExecution,
   type AutomationRunListResponse,
   type AutomationRunRpcResponse,
@@ -145,6 +146,32 @@ async function resolveStoredExecution(args: {
 
 function encodeRunCursor(startedAt: number, id: string): string {
   return Buffer.from(`${startedAt}:${id}`, "utf8").toString("base64url");
+}
+
+function applyAgentExecutionUpdate(
+  execution: AutomationExecution,
+  update: AgentExecutionUpdate,
+): Extract<AutomationExecution, { mode: "agent" }> {
+  if (execution.mode !== "agent") {
+    throw new Error("Agent execution options can only update agent automations");
+  }
+
+  const next = {
+    ...execution,
+    ...(update.prompt !== undefined ? { prompt: update.prompt } : {}),
+    ...(update.permissionMode !== undefined
+      ? { permissionMode: update.permissionMode }
+      : {}),
+  };
+  if (update.target === undefined) return next;
+  if (update.target.type === "target-thread") {
+    return { ...next, targetThreadId: update.target.threadId };
+  }
+  const { targetThreadId: _targetThreadId, ...withoutTargetThread } = next;
+  return {
+    ...withoutTargetThread,
+    environment: update.target.environment,
+  };
 }
 
 function parseRunCursor(
@@ -283,6 +310,9 @@ export function createAutomationService(args: {
     async update(input) {
       await requireProjectAvailable(bb, input.projectId);
       const current = requireProjectAutomation(db, input);
+      if (input.execution !== undefined && input.agent !== undefined) {
+        throw new Error("execution and agent updates cannot be combined");
+      }
       const now = Date.now();
       const patch: Parameters<typeof updateAutomation>[1]["patch"] = {};
       if (input.name !== undefined) patch.name = input.name;
@@ -297,6 +327,12 @@ export function createAutomationService(args: {
           automationId: current.id,
           execution: input.execution,
         });
+      }
+      if (input.agent !== undefined) {
+        patch.execution = applyAgentExecutionUpdate(
+          parseAutomationExecution(current.execution),
+          input.agent,
+        );
       }
       const updated = updateAutomation(db, {
         projectId: input.projectId,


### PR DESCRIPTION
Adds in-place agent automation updates for prompts, permission modes, and one execution target at a time. Omitted execution fields, name, and schedule remain unchanged; updates never recreate an automation. Includes CLI/RPC coverage and command guidance.