### PR TITLE
Fix stale thread drag opacity

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
+import type { ComponentProps } from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -27,6 +29,26 @@ const mockUpdateEnvironment = vi.hoisted(() => ({
 const mockDraftThreadIds = vi.hoisted(() => ({
   current: new Set<string>(),
 }));
+const mockSectionDragOverlay = vi.hoisted(() => ({
+  dndContextProps: undefined as unknown,
+  dropAnimation: undefined as unknown,
+}));
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  const { createElement } = await import("react");
+  return {
+    ...actual,
+    DndContext: (props: ComponentProps<typeof actual.DndContext>) => {
+      mockSectionDragOverlay.dndContextProps = props;
+      return createElement(actual.DndContext, props);
+    },
+    DragOverlay: (props: ComponentProps<typeof actual.DragOverlay>) => {
+      mockSectionDragOverlay.dropAnimation = props.dropAnimation;
+      return createElement(actual.DragOverlay, props);
+    },
+  };
+});
 
 vi.mock("@/hooks/useLocalPathPicker", () => ({
   usePathPickerHost: () => ({ hostId: null, hostName: null }),
@@ -295,6 +317,55 @@ describe("ProjectRow interactions", () => {
     expect(screen.getByLabelText("Plan mode active")).not.toBeNull();
     expect(screen.queryByLabelText("Goal active")).toBeNull();
     expect(screen.queryByLabelText("Thread working")).toBeNull();
+  });
+
+  it("keeps the drop animation from restoring stale source-row opacity", () => {
+    const store = createStore();
+    const queryClient = new QueryClient();
+    const sectionId = "sec_drag";
+
+    render(
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ChronologicalSectionThreadSections
+              threadListState={{
+                status: "ready",
+                threads: [
+                  makeThread({ id: "thr_drag", sectionId }),
+                  makeThread({ id: "thr_loose", createdAt: 1 }),
+                ],
+              }}
+              compareThreads={() => 0}
+              sections={[{ id: sectionId, name: "Drag target" }]}
+              collapsedThreadIds={new Set()}
+              collapsedEnvironmentIds={new Set()}
+              onToggleThreadCollapsed={vi.fn()}
+              onToggleEnvironmentCollapsed={vi.fn()}
+              topLevelSectionOrder={[
+                buildSidebarEntitySectionId("section", sectionId),
+                "threads",
+              ]}
+              onTopLevelSectionOrderChange={vi.fn()}
+              pinnedReorderPending={false}
+              pinnedThreads={[]}
+              onReorderPinnedThread={vi.fn()}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </Provider>,
+    );
+
+    act(() => {
+      const dndContextProps = mockSectionDragOverlay.dndContextProps as {
+        onDragStart?: (event: { active: { id: string } }) => void;
+      };
+      dndContextProps.onDragStart?.({ active: { id: "thr_drag" } });
+    });
+
+    expect(mockSectionDragOverlay.dropAnimation).toMatchObject({
+      sideEffects: null,
+    });
   });
 
   it("shows a working draft before Plan for a collapsed section", () => {

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -2134,6 +2134,11 @@ export const ChronologicalSectionThreadSections = memo(
                   ? {
                       duration: 180,
                       easing: "cubic-bezier(0.2, 0, 0, 1)",
+                      // The default side effect imperatively hides the source
+                      // row, then restores its pre-animation opacity. If that
+                      // cleanup lands after our projected-drag state clears,
+                      // it can restore the stale 0.25 drag opacity forever.
+                      sideEffects: null,
                     }
                   : null
               }


### PR DESCRIPTION
## Summary

- prevent the drag overlay cleanup from restoring a stale dimmed opacity after cross-section drops
- preserve the existing projected-row settle animation without imperative source-row opacity side effects
- add regression coverage for the active thread drop-animation contract

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with 112 existing warnings)
- targeted ProjectRow interaction tests: 9 passed
- full `@bb/app` suite: 250 files passed; one unrelated KeyboardSettingsSection timeout passed on isolated rerun
- review-loop: CORRECT, no P0–P2 findings

## QA

- Computer Use E2E against an isolated local instance: moved “Drag opacity probe” from “Drag source” to “Drag target”
- after the drop-animation window, the moved row remained at full opacity without a refresh
- database verification confirmed the thread persisted in `sec_e2e_target`
- captured before and after screenshots in the bb thread artifacts
