### PR TITLE
Revert server-side helper inference default to gpt-5.4-mini

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Use `bb-app config` for non-secret bb settings:
 
 ```bash
 npx bb-app config set BB_APP_URL http://<machine>.<tailnet>.ts.net:38886
-npx bb-app config set BB_INFERENCE codex/gpt-5.6-luna
+npx bb-app config set BB_INFERENCE codex/gpt-5.4-mini
 npx bb-app config set BB_TRANSCRIPTION codex/gpt-4o-mini-transcribe
 npx bb-app config list
 npx bb-app config unset BB_APP_URL
@@ -81,7 +81,7 @@ starts.
 | Key                | Command         | When to set             | Used for                                                                                                                                       |
 | ------------------ | --------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BB_APP_URL`       | `bb-app config` | Optional for remote use | Human-facing app URL used for generated links and allowed browser origins. Leave empty for local-only use.                                     |
-| `BB_INFERENCE`     | `bb-app config` | Optional                | Server-side helper model in `provider/model` format. Defaults to `codex/gpt-5.6-luna`.                                                         |
+| `BB_INFERENCE`     | `bb-app config` | Optional                | Server-side helper model in `provider/model` format. Defaults to `codex/gpt-5.4-mini`.                                                         |
 | `BB_TRANSCRIPTION` | `bb-app config` | Optional                | Voice transcription model in `provider/model` format. Defaults to `codex/gpt-4o-mini-transcribe`.                                              |
 | `BB_SERVER_URL`    | `bb-app config` | Remote CLI/host use     | Server URL for standalone `bb` CLI and `host-daemon` commands on the current machine. The CLI defaults to `http://127.0.0.1:38886` when unset. |
 | `BB_LOG_LEVEL`     | `bb-app config` | Debugging               | Log level for the next bb start: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`.                                                        |

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -131,7 +131,7 @@ Use `bb-app config` for persistent non-secret package settings under
 
 ```bash
 npx bb-app config set BB_APP_URL http://<machine>.<tailnet>.ts.net:38886
-npx bb-app config set BB_INFERENCE codex/gpt-5.6-luna
+npx bb-app config set BB_INFERENCE codex/gpt-5.4-mini
 npx bb-app config set BB_TRANSCRIPTION codex/gpt-4o-mini-transcribe
 npx bb-app config list
 npx bb-app config refresh

--- a/packages/config/src/defaults.ts
+++ b/packages/config/src/defaults.ts
@@ -9,6 +9,6 @@ export const DEFAULTS = {
   appVersion: "0.0.0-dev",
   logLevel: { prod: "info", dev: "debug" },
   secretToken: { dev: "dev-secret" },
-  inferenceModel: "codex/gpt-5.6-luna",
+  inferenceModel: "codex/gpt-5.4-mini",
   transcriptionModel: "codex/gpt-4o-mini-transcribe",
 } as const;

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -303,7 +303,7 @@ describe("consumer-specific config", () => {
     expect(serverConfig.BB_APP_SURFACE).toBe("web");
     expect(serverConfig.BB_APP_VERSION).toBe("0.0.0-dev");
     expect(serverConfig.BB_EXTERNAL_URL).toBe("");
-    expect(serverConfig.BB_INFERENCE).toBe("codex/gpt-5.6-luna");
+    expect(serverConfig.BB_INFERENCE).toBe("codex/gpt-5.4-mini");
     expect(serverConfig.BB_TRANSCRIPTION).toBe("codex/gpt-4o-mini-transcribe");
     expect(serverConfig.OPENAI_API_KEY).toBe("test-openai-key");
     expect(serverConfig.featureFlags).toEqual({ placeholder: false });


### PR DESCRIPTION
## Summary

Reverts #852. The `BB_INFERENCE` default goes back from `codex/gpt-5.6-luna` to `codex/gpt-5.4-mini`.

Thread title generation resolves its model through `config.inferenceModel` (managed `BB_INFERENCE` → env `BB_INFERENCE` → `DEFAULTS.inferenceModel`), so this is the one-line default plus its documented surfaces:

- `packages/config/src/defaults.ts` — the default itself
- `packages/config/test/config.test.ts` — default assertion
- `docs/configuration.md`, `packages/bb-app/README.md` — documented default

## Scope note

`BB_INFERENCE` has exactly two callers, and there is no title-specific knob today, so both move back:

- `apps/server/src/services/threads/title-generation.ts` (thread titles) — the intended target
- `apps/server/src/services/ai/commit-message.ts` (commit messages) — moves back as a side effect

If commit messages should stay on gpt-5.6-luna, that needs a separate env var plus CLI/SDK/doc surfaces; flagging rather than adding it here.

## Tests

`pnpm exec turbo run typecheck test --filter=@bb/config` — typecheck clean, 83/83 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)