### PR TITLE
Render plugin banners above queued messages

### DIFF
--- a/apps/app/src/components/plugin/PluginComposerBanners.tsx
+++ b/apps/app/src/components/plugin/PluginComposerBanners.tsx
@@ -9,7 +9,7 @@ import {
 } from "./plugin-composer-host";
 import { composerCustomizationsForScope } from "./composer-customizations";
 
-/** Plugin banner rows rendered at the bottom of a composer's measured stack. */
+/** Plugin banner rows rendered above a composer's native measured stack. */
 export function PluginComposerBanners({ view }: { view?: ComposerView }) {
   return view === undefined ? (
     <PluginComposerBannerRows />

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -312,6 +312,53 @@ describe("FollowUpPromptBox", () => {
     );
   });
 
+  it("renders plugin banners above native stack content", () => {
+    setPluginSlotRegistrations("ordered-banner", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [],
+      threadPanelActions: [],
+      composerCustomizations: [
+        {
+          id: "ordered",
+          banners: [
+            {
+              id: "header",
+              component: () => <div data-testid="plugin-header">Header</div>,
+            },
+          ],
+        },
+      ],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+    const draft = { text: "Follow up", mentions: [], attachments: [] };
+    const props = createFollowUpPromptBoxProps({ kind: "ready" });
+    render(
+      <FollowUpPromptBox
+        {...props}
+        stack={<div data-testid="queued-messages">Queued messages</div>}
+        pluginComposerHost={{
+          scope: { kind: "thread", threadId: "thr_test" },
+          draft,
+          textEffectKey: "thread:thr_test",
+          getCurrent: () => draft,
+          setDraft: vi.fn(),
+          focus: vi.fn(),
+        }}
+        pluginComposerScope={{ kind: "thread", threadId: "thr_test" }}
+      />,
+    );
+
+    const pluginHeaderRoot = screen
+      .getByTestId("plugin-header")
+      .closest("[data-bb-plugin-root]");
+    const queuedMessages = screen.getByTestId("queued-messages");
+    expect(queuedMessages.previousElementSibling).toBe(pluginHeaderRoot);
+  });
+
   it("moves one stateful composer between the bottom and inline targets without remounting", () => {
     const target = document.createElement("div");
     target.setAttribute("data-test-composer-target", "");

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -266,8 +266,8 @@ function FollowUpPromptBoxStackOnly({
       <PluginComposerHostProvider value={pluginComposerHost ?? null}>
         <div data-promptbox-shell="" className="space-y-2">
           <div className="space-y-2">
-            {stack}
             {composerScope ? <PluginComposerBanners /> : null}
+            {stack}
           </div>
         </div>
       </PluginComposerHostProvider>
@@ -680,10 +680,10 @@ function FollowUpPromptBoxWithComposer({
             className="space-y-2"
           >
             <div ref={stackRef} className="space-y-2">
-              {stack}
               {composerScope && !composerTarget ? (
                 <PluginComposerBanners />
               ) : null}
+              {stack}
             </div>
             <div
               ref={bottomComposerAnchorRef}


### PR DESCRIPTION
## Summary
- render plugin composer banners before the native composer stack
- keep queued-message inline-edit banners adjacent to their inline composer
- add a regression test for plugin banner and queued-message ordering

## Testing
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/FollowUpPromptBox.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- live browser QA with the composer-customization sample plugin and two queued messages