### PR TITLE
Fix mobile landing page header overflow

### DIFF
--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -2558,9 +2558,12 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
     justify-content: center;
   }
 
-  /* Keep the header on one line: at desktop the 26px gap is fine, but on a
-     narrow phone "Sign in" wraps against "Download for macOS". Tighten the gap
-     and keep the links from breaking. */
+  /* The full download CTA is repeated immediately below in the hero. Hide the
+     nav copy on mobile so the three utility links retain comfortable spacing. */
+  .nav-links .btn {
+    display: none;
+  }
+
   .nav-links {
     gap: 16px;
   }
@@ -2570,17 +2573,11 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   }
 }
 
-/* Below ~430px the download CTA + two text links still can't share one row at
-   the desktop scale — shrink the gap and the button so the header never wraps
-   (fix 9: "Sign in" wrapping against "Download for macOS" at 390px). */
+/* Give the remaining utility links a little more room on narrow phones. */
 @media (max-width: 430px) {
   .nav-links {
     gap: 12px;
     font-size: 13px;
-  }
-
-  .nav-links .btn-sm {
-    padding: 8px 12px;
   }
 
   .updates-label {


### PR DESCRIPTION
## Summary

- hide the redundant header download CTA at the existing mobile breakpoint
- keep the full download CTA in the hero
- remove the obsolete narrow-screen button padding workaround

## Validation

- verified responsive layout at 320, 360, 375, 390, 430, 720, and 721 px
- confirmed no horizontal overflow at mobile widths
- confirmed the desktop header CTA returns above the 720 px breakpoint
- `pnpm exec turbo run build --filter=@bb/web`