### PR TITLE
Accept maxPermissionMode in the Docs plugin's host schema

### DIFF
--- a/official-plugins/docs/server.ts
+++ b/official-plugins/docs/server.ts
@@ -194,6 +194,7 @@ const hostSchema = z
     name: z.string().min(1),
     type: z.literal("persistent"),
     status: z.enum(["connected", "disconnected"]),
+    maxPermissionMode: z.enum(["full", "auto", "accept-edits"]),
     lastSeenAt: z.number().nullable(),
     lastRejectedProtocolVersion: z.number().int().positive().nullable(),
     createdAt: z.number(),


### PR DESCRIPTION
## Summary

The Docs panel hung on "Loading vaults..." and every `listNotes` call returned a 500.

`bb.sdk.hosts.list()` now carries a `maxPermissionMode` field. The plugin's `hostSchema` is `.strict()`, so the host record tripped RPC output validation:

```
Unrecognized key: "maxPermissionMode" at hosts.0
```

This declares the field so the schema matches the host record it validates.

## Notable risk

The plugin's own tests did not catch this. Both fixtures in `server.test.ts` (lines 72 and 225) stub `hosts.list` as `async () => []`, so `hostSchema` never runs against a real host record. The SDK test double has no host fixture carrying `maxPermissionMode` either, so the next field added to the host record will break this plugin the same silent way. I left that alone — widening the shared test double is a bigger change than this fix.

## Tests

- `official-plugins/docs`: 57 tests pass.
- Verified in a headless browser against the running server: the Docs panel renders the vault tree, and `listNotes` returns 200 instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)