### PR TITLE
Make plugin reload re-read edited sources for path installs

### DIFF
--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync, type FSWatcher } from "node:fs";
+import { existsSync, realpathSync, type FSWatcher } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -88,24 +88,53 @@ function registerMutableRootHooks(): void {
     resolve(specifier, context, nextResolve) {
       const resolved = nextResolve(specifier, context);
       if (!resolved.url.startsWith("file:")) return resolved;
+      // A plugin's own files must keep the generation of the parent that
+      // pulled them in, so a later dynamic import from a still-active plugin
+      // cannot mix its modules with those of a newer (or failed) load.
+      const inherited = /[?&]bbPluginLoad=(\d+)/.exec(
+        context.parentURL ?? "",
+      )?.[1];
+      // Longest match wins: a plugin nested inside another plugin's tree owns
+      // its own files, and the outer root must not claim them.
+      let match: { rootUrl: string; generation: number } | undefined;
       for (const [rootUrl, generation] of mutableRootGenerations) {
         if (!resolved.url.startsWith(rootUrl)) continue;
-        const separator = resolved.url.includes("?") ? "&" : "?";
-        return {
-          ...resolved,
-          url: `${resolved.url}${separator}bbPluginLoad=${generation}`,
-          shortCircuit: true,
-        };
+        if (match !== undefined && rootUrl.length <= match.rootUrl.length) {
+          continue;
+        }
+        match = { rootUrl, generation };
       }
-      return resolved;
+      if (match === undefined) return resolved;
+      const separator = resolved.url.includes("?") ? "&" : "?";
+      return {
+        ...resolved,
+        url: `${resolved.url}${separator}bbPluginLoad=${inherited ?? match.generation}`,
+        shortCircuit: true,
+      };
     },
   });
+}
+
+/**
+ * Node canonicalizes ESM files through symbolic links, so the tracked root
+ * must be the real path — otherwise a symlinked install never matches and
+ * reload silently serves cached code.
+ */
+function mutableRootUrl(rootDir: string): string {
+  let canonical = rootDir;
+  try {
+    canonical = realpathSync(rootDir);
+  } catch {
+    // A vanished root fails later with a useful load error; resolve() is a
+    // good enough key until then.
+  }
+  return pathToFileURL(join(canonical, "/")).href;
 }
 
 /** Invalidate a mutable plugin tree so the next import re-reads from disk. */
 function bumpMutableRootGeneration(rootDir: string): void {
   registerMutableRootHooks();
-  const rootUrl = pathToFileURL(join(rootDir, "/")).href;
+  const rootUrl = mutableRootUrl(rootDir);
   mutableRootGenerations.set(
     rootUrl,
     (mutableRootGenerations.get(rootUrl) ?? 0) + 1,
@@ -1008,13 +1037,15 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
         deps.sharedPorts?.replaceDeclarationsForOwner(row.id, declarations);
       },
     });
+    // Mutable trees are edited between loads, so invalidate the previous
+    // generation's URLs before importing (managed git:/npm: artifacts are
+    // immutable after promotion and keep their cached modules). A failed
+    // candidate needs no rollback: the surviving plugin's lazy imports
+    // inherit their own generation from the parent URL.
+    if (row.sourceKind === "path" || row.sourceKind === "builtin") {
+      bumpMutableRootGeneration(row.rootDir);
+    }
     try {
-      // Mutable trees are edited between loads, so invalidate the previous
-      // generation's URLs before importing (managed git:/npm: artifacts are
-      // immutable after promotion and keep their cached modules).
-      if (row.sourceKind === "path" || row.sourceKind === "builtin") {
-        bumpMutableRootGeneration(row.rootDir);
-      }
       // Fresh instance per load: guarantees re-imports see current sources.
       const jiti = createJiti(import.meta.url, {
         moduleCache: false,

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -1,7 +1,8 @@
 import { existsSync, type FSWatcher } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { registerHooks } from "node:module";
 import { performance } from "node:perf_hooks";
 import { createJiti } from "jiti";
 import semver from "semver";
@@ -67,6 +68,49 @@ const pluginSdkAlias: Record<string, string> | undefined = existsSync(
 )
   ? { "@bb/plugin-sdk": pluginSdkRuntimePath }
   : undefined;
+
+/**
+ * Per-root reload generation for mutable (path:/source-builtin) plugin trees.
+ * `jiti.import` hands a `"type": "module"` entry to native `import()`, and
+ * Node's ESM registry keys modules by resolved URL forever — so a re-import
+ * after an edit returns the first-evaluated module and `bb plugin reload`
+ * silently keeps the old code. A resolve hook stamps the current generation
+ * onto every URL inside a mutable plugin root, which makes each reload a
+ * distinct URL for the entry AND every file it imports.
+ */
+const mutableRootGenerations = new Map<string, number>();
+let mutableRootHooksRegistered = false;
+
+function registerMutableRootHooks(): void {
+  if (mutableRootHooksRegistered) return;
+  mutableRootHooksRegistered = true;
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      const resolved = nextResolve(specifier, context);
+      if (!resolved.url.startsWith("file:")) return resolved;
+      for (const [rootUrl, generation] of mutableRootGenerations) {
+        if (!resolved.url.startsWith(rootUrl)) continue;
+        const separator = resolved.url.includes("?") ? "&" : "?";
+        return {
+          ...resolved,
+          url: `${resolved.url}${separator}bbPluginLoad=${generation}`,
+          shortCircuit: true,
+        };
+      }
+      return resolved;
+    },
+  });
+}
+
+/** Invalidate a mutable plugin tree so the next import re-reads from disk. */
+function bumpMutableRootGeneration(rootDir: string): void {
+  registerMutableRootHooks();
+  const rootUrl = pathToFileURL(join(rootDir, "/")).href;
+  mutableRootGenerations.set(
+    rootUrl,
+    (mutableRootGenerations.get(rootUrl) ?? 0) + 1,
+  );
+}
 
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
 const DEFAULT_SERVICE_STOP_TIMEOUT_MS = 5_000;
@@ -965,6 +1009,12 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       },
     });
     try {
+      // Mutable trees are edited between loads, so invalidate the previous
+      // generation's URLs before importing (managed git:/npm: artifacts are
+      // immutable after promotion and keep their cached modules).
+      if (row.sourceKind === "path" || row.sourceKind === "builtin") {
+        bumpMutableRootGeneration(row.rootDir);
+      }
       // Fresh instance per load: guarantees re-imports see current sources.
       const jiti = createJiti(import.meta.url, {
         moduleCache: false,

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -2,7 +2,7 @@ import { existsSync, realpathSync, type FSWatcher } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { registerHooks } from "node:module";
+import { createRequire, registerHooks } from "node:module";
 import { performance } from "node:perf_hooks";
 import { createJiti } from "jiti";
 import semver from "semver";
@@ -78,7 +78,18 @@ const pluginSdkAlias: Record<string, string> | undefined = existsSync(
  * onto every URL inside a mutable plugin root, which makes each reload a
  * distinct URL for the entry AND every file it imports.
  */
-const mutableRootGenerations = new Map<string, number>();
+interface MutableRoot {
+  /** Stable while the root stays registered; never reused after removal. */
+  id: number;
+  /** Process-wide unique load epoch, so a re-registered root cannot collide. */
+  epoch: number;
+}
+
+const mutableRoots = new Map<string, MutableRoot>();
+/** Marker shape: `<root id>.<epoch>`. */
+const MUTABLE_ROOT_MARKER = /[?&]bbPluginLoad=(\d+)\.(\d+)/;
+let nextMutableRootId = 1;
+let nextMutableRootEpoch = 1;
 let mutableRootHooksRegistered = false;
 
 function registerMutableRootHooks(): void {
@@ -87,28 +98,33 @@ function registerMutableRootHooks(): void {
   registerHooks({
     resolve(specifier, context, nextResolve) {
       const resolved = nextResolve(specifier, context);
+      if (mutableRoots.size === 0) return resolved;
       if (!resolved.url.startsWith("file:")) return resolved;
-      // A plugin's own files must keep the generation of the parent that
-      // pulled them in, so a later dynamic import from a still-active plugin
-      // cannot mix its modules with those of a newer (or failed) load.
-      const inherited = /[?&]bbPluginLoad=(\d+)/.exec(
-        context.parentURL ?? "",
-      )?.[1];
       // Longest match wins: a plugin nested inside another plugin's tree owns
       // its own files, and the outer root must not claim them.
-      let match: { rootUrl: string; generation: number } | undefined;
-      for (const [rootUrl, generation] of mutableRootGenerations) {
+      let match: MutableRoot | undefined;
+      let matchedLength = 0;
+      for (const [rootUrl, root] of mutableRoots) {
+        if (rootUrl.length <= matchedLength) continue;
         if (!resolved.url.startsWith(rootUrl)) continue;
-        if (match !== undefined && rootUrl.length <= match.rootUrl.length) {
-          continue;
-        }
-        match = { rootUrl, generation };
+        match = root;
+        matchedLength = rootUrl.length;
       }
       if (match === undefined) return resolved;
+      // A plugin's own files keep the epoch of the parent that pulled them in,
+      // so a later dynamic import from a still-active plugin cannot mix its
+      // modules with those of a newer (or failed) load. The marker carries the
+      // root id too: an import that crosses into a different plugin's tree
+      // must take that plugin's epoch, not the importer's.
+      const parent = MUTABLE_ROOT_MARKER.exec(context.parentURL ?? "");
+      const epoch =
+        parent !== null && Number(parent[1]) === match.id
+          ? parent[2]
+          : match.epoch;
       const separator = resolved.url.includes("?") ? "&" : "?";
       return {
         ...resolved,
-        url: `${resolved.url}${separator}bbPluginLoad=${inherited ?? match.generation}`,
+        url: `${resolved.url}${separator}bbPluginLoad=${match.id}.${epoch}`,
         shortCircuit: true,
       };
     },
@@ -120,25 +136,54 @@ function registerMutableRootHooks(): void {
  * must be the real path — otherwise a symlinked install never matches and
  * reload silently serves cached code.
  */
-function mutableRootUrl(rootDir: string): string {
-  let canonical = rootDir;
+function mutableRootDir(rootDir: string): string {
   try {
-    canonical = realpathSync(rootDir);
+    return realpathSync(rootDir);
   } catch {
-    // A vanished root fails later with a useful load error; resolve() is a
-    // good enough key until then.
+    // A vanished root fails later with a useful load error; the un-resolved
+    // path is a good enough key until then.
+    return rootDir;
   }
-  return pathToFileURL(join(canonical, "/")).href;
+}
+
+function mutableRootUrl(canonicalDir: string): string {
+  return pathToFileURL(join(canonicalDir, "/")).href;
+}
+
+/**
+ * The URL marker only re-keys ESM modules. Node caches a CommonJS child by
+ * resolved filename and ignores the query, so a `.cjs` file (or anything
+ * reached through `createRequire`) would survive the reload untouched.
+ */
+function purgeCommonJsCache(canonicalDir: string): void {
+  const prefix = join(canonicalDir, "/");
+  const cache = createRequire(import.meta.url).cache;
+  for (const filename of Object.keys(cache)) {
+    if (filename.startsWith(prefix)) delete cache[filename];
+  }
 }
 
 /** Invalidate a mutable plugin tree so the next import re-reads from disk. */
 function bumpMutableRootGeneration(rootDir: string): void {
   registerMutableRootHooks();
-  const rootUrl = mutableRootUrl(rootDir);
-  mutableRootGenerations.set(
-    rootUrl,
-    (mutableRootGenerations.get(rootUrl) ?? 0) + 1,
-  );
+  const canonicalDir = mutableRootDir(rootDir);
+  const rootUrl = mutableRootUrl(canonicalDir);
+  mutableRoots.set(rootUrl, {
+    // A removed-then-reinstalled root takes a fresh id, so its new modules
+    // can never collide with URLs the old registration already evaluated.
+    id: mutableRoots.get(rootUrl)?.id ?? nextMutableRootId++,
+    epoch: nextMutableRootEpoch++,
+  });
+  purgeCommonJsCache(canonicalDir);
+}
+
+/**
+ * Drop a root once its plugin is uninstalled, so the resolve hook does not
+ * keep scanning roots that no longer exist. Reload must NOT call this: the
+ * surviving module graph of a failed reload still resolves against its id.
+ */
+export function forgetMutableRoot(rootDir: string): void {
+  mutableRoots.delete(mutableRootUrl(mutableRootDir(rootDir)));
 }
 
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -90,12 +90,11 @@ const mutableRoots = new Map<string, MutableRoot>();
 const MUTABLE_ROOT_MARKER = /[?&]bbPluginLoad=(\d+)\.(\d+)/;
 let nextMutableRootId = 1;
 let nextMutableRootEpoch = 1;
-let mutableRootHooksRegistered = false;
+let mutableRootHooks: { deregister: () => void } | null = null;
 
 function registerMutableRootHooks(): void {
-  if (mutableRootHooksRegistered) return;
-  mutableRootHooksRegistered = true;
-  registerHooks({
+  if (mutableRootHooks !== null) return;
+  mutableRootHooks = registerHooks({
     resolve(specifier, context, nextResolve) {
       const resolved = nextResolve(specifier, context);
       if (mutableRoots.size === 0) return resolved;
@@ -153,28 +152,50 @@ function mutableRootUrl(canonicalDir: string): string {
 /**
  * The URL marker only re-keys ESM modules. Node caches a CommonJS child by
  * resolved filename and ignores the query, so a `.cjs` file (or anything
- * reached through `createRequire`) would survive the reload untouched.
+ * reached through `createRequire`) would survive the reload untouched. There
+ * is one CommonJS cache per filename and no room for a per-epoch key, so the
+ * evicted entries are returned and restored if the candidate never commits.
  */
-function purgeCommonJsCache(canonicalDir: string): void {
+function evictCommonJsCache(canonicalDir: string): Map<string, NodeModule> {
   const prefix = join(canonicalDir, "/");
   const cache = createRequire(import.meta.url).cache;
+  const evicted = new Map<string, NodeModule>();
   for (const filename of Object.keys(cache)) {
-    if (filename.startsWith(prefix)) delete cache[filename];
+    if (!filename.startsWith(prefix)) continue;
+    const entry = cache[filename];
+    if (entry !== undefined) evicted.set(filename, entry);
+    delete cache[filename];
   }
+  return evicted;
 }
 
-/** Invalidate a mutable plugin tree so the next import re-reads from disk. */
-function bumpMutableRootGeneration(rootDir: string): void {
+/**
+ * Invalidate a mutable plugin tree so the next import re-reads from disk.
+ * Returns a rollback for the candidate that never commits: the retained
+ * plugin keeps its own epoch, so a cross-root import cannot reach the
+ * rejected files, and its CommonJS children are put back as they were.
+ */
+function bumpMutableRootGeneration(rootDir: string): () => void {
   registerMutableRootHooks();
   const canonicalDir = mutableRootDir(rootDir);
   const rootUrl = mutableRootUrl(canonicalDir);
+  const previous = mutableRoots.get(rootUrl);
   mutableRoots.set(rootUrl, {
     // A removed-then-reinstalled root takes a fresh id, so its new modules
     // can never collide with URLs the old registration already evaluated.
-    id: mutableRoots.get(rootUrl)?.id ?? nextMutableRootId++,
+    id: previous?.id ?? nextMutableRootId++,
     epoch: nextMutableRootEpoch++,
   });
-  purgeCommonJsCache(canonicalDir);
+  const evicted = evictCommonJsCache(canonicalDir);
+  return () => {
+    if (previous === undefined) mutableRoots.delete(rootUrl);
+    else mutableRoots.set(rootUrl, previous);
+    const cache = createRequire(import.meta.url).cache;
+    for (const [filename, entry] of evicted) {
+      // Only restore what the failed candidate did not already replace.
+      if (cache[filename] === undefined) cache[filename] = entry;
+    }
+  };
 }
 
 /**
@@ -183,7 +204,19 @@ function bumpMutableRootGeneration(rootDir: string): void {
  * surviving module graph of a failed reload still resolves against its id.
  */
 export function forgetMutableRoot(rootDir: string): void {
-  mutableRoots.delete(mutableRootUrl(mutableRootDir(rootDir)));
+  releaseMutableRoots([mutableRootUrl(mutableRootDir(rootDir))]);
+}
+
+/**
+ * Release roots owned by a stopping runtime and tear the hook down once no
+ * roots remain, so a process that creates many services (tests, restarts)
+ * does not pay for historical roots on every later resolve.
+ */
+function releaseMutableRoots(rootUrls: Iterable<string>): void {
+  for (const rootUrl of rootUrls) mutableRoots.delete(rootUrl);
+  if (mutableRoots.size > 0 || mutableRootHooks === null) return;
+  mutableRootHooks.deregister();
+  mutableRootHooks = null;
 }
 
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
@@ -223,6 +256,8 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
   const REGISTRATION_MUTATION_KEY = "plugin-registration-mutations";
   const disposingPluginIds = new Set<string>();
   const builtinSourceWatchers: FSWatcher[] = [];
+  /** Mutable roots this runtime registered, released when it stops. */
+  const ownedRootUrls = new Set<string>();
 
   function withLifecycleLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const previous = lifecycleChains.get(id) ?? Promise.resolve();
@@ -1084,11 +1119,11 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     });
     // Mutable trees are edited between loads, so invalidate the previous
     // generation's URLs before importing (managed git:/npm: artifacts are
-    // immutable after promotion and keep their cached modules). A failed
-    // candidate needs no rollback: the surviving plugin's lazy imports
-    // inherit their own generation from the parent URL.
+    // immutable after promotion and keep their cached modules).
+    let rollbackGeneration: (() => void) | undefined;
     if (row.sourceKind === "path" || row.sourceKind === "builtin") {
-      bumpMutableRootGeneration(row.rootDir);
+      rollbackGeneration = bumpMutableRootGeneration(row.rootDir);
+      ownedRootUrls.add(mutableRootUrl(mutableRootDir(row.rootDir)));
     }
     try {
       // Fresh instance per load: guarantees re-imports see current sources.
@@ -1114,6 +1149,9 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
         handle.api,
       );
     } catch (error) {
+      // The candidate never commits, so its epoch and its CommonJS evictions
+      // must not outlive it: the retained plugin keeps serving its own files.
+      rollbackGeneration?.();
       for (const database of handle.databaseHandles.splice(0)) {
         try {
           database.close();
@@ -1277,6 +1315,10 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     for (const id of [...loaded.keys()]) {
       await withLifecycleLock(id, () => disposeOne(id));
     }
+    // This runtime is going away, so hand its roots back. The resolve hook is
+    // process-wide and is torn down once the last runtime releases its own.
+    releaseMutableRoots(ownedRootUrls);
+    ownedRootUrls.clear();
   }
 
   function clearRuntimeState(id: string): void {

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -86,7 +86,7 @@ import {
   type RegisterInstalledArgs,
 } from "./managed-plugin-artifacts.js";
 import { createPluginRegistration } from "./plugin-registration.js";
-import { createPluginRuntime } from "./plugin-runtime.js";
+import { createPluginRuntime, forgetMutableRoot } from "./plugin-runtime.js";
 import { createPluginUpdates } from "./plugin-updates.js";
 
 import { pluginUpdateCheckEntrySchema } from "./plugin-service-internal.js";
@@ -1585,6 +1585,9 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             : deleteInstalledPlugin(deps.db, id)
           : false;
         if (removed && row) {
+          // The uninstalled tree is no longer reloadable, so stop the module
+          // resolve hook from scanning it on every later import.
+          forgetMutableRoot(row.rootDir);
           // Configuration goes with the registration (a future same-id plugin
           // must not inherit secrets); kv rows and data.db are plugin data and
           // survive a remove/reinstall cycle. Schedule rows belong to the

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -365,6 +365,62 @@ describe("plugin service", () => {
     expect(await readShared()).toBe("shared2");
   });
 
+  // A candidate that never commits must stay private. Cross-root importers do
+  // not inherit the retained plugin's epoch (they resolve against the imported
+  // root), so without a rollback they would read the rejected files.
+  it("hides a failed reload's sources from a plugin that imports it", async () => {
+    const importerDir = join(workDir, "bb-plugin-fail-importer");
+    const importedDir = join(workDir, "bb-plugin-fail-imported");
+    await writeEsmPlugin(importerDir, "fail-importer");
+    await writeEsmPlugin(importedDir, "fail-imported");
+    await writeEsmSources(importedDir, "failImported", "entry1", "sub1");
+    await writeFile(
+      join(importerDir, "server.js"),
+      `export default function plugin() {
+         globalThis.failImporterRead = async () => {
+           const shared = await import(
+             ${JSON.stringify(join(importedDir, "shared.js"))}
+           );
+           const helper = (await import(
+             ${JSON.stringify(join(importedDir, "helper.cjs"))}
+           )).default;
+           return shared.SHARED + ":" + helper.H;
+         };
+       }\n`,
+    );
+    await writeFile(
+      join(importedDir, "shared.js"),
+      `export const SHARED = "shared1";\n`,
+    );
+    await writeFile(
+      join(importedDir, "helper.cjs"),
+      `module.exports = { H: "cjs1" };\n`,
+    );
+    await service.installPath(importedDir);
+    await service.installPath(importerDir);
+    const globals = globalThis as Record<string, unknown>;
+    const read = globals.failImporterRead as () => Promise<string>;
+    expect(await read()).toBe("shared1:cjs1");
+
+    // Edit every file, then break the entry so the reload cannot commit.
+    await writeFile(
+      join(importedDir, "shared.js"),
+      `export const SHARED = "shared-rejected";\n`,
+    );
+    await writeFile(
+      join(importedDir, "helper.cjs"),
+      `module.exports = { H: "cjs-rejected" };\n`,
+    );
+    await writeFile(join(importedDir, "server.js"), `export default 42;\n`);
+    await service.reload("fail-imported");
+    expect(service.list().find((p) => p.id === "fail-imported")?.status).toBe(
+      "running",
+    );
+
+    // The retained plugin's files must still be the committed ones.
+    expect(await read()).toBe("shared1:cjs1");
+  });
+
   // Node canonicalizes ESM files through symbolic links, so a root tracked as
   // the un-canonicalized install path never matches the module URL.
   it("reload re-reads an ESM plugin installed through a symbolic link", async () => {

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -291,6 +291,80 @@ describe("plugin service", () => {
     expect(globals.esmReloader).toBe("entry2:sub2");
   });
 
+  // The URL marker re-keys ESM modules only. Node caches a CommonJS child by
+  // resolved filename and ignores the query, so both a static `.cjs` import
+  // and a `createRequire()` call must be invalidated another way.
+  it("reload re-reads a plugin's CommonJS children", async () => {
+    const rootDir = join(workDir, "bb-plugin-cjs-child");
+    await writeEsmPlugin(rootDir, "cjs-child");
+    const writeSources = async (value: string): Promise<void> => {
+      await writeFile(
+        join(rootDir, "helper.cjs"),
+        `module.exports = { H: "${value}" };\n`,
+      );
+      await writeFile(
+        join(rootDir, "required.cjs"),
+        `module.exports = { R: "${value}" };\n`,
+      );
+    };
+    await writeFile(
+      join(rootDir, "server.js"),
+      `import { createRequire } from "node:module";
+       import helper from "./helper.cjs";
+       const require = createRequire(import.meta.url);
+       export default function plugin() {
+         globalThis.cjsChild = helper.H + ":" + require("./required.cjs").R;
+       }\n`,
+    );
+    const globals = globalThis as Record<string, unknown>;
+
+    await writeSources("cjs-before");
+    await service.installPath(rootDir);
+    expect(globals.cjsChild).toBe("cjs-before:cjs-before");
+
+    await writeSources("cjs-after");
+    await service.reload("cjs-child");
+    expect(globals.cjsChild).toBe("cjs-after:cjs-after");
+  });
+
+  // The marker carries the root id as well as the epoch. Without the id, an
+  // import that crosses into another plugin's tree would carry the importer's
+  // epoch and pin the imported plugin to a stale module.
+  it("reload of an imported plugin is visible to a plugin that imports it", async () => {
+    const importerDir = join(workDir, "bb-plugin-importer");
+    const importedDir = join(workDir, "bb-plugin-imported");
+    await writeEsmPlugin(importerDir, "importer");
+    await writeEsmPlugin(importedDir, "imported");
+    await writeEsmSources(importedDir, "imported", "entry1", "sub1");
+    await writeFile(
+      join(importerDir, "server.js"),
+      `export default function plugin() {
+         globalThis.importerReadShared = async () =>
+           (await import(${JSON.stringify(join(importedDir, "shared.js"))})).SHARED;
+       }\n`,
+    );
+    await writeFile(
+      join(importedDir, "shared.js"),
+      `export const SHARED = "shared1";\n`,
+    );
+    await service.installPath(importedDir);
+    await service.installPath(importerDir);
+    const globals = globalThis as Record<string, unknown>;
+    const readShared = globals.importerReadShared as () => Promise<string>;
+    expect(await readShared()).toBe("shared1");
+
+    // Reload only the imported plugin; the importer keeps running.
+    await writeFile(
+      join(importedDir, "shared.js"),
+      `export const SHARED = "shared2";\n`,
+    );
+    await writeEsmSources(importedDir, "imported", "entry2", "sub2");
+    await service.reload("imported");
+    expect(globals.imported).toBe("entry2:sub2");
+    // The importer's next cross-root import must see the reloaded plugin.
+    expect(await readShared()).toBe("shared2");
+  });
+
   // Node canonicalizes ESM files through symbolic links, so a root tracked as
   // the un-canonicalized install path never matches the module URL.
   it("reload re-reads an ESM plugin installed through a symbolic link", async () => {

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,6 +42,49 @@ async function writePlugin(
   );
   await writeFile(join(rootDir, "server.ts"), options.serverSource);
   return rootDir;
+}
+
+/**
+ * A fixture shaped like a real published plugin: `"type": "module"` plus a
+ * plain `.js` entry, which jiti hands to native `import()`. The TypeScript
+ * fixture above never reaches that path because jiti always transpiles TS.
+ */
+async function writeEsmPlugin(rootDir: string, id: string): Promise<void> {
+  await mkdir(rootDir, { recursive: true });
+  await writeFile(
+    join(rootDir, "package.json"),
+    JSON.stringify({
+      name: `bb-plugin-${id}`,
+      version: "0.1.0",
+      type: "module",
+      bb: {
+        name: `${id} fixture`,
+        description: "ESM reload fixture.",
+        branding: { icon: "Zap" },
+        server: "./server.js",
+      },
+    }),
+  );
+}
+
+/** Rewrite an ESM fixture's entry and its submodule with fresh markers. */
+async function writeEsmSources(
+  rootDir: string,
+  globalName: string,
+  entry: string,
+  sub: string,
+): Promise<void> {
+  await writeFile(
+    join(rootDir, "marker.js"),
+    `export const MARKER = "${sub}";\n`,
+  );
+  await writeFile(
+    join(rootDir, "server.js"),
+    `import { MARKER } from "./marker.js";
+     export default function plugin() {
+       globalThis.${globalName} = "${entry}:" + MARKER;
+     }\n`,
+  );
 }
 
 describe("plugin service", () => {
@@ -232,44 +275,96 @@ describe("plugin service", () => {
   // the entry, so both are asserted.
   it("reload re-reads an ESM plugin's entry and its submodules", async () => {
     const rootDir = join(workDir, "bb-plugin-esm-reloader");
-    await mkdir(rootDir, { recursive: true });
-    await writeFile(
-      join(rootDir, "package.json"),
-      JSON.stringify({
-        name: "bb-plugin-esm-reloader",
-        version: "0.1.0",
-        type: "module",
-        bb: {
-          name: "ESM reload fixture",
-          description: "ESM reload fixture.",
-          branding: { icon: "Zap" },
-          server: "./server.js",
-        },
-      }),
-    );
-    const writeSources = async (entry: string, sub: string): Promise<void> => {
-      await writeFile(join(rootDir, "marker.js"), `export const MARKER = "${sub}";\n`);
-      await writeFile(
-        join(rootDir, "server.js"),
-        `import { MARKER } from "./marker.js";
-         export default function plugin() {
-           globalThis.__esmReloader = "${entry}:" + MARKER;
-         }\n`,
-      );
-    };
+    await writeEsmPlugin(rootDir, "esm-reloader");
     const globals = globalThis as Record<string, unknown>;
 
-    await writeSources("entry1", "sub1");
+    await writeEsmSources(rootDir, "esmReloader", "entry1", "sub1");
     await service.installPath(rootDir);
-    expect(globals.__esmReloader).toBe("entry1:sub1");
+    expect(globals.esmReloader).toBe("entry1:sub1");
 
-    await writeSources("entry2", "sub1");
+    await writeEsmSources(rootDir, "esmReloader", "entry2", "sub1");
     await service.reload("esm-reloader");
-    expect(globals.__esmReloader).toBe("entry2:sub1");
+    expect(globals.esmReloader).toBe("entry2:sub1");
 
-    await writeSources("entry2", "sub2");
+    await writeEsmSources(rootDir, "esmReloader", "entry2", "sub2");
     await service.reload("esm-reloader");
-    expect(globals.__esmReloader).toBe("entry2:sub2");
+    expect(globals.esmReloader).toBe("entry2:sub2");
+  });
+
+  // Node canonicalizes ESM files through symbolic links, so a root tracked as
+  // the un-canonicalized install path never matches the module URL.
+  it("reload re-reads an ESM plugin installed through a symbolic link", async () => {
+    const realDir = join(workDir, "real-symlinked");
+    const linkDir = join(workDir, "link-symlinked");
+    await writeEsmPlugin(realDir, "symlinked");
+    await symlink(realDir, linkDir);
+    const globals = globalThis as Record<string, unknown>;
+
+    await writeEsmSources(realDir, "symlinked", "entry1", "sub1");
+    await service.installPath(linkDir);
+    expect(globals.symlinked).toBe("entry1:sub1");
+
+    await writeEsmSources(realDir, "symlinked", "entry2", "sub2");
+    await service.reload("symlinked");
+    expect(globals.symlinked).toBe("entry2:sub2");
+  });
+
+  // An outer plugin's root is a prefix of the nested plugin's root, so a
+  // first-match lookup would stamp the outer generation onto the inner files
+  // and reload the nested plugin to cached code.
+  it("reload of a plugin nested inside another plugin's tree re-reads sources", async () => {
+    const outerDir = join(workDir, "outer-host");
+    const nestedDir = join(outerDir, "vendor", "nested-guest");
+    await writeEsmPlugin(outerDir, "outer-host");
+    await writeEsmPlugin(nestedDir, "nested-guest");
+    const globals = globalThis as Record<string, unknown>;
+
+    await writeEsmSources(outerDir, "outerHost", "entry1", "sub1");
+    await writeEsmSources(nestedDir, "nestedGuest", "entry1", "sub1");
+    await service.installPath(outerDir);
+    await service.installPath(nestedDir);
+    expect(globals.nestedGuest).toBe("entry1:sub1");
+
+    await writeEsmSources(nestedDir, "nestedGuest", "entry2", "sub2");
+    await service.reload("nested-guest");
+    expect(globals.nestedGuest).toBe("entry2:sub2");
+  });
+
+  // A plugin's lazy imports must resolve against the generation it was loaded
+  // under, not whatever generation the root has reached since. Otherwise a
+  // surviving plugin mixes its own modules with those of a newer — or failed —
+  // load.
+  it("keeps a live plugin's lazy imports coherent after a failed reload", async () => {
+    const rootDir = join(workDir, "bb-plugin-rollback");
+    await writeEsmPlugin(rootDir, "rollbacker");
+    await writeFile(join(rootDir, "lazy.js"), `export const LAZY = "lazy1";\n`);
+    await writeFile(
+      join(rootDir, "server.js"),
+      `import { MARKER } from "./marker.js";
+       export default function plugin() {
+         globalThis.rollbacker = "entry1:" + MARKER;
+         globalThis.rollbackerLoadLazy = async () =>
+           (await import("./lazy.js")).LAZY;
+       }\n`,
+    );
+    await writeFile(
+      join(rootDir, "marker.js"),
+      `export const MARKER = "sub1";\n`,
+    );
+    await service.installPath(rootDir);
+    const globals = globalThis as Record<string, unknown>;
+    const loadLazy = globals.rollbackerLoadLazy as () => Promise<string>;
+    expect(await loadLazy()).toBe("lazy1");
+
+    // Break the entry so the candidate load fails and the old plugin survives.
+    await writeFile(join(rootDir, "server.js"), `export default 42;\n`);
+    await writeFile(join(rootDir, "lazy.js"), `export const LAZY = "lazy2";\n`);
+    await service.reload("rollbacker");
+    expect(service.list().find((p) => p.id === "rollbacker")?.status).toBe(
+      "running",
+    );
+    // The surviving plugin still sees its own generation, not the failed one.
+    expect(await loadLazy()).toBe("lazy1");
   });
 
   it("stale API handles throw after reload", async () => {

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -224,6 +224,54 @@ describe("plugin service", () => {
     );
   });
 
+  // The fixture above writes TypeScript, which jiti always transpiles, so it
+  // never exercises the path real plugins take: every published plugin ships
+  // `"type": "module"` with plain `.js`, which jiti hands to native import().
+  // Node's ESM registry then keys the module by URL forever, so reload used to
+  // re-run the first-evaluated factory. Submodules regressed separately from
+  // the entry, so both are asserted.
+  it("reload re-reads an ESM plugin's entry and its submodules", async () => {
+    const rootDir = join(workDir, "bb-plugin-esm-reloader");
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(
+      join(rootDir, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-esm-reloader",
+        version: "0.1.0",
+        type: "module",
+        bb: {
+          name: "ESM reload fixture",
+          description: "ESM reload fixture.",
+          branding: { icon: "Zap" },
+          server: "./server.js",
+        },
+      }),
+    );
+    const writeSources = async (entry: string, sub: string): Promise<void> => {
+      await writeFile(join(rootDir, "marker.js"), `export const MARKER = "${sub}";\n`);
+      await writeFile(
+        join(rootDir, "server.js"),
+        `import { MARKER } from "./marker.js";
+         export default function plugin() {
+           globalThis.__esmReloader = "${entry}:" + MARKER;
+         }\n`,
+      );
+    };
+    const globals = globalThis as Record<string, unknown>;
+
+    await writeSources("entry1", "sub1");
+    await service.installPath(rootDir);
+    expect(globals.__esmReloader).toBe("entry1:sub1");
+
+    await writeSources("entry2", "sub1");
+    await service.reload("esm-reloader");
+    expect(globals.__esmReloader).toBe("entry2:sub1");
+
+    await writeSources("entry2", "sub2");
+    await service.reload("esm-reloader");
+    expect(globals.__esmReloader).toBe("entry2:sub2");
+  });
+
   it("stale API handles throw after reload", async () => {
     const rootDir = await writePlugin(workDir, {
       name: "bb-plugin-staler",


### PR DESCRIPTION
## Problem

`bb plugin reload <id>` (and `bb plugin watch`) did not pick up source edits for a plugin installed from a local path. The loader re-ran the factory, but the factory it re-ran was the one evaluated at first load. A full `bb plugin install` from the same path did not help either.

Path installs are **not** snapshot-copied — `installPathSource` records the original directory as `rootDir`, and `resolveServerEntry` deliberately loads those from source so authors can iterate:

> "Path installs and source-layout builtins ALWAYS load from source, so author iteration via `bb plugin reload` and the builtin dev watcher sees edited files"

So this was a real bug against stated intent, not by-design behavior.

## Cause

`plugin-runtime.ts` loaded the entry with:

```js
// Fresh instance per load: guarantees re-imports see current sources.
const jiti = createJiti(import.meta.url, { moduleCache: false, ... });
const mod = await jiti.import(await resolveServerEntry(row, manifest));
```

That comment was wrong. jiti 2.7.0 only transpiles when:

```js
S = !isCjs && !(isTypeModule && isAsync) && (...)
```

A package with `"type": "module"` imported through `jiti.import` (async) hits `!(true && true)` → no transform → jiti calls native `import()`. Node's ESM registry keys modules by resolved URL permanently, so the second import returns the first module. `moduleCache: false` governs only jiti's own CJS cache, and a fresh jiti instance does not touch Node's registry.

Every plugin in this repo ships `"type": "module"` (all 7 `examples/plugins/*`, all 4 `official-plugins/*`), so this affected effectively every path-installed plugin.

## Fix

Register a `module.registerHooks` resolve hook that stamps a per-root reload generation onto every file URL inside a mutable plugin root. Each reload becomes a distinct URL for the entry **and** every file it imports, so submodule edits land too. Managed `git:`/`npm:` artifacts are immutable after promotion and are left alone.

Two smaller fixes were tried and rejected:
- a cache-busting query passed to `jiti.import` — jiti strips the query; three imports with distinct queries all returned the first value.
- `jiti.evalModule(..., { forceTranspile: true })` — fixes the entry file but leaves imported submodules stale.

## Why tests missed it

The existing reload test's fixture writes `server.ts`, and TypeScript always takes jiti's transpile path. The added test mirrors a real plugin (`"type": "module"` plus plain `.js`) and asserts both the entry and a submodule re-read. It fails on main with `expected 'entry1:sub1' to be 'entry2:sub1'`.

## Verification

Against a dev server launched from this worktree, a path-installed plugin edited between reloads:

Before — three consecutive loads (install, reinstall, reload) all ran the first version, whose string no longer existed on disk:
```
[reload-repro] FACTORY RAN, marker=MARKER_V1
[reload-repro] FACTORY RAN, marker=MARKER_V1
[reload-repro] FACTORY RAN, marker=MARKER_V1
```

After:
```
FACTORY entry=ENTRY_V1 sub=SUB_V1     (initial)
FACTORY entry=ENTRY_V2 sub=SUB_V1     (after entry edit)
FACTORY entry=ENTRY_V2 sub=SUB_V2     (after submodule edit)
```

`turbo run typecheck --filter=@bb/server` passes; 288 plugin tests across 29 files pass.

## Risks

- `module.registerHooks` needs Node >= 22.15. Electron is pinned at 41.7.0, whose Node is well past that, but this was verified under dev Node, not under the packaged Electron server.
- Each reload leaks the previous generation's module objects. That is inherent to ESM reload and matches the pre-existing leak; it is bounded by reload count in a dev loop.
- The hook is process-global and runs on every ESM resolve. It short-circuits only for URLs under a registered mutable plugin root, so server code and managed artifacts are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)