### PR TITLE
Fix paginated timeline scroll and streaming stability

### DIFF
--- a/apps/app/src/components/thread/timeline/useAutoLoadOlderRows.test.tsx
+++ b/apps/app/src/components/thread/timeline/useAutoLoadOlderRows.test.tsx
@@ -43,15 +43,34 @@ function emitIntersection(isIntersecting: boolean): void {
   });
 }
 
-function createBottomAnchor(): BottomAnchorContextValue {
+function createBottomAnchor(
+  scrollElement = document.createElement("div"),
+): BottomAnchorContextValue {
   return {
-    getScrollElement: () => null,
+    getScrollElement: () => scrollElement,
     isAtBottom: false,
     scrollToBottom: vi.fn(),
     scrollElementIntoView: vi.fn(),
     scrollElementIntoViewClampedToMaxScroll: vi.fn(),
     captureScrollAnchor: vi.fn(),
   };
+}
+
+function mockElementRect(
+  element: HTMLElement,
+  { bottom, top }: { bottom: number; top: number },
+): void {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 100,
+    top,
+    width: 100,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  });
 }
 
 function renderAutoLoad(args: {
@@ -76,10 +95,11 @@ function renderAutoLoad(args: {
     { initialProps: { isLoading: false }, wrapper },
   );
   // Mounting the sentinel is what starts observing.
+  const sentinel = document.createElement("div");
   act(() => {
-    result.result.current.sentinelRef(document.createElement("div"));
+    result.result.current.sentinelRef(sentinel);
   });
-  return result;
+  return { ...result, sentinel };
 }
 
 beforeEach(() => {
@@ -145,6 +165,35 @@ describe("useAutoLoadOlderRows", () => {
       rerender({ isLoading: false });
     });
     expect(onLoadOlderRows).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not recapture from stale intersection state after a prepend moves the sentinel away", async () => {
+    const scrollElement = document.createElement("div");
+    mockElementRect(scrollElement, { top: 0, bottom: 500 });
+    const anchor = createBottomAnchor(scrollElement);
+    const onLoadOlderRows = vi.fn(() => Promise.resolve());
+    const { rerender, sentinel } = renderAutoLoad({
+      anchor,
+      onLoadOlderRows,
+    });
+    mockElementRect(sentinel, { top: 100, bottom: 120 });
+
+    emitIntersection(true);
+    expect(onLoadOlderRows).toHaveBeenCalledTimes(1);
+    expect(anchor.captureScrollAnchor).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({ isLoading: true });
+    });
+    // The prepend moves the sentinel above the prefetch margin before the
+    // observer delivers its corresponding `false` entry.
+    mockElementRect(sentinel, { top: -800, bottom: -780 });
+    await act(async () => {
+      rerender({ isLoading: false });
+    });
+
+    expect(onLoadOlderRows).toHaveBeenCalledTimes(1);
+    expect(anchor.captureScrollAnchor).toHaveBeenCalledTimes(1);
   });
 
   it("stops auto-loading after a failure instead of retrying in a loop", async () => {

--- a/apps/app/src/components/thread/timeline/useAutoLoadOlderRows.ts
+++ b/apps/app/src/components/thread/timeline/useAutoLoadOlderRows.ts
@@ -29,6 +29,22 @@ export interface AutoLoadOlderRows {
   loadOlderRows: () => void;
 }
 
+function isSentinelWithinPrefetchRange({
+  scrollElement,
+  sentinel,
+}: {
+  scrollElement: HTMLElement;
+  sentinel: HTMLElement;
+}): boolean {
+  const scrollRect = scrollElement.getBoundingClientRect();
+  const sentinelRect = sentinel.getBoundingClientRect();
+  return (
+    sentinelRect.bottom >=
+      scrollRect.top - AUTO_LOAD_OLDER_ROWS_PREFETCH_MARGIN_PX &&
+    sentinelRect.top <= scrollRect.bottom
+  );
+}
+
 export function useAutoLoadOlderRows({
   hasOlderTimelineRows,
   isLoadingOlderTimelineRows,
@@ -117,12 +133,27 @@ export function useAutoLoadOlderRows({
     ) {
       return;
     }
+    const sentinel = sentinelNodeRef.current;
+    const scrollElement = bottomAnchor?.getScrollElement();
+    if (!sentinel || !scrollElement) {
+      return;
+    }
+    // The observer state can be stale during a prepend. Chromium may move the
+    // scroll position to preserve its native anchor before IntersectionObserver
+    // reports that the sentinel left the prefetch range. Starting another page
+    // from that stale `true` captures the transient scroll position and
+    // overwrites the anchor for the page that just landed.
+    if (!isSentinelWithinPrefetchRange({ scrollElement, sentinel })) {
+      isIntersectingRef.current = false;
+      return;
+    }
     // Re-checked whenever a load settles, not only on an intersection change:
     // a page that did not fill the viewport leaves the sentinel visible, and
     // IntersectionObserver reports changes rather than steady state, so it
     // would not fire again on its own.
     startLoad();
   }, [
+    bottomAnchor,
     intersectionTick,
     isAutoLoadEnabled,
     isLoadingOlderTimelineRows,

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -95,7 +95,17 @@ function requireHTMLElement(element: Element | null) {
 interface RenderArgs {
   threadId: string;
   rowIds: string[];
+  showCapturePrependAnchorControl?: boolean;
   showScrollToBottomControl?: boolean;
+}
+
+function CapturePrependAnchorControl() {
+  const bottomAnchor = useBottomAnchoredScroll();
+  return (
+    <button type="button" onClick={() => bottomAnchor?.captureScrollAnchor()}>
+      Capture prepend anchor
+    </button>
+  );
 }
 
 function ScrollToBottomControl() {
@@ -110,6 +120,7 @@ function ScrollToBottomControl() {
 function renderTimeline({
   threadId,
   rowIds,
+  showCapturePrependAnchorControl = false,
   showScrollToBottomControl = false,
 }: RenderArgs) {
   const view = render(
@@ -119,6 +130,9 @@ function renderTimeline({
       scrollAreaClassName={SCROLL_AREA_CLASS}
       scrollAnchorThreadId={threadId}
     >
+      {showCapturePrependAnchorControl ? (
+        <CapturePrependAnchorControl />
+      ) : null}
       {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
       {rowIds.map((rowId) => (
         <div key={rowId} data-timeline-row-id={rowId}>
@@ -226,6 +240,45 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
       offsetWithinRow: 20,
       atBottom: false,
     });
+  });
+
+  it("does not treat a native-anchor jump during prepend as bottom intent", () => {
+    const { getByRole, scrollArea } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+      showCapturePrependAnchorControl: true,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 150,
+    });
+
+    fireEvent.wheel(scrollArea, { deltaY: -100 });
+    fireEvent.scroll(scrollArea);
+    fireEvent.click(
+      getByRole("button", { name: "Capture prepend anchor" }),
+    );
+
+    // Chromium's native scroll anchoring can move the scrollport to its
+    // temporary maximum before the explicit prepend compensation runs.
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 300,
+    });
+    fireEvent.scroll(scrollArea);
+
+    // More of the prepended content settles. Sticky-bottom must still be off,
+    // or this resize moves scrollTop from 300 to the new maximum (400).
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: scrollArea.scrollTop,
+    });
+    getLatestResizeObserver().trigger();
+
+    expect(scrollArea.scrollTop).toBe(300);
   });
 
   it("restores near the saved row when returning to a thread", () => {

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -562,6 +562,22 @@ export function BottomAnchoredScrollBody({
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea) return;
 
+    if (
+      pendingPrependAnchorRef.current !== null &&
+      hasRecentUserScrollIntent()
+    ) {
+      // Native scroll anchoring can temporarily move a user-scrolled viewport
+      // to the current maximum while prepended rows mount. That is not a user
+      // request to resume following the bottom. Keep sticky-bottom disabled
+      // until the captured prepend anchor is applied; otherwise the
+      // ResizeObserver races the layout effect and yanks the viewport down.
+      userDetachedFromBottomRef.current = true;
+      shouldStickToBottomRef.current = false;
+      setIsAtBottom(false);
+      cancelQueuedRestore();
+      return;
+    }
+
     if (isScrolledNearBottom(scrollArea)) {
       userDetachedFromBottomRef.current = false;
       shouldStickToBottomRef.current = true;

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -29,6 +29,7 @@ import {
   listStoredEventRowsInRange,
   isTimelineCursorSequencePresent,
   listItemEventSpansByItemIds,
+  listStoredBufferedTextDeltaRowsByItemIds,
   listStoredItemLifecycleRowsByItemIds,
   listLatestBackgroundTaskStateRowsByItemIds,
   listLatestGoalEventRowsByThreadIds,
@@ -741,20 +742,51 @@ function ensureInTurnWindowWholeItemRows(
     return rows;
   }
 
+  const completedItemIds = new Set<string>();
+  for (const row of rows) {
+    if (row.type === "item/completed" && row.itemId !== null) {
+      completedItemIds.add(row.itemId);
+    }
+  }
+  const bufferedTextItemIds = new Set<string>();
+  for (const row of rows) {
+    if (
+      row.itemId !== null &&
+      itemIdsStartingBeforeWindow.has(row.itemId) &&
+      !completedItemIds.has(row.itemId) &&
+      (row.itemKind === "agentMessage" ||
+        row.itemKind === "plan" ||
+        row.itemKind === "reasoning")
+    ) {
+      bufferedTextItemIds.add(row.itemId);
+    }
+  }
+
   // This window owns these items, so it needs the lifecycle rows that fell
   // below the cut — without them a finished command renders "pending" and
   // carries neither its command line nor its start time. Only the two lifecycle
-  // types are fetched: the rest of what an item emitted below the cut is the
-  // older page's content, and pulling all of it back would restore exactly the
-  // unbounded read this window exists to avoid.
+  // types are fetched for ordinary items: the rest of what an item emitted
+  // below the cut is the older page's content, and pulling all of it back would
+  // restore exactly the unbounded read this window exists to avoid.
+  //
+  // Unfinished buffered text is the exception. Its deltas are the only current
+  // snapshot of the message, so dropping the prefix would make text disappear
+  // as the event-budget floor advances. Carry that one item's prefix into the
+  // owning page until item/completed supplies the canonical final text.
   const backfillRows = listStoredItemLifecycleRowsByItemIds(db, {
     itemIds: [...itemIdsStartingBeforeWindow],
     maxInlineOutputChars: args.maxInlineOutputChars,
     threadId: args.threadId,
   }).filter((row) => row.sequence < args.sequenceStart);
-  return backfillRows.length === 0
+  const bufferedTextRows = listStoredBufferedTextDeltaRowsByItemIds(db, {
+    beforeSequence: args.sequenceStart,
+    itemIds: [...bufferedTextItemIds],
+    threadId: args.threadId,
+  });
+  const prefixRows = [...backfillRows, ...bufferedTextRows];
+  return prefixRows.length === 0
     ? rows
-    : mergeStoredEventRowsById([...backfillRows, ...rows]);
+    : mergeStoredEventRowsById([...prefixRows, ...rows]);
 }
 
 /**

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -724,4 +724,89 @@ describe("in-turn windows and items that only stream", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0]).toContain('"status":"completed"');
   });
+
+  it("keeps an unfinished assistant message whole as its deltas cross the cut", () => {
+    const { db, thread } = setup();
+    const itemId = "assistant-1";
+    const turnId = "turn-1";
+    seedTurns(db, thread, {
+      completeLastTurn: false,
+      itemsPerTurn: [100],
+    });
+    const events: EventInput[] = [
+      {
+        threadId: thread.id,
+        sequence: 204,
+        type: "item/started",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId,
+        itemKind: "agentMessage",
+        data: JSON.stringify({
+          item: { type: "agentMessage", id: itemId, text: "" },
+          providerThreadId,
+        }),
+      },
+    ];
+    const chunks = Array.from({ length: 200 }, (_, index) => `[${index}]\n`);
+    chunks.forEach((delta, index) => {
+      events.push({
+        threadId: thread.id,
+        sequence: index + 205,
+        type: "item/agentMessage/delta",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId,
+        itemKind: "agentMessage",
+        data: JSON.stringify({
+          delta,
+          itemId,
+          providerThreadId,
+        }),
+      });
+    });
+    insertEvents(db, noopNotifier, events);
+
+    const budgeted = buildPage(db, thread, 100, null);
+    const assistant = budgeted.response.rows.find(
+      (row) => row.kind === "conversation" && row.role === "assistant",
+    );
+
+    expect(budgeted.response.timelinePage.hasOlderRows).toBe(true);
+    expect(assistant?.text).toBe(chunks.join(""));
+    const laterChunks = Array.from(
+      { length: 25 },
+      (_, index) => `[later-${index}]\n`,
+    );
+    insertEvents(
+      db,
+      noopNotifier,
+      laterChunks.map((delta, index) => ({
+        threadId: thread.id,
+        sequence: index + 405,
+        type: "item/agentMessage/delta",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId,
+        itemKind: "agentMessage",
+        data: JSON.stringify({
+          delta,
+          itemId,
+          providerThreadId,
+        }),
+      })),
+    );
+
+    const refreshed = buildPage(db, thread, 100, null);
+    const refreshedAssistant = refreshed.response.rows.find(
+      (row) => row.kind === "conversation" && row.role === "assistant",
+    );
+    expect(refreshedAssistant?.text).toBe(
+      [...chunks, ...laterChunks].join(""),
+    );
+    const unbudgeted = buildPage(db, thread, LARGE_BUDGET, null);
+    expect(walkAllPages(db, thread, 100).rows).toEqual(
+      unbudgeted.response.rows.map((row) => JSON.stringify(row)),
+    );
+  });
 });

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -1285,6 +1285,51 @@ export function listStoredItemLifecycleRowsByItemIds(
     .all();
 }
 
+export interface ListStoredBufferedTextDeltaRowsByItemIdsArgs {
+  beforeSequence: number;
+  itemIds: readonly string[];
+  threadId: string;
+}
+
+/**
+ * Every text delta for the given assistant, plan, or reasoning items.
+ *
+ * Unlike command output, buffered assistant text has no independent snapshot
+ * while its item is still running. A timeline window that starts inside such
+ * an item must carry its earlier deltas forward or every refresh would render
+ * only the moving suffix that remains inside the event budget.
+ */
+export function listStoredBufferedTextDeltaRowsByItemIds(
+  db: DbConnection,
+  args: ListStoredBufferedTextDeltaRowsByItemIdsArgs,
+): StoredEventRow[] {
+  const itemIds = [...new Set(args.itemIds)].filter(
+    (itemId) => itemId.length > 0,
+  );
+  if (itemIds.length === 0) {
+    return [];
+  }
+
+  return db
+    .select(storedEventRowFields)
+    .from(events)
+    .where(
+      and(
+        eq(events.threadId, args.threadId),
+        inArray(events.itemId, itemIds),
+        lt(events.sequence, args.beforeSequence),
+        inArray(events.type, [
+          "item/agentMessage/delta",
+          "item/plan/delta",
+          "item/reasoning/summaryTextDelta",
+          "item/reasoning/textDelta",
+        ]),
+      ),
+    )
+    .orderBy(events.sequence)
+    .all();
+}
+
 export function listStoredClientTurnRequestIdsInRange(
   db: DbConnection,
   args: ListStoredClientTurnRequestIdsInRangeArgs,

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -324,6 +324,7 @@ export {
   listStoredEventRowsInRange,
   isTimelineCursorSequencePresent,
   listItemEventSpansByItemIds,
+  listStoredBufferedTextDeltaRowsByItemIds,
   listStoredItemLifecycleRowsByItemIds,
   listStoredThreadProvisioningRowsByProvisioningId,
   listStoredTimelineWindowEventRows,


### PR DESCRIPTION
## Summary

- preserve the reader’s position when older timeline rows are prepended, even when Chromium native anchoring and stale intersection state race the restore
- keep unfinished assistant, plan, and reasoning text whole when an in-turn event-budget cutoff moves through the streaming item
- add focused regression coverage for both scroll races and for a streaming assistant message across repeated window refreshes

## Testing

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/timeline/useAutoLoadOlderRows.test.tsx src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx`
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/threads/timeline-head-state.test.ts test/services/threads/timeline-in-turn-window.test.ts test/services/threads/timeline-parented-pagination.test.ts test/services/threads/timeline-event-budget.test.ts test/services/threads/timeline-cache.test.ts test/services/threads/timeline-pagination.test.ts test/services/threads/timeline-output-truncation.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/server --filter=@bb/db --filter=@bb/app` (0 errors; 147 pre-existing app warnings)
- manual browser QA against the reported paginated thread