### PR TITLE
Add Opus 5 (1M) to the curated Claude Code model list

### DIFF
--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -403,6 +403,7 @@ describe("useThreadCreationOptions", () => {
       expect(result.current.modelOptions.map((option) => option.value)).toEqual(
         [
           "claude-fable-5",
+          "claude-opus-5[1m]",
           "claude-opus-4-8[1m]",
           "claude-opus-4-7[1m]",
           "claude-sonnet-5",

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -743,6 +743,7 @@ describe("resolveSystemExecutionOptions", () => {
         // models stay appended after it.
         expect(response.models.map((model) => model.model)).toEqual([
           "claude-fable-5",
+          "claude-opus-5[1m]",
           "claude-opus-4-8[1m]",
           "claude-opus-4-7[1m]",
           "claude-sonnet-5",
@@ -782,6 +783,7 @@ describe("resolveSystemExecutionOptions", () => {
       });
       expect(response.models.map((model) => model.model)).toEqual([
         "claude-fable-5",
+        "claude-opus-5[1m]",
         "claude-opus-4-8[1m]",
         "claude-opus-4-7[1m]",
         "claude-sonnet-5",
@@ -790,7 +792,7 @@ describe("resolveSystemExecutionOptions", () => {
         response.models
           .filter((model) => model.isDefault)
           .map((model) => model.model),
-      ).toEqual(["claude-opus-4-8[1m]"]);
+      ).toEqual(["claude-opus-5[1m]"]);
     });
   });
 

--- a/packages/agent-providers/src/claude-code-models.ts
+++ b/packages/agent-providers/src/claude-code-models.ts
@@ -31,7 +31,7 @@ export const CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS: readonly ModelReasoningEffo
     MAX_REASONING_EFFORT,
   ];
 
-export const DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-4-8[1m]";
+export const DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-5[1m]";
 
 /**
  * BB's curated, version-pinned Claude Code models. Lives here rather than in the
@@ -59,6 +59,14 @@ export const CLAUDE_CODE_ACTIVE_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
   {
     id: DEFAULT_CLAUDE_CODE_MODEL,
     model: DEFAULT_CLAUDE_CODE_MODEL,
+    displayName: "Opus 5 (1M)",
+    description: "Opus 5 with 1M context for complex long coding sessions",
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+    defaultReasoningEffort: "high",
+  },
+  {
+    id: "claude-opus-4-8[1m]",
+    model: "claude-opus-4-8[1m]",
     displayName: "Opus 4.8 (1M)",
     description: "Opus 4.8 with 1M context for complex long coding sessions",
     supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1698,15 +1698,15 @@ describe("bridge", () => {
         models: [
           {
             value: "default",
-            resolvedModel: "claude-opus-4-8[1m]",
+            resolvedModel: "claude-opus-5[1m]",
             displayName: "Default (recommended)",
-            description: "Opus 4.8 with 1M context",
+            description: "Opus 5 with 1M context",
           },
           {
             value: "opus[1m]",
-            resolvedModel: "claude-opus-4-8[1m]",
+            resolvedModel: "claude-opus-5[1m]",
             displayName: "Opus",
-            description: "Opus 4.8 with 1M context",
+            description: "Opus 5 with 1M context",
           },
           {
             value: "sonnet",
@@ -1726,14 +1726,15 @@ describe("bridge", () => {
     // Sonnet still yields every curated row; the probe's default wins.
     expect(models.map((model) => model.model)).toEqual([
       "claude-fable-5",
+      "claude-opus-5[1m]",
       "claude-opus-4-8[1m]",
       "claude-opus-4-7[1m]",
       "claude-sonnet-5",
     ]);
     expect(models.filter((model) => model.isDefault)).toEqual([
       expect.objectContaining({
-        model: "claude-opus-4-8[1m]",
-        displayName: "Opus 4.8 (1M)",
+        model: "claude-opus-5[1m]",
+        displayName: "Opus 5 (1M)",
       }),
     ]);
     expect(selectedOnlyModels.map((model) => model.model)).toEqual([

--- a/packages/agent-runtime/src/claude-code/model-list.test.ts
+++ b/packages/agent-runtime/src/claude-code/model-list.test.ts
@@ -5,15 +5,15 @@ import { buildClaudeCodeModels } from "./model-list.js";
 const DISCOVERED_MODELS: ModelInfo[] = [
   {
     value: "default",
-    resolvedModel: "claude-opus-4-8[1m]",
+    resolvedModel: "claude-opus-5[1m]",
     displayName: "Default (recommended)",
-    description: "Opus 4.8 with 1M context",
+    description: "Opus 5 with 1M context",
   },
   {
     value: "opus[1m]",
-    resolvedModel: "claude-opus-4-8[1m]",
+    resolvedModel: "claude-opus-5[1m]",
     displayName: "Opus",
-    description: "Opus 4.8 with 1M context",
+    description: "Opus 5 with 1M context",
   },
   {
     value: "claude-fable-5[1m]",
@@ -37,6 +37,7 @@ const DISCOVERED_MODELS: ModelInfo[] = [
 
 const CURATED_MODELS = [
   "claude-fable-5",
+  "claude-opus-5[1m]",
   "claude-opus-4-8[1m]",
   "claude-opus-4-7[1m]",
   "claude-sonnet-5",
@@ -53,7 +54,7 @@ describe("buildClaudeCodeModels", () => {
       "claude-haiku-4-5-20251001",
     ]);
     expect(result.models.find((model) => model.isDefault)?.model).toBe(
-      "claude-opus-4-8[1m]",
+      "claude-opus-5[1m]",
     );
     // Selected-only rows stay discovery-gated — they only label a selection the
     // user already has.
@@ -76,7 +77,7 @@ describe("buildClaudeCodeModels", () => {
 
     expect(result.models.map((model) => model.model)).toEqual(CURATED_MODELS);
     expect(result.models.find((model) => model.isDefault)?.model).toBe(
-      "claude-opus-4-8[1m]",
+      "claude-opus-5[1m]",
     );
     expect(result.selectedOnlyModels).toEqual([]);
   });

--- a/packages/agent-runtime/src/claude-code/model-list.ts
+++ b/packages/agent-runtime/src/claude-code/model-list.ts
@@ -128,10 +128,11 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
   {
     id: "opus[1m]",
     model: "opus[1m]",
-    displayName: "Opus Alias (1M, Legacy)",
-    description: "Legacy moving Opus 1M alias retained for existing selections",
-    supportedReasoningEfforts: OPUS_4_6_REASONING_EFFORTS,
-    defaultReasoningEffort: "medium",
+    displayName: "Opus Alias (1M, Current)",
+    description:
+      "Moving Opus 1M alias accepted by Claude Code; resolves to the current Opus 1M model",
+    supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
+    defaultReasoningEffort: "high",
   },
   {
     id: "opus",


### PR DESCRIPTION
## Summary

- add **Opus 5 (1M)** (`claude-opus-5[1m]`) to `CLAUDE_CODE_ACTIVE_CATALOG` and point `DEFAULT_CLAUDE_CODE_MODEL` at it
- relabel the selected-only `opus[1m]` alias as current and give it the xhigh-capable effort ladder, since it now resolves to Opus 5
- keep Opus 4.8 (1M) as an explicit curated row

## Ground truth

Probed the installed Claude Code (2.1.219) via the SDK's `initializationResult().models` rather than assuming the id shape. Opus 5 is advertised **only** in 1M form, with the full `low→max` ladder:

| value | resolvedModel | displayName |
| --- | --- | --- |
| `default` | `claude-opus-5[1m]` | Default (recommended) |
| `opus[1m]` | `claude-opus-5[1m]` | Opus (1M context) |
| `claude-fable-5[1m]` | `claude-fable-5` | Fable |
| `sonnet` | `claude-sonnet-5` | Sonnet |
| `haiku` | `claude-haiku-4-5-20251001` | Haiku |

`claude-opus-4-8[1m]` is no longer advertised at all.

## Why the default moves

Claude Code's own `default` row already resolves to `claude-opus-5[1m]`, and `markDefaultModel` prefers the discovered default. So once the curated row exists, a successful probe marks Opus 5 as default regardless of BB's constant. Leaving `DEFAULT_CLAUDE_CODE_MODEL` on Opus 4.8 would only desync the preloaded/probe-failure list from the probe result, making the picker's default visibly jump from 4.8 to Opus 5 once discovery lands.

Opus 4.8 (1M) stays in the catalog rather than moving to selected-only: the curated list is deliberately offered unfiltered, so accounts that can still run it keep a labelled row.

## The opus[1m] alias fix

`CLAUDE_CODE_SELECTED_ONLY_CATALOG` labelled `opus[1m]` "Opus Alias (1M, Legacy)" with `OPUS_4_6_REASONING_EFFORTS`, which omits xhigh and ultracode. That alias now resolves to Opus 5, so a user with a stored `opus[1m]` selection was being offered a strictly narrower effort ladder than the model supports. Relabelled "Current" with `CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS`, matching the sibling `opus` entry and the probe's reported `supportedEffortLevels`.

## Verification

Fed the real probe output through `buildClaudeCodeModels` and the strict `parseAvailableModelList` the adapter runs:

```
  claude-fable-5      — Fable 5        [low,medium,high,xhigh,ultracode,max] default=high
* claude-opus-5[1m]   — Opus 5 (1M)    [low,medium,high,xhigh,ultracode,max] default=high
  claude-opus-4-8[1m] — Opus 4.8 (1M)  [low,medium,high,xhigh,ultracode,max] default=high
  claude-opus-4-7[1m] — Opus 4.7 (1M)  [low,medium,high,xhigh,ultracode,max] default=medium
  claude-sonnet-5     — Sonnet 5       [low,medium,high,xhigh,ultracode,max] default=medium
  claude-haiku-4-5-20251001 / claude-opus-5[1m]  (discovered passthrough)
selected-only: opus[1m], sonnet, haiku
```

Tests: `@bb/agent-providers`, `@bb/agent-runtime` (799), `@bb/app` (2079), `@bb/server` (1254) pass; typecheck clean on all four. `apps/server/test/internal/internal-skill-trees.test.ts` fails identically on a stashed clean tree — pre-existing on `main`, unrelated to this change.

## Protocol version

Not bumped. This is catalog data only: no field shapes, requiredness, or `provider.list_models` semantics change, so a previously shipped daemon stays wire-compatible. An older daemon simply returns a probe list without the curated Opus 5 label, which the server's own fallback already supplies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
