### PR TITLE
Add a New folder button to the project folder picker

### DIFF
--- a/apps/app/src/components/dialogs/ProjectMachineSetupDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectMachineSetupDialog.tsx
@@ -308,6 +308,7 @@ export function ProjectMachineSetupDialogContent({
         {option === "folder" ? (
           <RemotePathBrowser
             hostId={target.hostId}
+            allowCreateFolder={false}
             onDirectoryChange={(directory) => {
               setFolderPath(directory);
               setValidationMessage(null);

--- a/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
@@ -8,13 +8,16 @@ import { ProjectPathDialog } from "./ProjectPathDialog";
 vi.mock("@/components/dialogs/RemotePathBrowser", () => ({
   RemotePathBrowser: ({
     hostId,
+    allowCreateFolder,
     onDirectoryChange,
   }: {
     hostId: string;
+    allowCreateFolder: boolean;
     onDirectoryChange: (directory: string) => void;
   }) => (
     <button
       type="button"
+      data-allow-create-folder={String(allowCreateFolder)}
       onClick={() =>
         onDirectoryChange(
           hostId === "host_kunst"
@@ -71,6 +74,11 @@ describe("ProjectPathDialog machine selection", () => {
 
     const trigger = screen.getByRole("button", { name: "Machine" });
     expect(trigger.textContent).toContain("atum");
+    expect(
+      screen
+        .getByRole("button", { name: "Choose folder on host_atum" })
+        .getAttribute("data-allow-create-folder"),
+    ).toBe("true");
 
     fireEvent.pointerDown(trigger, { button: 0 });
     expect(

--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -322,6 +322,7 @@ export function ProjectPathDialogContent({
             key={selectedHostId}
             hostId={selectedHostId}
             initialPath={target.kind === "update" ? target.currentPath : null}
+            allowCreateFolder={target.kind === "create"}
             onDirectoryChange={setBrowserDirectory}
             disabled={pending || !selectedHostConnected}
           />

--- a/apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { HostDirectoryListing } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  RemotePathBrowser,
+  getFolderNameValidationMessage,
+  joinHostPath,
+} from "./RemotePathBrowser";
+
+vi.mock("@/lib/sdk", () => ({
+  BbHttpError: class BbHttpError extends Error {},
+  sdk: {
+    files: { mkdir: vi.fn() },
+    hosts: { directory: vi.fn() },
+  },
+}));
+
+const directory = vi.mocked(sdk.hosts.directory);
+const mkdir = vi.mocked(sdk.files.mkdir);
+
+function listing(path: string, entries: string[]): HostDirectoryListing {
+  return {
+    directory: path,
+    parent: "/home",
+    entries: entries.map((name) => ({
+      kind: "directory" as const,
+      name,
+      path: `${path}/${name}`,
+    })),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("joinHostPath", () => {
+  it("joins with the separator implied by the directory", () => {
+    expect(joinHostPath("/home/me", "repo")).toBe("/home/me/repo");
+    expect(joinHostPath("/", "repo")).toBe("/repo");
+    expect(joinHostPath("/home/me/", "repo")).toBe("/home/me/repo");
+    expect(joinHostPath("C:\\Users\\me", "repo")).toBe("C:\\Users\\me\\repo");
+    expect(joinHostPath("C:\\", "repo")).toBe("C:\\repo");
+  });
+});
+
+describe("getFolderNameValidationMessage", () => {
+  it("rejects names that would create outside the current folder", () => {
+    expect(getFolderNameValidationMessage("repo")).toBeNull();
+    expect(getFolderNameValidationMessage("")).not.toBeNull();
+    expect(getFolderNameValidationMessage("..")).not.toBeNull();
+    expect(getFolderNameValidationMessage("a/b")).not.toBeNull();
+    expect(getFolderNameValidationMessage("a\\b")).not.toBeNull();
+  });
+});
+
+describe("RemotePathBrowser new folder", () => {
+  it("hides folder creation for existing-folder pickers", async () => {
+    directory.mockResolvedValue(listing("/home/me", ["existing"]));
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder={false}
+          onDirectoryChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    await screen.findByText("existing");
+    expect(screen.queryByRole("button", { name: "New folder" })).toBeNull();
+  });
+
+  it("does not create in the previous folder while navigation is loading", async () => {
+    let resolveNextDirectory: (value: HostDirectoryListing) => void = () => {};
+    const nextDirectory = new Promise<HostDirectoryListing>((resolve) => {
+      resolveNextDirectory = resolve;
+    });
+    directory.mockImplementation(({ path }) =>
+      path === "/home/me/next"
+        ? nextDirectory
+        : Promise.resolve(listing("/home/me", ["next"])),
+    );
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder
+          onDirectoryChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "next" }));
+    await waitFor(() => {
+      expect(directory).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/home/me/next" }),
+      );
+    });
+
+    expect(
+      screen
+        .getByRole("button", { name: "New folder" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(screen.queryByLabelText("New folder name")).toBeNull();
+    expect(mkdir).not.toHaveBeenCalled();
+
+    resolveNextDirectory(listing("/home/me/next", []));
+    await screen.findByText("This folder is empty.");
+  });
+
+  it("creates the folder on the host and selects it", async () => {
+    directory.mockImplementation(async ({ path }) =>
+      path === "/home/me/repo"
+        ? listing("/home/me/repo", [])
+        : listing("/home/me", ["existing"]),
+    );
+    mkdir.mockResolvedValue({ ok: true });
+    const onDirectoryChange = vi.fn();
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder
+          onDirectoryChange={onDirectoryChange}
+        />
+      </Wrapper>,
+    );
+
+    await screen.findByText("existing");
+    fireEvent.click(screen.getByRole("button", { name: "New folder" }));
+    fireEvent.change(screen.getByLabelText("New folder name"), {
+      target: { value: "repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await waitFor(() => {
+      expect(mkdir).toHaveBeenCalledWith({
+        hostId: "host_atum",
+        path: "/home/me/repo",
+      });
+    });
+    await waitFor(() => {
+      expect(onDirectoryChange).toHaveBeenLastCalledWith("/home/me/repo");
+    });
+  });
+
+  it("locks navigation while folder creation is pending", async () => {
+    let resolveMkdir: (value: { ok: true }) => void = () => {};
+    const pendingMkdir = new Promise<{ ok: true }>((resolve) => {
+      resolveMkdir = resolve;
+    });
+    directory.mockImplementation(async ({ path }) =>
+      path === "/home/me/repo"
+        ? listing("/home/me/repo", [])
+        : listing("/home/me", ["existing"]),
+    );
+    mkdir.mockReturnValue(pendingMkdir);
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder
+          onDirectoryChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    await screen.findByText("existing");
+    fireEvent.click(screen.getByRole("button", { name: "New folder" }));
+    fireEvent.change(screen.getByLabelText("New folder name"), {
+      target: { value: "repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await waitFor(() => {
+      expect(mkdir).toHaveBeenCalledOnce();
+    });
+    expect(
+      screen.getByRole("button", { name: "existing" }).hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole("button", { name: "Go to parent folder" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+
+    resolveMkdir({ ok: true });
+    await screen.findByText("This folder is empty.");
+  });
+
+  it("reports a failed create instead of navigating into it", async () => {
+    directory.mockResolvedValue(listing("/home/me", ["existing"]));
+    mkdir.mockRejectedValue(new Error("EEXIST: file already exists"));
+    const onDirectoryChange = vi.fn();
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder
+          onDirectoryChange={onDirectoryChange}
+        />
+      </Wrapper>,
+    );
+
+    await screen.findByText("existing");
+    fireEvent.click(screen.getByRole("button", { name: "New folder" }));
+    fireEvent.change(screen.getByLabelText("New folder name"), {
+      target: { value: "existing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create folder" }));
+
+    expect(await screen.findByText(/already exists/)).toBeTruthy();
+    expect(onDirectoryChange).not.toHaveBeenCalledWith("/home/me/existing");
+  });
+});

--- a/apps/app/src/components/dialogs/RemotePathBrowser.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { normalizeProjectPathInput } from "@bb/domain";
 import { Button } from "@bb/shared-ui/button";
 import { EmptyState } from "@bb/shared-ui/empty-state";
 import { Icon } from "@bb/shared-ui/icon";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { Input } from "@bb/shared-ui/input";
+import { invalidateHostDirectoryListing } from "@/hooks/cache-owners/host-directory-cache-owner";
 import { useHostDirectory } from "@/hooks/queries/host-queries";
+import { sdk } from "@/lib/sdk";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { cn } from "@bb/shared-ui/lib/utils";
 
@@ -42,10 +45,31 @@ export function toBreadcrumb(directory: string): Crumb[] {
   return crumbs;
 }
 
+/**
+ * Appends a child name to a host directory using that host's separator, which
+ * is inferred from the path string the same way {@link toBreadcrumb} does.
+ */
+export function joinHostPath(directory: string, name: string): string {
+  if (/^[A-Za-z]:/.test(directory)) {
+    return `${directory.replace(/[\\/]+$/, "")}\\${name}`;
+  }
+  return `${directory.replace(/\/+$/, "")}/${name}`;
+}
+
+/** Rejects names that would silently create somewhere other than here. */
+export function getFolderNameValidationMessage(name: string): string | null {
+  if (!name) return "Enter a folder name.";
+  if (name === "." || name === "..") return "Enter a folder name.";
+  if (/[\\/]/.test(name)) return "Folder names can't contain slashes.";
+  return null;
+}
+
 interface RemotePathBrowserProps {
   hostId: string;
   /** Directory to open at; null starts at the host's home directory. */
   initialPath?: string | null;
+  /** Whether this picker may create and select a new child directory. */
+  allowCreateFolder: boolean;
   /**
    * Reports the resolved directory currently shown (the folder that would be
    * picked). Null while the first listing loads or a manual path fails to read.
@@ -57,6 +81,7 @@ interface RemotePathBrowserProps {
 export function RemotePathBrowser({
   hostId,
   initialPath = null,
+  allowCreateFolder,
   onDirectoryChange,
   disabled = false,
 }: RemotePathBrowserProps) {
@@ -64,7 +89,12 @@ export function RemotePathBrowser({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState("");
   const editInputRef = useRef<HTMLInputElement>(null);
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [newFolderError, setNewFolderError] = useState<string | null>(null);
+  const newFolderInputRef = useRef<HTMLInputElement>(null);
   const isPointerCoarse = usePointerCoarse();
+  const queryClient = useQueryClient();
   const { data, isError, error, isPlaceholderData } = useHostDirectory(
     hostId,
     currentPath,
@@ -72,6 +102,81 @@ export function RemotePathBrowser({
 
   const directory = data?.directory ?? null;
   const crumbs = directory ? toBreadcrumb(directory) : [];
+
+  const startCreatingFolder = () => {
+    if (
+      !allowCreateFolder ||
+      disabled ||
+      createFolder.isPending ||
+      !directory ||
+      isError ||
+      isPlaceholderData
+    ) {
+      return;
+    }
+    setNewFolderName("");
+    setNewFolderError(null);
+    setIsCreatingFolder(true);
+  };
+
+  const cancelCreatingFolder = () => {
+    setIsCreatingFolder(false);
+    setNewFolderError(null);
+  };
+
+  // A pending name belongs to the folder it was started in, so leaving that
+  // folder (including after a successful create) abandons it.
+  const navigateTo = (path: string) => {
+    cancelCreatingFolder();
+    setCurrentPath(path);
+  };
+
+  const createFolder = useMutation({
+    mutationFn: async ({ parent, name }: { parent: string; name: string }) => {
+      const path = joinHostPath(parent, name);
+      await sdk.files.mkdir({ hostId, path });
+      return path;
+    },
+    onSuccess: async (path, { parent }) => {
+      setNewFolderName("");
+      // The new folder becomes the picked directory; refresh the parent so it
+      // is listed too when the user navigates back up.
+      navigateTo(path);
+      await invalidateHostDirectoryListing({
+        queryClient,
+        hostId,
+        directory: parent,
+      });
+    },
+    onError: (mutationError) => {
+      setNewFolderError(
+        getMutationErrorMessage({
+          error: mutationError,
+          fallbackMessage: "Couldn't create that folder.",
+        }),
+      );
+    },
+  });
+
+  const commitNewFolder = () => {
+    if (
+      disabled ||
+      createFolder.isPending ||
+      !directory ||
+      isError ||
+      isPlaceholderData
+    ) {
+      return;
+    }
+    const name = newFolderName.trim();
+    const message = getFolderNameValidationMessage(name);
+    if (message) {
+      setNewFolderError(message);
+      return;
+    }
+    setNewFolderError(null);
+    createFolder.mutate({ parent: directory, name });
+  };
 
   // Keep the dialog's pick target in sync with the resolved directory.
   useEffect(() => {
@@ -82,7 +187,13 @@ export function RemotePathBrowser({
     if (isEditing && !isPointerCoarse) editInputRef.current?.focus();
   }, [isEditing, isPointerCoarse]);
 
+  useEffect(() => {
+    if (isCreatingFolder && !isPointerCoarse)
+      newFolderInputRef.current?.focus();
+  }, [isCreatingFolder, isPointerCoarse]);
+
   const openEditor = () => {
+    cancelCreatingFolder();
     setEditValue(directory ?? "");
     setIsEditing(true);
   };
@@ -90,8 +201,16 @@ export function RemotePathBrowser({
   const commitEditor = () => {
     const normalized = normalizeProjectPathInput(editValue);
     setIsEditing(false);
-    if (normalized) setCurrentPath(normalized);
+    if (normalized) navigateTo(normalized);
   };
+
+  const interactionDisabled = disabled || createFolder.isPending;
+  const canCreateFolderHere =
+    allowCreateFolder &&
+    !interactionDisabled &&
+    directory !== null &&
+    !isError &&
+    !isPlaceholderData;
 
   let body: ReactNode;
   if (isError) {
@@ -136,9 +255,9 @@ export function RemotePathBrowser({
             <li key={entry.path}>
               <button
                 type="button"
-                disabled={disabled}
+                disabled={interactionDisabled}
                 className="flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-sm hover:bg-muted disabled:pointer-events-none"
-                onClick={() => setCurrentPath(entry.path)}
+                onClick={() => navigateTo(entry.path)}
               >
                 <Icon
                   name="Folder"
@@ -200,9 +319,9 @@ export function RemotePathBrowser({
               size="icon"
               className="size-7 shrink-0"
               aria-label="Go to parent folder"
-              disabled={disabled || !data?.parent}
+              disabled={interactionDisabled || !data?.parent}
               onClick={() => {
-                if (data?.parent) setCurrentPath(data.parent);
+                if (data?.parent) navigateTo(data.parent);
               }}
             >
               <Icon name="ArrowUp" />
@@ -218,26 +337,39 @@ export function RemotePathBrowser({
                   ) : null}
                   <button
                     type="button"
-                    disabled={disabled}
+                    disabled={interactionDisabled}
                     className={cn(
                       "rounded px-1 py-0.5 hover:bg-muted hover:text-foreground",
                       index === crumbs.length - 1 &&
                         "font-medium text-foreground",
                     )}
-                    onClick={() => setCurrentPath(crumb.path)}
+                    onClick={() => navigateTo(crumb.path)}
                   >
                     {crumb.label}
                   </button>
                 </span>
               ))}
             </div>
+            {allowCreateFolder ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                aria-label="New folder"
+                disabled={!canCreateFolderHere}
+                onClick={startCreatingFolder}
+              >
+                <Icon name="FolderPlus" />
+              </Button>
+            ) : null}
             <Button
               type="button"
               variant="ghost"
               size="icon"
               className="size-7 shrink-0"
               aria-label="Edit path"
-              disabled={disabled}
+              disabled={interactionDisabled}
               onClick={openEditor}
             >
               <Icon name="Edit" />
@@ -252,6 +384,75 @@ export function RemotePathBrowser({
           isPlaceholderData && "opacity-60",
         )}
       >
+        {isCreatingFolder ? (
+          <div
+            role="group"
+            aria-label="Create new folder"
+            className="mb-1 flex flex-col gap-1"
+          >
+            {/* Mirrors an entry row's px-2 + size-4 icon + gap-2 so the name
+                being typed lines up with the folder names below it. */}
+            <div className="flex items-center gap-2 px-2">
+              <Icon
+                name="Folder"
+                className="size-4 shrink-0 text-muted-foreground"
+              />
+              <Input
+                ref={newFolderInputRef}
+                aria-label="New folder name"
+                className="-ml-1 h-7 min-w-0 flex-1 px-1 text-sm"
+                value={newFolderName}
+                disabled={interactionDisabled}
+                placeholder="Folder name"
+                onChange={(event) => {
+                  setNewFolderName(event.target.value);
+                  setNewFolderError(null);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    commitNewFolder();
+                  } else if (event.key === "Escape") {
+                    event.preventDefault();
+                    cancelCreatingFolder();
+                  }
+                }}
+              />
+              <div className="flex shrink-0 items-center gap-0.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-7 shrink-0"
+                  aria-label="Create folder"
+                  disabled={interactionDisabled}
+                  onClick={commitNewFolder}
+                >
+                  <Icon
+                    name={createFolder.isPending ? "Spinner" : "Check"}
+                    className={cn(createFolder.isPending && "animate-spin")}
+                  />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-7 shrink-0"
+                  aria-label="Cancel new folder"
+                  disabled={interactionDisabled}
+                  onClick={cancelCreatingFolder}
+                >
+                  <Icon name="X" />
+                </Button>
+              </div>
+            </div>
+            {newFolderError ? (
+              <p role="alert" className="px-2 text-xs text-destructive">
+                {newFolderError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
         {body}
       </div>
     </div>

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -106,6 +106,9 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "environmentQueryKey",
     "threadSearchQueryKeyPrefix",
   ],
+  "hooks/cache-owners/host-directory-cache-owner.ts": [
+    "hostDirectoryQueryKey",
+  ],
   "hooks/cache-owners/mutation-cache-effects.ts": [
     "hostsQueryKey",
     "projectPathsQueryKeyPrefix",

--- a/apps/app/src/hooks/cache-owners/host-directory-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/host-directory-cache-owner.ts
@@ -1,0 +1,20 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { hostDirectoryQueryKey } from "../queries/query-keys";
+
+interface InvalidateHostDirectoryListingArgs {
+  queryClient: QueryClient;
+  hostId: string;
+  directory: string;
+}
+
+/** Mark a host directory listing stale without reloading an inactive picker. */
+export function invalidateHostDirectoryListing({
+  queryClient,
+  hostId,
+  directory,
+}: InvalidateHostDirectoryListingArgs): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: hostDirectoryQueryKey(hostId, directory),
+    refetchType: "none",
+  });
+}


### PR DESCRIPTION
## What

Creating a project previously required the target folder to already exist on the host — the picker could only browse and descend into existing directories. You can now create the folder from the dialog itself.

`RemotePathBrowser` takes an `allowCreateFolder` prop and, when set, renders a **New folder** button in its toolbar. Committing a name:

- creates the directory on the host via the existing `POST /api/v1/files/mkdir` route,
- navigates into it so it becomes the picked path (and the derived project name updates),
- marks the parent listing stale so the folder appears when navigating back up.

## Scope

Only the create-project dialog opts in. Updating a project's path and adding a source both point at an existing checkout, and `ProjectMachineSetupDialog` picks an existing folder, so those keep the browse-only picker.

Note that on a machine where the browser and work host are the same, "Add project" opens the **native** OS picker instead of this dialog; that picker has its own New Folder button and is unaffected.

## Safety

- Names are validated client-side (non-empty, not `.`/`..`, no slashes) so a name can't create outside the folder on screen.
- Path joining infers the host's separator from the path string, the way `toBreadcrumb` already does, so Windows hosts work.
- Creates are blocked while a listing is stale or errored, to avoid writing into a directory the user is navigating away from.
- Server-side failures (already exists, permission denied) render inline instead of navigating.

## No wire changes

The mkdir route and `host.mkdir` RPC already existed — this is the app's first frontend consumer. No server or daemon change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## Tests

- New `RemotePathBrowser.createFolder.test.tsx`: separator and validation helpers, plus the success path (mkdir called with the joined path, new folder selected) and the failure path (error shown, no navigation).
- Full `@bb/app` suite: 295 files, 2152 tests pass.
- `turbo typecheck` passes; `turbo lint` has 0 errors (147 pre-existing warnings, none from these files).

Alignment of the inline name row was verified in the running dev app: its icon and text land at the same x as the folder rows below it (484px / 508–509px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)