### PR TITLE
Preserve the starting number of rendered ordered lists

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -68,6 +68,14 @@ describe("MarkdownPreview", () => {
     expect(breakout?.style.getPropertyValue("--md-content-w")).toBe("320px");
   });
 
+  it("keeps the starting number of an ordered list", () => {
+    const { container } = render(
+      <MarkdownPreview content={"> 2. What happens if debt is unpaid?"} />,
+    );
+
+    expect(container.querySelector("ol")?.getAttribute("start")).toBe("2");
+  });
+
   it("HTML-escapes fenced code so it cannot inject markup", () => {
     const { container } = render(
       <MarkdownPreview

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -873,8 +873,23 @@ function MarkdownUnorderedList({ children }: MarkdownUnorderedListProps) {
   return <ul className="mb-2 list-disc pl-5 text-foreground">{children}</ul>;
 }
 
-function MarkdownOrderedList({ children }: MarkdownOrderedListProps) {
-  return <ol className="mb-2 list-decimal pl-5 text-foreground">{children}</ol>;
+// `start` carries the list's first number (`3.` renders as "3."), so it has to
+// reach the DOM: the marker comes from a CSS counter that otherwise restarts
+// at 1.
+function MarkdownOrderedList({
+  children,
+  className: _className,
+  node: _node,
+  ...orderedListProps
+}: MarkdownOrderedListProps) {
+  return (
+    <ol
+      {...orderedListProps}
+      className="mb-2 list-decimal pl-5 text-foreground"
+    >
+      {children}
+    </ol>
+  );
 }
 
 function MarkdownListItem({ children }: MarkdownListItemProps) {


### PR DESCRIPTION
## Summary

`MarkdownOrderedList` destructured only `children` and dropped the rest of its props, so the `start` attribute react-markdown passes never reached the DOM. Because the marker is drawn by the CSS `list-decimal` counter rather than the browser's own list numbering, every ordered list restarted at 1.

The reported symptom was a quoted question list. remark-gfm parses each `> 2.` / `> 3.` into a separate single-item list carrying `start: 2` / `start: 3`, so all three rendered as "1." instead of 1./2./3.

The `<ol>` renderer now forwards its remaining props, following the `MarkdownParagraph` convention in the same file of dropping `className`/`node` and spreading the rest.

## Notes

- **Scoped to `<ol>` deliberately.** I initially forwarded props on `<li>` too, for `value`, then reverted it: `mdast-util-to-hast`'s list-item handler only ever sets a task-list `className`, never a `value` (CommonMark renumbers ordered items sequentially), so that would have been speculative code forwarding nothing.
- **The composer was already correct.** `prompt-editor-serialization.ts` preserves `start` in both the markdown→ProseMirror and ProseMirror→markdown directions. This bug was display-only.
- **Affects assistant messages too**, not just user messages — both roles render through `MarkdownPreview`.
- The branch name is bb's thread-derived name and unrelated to this change.

## Tests

- New `markdown-preview.test.tsx` case asserting `<ol start="2">` survives. Verified it fails without the fix (`expected null to be "2"`) and passes with it; 15/15 pass.
- `turbo run typecheck --filter=@bb/app` clean.
- `turbo run lint --filter=@bb/app` clean (0 errors; no warnings in the changed files), prettier clean.

## Risk

Low. One presentational component; the forwarded props are the hast-derived attributes react-markdown already sanitizes, and `className` stays hardcoded so styling can't be overridden by content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)