### PR TITLE
Redesign the Updates settings page

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
@@ -1,14 +1,15 @@
 import type { ReactNode } from "react";
 import type { Host } from "@bb/domain";
+import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import type { ProviderCliIssue } from "@/components/provider-cli/provider-cli-install";
-import { SettingsSection } from "@/components/ui/settings-section";
 import type { UpdateInventoryMachine } from "@/hooks/useUpdateInventory";
 import {
   BbAppUpdateRows,
   MachineUpdatesRows,
   UpdatesRowList,
+  UpdatesSection,
 } from "./UpdatesSettingsSection";
 
 export default {
@@ -137,7 +138,7 @@ function machineOf(args: {
 
 function MachineSection({ machine }: { machine: UpdateInventoryMachine }) {
   return (
-    <SettingsSection title="Machines">
+    <UpdatesSection title="Machines">
       <UpdatesRowList>
         <MachineUpdatesRows
           machine={machine}
@@ -148,14 +149,126 @@ function MachineSection({ machine }: { machine: UpdateInventoryMachine }) {
           onRetryDaemonUpdate={noop}
         />
       </UpdatesRowList>
-    </SettingsSection>
+    </UpdatesSection>
   );
 }
 
-export function WebAppUpdateAvailable() {
+function StoryActionButton({ children }: { children: ReactNode }) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-6 px-2 text-xs"
+    >
+      {children}
+    </Button>
+  );
+}
+
+export function HealthyFleet() {
+  const statuses = {
+    codex: providerStatus("codex", {
+      currentVersion: "0.146.0",
+      latestVersion: "0.146.0",
+    }),
+    claudeCode: providerStatus("claudeCode", {
+      currentVersion: "2.1.0",
+      latestVersion: "2.1.0",
+    }),
+  };
   return (
     <Stage>
-      <SettingsSection title="bb">
+      <UpdatesSection
+        title="bb"
+        footnote="Connected machines follow the server version automatically."
+        action={
+          <>
+            <span className="text-xs text-subtle-foreground">
+              Checked 2m ago
+            </span>
+            <StoryActionButton>What's new</StoryActionButton>
+          </>
+        }
+      >
+        <UpdatesRowList>
+          <BbAppUpdateRows
+            systemVersion={{
+              currentVersion: "0.0.33",
+              latestVersion: "0.0.33",
+              source: "npm",
+              updateAvailable: false,
+              isDevelopment: false,
+              upgradeCommand: "npx bb-app@latest",
+            }}
+            desktopInfo={null}
+            isDesktop={false}
+            onRelaunchDesktop={null}
+            onRetryDesktop={null}
+          />
+        </UpdatesRowList>
+      </UpdatesSection>
+      <UpdatesSection
+        title="Machines"
+        action={
+          <span className="text-xs text-subtle-foreground">
+            2 machines, all in sync
+          </span>
+        }
+      >
+        <UpdatesRowList>
+          <MachineUpdatesRows
+            machine={machineOf({
+              host: makeHost({ id: "host-primary", name: "workstation" }),
+              statuses,
+            })}
+            runningJobKey={null}
+            queuedJobKeys={NO_JOBS}
+            retryUpdatePending={false}
+            onStartInstall={noop}
+            onRetryDaemonUpdate={noop}
+          />
+          <MachineUpdatesRows
+            machine={machineOf({
+              host: makeHost({ id: "host-remote", name: "studio-mac" }),
+              statuses,
+            })}
+            runningJobKey={null}
+            queuedJobKeys={NO_JOBS}
+            retryUpdatePending={false}
+            onStartInstall={noop}
+            onRetryDaemonUpdate={noop}
+          />
+        </UpdatesRowList>
+      </UpdatesSection>
+    </Stage>
+  );
+}
+
+export function MixedFleet() {
+  const codex = providerStatus("codex", {
+    currentVersion: "0.145.0",
+    latestVersion: "0.146.0",
+    needsUpdate: true,
+  });
+  const claude = providerStatus("claudeCode", {
+    currentVersion: "2.1.0",
+    latestVersion: "2.1.0",
+  });
+  return (
+    <Stage>
+      <UpdatesSection
+        title="bb"
+        footnote="Connected machines follow the server version automatically."
+        action={
+          <>
+            <span className="text-xs text-subtle-foreground">
+              Checked just now
+            </span>
+            <StoryActionButton>What's new</StoryActionButton>
+          </>
+        }
+      >
         <UpdatesRowList>
           <BbAppUpdateRows
             systemVersion={{
@@ -172,7 +285,80 @@ export function WebAppUpdateAvailable() {
             onRetryDesktop={null}
           />
         </UpdatesRowList>
-      </SettingsSection>
+      </UpdatesSection>
+      <UpdatesSection
+        title="Machines"
+        action={
+          <>
+            <span className="text-xs text-subtle-foreground">
+              1 machine can't connect
+            </span>
+            <StoryActionButton>Update all (1)</StoryActionButton>
+          </>
+        }
+      >
+        <UpdatesRowList>
+          <MachineUpdatesRows
+            machine={machineOf({
+              host: makeHost({ id: "host-primary", name: "workstation" }),
+              statuses: { codex, claudeCode: claude },
+              issues: [
+                issueFor("codex", {
+                  currentVersion: "0.145.0",
+                  latestVersion: "0.146.0",
+                  needsUpdate: true,
+                }),
+              ],
+            })}
+            runningJobKey={null}
+            queuedJobKeys={NO_JOBS}
+            retryUpdatePending={false}
+            onStartInstall={noop}
+            onRetryDaemonUpdate={noop}
+          />
+          <MachineUpdatesRows
+            machine={machineOf({
+              host: makeHost({
+                id: "host-remote",
+                name: "homelab",
+                status: "disconnected",
+                lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
+              }),
+              canRetryDaemonUpdate: true,
+            })}
+            runningJobKey={null}
+            queuedJobKeys={NO_JOBS}
+            retryUpdatePending={false}
+            onStartInstall={noop}
+            onRetryDaemonUpdate={noop}
+          />
+        </UpdatesRowList>
+      </UpdatesSection>
+    </Stage>
+  );
+}
+
+export function WebAppUpdateAvailable() {
+  return (
+    <Stage>
+      <UpdatesSection title="bb">
+        <UpdatesRowList>
+          <BbAppUpdateRows
+            systemVersion={{
+              currentVersion: "0.0.32",
+              latestVersion: "0.0.33",
+              source: "npm",
+              updateAvailable: true,
+              isDevelopment: false,
+              upgradeCommand: "npx bb-app@latest",
+            }}
+            desktopInfo={null}
+            isDesktop={false}
+            onRelaunchDesktop={null}
+            onRetryDesktop={null}
+          />
+        </UpdatesRowList>
+      </UpdatesSection>
     </Stage>
   );
 }
@@ -180,7 +366,7 @@ export function WebAppUpdateAvailable() {
 export function DesktopUpdateReady() {
   return (
     <Stage>
-      <SettingsSection title="bb">
+      <UpdatesSection title="bb">
         <UpdatesRowList>
           <BbAppUpdateRows
             systemVersion={undefined}
@@ -199,7 +385,7 @@ export function DesktopUpdateReady() {
             onRetryDesktop={noop}
           />
         </UpdatesRowList>
-      </SettingsSection>
+      </UpdatesSection>
     </Stage>
   );
 }
@@ -207,7 +393,7 @@ export function DesktopUpdateReady() {
 export function DesktopDownloading() {
   return (
     <Stage>
-      <SettingsSection title="bb">
+      <UpdatesSection title="bb">
         <UpdatesRowList>
           <BbAppUpdateRows
             systemVersion={undefined}
@@ -226,7 +412,7 @@ export function DesktopDownloading() {
             onRetryDesktop={noop}
           />
         </UpdatesRowList>
-      </SettingsSection>
+      </UpdatesSection>
     </Stage>
   );
 }
@@ -279,7 +465,7 @@ export function MachineRunningAndQueued() {
   });
   return (
     <Stage>
-      <SettingsSection title="Machines">
+      <UpdatesSection title="Machines">
         <UpdatesRowList>
           <MachineUpdatesRows
             machine={machine}
@@ -290,7 +476,7 @@ export function MachineRunningAndQueued() {
             onRetryDaemonUpdate={noop}
           />
         </UpdatesRowList>
-      </SettingsSection>
+      </UpdatesSection>
     </Stage>
   );
 }

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -6,11 +6,13 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Host } from "@bb/domain";
 import type { BbDesktopApi, BbDesktopInfo } from "@bb/desktop-contract";
+import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import type {
   ProviderCliIssue,
   ProviderCliActionableIssue,
@@ -49,10 +51,12 @@ vi.mock("@/hooks/useDesktopUpdateInfo", () => ({
   useDesktopUpdateInfo: vi.fn(),
 }));
 
+const retryHostUpdateMutateMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/hooks/mutations/host-mutations", () => ({
   useRetryHostUpdate: () => ({
     isPending: false,
-    mutate: vi.fn(),
+    mutate: retryHostUpdateMutateMock,
     variables: undefined,
   }),
 }));
@@ -124,6 +128,10 @@ function makeUpdateIssue(args: {
 function makeMachine(args: {
   host: Host;
   issues?: ProviderCliIssue[];
+  isPrimary?: boolean;
+  statusPending?: boolean;
+  statusError?: boolean;
+  canRetryDaemonUpdate?: boolean;
 }): UpdateInventoryMachine {
   const issues = args.issues ?? [];
   const upToDate = (provider: "codex" | "claudeCode") => {
@@ -150,7 +158,7 @@ function makeMachine(args: {
   };
   return {
     host: args.host,
-    isPrimary: false,
+    isPrimary: args.isPrimary ?? false,
     providerStatus:
       args.host.status === "connected"
         ? {
@@ -159,10 +167,10 @@ function makeMachine(args: {
             cursor: cursorStatus,
           }
         : null,
-    statusPending: false,
-    statusError: false,
+    statusPending: args.statusPending ?? false,
+    statusError: args.statusError ?? false,
     issues,
-    canRetryDaemonUpdate: false,
+    canRetryDaemonUpdate: args.canRetryDaemonUpdate ?? false,
   };
 }
 
@@ -183,6 +191,7 @@ function makeInventory(overrides: Partial<UpdateInventory>): UpdateInventory {
     machines: [],
     actionableCount: 0,
     hasAttention: false,
+    lastCheckedAt: null,
     ...overrides,
   };
 }
@@ -203,6 +212,14 @@ const useUpdateInventoryMock = vi.mocked(useUpdateInventory);
 const useDesktopUpdateInfoMock = vi.mocked(useDesktopUpdateInfo);
 const useProviderCliInstallRunnerMock = vi.mocked(useProviderCliInstallRunner);
 
+beforeEach(() => {
+  useProviderCliInstallRunnerMock.mockReturnValue({
+    queuedJobKeys: new Set<string>(),
+    runningJobKey: null,
+    startInstall: startInstallMock,
+  });
+});
+
 afterEach(() => {
   cleanup();
   resetAppUpdateCheckStoreForTests();
@@ -210,6 +227,139 @@ afterEach(() => {
 });
 
 describe("UpdatesSettingsSection", () => {
+  it("keeps a recently checked healthy fleet quiet and accessible", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        lastCheckedAt: Date.now() - 2 * 60 * 1000,
+        machines: [
+          makeMachine({
+            host: makeHost({ id: "host_1", name: "workstation" }),
+            isPrimary: true,
+          }),
+          makeMachine({
+            host: makeHost({ id: "host_2", name: "studio-mac" }),
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("Checked 2m ago")).toBeDefined();
+    expect(screen.getByText("2 machines, all in sync")).toBeDefined();
+    expect(screen.queryByText("Up to date")).toBeNull();
+    expect(screen.queryByText(/^In sync$/)).toBeNull();
+    expect(
+      screen.getByRole("group", { name: /workstation, Connected/ }),
+    ).toBeDefined();
+  });
+
+  it("does not call an offline fleet all in sync", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host: makeHost({
+              id: "host_1",
+              name: "homelab",
+              status: "disconnected",
+            }),
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("1 machine was not checked")).toBeDefined();
+    expect(screen.queryByText(/all in sync/)).toBeNull();
+    expect(
+      within(screen.getByRole("group", { name: /homelab, Offline/ })).getByText(
+        "Offline — connect to check for updates",
+      ),
+    ).toBeDefined();
+  });
+
+  it("explains and retries a stranded daemon update", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({
+      id: "host_1",
+      name: "homelab",
+      status: "disconnected",
+      lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host,
+            canRetryDaemonUpdate: true,
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("1 machine can't connect")).toBeDefined();
+    expect(
+      screen.getByText("Can't connect — its bb agent is out of date"),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        `Needs update · daemon protocol ${HOST_DAEMON_PROTOCOL_VERSION - 1} · server protocol ${HOST_DAEMON_PROTOCOL_VERSION}`,
+      ),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry update" }));
+    expect(retryHostUpdateMutateMock).toHaveBeenCalledWith(
+      host.id,
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("removes running and queued provider jobs from Update all", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    const codexIssue = makeUpdateIssue({ provider: "codex" });
+    const claudeIssue = makeUpdateIssue({ provider: "claudeCode" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, issues: [codexIssue, claudeIssue] })],
+      }),
+    );
+    useProviderCliInstallRunnerMock.mockReturnValue({
+      queuedJobKeys: new Set(["host_1:claudeCode"]),
+      runningJobKey: "host_1:codex",
+      startInstall: startInstallMock,
+    });
+
+    renderSection();
+
+    expect(screen.queryByRole("button", { name: /Update all/ })).toBeNull();
+    expect(screen.getByText("2 updates in progress")).toBeDefined();
+    expect(screen.getByText("Running…")).toBeDefined();
+    expect(screen.getByText("Queued")).toBeDefined();
+  });
+
   it("forces the web update check and shows the upgrade command inline", async () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -1,4 +1,10 @@
-import { useSyncExternalStore, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { BbDesktopInfo } from "@bb/desktop-contract";
 import type { SystemVersionResponse } from "@bb/server-contract";
@@ -18,10 +24,7 @@ import {
   subscribeAppUpdateCheck,
 } from "@/components/settings/app-update-check-store";
 import { MachineStatusDot } from "@/components/machines/MachineStatusDot";
-import {
-  SettingsBadge,
-  SettingsSection,
-} from "@/components/ui/settings-section";
+import { SettingsBadge } from "@/components/ui/settings-section";
 import { appToast } from "@/components/ui/app-toast";
 import { invalidateHostProviderCliStatus } from "@/hooks/cache-owners/provider-cli-status-cache-owner";
 import { hydrateSystemVersionCache } from "@/hooks/cache-owners/system-version-cache-owner";
@@ -32,10 +35,20 @@ import {
 } from "@/hooks/useUpdateInventory";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
 import { formatHostUpdateStatus } from "@/lib/host-update-status";
+import { formatRelativeTime } from "@/lib/relative-time";
 import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import { sdk } from "@/lib/sdk";
 
 const CHANGELOG_URL = "https://github.com/ymichael/bb/blob/main/CHANGELOG.md";
+
+/**
+ * The rows and the machine bands above them share one text edge: names start
+ * at `pl-7` (28px), and the status dot sits centred on `left-3.5` (14px) —
+ * the same column the child rows' hairline spine runs down. The dot therefore
+ * caps the spine instead of pushing the machine name out of alignment.
+ */
+const GUTTER_TEXT = "pl-7";
+const GUTTER_MARK = "absolute left-3.5 top-0 flex h-8 w-0 items-center";
 
 function updateCheckErrorDescription(error: unknown): string {
   if (error instanceof Error && error.message.length > 0) {
@@ -56,88 +69,145 @@ function RowButton({ className, ...props }: ButtonProps) {
   );
 }
 
+export interface UpdatesSectionProps {
+  title: string;
+  /** Right-hand slot: the freshness stamp and any section-wide action. */
+  action?: ReactNode;
+  /** Quiet line below the card, for the one caveat worth stating. */
+  footnote?: string;
+  children: ReactNode;
+}
+
 /**
- * A card whose rows are a shared 4-column grid (name / version / state /
- * action) via subgrid, so the columns line up across every row.
+ * A settings section whose card is flush — rows run edge to edge so their
+ * separators and machine bands are full-bleed. Deliberately not
+ * `SettingsSection`, whose padded card would inset every row.
  */
+export function UpdatesSection({
+  title,
+  action,
+  footnote,
+  children,
+}: UpdatesSectionProps) {
+  const titleId = useId();
+
+  return (
+    <section aria-labelledby={titleId} className="space-y-2.5">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <h2 id={titleId} className="text-sm font-semibold text-foreground">
+          {title}
+        </h2>
+        {action !== undefined ? (
+          <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+            {action}
+          </div>
+        ) : null}
+      </div>
+      <div className="overflow-hidden rounded-lg border border-border bg-card">
+        {children}
+      </div>
+      {footnote !== undefined ? (
+        <p className="text-xs text-subtle-foreground">{footnote}</p>
+      ) : null}
+    </section>
+  );
+}
+
+/** Groups rows so the first one drops its top separator. */
 export function UpdatesRowList({ children }: { children: ReactNode }) {
   return (
-    <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] gap-x-4">
+    <div className="[&>*:first-child]:border-t-0 [&>*:first-child>*:first-child]:border-t-0">
       {children}
     </div>
   );
 }
 
-function UpdatesRow({ children }: { children: ReactNode }) {
-  return (
-    <div className="col-span-4 grid grid-cols-subgrid items-center border-t border-border py-2.5 text-sm first:border-t-0 first:pt-0 last:pb-0">
-      {children}
-    </div>
-  );
-}
+type RowTone = "default" | "attention" | "destructive";
 
-function NameCell({
-  indent,
+function UpdatesRow({
+  tone = "default",
+  indent = false,
   children,
 }: {
+  tone?: RowTone;
   indent?: boolean;
   children: ReactNode;
 }) {
   return (
-    <span
+    <div
       className={cn(
-        "flex min-w-0 items-center gap-1.5 truncate text-foreground",
-        indent && "pl-4",
+        "relative flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 border-t border-border/70 py-2 pr-3 text-sm",
+        indent ? GUTTER_TEXT : "pl-3",
+        tone === "attention" && "bg-surface-attention",
+        tone === "destructive" && "bg-surface-destructive",
       )}
     >
+      {indent ? (
+        <span
+          aria-hidden
+          className="absolute inset-y-0 left-3.5 w-px -translate-x-1/2 bg-border/85"
+        />
+      ) : null}
       {children}
-    </span>
+    </div>
   );
 }
 
-function VersionCell({
+/**
+ * Name and version read as one phrase ("Codex 0.146.0") instead of being split
+ * across a wide gutter; the right edge belongs to state and actions only.
+ */
+function RowName({
+  name,
   current,
   latest,
 }: {
+  name: string;
   current: string | null;
   latest: string | null;
 }) {
-  if (current === null && latest === null) {
-    return <span />;
-  }
-  if (current === null) {
-    return (
-      <span className="justify-self-end font-mono text-xs font-semibold text-foreground">
-        {latest}
-      </span>
-    );
-  }
   return (
-    <span className="justify-self-end font-mono text-xs text-muted-foreground">
-      {current}
-      {latest !== null && latest !== current ? (
-        <>
-          <span className="px-1 text-subtle-foreground">→</span>
-          <span className="font-semibold text-foreground">{latest}</span>
-        </>
-      ) : null}
+    <span className="flex min-w-40 flex-1 items-baseline gap-2">
+      <span className="truncate font-medium text-foreground">{name}</span>
+      {/* No current version means nothing is installed here; showing `latest`
+          alone would read as the version you have. The row's label says it. */}
+      {current === null ? null : (
+        <span className="shrink-0 font-mono text-xs text-readback-foreground">
+          {current}
+          {latest !== null && latest !== current ? (
+            <>
+              <span className="px-1 text-subtle-foreground">→</span>
+              <span className="font-semibold text-foreground">{latest}</span>
+            </>
+          ) : null}
+        </span>
+      )}
     </span>
   );
 }
 
-function StateCell({
-  tone,
+/**
+ * The right-hand slot. A healthy row passes nothing: "Up to date" repeated
+ * down a column carried no information, so the settled state is now the
+ * absence of a label and only exceptions speak.
+ */
+function RowStatus({
+  tone = "subtle",
+  live = false,
   children,
 }: {
-  tone: "subtle" | "attention" | "destructive";
+  tone?: "subtle" | "attention" | "destructive";
+  live?: boolean;
   children: ReactNode;
 }) {
   return (
     <span
+      role={live ? "status" : undefined}
+      aria-live={live ? "polite" : undefined}
       className={cn(
         "text-xs",
         tone === "subtle" && "text-subtle-foreground",
-        tone === "attention" && "text-foreground",
+        tone === "attention" && "text-warning-text",
         tone === "destructive" && "text-destructive-text",
       )}
     >
@@ -146,8 +216,10 @@ function StateCell({
   );
 }
 
-function ActionCell({ children }: { children?: ReactNode }) {
-  return <span className="flex min-w-14 justify-end">{children ?? null}</span>;
+function RowActions({ children }: { children: ReactNode }) {
+  return (
+    <span className="ml-auto flex shrink-0 items-center gap-2">{children}</span>
+  );
 }
 
 export interface BbAppUpdateRowsProps {
@@ -173,12 +245,10 @@ export function BbAppUpdateRows({
   if (isDesktop && desktopInfo === null) {
     return (
       <UpdatesRow>
-        <NameCell>
-          <span className="truncate font-medium">bb desktop</span>
-        </NameCell>
-        <span />
-        <StateCell tone="subtle">Checking…</StateCell>
-        <ActionCell />
+        <RowName name="bb desktop" current={null} latest={null} />
+        <RowActions>
+          <RowStatus live>Checking…</RowStatus>
+        </RowActions>
       </UpdatesRow>
     );
   }
@@ -186,111 +256,125 @@ export function BbAppUpdateRows({
   if (desktopInfo !== null) {
     const pendingVersion =
       desktopInfo.pendingVersion ?? desktopInfo.latestVersion;
-    return (
-      <UpdatesRow>
-        <NameCell>
-          <span className="truncate font-medium">bb desktop</span>
-        </NameCell>
-        <VersionCell
-          current={desktopInfo.version}
-          latest={desktopInfo.updateAvailable ? pendingVersion : null}
-        />
-        {desktopInfo.updateDownloaded ? (
-          <>
-            <StateCell tone="attention">Downloaded</StateCell>
-            <ActionCell>
-              <RowButton onClick={() => onRelaunchDesktop?.()}>
-                Relaunch
-              </RowButton>
-            </ActionCell>
-          </>
-        ) : desktopInfo.downloadState === "downloading" ? (
-          <>
-            <StateCell tone="attention">
-              Downloading in the background…
-            </StateCell>
-            <ActionCell />
-          </>
-        ) : desktopInfo.downloadState === "failed" ? (
-          <>
-            <StateCell tone="destructive">Download failed</StateCell>
-            <ActionCell>
-              <RowButton onClick={() => onRetryDesktop?.()}>Retry</RowButton>
-            </ActionCell>
-          </>
-        ) : desktopInfo.updateAvailable ? (
-          <>
-            <StateCell tone="attention">Available</StateCell>
-            <ActionCell />
-          </>
-        ) : (
-          <>
-            <StateCell tone="subtle">Up to date</StateCell>
-            <ActionCell />
-          </>
-        )}
-      </UpdatesRow>
+    const latest = desktopInfo.updateAvailable ? pendingVersion : null;
+    const name = (
+      <RowName
+        name="bb desktop"
+        current={desktopInfo.version}
+        latest={latest}
+      />
     );
+
+    if (desktopInfo.updateDownloaded) {
+      return (
+        <UpdatesRow tone="attention">
+          {name}
+          <RowActions>
+            <RowStatus tone="attention">Downloaded</RowStatus>
+            <RowButton onClick={() => onRelaunchDesktop?.()}>
+              Relaunch
+            </RowButton>
+          </RowActions>
+        </UpdatesRow>
+      );
+    }
+    if (desktopInfo.downloadState === "downloading") {
+      return (
+        <UpdatesRow tone="attention">
+          {name}
+          <RowActions>
+            <RowStatus live tone="attention">
+              Downloading in the background…
+            </RowStatus>
+          </RowActions>
+        </UpdatesRow>
+      );
+    }
+    if (desktopInfo.downloadState === "failed") {
+      return (
+        <UpdatesRow tone="destructive">
+          {name}
+          <RowActions>
+            <RowStatus tone="destructive">Download failed</RowStatus>
+            <RowButton onClick={() => onRetryDesktop?.()}>Retry</RowButton>
+          </RowActions>
+        </UpdatesRow>
+      );
+    }
+    if (desktopInfo.updateAvailable) {
+      return (
+        <UpdatesRow tone="attention">
+          {name}
+          <RowActions>
+            <RowStatus tone="attention">Available</RowStatus>
+          </RowActions>
+        </UpdatesRow>
+      );
+    }
+    return <UpdatesRow>{name}</UpdatesRow>;
   }
 
   if (systemVersion === undefined) {
     return (
       <UpdatesRow>
-        <NameCell>
-          <span className="truncate font-medium">bb-app</span>
-        </NameCell>
-        <span />
-        <StateCell tone="subtle">Checking…</StateCell>
-        <ActionCell />
+        <RowName name="bb-app" current={null} latest={null} />
+        <RowActions>
+          <RowStatus>Checking…</RowStatus>
+        </RowActions>
       </UpdatesRow>
     );
   }
 
-  return (
-    <UpdatesRow>
-      <NameCell>
-        <span className="truncate font-medium">bb-app</span>
-        {systemVersion.updateAvailable ? (
-          <code className="ml-1.5 shrink-0 rounded-sm bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+  const name = (
+    <RowName
+      name="bb-app"
+      current={systemVersion.currentVersion}
+      latest={
+        systemVersion.updateAvailable ? systemVersion.latestVersion : null
+      }
+    />
+  );
+
+  if (systemVersion.isDevelopment) {
+    return (
+      <UpdatesRow>
+        {name}
+        <RowActions>
+          <RowStatus>Development mode</RowStatus>
+        </RowActions>
+      </UpdatesRow>
+    );
+  }
+
+  if (systemVersion.updateAvailable) {
+    return (
+      <UpdatesRow tone="attention">
+        {name}
+        <RowActions>
+          <RowStatus tone="attention">Available</RowStatus>
+          {/* The command sits with the button that copies it, rather than
+              crowding the app name on the left. */}
+          <code className="hidden rounded-sm bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-muted-foreground sm:inline">
             {systemVersion.upgradeCommand}
           </code>
-        ) : null}
-      </NameCell>
-      <VersionCell
-        current={systemVersion.currentVersion}
-        latest={
-          systemVersion.updateAvailable ? systemVersion.latestVersion : null
-        }
-      />
-      {systemVersion.isDevelopment ? (
-        <>
-          <StateCell tone="subtle">Development mode</StateCell>
-          <ActionCell />
-        </>
-      ) : systemVersion.updateAvailable ? (
-        <>
-          <StateCell tone="attention">Available</StateCell>
-          <ActionCell>
-            <RowButton
-              onClick={() => {
-                void navigator.clipboard
-                  .writeText(systemVersion.upgradeCommand)
-                  .then(() => appToast.success("Upgrade command copied"))
-                  .catch(() => undefined);
-              }}
-            >
-              Copy
-            </RowButton>
-          </ActionCell>
-        </>
-      ) : (
-        <>
-          <StateCell tone="subtle">Up to date</StateCell>
-          <ActionCell />
-        </>
-      )}
-    </UpdatesRow>
-  );
+          <RowButton
+            onClick={() => {
+              void navigator.clipboard
+                .writeText(systemVersion.upgradeCommand)
+                .then(() => appToast.success("Upgrade command copied"))
+                .catch(() => {
+                  appToast.error("Couldn't copy upgrade command");
+                });
+            }}
+          >
+            Copy
+          </RowButton>
+        </RowActions>
+      </UpdatesRow>
+    );
+  }
+
+  return <UpdatesRow>{name}</UpdatesRow>;
 }
 
 export interface MachineUpdatesRowsProps {
@@ -302,26 +386,98 @@ export interface MachineUpdatesRowsProps {
   onRetryDaemonUpdate: (hostId: string) => void;
 }
 
+interface ProviderRowState {
+  label: string;
+  rowTone: RowTone;
+  statusTone: "subtle" | "attention" | "destructive";
+}
+
 function providerRowState({
   issue,
   installed,
 }: {
   issue: ProviderCliIssue | null;
   installed: boolean;
-}): { label: string; tone: "subtle" | "attention" | "destructive" } {
+}): ProviderRowState | null {
   if (!installed) {
-    return { label: "Not installed", tone: "subtle" };
+    return { label: "Not installed", rowTone: "default", statusTone: "subtle" };
   }
+  // Up to date: the version alone says it. No label, no tint.
   if (issue === null) {
-    return { label: "Up to date", tone: "subtle" };
+    return null;
   }
   if (issue.status.versionUnsupported) {
-    return { label: "Update needed", tone: "destructive" };
+    return {
+      label: "Update needed",
+      rowTone: "destructive",
+      statusTone: "destructive",
+    };
   }
-  return { label: "Available", tone: "attention" };
+  return { label: "Available", rowTone: "attention", statusTone: "attention" };
 }
 
-/** One machine's rows: a host header row, then a row per provider CLI. */
+/** The band that heads a machine's rows. */
+function MachineBand({
+  connected,
+  name,
+  headingId,
+  statusLabel,
+  badge,
+  detail,
+  tone = "default",
+  children,
+}: {
+  connected: boolean;
+  name: string;
+  headingId: string;
+  statusLabel: string;
+  badge?: ReactNode;
+  detail?: ReactNode;
+  tone?: "default" | "destructive";
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative flex items-center justify-between gap-3 border-t text-sm",
+        GUTTER_TEXT,
+        "pr-3",
+        tone === "destructive"
+          ? "border-surface-destructive-border bg-surface-destructive"
+          : "border-border/70 bg-surface-recessed",
+        children === undefined ? "h-8" : "py-2",
+      )}
+    >
+      <span aria-hidden className={GUTTER_MARK}>
+        <MachineStatusDot
+          connected={connected}
+          className={cn(
+            "-translate-x-1/2",
+            // A stranded daemon is offline *and* broken; the shared hollow
+            // ring alone reads as merely idle.
+            tone === "destructive" && "border-destructive bg-destructive",
+          )}
+        />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="flex min-w-0 items-center gap-2">
+          <h3
+            id={headingId}
+            className="truncate text-xs font-semibold text-foreground"
+          >
+            {name}
+            <span className="sr-only">, {statusLabel}</span>
+          </h3>
+          {badge}
+        </span>
+        {children}
+      </span>
+      {detail !== undefined ? <span className="shrink-0">{detail}</span> : null}
+    </div>
+  );
+}
+
+/** One machine's rows: a header band, then a row per provider CLI. */
 export function MachineUpdatesRows({
   machine,
   runningJobKey,
@@ -331,63 +487,83 @@ export function MachineUpdatesRows({
   onRetryDaemonUpdate,
 }: MachineUpdatesRowsProps) {
   const { host } = machine;
+  const headingId = useId();
   const issuesByProvider = new Map(
     machine.issues.map((issue) => [issue.provider, issue]),
   );
-  const daemonUpdateStatus = formatHostUpdateStatus(host);
+
+  /*
+   * A protocol-rejected daemon is disconnected, so this machine has no
+   * provider rows at all — the band has to carry the whole story on its own,
+   * which is why it is the one header allowed to run multi-line. The raw
+   * protocol numbers stay, demoted below the plain-language cause.
+   */
+  if (machine.canRetryDaemonUpdate) {
+    const daemonStatus = formatHostUpdateStatus(host);
+    return (
+      <div role="group" aria-labelledby={headingId}>
+        <MachineBand
+          connected={false}
+          tone="destructive"
+          name={host.name}
+          headingId={headingId}
+          statusLabel="Agent update required"
+          badge={
+            machine.isPrimary ? (
+              <SettingsBadge>this machine</SettingsBadge>
+            ) : null
+          }
+          detail={
+            <RowButton
+              aria-busy={retryUpdatePending}
+              disabled={retryUpdatePending}
+              onClick={() => onRetryDaemonUpdate(host.id)}
+            >
+              {retryUpdatePending ? "Retrying…" : "Retry update"}
+            </RowButton>
+          }
+        >
+          <span className="text-xs text-destructive-text">
+            Can't connect — its bb agent is out of date
+          </span>
+          <span className="text-2xs text-subtle-foreground">
+            Usually it updates itself.
+          </span>
+          {daemonStatus === null ? null : (
+            <span className="text-2xs text-subtle-foreground">
+              {daemonStatus}
+            </span>
+          )}
+        </MachineBand>
+      </div>
+    );
+  }
 
   return (
-    <>
-      <UpdatesRow>
-        <NameCell>
-          <MachineStatusDot connected={host.status === "connected"} />
-          <span className="truncate font-medium">{host.name}</span>
-          {machine.isPrimary ? (
-            <SettingsBadge>this machine</SettingsBadge>
-          ) : null}
-        </NameCell>
-        <span />
-        {machine.canRetryDaemonUpdate ? (
-          <>
-            <StateCell tone="destructive">
-              {daemonUpdateStatus ?? "Needs update"}
-            </StateCell>
-            <ActionCell>
-              <RowButton
-                disabled={retryUpdatePending}
-                onClick={() => onRetryDaemonUpdate(host.id)}
-              >
-                {retryUpdatePending ? "Retrying…" : "Retry update"}
-              </RowButton>
-            </ActionCell>
-          </>
-        ) : host.status === "connected" ? (
-          <>
-            <StateCell tone="subtle">In sync</StateCell>
-            <ActionCell />
-          </>
-        ) : (
-          <>
-            <StateCell tone="subtle">
-              Offline — connect to check for updates
-            </StateCell>
-            <ActionCell />
-          </>
-        )}
-      </UpdatesRow>
+    <div role="group" aria-labelledby={headingId}>
+      <MachineBand
+        connected={host.status === "connected"}
+        name={host.name}
+        headingId={headingId}
+        statusLabel={host.status === "connected" ? "Connected" : "Offline"}
+        badge={
+          machine.isPrimary ? <SettingsBadge>this machine</SettingsBadge> : null
+        }
+        detail={
+          host.status === "connected" ? undefined : (
+            <RowStatus>Offline — connect to check for updates</RowStatus>
+          )
+        }
+      />
       {host.status !== "connected" ? null : machine.statusError ? (
-        <UpdatesRow>
-          <span className="col-span-3 pl-4 text-xs text-destructive-text">
+        <UpdatesRow indent>
+          <RowStatus tone="destructive">
             Couldn't check provider CLIs on this machine.
-          </span>
-          <ActionCell />
+          </RowStatus>
         </UpdatesRow>
       ) : machine.statusPending || machine.providerStatus === null ? (
-        <UpdatesRow>
-          <span className="col-span-3 pl-4 text-xs text-subtle-foreground">
-            Checking provider CLIs…
-          </span>
-          <ActionCell />
+        <UpdatesRow indent>
+          <RowStatus live>Checking provider CLIs…</RowStatus>
         </UpdatesRow>
       ) : (
         (["codex", "claudeCode"] as const).map((provider) => {
@@ -403,43 +579,59 @@ export function MachineUpdatesRows({
           const jobKey = providerCliJobKey(host.id, provider);
           const running = runningJobKey === jobKey;
           const queued = queuedJobKeys.has(jobKey);
+          const actionable =
+            issue !== null &&
+            hasProviderCliAction(issue) &&
+            !running &&
+            !queued;
           return (
-            <UpdatesRow key={provider}>
-              <NameCell indent>
-                <span className="truncate">{status.displayName}</span>
-              </NameCell>
-              <VersionCell
+            <UpdatesRow
+              key={provider}
+              indent
+              tone={
+                running || queued ? "default" : (state?.rowTone ?? "default")
+              }
+            >
+              <RowName
+                name={status.displayName}
                 current={status.currentVersion}
                 latest={issue !== null ? status.latestVersion : null}
               />
-              {running ? (
-                <StateCell tone="attention">
-                  <span className="inline-flex items-center gap-1.5">
-                    <Icon name="Spinner" className="size-3 animate-spin" />
-                    Running…
-                  </span>
-                </StateCell>
-              ) : queued ? (
-                <StateCell tone="subtle">Queued</StateCell>
-              ) : (
-                <StateCell tone={state.tone}>{state.label}</StateCell>
-              )}
-              <ActionCell>
-                {issue !== null &&
-                hasProviderCliAction(issue) &&
-                !running &&
-                !queued ? (
+              <RowActions>
+                {running ? (
+                  <RowStatus live tone="attention">
+                    <span className="inline-flex items-center gap-1.5">
+                      <Icon name="Spinner" className="size-3 animate-spin" />
+                      Running…
+                    </span>
+                  </RowStatus>
+                ) : queued ? (
+                  <RowStatus live>Queued</RowStatus>
+                ) : state === null ? null : (
+                  <RowStatus tone={state.statusTone}>{state.label}</RowStatus>
+                )}
+                {actionable ? (
                   <RowButton onClick={() => onStartInstall(host.id, issue)}>
                     {issue.action.label}
                   </RowButton>
                 ) : null}
-              </ActionCell>
+              </RowActions>
             </UpdatesRow>
           );
         })
       )}
-    </>
+    </div>
   );
+}
+
+/** Re-renders the relative "checked" stamp so it can't sit on a stale minute. */
+function useNow(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(timer);
+  }, [intervalMs]);
+  return now;
 }
 
 /**
@@ -455,10 +647,11 @@ export function UpdatesSettingsSection() {
     subscribeAppUpdateCheck,
     getAppUpdateCheckSnapshot,
   );
+  const now = useNow(30_000);
   const { queuedJobKeys, runningJobKey, startInstall } =
     useProviderCliInstallRunner();
 
-  const actionableIssues: {
+  const allActionableIssues: {
     hostId: string;
     issue: ProviderCliActionableIssue;
   }[] = inventory.machines.flatMap((machine) =>
@@ -466,6 +659,27 @@ export function UpdatesSettingsSection() {
       .filter(hasProviderCliAction)
       .map((issue) => ({ hostId: machine.host.id, issue })),
   );
+  const actionableIssues = allActionableIssues.filter(({ hostId, issue }) => {
+    const jobKey = providerCliJobKey(hostId, issue.provider);
+    return runningJobKey !== jobKey && !queuedJobKeys.has(jobKey);
+  });
+
+  const strandedMachines = inventory.machines.filter(
+    (machine) => machine.canRetryDaemonUpdate,
+  ).length;
+  const checkingMachines = inventory.machines.filter(
+    (machine) =>
+      machine.host.status === "connected" &&
+      !machine.statusError &&
+      (machine.statusPending || machine.providerStatus === null),
+  ).length;
+  const uncheckedMachines = inventory.machines.filter(
+    (machine) =>
+      !machine.canRetryDaemonUpdate &&
+      (machine.host.status !== "connected" || machine.statusError),
+  ).length;
+  const activeInstallCount =
+    (runningJobKey === null ? 0 : 1) + queuedJobKeys.size;
 
   // Snapshot the hosts at click time: the check runs in a module-level store
   // so it survives navigating away, and must not read React state afterwards.
@@ -489,13 +703,62 @@ export function UpdatesSettingsSection() {
     });
   }
 
+  /*
+   * "Up to date" is only credible next to a time, so the stamp — not the
+   * button — is what the section header leads with; checking is a quiet icon
+   * beside it.
+   */
+  const checkedLabel =
+    inventory.lastCheckedAt === null
+      ? null
+      : `Checked ${formatRelativeTime({ timestamp: inventory.lastCheckedAt, now })}`;
+
+  const machineSummary =
+    inventory.machines.length === 0
+      ? null
+      : strandedMachines > 0
+        ? `${strandedMachines} ${strandedMachines === 1 ? "machine" : "machines"} can't connect`
+        : uncheckedMachines > 0
+          ? `${uncheckedMachines} ${uncheckedMachines === 1 ? "machine was" : "machines were"} not checked`
+          : checkingMachines > 0
+            ? `Checking ${checkingMachines} ${checkingMachines === 1 ? "machine" : "machines"}…`
+            : activeInstallCount > 0
+              ? `${activeInstallCount} ${activeInstallCount === 1 ? "update" : "updates"} in progress`
+              : actionableIssues.length === 0
+                ? `${inventory.machines.length} ${inventory.machines.length === 1 ? "machine" : "machines"}, all in sync`
+                : null;
+
   return (
     <>
-      <SettingsSection
+      <UpdatesSection
         title="bb"
-        description="The bb app updates here; connected machines follow the server version automatically."
+        footnote="Connected machines follow the server version automatically."
         action={
-          <div className="flex items-center gap-1">
+          <>
+            {isChecking || checkedLabel !== null ? (
+              <span
+                role="status"
+                aria-atomic="true"
+                aria-live="polite"
+                className="text-xs text-subtle-foreground"
+              >
+                {isChecking ? "Checking…" : checkedLabel}
+              </span>
+            ) : null}
+            <RowButton
+              variant="ghost"
+              aria-label="Check for updates"
+              aria-busy={isChecking}
+              disabled={isChecking}
+              className="px-1.5 text-muted-foreground hover:text-foreground"
+              onClick={handleCheckForUpdates}
+            >
+              <Icon
+                aria-hidden
+                name={isChecking ? "Spinner" : "RotateCcw"}
+                className={cn("size-3.5", isChecking && "animate-spin")}
+              />
+            </RowButton>
             <RowButton
               variant="ghost"
               className="text-muted-foreground hover:text-foreground"
@@ -503,18 +766,7 @@ export function UpdatesSettingsSection() {
             >
               What's new
             </RowButton>
-            <RowButton
-              aria-busy={isChecking}
-              disabled={isChecking}
-              onClick={handleCheckForUpdates}
-            >
-              <Icon
-                name={isChecking ? "Spinner" : "RotateCcw"}
-                className={cn("size-3.5", isChecking && "animate-spin")}
-              />
-              {isChecking ? "Checking" : "Check for updates"}
-            </RowButton>
-          </div>
+          </>
         }
       >
         <UpdatesRowList>
@@ -548,27 +800,40 @@ export function UpdatesSettingsSection() {
             }
           />
         </UpdatesRowList>
-      </SettingsSection>
+      </UpdatesSection>
 
-      <SettingsSection
+      <UpdatesSection
         title="Machines"
-        description="Provider CLIs installed on each connected machine."
         action={
-          <RowButton
-            disabled={actionableIssues.length === 0}
-            onClick={() => {
-              for (const { hostId, issue } of actionableIssues) {
-                startInstall({ hostId, issue });
-              }
-            }}
-          >
-            Update all
-            {actionableIssues.length > 0 ? ` (${actionableIssues.length})` : ""}
-          </RowButton>
+          machineSummary === null &&
+          actionableIssues.length === 0 ? undefined : (
+            <>
+              {machineSummary === null ? null : (
+                <span
+                  role="status"
+                  aria-live="polite"
+                  className="text-xs text-subtle-foreground"
+                >
+                  {machineSummary}
+                </span>
+              )}
+              {actionableIssues.length > 0 ? (
+                <RowButton
+                  onClick={() => {
+                    for (const { hostId, issue } of actionableIssues) {
+                      startInstall({ hostId, issue });
+                    }
+                  }}
+                >
+                  Update all ({actionableIssues.length})
+                </RowButton>
+              ) : null}
+            </>
+          )
         }
       >
         {inventory.machines.length === 0 ? (
-          <p className="text-sm text-subtle-foreground">
+          <p className="px-3 py-2.5 text-sm text-subtle-foreground">
             {inventory.isLoading ? "Loading…" : "No machines yet."}
           </p>
         ) : (
@@ -599,7 +864,7 @@ export function UpdatesSettingsSection() {
             ))}
           </UpdatesRowList>
         )}
-      </SettingsSection>
+      </UpdatesSection>
     </>
   );
 }

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -60,6 +60,7 @@
   --color-surface-scrim: var(--surface-scrim);
   --color-surface-destructive: var(--surface-destructive);
   --color-surface-destructive-border: var(--surface-destructive-border);
+  --color-surface-attention: var(--surface-attention);
   --color-surface-selected: var(--surface-selected);
   --color-surface-selected-border: var(--surface-selected-border);
   --color-sidebar: var(--sidebar);
@@ -421,6 +422,10 @@
     var(--destructive) 25%,
     transparent
   );
+  /* Attention twin of the destructive pair: the row tint for "an update is
+   * waiting for you", a tier below destructive's "this is broken". Translucent
+   * so it composites over card and page alike. */
+  --surface-attention: color-mix(in oklab, var(--attention) 14%, transparent);
   --surface-selected: color-mix(in oklab, var(--primary) 16%, transparent);
   --surface-selected-border: color-mix(
     in oklab,
@@ -656,6 +661,7 @@
     var(--destructive) 30%,
     transparent
   );
+  --surface-attention: color-mix(in oklab, var(--attention) 12%, transparent);
   --surface-selected: color-mix(in oklab, var(--primary) 12%, transparent);
   --surface-selected-border: color-mix(
     in oklab,

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -20,10 +20,7 @@ const css = readFileSync(
 function modeBlock(scheme: "light" | "dark", source = css): string {
   const at = source.indexOf(`color-scheme: ${scheme};`);
   if (at === -1) throw new Error(`no ${scheme} block in theme.css`);
-  return source.slice(
-    source.lastIndexOf("{", at) + 1,
-    source.indexOf("}", at),
-  );
+  return source.slice(source.lastIndexOf("{", at) + 1, source.indexOf("}", at));
 }
 
 /**
@@ -249,6 +246,22 @@ describe("theme.css Cadence text tokens", () => {
       expect(contrastRatio(timelineAccent, canvas)).toBeGreaterThanOrEqual(4.5);
       expect(contrastRatio(destructiveText, canvas)).toBeGreaterThanOrEqual(
         4.5,
+      );
+    });
+  }
+});
+
+describe("theme.css semantic update surfaces", () => {
+  it("registers the attention surface utility with Tailwind", () => {
+    expect(css).toMatch(
+      /--color-surface-attention:\s*var\(--surface-attention\);/,
+    );
+  });
+
+  for (const mode of MODES) {
+    it(`derives the ${mode} attention surface from the semantic color in a hue-safe space`, () => {
+      expect(variableValue(modeBlock(mode), "surface-attention")).toMatch(
+        /^color-mix\(in oklab, var\(--attention\) [\d.]+%, transparent\)$/,
       );
     });
   }

--- a/apps/app/src/hooks/useUpdateInventory.ts
+++ b/apps/app/src/hooks/useUpdateInventory.ts
@@ -45,6 +45,13 @@ export interface UpdateInventory {
   /** Count of things a user can act on right now. */
   actionableCount: number;
   hasAttention: boolean;
+  /**
+   * Epoch ms when the oldest source in the current inventory was last checked.
+   * Null until the app and every connected machine have returned a result.
+   * Using the oldest source prevents one fresh response from making stale
+   * machine data look current.
+   */
+  lastCheckedAt: number | null;
 }
 
 interface UseUpdateInventoryOptions {
@@ -135,6 +142,22 @@ export function useUpdateInventory(
     (appUpdateAvailable ? 1 : 0) +
     (desktopUpdateReady ? 1 : 0);
 
+  const desktopLastCheckedAt =
+    desktopInfo?.lastCheckedAt === null ||
+    desktopInfo?.lastCheckedAt === undefined
+      ? 0
+      : Date.parse(desktopInfo.lastCheckedAt);
+  const checkTimestamps = [
+    isDesktop ? desktopLastCheckedAt : systemVersionQuery.dataUpdatedAt,
+    ...providerStatusQueries.map((query) => query.dataUpdatedAt),
+  ];
+  const hasCompleteCheck =
+    checkTimestamps.length > 0 &&
+    checkTimestamps.every(
+      (timestamp) => Number.isFinite(timestamp) && timestamp > 0,
+    );
+  const lastCheckedAt = hasCompleteCheck ? Math.min(...checkTimestamps) : null;
+
   return {
     isLoading: systemVersionQuery.isPending || hostsQuery.isPending,
     systemVersion,
@@ -144,5 +167,6 @@ export function useUpdateInventory(
     machines,
     actionableCount,
     hasAttention: actionableCount > 0,
+    lastCheckedAt,
   };
 }

--- a/packages/plugin-build/src/generated/plugin-theme.generated.ts
+++ b/packages/plugin-build/src/generated/plugin-theme.generated.ts
@@ -61,6 +61,7 @@ export const PLUGIN_THEME_CSS = `@theme inline {
   --color-surface-scrim: var(--surface-scrim);
   --color-surface-destructive: var(--surface-destructive);
   --color-surface-destructive-border: var(--surface-destructive-border);
+  --color-surface-attention: var(--surface-attention);
   --color-surface-selected: var(--surface-selected);
   --color-surface-selected-border: var(--surface-selected-border);
   --color-sidebar: var(--sidebar);


### PR DESCRIPTION
## Summary
- redesign Settings → Updates around a quieter, full-width hierarchy with aligned machine/provider rows
- surface actionable, offline, and stranded-daemon states clearly while removing repetitive healthy-state labels
- add responsive wrapping, accessible status/group semantics, truthful freshness and fleet summaries, and theme-derived attention surfaces
- add full-page healthy/mixed fleet stories plus focused component and theme coverage

## Validation
- `pnpm exec turbo run build typecheck lint test --filter=@bb/app --force`
- 294 test files / 2,152 tests passed
- lint completed with 0 errors (147 existing warnings)
- browser QA in light, dark, and 360px layouts with no console errors or horizontal overflow

## Risk
- UI-only change; no server/daemon wire contract changes
- freshness now reflects the oldest successfully checked source, so one fresh response cannot make stale fleet data appear current
