### PR TITLE
Fix plugin dev-loop hot reload: server-entry rebuilds, shim export staleness, visible build failures

### DIFF
--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -149,6 +149,11 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     string,
     { status: PluginRuntimeStatus; detail: string | null }
   >();
+  const baseStatuses = new Map<
+    string,
+    { status: PluginRuntimeStatus; detail: string | null }
+  >();
+  const devBuildProblems = new Map<string, string>();
   const statusListeners = new Map<
     string,
     Set<(status: PluginRuntimeStatus, detail: string | null) => void>
@@ -194,15 +199,38 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
   // bind-gated bb.server.loopbackBaseUrl.
   let boundLoopbackBaseUrl: string | undefined;
 
-  function setStatus(
+  function publishStatus(
     id: string,
     status: PluginRuntimeStatus,
-    detail: string | null = null,
+    detail: string | null,
   ): void {
     statuses.set(id, { status, detail });
     for (const listener of statusListeners.get(id) ?? []) {
       listener(status, detail);
     }
+  }
+
+  function setStatus(
+    id: string,
+    status: PluginRuntimeStatus,
+    detail: string | null = null,
+  ): void {
+    baseStatuses.set(id, { status, detail });
+    const buildProblem = devBuildProblems.get(id);
+    publishStatus(
+      id,
+      status,
+      [detail, buildProblem]
+        .filter((part): part is string => part !== null && part !== undefined)
+        .join("; ") || null,
+    );
+  }
+
+  function setDevBuildProblem(id: string, message: string | null): void {
+    if (message === null) devBuildProblems.delete(id);
+    else devBuildProblems.set(id, `frontend bundle build failed: ${message}`);
+    const base = baseStatuses.get(id);
+    if (base !== undefined) setStatus(id, base.status, base.detail);
   }
 
   function statsFor(id: string): PluginHandlerStats {
@@ -680,17 +708,29 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
    * The backend entry to import for this load. Managed (git:/npm:) installs
    * prefer a fresh, SDK-compatible prebuilt `dist/server.js` (design
    * §3 loader amendment, §6 prebuilt distribution) so consumers never need
-   * npm or node_modules; path installs ALWAYS load from source, so author
-   * iteration via `bb plugin reload` sees edited files. A present-but-stale
-   * or meta-less dist falls back to source with one warning. While the SDK
-   * is pre-1.0, minor bumps are breaking (semver), so compatibility requires
-   * the exact SDK version, not just a matching major.
+   * npm or node_modules. Path installs and source-layout builtins ALWAYS load
+   * from source, so author iteration via `bb plugin reload` and the builtin
+   * dev watcher sees edited files; packaged builtins declare dist/server.js
+   * as their manifest entry and still load that artifact. A present-but-stale
+   * or meta-less managed dist falls back to source with one warning. While
+   * the SDK is pre-1.0, minor bumps are breaking (semver), so compatibility
+   * requires the exact SDK version, not just a matching major.
    */
   async function resolveServerEntry(
     row: InstalledPluginRow,
     manifest: PluginManifest,
   ): Promise<string> {
-    if (row.sourceKind === "path") return manifest.serverEntry;
+    if (
+      row.sourceKind === "path" ||
+      (row.sourceKind === "builtin" &&
+        !isPackagedBuiltinServerEntry({
+          kind: row.sourceKind,
+          manifest,
+          rootDir: row.rootDir,
+        }))
+    ) {
+      return manifest.serverEntry;
+    }
     const distJsPath = join(row.rootDir, "dist", "server.js");
     try {
       await stat(distJsPath);
@@ -1097,6 +1137,8 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
 
   function clearRuntimeState(id: string): void {
     statuses.delete(id);
+    baseStatuses.delete(id);
+    devBuildProblems.delete(id);
     appBundles.delete(id);
     logos.delete(id);
     needsConfiguration.delete(id);
@@ -1198,6 +1240,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     loadOne,
     logos,
     needsConfiguration,
+    setDevBuildProblem,
     setStatus,
     shouldExposeLoadedPlugin,
     shouldExposePluginId,

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -1002,6 +1002,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     loaded,
     loadOne,
     logos,
+    setDevBuildProblem,
     setStatus,
     shouldExposeLoadedPlugin,
     shouldExposePluginId,
@@ -1416,7 +1417,18 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             pluginId: row.id,
             hasApp: manifest.appEntry !== undefined,
             buildApp: async () => {
-              await buildPluginApp(bundled.rootDir, deps.appVersion);
+              try {
+                await buildPluginApp(bundled.rootDir, deps.appVersion);
+                setDevBuildProblem(row.id, null);
+                notifyPluginsChanged();
+              } catch (error) {
+                setDevBuildProblem(
+                  row.id,
+                  error instanceof Error ? error.message : String(error),
+                );
+                notifyPluginsChanged();
+                throw error;
+              }
             },
             reloadPlugin: async () => {
               await withLifecycleLock(row.id, async () => {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -176,6 +176,7 @@ describe("builtin plugin reconciliation", () => {
   beforeEach(async () => {
     delete globals.__builtinFixtureLoads;
     delete globals.__packagedBuiltinLoads;
+    delete globals.__hotBuiltinServerVersion;
     db = createConnection(":memory:");
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-builtin-plugins-"));
@@ -498,18 +499,77 @@ describe("builtin plugin reconciliation", () => {
     });
   });
 
-  it("rebuilds and serves a new builtin app hash after a source edit while Plugins is off", async () => {
-    const mutableRoot = join(workDir, "bb-plugin-hot-builtin");
+  it("hot-reloads a source-layout builtin server instead of a compatible dist artifact", async () => {
+    const mutableRoot = join(workDir, "bb-plugin-hot-server-builtin");
+    await mkdir(join(mutableRoot, "dist"), { recursive: true });
+    await writeFile(
+      join(mutableRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-hot-server-builtin",
+        version: "0.1.0",
+        type: "module",
+        bb: {
+          name: "Hot server builtin",
+          description: "Hot server builtin plugin fixture.",
+          branding: { icon: "Zap" },
+          server: "./server.ts",
+        },
+      }),
+    );
+    await writeFile(
+      join(mutableRoot, "server.ts"),
+      'export default function plugin() { globalThis.__hotBuiltinServerVersion = "before"; }\n',
+    );
+    // A source-layout builtin may retain artifacts from a production build.
+    // Dev reloads must still execute the edited source entry.
+    await writeFile(
+      join(mutableRoot, "dist", "server.js"),
+      'export default function plugin() { globalThis.__hotBuiltinServerVersion = "stale-dist"; }\n',
+    );
+    await writeFile(
+      join(mutableRoot, "dist", "server.meta.json"),
+      JSON.stringify({
+        sdkMajor: PLUGIN_SDK_MAJOR,
+        sdkVersion: PLUGIN_SDK_VERSION,
+      }),
+    );
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      builtinName: "hot-server",
+      isEnabled: () => false,
+      rootDir: mutableRoot,
+      watchBuiltinPluginSources: true,
+    });
+    await service.start();
+    expect(globals.__hotBuiltinServerVersion).toBe("before");
+
+    await writeFile(
+      join(mutableRoot, "server.ts"),
+      'export default function plugin() { globalThis.__hotBuiltinServerVersion = "after"; }\n',
+    );
+    let deadline = Date.now() + 20_000;
+    while (
+      globals.__hotBuiltinServerVersion !== "after" &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+    }
+    expect(globals.__hotBuiltinServerVersion).toBe("after");
+  }, 30_000);
+
+  it("surfaces builtin app build failures in status until the next successful build", async () => {
+    const mutableRoot = join(workDir, "bb-plugin-hot-app-builtin");
     await mkdir(mutableRoot, { recursive: true });
     await writeFile(
       join(mutableRoot, "package.json"),
       JSON.stringify({
-        name: "bb-plugin-hot-builtin",
+        name: "bb-plugin-hot-app-builtin",
         version: "0.1.0",
         type: "module",
         bb: {
-          name: "Hot builtin",
-          description: "Hot builtin plugin fixture.",
+          name: "Hot app builtin",
+          description: "Hot app builtin plugin fixture.",
           branding: { icon: "Zap" },
           server: "./server.ts",
           app: "./app.tsx",
@@ -527,7 +587,7 @@ describe("builtin plugin reconciliation", () => {
     service = createService({
       db,
       dataDir: join(workDir, "data"),
-      builtinName: "hot",
+      builtinName: "hot-app",
       isEnabled: () => false,
       rootDir: mutableRoot,
       watchBuiltinPluginSources: true,
@@ -538,19 +598,41 @@ describe("builtin plugin reconciliation", () => {
 
     await writeFile(
       join(mutableRoot, "app.tsx"),
+      "export default function App( {\n",
+    );
+    let deadline = Date.now() + 20_000;
+    let failed = service.list()[0];
+    while (
+      !failed?.statusDetail?.includes("frontend bundle build failed") &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+      failed = service.list()[0];
+    }
+    expect(failed?.status).toBe("running");
+    expect(failed?.statusDetail).toContain("frontend bundle build failed");
+    expect(failed?.app.bundle?.hash).toBe(before?.hash);
+
+    await writeFile(
+      join(mutableRoot, "app.tsx"),
       "export default function App() { return <div>after</div>; }\n",
     );
-    let after = service.list()[0]?.app.bundle;
-    const deadline = Date.now() + 20_000;
-    while (after?.hash === before?.hash && Date.now() < deadline) {
+    deadline = Date.now() + 20_000;
+    let after = service.list()[0];
+    while (
+      (after?.statusDetail !== null ||
+        after.app.bundle?.hash === before?.hash) &&
+      Date.now() < deadline
+    ) {
       await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
-      after = service.list()[0]?.app.bundle;
+      after = service.list()[0];
     }
-    expect(after?.hash).not.toBe(before?.hash);
+    expect(after?.statusDetail).toBeNull();
+    expect(after?.app.bundle?.hash).not.toBe(before?.hash);
     await expect(
       readFile(join(mutableRoot, "dist", "app.js"), "utf8"),
     ).resolves.toContain("after");
-  }, 30_000);
+  }, 90_000);
 
   it("rejects unknown builtin install sources clearly", async () => {
     service = createService({ db, dataDir: join(workDir, "data") });

--- a/packages/plugin-build/package.json
+++ b/packages/plugin-build/package.json
@@ -12,6 +12,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "clean": "rimraf tsconfig.tsbuildinfo",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "node ./scripts/generate-plugin-theme.mjs --check && tsc --noEmit"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
     "@bb/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "typescript-7": "npm:typescript@^7.0.2"
+    "typescript-7": "npm:typescript@^7.0.2",
+    "vitest": "^4.1.1"
   }
 }

--- a/packages/plugin-build/src/build-plugin-app.test.ts
+++ b/packages/plugin-build/src/build-plugin-app.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { build } from "esbuild";
+import { runtimeShimPlugin } from "./build-plugin-app.js";
+
+describe("plugin app runtime shim", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("re-derives @bb/plugin-sdk/app exports for every rebuild", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bb-plugin-shim-"));
+    tempDirs.push(dir);
+    const facadePath = join(dir, "app-facade.mjs");
+    const facadeUrl = pathToFileURL(facadePath).href;
+
+    async function bundle(importName: string): Promise<string> {
+      const result = await build({
+        stdin: {
+          contents: `import { ${importName} } from "@bb/plugin-sdk/app"; export { ${importName} };`,
+          loader: "js",
+          resolveDir: dir,
+        },
+        bundle: true,
+        format: "esm",
+        platform: "browser",
+        write: false,
+        logLevel: "silent",
+        plugins: [runtimeShimPlugin(facadeUrl)],
+      });
+      return result.outputFiles[0]?.text ?? "";
+    }
+
+    await writeFile(facadePath, "export const first = 1;\n");
+    await expect(bundle("first")).resolves.toContain("first");
+
+    await writeFile(
+      facadePath,
+      "export const first = 1; export const addedLater = 2;\n",
+    );
+    await expect(bundle("addedLater")).resolves.toContain("addedLater");
+  });
+});

--- a/packages/plugin-build/src/build-plugin-app.ts
+++ b/packages/plugin-build/src/build-plugin-app.ts
@@ -11,7 +11,7 @@ import { createRequire } from "node:module";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { derivePluginId } from "@bb/domain";
 import type { Plugin } from "esbuild";
-import * as pluginSdkAppFacade from "@bb/plugin-sdk/app";
+import * as bundledPluginSdkAppFacade from "@bb/plugin-sdk/app";
 import {
   PLUGIN_THEME_CSS,
   TW_ANIMATE_CSS,
@@ -75,15 +75,46 @@ const RUNTIME_SLOT_BY_SPECIFIER: Record<string, string> = {
 };
 
 /**
- * Named exports of `@bb/plugin-sdk/app`, read from the facade module itself so
- * a declaration-only manifest cannot drift from the runtime module; the React
- * lists next to it come from
+ * Named exports of `@bb/plugin-sdk/app` are read from a fresh facade module on
+ * every app build. The dev server stays alive while the SDK source changes, so
+ * retaining the first module namespace here would make newly-added exports
+ * unavailable to every subsequent plugin rebuild until the server restarted.
+ * The React lists next to it come from
  * scripts/generate-runtime-export-manifest.mjs instead.
  */
-const PLUGIN_SDK_APP_EXPORTS = Object.keys(pluginSdkAppFacade).sort();
+let freshFacadeImportSequence = 0;
 
-function shimExportsOf(specifier: string): readonly string[] {
-  if (specifier === "@bb/plugin-sdk/app") return PLUGIN_SDK_APP_EXPORTS;
+async function freshModuleExports(moduleUrl: string): Promise<string[]> {
+  const freshUrl = new URL(moduleUrl);
+  freshUrl.searchParams.set(
+    "bb-plugin-build",
+    String(++freshFacadeImportSequence),
+  );
+  const moduleNamespace = await import(freshUrl.href);
+  return Object.keys(moduleNamespace).sort();
+}
+
+async function shimExportsOf(
+  specifier: string,
+  pluginSdkAppModuleUrl: string | undefined,
+): Promise<readonly string[]> {
+  if (specifier === "@bb/plugin-sdk/app") {
+    if (pluginSdkAppModuleUrl !== undefined) {
+      return freshModuleExports(pluginSdkAppModuleUrl);
+    }
+    let resolvedModuleUrl: string;
+    try {
+      resolvedModuleUrl = import.meta.resolve("@bb/plugin-sdk/app");
+    } catch {
+      // The built CLI bundles @bb/plugin-build and the facade itself, but does
+      // not install plugin-build's dependency as a directly resolvable package.
+      // That immutable packaged process cannot gain SDK exports mid-run, so its
+      // bundled namespace is the correct fallback; source dev servers resolve
+      // the workspace facade above and always take the fresh-import path.
+      return Object.keys(bundledPluginSdkAppFacade).sort();
+    }
+    return freshModuleExports(resolvedModuleUrl);
+  }
   const names = RUNTIME_EXPORT_MANIFEST[specifier];
   if (!names) {
     throw new Error(`no runtime export manifest entry for "${specifier}"`);
@@ -92,8 +123,12 @@ function shimExportsOf(specifier: string): readonly string[] {
 }
 
 /** ESM shim re-exporting a `globalThis.__bbPluginRuntime` slot. */
-function shimModuleSource(specifier: string, slot: string): string {
-  const names = shimExportsOf(specifier);
+async function shimModuleSource(
+  specifier: string,
+  slot: string,
+  pluginSdkAppModuleUrl: string | undefined,
+): Promise<string> {
+  const names = await shimExportsOf(specifier, pluginSdkAppModuleUrl);
   return [
     `const runtime = globalThis.__bbPluginRuntime;`,
     `if (runtime == null || runtime.${slot} == null) {`,
@@ -119,7 +154,8 @@ const SHIM_FILTER = new RegExp(
     .join("|")})$`,
 );
 
-function runtimeShimPlugin(): Plugin {
+/** Internal export for focused build tests; not re-exported by the package. */
+export function runtimeShimPlugin(pluginSdkAppModuleUrl?: string): Plugin {
   return {
     name: "bb-plugin-runtime-shims",
     setup(build) {
@@ -127,13 +163,17 @@ function runtimeShimPlugin(): Plugin {
         path: args.path,
         namespace: SHIM_NAMESPACE,
       }));
-      build.onLoad({ filter: /.*/, namespace: SHIM_NAMESPACE }, (args) => ({
-        contents: shimModuleSource(
-          args.path,
-          RUNTIME_SLOT_BY_SPECIFIER[args.path] ?? args.path,
-        ),
-        loader: "js",
-      }));
+      build.onLoad(
+        { filter: /.*/, namespace: SHIM_NAMESPACE },
+        async (args) => ({
+          contents: await shimModuleSource(
+            args.path,
+            RUNTIME_SLOT_BY_SPECIFIER[args.path] ?? args.path,
+            pluginSdkAppModuleUrl,
+          ),
+          loader: "js",
+        }),
+      );
     },
   };
 }

--- a/packages/plugin-build/vitest.config.ts
+++ b/packages/plugin-build/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    name: "@bb/plugin-build",
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1802,6 +1802,9 @@ importers:
       typescript-7:
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugin-registry:
     devDependencies:


### PR DESCRIPTION
## Summary

- Load source-layout builtin server entries from source during development even when a compatible prebuilt `dist/server.js` exists, while preserving packaged builtin and managed git/npm artifact behavior.
- Re-derive `@bb/plugin-sdk/app` runtime shim exports from a fresh facade module on every app rebuild, with a bundled-facade fallback for immutable packaged CLI processes.
- Compose frontend dev-loop build errors into the existing plugin `statusDetail` surface consumed by `bb plugin list` and Settings, retain the last good bundle, and clear the error on the next successful build.

## Validation

- `pnpm exec turbo run typecheck` — 50/50 tasks passed.
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/plugin-build --force` — plugin-build passed; 1,179/1,180 server tests passed, with only the documented machine umask failure in `internal-skill-trees` (expected mode 420, received 436).
- Live `pnpm dev` QA confirmed edited builtin server source wins over an untouched compatible prebuilt dist, failed app builds appear in plugin status while the last good bundle remains served, and a successful rebuild clears the status detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)