### PR TITLE
Demote skill-tier override dedup logs to debug

### DIFF
--- a/apps/server/src/services/skills/injected-skills.ts
+++ b/apps/server/src/services/skills/injected-skills.ts
@@ -581,7 +581,7 @@ function excludeOverriddenBuiltins(
     if (!userClaimedNames.has(source.name)) {
       return true;
     }
-    logger.info(
+    logger.debug(
       {
         name: source.name,
         sourceRootPath: sourceRootPath(source),
@@ -603,7 +603,7 @@ function excludeOverriddenLowerPriorityUserSources(
     if (!higherPriorityNames.has(source.name)) {
       return true;
     }
-    logger.info(
+    logger.debug(
       {
         name: source.name,
         sourceRootPath: sourceRootPath(source),


### PR DESCRIPTION
Every catalog resolution (each thread turn and project-page load) logs one line per deduped skill; with a 71-skill inherited root that is ~30K journald lines/day of expected-precedence noise.

Measured on a deployed instance: skill-scan log volume fell from ~1,300 lines/hour to ~9 lines/hour after deploying this change.