### PR TITLE
Force the host daemon to exit when a shutdown does not

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -137,6 +137,7 @@ export interface CreateHostDaemonAppOptions {
   fetchFn?: FetchFn;
   createWebSocket?: CreateReconnectingWebSocket;
   closeMachineAuthProxy?: () => Promise<void>;
+  forceExit?: (code: number) => void;
 }
 
 export interface HostDaemonApp {
@@ -889,6 +890,7 @@ export async function createHostDaemonApp(
     },
     logger: options.logger,
     releaseLock: options.releaseLock,
+    ...(options.forceExit ? { forceExit: options.forceExit } : {}),
     flushEvents: async () => {
       await eventSink.flush();
     },

--- a/apps/host-daemon/src/daemon.test.ts
+++ b/apps/host-daemon/src/daemon.test.ts
@@ -215,4 +215,54 @@ describe("daemon lifecycle", () => {
       );
     });
   });
+
+  it("forces the process to exit when a shutdown step never finishes", async () => {
+    const logger = createLogger();
+    const forceExit = vi.fn();
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      releaseLock: () => new Promise<void>(() => undefined),
+      forceExit,
+      shutdownExitGraceMs: 10,
+    });
+
+    await daemon.start();
+    void daemon.shutdown("self-update");
+
+    await vi.waitFor(() => {
+      expect(forceExit).toHaveBeenCalledWith(0);
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "self-update" }),
+      "Host daemon shutdown did not end the process; forcing exit so the service manager can restart it.",
+    );
+  });
+
+  it("forces the process to exit when cleanup succeeds but the event loop stays alive", async () => {
+    const logger = createLogger();
+    const forceExit = vi.fn();
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      releaseLock: async () => undefined,
+      forceExit,
+      shutdownExitGraceMs: 10,
+    });
+
+    await daemon.start();
+    await daemon.shutdown("self-update");
+
+    await vi.waitFor(() => {
+      expect(forceExit).toHaveBeenCalledWith(0);
+    });
+  });
 });

--- a/apps/host-daemon/src/daemon.ts
+++ b/apps/host-daemon/src/daemon.ts
@@ -20,6 +20,12 @@ export interface CreateDaemonOptions {
   shutdownRuntimes?: () => Promise<void>;
   onStart?: () => Promise<void>;
   signalSource?: SignalSource;
+  /**
+   * Ends the process when a shutdown does not. Only the real process
+   * entrypoint supplies this; in-process callers such as tests leave it unset.
+   */
+  forceExit?: (code: number) => void;
+  shutdownExitGraceMs?: number;
 }
 
 export interface HostDaemon {
@@ -30,6 +36,22 @@ export interface HostDaemon {
 }
 
 const TERMINATION_SIGNALS: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+
+/**
+ * How long a shutdown may take before the process is ended by force. A restart
+ * after a self-update only happens once the process really exits, so a hung
+ * shutdown step or an undrained event loop must not keep the daemon alive.
+ */
+export const DEFAULT_SHUTDOWN_EXIT_GRACE_MS = 15_000;
+
+function listActiveResources(): string[] {
+  const getActiveResourcesInfo = (
+    process as NodeJS.Process & {
+      getActiveResourcesInfo?: () => string[];
+    }
+  ).getActiveResourcesInfo;
+  return getActiveResourcesInfo ? getActiveResourcesInfo() : [];
+}
 
 export function createDaemon(options: CreateDaemonOptions): HostDaemon {
   let started = false;
@@ -51,10 +73,32 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
     listeners.clear();
   }
 
+  // Unref'd so a drained event loop still ends the process on its own; the
+  // timer only fires when something is still holding the loop open.
+  function armShutdownExitWatchdog(reason: string): void {
+    const forceExit = options.forceExit;
+    if (!forceExit) {
+      return;
+    }
+
+    const graceMs =
+      options.shutdownExitGraceMs ?? DEFAULT_SHUTDOWN_EXIT_GRACE_MS;
+    const timer = setTimeout(() => {
+      options.logger.error(
+        { reason, graceMs, activeResources: listActiveResources() },
+        "Host daemon shutdown did not end the process; forcing exit so the service manager can restart it.",
+      );
+      forceExit(0);
+    }, graceMs);
+    timer.unref?.();
+  }
+
   async function stop(reason: string): Promise<void> {
     if (stopPromise) {
       return stopPromise;
     }
+
+    armShutdownExitWatchdog(reason);
 
     stopPromise = (async () => {
       unregisterSignalHandlers();

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -277,6 +277,9 @@ export async function startHostDaemon(
       fetchFn: options.fetchFn,
       createWebSocket: options.createWebSocket,
       closeMachineAuthProxy: machineAuthProxy?.close,
+      // This function owns the daemon process, so it arms the shutdown
+      // force-exit. A self-update restart depends on the process exiting.
+      forceExit: (code) => process.exit(code),
     });
     const startedApp = app;
     handleDaemonLockLost = () => {


### PR DESCRIPTION
## Summary

A MacBook Air stopped connecting to bb after the server moved to host-daemon protocol 69. The daemon had installed the matching bb-app package and logged `Installed the server-matched bb-app package; restarting the daemon.`, but the process never exited. `launchd` uses `KeepAlive`, so it only restarts the job after the process exits — it saw a live PID and did nothing. The stale process looped on `protocol version 68 does not match 69` for over an hour.

`stop()` memoizes its promise, so the later self-update attempt could not retrigger the restart either. The same failure happened once before, on 2026-07-21.

The restart depends on the event loop draining. Any leftover socket, timer, watcher, or child process keeps the daemon alive forever, and there was no backstop.

## Change

`createDaemon` now arms a force-exit watchdog at the start of `stop()`:

- The timer is **unref'd**, so it does not hold the event loop open. A clean shutdown that drains still exits by itself, exactly as before.
- If the process is still alive after 15 seconds, the watchdog logs the shutdown reason plus `process.getActiveResourcesInfo()`, then calls `process.exit(0)`. The service manager restarts the daemon.
- The timer starts before the cleanup awaits, so it also covers a shutdown step that hangs.

This covers every shutdown path: self-update, signals, session-close, and startup-failure.

`forceExit` is injected. Only `startHostDaemon` supplies `process.exit`, so in-process callers and tests cannot kill the test runner.

The `activeResources` field in the new error log will name the handle kinds that blocked the exit the next time this happens.

## Tests

Two new tests in `daemon.test.ts` cover a hung cleanup step and a successful cleanup that leaves the event loop alive.

- `pnpm exec turbo run test --filter=@bb/host-daemon` — 473 tests pass
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon` — clean

## Notes

No wire format changed, so `HOST_DAEMON_PROTOCOL_VERSION` stays at 69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)