### PR TITLE
Give a t3sidebar child thread a way back to its parent

### DIFF
--- a/plugins/t3sidebar/README.md
+++ b/plugins/t3sidebar/README.md
@@ -35,11 +35,31 @@ Three shelves:
   back early if it starts working or asks you something.
 - **Settled** — work you are done with, collapsed to one line each.
 
+## Child threads live in the header
+
+A flat inbox has nowhere to nest a child thread, so the list hides a child
+while its parent is on screen. Two chips in the thread header carry that
+relation instead:
+
+- On a parent: a chip with one coloured disc per child. It opens the list of
+  children.
+- On a child: a chip that names the parent and opens it. Without it the child
+  is a dead end, because it is not in the list.
+
+The parent chip sits on the left of the children chip, so the header reads up
+then down. A child that has children of its own shows both. Each disc takes
+its colour from the thread id, so the same thread keeps one colour in the list
+and in both chips.
+
+An orphan — a child whose parent is deleted — stays in the list, and its
+header shows no parent chip.
+
 ## What it demonstrates
 
 | Plugin API | Used for |
 | --- | --- |
 | `experimental_threadList` | the sidebar's scrolling list (bb keeps the New-thread button, search, nav rows, and footer) |
+| `experimental_threadHeaderAction` | the two header chips: children on a parent, and the way back on a child |
 | `experimental_useSidebarThreads` | live threads and projects, from the host's own cache |
 | `experimental_useSidebarThreadActions` | open, open-in-split, new thread |
 | `experimental_useSidebarThreadSplit` | dragging a card out to a split pane |

--- a/plugins/t3sidebar/app.tsx
+++ b/plugins/t3sidebar/app.tsx
@@ -6,6 +6,7 @@
 // each card, not by position, so the sidebar only moves when you act.
 import { definePluginApp } from "@bb/plugin-sdk/app";
 import { ThreadInbox } from "./src/ThreadInbox";
+import { ParentChip } from "./src/ParentChip";
 import { SubagentsChip } from "./src/SubagentsChip";
 
 export default definePluginApp((app) => {
@@ -14,6 +15,17 @@ export default definePluginApp((app) => {
     title: "t3sidebar (inbox)",
     description: "One flat list of cards, newest first, that never re-orders.",
     component: ThreadInbox,
+  });
+
+  // Registered first, so it renders on the left of the children chip: the
+  // header then reads up (parent) then down (children).
+  //
+  // The hidden child is otherwise a dead end — it is not in the list, so this
+  // chip is its only route back to the parent.
+  app.slots.experimental_threadHeaderAction({
+    id: "parent",
+    title: "Parent thread",
+    component: ParentChip,
   });
 
   // A flat inbox has nowhere to nest child threads, so the list hides them

--- a/plugins/t3sidebar/src/Disc.tsx
+++ b/plugins/t3sidebar/src/Disc.tsx
@@ -1,0 +1,31 @@
+import type { PluginSidebarThread } from "@bb/plugin-sdk/app";
+
+/**
+ * A per-thread dot. Colour comes from the thread's id so the same thread keeps
+ * the same colour everywhere it appears, and every hue is a rotation of one
+ * accent, so a custom palette still applies.
+ *
+ * `thread` is null for the "and more" disc in a cluster.
+ */
+export function Disc({ thread }: { thread: PluginSidebarThread | null }) {
+  const hue = thread === null ? 0 : hashHue(thread.id);
+  return (
+    <span
+      className="inline-block size-3.5 shrink-0 rounded-full border border-background"
+      style={{
+        backgroundColor:
+          thread === null
+            ? "var(--muted-foreground)"
+            : `oklch(0.72 0.13 ${hue})`,
+      }}
+    />
+  );
+}
+
+export function hashHue(id: string): number {
+  let hash = 0;
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash * 31 + id.charCodeAt(index)) % 360;
+  }
+  return hash;
+}

--- a/plugins/t3sidebar/src/ParentChip.test.tsx
+++ b/plugins/t3sidebar/src/ParentChip.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import type { PluginSidebarThread } from "@bb/plugin-sdk";
+
+// Load through the harness so the plugin's `@bb/plugin-sdk/app` import binds
+// to the test runtime.
+const app = await loadPluginApp(() => import("../app"));
+const parentChip = app.threadHeaderActions.find((slot) => slot.id === "parent")!;
+
+function thread(
+  overrides: Partial<PluginSidebarThread> = {},
+): PluginSidebarThread {
+  return {
+    id: "thr_1",
+    projectId: "proj_1",
+    title: "A thread",
+    titleFallback: null,
+    parentThreadId: null,
+    sectionId: null,
+    originKind: null,
+    originPluginId: null,
+    providerId: "codex",
+    hasPendingInteraction: false,
+    activity: {
+      workflows: 0,
+      backgroundAgents: 0,
+      backgroundCommands: 0,
+      planMode: 0,
+      goals: 0,
+    },
+    indicator: "none",
+    indicatorLabel: null,
+    isUnread: false,
+    isPinned: false,
+    isArchived: false,
+    environment: null,
+    host: null,
+    createdAt: 100,
+    updatedAt: 100,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    ...overrides,
+  };
+}
+
+function render(
+  threads: PluginSidebarThread[],
+  threadId: string,
+  isCompactViewport = false,
+) {
+  return renderSlot(
+    parentChip,
+    { threadId, projectId: "proj_1", isCompactViewport },
+    {
+      sidebarThreads: {
+        status: "ready",
+        threads,
+        projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
+      },
+    },
+  );
+}
+
+afterEach(cleanup);
+
+describe("ParentChip", () => {
+  // The whole reason the chip exists: the list hides the child, so this is its
+  // only route back.
+  it("opens the parent on click", () => {
+    const rendered = render(
+      [
+        thread({ id: "parent", title: "Parent thread" }),
+        thread({ id: "child", parentThreadId: "parent" }),
+      ],
+      "child",
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(rendered.sidebarActionCalls).toContainEqual({
+      method: "open",
+      threadId: "parent",
+      options: undefined,
+    });
+  });
+
+  it("renders nothing on a root thread", () => {
+    render([thread({ id: "root" })], "root");
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  // An archived parent is out of the list but still the way back.
+  it("names an archived parent", () => {
+    render(
+      [
+        thread({ id: "parent", title: "Archived parent", isArchived: true }),
+        thread({ id: "child", parentThreadId: "parent" }),
+      ],
+      "child",
+    );
+    expect(screen.getByRole("button").getAttribute("aria-label")).toBe(
+      "Back to parent: Archived parent",
+    );
+  });
+
+  // The header row is short: a phone shows the chevron and the disc only, but
+  // the control keeps its name.
+  it("drops the title on a compact viewport", () => {
+    render(
+      [
+        thread({ id: "parent", title: "Parent thread" }),
+        thread({ id: "child", parentThreadId: "parent" }),
+      ],
+      "child",
+      true,
+    );
+    const button = screen.getByRole("button");
+    expect(button.textContent).toBe("");
+    expect(button.getAttribute("aria-label")).toBe(
+      "Back to parent: Parent thread",
+    );
+  });
+});

--- a/plugins/t3sidebar/src/ParentChip.tsx
+++ b/plugins/t3sidebar/src/ParentChip.tsx
@@ -1,0 +1,48 @@
+import {
+  experimental_useSidebarThreadActions as useSidebarThreadActions,
+  experimental_useSidebarThreads as useSidebarThreads,
+  type PluginThreadHeaderActionProps,
+} from "@bb/plugin-sdk/app";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { Disc } from "./Disc";
+import { parentOf, threadDisplayTitle } from "./inbox";
+
+/**
+ * The way back out of a child thread.
+ *
+ * The flat list hides a child while its parent is on screen, so opening a
+ * child from the parent's header chip leaves the user with no route back. This
+ * chip names the parent and opens it. The disc repeats the parent's colour
+ * from the list, so the chip points at a thread the user can recognise.
+ */
+export function ParentChip({
+  threadId,
+  isCompactViewport,
+}: PluginThreadHeaderActionProps) {
+  const { threads } = useSidebarThreads();
+  const actions = useSidebarThreadActions();
+
+  const parent = parentOf(threads, threadId);
+  if (parent === null) return null;
+
+  const title = threadDisplayTitle(parent);
+
+  return (
+    <button
+      type="button"
+      aria-label={`Back to parent: ${title}`}
+      title={title}
+      onClick={() => actions.open(parent.id)}
+      className={cn(
+        "flex h-7 max-w-full items-center gap-1.5 rounded-full border border-border text-2xs text-muted-foreground",
+        "hover:bg-accent hover:text-foreground",
+        isCompactViewport ? "px-1.5" : "px-2",
+      )}
+    >
+      <Icon name="ChevronLeft" className="size-3 shrink-0" aria-hidden />
+      <Disc thread={parent} />
+      {isCompactViewport ? null : <span className="truncate">{title}</span>}
+    </button>
+  );
+}

--- a/plugins/t3sidebar/src/SubagentsChip.tsx
+++ b/plugins/t3sidebar/src/SubagentsChip.tsx
@@ -5,8 +5,8 @@ import {
   type PluginSidebarThread,
   type PluginThreadHeaderActionProps,
 } from "@bb/plugin-sdk/app";
-import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { Disc } from "./Disc";
 import { StatusGlyph } from "./StatusGlyph";
 import { childrenOf, threadDisplayTitle } from "./inbox";
 
@@ -122,32 +122,4 @@ function DiscCluster({ threads }: { threads: readonly PluginSidebarThread[] }) {
       ) : null}
     </span>
   );
-}
-
-/**
- * A per-child dot. Colour comes from the child's id so the same thread keeps
- * the same colour, and every hue is a rotation of one accent, so a custom
- * palette still applies.
- */
-function Disc({ thread }: { thread: PluginSidebarThread | null }) {
-  const hue = thread === null ? 0 : hashHue(thread.id);
-  return (
-    <span
-      className="inline-block size-3.5 shrink-0 rounded-full border border-background"
-      style={{
-        backgroundColor:
-          thread === null
-            ? "var(--muted-foreground)"
-            : `oklch(0.72 0.13 ${hue})`,
-      }}
-    />
-  );
-}
-
-function hashHue(id: string): number {
-  let hash = 0;
-  for (let index = 0; index < id.length; index += 1) {
-    hash = (hash * 31 + id.charCodeAt(index)) % 360;
-  }
-  return hash;
 }

--- a/plugins/t3sidebar/src/inbox.test.ts
+++ b/plugins/t3sidebar/src/inbox.test.ts
@@ -4,6 +4,7 @@ import {
   childrenOf,
   filterByProject,
   hideChildrenOfVisibleParents,
+  parentOf,
   partitionPinned,
   searchThreadsByTitle,
   sortByCreatedAtDescending,
@@ -178,5 +179,29 @@ describe("child threads", () => {
       "parent",
     );
     expect(children.map((t) => t.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("parentOf", () => {
+  // The list hides an archived parent, but the child's header must still get
+  // it back — otherwise the child is a dead end.
+  it("finds a parent the inbox filters out", () => {
+    const parent = parentOf(
+      [
+        thread({ id: "parent", isArchived: true, projectId: "other" }),
+        thread({ id: "child", parentThreadId: "parent" }),
+      ],
+      "child",
+    );
+    expect(parent?.id).toBe("parent");
+  });
+
+  it("returns null for a root thread", () => {
+    expect(parentOf([thread({ id: "root" })], "root")).toBeNull();
+  });
+
+  it("returns null when the parent row is gone", () => {
+    const threads = [thread({ id: "child", parentThreadId: "deleted" })];
+    expect(parentOf(threads, "child")).toBeNull();
   });
 });

--- a/plugins/t3sidebar/src/inbox.ts
+++ b/plugins/t3sidebar/src/inbox.ts
@@ -89,6 +89,22 @@ export function hideChildrenOfVisibleParents(
   );
 }
 
+/**
+ * The parent of one thread, or null when the thread is a root, when the id is
+ * unknown, or when the parent row is gone (deleted). The parent may be
+ * archived or in another project: the flat list hides those, but the child
+ * still needs a way back to them.
+ */
+export function parentOf(
+  threads: readonly PluginSidebarThread[],
+  threadId: string,
+): PluginSidebarThread | null {
+  const thread = threads.find((candidate) => candidate.id === threadId);
+  const parentThreadId = thread?.parentThreadId;
+  if (!parentThreadId) return null;
+  return threads.find((candidate) => candidate.id === parentThreadId) ?? null;
+}
+
 /** The children of one thread, oldest first (the order they were spawned). */
 export function childrenOf(
   threads: readonly PluginSidebarThread[],


### PR DESCRIPTION
## What

The t3 inbox hides a child thread while its parent is on screen. A child opened from the parent's children chip therefore had no route back: it is not in the list, and its header showed nothing.

This adds a second `experimental_threadHeaderAction`, `ParentChip`. It names the parent and opens it on a click.

- Registered **before** the children chip, so the header reads up (parent) then down (children). A child that has children of its own shows both.
- The disc uses the same id-derived hue as the children chip, so one thread keeps one colour. `Disc` and `hashHue` moved out of `SubagentsChip` into `src/Disc.tsx`.
- A compact viewport drops the title and keeps the chevron, the disc, and the `aria-label` "Back to parent: <title>".
- `parentOf` finds a parent the inbox filters out — archived, or in another project — because the child still needs it. A root thread and a deleted parent both render nothing.

The chip keys off `parentThreadId`, the same field the children chip uses, so a fork or a side chat (which bb records in `sourceThreadId`) gets no chip. That matches today's children chip.

## Tests

`pnpm exec turbo run typecheck test --filter=bb-plugin-t3sidebar` — 80 pass.

New tests: `ParentChip.test.tsx` covers the click, the root case, an archived parent, and the compact viewport. `inbox.test.ts` covers `parentOf`.

Also checked in the dev app with a real parent thread and two child threads: the chip appears on the child, and a click opens the parent.

## Risks

Frontend only, inside one built-in plugin that ships disabled. No server, daemon, wire, or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)