### PR TITLE
Ask before the desktop app attaches to a running bb

### DIFF
--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -72,6 +72,15 @@ await Promise.all([
   }),
   build({
     ...commonOptions,
+    entryPoints: [
+      resolve(packageRoot, "src", "existing-server-dialog-preload.ts"),
+    ],
+    external: ["electron"],
+    format: "cjs",
+    outfile: resolve(distDir, "existing-server-dialog-preload.cjs"),
+  }),
+  build({
+    ...commonOptions,
     entryPoints: [resolve(packageRoot, "src", "bb-app-bridge.ts")],
     external: ["bb-app", "bb-app/*"],
     format: "esm",

--- a/apps/desktop/src/existing-server-dialog-ipc.ts
+++ b/apps/desktop/src/existing-server-dialog-ipc.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const BB_DESKTOP_EXISTING_SERVER_DIALOG_CHOOSE_CHANNEL =
+  "bb-desktop:existing-server-dialog:choose";
+
+export const EXISTING_SERVER_DIALOG_CHOICES = [
+  "connect",
+  "quit",
+  "replace",
+] as const;
+
+export const existingServerDialogChooseRequestSchema = z
+  .object({
+    choice: z.enum(EXISTING_SERVER_DIALOG_CHOICES),
+  })
+  .strict();
+export type ExistingServerDialogChooseRequest = z.infer<
+  typeof existingServerDialogChooseRequestSchema
+>;

--- a/apps/desktop/src/existing-server-dialog-preload.ts
+++ b/apps/desktop/src/existing-server-dialog-preload.ts
@@ -1,0 +1,36 @@
+import { ipcRenderer } from "electron";
+import {
+  BB_DESKTOP_EXISTING_SERVER_DIALOG_CHOOSE_CHANNEL,
+  EXISTING_SERVER_DIALOG_CHOICES,
+  type ExistingServerDialogChooseRequest,
+} from "./existing-server-dialog-ipc.js";
+
+// The dialog page carries no scripts of its own (CSP default-src 'none');
+// the preload wires the buttons from the isolated world instead.
+window.addEventListener("DOMContentLoaded", () => {
+  function choose(choice: ExistingServerDialogChooseRequest["choice"]): void {
+    ipcRenderer.send(BB_DESKTOP_EXISTING_SERVER_DIALOG_CHOOSE_CHANNEL, {
+      choice,
+    });
+  }
+
+  for (const choice of EXISTING_SERVER_DIALOG_CHOICES) {
+    const button = document.querySelector<HTMLButtonElement>(
+      `button[data-choice="${choice}"]`,
+    );
+    button?.addEventListener("click", () => {
+      choose(choice);
+    });
+  }
+
+  document
+    .querySelector<HTMLButtonElement>('button[data-choice="connect"]')
+    ?.focus();
+
+  window.addEventListener("keydown", (event) => {
+    // Escape must not silently attach. Closing the question means "do not run".
+    if (event.key === "Escape") {
+      choose("quit");
+    }
+  });
+});

--- a/apps/desktop/src/existing-server-dialog.ts
+++ b/apps/desktop/src/existing-server-dialog.ts
@@ -1,0 +1,283 @@
+import { BrowserWindow, ipcMain } from "electron";
+import { escapeHtmlText } from "@bb/domain";
+import {
+  BB_DESKTOP_EXISTING_SERVER_DIALOG_CHOOSE_CHANNEL,
+  existingServerDialogChooseRequestSchema,
+} from "./existing-server-dialog-ipc.js";
+import type { ForeignRuntimeDetails } from "./foreign-runtime.js";
+
+export type ExistingServerDialogChoice = "connect" | "quit" | "replace";
+
+export interface OpenExistingServerDialogArgs {
+  /** Null when the running bb is too old to describe itself. */
+  details: ForeignRuntimeDetails | null;
+  parentWindow: BrowserWindow | null;
+  preloadPath: string;
+  serverUrl: string;
+}
+
+interface DetailRow {
+  label: string;
+  value: string;
+}
+
+export function formatStartedAt(startedAt: string, now: Date): string {
+  const started = new Date(startedAt);
+  if (Number.isNaN(started.getTime())) {
+    return startedAt;
+  }
+
+  const elapsedMinutes = Math.floor(
+    (now.getTime() - started.getTime()) / 60_000,
+  );
+  if (elapsedMinutes < 1) {
+    return "just now";
+  }
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes} min ago`;
+  }
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) {
+    return `${elapsedHours} h ago`;
+  }
+  return `${Math.floor(elapsedHours / 24)} d ago`;
+}
+
+export function formatSurface(surface: string): string {
+  return surface === "desktop" ? "the bb desktop app" : "a terminal";
+}
+
+function buildDetailRows(args: {
+  details: ForeignRuntimeDetails | null;
+  now: Date;
+  serverUrl: string;
+}): DetailRow[] {
+  const rows: DetailRow[] = [{ label: "Address", value: args.serverUrl }];
+  if (args.details === null) {
+    return rows;
+  }
+  rows.push(
+    { label: "Data", value: args.details.dataDir },
+    { label: "Version", value: args.details.version },
+    {
+      label: "Started",
+      value: `${formatStartedAt(args.details.startedAt, args.now)} by ${formatSurface(
+        args.details.surface,
+      )} (pid ${String(args.details.pid)})`,
+    },
+  );
+  return rows;
+}
+
+export interface RenderExistingServerDialogHtmlArgs {
+  details: ForeignRuntimeDetails | null;
+  now: Date;
+  serverUrl: string;
+}
+
+export function renderExistingServerDialogHtml(
+  args: RenderExistingServerDialogHtmlArgs,
+): string {
+  const rows = buildDetailRows({
+    details: args.details,
+    now: args.now,
+    serverUrl: args.serverUrl,
+  });
+  const detailHtml = rows
+    .map(
+      (row) =>
+        `<div class="row"><span>${escapeHtmlText(row.label)}</span><code>${escapeHtmlText(
+          row.value,
+        )}</code></div>`,
+    )
+    .join("\n      ");
+  // Stopping the other copy needs a verified pid, which only the runtime file
+  // provides. Hide the option, and its warning, rather than offer an action
+  // that cannot work.
+  const canReplace = args.details !== null;
+  const replaceButtonHtml = canReplace
+    ? `<button type="button" data-choice="replace">Quit other bb</button>`
+    : "";
+  const replaceWarningHtml = canReplace
+    ? `<p class="warning">If you stop the running copy, its agent threads stop too.</p>`
+    : "";
+  const introText = canReplace
+    ? "This app can use the copy that is already running, or you can stop it and start a new one."
+    : "This app can use the copy that is already running. bb cannot identify that copy, so it cannot stop it for you.";
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+  <title>bb is already running</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      background: Canvas;
+      color: CanvasText;
+      margin: 0;
+      padding: 20px;
+    }
+
+    h1 {
+      font-size: 14px;
+      font-weight: 600;
+      margin: 0 0 4px;
+    }
+
+    p {
+      color: color-mix(in srgb, CanvasText 70%, transparent);
+      font-size: 12px;
+      line-height: 1.45;
+      margin: 0 0 12px;
+    }
+
+    .details {
+      border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+      border-radius: 6px;
+      padding: 8px 10px;
+    }
+
+    .row {
+      display: flex;
+      font-size: 12px;
+      gap: 10px;
+      line-height: 1.6;
+    }
+
+    .row span {
+      color: color-mix(in srgb, CanvasText 55%, transparent);
+      flex: 0 0 62px;
+    }
+
+    .row code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      overflow-wrap: anywhere;
+    }
+
+    .warning {
+      margin: 12px 0 0;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-top: 14px;
+    }
+
+    button {
+      background: color-mix(in srgb, CanvasText 8%, Canvas);
+      border: 1px solid color-mix(in srgb, CanvasText 22%, transparent);
+      border-radius: 6px;
+      color: CanvasText;
+      font-size: 13px;
+      padding: 5px 14px;
+    }
+
+    button[data-choice="connect"] {
+      background: AccentColor;
+      border-color: AccentColor;
+      color: AccentColorText;
+    }
+  </style>
+</head>
+<body>
+  <h1>bb is already running on this Mac</h1>
+  <p>${introText}</p>
+  <div class="details">
+      ${detailHtml}
+  </div>
+  ${replaceWarningHtml}
+  <div class="actions">
+    <button type="button" data-choice="quit">Quit this bb</button>
+    ${replaceButtonHtml}
+    <button type="button" data-choice="connect">Connect</button>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * Ask before the desktop app attaches to a bb it did not start. Closing the
+ * window resolves to "quit", because attaching must always be a deliberate act.
+ */
+export function openExistingServerDialog(
+  args: OpenExistingServerDialogArgs,
+): Promise<ExistingServerDialogChoice> {
+  const dialogWindow = new BrowserWindow({
+    fullscreenable: false,
+    height: args.details === null ? 182 : 280,
+    maximizable: false,
+    minimizable: false,
+    modal: args.parentWindow !== null,
+    parent: args.parentWindow ?? undefined,
+    resizable: false,
+    show: false,
+    title: "bb is already running",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: args.preloadPath,
+      sandbox: true,
+    },
+    width: 460,
+  });
+
+  return new Promise<ExistingServerDialogChoice>((resolvePromise) => {
+    let settled = false;
+
+    function finish(choice: ExistingServerDialogChoice): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      ipcMain.removeListener(
+        BB_DESKTOP_EXISTING_SERVER_DIALOG_CHOOSE_CHANNEL,
+        handleChoose,
+      );
+      if (!dialogWindow.isDestroyed()) {
+        dialogWindow.close();
+      }
+      resolvePromise(choice);
+    }
+
+    function handleChoose(
+      event: { sender: { id: number } },
+      payload: unknown,
+    ): void {
+      if (event.sender.id !== dialogWindow.webContents.id) {
+        return;
+      }
+      const parsed = existingServerDialogChooseRequestSchema.safeParse(payload);
+      if (!parsed.success) {
+        return;
+      }
+      finish(parsed.data.choice);
+    }
+
+    ipcMain.on(BB_DESKTOP_EXISTING_SERVER_DIALOG_CHOOSE_CHANNEL, handleChoose);
+    dialogWindow.on("closed", () => {
+      finish("quit");
+    });
+
+    dialogWindow.once("ready-to-show", () => {
+      dialogWindow.show();
+    });
+    void dialogWindow.loadURL(
+      `data:text/html;charset=utf-8,${encodeURIComponent(
+        renderExistingServerDialogHtml({
+          details: args.details,
+          now: new Date(),
+          serverUrl: args.serverUrl,
+        }),
+      )}`,
+    );
+  });
+}

--- a/apps/desktop/src/foreign-runtime.ts
+++ b/apps/desktop/src/foreign-runtime.ts
@@ -1,5 +1,6 @@
 import {
   bbAppRuntimeVerifyTokens,
+  clearOwnBbAppRuntimeFile,
   readBbAppRuntimeFile,
   type BbAppRuntimeFile,
 } from "@bb/config/app-runtime-file";
@@ -17,6 +18,7 @@ import type { VerifiedProcessOps } from "@bb/config/verified-process-stop";
  */
 export interface ForeignRuntimeDetails {
   dataDir: string;
+  entryPath: string;
   pid: number;
   startedAt: string;
   surface: string;
@@ -29,14 +31,17 @@ export interface ReadForeignRuntimeDetailsArgs {
 }
 
 export interface StopForeignRuntimeArgs {
-  dataDir: string;
+  /** The record the person saw and approved, not a fresh read. */
+  details: ForeignRuntimeDetails;
+  killTimeoutMs: number;
   processOps?: VerifiedProcessOps;
   timeoutMs: number;
 }
 
 export type StopForeignRuntimeResult =
-  | { kind: "no-runtime-file" }
   | { kind: "not-running" }
+  | { kind: "replaced" }
+  | { kind: "still-running"; pid: number }
   | { kind: "stopped" }
   | { kind: "unverified"; pid: number };
 
@@ -74,6 +79,7 @@ export async function readForeignRuntimeDetails(
 
   return {
     dataDir: args.dataDir,
+    entryPath: runtimeFile.entryPath,
     pid: runtimeFile.pid,
     startedAt: runtimeFile.startedAt,
     surface: runtimeFile.surface,
@@ -81,27 +87,50 @@ export async function readForeignRuntimeDetails(
   };
 }
 
+/**
+ * Stop the exact bb the person approved in the dialog.
+ *
+ * The dialog waits for a person, which can take any amount of time, and another
+ * launcher can replace the record during that wait. So this re-reads the record
+ * and refuses to act when it no longer describes what the dialog showed, rather
+ * than stopping a process nobody was asked about.
+ */
 export async function stopForeignRuntime(
   args: StopForeignRuntimeArgs,
 ): Promise<StopForeignRuntimeResult> {
-  const runtimeFile = await readBbAppRuntimeFile(args.dataDir);
-  if (runtimeFile === null) {
-    return { kind: "no-runtime-file" };
+  const current = await readBbAppRuntimeFile(args.details.dataDir);
+  if (
+    current !== null &&
+    (current.pid !== args.details.pid ||
+      current.startedAt !== args.details.startedAt)
+  ) {
+    return { kind: "replaced" };
   }
 
   const stopResult = await stopVerifiedProcess({
-    pid: runtimeFile.pid,
+    killTimeoutMs: args.killTimeoutMs,
+    pid: args.details.pid,
     processOps: args.processOps,
     signal: "SIGTERM",
+    startedAt: args.details.startedAt,
     timeoutMs: args.timeoutMs,
-    verifyTokens: bbAppRuntimeVerifyTokens(runtimeFile),
+    verifyTokens: bbAppRuntimeVerifyTokens(args.details.entryPath),
   });
 
   if (stopResult.kind === "unverified") {
-    return { kind: "unverified", pid: runtimeFile.pid };
+    return { kind: "unverified", pid: args.details.pid };
+  }
+  if (stopResult.kind === "still-running") {
+    return { kind: "still-running", pid: args.details.pid };
   }
   if (stopResult.kind === "not-running") {
     return { kind: "not-running" };
   }
+  // A SIGKILLed launcher never runs its own cleanup, so clear the record it
+  // left behind, but only while it still names the process that was stopped.
+  await clearOwnBbAppRuntimeFile({
+    dataDir: args.details.dataDir,
+    pid: args.details.pid,
+  });
   return { kind: "stopped" };
 }

--- a/apps/desktop/src/foreign-runtime.ts
+++ b/apps/desktop/src/foreign-runtime.ts
@@ -1,0 +1,107 @@
+import {
+  bbAppRuntimeVerifyTokens,
+  readBbAppRuntimeFile,
+  type BbAppRuntimeFile,
+} from "@bb/config/app-runtime-file";
+import { stopVerifiedProcess } from "@bb/config/verified-process-stop";
+import type { VerifiedProcessOps } from "@bb/config/verified-process-stop";
+
+/**
+ * A "foreign runtime" is a bb this desktop app did not start: a `bb-app start`
+ * from a terminal, a launchd service, or a second desktop build. The desktop
+ * finds it by probing the port, then describes it from the runtime file that
+ * the launcher writes into the data directory.
+ *
+ * A bb older than that file reports `null` details. The caller must then offer
+ * only "connect" and "quit", because it cannot name or safely stop the process.
+ */
+export interface ForeignRuntimeDetails {
+  dataDir: string;
+  pid: number;
+  startedAt: string;
+  surface: string;
+  version: string;
+}
+
+export interface ReadForeignRuntimeDetailsArgs {
+  dataDir: string | null;
+  serverUrl: string;
+}
+
+export interface StopForeignRuntimeArgs {
+  dataDir: string;
+  processOps?: VerifiedProcessOps;
+  timeoutMs: number;
+}
+
+export type StopForeignRuntimeResult =
+  | { kind: "no-runtime-file" }
+  | { kind: "not-running" }
+  | { kind: "stopped" }
+  | { kind: "unverified"; pid: number };
+
+function matchesProbedServer(
+  runtimeFile: BbAppRuntimeFile,
+  serverUrl: string,
+): boolean {
+  try {
+    return new URL(runtimeFile.serverUrl).host === new URL(serverUrl).host;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the details of the bb that answered a probe. Returns `null` when the
+ * data directory is unknown, when no runtime file exists, or when the file
+ * describes a different server than the one that answered — a stale file from
+ * an earlier run on another port must never be used to stop a live process.
+ */
+export async function readForeignRuntimeDetails(
+  args: ReadForeignRuntimeDetailsArgs,
+): Promise<ForeignRuntimeDetails | null> {
+  if (args.dataDir === null) {
+    return null;
+  }
+
+  const runtimeFile = await readBbAppRuntimeFile(args.dataDir);
+  if (runtimeFile === null) {
+    return null;
+  }
+  if (!matchesProbedServer(runtimeFile, args.serverUrl)) {
+    return null;
+  }
+
+  return {
+    dataDir: args.dataDir,
+    pid: runtimeFile.pid,
+    startedAt: runtimeFile.startedAt,
+    surface: runtimeFile.surface,
+    version: runtimeFile.version,
+  };
+}
+
+export async function stopForeignRuntime(
+  args: StopForeignRuntimeArgs,
+): Promise<StopForeignRuntimeResult> {
+  const runtimeFile = await readBbAppRuntimeFile(args.dataDir);
+  if (runtimeFile === null) {
+    return { kind: "no-runtime-file" };
+  }
+
+  const stopResult = await stopVerifiedProcess({
+    pid: runtimeFile.pid,
+    processOps: args.processOps,
+    signal: "SIGTERM",
+    timeoutMs: args.timeoutMs,
+    verifyTokens: bbAppRuntimeVerifyTokens(runtimeFile),
+  });
+
+  if (stopResult.kind === "unverified") {
+    return { kind: "unverified", pid: runtimeFile.pid };
+  }
+  if (stopResult.kind === "not-running") {
+    return { kind: "not-running" };
+  }
+  return { kind: "stopped" };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -43,6 +43,11 @@ import {
   type BbAppProcessExit,
   startBbAppProcess,
 } from "./bb-process.js";
+import { openExistingServerDialog } from "./existing-server-dialog.js";
+import {
+  readForeignRuntimeDetails,
+  stopForeignRuntime,
+} from "./foreign-runtime.js";
 import { createLocalViewUrl } from "./local-view.js";
 import { installApplicationMenu } from "./menu.js";
 import {
@@ -57,6 +62,7 @@ import {
 import {
   probeBbServer,
   waitForCompatibleServer,
+  type CompatibleServerProbeResult,
   type ServerProbeResult,
 } from "./server-probe.js";
 import {
@@ -155,6 +161,7 @@ import {
 
 const OWNED_RUNTIME_STOP_TIMEOUT_MS = 6_000;
 const OWNED_RUNTIME_KILL_TIMEOUT_MS = 1_000;
+const FOREIGN_RUNTIME_STOP_TIMEOUT_MS = 15_000;
 
 interface DesktopRuntime {
   bbProcess: BbAppProcess | null;
@@ -279,6 +286,7 @@ let builtinServerUrl: string = DEFAULT_BB_SERVER_URL;
 let desktopBridgePath: string | null = null;
 let desktopUserDataPath: string | null = null;
 let serverUrlDialogPreloadPath: string | null = null;
+let existingServerDialogPreloadPath: string | null = null;
 
 function resolveDesktopServerUrl(args: ResolveDesktopServerUrlArgs): string {
   const rawPort = args.env.BB_SERVER_PORT?.trim();
@@ -1524,6 +1532,96 @@ interface InitializeRuntimeArgs {
   userDataPath: string;
 }
 
+/**
+ * Attaching to a bb this app did not start is invisible to the person using it,
+ * so ask first. Local development stays silent, because attaching to a
+ * `pnpm dev` server is the whole point there.
+ */
+function shouldAskBeforeAttaching(): boolean {
+  if (!app.isPackaged || existingServerDialogPreloadPath === null) {
+    return false;
+  }
+  return (process.env.BB_DESKTOP_APP_URL ?? "").trim().length === 0;
+}
+
+/**
+ * Wait for the port to close after the other copy was told to stop. A new
+ * server cannot bind a port that the old process still holds.
+ */
+async function waitForServerToStop(serverUrl: string): Promise<boolean> {
+  const deadline = Date.now() + FOREIGN_RUNTIME_STOP_TIMEOUT_MS;
+  while (Date.now() <= deadline) {
+    const probe = await probeBbServer({
+      serverUrl,
+      timeoutMs: ATTACH_PROBE_TIMEOUT_MS,
+    });
+    if (probe.kind === "unavailable") {
+      return true;
+    }
+    await new Promise<void>((resolvePromise) => {
+      setTimeout(resolvePromise, STARTUP_POLL_INTERVAL_MS);
+    });
+  }
+  return false;
+}
+
+type ExistingServerDecision = "attach" | "quit" | "start-fresh";
+
+async function decideOnExistingServer(
+  probe: CompatibleServerProbeResult,
+): Promise<ExistingServerDecision> {
+  if (!shouldAskBeforeAttaching()) {
+    return "attach";
+  }
+
+  const preloadPath = existingServerDialogPreloadPath;
+  if (preloadPath === null) {
+    return "attach";
+  }
+
+  const details = await readForeignRuntimeDetails({
+    dataDir: probe.dataDir,
+    serverUrl: probe.serverUrl,
+  });
+  const choice = await openExistingServerDialog({
+    details,
+    parentWindow: getFocusedApplicationWindow(),
+    preloadPath,
+    serverUrl: probe.serverUrl,
+  });
+
+  if (choice === "quit") {
+    return "quit";
+  }
+  if (choice === "connect" || details === null) {
+    return "attach";
+  }
+
+  const stopResult = await stopForeignRuntime({
+    dataDir: details.dataDir,
+    timeoutMs: FOREIGN_RUNTIME_STOP_TIMEOUT_MS,
+  });
+  if (stopResult.kind === "unverified") {
+    await loadStartupError({
+      details:
+        `The bb at ${probe.serverUrl} records process ${String(stopResult.pid)}, but that ` +
+        "process does not look like bb. bb did not stop it. Stop it yourself, then open bb again.",
+      logs: "",
+      title: "Could not stop the running bb",
+    });
+    return "quit";
+  }
+  if (!(await waitForServerToStop(probe.serverUrl))) {
+    await loadStartupError({
+      details: `The bb at ${probe.serverUrl} stopped, but the address is still in use.`,
+      logs: "",
+      title: "Could not stop the running bb",
+    });
+    return "quit";
+  }
+  return "start-fresh";
+}
+
 async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
   const existingProbe = await probeBbServer({
     serverUrl: args.serverUrl,
@@ -1531,6 +1629,26 @@ async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
   });
 
   if (existingProbe.kind === "compatible") {
+    const decision = await decideOnExistingServer(existingProbe);
+    if (decision === "quit") {
+      app.quit();
+      return;
+    }
+    if (decision === "start-fresh") {
+      await loadLoadingView();
+      const freshRuntime = await startOwnedRuntime({
+        bridgePath: args.bridgePath,
+        serverUrl: args.serverUrl,
+        userDataPath: args.userDataPath,
+      });
+      if (freshRuntime !== null) {
+        await loadBbApp(freshRuntime.serverUrl);
+        startSystemConfigSync(freshRuntime.serverUrl);
+        refreshApplicationMenu();
+      }
+      return;
+    }
+
     setCurrentRuntime({
       bbProcess: null,
       ownership: "attached",
@@ -1656,6 +1774,11 @@ async function runDesktopApp(): Promise<void> {
     "log-viewer-preload.cjs",
   );
   const preloadPath = join(paths.appPath, "dist", "preload.cjs");
+  const resolvedExistingServerDialogPreloadPath = join(
+    paths.appPath,
+    "dist",
+    "existing-server-dialog-preload.cjs",
+  );
   const resolvedServerUrlDialogPreloadPath = join(
     paths.appPath,
     "dist",
@@ -1672,6 +1795,10 @@ async function runDesktopApp(): Promise<void> {
   desktopUserDataPath = userDataPath;
 
   assertPathExists({ label: "bb-app bridge", path: bridgePath });
+  assertPathExists({
+    label: "existing server dialog preload script",
+    path: resolvedExistingServerDialogPreloadPath,
+  });
   assertPathExists({
     label: "log viewer preload script",
     path: resolvedLogViewerPreloadPath,
@@ -1785,6 +1912,7 @@ async function runDesktopApp(): Promise<void> {
   };
   logViewerPreloadPath = resolvedLogViewerPreloadPath;
   serverUrlDialogPreloadPath = resolvedServerUrlDialogPreloadPath;
+  existingServerDialogPreloadPath = resolvedExistingServerDialogPreloadPath;
   desktopWindowFactory = createDesktopWindowFactory({
     browserWindowCreator,
     createWindowStateKey() {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -162,6 +162,7 @@ import {
 const OWNED_RUNTIME_STOP_TIMEOUT_MS = 6_000;
 const OWNED_RUNTIME_KILL_TIMEOUT_MS = 1_000;
 const FOREIGN_RUNTIME_STOP_TIMEOUT_MS = 15_000;
+const FOREIGN_RUNTIME_KILL_TIMEOUT_MS = 3_000;
 
 interface DesktopRuntime {
   bbProcess: BbAppProcess | null;
@@ -1598,14 +1599,33 @@ async function decideOnExistingServer(
   }
 
   const stopResult = await stopForeignRuntime({
-    dataDir: details.dataDir,
+    details,
+    killTimeoutMs: FOREIGN_RUNTIME_KILL_TIMEOUT_MS,
     timeoutMs: FOREIGN_RUNTIME_STOP_TIMEOUT_MS,
   });
   if (stopResult.kind === "unverified") {
     await loadStartupError({
       details:
         `The bb at ${probe.serverUrl} records process ${String(stopResult.pid)}, but that ` +
-        "process does not look like bb. bb did not stop it. Stop it yourself, then open bb again.",
+        "process no longer matches the record. bb did not stop it. Stop it yourself, then open bb again.",
+      logs: "",
+      title: "Could not stop the running bb",
+    });
+    return "quit";
+  }
+  if (stopResult.kind === "still-running") {
+    await loadStartupError({
+      details: `bb could not stop process ${String(stopResult.pid)}, even after SIGKILL.`,
+      logs: "",
+      title: "Could not stop the running bb",
+    });
+    return "quit";
+  }
+  if (stopResult.kind === "replaced") {
+    await loadStartupError({
+      details:
+        `Another bb started at ${probe.serverUrl} while the question was open, so bb stopped nothing. ` +
+        "Open bb again to see the copy that runs now.",
       logs: "",
       title: "Could not stop the running bb",
     });

--- a/apps/desktop/src/owned-runtime-supervisor.ts
+++ b/apps/desktop/src/owned-runtime-supervisor.ts
@@ -1,13 +1,14 @@
-import { execFile } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { promisify } from "node:util";
+import {
+  createNodeVerifiedProcessOps,
+  stopVerifiedProcess,
+  type VerifiedProcessOps,
+  type WaitForProcessExitArgs,
+} from "@bb/config/verified-process-stop";
 import { z } from "zod";
 
 const OWNED_RUNTIME_PID_FILE_NAME = "owned-runtime.json";
-const POLL_INTERVAL_MS = 100;
-
-const execFileAsync = promisify(execFile);
 
 const ownedRuntimePidFileSchema = z.object({
   bridgePath: z.string().min(1),
@@ -51,17 +52,8 @@ export interface ReapStaleOwnedRuntimeArgs {
   userDataPath: string;
 }
 
-export interface OwnedRuntimeProcessOps {
-  isRunning(pid: number): boolean;
-  kill(pid: number, signal: NodeJS.Signals): void;
-  readCommand(pid: number): Promise<string | null>;
-  waitForExit(args: WaitForProcessExitArgs): Promise<boolean>;
-}
-
-export interface WaitForProcessExitArgs {
-  pid: number;
-  timeoutMs: number;
-}
+export type OwnedRuntimeProcessOps = VerifiedProcessOps;
+export type { WaitForProcessExitArgs };
 
 export interface NoStaleOwnedRuntimePidFileResult {
   kind: "no-pid-file";
@@ -83,65 +75,12 @@ export interface SkippedStaleOwnedRuntimeResult {
   pid: number;
 }
 
-interface SleepArgs {
-  delayMs: number;
-}
-
 function ownedRuntimePidFilePath(userDataPath: string): string {
   return join(userDataPath, OWNED_RUNTIME_PID_FILE_NAME);
 }
 
-async function sleep(args: SleepArgs): Promise<void> {
-  await new Promise<void>((resolvePromise) => {
-    setTimeout(resolvePromise, args.delayMs);
-  });
-}
-
-async function readProcessCommand(pid: number): Promise<string | null> {
-  try {
-    const result = await execFileAsync("ps", [
-      "-p",
-      String(pid),
-      "-o",
-      "command=",
-    ]);
-    return result.stdout.trim();
-  } catch {
-    return null;
-  }
-}
-
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForProcessExit(
-  args: WaitForProcessExitArgs,
-): Promise<boolean> {
-  const deadline = Date.now() + args.timeoutMs;
-  while (Date.now() <= deadline) {
-    if (!isProcessRunning(args.pid)) {
-      return true;
-    }
-    await sleep({ delayMs: POLL_INTERVAL_MS });
-  }
-  return !isProcessRunning(args.pid);
-}
-
 export function createNodeOwnedRuntimeProcessOps(): OwnedRuntimeProcessOps {
-  return {
-    isRunning: (pid) => isProcessRunning(pid),
-    kill(pid, signal) {
-      process.kill(pid, signal);
-    },
-    readCommand: (pid) => readProcessCommand(pid),
-    waitForExit: (args) => waitForProcessExit(args),
-  };
+  return createNodeVerifiedProcessOps();
 }
 
 export async function writeOwnedRuntimePidFile(
@@ -194,7 +133,15 @@ export async function reapStaleOwnedRuntime(
     return { kind: "no-pid-file" };
   }
 
-  if (!processOps.isRunning(pidFile.pid)) {
+  const stopResult = await stopVerifiedProcess({
+    pid: pidFile.pid,
+    processOps,
+    signal: args.signal,
+    timeoutMs: args.timeoutMs,
+    verifyTokens: [pidFile.bridgePath],
+  });
+
+  if (stopResult.kind === "not-running") {
     await clearOwnedRuntimePidFile({ userDataPath: args.userDataPath });
     return {
       kind: "cleared-stale-pid-file",
@@ -202,26 +149,12 @@ export async function reapStaleOwnedRuntime(
     };
   }
 
-  const command = await processOps.readCommand(pidFile.pid);
-  if (command === null || !command.includes(pidFile.bridgePath)) {
+  if (stopResult.kind === "unverified") {
     return {
-      command,
+      command: stopResult.command,
       kind: "skipped-unverified-process",
       pid: pidFile.pid,
     };
-  }
-
-  processOps.kill(pidFile.pid, args.signal);
-  const exited = await processOps.waitForExit({
-    pid: pidFile.pid,
-    timeoutMs: args.timeoutMs,
-  });
-  if (!exited && processOps.isRunning(pidFile.pid)) {
-    processOps.kill(pidFile.pid, "SIGKILL");
-    await processOps.waitForExit({
-      pid: pidFile.pid,
-      timeoutMs: args.timeoutMs,
-    });
   }
 
   await clearOwnedRuntimePidFile({ userDataPath: args.userDataPath });

--- a/apps/desktop/src/owned-runtime-supervisor.ts
+++ b/apps/desktop/src/owned-runtime-supervisor.ts
@@ -9,6 +9,7 @@ import {
 import { z } from "zod";
 
 const OWNED_RUNTIME_PID_FILE_NAME = "owned-runtime.json";
+const KILL_TIMEOUT_MS = 3_000;
 
 const ownedRuntimePidFileSchema = z.object({
   bridgePath: z.string().min(1),
@@ -19,6 +20,7 @@ const ownedRuntimePidFileSchema = z.object({
 
 export type ReapStaleOwnedRuntimeResult =
   | ClearedStaleOwnedRuntimePidFileResult
+  | FailedToStopOwnedRuntimeResult
   | NoStaleOwnedRuntimePidFileResult
   | ReapedStaleOwnedRuntimeResult
   | SkippedStaleOwnedRuntimeResult;
@@ -66,6 +68,11 @@ export interface ClearedStaleOwnedRuntimePidFileResult {
 
 export interface ReapedStaleOwnedRuntimeResult {
   kind: "reaped";
+  pid: number;
+}
+
+export interface FailedToStopOwnedRuntimeResult {
+  kind: "failed-to-stop";
   pid: number;
 }
 
@@ -134,9 +141,11 @@ export async function reapStaleOwnedRuntime(
   }
 
   const stopResult = await stopVerifiedProcess({
+    killTimeoutMs: KILL_TIMEOUT_MS,
     pid: pidFile.pid,
     processOps,
     signal: args.signal,
+    startedAt: pidFile.startedAt,
     timeoutMs: args.timeoutMs,
     verifyTokens: [pidFile.bridgePath],
   });
@@ -153,6 +162,14 @@ export async function reapStaleOwnedRuntime(
     return {
       command: stopResult.command,
       kind: "skipped-unverified-process",
+      pid: pidFile.pid,
+    };
+  }
+
+  // Keep the pid file when the process survived, so the next launch retries it.
+  if (stopResult.kind === "still-running") {
+    return {
+      kind: "failed-to-stop",
       pid: pidFile.pid,
     };
   }

--- a/apps/desktop/src/server-probe.ts
+++ b/apps/desktop/src/server-probe.ts
@@ -8,6 +8,9 @@ const healthResponseSchema = z
 
 const systemConfigResponseSchema = z
   .object({
+    // Optional on purpose: the probed server can be an older bb that predates
+    // this field, and it is still compatible enough to attach to.
+    dataDir: z.string().min(1).optional(),
     hostDaemonPort: z.number().int().min(1).max(65_535),
     voiceTranscriptionEnabled: z.boolean(),
   })
@@ -24,6 +27,8 @@ export type ServerProbeFetch = (
 ) => Promise<Response>;
 
 export interface CompatibleServerProbeResult {
+  /** Data directory the probed server reports, or null on an older bb. */
+  dataDir: string | null;
   kind: "compatible";
   serverUrl: string;
 }
@@ -204,6 +209,7 @@ export async function probeBbServer(
   }
 
   return {
+    dataDir: configResult.value.dataDir ?? null,
     kind: "compatible",
     serverUrl: args.serverUrl,
   };

--- a/apps/desktop/src/server-target.ts
+++ b/apps/desktop/src/server-target.ts
@@ -185,8 +185,7 @@ export function createServerTargetStore(
       if (
         connectServer === null ||
         connectServer.handle !== server.handle ||
-        (connectServer.name === server.name &&
-          connectServer.url === server.url)
+        (connectServer.name === server.name && connectServer.url === server.url)
       ) {
         return false;
       }

--- a/apps/desktop/test/existing-server-dialog.test.ts
+++ b/apps/desktop/test/existing-server-dialog.test.ts
@@ -10,6 +10,7 @@ const NOW = new Date("2026-08-03T12:00:00.000Z");
 
 const DETAILS = {
   dataDir: "/Users/example/.bb",
+  entryPath: "/opt/bb/bb-app.js",
   pid: 4_242,
   startedAt: "2026-08-03T11:30:00.000Z",
   surface: "web",

--- a/apps/desktop/test/existing-server-dialog.test.ts
+++ b/apps/desktop/test/existing-server-dialog.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { EXISTING_SERVER_DIALOG_CHOICES } from "../src/existing-server-dialog-ipc.js";
+import {
+  formatStartedAt,
+  formatSurface,
+  renderExistingServerDialogHtml,
+} from "../src/existing-server-dialog.js";
+
+const NOW = new Date("2026-08-03T12:00:00.000Z");
+
+const DETAILS = {
+  dataDir: "/Users/example/.bb",
+  pid: 4_242,
+  startedAt: "2026-08-03T11:30:00.000Z",
+  surface: "web",
+  version: "0.34.0",
+};
+
+describe("formatStartedAt", () => {
+  it("describes how long ago bb started", () => {
+    expect(formatStartedAt("2026-08-03T11:59:30.000Z", NOW)).toBe("just now");
+    expect(formatStartedAt("2026-08-03T11:30:00.000Z", NOW)).toBe("30 min ago");
+    expect(formatStartedAt("2026-08-03T04:00:00.000Z", NOW)).toBe("8 h ago");
+    expect(formatStartedAt("2026-07-31T12:00:00.000Z", NOW)).toBe("3 d ago");
+  });
+
+  it("falls back to the raw value it cannot parse", () => {
+    expect(formatStartedAt("not-a-date", NOW)).toBe("not-a-date");
+  });
+});
+
+describe("formatSurface", () => {
+  it("names how bb was started", () => {
+    expect(formatSurface("desktop")).toBe("the bb desktop app");
+    expect(formatSurface("web")).toBe("a terminal");
+  });
+});
+
+describe("renderExistingServerDialogHtml", () => {
+  it("renders a button for every choice the preload wires up", () => {
+    const html = renderExistingServerDialogHtml({
+      details: DETAILS,
+      now: NOW,
+      serverUrl: "http://127.0.0.1:38886",
+    });
+
+    for (const choice of EXISTING_SERVER_DIALOG_CHOICES) {
+      expect(html).toContain(`data-choice="${choice}"`);
+    }
+    expect(html).toContain(">Quit this bb<");
+    expect(html).toContain(">Quit other bb<");
+    expect(html).toContain(">Connect<");
+  });
+
+  it("describes the running bb", () => {
+    const html = renderExistingServerDialogHtml({
+      details: DETAILS,
+      now: NOW,
+      serverUrl: "http://127.0.0.1:38886",
+    });
+
+    expect(html).toContain("http://127.0.0.1:38886");
+    expect(html).toContain("/Users/example/.bb");
+    expect(html).toContain("0.34.0");
+    expect(html).toContain("30 min ago by a terminal (pid 4242)");
+  });
+
+  it("hides the stop option for a bb that cannot be identified", () => {
+    const html = renderExistingServerDialogHtml({
+      details: null,
+      now: NOW,
+      serverUrl: "http://127.0.0.1:38886",
+    });
+
+    expect(html).toContain('data-choice="connect"');
+    expect(html).toContain('data-choice="quit"');
+    expect(html).not.toContain('data-choice="replace"');
+    // The warning only makes sense next to a stop button.
+    expect(html).not.toContain("agent threads stop too");
+  });
+
+  it("escapes values that come from the running bb", () => {
+    const html = renderExistingServerDialogHtml({
+      details: { ...DETAILS, dataDir: '/tmp/<img src=x onerror="boom">' },
+      now: NOW,
+      serverUrl: "http://127.0.0.1:38886",
+    });
+
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+});

--- a/apps/desktop/test/foreign-runtime.test.ts
+++ b/apps/desktop/test/foreign-runtime.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeBbAppRuntimeFile } from "@bb/config/app-runtime-file";
+import type { VerifiedProcessOps } from "@bb/config/verified-process-stop";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readForeignRuntimeDetails,
+  stopForeignRuntime,
+} from "../src/foreign-runtime.js";
+
+const tempDirs: string[] = [];
+
+async function createDataDir(): Promise<string> {
+  const dataDir = await mkdtemp(join(tmpdir(), "bb-foreign-runtime-"));
+  tempDirs.push(dataDir);
+  return dataDir;
+}
+
+function createProcessOps(
+  overrides: Partial<VerifiedProcessOps> = {},
+): VerifiedProcessOps {
+  return {
+    isRunning: vi.fn(() => true),
+    kill: vi.fn(),
+    readCommand: vi.fn(async () => "node /opt/bb/bb-app.js start"),
+    waitForExit: vi.fn(async () => true),
+    ...overrides,
+  };
+}
+
+async function writeRuntimeFile(args: {
+  dataDir: string;
+  entryPath?: string;
+  pid?: number;
+  serverUrl?: string;
+}): Promise<void> {
+  await writeBbAppRuntimeFile({
+    dataDir: args.dataDir,
+    entryPath: args.entryPath ?? "/opt/bb/bb-app.js",
+    pid: args.pid ?? 4_242,
+    serverUrl: args.serverUrl ?? "http://127.0.0.1:38886",
+    startedAt: "2026-08-03T10:00:00.000Z",
+    surface: "web",
+    version: "0.34.0",
+  });
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dataDir = tempDirs.pop();
+    if (dataDir !== undefined) {
+      await rm(dataDir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("readForeignRuntimeDetails", () => {
+  it("describes the running bb when the runtime file matches the probed server", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+
+    await expect(
+      readForeignRuntimeDetails({
+        dataDir,
+        serverUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toEqual({
+      dataDir,
+      pid: 4_242,
+      startedAt: "2026-08-03T10:00:00.000Z",
+      surface: "web",
+      version: "0.34.0",
+    });
+  });
+
+  it("ignores a runtime file left over from a run on a different port", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir, serverUrl: "http://127.0.0.1:39999" });
+
+    await expect(
+      readForeignRuntimeDetails({
+        dataDir,
+        serverUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for a bb that writes no runtime file", async () => {
+    const dataDir = await createDataDir();
+
+    await expect(
+      readForeignRuntimeDetails({
+        dataDir,
+        serverUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("stopForeignRuntime", () => {
+  it("signals the recorded process when its command line matches", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+    const processOps = createProcessOps();
+
+    await expect(
+      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+    ).resolves.toEqual({ kind: "stopped" });
+    expect(processOps.kill).toHaveBeenCalledWith(4_242, "SIGTERM");
+  });
+
+  it("recognises a launcher that was started with a relative path", async () => {
+    const dataDir = await createDataDir();
+    // Node resolves argv[1] to an absolute path, but ps reports what was typed.
+    await writeRuntimeFile({
+      dataDir,
+      entryPath: "/Users/example/bb/packages/bb-app/dist/bb-app.js",
+    });
+    const processOps = createProcessOps({
+      readCommand: vi.fn(
+        async () => "node packages/bb-app/dist/bb-app.js start",
+      ),
+    });
+
+    await expect(
+      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+    ).resolves.toEqual({ kind: "stopped" });
+    expect(processOps.kill).toHaveBeenCalledWith(4_242, "SIGTERM");
+  });
+
+  it("escalates to SIGKILL when the process outlives SIGTERM", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+    const processOps = createProcessOps({
+      waitForExit: vi.fn(async () => false),
+    });
+
+    await expect(
+      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+    ).resolves.toEqual({ kind: "stopped" });
+    expect(processOps.kill).toHaveBeenNthCalledWith(1, 4_242, "SIGTERM");
+    expect(processOps.kill).toHaveBeenNthCalledWith(2, 4_242, "SIGKILL");
+  });
+
+  it("refuses to signal a recycled pid that no longer looks like bb", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+    const processOps = createProcessOps({
+      readCommand: vi.fn(
+        async () => "/Applications/Mail.app/Contents/MacOS/Mail",
+      ),
+    });
+
+    await expect(
+      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+    ).resolves.toEqual({ kind: "unverified", pid: 4_242 });
+    expect(processOps.kill).not.toHaveBeenCalled();
+  });
+
+  it("reports a stale record when the recorded process already exited", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+    const processOps = createProcessOps({ isRunning: vi.fn(() => false) });
+
+    await expect(
+      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+    ).resolves.toEqual({ kind: "not-running" });
+    expect(processOps.kill).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/test/foreign-runtime.test.ts
+++ b/apps/desktop/test/foreign-runtime.test.ts
@@ -1,15 +1,20 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { writeBbAppRuntimeFile } from "@bb/config/app-runtime-file";
+import {
+  readBbAppRuntimeFile,
+  writeBbAppRuntimeFile,
+} from "@bb/config/app-runtime-file";
 import type { VerifiedProcessOps } from "@bb/config/verified-process-stop";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   readForeignRuntimeDetails,
   stopForeignRuntime,
+  type ForeignRuntimeDetails,
 } from "../src/foreign-runtime.js";
 
 const tempDirs: string[] = [];
+const STARTED_AT = new Date(Date.now() - 30 * 60_000).toISOString();
 
 async function createDataDir(): Promise<string> {
   const dataDir = await mkdtemp(join(tmpdir(), "bb-foreign-runtime-"));
@@ -24,6 +29,8 @@ function createProcessOps(
     isRunning: vi.fn(() => true),
     kill: vi.fn(),
     readCommand: vi.fn(async () => "node /opt/bb/bb-app.js start"),
+    // Matches STARTED_AT, so the identity check passes by default.
+    readElapsedSeconds: vi.fn(async () => 30 * 60),
     waitForExit: vi.fn(async () => true),
     ...overrides,
   };
@@ -34,16 +41,28 @@ async function writeRuntimeFile(args: {
   entryPath?: string;
   pid?: number;
   serverUrl?: string;
+  startedAt?: string;
 }): Promise<void> {
   await writeBbAppRuntimeFile({
     dataDir: args.dataDir,
     entryPath: args.entryPath ?? "/opt/bb/bb-app.js",
     pid: args.pid ?? 4_242,
     serverUrl: args.serverUrl ?? "http://127.0.0.1:38886",
-    startedAt: "2026-08-03T10:00:00.000Z",
+    startedAt: args.startedAt ?? STARTED_AT,
     surface: "web",
     version: "0.34.0",
   });
+}
+
+function detailsFor(dataDir: string): ForeignRuntimeDetails {
+  return {
+    dataDir,
+    entryPath: "/opt/bb/bb-app.js",
+    pid: 4_242,
+    startedAt: STARTED_AT,
+    surface: "web",
+    version: "0.34.0",
+  };
 }
 
 afterEach(async () => {
@@ -65,13 +84,7 @@ describe("readForeignRuntimeDetails", () => {
         dataDir,
         serverUrl: "http://127.0.0.1:38886",
       }),
-    ).resolves.toEqual({
-      dataDir,
-      pid: 4_242,
-      startedAt: "2026-08-03T10:00:00.000Z",
-      surface: "web",
-      version: "0.34.0",
-    });
+    ).resolves.toEqual(detailsFor(dataDir));
   });
 
   it("ignores a runtime file left over from a run on a different port", async () => {
@@ -99,24 +112,27 @@ describe("readForeignRuntimeDetails", () => {
 });
 
 describe("stopForeignRuntime", () => {
-  it("signals the recorded process when its command line matches", async () => {
+  it("signals the process the dialog showed, then clears its record", async () => {
     const dataDir = await createDataDir();
     await writeRuntimeFile({ dataDir });
     const processOps = createProcessOps();
 
     await expect(
-      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
     ).resolves.toEqual({ kind: "stopped" });
     expect(processOps.kill).toHaveBeenCalledWith(4_242, "SIGTERM");
+    await expect(readBbAppRuntimeFile(dataDir)).resolves.toBeNull();
   });
 
   it("recognises a launcher that was started with a relative path", async () => {
     const dataDir = await createDataDir();
     // Node resolves argv[1] to an absolute path, but ps reports what was typed.
-    await writeRuntimeFile({
-      dataDir,
-      entryPath: "/Users/example/bb/packages/bb-app/dist/bb-app.js",
-    });
+    await writeRuntimeFile({ dataDir });
     const processOps = createProcessOps({
       readCommand: vi.fn(
         async () => "node packages/bb-app/dist/bb-app.js start",
@@ -124,12 +140,73 @@ describe("stopForeignRuntime", () => {
     });
 
     await expect(
-      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
     ).resolves.toEqual({ kind: "stopped" });
     expect(processOps.kill).toHaveBeenCalledWith(4_242, "SIGTERM");
   });
 
+  it("refuses a recycled pid whose start time does not match the record", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+    // Same command name, but this process started seconds ago, not 30 min ago.
+    const processOps = createProcessOps({
+      readElapsedSeconds: vi.fn(async () => 5),
+    });
+
+    await expect(
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({ kind: "unverified", pid: 4_242 });
+    expect(processOps.kill).not.toHaveBeenCalled();
+  });
+
+  it("refuses to act when another launcher replaced the record during the prompt", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir, pid: 5_555 });
+    const processOps = createProcessOps();
+
+    await expect(
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({ kind: "replaced" });
+    expect(processOps.kill).not.toHaveBeenCalled();
+  });
+
   it("escalates to SIGKILL when the process outlives SIGTERM", async () => {
+    const dataDir = await createDataDir();
+    await writeRuntimeFile({ dataDir });
+    const waitForExit = vi
+      .fn<VerifiedProcessOps["waitForExit"]>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const processOps = createProcessOps({ waitForExit });
+
+    await expect(
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({ kind: "stopped" });
+    expect(processOps.kill).toHaveBeenNthCalledWith(1, 4_242, "SIGTERM");
+    expect(processOps.kill).toHaveBeenNthCalledWith(2, 4_242, "SIGKILL");
+  });
+
+  it("reports a process that survives SIGKILL and keeps its record", async () => {
     const dataDir = await createDataDir();
     await writeRuntimeFile({ dataDir });
     const processOps = createProcessOps({
@@ -137,10 +214,14 @@ describe("stopForeignRuntime", () => {
     });
 
     await expect(
-      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
-    ).resolves.toEqual({ kind: "stopped" });
-    expect(processOps.kill).toHaveBeenNthCalledWith(1, 4_242, "SIGTERM");
-    expect(processOps.kill).toHaveBeenNthCalledWith(2, 4_242, "SIGKILL");
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({ kind: "still-running", pid: 4_242 });
+    await expect(readBbAppRuntimeFile(dataDir)).resolves.not.toBeNull();
   });
 
   it("refuses to signal a recycled pid that no longer looks like bb", async () => {
@@ -153,7 +234,12 @@ describe("stopForeignRuntime", () => {
     });
 
     await expect(
-      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
     ).resolves.toEqual({ kind: "unverified", pid: 4_242 });
     expect(processOps.kill).not.toHaveBeenCalled();
   });
@@ -164,7 +250,12 @@ describe("stopForeignRuntime", () => {
     const processOps = createProcessOps({ isRunning: vi.fn(() => false) });
 
     await expect(
-      stopForeignRuntime({ dataDir, processOps, timeoutMs: 1_000 }),
+      stopForeignRuntime({
+        details: detailsFor(dataDir),
+        killTimeoutMs: 100,
+        processOps,
+        timeoutMs: 1_000,
+      }),
     ).resolves.toEqual({ kind: "not-running" });
     expect(processOps.kill).not.toHaveBeenCalled();
   });

--- a/apps/desktop/test/owned-runtime-supervisor.test.ts
+++ b/apps/desktop/test/owned-runtime-supervisor.test.ts
@@ -47,6 +47,11 @@ function createFakeProcessOps(args: CreateFakeProcessOpsArgs): FakeProcessOps {
     async readCommand() {
       return args.command;
     },
+    async readElapsedSeconds() {
+      // The pid file is written at spawn time, so the process start time and
+      // the recorded time always agree in these tests.
+      return 0;
+    },
     async waitForExit(_args: WaitForProcessExitArgs) {
       return !running;
     },

--- a/apps/desktop/test/server-probe.test.ts
+++ b/apps/desktop/test/server-probe.test.ts
@@ -4,10 +4,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  probeBbServer,
-  type ServerProbeFetch,
-} from "../src/server-probe.js";
+import { probeBbServer, type ServerProbeFetch } from "../src/server-probe.js";
 
 interface TestServer {
   close(): Promise<void>;
@@ -86,6 +83,7 @@ describe("probeBbServer", () => {
         timeoutMs: 1_000,
       }),
     ).resolves.toEqual({
+      dataDir: null,
       kind: "compatible",
       serverUrl: "https://studio.example",
     });
@@ -118,8 +116,34 @@ describe("probeBbServer", () => {
     await expect(
       probeBbServer({ serverUrl: testServer.url, timeoutMs: 500 }),
     ).resolves.toEqual({
+      dataDir: null,
       kind: "compatible",
       serverUrl: testServer.url,
+    });
+  });
+
+  it("reports the data directory the probed server declares", async () => {
+    const fetchImpl = vi
+      .fn<ServerProbeFetch>()
+      .mockResolvedValueOnce(Response.json({ ok: true }))
+      .mockResolvedValueOnce(
+        Response.json({
+          dataDir: "/Users/example/.bb",
+          hostDaemonPort: 4_242,
+          voiceTranscriptionEnabled: false,
+        }),
+      );
+
+    await expect(
+      probeBbServer({
+        fetchImpl,
+        serverUrl: "https://studio.example",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({
+      dataDir: "/Users/example/.bb",
+      kind: "compatible",
+      serverUrl: "https://studio.example",
     });
   });
 
@@ -174,6 +198,7 @@ describe("probeBbServer", () => {
     await expect(
       probeBbServer({ serverUrl: testServer.url, timeoutMs: 500 }),
     ).resolves.toEqual({
+      dataDir: null,
       kind: "compatible",
       serverUrl: testServer.url,
     });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,22 @@ right file and refresh the right server.
 Startup settings such as data directory and ports still apply when the process
 starts.
 
+## Stopping A Running bb
+
+A running `bb-app start` writes `<dataDir>/bb-app-runtime.json` and removes the
+file when it exits. The file records the launcher process id, the server URL,
+the version, the start time, and how bb was started. Do not edit it.
+
+Two things read that file:
+
+- `npx bb-app stop` stops the bb that owns the data directory. Pass the same
+  `--data-dir` you started with when it is not the default `~/.bb/`.
+- The macOS desktop app asks before it uses a bb it did not start, and offers to
+  stop that copy for you.
+
+Both confirm that the recorded process really is a bb launcher before they
+signal it, so a stale file left by a crash cannot stop an unrelated process.
+
 ## Common Keys
 
 | Key                | Command         | When to set             | Used for                                                                                                                                       |

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -76,6 +76,16 @@ local host daemon, and serves the web app. It stores bb-managed state under
 launcher restarts that child without stopping the other one. Press `Ctrl+C` in
 the terminal to stop both processes and exit with status `0`.
 
+To stop a bb that runs in another terminal or in the background:
+
+```bash
+npx bb-app stop
+```
+
+`stop` reads `bb-app-runtime.json` from the data directory, confirms that the
+recorded process really is that launcher, then stops it. Pass `--data-dir` when
+the bb you want to stop does not use the default `~/.bb/`.
+
 From the app, add or open a project, start a thread, and choose the provider
 you want that thread to use.
 
@@ -118,14 +128,14 @@ targets. Scripts launched by bb already receive `BB_SERVER_URL` and
 
 bb uses whichever providers you have configured. Common providers:
 
-| Provider      | Setup                                                                                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `codex`       | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                  |
-| `claude-code` | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                   |
-| `cursor`      | Install [Cursor's agent CLI](https://cursor.com/cli) (`agent`) and authenticate per Cursor's docs.                                                     |
-| `pi`          | See the [Pi coding agent docs](https://github.com/earendil-works/pi/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup. |
-| `opencode`    | Install [opencode](https://opencode.ai/) and authenticate per its docs.                                                                                |
-| `grok`        | Install [Grok Build](https://docs.x.ai/build/overview) and authenticate with `grok login` or `XAI_API_KEY`.                                           |
+| Provider       | Setup                                                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `codex`        | Install the [Codex CLI](https://developers.openai.com/codex/cli). Then run `codex login` or configure credentials per the Codex docs.                                                  |
+| `claude-code`  | Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and authenticate per its docs.                                                                                   |
+| `cursor`       | Install [Cursor's agent CLI](https://cursor.com/cli) (`agent`) and authenticate per Cursor's docs.                                                                                     |
+| `pi`           | See the [Pi coding agent docs](https://github.com/earendil-works/pi/tree/main/packages/coding-agent). Run `pi` and then `/login` for interactive setup.                                |
+| `opencode`     | Install [opencode](https://opencode.ai/) and authenticate per its docs.                                                                                                                |
+| `grok`         | Install [Grok Build](https://docs.x.ai/build/overview) and authenticate with `grok login` or `XAI_API_KEY`.                                                                            |
 | `hermes-agent` | Install [Hermes Agent](https://hermes-agent.nousresearch.com/docs/getting-started/installation), configure credentials with `hermes model`, then verify ACP with `hermes acp --check`. |
 
 Custom ACP agents can be configured through `customAcpAgents` in

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -17,9 +17,10 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import {
   bbAppRuntimeVerifyTokens,
-  clearBbAppRuntimeFile,
+  claimBbAppRuntimeFile,
+  clearOwnBbAppRuntimeFile,
+  formatBbAppRuntimeFilePath,
   readBbAppRuntimeFile,
-  writeBbAppRuntimeFile,
 } from "@bb/config/app-runtime-file";
 import { stopVerifiedProcess } from "@bb/config/verified-process-stop";
 import {
@@ -74,6 +75,7 @@ const MANAGED_PROCESS_RESTART_RETRY_DELAY_MS = 1_000;
 const START_COMMAND = "start";
 const STOP_COMMAND = "stop";
 const STOP_TIMEOUT_MS = 15_000;
+const STOP_KILL_TIMEOUT_MS = 3_000;
 const HOST_DAEMON_COMMAND = "host-daemon";
 const HOST_DAEMON_JOIN_COMMAND = "join";
 const CLIENT_COMMAND = "client";
@@ -593,6 +595,13 @@ function warnExistingDaemonLock(lockDir: string): void {
   log(yellow("!"), "Daemon lock exists - waiting or reclaiming if stale");
   log(" ", dim(`lock: ${lockDir}`));
   log(" ", dim("If startup fails, stop the other bb process or remove it."));
+  process.stdout.write("\n");
+}
+
+function warnExistingRuntimeRecord(dataDir: string): void {
+  log(yellow("!"), "Another bb already runs on this data directory");
+  log(" ", dim(`record: ${formatBbAppRuntimeFilePath(dataDir)}`));
+  log(" ", dim("Run `bb-app stop` to stop it."));
   process.stdout.write("\n");
 }
 
@@ -2809,14 +2818,19 @@ async function runStopCommand(args: { dataDir: string }): Promise<void> {
   }
 
   const result = await stopVerifiedProcess({
+    killTimeoutMs: STOP_KILL_TIMEOUT_MS,
     pid: runtimeFile.pid,
     signal: "SIGTERM",
+    startedAt: runtimeFile.startedAt,
     timeoutMs: STOP_TIMEOUT_MS,
-    verifyTokens: bbAppRuntimeVerifyTokens(runtimeFile),
+    verifyTokens: bbAppRuntimeVerifyTokens(runtimeFile.entryPath),
   });
 
   if (result.kind === "not-running") {
-    await clearBbAppRuntimeFile(args.dataDir);
+    await clearOwnBbAppRuntimeFile({
+      dataDir: args.dataDir,
+      pid: runtimeFile.pid,
+    });
     log(
       dim("●"),
       `bb was not running (removed a stale record of pid ${String(runtimeFile.pid)})`,
@@ -2825,14 +2839,30 @@ async function runStopCommand(args: { dataDir: string }): Promise<void> {
   }
 
   if (result.kind === "unverified") {
+    const detail =
+      result.reason === "start-time"
+        ? "started at a different time than the record"
+        : "does not look like bb";
     process.stderr.write(
-      `Process ${String(runtimeFile.pid)} does not look like bb, so it was left alone.\n`,
+      `Process ${String(runtimeFile.pid)} ${detail}, so it was left alone.\n`,
     );
     process.exitCode = 1;
     return;
   }
 
-  await clearBbAppRuntimeFile(args.dataDir);
+  // Keep the record when the process survived, so a later stop can retry it.
+  if (result.kind === "still-running") {
+    process.stderr.write(
+      `bb (pid ${String(runtimeFile.pid)}) did not stop, even after SIGKILL.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  await clearOwnBbAppRuntimeFile({
+    dataDir: args.dataDir,
+    pid: runtimeFile.pid,
+  });
   log(
     green("✓"),
     `Stopped bb (pid ${String(runtimeFile.pid)})${result.usedKill ? " with SIGKILL" : ""}`,
@@ -2935,8 +2965,10 @@ export async function runBbApp(
   }
 
   // Publish this launcher before the server binds its port, so a desktop app
-  // that probes the port can always describe and stop whatever it finds.
-  await writeBbAppRuntimeFile({
+  // that probes the port can always describe and stop whatever it finds. A live
+  // record from another launcher stays untouched: this start is about to fail on
+  // the port anyway, and overwriting would hide the bb that actually runs.
+  const runtimeRecordOwned = await claimBbAppRuntimeFile({
     dataDir: context.dataDir,
     entryPath: resolveLauncherEntryPath(),
     pid: process.pid,
@@ -2946,6 +2978,9 @@ export async function runBbApp(
       parseAppSurface(runtime.env[APP_SURFACE_ENV_NAME]) ?? DEFAULT_APP_SURFACE,
     version: context.appVersion,
   });
+  if (!runtimeRecordOwned) {
+    warnExistingRuntimeRecord(context.dataDir);
+  }
 
   const processes: ManagedFullStackProcesses = {
     daemonRun: null,
@@ -3056,6 +3091,11 @@ export async function runBbApp(
     throw error;
   } finally {
     removeSignalForwarding();
-    await clearBbAppRuntimeFile(context.dataDir);
+    if (runtimeRecordOwned) {
+      await clearOwnBbAppRuntimeFile({
+        dataDir: context.dataDir,
+        pid: process.pid,
+      });
+    }
   }
 }

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -15,7 +15,19 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
-import { APP_SURFACE_ENV_NAME, APP_SURFACE_WEB } from "@bb/config/app-surface";
+import {
+  bbAppRuntimeVerifyTokens,
+  clearBbAppRuntimeFile,
+  readBbAppRuntimeFile,
+  writeBbAppRuntimeFile,
+} from "@bb/config/app-runtime-file";
+import { stopVerifiedProcess } from "@bb/config/verified-process-stop";
+import {
+  APP_SURFACE_ENV_NAME,
+  APP_SURFACE_WEB,
+  DEFAULT_APP_SURFACE,
+  parseAppSurface,
+} from "@bb/config/app-surface";
 import {
   BB_APP_MANAGED_CONFIG_KEYS,
   bbAppManagedEnvFileSchema,
@@ -60,6 +72,8 @@ const MANAGED_PROCESS_TERMINATION_TIMEOUT_MS = 5_000;
 const MANAGED_PROCESS_KILL_TIMEOUT_MS = 1_000;
 const MANAGED_PROCESS_RESTART_RETRY_DELAY_MS = 1_000;
 const START_COMMAND = "start";
+const STOP_COMMAND = "stop";
+const STOP_TIMEOUT_MS = 15_000;
 const HOST_DAEMON_COMMAND = "host-daemon";
 const HOST_DAEMON_JOIN_COMMAND = "join";
 const CLIENT_COMMAND = "client";
@@ -185,6 +199,10 @@ export interface StartCommand {
   kind: "start";
 }
 
+export interface StopCommand {
+  kind: "stop";
+}
+
 export interface HostDaemonCommand {
   args: string[];
   kind: "host-daemon";
@@ -268,7 +286,8 @@ type BbAppCommand =
   | HelpCommand
   | HostDaemonCommand
   | InvalidCommand
-  | StartCommand;
+  | StartCommand
+  | StopCommand;
 
 interface WaitForNamedProcessExitArgs {
   childProcess: ChildProcess;
@@ -1262,6 +1281,17 @@ export function createHostEnrollKeyRequestBody(
   return requestBody;
 }
 
+/**
+ * The token another process can look for in `ps` output to confirm that a PID
+ * really is this launcher. `argv[1]` is the entry the runtime was invoked with,
+ * which is what the command line shows; the module path is only a fallback for
+ * an embedded runtime that passes no script argument.
+ */
+function resolveLauncherEntryPath(): string {
+  const scriptArgument = trimToUndefined(process.argv[1]);
+  return scriptArgument ?? fileURLToPath(import.meta.url);
+}
+
 export function resolveBbAppCommand(args: string[]): BbAppCommand {
   if (args.length === 0) {
     return { kind: "start" };
@@ -1269,6 +1299,10 @@ export function resolveBbAppCommand(args: string[]): BbAppCommand {
 
   if (args[0] === START_COMMAND && args.length === 1) {
     return { kind: "start" };
+  }
+
+  if (args[0] === STOP_COMMAND && args.length === 1) {
+    return { kind: "stop" };
   }
 
   if (args[0] === HOST_DAEMON_COMMAND) {
@@ -2548,6 +2582,7 @@ function printBbAppHelp(): void {
 Usage:
   bb-app [--data-dir <path>] [--server-port <port>] [--host-daemon-port <port>]
   bb-app start
+  bb-app stop
   bb-app config set <key> <value>
   bb-app config refresh
   bb-app env set <key> <value>
@@ -2761,6 +2796,49 @@ export async function completeFullStackSupervision(
   }
 }
 
+/**
+ * Stop the `bb-app start` that owns this data directory. It reads the runtime
+ * file that the running launcher wrote, verifies the recorded process really is
+ * that launcher, then sends SIGTERM and escalates to SIGKILL.
+ */
+async function runStopCommand(args: { dataDir: string }): Promise<void> {
+  const runtimeFile = await readBbAppRuntimeFile(args.dataDir);
+  if (runtimeFile === null) {
+    log(dim("●"), `No running bb recorded in ${args.dataDir}`);
+    return;
+  }
+
+  const result = await stopVerifiedProcess({
+    pid: runtimeFile.pid,
+    signal: "SIGTERM",
+    timeoutMs: STOP_TIMEOUT_MS,
+    verifyTokens: bbAppRuntimeVerifyTokens(runtimeFile),
+  });
+
+  if (result.kind === "not-running") {
+    await clearBbAppRuntimeFile(args.dataDir);
+    log(
+      dim("●"),
+      `bb was not running (removed a stale record of pid ${String(runtimeFile.pid)})`,
+    );
+    return;
+  }
+
+  if (result.kind === "unverified") {
+    process.stderr.write(
+      `Process ${String(runtimeFile.pid)} does not look like bb, so it was left alone.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  await clearBbAppRuntimeFile(args.dataDir);
+  log(
+    green("✓"),
+    `Stopped bb (pid ${String(runtimeFile.pid)})${result.usedKill ? " with SIGKILL" : ""}`,
+  );
+}
+
 export async function runBbApp(
   cliArgs: string[] = process.argv.slice(2),
 ): Promise<void> {
@@ -2814,6 +2892,11 @@ export async function runBbApp(
     return;
   }
 
+  if (command.kind === "stop") {
+    await runStopCommand({ dataDir: runtime.context.dataDir });
+    return;
+  }
+
   if (command.kind === "client") {
     await runClientCommand({
       args: command.args,
@@ -2850,6 +2933,19 @@ export async function runBbApp(
   if (existsSync(runtime.context.daemonLockDir)) {
     warnExistingDaemonLock(runtime.context.daemonLockDir);
   }
+
+  // Publish this launcher before the server binds its port, so a desktop app
+  // that probes the port can always describe and stop whatever it finds.
+  await writeBbAppRuntimeFile({
+    dataDir: context.dataDir,
+    entryPath: resolveLauncherEntryPath(),
+    pid: process.pid,
+    serverUrl: context.serverUrl,
+    startedAt: new Date().toISOString(),
+    surface:
+      parseAppSurface(runtime.env[APP_SURFACE_ENV_NAME]) ?? DEFAULT_APP_SURFACE,
+    version: context.appVersion,
+  });
 
   const processes: ManagedFullStackProcesses = {
     daemonRun: null,
@@ -2960,5 +3056,6 @@ export async function runBbApp(
     throw error;
   } finally {
     removeSignalForwarding();
+    await clearBbAppRuntimeFile(context.dataDir);
   }
 }

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -525,6 +525,14 @@ describe("bb-app launcher", () => {
     expect(resolveBbAppCommand(["start"])).toEqual({ kind: "start" });
   });
 
+  it("stops bb on the explicit stop command only", () => {
+    expect(resolveBbAppCommand(["stop"])).toEqual({ kind: "stop" });
+    expect(resolveBbAppCommand(["stop", "now"])).toEqual({
+      command: "stop",
+      kind: "invalid",
+    });
+  });
+
   it("keeps CLI commands on the bb binary", () => {
     expect(resolveBbAppCommand(["status"])).toEqual({
       command: "status",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -103,6 +103,11 @@
       "types": "./src/client-config.ts",
       "default": "./src/client-config.ts"
     },
+    "./app-runtime-file": {
+      "source": "./src/app-runtime-file.ts",
+      "types": "./src/app-runtime-file.ts",
+      "default": "./src/app-runtime-file.ts"
+    },
     "./app-surface": {
       "source": "./src/app-surface.ts",
       "types": "./src/app-surface.ts",
@@ -112,6 +117,11 @@
       "source": "./src/skill-storage-paths.ts",
       "types": "./src/skill-storage-paths.ts",
       "default": "./src/skill-storage-paths.ts"
+    },
+    "./verified-process-stop": {
+      "source": "./src/verified-process-stop.ts",
+      "types": "./src/verified-process-stop.ts",
+      "default": "./src/verified-process-stop.ts"
     }
   },
   "scripts": {

--- a/packages/config/src/app-runtime-file.ts
+++ b/packages/config/src/app-runtime-file.ts
@@ -42,6 +42,15 @@ export function formatBbAppRuntimeFilePath(dataDir: string): string {
   return join(dataDir, BB_APP_RUNTIME_FILE_NAME);
 }
 
+function defaultIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function writeBbAppRuntimeFile(
   args: WriteBbAppRuntimeFileArgs,
 ): Promise<void> {
@@ -61,21 +70,67 @@ export async function writeBbAppRuntimeFile(
   );
 }
 
+/**
+ * Write the record unless another launcher already owns it. Returns whether
+ * this process now owns the record; a caller that does not own it must not
+ * remove the file when it exits.
+ *
+ * Ownership is decided by liveness alone. A record whose process is gone is
+ * stale and gets replaced. This is not an exclusive lock: the daemon lock and
+ * the server port are what actually prevent two bb instances on one data
+ * directory. The check only stops a doomed second start from erasing the record
+ * of the bb that is running.
+ */
+export async function claimBbAppRuntimeFile(
+  args: WriteBbAppRuntimeFileArgs & { isRunning?: (pid: number) => boolean },
+): Promise<boolean> {
+  const isRunning = args.isRunning ?? defaultIsRunning;
+  const existing = await readBbAppRuntimeFile(args.dataDir);
+  if (
+    existing !== null &&
+    existing.pid !== args.pid &&
+    isRunning(existing.pid)
+  ) {
+    return false;
+  }
+  await writeBbAppRuntimeFile(args);
+  return true;
+}
+
 export async function clearBbAppRuntimeFile(dataDir: string): Promise<void> {
   await rm(formatBbAppRuntimeFilePath(dataDir), { force: true });
 }
 
 /**
- * Substrings that prove a `ps` command line belongs to the launcher this file
- * describes. Node resolves `argv[1]` to an absolute path before the launcher
- * records it, but `ps` reports the command line as it was typed. A launcher
- * started with a relative path therefore never shows the absolute form, so the
- * file name is offered as a second spelling.
+ * Remove the record only while it still names `pid`. A second launcher that
+ * overwrote the file must not delete the live launcher's record when it exits,
+ * because `bb-app stop` would then be unable to find the bb that is running.
  */
-export function bbAppRuntimeVerifyTokens(
-  runtimeFile: BbAppRuntimeFile,
-): string[] {
-  return [runtimeFile.entryPath, basename(runtimeFile.entryPath)];
+export async function clearOwnBbAppRuntimeFile(args: {
+  dataDir: string;
+  pid: number;
+}): Promise<boolean> {
+  const runtimeFile = await readBbAppRuntimeFile(args.dataDir);
+  if (runtimeFile === null || runtimeFile.pid !== args.pid) {
+    return false;
+  }
+  await clearBbAppRuntimeFile(args.dataDir);
+  return true;
+}
+
+/**
+ * Spellings of the entry path that a `ps` command line may show. Node resolves
+ * `argv[1]` to an absolute path before the launcher records it, but `ps`
+ * reports the command line as it was typed, so a launcher started with a
+ * relative path never shows the absolute form.
+ *
+ * These tokens do not establish identity on their own: every bb launcher on the
+ * machine shares the same file name. The caller must also compare the recorded
+ * start time, which is what separates this launcher from another one and from a
+ * recycled PID.
+ */
+export function bbAppRuntimeVerifyTokens(entryPath: string): string[] {
+  return [entryPath, basename(entryPath)];
 }
 
 export async function readBbAppRuntimeFile(

--- a/packages/config/src/app-runtime-file.ts
+++ b/packages/config/src/app-runtime-file.ts
@@ -1,0 +1,97 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { z } from "zod";
+
+/**
+ * A running `bb-app start` writes this file into its data directory and removes
+ * it on exit. It lets another process on the same machine identify the running
+ * bb, describe it to a person, and stop it.
+ *
+ * The desktop app reads it after a server probe succeeds, so it can offer to
+ * quit the other copy instead of attaching to it. A bb that predates this file
+ * simply writes nothing; readers must treat a missing file as "unknown", not as
+ * "not running".
+ */
+export const BB_APP_RUNTIME_FILE_NAME = "bb-app-runtime.json";
+
+export const bbAppRuntimeFileSchema = z.object({
+  /** Absolute path of the entry module. Readers verify it against `ps`. */
+  entryPath: z.string().min(1),
+  /** PID of the launcher process that supervises the server and daemon. */
+  pid: z.number().int().positive(),
+  /** How the launcher was started, from `BB_APP_SURFACE`. */
+  surface: z.string().min(1),
+  serverUrl: z.string().min(1),
+  startedAt: z.string().min(1),
+  version: z.string().min(1),
+});
+
+export type BbAppRuntimeFile = z.infer<typeof bbAppRuntimeFileSchema>;
+
+export interface WriteBbAppRuntimeFileArgs {
+  dataDir: string;
+  entryPath: string;
+  pid: number;
+  serverUrl: string;
+  startedAt: string;
+  surface: string;
+  version: string;
+}
+
+export function formatBbAppRuntimeFilePath(dataDir: string): string {
+  return join(dataDir, BB_APP_RUNTIME_FILE_NAME);
+}
+
+export async function writeBbAppRuntimeFile(
+  args: WriteBbAppRuntimeFileArgs,
+): Promise<void> {
+  const runtimeFile: BbAppRuntimeFile = {
+    entryPath: args.entryPath,
+    pid: args.pid,
+    serverUrl: args.serverUrl,
+    startedAt: args.startedAt,
+    surface: args.surface,
+    version: args.version,
+  };
+  await mkdir(args.dataDir, { recursive: true });
+  await writeFile(
+    formatBbAppRuntimeFilePath(args.dataDir),
+    `${JSON.stringify(runtimeFile, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export async function clearBbAppRuntimeFile(dataDir: string): Promise<void> {
+  await rm(formatBbAppRuntimeFilePath(dataDir), { force: true });
+}
+
+/**
+ * Substrings that prove a `ps` command line belongs to the launcher this file
+ * describes. Node resolves `argv[1]` to an absolute path before the launcher
+ * records it, but `ps` reports the command line as it was typed. A launcher
+ * started with a relative path therefore never shows the absolute form, so the
+ * file name is offered as a second spelling.
+ */
+export function bbAppRuntimeVerifyTokens(
+  runtimeFile: BbAppRuntimeFile,
+): string[] {
+  return [runtimeFile.entryPath, basename(runtimeFile.entryPath)];
+}
+
+export async function readBbAppRuntimeFile(
+  dataDir: string,
+): Promise<BbAppRuntimeFile | null> {
+  let rawContents: string;
+  try {
+    rawContents = await readFile(formatBbAppRuntimeFilePath(dataDir), "utf8");
+  } catch {
+    return null;
+  }
+
+  try {
+    const parsed = bbAppRuntimeFileSchema.safeParse(JSON.parse(rawContents));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/config/src/verified-process-stop.ts
+++ b/packages/config/src/verified-process-stop.ts
@@ -5,15 +5,24 @@ const execFileAsync = promisify(execFile);
 const POLL_INTERVAL_MS = 100;
 
 /**
+ * How far the recorded start time may sit from the real process start time.
+ * A launcher records the time a moment after the process starts, and `ps`
+ * reports whole seconds, so the two never match exactly. The window stays small
+ * enough that a recycled PID from an earlier session cannot pass.
+ */
+export const PROCESS_START_TOLERANCE_MS = 60_000;
+
+/**
  * Stopping a PID recorded in a file is only safe when the PID still belongs to
  * the process that wrote it. The operating system reuses PIDs, so a stale file
- * can name an unrelated process. Every caller therefore verifies the command
- * line before it sends a signal.
+ * can name an unrelated process. Every caller therefore checks both the command
+ * line and the process start time before it sends a signal.
  */
 export interface VerifiedProcessOps {
   isRunning(pid: number): boolean;
   kill(pid: number, signal: NodeJS.Signals): void;
   readCommand(pid: number): Promise<string | null>;
+  readElapsedSeconds(pid: number): Promise<number | null>;
   waitForExit(args: WaitForProcessExitArgs): Promise<boolean>;
 }
 
@@ -23,24 +32,30 @@ export interface WaitForProcessExitArgs {
 }
 
 export interface StopVerifiedProcessArgs {
+  /** How long to wait after SIGKILL. SIGKILL is not catchable, so keep it short. */
+  killTimeoutMs: number;
   pid: number;
   processOps?: VerifiedProcessOps;
   signal: NodeJS.Signals;
+  /** ISO time the record was written, checked against the real start time. */
+  startedAt: string;
   timeoutMs: number;
   /**
-   * The `ps` command line must contain at least one of these substrings for the
-   * PID to be trusted. Callers pass more than one when the same process can
-   * appear under different spellings: Node resolves `argv[1]` to an absolute
-   * path, but `ps` shows the command line as it was typed, so a relative
-   * invocation never contains the absolute path.
+   * The `ps` command line must contain at least one of these substrings. Node
+   * resolves `argv[1]` to an absolute path, but `ps` shows the command line as
+   * it was typed, so a relative invocation never contains the absolute path.
+   * This is a weak signal on its own; the start-time check carries the identity.
    */
   verifyTokens: string[];
 }
 
 export type StopVerifiedProcessResult =
+  | { command: string | null; kind: "unverified"; reason: UnverifiedReason }
   | { kind: "not-running" }
-  | { command: string | null; kind: "unverified" }
+  | { kind: "still-running" }
   | { kind: "stopped"; usedKill: boolean };
+
+export type UnverifiedReason = "command" | "start-time";
 
 interface SleepArgs {
   delayMs: number;
@@ -61,18 +76,28 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
-async function readProcessCommand(pid: number): Promise<string | null> {
+async function readPsField(pid: number, field: string): Promise<string | null> {
   try {
-    const result = await execFileAsync("ps", [
-      "-p",
-      String(pid),
-      "-o",
-      "command=",
-    ]);
+    const result = await execFileAsync("ps", ["-p", String(pid), "-o", field]);
     return result.stdout.trim();
   } catch {
     return null;
   }
+}
+
+/** Parse the `ps -o etime=` format `[[dd-]hh:]mm:ss` into seconds. */
+export function parseElapsedSeconds(rawElapsed: string): number | null {
+  const match = rawElapsed
+    .trim()
+    .match(/^(?:(?:(\d+)-)?(\d+):)?(\d{1,2}):(\d{2})$/u);
+  if (match === null) {
+    return null;
+  }
+  const days = Number(match[1] ?? "0");
+  const hours = Number(match[2] ?? "0");
+  const minutes = Number(match[3]);
+  const seconds = Number(match[4]);
+  return ((days * 24 + hours) * 60 + minutes) * 60 + seconds;
 }
 
 async function waitForProcessExit(
@@ -94,15 +119,54 @@ export function createNodeVerifiedProcessOps(): VerifiedProcessOps {
     kill(pid, signal) {
       process.kill(pid, signal);
     },
-    readCommand: (pid) => readProcessCommand(pid),
+    readCommand: (pid) => readPsField(pid, "command="),
+    async readElapsedSeconds(pid) {
+      const rawElapsed = await readPsField(pid, "etime=");
+      return rawElapsed === null ? null : parseElapsedSeconds(rawElapsed);
+    },
     waitForExit: (args) => waitForProcessExit(args),
   };
 }
 
+interface VerifyProcessIdentityArgs {
+  pid: number;
+  processOps: VerifiedProcessOps;
+  startedAt: string;
+  verifyTokens: string[];
+}
+
+async function verifyProcessIdentity(
+  args: VerifyProcessIdentityArgs,
+): Promise<{ command: string | null; reason: UnverifiedReason } | null> {
+  const command = await args.processOps.readCommand(args.pid);
+  const commandMatches =
+    command !== null &&
+    args.verifyTokens.some(
+      (token) => token.length > 0 && command.includes(token),
+    );
+  if (!commandMatches) {
+    return { command, reason: "command" };
+  }
+
+  // The command line alone cannot tell two bb launchers apart, and a recycled
+  // PID can carry a matching name. The start time is what proves identity.
+  const recordedStart = Date.parse(args.startedAt);
+  const elapsedSeconds = await args.processOps.readElapsedSeconds(args.pid);
+  if (Number.isNaN(recordedStart) || elapsedSeconds === null) {
+    return { command, reason: "start-time" };
+  }
+  const actualStart = Date.now() - elapsedSeconds * 1_000;
+  if (Math.abs(actualStart - recordedStart) > PROCESS_START_TOLERANCE_MS) {
+    return { command, reason: "start-time" };
+  }
+  return null;
+}
+
 /**
  * Send `signal` to a PID, then escalate to SIGKILL when it does not exit in
- * time. Returns `unverified` without signalling anything when the command line
- * matches none of `verifyTokens`.
+ * time. Signals nothing unless the process still matches the record, and
+ * reports `still-running` when even SIGKILL does not end it, so callers never
+ * treat a surviving process as stopped.
  */
 export async function stopVerifiedProcess(
   args: StopVerifiedProcessArgs,
@@ -113,14 +177,18 @@ export async function stopVerifiedProcess(
     return { kind: "not-running" };
   }
 
-  const command = await processOps.readCommand(args.pid);
-  const verified =
-    command !== null &&
-    args.verifyTokens.some(
-      (token) => token.length > 0 && command.includes(token),
-    );
-  if (!verified) {
-    return { command, kind: "unverified" };
+  const mismatch = await verifyProcessIdentity({
+    pid: args.pid,
+    processOps,
+    startedAt: args.startedAt,
+    verifyTokens: args.verifyTokens,
+  });
+  if (mismatch !== null) {
+    return {
+      command: mismatch.command,
+      kind: "unverified",
+      reason: mismatch.reason,
+    };
   }
 
   processOps.kill(args.pid, args.signal);
@@ -133,9 +201,12 @@ export async function stopVerifiedProcess(
   }
 
   processOps.kill(args.pid, "SIGKILL");
-  await processOps.waitForExit({
+  const killed = await processOps.waitForExit({
     pid: args.pid,
-    timeoutMs: args.timeoutMs,
+    timeoutMs: args.killTimeoutMs,
   });
+  if (!killed && processOps.isRunning(args.pid)) {
+    return { kind: "still-running" };
+  }
   return { kind: "stopped", usedKill: true };
 }

--- a/packages/config/src/verified-process-stop.ts
+++ b/packages/config/src/verified-process-stop.ts
@@ -1,0 +1,141 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const POLL_INTERVAL_MS = 100;
+
+/**
+ * Stopping a PID recorded in a file is only safe when the PID still belongs to
+ * the process that wrote it. The operating system reuses PIDs, so a stale file
+ * can name an unrelated process. Every caller therefore verifies the command
+ * line before it sends a signal.
+ */
+export interface VerifiedProcessOps {
+  isRunning(pid: number): boolean;
+  kill(pid: number, signal: NodeJS.Signals): void;
+  readCommand(pid: number): Promise<string | null>;
+  waitForExit(args: WaitForProcessExitArgs): Promise<boolean>;
+}
+
+export interface WaitForProcessExitArgs {
+  pid: number;
+  timeoutMs: number;
+}
+
+export interface StopVerifiedProcessArgs {
+  pid: number;
+  processOps?: VerifiedProcessOps;
+  signal: NodeJS.Signals;
+  timeoutMs: number;
+  /**
+   * The `ps` command line must contain at least one of these substrings for the
+   * PID to be trusted. Callers pass more than one when the same process can
+   * appear under different spellings: Node resolves `argv[1]` to an absolute
+   * path, but `ps` shows the command line as it was typed, so a relative
+   * invocation never contains the absolute path.
+   */
+  verifyTokens: string[];
+}
+
+export type StopVerifiedProcessResult =
+  | { kind: "not-running" }
+  | { command: string | null; kind: "unverified" }
+  | { kind: "stopped"; usedKill: boolean };
+
+interface SleepArgs {
+  delayMs: number;
+}
+
+async function sleep(args: SleepArgs): Promise<void> {
+  await new Promise<void>((resolvePromise) => {
+    setTimeout(resolvePromise, args.delayMs);
+  });
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readProcessCommand(pid: number): Promise<string | null> {
+  try {
+    const result = await execFileAsync("ps", [
+      "-p",
+      String(pid),
+      "-o",
+      "command=",
+    ]);
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+async function waitForProcessExit(
+  args: WaitForProcessExitArgs,
+): Promise<boolean> {
+  const deadline = Date.now() + args.timeoutMs;
+  while (Date.now() <= deadline) {
+    if (!isProcessRunning(args.pid)) {
+      return true;
+    }
+    await sleep({ delayMs: POLL_INTERVAL_MS });
+  }
+  return !isProcessRunning(args.pid);
+}
+
+export function createNodeVerifiedProcessOps(): VerifiedProcessOps {
+  return {
+    isRunning: (pid) => isProcessRunning(pid),
+    kill(pid, signal) {
+      process.kill(pid, signal);
+    },
+    readCommand: (pid) => readProcessCommand(pid),
+    waitForExit: (args) => waitForProcessExit(args),
+  };
+}
+
+/**
+ * Send `signal` to a PID, then escalate to SIGKILL when it does not exit in
+ * time. Returns `unverified` without signalling anything when the command line
+ * matches none of `verifyTokens`.
+ */
+export async function stopVerifiedProcess(
+  args: StopVerifiedProcessArgs,
+): Promise<StopVerifiedProcessResult> {
+  const processOps = args.processOps ?? createNodeVerifiedProcessOps();
+
+  if (!processOps.isRunning(args.pid)) {
+    return { kind: "not-running" };
+  }
+
+  const command = await processOps.readCommand(args.pid);
+  const verified =
+    command !== null &&
+    args.verifyTokens.some(
+      (token) => token.length > 0 && command.includes(token),
+    );
+  if (!verified) {
+    return { command, kind: "unverified" };
+  }
+
+  processOps.kill(args.pid, args.signal);
+  const exited = await processOps.waitForExit({
+    pid: args.pid,
+    timeoutMs: args.timeoutMs,
+  });
+  if (exited || !processOps.isRunning(args.pid)) {
+    return { kind: "stopped", usedKill: false };
+  }
+
+  processOps.kill(args.pid, "SIGKILL");
+  await processOps.waitForExit({
+    pid: args.pid,
+    timeoutMs: args.timeoutMs,
+  });
+  return { kind: "stopped", usedKill: true };
+}

--- a/packages/config/test/app-runtime-file.test.ts
+++ b/packages/config/test/app-runtime-file.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  claimBbAppRuntimeFile,
+  clearOwnBbAppRuntimeFile,
+  readBbAppRuntimeFile,
+} from "../src/app-runtime-file.js";
+import {
+  parseElapsedSeconds,
+  stopVerifiedProcess,
+  type VerifiedProcessOps,
+} from "../src/verified-process-stop.js";
+
+const tempDirs: string[] = [];
+
+async function createDataDir(): Promise<string> {
+  const dataDir = await mkdtemp(join(tmpdir(), "bb-runtime-file-"));
+  tempDirs.push(dataDir);
+  return dataDir;
+}
+
+function recordFor(dataDir: string, pid: number) {
+  return {
+    dataDir,
+    entryPath: "/opt/bb/bb-app.js",
+    pid,
+    serverUrl: "http://127.0.0.1:38886",
+    startedAt: "2026-08-03T10:00:00.000Z",
+    surface: "web",
+    version: "0.34.0",
+  };
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dataDir = tempDirs.pop();
+    if (dataDir !== undefined) {
+      await rm(dataDir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("claimBbAppRuntimeFile", () => {
+  it("refuses to overwrite a record whose launcher still runs", async () => {
+    const dataDir = await createDataDir();
+    await claimBbAppRuntimeFile({
+      ...recordFor(dataDir, 1_111),
+      isRunning: () => true,
+    });
+
+    await expect(
+      claimBbAppRuntimeFile({
+        ...recordFor(dataDir, 2_222),
+        isRunning: () => true,
+      }),
+    ).resolves.toBe(false);
+    // The live launcher keeps the record, so `bb-app stop` can still find it.
+    await expect(readBbAppRuntimeFile(dataDir)).resolves.toMatchObject({
+      pid: 1_111,
+    });
+  });
+
+  it("replaces a record whose launcher is gone", async () => {
+    const dataDir = await createDataDir();
+    await claimBbAppRuntimeFile({
+      ...recordFor(dataDir, 1_111),
+      isRunning: () => true,
+    });
+
+    await expect(
+      claimBbAppRuntimeFile({
+        ...recordFor(dataDir, 2_222),
+        isRunning: () => false,
+      }),
+    ).resolves.toBe(true);
+    await expect(readBbAppRuntimeFile(dataDir)).resolves.toMatchObject({
+      pid: 2_222,
+    });
+  });
+});
+
+describe("clearOwnBbAppRuntimeFile", () => {
+  it("leaves a record that belongs to another launcher", async () => {
+    const dataDir = await createDataDir();
+    await claimBbAppRuntimeFile({
+      ...recordFor(dataDir, 1_111),
+      isRunning: () => true,
+    });
+
+    await expect(
+      clearOwnBbAppRuntimeFile({ dataDir, pid: 2_222 }),
+    ).resolves.toBe(false);
+    await expect(readBbAppRuntimeFile(dataDir)).resolves.not.toBeNull();
+  });
+
+  it("removes its own record", async () => {
+    const dataDir = await createDataDir();
+    await claimBbAppRuntimeFile({
+      ...recordFor(dataDir, 1_111),
+      isRunning: () => true,
+    });
+
+    await expect(
+      clearOwnBbAppRuntimeFile({ dataDir, pid: 1_111 }),
+    ).resolves.toBe(true);
+    await expect(readBbAppRuntimeFile(dataDir)).resolves.toBeNull();
+  });
+});
+
+describe("parseElapsedSeconds", () => {
+  it("reads every ps etime shape", () => {
+    expect(parseElapsedSeconds("00:05")).toBe(5);
+    expect(parseElapsedSeconds("30:00")).toBe(1_800);
+    expect(parseElapsedSeconds("2:03:04")).toBe(7_384);
+    expect(parseElapsedSeconds("13-16:51:17")).toBe(1_183_877);
+    expect(parseElapsedSeconds("  01:00 ")).toBe(60);
+    expect(parseElapsedSeconds("nonsense")).toBeNull();
+    expect(parseElapsedSeconds("")).toBeNull();
+  });
+});
+
+describe("stopVerifiedProcess", () => {
+  function createOps(
+    overrides: Partial<VerifiedProcessOps> = {},
+  ): VerifiedProcessOps {
+    return {
+      isRunning: () => true,
+      kill: () => undefined,
+      readCommand: async () => "node /opt/bb/bb-app.js start",
+      readElapsedSeconds: async () => 60,
+      waitForExit: async () => true,
+      ...overrides,
+    };
+  }
+
+  const startedAt = new Date(Date.now() - 60_000).toISOString();
+
+  it("reports still-running when the process survives SIGKILL", async () => {
+    await expect(
+      stopVerifiedProcess({
+        killTimeoutMs: 10,
+        pid: 4_242,
+        processOps: createOps({ waitForExit: async () => false }),
+        signal: "SIGTERM",
+        startedAt,
+        timeoutMs: 10,
+        verifyTokens: ["bb-app.js"],
+      }),
+    ).resolves.toEqual({ kind: "still-running" });
+  });
+
+  it("refuses a process whose start time contradicts the record", async () => {
+    const result = await stopVerifiedProcess({
+      killTimeoutMs: 10,
+      pid: 4_242,
+      // A recycled pid: same command name, but it started two days ago.
+      processOps: createOps({ readElapsedSeconds: async () => 172_800 }),
+      signal: "SIGTERM",
+      startedAt,
+      timeoutMs: 10,
+      verifyTokens: ["bb-app.js"],
+    });
+
+    expect(result).toMatchObject({ kind: "unverified", reason: "start-time" });
+  });
+
+  it("refuses when the start time cannot be read at all", async () => {
+    const result = await stopVerifiedProcess({
+      killTimeoutMs: 10,
+      pid: 4_242,
+      processOps: createOps({ readElapsedSeconds: async () => null }),
+      signal: "SIGTERM",
+      startedAt,
+      timeoutMs: 10,
+      verifyTokens: ["bb-app.js"],
+    });
+
+    expect(result).toMatchObject({ kind: "unverified", reason: "start-time" });
+  });
+});


### PR DESCRIPTION
## What

The desktop app attached to any compatible bb on its port silently. If you had started bb in a terminal, the app opened and gave no sign that it was using that other copy.

Now it asks first, and it can stop the other copy for you.

| A bb it can identify | An older bb it cannot |
| --- | --- |
| Quit this bb / Quit other bb / Connect | Quit this bb / Connect |

## How

- A running `bb-app start` writes `<dataDir>/bb-app-runtime.json` (pid, server URL, version, start time, surface) and removes it on exit.
- The server probe now returns the server's `dataDir`, so the desktop app can find that file and describe what it found: address, data directory, version, and how long ago it started.
- New modal dialog (`existing-server-dialog.ts`, following the existing `server-url-dialog.ts` preload/IPC pattern, because the local-view CSP blocks scripts). Closing the window or pressing Escape quits rather than attaching — attaching must be deliberate.
- Local development stays silent: the prompt is skipped when the app is unpackaged or `BB_DESKTOP_APP_URL` is set, so the `pnpm dev` attach is unchanged.
- A bb older than the runtime file cannot be identified, so the stop option and its warning disappear and the copy explains why.
- New `npx bb-app stop` gives the CLI and agents the same ability.
- `verified-process-stop.ts` holds the shared verify-then-signal logic (`ps` check, SIGTERM, then SIGKILL). The desktop's `owned-runtime-supervisor.ts` now uses it instead of its own copy.

## Safety

Both stop paths confirm the recorded pid against the `ps` command line before signalling, so a stale file left by a crash cannot stop an unrelated process. Verification accepts the entry path or its file name: Node resolves `argv[1]` to an absolute path, but `ps` reports the command line as typed, so a relative launch never contains the absolute form. A runtime file describing a different server than the one that answered is ignored.

## Tests

`turbo run lint typecheck test build` for `@bb/desktop`, `bb-app`, and `@bb/config`. New coverage: stale-file matching, SIGKILL escalation, refusal to signal a recycled pid, relative-path verification, dialog markup and escaping, and the `dataDir` probe field.

Also verified by hand against a real bb on an isolated data directory and ports: the runtime file appeared with the right contents, `bb-app stop` stopped the server and daemon and freed both ports, and a second stop reported no running bb and exited 0. That run is what caught the relative-path verification bug.

## Notes

- Docs updated: `packages/bb-app/README.md` and a "Stopping A Running bb" section in `docs/configuration.md`.
- No host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is untouched.
- Not verified: the dialog inside a packaged Electron build. The gate needs `app.isPackaged`, so the markup and rendering were checked instead. The primary button uses `AccentColor`, matching the existing Set Server URL dialog.
- Follow-up filed as BB-81: stop starting a local server at all when a remote target is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)