### PR TITLE
Steer hidden workflow completion notifications

### DIFF
--- a/plugins/workflows/README.md
+++ b/plugins/workflows/README.md
@@ -132,14 +132,17 @@ Workflows declares six plugin settings:
 changes how many queued runs the worker may claim. The other five values are
 snapshotted into each new run and remain fixed for that run, including a resumed
 run. Saving settings does not require a plugin reload.
-Polling the compact `status` summary remains authoritative when a completion message is truncated
-or temporarily cannot be delivered. Completion delivery is at-least-once: a
-successful `threads.send` followed by a crash before its durable acknowledgement
-may produce a duplicate because the API has no idempotency key. Duplicates carry
-the same stable run ID marker. Failed attempts use durable, capped exponential
-backoff. Status exposes notification outcome as `pending`, `delivered`, or
-`abandoned`; a missing or deleted origin permanently records `abandoned` so it
-cannot block retention.
+Terminal runs send an agent-only completion input back to the origin thread. It
+steers an active origin immediately or starts a turn when the origin is idle,
+while remaining absent from the user-facing timeline and search. Polling the
+compact `status` summary remains authoritative when a completion message is
+truncated or temporarily cannot be delivered. Completion delivery is
+at-least-once: a successful `threads.send` followed by a crash before its durable
+acknowledgement may produce a duplicate because the API has no idempotency key.
+Duplicates carry the same stable run ID marker. Failed attempts use durable,
+capped exponential backoff. Status exposes notification outcome as `pending`,
+`delivered`, or `abandoned`; a missing or deleted origin permanently records
+`abandoned` so it cannot block retention.
 
 Useful checks:
 

--- a/plugins/workflows/skills/workflows/SKILL.md
+++ b/plugins/workflows/skills/workflows/SKILL.md
@@ -414,10 +414,11 @@ Plugin-bundled workflow discovery is not supported.
 `bb_workflow_run` also accepts optional JSON `args` and optional `resumeRunId`.
 It returns a durable run ID immediately. Use the compact `bb workflows status`
 summary, paged `bb workflows history`, `bb workflows list`, and
-`bb workflows stop` afterward. Completion is queued
-back to the origin thread, so an active origin is not interrupted. Delivery is
-duplicate-tolerant at-least-once because `threads.send` has no idempotency key.
-CLI status polling remains authoritative.
+`bb workflows stop` afterward. Completion is sent back as an agent-only input:
+it steers an active origin immediately or starts a turn when the origin is idle,
+without rendering a user-facing message. Delivery is duplicate-tolerant
+at-least-once because `threads.send` has no idempotency key. CLI status polling
+remains authoritative.
 
 `list` also returns compact summaries; it is safe for discovery but is not a
 substitute for the redirected detailed history.

--- a/plugins/workflows/src/server-harness.test.ts
+++ b/plugins/workflows/src/server-harness.test.ts
@@ -336,6 +336,19 @@ describe("workflows plugin", () => {
     await eventually(() => {
       expect(harness.sdk.callsTo("threads.send")).toHaveLength(1);
     });
+    expect(harness.sdk.callsTo("threads.send")[0]?.[0]).toMatchObject({
+      threadId: "thread-test",
+      mode: "steer-if-active",
+      input: [
+        {
+          type: "text",
+          text: expect.stringContaining(
+            `[BB workflow finished · ${started.runId}]`,
+          ),
+          visibility: "agent-only",
+        },
+      ],
+    });
 
     await expect(workflowStatus(harness, started.runId)).resolves.toMatchObject(
       {

--- a/plugins/workflows/src/service.ts
+++ b/plugins/workflows/src/service.ts
@@ -1137,7 +1137,7 @@ export function createWorkflowService(
     try {
       await bb.sdk.threads.send({
         threadId: latest.originThreadId,
-        mode: "queue-if-active",
+        mode: "steer-if-active",
         input: [
           {
             type: "text",
@@ -1146,6 +1146,7 @@ export function createWorkflowService(
               settings.maxNotificationBytes,
             ),
             mentions: [],
+            visibility: "agent-only",
           },
         ],
       });


### PR DESCRIPTION
## Summary

- deliver workflow completion context as an agent-only prompt input
- steer active origin threads immediately instead of queueing completion
- document the hidden completion behavior and cover it with a plugin regression test

## Validation

- `pnpm exec turbo run test --filter=bb-plugin-workflows --force` (213 tests)
- `pnpm exec turbo run typecheck --filter=bb-plugin-workflows`

## Risk

Low. The change is confined to the workflows plugin completion-delivery payload; durable retry and notification accounting are unchanged.