### PR TITLE
Fix sidebar rows staying greyed out after a section drag

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -106,6 +106,7 @@ import {
   getSidebarThreadRowPaddingLeft,
 } from "./sidebarRowClasses";
 import {
+  SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION,
   useSidebarSortable,
   type SidebarSortableDragBindings,
 } from "./sortableMotion";
@@ -2088,17 +2089,13 @@ export const ChronologicalSectionThreadSections = memo(
         <SectionThreadDndProvider value={renderedSectionDnd}>
           {orderedSections}
           {createPortal(
-            // The overlay only renders thread content. Its default drop side
-            // effect hides the active DOM node, so enabling it for a section
-            // drag would make that section flash invisible on mouse-up.
+            // The overlay only renders thread content, so a section drag has
+            // nothing to fly home and skips the drop animation entirely.
             <DragOverlay
               className="cursor-grabbing"
               dropAnimation={
                 sectionDnd.activeThread
-                  ? {
-                      duration: 180,
-                      easing: "cubic-bezier(0.2, 0, 0, 1)",
-                    }
+                  ? SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION
                   : null
               }
             >

--- a/apps/app/src/components/sidebar/sortableMotion.test.ts
+++ b/apps/app/src/components/sidebar/sortableMotion.test.ts
@@ -1,0 +1,22 @@
+import { defaultDropAnimation } from "@dnd-kit/core";
+import { describe, expect, it } from "vitest";
+import { SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION } from "./sortableMotion";
+
+describe("SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION", () => {
+  // Sidebar rows dim their drag source through a React-owned inline opacity, so
+  // dnd-kit must not capture and restore that property from its drop-animation
+  // finish callback: a restore that lands after the drop settles re-applies the
+  // dim value as a raw DOM write React can no longer diff away, leaving the row
+  // greyed out for good. dnd-kit merges caller options over its defaults, so an
+  // omitted `sideEffects` silently reinstates the mutating default.
+  it("cancels dnd-kit's opacity-mutating drop side effect", () => {
+    expect(defaultDropAnimation.sideEffects).toBeTypeOf("function");
+
+    const effectiveConfig = {
+      ...defaultDropAnimation,
+      ...SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION,
+    };
+
+    expect(effectiveConfig.sideEffects).toBeNull();
+  });
+});

--- a/apps/app/src/components/sidebar/sortableMotion.ts
+++ b/apps/app/src/components/sidebar/sortableMotion.ts
@@ -2,6 +2,7 @@ import { useMemo, type CSSProperties } from "react";
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
+  DropAnimation,
 } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -9,6 +10,29 @@ import { CSS } from "@dnd-kit/utilities";
 const SIDEBAR_SORTABLE_TRANSITION = {
   duration: 160,
   easing: "cubic-bezier(0.2, 0, 0, 1)",
+};
+
+/**
+ * Drop animation for sidebar `DragOverlay`s — the overlay flies back onto the
+ * row the thread will land on, with dnd-kit's side effects switched off.
+ *
+ * dnd-kit's default side effect hides the drag source by writing `opacity: 0`
+ * directly onto its DOM node, then restores the value it captured at drop time
+ * from `animation.onfinish`. Sidebar rows dim their drag source through a
+ * React-owned inline opacity (below, and the section-thread ghost row in
+ * `ProjectRow`), so that restore is a raw DOM write racing React: it only has
+ * to land after the drop-settle window clears the ghost — main-thread work from
+ * the move mutation is enough — and the dim value is re-applied permanently.
+ * React's committed style no longer carries an opacity, so there is nothing
+ * left for it to diff away and the row stays greyed out until it remounts.
+ * With side effects off the source row's opacity stays owned by React alone,
+ * and the dimmed row reads as the landing slot while the overlay animates onto
+ * it.
+ */
+export const SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION: DropAnimation = {
+  duration: 180,
+  easing: "cubic-bezier(0.2, 0, 0, 1)",
+  sideEffects: null,
 };
 
 /**
@@ -66,6 +90,9 @@ export function useSidebarSortable({
       // that stack so its label never disappears underneath a peer header.
       position: isDragging ? "relative" : undefined,
       zIndex: isDragging ? 100 : undefined,
+      // React owns this opacity. Any overlay animating over a sidebar row must
+      // use SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION so dnd-kit never captures and
+      // restores it behind React's back.
       opacity: isDragging ? 0.8 : undefined,
     }),
     [isDragging, transform, transition],


### PR DESCRIPTION
## Summary

- Stop a dropped sidebar thread from staying dimmed after being dragged into another section.
- Move the section-thread drag overlay's drop-animation config into `sortableMotion` and disable dnd-kit's drop side effects so the source row's opacity stays owned by React.

## Root cause

The drag source row carries a React-owned inline `opacity: 0.25` ghost style while `activeThread` is set. dnd-kit's default drop-animation side effect captures that inline opacity, writes `opacity: 0` to hide the source during the overlay's flight, then re-applies the captured value from `animation.onfinish` as a raw DOM write.

The overlay animation is 180ms and `DROP_SETTLE_MS` (which keeps the ghost alive until the move mutation lands) is 220ms — a 40ms margin. Any main-thread work around the mutation and sidebar re-render pushes the restore past the clear: React removes the ghost opacity at 220ms, dnd-kit writes `0.25` back at ~240ms, and React's committed style no longer carries an opacity to diff away. Nothing repairs it afterwards, because later drags only re-render other rows.

The 0.25 ghost already marks the landing slot, so dnd-kit's hide-the-source effect was redundant on this surface.

## QA and validation

- Drove real drags (`mouse.down`, stepped moves, dwell, `mouse.up`) through the dev app with dev-browser, in the chronological/sections sidebar mode.
- Forced the race deterministically by stretching the drop animation to 800ms. On the old code the row clears at the settle and then regains `opacity: 0.25` ~1s after the drop, staying dim through a later drag of a different row — matching the reported screenshot. On the fixed build the ghost clears and is never written back.
- Natural-timing pass over loose->section, section->loose, and pinned-reorder drags: every row ends at computed opacity 1, with `section_id` / pin state in the database matching each gesture.
- `sortableMotion.test.ts` pins the invariant and fails (`expected [Function] to be null`) without the `sideEffects: null` line.
- `turbo run typecheck --filter=@bb/app`, eslint on the touched files, and the full `components/sidebar` suite (21 files, 169 tests) pass.

## Risks

One deliberate visual change: the source row is no longer hidden during the 180ms overlay flight. For section moves it is the 0.25 ghost (the landing slot). For a pinned reorder there is no ghost dim, so the row sits at full opacity under the incoming opaque overlay for those 180ms. If the hide is wanted back, a `visibility` side effect would do it race-free, since React never sets `visibility` on these rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)