### PR TITLE
Stop the Claude Code bridge from silently dropping requests

### DIFF
--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -826,12 +826,14 @@ describe("bridge", () => {
     expect(askOptions.permissionMode).toBe("acceptEdits");
     expect(askOptions.sandbox).toEqual({
       enabled: true,
+      failIfUnavailable: false,
       autoAllowBashIfSandboxed: true,
       allowUnsandboxedCommands: true,
     });
     expect(denyOptions.permissionMode).toBe("auto");
     expect(denyOptions.sandbox).toEqual({
       enabled: true,
+      failIfUnavailable: false,
       autoAllowBashIfSandboxed: true,
       allowUnsandboxedCommands: false,
     });
@@ -881,6 +883,7 @@ describe("bridge", () => {
     ]);
     expect(options.sandbox).toEqual({
       enabled: true,
+      failIfUnavailable: false,
       autoAllowBashIfSandboxed: true,
       allowUnsandboxedCommands: false,
       filesystem: {
@@ -1428,6 +1431,93 @@ describe("bridge", () => {
       });
 
       await stopBridgeThread({ bridge, queries, threadId });
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  // Both directions number their outgoing requests with a counter from 1, so a
+  // daemon request id routinely matches one the bridge is still waiting on. The
+  // `method` field is what separates them; without that check the request was
+  // settled as a bogus response and dropped, and the daemon only found out when
+  // it timed out 30s later.
+  it("dispatches an inbound request whose id collides with a pending bb request", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-colliding-request-id";
+      await startBridgeThread({ bridge, threadId });
+      const { questionRequest, resultPromise } = await forwardAskUserQuestion({
+        bridge,
+        toolUseID: "tool-question-collision",
+      });
+      const collidingId = questionRequest.id;
+      if (collidingId === undefined) {
+        throw new Error("Expected a pending bridge request id");
+      }
+
+      let questionSettled = false;
+      void resultPromise.then(() => {
+        questionSettled = true;
+      });
+
+      bridge.sendRequest(collidingId, "turn/start", {
+        threadId,
+        providerThreadId: null,
+        input: [{ type: "text", text: "colliding turn", mentions: [] }],
+      });
+      await bridge.flushWork();
+
+      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+        "colliding turn",
+      );
+      expect(questionSettled).toBe(false);
+
+      handleLine(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: collidingId,
+          result: { kind: "user_question", behavior: "deny" },
+        }),
+      );
+      await expect(resultPromise).resolves.toMatchObject({
+        behavior: "deny",
+      });
+
+      await stopBridgeThread({ bridge, queries, threadId });
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("answers a schema-invalid request with an error instead of dropping it", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+
+    try {
+      // Any params mismatch used to be dropped without a reply, so the caller
+      // learned nothing until its 30s timeout. The reply now names the field.
+      bridge.sendRequest(11, "turn/start", {
+        threadId: "thread-invalid-params",
+        providerThreadId: null,
+        input: [{ type: "text", text: "hi", mentions: [] }],
+        inputGroups: [[]],
+      });
+      const invalidParams = await bridge.waitForResponse(11);
+      expect(invalidParams.error?.code).toBe(-32602);
+      expect(invalidParams.error?.message).toContain("inputGroups");
+
+      bridge.sendRequest(12, "turn/teleport", { threadId: "thread-unknown" });
+      const unknownMethod = await bridge.waitForResponse(12);
+      expect(unknownMethod.error).toMatchObject({
+        code: -32601,
+        message: "Unknown method: turn/teleport",
+      });
     } finally {
       bridge.restore();
     }

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/commands.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/commands.test.ts
@@ -23,8 +23,11 @@ describe("decodeClaudeCodeJsonRpcRequest", () => {
       params: baseThreadStartParams,
     });
     expect(decoded).toMatchObject({
-      method: "thread/start",
-      params: { workflowsEnabled: false },
+      kind: "request",
+      request: {
+        method: "thread/start",
+        params: { workflowsEnabled: false },
+      },
     });
   });
 
@@ -38,7 +41,12 @@ describe("decodeClaudeCodeJsonRpcRequest", () => {
         method: "thread/start",
         params: withoutWorkflowsEnabled,
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      kind: "invalid_params",
+      id: 1,
+      method: "thread/start",
+      issues: expect.stringContaining("workflowsEnabled"),
+    });
     expect(
       decodeClaudeCodeJsonRpcRequest({
         jsonrpc: "2.0",
@@ -49,6 +57,27 @@ describe("decodeClaudeCodeJsonRpcRequest", () => {
           providerThreadId: "claude-session-1",
         },
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      kind: "invalid_params",
+      id: 2,
+      method: "thread/resume",
+    });
+  });
+
+  it("reports an unknown method separately from invalid params", () => {
+    expect(
+      decodeClaudeCodeJsonRpcRequest({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "turn/teleport",
+        params: {},
+      }),
+    ).toEqual({ kind: "unknown_method", id: 3, method: "turn/teleport" });
+  });
+
+  it("ignores lines that are not requests", () => {
+    expect(
+      decodeClaudeCodeJsonRpcRequest({ jsonrpc: "2.0", id: 4, result: {} }),
+    ).toEqual({ kind: "not_a_request" });
   });
 });

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -414,6 +414,12 @@ function sendError(id: string | number, code: number, message: string): void {
   send({ jsonrpc: "2.0", id, error: { code, message } });
 }
 
+// stdout is the JSON-RPC channel; the runtime captures stderr into the
+// provider's diagnostics buffer.
+function logBridgeError(message: string): void {
+  process.stderr.write(`claude-code bridge: ${message}\n`);
+}
+
 function ignoreInputConsumption(promise: Promise<void>): void {
   void promise.catch(() => {});
 }
@@ -1586,12 +1592,29 @@ export function handleLine(line: string): void {
     return;
   }
 
-  const request = decodeClaudeCodeJsonRpcRequest(parsed);
-  if (!request) return;
-  void handleRequest(request).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    sendError(request.id, -32000, message);
-  });
+  const decoded = decodeClaudeCodeJsonRpcRequest(parsed);
+  switch (decoded.kind) {
+    case "not_a_request":
+      return;
+    case "unknown_method":
+      logBridgeError(`Unknown method: ${decoded.method}`);
+      sendError(decoded.id, -32601, `Unknown method: ${decoded.method}`);
+      return;
+    case "invalid_params": {
+      const message = `Invalid params for ${decoded.method}: ${decoded.issues}`;
+      logBridgeError(message);
+      sendError(decoded.id, -32602, message);
+      return;
+    }
+    case "request": {
+      const request = decoded.request;
+      void handleRequest(request).catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        sendError(request.id, -32000, message);
+      });
+      return;
+    }
+  }
 }
 
 // Main entry point

--- a/packages/agent-runtime/src/claude-code/bridge/commands.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/commands.ts
@@ -180,17 +180,61 @@ export type ThreadStopParams = Extract<
   { method: "thread/stop" }
 >["params"];
 
+const claudeCodeCommandMethods = new Set<string>(
+  claudeCodeCommandSchema.options.map((option) => option.shape.method.value),
+);
+
+/**
+ * A decode failure on a well-formed envelope is a caller-visible error, not
+ * something to drop: the caller is waiting on `id` and would otherwise learn
+ * nothing until its request timed out.
+ */
+export type ClaudeCodeJsonRpcRequestDecodeResult =
+  | { kind: "request"; request: ClaudeCodeJsonRpcRequest }
+  | { kind: "not_a_request" }
+  | { kind: "unknown_method"; id: string | number; method: string }
+  | {
+      kind: "invalid_params";
+      id: string | number;
+      method: string;
+      issues: string;
+    };
+
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}
+
 export function decodeClaudeCodeJsonRpcRequest(
   raw: unknown,
-): ClaudeCodeJsonRpcRequest | null {
+): ClaudeCodeJsonRpcRequestDecodeResult {
   const envelope = jsonRpcEnvelopeSchema.safeParse(raw);
-  if (!envelope.success) return null;
+  if (!envelope.success) return { kind: "not_a_request" };
+
+  const { id, method } = envelope.data;
+  if (!claudeCodeCommandMethods.has(method)) {
+    return { kind: "unknown_method", id, method };
+  }
 
   const command = claudeCodeCommandSchema.safeParse({
-    method: envelope.data.method,
+    method,
     params: envelope.data.params ?? {},
   });
-  if (!command.success) return null;
+  if (!command.success) {
+    return {
+      kind: "invalid_params",
+      id,
+      method,
+      issues: formatZodIssues(command.error),
+    };
+  }
 
-  return { ...command.data, jsonrpc: "2.0", id: envelope.data.id };
+  return {
+    kind: "request",
+    request: { ...command.data, jsonrpc: "2.0", id },
+  };
 }

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -167,6 +167,13 @@ function buildWorkspaceWriteSandbox(
   const allowWrite = params.additionalWorkspaceWriteRoots ?? [];
   return {
     enabled: true,
+    // The SDK defaults this to true, which aborts the whole session when the
+    // host lacks sandbox dependencies (bubblewrap on Linux). Headless servers
+    // routinely lack them, and a missing sandbox should cost the session its
+    // auto-allow, not its ability to run: `autoAllowBashIfSandboxed` only
+    // auto-approves while the sandbox is actually active, so degrading falls
+    // back to bb's own `canUseTool` gating instead of running wide open.
+    failIfUnavailable: false,
     autoAllowBashIfSandboxed: true,
     allowUnsandboxedCommands: params.permissionEscalation === "ask",
     ...(allowWrite.length > 0

--- a/packages/agent-runtime/src/shared/bridge-tool-calls.ts
+++ b/packages/agent-runtime/src/shared/bridge-tool-calls.ts
@@ -66,9 +66,30 @@ export type BridgeJsonRpcResponse =
   | z.infer<typeof jsonRpcSuccessResponseSchema>
   | z.infer<typeof jsonRpcErrorResponseSchema>;
 
+/**
+ * Requests and responses share one id space on the bidirectional bridge
+ * channel: both sides number their outgoing requests with a plain counter from
+ * 1. `method` is what tells them apart — a response never carries one. Without
+ * this check an inbound request whose id collides with an outstanding outgoing
+ * request decodes as a success response (the schemas are non-strict and
+ * `result: z.unknown()` also accepts a missing key), so the bridge settles the
+ * wrong promise and drops the request without replying, leaving the caller to
+ * time out 30s later with no diagnostic.
+ */
+function isJsonRpcRequest(input: unknown): boolean {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    "method" in input &&
+    input.method !== undefined
+  );
+}
+
 export function decodeBridgeJsonRpcResponse(
   input: unknown,
 ): BridgeJsonRpcResponse | null {
+  if (isJsonRpcRequest(input)) return null;
+
   const error = jsonRpcErrorResponseSchema.safeParse(input);
   if (error.success) return error.data;
 


### PR DESCRIPTION
Fixes the silent-drop failure mode reported in #853, plus the 0.33.0 change behind that report's first error.

## The silent drop had a mechanism

@amadad correctly identified that `handleLine` drops any request that fails schema validation (`if (!request) return`), turning every mismatch into an undebuggable 30s timeout. But that alone does not explain a *well-formed* `turn/start` vanishing. This does:

Both directions number their outgoing requests with a plain integer counter from 1 — `runtime.ts:230` (`nextRequestId = 1`) and `bridge.ts:298` (`toolCallRequestIdCounter = 0`, then `+= 1` per forwarded tool call and per permission request). They share one id space on a bidirectional channel.

Meanwhile `decodeBridgeJsonRpcResponse` accepted an inbound **request** as a success response: the response schemas are non-strict `z.object`s, so the extra `method`/`params` are allowed, and `result: z.unknown()` also matches a *missing* key. Since `handleLine` checks the response branch first, a daemon request whose id collided with an outstanding tool call or permission request settled that pending promise with garbage and returned **before reaching the request decoder** — no reply, no log, caller times out 30s later.

That matches the reported forensics exactly: bytes consumed off the socketpair (`Recv-Q`/`Send-Q` 0), bridge idle in `epoll_wait`, handler never invoked.

Fixed by discriminating on `method`, which is what separates the two per the JSON-RPC spec and what the daemon side already does (`parseJsonRpcLine` checks `!parsedMethod`). This also fixes the pi and acp bridges, which share the decoder and the same counter pattern.

## Remaining decode failures are now loud

Both of @amadad's suggestions, implemented:

- `decodeClaudeCodeJsonRpcRequest` returns a discriminated result instead of `null`, so `handleLine` answers **-32602** carrying the zod issue summary (e.g. `params.workflowsEnabled: expected boolean, received undefined`) and logs to stderr, which the runtime already captures into provider diagnostics.
- Unknown methods get **-32601**. The known-method set is derived from the schema union rather than hardcoded, so it cannot drift.

## Sandbox degrades instead of aborting

The approval-preset migration in #797 rewrote `readonly` **and** `workspace-write` defaults to `accept-edits` (`0078_permission_modes.sql`), and `accept-edits` enables the Claude SDK OS sandbox — which 0.0.32's `readonly` mapping did not. The SDK defaults `failIfUnavailable` to `true`, so an install that previously defaulted to `readonly` lost every session on a host without `bubblewrap`. That is the "sandbox deps missing" error in the report.

Now `failIfUnavailable: false`. `autoAllowBashIfSandboxed` only auto-approves while the sandbox is actually active, so degrading costs the session its auto-allow and falls back to bb's own `canUseTool` gating rather than running unsandboxed.

Worth deciding separately whether the headless Linux install should declare `bubblewrap`/`socat` as dependencies, since a degraded sandbox is a quieter posture than the operator may expect.

## Two things I did *not* change

- **Empty `inputGroups` group.** The bridge requires `.min(1)` per group and the adapter maps groups through `stripClaudePlanCommandInput`, so I expected a `/plan`-only group to empty and take the turn down. It cannot: `removeCommandMentionsFromPromptInput` is a `.map` that rewrites entry text and never drops entries. I implemented the fix, found the premise wrong, and reverted it. If such a group ever arrives from upstream, it is now a `-32602` naming `inputGroups`.
- **Renumbering the bridge's outgoing ids.** Once requests and responses are discriminated correctly, colliding ids are harmless — each side matches responses against its own outgoing requests, so the directions are independent id spaces. Renumbering would have changed `callId: call-${requestId}`, which is carried in tool-call payloads, for no correctness gain.

## Testing

`turbo run test typecheck lint --filter=@bb/agent-runtime` — 798 tests, clean. Each new test was verified to fail against the unfixed code:

- a `turn/start` whose id collides with a pending `AskUserQuestion` is still dispatched, and the pending request is not settled by it
- a schema-invalid `turn/start` gets `-32602` naming the offending field; an unknown method gets `-32601`
- `decodeClaudeCodeJsonRpcRequest` reports `unknown_method` and `invalid_params` distinctly

No `HOST_DAEMON_PROTOCOL_VERSION` bump: the bridge ships inside the daemon bundle, and nothing on the server/daemon wire changed.

I cannot prove from here that the id collision is @amadad's exact trigger — that needs a turn with a tool call or permission request outstanding when the daemon sends its next request. It is the only mechanism I found that reproduces their forensics, and the `-32602` path is what will pin it definitively on their machine: the next failure names a field instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
