### PR TITLE
Fix long thread timeline scroll stalls

### DIFF
--- a/apps/app/src/components/thread/timeline/useScrollOverflowState.ts
+++ b/apps/app/src/components/thread/timeline/useScrollOverflowState.ts
@@ -35,6 +35,11 @@ export interface ScrollOverflowStateBinding<TElement extends HTMLElement>
 
 export interface UseScrollOverflowStateOptions {
   /**
+   * Enables observation after a conditionally-rendered scroll region mounts.
+   * Disable it while the region is absent so reopening rebinds fresh nodes.
+   */
+  enabled?: boolean;
+  /**
    * Adds a measurement fallback for compact scroll regions whose overflow
    * affordance must appear immediately on mount. IntersectionObserver remains
    * the primary path; this fallback covers environments where sentinel
@@ -70,6 +75,10 @@ export function useScrollOverflowState<
   }, []);
 
   useEffect(() => {
+    if (options.enabled === false) {
+      applyFlags({ above: false, below: false });
+      return;
+    }
     if (!options.measureOverflow || typeof window === "undefined") {
       return;
     }
@@ -126,9 +135,10 @@ export function useScrollOverflowState<
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();
     };
-  }, [applyFlags, options.measureOverflow]);
+  }, [applyFlags, options.enabled, options.measureOverflow]);
 
   useEffect(() => {
+    if (options.enabled === false) return;
     const scroll = scrollRef.current;
     const topSentinel = topSentinelRef.current;
     const bottomSentinel = bottomSentinelRef.current;
@@ -167,7 +177,7 @@ export function useScrollOverflowState<
     return () => {
       observer.disconnect();
     };
-  }, [applyFlags]);
+  }, [applyFlags, options.enabled]);
 
   return {
     scrollRef,

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ThreadListEntry, ThreadWithRuntime } from "@bb/domain";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -149,8 +150,9 @@ function createScrollElement({
   for (const row of rows) {
     const rowElement = document.createElement("div");
     rowElement.dataset.timelineRowId = row.id;
-    rowElement.getBoundingClientRect = () =>
-      rect({ bottom: row.bottom, top: row.top });
+    rowElement.getBoundingClientRect = vi.fn(() =>
+      rect({ bottom: row.bottom, top: row.top }),
+    );
     scrollElement.append(rowElement);
   }
 
@@ -283,6 +285,12 @@ function manyUserItems(count: number): TocItem[] {
 let scrollElement: HTMLElement;
 let scrollElementIntoView: ReturnType<typeof vi.fn>;
 
+function openTocPanel(): void {
+  const toc = document.querySelector<HTMLElement>("[data-thread-toc]");
+  if (!toc) throw new Error("Expected the thread table of contents.");
+  fireEvent.mouseEnter(toc);
+}
+
 beforeEach(() => {
   vi.stubGlobal("ResizeObserver", ResizeObserverMock);
   vi.stubGlobal(
@@ -311,6 +319,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
@@ -373,6 +382,7 @@ describe("ThreadTableOfContents", () => {
         ]}
       />,
     );
+    openTocPanel();
 
     expect(await screen.findByText("Your messages")).not.toBeNull();
     expect(
@@ -398,8 +408,167 @@ describe("ThreadTableOfContents", () => {
         ]}
       />,
     );
+    openTocPanel();
 
     expect(screen.queryByText("Your messages")).not.toBeNull();
+  });
+
+  it("measures fresh geometry only after scrolling settles", () => {
+    vi.useFakeTimers();
+    const rows = [
+      userConversationRow(1),
+      userConversationRow(2),
+      userConversationRow(3),
+    ];
+    const rowElements = rows.map((row) => {
+      const element = timelineRowElement(row.id);
+      scrollElement.append(element);
+      return element;
+    });
+    const positions = [
+      { top: 0, bottom: 20 },
+      { top: 100, bottom: 120 },
+      { top: 200, bottom: 220 },
+    ];
+    rowElements.forEach((element, index) => {
+      element.getBoundingClientRect = vi.fn(() => rect(positions[index]!));
+    });
+    Object.defineProperties(scrollElement, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 400 },
+    });
+    scrollElement.getBoundingClientRect = () => rect({ top: 0, bottom: 100 });
+
+    render(<TocHost timelineRows={rows} />);
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const railTicks = () =>
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-thread-toc] [aria-hidden] > span",
+        ),
+      );
+    expect(railTicks()[0]?.classList.contains("w-5")).toBe(true);
+
+    act(() => {
+      positions[0] = { top: -30, bottom: -10 };
+      positions[1] = { top: 0, bottom: 20 };
+      fireEvent.scroll(scrollElement);
+      vi.advanceTimersByTime(119);
+    });
+    expect(railTicks()[0]?.classList.contains("w-5")).toBe(true);
+    expect(railTicks()[1]?.classList.contains("w-5")).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(railTicks()[0]?.classList.contains("w-5")).toBe(false);
+    expect(railTicks()[1]?.classList.contains("w-5")).toBe(true);
+  });
+
+  it("opens consistently from pointer and keyboard activation and preserves focus", () => {
+    render(
+      <TocHost
+        timelineRows={[
+          userConversationRow(1),
+          userConversationRow(2),
+          userConversationRow(3),
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Thread table of contents",
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Your messages")).toBeNull();
+
+    const toc = document.querySelector<HTMLElement>("[data-thread-toc]");
+    if (!toc) throw new Error("Expected the thread table of contents.");
+    fireEvent.mouseEnter(toc);
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.mouseLeave(toc);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => trigger.focus());
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Your messages")).not.toBeNull();
+
+    const firstMessage = screen.getByRole("button", {
+      name: "Loaded after client-side navigation 1",
+    });
+    act(() => firstMessage.focus());
+    fireEvent.mouseLeave(toc);
+
+    expect(document.activeElement).toBe(firstMessage);
+    expect(screen.getByText("Your messages")).not.toBeNull();
+  });
+
+  it("tracks overflow when an initially closed panel opens and reopens", () => {
+    render(
+      <TocHost
+        timelineRows={Array.from({ length: 30 }, (_, index) =>
+          userConversationRow(index + 1),
+        )}
+      />,
+    );
+    const trigger = screen.getByRole("button", {
+      name: "Thread table of contents",
+    });
+    const toc = document.querySelector<HTMLElement>("[data-thread-toc]");
+    if (!toc) throw new Error("Expected the thread table of contents.");
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      }),
+    );
+    const flushAnimationFrames = () => {
+      act(() => {
+        for (const callback of animationFrames.splice(0)) callback(0);
+      });
+    };
+
+    const openAndOverflow = () => {
+      fireEvent.click(trigger);
+      const scrollRegion = document.querySelector<HTMLElement>(
+        '[id^="thread-toc-panel-"] .max-h-64',
+      );
+      if (!scrollRegion) throw new Error("Expected the TOC scroll region.");
+      Object.defineProperties(scrollRegion, {
+        clientHeight: { configurable: true, value: 100 },
+        scrollHeight: { configurable: true, value: 500 },
+        scrollTop: { configurable: true, writable: true, value: 0 },
+      });
+      flushAnimationFrames();
+      expect(
+        document.querySelector('[class*="bg-gradient-to-t"]'),
+      ).not.toBeNull();
+
+      scrollRegion.scrollTop = 400;
+      fireEvent.scroll(scrollRegion);
+      flushAnimationFrames();
+      expect(
+        document.querySelector('[class*="bg-gradient-to-b"]'),
+      ).not.toBeNull();
+      expect(document.querySelector('[class*="bg-gradient-to-t"]')).toBeNull();
+    };
+
+    openAndOverflow();
+    fireEvent.mouseLeave(toc);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    openAndOverflow();
   });
 
   it("renders the full conversation outline, including attachment-only labels", async () => {
@@ -433,6 +602,7 @@ describe("ThreadTableOfContents", () => {
     // timelineRows is empty: the minimap lists the full thread from the outline,
     // not just the loaded window.
     render(<TocHost timelineRows={[]} />);
+    openTocPanel();
 
     expect(await screen.findByText("First question")).not.toBeNull();
     expect(screen.getByText("Second question")).not.toBeNull();
@@ -465,6 +635,7 @@ describe("ThreadTableOfContents", () => {
     ]);
 
     render(<TocHost timelineRows={[]} />);
+    openTocPanel();
 
     expect(await screen.findByText("Agent")).not.toBeNull();
     expect(
@@ -527,6 +698,7 @@ describe("ThreadTableOfContents", () => {
         </ThreadTitleMentionResourcesProvider>
       </QueryClientProvider>,
     );
+    openTocPanel();
 
     expect(await screen.findByText("Ask Calendar specialist")).not.toBeNull();
     expect(screen.queryByText("@thread:thr_nested")).toBeNull();
@@ -575,6 +747,7 @@ describe("ThreadTableOfContents", () => {
         loadOlderTimelineRows={loadOlder}
       />,
     );
+    openTocPanel();
     fireEvent.click(await screen.findByText("Loaded question"));
 
     await waitFor(() => expect(scrollElementIntoView).toHaveBeenCalledTimes(1));
@@ -615,6 +788,7 @@ describe("ThreadTableOfContents", () => {
         loadOlderTimelineRows={loadOlder}
       />,
     );
+    openTocPanel();
     fireEvent.click(await screen.findByText("Ancient question"));
 
     await waitFor(() => expect(loadOlder).toHaveBeenCalled());
@@ -651,6 +825,7 @@ describe("ThreadTableOfContents", () => {
         loadOlderTimelineRows={loadOlder}
       />,
     );
+    openTocPanel();
     fireEvent.click(await screen.findByText("Unreachable"));
 
     // hasOlder is false, so the loop body never runs; no scroll, no pagination.
@@ -739,5 +914,47 @@ describe("ThreadTableOfContents", () => {
         user: null,
       },
     );
+  });
+
+  it("finds active items with logarithmic row measurements", () => {
+    const allItems = Array.from(
+      { length: 256 },
+      (_, index): TocItem => ({
+        id: `item-${index}`,
+        label: `Message ${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+      }),
+    );
+    const manyUserItems = allItems.filter((item) => item.role === "user");
+    const manyAgentItems = allItems.filter((item) => item.role === "assistant");
+    const visibleIndex = 200;
+    const scrollElement = createScrollElement({
+      clientHeight: 100,
+      scrollHeight: 3_000,
+      scrollTop: 400,
+      rows: allItems.map((item, index) => {
+        const top = (index - visibleIndex) * 10;
+        return { id: item.id, top, bottom: top + 10 };
+      }),
+    });
+
+    expect(
+      findActiveItemIds({
+        agentItems: manyAgentItems,
+        scrollElement,
+        userItems: manyUserItems,
+      }),
+    ).toEqual({
+      agent: "item-201",
+      user: "item-200",
+    });
+    const rowMeasurementCount = Array.from(
+      scrollElement.querySelectorAll<HTMLElement>("[data-timeline-row-id]"),
+    ).reduce(
+      (count, row) =>
+        count + vi.mocked(row.getBoundingClientRect).mock.calls.length,
+      0,
+    );
+    expect(rowMeasurementCount).toBeLessThanOrEqual(16);
   });
 });

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -45,6 +45,10 @@ const TOC_BOTTOM_ACTIVE_THRESHOLD_PX = 4;
 // Only worth showing once the conversation has enough user turns to navigate.
 const TOC_MIN_USER_MESSAGES = 3;
 const TOC_MAX_RAIL_TICKS = 20;
+// Updating the active rail tick changes overlay DOM and invalidates layout.
+// Wait for a scroll burst to settle instead of doing that work in the same
+// animation frames the timeline is trying to paint.
+const TOC_ACTIVE_UPDATE_IDLE_MS = 120;
 // Hard stop so a pagination bug can never spin the jump loop forever.
 const TOC_JUMP_MAX_PAGE_LOADS = 1000;
 // Frames to wait for prepended rows to commit before paginating again.
@@ -230,22 +234,24 @@ function useConversationTocItems({
   outlineItems: readonly ThreadConversationOutlineItem[] | undefined;
   timelineRows: readonly TimelineRow[];
 }) {
-  return useMemo(() => {
+  const outlineTocItems = useMemo(() => {
+    if (!outlineItems || outlineItems.length === 0) return null;
     const userItems: TocItem[] = [];
     const agentItems: TocItem[] = [];
-
-    if (outlineItems && outlineItems.length > 0) {
-      for (const item of outlineItems) {
-        const tocItem = outlineItemToTocItem(item);
-        if (tocItem.role === "user") {
-          userItems.push(tocItem);
-        } else {
-          agentItems.push(tocItem);
-        }
+    for (const item of outlineItems) {
+      const tocItem = outlineItemToTocItem(item);
+      if (tocItem.role === "user") {
+        userItems.push(tocItem);
+      } else {
+        agentItems.push(tocItem);
       }
-      return { agentItems, userItems };
     }
+    return { agentItems, userItems };
+  }, [outlineItems]);
 
+  const timelineTocItems = useMemo(() => {
+    const userItems: TocItem[] = [];
+    const agentItems: TocItem[] = [];
     for (const row of timelineRows) {
       if (row.kind !== "conversation") continue;
       const item: TocItem = {
@@ -261,7 +267,9 @@ function useConversationTocItems({
     }
 
     return { agentItems, userItems };
-  }, [outlineItems, timelineRows]);
+  }, [timelineRows]);
+
+  return outlineTocItems ?? timelineTocItems;
 }
 
 function useThreadTocVisible(rootElement: HTMLDivElement | null): boolean {
@@ -343,6 +351,74 @@ function isScrollElementNearBottom(scrollElement: HTMLElement): boolean {
   );
 }
 
+function findFirstVisibleItemId({
+  rows,
+  scrollBottom,
+  scrollTop,
+}: {
+  rows: readonly HTMLElement[];
+  scrollBottom: number;
+  scrollTop: number;
+}): string | null {
+  let low = 0;
+  let high = rows.length - 1;
+  let visibleRow: HTMLElement | null = null;
+  let visibleRect: DOMRect | null = null;
+
+  while (low <= high) {
+    const index = low + Math.floor((high - low) / 2);
+    const row = rows[index];
+    if (!row) break;
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom <= scrollTop) {
+      low = index + 1;
+      continue;
+    }
+    visibleRow = row;
+    visibleRect = rect;
+    high = index - 1;
+  }
+
+  if (!visibleRow || !visibleRect || visibleRect.top >= scrollBottom) {
+    return null;
+  }
+  return visibleRow.dataset.timelineRowId ?? null;
+}
+
+function findLastVisibleItemId({
+  rows,
+  scrollBottom,
+  scrollTop,
+}: {
+  rows: readonly HTMLElement[];
+  scrollBottom: number;
+  scrollTop: number;
+}): string | null {
+  let low = 0;
+  let high = rows.length - 1;
+  let visibleRow: HTMLElement | null = null;
+  let visibleRect: DOMRect | null = null;
+
+  while (low <= high) {
+    const index = low + Math.floor((high - low) / 2);
+    const row = rows[index];
+    if (!row) break;
+    const rect = row.getBoundingClientRect();
+    if (rect.top >= scrollBottom) {
+      high = index - 1;
+      continue;
+    }
+    visibleRow = row;
+    visibleRect = rect;
+    low = index + 1;
+  }
+
+  if (!visibleRow || !visibleRect || visibleRect.bottom <= scrollTop) {
+    return null;
+  }
+  return visibleRow.dataset.timelineRowId ?? null;
+}
+
 export function findActiveItemIds({
   agentItems,
   scrollElement,
@@ -362,45 +438,52 @@ export function findActiveItemIds({
   const rolesById = new Map<string, TocTab>();
   for (const item of userItems) rolesById.set(item.id, "user");
   for (const item of agentItems) rolesById.set(item.id, "agent");
-  let nearestUser: { id: string; distance: number } | null = null;
-  let nearestAgent: { id: string; distance: number } | null = null;
-  let lastVisibleUserId: string | null = null;
-  let lastVisibleAgentId: string | null = null;
+  const userRows: HTMLElement[] = [];
+  const agentRows: HTMLElement[] = [];
 
   for (const row of findTimelineRowElements(scrollElement)) {
     const rowId = row.dataset.timelineRowId;
     if (!rowId) continue;
     const role = rolesById.get(rowId);
-    if (!role) continue;
-    const rect = row.getBoundingClientRect();
-    if (rect.bottom <= scrollTop || rect.top >= scrollBottom) continue;
-    if (isNearBottom) {
-      if (role === "user") {
-        lastVisibleUserId = rowId;
-      } else {
-        lastVisibleAgentId = rowId;
-      }
-      continue;
-    }
-    const distance =
-      rect.top <= scrollTop
-        ? Math.max(0, scrollTop - rect.bottom)
-        : rect.top - scrollTop;
-    const nearest = { id: rowId, distance };
     if (role === "user") {
-      if (!nearestUser || distance < nearestUser.distance) {
-        nearestUser = nearest;
-      }
-    } else if (!nearestAgent || distance < nearestAgent.distance) {
-      nearestAgent = nearest;
+      userRows.push(row);
+    } else if (role === "agent") {
+      agentRows.push(row);
     }
   }
 
+  // Conversation rows are non-overlapping and retain document order, so their
+  // top/bottom edges are monotonic within each role. The former full scan
+  // measured every loaded conversation row on every animation-frame scroll
+  // update; binary search keeps the same nearest/last-visible semantics with
+  // logarithmic layout reads.
   if (isNearBottom) {
-    return { agent: lastVisibleAgentId, user: lastVisibleUserId };
+    return {
+      agent: findLastVisibleItemId({
+        rows: agentRows,
+        scrollBottom,
+        scrollTop,
+      }),
+      user: findLastVisibleItemId({
+        rows: userRows,
+        scrollBottom,
+        scrollTop,
+      }),
+    };
   }
 
-  return { agent: nearestAgent?.id ?? null, user: nearestUser?.id ?? null };
+  return {
+    agent: findFirstVisibleItemId({
+      rows: agentRows,
+      scrollBottom,
+      scrollTop,
+    }),
+    user: findFirstVisibleItemId({
+      rows: userRows,
+      scrollBottom,
+      scrollTop,
+    }),
+  };
 }
 
 export function ThreadTableOfContents({
@@ -436,13 +519,11 @@ export function ThreadTableOfContents({
     scrollRef,
     topSentinelRef,
   } = useScrollOverflowState<HTMLDivElement>({
+    enabled: open,
     measureOverflow: true,
   });
-  const railRef = useRef<HTMLDivElement>(null);
-  const tickEls = useRef(new Map<string, HTMLElement>());
   const itemEls = useRef(new Map<string, HTMLElement>());
   const activeIdsRef = useRef<ActiveItemIds>({ agent: null, user: null });
-  const activeUpdateFrameRef = useRef<number | null>(null);
   const hasAgentMessages = agentItems.length > 0;
   const activeTab = tab === "agent" && hasAgentMessages ? "agent" : "user";
   const items = activeTab === "user" ? userItems : agentItems;
@@ -470,36 +551,36 @@ export function ThreadTableOfContents({
     };
   }, []);
 
-  const updateActiveItems = useCallback(() => {
-    const scrollElement = bottomAnchor?.getScrollElement() ?? null;
-    const nextActiveIds = findActiveItemIds({
-      agentItems,
-      scrollElement,
-      userItems,
-    });
-    const currentActiveIds = activeIdsRef.current;
-    if (nextActiveIds.user !== currentActiveIds.user) {
-      setActiveUserId(nextActiveIds.user);
-    }
-    if (nextActiveIds.agent !== currentActiveIds.agent) {
-      setActiveAgentId(nextActiveIds.agent);
-    }
-    activeIdsRef.current = nextActiveIds;
-  }, [agentItems, bottomAnchor, userItems]);
-
-  const scheduleActiveItemsUpdate = useCallback(() => {
-    if (activeUpdateFrameRef.current !== null) return;
-    activeUpdateFrameRef.current = window.requestAnimationFrame(() => {
-      activeUpdateFrameRef.current = null;
-      updateActiveItems();
-    });
-  }, [updateActiveItems]);
-
   useEffect(() => {
     if (!tocVisible) return;
-    scheduleActiveItemsUpdate();
     const scrollElement = bottomAnchor?.getScrollElement();
     if (!scrollElement) return;
+    const publishActiveItems = (nextActiveIds: ActiveItemIds) => {
+      const currentActiveIds = activeIdsRef.current;
+      if (nextActiveIds.user !== currentActiveIds.user) {
+        setActiveUserId(nextActiveIds.user);
+      }
+      if (nextActiveIds.agent !== currentActiveIds.agent) {
+        setActiveAgentId(nextActiveIds.agent);
+      }
+      activeIdsRef.current = nextActiveIds;
+    };
+    const updateActiveItems = () => {
+      publishActiveItems(
+        findActiveItemIds({ agentItems, scrollElement, userItems }),
+      );
+    };
+    let updateTimeout: number | null = null;
+    const scheduleActiveItemsUpdate = () => {
+      if (updateTimeout !== null) {
+        window.clearTimeout(updateTimeout);
+      }
+      updateTimeout = window.setTimeout(() => {
+        updateTimeout = null;
+        updateActiveItems();
+      }, TOC_ACTIVE_UPDATE_IDLE_MS);
+    };
+    scheduleActiveItemsUpdate();
     scrollElement.addEventListener("scroll", scheduleActiveItemsUpdate, {
       passive: true,
     });
@@ -508,41 +589,18 @@ export function ThreadTableOfContents({
         ? null
         : new ResizeObserver(scheduleActiveItemsUpdate);
     resizeObserver?.observe(scrollElement);
+
     return () => {
       scrollElement.removeEventListener("scroll", scheduleActiveItemsUpdate);
       resizeObserver?.disconnect();
-      if (activeUpdateFrameRef.current !== null) {
-        window.cancelAnimationFrame(activeUpdateFrameRef.current);
-        activeUpdateFrameRef.current = null;
+      if (updateTimeout !== null) {
+        window.clearTimeout(updateTimeout);
       }
     };
-  }, [bottomAnchor, scheduleActiveItemsUpdate, tocVisible]);
-
-  // Keep the active tick visible if the rail overflows in constrained layouts.
-  useEffect(() => {
-    if (!tocVisible) return;
-    const container = railRef.current;
-    const el = activeUserId ? tickEls.current.get(activeUserId) : null;
-    if (!container || !el) return;
-    const containerRect = container.getBoundingClientRect();
-    const elRect = el.getBoundingClientRect();
-    const pad = 12;
-    if (elRect.top < containerRect.top + pad) {
-      container.scrollTo({
-        top: container.scrollTop - (containerRect.top + pad - elRect.top),
-      });
-    } else if (elRect.bottom > containerRect.bottom - pad) {
-      container.scrollTo({
-        top:
-          container.scrollTop + (elRect.bottom - (containerRect.bottom - pad)),
-      });
-    }
-    // `railItems` is a dep so the active tick re-centers when the rail content
-    // swaps (e.g. the full outline replacing the loaded-window fallback).
-  }, [activeUserId, railItems, tocVisible]);
+  }, [agentItems, bottomAnchor, tocVisible, userItems]);
 
   useEffect(() => {
-    if (!tocVisible) return;
+    if (!tocVisible || !open) return;
     const container = scrollRef.current;
     const el = activeId ? itemEls.current.get(activeId) : null;
     if (!container || !el) return;
@@ -627,7 +685,10 @@ export function ThreadTableOfContents({
       data-thread-toc=""
       className="group/toc relative w-8"
       onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
+      onMouseLeave={(event) => {
+        if (event.currentTarget.contains(document.activeElement)) return;
+        setOpen(false);
+      }}
       onFocusCapture={() => setOpen(true)}
       onBlurCapture={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node)) {
@@ -637,126 +698,128 @@ export function ThreadTableOfContents({
     >
       {tocVisible ? (
         <div className="relative">
-          <div
-            ref={railRef}
-            aria-hidden
+          <button
+            type="button"
+            aria-label="Thread table of contents"
+            aria-expanded={open}
+            aria-controls={`thread-toc-panel-${threadId}`}
+            onClick={() => setOpen(true)}
             className="no-scrollbar flex max-h-[calc(100vh-7rem)] w-8 cursor-pointer flex-col items-center gap-2 overflow-y-auto py-2"
           >
-            {railItems.map((item) => (
-              <span
-                key={item.id}
-                ref={(node) => {
-                  if (node) tickEls.current.set(item.id, node);
-                  else tickEls.current.delete(item.id);
-                }}
-                className={cn(
-                  "h-[3px] shrink-0 rounded-full transition-all duration-150",
-                  item.id === activeUserId
-                    ? "w-5 bg-foreground/30 group-hover/toc:bg-foreground/70"
-                    : "w-3 bg-foreground/5 group-hover/toc:bg-foreground/20",
-                )}
-              />
-            ))}
-          </div>
-
-          <div
-            className={cn(
-              "absolute right-full top-0 w-[18.25rem] max-w-[calc(100vw-3rem)] pr-1 transition-all duration-150",
-              open
-                ? "pointer-events-auto translate-x-0 opacity-100"
-                : "pointer-events-none translate-x-1 opacity-0",
-            )}
-          >
-            <div className="rounded-lg border border-border bg-popover p-1 shadow-lg">
-              <div className="flex items-center gap-1 pb-1">
-                {hasAgentMessages ? (
-                  <TocPanelTab
-                    label="Agent messages"
-                    active={activeTab === "agent"}
-                    onSelect={() => setTab("agent")}
-                  />
-                ) : null}
-                <TocPanelTab
-                  label="Your messages"
-                  active={activeTab === "user"}
-                  onSelect={() => setTab("user")}
+            <span
+              aria-hidden
+              className="flex w-full flex-col items-center gap-2"
+            >
+              {railItems.map((item) => (
+                <span
+                  key={item.id}
+                  className={cn(
+                    "h-[3px] shrink-0 rounded-full transition-all duration-150",
+                    item.id === activeUserId
+                      ? "w-5 bg-foreground/30 group-hover/toc:bg-foreground/70"
+                      : "w-3 bg-foreground/5 group-hover/toc:bg-foreground/20",
+                  )}
                 />
-              </div>
-              <div className="relative isolate">
-                <div
-                  ref={scrollRef}
-                  className="max-h-64 overflow-y-auto overflow-x-hidden"
-                >
-                  <div
-                    ref={topSentinelRef}
-                    aria-hidden
-                    className="h-px w-full"
-                  />
-                  <ul className="flex flex-col">
-                    {items.map((item) => {
-                      const active = item.id === activeId;
-                      const pending = item.id === pendingJumpId;
-                      return (
-                        <li key={item.id}>
-                          <button
-                            ref={(node) => {
-                              if (node) itemEls.current.set(item.id, node);
-                              else itemEls.current.delete(item.id);
-                            }}
-                            type="button"
-                            aria-busy={pending}
-                            onClick={() => {
-                              void handleSelect(item.id);
-                            }}
-                            className={cn(
-                              "flex w-full cursor-pointer rounded-md px-2 py-1.5 text-left transition-colors",
-                              active
-                                ? "bg-state-hover"
-                                : "hover:bg-state-hover",
-                            )}
-                          >
-                            <span
-                              className={cn(
-                                "text-xs leading-snug",
-                                active
-                                  ? "text-foreground"
-                                  : "text-muted-foreground",
-                                pending && "animate-pulse",
-                              )}
-                            >
-                              <TocItemPreview
-                                item={item}
-                                senderThreadMetadataById={
-                                  senderThreadMetadataById
-                                }
-                              />
-                            </span>
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                  <div
-                    ref={bottomSentinelRef}
-                    aria-hidden
-                    className="h-px w-full"
+              ))}
+            </span>
+          </button>
+
+          {open ? (
+            <div
+              id={`thread-toc-panel-${threadId}`}
+              className="pointer-events-auto absolute right-full top-0 w-[18.25rem] max-w-[calc(100vw-3rem)] pr-1"
+            >
+              <div className="rounded-lg border border-border bg-popover p-1 shadow-lg">
+                <div className="flex items-center gap-1 pb-1">
+                  {hasAgentMessages ? (
+                    <TocPanelTab
+                      label="Agent messages"
+                      active={activeTab === "agent"}
+                      onSelect={() => setTab("agent")}
+                    />
+                  ) : null}
+                  <TocPanelTab
+                    label="Your messages"
+                    active={activeTab === "user"}
+                    onSelect={() => setTab("user")}
                   />
                 </div>
-                {aboveOverflow ? (
+                <div className="relative isolate">
                   <div
-                    aria-hidden
-                    className="pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-gradient-to-b from-popover/90 via-popover/60 to-transparent"
-                  />
-                ) : null}
-                {belowOverflow ? (
-                  <div
-                    aria-hidden
-                    className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-popover/90 via-popover/60 to-transparent"
-                  />
-                ) : null}
+                    ref={scrollRef}
+                    className="max-h-64 overflow-y-auto overflow-x-hidden"
+                  >
+                    <div
+                      ref={topSentinelRef}
+                      aria-hidden
+                      className="h-px w-full"
+                    />
+                    <ul className="flex flex-col">
+                      {items.map((item) => {
+                        const active = item.id === activeId;
+                        const pending = item.id === pendingJumpId;
+                        return (
+                          <li key={item.id}>
+                            <button
+                              ref={(node) => {
+                                if (node) itemEls.current.set(item.id, node);
+                                else itemEls.current.delete(item.id);
+                              }}
+                              type="button"
+                              aria-busy={pending}
+                              onClick={() => {
+                                void handleSelect(item.id);
+                              }}
+                              className={cn(
+                                "flex w-full cursor-pointer rounded-md px-2 py-1.5 text-left transition-colors",
+                                active
+                                  ? "bg-state-hover"
+                                  : "hover:bg-state-hover",
+                              )}
+                            >
+                              <span
+                                className={cn(
+                                  "text-xs leading-snug",
+                                  active
+                                    ? "text-foreground"
+                                    : "text-muted-foreground",
+                                  pending && "animate-pulse",
+                                )}
+                              >
+                                <TocItemPreview
+                                  item={item}
+                                  senderThreadMetadataById={
+                                    senderThreadMetadataById
+                                  }
+                                />
+                              </span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    <div
+                      ref={bottomSentinelRef}
+                      aria-hidden
+                      className="h-px w-full"
+                    />
+                  </div>
+                  {aboveOverflow ? (
+                    <div
+                      aria-hidden
+                      className="pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-gradient-to-b from-popover/90 via-popover/60 to-transparent"
+                    />
+                  ) : null}
+                  {belowOverflow ? (
+                    <div
+                      aria-hidden
+                      className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-popover/90 via-popover/60 to-transparent"
+                    />
+                  ) : null}
+                </div>
               </div>
             </div>
-          </div>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -130,9 +130,7 @@ function renderTimeline({
       scrollAreaClassName={SCROLL_AREA_CLASS}
       scrollAnchorThreadId={threadId}
     >
-      {showCapturePrependAnchorControl ? (
-        <CapturePrependAnchorControl />
-      ) : null}
+      {showCapturePrependAnchorControl ? <CapturePrependAnchorControl /> : null}
       {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
       {rowIds.map((rowId) => (
         <div key={rowId} data-timeline-row-id={rowId}>
@@ -242,6 +240,43 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     });
   });
 
+  it("finds the visible anchor with logarithmic row measurements", () => {
+    const rowIds = Array.from({ length: 128 }, (_, index) => `row-${index}`);
+    const { scrollArea, rowElements } = renderTimeline({
+      threadId: "thread-a",
+      rowIds,
+    });
+    mockScrollAreaRect(scrollArea);
+    const visibleIndex = 100;
+    const rowRectSpies = rowIds.map((rowId, index) => {
+      const top = (index - visibleIndex) * 10;
+      const row = requireHTMLElement(rowElements.get(rowId)!);
+      return vi
+        .spyOn(row, "getBoundingClientRect")
+        .mockReturnValue(new DOMRect(0, top, 100, 10));
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 1_400,
+      clientHeight: 100,
+      scrollTop: 1_000,
+    });
+
+    fireEvent.wheel(scrollArea);
+    fireEvent.scroll(scrollArea);
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "row-100",
+      offsetWithinRow: 0,
+      atBottom: false,
+    });
+    expect(
+      rowRectSpies.reduce(
+        (measurementCount, spy) => measurementCount + spy.mock.calls.length,
+        0,
+      ),
+    ).toBeLessThanOrEqual(8);
+  });
+
   it("does not treat a native-anchor jump during prepend as bottom intent", () => {
     const { getByRole, scrollArea } = renderTimeline({
       threadId: "thread-a",
@@ -256,9 +291,7 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
 
     fireEvent.wheel(scrollArea, { deltaY: -100 });
     fireEvent.scroll(scrollArea);
-    fireEvent.click(
-      getByRole("button", { name: "Capture prepend anchor" }),
-    );
+    fireEvent.click(getByRole("button", { name: "Capture prepend anchor" }));
 
     // Chromium's native scroll anchoring can move the scrollport to its
     // temporary maximum before the explicit prepend compensation runs.

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -93,6 +93,9 @@ const SCROLL_ANCHOR_CAPTURE_THROTTLE_MS = 100;
 // observed re-applies so a deleted/never-arriving row can't hang at the top.
 const SCROLL_ANCHOR_RESTORE_MAX_ATTEMPTS = 8;
 const TIMELINE_ROW_ID_SELECTOR = "[data-timeline-row-id]";
+const TOP_LEVEL_TIMELINE_ROW_LIST_SELECTOR =
+  '[data-timeline-row-list="top-level"]';
+const DIRECT_TIMELINE_ROW_SELECTOR = `:scope > ${TIMELINE_ROW_ID_SELECTOR}`;
 const SCROLL_INTENT_KEYS = new Set([
   "ArrowDown",
   "ArrowUp",
@@ -161,6 +164,20 @@ interface TopMostVisibleRow {
   offsetWithinRow: number;
 }
 
+function getScrollAnchorRows(scrollArea: HTMLElement): NodeListOf<HTMLElement> {
+  const topLevelList = scrollArea.querySelector<HTMLElement>(
+    TOP_LEVEL_TIMELINE_ROW_LIST_SELECTOR,
+  );
+  if (topLevelList) {
+    return topLevelList.querySelectorAll<HTMLElement>(
+      DIRECT_TIMELINE_ROW_SELECTOR,
+    );
+  }
+  // Embedded/test surfaces may render timeline rows without the app's
+  // top-level list wrapper.
+  return scrollArea.querySelectorAll<HTMLElement>(TIMELINE_ROW_ID_SELECTOR);
+}
+
 // The top-most timeline row whose bottom edge is below the scroll area's top
 // edge — i.e. the first row still (at least partially) visible. `offsetWithinRow`
 // is how far the scroll area's top sits past that row's top, so restore can
@@ -169,20 +186,37 @@ function getTopMostVisibleRow(
   scrollArea: HTMLElement,
 ): TopMostVisibleRow | null {
   const scrollAreaTop = scrollArea.getBoundingClientRect().top;
-  const rows = scrollArea.querySelectorAll<HTMLElement>(
-    TIMELINE_ROW_ID_SELECTOR,
-  );
-  for (const row of rows) {
-    const rowId = row.dataset.timelineRowId;
-    if (!rowId) continue;
+  const rows = getScrollAnchorRows(scrollArea);
+  let low = 0;
+  let high = rows.length - 1;
+  let visibleRow: HTMLElement | null = null;
+  let visibleRowRect: DOMRect | null = null;
+
+  // Top-level timeline rows are laid out in document order without overlap, so
+  // their bottom edges are monotonic. Binary search avoids the old O(n) walk
+  // from the first loaded row on every throttled scroll-anchor capture. On a
+  // long thread near the bottom, that walk forced hundreds of layout reads per
+  // sample while the browser was already busy scrolling.
+  while (low <= high) {
+    const index = low + Math.floor((high - low) / 2);
+    const row = rows[index];
+    if (!row) break;
     const rowRect = row.getBoundingClientRect();
-    if (rowRect.bottom <= scrollAreaTop + 1) continue;
-    return {
-      rowId,
-      offsetWithinRow: Math.max(0, scrollAreaTop - rowRect.top),
-    };
+    if (rowRect.bottom <= scrollAreaTop + 1) {
+      low = index + 1;
+      continue;
+    }
+    visibleRow = row;
+    visibleRowRect = rowRect;
+    high = index - 1;
   }
-  return null;
+
+  const rowId = visibleRow?.dataset.timelineRowId;
+  if (!rowId || !visibleRowRect) return null;
+  return {
+    rowId,
+    offsetWithinRow: Math.max(0, scrollAreaTop - visibleRowRect.top),
+  };
 }
 
 function findTimelineRowElement(


### PR DESCRIPTION
## Summary

- replace per-frame linear timeline geometry scans with debounced logarithmic lookups using fresh row geometry
- bound scroll-anchor capture work to top-level timeline rows while preserving prepend and streaming anchoring
- avoid rendering the closed TOC panel and stabilize outline-derived inputs during streaming updates
- preserve keyboard, pointer, focus, and overflow affordance behavior for the thread table of contents

## Profiling

Before, the fully loaded long thread produced 33 long tasks, 4.21s aggregate blocking, a 190ms worst task, and 32 frames over 50ms during a bottom → top → bottom sweep. After removing the forced-layout hot paths, the same thread produced 0 long tasks and no frames over 50ms with flat heap. A synthetic 1,100-row sweep remained frame-smooth, so virtualization was not warranted after the measured low-hanging work was removed.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- full `@bb/app` suite: 295 files / 2,169 tests
- post-rebase focused suite: 32 tests
- live browser QA for bottom anchoring, keyboard/pointer access, focus preservation, overflow fades, and geometry-read count
- independent GPT-5.6-Sol review: APPROVE