### PR TITLE
Keep updates running when you navigate off the Updates page

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -40,6 +40,7 @@ import {
   getSkillDetailRoutePath,
 } from "./lib/route-paths";
 import { AppCommandProvider } from "./components/commands/AppCommandProvider";
+import { ProviderCliInstallLogDialogHost } from "./components/provider-cli/provider-cli-install";
 import { ToolsExperimentGate } from "./components/tools/ToolsExperimentGate";
 import { PluginSettingsCompatibilityRoute } from "./components/settings/PluginSettingsCompatibilityRoute";
 
@@ -228,6 +229,10 @@ export function App() {
             />
             <Route path="*" element={<AppRoutes />} />
           </Routes>
+          {/* Outside <Routes>: a provider CLI install outlives the page that
+              started it, so its failure toast can be clicked from any route —
+              including auth callback, which renders no app shell. */}
+          <ProviderCliInstallLogDialogHost />
         </RouteNavigationProvider>
       </AppCommandProvider>
     </QuickCreateProjectProvider>

--- a/apps/app/src/components/provider-cli/provider-cli-install-store.ts
+++ b/apps/app/src/components/provider-cli/provider-cli-install-store.ts
@@ -1,0 +1,282 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type {
+  ProviderCliInstallActionKind,
+  ProviderCliInstallEvent,
+  ProviderCliKey,
+} from "@bb/host-daemon-contract";
+import type { ProviderCliInstallLogDialogState } from "@/components/dialogs/ProviderCliInstallLogDialog";
+import type { ProviderCliActionableIssue } from "@/components/provider-cli/provider-cli-install";
+import { appToast } from "@/components/ui/app-toast";
+import { invalidateHostProviderCliStatus } from "@/hooks/cache-owners/provider-cli-status-cache-owner";
+import { sdk } from "@/lib/sdk";
+
+type ProviderCliInstallCompletedEvent = Extract<
+  ProviderCliInstallEvent,
+  { type: "completed" }
+>;
+
+type ProviderCliTitlePhase = "failure" | "log";
+type ProviderCliTitleTemplate = (displayName: string) => string;
+
+export interface ProviderCliInstallJob {
+  hostId: string;
+  issue: ProviderCliActionableIssue;
+}
+
+export interface ProviderCliInstallSnapshot {
+  /** The job currently executing on a host, or null when nothing is running. */
+  runningJobKey: string | null;
+  /** Jobs waiting behind the running one. */
+  queuedJobKeys: ReadonlySet<string>;
+  /** The failure log a user opened from a toast, or null when closed. */
+  logDialogState: ProviderCliInstallLogDialogState | null;
+}
+
+const PROVIDER_CLI_TITLE_TEMPLATES = {
+  failure: {
+    install: (displayName) => `${displayName} install failed`,
+    update: (displayName) => `${displayName} update failed`,
+  },
+  log: {
+    install: (displayName) => `${displayName} install log`,
+    update: (displayName) => `${displayName} update log`,
+  },
+} satisfies Record<
+  ProviderCliTitlePhase,
+  Record<ProviderCliInstallActionKind, ProviderCliTitleTemplate>
+>;
+
+const EMPTY_QUEUED_JOB_KEYS: ReadonlySet<string> = new Set();
+
+const INITIAL_SNAPSHOT: ProviderCliInstallSnapshot = {
+  runningJobKey: null,
+  queuedJobKeys: EMPTY_QUEUED_JOB_KEYS,
+  logDialogState: null,
+};
+
+// Module-level, not component state: a provider CLI install keeps running (and
+// its queue keeps draining) after the user navigates away from Settings →
+// Updates. Components subscribe to mirror progress; they never own it.
+let snapshot: ProviderCliInstallSnapshot = INITIAL_SNAPSHOT;
+let queuedJobs: ProviderCliInstallJob[] = [];
+let queryClient: QueryClient | null = null;
+const listeners = new Set<() => void>();
+
+function setSnapshot(patch: Partial<ProviderCliInstallSnapshot>): void {
+  snapshot = { ...snapshot, ...patch };
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Stable identity for a (machine, provider) install slot. */
+export function providerCliJobKey(
+  hostId: string,
+  provider: ProviderCliKey,
+): string {
+  return `${hostId}:${provider}`;
+}
+
+export function subscribeProviderCliInstalls(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getProviderCliInstallSnapshot(): ProviderCliInstallSnapshot {
+  return snapshot;
+}
+
+/**
+ * The store outlives every component, so it cannot read the query client from
+ * React context when an install finishes. Mounted consumers hand it over; the
+ * app's client is process-stable, so the last registration stays correct even
+ * after they all unmount.
+ */
+export function registerProviderCliInstallQueryClient(
+  client: QueryClient,
+): void {
+  queryClient = client;
+}
+
+export function openProviderCliInstallLog(
+  logDialogState: ProviderCliInstallLogDialogState,
+): void {
+  setSnapshot({ logDialogState });
+}
+
+export function closeProviderCliInstallLog(): void {
+  setSnapshot({ logDialogState: null });
+}
+
+function setQueuedJobKey(jobKey: string, queued: boolean): void {
+  if (queued === snapshot.queuedJobKeys.has(jobKey)) {
+    return;
+  }
+  const next = new Set(snapshot.queuedJobKeys);
+  if (queued) {
+    next.add(jobKey);
+  } else {
+    next.delete(jobKey);
+  }
+  setSnapshot({ queuedJobKeys: next });
+}
+
+function exitDescription(event: ProviderCliInstallCompletedEvent): string {
+  if (event.exitCode !== null) {
+    return `Command exited with code ${event.exitCode}`;
+  }
+  return `Command exited after signal ${event.signal ?? "unknown"}`;
+}
+
+function getProviderCliTitle(args: {
+  issue: ProviderCliActionableIssue;
+  phase: ProviderCliTitlePhase;
+}): string {
+  return PROVIDER_CLI_TITLE_TEMPLATES[args.phase][args.issue.action.kind](
+    args.issue.status.displayName,
+  );
+}
+
+function showProviderCliInstallFailureToast(args: {
+  issue: ProviderCliActionableIssue;
+  log: string;
+  message: string;
+  toastId: string;
+}): void {
+  const logDialogState: ProviderCliInstallLogDialogState = {
+    displayName: args.issue.status.displayName,
+    log: args.log,
+    message: args.message,
+    title: getProviderCliTitle({ issue: args.issue, phase: "log" }),
+  };
+
+  appToast.error(getProviderCliTitle({ issue: args.issue, phase: "failure" }), {
+    id: args.toastId,
+    description: args.message,
+    action: {
+      label: "View log",
+      onClick: () => openProviderCliInstallLog(logDialogState),
+    },
+  });
+}
+
+function runInstall(job: ProviderCliInstallJob): void {
+  const { hostId, issue } = job;
+  const { action, provider } = issue;
+  const jobKey = providerCliJobKey(hostId, provider);
+
+  setSnapshot({ runningJobKey: jobKey });
+  const failureToastId = `provider-cli-install-failure:${jobKey}`;
+  let installLogChunks = [`$ ${action.command}\n`];
+  let completedEvent: ProviderCliInstallCompletedEvent | null = null;
+  let errorMessage: string | null = null;
+
+  void sdk.hosts
+    .installProviderCli({ hostId, provider, actionKind: action.kind })
+    .then((events) => {
+      for (const event of events) {
+        if (event.provider !== provider) {
+          continue;
+        }
+        switch (event.type) {
+          case "started":
+            installLogChunks = [`$ ${event.command}\n`];
+            break;
+          case "output":
+            if (event.text.length > 0) {
+              installLogChunks.push(event.text);
+            }
+            break;
+          case "completed":
+            completedEvent = event;
+            break;
+          case "error":
+            errorMessage = event.message;
+            installLogChunks.push(`\n${event.message}\n`);
+            break;
+        }
+      }
+
+      if (completedEvent?.success) {
+        if (queryClient !== null) {
+          void invalidateHostProviderCliStatus({ queryClient, hostId });
+        }
+        return;
+      }
+
+      const failureMessage =
+        errorMessage ??
+        (completedEvent
+          ? exitDescription(completedEvent)
+          : "Command finished without reporting success.");
+      showProviderCliInstallFailureToast({
+        issue,
+        log: installLogChunks.join(""),
+        message: failureMessage,
+        toastId: failureToastId,
+      });
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      installLogChunks.push(`\n${message}\n`);
+      showProviderCliInstallFailureToast({
+        issue,
+        log: installLogChunks.join(""),
+        message,
+        toastId: failureToastId,
+      });
+    })
+    .finally(() => {
+      if (snapshot.runningJobKey === jobKey) {
+        setSnapshot({ runningJobKey: null });
+      }
+      processNextInstall();
+    });
+}
+
+function processNextInstall(): void {
+  if (snapshot.runningJobKey !== null) {
+    return;
+  }
+  const nextJob = queuedJobs.shift();
+  if (nextJob === undefined) {
+    return;
+  }
+  setQueuedJobKey(
+    providerCliJobKey(nextJob.hostId, nextJob.issue.provider),
+    false,
+  );
+  runInstall(nextJob);
+}
+
+export function startProviderCliInstall(job: ProviderCliInstallJob): void {
+  const jobKey = providerCliJobKey(job.hostId, job.issue.provider);
+  if (snapshot.runningJobKey === jobKey) {
+    return;
+  }
+  if (
+    queuedJobs.some(
+      (queued) =>
+        providerCliJobKey(queued.hostId, queued.issue.provider) === jobKey,
+    )
+  ) {
+    return;
+  }
+  if (snapshot.runningJobKey !== null) {
+    queuedJobs.push(job);
+    setQueuedJobKey(jobKey, true);
+    return;
+  }
+
+  runInstall(job);
+}
+
+/** Drop all cross-test state from this module-level store. */
+export function resetProviderCliInstallStoreForTests(): void {
+  snapshot = INITIAL_SNAPSHOT;
+  queuedJobs = [];
+  queryClient = null;
+  listeners.clear();
+}

--- a/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type {
   ProviderCliInstallEvent,
@@ -8,8 +10,13 @@ import type {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
 import { appToast } from "@/components/ui/app-toast";
+import { hostProviderCliStatusQueryKey } from "@/hooks/queries/query-keys";
 import type { ProviderCliActionableIssue } from "./provider-cli-install";
 import { useProviderCliInstallRunner } from "./provider-cli-install";
+import {
+  registerProviderCliInstallQueryClient,
+  resetProviderCliInstallStoreForTests,
+} from "./provider-cli-install-store";
 
 interface DeferredInstall {
   args: Parameters<typeof sdk.hosts.installProviderCli>[0];
@@ -46,6 +53,17 @@ const installHostProviderCliMock = vi.mocked(sdk.hosts.installProviderCli);
 const appToastMock = vi.mocked(appToast);
 
 let pendingInstalls: DeferredInstall[] = [];
+let queryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRunner() {
+  return renderHook(() => useProviderCliInstallRunner(), { wrapper: Wrapper });
+}
 
 function issueForProvider(
   provider: Extract<ProviderCliKey, "codex" | "claudeCode">,
@@ -100,6 +118,12 @@ function installAt(index: number): DeferredInstall {
 
 beforeEach(() => {
   pendingInstalls = [];
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  resetProviderCliInstallStoreForTests();
+  // main.tsx does this at bootstrap; the store never reads React context.
+  registerProviderCliInstallQueryClient(queryClient);
   installHostProviderCliMock.mockImplementation(
     (args) =>
       new Promise<ProviderCliInstallEvent[]>((resolve, reject) => {
@@ -115,12 +139,8 @@ afterEach(() => {
 
 describe("useProviderCliInstallRunner", () => {
   it("queues a second provider CLI setup behind the active one", async () => {
-    const onStatusUpdated = vi.fn();
-    const { result } = renderHook(() =>
-      useProviderCliInstallRunner({
-        onStatusUpdated,
-      }),
-    );
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderRunner();
 
     act(() => {
       result.current.startInstall({
@@ -180,8 +200,83 @@ describe("useProviderCliInstallRunner", () => {
       });
     });
 
-    expect(onStatusUpdated).toHaveBeenCalledTimes(2);
-    expect(onStatusUpdated).toHaveBeenLastCalledWith("host_1");
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: hostProviderCliStatusQueryKey("host_1"),
+    });
     expect(appToastMock.success).not.toHaveBeenCalled();
+  });
+
+  // The whole point of the module-level store: leaving Settings → Updates must
+  // not abandon the queue or drop the status refresh on the floor.
+  it("keeps draining the queue after every consumer unmounts", async () => {
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    const { result, unmount } = renderRunner();
+
+    act(() => {
+      result.current.startInstall({
+        hostId: "host_1",
+        issue: issueForProvider("codex"),
+      });
+      result.current.startInstall({
+        hostId: "host_1",
+        issue: issueForProvider("claudeCode"),
+      });
+    });
+    expect(installHostProviderCliMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      completeInstall(installAt(0), {
+        type: "completed",
+        provider: "codex",
+        success: true,
+        exitCode: 0,
+        signal: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(installHostProviderCliMock).toHaveBeenCalledTimes(2);
+    });
+    expect(installHostProviderCliMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ provider: "claudeCode" }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: hostProviderCliStatusQueryKey("host_1"),
+    });
+
+    // Remounting elsewhere in the app picks the still-running job back up.
+    const remounted = renderRunner();
+    expect(remounted.result.current.runningJobKey).toBe("host_1:claudeCode");
+  });
+
+  it("reports a failed install with a log the user can still open", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.startInstall({
+        hostId: "host_1",
+        issue: issueForProvider("codex"),
+      });
+    });
+
+    await act(async () => {
+      completeInstall(installAt(0), {
+        type: "completed",
+        provider: "codex",
+        success: false,
+        exitCode: 1,
+        signal: null,
+      });
+    });
+
+    expect(appToastMock.error).toHaveBeenCalledWith(
+      "Codex update failed",
+      expect.objectContaining({
+        description: "Command exited with code 1",
+        action: expect.objectContaining({ label: "View log" }),
+      }),
+    );
   });
 });

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -1,21 +1,17 @@
-import { useCallback, useRef, useState } from "react";
+import { useSyncExternalStore } from "react";
 import type {
   ProviderCliInstallAction,
-  ProviderCliInstallActionKind,
-  ProviderCliInstallEvent,
   ProviderCliKey,
   ProviderCliStatus,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
 import { ProviderCliInstallLogDialog } from "@/components/dialogs/ProviderCliInstallLogDialog";
-import type { ProviderCliInstallLogDialogState } from "@/components/dialogs/ProviderCliInstallLogDialog";
-import { appToast } from "@/components/ui/app-toast";
-import { sdk } from "@/lib/sdk";
-
-type ProviderCliInstallCompletedEvent = Extract<
-  ProviderCliInstallEvent,
-  { type: "completed" }
->;
+import {
+  closeProviderCliInstallLog,
+  getProviderCliInstallSnapshot,
+  startProviderCliInstall,
+  subscribeProviderCliInstalls,
+} from "@/components/provider-cli/provider-cli-install-store";
 
 export interface ProviderCliStatusEntry {
   provider: ProviderCliKey;
@@ -34,53 +30,6 @@ export interface ProviderCliIssue {
 export interface ProviderCliActionableIssue extends ProviderCliIssue {
   action: ProviderCliInstallAction;
 }
-
-type ProviderCliTitlePhase = "failure" | "log";
-type ProviderCliTitleTemplate = (displayName: string) => string;
-
-interface GetProviderCliTitleParams {
-  issue: ProviderCliActionableIssue;
-  phase: ProviderCliTitlePhase;
-}
-
-interface UseProviderCliInstallRunnerArgs {
-  onStatusUpdated?: (hostId: string) => void;
-}
-
-interface ShowProviderCliInstallFailureToastParams {
-  issue: ProviderCliActionableIssue;
-  log: string;
-  message: string;
-  onViewLog: (state: ProviderCliInstallLogDialogState) => void;
-  toastId: string;
-}
-
-export interface ProviderCliInstallJob {
-  hostId: string;
-  issue: ProviderCliActionableIssue;
-}
-
-/** Stable identity for a (machine, provider) install slot. */
-export function providerCliJobKey(
-  hostId: string,
-  provider: ProviderCliKey,
-): string {
-  return `${hostId}:${provider}`;
-}
-
-const PROVIDER_CLI_TITLE_TEMPLATES = {
-  failure: {
-    install: (displayName) => `${displayName} install failed`,
-    update: (displayName) => `${displayName} update failed`,
-  },
-  log: {
-    install: (displayName) => `${displayName} install log`,
-    update: (displayName) => `${displayName} update log`,
-  },
-} satisfies Record<
-  ProviderCliTitlePhase,
-  Record<ProviderCliInstallActionKind, ProviderCliTitleTemplate>
->;
 
 const PROVIDER_CLI_MANAGED_PROVIDERS = [
   "codex",
@@ -172,218 +121,40 @@ export function hasProviderCliAction(
   return issue.action !== null;
 }
 
-function exitDescription(event: ProviderCliInstallCompletedEvent): string {
-  if (event.exitCode !== null) {
-    return `Command exited with code ${event.exitCode}`;
-  }
-  return `Command exited after signal ${event.signal ?? "unknown"}`;
-}
-
-function getProviderCliFailureToastId(job: ProviderCliInstallJob): string {
-  return `provider-cli-install-failure:${providerCliJobKey(job.hostId, job.issue.provider)}`;
-}
-
-function getProviderCliTitle({
-  issue,
-  phase,
-}: GetProviderCliTitleParams): string {
-  return PROVIDER_CLI_TITLE_TEMPLATES[phase][issue.action.kind](
-    issue.status.displayName,
-  );
-}
-
-function showProviderCliInstallFailureToast({
-  issue,
-  log,
-  message,
-  onViewLog,
-  toastId,
-}: ShowProviderCliInstallFailureToastParams): void {
-  const logDialogState: ProviderCliInstallLogDialogState = {
-    displayName: issue.status.displayName,
-    log,
-    message,
-    title: getProviderCliTitle({ issue, phase: "log" }),
-  };
-
-  appToast.error(getProviderCliTitle({ issue, phase: "failure" }), {
-    id: toastId,
-    description: message,
-    action: {
-      label: "View log",
-      onClick: () => onViewLog(logDialogState),
-    },
-  });
-}
-
-export function useProviderCliInstallRunner({
-  onStatusUpdated,
-}: UseProviderCliInstallRunnerArgs) {
-  const queuedInstallsRef = useRef<ProviderCliInstallJob[]>([]);
-  const processNextInstallRef = useRef<() => void>(() => {});
-  const runningJobKeyRef = useRef<string | null>(null);
-  const [queuedJobKeys, setQueuedJobKeys] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
-  const [runningJobKey, setRunningJobKey] = useState<string | null>(null);
-  const [logDialogState, setLogDialogState] =
-    useState<ProviderCliInstallLogDialogState | null>(null);
-
-  const handleCloseProviderCliInstallLog = useCallback(() => {
-    setLogDialogState(null);
-  }, []);
-
-  const updateQueuedJob = useCallback((jobKey: string, queued: boolean) => {
-    setQueuedJobKeys((previous) => {
-      if (queued === previous.has(jobKey)) {
-        return previous;
-      }
-      const next = new Set(previous);
-      if (queued) {
-        next.add(jobKey);
-      } else {
-        next.delete(jobKey);
-      }
-      return next;
-    });
-  }, []);
-
-  const runInstall = useCallback(
-    (job: ProviderCliInstallJob) => {
-      const { hostId: installHostId, issue } = job;
-      const { action } = issue;
-      const provider = issue.provider;
-      const jobKey = providerCliJobKey(installHostId, provider);
-
-      runningJobKeyRef.current = jobKey;
-      setRunningJobKey(jobKey);
-      const failureToastId = getProviderCliFailureToastId(job);
-      let installLogChunks = [`$ ${action.command}\n`];
-      let completedEvent: ProviderCliInstallCompletedEvent | null = null;
-      let errorMessage: string | null = null;
-
-      void sdk.hosts
-        .installProviderCli({
-          hostId: installHostId,
-          provider,
-          actionKind: action.kind,
-        })
-        .then((events) => {
-          for (const event of events) {
-            if (event.provider !== provider) {
-              continue;
-            }
-            switch (event.type) {
-              case "started":
-                installLogChunks = [`$ ${event.command}\n`];
-                break;
-              case "output":
-                if (event.text.length > 0) {
-                  installLogChunks.push(event.text);
-                }
-                break;
-              case "completed":
-                completedEvent = event;
-                break;
-              case "error":
-                errorMessage = event.message;
-                installLogChunks.push(`\n${event.message}\n`);
-                break;
-            }
-          }
-
-          if (completedEvent?.success) {
-            onStatusUpdated?.(installHostId);
-            return;
-          }
-
-          const failureMessage =
-            errorMessage ??
-            (completedEvent
-              ? exitDescription(completedEvent)
-              : "Command finished without reporting success.");
-          showProviderCliInstallFailureToast({
-            issue,
-            log: installLogChunks.join(""),
-            message: failureMessage,
-            onViewLog: setLogDialogState,
-            toastId: failureToastId,
-          });
-        })
-        .catch((error) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          installLogChunks.push(`\n${message}\n`);
-          showProviderCliInstallFailureToast({
-            issue,
-            log: installLogChunks.join(""),
-            message,
-            onViewLog: setLogDialogState,
-            toastId: failureToastId,
-          });
-        })
-        .finally(() => {
-          if (runningJobKeyRef.current === jobKey) {
-            runningJobKeyRef.current = null;
-            setRunningJobKey(null);
-          }
-          processNextInstallRef.current();
-        });
-    },
-    [onStatusUpdated],
-  );
-
-  const processNextInstall = useCallback(() => {
-    if (runningJobKeyRef.current !== null) {
-      return;
-    }
-    const nextJob = queuedInstallsRef.current.shift();
-    if (nextJob === undefined) {
-      return;
-    }
-    updateQueuedJob(
-      providerCliJobKey(nextJob.hostId, nextJob.issue.provider),
-      false,
-    );
-    runInstall(nextJob);
-  }, [runInstall, updateQueuedJob]);
-
-  processNextInstallRef.current = processNextInstall;
-
-  const startInstall = useCallback(
-    (job: ProviderCliInstallJob) => {
-      const jobKey = providerCliJobKey(job.hostId, job.issue.provider);
-      if (runningJobKeyRef.current === jobKey) {
-        return;
-      }
-      if (
-        queuedInstallsRef.current.some(
-          (queued) =>
-            providerCliJobKey(queued.hostId, queued.issue.provider) === jobKey,
-        )
-      ) {
-        return;
-      }
-      if (runningJobKeyRef.current !== null) {
-        queuedInstallsRef.current.push(job);
-        updateQueuedJob(jobKey, true);
-        return;
-      }
-
-      runInstall(job);
-    },
-    [runInstall, updateQueuedJob],
+/**
+ * Mirror the module-level install store into React. The store — not this hook —
+ * owns the running job and its queue, so an install started from Settings →
+ * Updates keeps running and keeps draining its queue after the user navigates
+ * away and this hook unmounts.
+ */
+export function useProviderCliInstallRunner() {
+  const snapshot = useSyncExternalStore(
+    subscribeProviderCliInstalls,
+    getProviderCliInstallSnapshot,
   );
 
   return {
-    installLogDialog: (
-      <ProviderCliInstallLogDialog
-        state={logDialogState}
-        onClose={handleCloseProviderCliInstallLog}
-      />
-    ),
-    queuedJobKeys,
-    runningJobKey,
-    startInstall,
+    queuedJobKeys: snapshot.queuedJobKeys,
+    runningJobKey: snapshot.runningJobKey,
+    startInstall: startProviderCliInstall,
   };
+}
+
+/**
+ * Renders the install failure log for whichever install failed, wherever the
+ * user happens to be. Mounted once by the app shell because the failing install
+ * may well have outlived the page that started it.
+ */
+export function ProviderCliInstallLogDialogHost() {
+  const snapshot = useSyncExternalStore(
+    subscribeProviderCliInstalls,
+    getProviderCliInstallSnapshot,
+  );
+
+  return (
+    <ProviderCliInstallLogDialog
+      state={snapshot.logDialogState}
+      onClose={closeProviderCliInstallLog}
+    />
+  );
 }

--- a/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
@@ -167,6 +167,7 @@ export function WebAppUpdateAvailable() {
               upgradeCommand: "npx bb-app@latest",
             }}
             desktopInfo={null}
+            isDesktop={false}
             onRelaunchDesktop={null}
             onRetryDesktop={null}
           />
@@ -193,6 +194,7 @@ export function DesktopUpdateReady() {
               updateDownloaded: true,
               version: "0.0.32",
             }}
+            isDesktop
             onRelaunchDesktop={noop}
             onRetryDesktop={noop}
           />
@@ -219,6 +221,7 @@ export function DesktopDownloading() {
               updateDownloaded: false,
               version: "0.0.32",
             }}
+            isDesktop
             onRelaunchDesktop={noop}
             onRetryDesktop={noop}
           />

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -16,6 +16,7 @@ import type {
   ProviderCliActionableIssue,
 } from "@/components/provider-cli/provider-cli-install";
 import { useProviderCliInstallRunner } from "@/components/provider-cli/provider-cli-install";
+import { resetAppUpdateCheckStoreForTests } from "@/components/settings/app-update-check-store";
 import { sdk } from "@/lib/sdk";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
 import {
@@ -66,7 +67,6 @@ vi.mock("@/components/provider-cli/provider-cli-install", async (original) => {
   return {
     ...actual,
     useProviderCliInstallRunner: vi.fn(() => ({
-      installLogDialog: null,
       queuedJobKeys: new Set<string>(),
       runningJobKey: null,
       startInstall: startInstallMock,
@@ -205,6 +205,7 @@ const useProviderCliInstallRunnerMock = vi.mocked(useProviderCliInstallRunner);
 
 afterEach(() => {
   cleanup();
+  resetAppUpdateCheckStoreForTests();
   vi.clearAllMocks();
 });
 
@@ -213,6 +214,7 @@ describe("UpdatesSettingsSection", () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,
       desktopInfo: null,
+      isDesktop: false,
     });
     const availableVersion = {
       currentVersion: "0.0.5",
@@ -257,6 +259,7 @@ describe("UpdatesSettingsSection", () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: { checkForUpdates } as unknown as BbDesktopApi,
       desktopInfo,
+      isDesktop: true,
     });
     useUpdateInventoryMock.mockReturnValue(
       makeInventory({
@@ -290,6 +293,7 @@ describe("UpdatesSettingsSection", () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: {} as BbDesktopApi,
       desktopInfo,
+      isDesktop: true,
     });
     useUpdateInventoryMock.mockReturnValue(makeInventory({ desktopInfo }));
 
@@ -314,6 +318,7 @@ describe("UpdatesSettingsSection", () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: { checkForUpdates } as unknown as BbDesktopApi,
       desktopInfo,
+      isDesktop: true,
     });
     useUpdateInventoryMock.mockReturnValue(makeInventory({ desktopInfo }));
 
@@ -329,6 +334,7 @@ describe("UpdatesSettingsSection", () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,
       desktopInfo: null,
+      isDesktop: false,
     });
     const laptop = makeHost({ id: "host_1", name: "laptop" });
     const homelab = makeHost({ id: "host_2", name: "homelab" });

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useSyncExternalStore, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { BbDesktopInfo } from "@bb/desktop-contract";
 import type { SystemVersionResponse } from "@bb/server-contract";
@@ -7,11 +7,16 @@ import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   hasProviderCliAction,
-  providerCliJobKey,
   useProviderCliInstallRunner,
   type ProviderCliActionableIssue,
   type ProviderCliIssue,
 } from "@/components/provider-cli/provider-cli-install";
+import { providerCliJobKey } from "@/components/provider-cli/provider-cli-install-store";
+import {
+  getAppUpdateCheckSnapshot,
+  startAppUpdateCheck,
+  subscribeAppUpdateCheck,
+} from "@/components/settings/app-update-check-store";
 import { MachineStatusDot } from "@/components/machines/MachineStatusDot";
 import {
   SettingsBadge,
@@ -148,6 +153,7 @@ function ActionCell({ children }: { children?: ReactNode }) {
 export interface BbAppUpdateRowsProps {
   systemVersion: SystemVersionResponse | undefined;
   desktopInfo: BbDesktopInfo | null;
+  isDesktop: boolean;
   onRelaunchDesktop: (() => void) | null;
   onRetryDesktop: (() => void) | null;
 }
@@ -160,9 +166,23 @@ export interface BbAppUpdateRowsProps {
 export function BbAppUpdateRows({
   systemVersion,
   desktopInfo,
+  isDesktop,
   onRelaunchDesktop,
   onRetryDesktop,
 }: BbAppUpdateRowsProps) {
+  if (isDesktop && desktopInfo === null) {
+    return (
+      <UpdatesRow>
+        <NameCell>
+          <span className="truncate font-medium">bb desktop</span>
+        </NameCell>
+        <span />
+        <StateCell tone="subtle">Checking…</StateCell>
+        <ActionCell />
+      </UpdatesRow>
+    );
+  }
+
   if (desktopInfo !== null) {
     const pendingVersion =
       desktopInfo.pendingVersion ?? desktopInfo.latestVersion;
@@ -429,15 +449,14 @@ export function MachineUpdatesRows({
 export function UpdatesSettingsSection() {
   const queryClient = useQueryClient();
   const inventory = useUpdateInventory();
-  const { desktopApi, desktopInfo } = useDesktopUpdateInfo();
+  const { desktopApi, desktopInfo, isDesktop } = useDesktopUpdateInfo();
   const retryHostUpdate = useRetryHostUpdate();
-  const [isChecking, setIsChecking] = useState(false);
-  const { installLogDialog, queuedJobKeys, runningJobKey, startInstall } =
-    useProviderCliInstallRunner({
-      onStatusUpdated: (hostId) => {
-        void invalidateHostProviderCliStatus({ queryClient, hostId });
-      },
-    });
+  const isChecking = useSyncExternalStore(
+    subscribeAppUpdateCheck,
+    getAppUpdateCheckSnapshot,
+  );
+  const { queuedJobKeys, runningJobKey, startInstall } =
+    useProviderCliInstallRunner();
 
   const actionableIssues: {
     hostId: string;
@@ -448,12 +467,14 @@ export function UpdatesSettingsSection() {
       .map((issue) => ({ hostId: machine.host.id, issue })),
   );
 
-  async function handleCheckForUpdates(): Promise<void> {
-    if (isChecking) {
-      return;
-    }
-    setIsChecking(true);
-    try {
+  // Snapshot the hosts at click time: the check runs in a module-level store
+  // so it survives navigating away, and must not read React state afterwards.
+  const connectedHostIds = inventory.machines
+    .filter((machine) => machine.host.status === "connected")
+    .map((machine) => machine.host.id);
+
+  function handleCheckForUpdates(): void {
+    startAppUpdateCheck(async () => {
       if (desktopApi !== null) {
         await desktopApi.checkForUpdates();
       } else {
@@ -461,22 +482,11 @@ export function UpdatesSettingsSection() {
         hydrateSystemVersionCache({ queryClient, version });
       }
       await Promise.all(
-        inventory.machines
-          .filter((machine) => machine.host.status === "connected")
-          .map((machine) =>
-            invalidateHostProviderCliStatus({
-              queryClient,
-              hostId: machine.host.id,
-            }),
-          ),
+        connectedHostIds.map((hostId) =>
+          invalidateHostProviderCliStatus({ queryClient, hostId }),
+        ),
       );
-    } catch (error: unknown) {
-      appToast.error("Update check failed", {
-        description: updateCheckErrorDescription(error),
-      });
-    } finally {
-      setIsChecking(false);
-    }
+    });
   }
 
   return (
@@ -496,9 +506,7 @@ export function UpdatesSettingsSection() {
             <RowButton
               aria-busy={isChecking}
               disabled={isChecking}
-              onClick={() => {
-                void handleCheckForUpdates();
-              }}
+              onClick={handleCheckForUpdates}
             >
               <Icon
                 name={isChecking ? "Spinner" : "RotateCcw"}
@@ -513,6 +521,7 @@ export function UpdatesSettingsSection() {
           <BbAppUpdateRows
             systemVersion={inventory.systemVersion}
             desktopInfo={desktopInfo}
+            isDesktop={isDesktop}
             onRelaunchDesktop={
               desktopApi === null
                 ? null
@@ -591,7 +600,6 @@ export function UpdatesSettingsSection() {
           </UpdatesRowList>
         )}
       </SettingsSection>
-      {installLogDialog}
     </>
   );
 }

--- a/apps/app/src/components/settings/app-update-check-store.ts
+++ b/apps/app/src/components/settings/app-update-check-store.ts
@@ -1,0 +1,60 @@
+import { appToast } from "@/components/ui/app-toast";
+
+// Module-level, not component state: an update check keeps running (and still
+// reports its result) after the user navigates away from Settings → Updates.
+let isChecking = false;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeAppUpdateCheck(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getAppUpdateCheckSnapshot(): boolean {
+  return isChecking;
+}
+
+function checkErrorDescription(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+  return "The update check did not complete.";
+}
+
+/**
+ * Run one update check at a time. `check` is started here rather than in an
+ * effect so it finishes — and toasts its failure — even if the caller unmounts
+ * mid-flight.
+ */
+export function startAppUpdateCheck(check: () => Promise<void>): void {
+  if (isChecking) {
+    return;
+  }
+  isChecking = true;
+  notify();
+
+  void check()
+    .catch((error: unknown) => {
+      appToast.error("Update check failed", {
+        description: checkErrorDescription(error),
+      });
+    })
+    .finally(() => {
+      isChecking = false;
+      notify();
+    });
+}
+
+/** Drop all cross-test state from this module-level store. */
+export function resetAppUpdateCheckStoreForTests(): void {
+  isChecking = false;
+  listeners.clear();
+}

--- a/apps/app/src/hooks/cache-owners/system-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/system-cache-effects.ts
@@ -36,6 +36,7 @@ import {
 import { allThreadDefaultExecutionOptionsQueryKeyPrefix } from "../queries/thread-default-execution-options-query";
 import type { QueryClientArg } from "../cache-effect-types";
 import { bumpAllDiffPatchEvictionGenerations } from "./environment-diff-patch-cache-owner";
+import { invalidateSystemVersion } from "./system-version-cache-owner";
 import {
   invalidateQueryKeys,
   refetchFailedActiveQueryKeys,
@@ -68,6 +69,10 @@ export function invalidateRealtimeQueriesAfterServerReconnect({
     queryClient,
     queryKeys: getServerReconnectInvalidationQueryKeys(),
   });
+  // A reconnect is how the app learns the server restarted, which is exactly
+  // what a bb self-update does — so re-check the version rather than keep
+  // advertising the update the user just applied.
+  invalidateSystemVersion({ queryClient });
   // The per-file diff patch cache is observer-less: invalidation only marks it
   // stale and never refetches or evicts, so a reconnect must remove it. The
   // diff TOC refetch (invalidated above) then drives the panel to re-request

--- a/apps/app/src/hooks/cache-owners/system-version-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/system-version-cache-owner.ts
@@ -12,3 +12,15 @@ export function hydrateSystemVersionCache(
 ): void {
   args.queryClient.setQueryData(systemVersionQueryKey(), args.version);
 }
+
+/**
+ * Re-check the running version against the registry. The cached answer is held
+ * for an hour and never refetched on focus, so without this a self-update — the
+ * one event that always makes it wrong — would leave "update available" showing
+ * on the running app until the tab reloads.
+ */
+export function invalidateSystemVersion(args: {
+  queryClient: QueryClient;
+}): void {
+  void args.queryClient.invalidateQueries({ queryKey: systemVersionQueryKey() });
+}

--- a/apps/app/src/hooks/system-cache-effects.test.ts
+++ b/apps/app/src/hooks/system-cache-effects.test.ts
@@ -9,6 +9,7 @@ import {
   sidebarNavigationQueryKey,
   systemProvidersQueryKey,
   systemExecutionOptionsQueryKey,
+  systemVersionQueryKey,
   terminalsQueryKey,
   threadConversationOutlineQueryKey,
   threadDefaultExecutionOptionsQueryKey,
@@ -187,6 +188,27 @@ describe("system cache effects", () => {
     expect(queryClient.getQueryState(sidebarNavigationKey)?.isInvalidated).toBe(
       true,
     );
+  });
+
+  // A bb self-update restarts the server, which is what the reconnect signals.
+  // Without this the app would keep advertising the update it just applied
+  // until the tab reloads: the version answer is cached for an hour and never
+  // refetched on focus.
+  it("re-checks the app version after reconnect", () => {
+    const queryClient = createCacheEffectQueryClient();
+    const versionKey = systemVersionQueryKey();
+    queryClient.setQueryData(versionKey, {
+      currentVersion: "0.0.5",
+      latestVersion: "0.0.6",
+      source: "npm",
+      updateAvailable: true,
+      isDevelopment: false,
+      upgradeCommand: "npx bb-app@latest",
+    });
+
+    invalidateRealtimeQueriesAfterServerReconnect({ queryClient });
+
+    expect(queryClient.getQueryState(versionKey)?.isInvalidated).toBe(true);
   });
 
   it("refetches active thread bundle queries together after reconnect", async () => {

--- a/apps/app/src/hooks/useDesktopUpdateInfo.ts
+++ b/apps/app/src/hooks/useDesktopUpdateInfo.ts
@@ -5,6 +5,14 @@ import { getBbDesktopInfo } from "@/lib/bb-desktop";
 export interface DesktopUpdateInfo {
   desktopApi: BbDesktopApi | null;
   desktopInfo: BbDesktopInfo | null;
+  /**
+   * Whether this is the desktop shell at all. Known on the first render,
+   * unlike `desktopInfo`, which only arrives once the shell answers. Callers
+   * deciding whether bb updates itself must gate on this — gating on
+   * `desktopInfo` would treat the desktop as a web install until then and
+   * surface the npm upgrade path that the desktop never uses.
+   */
+  isDesktop: boolean;
 }
 
 /**
@@ -13,7 +21,9 @@ export interface DesktopUpdateInfo {
  * its info object into React state.
  */
 export function useDesktopUpdateInfo(): DesktopUpdateInfo {
-  const [desktopApi, setDesktopApi] = useState<BbDesktopApi | null>(null);
+  // The preload script installs `window.bbDesktop` before this bundle runs, so
+  // the bridge is readable on the first render; only its info is asynchronous.
+  const [desktopApi] = useState<BbDesktopApi | null>(() => getBbDesktopInfo());
   const [desktopInfo, setDesktopInfo] = useState<BbDesktopInfo | null>(null);
 
   useEffect(() => {
@@ -21,7 +31,6 @@ export function useDesktopUpdateInfo(): DesktopUpdateInfo {
     if (api === null) {
       return;
     }
-    setDesktopApi(api);
 
     let mounted = true;
     void api
@@ -42,5 +51,5 @@ export function useDesktopUpdateInfo(): DesktopUpdateInfo {
     };
   }, []);
 
-  return { desktopApi, desktopInfo };
+  return { desktopApi, desktopInfo, isDesktop: desktopApi !== null };
 }

--- a/apps/app/src/hooks/useUpdateInventory.ts
+++ b/apps/app/src/hooks/useUpdateInventory.ts
@@ -65,7 +65,7 @@ export function useUpdateInventory(
   const systemVersionQuery = useSystemVersion({ enabled });
   const systemConfigQuery = useSystemConfig({ enabled });
   const hostsQuery = useHosts({ enabled });
-  const { desktopInfo } = useDesktopUpdateInfo();
+  const { desktopInfo, isDesktop } = useDesktopUpdateInfo();
 
   const hosts = useMemo(() => hostsQuery.data ?? [], [hostsQuery.data]);
   const connectedHosts = useMemo(
@@ -117,8 +117,11 @@ export function useUpdateInventory(
   });
 
   const systemVersion = systemVersionQuery.data;
+  // Gate on `isDesktop`, not on `desktopInfo`: the desktop shell answers
+  // `getInfo()` a render or two after mount, and treating that gap as "web"
+  // flashes an npm-upgrade prompt the desktop build never uses.
   const appUpdateAvailable =
-    desktopInfo === null &&
+    !isDesktop &&
     systemVersion !== undefined &&
     !systemVersion.isDevelopment &&
     systemVersion.updateAvailable;

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 import { AppToaster } from "./components/AppToaster";
+import { registerProviderCliInstallQueryClient } from "./components/provider-cli/provider-cli-install-store";
 import { initializePreferredTheme } from "./hooks/useTheme";
 import { initializeFavicon } from "./lib/favicon-color-preference";
 import {
@@ -16,6 +17,9 @@ import "./app.css";
 
 const queryClient = createAppQueryClient();
 installAppQueryClientBrowserEvents(queryClient);
+// The provider CLI install store outlives every component, so it takes the
+// client here rather than reading it from context when an install finishes.
+registerProviderCliInstallQueryClient(queryClient);
 
 initializePreferredTheme();
 // Apply the palette cached from the last load before React renders, so a

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -35,10 +35,10 @@ import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
 import {
   buildProviderCliIssue,
   hasProviderCliAction,
-  providerCliJobKey,
   useProviderCliInstallRunner,
   type ProviderCliActionableIssue,
 } from "@/components/provider-cli/provider-cli-install";
+import { providerCliJobKey } from "@/components/provider-cli/provider-cli-install-store";
 import { withAutomationPromptAction } from "@/components/promptbox/PromptBoxActionsMenu";
 import { buildProviderPromptActionProps } from "@/components/promptbox/mentions/command-trigger";
 import { type PromptBoxHandle } from "@/components/promptbox/PromptBoxInternal";
@@ -1489,17 +1489,8 @@ export function RootComposeView() {
     hostId: composeHostId,
     enabled: composeHostId !== null,
   });
-  const refetchProviderCliStatus = providerCliStatus.refetch;
-  const {
-    installLogDialog: providerCliInstallLogDialog,
-    queuedJobKeys,
-    runningJobKey,
-    startInstall,
-  } = useProviderCliInstallRunner({
-    onStatusUpdated: () => {
-      void refetchProviderCliStatus();
-    },
-  });
+  const { queuedJobKeys, runningJobKey, startInstall } =
+    useProviderCliInstallRunner();
   const codexCliStatus = providerCliStatus.data?.codex ?? null;
   const isCodexCliVersionBlocked =
     selectedProviderId === "codex" &&
@@ -3659,7 +3650,6 @@ export function RootComposeView() {
         onClose={handleCloseWindowRequest}
         onToggle={handleToggleSecondaryPanel}
       />
-      {providerCliInstallLogDialog}
       {machineSetupDialog}
       {rootPanelToggle}
       <PluginComposerHostProvider value={pluginComposerHost}>


### PR DESCRIPTION
Two bugs on Settings → Updates.

## Updates stopped when you navigated away

The provider CLI install queue lived in `useProviderCliInstallRunner`'s component state, so leaving Settings → Updates unmounted it. The running install's HTTP request kept going server-side, but the queue was abandoned, the UI lost all progress, and the success callback that refreshes provider CLI status never fired.

The queue and running job now live in a module-level store (`provider-cli-install-store.ts`) that outlives components. The hook is a `useSyncExternalStore` mirror, so the Updates page and the compose view's Codex banner share one live state and re-attach on remount. The failure-log dialog mounts once in `App.tsx` **outside** `<Routes>` so a toast's "View log" works on any route — including `/auth/callback`, which renders no app shell. `main.tsx` registers the query client with the store so provider CLI status is invalidated even with nothing mounted. "Check for updates" got the same treatment via `app-update-check-store.ts`.

## The bb chip showed with no bb update

- `/system/version` is cached for an hour with no focus or reconnect refetch. A bb self-update restarts the server — the one event guaranteed to invalidate that answer — so the chip outlived the update it advertised. Now invalidated on websocket reconnect.
- `useUpdateInventory` decided "this is a web/npm install" from `desktopInfo === null`, which is briefly true on desktop before the shell answers `getInfo()`. That flashed an npm-upgrade prompt the desktop never uses. Now gated on a synchronous `isDesktop` read of `window.bbDesktop`.

## Tests

- `@bb/app` lint, typecheck, and 2145 tests across 294 files pass. Lint warnings went 148 → 147 (one fixed, none added).
- New coverage for the actual bugs: unmounting every consumer mid-install still drains the queue, still invalidates status, and a remount picks the running job back up; plus the reconnect version re-check.
- Verified end to end against a temporary mock (daemon reporting outdated CLIs with a `sleep` install command, server reporting `0.33.0 → 0.34.0`), then reverted:
  - "Update all" → Codex `Running…`, Claude Code `Queued`; survived client-side navigation to Appearance → app root → back.
  - Parked on the app root, Codex's `sleep 25` completed and Claude Code's `sleep 8` started and finished with the Updates page unmounted.
  - A delayed failure's toast and log dialog opened correctly from a non-Settings route.
  - With a real bb update the `bb` chip appeared; after clearing it and restarting the server, an already-open tab dropped the chip within seconds with no reload.

## Risks

A full page reload mid-install still resets the UI's view of it — the install keeps running server-side, but a reload is a fresh JS context. Only client-side navigation is covered, which is what was reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)