### PR TITLE
Make the Add project machine selector a dropdown

### DIFF
--- a/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
@@ -69,16 +69,17 @@ describe("ProjectPathDialog machine selection", () => {
       />,
     );
 
-    expect(
-      (screen.getByRole("radio", { name: "atum" }) as HTMLInputElement).checked,
-    ).toBe(true);
+    const trigger = screen.getByRole("button", { name: "Machine" });
+    expect(trigger.textContent).toContain("atum");
+
+    fireEvent.pointerDown(trigger, { button: 0 });
     expect(
       screen
-        .getByRole("radio", { name: "Offline Mac" })
-        .hasAttribute("disabled"),
-    ).toBe(true);
+        .getByRole("menuitem", { name: /Offline Mac/u })
+        .getAttribute("aria-disabled"),
+    ).toBe("true");
 
-    fireEvent.click(screen.getByRole("radio", { name: "Kunst" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Kunst/u }));
     fireEvent.click(
       screen.getByRole("button", { name: "Choose folder on host_kunst" }),
     );
@@ -105,7 +106,7 @@ describe("ProjectPathDialog machine selection", () => {
       />,
     );
 
-    expect(screen.queryByRole("radiogroup", { name: "Machine" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Machine" })).toBeNull();
     fireEvent.click(
       screen.getByRole("button", { name: "Choose folder on host_atum" }),
     );

--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useId, useState, type FormEvent } from "react";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@bb/shared-ui/dropdown-menu";
+import { Icon } from "@bb/shared-ui/icon";
+import {
   deriveProjectNameFromPath,
   getProjectPathValidationMessage,
   normalizeProjectPathInput,
@@ -247,50 +254,68 @@ export function ProjectPathDialogContent({
       </DialogHeader>
       <form className="space-y-4" onSubmit={handleSubmit}>
         {showMachinePicker ? (
-          <div
-            role="radiogroup"
-            aria-label="Machine"
-            className="grid max-h-36 gap-1 overflow-y-auto rounded-md border p-1"
-          >
-            {machineOptions?.map((host) => {
-              const connected = host.status === "connected";
-              const selected = host.id === selectedHostId;
-              return (
-                <label
-                  key={host.id}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-none ring-ring focus-within:ring-2",
-                    selected
-                      ? "bg-state-active text-foreground"
-                      : "text-muted-foreground hover:bg-state-hover hover:text-foreground",
-                    pending || !connected
-                      ? "cursor-not-allowed opacity-50"
-                      : "cursor-pointer",
-                  )}
-                >
-                  <input
-                    type="radio"
-                    name={`project-machine-${inputId}`}
-                    aria-label={host.name}
-                    checked={selected}
-                    disabled={pending || !connected}
-                    className="sr-only"
-                    onChange={() => {
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild disabled={pending}>
+              <Button
+                type="button"
+                variant="outline"
+                aria-label="Machine"
+                disabled={pending}
+                className="w-full justify-between font-normal"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  {selectedHost ? (
+                    <MachineStatusDot connected={selectedHostConnected} />
+                  ) : null}
+                  <span className="min-w-0 truncate">
+                    {selectedHost?.name ?? "Select a machine"}
+                  </span>
+                </span>
+                <Icon
+                  name="ChevronDown"
+                  className="size-4 shrink-0 text-muted-foreground"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
+              mobileTitle="Machine"
+              className="max-h-72 w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+            >
+              {machineOptions?.map((host) => {
+                const connected = host.status === "connected";
+                return (
+                  <DropdownMenuItem
+                    key={host.id}
+                    disabled={!connected}
+                    className="flex items-center gap-2"
+                    onSelect={() => {
+                      if (!connected) return;
                       setSelectedHostId(host.id);
                       setBrowserDirectory(null);
                     }}
-                  />
-                  <MachineStatusDot connected={connected} />
-                  <span className="min-w-0 flex-1 truncate">{host.name}</span>
-                  {!connected ? (
-                    <span className="text-xs text-subtle-foreground">
-                      Offline
-                    </span>
-                  ) : null}
-                </label>
-              );
-            })}
-          </div>
+                  >
+                    <MachineStatusDot connected={connected} />
+                    <span className="min-w-0 flex-1 truncate">{host.name}</span>
+                    {!connected ? (
+                      <span className="shrink-0 text-xs text-subtle-foreground">
+                        Offline
+                      </span>
+                    ) : null}
+                    <Icon
+                      name="Check"
+                      className={cn(
+                        "size-4 shrink-0",
+                        host.id === selectedHostId
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
         ) : null}
         {selectedHostId ? (
           <RemotePathBrowser


### PR DESCRIPTION
## Summary

The machine list in the Add project dialog was an inline radio group that ate a fixed block of vertical space above the folder browser and grew with every enrolled machine. It's now a dropdown, using the same `DropdownMenu` idiom as `MachinePicker`:

- Full-width outline trigger with the selected machine's status dot, name, and a chevron.
- Menu matches the trigger width, with a status dot, name, "Offline" label for disconnected hosts, and a checkmark on the selection.
- Offline machines stay disabled; picking a machine still resets the browsed directory.
- Still only rendered when more than one machine exists.

## Tests

- `pnpm exec turbo run test --filter=@bb/app -- ProjectPathDialog` — 3 passed (updated to drive the dropdown instead of radios).
- `pnpm exec turbo run typecheck --filter=@bb/app` — clean.
- Visually verified via the `dialogs/Project Path` Ladle story, closed and open.

## Risks

UI-only, scoped to this one dialog. The accessible name on the picker changes from a `radiogroup` to a `button`, both labeled "Machine".

🤖 Generated with [Claude Code](https://claude.com/claude-code)