### PR TITLE
Split the sidebar update indicator into bb and agent buckets

### DIFF
--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -429,7 +429,16 @@ export function AppSidebar({
         </SidebarContent>
         <SidebarFooter className="relative">
           <OverflowFade placement="above" tone="sidebar" size="sm" />
-          <SidebarMenu className="flex-row items-center gap-1">
+          {/* The footer holds a variable number of plugin action buttons, so a
+           * narrowed sidebar plus several plugins can no longer fit the action
+           * row and the update chips on one line. `flex-wrap-reverse` plus the
+           * flexible spacer below handles both layouts without measuring:
+           * while everything fits, the spacer stretches and pushes the chips to
+           * the right of a single row; once it doesn't, the chips wrap onto
+           * their own line, which wrap-reverse renders above the actions, and
+           * they sit flush left because the spacer stays behind on the action
+           * line. */}
+          <SidebarMenu className="flex-row flex-wrap-reverse items-center gap-1">
             <SidebarMenuItem className="min-w-0">
               <SidebarMenuButton
                 asChild
@@ -473,6 +482,7 @@ export function AppSidebar({
                 <span className="sr-only">Report a bug</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
+            <li aria-hidden="true" className="min-w-0 flex-1" />
             <SidebarUpdatesBadge onNavigate={closeOnMobile} />
           </SidebarMenu>
         </SidebarFooter>

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import type { Host } from "@bb/domain";
+import type { ProviderCliKey } from "@bb/host-daemon-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderCliIssue } from "@/components/provider-cli/provider-cli-install";
+import type {
+  UpdateInventory,
+  UpdateInventoryMachine,
+} from "@/hooks/useUpdateInventory";
+import { SidebarUpdatesBadge } from "./SidebarUpdatesBadge";
+
+const useUpdateInventoryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useUpdateInventory", () => ({
+  useUpdateInventory: useUpdateInventoryMock,
+}));
+
+afterEach(() => {
+  cleanup();
+  useUpdateInventoryMock.mockReset();
+});
+
+function providerIssue(
+  provider: ProviderCliKey,
+  displayName: string,
+): ProviderCliIssue {
+  return {
+    provider,
+    status: {
+      displayName,
+      executableName: provider,
+      executablePath: `/usr/local/bin/${provider}`,
+      installed: true,
+      installSource: "npmGlobal",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      minimumSupportedVersion: "1.0.0",
+      npmPackageName: `@example/${provider}`,
+      npmGlobalPackageVersion: "1.0.0",
+      installAction: null,
+      needsUpdate: true,
+      versionUnsupported: false,
+    },
+    action: null,
+    title: `${displayName} update available`,
+    description: "1.0.0 -> 1.1.0",
+    fingerprint: `${provider}:outdated`,
+  };
+}
+
+function host(id: string): Host {
+  return {
+    id,
+    name: id,
+    type: "persistent",
+    status: "connected",
+    lastSeenAt: null,
+    lastRejectedProtocolVersion: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function machine(
+  overrides: Partial<UpdateInventoryMachine>,
+): UpdateInventoryMachine {
+  return {
+    host: host("host-1"),
+    isPrimary: true,
+    providerStatus: null,
+    statusPending: false,
+    statusError: false,
+    issues: [],
+    canRetryDaemonUpdate: false,
+    ...overrides,
+  };
+}
+
+function renderBadge(inventory: Partial<UpdateInventory>) {
+  useUpdateInventoryMock.mockReturnValue({
+    isLoading: false,
+    systemVersion: undefined,
+    desktopInfo: null,
+    appUpdateAvailable: false,
+    desktopUpdateReady: false,
+    machines: [],
+    actionableCount: 0,
+    hasAttention: false,
+    ...inventory,
+  });
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <SidebarUpdatesBadge />
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("SidebarUpdatesBadge", () => {
+  it("renders nothing when no update needs attention", () => {
+    const result = renderBadge({});
+    expect(result.container.innerHTML).toBe("");
+  });
+
+  it("shows only the bb chip for a bb-only update", () => {
+    renderBadge({ appUpdateAvailable: true });
+
+    expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
+    expect(screen.queryByTestId("sidebar-updates-badge-providers")).toBeNull();
+  });
+
+  it("counts a daemon stuck on an old protocol as a bb update, not a provider one", () => {
+    renderBadge({ machines: [machine({ canRetryDaemonUpdate: true })] });
+
+    expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
+    expect(screen.queryByTestId("sidebar-updates-badge-providers")).toBeNull();
+  });
+
+  it("shows only the provider chip when bb itself is current", () => {
+    renderBadge({
+      machines: [
+        machine({ issues: [providerIssue("claudeCode", "Claude Code")] }),
+      ],
+    });
+
+    expect(screen.queryByTestId("sidebar-updates-badge-bb")).toBeNull();
+    expect(
+      screen
+        .getByTestId("sidebar-updates-badge-providers")
+        .getAttribute("aria-label"),
+    ).toBe("Claude Code update available");
+  });
+
+  it("renders one mark per provider in a stable order when the same CLI is stale on several machines", () => {
+    renderBadge({
+      appUpdateAvailable: true,
+      machines: [
+        machine({
+          host: host("host-1"),
+          issues: [providerIssue("claudeCode", "Claude Code")],
+        }),
+        machine({
+          host: host("host-2"),
+          issues: [
+            providerIssue("claudeCode", "Claude Code"),
+            providerIssue("codex", "Codex"),
+          ],
+        }),
+      ],
+    });
+
+    const providerChip = screen.getByTestId("sidebar-updates-badge-providers");
+    // Codex leads regardless of which machine surfaced the issue first.
+    expect(providerChip.getAttribute("aria-label")).toBe(
+      "Codex and Claude Code updates available",
+    );
+    expect(providerChip.querySelectorAll("svg[viewBox]").length).toBe(3);
+    expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
@@ -1,7 +1,14 @@
 import { Link } from "react-router-dom";
+import type { ProviderCliKey } from "@bb/host-daemon-contract";
 import { Icon } from "@bb/shared-ui/icon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
+import { cn } from "@bb/shared-ui/lib/utils";
 import { SidebarMenuItem } from "@/components/ui/sidebar.js";
 import { useUpdateInventory } from "@/hooks/useUpdateInventory";
+import {
+  getProviderIconColorClass,
+  getProviderIconInfo,
+} from "@/lib/provider-icon";
 import { getSettingsRoutePath } from "@/lib/route-paths";
 
 export interface SidebarUpdatesBadgeProps {
@@ -9,28 +16,145 @@ export interface SidebarUpdatesBadgeProps {
 }
 
 /**
- * The quiet update affordance (BB-48): a small primary pill in the sidebar
+ * Provider CLI keys are their own namespace (`claudeCode`), distinct from the
+ * agent provider ids the icon registry is keyed by (`claude-code`).
+ */
+const PROVIDER_CLI_AGENT_PROVIDER_ID = {
+  codex: "codex",
+  claudeCode: "claude-code",
+  cursor: "acp-cursor",
+} as const satisfies Record<ProviderCliKey, string>;
+
+/** Stable left-to-right order so the marks never reshuffle between polls. */
+const PROVIDER_CLI_DISPLAY_ORDER = [
+  "codex",
+  "claudeCode",
+  "cursor",
+] as const satisfies readonly ProviderCliKey[];
+
+const CHIP_CLASS = cn(
+  "flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-sidebar-border px-2",
+  "text-xs font-medium text-sidebar-foreground transition-colors hover:bg-sidebar-accent",
+);
+
+function joinNames(names: string[]): string {
+  if (names.length <= 1) {
+    return names[0] ?? "";
+  }
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+interface StaleProvider {
+  provider: ProviderCliKey;
+  displayName: string;
+}
+
+/**
+ * The quiet update affordance (BB-48): small outlined chips in the sidebar
  * footer's lower-right corner, rendered only while an update needs attention.
- * It replaces the stacked update/provider-health toasts — clicking it opens
- * the consolidated Settings → Updates view.
+ * Updates split into the two buckets a user acts on separately — bb itself
+ * (app release, downloaded desktop update, or a daemon stuck on an old
+ * protocol) and the agent CLIs, which carry their own brand marks so it is
+ * clear which agent is stale without hovering. Both chips open the
+ * consolidated Settings → Updates view.
  */
 export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
   const inventory = useUpdateInventory();
-  if (!inventory.hasAttention) {
+
+  const stuckDaemonCount = inventory.machines.filter(
+    (machine) => machine.canRetryDaemonUpdate,
+  ).length;
+  const bbUpdateCount =
+    (inventory.appUpdateAvailable ? 1 : 0) +
+    (inventory.desktopUpdateReady ? 1 : 0) +
+    stuckDaemonCount;
+
+  // One mark per provider, even when the same CLI is stale on several machines.
+  const staleProvidersByKey = new Map<ProviderCliKey, StaleProvider>();
+  for (const machine of inventory.machines) {
+    for (const issue of machine.issues) {
+      if (!staleProvidersByKey.has(issue.provider)) {
+        staleProvidersByKey.set(issue.provider, {
+          provider: issue.provider,
+          displayName: issue.status.displayName,
+        });
+      }
+    }
+  }
+  const staleProviders = PROVIDER_CLI_DISPLAY_ORDER.flatMap((provider) => {
+    const stale = staleProvidersByKey.get(provider);
+    return stale === undefined ? [] : [stale];
+  });
+
+  if (bbUpdateCount === 0 && staleProviders.length === 0) {
     return null;
   }
+
+  const updatesRoutePath = getSettingsRoutePath("updates");
+  const bbLabel =
+    bbUpdateCount === 1 ? "bb update available" : "bb updates available";
+  const providerLabel = `${joinNames(
+    staleProviders.map((stale) => stale.displayName),
+  )} ${staleProviders.length === 1 ? "update" : "updates"} available`;
+
   return (
-    <SidebarMenuItem className="ml-auto min-w-0">
-      <Link
-        to={getSettingsRoutePath("updates")}
-        onClick={onNavigate}
-        aria-label={`Updates available (${inventory.actionableCount})`}
-        data-testid="sidebar-updates-badge"
-        className="flex h-6 shrink-0 items-center gap-1.5 rounded-full bg-primary px-2.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/85"
-      >
-        <Icon name="PackageReceive" className="size-3.5" />
-        Updates
-      </Link>
+    // Right-alignment on a single row comes from the flexible spacer the
+    // sidebar footer renders before this item, not from a margin here — a
+    // margin would also push the chips right on their own wrapped line.
+    <SidebarMenuItem className="flex min-w-0 items-center gap-1">
+      {bbUpdateCount > 0 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              to={updatesRoutePath}
+              onClick={onNavigate}
+              aria-label={bbLabel}
+              data-testid="sidebar-updates-badge-bb"
+              className={CHIP_CLASS}
+            >
+              <Icon name="Download" className="size-3 text-muted-foreground" />
+              bb
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="top">{bbLabel}</TooltipContent>
+        </Tooltip>
+      ) : null}
+      {staleProviders.length > 0 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              to={updatesRoutePath}
+              onClick={onNavigate}
+              aria-label={providerLabel}
+              data-testid="sidebar-updates-badge-providers"
+              className={CHIP_CLASS}
+            >
+              <Icon name="Download" className="size-3 text-muted-foreground" />
+              <span className="flex items-center gap-1">
+                {staleProviders.map((stale) => {
+                  const providerId =
+                    PROVIDER_CLI_AGENT_PROVIDER_ID[stale.provider];
+                  const iconInfo = getProviderIconInfo(providerId);
+                  if (iconInfo === undefined) {
+                    return null;
+                  }
+                  const { icon: ProviderIcon } = iconInfo;
+                  return (
+                    <ProviderIcon
+                      key={stale.provider}
+                      className={cn(
+                        "size-3",
+                        getProviderIconColorClass(providerId),
+                      )}
+                    />
+                  );
+                })}
+              </span>
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="top">{providerLabel}</TooltipContent>
+        </Tooltip>
+      ) : null}
     </SidebarMenuItem>
   );
 }


### PR DESCRIPTION
## What

The sidebar footer showed a single filled primary pill for every pending update. In dark mode `--primary` is near-white, so it read as the loudest object in the sidebar, and it said nothing about *what* was stale.

It is now up to two outlined chips, each rendered only when its bucket has something actionable:

- **bb** — the app release, a downloaded desktop update, or a daemon stuck on an old protocol version. That last one is bb software on a remote host, so it belongs here rather than with the agents.
- **agents** — one brand mark per stale agent CLI, in a fixed `codex → claudeCode → cursor` order so the marks don't reshuffle between polls, deduped so the same CLI stale on three machines shows one mark.

Both chips open Settings → Updates and carry a tooltip plus an `aria-label` naming what's stale.

The update inventory keys providers as `claudeCode` while the icon registry keys them as `claude-code`; a small `satisfies Record<ProviderCliKey, string>` table bridges the two so adding a key can't silently skip its icon.

## Footer overflow

The footer also holds a variable number of plugin `sidebarFooterAction` buttons (the connect plugin ships one). Measured against the real compiled CSS, the row had zero slack at the default 256px width and overflowed below it:

| Case | Content / available | Overflow |
|---|---|---|
| No plugins · 256px | 240 / 240 | 0px |
| Connect · 256px | 240 / 240 | 0px |
| Connect · 240px (resize min) | 226 / 224 | 2px |
| Connect + 1 plugin · 240px | 243 / 224 | 19px |
| Connect + 3 plugins · 240px | 267 / 224 | 43px |

This predates the change — the old pill overflowed too once enough plugins were installed — but the two chips are ~25px wider and hit it sooner.

Fixed with `flex-wrap-reverse` on the footer menu plus a flexible spacer before the badge, which needs no runtime measurement: while everything fits the spacer stretches and pushes the chips right on a single row; once it doesn't, the chips wrap onto their own line, which `wrap-reverse` renders *above* the actions, flush left because the spacer stays behind on the action line. The spacer is `flex-1 min-w-0` so it shrinks to zero rather than triggering a premature wrap. Re-measured: no overflow in any case, single row preserved at the default width.

## Tests

- New `SidebarUpdatesBadge.test.tsx` — 5 tests: empty state, bb-only, stuck daemon counted as bb rather than a provider, provider-only, and dedupe + ordering across machines.
- `turbo run typecheck lint --filter=@bb/app` — clean (the 151 lint warnings are pre-existing; none in the touched files).
- Full `src/components/sidebar` suite — 188 passing.

## Risks

Layout verified by rendering the real components against the app's compiled stylesheet across both themes, all update states, five plugin-count/width combinations, and the 240px resize minimum. Not exercised against a live server reporting a genuine pending update — `useUpdateInventory`'s query wiring is unchanged by this PR, but it is stubbed in the tests rather than driven end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)