### PR TITLE
Correct official plugin catalog projections

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -388,6 +388,8 @@ describe("PluginsOverview", () => {
         name: "Inactive Official",
         enabled: false,
         status: "disabled",
+        provenance: "catalog",
+        catalogEntryId: "inactive-official",
       },
       {
         ...AUTOMATIONS_PLUGIN,
@@ -476,6 +478,52 @@ describe("PluginsOverview", () => {
       "plugin-row-inactive-official",
       "plugin-row-inactive-local",
     ]);
+  });
+
+  it("omits disabled auto-included builtins from the installed projection", async () => {
+    installFetch([
+      AUTOMATIONS_PLUGIN,
+      {
+        ...AUTOMATIONS_PLUGIN,
+        id: "inactive-builtin",
+        name: "Inactive Builtin",
+        enabled: false,
+        status: "disabled",
+      },
+      {
+        ...AUTOMATIONS_PLUGIN,
+        id: "inactive-catalog",
+        name: "Inactive Catalog Plugin",
+        enabled: false,
+        status: "disabled",
+        provenance: "catalog",
+        catalogEntryId: "inactive-catalog",
+      },
+      {
+        ...AUTOMATIONS_PLUGIN,
+        id: "inactive-local",
+        name: "Inactive Local Plugin",
+        enabled: false,
+        status: "disabled",
+        provenance: "direct",
+      },
+    ]);
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter initialEntries={["/tools/plugins"]}>
+        <QueryClientWrapper>
+          <PluginsOverview />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Automations")).toBeTruthy();
+    expect(
+      screen.getByRole("tab", { name: "Installed, 3 plugins" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Inactive Builtin")).toBeNull();
+    expect(screen.getByText("Inactive Catalog Plugin")).toBeTruthy();
+    expect(screen.getByText("Inactive Local Plugin")).toBeTruthy();
   });
 
   it("consolidates built-in and catalog plugins under BB Official", async () => {

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -47,7 +47,10 @@ export function PluginsOverview() {
   const [searchParams, setSearchParams] = useSearchParams();
   const listQuery = usePluginList({ enabled: true });
   const plugins = useMemo(
-    () => listQuery.data?.plugins ?? [],
+    () =>
+      (listQuery.data?.plugins ?? []).filter(
+        (plugin) => plugin.provenance !== "builtin" || plugin.enabled,
+      ),
     [listQuery.data],
   );
   const activeMode = modeFromSearchParams(searchParams.get("view"));

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -99,10 +99,7 @@ describe("BrowsePluginsTab", () => {
         entryId: `official-${index + 1}`,
         pluginId: `official-${index + 1}`,
         displayName: `Official ${index + 1}`,
-        category:
-          index < CATALOG_STATUS.includedPluginCount
-            ? "Included with BB"
-            : "Productivity",
+        category: index % 2 === 0 ? "Productivity" : "Developer tools",
       }),
     );
     vi.stubGlobal(
@@ -132,6 +129,9 @@ describe("BrowsePluginsTab", () => {
     expect(
       screen.getAllByRole("button", { name: /^Open Official \d+ details$/ }),
     ).toHaveLength(CATALOG_STATUS.pluginCount);
+    expect(
+      screen.queryByRole("heading", { name: "Included with BB" }),
+    ).toBeNull();
   });
 
   it("shows the official plugins and entries", async () => {

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -38,8 +38,7 @@ export function createPluginCatalogService(deps: {
     deps.bundledPlugins ?? listBundledPluginRegistrations();
   const officialPlugins = bundledPlugins.map((plugin) => ({
     ...plugin,
-    category:
-      plugin.category ?? (plugin.autoInstall ? "Included with BB" : "Other"),
+    category: plugin.category ?? "Other",
   }));
 
   // Manifests are read per search so a dev checkout editing a bundled

--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -36,21 +36,58 @@ export const BUILTIN_PLUGINS = [
     name: "ask-user-question",
     pluginId: "ask-user-question",
     defaultEnabled: false,
+    category: "Productivity",
   },
-  { name: "automations", pluginId: "automations", defaultEnabled: true },
-  { name: "connect", pluginId: "connect", defaultEnabled: true },
+  {
+    name: "automations",
+    pluginId: "automations",
+    defaultEnabled: true,
+    category: "Productivity",
+  },
+  {
+    name: "connect",
+    pluginId: "connect",
+    defaultEnabled: true,
+    category: "Developer tools",
+  },
   {
     name: "custom-instructions",
     pluginId: "custom-instructions",
     defaultEnabled: true,
+    category: "Productivity",
   },
-  { name: "inline-vis", pluginId: "inline-vis", defaultEnabled: true },
-  { name: "secrets", pluginId: "secrets", defaultEnabled: true },
-  { name: "side-chat", pluginId: "side-chat", defaultEnabled: true },
-  { name: "workflows", pluginId: "workflows", defaultEnabled: false },
+  {
+    name: "inline-vis",
+    pluginId: "inline-vis",
+    defaultEnabled: true,
+    category: "Developer tools",
+  },
+  {
+    name: "secrets",
+    pluginId: "secrets",
+    defaultEnabled: true,
+    category: "Developer tools",
+  },
+  {
+    name: "side-chat",
+    pluginId: "side-chat",
+    defaultEnabled: true,
+    category: "Productivity",
+  },
+  {
+    name: "workflows",
+    pluginId: "workflows",
+    defaultEnabled: false,
+    category: "Productivity",
+  },
   // Ships with the app but stays off: it replaces the sidebar, which is a
   // choice the user makes in Settings, never something an install does.
-  { name: "t3sidebar", pluginId: "t3sidebar", defaultEnabled: false },
+  {
+    name: "t3sidebar",
+    pluginId: "t3sidebar",
+    defaultEnabled: false,
+    category: "Productivity",
+  },
 ].map(
   (plugin): BundledPluginDefinition => ({
     ...plugin,

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -87,9 +87,12 @@ describe("bundled plugin catalog service", () => {
       BUNDLED_PLUGINS.map((plugin) => plugin.name).sort(),
     );
     expect(results).toHaveLength(catalog.status().pluginCount);
-    expect(
-      results.filter((entry) => entry.category === "Included with BB"),
-    ).toHaveLength(BUILTIN_PLUGINS.length);
+    expect(results.some((entry) => entry.category === "Included with BB")).toBe(
+      false,
+    );
+    expect(new Set(results.map((entry) => entry.category))).toEqual(
+      new Set(["Developer tools", "Productivity"]),
+    );
     const docs = results.find((entry) => entry.entryId === "docs");
     expect(docs).toMatchObject({
       pluginId: "simple-notes",


### PR DESCRIPTION
Summary

- Keep the Browse catalog grouped by real plugin taxonomy; Included with BB remains provenance summary copy, not a category.
- Exclude disabled auto-included built-ins from the Installed projection while preserving disabled installed catalog and direct plugins.
- Derive counts and cards from the same catalog projections.

Verification

- Focused server catalog tests: 6 passed.
- Focused app plugin overview and browse tests: 13 passed.
- Turbo typecheck: @bb/server and @bb/app passed.
- Branch dev app: visually verified Browse categories/cards/counts and Installed count/rows.