### PR TITLE
Fix new tab sticky header surface

### DIFF
--- a/apps/app/src/components/secondary-panel/launcherRow.tsx
+++ b/apps/app/src/components/secondary-panel/launcherRow.tsx
@@ -104,7 +104,7 @@ export function LauncherSectionHeader({
       className={cn(
         "flex items-baseline gap-2 px-2 pb-2",
         LAUNCHER_SECTION_LABEL_CLASS,
-        sticky && "sticky top-0 z-10 bg-background",
+        sticky && "sticky top-0 z-10 bg-sidebar",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

- match sticky launcher section headers to the side panel surface
- remove the stray white background behind the Recent header
- preserve sticky behavior for populated Files and Recent sections

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force`