### PR TITLE
Use the shadcn select for the t3sidebar project scope

### DIFF
--- a/plugins/t3sidebar/src/ThreadInbox.test.tsx
+++ b/plugins/t3sidebar/src/ThreadInbox.test.tsx
@@ -180,9 +180,10 @@ describe("ThreadInbox", () => {
         { id: "proj_2", name: "other", isPersonal: false },
       ],
     );
-    fireEvent.change(screen.getByLabelText(/Project scope/), {
-      target: { value: "proj_2" },
-    });
+    // Radix opens on keyboard too, which jsdom can drive without pointer
+    // capture. Enter opens the list; the option click picks the scope.
+    fireEvent.keyDown(screen.getByLabelText(/Project scope/), { key: "Enter" });
+    fireEvent.click(screen.getByRole("option", { name: "other" }));
     expect(screen.getAllByRole("listitem")).toHaveLength(1);
     expect(screen.getByText("In other")).toBeDefined();
   });

--- a/plugins/t3sidebar/src/ThreadInbox.tsx
+++ b/plugins/t3sidebar/src/ThreadInbox.tsx
@@ -7,6 +7,13 @@ import {
 } from "@bb/plugin-sdk/app";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@bb/shared-ui/select";
 import { ThreadCard } from "./ThreadCard";
 import { SlimRow } from "./SlimRow";
 import { useLifecycle } from "./useLifecycle";
@@ -101,23 +108,30 @@ export function ThreadInbox({
       {/* The one control the host has no equivalent for. Everything else in
           the chrome above — New thread, search — is bb's and stays bb's. */}
       <div className="flex shrink-0 items-center gap-1 px-2 pb-1">
-        <label className="sr-only" htmlFor="t3sidebar-scope">
-          Project scope
-        </label>
-        <select
-          id="t3sidebar-scope"
-          value={scope}
-          onChange={(event) => setScope(event.target.value)}
-          className="min-w-0 flex-1 truncate rounded-md bg-transparent px-1.5 py-1 text-xs font-medium text-muted-foreground hover:bg-sidebar-accent focus:outline-none"
-          aria-label={`Project scope: ${scopeLabel}`}
-        >
-          <option value={ALL_PROJECTS}>All projects</option>
-          {projects.map((project) => (
-            <option key={project.id} value={project.id}>
-              {project.name}
-            </option>
-          ))}
-        </select>
+        <Select value={scope} onValueChange={setScope}>
+          {/* Ghost trigger: no border, no filled track — it reads as a label
+              until you hover it. */}
+          <SelectTrigger
+            className="h-7 min-w-0 flex-1 border-0 px-1.5 py-1 text-xs font-medium text-muted-foreground shadow-none hover:bg-sidebar-accent focus:ring-0"
+            aria-label={`Project scope: ${scopeLabel}`}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_PROJECTS} className="text-xs">
+              All projects
+            </SelectItem>
+            {projects.map((project) => (
+              <SelectItem
+                key={project.id}
+                value={project.id}
+                className="text-xs"
+              >
+                {project.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-2">


### PR DESCRIPTION
## Summary

The t3sidebar project scope picker used a native `<select>`, so it did not match the app's controls. It now uses the shared shadcn `Select` from `@bb/shared-ui/select`, with a ghost trigger: no border, no filled track, no focus ring, and a hover surface only.

The popup portals outside the plugin mount, but `shared-ui/select` already re-attaches the plugin CSS scope, so the menu keeps the theme.

## Tests

- `pnpm exec turbo run test --filter=bb-plugin-t3sidebar` — 80 passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-t3sidebar` — clean.
- Manual QA in the dev app: the closed trigger reads as a label, the popup shows a check on the current value, and picking a project filters the list.

The scope test now drives Radix by key press and option click, because the trigger is a button and no longer a native select.

## Risks

Low. The change is one control in one plugin. No server, daemon, or wire contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)