### PR TITLE
Refine Extensions defaults and plugin ordering

### DIFF
--- a/apps/app/src/App.legacy-skill-route.test.tsx
+++ b/apps/app/src/App.legacy-skill-route.test.tsx
@@ -3,9 +3,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { LegacySkillDetailRedirect } from "./App";
+import { ExtensionsLandingRedirect, LegacySkillDetailRedirect } from "./App";
 import {
   LEGACY_TOOLS_SKILL_DETAIL_ROUTE_PATH,
+  TOOLS_PLUGINS_ROUTE_PATH,
+  TOOLS_ROUTE_PATH,
   TOOLS_SKILL_DETAIL_ROUTE_PATH,
 } from "./lib/route-paths";
 
@@ -33,5 +35,25 @@ describe("LegacySkillDetailRedirect", () => {
     );
 
     expect(screen.getByText("/tools/skills/library/skill_abc123")).toBeTruthy();
+  });
+});
+
+describe("ExtensionsLandingRedirect", () => {
+  afterEach(cleanup);
+
+  it("opens Extensions on Plugins by default", () => {
+    render(
+      <MemoryRouter initialEntries={[TOOLS_ROUTE_PATH]}>
+        <Routes>
+          <Route
+            path={TOOLS_ROUTE_PATH}
+            element={<ExtensionsLandingRedirect />}
+          />
+          <Route path={TOOLS_PLUGINS_ROUTE_PATH} element={<LocationPath />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(TOOLS_PLUGINS_ROUTE_PATH)).toBeTruthy();
   });
 });

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -124,6 +124,10 @@ export function LegacySkillDetailRedirect() {
   );
 }
 
+export function ExtensionsLandingRedirect() {
+  return <Navigate to={TOOLS_PLUGINS_ROUTE_PATH} replace />;
+}
+
 function AppRoutes() {
   return (
     <AppLayout>
@@ -197,7 +201,7 @@ function AppRoutes() {
           <Route element={<ToolsExperimentGate />}>
             <Route
               path={TOOLS_ROUTE_PATH}
-              element={<Navigate to={SKILLS_ROUTE_PATH} replace />}
+              element={<ExtensionsLandingRedirect />}
             />
             <Route path={SKILLS_ROUTE_PATH} element={<ToolsView />} />
             <Route

--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -250,6 +250,19 @@ describe("PluginsOverview", () => {
     expect(screen.getByText("Plugin 11")).toBeTruthy();
     expect(screen.queryByText("Plugin 01")).toBeNull();
 
+    fireEvent.click(screen.getByRole("button", { name: "Previous" }));
+    expect(screen.getByText("1–10 of 12")).toBeTruthy();
+    expect(screen.getByText("Plugin 01")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("11–12 of 12")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
+    expect(await screen.findByText("GitHub")).toBeTruthy();
+    fireEvent.click(screen.getByRole("tab", { name: "Installed, 12 plugins" }));
+    expect(screen.getByText("11–12 of 12")).toBeTruthy();
+    expect(screen.getByText("Plugin 11")).toBeTruthy();
+
     fireEvent.change(
       screen.getByRole("textbox", { name: "Search installed plugins" }),
       { target: { value: "Plugin 01" } },
@@ -361,22 +374,39 @@ describe("PluginsOverview", () => {
     }
   });
 
-  it("sorts built-ins first and alphabetically within provenance groups", async () => {
+  it("sorts enabled plugins before inactive plugins and BB Official first within enabled", async () => {
     installFetch([
       {
         ...AUTOMATIONS_PLUGIN,
-        id: "local-zulu",
-        name: "Local Zulu",
-        provenance: "direct",
+        id: "inactive-official",
+        name: "Inactive Official",
+        enabled: false,
+        status: "disabled",
       },
-      { ...AUTOMATIONS_PLUGIN, id: "built-zulu", name: "Built Zulu" },
       {
         ...AUTOMATIONS_PLUGIN,
-        id: "local-alpha",
-        name: "Local Alpha",
+        id: "enabled-local-alpha",
+        name: "Enabled Local",
         provenance: "direct",
       },
-      { ...AUTOMATIONS_PLUGIN, id: "built-alpha", name: "Built Alpha" },
+      {
+        ...AUTOMATIONS_PLUGIN,
+        id: "enabled-official-zulu",
+        name: "Enabled Official Zulu",
+      },
+      {
+        ...AUTOMATIONS_PLUGIN,
+        id: "enabled-official-alpha",
+        name: "Enabled Official Alpha",
+      },
+      {
+        ...AUTOMATIONS_PLUGIN,
+        id: "inactive-local",
+        name: "Inactive Local",
+        enabled: false,
+        status: "disabled",
+        provenance: "direct",
+      },
     ]);
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
@@ -387,16 +417,17 @@ describe("PluginsOverview", () => {
       </MemoryRouter>,
     );
 
-    await screen.findByText("Built Alpha");
+    await screen.findByText("Enabled Official Alpha");
     const rows = [...document.querySelectorAll('[data-testid^="plugin-row-"]')];
     expect(rows.map((row) => row.getAttribute("data-testid"))).toEqual([
-      "plugin-row-built-alpha",
-      "plugin-row-built-zulu",
-      "plugin-row-local-alpha",
-      "plugin-row-local-zulu",
+      "plugin-row-enabled-official-alpha",
+      "plugin-row-enabled-official-zulu",
+      "plugin-row-enabled-local-alpha",
+      "plugin-row-inactive-local",
+      "plugin-row-inactive-official",
     ]);
     const officialPills = screen.getAllByText("BB Official");
-    expect(officialPills).toHaveLength(2);
+    expect(officialPills).toHaveLength(3);
     expect(officialPills[0]?.parentElement?.className).toContain("rounded-md");
     expect(officialPills[0]?.parentElement?.className).toContain(
       "bg-surface-recessed/45",
@@ -407,6 +438,38 @@ describe("PluginsOverview", () => {
     expect(officialPills[0]?.parentElement?.className).toContain("font-medium");
     expect(officialPills[0]?.parentElement?.className).toContain("px-2");
     expect(officialPills[0]?.parentElement?.className).toContain("py-1");
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Sort" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Plugin name" }));
+    expect(
+      [...document.querySelectorAll('[data-testid^="plugin-row-"]')].map(
+        (row) => row.getAttribute("data-testid"),
+      ),
+    ).toEqual([
+      "plugin-row-enabled-official-zulu",
+      "plugin-row-enabled-official-alpha",
+      "plugin-row-enabled-local-alpha",
+      "plugin-row-inactive-official",
+      "plugin-row-inactive-local",
+    ]);
+
+    fireEvent.keyDown(screen.getByRole("menu", { name: "Sort" }), {
+      key: "Escape",
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
+    await screen.findByText("GitHub");
+    fireEvent.click(screen.getByRole("tab", { name: "Installed, 5 plugins" }));
+    expect(
+      [...document.querySelectorAll('[data-testid^="plugin-row-"]')].map(
+        (row) => row.getAttribute("data-testid"),
+      ),
+    ).toEqual([
+      "plugin-row-enabled-official-zulu",
+      "plugin-row-enabled-official-alpha",
+      "plugin-row-enabled-local-alpha",
+      "plugin-row-inactive-official",
+      "plugin-row-inactive-local",
+    ]);
   });
 
   it("consolidates built-in and catalog plugins under BB Official", async () => {

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -92,14 +92,24 @@ export function PluginsOverview() {
             .includes(normalizedInstalledQuery);
         })
         .sort((left, right) => {
-          const provenanceResult =
-            Number(left.provenance !== "builtin") -
-            Number(right.provenance !== "builtin");
-          if (provenanceResult !== 0) return provenanceResult;
+          const enabledResult = Number(!left.enabled) - Number(!right.enabled);
+          if (enabledResult !== 0) return enabledResult;
+          if (left.enabled) {
+            const leftOfficial =
+              left.provenance === "builtin" || left.provenance === "catalog";
+            const rightOfficial =
+              right.provenance === "builtin" || right.provenance === "catalog";
+            const provenanceResult =
+              Number(!leftOfficial) - Number(!rightOfficial);
+            if (provenanceResult !== 0) return provenanceResult;
+          }
           const result = (left.name ?? left.id).localeCompare(
             right.name ?? right.id,
           );
-          return installedSortDirection === "asc" ? result : -result;
+          if (result !== 0) {
+            return installedSortDirection === "asc" ? result : -result;
+          }
+          return left.id.localeCompare(right.id);
         }),
     [installedSortDirection, normalizedInstalledQuery, plugins],
   );

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.tsx
@@ -119,7 +119,7 @@ export function BrowserTabDeck({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col bg-sidebar">
       <BrowserTabContent
         key={activeBrowserTab.id}
         tabId={activeBrowserTab.id}

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -631,10 +631,10 @@ function FilePreviewHeader({
   const copyFileContentsLabel = getFileContentsCopyLabel(toggleKind);
 
   return (
-    // The wrapper carries an opaque `bg-background` base so the translucent
+    // The wrapper carries an opaque panel-surface base so the translucent
     // `bg-surface-recessed` tint on the bar composites to a solid tone — without
     // it, body content scrolling under the sticky header would bleed through.
-    <div className="sticky top-0 z-10 bg-background">
+    <div className="sticky top-0 z-10 bg-sidebar">
       <div className="flex h-9 items-center gap-2 bg-surface-raised px-4">
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <Icon

--- a/apps/app/src/components/secondary-panel/NewTabPage.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NewTabPage } from "./NewTabPage";
+
+vi.mock("./NewTabFileSearch", () => ({
+  NewTabActions: () => null,
+  NewTabFileSearch: () => <div data-testid="new-tab-file-search" />,
+}));
+
+afterEach(cleanup);
+
+describe("NewTabPage", () => {
+  it("uses the themeable sidebar surface on the new-thread panel", () => {
+    const { container } = render(
+      <NewTabPage
+        currentThreadId=""
+        environmentId={null}
+        focusRequest={0}
+        onSelect={() => undefined}
+        projectId={undefined}
+      />,
+    );
+
+    expect(container.firstElementChild?.classList.contains("bg-sidebar")).toBe(
+      true,
+    );
+  });
+});

--- a/apps/app/src/components/secondary-panel/NewTabPage.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.tsx
@@ -35,7 +35,7 @@ export function NewTabPage({
   showFileSearch,
 }: NewTabPageProps) {
   return (
-    <div className="flex min-h-full flex-col gap-3 px-4 pb-3 pt-1">
+    <div className="flex min-h-full flex-col gap-3 bg-sidebar px-4 pb-3 pt-1">
       <NewTabFileSearch
         projectId={projectId}
         environmentId={environmentId}

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTabStripChevronGradientClass,
+  getTabStripChevronVisibilityClass,
+  SECONDARY_PANEL_TAB_STRIP_FADE_TONE,
+} from "./SecondaryPanelTabStrip";
+
+describe("secondary panel tab-strip edge fades", () => {
+  it("fades both edge layers into the themeable sidebar surface", () => {
+    expect(SECONDARY_PANEL_TAB_STRIP_FADE_TONE).toBe("sidebar");
+    expect(getTabStripChevronGradientClass("left")).toContain("to-sidebar");
+    expect(getTabStripChevronGradientClass("right")).toContain("to-sidebar");
+  });
+
+  it("keeps an available scroll control visible without requiring hover", () => {
+    const visibleClass = getTabStripChevronVisibilityClass(true);
+
+    expect(visibleClass).toContain("pointer-events-auto");
+    expect(visibleClass).toContain("opacity-100");
+    expect(visibleClass).not.toContain("hover:");
+    expect(getTabStripChevronVisibilityClass(false)).toBe(
+      "pointer-events-none opacity-0",
+    );
+  });
+});

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -30,7 +30,10 @@ import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@bb/shared-ui/button";
 import { COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { Icon } from "@bb/shared-ui/icon";
-import { OverflowFade } from "@/components/ui/overflow-fade";
+import {
+  OverflowFade,
+  type OverflowFadeTone,
+} from "@/components/ui/overflow-fade";
 import { TabPill } from "@/components/ui/tab-pill";
 import { useDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -51,6 +54,22 @@ const CHEVRON_SCROLL_STEP_PX = 140;
 // Slack so sub-pixel scroll offsets don't leave a fade/chevron stuck on at a
 // hard edge.
 const EDGE_EPSILON_PX = 1;
+
+export const SECONDARY_PANEL_TAB_STRIP_FADE_TONE: OverflowFadeTone = "sidebar";
+
+export function getTabStripChevronGradientClass(
+  direction: "left" | "right",
+): string {
+  return direction === "left"
+    ? "left-0 justify-start bg-gradient-to-l from-transparent to-sidebar"
+    : "right-0 justify-end bg-gradient-to-r from-transparent to-sidebar";
+}
+
+export function getTabStripChevronVisibilityClass(canScroll: boolean): string {
+  return canScroll
+    ? "pointer-events-auto opacity-100"
+    : "pointer-events-none opacity-0";
+}
 
 interface TabStripOverflowState {
   /** Scrolled away from the left edge (content hidden to the left). */
@@ -385,6 +404,7 @@ export function SecondaryPanelTabStrip({
           layout every edge crossing, which at narrow widths is constant. */}
       <OverflowFade
         placement="left"
+        tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
         className={cn(
           "z-10 transition-opacity",
           overflow.canScrollLeft ? "opacity-100" : "opacity-0",
@@ -392,6 +412,7 @@ export function SecondaryPanelTabStrip({
       />
       <OverflowFade
         placement="right"
+        tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
         className={cn(
           "z-10 transition-opacity",
           overflow.canScrollRight ? "opacity-100" : "opacity-0",
@@ -519,18 +540,16 @@ function TabStripScrollChevron({
         // edge of the fade and clears the central tabs — rather than nudging the
         // button itself outward, which a clipping ancestor would cut off.
         "absolute z-50 shrink-0 text-muted-foreground hover:bg-transparent focus-visible:bg-transparent",
-        direction === "left"
-          ? "left-0 justify-start bg-gradient-to-l from-transparent to-background"
-          : "right-0 justify-end bg-gradient-to-r from-transparent to-background",
+        getTabStripChevronGradientClass(direction),
         COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
         // Always mounted (so reaching an edge toggles opacity rather than
-        // committing/removing DOM mid-scroll), revealed only while the strip is
-        // hovered/focused AND there is actually more to scroll in this direction.
-        // `pointer-events` follow visibility so a hidden chevron never intercepts
-        // clicks meant for the tab beneath it.
-        "pointer-events-none opacity-0 transition-opacity",
-        canScroll &&
-          "group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100",
+        // committing/removing DOM mid-scroll) and always visible whenever there
+        // is more content in that direction. Keeping discovery independent of
+        // browser hover capability also makes the control reliable for pen and
+        // touch users. `pointer-events` follow visibility so an inert chevron
+        // never intercepts clicks meant for the tab beneath it.
+        "transition-opacity",
+        getTabStripChevronVisibilityClass(canScroll),
         className,
       )}
     >

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { PanelGroup } from "react-resizable-panels";
 import {
   ThreadSecondaryPanel,
   type SecondaryPanelFileTab,
@@ -18,8 +19,19 @@ import {
   type HostFilePreviewFixedPanelTab,
   type SecondaryFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
+import type { WorkspaceFile } from "@bb/server-contract";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
+import {
+  ThreadMetadataContent,
+  type ThreadMetadataContentProps,
+} from "./ThreadMetadataContent";
+import {
+  baseProps as baseMetadataProps,
+  makePullRequest,
+  makeWorkspaceStatus,
+} from "./ThreadMetadataContent.fixtures";
 import { resolveRightPanelFileVisual } from "./rightPanelFileVisuals";
+import { useThreadStorageBrowser } from "./useThreadStorageBrowser";
 
 export default {
   title: "right-panel/Tabbed shell",
@@ -47,19 +59,32 @@ function createStoryFileTab(filename: string): HostFilePreviewFixedPanelTab {
   };
 }
 
-// The right panel renders inside a flex column; give it explicit height so the
-// inner scroll regions get something to fill.
-function PanelStage({ children }: { children: ReactNode }) {
+// The shell is inline, matching the desktop surface without introducing the
+// drawer-only close button or the conversation-collapse affordance.
+function PanelStage({
+  children,
+  height = "compact",
+}: {
+  children: ReactNode;
+  height?: "compact" | "info";
+}) {
   return (
-    <div className="flex h-[160px] w-full max-w-[640px] min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background">
-      {children}
+    <div
+      className={`flex w-full max-w-[640px] min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background ${
+        height === "info" ? "h-[520px]" : "h-[160px]"
+      }`}
+    >
+      <PanelGroup direction="horizontal">{children}</PanelGroup>
     </div>
   );
 }
 
 interface PanelHarnessProps {
   initialPanel: ThreadSecondaryPanelTab;
-  children: (panel: ThreadSecondaryPanelTab) => ReactNode;
+  children: (
+    panel: ThreadSecondaryPanelTab,
+    setPanel: (panel: ThreadSecondaryPanelTab) => void,
+  ) => ReactNode;
 }
 
 function PanelHarness({ initialPanel, children }: PanelHarnessProps) {
@@ -67,14 +92,106 @@ function PanelHarness({ initialPanel, children }: PanelHarnessProps) {
   useEffect(() => {
     setPanel(initialPanel);
   }, [initialPanel]);
-  return children(panel);
+  return children(panel, setPanel);
 }
 
-const placeholderInfoContent = (
-  <div className="space-y-2 pt-1 text-sm text-muted-foreground">
-    <p>Info tab content (see "right-panel/Info" story for variants).</p>
-  </div>
-);
+const INFO_STORAGE_FILES: readonly WorkspaceFile[] = [
+  { path: "plans/sidebar-surface-qa.md", name: "sidebar-surface-qa.md" },
+  { path: "reports/visual-regression.md", name: "visual-regression.md" },
+  { path: "screenshots/right-panel-light.png", name: "right-panel-light.png" },
+];
+
+const INFO_COMMITS = [
+  {
+    sha: "48a1bd6700000000000000000000000000000000",
+    shortSha: "48a1bd67",
+    subject: "Match right panel surfaces to the themed sidebar",
+    authorName: "Ada Lovelace",
+    authoredAt: 1_785_733_200_000,
+  },
+  {
+    sha: "e6cf24b100000000000000000000000000000000",
+    shortSha: "e6cf24b1",
+    subject: "Keep tab overflow controls visible",
+    authorName: "Grace Hopper",
+    authoredAt: 1_785_729_600_000,
+  },
+];
+
+const representativeWorkspaceStatus = makeWorkspaceStatus({
+  workingTree: {
+    hasUncommittedChanges: true,
+    state: "dirty_and_committed_unmerged",
+    insertions: 41,
+    deletions: 12,
+    files: [
+      {
+        path: "apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx",
+        status: "M",
+        insertions: 34,
+        deletions: 8,
+      },
+      {
+        path: "apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx",
+        status: "M",
+        insertions: 7,
+        deletions: 4,
+      },
+    ],
+  },
+  mergeBase: {
+    mergeBaseBranch: "main",
+    baseRef: "main",
+    aheadCount: INFO_COMMITS.length,
+    behindCount: 0,
+    hasCommittedUnmergedChanges: true,
+    commits: INFO_COMMITS,
+    insertions: 86,
+    deletions: 19,
+    files: [
+      {
+        path: "apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx",
+        status: "M",
+        insertions: 58,
+        deletions: 11,
+      },
+      {
+        path: "apps/app/src/components/secondary-panel/NewTabPage.tsx",
+        status: "M",
+        insertions: 28,
+        deletions: 8,
+      },
+    ],
+  },
+});
+
+function RepresentativeInfoContent() {
+  const [selectedStoragePath, setSelectedStoragePath] = useState<string | null>(
+    null,
+  );
+  const storageController = useThreadStorageBrowser({
+    files: INFO_STORAGE_FILES,
+    onSelectPath: setSelectedStoragePath,
+    selectedPath: selectedStoragePath,
+  });
+  const props: ThreadMetadataContentProps = {
+    ...baseMetadataProps,
+    pullRequest: makePullRequest({
+      number: 947,
+      title: "Use the sidebar surface throughout the right panel",
+    }),
+    selectedMergeBaseBranch: "main",
+    workspaceStatus: representativeWorkspaceStatus,
+    storage: {
+      controller: storageController,
+      filesError: null,
+      isFilesLoading: false,
+    },
+    onCommitClick: noop,
+  };
+
+  return <ThreadMetadataContent {...props} />;
+}
 
 interface ShellArgs {
   initialPanel: ThreadSecondaryPanelTab;
@@ -89,25 +206,27 @@ function ShellRow({
 }: ShellArgs) {
   return (
     <PanelHarness initialPanel={initialPanel}>
-      {(panel) => (
-        <PanelStage>
+      {(panel, setPanel) => (
+        <PanelStage height="info">
           <ThreadSecondaryPanel
             activeTab={createStoryFixedPanelTab(panel)}
             canUseGitUi={canUseGitUi}
             defaultMergeBaseBranch="main"
             environmentId={undefined}
             isOpen
-            metadataContent={placeholderInfoContent}
+            metadataContent={<RepresentativeInfoContent />}
             showGitDiffTab={showGitDiffTab}
             onPanelFocus={noop}
-            onPanelChange={noop}
+            onPanelChange={setPanel}
             onCollapse={noop}
             onClose={noop}
             onFileTabReorder={noop}
             onOpenNewTab={noop}
             isConversationCollapsed={false}
             onToggleConversationCollapse={noop}
-            renderAsDrawer
+            renderAsDrawer={false}
+            inlinePanelToggle="hidden"
+            showConversationCollapseControl={false}
           />
         </PanelStage>
       )}
@@ -115,9 +234,12 @@ function ShellRow({
   );
 }
 
-const placeholderFileContent = (
-  <div className="space-y-2 px-4 py-2 text-sm text-muted-foreground">
-    <p>File tab content placeholder.</p>
+const representativeFileContent = (
+  <div className="space-y-3 px-4 py-3 font-mono text-xs text-foreground">
+    <p className="text-muted-foreground">ThreadSecondaryPanel.tsx</p>
+    <pre className="whitespace-pre-wrap">{`export function ThreadSecondaryPanel() {
+  return <Panel className="bg-sidebar">…</Panel>;
+}`}</pre>
   </div>
 );
 
@@ -127,7 +249,7 @@ interface TerminalTabFixture {
   statusLabel: string | null;
 }
 
-interface TerminalContentPlaceholderProps {
+interface RepresentativeTerminalContentProps {
   title: string;
 }
 
@@ -140,13 +262,13 @@ const TERMINAL_TABS: TerminalTabFixture[] = [
   },
 ];
 
-function TerminalContentPlaceholder({
+function RepresentativeTerminalContent({
   title,
-}: TerminalContentPlaceholderProps) {
+}: RepresentativeTerminalContentProps) {
   return (
     <div className="flex h-full min-h-0 flex-col bg-neutral-950 px-3 py-2 font-mono text-xs text-emerald-100">
       <p>$ {title}</p>
-      <p className="pt-1 text-emerald-300">Right panel terminal tab content.</p>
+      <p className="pt-1 text-emerald-300">Tests passed in 1.8s.</p>
     </div>
   );
 }
@@ -213,9 +335,9 @@ function FileTabsShellInner({
         defaultMergeBaseBranch="main"
         environmentId={undefined}
         isOpen
-        metadataContent={placeholderInfoContent}
+        metadataContent={<RepresentativeInfoContent />}
         fileTabs={fileTabs}
-        fileTabContent={activeFilename ? placeholderFileContent : null}
+        fileTabContent={activeFilename ? representativeFileContent : null}
         showGitDiffTab
         onPanelFocus={noop}
         onPanelChange={(panel) => {
@@ -228,7 +350,9 @@ function FileTabsShellInner({
         onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
-        renderAsDrawer
+        renderAsDrawer={false}
+        inlinePanelToggle="hidden"
+        showConversationCollapseControl={false}
       />
     </PanelStage>
   );
@@ -318,11 +442,11 @@ function TerminalTabsShellInner({
         defaultMergeBaseBranch="main"
         environmentId={undefined}
         isOpen
-        metadataContent={placeholderInfoContent}
+        metadataContent={<RepresentativeInfoContent />}
         fileTabs={fileTabs}
         fileTabContent={
           activeTerminal ? (
-            <TerminalContentPlaceholder title={activeTerminal.title} />
+            <RepresentativeTerminalContent title={activeTerminal.title} />
           ) : null
         }
         showGitDiffTab
@@ -337,7 +461,9 @@ function TerminalTabsShellInner({
         onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
-        renderAsDrawer
+        renderAsDrawer={false}
+        inlinePanelToggle="hidden"
+        showConversationCollapseControl={false}
       />
     </PanelStage>
   );

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
@@ -3,12 +3,29 @@ import {
   getSecondaryPanelChromeStackClassName,
   getReservedInlinePanelToggleClassName,
   resolveCollapsedPanelTrafficLightReserveClassName,
+  resolveSecondaryPanelHideControl,
 } from "./ThreadSecondaryPanel";
 import {
   CHROME_ROW_CLASS,
   CHROME_ROW_HEIGHT_CLASS,
   MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS,
 } from "@/lib/bb-desktop";
+import { SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS } from "./panelChromeClasses";
+
+describe("secondary panel surface tone", () => {
+  it("uses the same sidebar background token as the primary sidebar", () => {
+    expect(SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS).toBe("bg-sidebar");
+  });
+});
+
+describe("secondary panel hide control", () => {
+  it("uses the existing collapse affordance in the compact drawer", () => {
+    expect(resolveSecondaryPanelHideControl()).toEqual({
+      iconName: "PanelRight",
+      label: "Hide right panel",
+    });
+  });
+});
 
 describe("getSecondaryPanelChromeStackClassName", () => {
   it("reserves the combined navigation and active Diff toolbar height", () => {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -190,6 +190,13 @@ interface ResolveActiveFixedPanelArgs {
   canUseGitUi: boolean;
 }
 
+export function resolveSecondaryPanelHideControl() {
+  return {
+    iconName: "PanelRight" as const,
+    label: "Hide right panel",
+  };
+}
+
 export interface ThreadSecondaryPanelProps {
   activeTab: SecondaryFixedPanelTab | null;
   canUseGitUi: boolean;
@@ -245,6 +252,8 @@ export interface ThreadSecondaryPanelProps {
    */
   resizablePanelId?: string;
   onPanelFocus: () => void;
+  /** Reports the panel's live percentage while it resizes. */
+  onPanelResize?: (sizePercent: number) => void;
   onPanelChange: (panel: ThreadSecondaryPanelTab) => void;
   onCollapse: () => void;
   onClose: () => void;
@@ -319,6 +328,7 @@ export function ThreadSecondaryPanel({
   inlinePanelToggle = "button",
   resizablePanelId = "thread-detail-secondary-panel",
   onPanelFocus,
+  onPanelResize,
   onPanelChange,
   onCollapse,
   onClose,
@@ -339,7 +349,7 @@ export function ThreadSecondaryPanel({
   const hasActiveFileTab = activeFileTab !== undefined;
   const isTerminalTabActive =
     activeTab?.kind === "terminal" && hasActiveFileTab;
-  const togglePanelIconName = renderAsDrawer ? "X" : "PanelRight";
+  const hideControl = resolveSecondaryPanelHideControl();
   // The conversation-collapse toggle only exists on a wide viewport; the drawer
   // layout fills the screen and cannot collapse the conversation.
   const conversationCollapseControl =
@@ -385,10 +395,11 @@ export function ThreadSecondaryPanel({
     (size: number) => {
       if (size > 0) {
         hasPanelExpandedRef.current = true;
+        onPanelResize?.(size);
       }
       handleSecondaryPanelResize(size);
     },
-    [handleSecondaryPanelResize],
+    [handleSecondaryPanelResize, onPanelResize],
   );
   const handlePanelCollapse = useCallback(() => {
     if (!hasPanelExpandedRef.current) {
@@ -695,14 +706,12 @@ export function ThreadSecondaryPanel({
                 onClick={onClose}
                 aria-label={
                   togglePanelShortcut
-                    ? `${renderAsDrawer ? "Close right panel" : "Hide right panel"} (${togglePanelShortcut.label})`
-                    : renderAsDrawer
-                      ? "Close right panel"
-                      : "Hide right panel"
+                    ? `${hideControl.label} (${togglePanelShortcut.label})`
+                    : hideControl.label
                 }
                 aria-keyshortcuts={togglePanelShortcut?.ariaKeyshortcuts}
               >
-                <Icon name={togglePanelIconName} />
+                <Icon name={hideControl.iconName} />
                 <AppCommandShortcutHint
                   shortcut={togglePanelShortcut}
                   className="absolute right-full mr-1"

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
@@ -195,6 +195,7 @@ const LONG_RECENT_ROW_ITEMS: ThreadRecentItem[] = [
 
 interface PanelStageProps {
   children: ReactNode;
+  presentation?: "card" | "sidebar";
 }
 
 interface NewTabPanelStoryProps {
@@ -206,6 +207,7 @@ interface NewTabPanelStoryProps {
   showOpenBrowser: boolean;
   threadStoragePaths: readonly WorkspacePathEntry[];
   workspacePaths: readonly WorkspacePathEntry[];
+  presentation?: "card" | "sidebar";
 }
 
 type NewTabStoryOutcome =
@@ -282,9 +284,15 @@ interface SeededNewTabPageProps {
   recentItems: readonly ThreadRecentItem[];
 }
 
-function PanelStage({ children }: PanelStageProps) {
+function PanelStage({ children, presentation = "card" }: PanelStageProps) {
   return (
-    <div className="flex h-[380px] w-full max-w-[720px] min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background">
+    <div
+      className={
+        presentation === "sidebar"
+          ? "flex h-screen min-h-[640px] w-full max-w-[480px] min-w-0 flex-col overflow-hidden border-l border-border bg-sidebar"
+          : "flex h-[380px] w-full max-w-[720px] min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background"
+      }
+    >
       {children}
     </div>
   );
@@ -405,6 +413,7 @@ function NewTabPanelStory({
   showOpenBrowser,
   threadStoragePaths,
   workspacePaths,
+  presentation,
 }: NewTabPanelStoryProps) {
   const [outcome, setOutcome] = useState<NewTabStoryOutcome | null>(null);
   const queryClient = useStoryQueryClient({
@@ -525,7 +534,7 @@ function NewTabPanelStory({
     );
 
   return (
-    <PanelStage>
+    <PanelStage presentation={presentation}>
       <ThreadSecondaryPanel
         activeTab={activeTab}
         canUseGitUi
@@ -547,6 +556,25 @@ function NewTabPanelStory({
         showGitDiffTab
       />
     </PanelStage>
+  );
+}
+
+export function CollapseControl() {
+  return (
+    <WithDesktopBrowser>
+      <div className="flex min-h-screen w-full justify-end bg-background">
+        <NewTabPanelStory
+          currentThreadId={BLANK_THREAD_ID}
+          initialQuery=""
+          projectId={PROJECT_ID}
+          recentItems={[]}
+          showOpenBrowser
+          threadStoragePaths={[]}
+          workspacePaths={[]}
+          presentation="sidebar"
+        />
+      </div>
+    </WithDesktopBrowser>
   );
 }
 

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
@@ -30,9 +30,9 @@ export function ThreadTerminalPanel({
     <section
       aria-label="Terminal"
       data-app-terminal=""
-      className="flex h-full min-h-0 min-w-0 flex-col bg-background"
+      className="flex h-full min-h-0 min-w-0 flex-col bg-sidebar"
     >
-      <div className="min-h-0 flex-1 overflow-hidden bg-background">
+      <div className="min-h-0 flex-1 overflow-hidden bg-sidebar">
         <ThreadTerminalContent
           controller={terminalController}
           onOpenLink={onOpenLink}

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildTerminalThemeFromCssColors } from "./ThreadTerminalView";
+
+describe("buildTerminalThemeFromCssColors", () => {
+  it("paints the terminal canvas and cursor cutout with the sidebar surface", () => {
+    const get = vi.fn((name: string) => name);
+
+    const theme = buildTerminalThemeFromCssColors(get);
+
+    expect(theme.background).toBe("--sidebar");
+    expect(theme.cursorAccent).toBe("--sidebar");
+  });
+});

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -8,7 +8,10 @@ import {
 import "@xterm/xterm/css/xterm.css";
 import type { ITheme, Terminal as XTermTerminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
-import type { TerminalServerMessage, TerminalSession } from "@bb/server-contract";
+import type {
+  TerminalServerMessage,
+  TerminalSession,
+} from "@bb/server-contract";
 import { terminalServerMessageSchema } from "@bb/server-contract";
 import { useAppThemeEpoch } from "@/hooks/useAppTheme";
 import { usePreferredTheme } from "@/hooks/useTheme";
@@ -56,21 +59,16 @@ function readResolvedCssColor(
   return getComputedStyle(probe).color;
 }
 
-function buildTerminalTheme(): ITheme {
-  if (typeof document === "undefined") {
-    return {};
-  }
-  const probe = document.createElement("span");
-  probe.style.position = "absolute";
-  probe.style.visibility = "hidden";
-  probe.style.pointerEvents = "none";
-  document.body.appendChild(probe);
-  const get = (name: string) => readResolvedCssColor(probe, name);
-  const theme: ITheme = {
-    background: get("--background"),
+type TerminalCssColorReader = (name: string) => string | undefined;
+
+export function buildTerminalThemeFromCssColors(
+  get: TerminalCssColorReader,
+): ITheme {
+  return {
+    background: get("--sidebar"),
     foreground: get("--foreground"),
     cursor: get("--foreground"),
-    cursorAccent: get("--background"),
+    cursorAccent: get("--sidebar"),
     selectionBackground: get("--muted"),
     black: get("--ansi-0"),
     red: get("--ansi-1"),
@@ -89,6 +87,19 @@ function buildTerminalTheme(): ITheme {
     brightCyan: get("--ansi-14"),
     brightWhite: get("--ansi-15"),
   };
+}
+
+function buildTerminalTheme(): ITheme {
+  if (typeof document === "undefined") {
+    return {};
+  }
+  const probe = document.createElement("span");
+  probe.style.position = "absolute";
+  probe.style.visibility = "hidden";
+  probe.style.pointerEvents = "none";
+  document.body.appendChild(probe);
+  const get = (name: string) => readResolvedCssColor(probe, name);
+  const theme = buildTerminalThemeFromCssColors(get);
   probe.remove();
   return theme;
 }
@@ -251,7 +262,10 @@ function buildTerminalSelection({
   return selection;
 }
 
-function writeTerminalStatus({ terminal, text }: WriteTerminalStatusArgs): void {
+function writeTerminalStatus({
+  terminal,
+  text,
+}: WriteTerminalStatusArgs): void {
   terminal.write(`\r\n\x1b[2m${text}\x1b[0m\r\n`);
 }
 
@@ -390,14 +404,12 @@ export function ThreadTerminalView({
   // changes too, not just light/dark toggles.
   const appThemeEpoch = useAppThemeEpoch();
   const openUrlByPreference = useOpenUrlByPreference();
-  const handleOpenLinkByPreference =
-    useCallback<MarkdownPreviewLinkHandler>(
-      ({ href }) => openUrlByPreference(href),
-      [openUrlByPreference],
-    );
+  const handleOpenLinkByPreference = useCallback<MarkdownPreviewLinkHandler>(
+    ({ href }) => openUrlByPreference(href),
+    [openUrlByPreference],
+  );
   const effectiveOnOpenLink = onOpenLink ?? handleOpenLinkByPreference;
-  const onOpenLinkRef =
-    useRef<MarkdownPreviewLinkHandler>(effectiveOnOpenLink);
+  const onOpenLinkRef = useRef<MarkdownPreviewLinkHandler>(effectiveOnOpenLink);
 
   isPanelOpenRef.current = isPanelOpen;
   sessionStatusRef.current = session.status;
@@ -494,16 +506,15 @@ export function ThreadTerminalView({
     let resizeObserver: ResizeObserver | null = null;
     let selectionChangeDisposable: { dispose: () => void } | null = null;
 
-    async function mountTerminal(containerElement: HTMLDivElement): Promise<void> {
-      const [
-        { Terminal },
-        { FitAddon: LoadedFitAddon },
-        { WebLinksAddon },
-      ] = await Promise.all([
-        import("@xterm/xterm"),
-        import("@xterm/addon-fit"),
-        import("@xterm/addon-web-links"),
-      ]);
+    async function mountTerminal(
+      containerElement: HTMLDivElement,
+    ): Promise<void> {
+      const [{ Terminal }, { FitAddon: LoadedFitAddon }, { WebLinksAddon }] =
+        await Promise.all([
+          import("@xterm/xterm"),
+          import("@xterm/addon-fit"),
+          import("@xterm/addon-web-links"),
+        ]);
       if (disposed) {
         return;
       }
@@ -712,7 +723,7 @@ export function ThreadTerminalView({
 
   return (
     <div
-      className="h-full min-h-0 w-full overflow-hidden bg-background p-2"
+      className="h-full min-h-0 w-full overflow-hidden bg-sidebar p-2"
       onPointerDown={handleTerminalPointerDown}
       onPointerUp={handleTerminalPointerRelease}
       onPointerCancel={handleTerminalPointerCancel}

--- a/apps/app/src/components/tools/Automations.stories.tsx
+++ b/apps/app/src/components/tools/Automations.stories.tsx
@@ -231,7 +231,7 @@ const PROVIDER_AUTOMATIONS = [
         mode: "agent",
         prompt: "Summarize yesterday's commits and open pull requests.",
         providerId: "codex",
-        model: "gpt-5.5-sol",
+        model: "gpt-5.6-sol",
         permissionMode: "auto",
         environment: { type: "host", workspace: { type: "personal" } },
       },

--- a/apps/app/src/components/tools/Automations.stories.tsx
+++ b/apps/app/src/components/tools/Automations.stories.tsx
@@ -69,6 +69,14 @@ const OVERVIEW_ENTRIES: AutomationsOverviewResponse["automations"] = [
     project: { id: "proj_bb", name: "bb" },
   },
   {
+    automation: automation("pending-reminder", "A pending launch reminder", {
+      projectId: "proj_bb",
+      trigger: { triggerType: "once", runAt: now + 86_400_000 },
+      nextRunAt: now + 86_400_000,
+    }),
+    project: { id: "proj_bb", name: "bb" },
+  },
+  {
     automation: automation("dependencies", "Dependency drift", {
       projectId: "proj_bb",
       enabled: false,
@@ -223,7 +231,7 @@ const PROVIDER_AUTOMATIONS = [
         mode: "agent",
         prompt: "Summarize yesterday's commits and open pull requests.",
         providerId: "codex",
-        model: "gpt-5",
+        model: "gpt-5.5-sol",
         permissionMode: "auto",
         environment: { type: "host", workspace: { type: "personal" } },
       },

--- a/apps/app/src/components/tools/SkillsBrowse.tsx
+++ b/apps/app/src/components/tools/SkillsBrowse.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { SkillSummary } from "@bb/server-contract";
 import { ResourcePagination } from "@bb/shared-ui/resource-pagination";
+import { Skeleton } from "@bb/shared-ui/skeleton";
 import {
   ResourceBrowseCard,
   ResourceBrowseGrid,
@@ -100,6 +101,26 @@ function RegistrySkillSourceItem({
   );
 }
 
+function RegistrySkillSourceItemSkeleton({ skillName }: { skillName: string }) {
+  return (
+    <div
+      role="status"
+      aria-label={`Loading ${skillName}`}
+      className="grid min-h-28 w-full grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_1fr_auto] gap-2 rounded-lg border border-border bg-card p-3"
+    >
+      <span className="sr-only">Loading {skillName}</span>
+      <Skeleton className="h-3.5 w-32 max-w-full self-center" />
+      <Skeleton className="size-7 rounded-md" />
+      <span className="col-span-2 row-start-2 space-y-1.5 self-center">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-4/5" />
+      </span>
+      <Skeleton className="h-3 w-28 max-w-full self-end" />
+      <Skeleton className="h-3 w-20 self-end justify-self-end" />
+    </div>
+  );
+}
+
 function SkillsShAttributionLink() {
   return (
     <a
@@ -116,6 +137,7 @@ function SkillsShAttributionLink() {
 
 export function RegistrySkillsBrowsePage({
   skills,
+  pendingSkillIds,
   pagination,
   isLoading,
   hasError,
@@ -127,6 +149,7 @@ export function RegistrySkillsBrowsePage({
   onSelect,
 }: {
   skills: readonly RegistrySkill[];
+  pendingSkillIds: ReadonlySet<string>;
   pagination: RegistryPagination;
   isLoading: boolean;
   hasError: boolean;
@@ -188,14 +211,21 @@ export function RegistrySkillsBrowsePage({
         />
       ) : (
         <ResourceBrowseGrid>
-          {skills.map((skill) => (
-            <RegistrySkillSourceItem
-              key={skill.id}
-              skill={skill}
-              onFork={onFork}
-              onSelect={onSelect}
-            />
-          ))}
+          {skills.map((skill) =>
+            pendingSkillIds.has(skill.id) ? (
+              <RegistrySkillSourceItemSkeleton
+                key={skill.id}
+                skillName={skill.name}
+              />
+            ) : (
+              <RegistrySkillSourceItem
+                key={skill.id}
+                skill={skill}
+                onFork={onFork}
+                onSelect={onSelect}
+              />
+            ),
+          )}
         </ResourceBrowseGrid>
       )}
     </ResourceCollectionViewport>

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -204,7 +204,7 @@ export function SkillsOverview({
 }: SkillsOverviewProps) {
   const [providerFilters, setProviderFilters] = useState<
     ResourceProviderFilter[]
-  >([]);
+  >(["bb"]);
   const [sortMode, setSortMode] = useState<ResourceSortMode>("alpha");
   const [sortDirection, setSortDirection] =
     useState<ResourceSortDirection>("asc");
@@ -230,10 +230,11 @@ export function SkillsOverview({
     }));
   }, [providerCounts]);
   useEffect(() => {
+    if (isLoading || hasError) return;
     setProviderFilters((current) =>
       current.filter((provider) => providerCounts.has(provider)),
     );
-  }, [providerCounts]);
+  }, [hasError, isLoading, providerCounts]);
   useEffect(() => {
     if (sortMode === "provider" && providerBucketCount <= 1) {
       setSortMode("alpha");
@@ -262,13 +263,20 @@ export function SkillsOverview({
       );
     });
     return [...filtered].sort((left, right) => {
+      if (providerFilters.length === 1 && providerFilters[0] === "bb") {
+        const officialResult =
+          Number(left.scope !== "bb-builtin") -
+          Number(right.scope !== "bb-builtin");
+        if (officialResult !== 0) return officialResult;
+      }
       const base =
         sortMode === "provider"
           ? providerLabel(left.provider).localeCompare(
               providerLabel(right.provider),
             ) || left.name.localeCompare(right.name)
           : left.name.localeCompare(right.name);
-      return sortDirection === "asc" ? base : -base;
+      if (base !== 0) return sortDirection === "asc" ? base : -base;
+      return left.filePath.localeCompare(right.filePath);
     });
   }, [normalizedQuery, providerFilters, skills, sortDirection, sortMode]);
   const libraryPagination = useResourcePagination(visibleSkills, {

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -226,15 +226,10 @@ export function SkillsOverview({
     return RESOURCE_PROVIDER_FILTERS.map((provider) => ({
       id: provider,
       label: providerFilterLabel(provider),
-      disabled: !providerCounts.has(provider),
+      disabled:
+        !providerCounts.has(provider) && !providerFilters.includes(provider),
     }));
-  }, [providerCounts]);
-  useEffect(() => {
-    if (isLoading || hasError) return;
-    setProviderFilters((current) =>
-      current.filter((provider) => providerCounts.has(provider)),
-    );
-  }, [hasError, isLoading, providerCounts]);
+  }, [providerCounts, providerFilters]);
   useEffect(() => {
     if (sortMode === "provider" && providerBucketCount <= 1) {
       setSortMode("alpha");

--- a/apps/app/src/components/tools/SkillsLibrary.tsx
+++ b/apps/app/src/components/tools/SkillsLibrary.tsx
@@ -201,7 +201,11 @@ export function SkillsLibrary() {
           return value === undefined ? [] : ([[repositoryKey, value]] as const);
         }),
       ),
-      isPending: results.some((result) => result.isPending),
+      pendingRepositoryKeys: new Set(
+        registryRepositorySources.flatMap(({ repositoryKey }, index) =>
+          results[index]?.isPending ? [repositoryKey] : [],
+        ),
+      ),
     }),
   });
   const registryDescriptionSkills = useMemo(
@@ -228,7 +232,11 @@ export function SkillsLibrary() {
           return entry === undefined ? [] : ([[skill.id, entry]] as const);
         }),
       ),
-      isPending: results.some((result) => result.isPending),
+      pendingSkillIds: new Set(
+        registryDescriptionSkills.flatMap((skill, index) =>
+          results[index]?.isPending ? [skill.id] : [],
+        ),
+      ),
     }),
   });
   const registrySkills = useMemo(
@@ -251,6 +259,24 @@ export function SkillsLibrary() {
       registryQuery.data?.skills,
       registryDescriptions.values,
       registryRepositoryStars.values,
+    ],
+  );
+  const pendingRegistrySkillIds = useMemo(
+    () =>
+      new Set(
+        (registryQuery.data?.skills ?? []).flatMap((skill) =>
+          registryDescriptions.pendingSkillIds.has(skill.id) ||
+          registryRepositoryStars.pendingRepositoryKeys.has(
+            registryRepositoryKey(skill.source),
+          )
+            ? [skill.id]
+            : [],
+        ),
+      ),
+    [
+      registryDescriptions.pendingSkillIds,
+      registryQuery.data?.skills,
+      registryRepositoryStars.pendingRepositoryKeys,
     ],
   );
   const selectedSkill = useMemo(() => {
@@ -464,6 +490,7 @@ export function SkillsLibrary() {
           browseContent={
             <RegistrySkillsBrowsePage
               skills={registrySkills}
+              pendingSkillIds={pendingRegistrySkillIds}
               pagination={
                 registryQuery.data?.pagination ?? {
                   ...EMPTY_REGISTRY_PAGINATION,
@@ -471,9 +498,7 @@ export function SkillsLibrary() {
                 }
               }
               isLoading={
-                (registryQuery.isFetching && registryQuery.data === undefined) ||
-                registryDescriptions.isPending ||
-                registryRepositoryStars.isPending
+                registryQuery.isFetching && registryQuery.data === undefined
               }
               hasError={registryQuery.isError}
               query={registrySearch}

--- a/apps/app/src/components/tools/SkillsLibrary.tsx
+++ b/apps/app/src/components/tools/SkillsLibrary.tsx
@@ -194,13 +194,15 @@ export function SkillsLibrary() {
     // `combine` results are structurally shared, so this Map is referentially
     // stable across renders. That lets the enrichment memo below list honest
     // dependencies instead of hashing query data by hand.
-    combine: (results) =>
-      new Map(
+    combine: (results) => ({
+      values: new Map(
         registryRepositorySources.flatMap(({ repositoryKey }, index) => {
           const value = results[index]?.data;
           return value === undefined ? [] : ([[repositoryKey, value]] as const);
         }),
       ),
+      isPending: results.some((result) => result.isPending),
+    }),
   });
   const registryDescriptionSkills = useMemo(
     () =>
@@ -219,31 +221,37 @@ export function SkillsLibrary() {
       retry: false,
       refetchOnWindowFocus: false,
     })),
-    combine: (results) =>
-      new Map(
+    combine: (results) => ({
+      values: new Map(
         registryDescriptionSkills.flatMap((skill, index) => {
           const entry = results[index]?.data;
           return entry === undefined ? [] : ([[skill.id, entry]] as const);
         }),
       ),
+      isPending: results.some((result) => result.isPending),
+    }),
   });
   const registrySkills = useMemo(
     () =>
       (registryQuery.data?.skills ?? []).map((skill) => {
-        const entry = registryDescriptions.get(skill.id);
+        const entry = registryDescriptions.values.get(skill.id);
         const describedSkill =
           entry === undefined
             ? skill
             : { ...skill, topic: entry.topic, summary: entry.summary };
         if (describedSkill.stars !== null) return describedSkill;
-        const stars = registryRepositoryStars.get(
+        const stars = registryRepositoryStars.values.get(
           registryRepositoryKey(describedSkill.source),
         );
         return stars === undefined
           ? describedSkill
           : { ...describedSkill, stars };
       }),
-    [registryQuery.data?.skills, registryDescriptions, registryRepositoryStars],
+    [
+      registryQuery.data?.skills,
+      registryDescriptions.values,
+      registryRepositoryStars.values,
+    ],
   );
   const selectedSkill = useMemo(() => {
     if (routeSkillId === undefined) return null;
@@ -463,7 +471,9 @@ export function SkillsLibrary() {
                 }
               }
               isLoading={
-                registryQuery.isFetching && registryQuery.data === undefined
+                (registryQuery.isFetching && registryQuery.data === undefined) ||
+                registryDescriptions.isPending ||
+                registryRepositoryStars.isPending
               }
               hasError={registryQuery.isError}
               query={registrySearch}

--- a/apps/app/src/components/tools/automation-overview.test.tsx
+++ b/apps/app/src/components/tools/automation-overview.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AutomationOverviewView } from "bb-plugin-automations/overview-view";
 import type { AutomationsOverviewResponse } from "bb-plugin-automations/rpc-types";
 
@@ -40,7 +40,67 @@ const INSTALLED_AUTOMATIONS: AutomationsOverviewResponse["automations"] = [
   },
 ];
 
+afterEach(cleanup);
+
 describe("AutomationOverviewView", () => {
+  it("keeps lifecycle groups stable around the selected sort", () => {
+    const baseEntry = INSTALLED_AUTOMATIONS[0]!;
+    const entry = (
+      name: string,
+      overrides: Partial<(typeof baseEntry)["automation"]> = {},
+    ) => ({
+      ...baseEntry,
+      automation: {
+        ...baseEntry.automation,
+        id: `auto_${name.toLowerCase().replaceAll(" ", "_")}`,
+        name,
+        ...overrides,
+      },
+    });
+    const entries = [
+      entry("Aardvark completed", {
+        enabled: false,
+        trigger: { triggerType: "once", runAt: Date.now() - 1_000 },
+        nextRunAt: null,
+        runCount: 1,
+        lastRunStatus: "succeeded",
+      }),
+      entry("Zulu inactive", { enabled: false, nextRunAt: null }),
+      entry("Aardvark pending", {
+        trigger: { triggerType: "once", runAt: Date.now() + 60_000 },
+        nextRunAt: Date.now() + 60_000,
+      }),
+      entry("Zulu active"),
+      entry("Alpha inactive", { enabled: false, nextRunAt: null }),
+      entry("Alpha active"),
+    ];
+    const { container } = render(
+      <AutomationOverviewView
+        entries={entries}
+        error={null}
+        onRetry={() => {}}
+        onOpenDetail={() => {}}
+        onEnabledChange={async () => {}}
+        onCreateViaChat={() => {}}
+        activeMode="installed"
+        onModeChange={() => {}}
+      />,
+    );
+
+    const rowTitles = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-resource-row]"),
+      (row) => row.querySelector("button")?.textContent,
+    );
+    expect(rowTitles).toEqual([
+      "Alpha active",
+      "Zulu active",
+      "Aardvark pending",
+      "Alpha inactive",
+      "Zulu inactive",
+      "Aardvark completed",
+    ]);
+  });
+
   it("renders the production collection shell for an empty library", () => {
     render(
       <AutomationOverviewView

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -484,7 +484,7 @@ const FAILED_SCRIPT_RUN: AutomationRunResponse = {
 };
 
 describe("Automation detail recipe", () => {
-  it("keeps Definition ahead of Runs, including with no runs yet", () => {
+  it("keeps Definition ahead of Runs, including with no runs yet", async () => {
     const { container } = render(
       <MemoryRouter>
         <AutomationDetailView
@@ -588,11 +588,9 @@ describe("Automation detail recipe", () => {
     expect(promptPanel.textContent).toContain("Claude");
     expect(promptPanel.textContent).not.toContain("Reasoning");
     expect(promptPanel.textContent).not.toContain("Default");
-    const readOnlyLabel = container.querySelector(
-      '[data-automation-read-only-label=""]',
-    ) as HTMLElement;
-    expect(readOnlyLabel.textContent).toContain("Read only");
-    expect(readOnlyLabel.querySelector('[data-icon="Lock"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-automation-read-only-label=""]'),
+    ).toBeNull();
     const modelSelector = promptPanel.querySelector(
       '[data-disabled-automation-selector="Provider and model"]',
     ) as HTMLButtonElement;
@@ -606,6 +604,24 @@ describe("Automation detail recipe", () => {
     expect(
       container.querySelector('[data-automation-provider-icon="claude"] svg'),
     ).not.toBeNull();
+    const modelDisabledTrigger = screen.getByLabelText(
+      "Provider and model. Use Edit with chat to change the provider and model.",
+    );
+    expect(modelDisabledTrigger.className).toContain("cursor-not-allowed");
+    fireEvent.focus(modelDisabledTrigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Use Edit with chat to change the provider and model.",
+    );
+    fireEvent.blur(modelDisabledTrigger);
+
+    const permissionDisabledTrigger = screen.getByLabelText(
+      "Permission mode. Use Edit with chat to change permissions.",
+    );
+    expect(permissionDisabledTrigger.className).toContain("cursor-not-allowed");
+    fireEvent.focus(permissionDisabledTrigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Use Edit with chat to change permissions.",
+    );
   });
 
   it("uses the composer metadata treatment without inventing reasoning", () => {
@@ -687,9 +703,9 @@ describe("Automation detail recipe", () => {
     },
     {
       providerId: "codex",
-      model: "gpt-5",
+      model: "gpt-5.5-sol",
       providerLabel: "Codex",
-      modelLabel: "5",
+      modelLabel: "5.5 Sol",
       iconId: "codex",
     },
     {
@@ -759,6 +775,10 @@ describe("Automation detail recipe", () => {
       expect(selector.getAttribute("aria-label")).toBe(
         `Provider and model: ${providerLabel}, ${modelLabel}. Read only`,
       );
+      expect(selector.textContent).toContain(modelLabel);
+      expect(
+        selector.querySelector('[data-promptbox-compact-label=""]'),
+      ).toBeNull();
       if (iconId) {
         expect(
           selector.querySelector(

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -703,9 +703,9 @@ describe("Automation detail recipe", () => {
     },
     {
       providerId: "codex",
-      model: "gpt-5.5-sol",
+      model: "gpt-5.6-sol",
       providerLabel: "Codex",
-      modelLabel: "5.5 Sol",
+      modelLabel: "5.6 Sol",
       iconId: "codex",
     },
     {

--- a/apps/app/src/components/ui/tab-pill.test.tsx
+++ b/apps/app/src/components/ui/tab-pill.test.tsx
@@ -7,6 +7,27 @@ import { TabPill } from "./tab-pill";
 afterEach(cleanup);
 
 describe("TabPill", () => {
+  it("reveals a tab close action only from tab hover or keyboard focus", () => {
+    render(
+      <TabPill
+        label="release notes"
+        title="release notes"
+        isActive
+        onSelect={vi.fn()}
+        closeAction={{
+          onClose: vi.fn(),
+          closeLabel: "Close release notes",
+          closeTooltip: "Close tab",
+        }}
+      />,
+    );
+
+    const close = screen.getByRole("button", { name: "Close release notes" });
+    expect(close.className).toContain("opacity-0");
+    expect(close.className).toContain("group-hover/tab-pill:opacity-100");
+    expect(close.className).toContain("focus-visible:opacity-100");
+  });
+
   it("uses the shared active shell for an accessible icon-only tab", () => {
     render(
       <TabPill

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
@@ -80,7 +80,7 @@ describe("useAppSettingsRouteMemory", () => {
     );
 
     fireEvent.click(screen.getByRole("link", { name: "Tools" }));
-    expect(screen.getByTestId("location").textContent).toBe("/tools/skills");
+    expect(screen.getByTestId("location").textContent).toBe("/tools/plugins");
 
     fireEvent.click(screen.getByRole("link", { name: "Plugin detail" }));
     expect(screen.getByTestId("location").textContent).toBe(
@@ -120,7 +120,9 @@ describe("useAppSettingsRouteMemory", () => {
       );
 
       fireEvent.click(screen.getByRole("link", { name: "Tools" }));
-      expect(screen.getByTestId("location").textContent).toBe("/tools/skills");
+      expect(screen.getByTestId("location").textContent).toBe(
+        "/tools/plugins",
+      );
     },
   );
 });

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.ts
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { matchPath, useLocation } from "react-router-dom";
 import {
   getRootComposeRoutePath,
-  getSkillsRoutePath,
+  getPluginsRoutePath,
   isToolsRoutePath,
   SETTINGS_ROUTE_PATH,
 } from "@/lib/route-paths";
@@ -48,7 +48,7 @@ export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
     isSettingsRoute ? currentRoutePath : SETTINGS_ROUTE_PATH,
   );
   const lastToolsRoutePathRef = useRef(
-    isCurrentToolsRoute ? currentRoutePath : getSkillsRoutePath(),
+    isCurrentToolsRoute ? currentRoutePath : getPluginsRoutePath(),
   );
 
   useEffect(() => {

--- a/apps/app/src/views/RootComposeRightPanelToggle.test.tsx
+++ b/apps/app/src/views/RootComposeRightPanelToggle.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RootComposeRightPanelToggle } from "./RootComposeView";
+
+afterEach(cleanup);
+
+describe("RootComposeRightPanelToggle", () => {
+  it("uses a disclosure state without painting the whole click target as selected", () => {
+    const onToggle = vi.fn();
+
+    render(<RootComposeRightPanelToggle isOpen onToggle={onToggle} />);
+
+    const button = screen.getByRole("button", { name: "Hide right panel" });
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(button.getAttribute("aria-pressed")).toBeNull();
+    expect(button.className).toContain("h-[28px]");
+    expect(button.className).toContain("w-[28px]");
+
+    fireEvent.click(button);
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -462,7 +462,7 @@ function RightPanelFileTabIcon({ path }: RightPanelFileTabIconProps) {
   );
 }
 
-function RootComposeRightPanelToggle({
+export function RootComposeRightPanelToggle({
   isOpen,
   onToggle,
 }: RootComposeRightPanelToggleProps) {

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -233,33 +233,38 @@ function renderRegistrySkillRoute() {
 }
 
 describe("SkillsOverview", () => {
-  it("renders flat rows with provider filter and sort controls", () => {
+  it("defaults to BB skills and places BB Official skills first", () => {
     const markup = render({
       skills: [
         makeSkill({ name: "claude-skill", provider: "claude-code" }),
         makeSkill({
-          name: "bb-skill",
+          name: "aa-user-skill",
+          provider: null,
+          scope: "bb-user",
+        }),
+        makeSkill({
+          name: "zz-official-skill",
           provider: null,
           scope: "bb-builtin",
           manageable: false,
         }),
       ],
     });
-    expect(markup).toContain("claude-skill");
+    expect(markup).not.toContain("claude-skill");
     expect(markup).toContain("Review the current diff.");
-    expect(markup).toContain('aria-label="Agent"');
+    expect(markup).toContain('aria-label="Agent: 1 selected"');
     expect(markup).toContain("Sort");
     expect(markup).toContain('role="tab"');
     expect(markup).toContain("Library");
     expect(markup).toContain("Browse");
     expect(markup).toContain("BB Official");
     expect(markup).toContain("New bb skill");
-    expect(markup).not.toContain('aria-label="Open bb-skill"');
+    expect(markup).not.toContain('aria-label="Open zz-official-skill"');
     expect(markup.indexOf("Library")).toBeLessThan(
       markup.indexOf('placeholder="Search skills"'),
     );
-    expect(markup.indexOf("bb-skill")).toBeLessThan(
-      markup.indexOf("claude-skill"),
+    expect(markup.indexOf("zz-official-skill")).toBeLessThan(
+      markup.indexOf("aa-user-skill"),
     );
   });
 
@@ -323,6 +328,61 @@ describe("SkillsOverview", () => {
         .getByRole("menuitemcheckbox", { name: "Codex" })
         .getAttribute("aria-disabled"),
     ).toBeNull();
+  });
+
+  it("preserves a user-selected provider filter across library refreshes", async () => {
+    const initialSkills = [
+      makeSkill({
+        id: `skill_${"b".repeat(64)}`,
+        name: "bb-skill",
+        provider: null,
+        scope: "bb-user",
+      }),
+      makeSkill({ name: "claude-skill", provider: "claude-code" }),
+    ];
+    const view = renderDom(
+      <SkillsOverview
+        skills={initialSkills}
+        isLoading={false}
+        hasError={false}
+        onCreateSkill={() => {}}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Agent: 1 selected" }),
+    );
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "bb" }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: "Claude Code" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("claude-skill")).toBeTruthy();
+      expect(screen.queryByText("bb-skill")).toBeNull();
+    });
+
+    view.rerender(
+      <SkillsOverview
+        skills={[
+          ...initialSkills,
+          makeSkill({
+            id: `skill_${"c".repeat(64)}`,
+            name: "new-bb-skill",
+            provider: null,
+            scope: "bb-user",
+          }),
+        ]}
+        isLoading={false}
+        hasError={false}
+        onCreateSkill={() => {}}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("claude-skill")).toBeTruthy();
+    expect(screen.queryByText("new-bb-skill")).toBeNull();
   });
 
   it("keeps edit and delete actions in detail rather than overview rows", () => {

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -560,7 +560,7 @@ describe("SkillsLibrary registry detail lifecycle", () => {
     ).toBe(false);
   });
 
-  it("loads repository stars once and progressively updates every matching card", async () => {
+  it("reveals registry cards only after repository stars finish loading", async () => {
     const firstSkill = makeRegistrySkill({
       id: "owner/shared-repo/first-skill",
       source: "owner/shared-repo",
@@ -615,9 +615,6 @@ describe("SkillsLibrary registry detail lifecycle", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("First skill")).toBeTruthy();
-    expect(screen.getByText("Second skill")).toBeTruthy();
-    expect(screen.queryByLabelText(/stars$/u)).toBeNull();
     await waitFor(() => {
       expect(
         fetchMock.mock.calls.filter(
@@ -627,13 +624,17 @@ describe("SkillsLibrary registry detail lifecycle", () => {
         ),
       ).toHaveLength(1);
     });
+    expect(screen.queryByText("First skill")).toBeNull();
+    expect(screen.queryByText("Second skill")).toBeNull();
 
     resolveStars?.(Response.json({ stars: 27_053 }));
 
+    expect(await screen.findByText("First skill")).toBeTruthy();
+    expect(screen.getByText("Second skill")).toBeTruthy();
     expect(await screen.findAllByLabelText("27.1K stars")).toHaveLength(2);
   });
 
-  it("renders registry cards before progressively loading their descriptions", async () => {
+  it("reveals registry cards only after their descriptions finish loading", async () => {
     const registrySkill = makeRegistrySkill({ summary: null });
     let resolveEntry: ((response: Response) => void) | undefined;
     const entryResponse = new Promise<Response>((resolve) => {
@@ -674,8 +675,6 @@ describe("SkillsLibrary registry detail lifecycle", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("Useful skill")).toBeTruthy();
-    expect(screen.queryByText("Loaded after the card")).toBeNull();
     await waitFor(() => {
       expect(
         fetchMock.mock.calls.filter(
@@ -685,6 +684,8 @@ describe("SkillsLibrary registry detail lifecycle", () => {
         ),
       ).toHaveLength(1);
     });
+    expect(screen.queryByText("Useful skill")).toBeNull();
+    expect(screen.queryByText("Loaded after the card")).toBeNull();
 
     resolveEntry?.(
       Response.json({
@@ -693,7 +694,8 @@ describe("SkillsLibrary registry detail lifecycle", () => {
       }),
     );
 
-    expect(await screen.findByText("Loaded after the card")).toBeTruthy();
+    expect(await screen.findByText("Useful skill")).toBeTruthy();
+    expect(screen.getByText("Loaded after the card")).toBeTruthy();
   });
 });
 
@@ -747,6 +749,9 @@ describe("RegistrySkillsBrowsePage", () => {
     expect(screen.getByRole("textbox", { name: "Search skills" })).toBeTruthy();
     expect(screen.getByLabelText("10 installs")).toBeTruthy();
     expect(screen.getByLabelText("100 stars")).toBeTruthy();
+    for (const byline of screen.getAllByText("by owner/repo")) {
+      expect(byline.className).toContain("text-xs");
+    }
     expect(
       screen.getByRole("button", {
         name: "Fork Alpha into a new bb skill",

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -154,6 +154,7 @@ function renderRegistryBrowse(
   return renderDom(
     <RegistrySkillsBrowsePage
       skills={[makeRegistrySkill()]}
+      pendingSkillIds={new Set()}
       pagination={{ page: 0, perPage: 24, total: 1, hasMore: false }}
       isLoading={false}
       hasError={false}
@@ -279,6 +280,7 @@ describe("SkillsOverview", () => {
         browseContent={
           <RegistrySkillsBrowsePage
             skills={[registrySkill]}
+            pendingSkillIds={new Set()}
             pagination={{ page: 0, perPage: 24, total: 1, hasMore: false }}
             isLoading={false}
             hasError={false}
@@ -626,6 +628,12 @@ describe("SkillsLibrary registry detail lifecycle", () => {
     });
     expect(screen.queryByText("First skill")).toBeNull();
     expect(screen.queryByText("Second skill")).toBeNull();
+    expect(
+      screen.getByRole("status", { name: "Loading First skill" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("status", { name: "Loading Second skill" }),
+    ).toBeTruthy();
 
     resolveStars?.(Response.json({ stars: 27_053 }));
 
@@ -634,32 +642,50 @@ describe("SkillsLibrary registry detail lifecycle", () => {
     expect(await screen.findAllByLabelText("27.1K stars")).toHaveLength(2);
   });
 
-  it("reveals registry cards only after their descriptions finish loading", async () => {
-    const registrySkill = makeRegistrySkill({ summary: null });
-    let resolveEntry: ((response: Response) => void) | undefined;
-    const entryResponse = new Promise<Response>((resolve) => {
-      resolveEntry = resolve;
+  it("reveals each registry card as soon as that card is complete", async () => {
+    const firstSkill = makeRegistrySkill({
+      id: "owner/repo/first-skill",
+      skillId: "first-skill",
+      name: "First skill",
+      summary: null,
     });
+    const secondSkill = makeRegistrySkill({
+      id: "owner/repo/second-skill",
+      skillId: "second-skill",
+      name: "Second skill",
+      summary: null,
+    });
+    const entryResolvers = new Map<string, (response: Response) => void>();
+    const entryResponses = new Map(
+      [firstSkill, secondSkill].map((skill) => [
+        skill.id,
+        new Promise<Response>((resolve) => {
+          entryResolvers.set(skill.id, resolve);
+        }),
+      ]),
+    );
     vi.spyOn(sdk.skills, "list").mockResolvedValue({ skills: [] });
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = requestPath(input);
       if (url.startsWith("/api/v1/skills-registry?")) {
         return Promise.resolve(
           Response.json({
-            skills: [registrySkill],
+            skills: [firstSkill, secondSkill],
             pagination: {
               page: 0,
               perPage: 24,
-              total: 1,
+              total: 2,
               hasMore: false,
             },
           }),
         );
       }
-      if (
-        url === "/api/v1/skills-registry/entry?id=owner%2Frepo%2Fuseful-skill"
-      ) {
-        return entryResponse;
+      const entryId = new URL(url, "http://localhost").searchParams.get("id");
+      if (url.startsWith("/api/v1/skills-registry/entry?") && entryId) {
+        return (
+          entryResponses.get(entryId) ??
+          Promise.resolve(new Response(null, { status: 404 }))
+        );
       }
       return Promise.resolve(new Response(null, { status: 404 }));
     });
@@ -677,25 +703,37 @@ describe("SkillsLibrary registry detail lifecycle", () => {
 
     await waitFor(() => {
       expect(
-        fetchMock.mock.calls.filter(
-          ([input]) =>
-            requestPath(input) ===
-            "/api/v1/skills-registry/entry?id=owner%2Frepo%2Fuseful-skill",
+        fetchMock.mock.calls.filter(([input]) =>
+          requestPath(input).startsWith("/api/v1/skills-registry/entry?"),
         ),
-      ).toHaveLength(1);
+      ).toHaveLength(2);
     });
-    expect(screen.queryByText("Useful skill")).toBeNull();
-    expect(screen.queryByText("Loaded after the card")).toBeNull();
+    expect(screen.queryByText("First skill")).toBeNull();
+    expect(screen.queryByText("Second skill")).toBeNull();
 
-    resolveEntry?.(
+    entryResolvers.get(firstSkill.id)?.(
       Response.json({
-        ...registrySkill,
-        summary: "Loaded after the card",
+        ...firstSkill,
+        summary: "First description",
       }),
     );
 
-    expect(await screen.findByText("Useful skill")).toBeTruthy();
-    expect(screen.getByText("Loaded after the card")).toBeTruthy();
+    expect(await screen.findByText("First skill")).toBeTruthy();
+    expect(screen.getByText("First description")).toBeTruthy();
+    expect(screen.queryByText("Second skill")).toBeNull();
+    expect(
+      screen.getByRole("status", { name: "Loading Second skill" }),
+    ).toBeTruthy();
+
+    entryResolvers.get(secondSkill.id)?.(
+      Response.json({
+        ...secondSkill,
+        summary: "Second description",
+      }),
+    );
+
+    expect(await screen.findByText("Second skill")).toBeTruthy();
+    expect(screen.getByText("Second description")).toBeTruthy();
   });
 });
 

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -314,7 +314,9 @@ describe("SkillsOverview", () => {
       />,
     );
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Agent" }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Agent: 1 selected" }),
+    );
 
     await waitFor(() => {
       expect(
@@ -328,6 +330,47 @@ describe("SkillsOverview", () => {
         .getByRole("menuitemcheckbox", { name: "Codex" })
         .getAttribute("aria-disabled"),
     ).toBeNull();
+    expect(
+      screen
+        .getByRole("menuitemcheckbox", { name: "bb" })
+        .getAttribute("aria-disabled"),
+    ).toBeNull();
+  });
+
+  it("keeps the default BB filter selected when only provider skills exist", async () => {
+    renderDom(
+      <SkillsOverview
+        skills={[
+          makeSkill({
+            name: "codex-skill",
+            provider: "codex",
+            scope: "codex-user",
+          }),
+        ]}
+        isLoading={false}
+        hasError={false}
+        onCreateSkill={() => {}}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Agent: 1 selected" }),
+      ).toBeTruthy();
+      expect(screen.queryByText("codex-skill")).toBeNull();
+    });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Agent: 1 selected" }),
+    );
+    const bbFilter = screen.getByRole("menuitemcheckbox", { name: "bb" });
+    expect(bbFilter.getAttribute("aria-checked")).toBe("true");
+    expect(bbFilter.getAttribute("aria-disabled")).toBeNull();
+
+    fireEvent.click(bbFilter);
+
+    expect(await screen.findByText("codex-skill")).toBeTruthy();
   });
 
   it("preserves a user-selected provider filter across library refreshes", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.stories.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.stories.tsx
@@ -185,14 +185,14 @@ function createStoryQueryClient(): QueryClient {
   return queryClient;
 }
 
-function SplitWorkspaceStory() {
+function SplitWorkspaceStory({ maximized = false }: { maximized?: boolean }) {
   const queryClient = useMemo(() => createStoryQueryClient(), []);
   const store = useMemo(() => {
     const nextStore = createStore();
     nextStore.set(splitLayoutAtom, splitLayout);
-    nextStore.set(maximizedPaneIdAtom, null);
+    nextStore.set(maximizedPaneIdAtom, maximized ? "pane-active" : null);
     return nextStore;
-  }, []);
+  }, [maximized]);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -215,4 +215,8 @@ function SplitWorkspaceStory() {
 
 export function ActiveAndIdle() {
   return <SplitWorkspaceStory />;
+}
+
+export function MaximizedWithoutRail() {
+  return <SplitWorkspaceStory maximized />;
 }

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -46,6 +46,11 @@ const threadStore = vi.hoisted(
 const experimentState = vi.hoisted(() => ({ enabled: true }));
 const viewportState = vi.hoisted(() => ({ compact: false }));
 const sidebarState = vi.hoisted(() => ({ showing: true }));
+const collapsedRailState = vi.hoisted(() => ({
+  enabled: false,
+  isMainCollapsed: false,
+}));
+const panelGroupLayoutState = vi.hoisted(() => ({ layout: [100, 0] }));
 const commandHandlers = vi.hoisted(() => new Map<string, () => boolean>());
 interface ShortcutPresentationFixture {
   ariaKeyshortcuts: string;
@@ -113,7 +118,12 @@ vi.mock("react-resizable-panels", async () => {
   >(({ children }, ref) => {
     React.useImperativeHandle(
       ref,
-      () => ({ getLayout: () => [100, 0], setLayout: () => undefined }),
+      () => ({
+        getLayout: () => panelGroupLayoutState.layout,
+        setLayout: (layout: number[]) => {
+          panelGroupLayoutState.layout = layout;
+        },
+      }),
       [],
     );
     return <div data-testid="workspace-panel-group">{children}</div>;
@@ -174,7 +184,7 @@ vi.mock("./ThreadDetailView", () => ({
       () => ({
         composerHost,
         contentKey: threadId,
-        isMainCollapsed: false,
+        isMainCollapsed: collapsedRailState.isMainCollapsed,
         isOpen: isPanelOpen,
         panel: (
           <div data-testid={`hosted-panel-${threadId}`}>
@@ -449,6 +459,9 @@ beforeEach(() => {
   experimentState.enabled = true;
   viewportState.compact = false;
   sidebarState.showing = true;
+  collapsedRailState.enabled = false;
+  collapsedRailState.isMainCollapsed = false;
+  panelGroupLayoutState.layout = [100, 0];
   commandHandlers.clear();
   commandPresentationState.isModifierHeld = false;
   commandPresentationState.shortcut = null;
@@ -508,6 +521,32 @@ describe("SplitThreadArea", () => {
     fireEvent.change(screen.getByTestId("draft-thr-b"), {
       target: { value: "" },
     });
+  });
+
+  it("removes the collapsed-thread rail while maximized and keeps the restore control", async () => {
+    collapsedRailState.enabled = true;
+    collapsedRailState.isMainCollapsed = true;
+    renderSplitArea({
+      path: threadPath("thr-a"),
+      layout: twoPaneLayout("pane-1"),
+    });
+
+    expect(
+      await screen.findByTestId("mock-collapsed-thread-rail"),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByTestId("maximize-thr-a"));
+
+    expect(screen.queryByTestId("mock-collapsed-thread-rail")).toBeNull();
+    expect(screen.getByTestId("maximize-thr-a").textContent).toBe("restore");
+    await waitFor(() => {
+      expect(panelGroupLayoutState.layout[0]).toBeGreaterThan(0);
+      expect(panelGroupLayoutState.layout[1]).toBeLessThan(100);
+    });
+
+    fireEvent.click(screen.getByTestId("maximize-thr-a"));
+    expect(
+      await screen.findByTestId("mock-collapsed-thread-rail"),
+    ).toBeTruthy();
   });
 
   it("preserves a hidden pane's mounted scroll position through restore", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -47,7 +47,6 @@ const experimentState = vi.hoisted(() => ({ enabled: true }));
 const viewportState = vi.hoisted(() => ({ compact: false }));
 const sidebarState = vi.hoisted(() => ({ showing: true }));
 const collapsedRailState = vi.hoisted(() => ({
-  enabled: false,
   isMainCollapsed: false,
 }));
 const panelGroupLayoutState = vi.hoisted(() => ({ layout: [100, 0] }));
@@ -459,7 +458,6 @@ beforeEach(() => {
   experimentState.enabled = true;
   viewportState.compact = false;
   sidebarState.showing = true;
-  collapsedRailState.enabled = false;
   collapsedRailState.isMainCollapsed = false;
   panelGroupLayoutState.layout = [100, 0];
   commandHandlers.clear();
@@ -524,16 +522,13 @@ describe("SplitThreadArea", () => {
   });
 
   it("removes the collapsed-thread rail while maximized and keeps the restore control", async () => {
-    collapsedRailState.enabled = true;
     collapsedRailState.isMainCollapsed = true;
     renderSplitArea({
       path: threadPath("thr-a"),
       layout: twoPaneLayout("pane-1"),
     });
 
-    expect(
-      await screen.findByTestId("mock-collapsed-thread-rail"),
-    ).toBeTruthy();
+    expect(screen.queryByTestId("mock-collapsed-thread-rail")).toBeNull();
     fireEvent.click(screen.getByTestId("maximize-thr-a"));
 
     expect(screen.queryByTestId("mock-collapsed-thread-rail")).toBeNull();
@@ -544,9 +539,7 @@ describe("SplitThreadArea", () => {
     });
 
     fireEvent.click(screen.getByTestId("maximize-thr-a"));
-    expect(
-      await screen.findByTestId("mock-collapsed-thread-rail"),
-    ).toBeTruthy();
+    expect(screen.queryByTestId("mock-collapsed-thread-rail")).toBeNull();
   });
 
   it("preserves a hidden pane's mounted scroll position through restore", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -592,6 +592,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
       >
         <SplitWorkspaceSecondaryPanelHost
           focusedPaneId={effectiveMaximizedPaneId ?? layout.focusedPaneId}
+          isPaneMaximized={effectiveMaximizedPaneId !== null}
           registry={secondaryPanelRegistry}
         >
           <SplitTree

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -49,12 +49,14 @@ const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
 interface SplitWorkspaceSecondaryPanelHostProps {
   children: ReactNode;
   focusedPaneId: string;
+  isPaneMaximized: boolean;
   registry: PaneSecondaryPanelRegistry;
 }
 
 export function SplitWorkspaceSecondaryPanelHost({
   children,
   focusedPaneId,
+  isPaneMaximized,
   registry,
 }: SplitWorkspaceSecondaryPanelHostProps) {
   const model = usePaneSecondaryPanelModel(registry, focusedPaneId);
@@ -126,7 +128,7 @@ export function SplitWorkspaceSecondaryPanelHost({
       group.setLayout([MAIN_PANEL_OPEN_SIZE_PERCENT, 0]);
       return;
     }
-    if (model?.isMainCollapsed) {
+    if (model?.isMainCollapsed && !isPaneMaximized) {
       group.setLayout([0, MAIN_PANEL_OPEN_SIZE_PERCENT]);
       return;
     }
@@ -134,7 +136,13 @@ export function SplitWorkspaceSecondaryPanelHost({
       MAIN_PANEL_OPEN_SIZE_PERCENT - panelWidthPercent,
       panelWidthPercent,
     ]);
-  }, [focusedPaneId, isOpen, model?.isMainCollapsed, panelWidthPercent]);
+  }, [
+    focusedPaneId,
+    isOpen,
+    isPaneMaximized,
+    model?.isMainCollapsed,
+    panelWidthPercent,
+  ]);
 
   // Panes without a secondary panel (plugin panes) leave the window panel in
   // place with an empty state; their toggle drives the window visibility
@@ -230,7 +238,7 @@ export function SplitWorkspaceSecondaryPanelHost({
             collapsible
             collapsedSize={0}
             defaultSize={
-              model?.isMainCollapsed
+              model?.isMainCollapsed && !isPaneMaximized
                 ? 0
                 : isOpen
                   ? MAIN_PANEL_OPEN_SIZE_PERCENT - panelWidthPercent

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -20,7 +20,10 @@ import { DETAIL_GRID_CLASS } from "@/components/ui/detail-card.js";
 import { useAtomValue } from "jotai";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ThreadSecondaryPanel } from "@/components/secondary-panel/ThreadSecondaryPanel";
-import { secondaryPanelWidthPercentAtom } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
+import {
+  secondaryPanelWidthPercentAtom,
+  threadSecondaryPanelResizingAtom,
+} from "@/components/secondary-panel/threadSecondaryPanelAtoms";
 import {
   ThreadMetadataCard,
   ThreadMetadataContent,
@@ -282,6 +285,7 @@ function ThreadDetailSecondaryContentBody({
         <ThreadSecondaryPanel
           {...threadSecondaryPanelProps}
           browserDeck={browserDeck}
+          onPanelResize={setLiveSecondaryWidthPercent}
           renderAsDrawer={false}
           isConversationCollapsed={isConversationCollapsedActive}
           onToggleConversationCollapse={onToggleConversationCollapse}
@@ -362,6 +366,13 @@ function ThreadDetailSecondaryContentBody({
     );
   }
 
+  const headerSidebarSurfaceWidth =
+    isSecondaryPanelOpen && !renderAsDrawer
+      ? isConversationCollapsedActive
+        ? "100%"
+        : `${liveSecondaryWidthPercent}%`
+      : "0%";
+
   return (
     <div
       className={cn(
@@ -374,7 +385,19 @@ function ThreadDetailSecondaryContentBody({
         actions stay anchored to the window edge instead of riding the timeline
         panel's width as the secondary panel opens and closes.
       */}
-      {header}
+      <div className="relative shrink-0 bg-surface-scrim">
+        <div
+          aria-hidden
+          data-testid="thread-secondary-panel-header-surface"
+          className={cn(
+            "pointer-events-none absolute inset-y-0 right-0 bg-sidebar",
+            !isSecondaryPanelResizing &&
+              `transition-[width] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
+          )}
+          style={{ width: headerSidebarSurfaceWidth }}
+        />
+        <div className="relative [&>header]:bg-transparent">{header}</div>
+      </div>
       {/*
         When collapsed we keep the resizable PanelGroup mounted: the timeline
         lifts to 0% and the panel to 100% via the layout effect. Nothing

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -120,6 +120,12 @@ function ThreadDetailSecondaryContentBody({
   const persistedSecondaryWidthPercent = useAtomValue(
     secondaryPanelWidthPercentAtom,
   );
+  const isSecondaryPanelResizing = useAtomValue(
+    threadSecondaryPanelResizingAtom,
+  );
+  const [liveSecondaryWidthPercent, setLiveSecondaryWidthPercent] = useState(
+    persistedSecondaryWidthPercent,
+  );
   // Collapsing the conversation only makes sense on a wide viewport with the
   // secondary panel open — there is otherwise nothing to expand into.
   const canCollapseConversation = isSecondaryPanelOpen && !renderAsDrawer;

--- a/packages/shared-ui/src/components/ui/resource/collection.tsx
+++ b/packages/shared-ui/src/components/ui/resource/collection.tsx
@@ -504,7 +504,7 @@ export function ResourceBrowseCard({
         </span>
       ) : null}
       {byline ? (
-        <span className="pointer-events-none relative col-start-1 row-start-3 block truncate text-left text-2xs text-subtle-foreground">
+        <span className="pointer-events-none relative col-start-1 row-start-3 block truncate text-left text-xs text-subtle-foreground">
           {byline}
         </span>
       ) : null}

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -279,6 +279,7 @@ function AutomationEnvironmentVariables({
 interface DisabledAutomationSelectorProps {
   label: string;
   value: string;
+  disabledReason: string;
   accessibleValue?: string;
   compactValue?: string;
   leading?: ReactNode;
@@ -289,13 +290,14 @@ interface DisabledAutomationSelectorProps {
 function DisabledAutomationSelector({
   label,
   value,
+  disabledReason,
   accessibleValue,
   compactValue,
   leading,
   title,
   className,
 }: DisabledAutomationSelectorProps) {
-  return (
+  const control = (
     <Button
       type="button"
       variant="ghost"
@@ -307,7 +309,7 @@ function DisabledAutomationSelector({
         OPTION_BASE_CLASS_NAME,
         OPTION_INTERACTIVE_CLASS_NAME,
         OPTION_MUTED_CLASS_NAME,
-        "cursor-default disabled:opacity-100",
+        "cursor-not-allowed disabled:cursor-not-allowed disabled:opacity-100",
         className,
       )}
     >
@@ -331,6 +333,25 @@ function DisabledAutomationSelector({
         aria-hidden
       />
     </Button>
+  );
+
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex shrink-0 cursor-not-allowed rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            tabIndex={0}
+            aria-label={`${label}. ${disabledReason}`}
+          >
+            {control}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-64">
+          {disabledReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -670,23 +691,12 @@ export function AutomationDetailView({
         <ResourceDefinitionSection
           label={bodyLabel}
           actions={
-            <>
-              {execution.mode === "agent" ? (
-                <span
-                  data-automation-read-only-label=""
-                  className="mr-1 inline-flex items-center gap-1 text-xs text-muted-foreground"
-                >
-                  <Icon name="Lock" className="size-3.5" aria-hidden />
-                  Read only
-                </span>
-              ) : null}
-              <ResourceActionButton
-                label="Edit with chat"
-                tooltipLabel="Edit with chat"
-                icon="MessageCirclePlus"
-                onClick={onEdit}
-              />
-            </>
+            <ResourceActionButton
+              label="Edit with chat"
+              tooltipLabel="Edit with chat"
+              icon="MessageCirclePlus"
+              onClick={onEdit}
+            />
           }
         >
           {execution.mode === "agent" ? (
@@ -698,15 +708,12 @@ export function AutomationDetailView({
                     label: (
                       <DisabledAutomationSelector
                         label="Provider and model"
+                        disabledReason="Use Edit with chat to change the provider and model."
                         value={formatAutomationModelLabel(
                           execution.model,
                           execution.providerId,
                         )}
                         accessibleValue={`${formatAutomationProviderLabel(execution.providerId)}, ${formatAutomationModelLabel(execution.model, execution.providerId)}`}
-                        compactValue={formatAutomationModelLabel(
-                          execution.model,
-                          execution.providerId,
-                        )}
                         leading={
                           <AutomationProviderIcon
                             providerId={execution.providerId}
@@ -761,6 +768,7 @@ export function AutomationDetailView({
                 </div>
                 <DisabledAutomationSelector
                   label="Permission mode"
+                  disabledReason="Use Edit with chat to change permissions."
                   value={formatPermissionMode(execution.permissionMode)}
                   compactValue={formatPermissionModeCompact(
                     execution.permissionMode,

--- a/plugins/automations/lib/format-schedule.ts
+++ b/plugins/automations/lib/format-schedule.ts
@@ -224,6 +224,8 @@ export function matchesAutomationStatusFilters(
     now: automation.now,
   });
   if (lifecycle === "running") return filters.includes("active");
-  if (lifecycle === "paused") return filters.includes("paused");
+  if (lifecycle === "paused" || lifecycle === "completed") {
+    return filters.includes("paused");
+  }
   return false;
 }

--- a/plugins/automations/overview-view.tsx
+++ b/plugins/automations/overview-view.tsx
@@ -158,6 +158,19 @@ function applyAutomationSortDirection(
   return direction === "asc" ? result : -result;
 }
 
+function automationLifecycleSortRank(automation: AutomationResponse): number {
+  const oneShotLifecycle = getOneShotLifecycle({
+    enabled: automation.enabled,
+    trigger: automation.trigger,
+    runCount: automation.runCount,
+    lastRunStatus: automation.lastRunStatus,
+  });
+  if (oneShotLifecycle === "completed") return 3;
+  if (!automation.enabled && oneShotLifecycle !== "running") return 2;
+  if (oneShotLifecycle === "scheduled") return 1;
+  return 0;
+}
+
 function OverviewRow({
   entry,
   onNavigate,
@@ -336,6 +349,10 @@ export function AutomationOverviewView({
   }, [entries, normalizedQuery, projectFilters, statusFilters]);
   const visibleEntries = useMemo(() => {
     return [...filteredEntries].sort((left, right) => {
+      const lifecycleOrder =
+        automationLifecycleSortRank(left.automation) -
+        automationLifecycleSortRank(right.automation);
+      if (lifecycleOrder !== 0) return lifecycleOrder;
       const base =
         sortMode === "project"
           ? automationProjectLabel(left.project).localeCompare(

--- a/plugins/automations/src/format-schedule.test.ts
+++ b/plugins/automations/src/format-schedule.test.ts
@@ -72,7 +72,7 @@ describe("automation list and detail states", () => {
         },
         ["paused"],
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       matchesAutomationStatusFilters(
         {

--- a/plugins/automations/src/model-label.test.ts
+++ b/plugins/automations/src/model-label.test.ts
@@ -7,6 +7,7 @@ import {
 describe("automation model labels", () => {
   it.each([
     ["codex", "gpt-5", "5"],
+    ["codex", "gpt-5.5-sol", "5.5 Sol"],
     ["codex", "gpt-5.4-mini", "5.4 Mini"],
     ["claude-code", "claude-sonnet-4-6", "Sonnet 4.6"],
     ["claude-code", "claude-opus-5[1m]", "Opus 5 (1M)"],

--- a/plugins/automations/src/model-label.test.ts
+++ b/plugins/automations/src/model-label.test.ts
@@ -7,7 +7,7 @@ import {
 describe("automation model labels", () => {
   it.each([
     ["codex", "gpt-5", "5"],
-    ["codex", "gpt-5.5-sol", "5.5 Sol"],
+    ["codex", "gpt-5.6-sol", "5.6 Sol"],
     ["codex", "gpt-5.4-mini", "5.4 Mini"],
     ["claude-code", "claude-sonnet-4-6", "Sonnet 4.6"],
     ["claude-code", "claude-opus-5[1m]", "Opus 5 (1M)"],


### PR DESCRIPTION
## What changed

- Open Extensions on Plugins from both the root route and the sidebar entry path.
- Default the Skills agent filter to BB, keep it selected even when the current library has no BB skills, and place BB Official skills first.
- Order installed plugins with enabled plugins first, then inactive plugins; enabled BB Official plugins lead their group, with name direction and plugin ID providing stable tie-breaks.
- Preserve user-selected filters, sort direction, and pagination after defaults are applied.
- Render the skills.sh Browse grid incrementally with one stable loading slot per skill; each slot becomes a fully populated card only after that card description and repository stats settle.
- Increase Browse card bylines from the `text-2xs` token to the sanctioned `text-xs` token.
- Expand regression coverage for Extensions entry routing, Skills defaults, Plugins pagination and mode switching, and per-card skills.sh loading.

## Why

The Extensions landing page and collection defaults should surface the most relevant BB-owned resources first without overwriting later user choices. Installed plugin ordering should make active plugins easiest to scan while remaining stable when names collide. Browse skill cards should appear progressively as coherent units, without either blocking the entire grid or visibly reshaping individual cards as secondary skills.sh requests complete.

The reported page-2 freeze came from the shared resource-pagination race already fixed on current main in `0a84c3708`: a stale page-size synchronization effect could overwrite a newer page selection. This PR verifies that shared fix through the Plugins integration rather than adding a plugin-specific workaround.

## Validation

- Route-memory regression: 7 tests passed.
- Skills view and per-card skills.sh loading regressions: 24 tests passed.
- App and shared UI Turbo typechecks passed.
- App and shared UI lint passed with 0 errors; the app reports 147 existing warnings.
- Running PR desktop verified Plugins opens first and Browse transitions from initial search loading into the card grid.
- Deterministic regression resolves one card while another remains pending and verifies only the complete card appears.
- Review loop completed with no remaining P0-P2 findings.