### PR TITLE
Fix two races breaking CI on main

### DIFF
--- a/apps/app/src/components/ui/resource-pagination.test.tsx
+++ b/apps/app/src/components/ui/resource-pagination.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useResourcePagination } from "@bb/shared-ui/resource-pagination";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROWS = Array.from({ length: 30 }, (_, index) => index + 1);
+const SELECTABLE_PAGES = [0, 1, 2];
+
+function Probe({
+  pageSize,
+  resetKey,
+  rowCount = ROWS.length,
+}: {
+  pageSize: number;
+  resetKey?: string;
+  rowCount?: number;
+}) {
+  const pagination = useResourcePagination(ROWS.slice(0, rowCount), {
+    pageSize,
+    resetKey,
+  });
+  return (
+    <>
+      <span data-testid="page">{pagination.page}</span>
+      <span data-testid="rows">{pagination.items.join(",")}</span>
+      {SELECTABLE_PAGES.map((page) => (
+        <button
+          key={page}
+          type="button"
+          onClick={() => pagination.setPage(page)}
+        >
+          {`go to ${page}`}
+        </button>
+      ))}
+    </>
+  );
+}
+
+function selectedPage(): number {
+  return Number(screen.getByTestId("page").textContent);
+}
+
+function visibleRows(): number[] {
+  const rows = screen.getByTestId("rows").textContent ?? "";
+  return rows === "" ? [] : rows.split(",").map(Number);
+}
+
+function goToPage(page: number): void {
+  fireEvent.click(screen.getByRole("button", { name: `go to ${page}` }));
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useResourcePagination", () => {
+  /**
+   * The selected page used to be mirrored back into state from an effect. That
+   * discarded the page the user picked as soon as a measured page size changed,
+   * and — because the write-back carried a pre-interaction page — a click that
+   * beat the effect was silently reverted. Surviving this round trip is the
+   * observable proof that nothing but setPage writes the selection.
+   */
+  it("rescales the selection across page-size changes instead of overwriting it", () => {
+    const { rerender } = render(<Probe pageSize={10} />);
+    goToPage(1);
+    expect(visibleRows()).toEqual(ROWS.slice(10, 20));
+
+    // Row 11 stays in view at the larger page size...
+    rerender(<Probe pageSize={15} />);
+    expect(selectedPage()).toBe(0);
+    expect(visibleRows()).toEqual(ROWS.slice(0, 15));
+
+    // ...and remeasuring back restores the page the user actually chose.
+    rerender(<Probe pageSize={10} />);
+    expect(selectedPage()).toBe(1);
+    expect(visibleRows()).toEqual(ROWS.slice(10, 20));
+  });
+
+  it("resets to the first page for each new projection", () => {
+    const { rerender } = render(<Probe pageSize={10} resetKey="all" />);
+    goToPage(2);
+    expect(selectedPage()).toBe(2);
+
+    rerender(<Probe pageSize={10} resetKey="filtered" />);
+    expect(selectedPage()).toBe(0);
+
+    // Returning to an earlier projection is still a new projection, not a
+    // reason to resurrect the page that was selected under it.
+    rerender(<Probe pageSize={10} resetKey="all" />);
+    expect(selectedPage()).toBe(0);
+  });
+
+  it("clamps the page when live data shrinks past it", () => {
+    const { rerender } = render(<Probe pageSize={10} />);
+    goToPage(2);
+    expect(visibleRows()).toEqual(ROWS.slice(20, 30));
+
+    rerender(<Probe pageSize={10} rowCount={12} />);
+    expect(selectedPage()).toBe(1);
+    expect(visibleRows()).toEqual(ROWS.slice(10, 12));
+  });
+});

--- a/packages/shared-ui/src/components/ui/resource-pagination.tsx
+++ b/packages/shared-ui/src/components/ui/resource-pagination.tsx
@@ -131,6 +131,8 @@ export function useResourceViewportPageSize(
  * Client-side pagination for the bounded arrays returned by resource APIs.
  * The selected page resets with the projection and clamps when live data
  * shrinks, while retaining the current page across ordinary data refreshes.
+ * A changing page size rescales the selection to keep the same rows in view
+ * rather than resetting it.
  */
 export function useResourcePagination<Item>(
   items: readonly Item[],
@@ -142,35 +144,30 @@ export function useResourcePagination<Item>(
   );
   const resetKey = options.resetKey ?? "";
   const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
-  const [pageState, setPageState] = useState({
-    resetKey,
-    page: 0,
-    pageSize,
-  });
-  const requestedPage =
-    pageState.resetKey !== resetKey
-      ? 0
-      : pageState.pageSize === pageSize
-        ? pageState.page
-        : Math.floor((pageState.page * pageState.pageSize) / pageSize);
-  const page = Math.min(requestedPage, pageCount - 1);
+  // Anchors the selected page to the page size it was selected under. Only an
+  // explicit setPage or a new projection writes it; the rendered page is derived
+  // from it. Mirroring the derived page back from an effect used to drop clicks:
+  // a viewport measurement that changed pageSize left a queued write-back
+  // holding the pre-click page, which then overwrote the interaction.
+  const [anchor, setAnchor] = useState({ resetKey, page: 0, pageSize });
 
-  useEffect(() => {
-    setPageState((current) => {
-      if (
-        current.resetKey === resetKey &&
-        current.page === page &&
-        current.pageSize === pageSize
-      ) {
-        return current;
-      }
-      return { resetKey, page, pageSize };
-    });
-  }, [page, pageSize, resetKey]);
+  // A new projection starts at its first page. This adjusts state during render
+  // rather than from an effect so the reset cannot land after an interaction.
+  if (anchor.resetKey !== resetKey) {
+    setAnchor({ resetKey, page: 0, pageSize });
+  }
+
+  const requestedPage =
+    anchor.resetKey !== resetKey
+      ? 0
+      : anchor.pageSize === pageSize
+        ? anchor.page
+        : Math.floor((anchor.page * anchor.pageSize) / pageSize);
+  const page = Math.min(requestedPage, pageCount - 1);
 
   const setPage = useCallback(
     (nextPage: number) => {
-      setPageState({
+      setAnchor({
         resetKey,
         page: Math.max(0, Math.min(Math.floor(nextPage), pageCount - 1)),
         pageSize,

--- a/plugins/workflows/src/cli.test.ts
+++ b/plugins/workflows/src/cli.test.ts
@@ -16,12 +16,33 @@ const DOCUMENTATION_EXTENSIONS = new Set([
   ".tsx",
 ]);
 const IGNORED_DOCUMENTATION_DIRECTORIES = new Set([
-  ".git",
-  ".turbo",
   "coverage",
   "dist",
   "node_modules",
 ]);
+
+/**
+ * This walks the whole checkout while the `packages` CI shard runs every other
+ * package's tests concurrently, so it has to ignore paths those tests own.
+ * Dot-directories cover VCS internals, tool caches, and the scratch trees
+ * siblings create inside their own package roots — the plugin registry's
+ * `.vendor-fixture-*` and agent-runtime's `.bb-codex-outside-*`. None are
+ * project documentation, and descending into them both races their cleanup and
+ * can report a generated copy of a file instead of its real source.
+ */
+function isScannableDirectory(name: string): boolean {
+  return !name.startsWith(".") && !IGNORED_DOCUMENTATION_DIRECTORIES.has(name);
+}
+
+/** Paths a concurrent test deletes mid-walk are not project documentation. */
+function readIfPresent(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw error;
+  }
+}
 
 function documentationFiles(root: string): string[] {
   const files: string[] = [];
@@ -32,7 +53,7 @@ function documentationFiles(root: string): string[] {
       if (entry.isSymbolicLink()) continue;
       const path = resolve(directory, entry.name);
       if (entry.isDirectory()) {
-        if (!IGNORED_DOCUMENTATION_DIRECTORIES.has(entry.name)) {
+        if (isScannableDirectory(entry.name)) {
           pending.push(path);
         }
       } else if (
@@ -194,7 +215,7 @@ describe("workflows CLI argument validation", () => {
     const root = resolve(process.cwd(), "../..");
     const removedCommand = ["bb workflows", "catalog"].join(" ");
     const matches = documentationFiles(root)
-      .filter((path) => readFileSync(path, "utf8").includes(removedCommand))
+      .filter((path) => readIfPresent(path).includes(removedCommand))
       .map((path) => relative(root, path))
       .sort();
     expect(matches).toEqual([]);


### PR DESCRIPTION
CI on `main` was failing intermittently from two independent races. Both are ~2% flakes, so they broke main sporadically rather than outright — main run [30406401925](https://github.com/ymichael/bb/actions/runs/30406401925) (#884) failed `Tests (app)`, and run [30403074723](https://github.com/ymichael/bb/actions/runs/30403074723) (#883) failed `Tests (packages)`.

## 1. `useResourcePagination` dropped clicks

`useResourcePagination` mirrored the derived `page` back into state from a `useEffect`. That write-back captured the pre-interaction page, so when a viewport measurement changed `pageSize`, the queued effect flushed *after* a click and overwrote it:

1. The measurement raises `pageSize` 10 → 15. That commit renders `page=0` at `pageSize=15` while the stored `pageSize` is still `10`, and schedules the write-back with `page=0` captured.
2. Under load the effect hasn't flushed when the click lands, so `setPage(1)` writes `{page: 1, pageSize: 15}`.
3. React then flushes the stale effect, which sees `current.page (1) !== page (0)` and resets state to `{page: 0, pageSize: 15}` — discarding the click.

Instrumenting `setPage` printed exactly this, and only in the failing runs:

```
[DIAG] setPage(1) closurePageSize=15 statePageSize=10 statePage=0 renderPageSize=15
```

This is a real product bug, not just a test flake: a user clicking **Next** in the instant after a list first measures its row height has the click silently ignored. It affects every paginated resource list — plugins, skills, browse, and automations.

State is now an **anchor** (the page plus the page size it was chosen under), written only by `setPage` or a new projection, with the rendered page derived from it. The projection reset moved from an effect to a render-time adjustment so it can't land after an interaction. A side benefit falls out: the anchor survives page-size changes, so remeasuring 15 → 10 rows returns you to the page you picked instead of stranding you on page 1.

## 2. Cross-package fixture race

`plugins/workflows/src/cli.test.ts` walks the entire checkout, and the `packages` CI shard runs every other package's tests concurrently in one turbo invocation. It enumerated `packages/plugin-registry/.vendor-fixture-*/app.tsx` and then read it after the plugin registry's `afterAll` deleted it → `ENOENT`.

The walk now skips dot-directories — covering VCS internals, tool caches, and the scratch trees siblings create in their own package roots (`.vendor-fixture-*`, and agent-runtime's `.bb-codex-outside-*`) — and tolerates a path deleted mid-walk. `.git`/`.turbo` dropped out of the explicit ignore set since the dot rule subsumes them.

## Verification

- The stress harness that reproduced the pagination flake at ~2/128 under 8× contention now runs **160/160 clean**.
- New `apps/app/src/components/ui/resource-pagination.test.tsx` pins the anchor semantics; its first test **fails on the original hook** (`expected +0 to be 1`) and passes on the fix. It lives in `apps/app` because `shared-ui` has no test runner, matching the existing `apps/app/src/components/ui/theme.test.ts` convention.
- With a `.vendor-fixture-PROOF/app.tsx` containing the removed command in place, the workflows test passes (fixture ignored); with the same string in `docs/cli-guide-and-skill.md` it still fails as intended, so coverage is unchanged.
- `turbo run typecheck lint` on app/shared-ui/workflows/automations: 0 errors.
- `turbo run test`: app 292 files, workflows 13, automations 3, plugin-registry 1 — all pass.
- Full CI `packages` shard: 47/48, with the two previously-racing packages passing concurrently.

Two failures left untouched, both pre-existing and local-only (they pass in CI): `@bb/desktop#test` needs an Electron binary that was never downloaded in my sandbox, and `bb-plugin-tasks#test` fails on `window.localStorage` being undefined — confirmed failing identically on a pristine HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)