### PR TITLE
Fix Add a machine RPC input validation

### DIFF
--- a/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
@@ -3,21 +3,24 @@
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { Host } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { sdk } from "@/lib/sdk";
+import { BbHttpError, sdk } from "@/lib/sdk";
 import { hostsQueryKey } from "@/hooks/queries/query-keys";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { AddMachineDialog } from "./AddMachineDialog";
 
-vi.mock("@/lib/sdk", () => ({
-  BbHttpError: class BbHttpError extends Error {},
-  sdk: {
-    hosts: {
-      createJoinCode: vi.fn(),
-      list: vi.fn(),
+vi.mock("@/lib/sdk", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/sdk")>();
+  return {
+    ...original,
+    sdk: {
+      hosts: {
+        createJoinCode: vi.fn(),
+        list: vi.fn(),
+      },
+      plugins: { callRpc: vi.fn() },
     },
-    plugins: { callRpc: vi.fn() },
-  },
-}));
+  };
+});
 
 vi.mock("@/lib/ws", () => ({
   wsManager: { subscribe: vi.fn(), unsubscribe: vi.fn() },
@@ -104,13 +107,23 @@ describe("AddMachineDialog", () => {
     ).toBeNull();
   });
 
-  it("ignores hosts that were already known at open time", async () => {
+  it("falls back to direct pairing when connect is unpaired and ignores known hosts", async () => {
     vi.mocked(sdk.hosts.createJoinCode).mockResolvedValue({
       joinCode: "jc_test123",
       hostId: "host_new",
       expiresAt: Date.now() + 15 * 60 * 1000,
     });
-    vi.mocked(sdk.plugins.callRpc).mockResolvedValue(null);
+    vi.mocked(sdk.plugins.callRpc).mockRejectedValue(
+      new BbHttpError({
+        body: {
+          ok: false,
+          error: { code: "handler_error", message: "not_paired" },
+        },
+        code: "handler_error",
+        message: "not_paired",
+        status: 500,
+      }),
+    );
     vi.mocked(sdk.hosts.list).mockResolvedValue([
       existingHost,
       host({ id: "host_offline", name: "dev-vm", status: "disconnected" }),

--- a/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
@@ -62,6 +62,13 @@ describe("AddMachineDialog", () => {
     render(<AddMachineDialog open onOpenChange={vi.fn()} />, { wrapper });
 
     const command = await screen.findByText(/--join-code jc_test123/);
+    expect(sdk.plugins.callRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "connect",
+        method: "createMachineCode",
+        input: null,
+      }),
+    );
     expect(command.textContent).toContain("--host-id host_new");
     expect(command.textContent).toContain(
       "curl -fsSL https://example.getbb.app/install.sh",

--- a/apps/app/src/components/dialogs/AddMachineDialog.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.tsx
@@ -35,7 +35,7 @@ async function createConnectMachineCode(): Promise<ConnectMachineCode | null> {
     return await sdk.plugins.callRpc({
       pluginId: "connect",
       method: "createMachineCode",
-      input: {},
+      input: null,
       outputSchema: connectMachineCodeSchema,
     });
   } catch (error) {

--- a/apps/app/src/components/dialogs/AddMachineDialog.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.tsx
@@ -28,7 +28,16 @@ const connectMachineCodeSchema = z.object({
   serverUrl: z.string(),
 });
 
+const pluginRpcErrorEnvelopeSchema = z.object({
+  error: z.object({ message: z.string() }),
+});
+
 type ConnectMachineCode = z.infer<typeof connectMachineCodeSchema>;
+
+function isNotPairedRpcError(error: BbHttpError): boolean {
+  const envelope = pluginRpcErrorEnvelopeSchema.safeParse(error.body);
+  return envelope.success && envelope.data.error.message === "not_paired";
+}
 
 async function createConnectMachineCode(): Promise<ConnectMachineCode | null> {
   try {
@@ -42,6 +51,7 @@ async function createConnectMachineCode(): Promise<ConnectMachineCode | null> {
     if (
       error instanceof BbHttpError &&
       (error.code === "not_paired" ||
+        isNotPairedRpcError(error) ||
         error.status === 404 ||
         error.status === 422 ||
         error.status === 503)


### PR DESCRIPTION
Closes #833

Summary:

- Send JSON `null` for the connect `createMachineCode` RPC, matching its `z.null()` contract.
- Parse the structured RPC error envelope so an unpaired/local server falls back to direct enrollment instead of surfacing `not_paired`.
- Add focused `AddMachineDialog` coverage for both a paired machine-code command and the real unpaired error shape.
- Leave the CLI join-code path and connect plugin contract unchanged.

Root cause:

The host Settings dialog calls plugin RPC through the generic `@bb/sdk` transport, not the contract-typed plugin `useRpc` hook. A stale empty-object payload therefore compiled but was rejected by the server before the handler ran.

Live QA also found that the intended unpaired fallback checked `BbHttpError.code === "not_paired"`, while plugin handler failures use envelope code `handler_error` and carry `not_paired` in the structured error message. The dialog now validates that boundary payload before using it.

Validation:

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/dialogs/AddMachineDialog.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=bb-plugin-connect --force`
- `pnpm exec turbo run typecheck --filter=bb-plugin-connect`
- `pnpm exec turbo run build --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with 129 existing warnings)
- Live browser QA against an unpaired dev server: the dialog renders the direct installer command and expiry countdown.
