### PR TITLE
Give the t3sidebar row one fixed-width status slot

### DIFF
--- a/plugins/t3sidebar/README.md
+++ b/plugins/t3sidebar/README.md
@@ -20,10 +20,17 @@ away under your cursor because an agent finished something.
 
 Three shelves:
 
-- **Inbox** — three-line cards: project, status and age on the first line;
-  title on the second; then branch (or the machine, when a thread has no
-  worktree), activity counts, the pull-request number, and the agent glyph.
-  Pinned threads sit above.
+- **Inbox** — three-line cards: project and one fixed-width status slot on the
+  first line; title on the second; then branch (or the machine, when a thread
+  has no worktree), activity counts, the pull-request number, and the agent
+  glyph. Pinned threads sit above.
+
+  One slot, one marker, one width, so the whole column lines up. The slot
+  shows the status glyph while a thread has something to say, and the age
+  ("now", "7m") once it does not. The glyphs are bb's own: the red circle-x
+  for a failure, the circle-question for a raised hand, the spinner for live
+  work, and a blue notification dot for a thread that finished while you were
+  not looking. Both lists sit in the same window, so they speak one language.
 - **Snoozed** — hidden until a wake time you chose. A snoozed thread comes
   back early if it starts working or asks you something.
 - **Settled** — work you are done with, collapsed to one line each.

--- a/plugins/t3sidebar/src/SlimRow.tsx
+++ b/plugins/t3sidebar/src/SlimRow.tsx
@@ -5,6 +5,7 @@ import {
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { RowContextMenu } from "./RowContextMenu";
+import { STATUS_SLOT_CLASS, StatusOrTime } from "./StatusSlot";
 import { threadDisplayTitle } from "./inbox";
 import { snoozeWakeLabel } from "./lifecycle";
 
@@ -67,19 +68,22 @@ export function SlimRow({
           >
             {title}
           </span>
-          {thread.isUnread ? (
-            <span
-              aria-label="Unread"
-              className="pointer-events-none relative size-[5px] shrink-0 rounded-full bg-muted-foreground/60"
-            />
-          ) : null}
-          {shelf === "snoozed" && wakeAt !== null ? (
-            // A snoozed row shows when it comes BACK, not when it was last
-            // touched: the return ticket is the row's whole story.
-            <span className="pointer-events-none relative shrink-0 tabular-nums text-muted-foreground/60">
-              {snoozeWakeLabel(wakeAt, now)}
-            </span>
-          ) : null}
+          {/* The same slot as a card, so a shelf keeps the card's column. A
+              snoozed row spends it on the wake time: when the thread comes
+              BACK is that shelf's whole question, and it outranks an age the
+              user has already decided to ignore. */}
+          <span
+            className={cn(
+              STATUS_SLOT_CLASS,
+              "pointer-events-none relative tabular-nums text-2xs text-muted-foreground/60",
+            )}
+          >
+            {shelf === "snoozed" && wakeAt !== null ? (
+              snoozeWakeLabel(wakeAt, now)
+            ) : (
+              <StatusOrTime thread={thread} now={now} />
+            )}
+          </span>
           <button
             type="button"
             aria-label={

--- a/plugins/t3sidebar/src/StatusGlyph.tsx
+++ b/plugins/t3sidebar/src/StatusGlyph.tsx
@@ -3,16 +3,48 @@ import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 
 /**
- * This plugin's own status glyphs.
+ * This plugin's status glyphs, matching bb's own sidebar shape for shape: the
+ * red circle-x for a failure, the circle-question for a raised hand, the
+ * spinner for live work, and a dot for a finished thread you have not read.
  *
  * The SDK ships `indicator` as data and no status component on purpose, so a
- * replaced sidebar can choose its own look. These follow bb's convention —
- * colour only for an unread failure, everything else neutral — because bb's
- * own restraint is the part worth keeping.
+ * replaced sidebar can choose its own look. This one deliberately does not:
+ * the two lists sit in the same window, and a user who switches between them
+ * should not have to learn a second vocabulary.
  *
  * An unrecognized indicator draws nothing: bb adds kinds over time, and a
  * plugin built today must not break on a kind shipped tomorrow.
  */
+
+/**
+ * Whether this indicator draws a glyph that speaks for the row.
+ *
+ * The row gives the glyph and the age ONE slot, so this decides which of the
+ * two the user sees. Listed kind by kind rather than "anything but none": an
+ * indicator bb ships tomorrow must fall through to the age label, not blank
+ * the slot.
+ */
+export function hasStatusGlyph(
+  indicator: PluginSidebarThreadIndicator,
+): boolean {
+  switch (indicator) {
+    case "unread-error":
+    case "waiting-for-input":
+    case "unread-success":
+    case "runtime":
+    case "workflow":
+    case "background-agent":
+    case "background-command":
+    case "plan-mode":
+    case "goal":
+    case "draft":
+    case "working-draft":
+      return true;
+    default:
+      return false;
+  }
+}
+
 export function StatusGlyph({
   indicator,
   label,
@@ -62,11 +94,16 @@ export function StatusGlyph({
         <Icon name="Edit" aria-label={aria} className={cn(shared, "text-muted-foreground")} />
       );
     case "unread-success":
+      // The notification dot, in a box the size of every other glyph, the way
+      // bb centers its own trailing indicators. Right-aligned on its own, a
+      // 5px dot would sit ~4px off the column the icons share.
       return (
         <span
           aria-label={aria}
-          className="size-[5px] shrink-0 rounded-full bg-muted-foreground/60"
-        />
+          className={cn("flex items-center justify-center", shared)}
+        >
+          <span className="size-[5px] rounded-full bg-timeline-accent" />
+        </span>
       );
     case "none":
       return null;

--- a/plugins/t3sidebar/src/StatusSlot.tsx
+++ b/plugins/t3sidebar/src/StatusSlot.tsx
@@ -1,0 +1,40 @@
+import type { PluginSidebarThread } from "@bb/plugin-sdk/app";
+import { StatusGlyph, hasStatusGlyph } from "./StatusGlyph";
+import { relativeTimeLabel } from "./relative-time";
+
+/**
+ * The row's trailing slot: one fixed width, right-aligned, on every row.
+ *
+ * Fixed rather than intrinsic because the age label's width follows its text —
+ * "now" is wider than "7m" — and an intrinsic slot drags whatever sits beside
+ * it back and forth, so no two rows agree on a column. The width holds the
+ * widest label this sidebar can produce ("now", "59m", "52w").
+ */
+export const STATUS_SLOT_CLASS = "flex w-7 shrink-0 items-center justify-end";
+
+/**
+ * Status OR age, never both: the glyph already implies the row is current, and
+ * the age only earns its place once the thread has nothing to say.
+ */
+export function StatusOrTime({
+  thread,
+  now,
+}: {
+  thread: PluginSidebarThread;
+  /** Quantized clock, shared by every row in one render. */
+  now: number;
+}) {
+  if (hasStatusGlyph(thread.indicator)) {
+    return (
+      <StatusGlyph
+        indicator={thread.indicator}
+        label={thread.indicatorLabel}
+      />
+    );
+  }
+  return (
+    <span className="tabular-nums text-2xs text-muted-foreground">
+      {relativeTimeLabel(thread.updatedAt, now)}
+    </span>
+  );
+}

--- a/plugins/t3sidebar/src/ThreadCard.tsx
+++ b/plugins/t3sidebar/src/ThreadCard.tsx
@@ -8,8 +8,7 @@ import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { RowContextMenu } from "./RowContextMenu";
 import { ProviderGlyph } from "./ProviderGlyph";
-import { StatusGlyph } from "./StatusGlyph";
-import { relativeTimeLabel } from "./relative-time";
+import { STATUS_SLOT_CLASS, StatusOrTime } from "./StatusSlot";
 import { threadDisplayTitle } from "./inbox";
 import { resolveSnoozePresets } from "./lifecycle";
 
@@ -101,17 +100,11 @@ export function ThreadCard({
             ) : null}
             <span
               className={cn(
-                "flex items-center gap-1.5",
+                STATUS_SLOT_CLASS,
                 canPark && "group-hover/card:hidden",
               )}
             >
-              <StatusGlyph
-                indicator={thread.indicator}
-                label={thread.indicatorLabel}
-              />
-              <span className="tabular-nums text-2xs text-muted-foreground">
-                {relativeTimeLabel(thread.updatedAt, now)}
-              </span>
+              <StatusOrTime thread={thread} now={now} />
             </span>
           </div>
           <div

--- a/plugins/t3sidebar/src/ThreadInbox.test.tsx
+++ b/plugins/t3sidebar/src/ThreadInbox.test.tsx
@@ -419,6 +419,75 @@ describe("card metadata", () => {
     ]);
     expect(await screen.findByText("3h")).toBeDefined();
   });
+
+  // Status and age share one slot. A row that shows both puts a variable-width
+  // label in the column, and no two rows line up.
+  it("replaces the age label with the status glyph while work runs", async () => {
+    render([
+      thread({
+        id: "thr_run",
+        indicator: "runtime",
+        indicatorLabel: "Agent is working",
+        updatedAt: Date.now() - (3 * 3_600_000 + 60_000),
+      }),
+    ]);
+    expect(await screen.findByLabelText("Agent is working")).toBeDefined();
+    expect(screen.queryByText("3h")).toBeNull();
+  });
+
+  // An indicator this plugin does not know must fall through to the age label
+  // rather than leave the slot blank.
+  it("keeps the age label for an unrecognized indicator", async () => {
+    render([
+      thread({
+        id: "thr_new",
+        indicator: "something-bb-ships-later" as never,
+        updatedAt: Date.now() - (3 * 3_600_000 + 60_000),
+      }),
+    ]);
+    expect(await screen.findByText("3h")).toBeDefined();
+  });
+});
+
+// The three states that want the user take the slot from the age label, and
+// they use bb's own glyphs: the two lists sit in one window, and a user who
+// switches between them should not have to learn a second vocabulary.
+describe("attention states", () => {
+  const states = [
+    ["waiting-for-input", "Thread needs user input"],
+    ["unread-error", "Unread thread failed"],
+    ["unread-success", "Unread thread succeeded"],
+  ] as const;
+
+  for (const [indicator, label] of states) {
+    it(`shows the ${indicator} glyph instead of the age`, async () => {
+      render([
+        thread({
+          id: `thr_${indicator}`,
+          indicator,
+          indicatorLabel: label,
+          updatedAt: Date.now() - (3 * 3_600_000 + 60_000),
+        }),
+      ]);
+      expect(await screen.findByLabelText(label)).toBeDefined();
+      expect(screen.queryByText("3h")).toBeNull();
+    });
+  }
+
+  // Running work is the one state the user does NOT have to act on, so it gets
+  // the neutral spinner and no notification dot.
+  it("shows the spinner, not a dot, while work runs", async () => {
+    render([
+      thread({
+        id: "thr_busy",
+        isUnread: true,
+        indicator: "runtime",
+        indicatorLabel: "Thread working",
+      }),
+    ]);
+    expect(await screen.findByLabelText("Thread working")).toBeDefined();
+    expect(screen.queryByLabelText("Unread thread succeeded")).toBeNull();
+  });
 });
 
 describe("pull request badge", () => {


### PR DESCRIPTION
## What

In the t3sidebar plugin, the status glyph and the age label shared a row but not a column. The label's width follows its text, so `now` pushed the glyph further left than `7m` did, and no two rows lined up.

Both now share **one fixed-width, right-aligned slot**, and only one of them shows at a time:

- the status glyph while the thread has something to say,
- the age (`now`, `7m`, `3h`) once it does not.

An indicator this plugin does not recognize falls through to the age label rather than blanking the slot, so a kind bb ships later degrades quietly.

The glyphs stay bb's own — `CircleX` for a failure, `CircleQuestion` for a raised hand, the spinner for live work — so both sidebars speak one language. The `unread-success` dot moves into a glyph-sized box, which centers it on the same axis as the icons the way bb centers its own trailing indicators, and it takes bb's accent blue (`bg-timeline-accent`) instead of the built-in gray.

The parked-shelf rows use the same slot. A snoozed row still spends it on the wake time: when a parked thread comes back is that shelf's whole question.

## Verification

- `pnpm exec turbo run test typecheck --filter=bb-plugin-t3sidebar` — 73 tests pass.
- Ran the dev app with the plugin enabled and real threads in each state. Measured the live DOM: every marker centers on x=296, and the age label's right edge lands on the same 303 the glyphs do.

New tests cover the replacement rule, the unknown-indicator fallback, and each attention state.

## Risks

Plugin-only, behind the Settings → Appearance → Sidebar opt-in. No server, daemon, or protocol surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)