### PR TITLE
Ensure daemons exit after startup failure

### DIFF
--- a/apps/host-daemon/src/daemon.test.ts
+++ b/apps/host-daemon/src/daemon.test.ts
@@ -102,6 +102,59 @@ describe("daemon lifecycle", () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
+  it("cleans up fully when startup fails so a service manager can restart it", async () => {
+    const logger = createLogger();
+    const startupFailure = new Error("server unavailable");
+    const shutdownRuntimes = vi.fn(async () => undefined);
+    const releaseLock = vi.fn(async () => undefined);
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      onStart: async () => {
+        throw startupFailure;
+      },
+      releaseLock,
+      shutdownRuntimes,
+    });
+
+    await expect(daemon.start()).rejects.toBe(startupFailure);
+    await expect(daemon.waitUntilStopped()).resolves.toBeUndefined();
+
+    expect(shutdownRuntimes).toHaveBeenCalledOnce();
+    expect(releaseLock).toHaveBeenCalledOnce();
+    expect(logger.info).toHaveBeenCalledWith(
+      { mode: "shutdown", reason: "startup-failed" },
+      "Shutting down host daemon",
+    );
+  });
+
+  it("preserves the startup error when startup cleanup also fails", async () => {
+    const logger = createLogger();
+    const startupFailure = new Error("server unavailable");
+    const cleanupFailure = new Error("cleanup failed");
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      onStart: async () => {
+        throw startupFailure;
+      },
+      releaseLock: async () => {
+        throw cleanupFailure;
+      },
+    });
+
+    await expect(daemon.start()).rejects.toBe(startupFailure);
+    await expect(daemon.waitUntilStopped()).rejects.toBe(cleanupFailure);
+  });
+
   it("rejects direct shutdown and waitUntilStopped when shutdown cleanup fails", async () => {
     const logger = createLogger();
     const shutdownFailure = new Error("release failed");

--- a/apps/host-daemon/src/daemon.ts
+++ b/apps/host-daemon/src/daemon.ts
@@ -140,7 +140,11 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
           "Host daemon started",
         );
       } catch (error) {
-        unregisterSignalHandlers();
+        // A failed connection attempt happens after the app has opened its
+        // local API and started background monitors/watchers. Run the same
+        // cleanup as an ordinary shutdown so the process can actually exit
+        // and its service manager can restart it.
+        await stop("startup-failed").catch(() => undefined);
         throw error;
       }
     },

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -288,9 +288,13 @@ export async function startHostDaemon(
     await app.daemon.start();
     return app.daemon;
   } catch (error) {
-    await app?.localApi?.close().catch(() => undefined);
-    await machineAuthProxy?.close().catch(() => undefined);
-    await releaseLock().catch(() => undefined);
+    // Once the app exists, daemon.start() owns startup-failure cleanup through
+    // the normal shutdown lifecycle. Before that point, release the resources
+    // acquired directly by this function.
+    if (!app) {
+      await machineAuthProxy?.close().catch(() => undefined);
+      await releaseLock().catch(() => undefined);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

- run the full daemon shutdown lifecycle when the initial server connection fails
- release watchers, timers, local API state, and the daemon lock so launchd/systemd can restart the process
- preserve the original startup error even if cleanup also fails

## Validation

- pnpm exec turbo run test --filter=@bb/host-daemon --only --force (450 passed)
- pnpm exec turbo run typecheck --filter=@bb/host-daemon --only --force
- reproduced recovery on the affected MacBook Air and MacBook Pro; both protocol-62 daemons reconnected after launchd kickstart

## Notes

The ordinary Turbo dependency path is currently blocked by the repository native-module bootstrap segfaulting under both Node 24 and Node 26. The package test and typecheck tasks themselves pass through Turbo with --only.