### PR TITLE
Fill the screen in the iOS standalone PWA

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -13,6 +13,23 @@
     height: 100%;
   }
 
+  /*
+   * iOS standalone subtracts the top safe-area inset from the small and
+   * dynamic viewports but not from the large one. On a 852pt screen with a
+   * 59pt inset, innerHeight/100svh/100dvh/height:100% all report 793 while
+   * 100lvh reports the true 852. The shell starts at y=0 under the
+   * translucent status bar, so a 793pt shell leaves a 59pt dead band at the
+   * bottom. 100lvh is the only value that spans the screen.
+   *
+   * Scoped to standalone: in a Safari tab, lvh is the toolbars-retracted
+   * height, which is taller than what the user can see.
+   */
+  @media (display-mode: standalone) {
+    html.bb-app-shell-root {
+      height: 100lvh;
+    }
+  }
+
   html.bb-app-shell-root,
   body.bb-app-shell {
     overflow: hidden;

--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -23,10 +23,23 @@
    *
    * Scoped to standalone: in a Safari tab, lvh is the toolbars-retracted
    * height, which is taller than what the user can see.
+   *
+   * `position: fixed` elements cannot inherit the shell height: a percentage
+   * height on them resolves against the initial containing block, which is the
+   * short 793pt viewport. They have to name the unit themselves, so this
+   * variable is the single switch both they and the shell root read.
    */
+  :root {
+    --bb-shell-height: 100dvh;
+  }
+
   @media (display-mode: standalone) {
+    :root {
+      --bb-shell-height: 100lvh;
+    }
+
     html.bb-app-shell-root {
-      height: 100lvh;
+      height: var(--bb-shell-height);
     }
   }
 

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -872,7 +872,7 @@ export function AppLayout({ children }: AppLayoutProps) {
                 <div
                   ref={contentShellRef}
                   data-testid="app-layout-content-shell"
-                  className="relative flex h-[100dvh] min-w-0 w-full flex-col pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]"
+                  className="relative flex h-full min-h-0 min-w-0 w-full flex-col pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]"
                 >
                   {showHeader ? (
                     <AppHeader

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -451,7 +451,11 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              // Fill the shell root (html/body/#root are height:100%) instead of
+              // re-measuring the viewport. On iOS standalone, viewport units and
+              // the safe-area insets disagree, and app.css clips the difference
+              // into an unreachable band at the bottom of the screen.
+              "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
               className,
             )}
             ref={ref}
@@ -638,7 +642,7 @@ const Sidebar = React.forwardRef<
         <div
           data-sidebar="gap"
           className={cn(
-            "relative hidden h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear md:block",
+            "relative hidden h-full w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear md:block",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
@@ -649,7 +653,7 @@ const Sidebar = React.forwardRef<
         <div
           data-sidebar="panel"
           className={cn(
-            "fixed inset-y-0 z-10 flex h-svh w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground transition-[left,right,width] duration-200 ease-linear",
+            "fixed inset-y-0 z-10 flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground transition-[left,right,width] duration-200 ease-linear",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -1173,8 +1177,8 @@ const SidebarInset = React.forwardRef<
       ref={ref}
       data-sidebar="inset"
       className={cn(
-        "relative flex min-h-svh min-w-0 flex-1 flex-col bg-background",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+        "relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className,
       )}
       {...props}

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -594,7 +594,9 @@ const Sidebar = React.forwardRef<
                 suppressMobileOpenAnimation ? "true" : undefined
               }
               className={cn(
-                "group fixed inset-y-0 z-40 flex h-dvh w-(--sidebar-width-mobile) flex-col bg-sidebar text-sidebar-foreground outline-none",
+                // Fixed: a percentage height would resolve against the short
+                // initial containing block, so it reads the shell unit directly.
+                "group fixed inset-y-0 z-40 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) flex-col bg-sidebar text-sidebar-foreground outline-none",
                 "[&[data-sidebar-suppress-open-animation=true][data-state=open]]:![animation:none]",
                 side === "left" ? "left-0" : "right-0",
                 variant === "floating" || variant === "inset"
@@ -653,7 +655,9 @@ const Sidebar = React.forwardRef<
         <div
           data-sidebar="panel"
           className={cn(
-            "fixed inset-y-0 z-10 flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground transition-[left,right,width] duration-200 ease-linear",
+            // Fixed: a percentage height would resolve against the short
+            // initial containing block, so it reads the shell unit directly.
+            "fixed inset-y-0 z-10 flex h-(--bb-shell-height) w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground transition-[left,right,width] duration-200 ease-linear",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -51,8 +51,19 @@ const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
 // the toggle itself would just be re-added by the strip's own drag rect. The
 // carve has to live inside the strip, and this constant keeps the two footprints
 // from drifting apart.
+// The toggle is `fixed`, so it positions against the viewport, whose origin
+// is under the translucent status bar in an iOS standalone PWA. Without the
+// safe-area insets it lands on the status bar and collides with the battery.
+// The insets are 0 everywhere else, so desktop and Safari keep the same
+// offsets.
+//
+// The top offset centers the toggle on the same axis as the pinned sidebar
+// trigger, which CHROME_ROW_CLASS box-centers in a 48px row (center = 24px).
+// The button box is 28px normally and 36px under a coarse pointer, so the
+// offset has to change with it: 24 - 28/2 = 10px, and 24 - 36/2 = 6px. A single
+// offset lines up in one pointer mode and sits 4px low in the other.
 export const ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS =
-  "right-4 top-2.5";
+  "right-[calc(1rem+env(safe-area-inset-right))] top-[calc(0.625rem+env(safe-area-inset-top))] max-md:pointer-coarse:top-[calc(0.375rem+env(safe-area-inset-top))]";
 
 type RootSecondaryPanelProps = Omit<
   ComponentProps<typeof ThreadSecondaryPanel>,


### PR DESCRIPTION
Fixes #871.

## The bug

Launched from the iOS home-screen icon, the app shell rendered shorter than the screen: a dead band at the bottom, and content pushed up under the status bar. The same build was fine in a Safari tab.

## Root cause

Measured on a physical iPhone in standalone mode (393x852 screen, 59pt top inset, 34pt bottom inset):

| Value | Reported |
|---|---|
| `innerHeight` / `visualViewport` | 793 |
| `100svh` / `100dvh` / `height: 100%` | 793 |
| `100lvh` / `100vh` | **852** |

`793 = 852 - 59`. iOS standalone subtracts the **top** inset from the small and dynamic viewports, but leaves the large viewport at the full screen height. The shell painted 793pt starting at y=0, so it stopped 59pt above the bottom of the screen.

The original issue theorized a double-counted *bottom* inset. That was not it — the insets are applied once and correctly. `100lvh` is the only unit that reports the real screen.

## The fix

- `app.css`: in standalone only, `html` is `height: 100lvh`. Scoped to standalone because in a Safari tab `lvh` is the toolbars-retracted height, which is taller than the visible area.
- `sidebar.tsx` / `AppLayout.tsx`: the shell had three independent viewport measurements (two `min-h-svh`, one `h-[100dvh]`) nested inside ancestors that clip. They agree in a browser tab and disagree in standalone. Each now fills its parent, so one place measures the screen.
- `RootComposeSecondaryContent.tsx`: the pinned panel toggle is `fixed`, so it positioned against a viewport whose origin is under the translucent status bar. At `top-2.5` it landed on the battery. It now carries the safe-area insets, and its top offset tracks the button box size (28px fine, 36px coarse) so it centers on the same 48px chrome axis as the sidebar trigger in both pointer modes.
- Drops the `peer-data-[variant=inset]` min-height rule. Nothing in the app sets that variant.

## Testing

Verified on a physical iPhone in standalone mode: the shell now spans the full 852pt, `innerHeight` and `100dvh` correct themselves to 852, and the toggle clears the status bar.

Desktop and desktop web, measured in a headless browser:

| Check | 1440x900 | 1024x768 |
|---|---|---|
| Sidebar trigger center Y | 24 | 24 |
| Panel toggle center Y | 24 | 24 |
| Shell height vs `innerHeight` | 900 / 900 | 768 / 768 |
| Document overflow | 0 | 0 |
| Sidebar panel height | 900 | 768 |

`display-mode: standalone` is false on desktop web, so the `100lvh` rule never applies there. The insets resolve to 0 off-device, so the toggle computes to exactly `top: 10px; right: 16px` — unchanged from before. Electron uses a different trigger branch (`AppLayout.tsx:230`) that this does not touch.

`pnpm exec turbo run test --filter=@bb/app`: 307 files, 2330 tests, all passing. Typecheck passes.

## Risks

`env(safe-area-inset-*)` cannot be emulated in any headless runner, so the standalone path is covered by device testing rather than automated tests. The macOS drag-strip cutout reads the same position constant as the toggle, so their footprints stay paired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)