### PR TITLE
Make the new thread surface flush with the window edges

### DIFF
--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -1022,7 +1022,11 @@ function NonThreadPaneContent({
     <div
       className={cn(
         "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
-        content.kind === "plugin-panel" && !isBoundedPane && "-m-4 md:-m-5",
+        // Single-pane surfaces own their own padding (the compose page and
+        // plugin panels both re-apply it inside), so cancel the app layout's
+        // page padding here. Otherwise the right panel floats 20px off the
+        // window edges instead of sitting flush like it does on a thread.
+        !isBoundedPane && "-m-4 md:-m-5",
       )}
     >
       {isBoundedPane || panel ? (


### PR DESCRIPTION
## What

The right panel on the **New thread** surface floated 20px off the top, right, and bottom window edges. On a thread page the same panel sits flush.

## Why

The new-thread pane body received the app page padding twice and cancelled only one level.

1. `AppLayout` wraps the page in `<main className="... p-4 md:p-5">`.
2. `SplitThreadArea` adds a second `p-4 md:p-5` around the pane body.
3. `RootComposeSecondaryContent` cancels one level with `-mx-4 -mb-4 -mt-4 md:-m*-5`.

Plugin panels already cancelled the second level with `-m-4 md:-m-5`. The new-thread pane did not. A thread page returns `ThreadDetailView` directly and skips the wrapper, which is why only the new-thread view looked wrong.

## How

Apply the full-bleed cancel to every single-pane surface instead of only plugin panels:

```diff
-content.kind === "plugin-panel" && !isBoundedPane && "-m-4 md:-m-5",
+!isBoundedPane && "-m-4 md:-m-5",
```

Split (bounded) panes keep their padding, so split layouts do not change.

## Test

- In a 1440x900 window the right panel now measures `x 880, y 0, w 560, h 900`. Before it measured `x 880, y 20, w 540, h 860`.
- The compose column top now sits at `56px`, level with the `New thread` sidebar row (`top 56`). That is what the existing `pt-14` token intended; the extra 20px had pushed it to 76.
- Checked the root landing page, the new-thread compose page, and a compact viewport in the local dev app.
- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- 175 tests pass across `src/views/thread-detail` and `plugin-slot-mounts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)