### PR TITLE
Always offer BB's curated Claude models and preload the picker

### DIFF
--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -1,4 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import {
+  listBuiltInAgentProviderInfos,
+  listClaudeCodeFallbackModels,
+} from "@bb/agent-providers";
 import { toRecord } from "@bb/core-ui";
 import type {
   SystemConfigResponse,
@@ -8,6 +12,11 @@ import type {
 import type { ProviderCliStatusResponse } from "@bb/host-daemon-contract";
 import type { ProviderUsageResponse } from "@bb/host-daemon-contract";
 import { BbHttpError, sdk } from "@/lib/sdk";
+import {
+  claudeModelCatalogCacheKey,
+  readCachedClaudeModelCatalog,
+  writeCachedClaudeModelCatalog,
+} from "@/lib/claude-model-catalog-cache";
 import { useSystemRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import {
   hostProviderCliStatusQueryKey,
@@ -36,6 +45,32 @@ interface QueryOptions {
 
 const SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS = 250;
 const SYSTEM_EXECUTION_OPTIONS_RETRY_COUNT = 1;
+const CLAUDE_CODE_PROVIDER_ID = "claude-code";
+
+// Claude's account-scoped model probe spawns a CLI process on the host, so
+// waiting for it leaves the composer with no model list for seconds. Render a
+// provisional catalog immediately and let the authoritative rows replace it when
+// the probe lands.
+//
+// Prefer the last catalog this account actually reported: its ids match what the
+// fresh probe will return, so a selection made during the preload window
+// survives instead of snapping back to a default. The curated aliases are only
+// for a cold cache, where no account-scoped ids are known yet.
+//
+// Callers must gate model recovery on `isPlaceholderData` either way: a cached
+// catalog can be stale, so absence from this list is not evidence that a stored
+// model was retired.
+function claudeCodePlaceholderExecutionOptions(
+  cacheKey: string,
+): SystemExecutionOptionsResponse {
+  const cached = readCachedClaudeModelCatalog(cacheKey);
+  return {
+    providers: listBuiltInAgentProviderInfos(),
+    models: cached?.models ?? listClaudeCodeFallbackModels(),
+    selectedOnlyModels: cached?.selectedOnlyModels ?? [],
+    modelLoadError: null,
+  };
+}
 
 function isAbortLikeError(error: unknown): boolean {
   return toRecord(error)?.name === "AbortError";
@@ -68,6 +103,11 @@ export function useSystemExecutionOptions(
   const providerId = args.providerId ?? null;
   const enabled = args.enabled ?? true;
   useSystemRealtimeSubscription({ enabled });
+  const isClaudeCode = providerId === CLAUDE_CODE_PROVIDER_ID;
+  const catalogCacheKey = claudeModelCatalogCacheKey({
+    environmentId,
+    hostId,
+  });
 
   return useQuery<SystemExecutionOptionsResponse>({
     queryKey: systemExecutionOptionsQueryKey({
@@ -75,17 +115,34 @@ export function useSystemExecutionOptions(
       hostId,
       providerId,
     }),
-    queryFn: ({ signal }) =>
-      sdk.system.executionOptions({
+    queryFn: async ({ signal }) => {
+      const response = await sdk.system.executionOptions({
         environmentId: args.environmentId,
         hostId: args.hostId,
         providerId: args.providerId,
         signal,
-      }),
+      });
+      // Only a verified catalog is worth remembering. Caching a provisional list
+      // would let the server's probe-failure fallback masquerade as this
+      // account's real models on the next cold load.
+      if (isClaudeCode && response.modelLoadError === null) {
+        writeCachedClaudeModelCatalog(catalogCacheKey, {
+          models: response.models,
+          selectedOnlyModels: response.selectedOnlyModels,
+        });
+      }
+      return response;
+    },
     enabled,
     staleTime: 60_000,
     retry: shouldRetrySystemExecutionOptions,
     retryDelay: SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS,
+    ...(isClaudeCode
+      ? {
+          placeholderData: () =>
+            claudeCodePlaceholderExecutionOptions(catalogCacheKey),
+        }
+      : {}),
   });
 }
 

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -87,6 +87,67 @@ function executionOptionsResponse(): SystemExecutionOptionsResponse {
   };
 }
 
+function claudeExecutionOptionsResponse(): SystemExecutionOptionsResponse {
+  return {
+    providers: [
+      {
+        id: "claude-code",
+        displayName: "Claude Code",
+        logoUrl: null,
+        available: true,
+        composerActions: [],
+        capabilities: {
+          supportsArchive: true,
+          supportsRename: true,
+          supportsServiceTier: true,
+          supportsUserQuestion: true,
+          supportsFork: true,
+          supportedPermissionModes: ["accept-edits", "auto", "full"],
+        },
+      },
+    ],
+    models: [
+      {
+        id: "claude-opus-4-8[1m]",
+        model: "claude-opus-4-8[1m]",
+        displayName: "Opus 4.8 (1M)",
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+        ],
+        defaultReasoningEffort: "high",
+        isDefault: true,
+      },
+      {
+        id: "claude-sonnet-5",
+        model: "claude-sonnet-5",
+        displayName: "Sonnet 5",
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+        ],
+        defaultReasoningEffort: "medium",
+        isDefault: false,
+      },
+    ],
+    selectedOnlyModels: [],
+    modelLoadError: null,
+  };
+}
+
+function claudeThreadCreationArgs(resetKey: string, initialModel: string) {
+  return {
+    scope: "component-local" as const,
+    resetKey,
+    initialProviderId: "claude-code",
+    initialModel,
+    initialReasoningLevel: "high" as const,
+    initialPermissionMode: "full" as const,
+  };
+}
+
 function setProjectScopedValue(baseKey: string, value: string): void {
   window.localStorage.setItem(
     getProjectScopedStorageKey(baseKey, PROJECT_ID),
@@ -310,6 +371,114 @@ describe("useThreadCreationOptions", () => {
       expect(result.current.modelLoadFailed).toBe(true);
       expect(result.current.selectedModel).toBe("still-valid-model");
       expect(result.current.executionInputSources.model).toBeUndefined();
+    });
+  });
+
+  it("preloads Claude models and defers recovery until the probe lands", async () => {
+    let resolveOptions: (
+      value: SystemExecutionOptionsResponse,
+    ) => void = () => {};
+    vi.mocked(sdk.system.executionOptions).mockReturnValueOnce(
+      new Promise<SystemExecutionOptionsResponse>((resolve) => {
+        resolveOptions = resolve;
+      }),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          resetKey: "thr_claude_preload",
+          initialProviderId: "claude-code",
+          initialModel: "claude-mythos-5",
+          initialReasoningLevel: "high",
+          initialPermissionMode: "full",
+        }),
+      { wrapper },
+    );
+
+    // The curated catalog renders before the host model probe returns, so the
+    // picker is usable immediately instead of empty for the probe's duration.
+    await waitFor(() => {
+      expect(result.current.modelOptions.map((option) => option.value)).toEqual(
+        [
+          "claude-fable-5",
+          "claude-opus-4-8[1m]",
+          "claude-opus-4-7[1m]",
+          "claude-sonnet-5",
+        ],
+      );
+    });
+    // A provisional catalog is never proof that the stored model was retired,
+    // so the selection must survive until the authoritative probe lands.
+    expect(result.current.selectedModel).toBe("claude-mythos-5");
+    expect(result.current.executionInputSources.model).toBeUndefined();
+
+    act(() => {
+      resolveOptions(claudeExecutionOptionsResponse());
+    });
+
+    // Once discovery succeeds, absence is definitive and recovery is explicit.
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("claude-opus-4-8[1m]");
+      expect(result.current.executionInputSources.model).toBe("explicit");
+    });
+  });
+
+  it("preloads the account's real model ids so a preload-window pick survives", async () => {
+    vi.mocked(sdk.system.executionOptions).mockResolvedValue(
+      claudeExecutionOptionsResponse(),
+    );
+
+    // A first successful probe records this account's catalog.
+    const first = renderHook(
+      () =>
+        useThreadCreationOptions(
+          claudeThreadCreationArgs("thr_cached_first", "claude-opus-4-8[1m]"),
+        ),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+    await waitFor(() => {
+      expect(
+        first.result.current.modelOptions.map((option) => option.value),
+      ).toEqual(["claude-opus-4-8[1m]", "claude-sonnet-5"]);
+    });
+    first.unmount();
+
+    // A cold client (page reload) with the probe still in flight: the preloaded
+    // rows are the account's real ids, not generic aliases.
+    let resolveOptions: (
+      value: SystemExecutionOptionsResponse,
+    ) => void = () => {};
+    vi.mocked(sdk.system.executionOptions).mockReturnValueOnce(
+      new Promise<SystemExecutionOptionsResponse>((resolve) => {
+        resolveOptions = resolve;
+      }),
+    );
+    const second = renderHook(
+      () =>
+        useThreadCreationOptions(
+          claudeThreadCreationArgs("thr_cached_second", "claude-sonnet-5"),
+        ),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+
+    await waitFor(() => {
+      expect(
+        second.result.current.modelOptions.map((option) => option.value),
+      ).toEqual(["claude-opus-4-8[1m]", "claude-sonnet-5"]);
+    });
+    expect(second.result.current.selectedModel).toBe("claude-sonnet-5");
+
+    act(() => {
+      resolveOptions(claudeExecutionOptionsResponse());
+    });
+
+    // The authoritative rows carry the same ids, so nothing snaps back to the
+    // catalog default.
+    await waitFor(() => {
+      expect(second.result.current.selectedModel).toBe("claude-sonnet-5");
+      expect(second.result.current.executionInputSources.model).toBeUndefined();
     });
   });
 

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -309,6 +309,12 @@ export function useThreadCreationOptions(
     executionOptionsQuery.data?.modelLoadError ?? NO_MODEL_LOAD_ERROR;
   const modelLoadFailed =
     executionOptionsQuery.isError || modelLoadError !== null;
+  // Preloaded placeholder rows and the server's probe-failure fallback are both
+  // provisional catalogs. Only a successful probe proves a stored model is gone,
+  // so recovery is gated on the catalog being verified. Placeholder data is not
+  // a failure, so it deliberately stays out of `modelLoadFailed`.
+  const modelCatalogIsUnverified =
+    modelLoadError !== null || executionOptionsQuery.isPlaceholderData;
   const hasMultipleProviders = providers.length >= 2;
 
   // Resolve the effective provider: use selectedProviderId if it matches a known
@@ -386,11 +392,12 @@ export function useThreadCreationOptions(
     rawSelectedModel,
   ]);
   const selectedModel = useMemo(() => {
-    // A provider discovery error is temporary: keep an existing explicit
-    // selection instead of treating a partial/custom catalog as proof that it
-    // disappeared. Once discovery succeeds, absence is definitive and the
-    // catalog default becomes a recovery selection.
-    if (modelLoadError !== null && rawSelectedModel) {
+    // An unverified catalog (discovery error, or preloaded placeholder rows) is
+    // temporary: keep an existing explicit selection instead of treating a
+    // partial/provisional catalog as proof that it disappeared. Once discovery
+    // succeeds, absence is definitive and the catalog default becomes a recovery
+    // selection.
+    if (modelCatalogIsUnverified && rawSelectedModel) {
       return rawSelectedModel;
     }
     if (availableModels.length === 0) {
@@ -403,9 +410,9 @@ export function useThreadCreationOptions(
       availableModels.find((model) => model.isDefault)?.model ??
       availableModels[0].model
     );
-  }, [availableModels, modelLoadError, rawSelectedModel]);
+  }, [availableModels, modelCatalogIsUnverified, rawSelectedModel]);
   const isUnavailableModelRecovery =
-    modelLoadError === null &&
+    !modelCatalogIsUnverified &&
     rawSelectedModel.length > 0 &&
     selectedModel !== rawSelectedModel;
 

--- a/apps/app/src/lib/claude-model-catalog-cache.ts
+++ b/apps/app/src/lib/claude-model-catalog-cache.ts
@@ -1,0 +1,64 @@
+import { availableModelSchema } from "@bb/domain";
+import { z } from "zod";
+import { createJsonLocalStorage } from "@/lib/browser-storage";
+
+const CLAUDE_MODEL_CATALOG_CACHE_PREFIX = "bb.claude-model-catalog";
+const CLAUDE_MODEL_CATALOG_CACHE_VERSION = "1";
+
+const cachedClaudeModelCatalogSchema = z.object({
+  models: z.array(availableModelSchema),
+  selectedOnlyModels: z.array(availableModelSchema),
+});
+
+export type CachedClaudeModelCatalog = z.infer<
+  typeof cachedClaudeModelCatalogSchema
+>;
+
+interface ClaudeModelCatalogCacheKeyArgs {
+  environmentId: string | null;
+  hostId: string | null;
+}
+
+const catalogStorage = createJsonLocalStorage<unknown>();
+
+/**
+ * Scoped to the same routing dimensions as the execution-options query, because
+ * two hosts can be signed into different Claude accounts with different
+ * entitlements. The version segment lets a shape change invalidate old entries
+ * instead of relying on the parse below to reject every one of them.
+ */
+export function claudeModelCatalogCacheKey({
+  environmentId,
+  hostId,
+}: ClaudeModelCatalogCacheKeyArgs): string {
+  return [
+    CLAUDE_MODEL_CATALOG_CACHE_PREFIX,
+    CLAUDE_MODEL_CATALOG_CACHE_VERSION,
+    environmentId ?? "-",
+    hostId ?? "-",
+  ].join(".");
+}
+
+/**
+ * The last catalog a successful account-scoped probe returned, used to preload
+ * the picker with this account's real model ids rather than generic aliases. A
+ * cached catalog can be stale, so callers must keep reporting preloaded rows as
+ * provisional: only a fresh probe may retire a stored selection.
+ */
+export function readCachedClaudeModelCatalog(
+  key: string,
+): CachedClaudeModelCatalog | null {
+  const stored = catalogStorage.getItem(key, null);
+  if (stored === null) {
+    return null;
+  }
+  const parsed = cachedClaudeModelCatalogSchema.safeParse(stored);
+  return parsed.success ? parsed.data : null;
+}
+
+export function writeCachedClaudeModelCatalog(
+  key: string,
+  catalog: CachedClaudeModelCatalog,
+): void {
+  catalogStorage.setItem(key, catalog);
+}

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -8,6 +8,7 @@ import type {
 import {
   buildAcpProviderInfo,
   listBuiltInAgentProviderInfos,
+  listClaudeCodeFallbackModels,
 } from "@bb/agent-providers";
 import {
   formatCustomAcpAgentProviderId,
@@ -483,15 +484,41 @@ async function loadSystemProviderModels(
       },
       "Failed to resolve provider models",
     );
+    const modelLoadError = buildModelLoadError({
+      error,
+      provider,
+    });
     return {
-      models: [],
-      selectedOnlyModels: [],
-      modelLoadError: buildModelLoadError({
-        error,
-        provider,
+      models: listFallbackModelsForLoadError({
+        code: modelLoadError.code,
+        providerId: provider.id,
       }),
+      selectedOnlyModels: [],
+      modelLoadError,
     };
   }
+}
+
+// A transient probe failure is not evidence that a model was retired, so the
+// picker gets a provisional list instead of an empty one. `modelLoadError` stays
+// set, which is what keeps callers treating this list as unverified: absence
+// from it must never trigger thread model recovery. `missing_executable` and
+// `auth_required` are excluded on purpose — those are actionable setup states
+// the app routes to an install/auth prompt, so offering models there would only
+// defer the real failure to submit time.
+function listFallbackModelsForLoadError({
+  code,
+  providerId,
+}: {
+  code: SystemExecutionOptionsModelLoadErrorCode;
+  providerId: string;
+}): AvailableModel[] {
+  if (providerId !== "claude-code") {
+    return [];
+  }
+  return code === "timeout" || code === "failed"
+    ? listClaudeCodeFallbackModels()
+    : [];
 }
 
 function buildModelLoadError({

--- a/apps/server/src/services/threads/thread-execution-override.ts
+++ b/apps/server/src/services/threads/thread-execution-override.ts
@@ -243,7 +243,9 @@ async function loadThreadProviderModels(
     );
   }
   // Selected-only models are browsable in the picker's collapsed "More
-  // models" section, so they are valid swap targets too.
+  // models" section, so they are valid swap targets too. The curated Claude
+  // catalog needs no special handling here: it is always present in
+  // `result.models`, so any row the picker can offer already validates.
   return [...result.models, ...result.selectedOnlyModels];
 }
 

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -739,16 +739,97 @@ describe("resolveSystemExecutionOptions", () => {
           providerId: "claude-code",
           code: "failed",
         });
-        expect(response.models).toEqual([
-          expect.objectContaining({
-            model: "claude-example-preview",
-            displayName: "Example Preview",
-          }),
+        // A transient failure serves the provisional alias catalog, and custom
+        // models stay appended after it.
+        expect(response.models.map((model) => model.model)).toEqual([
+          "claude-fable-5",
+          "claude-opus-4-8[1m]",
+          "claude-opus-4-7[1m]",
+          "claude-sonnet-5",
+          "claude-example-preview",
         ]);
         expect(response.selectedOnlyModels).toEqual([]);
       },
     );
   });
+
+  it("serves the curated Claude catalog when the model probe fails transiently", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-execution-options-claude-provisional",
+      });
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelErrorsByProviderId: {
+          "claude-code": {
+            errorCode: "command_timeout",
+            errorMessage: "Model probe timed out",
+          },
+        },
+      });
+
+      const response = await resolveSystemExecutionOptions(harness.deps, {
+        hostId: host.id,
+        providerId: "claude-code",
+      });
+
+      // The catalog is provisional, so the error must still be reported:
+      // callers gate thread model recovery on `modelLoadError` being null.
+      expect(response.modelLoadError).toEqual({
+        providerId: "claude-code",
+        code: "timeout",
+      });
+      expect(response.models.map((model) => model.model)).toEqual([
+        "claude-fable-5",
+        "claude-opus-4-8[1m]",
+        "claude-opus-4-7[1m]",
+        "claude-sonnet-5",
+      ]);
+      expect(
+        response.models
+          .filter((model) => model.isDefault)
+          .map((model) => model.model),
+      ).toEqual(["claude-opus-4-8[1m]"]);
+    });
+  });
+
+  it.each([
+    ["auth required", "auth_required"],
+    ["missing executable", "missing_executable"],
+  ] as const)(
+    "offers no provisional Claude models for %s setup failures",
+    async (_name, errorCode) => {
+      await withTestHarness({}, async (harness) => {
+        const { host, session } = seedHostSession(harness.deps, {
+          id: `host-execution-options-claude-${errorCode}`,
+        });
+        registerProviderHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+          modelErrorsByProviderId: {
+            "claude-code": {
+              errorCode,
+              errorMessage: "Claude Code is not usable",
+            },
+          },
+        });
+
+        const response = await resolveSystemExecutionOptions(harness.deps, {
+          hostId: host.id,
+          providerId: "claude-code",
+        });
+
+        // These are actionable setup states the app routes to an install/auth
+        // prompt. Offering models would only defer the failure to submit time.
+        expect(response.modelLoadError).toEqual({
+          providerId: "claude-code",
+          code: errorCode,
+        });
+        expect(response.models).toEqual([]);
+      });
+    },
+  );
 
   it("logs model load fallback errors without stack-bearing err objects", async () => {
     await withTestHarness(async (harness) => {

--- a/packages/agent-providers/src/claude-code-models.ts
+++ b/packages/agent-providers/src/claude-code-models.ts
@@ -1,0 +1,110 @@
+import {
+  cloneReasoningEfforts,
+  HIGH_REASONING_EFFORT,
+  LOW_REASONING_EFFORT,
+  MAX_REASONING_EFFORT,
+  MEDIUM_REASONING_EFFORT,
+  ULTRACODE_REASONING_EFFORT,
+  XHIGH_REASONING_EFFORT,
+  type AvailableModel,
+  type ModelReasoningEffort,
+} from "@bb/domain";
+
+export interface ClaudeCodeCatalogEntry {
+  id: string;
+  model: string;
+  displayName: string;
+  description: string;
+  supportedReasoningEfforts: readonly ModelReasoningEffort[];
+  defaultReasoningEffort: AvailableModel["defaultReasoningEffort"];
+}
+
+// Ultracode requires an xhigh-capable model (it decomposes to xhigh effort plus
+// standing workflow orchestration), so only the xhigh ladder offers it.
+export const CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS: readonly ModelReasoningEffort[] =
+  [
+    LOW_REASONING_EFFORT,
+    MEDIUM_REASONING_EFFORT,
+    HIGH_REASONING_EFFORT,
+    XHIGH_REASONING_EFFORT,
+    ULTRACODE_REASONING_EFFORT,
+    MAX_REASONING_EFFORT,
+  ];
+
+export const DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-8[1m]";
+
+/**
+ * BB's curated, version-pinned Claude Code models. Lives here rather than in the
+ * daemon because two consumers need the same rows:
+ *
+ * - the daemon filters this list against an account-scoped probe, so only models
+ *   the account can actually run reach the picker
+ * - the app and server show it unfiltered as a provisional catalog, before or
+ *   instead of a successful probe
+ *
+ * Secondary "More models" choices, moving aliases, and retired model strings are
+ * deliberately absent: they live in the daemon's selected-only catalog, which
+ * exists to label an already-stored selection rather than to offer new ones.
+ */
+export const CLAUDE_CODE_ACTIVE_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
+  {
+    id: "claude-fable-5",
+    model: "claude-fable-5",
+    displayName: "Fable 5",
+    description:
+      "Fable 5 for demanding reasoning; requires Claude Code v2.1.170+",
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+    defaultReasoningEffort: "high",
+  },
+  {
+    id: DEFAULT_CLAUDE_CODE_MODEL,
+    model: DEFAULT_CLAUDE_CODE_MODEL,
+    displayName: "Opus 4.8 (1M)",
+    description: "Opus 4.8 with 1M context for complex long coding sessions",
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+    defaultReasoningEffort: "high",
+  },
+  {
+    id: "claude-opus-4-7[1m]",
+    model: "claude-opus-4-7[1m]",
+    displayName: "Opus 4.7 (1M)",
+    description: "Opus 4.7 with 1M context for complex long coding sessions",
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+    defaultReasoningEffort: "medium",
+  },
+  {
+    id: "claude-sonnet-5",
+    model: "claude-sonnet-5",
+    displayName: "Sonnet 5",
+    description: "Sonnet 5 for everyday coding tasks with deeper reasoning",
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+    defaultReasoningEffort: "medium",
+  },
+];
+
+/**
+ * The curated catalog as picker rows, for use before or instead of a successful
+ * account-scoped probe:
+ *
+ * - the app renders it as react-query placeholder data on a cold cache, so the
+ *   picker is populated immediately rather than waiting on a CLI process spawn
+ * - the server substitutes it when the probe fails transiently
+ *
+ * These rows are pinned model ids, so an account without the matching
+ * entitlement or CLI version will not be able to run every one of them. Neither
+ * caller may treat this list as authoritative: absence from it is never proof
+ * that a stored model was retired, and only a successful probe may trigger model
+ * recovery. Once a probe succeeds, its result is what should be shown and
+ * remembered.
+ *
+ * Returns fresh objects because these flow into mutable API responses.
+ */
+export function listClaudeCodeFallbackModels(): AvailableModel[] {
+  return CLAUDE_CODE_ACTIVE_CATALOG.map((entry) => ({
+    ...entry,
+    supportedReasoningEfforts: cloneReasoningEfforts(
+      entry.supportedReasoningEfforts,
+    ),
+    isDefault: entry.model === DEFAULT_CLAUDE_CODE_MODEL,
+  }));
+}

--- a/packages/agent-providers/src/index.ts
+++ b/packages/agent-providers/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  CLAUDE_CODE_ACTIVE_CATALOG,
+  CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+  DEFAULT_CLAUDE_CODE_MODEL,
+  listClaudeCodeFallbackModels,
+} from "./claude-code-models.js";
+export type { ClaudeCodeCatalogEntry } from "./claude-code-models.js";
+export {
   agentProviderIdSchema,
   buildAcpProviderInfo,
   getAcpProviderServerCapabilities,

--- a/packages/agent-providers/test/claude-code-models.test.ts
+++ b/packages/agent-providers/test/claude-code-models.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLAUDE_CODE_ACTIVE_CATALOG,
+  DEFAULT_CLAUDE_CODE_MODEL,
+  listClaudeCodeFallbackModels,
+} from "../src/index.js";
+
+describe("Claude Code curated catalog", () => {
+  // Moving aliases resolve per account, which reads as safer, but they are not
+  // what this list is for: it is the always-offered base set, and it must carry
+  // BB's real labels and reasoning ladders. Aliases belong in the daemon's
+  // selected-only catalog, which exists to label an already-stored selection.
+  it("names version-pinned models rather than moving aliases", () => {
+    for (const entry of CLAUDE_CODE_ACTIVE_CATALOG) {
+      expect(entry.model).toMatch(/^claude-/);
+      expect(entry.id).toBe(entry.model);
+    }
+  });
+
+  // Mythos was offered to every account for "Project Glasswing access" while
+  // most accounts could not run it. Entitlement-gated models must reach the
+  // picker through account-scoped discovery, never through this list.
+  it("omits entitlement-gated models", () => {
+    expect(
+      CLAUDE_CODE_ACTIVE_CATALOG.some((entry) =>
+        entry.model.includes("mythos"),
+      ),
+    ).toBe(false);
+  });
+
+  it("marks exactly the product default model", () => {
+    const defaults = listClaudeCodeFallbackModels().filter(
+      (model) => model.isDefault,
+    );
+
+    expect(defaults.map((model) => model.model)).toEqual([
+      DEFAULT_CLAUDE_CODE_MODEL,
+    ]);
+  });
+
+  it("advertises a default reasoning effort each model actually supports", () => {
+    for (const model of listClaudeCodeFallbackModels()) {
+      expect(
+        model.supportedReasoningEfforts.map((effort) => effort.reasoningEffort),
+      ).toContain(model.defaultReasoningEffort);
+    }
+  });
+
+  // These rows flow into mutable API responses and react-query placeholder
+  // data, so a caller mutating one must not corrupt every later reader.
+  it("returns fresh objects on each call", () => {
+    const first = listClaudeCodeFallbackModels();
+    first[0].supportedReasoningEfforts.length = 0;
+    first[0].displayName = "mutated";
+
+    const second = listClaudeCodeFallbackModels();
+    expect(second[0].displayName).not.toBe("mutated");
+    expect(second[0].supportedReasoningEfforts.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1632,18 +1632,18 @@ describe("bridge", () => {
     const { models, selectedOnlyModels } = await listClaudeCodeBridgeModels({
       PATH: binDir,
     });
-    expect(models).toEqual([
+    // The curated catalog is always offered, so a probe reporting only Opus and
+    // Sonnet still yields every curated row; the probe's default wins.
+    expect(models.map((model) => model.model)).toEqual([
+      "claude-fable-5",
+      "claude-opus-4-8[1m]",
+      "claude-opus-4-7[1m]",
+      "claude-sonnet-5",
+    ]);
+    expect(models.filter((model) => model.isDefault)).toEqual([
       expect.objectContaining({
-        id: "claude-opus-4-8[1m]",
         model: "claude-opus-4-8[1m]",
         displayName: "Opus 4.8 (1M)",
-        isDefault: true,
-      }),
-      expect.objectContaining({
-        id: "claude-sonnet-5",
-        model: "claude-sonnet-5",
-        displayName: "Sonnet 5",
-        isDefault: false,
       }),
     ]);
     expect(selectedOnlyModels.map((model) => model.model)).toEqual([

--- a/packages/agent-runtime/src/claude-code/model-list.test.ts
+++ b/packages/agent-runtime/src/claude-code/model-list.test.ts
@@ -35,19 +35,28 @@ const DISCOVERED_MODELS: ModelInfo[] = [
   },
 ];
 
+const CURATED_MODELS = [
+  "claude-fable-5",
+  "claude-opus-4-8[1m]",
+  "claude-opus-4-7[1m]",
+  "claude-sonnet-5",
+];
+
 describe("buildClaudeCodeModels", () => {
-  it("only exposes curated identifiers covered by account-scoped discovery", () => {
+  it("always offers the curated catalog and appends discovered extras", () => {
     const result = buildClaudeCodeModels(DISCOVERED_MODELS);
 
+    // Discovery is additive: every curated row survives, and only the reported
+    // model BB has no curated entry for (Haiku's dated id) is appended.
     expect(result.models.map((model) => model.model)).toEqual([
-      "claude-fable-5",
-      "claude-opus-4-8[1m]",
-      "claude-sonnet-5",
+      ...CURATED_MODELS,
       "claude-haiku-4-5-20251001",
     ]);
     expect(result.models.find((model) => model.isDefault)?.model).toBe(
       "claude-opus-4-8[1m]",
     );
+    // Selected-only rows stay discovery-gated — they only label a selection the
+    // user already has.
     expect(result.selectedOnlyModels.map((model) => model.model)).toEqual([
       "opus[1m]",
       "sonnet",
@@ -60,11 +69,16 @@ describe("buildClaudeCodeModels", () => {
     ).toBe(false);
   });
 
-  it("returns an empty catalog when the provider reports no models", () => {
-    expect(buildClaudeCodeModels([])).toEqual({
-      models: [],
-      selectedOnlyModels: [],
-    });
+  // A probe that returns nothing must not strand the picker. This is the whole
+  // point of the always-offered base set.
+  it("still offers the curated catalog when the provider reports no models", () => {
+    const result = buildClaudeCodeModels([]);
+
+    expect(result.models.map((model) => model.model)).toEqual(CURATED_MODELS);
+    expect(result.models.find((model) => model.isDefault)?.model).toBe(
+      "claude-opus-4-8[1m]",
+    );
+    expect(result.selectedOnlyModels).toEqual([]);
   });
 
   it("keeps authoritative models that do not have curated metadata yet", () => {
@@ -79,13 +93,34 @@ describe("buildClaudeCodeModels", () => {
       },
     ]);
 
-    expect(result.models).toEqual([
+    expect(result.models.map((model) => model.model)).toEqual([
+      ...CURATED_MODELS,
+      "claude-future-6",
+    ]);
+    expect(result.models.at(-1)).toEqual(
       expect.objectContaining({
         model: "claude-future-6",
         displayName: "Future 6",
-        isDefault: true,
+        isDefault: false,
         defaultReasoningEffort: "high",
       }),
+    );
+  });
+
+  // The account's own default wins over BB's product default when the probe
+  // reports one, so a curated row can never override the provider's choice.
+  it("prefers the discovered default model", () => {
+    const result = buildClaudeCodeModels([
+      {
+        value: "default",
+        resolvedModel: "claude-sonnet-5",
+        displayName: "Default (recommended)",
+        description: "Sonnet 5",
+      },
     ]);
+
+    expect(result.models.find((model) => model.isDefault)?.model).toBe(
+      "claude-sonnet-5",
+    );
   });
 });

--- a/packages/agent-runtime/src/claude-code/model-list.ts
+++ b/packages/agent-runtime/src/claude-code/model-list.ts
@@ -1,5 +1,11 @@
 import type { ModelInfo } from "@anthropic-ai/claude-agent-sdk";
 import {
+  CLAUDE_CODE_ACTIVE_CATALOG,
+  CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+  DEFAULT_CLAUDE_CODE_MODEL,
+  type ClaudeCodeCatalogEntry,
+} from "@bb/agent-providers";
+import {
   cloneReasoningEfforts,
   HIGH_REASONING_EFFORT,
   LOW_REASONING_EFFORT,
@@ -11,28 +17,8 @@ import {
   type ModelReasoningEffort,
 } from "@bb/domain";
 
-type ClaudeCodeCatalogEntry = {
-  id: string;
-  model: string;
-  displayName: string;
-  description: string;
-  supportedReasoningEfforts: readonly ModelReasoningEffort[];
-  defaultReasoningEffort: AvailableModel["defaultReasoningEffort"];
-};
-
-// Ultracode requires an xhigh-capable model (it decomposes to xhigh effort +
-// standing workflow orchestration), so only the xhigh ladder offers it.
-const XHIGH_CAPABLE_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
-  LOW_REASONING_EFFORT,
-  MEDIUM_REASONING_EFFORT,
-  HIGH_REASONING_EFFORT,
-  XHIGH_REASONING_EFFORT,
-  ULTRACODE_REASONING_EFFORT,
-  MAX_REASONING_EFFORT,
-];
-
 const OPUS_4_7_REASONING_EFFORTS: readonly ModelReasoningEffort[] =
-  XHIGH_CAPABLE_REASONING_EFFORTS;
+  CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS;
 
 const OPUS_4_6_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
   LOW_REASONING_EFFORT,
@@ -52,67 +38,15 @@ const HAIKU_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
   LOW_REASONING_EFFORT,
 ];
 
-const CLAUDE_FABLE_5_MODEL = "claude-fable-5";
-const CLAUDE_MYTHOS_5_MODEL = "claude-mythos-5";
 const CLAUDE_OPUS_4_8_MODEL = "claude-opus-4-8";
 const CLAUDE_OPUS_4_7_MODEL = "claude-opus-4-7";
 const CLAUDE_OPUS_4_6_MODEL = "claude-opus-4-6";
-const CLAUDE_SONNET_5_MODEL = "claude-sonnet-5";
 const CLAUDE_SONNET_4_6_MODEL = "claude-sonnet-4-6";
 const CLAUDE_HAIKU_4_5_MODEL = "claude-haiku-4-5";
 
 function withOneMillionContext(model: string): string {
   return `${model}[1m]`;
 }
-
-const DEFAULT_CLAUDE_CODE_MODEL = withOneMillionContext(CLAUDE_OPUS_4_8_MODEL);
-
-// Keep the active catalog version-pinned. Secondary "More models" choices,
-// moving aliases, and retired model strings live in the selected-only catalog
-// so existing stored selections can render with their proper label.
-const CLAUDE_CODE_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
-  {
-    id: CLAUDE_FABLE_5_MODEL,
-    model: CLAUDE_FABLE_5_MODEL,
-    displayName: "Fable 5",
-    description:
-      "Fable 5 for demanding reasoning; requires Claude Code v2.1.170+",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
-    defaultReasoningEffort: "high",
-  },
-  {
-    id: CLAUDE_MYTHOS_5_MODEL,
-    model: CLAUDE_MYTHOS_5_MODEL,
-    displayName: "Mythos 5",
-    description: "Mythos 5 for approved Project Glasswing access",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
-    defaultReasoningEffort: "high",
-  },
-  {
-    id: withOneMillionContext(CLAUDE_OPUS_4_8_MODEL),
-    model: withOneMillionContext(CLAUDE_OPUS_4_8_MODEL),
-    displayName: "Opus 4.8 (1M)",
-    description: "Opus 4.8 with 1M context for complex long coding sessions",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
-    defaultReasoningEffort: "high",
-  },
-  {
-    id: withOneMillionContext(CLAUDE_OPUS_4_7_MODEL),
-    model: withOneMillionContext(CLAUDE_OPUS_4_7_MODEL),
-    displayName: "Opus 4.7 (1M)",
-    description: "Opus 4.7 with 1M context for complex long coding sessions",
-    supportedReasoningEfforts: OPUS_4_7_REASONING_EFFORTS,
-    defaultReasoningEffort: "medium",
-  },
-  {
-    id: CLAUDE_SONNET_5_MODEL,
-    model: CLAUDE_SONNET_5_MODEL,
-    displayName: "Sonnet 5",
-    description: "Sonnet 5 for everyday coding tasks with deeper reasoning",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
-    defaultReasoningEffort: "medium",
-  },
-];
 
 const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
   {
@@ -145,7 +79,7 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
     displayName: "Opus 4.8 (Legacy)",
     description:
       "Legacy Opus 4.8 model retained for existing non-1M selections",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
     defaultReasoningEffort: "high",
   },
   {
@@ -179,7 +113,7 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
     displayName: "Best Alias",
     description:
       "Moving best alias retained for existing selections; resolves to Fable 5 where available",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
     defaultReasoningEffort: "high",
   },
   {
@@ -188,7 +122,7 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
     displayName: "Fable Alias",
     description:
       "Moving Fable alias retained for existing selections; resolves to Claude Fable 5",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
     defaultReasoningEffort: "high",
   },
   {
@@ -205,7 +139,7 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
     displayName: "Opus Alias (Current)",
     description:
       "Moving Opus alias accepted by Claude Code; resolves to the current Opus model",
-    supportedReasoningEfforts: XHIGH_CAPABLE_REASONING_EFFORTS,
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
     defaultReasoningEffort: "high",
   },
   {
@@ -332,13 +266,20 @@ export interface ListClaudeCodeModelsResult {
 export function buildClaudeCodeModels(
   discoveredModels: readonly ModelInfo[],
 ): ListClaudeCodeModelsResult {
-  const models = CLAUDE_CODE_CATALOG.filter((entry) =>
-    modelIsDiscovered(entry.model, discoveredModels),
-  ).map(buildCatalogModel);
-  // Discovery can move faster than BB's curated labels. Preserve those new
-  // authoritative rows instead of returning an empty/partial picker until the
-  // static metadata catches up. Prefer non-"default" rows so aliases carrying
-  // the same resolved id provide the useful provider label.
+  // The curated catalog is always offered and discovery is purely additive, so
+  // the picker keeps a stable, well-labelled base set no matter what a probe
+  // returns. The trade-off is deliberate: a curated row can name a model this
+  // account cannot run (an entitlement it lacks, or a CLI too old for Fable),
+  // and that only surfaces when a turn is submitted. In exchange, a probe that
+  // returns a narrow list can never strand the picker.
+  //
+  // Because absence from this list is therefore no longer evidence that a model
+  // was retired, callers must not use it to retire a stored selection.
+  const models = CLAUDE_CODE_ACTIVE_CATALOG.map(buildCatalogModel);
+  // Discovery can move faster than BB's curated labels, so an account-scoped row
+  // BB has no metadata for is appended rather than dropped. Prefer non-"default"
+  // rows so aliases carrying the same resolved id provide the useful provider
+  // label.
   for (const discovered of [
     ...discoveredModels.filter((model) => model.value !== "default"),
     ...discoveredModels.filter((model) => model.value === "default"),
@@ -349,6 +290,8 @@ export function buildClaudeCodeModels(
     }
     models.push(buildDiscoveredModel(discovered));
   }
+  // Selected-only rows stay discovery-gated: they exist to label a selection the
+  // user already has, not to offer new ones, so there is nothing to keep stable.
   const selectedOnlyModels = CLAUDE_CODE_SELECTED_ONLY_CATALOG.filter(
     (entry) =>
       modelIsDiscovered(entry.model, discoveredModels) &&

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 64 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 65 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1009,8 +1009,11 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  it("uses protocol version 64 for workflow turn-completion timing", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(64);
+  // `provider.list_models` now always returns BB's curated Claude catalog and
+  // treats discovery as additive, so an older daemon would keep returning a
+  // discovery-filtered list. The bump is what forces it to update.
+  it("uses protocol version 65 for always-offered Claude catalog models", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(65);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

- always offer BB's curated, version-pinned Claude models and make account-scoped discovery purely additive, so a narrow probe result can never strand the model picker
- preload the picker from the last catalog this account reported, so it is populated instantly instead of waiting ~2-3s on a CLI process spawn, and a selection made during that window does not snap back
- substitute the curated rows server-side when the probe fails transiently
- remove Mythos from the curated catalog
- bump `HOST_DAEMON_PROTOCOL_VERSION` because `provider.list_models` semantics changed

## Problem

Claude's model probe spawns a CLI process on the host. Measured on this branch: `provider.list_models` takes 2.1-2.6s and `/api/v1/system/execution-options` 2.2-2.3s. Until it returned, the picker was empty. A probe that reported a narrow list could strand it entirely.

#835 had made the catalog `curated ∩ discovered` to fix Mythos being offered to accounts that could not run it. That fixed phantoms but left the picker fully dependent on a slow, failable probe.

## Approach

**Catalog rule inverted.** `buildClaudeCodeModels` now emits `CLAUDE_CODE_ACTIVE_CATALOG` unconditionally and appends only discovered ids BB has no curated entry for. Selected-only rows stay discovery-gated — they exist to label a selection the user already has, so there is nothing to keep stable. Mythos is deleted outright; the discovered-passthrough path already surfaces it with Anthropic's own label for entitled accounts.

**Catalog moved to `@bb/agent-providers`**, since the daemon (filtering), server (fallback), and app (preload) all need the same rows. `DEFAULT_CLAUDE_CODE_MODEL` and the xhigh reasoning ladder are single-sourced there too.

**Preload.** `useSystemExecutionOptions` sets react-query `placeholderData` for `claude-code` from the last catalog the account reported, cached in localStorage keyed by host/environment. Because those ids match what the fresh probe returns, a pick during the preload window survives. Curated rows are the cold-cache path only.

**Failure fallback.** The server substitutes the curated rows in `loadSystemProviderModels`'s catch, gated to `timeout`/`failed` — not `missing_executable`/`auth_required`, which the app routes to an install/auth prompt where offering models would only defer the failure to submit time.

**The invariant that keeps this safe.** A provisional catalog must never look authoritative. Recovery is now gated on `modelCatalogIsUnverified`, covering both a load error and placeholder data, so neither can retire a stored selection — only a successful probe can. Caching is likewise gated on `modelLoadError === null`, so the failure fallback cannot later masquerade as the account's real models.

## Trade-off

Deliberate and reviewer-visible: a curated row can name a model an account cannot run — an entitlement it lacks, or a CLI older than Fable 5's v2.1.170 requirement. Verified live on this account, whose probe does not report `claude-opus-4-7[1m]` yet is now offered it. That failure surfaces from Claude Code at turn time rather than as a clean 400 from BB, because absence from the list is no longer evidence of unavailability. In exchange the picker is always usable. Both sites carry comments saying so.

## Protocol bump

`provider.list_models` results change meaning from "account-verified" to "curated ∪ discovered". An enrolled daemon on the old build would keep returning a discovery-filtered list, so the bump is what forces it to update. The contract test pins 65 and records why.

## Validation

Verified against a live dev instance — the curated four are present including `claude-opus-4-7[1m]` (not reported by this account's probe), plus additive `claude-haiku-4-5-20251001` and `claude-opus-5[1m]`.

- `@bb/app` 2077/2077
- `@bb/agent-runtime` 795/795
- `@bb/agent-providers` 9/9, `@bb/host-daemon-contract` 50/50
- `@bb/server` 1253/1255 — both failures pre-existing and environment-dependent: a umask-sensitive skill-tree fixture (asserts 0644, local umask 0002 creates 0664) and `plugin-update.test.ts`, which passes 13/13 in isolation
- `turbo run build typecheck lint` passes on all five affected packages

`model-list.test.ts`'s old *"returns an empty catalog when the provider reports no models"* asserted exactly the behavior this PR removes; it is rewritten as *"still offers the curated catalog when the provider reports no models"* so the suite guards the new contract instead of losing the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
