### PR TITLE
Bound timeline cache revisions per request shape

### DIFF
--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -54,7 +54,6 @@ import {
 } from "../../services/threads/timeline.js";
 import { createSlowThreadTimelineBuildLogger } from "../../services/threads/timeline-build-log.js";
 import {
-  buildThreadTimelineCacheKey,
   buildThreadTimelineParamsKey,
   createThreadTimelineCache,
 } from "../../services/threads/timeline-cache.js";
@@ -399,30 +398,27 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       summaryOnly,
       includeProviderUnhandledOperations,
     };
-    const full = timelineCache.getOrBuild(
-      buildThreadTimelineCacheKey({ ...keyArgs, maxSeq }),
-      () => {
-        const { profile, response } = buildThreadTimelineWithProfile(
-          deps.db,
-          thread,
-          {
-            eventBudget,
-            includeProviderUnhandledOperations,
-            includeNestedRows,
-            maxInlineOutputChars: DEFAULT_MAX_INLINE_OUTPUT_CHARS,
-            maxSeq,
-            page,
-            providerDisplayName,
-            summaryOnly,
-          },
-        );
-        slowTimelineBuildLogger.log({ profile, threadId: thread.id });
-        return truncateTimelineResponseOutputs(
-          response,
-          DEFAULT_MAX_INLINE_OUTPUT_CHARS,
-        );
-      },
-    );
+    const full = timelineCache.getOrBuild({ ...keyArgs, maxSeq }, () => {
+      const { profile, response } = buildThreadTimelineWithProfile(
+        deps.db,
+        thread,
+        {
+          eventBudget,
+          includeProviderUnhandledOperations,
+          includeNestedRows,
+          maxInlineOutputChars: DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+          maxSeq,
+          page,
+          providerDisplayName,
+          summaryOnly,
+        },
+      );
+      slowTimelineBuildLogger.log({ profile, threadId: thread.id });
+      return truncateTimelineResponseOutputs(
+        response,
+        DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+      );
+    });
 
     // Delta: when the client tells us the revision it currently holds and our
     // last-sent snapshot still matches it exactly, return only the changed rows.

--- a/apps/server/src/services/threads/timeline-cache.ts
+++ b/apps/server/src/services/threads/timeline-cache.ts
@@ -13,9 +13,11 @@ import type { ThreadTimelinePageRequest } from "./timeline-pagination.js";
  * (detail view + side-chat tabs), debounced realtime invalidations that fire
  * after the tail already settled, and re-opening a thread.
  *
- * Keying on the thread high-water `maxSeq` makes invalidation implicit: any
- * appended event bumps `maxSeq`, producing a new key and a cold rebuild. The
- * key MUST also include every other input the projection depends on:
+ * The thread high-water `maxSeq` makes invalidation implicit: any appended
+ * event bumps `maxSeq`, producing a cold rebuild. Each request shape retains
+ * only its newest revision because the endpoint always resolves the current
+ * high-water sequence; client deltas use a separate latest-rows cache. The
+ * request shape MUST also include every other input the projection depends on:
  * `thread.status` (interrupt flips earlier rows), `environmentId` (workspace
  * root relativizes file paths), provider display name (labels dynamic-provider
  * diagnostic rows), and the row-shape request flags. Event pruning
@@ -23,10 +25,10 @@ import type { ThreadTimelinePageRequest } from "./timeline-pagination.js";
  * and never lowers `maxSeq`, so it cannot stale a cached entry.
  *
  * Entries with many rows are not cached: an expanded active turn (the streaming
- * case) produces hundreds of rows AND a `maxSeq` that changes on every event,
- * so caching it only thrashes the LRU and pins large objects for no reuse. Idle
- * windows collapse completed turns to a handful of rows regardless of thread
- * size, so the cap excludes exactly the entries that would never be reused.
+ * case) can produce hundreds of rows and a `maxSeq` that changes on every
+ * event, so caching it only pins large objects for no reuse. Smaller active
+ * windows can still fall below the row cap; replacing their prior revision
+ * prevents streaming updates from filling the LRU with unreachable responses.
  */
 
 const DEFAULT_MAX_ENTRIES = 128;
@@ -40,7 +42,7 @@ export interface ThreadTimelineCacheOptions {
 
 export interface ThreadTimelineCache {
   getOrBuild(
-    key: string,
+    keyArgs: ThreadTimelineCacheKeyArgs,
     build: () => ThreadTimelineResponse,
   ): ThreadTimelineResponse;
   /** Number of currently cached entries (for tests/metrics). */
@@ -53,21 +55,29 @@ export function createThreadTimelineCache(
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
   const maxCacheableRows =
     options.maxCacheableRows ?? DEFAULT_MAX_CACHEABLE_ROWS;
-  const entries = new Map<string, ThreadTimelineResponse>();
+  const entries = new Map<
+    string,
+    { revisionKey: string; response: ThreadTimelineResponse }
+  >();
 
   return {
-    getOrBuild(key, build) {
-      const cached = entries.get(key);
-      if (cached !== undefined) {
+    getOrBuild(keyArgs, build) {
+      const paramsKey = buildThreadTimelineParamsKey(keyArgs);
+      const revisionKey = buildThreadTimelineCacheKey(keyArgs);
+      const cached = entries.get(paramsKey);
+      if (cached?.revisionKey === revisionKey) {
         // Re-insert to mark most-recently-used.
-        entries.delete(key);
-        entries.set(key, cached);
-        return cached;
+        entries.delete(paramsKey);
+        entries.set(paramsKey, cached);
+        return cached.response;
       }
 
       const value = build();
+      // A successful build supersedes the unreachable prior revision even when
+      // the new response is too large to cache.
+      entries.delete(paramsKey);
       if (value.rows.length <= maxCacheableRows) {
-        entries.set(key, value);
+        entries.set(paramsKey, { revisionKey, response: value });
         while (entries.size > maxEntries) {
           const oldest = entries.keys().next().value;
           if (oldest === undefined) {

--- a/apps/server/test/services/threads/timeline-cache.test.ts
+++ b/apps/server/test/services/threads/timeline-cache.test.ts
@@ -62,8 +62,8 @@ describe("createThreadTimelineCache", () => {
     const cache = createThreadTimelineCache();
     const build = vi.fn(() => makeResponse(3));
 
-    const first = cache.getOrBuild("k", build);
-    const second = cache.getOrBuild("k", build);
+    const first = cache.getOrBuild(baseKeyArgs, build);
+    const second = cache.getOrBuild(baseKeyArgs, build);
 
     expect(build).toHaveBeenCalledTimes(1);
     expect(second).toBe(first);
@@ -74,36 +74,94 @@ describe("createThreadTimelineCache", () => {
     const cache = createThreadTimelineCache();
     const build = vi.fn(() => makeResponse(3));
 
-    cache.getOrBuild("k1", build);
-    cache.getOrBuild("k2", build);
+    cache.getOrBuild(baseKeyArgs, build);
+    cache.getOrBuild({ ...baseKeyArgs, maxSeq: 11 }, build);
 
     expect(build).toHaveBeenCalledTimes(2);
+    expect(cache.size).toBe(1);
+  });
+
+  it("retains only the newest revision for the same request shape", () => {
+    const cache = createThreadTimelineCache();
+    const build = vi.fn(() => makeResponse(3));
+
+    for (let maxSeq = 1; maxSeq <= 128; maxSeq += 1) {
+      cache.getOrBuild({ ...baseKeyArgs, maxSeq }, build);
+    }
+
+    expect(build).toHaveBeenCalledTimes(128);
+    expect(cache.size).toBe(1);
   });
 
   it("does not cache responses above the row cap (streaming expanded turns)", () => {
     const cache = createThreadTimelineCache({ maxCacheableRows: 5 });
     const build = vi.fn(() => makeResponse(50));
 
-    cache.getOrBuild("k", build);
-    cache.getOrBuild("k", build);
+    cache.getOrBuild(baseKeyArgs, build);
+    cache.getOrBuild(baseKeyArgs, build);
 
     expect(build).toHaveBeenCalledTimes(2);
     expect(cache.size).toBe(0);
   });
 
+  it("drops an obsolete revision when its replacement exceeds the row cap", () => {
+    const cache = createThreadTimelineCache({ maxCacheableRows: 5 });
+    cache.getOrBuild(baseKeyArgs, () => makeResponse(3));
+
+    const buildLarge = vi.fn(() => makeResponse(50));
+    const nextRevision = { ...baseKeyArgs, maxSeq: 11 };
+    cache.getOrBuild(nextRevision, buildLarge);
+
+    expect(cache.size).toBe(0);
+    cache.getOrBuild(nextRevision, buildLarge);
+    expect(buildLarge).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves the prior revision when its replacement build fails", () => {
+    const cache = createThreadTimelineCache();
+    const first = cache.getOrBuild(baseKeyArgs, () => makeResponse(3));
+
+    expect(() =>
+      cache.getOrBuild({ ...baseKeyArgs, maxSeq: 11 }, () => {
+        throw new Error("build failed");
+      }),
+    ).toThrow("build failed");
+
+    expect(cache.getOrBuild(baseKeyArgs, () => makeResponse(4))).toBe(first);
+    expect(cache.size).toBe(1);
+  });
+
+  it("keeps different request shapes independently cached", () => {
+    const cache = createThreadTimelineCache();
+    const build = vi.fn(() => makeResponse(1));
+    const summaryKeyArgs = { ...baseKeyArgs, summaryOnly: true };
+
+    cache.getOrBuild(baseKeyArgs, build);
+    cache.getOrBuild(summaryKeyArgs, build);
+    cache.getOrBuild(baseKeyArgs, build);
+    cache.getOrBuild(summaryKeyArgs, build);
+
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(cache.size).toBe(2);
+  });
+
   it("evicts least-recently-used entries beyond maxEntries", () => {
     const cache = createThreadTimelineCache({ maxEntries: 2 });
     const build = vi.fn(() => makeResponse(1));
+    const a1 = { ...baseKeyArgs, threadId: "thr_a", maxSeq: 1 };
+    const a2 = { ...a1, maxSeq: 2 };
+    const b1 = { ...baseKeyArgs, threadId: "thr_b", maxSeq: 1 };
+    const c1 = { ...baseKeyArgs, threadId: "thr_c", maxSeq: 1 };
 
-    cache.getOrBuild("a", build); // [a]
-    cache.getOrBuild("b", build); // [a,b]
-    cache.getOrBuild("a", build); // touch a -> [b,a]
-    cache.getOrBuild("c", build); // evict b -> [a,c]
+    cache.getOrBuild(a1, build); // [a1]
+    cache.getOrBuild(b1, build); // [a1,b1]
+    cache.getOrBuild(a2, build); // replace a1 -> [b1,a2]
+    cache.getOrBuild(c1, build); // evict b1 -> [a2,c1]
 
     expect(cache.size).toBe(2);
     const buildAgain = vi.fn(() => makeResponse(1));
-    cache.getOrBuild("a", buildAgain); // still cached
-    cache.getOrBuild("b", buildAgain); // evicted -> rebuild
+    cache.getOrBuild(a2, buildAgain); // still cached
+    cache.getOrBuild(b1, buildAgain); // evicted -> rebuild
     expect(buildAgain).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Retain at most one built timeline response revision per request shape.
- Replace obsolete streaming revisions even when the new response exceeds the cache row cap.
- Preserve the previous cached revision when a replacement build throws.
- Keep the existing LRU bound across independent request shapes and leave row-delta state in its separate cache.

## Why

The response cache was keyed by `maxSeq`, so every appended event could add a new entry. The intended safeguard skips responses above 200 projected rows. It does not cover many real active windows. Observed streaming windows projected only 28–74 rows while reading hundreds of events. One request shape could therefore consume all 128 LRU slots with unreachable revisions.

The cache now owns both identities. The request shape selects the slot. `maxSeq` selects the revision stored in that slot. Callers no longer encode this retention policy in an opaque string key.

## Regression proof

Before the fix, 128 successive `maxSeq` values for one request shape produced `cache.size === 128`. The regression now asserts `cache.size === 1`. Tests also cover:

- cacheable to over-row-cap replacement
- failed replacement builds
- independent request shapes
- revision replacement preserving LRU order
- the unchanged public timeline row-delta route

## Validation

- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/threads/timeline-cache.test.ts test/public/public-thread-timeline-delta.test.ts` — 14 passed
- `umask 0022 && pnpm exec turbo run test --filter=@bb/server --force` — 1,319 passed
- `pnpm exec turbo run typecheck --filter=@bb/server --force` — passed
- `pnpm exec turbo run lint --filter=@bb/server --force` — no server lint task configured
- Prettier and `git diff --check` — passed
- Independent diff review — no findings

No API, database, or server/daemon wire contract changes.