### PR TITLE
Refresh dynamic provider model availability

### DIFF
--- a/apps/app/src/hooks/queries/system-queries.test.tsx
+++ b/apps/app/src/hooks/queries/system-queries.test.tsx
@@ -39,6 +39,8 @@ const EXECUTION_OPTIONS_RESPONSE: SystemExecutionOptionsResponse = {
   modelLoadError: null,
 };
 
+const SYSTEM_EXECUTION_OPTIONS_REFETCH_MS = 60_000;
+
 const PROVIDER_CLI_STATUS_RESPONSE = {} as ProviderCliStatusResponse;
 
 const PROVIDER_USAGE_RESPONSE: ProviderUsageResponse = {
@@ -53,6 +55,36 @@ afterEach(() => {
 });
 
 describe("useSystemExecutionOptions", () => {
+  it("polls while mounted because provider model availability can change", async () => {
+    vi.mocked(sdk.system.executionOptions).mockResolvedValue(
+      EXECUTION_OPTIONS_RESPONSE,
+    );
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+
+    renderHook(
+      () => useSystemExecutionOptions({ providerId: "claude-code" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(sdk.system.executionOptions).toHaveBeenCalledTimes(1);
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: systemExecutionOptionsQueryKey({
+        environmentId: null,
+        hostId: null,
+        providerId: "claude-code",
+      }),
+    });
+
+    expect(query?.options).toEqual(
+      expect.objectContaining({
+        refetchInterval: SYSTEM_EXECUTION_OPTIONS_REFETCH_MS,
+      }),
+    );
+  });
+
   it("separates requests and cache entries for different hosts", async () => {
     vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
       args?.hostId === "host-a"

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -36,6 +36,7 @@ interface QueryOptions {
 
 const SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS = 250;
 const SYSTEM_EXECUTION_OPTIONS_RETRY_COUNT = 1;
+const SYSTEM_EXECUTION_OPTIONS_REFETCH_MS = 60_000;
 
 function isAbortLikeError(error: unknown): boolean {
   return toRecord(error)?.name === "AbortError";
@@ -83,6 +84,7 @@ export function useSystemExecutionOptions(
         signal,
       }),
     enabled,
+    refetchInterval: SYSTEM_EXECUTION_OPTIONS_REFETCH_MS,
     staleTime: 60_000,
     retry: shouldRetrySystemExecutionOptions,
     retryDelay: SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS,


### PR DESCRIPTION
Summary

- Refresh active execution-options queries every 60 seconds so provider model availability changes appear without reloading bb.
- Preserve Claude Code runtime fallback behavior; this only refreshes the model catalog.
- Add a regression test covering the mounted-query polling policy.

Verification

- Focused system query tests: 6 passed
- @bb/app typecheck: passed
- @bb/app lint: passed (existing warnings only)
- Full @bb/app suite: 2,055 passed, one unrelated PluginsOverview pagination failure that passed immediately in isolation
- Review loop: CORRECT, no P0-P2 findings