### PR TITLE
Keep the split divider above pane headers

### DIFF
--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -250,6 +250,19 @@ function threadContent(threadId: string) {
   };
 }
 
+// Tailwind utilities are not compiled in jsdom, so read the layer from the
+// class token rather than from computed styles. `z-auto` and an absent z-index
+// class both mean "paints in DOM order", which is layer 0 here.
+function stackingLayer(element: HTMLElement): number {
+  for (const token of element.classList) {
+    const match = /^z-(?:\[(\d+)\]|(\d+))$/.exec(token);
+    if (match !== null) {
+      return Number(match[1] ?? match[2]);
+    }
+  }
+  return 0;
+}
+
 function twoPaneLayout(focusedPaneId: "pane-1" | "pane-2"): SplitLayout {
   return {
     root: {
@@ -752,6 +765,45 @@ describe("SplitThreadArea", () => {
     expect(separator.classList).toContain("bg-border-seam");
     expect(separator.classList).not.toContain("w-1.5");
     expect(separator.firstElementChild?.classList).toContain("-inset-x-1.5");
+  });
+
+  it("keeps the divider above pane headers so stacked splits stay resizable", () => {
+    renderSplitArea({
+      path: "/",
+      layout: {
+        root: {
+          type: "split",
+          dir: "col",
+          sizes: [0.5, 0.5],
+          children: [
+            { type: "pane", paneId: "pane-1", content: threadContent("thr-a") },
+            { type: "pane", paneId: "pane-2", content: newThreadContent },
+          ],
+        },
+        focusedPaneId: "pane-2",
+      },
+      routeContent: newThreadContent,
+    });
+
+    // The lower pane's header touches the seam, so a header that paints above
+    // the divider swallows its grab target and blocks vertical resizing.
+    const separator = screen.getByRole("separator");
+    expect(separator.classList).toContain("h-px");
+    expect(separator.firstElementChild?.classList).toContain("-inset-y-1.5");
+    const dividerLayer = stackingLayer(separator);
+    const lowerHeader = document
+      .querySelector<HTMLElement>('[data-split-pane-id="pane-2"]')
+      ?.querySelector("header");
+    const scrim = document.querySelector<HTMLElement>(
+      "[data-pane-focus-scrim]",
+    );
+    expect(lowerHeader).toBeInstanceOf(HTMLElement);
+    expect(scrim).toBeInstanceOf(HTMLElement);
+    if (lowerHeader === null || lowerHeader === undefined || scrim === null) {
+      return;
+    }
+    expect(stackingLayer(lowerHeader)).toBeLessThan(dividerLayer);
+    expect(stackingLayer(scrim)).toBeLessThan(dividerLayer);
   });
 
   it("uses one title tab to distinguish the focused new-thread split", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -1258,7 +1258,11 @@ function SplitDivider({ dir, hidden, onResize }: SplitDividerProps) {
         // only BETWEEN splits (outer edges stay flush). Hover/drag warms it as
         // the resize affordance. The absolutely-positioned child preserves a
         // generous grab target without consuming layout space.
-        "group relative z-[5] flex-shrink-0 transition-colors",
+        //
+        // Stay above the pane focus scrim (z-20) and the pane headers (z-[21]).
+        // In a column split, the lower pane's header touches the seam, so a
+        // lower divider layer loses the grab target to that header.
+        "group relative z-[25] flex-shrink-0 transition-colors",
         "bg-border-seam",
         "hover:bg-ring/40 data-[dragging]:bg-ring/40",
         hidden && "invisible pointer-events-none",


### PR DESCRIPTION
## Summary

Stacked (column) splits could not be resized. This restores the divider drag.

## Cause

[#934](https://github.com/ymichael/bb/commit/dbdcc20c76e4f8fe30d2517950545db45d808006) added a pane focus scrim at `z-20` and lifted the pane headers to `z-[21]` so titles and tabs stay above it. `SplitDivider` stayed at `z-[5]`. Panes are `relative` with no z-index, so they open no stacking context and the headers paint over the divider.

The divider is a 1px line with a ±6px absolutely positioned grab target. In a column split, the lower pane's header starts exactly at the seam, so it covers that grab strip and takes all the pointer events. Row splits kept working because the header overlaps the seam for only one header row.

## Fix

The divider now uses `z-[25]` — above the scrim and the headers, below a maximized pane at `z-30`.

## Tests

- New regression test in `SplitThreadArea.test.tsx`: it renders a column split and asserts the divider layer beats the lower pane's real header and the focus scrim. It fails on `z-[5]` and passes on `z-[25]`.
- `pnpm exec turbo run test --filter=@bb/app -- SplitThreadArea` — 37 passed
- `pnpm exec turbo run typecheck --filter=@bb/app` — clean
- ESLint and Prettier — clean
- Manual check in the dev app: stacked and side-by-side splits both resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)