### PR TITLE
Fix thread detail header separator

### DIFF
--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -12,13 +12,15 @@ vi.mock("@/components/layout/AppPageHeader", () => ({
   AppPageHeader: ({
     actions,
     center,
+    className,
     headerRef,
   }: {
     actions?: ReactNode;
     center?: ReactNode;
+    className?: string;
     headerRef?: Ref<HTMLElement>;
   }) => (
-    <header ref={headerRef}>
+    <header ref={headerRef} className={className}>
       {center}
       {actions}
     </header>
@@ -50,6 +52,26 @@ afterEach(() => {
 });
 
 describe("ThreadDetailHeader", () => {
+  it("keeps the thread header visually separated from the timeline", () => {
+    const { container } = render(
+      <PaneContext.Provider value={PANE_CONTEXT}>
+        <ThreadDetailHeader
+          actionsMenu={null}
+          childPillLabel={null}
+          isSecondaryPanelOpen={false}
+          onOpenThreadGitAction={vi.fn()}
+          onToggleSecondaryPanel={vi.fn()}
+          threadHeaderGitActions={[]}
+          threadTitle="Header separator"
+        />
+      </PaneContext.Provider>,
+    );
+
+    const header = container.querySelector("header");
+    expect(header?.classList).toContain("border-b");
+    expect(header?.classList).toContain("border-border-seam-vertical/60");
+  });
+
   it("uses a neutral disclosure state for the right-panel toggle", () => {
     render(
       <PaneContext.Provider value={PANE_CONTEXT}>

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -300,7 +300,10 @@ export function ThreadDetailHeader({
       actions={actions}
       isWindowDragRegion={isTopRow}
       ownsWindowTopLeft={ownsWindowTopLeft}
-      className={cn(beginPaneDrag && "z-[21]")}
+      className={cn(
+        "border-b border-border-seam-vertical/60",
+        beginPaneDrag && "z-[21]",
+      )}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Restore the subtle bottom separator under the thread detail header.
- Add a focused regression test so future header chrome changes do not drop it silently.

## Verification
- pnpm exec turbo run test --filter=@bb/app -- src/views/thread-detail/ThreadDetailHeader.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app