### PR TITLE
Keep streaming message prefixes across the in-turn window cut

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -742,26 +742,6 @@ function ensureInTurnWindowWholeItemRows(
     return rows;
   }
 
-  const completedItemIds = new Set<string>();
-  for (const row of rows) {
-    if (row.type === "item/completed" && row.itemId !== null) {
-      completedItemIds.add(row.itemId);
-    }
-  }
-  const bufferedTextItemIds = new Set<string>();
-  for (const row of rows) {
-    if (
-      row.itemId !== null &&
-      itemIdsStartingBeforeWindow.has(row.itemId) &&
-      !completedItemIds.has(row.itemId) &&
-      (row.itemKind === "agentMessage" ||
-        row.itemKind === "plan" ||
-        row.itemKind === "reasoning")
-    ) {
-      bufferedTextItemIds.add(row.itemId);
-    }
-  }
-
   // This window owns these items, so it needs the lifecycle rows that fell
   // below the cut — without them a finished command renders "pending" and
   // carries neither its command line nor its start time. Only the two lifecycle
@@ -778,6 +758,29 @@ function ensureInTurnWindowWholeItemRows(
     maxInlineOutputChars: args.maxInlineOutputChars,
     threadId: args.threadId,
   }).filter((row) => row.sequence < args.sequenceStart);
+
+  const completedItemIds = new Set<string>();
+  for (const row of [...rows, ...backfillRows]) {
+    if (row.type === "item/completed" && row.itemId !== null) {
+      completedItemIds.add(row.itemId);
+    }
+  }
+  // Delta rows are stored with a null itemKind, and an item that started below
+  // the cut has only delta rows inside the window — so the kind must be read
+  // from the backfilled item/started row, never from the in-window rows.
+  const bufferedTextItemIds = new Set<string>();
+  for (const row of backfillRows) {
+    if (
+      row.type === "item/started" &&
+      row.itemId !== null &&
+      !completedItemIds.has(row.itemId) &&
+      (row.itemKind === "agentMessage" ||
+        row.itemKind === "plan" ||
+        row.itemKind === "reasoning")
+    ) {
+      bufferedTextItemIds.add(row.itemId);
+    }
+  }
   const bufferedTextRows = listStoredBufferedTextDeltaRowsByItemIds(db, {
     beforeSequence: args.sequenceStart,
     itemIds: [...bufferedTextItemIds],

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -255,7 +255,10 @@ function seedTurns(
           scope: turnScope(turnId),
           providerThreadId,
           itemId: `${turnId}-item-${streaming}`,
-          itemKind: "commandExecution",
+          // Delta rows are persisted with a null itemKind (see
+          // deriveStoredEventItemFieldsFromSource); seeding a kind here would
+          // exercise a row shape production can never write.
+          itemKind: null,
           data: JSON.stringify({
             threadId: thread.id,
             providerThreadId,
@@ -757,7 +760,7 @@ describe("in-turn windows and items that only stream", () => {
         scope: turnScope(turnId),
         providerThreadId,
         itemId,
-        itemKind: "agentMessage",
+        itemKind: null,
         data: JSON.stringify({
           delta,
           itemId,
@@ -788,7 +791,7 @@ describe("in-turn windows and items that only stream", () => {
         scope: turnScope(turnId),
         providerThreadId,
         itemId,
-        itemKind: "agentMessage",
+        itemKind: null,
         data: JSON.stringify({
           delta,
           itemId,


### PR DESCRIPTION
## The problem

Since #891 bounded timeline cost within long-running turns, the tops of long streaming assistant messages were clipped — the message rendered starting mid-sentence, and the cut point kept advancing as the stream grew (observed live in a real thread whose final message streamed ~28KB across ~5,700 events in one turn).

#894 added a guard meant to carry a still-streaming message's below-the-cut deltas into the owning window, but the guard keyed off `row.itemKind` on the in-window rows. The only in-window rows for a message that began below the budget floor are delta rows, and delta rows are always persisted with `item_kind = NULL` (`deriveStoredEventItemFieldsFromSource`). The guard therefore never fired in production: verified against a live database where all 9,242 `item/agentMessage/delta` rows have a NULL kind.

## The fix

`ensureInTurnWindowWholeItemRows` now reads the item kind from the backfilled `item/started` lifecycle row instead of from in-window rows. The lifecycle backfill is fetched first, and the completed-item check covers backfilled rows too, so an item that completed below the cut is never treated as still streaming.

## Why CI was green

The #894 regression test seeded delta rows with `itemKind: "agentMessage"` through raw `insertEvents` — a row shape the production write path can never produce. The test now seeds deltas with `itemKind: null`, and fails against the previous server code.

The parented-toolCall `itemKind === "toolCall"` checks elsewhere in `timeline.ts` were audited and left alone: they run after whole-item backfill has merged in lifecycle rows, so the kind is available there.

## Testing

- `pnpm exec turbo run test --filter=@bb/server -- --run` on all 7 timeline suites (33 tests pass)
- rewritten regression test confirmed to fail against pre-fix `timeline.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)