### PR TITLE
Restore the automations panel page frame

### DIFF
--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -685,8 +685,6 @@ function AutomationsToolView() {
       : new URLSearchParams(location.search).get("view") === "browse"
         ? "browse"
         : "";
-  const isCollection = !(projectId && automationId);
-
   if (panel === null) {
     return (
       <ToolsScrollPage maxWidthClassName="max-w-3xl">
@@ -720,7 +718,11 @@ function AutomationsToolView() {
       </WorkerPoolContextProvider>
     );
 
-  return <ToolsScrollPage fillViewport={isCollection}>{mount}</ToolsScrollPage>;
+  // No `ToolsScrollPage` here: the automations panel is a plugin nav panel, and
+  // nav panels own their page padding, max width, and scrolling so they render
+  // the same on this route and on the /plugins panel route. Wrapping it again
+  // would double the page padding.
+  return <div className="relative h-full overflow-hidden">{mount}</div>;
 }
 
 export function PluginDetail({

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -1116,6 +1116,37 @@ function DetailView({
 // Panel root — routes between overview and detail by subPath.
 // ---------------------------------------------------------------------------
 
+/**
+ * The panel's own page frame. The host mounts nav panels full-bleed with zero
+ * padding, so page padding, max width, and page scrolling belong to the
+ * plugin — otherwise the panel renders edge to edge at the full window width
+ * wherever the host does not wrap it (the /plugins panel route).
+ *
+ * `fill` pins the content box to the viewport for the collection, whose
+ * toolbar and pagination stay put while its own viewport scrolls; the detail
+ * route scrolls this frame instead.
+ */
+function AutomationsPageFrame({
+  fill,
+  children,
+}: {
+  fill: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="h-full min-h-0 flex-1 overflow-y-auto">
+      <div
+        className={cn(
+          "mx-auto box-border min-h-full w-full max-w-5xl px-4 pb-4 pt-3 md:px-5 md:pt-4",
+          fill && "h-full",
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function AutomationsPanel({ subPath }: PluginNavPanelProps) {
   const navigate = useBbNavigate();
   const parsedRoute = useMemo(() => parseSubPath(subPath), [subPath]);
@@ -1144,19 +1175,23 @@ function AutomationsPanel({ subPath }: PluginNavPanelProps) {
   );
   if (parsedRoute !== null) {
     return (
-      <DetailView
-        route={parsedRoute.route}
-        initialEditing={parsedRoute.editing}
-        onBack={backToList}
-      />
+      <AutomationsPageFrame fill={false}>
+        <DetailView
+          route={parsedRoute.route}
+          initialEditing={parsedRoute.editing}
+          onBack={backToList}
+        />
+      </AutomationsPageFrame>
     );
   }
   return (
-    <OverviewView
-      onOpenDetail={openDetail}
-      activeMode={collectionMode}
-      onModeChange={changeCollectionMode}
-    />
+    <AutomationsPageFrame fill>
+      <OverviewView
+        onOpenDetail={openDetail}
+        activeMode={collectionMode}
+        onModeChange={changeCollectionMode}
+      />
+    </AutomationsPageFrame>
   );
 }
 


### PR DESCRIPTION
## What broke

The automations page is a plugin nav panel, and the host mounts nav panels full-bleed with zero padding — `PluginPanelView` cancels the route padding (`-m-4 md:-m-5`) because plugins opt into their own padding and scrolling.

Before #845 the plugin supplied that frame itself (`min-h-0 flex-1 overflow-y-auto p-4 md:p-5` plus an inner `mx-auto max-w-3xl`). The Tools Hub rewrite dropped it and let the new experiment-gated `/tools/automations` route supply the frame instead, via `ToolsScrollPage` (`mx-auto max-w-5xl`, page padding, scroll container).

So the frame only existed on the experiment path. With `toolsHub` off, the sidebar row points at `/plugins/automations/automations` → `PluginPanelView` → no padding, no max width: the collection and detail routes rendered flush to the window edge, stretched across the full window width.

## What changed

- `plugins/automations/app.tsx` — added `AutomationsPageFrame`: scroll container plus `mx-auto max-w-5xl px-4 pb-4 pt-3 md:px-5 md:pt-4`, with `h-full` for the collection so its toolbar and pagination stay pinned while its own viewport scrolls. The detail route scrolls the frame.
- `apps/app/src/views/ToolsView.tsx` — `AutomationsToolView` no longer wraps the mount in `ToolsScrollPage` (that would double the page padding); it renders the structurally identical bare `relative h-full overflow-hidden` container.

Both routes now render the panel identically. Note this restores the page framing, not the pre-#845 list design — the new collection UI is the plugin's own UI and is not experiment-gated (plugin apps cannot read experiment flags).

One deliberate tradeoff: `ToolsScrollPage`'s top/bottom overflow fades no longer apply to the automations detail route in Tools Hub, since the plugin now owns scrolling.

## Verification

- `turbo run typecheck test lint --filter=@bb/app --filter=bb-plugin-automations` all pass (lint has pre-existing warnings only).
- Built the plugin bundle and confirmed the new utilities (`max-w-5xl`, `min-h-full`, `box-border`, `pt-3`) are emitted into `dist/app.css` by the plugin Tailwind pass.
- Ran a dev server with `toolsHub` off, seeded a project and three automations, and confirmed the served bundle carries the fix. No headless browser was available in the environment, so the rendered page was reviewed by the requester rather than screenshotted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)