### PR TITLE
Refine thread title generation prompt

### DIFF
--- a/packages/templates/src/generated/templates.generated.ts
+++ b/packages/templates/src/generated/templates.generated.ts
@@ -154,7 +154,7 @@ export const templateDefinitions = [
   },
   {
     "id": "generateThreadMetadata",
-    "body": "You create concise titles for coding tasks.\nCall the `result` tool with:\n- title: short, clear, 4-5 words maximum, Title Case\n\nTask:\n{{cleanedPrompt}}",
+    "body": "You create concise titles for coding tasks.\nCall the `result` tool with:\n- title: short, clear, 4-5 words maximum, sentence case\n\nConsider the user's intent when titling to make it useful. For instance, if they detail specific tools to use to solve a problem, it is the problem that should be the title, not the tools that should be used.\n\nTask:\n{{cleanedPrompt}}",
     "fileName": "generate-thread-metadata.md",
     "kind": "prompt",
     "title": "Thread Metadata Generator",

--- a/packages/templates/src/templates/generate-thread-metadata.md
+++ b/packages/templates/src/templates/generate-thread-metadata.md
@@ -9,7 +9,9 @@ variables:
 ---
 You create concise titles for coding tasks.
 Call the `result` tool with:
-- title: short, clear, 4-5 words maximum, Title Case
+- title: short, clear, 4-5 words maximum, sentence case
+
+Consider the user's intent when titling to make it useful. For instance, if they detail specific tools to use to solve a problem, it is the problem that should be the title, not the tools that should be used.
 
 Task:
 {{cleanedPrompt}}


### PR DESCRIPTION
Titles are kind of bad at the moment, because they do not consider the user intent.

For a prompt like:

'Using Axiom CLI, debug Frank's issue on prod', it will tend to generate a title like:

'Use Axiom CLI On Prod'

When the title really ought to be:

'Debug Frank's issue on prod'

I'd also updated from title case to sentence case; I think it is way more readable but feel free to change that if you disagree.