### PR TITLE
Protect browser mutation and WebSocket boundaries

### DIFF
--- a/apps/app/vite.dev.config.ts
+++ b/apps/app/vite.dev.config.ts
@@ -21,11 +21,13 @@ export default defineConfig({
       "/api": {
         target: viteDevConfig.serverHttpOrigin,
         changeOrigin: true,
+        xfwd: true,
       },
       "/ws": {
         target: viteDevConfig.serverHttpOrigin,
         changeOrigin: true,
         ws: true,
+        xfwd: true,
       },
     },
   },

--- a/apps/server/src/browser-request-guard.ts
+++ b/apps/server/src/browser-request-guard.ts
@@ -1,0 +1,175 @@
+import {
+  buildLocalAppOrigins,
+  type BuildLocalAppOriginsArgs,
+} from "@bb/config/local-app-origins";
+import type { ServerRuntimeConfig } from "./types.js";
+
+export interface BrowserRequestGuardDeps {
+  config: Pick<ServerRuntimeConfig, "serverPort" | "appUrl" | "devAppPort">;
+}
+
+export interface BrowserRequestProblem {
+  status: 403 | 415;
+  error: string;
+}
+
+interface BrowserRequestGuardOptions {
+  requireJsonForMutation?: boolean;
+}
+
+interface BrowserRequestContext {
+  req: {
+    url: string;
+    method: string;
+    header(name: string): string | undefined;
+  };
+}
+
+function allowedAppOrigins(deps: BrowserRequestGuardDeps): Set<string> {
+  const args: BuildLocalAppOriginsArgs = {
+    serverPort: deps.config.serverPort,
+  };
+  if (deps.config.appUrl !== undefined) {
+    args.appUrl = deps.config.appUrl;
+  }
+  if (deps.config.devAppPort !== undefined) {
+    args.devAppPort = deps.config.devAppPort;
+  }
+  return new Set(buildLocalAppOrigins(args));
+}
+
+function knownAppPorts(deps: BrowserRequestGuardDeps): Set<number> {
+  const ports = new Set<number>([deps.config.serverPort]);
+  if (deps.config.devAppPort !== undefined) {
+    ports.add(deps.config.devAppPort);
+  }
+  return ports;
+}
+
+function effectivePort(url: URL): number | null {
+  if (url.port.length > 0) {
+    const port = Number(url.port);
+    return Number.isInteger(port) ? port : null;
+  }
+  if (url.protocol === "http:") {
+    return 80;
+  }
+  if (url.protocol === "https:") {
+    return 443;
+  }
+  return null;
+}
+
+function parseRequestHost(host: string, protocol: string): URL | null {
+  try {
+    const url = new URL(`${protocol}//${host}`);
+    return url.username.length === 0 &&
+      url.password.length === 0 &&
+      url.pathname === "/" &&
+      url.search.length === 0 &&
+      url.hash.length === 0
+      ? url
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function requestTargets(context: BrowserRequestContext): URL[] {
+  const requestUrl = new URL(context.req.url);
+  const targets = [requestUrl];
+  const forwardedProtocol =
+    context.req.header("x-forwarded-proto")?.split(",", 1)[0]?.trim() ||
+    requestUrl.protocol.replace(/:$/u, "");
+
+  for (const rawHost of [
+    context.req.header("host"),
+    context.req.header("x-forwarded-host")?.split(",", 1)[0]?.trim(),
+  ]) {
+    if (rawHost === undefined || rawHost.length === 0) {
+      continue;
+    }
+    const target = parseRequestHost(rawHost, `${forwardedProtocol}:`);
+    if (target !== null) {
+      targets.push(target);
+    }
+  }
+  return targets;
+}
+
+function isTrustedOrigin(
+  context: BrowserRequestContext,
+  deps: BrowserRequestGuardDeps,
+  origin: string,
+): boolean {
+  let originUrl: URL;
+  try {
+    originUrl = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (
+    originUrl.origin !== origin ||
+    (originUrl.protocol !== "http:" && originUrl.protocol !== "https:")
+  ) {
+    return false;
+  }
+
+  if (allowedAppOrigins(deps).has(originUrl.origin)) {
+    return true;
+  }
+
+  const targets = requestTargets(context);
+  if (targets.some((target) => target.origin === originUrl.origin)) {
+    return true;
+  }
+
+  const originPort = effectivePort(originUrl);
+  if (originPort === null || !knownAppPorts(deps).has(originPort)) {
+    return false;
+  }
+
+  return targets.some((target) => target.hostname === originUrl.hostname);
+}
+
+function isJsonContentType(contentType: string | undefined): boolean {
+  return (
+    contentType?.split(";", 1)[0]?.trim().toLowerCase() === "application/json"
+  );
+}
+
+/**
+ * Guards privileged local-browser boundaries without imposing credentials on
+ * non-browser clients. Browsers send Origin; Node SDK, CLI, and server-to-server
+ * callers commonly do not. Dynamic LAN/dev origins must share the request host
+ * and use a configured BB port, while configured app origins match exactly.
+ */
+export function browserRequestProblem(
+  context: BrowserRequestContext,
+  deps: BrowserRequestGuardDeps,
+  options: BrowserRequestGuardOptions = {},
+): BrowserRequestProblem | null {
+  const origin = context.req.header("origin");
+  if (origin !== undefined && !isTrustedOrigin(context, deps, origin)) {
+    return {
+      status: 403,
+      error: `origin "${origin}" is not a local BB app origin`,
+    };
+  }
+
+  const method = context.req.method.toUpperCase();
+  if (
+    options.requireJsonForMutation === true &&
+    method !== "GET" &&
+    method !== "HEAD" &&
+    method !== "OPTIONS" &&
+    !isJsonContentType(context.req.header("content-type"))
+  ) {
+    return {
+      status: 415,
+      error: "content-type must be application/json",
+    };
+  }
+
+  return null;
+}

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -9,6 +9,7 @@ import {
 } from "@bb/server-contract";
 import { COMMAND_TIMEOUT_MS } from "../constants.js";
 import { ApiError } from "../errors.js";
+import { browserRequestProblem } from "../browser-request-guard.js";
 import type { AppDeps, LoggedWorkSessionDeps } from "../types.js";
 import {
   callHostOnlineRpc,
@@ -168,6 +169,35 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
     assertUsableHostId(deps, { hostId: resolved });
     return resolved;
   };
+
+  const requirePrivilegedJsonMutation = (
+    context: Parameters<typeof browserRequestProblem>[0],
+  ): void => {
+    const problem = browserRequestProblem(context, deps, {
+      requireJsonForMutation: true,
+    });
+    if (problem === null) {
+      return;
+    }
+    throw new ApiError(
+      problem.status,
+      problem.status === 403 ? "forbidden_origin" : "unsupported_media_type",
+      problem.error,
+      false,
+    );
+  };
+
+  for (const route of [
+    fileRoutes.write,
+    fileRoutes.mkdir,
+    fileRoutes.move,
+    fileRoutes.remove,
+  ]) {
+    app.use(route.path, async (context, next) => {
+      requirePrivilegedJsonMutation(context);
+      await next();
+    });
+  }
 
   post(fileRoutes.read, async (context, payload) => {
     const hostId = resolveHostId(payload.hostId);

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -1,11 +1,11 @@
 import { timingSafeEqual } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import type { Context, Hono } from "hono";
-import {
-  buildLocalAppOrigins,
-  type BuildLocalAppOriginsArgs,
-} from "@bb/config/local-app-origins";
 import type { ServerRuntimeConfig } from "../types.js";
+import {
+  browserRequestProblem,
+  type BrowserRequestProblem,
+} from "../browser-request-guard.js";
 import type {
   PluginService,
   PluginWireLookup,
@@ -26,45 +26,7 @@ export interface PluginRoutesDeps {
   db: import("@bb/db").DbConnection;
 }
 
-interface WireAuthProblem {
-  status: 401 | 403 | 415;
-  error: string;
-}
-
-/** Same allowlist the CORS middleware enforces (server.ts), per request. */
-function allowedAppOrigins(deps: PluginRoutesDeps): Set<string> {
-  const args: BuildLocalAppOriginsArgs = {
-    serverPort: deps.config.serverPort,
-  };
-  if (deps.config.appUrl !== undefined) args.appUrl = deps.config.appUrl;
-  if (deps.config.devAppPort !== undefined) {
-    args.devAppPort = deps.config.devAppPort;
-  }
-  return new Set(buildLocalAppOrigins(args));
-}
-
-/**
- * Ports BB legitimately serves the app on (server, dev app, appUrl).
- * Deliberately EXPLICIT ports only: mapping https' implicit 443 here would
- * make every ordinary internet origin match whenever appUrl is a standard
- * https URL. Standard-port deployments are covered by the exact-origin
- * allowlist instead.
- */
-function knownAppPorts(deps: PluginRoutesDeps): Set<string> {
-  const ports = new Set<string>([String(deps.config.serverPort)]);
-  if (deps.config.devAppPort !== undefined) {
-    ports.add(String(deps.config.devAppPort));
-  }
-  if (deps.config.appUrl !== undefined) {
-    try {
-      const port = new URL(deps.config.appUrl).port;
-      if (port.length > 0) ports.add(port);
-    } catch {
-      // Ignore an unparseable appUrl; the other ports still apply.
-    }
-  }
-  return ports;
-}
+type WireAuthProblem = BrowserRequestProblem | { status: 401; error: string };
 
 function parsePluginMentionTrigger(
   value: string | undefined,
@@ -88,52 +50,17 @@ function parsePluginMentionTrigger(
  * "local" auth (design §4.6): the request must come from the BB app itself.
  * The load-bearing CSRF defense is the JSON-only rule below — a cross-origin
  * JSON POST always triggers a CORS preflight, which the server's allowlist
- * denies. The Origin check adds a cheap second layer, but it must tolerate
- * BB being served over LAN/Tailscale addresses the server cannot enumerate
- * (and the dev proxy rewriting Host): any origin on a known BB app port is
- * accepted. There is deliberately NO Host allowlist — pinning Host only on
- * plugin routes adds no real protection while the rest of the local API has
- * none (a whole-server story is the actual fix; design doc §10).
+ * denies. The shared Origin check also tolerates BB being served over
+ * LAN/Tailscale addresses the server cannot enumerate, but only when the
+ * origin hostname is bound to the request hostname.
  */
 function localAuthProblem(
   context: Context,
   deps: PluginRoutesDeps,
 ): WireAuthProblem | null {
-  const allowedOrigins = allowedAppOrigins(deps);
-  const requestUrl = new URL(context.req.url);
-  const origin = context.req.header("origin");
-  if (origin !== undefined && origin !== requestUrl.origin) {
-    // Only an origin with an EXPLICIT port can match the port rule —
-    // implicit-port origins (ordinary internet sites) must match the exact
-    // allowlist.
-    let originPort: string | null = null;
-    try {
-      const port = new URL(origin).port;
-      originPort = port.length > 0 ? port : null;
-    } catch {
-      originPort = null;
-    }
-    if (
-      !allowedOrigins.has(origin) &&
-      (originPort === null || !knownAppPorts(deps).has(originPort))
-    ) {
-      return {
-        status: 403,
-        error: `origin "${origin}" is not a local BB app origin`,
-      };
-    }
-  }
-  const method = context.req.method.toUpperCase();
-  if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
-    const contentType = context.req.header("content-type") ?? "";
-    if (!contentType.toLowerCase().startsWith("application/json")) {
-      return {
-        status: 415,
-        error: "content-type must be application/json",
-      };
-    }
-  }
-  return null;
+  return browserRequestProblem(context, deps, {
+    requireJsonForMutation: true,
+  });
 }
 
 function isStringArray(value: unknown): value is string[] {
@@ -462,6 +389,10 @@ export function registerPluginRoutes(
   });
 
   app.post("/plugins/install", async (context) => {
+    const problem = localAuthProblem(context, deps);
+    if (problem) {
+      return context.json({ ok: false, error: problem.error }, problem.status);
+    }
     const json: unknown = await context.req.json().catch(() => null);
     const parsed = pluginInstallRequestSchema.safeParse(json);
     if (!parsed.success) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -71,6 +71,7 @@ import {
   type PluginCatalogService,
 } from "./services/plugin-catalog/plugin-catalog-service.js";
 import { callHostRetryableOnlineRpc } from "./services/hosts/online-rpc.js";
+import { browserRequestProblem } from "./browser-request-guard.js";
 
 export type CloseWebSockets = () => Promise<void>;
 type NodeWebSocketServer = ReturnType<typeof createNodeWebSocket>["wss"];
@@ -469,17 +470,37 @@ export function createApp(
 
   app.get(
     "/ws",
-    upgradeWebSocket(() => ({
-      onOpen: (_event, socket) => onClientSocketOpen(deps.hub, socket),
-      onMessage: (event, socket) =>
-        onClientSocketMessage(deps, socket, event.data),
-      onClose: (_event, socket) => onClientSocketClose(deps, socket),
-    })),
+    upgradeWebSocket((context) => {
+      const problem = browserRequestProblem(context, deps);
+      if (problem !== null) {
+        throw new ApiError(
+          problem.status,
+          "forbidden_origin",
+          problem.error,
+          false,
+        );
+      }
+      return {
+        onOpen: (_event, socket) => onClientSocketOpen(deps.hub, socket),
+        onMessage: (event, socket) =>
+          onClientSocketMessage(deps, socket, event.data),
+        onClose: (_event, socket) => onClientSocketClose(deps, socket),
+      };
+    }),
   );
 
   app.get(
     "/ws/terminals/:terminalId",
     upgradeWebSocket((context) => {
+      const problem = browserRequestProblem(context, deps);
+      if (problem !== null) {
+        throw new ApiError(
+          problem.status,
+          "forbidden_origin",
+          problem.error,
+          false,
+        );
+      }
       const terminalId = context.req.param("terminalId");
       return {
         onOpen: (_event, socket) =>

--- a/apps/server/test/files/host-file-routes.test.ts
+++ b/apps/server/test/files/host-file-routes.test.ts
@@ -33,6 +33,56 @@ function postJson(path: string, body: unknown): [string, RequestInit] {
 }
 
 describe("host file routes", () => {
+  it("rejects hostile-origin and text/plain privileged mutations before host RPC", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps);
+      seedPrimaryHost(harness.deps, host.id);
+      const commands: HostDaemonOnlineRpcRequestMessage["command"][] = [];
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          commands.push(request.command);
+          return { ok: true, result: { ok: true } };
+        },
+      });
+
+      const mutations = [
+        ["/api/v1/files/write", { path: "/notes/a.md", content: "attacker" }],
+        ["/api/v1/files/mkdir", { path: "/notes/private" }],
+        [
+          "/api/v1/files/move",
+          {
+            sourcePath: "/notes/a.md",
+            destinationPath: "/notes/b.md",
+          },
+        ],
+        ["/api/v1/files/remove", { path: "/notes/b.md" }],
+      ] as const;
+
+      for (const [route, payload] of mutations) {
+        const hostile = await harness.app.request(route, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            origin: "https://evil.example",
+          },
+          body: JSON.stringify(payload),
+        });
+        expect(hostile.status, route).toBe(403);
+
+        const simpleRequest = await harness.app.request(route, {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: JSON.stringify(payload),
+        });
+        expect(simpleRequest.status, route).toBe(415);
+      }
+
+      expect(commands).toEqual([]);
+    });
+  });
+
   it("creates opaque path-shaped preview leases and serves sandboxed HTML", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps);

--- a/apps/server/test/security/browser-websocket-origin.test.ts
+++ b/apps/server/test/security/browser-websocket-origin.test.ts
@@ -1,0 +1,156 @@
+import { createNodeBbSdk } from "@bb/sdk/node";
+import { createNodeWebsocketFactory } from "@bb/sdk/node-websocket";
+import { afterEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../helpers/test-app.js";
+
+const sockets = new Set<WebSocket>();
+let server: RunningTestServer | null = null;
+
+function websocketUrl(baseUrl: string, path: string): string {
+  const url = new URL(path, baseUrl);
+  url.protocol = "ws:";
+  return url.href;
+}
+
+function openWebSocket(url: string, origin?: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket =
+      origin === undefined
+        ? new WebSocket(url)
+        : new WebSocket(url, { origin });
+    sockets.add(socket);
+    socket.once("open", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function rejectedWebSocketStatus(url: string, origin: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url, { origin });
+    sockets.add(socket);
+    socket.once("open", () =>
+      reject(new Error(`WebSocket unexpectedly opened for ${origin}`)),
+    );
+    socket.once("unexpected-response", (_request, response) => {
+      const status = response.statusCode;
+      response.resume();
+      if (status === undefined) {
+        reject(new Error("WebSocket rejection omitted an HTTP status"));
+        return;
+      }
+      resolve(status);
+    });
+    socket.once("error", () => {
+      // The status-bearing unexpected-response event is asserted above.
+    });
+  });
+}
+
+async function closeSocket(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.CLOSED) {
+    sockets.delete(socket);
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    socket.once("close", resolve);
+    socket.close();
+  });
+  sockets.delete(socket);
+}
+
+afterEach(async () => {
+  for (const socket of sockets) {
+    socket.terminate();
+  }
+  sockets.clear();
+  if (server !== null) {
+    await server.close();
+    server = null;
+  }
+});
+
+describe("browser WebSocket origin boundary", () => {
+  it("rejects hostile browser origins on realtime and terminal sockets", async () => {
+    server = await startTestServer();
+    const realtimeUrl = websocketUrl(server.baseUrl, "/ws");
+    const terminalUrl = websocketUrl(
+      server.baseUrl,
+      "/ws/terminals/known-to-attacker",
+    );
+
+    await expect(
+      rejectedWebSocketStatus(realtimeUrl, "https://evil.example"),
+    ).resolves.toBe(403);
+    await expect(
+      rejectedWebSocketStatus(terminalUrl, "https://evil.example"),
+    ).resolves.toBe(403);
+  });
+
+  it("accepts trusted browser origins for both browser-facing sockets", async () => {
+    server = await startTestServer({
+      appUrl: "https://bb.example.test",
+      devAppPort: 5173,
+    });
+    const realtimeUrl = websocketUrl(server.baseUrl, "/ws");
+    const terminalUrl = websocketUrl(
+      server.baseUrl,
+      "/ws/terminals/missing-terminal",
+    );
+
+    const sameOrigin = await openWebSocket(realtimeUrl, server.baseUrl);
+    await closeSocket(sameOrigin);
+
+    const configuredApp = await openWebSocket(
+      realtimeUrl,
+      "https://bb.example.test",
+    );
+    await closeSocket(configuredApp);
+
+    const devOrigin = new URL(server.baseUrl);
+    devOrigin.port = "5173";
+    const dev = await openWebSocket(realtimeUrl, devOrigin.origin);
+    await closeSocket(dev);
+
+    const terminal = await openWebSocket(terminalUrl, server.baseUrl);
+    await closeSocket(terminal);
+  });
+
+  it("keeps absent-Origin Node SDK realtime and CLI terminal sockets working", async () => {
+    server = await startTestServer();
+    const sdk = createNodeBbSdk({ baseUrl: server.baseUrl });
+
+    let stopTarget = (): void => {};
+    let stopConnection = (): void => {};
+    const connected = new Promise<void>((resolve) => {
+      stopConnection = sdk.subscribe({
+        event: "realtime:connection",
+        callback: (event) => {
+          if (event.state === "connected") {
+            resolve();
+          }
+        },
+      });
+      stopTarget = sdk.subscribe({
+        event: "system:changed",
+        callback: () => {},
+      });
+    });
+    await connected;
+    stopTarget();
+    stopConnection();
+
+    const terminalSocket = createNodeWebsocketFactory()(
+      websocketUrl(server.baseUrl, "/ws/terminals/missing-terminal"),
+    );
+    await new Promise<void>((resolve, reject) => {
+      terminalSocket.onopen = () => resolve();
+      terminalSocket.onerror = () =>
+        reject(new Error("CLI terminal WebSocket handshake failed"));
+    });
+    terminalSocket.close();
+  });
+});

--- a/apps/server/test/services/plugins/plugin-wire.test.ts
+++ b/apps/server/test/services/plugins/plugin-wire.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTestAppHarness,
   type TestAppHarness,
@@ -122,7 +122,7 @@ describe("plugin wire surfaces (http/rpc dispatcher + realtime)", () => {
   let rootDir: string;
 
   beforeEach(async () => {
-    harness = await createTestAppHarness();
+    harness = await createTestAppHarness({ devAppPort: 5173 });
     rootDir = await writePlugin(join(harness.config.dataDir, "fixtures"), {
       name: "bb-plugin-wire",
       serverSource: WIRE_SOURCE,
@@ -157,7 +157,7 @@ describe("plugin wire surfaces (http/rpc dispatcher + realtime)", () => {
     expect(appOrigin.status).toBe(200);
   });
 
-  it("local auth rejects foreign origins but tolerates LAN/Tailscale serving", async () => {
+  it("local auth rejects foreign origins but tolerates host-bound LAN/Tailscale serving", async () => {
     const foreignOrigin = await harness.app.request(
       `${BASE}/api/v1/plugins/wire/http/hello`,
       { headers: { origin: EVIL_ORIGIN } },
@@ -168,23 +168,46 @@ describe("plugin wire surfaces (http/rpc dispatcher + realtime)", () => {
       error: expect.stringContaining("not a local BB app origin"),
     });
 
-    // Tailscale/LAN serving (regression): the app reaches the server through
-    // the dev proxy, so the browser origin is a non-loopback host on a known
-    // BB app port while the request URL origin differs. Must be allowed.
-    const tailscaleOrigin = await harness.app.request(
+    // Merely copying a known BB port is insufficient when the hostile origin
+    // hostname is unrelated to the request hostname.
+    const copiedPort = await harness.app.request(
       `${BASE}/api/v1/plugins/wire/http/hello`,
-      { headers: { origin: "http://100.64.158.8:3334" } },
+      { headers: { origin: "http://evil.example:3334" } },
     );
-    expect(tailscaleOrigin.status).toBe(200);
+    expect(copiedPort.status).toBe(403);
 
-    // A foreign origin on a random port stays rejected even with a
-    // rebinding-shaped request URL; a same-origin non-loopback URL passes
-    // (no Host allowlist — LAN serving is legitimate).
+    // Direct LAN/Tailscale serving binds the app origin to the request host.
     const sameOriginLan = await harness.app.request(
       "http://100.64.158.8:3334/api/v1/plugins/wire/http/hello",
       { headers: { origin: "http://100.64.158.8:3334" } },
     );
     expect(sameOriginLan.status).toBe(200);
+
+    const sameOriginReverseProxy = await harness.app.request(
+      "https://bb.lan.test/api/v1/plugins/wire/http/hello",
+      { headers: { origin: "https://bb.lan.test" } },
+    );
+    expect(sameOriginReverseProxy.status).toBe(200);
+
+    // Direct development WebSockets use the dev origin hostname with the
+    // backend port, while Vite's HTTP proxy preserves the browser-facing host
+    // in X-Forwarded-Host.
+    const directDev = await harness.app.request(
+      "http://100.64.158.8:3334/api/v1/plugins/wire/http/hello",
+      { headers: { origin: "http://100.64.158.8:5173" } },
+    );
+    expect(directDev.status).toBe(200);
+
+    const proxiedDev = await harness.app.request(
+      `${BASE}/api/v1/plugins/wire/http/hello`,
+      {
+        headers: {
+          origin: "http://100.64.158.8:5173",
+          "x-forwarded-host": "100.64.158.8:5173",
+        },
+      },
+    );
+    expect(proxiedDev.status).toBe(200);
   });
 
   it("local auth requires application/json on non-GET requests", async () => {
@@ -204,6 +227,53 @@ describe("plugin wire surfaces (http/rpc dispatcher + realtime)", () => {
     );
     expect(json.status).toBe(200);
     expect(await json.json()).toEqual({ echoed: { a: 1 } });
+  });
+
+  it("guards plugin install while preserving missing-Origin JSON clients", async () => {
+    const install = vi
+      .spyOn(harness.pluginService, "install")
+      .mockRejectedValue(new Error("install sentinel"));
+    const body = JSON.stringify({ source: "npm:attacker-plugin@1.0.0" });
+
+    const hostile = await harness.app.request(
+      `${BASE}/api/v1/plugins/install`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: EVIL_ORIGIN,
+        },
+        body,
+      },
+    );
+    expect(hostile.status).toBe(403);
+    expect(install).not.toHaveBeenCalled();
+
+    const simpleRequest = await harness.app.request(
+      `${BASE}/api/v1/plugins/install`,
+      {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body,
+      },
+    );
+    expect(simpleRequest.status).toBe(415);
+    expect(install).not.toHaveBeenCalled();
+
+    const nodeClient = await harness.app.request(
+      `${BASE}/api/v1/plugins/install`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    );
+    expect(nodeClient.status).toBe(422);
+    expect(await nodeClient.json()).toEqual({
+      ok: false,
+      error: "install sentinel",
+    });
+    expect(install).toHaveBeenCalledOnce();
   });
 
   it("token auth: 401 without the token, works with header or query, rotate invalidates", async () => {


### PR DESCRIPTION
## Summary

- add a shared browser request guard with strict `Origin` validation
- protect browser WebSocket handshakes, plugin installation, and file mutation routes
- require `application/json` on privileged mutation endpoints
- preserve origin-less Node SDK, CLI, scripts, and server-to-server clients
- forward the original browser host through the Vite development proxy

## Why

Browser-accessible mutation and WebSocket endpoints trusted requests without validating their browser origin. A hostile web page able to reach a BB server could therefore attempt privileged requests using the user’s browser.

## Compatibility

No server-daemon wire contract changes. `HOST_DAEMON_PROTOCOL_VERSION` remains 66. Missing-`Origin` non-browser clients, same-origin browser traffic, configured app URLs, Vite development, LAN, and Tailscale access remain supported. Internal WebSockets and webhook routes are unchanged.

## Validation

- focused server suite: 3 files and 30 tests passed
- Turbo typecheck passed for `@bb/server` and `@bb/app`
- Turbo build passed for `@bb/server` and `@bb/app`
- live dev-server QA: UI loaded without errors; trusted proxied/direct WebSockets opened; hostile WebSocket origin was rejected
- live route QA: hostile origins returned 403, wrong content types returned 415, and trusted/origin-less requests reached normal validation
- live CLI QA: `bb status` and `bb project list` succeeded

## Security boundary

This is a browser CSRF boundary, not authentication. Origin-less non-browser clients remain allowed for compatibility.

## Stack

Layer 2 of 2, stacked on #904.
