### PR TITLE
Stop showing a provisioning row when nothing is provisioned

### DIFF
--- a/apps/server/src/services/threads/thread-lifecycle.ts
+++ b/apps/server/src/services/threads/thread-lifecycle.ts
@@ -94,6 +94,7 @@ import {
   forgetActiveThreadProvisionContext,
   getActiveThreadProvisionContext,
 } from "./thread-provisioning-active-context.js";
+import { hasProvisioningTimelineRow } from "./thread-provisioning-context.js";
 import { isPreStartThreadStatus } from "./thread-status.js";
 
 type ReadyThreadTurnDispatchKind = "thread.start" | "turn.submit";
@@ -478,6 +479,11 @@ function appendProvisioningInterruptedEventInTransaction(
   }
   const environmentId = context.state.environmentId ?? thread.environmentId;
   if (environmentId === null) {
+    return;
+  }
+  // Nothing was provisioned, so there is no row to cancel; appending one would
+  // introduce a provisioning row at the moment the thread stops.
+  if (!hasProvisioningTimelineRow(context)) {
     return;
   }
 
@@ -1065,7 +1071,13 @@ function dispatchThreadStartFromRequest(
       }
 
       let completedProvisionSequence: number | null = null;
-      if (activeProvisionContext !== null) {
+      // Only close a provisioning row that exists: a start that attached to an
+      // already-ready environment provisioned nothing and emitted no row, and a
+      // lone `completed` event would render as "Provisioned thread".
+      if (
+        activeProvisionContext !== null &&
+        hasProvisioningTimelineRow(activeProvisionContext)
+      ) {
         completedProvisionSequence = appendThreadProvisioningEventInTransaction(
           tx,
           {

--- a/apps/server/src/services/threads/thread-provisioning-context.ts
+++ b/apps/server/src/services/threads/thread-provisioning-context.ts
@@ -169,7 +169,10 @@ export type ThreadProvisionWorkspaceReadyContext = ThreadProvisionContext & {
   state: ThreadProvisioningState & {
     environmentId: string;
     stage: "workspace-ready";
-    workspaceReadyEventSequence: number;
+    // null ⇒ reaching workspace-ready appended no `system/thread-provisioning`
+    // row because nothing was provisioned (the thread attached to an
+    // already-ready environment). See `hasProvisioningTimelineRow`.
+    workspaceReadyEventSequence: number | null;
   };
 };
 
@@ -228,7 +231,7 @@ export interface CreateReprovisioningContextArgs {
 }
 
 export interface CreateWorkspaceReadyContextArgs {
-  workspaceReadyEventSequence: number;
+  workspaceReadyEventSequence: number | null;
 }
 
 export interface ResolvePreparedEnvironmentMetadataArgs {
@@ -307,7 +310,25 @@ export function isWorkspaceReadyContext(
 ): context is ThreadProvisionWorkspaceReadyContext {
   return (
     context.state.stage === "workspace-ready" &&
-    context.state.environmentId !== null &&
+    context.state.environmentId !== null
+  );
+}
+
+/**
+ * True when this provisioning run has already appended at least one
+ * `system/thread-provisioning` row to the thread timeline.
+ *
+ * A start that attaches to an already-ready environment provisions nothing and
+ * emits no row. Terminal rows (`completed`, `cancelled`) must be suppressed for
+ * those runs too — the client keys every provisioning event into a single
+ * operation row, so a lone terminal event would surface as "Provisioned thread"
+ * for a start that never provisioned anything.
+ */
+export function hasProvisioningTimelineRow(
+  context: ThreadProvisionContext,
+): boolean {
+  return (
+    context.state.provisionEventSequence !== null ||
     context.state.workspaceReadyEventSequence !== null
   );
 }

--- a/apps/server/src/services/threads/thread-provisioning-environment.ts
+++ b/apps/server/src/services/threads/thread-provisioning-environment.ts
@@ -109,6 +109,17 @@ interface EnsureWorkspaceReadyEventArgs {
   threadId: string;
 }
 
+/**
+ * `reached: false` ⇒ the thread is no longer provisionable into this
+ * environment, so it did not land in `workspace-ready`.
+ *
+ * `appendedSequence: null` ⇒ workspace-ready was reached without appending a
+ * `system/thread-provisioning` row, because nothing was provisioned.
+ */
+export type EnsureWorkspaceReadyEventResult =
+  | { reached: true; appendedSequence: number | null }
+  | { reached: false };
+
 interface ThreadProvisionTransactionDeps {
   db: DbTransaction;
   hub: DbNotifier;
@@ -299,7 +310,7 @@ export function saveThreadProvisionContext(
 export function ensureWorkspaceReadyEvent(
   deps: Pick<AppDeps, "db" | "hub">,
   args: EnsureWorkspaceReadyEventArgs,
-): number | null {
+): EnsureWorkspaceReadyEventResult {
   return deps.db.transaction(
     (tx) =>
       ensureWorkspaceReadyEventInTransaction({ db: tx, hub: deps.hub }, args),
@@ -310,7 +321,7 @@ export function ensureWorkspaceReadyEvent(
 function ensureWorkspaceReadyEventRecord(
   db: DbTransaction,
   args: EnsureWorkspaceReadyEventArgs,
-): number | null {
+): EnsureWorkspaceReadyEventResult {
   const thread = getThread(db, args.threadId);
   const context =
     args.context ?? getActiveThreadProvisionContext(args.threadId);
@@ -322,40 +333,51 @@ function ensureWorkspaceReadyEventRecord(
     (context.state.environmentId !== null &&
       context.state.environmentId !== args.environmentId)
   ) {
-    return null;
+    return { reached: false };
   }
   if (context.state.stage === "workspace-ready") {
-    return context.state.workspaceReadyEventSequence;
+    return {
+      reached: true,
+      appendedSequence: context.state.workspaceReadyEventSequence,
+    };
   }
   if (!isAttachableContext(context)) {
-    return null;
+    return { reached: false };
   }
   const provisionableContext = provisionableContextForWorkspaceReady(context, {
     attachedEnvironmentId: args.environmentId,
   });
 
-  const appendedSequence = appendThreadProvisioningEventInTransaction(db, {
-    threadId: args.threadId,
-    environmentId: args.environmentId,
-    provisioningId: context.state.provisioningId,
-    status: "active",
-    entries: args.entries,
-  });
+  // Nothing was provisioned when the thread attached straight to an
+  // already-ready environment: no provisioning was started, so the transcript
+  // would only restate the workspace path and branch. Reach workspace-ready
+  // without a timeline row rather than showing "Provisioned thread" for work
+  // that never happened.
+  const appendedSequence =
+    provisionableContext.state.provisionEventSequence === null
+      ? null
+      : appendThreadProvisioningEventInTransaction(db, {
+          threadId: args.threadId,
+          environmentId: args.environmentId,
+          provisioningId: context.state.provisioningId,
+          status: "active",
+          entries: args.entries,
+        });
   saveThreadProvisionContext({
     threadId: args.threadId,
     context: createWorkspaceReadyContext(provisionableContext, {
       workspaceReadyEventSequence: appendedSequence,
     }),
   });
-  return appendedSequence;
+  return { reached: true, appendedSequence };
 }
 
 export function ensureWorkspaceReadyEventInTransaction(
   deps: ThreadProvisionTransactionDeps,
   args: EnsureWorkspaceReadyEventArgs,
-): number | null {
+): EnsureWorkspaceReadyEventResult {
   const result = ensureWorkspaceReadyEventRecord(deps.db, args);
-  if (result !== null) {
+  if (result.reached && result.appendedSequence !== null) {
     deps.hub.notifyThread(args.threadId, ["events-appended"], {
       eventTypes: ["system/thread-provisioning"],
     });

--- a/apps/server/src/services/threads/thread-provisioning.ts
+++ b/apps/server/src/services/threads/thread-provisioning.ts
@@ -167,7 +167,7 @@ async function startThreadIfEnvironmentReady(
     return;
   }
 
-  const workspaceReadyEventSequence = ensureWorkspaceReadyEvent(deps, {
+  const workspaceReady = ensureWorkspaceReadyEvent(deps, {
     context: args.context,
     threadId: args.thread.id,
     environmentId: args.environment.id,
@@ -176,8 +176,8 @@ async function startThreadIfEnvironmentReady(
       branchName: args.environment.branchName,
     }),
   });
-  if (workspaceReadyEventSequence === null) {
-    throw new Error("Workspace ready event sequence was not recorded");
+  if (!workspaceReady.reached) {
+    throw new Error("Thread did not reach workspace-ready provisioning state");
   }
 
   if (

--- a/tests/integration/fake/smoke/reuse-and-reprovision.test.ts
+++ b/tests/integration/fake/smoke/reuse-and-reprovision.test.ts
@@ -21,6 +21,24 @@ import {
   TURN_TIMEOUT_MS,
 } from "./shared.js";
 
+/**
+ * Provisioning event statuses the timeline would render for a thread. The
+ * synthetic `thread-start:` bookkeeping event is dropped by the client, so it
+ * is excluded here too.
+ */
+async function visibleProvisioningStatuses(
+  api: Parameters<typeof getThreadEvents>[0],
+  threadId: string,
+): Promise<string[]> {
+  const events = await getThreadEvents(api, threadId);
+  return events.flatMap((event) =>
+    event.type === "system/thread-provisioning" &&
+    !event.data.provisioningId.startsWith("thread-start:")
+      ? [event.data.status]
+      : [],
+  );
+}
+
 describe.sequential("fake provider smoke reuse integration", () => {
   it("moves a thread to error and records failure events when environment provisioning fails", () =>
     withHarness(async (harness) => {
@@ -136,6 +154,17 @@ describe.sequential("fake provider smoke reuse integration", () => {
       );
       expect(reusedEnvironment.id).toBe(environment.id);
       expect(output).toContain("reuse environment");
+
+      // The reuse start provisions nothing, so it must not emit a provisioning
+      // row — otherwise the timeline shows "Provisioned thread" for a start
+      // that only attached to a ready environment. The first thread did
+      // provision, so it keeps its row.
+      expect(await visibleProvisioningStatuses(harness.api,thread.id)).not.toEqual(
+        [],
+      );
+      expect(
+        await visibleProvisioningStatuses(harness.api,reusedThread.thread.id),
+      ).toEqual([]);
     }));
 
   // Decision B*: un-archiving a thread whose managed environment was destroyed


### PR DESCRIPTION
## Problem

Creating a thread in an environment that is already ready shows a **"Provisioned thread"** row in the timeline, even though nothing was provisioned.

The row was never gated on provisioning *work* — only on the provisioning state machine running, which every thread start does. On a reuse start, `ensureWorkspaceReadyEvent` appended an `active` event whose transcript only restated `Using workspace: <path>` / `Using branch: <name>`, and start dispatch appended a `completed` event. The client keys every provisioning event for a `provisioningId` into one operation row, so those two rendered as "Provisioned thread".

The only existing suppression was the narrow `thread-start:` prefix filter in `parse-operation-message.ts` for the synthetic bookkeeping event.

## Change

Cut at the producer, not the renderer:

- `ensureWorkspaceReadyEvent` skips the append when `provisionEventSequence === null` (nothing was ever started), still transitioning to `workspace-ready`. Its return type is now a discriminated `EnsureWorkspaceReadyEventResult` so "reached ready without a row" is distinguishable from "no longer provisionable" — the old `number | null` conflated them and the caller threw on `null`.
- `hasProvisioningTimelineRow(context)` gates the two terminal-row producers in `thread-lifecycle`: `completed` at start dispatch and `cancelled` when a starting thread is stopped. Without these a lone terminal event still renders the label on its own.
- `ThreadProvisionWorkspaceReadyContext.workspaceReadyEventSequence` is now `number | null`, where null means "no row was emitted".

Filtering client-side on an empty transcript would not work — the reuse path does carry entries, they just are not work.

Real provisioning is unaffected. Failure and interrupt titles are unaffected too: `finalizeOperationMessage` / `interruptOperationMessage` only retitle an *existing* pending row, and `failThreadProvisioning` appends a `system/error`, not a provisioning event.

No `HOST_DAEMON_PROTOCOL_VERSION` bump — this only changes which events the server writes to its own timeline; nothing on the server↔daemon wire moved.

## Tests

- New assertion in `tests/integration/fake/smoke/reuse-and-reprovision.test.ts`: the reuse thread must have no timeline-visible provisioning events, and the first thread — which did provision — must still have them, so it also catches over-suppression. Reverting only `apps/server/` makes it fail with `expected [ 'active', 'completed' ] to deeply equal []`.
- `@bb/integration-tests`: 54/54 pass.
- `@bb/server`: 1262/1263 pass. The one failure (`internal-skill-trees.test.ts`, file mode `0644` vs `0664`) is a local umask issue that fails identically on a clean tree.
- Typecheck clean for `@bb/server` and `@bb/integration-tests`.

## Manual QA

Verified end to end on a dev server with the Codex provider, driving the real UI, including an A/B against the unfixed code in the same app instance — all three threads sharing one environment:

| Thread | Scenario | Row | DB provisioning events |
| --- | --- | --- | --- |
| 1 | fresh environment, real provisioning | shown (correct) | 3 × `active`, 1 × `completed` |
| 2 | reuse, **with** fix | none | zero |
| 3 | reuse, **without** fix (server stashed + restarted) | shown (the bug) | `active`, `completed` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)