### PR TITLE
Correct right-panel control order

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -45,6 +45,24 @@ function renderPanel(args: {
 // — there is no standalone rail to click. Pin both halves of the same-slot
 // expansion pair so a full-screen tab can always restore its prior layout.
 describe("ThreadSecondaryPanel full-screen control", () => {
+  it("keeps Full Screen before Hide right panel in the trailing toolbar", () => {
+    const view = renderPanel({
+      isConversationCollapsed: false,
+      onToggleConversationCollapse: noop,
+    });
+
+    const fullScreenControl = view.getByRole("button", {
+      name: "Full Screen",
+    });
+    const hideControl = view.getByRole("button", {
+      name: "Hide right panel",
+    });
+    expect(
+      fullScreenControl.compareDocumentPosition(hideControl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
+
   it("expands the panel while the conversation is shown", () => {
     const onToggleConversationCollapse = vi.fn();
     const view = renderPanel({

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -1140,6 +1140,7 @@ describe("SplitThreadArea", () => {
 
     const toggle = await screen.findByTestId("split-workspace-panel-toggle");
     expect(toggle.classList).toContain("absolute");
+    expect(toggle.classList).toContain("hidden");
     expect(toggle.classList).not.toContain("relative");
     expect(toggle.classList).toContain("right-2.5");
     expect(toggle.classList).toContain("top-2.5");
@@ -1167,6 +1168,7 @@ describe("SplitThreadArea", () => {
     expect(toggle.querySelector("button")?.getAttribute("aria-expanded")).toBe(
       "true",
     );
+    expect(toggle.classList).toContain("hidden");
     expect(toggle.querySelector("button")?.hasAttribute("aria-pressed")).toBe(
       false,
     );
@@ -1195,6 +1197,7 @@ describe("SplitThreadArea", () => {
         .querySelector("button")
         ?.getAttribute("aria-expanded"),
     ).toBe("false");
+    expect(toggle.classList).not.toContain("hidden");
 
     fireEvent.pointerDown(screen.getByTestId("pane-thr-a"));
     await screen.findByTestId("hosted-panel-thr-a");

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -181,7 +181,7 @@ export function SplitWorkspaceSecondaryPanelHost({
           data-testid="split-workspace-panel-toggle"
           className={cn(
             "absolute right-2.5 top-2.5 z-40",
-            isPaneMaximized && "hidden",
+            (isOpen || isPaneMaximized) && "hidden",
             // This overlay already owns positioning and stacking. Use only the
             // raw app-region token: MACOS_WINDOW_NO_DRAG_CLASS adds `relative
             // z-50`, which tailwind-merge would resolve against `absolute` and

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -10,6 +10,7 @@ import {
   DefaultPaneContextProvider,
   PaneContext,
   type PaneContextValue,
+  type PaneSecondaryPanelViewModel,
 } from "./PaneContext";
 import { MemoryRouter } from "react-router-dom";
 
@@ -135,6 +136,7 @@ vi.mock(
 
     const ThreadSecondaryPanel = ({
       browserDeck,
+      inlinePanelToggle,
       isOpen,
       renderAsDrawer,
     }: ComponentProps<typeof actual.ThreadSecondaryPanel>) =>
@@ -142,6 +144,7 @@ vi.mock(
         "section",
         {
           "data-open": String(isOpen),
+          "data-inline-panel-toggle": inlinePanelToggle,
           "data-testid": renderAsDrawer
             ? "drawer-secondary-panel"
             : "inline-secondary-panel",
@@ -185,9 +188,14 @@ interface RenderThreadDetailArgs {
 
 const noop = () => {};
 
+let publishedHostedPanel: PaneSecondaryPanelViewModel | null = null;
 const hostedPaneRegistration = {
-  clear: noop,
-  publish: noop,
+  clear: () => {
+    publishedHostedPanel = null;
+  },
+  publish: (model: PaneSecondaryPanelViewModel) => {
+    publishedHostedPanel = model;
+  },
 };
 
 function ThreadDetailTestPaneProvider({
@@ -452,10 +460,31 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  publishedHostedPanel = null;
   vi.mocked(dispatchBrowserViewBoundsSync).mockReset();
 });
 
 describe("ThreadDetailSecondaryContent compact drawer settling", () => {
+  it("places the hosted panel hide control at the outer edge of its own toolbar", () => {
+    renderThreadDetail({
+      isCompactViewport: false,
+      isFocusedHosted: true,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck: createBrowserDeckRenderer(),
+      threadId: "thread-1",
+    });
+
+    if (publishedHostedPanel === null) {
+      throw new Error("Expected the focused pane to publish its panel model");
+    }
+    render(<>{publishedHostedPanel.panel}</>);
+    expect(
+      screen
+        .getByTestId("inline-secondary-panel")
+        .getAttribute("data-inline-panel-toggle"),
+    ).toBe("button");
+  });
+
   it("keeps the thread header inside the timeline column beside the side panel", () => {
     renderThreadDetail({
       isCompactViewport: false,

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -287,11 +287,12 @@ function ThreadDetailSecondaryContentBody({
           renderAsDrawer={false}
           isConversationCollapsed={isConversationCollapsedActive}
           onToggleConversationCollapse={onToggleConversationCollapse}
-          // The full-width header bar owns the (stable) right-panel toggle, so
-          // the panel drops its own inline hide control entirely — no reserved
-          // slot, so the trailing expand control sits flush at the edge.
+          // The split-workspace host owns the show control while the panel is
+          // closed. Once open, the panel owns its hide control so the two
+          // trailing actions read in their natural order: Full Screen, then
+          // Hide right panel at the outer edge.
           inlinePanelToggle={
-            secondaryPanelHost === null ? "hidden" : "reserved"
+            secondaryPanelHost === null ? "hidden" : "button"
           }
           // In the split-workspace host, panes' panels share one PanelGroup, so
           // each pane's Panel needs its own layout identity (see the prop doc).


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>