### PR TITLE
Align sidebar nav row menus with the search icon

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -557,7 +557,10 @@ function SidebarNavRowChrome({
             data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
             className={cn(
               SIDEBAR_HOVER_ACTIONS_CLASS,
-              "absolute inset-y-0 right-1 flex items-center",
+              // right-0 (not right-1): the trigger's own m-1 supplies the inset,
+              // so the glyph centers on the same column as the sidebar search
+              // icon above and the thread-row more menus below.
+              "absolute inset-y-0 right-0 flex items-center",
             )}
           >
             <DropdownMenu onOpenChange={setIsActionsOpen}>


### PR DESCRIPTION
## What

The plugin nav rows (**Tasks**, **Automations**, **Extensions**) drew their 3-dot trigger 4px left of the search icon on the **New thread** row above.

## Why

The hover-actions wrapper used `right-1`, and the trigger button adds its own `m-1`. The two insets stacked to 8px. The search icon sits flush at the container edge, and thread-row menus use `inset-0` plus the same `m-1`, so both center 22px from the sidebar edge while the nav rows centered at 26px.

## How

Drop the wrapper to `right-0` and let the trigger's `m-1` supply the whole inset. The row button's `pr-7` still clears the 28px actions block.

## Test

- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- The 6 `PluginNavSidebarItems` tests pass.
- Checked the rows in the local dev app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)