### PR TITLE
Keep the mobile submit tap ahead of keyboard dismissal

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1601,6 +1601,34 @@ describe("PromptBoxInternal compact layout", () => {
     ).toBe(true);
   });
 
+  it("keeps the editor focused through a pointer submit", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          value: "Send this follow-up",
+          onSubmit,
+          compact: {
+            isCompact: true,
+            placeholder: "Ask a follow-up",
+          },
+        })}
+      />,
+    );
+
+    await waitForPromptFocus();
+    const editor = getPromptEditorElement();
+    const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+
+    expect(
+      fireEvent.pointerDown(submit, { button: 0, pointerType: "touch" }),
+    ).toBe(false);
+    expect(document.activeElement).toBe(editor);
+
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
   it("keeps all Markdown and mention text in the navigable preview", async () => {
     const mentionToken =
       "@apps/app/src/components/promptbox/PromptBoxInternal.tsx";

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -19,6 +19,7 @@ import {
   type ChangeEvent,
   type FormEvent,
   type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type Ref,
 } from "react";
@@ -2319,6 +2320,27 @@ export function PromptBoxInternal({
     resetZenModeAfterSubmit();
   }, [canSubmit, onSubmit, resetZenModeAfterSubmit]);
 
+  const handleSubmitPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+      const currentEditor = editorRef.current;
+      if (
+        !currentEditor ||
+        currentEditor.isDestroyed ||
+        !currentEditor.isFocused
+      ) {
+        return;
+      }
+
+      // Focus transfer happens before click. On iOS, moving focus from the
+      // editor to this button begins keyboard dismissal and resizes the app
+      // shell before the form can submit. Keep the editor focused; the click
+      // still owns the commit, while genuine outside focus dismisses normally.
+      event.preventDefault();
+    },
+    [],
+  );
+
   // A no-argument built-in command (currently only `/compact`) is a complete
   // action the moment it is selected, so applying it with Enter should also
   // submit instead of leaving the pill parked for a second Enter. The submit is
@@ -3028,6 +3050,7 @@ export function PromptBoxInternal({
                       variant="default"
                       aria-label={effectiveSubmitTitle}
                       disabled={!canSubmit}
+                      onPointerDown={handleSubmitPointerDown}
                       className={cn(
                         showCompactLayout
                           ? COMPACT_PROMPT_ACTION_BUTTON_CLASS


### PR DESCRIPTION
## Summary

Prevent the default focus transfer on the submit button's `pointerdown` so the prompt editor keeps focus through a tap. The click still owns the commit.

## Why

On iOS, focus transfer happens before `click`. Moving focus from the editor to the submit button starts keyboard dismissal, which resizes the app shell while the tap is still resolving — so the submit races a viewport resize and can be lost. Keeping the editor focused for the duration of the tap removes the race; genuine focus changes elsewhere still dismiss the keyboard normally.

## Scope

The handler is deliberately narrow — it only calls `preventDefault()` when all of the following hold:

- the pointer is the primary button (`event.button === 0`)
- the editor exists and is not destroyed
- the editor is already focused

Keyboard activation is unaffected: `Enter`/`Space` on the button dispatch `click` without `pointerdown`, so they never reach this path.

## Verification

- `apps/app` — `PromptBoxInternal.test.tsx`, 67/67 passing, including a new regression test asserting `pointerdown` is default-prevented, `document.activeElement` is still the editor, and `onSubmit` still fires once on the subsequent click
- `pnpm exec turbo run typecheck --filter=@bb/app` clean