### PR TITLE
Use gpt-5.6-luna for server-side helper inference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Use `bb-app config` for non-secret bb settings:
 
 ```bash
 npx bb-app config set BB_APP_URL http://<machine>.<tailnet>.ts.net:38886
-npx bb-app config set BB_INFERENCE codex/gpt-5.4-mini
+npx bb-app config set BB_INFERENCE codex/gpt-5.6-luna
 npx bb-app config set BB_TRANSCRIPTION codex/gpt-4o-mini-transcribe
 npx bb-app config list
 npx bb-app config unset BB_APP_URL
@@ -81,7 +81,7 @@ starts.
 | Key                | Command         | When to set             | Used for                                                                                                                                       |
 | ------------------ | --------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BB_APP_URL`       | `bb-app config` | Optional for remote use | Human-facing app URL used for generated links and allowed browser origins. Leave empty for local-only use.                                     |
-| `BB_INFERENCE`     | `bb-app config` | Optional                | Server-side helper model in `provider/model` format. Defaults to `codex/gpt-5.4-mini`.                                                         |
+| `BB_INFERENCE`     | `bb-app config` | Optional                | Server-side helper model in `provider/model` format. Defaults to `codex/gpt-5.6-luna`.                                                         |
 | `BB_TRANSCRIPTION` | `bb-app config` | Optional                | Voice transcription model in `provider/model` format. Defaults to `codex/gpt-4o-mini-transcribe`.                                              |
 | `BB_SERVER_URL`    | `bb-app config` | Remote CLI/host use     | Server URL for standalone `bb` CLI and `host-daemon` commands on the current machine. The CLI defaults to `http://127.0.0.1:38886` when unset. |
 | `BB_LOG_LEVEL`     | `bb-app config` | Debugging               | Log level for the next bb start: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`.                                                        |

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -131,7 +131,7 @@ Use `bb-app config` for persistent non-secret package settings under
 
 ```bash
 npx bb-app config set BB_APP_URL http://<machine>.<tailnet>.ts.net:38886
-npx bb-app config set BB_INFERENCE codex/gpt-5.4-mini
+npx bb-app config set BB_INFERENCE codex/gpt-5.6-luna
 npx bb-app config set BB_TRANSCRIPTION codex/gpt-4o-mini-transcribe
 npx bb-app config list
 npx bb-app config refresh

--- a/packages/config/src/defaults.ts
+++ b/packages/config/src/defaults.ts
@@ -9,6 +9,6 @@ export const DEFAULTS = {
   appVersion: "0.0.0-dev",
   logLevel: { prod: "info", dev: "debug" },
   secretToken: { dev: "dev-secret" },
-  inferenceModel: "codex/gpt-5.4-mini",
+  inferenceModel: "codex/gpt-5.6-luna",
   transcriptionModel: "codex/gpt-4o-mini-transcribe",
 } as const;

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -303,7 +303,7 @@ describe("consumer-specific config", () => {
     expect(serverConfig.BB_APP_SURFACE).toBe("web");
     expect(serverConfig.BB_APP_VERSION).toBe("0.0.0-dev");
     expect(serverConfig.BB_EXTERNAL_URL).toBe("");
-    expect(serverConfig.BB_INFERENCE).toBe("codex/gpt-5.4-mini");
+    expect(serverConfig.BB_INFERENCE).toBe("codex/gpt-5.6-luna");
     expect(serverConfig.BB_TRANSCRIPTION).toBe("codex/gpt-4o-mini-transcribe");
     expect(serverConfig.OPENAI_API_KEY).toBe("test-openai-key");
     expect(serverConfig.featureFlags).toEqual({ placeholder: false });


### PR DESCRIPTION
## Summary

Bumps the `BB_INFERENCE` default from `codex/gpt-5.4-mini` to `codex/gpt-5.6-luna`.

The model backing thread title generation is not hardcoded in the title code — it resolves through `config.inferenceModel` (managed `BB_INFERENCE` → env `BB_INFERENCE` → `DEFAULTS.inferenceModel`), so this is a one-line default change plus its documented surfaces.

- `packages/config/src/defaults.ts` — the default itself
- `packages/config/test/config.test.ts` — default assertion
- `docs/configuration.md`, `packages/bb-app/README.md` — documented default

Codex model IDs are parsed dynamically from `model/list` (`packages/agent-runtime/src/codex/models.ts`), so there is no model catalog to update; the ID passes straight through to the `codex.inference.complete` host command.

## Scope note

`BB_INFERENCE` has exactly two callers, so **both** move to gpt-5.6-luna:

- `apps/server/src/services/threads/title-generation.ts` (thread titles)
- `apps/server/src/services/ai/commit-message.ts` (commit messages)

There is no title-specific knob today, and adding one would mean a new env var plus CLI/SDK/doc surfaces. Flagging in case commit messages should stay on the previous model.

## Tests

- `pnpm exec turbo run typecheck test --filter=@bb/config` — typecheck clean, 83/83 pass.
- `pnpm exec turbo run test --filter=@bb/server` — 1247/1248 pass. The one failure, `test/internal/internal-skill-trees.test.ts`, is **pre-existing and unrelated**: it asserts file mode `420` (`0o644`) but gets `436` (`0o664`) because my local `umask` is `0002`. Verified it fails identically with this branch's changes stashed.

Verified end to end against a local dev server, first confirming no `BB_INFERENCE` override was present (env files, dev data dir, `~/.bb/config.json`, shell) so the runs genuinely exercised the new default. Three threads spawned with no title:

| Prompt | Generated title |
| --- | --- |
| Add a retry helper for flaky network calls in the uploader | Add uploader network retry helper |
| Fix the pagination bug on the settings audit page | Fix settings audit pagination |
| Document the websocket reconnect strategy for enrolled machines | Document websocket reconnect strategy |

All ≤5 words and sentence case, consistent with the prompt refined in #847.

## Risks

Observed inference latencies were 2523ms (first, cold), 1302ms, 1287ms. Steady state sits well inside the 2.5s × 2-attempt budget in `thread-metadata-inference.ts`, but the cold call exceeded 2500ms and would have burned one attempt under managed provisioning. It recovers on retry, so no timeout change is included here — flagging rather than pre-emptively tuning product policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)