### PR TITLE
Fix Node 20 plugin manifest generation

### DIFF
--- a/packages/plugin-build/scripts/generate-runtime-export-manifest.mjs
+++ b/packages/plugin-build/scripts/generate-runtime-export-manifest.mjs
@@ -12,6 +12,17 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { build } from "esbuild";
 
+// Node 20 does not expose the browser-compatible Navigator global added in
+// later Node releases. Some shared browser runtimes (currently @pierre/diffs)
+// read navigator.userAgent during module initialization, so give export
+// introspection the same minimal environment on every supported Node version.
+if (typeof globalThis.navigator === "undefined") {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { userAgent: "node" },
+  });
+}
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 // Resolve React exactly as the host app does — apps/app owns the runtime the
 // shims will read at load time.

--- a/packages/plugin-build/src/runtime-export-manifest.test.ts
+++ b/packages/plugin-build/src/runtime-export-manifest.test.ts
@@ -1,0 +1,30 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("runtime export manifest generator", () => {
+  it("runs when Node does not provide a global Navigator", async () => {
+    const scriptUrl = new URL(
+      "../scripts/generate-runtime-export-manifest.mjs",
+      import.meta.url,
+    ).href;
+    const source = `
+      delete globalThis.navigator;
+      if (typeof globalThis.navigator !== "undefined") {
+        throw new Error("test could not remove globalThis.navigator");
+      }
+      process.argv.push("--check");
+      await import(${JSON.stringify(scriptUrl)});
+    `;
+
+    const result = await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "--eval", source],
+      { timeout: 30_000 },
+    );
+
+    expect(result.stdout).toContain("runtime-export-manifest.ts");
+  });
+});


### PR DESCRIPTION
## Summary

- provide a minimal `navigator.userAgent` shim while introspecting browser runtime exports on Node 20
- add a regression test that runs manifest generation without a global Navigator

## Tests

- `pnpm exec turbo run test --filter=@bb/plugin-build --force`
- `pnpm exec turbo run typecheck --filter=@bb/plugin-build --force`
- full `bb-app` tarball smoke with `NODE_OPTIONS=--no-experimental-global-navigator`
- manifest generation with Node 20.20.2