### PR TITLE
Let Claude workflows run without blocking the composer

### DIFF
--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -281,6 +281,9 @@ function createFakeRuntime(): AgentRuntime {
     getActiveThreadIds() {
       return [];
     },
+    hasOpenBackgroundWork() {
+      return false;
+    },
     async shutdown() {},
   };
 }

--- a/apps/host-daemon/src/command-dispatch-support.test.ts
+++ b/apps/host-daemon/src/command-dispatch-support.test.ts
@@ -84,6 +84,9 @@ function makeRuntime(args: MakeRuntimeArgs): AgentRuntime {
     getActiveThreadIds() {
       return [];
     },
+    hasOpenBackgroundWork() {
+      return false;
+    },
     shutdown: args.shutdown,
   };
 }

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -202,6 +202,7 @@ function createRuntime(): FakeDispatchRuntime {
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: (threadId) => hostedThreadIds.has(threadId),
     getActiveThreadIds: () => [...activeTurnsByThreadId.keys()],
+    hasOpenBackgroundWork: () => false,
     shutdown: vi.fn(async () => undefined),
     setActiveTurn: (threadId, turnId) => {
       hostedThreadIds.add(threadId);

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -244,10 +244,12 @@ interface FakeAgentRuntime extends AgentRuntime {
   /** Test-only mutators for the runtime-owned per-thread turn state. */
   endActiveTurn: (threadId: string) => void;
   setActiveTurn: (threadId: string, turnId: string) => void;
+  setOpenBackgroundWork: (hasOpenWork: boolean) => void;
 }
 
 function createFakeRuntime() {
   const activeTurnsByThreadId = new Map<string, string>();
+  let openBackgroundWork = false;
   return {
     ensureProvider: vi.fn(async (_args: EnsureProviderArgs) => undefined),
     startThread: vi.fn(async (_args: StartThreadArgs) => ({
@@ -279,12 +281,16 @@ function createFakeRuntime() {
     ),
     hasThread: (threadId) => activeTurnsByThreadId.has(threadId),
     getActiveThreadIds: () => [...activeTurnsByThreadId.keys()],
+    hasOpenBackgroundWork: () => openBackgroundWork,
     shutdown: vi.fn(async () => undefined),
     endActiveTurn: (threadId) => {
       activeTurnsByThreadId.delete(threadId);
     },
     setActiveTurn: (threadId, turnId) => {
       activeTurnsByThreadId.set(threadId, turnId);
+    },
+    setOpenBackgroundWork: (hasOpenWork) => {
+      openBackgroundWork = hasOpenWork;
     },
   } satisfies FakeAgentRuntime;
 }
@@ -1298,6 +1304,41 @@ describe("RuntimeManager", () => {
       }),
     );
     expect(secondRuntime.shutdown).not.toHaveBeenCalled();
+  });
+
+  it("keeps an environment runtime while a background task is still open", async () => {
+    const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
+    const runtime = createFakeRuntime();
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      createRuntime: () => runtime,
+      shellEnv: {
+        PATH: "/old/bin:/usr/bin",
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+    // A workflow outlives its turn, so the runtime has no active turn while it
+    // runs. Evicting here would SIGTERM the provider process running it.
+    runtime.setOpenBackgroundWork(true);
+
+    await manager.replaceBaseShellEnv({
+      PATH: "/new/bin:/usr/bin",
+    });
+
+    expect(manager.get("env-1")?.runtime).toBe(runtime);
+    expect(runtime.shutdown).not.toHaveBeenCalled();
+
+    runtime.setOpenBackgroundWork(false);
+    await manager.replaceBaseShellEnv({
+      PATH: "/newer/bin:/usr/bin",
+    });
+
+    expect(manager.get("env-1")).toBeUndefined();
+    expect(runtime.shutdown).toHaveBeenCalledTimes(1);
   });
 
   it("keeps an environment runtime while a thread command is being prepared", async () => {

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -457,9 +457,17 @@ export class RuntimeManager {
     });
   }
 
+  /**
+   * Background tasks outlive their turn, so an entry with no active turn can
+   * still be running a workflow or a backgrounded command inside its provider
+   * process. Shutting that runtime down would kill them, so they count as
+   * active work.
+   */
   private entryHasActiveRuntimeWork(entry: RuntimeEntry): boolean {
     return (
-      entry.terminals.size > 0 || entry.runtime.getActiveThreadIds().length > 0
+      entry.terminals.size > 0 ||
+      entry.runtime.getActiveThreadIds().length > 0 ||
+      entry.runtime.hasOpenBackgroundWork()
     );
   }
 

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -229,6 +229,7 @@ function createFakeRuntime(): AgentRuntime {
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: vi.fn(() => false),
     getActiveThreadIds: vi.fn(() => []),
+    hasOpenBackgroundWork: vi.fn(() => false),
     shutdown: vi.fn(async () => undefined),
   };
 }

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -431,6 +431,9 @@ export function createFakeRuntime() {
     getActiveThreadIds() {
       return [...activeTurnsByThreadId.keys()];
     },
+    hasOpenBackgroundWork() {
+      return false;
+    },
     async listModels(args) {
       state.listedModelsProviderId = args.providerId;
       state.listedModelsAcpLaunchSpec = args.acpLaunchSpec;

--- a/apps/server/src/services/threads/child-thread-notifications.ts
+++ b/apps/server/src/services/threads/child-thread-notifications.ts
@@ -3,6 +3,7 @@ import type {
   SystemMessageSubject,
   ThreadEventTurnStatus,
 } from "@bb/domain";
+import { listActiveBackgroundTaskCountsByThreadIds } from "@bb/db";
 import { renderTemplate } from "@bb/templates";
 import type { LoggedPendingInteractionWorkSessionDeps } from "../../types.js";
 import {
@@ -24,6 +25,7 @@ import { getLastThreadOutput } from "./thread-data.js";
 export type ChildThreadNotificationSource = ParentSystemThreadMentionSource;
 
 export interface ChildThreadTurnNotificationBatchItem {
+  activeWorkflowCount: number;
   childThread: ChildThreadNotificationSource;
   terminalOutput: string | null;
   turnStatus: ThreadEventTurnStatus;
@@ -77,8 +79,7 @@ const CHILD_THREAD_OUTCOME_BATCH_UPDATES_SLOT =
   "__BB_CHILD_THREAD_OUTCOME_BATCH_UPDATES__";
 const CHILD_THREAD_MENTION_SLOT = "__BB_CHILD_THREAD_MENTION__";
 const CHILD_THREAD_TERMINAL_OUTPUT_EXCERPT_CHAR_LIMIT = 4_000;
-const CHILD_THREAD_OUTPUT_TRUNCATION_MARKER =
-  "\n\n[... output truncated ...]";
+const CHILD_THREAD_OUTPUT_TRUNCATION_MARKER = "\n\n[... output truncated ...]";
 const CHILD_THREAD_INSPECTION_GUIDANCE =
   "Review the thread before deciding next steps.";
 const CHILD_THREAD_INTERRUPTED_GUIDANCE =
@@ -87,6 +88,10 @@ const CHILD_THREAD_BATCH_INTERRUPTED_GUIDANCE =
   "If the user stopped any interrupted thread manually, do not resume, restart, retry, replace, or continue the work unless the user explicitly asks.";
 const CHILD_THREAD_NEEDS_ATTENTION_FALLBACK_SUMMARY =
   "It is blocked on a pending interaction.";
+const CHILD_THREAD_RUNNING_WORKFLOW_GUIDANCE =
+  "A workflow it started is still running, so this output is not its final result. The thread will report again when the workflow finishes.";
+const CHILD_THREAD_BATCH_RUNNING_WORKFLOW_GUIDANCE =
+  "Threads with a workflow still running have not finished; they will report again when their workflow does.";
 const childThreadTurnNotificationBatches = new Map<
   string,
   ChildThreadTurnNotificationBatch
@@ -135,7 +140,9 @@ function formatChildThreadCompletionOutputExcerpt(
   );
 }
 
-function formatChildThreadNeedsAttentionSummary(summary: string | null): string {
+function formatChildThreadNeedsAttentionSummary(
+  summary: string | null,
+): string {
   const trimmedSummary = summary?.trim();
   if (!trimmedSummary) {
     return CHILD_THREAD_NEEDS_ATTENTION_FALLBACK_SUMMARY;
@@ -143,19 +150,41 @@ function formatChildThreadNeedsAttentionSummary(summary: string | null): string 
   return trimmedSummary;
 }
 
+/**
+ * A workflow keeps running after the turn that started it completes, so a
+ * child thread can report an outcome while its workflow work is still in
+ * flight. Say so, otherwise the parent reads the excerpt as the final result.
+ */
+function formatChildThreadRunningWorkflowClause(count: number): string {
+  if (count < 1) {
+    return "";
+  }
+  return count === 1
+    ? ", with 1 workflow still running"
+    : `, with ${count} workflows still running`;
+}
+
 function buildSingleChildThreadTurnStatusSegments(
   args: FormatChildThreadTurnStatusLineArgs,
 ): ParentSystemInputSegment[] {
   const { line } = args;
   switch (line.item.turnStatus) {
-    case "completed":
+    case "completed": {
+      const workflowClause = formatChildThreadRunningWorkflowClause(
+        line.item.activeWorkflowCount,
+      );
+      const workflowGuidance =
+        workflowClause === ""
+          ? ""
+          : `\n\n${CHILD_THREAD_RUNNING_WORKFLOW_GUIDANCE}`;
       return [
         { kind: "mention", mention: line.mention },
         {
           kind: "text",
-          text: ` completed:\n\n${formatChildThreadCompletionOutputExcerpt(line.item.terminalOutput)}`,
+          text: ` completed${workflowClause}:\n\n${formatChildThreadCompletionOutputExcerpt(line.item.terminalOutput)}${workflowGuidance}`,
         },
       ];
+    }
     case "failed":
       return [
         { kind: "mention", mention: line.mention },
@@ -183,11 +212,14 @@ function buildChildThreadBatchStatusLineSegments(
   args: FormatChildThreadTurnStatusLineArgs,
 ): ParentSystemInputSegment[] {
   const { line } = args;
+  const workflowClause = formatChildThreadRunningWorkflowClause(
+    line.item.activeWorkflowCount,
+  );
   return [
     { kind: "mention", mention: line.mention },
     {
       kind: "text",
-      text: ` ${childThreadTurnStatusLabel(line.item.turnStatus)}.`,
+      text: ` ${childThreadTurnStatusLabel(line.item.turnStatus)}${workflowClause}.`,
     },
   ];
 }
@@ -200,6 +232,20 @@ function getChildThreadCompletionOutput(
     return null;
   }
   return getLastThreadOutput(deps.db, args.childThread.id);
+}
+
+/**
+ * Read at queue time rather than at batch flush, so the count reflects the
+ * moment the turn settled — the same instant the output excerpt is captured.
+ */
+function getChildThreadActiveWorkflowCount(
+  deps: LoggedPendingInteractionWorkSessionDeps,
+  args: QueueChildThreadTurnNotificationArgs,
+): number {
+  const [activity] = listActiveBackgroundTaskCountsByThreadIds(deps.db, {
+    threadIds: [args.childThread.id],
+  });
+  return activity?.activeWorkflowCount ?? 0;
 }
 
 function buildChildThreadTurnStatusBatchSegments(
@@ -221,6 +267,12 @@ function buildChildThreadTurnStatusBatchSegments(
     segments.push({
       kind: "text",
       text: `\n\n${CHILD_THREAD_BATCH_INTERRUPTED_GUIDANCE}`,
+    });
+  }
+  if (args.lines.some((line) => line.item.activeWorkflowCount > 0)) {
+    segments.push({
+      kind: "text",
+      text: `\n\n${CHILD_THREAD_BATCH_RUNNING_WORKFLOW_GUIDANCE}`,
     });
   }
   return segments;
@@ -408,6 +460,7 @@ function queueChildThreadTurnNotificationBatchItem(
   );
   if (existingBatch) {
     existingBatch.items.push({
+      activeWorkflowCount: getChildThreadActiveWorkflowCount(deps, args),
       childThread: args.childThread,
       terminalOutput: getChildThreadCompletionOutput(deps, args),
       turnStatus: args.turnStatus,
@@ -423,6 +476,7 @@ function queueChildThreadTurnNotificationBatchItem(
   childThreadTurnNotificationBatches.set(args.parentThreadId, {
     items: [
       {
+        activeWorkflowCount: getChildThreadActiveWorkflowCount(deps, args),
         childThread: args.childThread,
         terminalOutput: getChildThreadCompletionOutput(deps, args),
         turnStatus: args.turnStatus,

--- a/apps/server/test/services/threads/child-thread-notifications.test.ts
+++ b/apps/server/test/services/threads/child-thread-notifications.test.ts
@@ -24,6 +24,7 @@ describe("child thread notifications", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child",
             title: "Fix checkout flow",
@@ -48,6 +49,7 @@ describe("child thread notifications", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child",
             title: "Patch deploy script",
@@ -59,9 +61,11 @@ describe("child thread notifications", () => {
     });
 
     expect(message).toContain(
-      ["@thread:thr_child failed.", "", "Review the thread before deciding next steps."].join(
-        "\n",
-      ),
+      [
+        "@thread:thr_child failed.",
+        "",
+        "Review the thread before deciding next steps.",
+      ].join("\n"),
     );
     expect(message).not.toContain("Deploy script failed on preflight.");
   });
@@ -70,6 +74,7 @@ describe("child thread notifications", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child",
             title: "Fix checkout flow",
@@ -90,13 +95,16 @@ describe("child thread notifications", () => {
       ].join("\n"),
     );
     expect(message).not.toContain("Child thread updates:");
-    expect(message).not.toContain("Stopped after writing the checkout summary.");
+    expect(message).not.toContain(
+      "Stopped after writing the checkout summary.",
+    );
   });
 
   it("renders multiple child outcomes as status-only bullet lines", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child_one",
             title: "Fix checkout flow",
@@ -105,6 +113,7 @@ describe("child thread notifications", () => {
           turnStatus: "completed",
         },
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child_two",
             title: "Patch deploy script",
@@ -133,6 +142,7 @@ describe("child thread notifications", () => {
     const input = buildChildThreadTurnStatusBatchInput({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child_one",
             title: "Fix checkout flow",
@@ -141,6 +151,7 @@ describe("child thread notifications", () => {
           turnStatus: "completed",
         },
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child_two",
             title: null,
@@ -196,6 +207,7 @@ describe("child thread notifications", () => {
     const input = buildChildThreadTurnStatusBatchInput({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child_one",
             title: `Title mentions ${nestedToken}`,
@@ -204,6 +216,7 @@ describe("child thread notifications", () => {
           turnStatus: "completed",
         },
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child_two",
             title: "Second thread",
@@ -237,6 +250,7 @@ describe("child thread notifications", () => {
     const message = renderChildThreadTurnStatusBatchMessage({
       items: [
         {
+          activeWorkflowCount: 0,
           childThread: testThread({
             id: "thr_child",
             title: "Patch deploy script",
@@ -248,9 +262,73 @@ describe("child thread notifications", () => {
     });
 
     expect(message).toContain(
-      ["@thread:thr_child completed:", "", "No final output was recorded."].join(
-        "\n",
-      ),
+      [
+        "@thread:thr_child completed:",
+        "",
+        "No final output was recorded.",
+      ].join("\n"),
+    );
+  });
+
+  it("flags a still-running workflow on a single completed outcome", () => {
+    const message = renderChildThreadTurnStatusBatchMessage({
+      items: [
+        {
+          activeWorkflowCount: 1,
+          childThread: testThread({
+            id: "thr_child",
+            title: "Rebalance archetypes",
+          }),
+          terminalOutput: "Kicked off the balance pass.",
+          turnStatus: "completed",
+        },
+      ],
+    });
+
+    expect(message).toContain(
+      [
+        "@thread:thr_child completed, with 1 workflow still running:",
+        "",
+        "Kicked off the balance pass.",
+        "",
+        "A workflow it started is still running, so this output is not its final result. The thread will report again when the workflow finishes.",
+      ].join("\n"),
+    );
+  });
+
+  it("pluralizes and flags still-running workflows across batched outcomes", () => {
+    const message = renderChildThreadTurnStatusBatchMessage({
+      items: [
+        {
+          activeWorkflowCount: 2,
+          childThread: testThread({
+            id: "thr_child_one",
+            title: "Rebalance archetypes",
+          }),
+          terminalOutput: "Kicked off two workflows.",
+          turnStatus: "completed",
+        },
+        {
+          activeWorkflowCount: 0,
+          childThread: testThread({
+            id: "thr_child_two",
+            title: "Patch deploy script",
+          }),
+          terminalOutput: "Deploy script failed on preflight.",
+          turnStatus: "failed",
+        },
+      ],
+    });
+
+    expect(message).toContain(
+      [
+        "Child thread updates:",
+        "",
+        "- @thread:thr_child_one completed, with 2 workflows still running.",
+        "- @thread:thr_child_two failed.",
+        "",
+        "Threads with a workflow still running have not finished; they will report again when their workflow does.",
+      ].join("\n"),
     );
   });
 

--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -3649,9 +3649,8 @@ describe("claude-code provider adapter", () => {
     );
   });
 
-  it("treats workflows and legacy subagents as completion-blocking", () => {
+  it("treats legacy subagents as completion-blocking", () => {
     const blockingTasks = [
-      loadFixture("task-started-workflow.json"),
       {
         type: "system",
         subtype: "task_started",
@@ -3750,6 +3749,114 @@ describe("claude-code provider adapter", () => {
         }),
       );
     }
+  });
+
+  it("completes the turn while a workflow keeps running, leaving the task open", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const context = { threadId: "bb-thread-workflow" };
+    adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "started the workflow" }],
+        },
+        session_id: "sess-1",
+      },
+      context,
+    );
+    const started = adapter.translateEvent(
+      loadFixture("task-started-workflow.json"),
+      context,
+    );
+
+    const events = adapter.translateEvent(
+      {
+        type: "result",
+        subtype: "end_turn",
+        session_id: "sess-1",
+      },
+      context,
+    );
+
+    // The turn ends so the thread goes idle and the composer sends instead of
+    // queueing, while the still-pending task keeps driving the workflow
+    // indicators.
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      }),
+    );
+    expect(started).toContainEqual(
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({
+          type: "backgroundTask",
+          taskType: "local_workflow",
+          status: "pending",
+        }),
+      }),
+    );
+  });
+
+  it("opens a fresh turn when a settled workflow reinvokes the model", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const context = { threadId: "bb-thread-workflow-settle" };
+    adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "started the workflow" }],
+        },
+        session_id: "sess-1",
+      },
+      context,
+    );
+    adapter.translateEvent(loadFixture("task-started-workflow.json"), context);
+    adapter.translateEvent(
+      { type: "result", subtype: "end_turn", session_id: "sess-1" },
+      context,
+    );
+
+    adapter.translateEvent(
+      loadFixture("task-notification-workflow.json"),
+      context,
+    );
+    const reinvoked = adapter.translateEvent(
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "The workflow finished." }],
+        },
+        session_id: "sess-1",
+      },
+      context,
+    );
+
+    // The first turn already closed, so the workflow's follow-up work gets its
+    // own turn instead of reopening the settled one.
+    expect(reinvoked).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("turn-2"),
+      }),
+    );
+    expect(
+      adapter.translateEvent(
+        { type: "result", subtype: "end_turn", session_id: "sess-1" },
+        context,
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-2"),
+        status: "completed",
+      }),
+    );
   });
 
   it("closes a failed result even while a background agent is open", () => {

--- a/packages/agent-runtime/src/claude-code/task-translation.ts
+++ b/packages/agent-runtime/src/claude-code/task-translation.ts
@@ -92,6 +92,13 @@ export function hasOpenClaudeBackgroundTasks(tasks: ClaudeTaskMap): boolean {
  * Backgrounded shell commands are deliberately excluded: they are detached
  * work and may be long-lived (for example, a dev server). Ambient tasks are
  * excluded for the same reason.
+ *
+ * Workflows are excluded too, even though they do reinvoke the parent model.
+ * They routinely run for many minutes, and holding the turn open kept the
+ * thread `active` for their whole duration, which made the composer queue
+ * follow-ups instead of sending them. A workflow therefore lets the turn
+ * complete and the thread go idle; its progress stays visible through the
+ * thread's background-task activity rather than through turn status.
  */
 export function hasCompletionBlockingClaudeTasks(
   tasks: ClaudeTaskMap,
@@ -100,8 +107,7 @@ export function hasCompletionBlockingClaudeTasks(
     if (
       !task.terminal &&
       !task.skipTranscript &&
-      (isBackgroundAgentTaskType(task.taskType) ||
-        task.taskType === LOCAL_WORKFLOW_TASK_TYPE)
+      isBackgroundAgentTaskType(task.taskType)
     ) {
       return true;
     }

--- a/packages/agent-runtime/src/runtime-background-work-state.test.ts
+++ b/packages/agent-runtime/src/runtime-background-work-state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadEvent, ThreadEventBackgroundTaskItem } from "@bb/domain";
+import { threadScope, turnScope } from "@bb/domain";
+import { RuntimeBackgroundWorkState } from "./runtime-background-work-state.js";
+
+interface TaskOptions {
+  skipTranscript?: boolean;
+  status?: ThreadEventBackgroundTaskItem["status"];
+  taskType?: string;
+}
+
+function task(
+  id: string,
+  options: TaskOptions = {},
+): ThreadEventBackgroundTaskItem {
+  return {
+    type: "backgroundTask",
+    id,
+    taskType: options.taskType ?? "local_workflow",
+    description: `task ${id}`,
+    status: options.status ?? "pending",
+    taskStatus: options.status === undefined ? "running" : "completed",
+    skipTranscript: options.skipTranscript ?? false,
+  };
+}
+
+function taskStarted(
+  id: string,
+  options: TaskOptions & { threadId?: string } = {},
+): ThreadEvent {
+  return {
+    type: "item/started",
+    threadId: options.threadId ?? "t1",
+    providerThreadId: "p1",
+    scope: turnScope("turn-1"),
+    item: task(id, options),
+  };
+}
+
+function taskCompleted(
+  id: string,
+  options: { threadId?: string } = {},
+): ThreadEvent {
+  return {
+    type: "item/backgroundTask/completed",
+    threadId: options.threadId ?? "t1",
+    providerThreadId: "p1",
+    scope: threadScope(),
+    item: task(id, { status: "completed" }),
+  };
+}
+
+describe("RuntimeBackgroundWorkState", () => {
+  it("reports open work until every task settles", () => {
+    const state = new RuntimeBackgroundWorkState();
+    expect(state.hasOpenWork()).toBe(false);
+
+    state.observe(taskStarted("task-1"));
+    state.observe(taskStarted("task-2"));
+    expect(state.hasOpenWork()).toBe(true);
+
+    state.observe(taskCompleted("task-1"));
+    expect(state.hasOpenWork()).toBe(true);
+
+    state.observe(taskCompleted("task-2"));
+    expect(state.hasOpenWork()).toBe(false);
+  });
+
+  it("settles a task that only reports a terminal status through progress", () => {
+    const state = new RuntimeBackgroundWorkState();
+    state.observe(taskStarted("task-1"));
+
+    state.observe({
+      type: "item/backgroundTask/progress",
+      threadId: "t1",
+      providerThreadId: "p1",
+      scope: threadScope(),
+      item: task("task-1", { status: "failed" }),
+    });
+
+    expect(state.hasOpenWork()).toBe(false);
+  });
+
+  it("keeps ambient tasks open because a shutdown would still kill them", () => {
+    const state = new RuntimeBackgroundWorkState();
+
+    state.observe(taskStarted("task-1", { skipTranscript: true }));
+
+    expect(state.hasOpenWork()).toBe(true);
+  });
+
+  it("forgets a thread's open work without disturbing other threads", () => {
+    const state = new RuntimeBackgroundWorkState();
+    state.observe(taskStarted("task-1", { threadId: "t1" }));
+    state.observe(taskStarted("task-2", { threadId: "t2" }));
+
+    state.clearThread("t1");
+    expect(state.hasOpenWork()).toBe(true);
+
+    state.clearThread("t2");
+    expect(state.hasOpenWork()).toBe(false);
+  });
+
+  it("ignores non-background item lifecycle events", () => {
+    const state = new RuntimeBackgroundWorkState();
+
+    state.observe({
+      type: "item/started",
+      threadId: "t1",
+      providerThreadId: "p1",
+      scope: turnScope("turn-1"),
+      item: {
+        type: "agentMessage",
+        id: "msg-1",
+        text: "hello",
+      },
+    });
+
+    expect(state.hasOpenWork()).toBe(false);
+  });
+});

--- a/packages/agent-runtime/src/runtime-background-work-state.ts
+++ b/packages/agent-runtime/src/runtime-background-work-state.ts
@@ -1,0 +1,77 @@
+import type { ThreadEvent } from "@bb/domain";
+
+/**
+ * Tracks background tasks that are still open per thread, from the same
+ * normalized event stream the runtime forwards to the server.
+ *
+ * Background tasks outlive the turn that spawned them, so a thread can be idle
+ * while its workflow or backgrounded command is still running inside the
+ * provider process. Turn state alone therefore cannot tell a caller whether
+ * shutting the runtime down would destroy live work — this can.
+ *
+ * Ambient (`skipTranscript`) tasks count too: they are hidden from the
+ * transcript, not detached from the process that would be killed.
+ */
+export class RuntimeBackgroundWorkState {
+  private readonly openTaskIdsByThreadId = new Map<string, Set<string>>();
+
+  clear(): void {
+    this.openTaskIdsByThreadId.clear();
+  }
+
+  clearThread(threadId: string): void {
+    this.openTaskIdsByThreadId.delete(threadId);
+  }
+
+  hasOpenWork(): boolean {
+    return this.openTaskIdsByThreadId.size > 0;
+  }
+
+  observe(event: ThreadEvent): void {
+    if (event.type === "item/started") {
+      if (event.item.type === "backgroundTask") {
+        this.setTaskOpen({
+          isOpen: event.item.status === "pending",
+          taskId: event.item.id,
+          threadId: event.threadId,
+        });
+      }
+      return;
+    }
+
+    if (
+      event.type === "item/backgroundTask/progress" ||
+      event.type === "item/backgroundTask/completed"
+    ) {
+      this.setTaskOpen({
+        isOpen: event.item.status === "pending",
+        taskId: event.item.id,
+        threadId: event.threadId,
+      });
+    }
+  }
+
+  private setTaskOpen(args: {
+    isOpen: boolean;
+    taskId: string;
+    threadId: string;
+  }): void {
+    const openTaskIds = this.openTaskIdsByThreadId.get(args.threadId);
+    if (!args.isOpen) {
+      if (!openTaskIds) {
+        return;
+      }
+      openTaskIds.delete(args.taskId);
+      if (openTaskIds.size === 0) {
+        this.openTaskIdsByThreadId.delete(args.threadId);
+      }
+      return;
+    }
+
+    if (openTaskIds) {
+      openTaskIds.add(args.taskId);
+      return;
+    }
+    this.openTaskIdsByThreadId.set(args.threadId, new Set([args.taskId]));
+  }
+}

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -51,6 +51,7 @@ import {
 } from "./runtime-thread-identity.js";
 import { RuntimeThreadGoalState } from "./runtime-thread-goal-state.js";
 import { RuntimeTurnReplayFilter } from "./runtime-turn-replay-filter.js";
+import { RuntimeBackgroundWorkState } from "./runtime-background-work-state.js";
 import { RuntimeTurnState } from "./runtime-turn-state.js";
 import type {
   AgentRuntime,
@@ -235,6 +236,7 @@ function createAgentRuntimeInternal(
   const threadOperationCounts = new Map<string, number>();
   const threadGoalState = new RuntimeThreadGoalState();
   const turnState = new RuntimeTurnState();
+  const backgroundWorkState = new RuntimeBackgroundWorkState();
   const turnReplayFilter = new RuntimeTurnReplayFilter();
   const bridgeNodeEnv = options.bridgeNodeEnv ?? defaultBridgeNodeEnv();
 
@@ -278,6 +280,7 @@ function createAgentRuntimeInternal(
       threadIdentityRegistry.clearThread(threadId);
       clearThreadRuntimeConfig(threadId);
       turnState.clearThread(threadId);
+      backgroundWorkState.clearThread(threadId);
       turnReplayFilter.clearThread(threadId);
     },
     onStderr: options.onStderr,
@@ -500,6 +503,7 @@ function createAgentRuntimeInternal(
     });
     clearThreadRuntimeConfig(threadId);
     turnState.clearThread(threadId);
+    backgroundWorkState.clearThread(threadId);
     turnReplayFilter.clearThread(threadId);
   }
 
@@ -888,6 +892,7 @@ function createAgentRuntimeInternal(
         replayResult.event,
       );
       turnState.observe(normalizedEvent);
+      backgroundWorkState.observe(normalizedEvent);
       observeProviderSessionIdleState(normalizedEvent);
       if (shouldRestartCodexThreadAfterEvent(normalizedEvent, args.proc)) {
         codexThreadsRequiringAccountRestart.add(normalizedEvent.threadId);
@@ -1659,12 +1664,17 @@ function createAgentRuntimeInternal(
       return turnState.getActiveThreadIds();
     },
 
+    hasOpenBackgroundWork() {
+      return backgroundWorkState.hasOpenWork();
+    },
+
     async shutdown() {
       idleProviderSessionSinceMsByThreadId.clear();
       pendingTurnStartThreadIds.clear();
       threadOperationCounts.clear();
       threadGoalState.clear();
       turnState.clear();
+      backgroundWorkState.clear();
       turnReplayFilter.clear();
       await providerProcesses.shutdown();
     },

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -341,5 +341,12 @@ export interface AgentRuntime {
   /** Thread ids with an active turn. */
   getActiveThreadIds(): string[];
 
+  /**
+   * Whether any hosted thread still has an open background task (a workflow or
+   * backgrounded command). These outlive their spawning turn, so a runtime with
+   * no active turn can still be doing real work that a shutdown would destroy.
+   */
+  hasOpenBackgroundWork(): boolean;
+
   shutdown(): Promise<void>;
 }

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 63 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 64 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1009,8 +1009,8 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  it("uses protocol version 63 for the skill management contract", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(63);
+  it("uses protocol version 64 for workflow turn-completion timing", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(64);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

A native Claude workflow (`local_workflow`) was treated as completion-blocking by `hasCompletionBlockingClaudeTasks`, so the logical bb turn stayed open for the workflow's entire run. That kept the thread `active`, and `shouldQueueFollowUpMessage` queues on `active` — so typing during a workflow queued the message instead of sending it. Introduced in #633, which added the predicate for background agents and folded workflows in alongside them.

Workflows now let the turn complete and the thread go idle. Background agents and legacy subagents still block, unchanged. When the workflow settles and reinvokes the parent model, that work opens a fresh turn.

**The busy status disappears with no UI change.** `displayStatus` derives from `thread.status` plus host connectivity only — background activity never feeds it. So once the turn completes, the thread-row indicator falls through from the generic "Thread working" spinner to the specific "Workflow running" glyph, while the timeline pill and the composer workflow cards keep rendering off background-task activity. All three workflow indicators survive; only the busy status goes.

Two consequences handled here:

- **Parent notification.** A child thread can now report an outcome while its workflow is still running, so the notification says so (`@thread:x completed, with 2 workflows still running:`) and tells the parent to expect a second report rather than reading the excerpt as final. The count is captured at queue time, the same instant as the output excerpt.
- **Runtime eviction.** With the turn closed, the thread no longer sits in the runtime's active set, so `evictIdleRuntimeEntries` could shut a runtime down mid-workflow and SIGTERM the provider process running it. `AgentRuntime` now tracks open background tasks from the event stream it already observes and exposes `hasOpenBackgroundWork()`, which `entryHasActiveRuntimeWork` counts as active work. This also fixes the pre-existing case of a backgrounded dev server being killed by a shell-env change.

`HOST_DAEMON_PROTOCOL_VERSION` 63 → 64 so enrolled daemons pick up the new turn timing. The wire shape is unchanged, so an older daemon keeps the old blocking behavior rather than entering an `invalid-message` loop.

## Notes

- `RuntimeBackgroundWorkState` observes the normalized event stream rather than plumbing the adapter's `hasOpenClaudeBackgroundTasks` up through `AgentRuntime` — the adapter's copy is buried in a per-provider turn-state registry reachable only by the LRU pruner, and reading events keeps this provider-agnostic.
- Ambient (`skipTranscript`) tasks **do** count for eviction. #633 excluded them from turn completion because they're long-lived, but hiding a task from the transcript doesn't make it survive a SIGTERM. This matches the adapter's existing `isEvictable`.

## Tests

- `pnpm exec turbo run typecheck test --filter=@bb/agent-runtime` — 794 passed
- `pnpm exec turbo run typecheck test --filter=@bb/host-daemon` — 467 passed
- `pnpm exec turbo run typecheck test --filter=@bb/server` — 1249 passed
- `pnpm exec turbo run typecheck test --filter=@bb/app --filter=@bb/thread-view` — passed

New coverage:
- the turn completes while a workflow stays open, leaving the task pending
- a settled workflow's reinvocation opens a fresh turn (`turn-2`) and completes it
- `RuntimeBackgroundWorkState` across multi-task settling, terminal-status-via-progress, ambient tasks, and per-thread clearing
- an entry with open background work survives `replaceBaseShellEnv`, then evicts once the work settles — **verified to fail without the fix**

One pre-existing local failure unrelated to this change: `internal-skill-trees.test.ts` expects file mode `420` and gets `436` (umask artifact); it fails identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)