### PR TITLE
Preserve agent messages around timeline steers

### DIFF
--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -4,7 +4,10 @@ import type {
 } from "./event-projection-types.js";
 import { getProjectionSummaryCount } from "./apply-turn-message-detail.js";
 import { getMessageStartedAt } from "./format-helpers.js";
-import { isTimelineUngroupableMessage } from "./timeline-message-helpers.js";
+import {
+  findLastTerminalTimelineMessage,
+  isTimelineUngroupableMessage,
+} from "./timeline-message-helpers.js";
 
 export interface CompletedTurnSummaryGroup {
   kind: "summary";
@@ -145,12 +148,13 @@ function groupCompletedTurnSummaryMessages(
   let segmentIndex = 0;
   let externalBoundaryIndex = 0;
 
-  function flushGroupedMessages(): void {
-    if (groupedMessages.length === 0) {
+  function appendSummaryGroup(
+    sourceMessages: EventProjectionMessage[],
+  ): void {
+    if (sourceMessages.length === 0) {
       return;
     }
 
-    const sourceMessages = groupedMessages;
     const bounds = getSummaryMessageBounds(sourceMessages);
     items.push({
       kind: "summary",
@@ -161,7 +165,33 @@ function groupCompletedTurnSummaryMessages(
       summaryCount: getProjectionSummaryCount(sourceMessages, undefined),
     });
     segmentIndex += 1;
+  }
+
+  function flushGroupedMessages(preserveLastTerminalMessage = false): void {
+    if (groupedMessages.length === 0) {
+      return;
+    }
+
+    // Human follow-ups split one provider turn into multiple visible exchange
+    // segments. Keep each segment's last assistant/error message beside the
+    // user row instead of burying it inside that segment's collapsed summary.
+    const sourceMessages = groupedMessages;
     groupedMessages = [];
+    const terminalMessage = preserveLastTerminalMessage
+      ? findLastTerminalTimelineMessage(sourceMessages)
+      : undefined;
+    if (!terminalMessage) {
+      appendSummaryGroup(sourceMessages);
+      return;
+    }
+
+    appendSummaryGroup(
+      sourceMessages.filter((message) => message.id !== terminalMessage.id),
+    );
+    items.push({
+      kind: "ungrouped-message",
+      message: terminalMessage,
+    });
   }
 
   function flushExternalBoundariesBefore(message: EventProjectionMessage): void {
@@ -170,7 +200,7 @@ function groupCompletedTurnSummaryMessages(
       (externalBoundarySeqs[externalBoundaryIndex] ?? 0) <
         message.sourceSeqStart
     ) {
-      flushGroupedMessages();
+      flushGroupedMessages(true);
       externalBoundaryIndex += 1;
     }
   }
@@ -178,7 +208,9 @@ function groupCompletedTurnSummaryMessages(
   for (const message of summaryMessages) {
     flushExternalBoundariesBefore(message);
     if (isTimelineUngroupableMessage(message)) {
-      flushGroupedMessages();
+      flushGroupedMessages(
+        message.kind === "user" && message.initiator === "user",
+      );
       items.push({
         kind: "ungrouped-message",
         message,
@@ -188,6 +220,10 @@ function groupCompletedTurnSummaryMessages(
     groupedMessages.push(message);
   }
 
+  while (externalBoundaryIndex < externalBoundarySeqs.length) {
+    flushGroupedMessages(true);
+    externalBoundaryIndex += 1;
+  }
   flushGroupedMessages();
   return applySingleSummaryTurnBounds(turn, items);
 }

--- a/packages/thread-view/test/completed-turn-grouping.test.ts
+++ b/packages/thread-view/test/completed-turn-grouping.test.ts
@@ -123,24 +123,31 @@ describe("groupCompletedTurnMessages", () => {
     ]);
   });
 
-  it("segments summary groups around ungroupable user messages", () => {
+  it("preserves the last assistant message before an ungroupable user message", () => {
+    const assistantBefore = assistantMessage({
+      id: "assistant-before",
+      seq: 1,
+    });
+    const assistantAfter = assistantMessage({
+      id: "assistant-after",
+      seq: 3,
+    });
     const turn = completedTurn(
       [
-        assistantMessage({ id: "assistant-before", seq: 1 }),
+        assistantBefore,
         userMessage({ id: "user", seq: 2 }),
-        assistantMessage({ id: "assistant-after", seq: 3 }),
+        assistantAfter,
       ],
-      undefined,
+      assistantAfter,
     );
     const groups = groupCompletedTurnMessages(turn);
 
     expect(groups.summaryItems).toMatchObject([
       {
-        kind: "summary",
-        startedAt: 1,
-        completedAt: null,
-        segmentIndex: 0,
-        summaryCount: 1,
+        kind: "ungrouped-message",
+        message: {
+          id: "assistant-before",
+        },
       },
       {
         kind: "ungrouped-message",
@@ -148,17 +155,10 @@ describe("groupCompletedTurnMessages", () => {
           id: "user",
         },
       },
-      {
-        kind: "summary",
-        startedAt: 3,
-        completedAt: null,
-        segmentIndex: 1,
-        summaryCount: 1,
-      },
     ]);
-    expect(summarySourceMessageIds(groups)).toEqual([
-      ["assistant-before"],
-      ["assistant-after"],
+    expect(summarySourceMessageIds(groups)).toEqual([]);
+    expect(groups.terminalMessages.map((message) => message.id)).toEqual([
+      "assistant-after",
     ]);
   });
 

--- a/packages/thread-view/test/completed-turn-summary-rendering.test.ts
+++ b/packages/thread-view/test/completed-turn-summary-rendering.test.ts
@@ -312,6 +312,69 @@ describe("completed turn summary rendering", () => {
     ).toEqual([["work:command"], ["work:command"]]);
   });
 
+  it("keeps the last assistant message visible before an accepted in-turn steer", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const events: TimelineFixtureEvent[] = [
+      event.turnStarted(),
+      event.commandCompleted({
+        itemId: "tool-before-steer",
+        command: "pnpm test",
+      }),
+      event.assistantDelta({
+        itemId: "assistant-before-steer",
+        delta: "The existing server is still running.",
+      }),
+    ];
+    const steerRequest = event.clientTurnRequested({
+      target: { kind: "auto", expectedTurnId: "turn-1" },
+      text: "Show me the icon",
+    });
+    events.push(
+      steerRequest,
+      event.inputAccepted({
+        clientRequestId: steerRequest.data.requestId,
+      }),
+      event.assistantCompleted({
+        itemId: "assistant-before-steer",
+        text: "The existing server is still running.",
+      }),
+      event.commandCompleted({
+        itemId: "tool-after-steer",
+        command: "open icon-nightly.png",
+      }),
+      event.assistantCompleted({
+        itemId: "assistant-final",
+        text: "Here is the nightly icon.",
+      }),
+      event.turnCompleted(),
+    );
+
+    const timeline = renderCompletedTimeline({ events });
+
+    expect(rowSignatures(timeline.rows)).toEqual([
+      "turn:2-2",
+      "conversation:assistant",
+      "conversation:user",
+      "turn:7-7",
+      "conversation:assistant",
+    ]);
+    expect(
+      timeline.rows
+        .filter(
+          (row): row is Extract<TimelineRow, { kind: "conversation" }> =>
+            row.kind === "conversation",
+        )
+        .map((row) => row.text),
+    ).toEqual([
+      "The existing server is still running.",
+      "Show me the icon",
+      "Here is the nightly icon.",
+    ]);
+    expect(
+      turnRows(timeline.rows).map((row) => rowSignatures(row.children ?? [])),
+    ).toEqual([["work:command"], ["work:command"]]);
+  });
+
   it("splits completed turn summaries at external human new-turn boundaries", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const initialRequest = event.clientTurnRequested({
@@ -330,6 +393,11 @@ describe("completed turn summary rendering", () => {
         itemId: "before-user",
         turnId: "long-turn",
       }),
+      event.assistantDelta({
+        delta: "The first check passed.",
+        itemId: "assistant-before-user",
+        turnId: "long-turn",
+      }),
     ];
     const followUpRequest = event.clientTurnRequested({
       target: { kind: "new-turn" },
@@ -337,6 +405,11 @@ describe("completed turn summary rendering", () => {
     });
     events.push(
       followUpRequest,
+      event.assistantCompleted({
+        itemId: "assistant-before-user",
+        text: "The first check passed.",
+        turnId: "long-turn",
+      }),
       event.commandCompleted({
         command: "pnpm typecheck",
         itemId: "after-user",
@@ -355,8 +428,9 @@ describe("completed turn summary rendering", () => {
     expect(rowSignatures(timeline.rows)).toEqual([
       "conversation:user",
       "turn:4-4",
+      "conversation:assistant",
       "conversation:user",
-      "turn:6-6",
+      "turn:8-8",
       "conversation:assistant",
     ]);
     expect(


### PR DESCRIPTION
## What changed

- preserve the last assistant or error message for each human-boundary segment of a completed provider turn
- keep that terminal message visible between the collapsed work summary and the following user steer
- add regression coverage for accepted in-turn steers and external human new-turn boundaries

## Why

Completed-turn grouping only preserved the globally final assistant message for a provider turn. When a human steer split a long provider turn into multiple visible exchanges, the preceding segment's last agent message remained inside the collapsed work summary and disappeared from the conversation flow.

This restores the intended visible order:

1. user message
2. collapsed work summary
3. last agent message
4. next user message

History tracing shows this behavior was introduced by `a0c5475ab` (June 23, "Split completed turn summaries at user boundaries"), not by the July timeline pagination optimizations.

## Cross-version DOM audit

Three isolated builds were run against identical thread-only databases:

- pre-optimization: `ec8b31a1e`, the parent of PR #882
- post-optimization/pre-fix: `afe167761`, containing PRs #882, #891, and #894
- this PR: `1f389914d`

The corpus contains 19 selected threads and 45,418 events, spanning 10 to 10,207 events and including Codex/Claude threads, parent/child threads, giant completed turns, and multi-page histories. The databases contain no hosts, environments, project sources, daemon sessions, app settings, or Connect configuration.

After loading every older page, canonicalized top-level timeline row DOM was exact for all 19/19 threads between the pre-optimization and post-optimization builds. Canonicalization removed only transient inline transition measurements and generated Radix IDs; row order, IDs, structure, classes, attributes, and rendered text remained strict.

This PR changed 11/19 sampled threads by restoring 102 assistant rows at human boundaries. No conversation row was removed. Two now-empty collapsed summary rows disappeared because their only content became the visible assistant row; the remaining in-place text changes were collapsed-duration labels recalculated without the extracted terminal message.

## Validation

- full `@bb/thread-view` test suite: 345 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- rendered the originally reported production thread from an isolated thread-only import and confirmed the corrected DOM order in the browser
- cross-version DOM audit described above: 19/19 optimization comparisons exact
- `git diff --check`
