### PR TITLE
Render attachment images in embedded chat surfaces

### DIFF
--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   // while the component is unmounted must appear after a remount.
   timelineRows: [] as Array<{ text: string }>,
   injectedTimelineProps: [] as Array<unknown>,
+  timelineProjectIds: [] as Array<string | undefined>,
 }));
 
 vi.mock("@/components/promptbox/FollowUpPromptBox", () => ({
@@ -77,8 +78,12 @@ vi.mock("@/components/ui/overflow-fade", () => ({
 
 vi.mock("@/components/thread/timeline", () => ({
   isRunningThreadRuntimeDisplayStatus: (status: string) => status === "active",
-  ThreadTimelinePanelContent: (props: { timeline?: unknown }) => {
+  ThreadTimelinePanelContent: (props: {
+    timeline?: unknown;
+    projectId?: string;
+  }) => {
     mocks.injectedTimelineProps.push(props.timeline);
+    mocks.timelineProjectIds.push(props.projectId);
     return (
       <div>
         {mocks.timelineRows.map((row, index) => (
@@ -268,9 +273,17 @@ describe("EmbeddedThreadChat", () => {
     mocks.threadRuntimeDisplayStatus = "idle";
     mocks.timelineRows = [];
     mocks.injectedTimelineProps = [];
+    mocks.timelineProjectIds = [];
   });
   afterEach(() => {
     cleanup();
+  });
+
+  it("forwards the project to the timeline so attachment images resolve to API URLs", () => {
+    // Without it, uploaded attachment paths stay relative and the browser
+    // resolves them against the current route (e.g. /plugins/<id>/...).
+    renderEmbeddedChat();
+    expect(mocks.timelineProjectIds.at(-1)).toBe("proj-1");
   });
 
   it("restores the draft and a stream that advanced while unmounted on remount", () => {

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -1321,6 +1321,7 @@ function EmbeddedThreadChatWithComposer({
         onSendToMainMessage={onSendToMainMessage}
         onMessageAddToChat={handleAddToChat}
         onSelectionAddToChat={handleAddToChat}
+        projectId={projectId}
         provisioningLabel={labels.provisioning}
         rowFilter={rowFilter}
         showLoadOlderRows={showLoadOlderRows}


### PR DESCRIPTION
## Problem

In the Cascade plugin panel (`/plugins/cascade/cascade`), user messages with image attachments render as broken images. The same thread in the normal thread view is fine.

The failing request, captured in the running app:

```
<img src="image-1785446275373-iyvaj2.png">
→ GET http://127.0.0.1:38886/plugins/cascade/image-1785446275373-iyvaj2.png  200 (index.html)
```

The `src` is the raw uploaded-attachment path, resolved by the browser against the current route. The SPA fallback answers with `index.html`, so the image decodes as broken.

## Root cause

`apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx:1315` — `EmbeddedThreadChatWithComposer` renders `ThreadTimelinePanelContent` without forwarding its own (required) `projectId` prop. `projectId` is optional downstream, so nothing caught it.

That prop is what `toUserAttachmentImageSrc` needs (`apps/app/src/lib/user-attachment-images.ts:11`) to build `/api/v1/projects/:id/attachments/content?path=…`. Without it the function falls through to returning `pathOrUrl` unchanged.

This affects every composer-mode embedded surface — the plugin SDK's `ThreadChat` and the side-chat panel. The main thread view goes through `EmbeddedThreadChat`'s `hosted-footer` variant, which passes the full `ThreadTimelineSurfaceProps` (including `projectId`), which is why it renders correctly.

Not a plugin bug; `bb-plugin-cascade` is unchanged.

## Fix

Forward `projectId` to `ThreadTimelinePanelContent`, plus a regression test.

## Verification

A/B on a dev instance from this branch with an uploaded PNG attachment rendered in the Cascade panel:

| | `src` | `naturalWidth` |
|---|---|---|
| before | `testimg-1785446752770-2b04ey.png` | 0 |
| after | `/api/v1/projects/proj_personal/attachments/content?path=testimg-1785446752770-2b04ey.png` | 64 |

`turbo run typecheck --filter=@bb/app` passes; `EmbeddedThreadChat.test.tsx` 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)