### PR TITLE
Recover threads from unavailable models

### DIFF
--- a/apps/app/src/hooks/thread-creation-options/selection-state.ts
+++ b/apps/app/src/hooks/thread-creation-options/selection-state.ts
@@ -71,6 +71,7 @@ export interface EffectiveCreateExecutionValues {
 
 export interface BuildExecutionInputSourcesArgs {
   effectiveValues: EffectiveCreateExecutionValues;
+  forceExplicitModel?: boolean;
   scope: ThreadCreationOptionsScope;
   storedValues: StoredCreateExecutionValues;
   touchedFields: ReadonlySet<ThreadPromptField>;
@@ -208,6 +209,7 @@ export function updateThreadPromptSelections({
 
 export function buildExecutionInputSources({
   effectiveValues,
+  forceExplicitModel = false,
   scope,
   storedValues,
   touchedFields,
@@ -243,7 +245,9 @@ export function buildExecutionInputSources({
       storedValues.selectedModel === effectiveValues.selectedModel,
     hasValue: hasValue(effectiveValues.selectedModel),
     touched:
-      forcesExplicitExecutionFields || touchedFields.has("selectedModel"),
+      forceExplicitModel ||
+      forcesExplicitExecutionFields ||
+      touchedFields.has("selectedModel"),
   });
   const serviceTierSource = resolveCreateExecutionInputSource({
     hasStoredValue:

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -245,6 +245,74 @@ describe("useThreadCreationOptions", () => {
     });
   });
 
+  it("marks a definitive missing component-local model fallback as explicit", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          resetKey: "thr_stale_model",
+          initialProviderId: GLOBAL_PROVIDER_ID,
+          initialModel: "claude-mythos-5",
+          initialReasoningLevel: "high",
+          initialPermissionMode: "full",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-model");
+      expect(result.current.executionInputSources.model).toBe("explicit");
+    });
+  });
+
+  it("overrides a stale project model default when creating a new thread", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "new-thread",
+          preferenceProjectId: PROJECT_ID,
+          initialProviderId: GLOBAL_PROVIDER_ID,
+          initialModel: "removed-project-default",
+          initialReasoningLevel: "high",
+          initialPermissionMode: "full",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-model");
+      expect(result.current.executionInputSources.model).toBe("explicit");
+    });
+  });
+
+  it("keeps an existing model when provider discovery fails temporarily", async () => {
+    vi.mocked(sdk.system.executionOptions).mockResolvedValueOnce({
+      ...executionOptionsResponse(),
+      modelLoadError: { providerId: GLOBAL_PROVIDER_ID, code: "failed" },
+    });
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          resetKey: "thr_model_discovery_failure",
+          initialProviderId: GLOBAL_PROVIDER_ID,
+          initialModel: "still-valid-model",
+          initialReasoningLevel: "high",
+          initialPermissionMode: "full",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.modelLoadFailed).toBe(true);
+      expect(result.current.selectedModel).toBe("still-valid-model");
+      expect(result.current.executionInputSources.model).toBeUndefined();
+    });
+  });
+
   it("loads the product default provider before any persisted selection exists", async () => {
     const { wrapper } = createQueryClientTestHarness();
 

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -386,6 +386,13 @@ export function useThreadCreationOptions(
     rawSelectedModel,
   ]);
   const selectedModel = useMemo(() => {
+    // A provider discovery error is temporary: keep an existing explicit
+    // selection instead of treating a partial/custom catalog as proof that it
+    // disappeared. Once discovery succeeds, absence is definitive and the
+    // catalog default becomes a recovery selection.
+    if (modelLoadError !== null && rawSelectedModel) {
+      return rawSelectedModel;
+    }
     if (availableModels.length === 0) {
       return rawSelectedModel;
     }
@@ -396,7 +403,11 @@ export function useThreadCreationOptions(
       availableModels.find((model) => model.isDefault)?.model ??
       availableModels[0].model
     );
-  }, [availableModels, rawSelectedModel]);
+  }, [availableModels, modelLoadError, rawSelectedModel]);
+  const isUnavailableModelRecovery =
+    modelLoadError === null &&
+    rawSelectedModel.length > 0 &&
+    selectedModel !== rawSelectedModel;
 
   const modelOptions = useMemo(
     (): PickerOption<string>[] =>
@@ -488,6 +499,7 @@ export function useThreadCreationOptions(
           reasoningLevel,
           permissionMode,
         },
+        forceExplicitModel: isUnavailableModelRecovery,
         scope,
         storedValues: {
           selectedProviderId: storedProviderId,
@@ -500,6 +512,7 @@ export function useThreadCreationOptions(
       }),
     [
       effectiveProviderId,
+      isUnavailableModelRecovery,
       permissionMode,
       reasoningLevel,
       scope,

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -20,7 +20,7 @@ import {
   type ProviderInfo,
 } from "@bb/domain";
 import { normalizeHostDaemonAcpLaunchSpec } from "@bb/host-daemon-contract";
-import type { AppDeps } from "../../types.js";
+import type { LoggedWorkSessionDeps } from "../../types.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { ApiError } from "../../errors.js";
 import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
@@ -149,7 +149,7 @@ function expectedFallbackErrorLogFields(
 }
 
 async function listInstalledKnownAcpAgents(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   hostId: string,
 ): Promise<KnownAcpAgent[]> {
   const customProviderIds = new Set(
@@ -198,7 +198,7 @@ async function listInstalledKnownAcpAgents(
 }
 
 async function listSystemProviderInfosForHost(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   hostId: string,
 ): Promise<ProviderInfo[]> {
   return listConfiguredSystemProviderInfos(
@@ -208,7 +208,7 @@ async function listSystemProviderInfosForHost(
 }
 
 function resolveSystemProviderInfosPlan(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   query: ListSystemProviderInfosRequest = {},
 ): ResolveSystemProviderInfosPlanResult {
   try {
@@ -237,7 +237,7 @@ function resolveSystemProviderInfosPlan(
 }
 
 async function resolveSystemProviderInfos(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   query: ListSystemProviderInfosRequest = {},
 ): Promise<ListSystemProviderInfosResult> {
   const { hostId, hostLookupError, providersPromise } =
@@ -250,7 +250,7 @@ async function resolveSystemProviderInfos(
 }
 
 export async function listSystemProviderInfos(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   query: ListSystemProviderInfosRequest = {},
 ): Promise<ProviderInfo[]> {
   return (await resolveSystemProviderInfos(deps, query)).providers;
@@ -336,7 +336,7 @@ export function appendCustomModels({
 }
 
 export async function resolveSystemExecutionOptions(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   query: SystemExecutionOptionsRequest,
 ): Promise<SystemExecutionOptionsResponse> {
   const { hostId, hostLookupError, providersPromise } =
@@ -423,7 +423,7 @@ export async function resolveSystemExecutionOptions(
 }
 
 async function loadSystemProviderModels(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   {
     hostId,
     provider,

--- a/apps/server/src/services/system/host-lookup.ts
+++ b/apps/server/src/services/system/host-lookup.ts
@@ -1,5 +1,5 @@
 import type { SystemProvidersQuery } from "@bb/server-contract";
-import type { AppDeps } from "../../types.js";
+import type { WorkSessionDeps } from "../../types.js";
 import { requireEnvironment } from "../lib/entity-lookup.js";
 import {
   assertUsableHostId,
@@ -9,7 +9,7 @@ import {
 export type SystemHostLookupQuery = SystemProvidersQuery;
 
 export function resolveSystemLookupHostId(
-  deps: AppDeps,
+  deps: WorkSessionDeps,
   query: SystemHostLookupQuery,
 ): string {
   if (query.environmentId) {

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -43,6 +43,7 @@ import {
 import { resolvePluginMentionContextInputs } from "../plugins/plugin-mentions.js";
 import { appendClientTurnEventInTransaction } from "./thread-events.js";
 import { getLastProviderThreadId } from "./thread-events.js";
+import { recoverThreadModelOverride } from "./thread-execution-override.js";
 import { ensureThreadCanStartRequest } from "./thread-lifecycle.js";
 import { requireReadyThreadEnvironment } from "./thread-turn-dispatch.js";
 import { resolvePermissionEscalation } from "./thread-runtime-config.js";
@@ -306,6 +307,16 @@ async function sendClaimedQueuedMessageForIdleProviderThread(
   );
   const initiator: ThreadTurnInitiator =
     senderThreadId === null ? "user" : "agent";
+  if (initiator === "user") {
+    await recoverThreadModelOverride(deps, {
+      model: payload.model,
+      modelSource:
+        payload.executionInputSources === undefined
+          ? "explicit"
+          : payload.executionInputSources.model,
+      thread,
+    });
+  }
   const execution = await buildExecutionOptions(
     deps,
     payload,

--- a/apps/server/src/services/threads/thread-execution-override.ts
+++ b/apps/server/src/services/threads/thread-execution-override.ts
@@ -12,11 +12,12 @@ import {
 import {
   reconcileReasoningLevel,
   type AvailableModel,
+  type CallerExecutionInputSource,
   type ReasoningLevel,
   type Thread,
 } from "@bb/domain";
 import { ApiError } from "../../errors.js";
-import type { AppDeps } from "../../types.js";
+import type { LoggedWorkSessionDeps } from "../../types.js";
 import { resolveSystemExecutionOptions } from "../system/execution-options.js";
 import { getLastExecutionOptions } from "./thread-events.js";
 import { getSupportedReasoningLevelsForProvider } from "./thread-reasoning-policy.js";
@@ -72,6 +73,12 @@ export interface ResolveThreadExecutionOverrideUpdateArgs {
 export interface ApplyThreadExecutionOverrideArgs {
   thread: Thread;
   patch: ThreadExecutionOverridePatch;
+}
+
+export interface RecoverThreadModelOverrideArgs {
+  model: string | undefined;
+  modelSource: CallerExecutionInputSource | undefined;
+  thread: Thread;
 }
 
 /**
@@ -157,7 +164,7 @@ export function resolveThreadExecutionOverrideUpdate(
  * `resolveExecutionOptions` + the runtime's `reconfigureThreadIfNeeded`.
  */
 export async function applyThreadExecutionOverride(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   args: ApplyThreadExecutionOverrideArgs,
 ): Promise<void> {
   const { thread, patch } = args;
@@ -191,8 +198,35 @@ export async function applyThreadExecutionOverride(
   });
 }
 
+/**
+ * Replaces a sticky model override when a user explicitly submits a different
+ * model. This is the recovery path for an override whose model was removed:
+ * the replacement is validated against a successfully loaded catalog before
+ * persistence, while a discovery failure remains a retryable 503.
+ */
+export async function recoverThreadModelOverride(
+  deps: LoggedWorkSessionDeps,
+  args: RecoverThreadModelOverrideArgs,
+): Promise<void> {
+  const existing = getThreadExecutionOverride(deps.db, args.thread.id);
+  if (
+    args.model === undefined ||
+    args.modelSource !== "explicit" ||
+    existing?.modelOverride === null ||
+    existing?.modelOverride === undefined ||
+    existing.modelOverride === args.model
+  ) {
+    return;
+  }
+
+  await applyThreadExecutionOverride(deps, {
+    thread: args.thread,
+    patch: { model: args.model },
+  });
+}
+
 async function loadThreadProviderModels(
-  deps: AppDeps,
+  deps: LoggedWorkSessionDeps,
   thread: Thread,
 ): Promise<readonly AvailableModel[]> {
   const result = await resolveSystemExecutionOptions(deps, {
@@ -213,7 +247,10 @@ async function loadThreadProviderModels(
   return [...result.models, ...result.selectedOnlyModels];
 }
 
-function resolveFallbackModel(deps: AppDeps, thread: Thread): string | null {
+function resolveFallbackModel(
+  deps: LoggedWorkSessionDeps,
+  thread: Thread,
+): string | null {
   const lastExecution = getLastExecutionOptions(deps, thread.id);
   if (lastExecution?.model) {
     return lastExecution.model;

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -31,6 +31,7 @@ import {
   createClientTurnRequestId,
   getActiveTurnId,
 } from "./thread-events.js";
+import { recoverThreadModelOverride } from "./thread-execution-override.js";
 import {
   ensureThreadCanStartRequest,
   prepareReadyThreadTurnCommand,
@@ -442,6 +443,16 @@ export async function sendThreadMessage(
     mode === "auto" || mode === "steer"
       ? getActiveTurnId(deps, thread.id)
       : null;
+  if (senderThreadId === null) {
+    await recoverThreadModelOverride(deps, {
+      model: payload.model,
+      modelSource:
+        payload.executionInputSources === undefined
+          ? "explicit"
+          : payload.executionInputSources.model,
+      thread,
+    });
+  }
   const execution = await buildExecutionOptions(
     deps,
     payload,

--- a/apps/server/test/services/threads/thread-model-recovery.test.ts
+++ b/apps/server/test/services/threads/thread-model-recovery.test.ts
@@ -1,0 +1,148 @@
+import { getThreadExecutionOverride, setThreadExecutionOverride } from "@bb/db";
+import { describe, expect, it } from "vitest";
+import { recoverThreadModelOverride } from "../../../src/services/threads/thread-execution-override.js";
+import { resolveExecutionOptions } from "../../../src/services/threads/thread-runtime-config.js";
+import { availableModelFixture } from "../../helpers/available-models.js";
+import { registerProviderHostRpcResponder } from "../../helpers/host-rpc.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedThread,
+} from "../../helpers/seed.js";
+import { withTestHarness } from "../../helpers/test-app.js";
+
+describe("stale model recovery", () => {
+  it("replaces an unavailable sticky override from an explicit available follow-up", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-stale-model-recovery",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/stale-model-recovery",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/stale-model-recovery",
+        status: "ready",
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+        providerId: "claude-code",
+        status: "idle",
+      });
+      setThreadExecutionOverride(harness.db, {
+        threadId: thread.id,
+        modelOverride: "claude-mythos-5",
+        reasoningLevelOverride: "high",
+      });
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelsByProviderId: {
+          "claude-code": {
+            models: [
+              availableModelFixture({
+                model: "claude-opus-4-8[1m]",
+                reasoningLevels: ["low", "medium", "high", "xhigh", "max"],
+              }),
+            ],
+            selectedOnlyModels: [],
+          },
+        },
+      });
+
+      await recoverThreadModelOverride(harness.deps, {
+        model: "claude-opus-4-8[1m]",
+        modelSource: "explicit",
+        thread,
+      });
+
+      expect(getThreadExecutionOverride(harness.db, thread.id)).toEqual({
+        modelOverride: "claude-opus-4-8[1m]",
+        reasoningLevelOverride: "high",
+      });
+      await expect(
+        resolveExecutionOptions(harness.deps, {
+          threadId: thread.id,
+          requestedExecution: { source: "client/turn/requested" },
+        }),
+      ).resolves.toMatchObject({ model: "claude-opus-4-8[1m]" });
+    });
+  });
+
+  it("distinguishes temporary discovery failure from a missing replacement", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-stale-model-errors",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/stale-model-errors",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/stale-model-errors",
+        status: "ready",
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+        providerId: "claude-code",
+        status: "idle",
+      });
+      setThreadExecutionOverride(harness.db, {
+        threadId: thread.id,
+        modelOverride: "claude-mythos-5",
+      });
+      const temporaryFailure = registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelErrorsByProviderId: {
+          "claude-code": {
+            errorCode: "provider_rpc_error",
+            errorMessage: "temporary discovery failure",
+          },
+        },
+      });
+      const recovery = {
+        model: "claude-opus-4-8[1m]",
+        modelSource: "explicit" as const,
+        thread,
+      };
+
+      await expect(
+        recoverThreadModelOverride(harness.deps, recovery),
+      ).rejects.toMatchObject({
+        status: 503,
+        body: { code: "model_catalog_unavailable" },
+      });
+      temporaryFailure.unregister();
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelsByProviderId: {
+          "claude-code": {
+            models: [availableModelFixture({ model: "claude-sonnet-5" })],
+            selectedOnlyModels: [],
+          },
+        },
+      });
+
+      await expect(
+        recoverThreadModelOverride(harness.deps, recovery),
+      ).rejects.toMatchObject({
+        status: 400,
+        body: { code: "invalid_request" },
+      });
+      expect(getThreadExecutionOverride(harness.db, thread.id)).toEqual({
+        modelOverride: "claude-mythos-5",
+        reasoningLevelOverride: null,
+      });
+    });
+  });
+});

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1601,31 +1601,40 @@ describe("bridge", () => {
   });
 
   it("returns the bridge-owned Claude model list from the SDK probe", async () => {
+    const close = vi.fn();
+    queryMock.mockReturnValueOnce({
+      initializationResult: vi.fn().mockResolvedValue({
+        models: [
+          {
+            value: "default",
+            resolvedModel: "claude-opus-4-8[1m]",
+            displayName: "Default (recommended)",
+            description: "Opus 4.8 with 1M context",
+          },
+          {
+            value: "opus[1m]",
+            resolvedModel: "claude-opus-4-8[1m]",
+            displayName: "Opus",
+            description: "Opus 4.8 with 1M context",
+          },
+          {
+            value: "sonnet",
+            resolvedModel: "claude-sonnet-5",
+            displayName: "Sonnet",
+            description: "Sonnet 5",
+          },
+        ],
+      }),
+      close,
+    });
+
     const { models, selectedOnlyModels } = await listClaudeCodeBridgeModels();
     expect(models).toEqual([
-      expect.objectContaining({
-        id: "claude-fable-5",
-        model: "claude-fable-5",
-        displayName: "Fable 5",
-        isDefault: false,
-      }),
-      expect.objectContaining({
-        id: "claude-mythos-5",
-        model: "claude-mythos-5",
-        displayName: "Mythos 5",
-        isDefault: false,
-      }),
       expect.objectContaining({
         id: "claude-opus-4-8[1m]",
         model: "claude-opus-4-8[1m]",
         displayName: "Opus 4.8 (1M)",
         isDefault: true,
-      }),
-      expect.objectContaining({
-        id: "claude-opus-4-7[1m]",
-        model: "claude-opus-4-7[1m]",
-        displayName: "Opus 4.7 (1M)",
-        isDefault: false,
       }),
       expect.objectContaining({
         id: "claude-sonnet-5",
@@ -1635,22 +1644,29 @@ describe("bridge", () => {
       }),
     ]);
     expect(selectedOnlyModels.map((model) => model.model)).toEqual([
-      "claude-sonnet-4-6[1m]",
-      "claude-sonnet-4-6",
-      "claude-haiku-4-5",
-      "claude-opus-4-8",
-      "claude-opus-4-7",
-      "claude-opus-4-6[1m]",
-      "claude-opus-4-6",
-      "best",
-      "fable",
       "opus[1m]",
-      "opus",
-      "sonnet[1m]",
       "sonnet",
-      "haiku",
     ]);
-    expect(queryMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledWith({
+      prompt: ".",
+      options: expect.objectContaining({ maxTurns: 0, persistSession: false }),
+    });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("propagates Claude model discovery failures and closes the probe", async () => {
+    const close = vi.fn();
+    queryMock.mockReturnValueOnce({
+      initializationResult: vi
+        .fn()
+        .mockRejectedValue(new Error("temporary discovery failure")),
+      close,
+    });
+
+    await expect(listClaudeCodeBridgeModels()).rejects.toThrow(
+      "temporary discovery failure",
+    );
+    expect(close).toHaveBeenCalledOnce();
   });
 
   it("exposes the host HOME and CLAUDE settings cascade to the Claude SDK on thread/start", async () => {

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1601,6 +1601,7 @@ describe("bridge", () => {
   });
 
   it("returns the bridge-owned Claude model list from the SDK probe", async () => {
+    const { binDir, executablePath } = createTempClaudeExecutable();
     const close = vi.fn();
     queryMock.mockReturnValueOnce({
       initializationResult: vi.fn().mockResolvedValue({
@@ -1628,7 +1629,9 @@ describe("bridge", () => {
       close,
     });
 
-    const { models, selectedOnlyModels } = await listClaudeCodeBridgeModels();
+    const { models, selectedOnlyModels } = await listClaudeCodeBridgeModels({
+      PATH: binDir,
+    });
     expect(models).toEqual([
       expect.objectContaining({
         id: "claude-opus-4-8[1m]",
@@ -1649,7 +1652,11 @@ describe("bridge", () => {
     ]);
     expect(queryMock).toHaveBeenCalledWith({
       prompt: ".",
-      options: expect.objectContaining({ maxTurns: 0, persistSession: false }),
+      options: expect.objectContaining({
+        maxTurns: 0,
+        pathToClaudeCodeExecutable: executablePath,
+        persistSession: false,
+      }),
     });
     expect(close).toHaveBeenCalledOnce();
   });

--- a/packages/agent-runtime/src/claude-code/bridge/model-list.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/model-list.ts
@@ -1,8 +1,10 @@
 import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
 import type { AvailableModel } from "@bb/domain";
 import { buildClaudeCodeModels } from "../model-list.js";
+import { resolveClaudeCodeExecutable } from "./session-options.js";
 
-function buildModelProbeOptions(): Options {
+function buildModelProbeOptions(env: NodeJS.ProcessEnv): Options {
+  const pathToClaudeCodeExecutable = resolveClaudeCodeExecutable({ env });
   return {
     cwd: process.cwd(),
     maxTurns: 0,
@@ -10,10 +12,13 @@ function buildModelProbeOptions(): Options {
     allowDangerouslySkipPermissions: true,
     permissionMode: "bypassPermissions",
     settingSources: [],
+    ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
   };
 }
 
-export async function listClaudeCodeBridgeModels(): Promise<{
+export async function listClaudeCodeBridgeModels(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{
   models: AvailableModel[];
   selectedOnlyModels: AvailableModel[];
 }> {
@@ -24,7 +29,7 @@ export async function listClaudeCodeBridgeModels(): Promise<{
   // callers can distinguish temporary discovery failure from definite absence.
   const session = query({
     prompt: ".",
-    options: buildModelProbeOptions(),
+    options: buildModelProbeOptions(env),
   });
 
   try {

--- a/packages/agent-runtime/src/claude-code/bridge/model-list.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/model-list.ts
@@ -1,9 +1,36 @@
+import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
 import type { AvailableModel } from "@bb/domain";
-import { listClaudeCodeModels } from "../model-list.js";
+import { buildClaudeCodeModels } from "../model-list.js";
+
+function buildModelProbeOptions(): Options {
+  return {
+    cwd: process.cwd(),
+    maxTurns: 0,
+    persistSession: false,
+    allowDangerouslySkipPermissions: true,
+    permissionMode: "bypassPermissions",
+    settingSources: [],
+  };
+}
 
 export async function listClaudeCodeBridgeModels(): Promise<{
   models: AvailableModel[];
   selectedOnlyModels: AvailableModel[];
 }> {
-  return listClaudeCodeModels();
+  // Claude's initialization response is account-scoped and is the provider's
+  // authoritative list of runnable models. Keep BB's curated labels and
+  // reasoning policy, but only expose entries covered by a discovered value or
+  // its canonical resolved model id. Probe failures intentionally propagate so
+  // callers can distinguish temporary discovery failure from definite absence.
+  const session = query({
+    prompt: ".",
+    options: buildModelProbeOptions(),
+  });
+
+  try {
+    const initialization = await session.initializationResult();
+    return buildClaudeCodeModels(initialization.models);
+  } finally {
+    session.close();
+  }
 }

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -198,7 +198,7 @@ function resolveExecutableOnPath(
   return null;
 }
 
-function resolveClaudeCodeExecutable(
+export function resolveClaudeCodeExecutable(
   args: ResolveClaudeCodeExecutableArgs,
 ): string | null {
   const explicitPath = args.env[CLAUDE_CODE_EXECUTABLE_ENV];

--- a/packages/agent-runtime/src/claude-code/model-list.test.ts
+++ b/packages/agent-runtime/src/claude-code/model-list.test.ts
@@ -1,0 +1,91 @@
+import type { ModelInfo } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it } from "vitest";
+import { buildClaudeCodeModels } from "./model-list.js";
+
+const DISCOVERED_MODELS: ModelInfo[] = [
+  {
+    value: "default",
+    resolvedModel: "claude-opus-4-8[1m]",
+    displayName: "Default (recommended)",
+    description: "Opus 4.8 with 1M context",
+  },
+  {
+    value: "opus[1m]",
+    resolvedModel: "claude-opus-4-8[1m]",
+    displayName: "Opus",
+    description: "Opus 4.8 with 1M context",
+  },
+  {
+    value: "claude-fable-5[1m]",
+    resolvedModel: "claude-fable-5",
+    displayName: "Fable",
+    description: "Fable 5",
+  },
+  {
+    value: "sonnet",
+    resolvedModel: "claude-sonnet-5",
+    displayName: "Sonnet",
+    description: "Sonnet 5",
+  },
+  {
+    value: "haiku",
+    resolvedModel: "claude-haiku-4-5-20251001",
+    displayName: "Haiku",
+    description: "Haiku 4.5",
+  },
+];
+
+describe("buildClaudeCodeModels", () => {
+  it("only exposes curated identifiers covered by account-scoped discovery", () => {
+    const result = buildClaudeCodeModels(DISCOVERED_MODELS);
+
+    expect(result.models.map((model) => model.model)).toEqual([
+      "claude-fable-5",
+      "claude-opus-4-8[1m]",
+      "claude-sonnet-5",
+      "claude-haiku-4-5-20251001",
+    ]);
+    expect(result.models.find((model) => model.isDefault)?.model).toBe(
+      "claude-opus-4-8[1m]",
+    );
+    expect(result.selectedOnlyModels.map((model) => model.model)).toEqual([
+      "opus[1m]",
+      "sonnet",
+      "haiku",
+    ]);
+    expect(
+      [...result.models, ...result.selectedOnlyModels].some(
+        (model) => model.model === "claude-mythos-5",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns an empty catalog when the provider reports no models", () => {
+    expect(buildClaudeCodeModels([])).toEqual({
+      models: [],
+      selectedOnlyModels: [],
+    });
+  });
+
+  it("keeps authoritative models that do not have curated metadata yet", () => {
+    const result = buildClaudeCodeModels([
+      {
+        value: "future",
+        resolvedModel: "claude-future-6",
+        displayName: "Future 6",
+        description: "Newly discovered model",
+        supportsEffort: true,
+        supportedEffortLevels: ["low", "high"],
+      },
+    ]);
+
+    expect(result.models).toEqual([
+      expect.objectContaining({
+        model: "claude-future-6",
+        displayName: "Future 6",
+        isDefault: true,
+        defaultReasoningEffort: "high",
+      }),
+    ]);
+  });
+});

--- a/packages/agent-runtime/src/claude-code/model-list.ts
+++ b/packages/agent-runtime/src/claude-code/model-list.ts
@@ -1,3 +1,4 @@
+import type { ModelInfo } from "@anthropic-ai/claude-agent-sdk";
 import {
   cloneReasoningEfforts,
   HIGH_REASONING_EFFORT,
@@ -248,11 +249,78 @@ function buildCatalogModel(entry: ClaudeCodeCatalogEntry): AvailableModel {
   };
 }
 
-function markDefaultModel(models: AvailableModel[]): AvailableModel[] {
+function buildDiscoveredModel(modelInfo: ModelInfo): AvailableModel {
+  const supportedReasoningEfforts = (
+    modelInfo.supportedEffortLevels?.length
+      ? modelInfo.supportedEffortLevels.flatMap((level) => {
+          switch (level) {
+            case "low":
+              return [LOW_REASONING_EFFORT];
+            case "medium":
+              return [MEDIUM_REASONING_EFFORT];
+            case "high":
+              return [HIGH_REASONING_EFFORT];
+            case "xhigh":
+              return [XHIGH_REASONING_EFFORT, ULTRACODE_REASONING_EFFORT];
+            case "max":
+              return [MAX_REASONING_EFFORT];
+          }
+        })
+      : [LOW_REASONING_EFFORT]
+  ).map((effort) => ({ ...effort }));
+  const supportedLevels = supportedReasoningEfforts.map(
+    (effort) => effort.reasoningEffort,
+  );
+  const defaultReasoningEffort = supportedLevels.includes("high")
+    ? "high"
+    : supportedLevels.includes("medium")
+      ? "medium"
+      : (supportedLevels[0] ?? "low");
+  const model = modelInfo.resolvedModel ?? modelInfo.value;
+  return {
+    id: model,
+    model,
+    displayName: modelInfo.displayName,
+    description: modelInfo.description,
+    supportedReasoningEfforts,
+    defaultReasoningEffort,
+    isDefault: false,
+  };
+}
+
+function modelIsDiscovered(
+  model: string,
+  discoveredModels: readonly ModelInfo[],
+): boolean {
+  return discoveredModels.some(
+    (discovered) =>
+      discovered.value === model || discovered.resolvedModel === model,
+  );
+}
+
+function resolveDiscoveredDefaultModel(
+  discoveredModels: readonly ModelInfo[],
+): string | null {
+  const defaultModel = discoveredModels.find(
+    (model) => model.value === "default",
+  );
+  return defaultModel?.resolvedModel ?? null;
+}
+
+function markDefaultModel(
+  models: AvailableModel[],
+  discoveredModels: readonly ModelInfo[],
+): AvailableModel[] {
+  const discoveredDefault = resolveDiscoveredDefaultModel(discoveredModels);
+  const defaultModel =
+    discoveredDefault &&
+    models.some((model) => model.model === discoveredDefault)
+      ? discoveredDefault
+      : models.some((model) => model.model === DEFAULT_CLAUDE_CODE_MODEL)
+        ? DEFAULT_CLAUDE_CODE_MODEL
+        : models[0]?.model;
   return models.map((model) =>
-    model.model === DEFAULT_CLAUDE_CODE_MODEL
-      ? { ...model, isDefault: true }
-      : model,
+    model.model === defaultModel ? { ...model, isDefault: true } : model,
   );
 }
 
@@ -261,10 +329,33 @@ export interface ListClaudeCodeModelsResult {
   selectedOnlyModels: AvailableModel[];
 }
 
-export function listClaudeCodeModels(): ListClaudeCodeModelsResult {
+export function buildClaudeCodeModels(
+  discoveredModels: readonly ModelInfo[],
+): ListClaudeCodeModelsResult {
+  const models = CLAUDE_CODE_CATALOG.filter((entry) =>
+    modelIsDiscovered(entry.model, discoveredModels),
+  ).map(buildCatalogModel);
+  // Discovery can move faster than BB's curated labels. Preserve those new
+  // authoritative rows instead of returning an empty/partial picker until the
+  // static metadata catches up. Prefer non-"default" rows so aliases carrying
+  // the same resolved id provide the useful provider label.
+  for (const discovered of [
+    ...discoveredModels.filter((model) => model.value !== "default"),
+    ...discoveredModels.filter((model) => model.value === "default"),
+  ]) {
+    const resolvedModel = discovered.resolvedModel ?? discovered.value;
+    if (models.some((model) => model.model === resolvedModel)) {
+      continue;
+    }
+    models.push(buildDiscoveredModel(discovered));
+  }
+  const selectedOnlyModels = CLAUDE_CODE_SELECTED_ONLY_CATALOG.filter(
+    (entry) =>
+      modelIsDiscovered(entry.model, discoveredModels) &&
+      !models.some((model) => model.model === entry.model),
+  ).map(buildCatalogModel);
   return {
-    models: markDefaultModel(CLAUDE_CODE_CATALOG.map(buildCatalogModel)),
-    selectedOnlyModels:
-      CLAUDE_CODE_SELECTED_ONLY_CATALOG.map(buildCatalogModel),
+    models: markDefaultModel(models, discoveredModels),
+    selectedOnlyModels,
   };
 }

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -311,7 +311,11 @@ function waitForJsonRpcResponse({ childProcess, id, label, output }) {
   });
 }
 
-async function smokeBridgeModelList({ bridgePath, label }) {
+async function smokeBridgeModelList({
+  allowUnavailableProvider = false,
+  bridgePath,
+  label,
+}) {
   const childProcess = spawn(process.execPath, [bridgePath], {
     cwd: tempRoot,
     stdio: ["pipe", "pipe", "pipe"],
@@ -349,10 +353,21 @@ async function smokeBridgeModelList({ bridgePath, label }) {
   }
 
   if (
-    !("result" in modelListResponse) ||
-    !isRecord(modelListResponse.result) ||
-    !Array.isArray(modelListResponse.result.models)
+    "result" in modelListResponse &&
+    isRecord(modelListResponse.result) &&
+    Array.isArray(modelListResponse.result.models)
   ) {
+    return;
+  }
+
+  const unavailableProviderMessage =
+    "error" in modelListResponse &&
+    isRecord(modelListResponse.error) &&
+    typeof modelListResponse.error.message === "string" &&
+    /(?:Native CLI binary|Claude Code executable).*not found/u.test(
+      modelListResponse.error.message,
+    );
+  if (!allowUnavailableProvider || !unavailableProviderMessage) {
     throw new Error(
       `${label} did not return a model/list response\n${formatProcessOutput(output)}`,
     );
@@ -362,6 +377,10 @@ async function smokeBridgeModelList({ bridgePath, label }) {
 async function smokeProviderBridgeBundles(tarballPath) {
   const packageDir = await extractTarball(tarballPath);
   await smokeBridgeModelList({
+    // The packaged bridge intentionally relies on the host's Claude CLI for
+    // account-scoped discovery. CI does not install that provider binary, so
+    // its explicit unavailable-provider response is a valid smoke outcome.
+    allowUnavailableProvider: true,
     bridgePath: join(
       packageDir,
       "host-daemon",

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 61 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 62 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,


### PR DESCRIPTION
## Summary

- make Claude Code model discovery account-authoritative by filtering BB's curated catalog against the SDK initialization response, while preserving newly discovered provider rows
- recover existing threads and new-thread project defaults when a stored model is definitively absent, without replacing a selection during temporary discovery failure
- validate and persist explicit user recovery over stale sticky model overrides for direct and queued follow-ups
- bump the host daemon protocol because `provider.list_models` semantics changed

## Root cause

BB had replaced Claude's SDK model probe with a static active catalog. That catalog included `claude-mythos-5` for “Project Glasswing access,” so Mythos appeared for accounts whose authoritative SDK catalog did not contain it. A live SDK probe reproduced that mismatch: the account reported Fable, Opus, Sonnet, and Haiku, but not Mythos.

After Mythos was submitted, `client/turn/requested.execution.model` (or a sticky `threads.model_override`) persisted it. On the next render the app saw that the id was missing and displayed the catalog default, but because the user had not touched the fallback, `executionInputSources.model` was omitted. The server therefore discarded the displayed Opus value and resumed with the stale Mythos id. This explains the issue screenshot showing Opus in the composer while every provider error still named `claude-mythos-5`.

The fix treats a missing model as definitive only after successful discovery. That fallback is sent explicitly, and a stale sticky override is replaced only after live-catalog validation. Discovery failures stay retryable (`503 model_catalog_unavailable`); a successfully loaded catalog that lacks the requested replacement returns `400 invalid_request`.

## Validation

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- src/claude-code/model-list.test.ts src/claude-code/bridge/__tests__/bridge.test.ts` (61 passed)
- `pnpm exec turbo run test --filter=@bb/app --force -- src/hooks/useThreadCreationOptions.test.tsx` (8 passed)
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/threads/thread-model-recovery.test.ts test/services/threads/thread-execution-override.test.ts test/public/public-threads.execution-override.test.ts` (14 passed)
- full `@bb/app` suite (1,853 passed)
- full `@bb/agent-runtime` (39 files), `@bb/host-daemon` (41 files), and `@bb/host-daemon-contract` (3 files) suites passed
- Turbo typechecks passed for `@bb/agent-runtime`, `@bb/app`, `@bb/server`, `@bb/host-daemon`, and `@bb/host-daemon-contract`
- full `@bb/server` suite: 1,194/1,196 passed; unrelated failures were an umask-sensitive skill-tree fixture mode assertion (expected 0644, environment created 0664; reproduced alone) and a host-management timeout that passed on isolated rerun

Closes #832