### PR TITLE
Enable direct automation configuration

### DIFF
--- a/apps/app/src/components/tools/Automations.stories.tsx
+++ b/apps/app/src/components/tools/Automations.stories.tsx
@@ -6,6 +6,7 @@ import {
   type AutomationCollectionMode,
 } from "bb-plugin-automations/overview-view";
 import type {
+  AutomationExecutionOptionsResponse,
   AutomationResponse,
   AutomationRunResponse,
   AutomationsOverviewResponse,
@@ -19,6 +20,16 @@ export default {
 };
 
 const noop = () => {};
+const executionOptions: AutomationExecutionOptionsResponse = {
+  models: [
+    {
+      id: "claude:claude-opus-5",
+      model: "claude-opus-5",
+      displayName: "Opus 5",
+    },
+  ],
+  permissionModes: ["accept-edits", "auto", "full"],
+};
 const now = new Date(2027, 0, 15, 9).getTime();
 
 function automation(
@@ -509,8 +520,11 @@ function AutomationDetail({
         retry: noop,
       }}
       actionPending={false}
+      executionOptions={executionOptions}
+      executionOptionsError={null}
       onToggle={noop}
       onEdit={noop}
+      onUpdateAgent={async () => {}}
       onRunNow={noop}
       onDelete={noop}
       onOpenThread={noop}

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -10,14 +10,16 @@
  */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AutomationExecutionOptionsResponse,
   AutomationResponse,
   AutomationRunResponse,
 } from "bb-plugin-automations/rpc-types";
 import {
-  AutomationDetailView,
+  AutomationDetailView as AutomationDetailViewBase,
   AutomationRunStatusIndicator,
 } from "bb-plugin-automations/detail-view";
 import {
@@ -233,9 +235,9 @@ describe("Plugin detail recipe", () => {
 
     expect(detail.className).not.toContain("line-clamp-3");
     expect(
-      screen.getByRole("button", { name: "Show less" }).getAttribute(
-        "aria-expanded",
-      ),
+      screen
+        .getByRole("button", { name: "Show less" })
+        .getAttribute("aria-expanded"),
     ).toBe("true");
     expect(container.textContent).toContain(description);
   });
@@ -498,6 +500,44 @@ const AUTOMATION: AutomationResponse = {
   updatedAt: 1_700_000_000_000,
 };
 
+const AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptionsResponse = {
+  models: [
+    {
+      id: "claude:claude-opus-5",
+      model: "claude-opus-5",
+      displayName: "Opus 5",
+    },
+  ],
+  permissionModes: ["accept-edits", "auto", "full"],
+};
+
+type TestAutomationDetailProps = Omit<
+  ComponentProps<typeof AutomationDetailViewBase>,
+  "executionOptions" | "executionOptionsError" | "onUpdateAgent"
+> &
+  Partial<
+    Pick<
+      ComponentProps<typeof AutomationDetailViewBase>,
+      "executionOptions" | "executionOptionsError" | "onUpdateAgent"
+    >
+  >;
+
+function AutomationDetailView({
+  executionOptions = AUTOMATION_EXECUTION_OPTIONS,
+  executionOptionsError = null,
+  onUpdateAgent = async () => {},
+  ...props
+}: TestAutomationDetailProps) {
+  return (
+    <AutomationDetailViewBase
+      {...props}
+      executionOptions={executionOptions}
+      executionOptionsError={executionOptionsError}
+      onUpdateAgent={onUpdateAgent}
+    />
+  );
+}
+
 const FAILED_SCRIPT_RUN: AutomationRunResponse = {
   id: "run_failed",
   automationId: AUTOMATION.id,
@@ -516,6 +556,7 @@ const FAILED_SCRIPT_RUN: AutomationRunResponse = {
 
 describe("Automation detail recipe", () => {
   it("keeps Definition ahead of Runs, including with no runs yet", async () => {
+    const updateAgent = vi.fn(async () => {});
     const { container } = render(
       <MemoryRouter>
         <AutomationDetailView
@@ -531,6 +572,7 @@ describe("Automation detail recipe", () => {
             retry: () => {},
           }}
           actionPending={false}
+          onUpdateAgent={updateAgent}
           onToggle={() => {}}
           onEdit={() => {}}
           onRunNow={() => {}}
@@ -577,24 +619,20 @@ describe("Automation detail recipe", () => {
     expect(runsTable.className).toContain("border-border");
     expect(runsTable.className).not.toContain("inline-block");
 
-    const promptPanel = screen.getByText("Summarize yesterday's commits.")
-      .parentElement as HTMLElement;
+    const promptContent = screen.getByRole("textbox", {
+      name: "Automation prompt",
+    }) as HTMLTextAreaElement;
+    const promptPanel = promptContent.closest("form") as HTMLElement;
     expect(promptPanel.className).toContain("bg-background");
     expect(promptPanel.className).toContain("rounded-xl");
     expect(promptPanel.className).not.toContain("rounded-md");
     expect(promptPanel.className).not.toContain("shadow-xs");
     expect(promptPanel.className).not.toContain("shadow-sm");
-    expect(promptPanel.lastElementChild?.className).not.toContain("border-t");
-    const promptContent = promptPanel.querySelector(
-      '[data-resource-prompt-content=""]',
-    ) as HTMLElement;
-    expect(promptContent.getAttribute("role")).toBe("textbox");
-    expect(promptContent.getAttribute("aria-label")).toBe("Saved prompt");
-    expect(promptContent.getAttribute("aria-readonly")).toBe("true");
-    expect(promptContent.className).toContain("min-h-[68px]");
+    expect(promptContent.value).toBe("Summarize yesterday's commits.");
+    expect(promptContent.readOnly).toBe(false);
+    expect(promptContent.className).toContain("min-h-28");
     expect(promptContent.className).toContain("px-4");
-    expect(promptContent.className).toContain("pt-3");
-    expect(promptContent.className).toContain("pb-1");
+    expect(promptContent.className).toContain("py-3");
     const promptFooter = container.querySelector(
       '[data-automation-prompt-footer=""]',
     ) as HTMLElement;
@@ -606,12 +644,10 @@ describe("Automation detail recipe", () => {
       promptFooter.querySelectorAll('[data-option-display=""]'),
     ).toHaveLength(1);
     const accessSelector = promptFooter.querySelector(
-      '[data-disabled-automation-selector="Permission mode"]',
+      '[data-automation-selector="Permission mode"]',
     ) as HTMLButtonElement;
-    expect(accessSelector.disabled).toBe(true);
-    expect(accessSelector.getAttribute("aria-label")).toBe(
-      "Permission mode: Approve for me. Read only",
-    );
+    expect(accessSelector.disabled).toBe(false);
+    expect(accessSelector.getAttribute("aria-label")).toBe("Permission mode");
     expect(
       accessSelector.querySelector('[data-icon="ChevronDown"]'),
     ).not.toBeNull();
@@ -623,11 +659,11 @@ describe("Automation detail recipe", () => {
       container.querySelector('[data-automation-read-only-label=""]'),
     ).toBeNull();
     const modelSelector = promptPanel.querySelector(
-      '[data-disabled-automation-selector="Provider and model"]',
+      '[data-automation-selector="Provider and model"]',
     ) as HTMLButtonElement;
-    expect(modelSelector.disabled).toBe(true);
+    expect(modelSelector.disabled).toBe(false);
     expect(modelSelector.getAttribute("aria-label")).toBe(
-      "Provider and model: Claude, Opus 5. Read only",
+      "Provider and model: Claude, Opus 5",
     );
     expect(
       modelSelector.querySelector('[data-icon="ChevronDown"]'),
@@ -635,24 +671,16 @@ describe("Automation detail recipe", () => {
     expect(
       container.querySelector('[data-automation-provider-icon="claude"] svg'),
     ).not.toBeNull();
-    const modelDisabledTrigger = screen.getByLabelText(
-      "Provider and model. Use Edit with chat to change the provider and model.",
-    );
-    expect(modelDisabledTrigger.className).toContain("cursor-not-allowed");
-    fireEvent.focus(modelDisabledTrigger);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Use Edit with chat to change the provider and model.",
-    );
-    fireEvent.blur(modelDisabledTrigger);
-
-    const permissionDisabledTrigger = screen.getByLabelText(
-      "Permission mode. Use Edit with chat to change permissions.",
-    );
-    expect(permissionDisabledTrigger.className).toContain("cursor-not-allowed");
-    fireEvent.focus(permissionDisabledTrigger);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Use Edit with chat to change permissions.",
-    );
+    const savePrompt = screen.getByRole("button", { name: "Save prompt" });
+    expect((savePrompt as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(promptContent, {
+      target: { value: "Summarize the last two days." },
+    });
+    expect((savePrompt as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(savePrompt);
+    expect(updateAgent).toHaveBeenCalledWith({
+      prompt: "Summarize the last two days.",
+    });
   });
 
   it("uses the composer metadata treatment without inventing reasoning", () => {
@@ -718,10 +746,8 @@ describe("Automation detail recipe", () => {
       promptShell.querySelectorAll('[data-option-display=""]'),
     ).toHaveLength(2);
     expect(
-      promptShell.querySelectorAll(
-        "[data-disabled-automation-selector]:disabled",
-      ),
-    ).toHaveLength(2);
+      promptShell.querySelectorAll("[data-automation-selector]:disabled"),
+    ).toHaveLength(0);
   });
 
   it.each([
@@ -801,10 +827,10 @@ describe("Automation detail recipe", () => {
       );
 
       const selector = container.querySelector(
-        '[data-disabled-automation-selector="Provider and model"]',
+        '[data-automation-selector="Provider and model"]',
       ) as HTMLButtonElement;
       expect(selector.getAttribute("aria-label")).toBe(
-        `Provider and model: ${providerLabel}, ${modelLabel}. Read only`,
+        `Provider and model: ${providerLabel}, ${modelLabel}`,
       );
       expect(selector.textContent).toContain(modelLabel);
       expect(
@@ -880,11 +906,9 @@ describe("Automation detail recipe", () => {
     ).toHaveLength(2);
     expect(
       container
-        .querySelector(
-          '[data-disabled-automation-selector="Provider and model"]',
-        )
+        .querySelector('[data-automation-selector="Provider and model"]')
         ?.getAttribute("aria-label"),
-    ).toBe("Provider and model: Codex, 5. Read only");
+    ).toBe("Provider and model: Codex, 5");
   });
 
   it("shows the stored script with capped overflow and no environment values", () => {

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -20,6 +20,8 @@ import type { automationRpcContract } from "./src/rpc.js";
 import { toast } from "sonner";
 import type {
   AutomationResponse,
+  AutomationExecutionOptionsResponse,
+  AgentExecutionUpdate,
   AutomationRunListResponse,
   AutomationRunResponse,
   AutomationsOverviewResponse,
@@ -242,6 +244,42 @@ function useAutomation(route: DetailRoute): {
   return { ...state, refetch };
 }
 
+function useAutomationExecutionOptions(
+  route: DetailRoute,
+  enabled: boolean,
+): {
+  options: AutomationExecutionOptionsResponse | null;
+  error: string | null;
+} {
+  const rpc = useRpc<typeof automationRpcContract>();
+  const { projectId, automationId } = route;
+  const [state, setState] = useState<{
+    options: AutomationExecutionOptionsResponse | null;
+    error: string | null;
+  }>({ options: null, error: null });
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ options: null, error: null });
+      return;
+    }
+    let active = true;
+    rpc.call("automations_execution_options", { projectId, automationId }).then(
+      (options) => {
+        if (active) setState({ options, error: null });
+      },
+      (error: unknown) => {
+        if (active) setState({ options: null, error: errorText(error) });
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [automationId, enabled, projectId, rpc]);
+
+  return state;
+}
+
 interface RunsState {
   runs: AutomationRunResponse[];
   nextCursor: string | null;
@@ -369,6 +407,8 @@ function useMutations() {
     resume: (route: DetailRoute) => call("automations_resume", route),
     run: (route: DetailRoute) => call("automations_run", route),
     delete: (route: DetailRoute) => call("automations_delete", route),
+    update: (route: DetailRoute, agent: AgentExecutionUpdate) =>
+      rpc.call("automations_update", { ...route, agent }),
   };
 }
 
@@ -498,6 +538,10 @@ function DetailView({
 }) {
   const navigate = useBbNavigate();
   const { automation, error, missing, refetch } = useAutomation(route);
+  const executionOptionsState = useAutomationExecutionOptions(
+    route,
+    automation?.execution.mode === "agent",
+  );
   const overviewState = useOverview();
   const runsState = useRuns(route);
   const mutations = useMutations();
@@ -551,6 +595,22 @@ function DetailView({
     if (automation === null) return;
     editViaThread(automation);
   }, [automation, editViaThread]);
+
+  const updateAgent = useCallback(
+    async (agent: AgentExecutionUpdate) => {
+      setActionPending(true);
+      try {
+        await mutations.update(route, agent);
+        toast.success("Automation updated");
+        refetch();
+      } catch (rpcError: unknown) {
+        toast.error(`Failed to update automation: ${errorText(rpcError)}`);
+      } finally {
+        setActionPending(false);
+      }
+    },
+    [mutations, refetch, route],
+  );
 
   const confirmDelete = useCallback(() => {
     setDeleting(true);
@@ -621,8 +681,11 @@ function DetailView({
       projectLabel={projectLabel}
       runsState={runsState}
       actionPending={actionPending}
+      executionOptions={executionOptionsState.options}
+      executionOptionsError={executionOptionsState.error}
       onToggle={(checked) => runAction(checked ? "resume" : "pause")}
       onEdit={openEdit}
+      onUpdateAgent={updateAgent}
       onRunNow={() => runAction("run")}
       onDelete={() => setDeleteOpen(true)}
       onOpenThread={openThread}

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -54,7 +54,10 @@ import {
   getOneShotLifecycle,
   oneShotLifecycleAllowsToggle,
 } from "./lib/format-schedule";
-import { formatAutomationModelLabel } from "./lib/model-label";
+import {
+  formatAutomationModelLabel,
+  formatAutomationProviderLabel,
+} from "./lib/model-label";
 import { AutomationProviderIcon } from "./lib/provider-icon";
 import { AutomationMetadataItem } from "./metadata";
 
@@ -287,6 +290,7 @@ function AutomationEnvironmentVariables({
 
 interface AutomationSelectorProps {
   label: string;
+  accessibleLabel?: string;
   value: string;
   options: readonly { value: string; label: string }[];
   onValueChange: (value: string) => void;
@@ -297,6 +301,7 @@ interface AutomationSelectorProps {
 
 function AutomationSelector({
   label,
+  accessibleLabel,
   value,
   options,
   onValueChange,
@@ -307,7 +312,8 @@ function AutomationSelector({
   return (
     <Select value={value} onValueChange={onValueChange} disabled={disabled}>
       <SelectTrigger
-        aria-label={label}
+        aria-label={accessibleLabel ?? label}
+        data-automation-selector={label}
         className={cn(
           OPTION_BASE_CLASS_NAME,
           OPTION_INTERACTIVE_CLASS_NAME,
@@ -600,7 +606,7 @@ function AgentAutomationEditor({
   return (
     <div data-promptbox-shell="" className="min-w-0">
       <form
-        className="rounded-md border border-border bg-background"
+        className="rounded-xl border border-border bg-background"
         onSubmit={(event) => {
           event.preventDefault();
           if (!promptDirty || trimmedPrompt.length === 0) return;
@@ -617,7 +623,8 @@ function AgentAutomationEditor({
         />
         <div className="flex min-w-0 items-center justify-between gap-2 border-t border-border px-2 py-1.5">
           <AutomationSelector
-            label="Model"
+            label="Provider and model"
+            accessibleLabel={`Provider and model: ${formatAutomationProviderLabel(execution.providerId)}, ${modelOptions.find((option) => option.value === execution.model)?.label ?? execution.model}`}
             value={execution.model}
             options={modelOptions}
             disabled={pending || options === null}

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -1,11 +1,14 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ReactNode, UIEvent } from "react";
 import type {
   AutomationExecution,
+  AutomationExecutionOptionsResponse,
   AutomationResponse,
   AutomationRunResponse,
   AutomationRunStatus,
+  AgentExecutionUpdate,
 } from "./src/rpc-types";
+import { AUTOMATION_PROMPT_MAX_LENGTH } from "./src/rpc-types";
 import { Button } from "@bb/shared-ui/button";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import {
@@ -15,19 +18,25 @@ import {
   ResourceDetailCollection,
   ResourceDetailPage,
   ResourceDetailPanel,
-  ResourcePromptPreview,
   ResourceDetailStack,
   ResourceMeta,
   ResourceOverflowMenu,
   useResourceRouteLabel,
 } from "@bb/shared-ui/resource-list";
 import { Switch } from "@bb/shared-ui/switch";
+import { Textarea } from "@bb/shared-ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@bb/shared-ui/select";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import {
   OptionDisplay,
   OPTION_BASE_CLASS_NAME,
   OPTION_INTERACTIVE_CLASS_NAME,
-  OPTION_MUTED_CLASS_NAME,
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
 import {
@@ -45,10 +54,7 @@ import {
   getOneShotLifecycle,
   oneShotLifecycleAllowsToggle,
 } from "./lib/format-schedule";
-import {
-  formatAutomationModelLabel,
-  formatAutomationProviderLabel,
-} from "./lib/model-label";
+import { formatAutomationModelLabel } from "./lib/model-label";
 import { AutomationProviderIcon } from "./lib/provider-icon";
 import { AutomationMetadataItem } from "./metadata";
 
@@ -67,8 +73,11 @@ export interface AutomationDetailViewProps {
   projectLabel: string;
   runsState: AutomationRunsViewState;
   actionPending: boolean;
+  executionOptions: AutomationExecutionOptionsResponse | null;
+  executionOptionsError: string | null;
   onToggle: (enabled: boolean) => void;
   onEdit: () => void;
+  onUpdateAgent: (update: AgentExecutionUpdate) => Promise<void>;
   onRunNow: () => void;
   onDelete: () => void;
   onOpenThread: (threadId: string) => void;
@@ -276,82 +285,53 @@ function AutomationEnvironmentVariables({
   );
 }
 
-interface DisabledAutomationSelectorProps {
+interface AutomationSelectorProps {
   label: string;
   value: string;
-  disabledReason: string;
-  accessibleValue?: string;
-  compactValue?: string;
+  options: readonly { value: string; label: string }[];
+  onValueChange: (value: string) => void;
+  disabled?: boolean;
   leading?: ReactNode;
-  title?: string;
   className?: string;
 }
 
-function DisabledAutomationSelector({
+function AutomationSelector({
   label,
   value,
-  disabledReason,
-  accessibleValue,
-  compactValue,
+  options,
+  onValueChange,
+  disabled = false,
   leading,
-  title,
   className,
-}: DisabledAutomationSelectorProps) {
-  const control = (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      aria-label={`${label}: ${accessibleValue ?? value}. Read only`}
-      disabled
-      data-disabled-automation-selector={label}
-      className={cn(
-        OPTION_BASE_CLASS_NAME,
-        OPTION_INTERACTIVE_CLASS_NAME,
-        OPTION_MUTED_CLASS_NAME,
-        "cursor-not-allowed disabled:cursor-not-allowed disabled:opacity-100",
-        className,
-      )}
-    >
-      <span
-        className={OPTION_TRIGGER_CONTENT_CLASS_NAME}
-        title={title ?? `${label}: ${value}`}
-      >
-        {leading}
-        <span className="min-w-0 truncate" data-promptbox-full-label="">
-          {value}
-        </span>
-        {compactValue ? (
-          <span className="min-w-0 truncate" data-promptbox-compact-label="">
-            {compactValue}
-          </span>
-        ) : null}
-      </span>
-      <Icon
-        name="ChevronDown"
-        className="size-3.5 shrink-0 text-muted-foreground"
-        aria-hidden
-      />
-    </Button>
-  );
-
+}: AutomationSelectorProps) {
   return (
-    <TooltipProvider delayDuration={250}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className="inline-flex shrink-0 cursor-not-allowed rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            tabIndex={0}
-            aria-label={`${label}. ${disabledReason}`}
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger
+        aria-label={label}
+        className={cn(
+          OPTION_BASE_CLASS_NAME,
+          OPTION_INTERACTIVE_CLASS_NAME,
+          "w-auto min-w-0 border-0 bg-transparent shadow-none focus:ring-0",
+          className,
+        )}
+      >
+        <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>
+          {leading}
+          <SelectValue />
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem
+            key={option.value}
+            value={option.value}
+            className="text-xs"
           >
-            {control}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-64">
-          {disabledReason}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 
@@ -412,17 +392,6 @@ function formatPermissionMode(
   if (permissionMode === "accept-edits") return "Accept Edits";
   if (permissionMode === "auto") return "Approve for me";
   return "Full Access";
-}
-
-function formatPermissionModeCompact(
-  permissionMode: Extract<
-    AutomationExecution,
-    { mode: "agent" }
-  >["permissionMode"],
-): string {
-  if (permissionMode === "accept-edits") return "Edits";
-  if (permissionMode === "auto") return "Auto";
-  return "Full";
 }
 
 function formatRunDuration(run: AutomationRunResponse): string | null {
@@ -596,13 +565,95 @@ function RunRow({
   );
 }
 
+function AgentAutomationEditor({
+  execution,
+  options,
+  optionsError,
+  pending,
+  onUpdate,
+}: {
+  execution: Extract<AutomationExecution, { mode: "agent" }>;
+  options: AutomationExecutionOptionsResponse | null;
+  optionsError: string | null;
+  pending: boolean;
+  onUpdate: (update: AgentExecutionUpdate) => Promise<void>;
+}) {
+  const [prompt, setPrompt] = useState(execution.prompt);
+  useEffect(() => setPrompt(execution.prompt), [execution.prompt]);
+  const trimmedPrompt = prompt.trim();
+  const promptDirty = prompt !== execution.prompt;
+  const modelOptions = options?.models.map((model) => ({
+    value: model.model,
+    label: model.displayName,
+  })) ?? [
+    {
+      value: execution.model,
+      label: formatAutomationModelLabel(execution.model, execution.providerId),
+    },
+  ];
+  if (!modelOptions.some((option) => option.value === execution.model)) {
+    modelOptions.unshift({
+      value: execution.model,
+      label: formatAutomationModelLabel(execution.model, execution.providerId),
+    });
+  }
+  return (
+    <div data-promptbox-shell="" className="min-w-0">
+      <form
+        className="rounded-md border border-border bg-background"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!promptDirty || trimmedPrompt.length === 0) return;
+          void onUpdate({ prompt: trimmedPrompt });
+        }}
+      >
+        <Textarea
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
+          aria-label="Automation prompt"
+          disabled={pending}
+          className="min-h-28 resize-y border-0 bg-transparent px-4 py-3 text-sm shadow-none focus-visible:ring-0"
+        />
+        <div className="flex min-w-0 items-center justify-between gap-2 border-t border-border px-2 py-1.5">
+          <AutomationSelector
+            label="Model"
+            value={execution.model}
+            options={modelOptions}
+            disabled={pending || options === null}
+            onValueChange={(model) => void onUpdate({ model })}
+            leading={
+              <AutomationProviderIcon providerId={execution.providerId} />
+            }
+          />
+          <Button
+            type="submit"
+            size="sm"
+            disabled={pending || !promptDirty || trimmedPrompt.length === 0}
+          >
+            Save prompt
+          </Button>
+        </div>
+      </form>
+      {optionsError ? (
+        <p className="mt-1 px-3.5 text-xs text-destructive">
+          Couldn&apos;t load model options. {optionsError}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export function AutomationDetailView({
   automation,
   projectLabel,
   runsState,
   actionPending,
+  executionOptions,
+  executionOptionsError,
   onToggle,
   onEdit,
+  onUpdateAgent,
   onRunNow,
   onDelete,
   onOpenThread,
@@ -618,8 +669,8 @@ export function AutomationDetailView({
   const lifecycleLocked = !oneShotLifecycleAllowsToggle(oneShotLifecycle);
   const lifecycleDisabledReason = lifecycleLocked
     ? oneShotLifecycle === "expired"
-      ? "This one-time automation expired. Edit it to schedule another run."
-      : "This one-time automation has completed. Edit it to schedule another run."
+      ? "Missed its run time. Edit to reschedule."
+      : "Already ran. Edit to reschedule."
     : undefined;
   const bodyLabel = automationBodyLabel(automation.execution);
   const execution = automation.execution;
@@ -691,42 +742,25 @@ export function AutomationDetailView({
         <ResourceDefinitionSection
           label={bodyLabel}
           actions={
-            <ResourceActionButton
-              label="Edit with chat"
-              tooltipLabel="Edit with chat"
-              icon="MessageCirclePlus"
-              onClick={onEdit}
-            />
+            execution.mode === "script" ? (
+              <ResourceActionButton
+                label="Edit with chat"
+                tooltipLabel="Edit with chat"
+                icon="MessageCirclePlus"
+                onClick={onEdit}
+              />
+            ) : undefined
           }
         >
           {execution.mode === "agent" ? (
             <div data-promptbox-shell="" className="min-w-0">
-              <ResourcePromptPreview
-                className="bg-background"
-                context={[
-                  {
-                    label: (
-                      <DisabledAutomationSelector
-                        label="Provider and model"
-                        disabledReason="Use Edit with chat to change the provider and model."
-                        value={formatAutomationModelLabel(
-                          execution.model,
-                          execution.providerId,
-                        )}
-                        accessibleValue={`${formatAutomationProviderLabel(execution.providerId)}, ${formatAutomationModelLabel(execution.model, execution.providerId)}`}
-                        leading={
-                          <AutomationProviderIcon
-                            providerId={execution.providerId}
-                          />
-                        }
-                        title={`${formatAutomationProviderLabel(execution.providerId)}: ${formatAutomationModelLabel(execution.model, execution.providerId)}`}
-                      />
-                    ),
-                  },
-                ]}
-              >
-                {execution.prompt}
-              </ResourcePromptPreview>
+              <AgentAutomationEditor
+                execution={execution}
+                options={executionOptions}
+                optionsError={executionOptionsError}
+                pending={actionPending}
+                onUpdate={onUpdateAgent}
+              />
               <div
                 data-automation-prompt-footer=""
                 className="mt-1 flex min-h-6 min-w-0 items-center justify-between gap-2 px-3.5 text-xs text-muted-foreground"
@@ -766,13 +800,27 @@ export function AutomationDetailView({
                     muted
                   />
                 </div>
-                <DisabledAutomationSelector
+                <AutomationSelector
                   label="Permission mode"
-                  disabledReason="Use Edit with chat to change permissions."
-                  value={formatPermissionMode(execution.permissionMode)}
-                  compactValue={formatPermissionModeCompact(
-                    execution.permissionMode,
-                  )}
+                  value={execution.permissionMode}
+                  options={(
+                    executionOptions?.permissionModes ?? [
+                      execution.permissionMode,
+                    ]
+                  ).map((mode) => ({
+                    value: mode,
+                    label: formatPermissionMode(mode),
+                  }))}
+                  disabled={actionPending || executionOptions === null}
+                  onValueChange={(value) => {
+                    const permissionMode =
+                      executionOptions?.permissionModes.find(
+                        (mode) => mode === value,
+                      );
+                    if (permissionMode !== undefined) {
+                      void onUpdateAgent({ permissionMode });
+                    }
+                  }}
                   className="h-6 shrink-0"
                 />
               </div>

--- a/plugins/automations/lib/format-schedule.ts
+++ b/plugins/automations/lib/format-schedule.ts
@@ -181,6 +181,7 @@ export function formatOverviewScheduleMetadata(
   if (
     label === "Failed" ||
     label === "Paused" ||
+    label === "Completed" ||
     label === "Expired — edit to reschedule"
   ) {
     return null;

--- a/plugins/automations/overview-view.tsx
+++ b/plugins/automations/overview-view.tsx
@@ -243,8 +243,8 @@ function OverviewRow({
           disabledReason={
             lifecycleLocked
               ? oneShotLifecycle === "expired"
-                ? "This one-time automation expired. Open it and edit the schedule to run it again."
-                : "This one-time automation has completed. Open it and edit the schedule to run it again."
+                ? "Missed its run time. Edit to reschedule."
+                : "Already ran. Edit to reschedule."
               : undefined
           }
           label={`${automation.enabled ? "Disable" : "Enable"} ${automation.name}`}

--- a/plugins/automations/src/format-schedule.test.ts
+++ b/plugins/automations/src/format-schedule.test.ts
@@ -111,6 +111,17 @@ describe("one-shot automation lifecycle", () => {
     expect(
       formatOverviewScheduleMetadata({
         enabled: false,
+        nextRunAt: null,
+        trigger: { triggerType: "once", runAt: NOW - 1_000 },
+        runCount: 1,
+        lastRunStatus: "succeeded",
+        now: NOW,
+      }),
+    ).toBeNull();
+
+    expect(
+      formatOverviewScheduleMetadata({
+        enabled: false,
         nextRunAt: NOW + 60_000,
         trigger: {
           triggerType: "schedule",

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -195,6 +195,7 @@ export type AgentExecutionTarget = z.infer<typeof agentExecutionTargetSchema>;
 export const agentExecutionUpdateSchema = z
   .object({
     prompt: z.string().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH).optional(),
+    model: z.string().min(1).optional(),
     permissionMode: permissionModeSchema.optional(),
     target: agentExecutionTargetSchema.optional(),
   })
@@ -202,11 +203,30 @@ export const agentExecutionUpdateSchema = z
   .refine(
     (value) =>
       value.prompt !== undefined ||
+      value.model !== undefined ||
       value.permissionMode !== undefined ||
       value.target !== undefined,
     { message: "at least one agent execution field is required" },
   );
 export type AgentExecutionUpdate = z.infer<typeof agentExecutionUpdateSchema>;
+
+export const automationExecutionOptionsResponseSchema = z
+  .object({
+    models: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          model: z.string().min(1),
+          displayName: z.string().min(1),
+        })
+        .strict(),
+    ),
+    permissionModes: z.array(permissionModeSchema),
+  })
+  .strict();
+export type AutomationExecutionOptionsResponse = z.infer<
+  typeof automationExecutionOptionsResponseSchema
+>;
 
 export const automationResponseSchema = z
   .object({

--- a/plugins/automations/src/rpc.ts
+++ b/plugins/automations/src/rpc.ts
@@ -1,5 +1,6 @@
 import {
   automationListResponseSchema,
+  automationExecutionOptionsResponseSchema,
   automationResponseSchema,
   automationRunListResponseSchema,
   automationRunRpcResponseSchema,
@@ -30,6 +31,10 @@ export const automationRpcContract = defineRpcContract({
   automations_get: {
     input: projectAutomationInputSchema,
     output: automationResponseSchema,
+  },
+  automations_execution_options: {
+    input: projectAutomationInputSchema,
+    output: automationExecutionOptionsResponseSchema,
   },
   automations_create: {
     input: createAutomationInputSchema,
@@ -71,6 +76,11 @@ export function createRpcHandlers(service: AutomationService) {
     },
     automations_get(input: z.output<typeof projectAutomationInputSchema>) {
       return service.get(input);
+    },
+    automations_execution_options(
+      input: z.output<typeof projectAutomationInputSchema>,
+    ) {
+      return service.executionOptions(input);
     },
     automations_create(input: z.output<typeof createAutomationInputSchema>) {
       return service.create(input);

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -24,6 +24,7 @@ const rpcMethods = [
   "automations_overview",
   "automations_list",
   "automations_get",
+  "automations_execution_options",
   "automations_create",
   "automations_update",
   "automations_delete",
@@ -81,6 +82,27 @@ async function bootAutomationsPlugin(
               capabilities: { supportedPermissionModes },
             },
           ] as never;
+        },
+        async models() {
+          return {
+            providers: [
+              {
+                id: "codex",
+                available: true,
+                capabilities: { supportedPermissionModes },
+              },
+            ],
+            permissionCeiling: "full",
+            models: [
+              {
+                id: "gpt-5.6-codex",
+                model: "gpt-5.6-codex",
+                displayName: "5.6 Sol",
+              },
+            ],
+            selectedOnlyModels: [],
+            modelLoadError: null,
+          } as never;
         },
       },
       threads: {
@@ -618,6 +640,7 @@ describe("automations server plugin harness", () => {
         automationId: created.id,
         agent: {
           prompt: "updated by RPC",
+          model: "gpt-5.6-codex",
           permissionMode: "full",
           target: { type: "target-thread", threadId: THREAD_ID },
         },
@@ -629,11 +652,20 @@ describe("automations server plugin harness", () => {
         mode: "agent",
         prompt: "updated by RPC",
         providerId: "codex",
-        model: "gpt-5",
+        model: "gpt-5.6-codex",
         permissionMode: "full",
         environment: { type: "project-default" },
         targetThreadId: THREAD_ID,
       },
+    });
+
+    const options = await harness.callRpc("automations_execution_options", {
+      projectId: PROJECT_ID,
+      automationId: created.id,
+    });
+    expect(options).toMatchObject({
+      models: [{ model: "gpt-5.6-codex", displayName: "5.6 Sol" }],
+      permissionModes: ["accept-edits", "auto", "full"],
     });
 
     await expect(

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -28,6 +28,7 @@ import {
   automationsOverviewResponseSchema,
   type AgentExecutionUpdate,
   type AutomationExecution,
+  type AutomationExecutionOptionsResponse,
   type AutomationRunListResponse,
   type AutomationRunRpcResponse,
   type AutomationResponse,
@@ -54,7 +55,8 @@ import { executeAgentRun, executeScriptRun } from "./run.js";
 type ServiceApi = Pick<BbPluginApi, "realtime" | "log"> & {
   sdk: {
     projects: Pick<BbPluginApi["sdk"]["projects"], "get" | "list">;
-    providers: Pick<BbPluginApi["sdk"]["providers"], "list">;
+    providers: Pick<BbPluginApi["sdk"]["providers"], "list"> &
+      Partial<Pick<BbPluginApi["sdk"]["providers"], "models">>;
     threads: Pick<BbPluginApi["sdk"]["threads"], "get" | "send" | "spawn">;
   };
 };
@@ -66,6 +68,10 @@ export interface AutomationService {
     projectId: string;
     automationId: string;
   }): Promise<AutomationResponse>;
+  executionOptions(input: {
+    projectId: string;
+    automationId: string;
+  }): Promise<AutomationExecutionOptionsResponse>;
   create(input: ResolvedCreateAutomationInput): Promise<AutomationResponse>;
   update(input: UpdateAutomationInput): Promise<AutomationResponse>;
   delete(input: {
@@ -258,6 +264,7 @@ function applyAgentExecutionUpdate(
   const next = {
     ...execution,
     ...(update.prompt !== undefined ? { prompt: update.prompt } : {}),
+    ...(update.model !== undefined ? { model: update.model } : {}),
     ...(update.permissionMode !== undefined
       ? { permissionMode: update.permissionMode }
       : {}),
@@ -388,6 +395,47 @@ export function createAutomationService(args: {
         pluginDataDir,
         row: requireProjectAutomation(db, input),
       });
+    },
+
+    async executionOptions(input) {
+      const automation = requireProjectAutomation(db, input);
+      const execution = parseAutomationExecution(automation.execution);
+      if (execution.mode !== "agent") {
+        throw new Error(
+          "Execution options are only available for agent automations",
+        );
+      }
+      const environment = execution.environment;
+      const routing =
+        environment.type === "reuse"
+          ? { environmentId: environment.environmentId }
+          : environment.type === "host" && environment.hostId !== undefined
+            ? { hostId: environment.hostId }
+            : {};
+      const loadModels = bb.sdk.providers.models;
+      if (loadModels === undefined) {
+        throw new Error("Provider model discovery is unavailable.");
+      }
+      const options = await loadModels({
+        ...routing,
+        providerId: execution.providerId,
+      });
+      const provider = options.providers.find(
+        (candidate) => candidate.id === execution.providerId,
+      );
+      if (provider === undefined || !provider.available) {
+        throw new Error(`Provider ${execution.providerId} is not available.`);
+      }
+      const seenModels = new Set<string>();
+      const models = [...options.selectedOnlyModels, ...options.models]
+        .filter((model) => {
+          if (seenModels.has(model.model)) return false;
+          seenModels.add(model.model);
+          return true;
+        })
+        .map(({ id, model, displayName }) => ({ id, model, displayName }));
+      const permissionModes = provider.capabilities.supportedPermissionModes;
+      return { models, permissionModes };
     },
 
     async create(payload) {


### PR DESCRIPTION
## Summary

- edit automation prompts inline and persist through the existing update RPC
- replace read-only model and permission controls with provider-backed dropdowns
- shorten completed one-time guidance and omit redundant Completed row metadata

## Verification

- `pnpm exec turbo run typecheck test --filter=bb-plugin-automations --force` (55 tests passed; typecheck passed)
- branch dev app: saved/restored prompt, opened real model and permission menus, verified completed one-time row and tooltip copy

Stack parent: #965. Do not merge independently.