### PR TITLE
Restore scoped automation prompt editing

### DIFF
--- a/apps/app/src/components/tools/Automations.stories.tsx
+++ b/apps/app/src/components/tools/Automations.stories.tsx
@@ -520,6 +520,7 @@ function AutomationDetail({
         retry: noop,
       }}
       actionPending={false}
+      editing={false}
       executionOptions={executionOptions}
       executionOptionsError={null}
       onToggle={noop}

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { ComponentProps } from "react";
+import { useState, type ComponentProps } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -505,7 +505,12 @@ const AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptionsResponse = {
     {
       id: "claude:claude-opus-5",
       model: "claude-opus-5",
-      displayName: "Opus 5",
+      displayName: "Claude-Opus-5",
+    },
+    {
+      id: "claude:claude-sonnet-5",
+      model: "claude-sonnet-5",
+      displayName: "Claude-Sonnet-5",
     },
   ],
   permissionModes: ["accept-edits", "auto", "full"],
@@ -513,16 +518,17 @@ const AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptionsResponse = {
 
 type TestAutomationDetailProps = Omit<
   ComponentProps<typeof AutomationDetailViewBase>,
-  "executionOptions" | "executionOptionsError" | "onUpdateAgent"
+  "editing" | "executionOptions" | "executionOptionsError" | "onUpdateAgent"
 > &
   Partial<
     Pick<
       ComponentProps<typeof AutomationDetailViewBase>,
-      "executionOptions" | "executionOptionsError" | "onUpdateAgent"
+      "editing" | "executionOptions" | "executionOptionsError" | "onUpdateAgent"
     >
   >;
 
 function AutomationDetailView({
+  editing = false,
   executionOptions = AUTOMATION_EXECUTION_OPTIONS,
   executionOptionsError = null,
   onUpdateAgent = async () => {},
@@ -531,6 +537,7 @@ function AutomationDetailView({
   return (
     <AutomationDetailViewBase
       {...props}
+      editing={editing}
       executionOptions={executionOptions}
       executionOptionsError={executionOptionsError}
       onUpdateAgent={onUpdateAgent}
@@ -557,8 +564,9 @@ const FAILED_SCRIPT_RUN: AutomationRunResponse = {
 describe("Automation detail recipe", () => {
   it("keeps Definition ahead of Runs, including with no runs yet", async () => {
     const updateAgent = vi.fn(async () => {});
-    const { container } = render(
-      <MemoryRouter>
+    function Harness() {
+      const [editing, setEditing] = useState(false);
+      return (
         <AutomationDetailView
           automation={AUTOMATION}
           projectLabel="Local"
@@ -572,13 +580,19 @@ describe("Automation detail recipe", () => {
             retry: () => {},
           }}
           actionPending={false}
+          editing={editing}
           onUpdateAgent={updateAgent}
           onToggle={() => {}}
-          onEdit={() => {}}
+          onEdit={() => setEditing(true)}
           onRunNow={() => {}}
           onDelete={() => {}}
           onOpenThread={() => {}}
         />
+      );
+    }
+    const { container } = render(
+      <MemoryRouter>
+        <Harness />
       </MemoryRouter>,
     );
 
@@ -618,6 +632,23 @@ describe("Automation detail recipe", () => {
     expect(runsTable.className).toContain("border");
     expect(runsTable.className).toContain("border-border");
     expect(runsTable.className).not.toContain("inline-block");
+
+    const savedPrompt = screen.getByRole("textbox", { name: "Saved prompt" });
+    expect(savedPrompt.getAttribute("aria-readonly")).toBe("true");
+    expect(savedPrompt.textContent).toBe("Summarize yesterday's commits.");
+    expect(screen.queryByRole("button", { name: "Save prompt" })).toBeNull();
+    expect(
+      container.querySelector(
+        '[data-disabled-automation-selector="Provider and model"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[data-disabled-automation-selector="Permission mode"]',
+      ),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit via chat" }));
 
     const promptContent = screen.getByRole("textbox", {
       name: "Automation prompt",
@@ -676,10 +707,16 @@ describe("Automation detail recipe", () => {
     fireEvent.change(promptContent, {
       target: { value: "Summarize the last two days." },
     });
+    fireEvent.keyDown(modelSelector, { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Sonnet 5" }));
+    fireEvent.keyDown(accessSelector, { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Full Access" }));
     expect((savePrompt as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(savePrompt);
     expect(updateAgent).toHaveBeenCalledWith({
       prompt: "Summarize the last two days.",
+      model: "claude-sonnet-5",
+      permissionMode: "full",
     });
   });
 
@@ -746,8 +783,8 @@ describe("Automation detail recipe", () => {
       promptShell.querySelectorAll('[data-option-display=""]'),
     ).toHaveLength(2);
     expect(
-      promptShell.querySelectorAll("[data-automation-selector]:disabled"),
-    ).toHaveLength(0);
+      promptShell.querySelectorAll("[data-disabled-automation-selector]"),
+    ).toHaveLength(2);
   });
 
   it.each([
@@ -827,10 +864,10 @@ describe("Automation detail recipe", () => {
       );
 
       const selector = container.querySelector(
-        '[data-automation-selector="Provider and model"]',
+        '[data-disabled-automation-selector="Provider and model"]',
       ) as HTMLButtonElement;
       expect(selector.getAttribute("aria-label")).toBe(
-        `Provider and model: ${providerLabel}, ${modelLabel}`,
+        `Provider and model: ${providerLabel}, ${modelLabel}. Read only`,
       );
       expect(selector.textContent).toContain(modelLabel);
       expect(
@@ -906,9 +943,11 @@ describe("Automation detail recipe", () => {
     ).toHaveLength(2);
     expect(
       container
-        .querySelector('[data-automation-selector="Provider and model"]')
+        .querySelector(
+          '[data-disabled-automation-selector="Provider and model"]',
+        )
         ?.getAttribute("aria-label"),
-    ).toBe("Provider and model: Codex, 5");
+    ).toBe("Provider and model: Codex, 5. Read only");
   });
 
   it("shows the stored script with capped overflow and no environment values", () => {

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -538,9 +538,10 @@ function DetailView({
 }) {
   const navigate = useBbNavigate();
   const { automation, error, missing, refetch } = useAutomation(route);
+  const [editing, setEditing] = useState(initialEditing);
   const executionOptionsState = useAutomationExecutionOptions(
     route,
-    automation?.execution.mode === "agent",
+    editing && automation?.execution.mode === "agent",
   );
   const overviewState = useOverview();
   const runsState = useRuns(route);
@@ -568,11 +569,6 @@ function DetailView({
     [navigate, route],
   );
 
-  useEffect(() => {
-    if (!initialEditing || automation === null) return;
-    editViaThread(automation);
-  }, [automation, editViaThread, initialEditing]);
-
   const runAction = useCallback(
     (method: "pause" | "resume" | "run") => {
       setActionPending(true);
@@ -593,6 +589,10 @@ function DetailView({
 
   const openEdit = useCallback(() => {
     if (automation === null) return;
+    if (automation.execution.mode === "agent") {
+      setEditing(true);
+      return;
+    }
     editViaThread(automation);
   }, [automation, editViaThread]);
 
@@ -602,9 +602,11 @@ function DetailView({
       try {
         await mutations.update(route, agent);
         toast.success("Automation updated");
+        setEditing(false);
         refetch();
       } catch (rpcError: unknown) {
         toast.error(`Failed to update automation: ${errorText(rpcError)}`);
+        throw rpcError;
       } finally {
         setActionPending(false);
       }
@@ -653,16 +655,6 @@ function DetailView({
     );
   }
 
-  if (initialEditing) {
-    return (
-      <ResourceListState
-        state="loading"
-        message="Opening composer"
-        layout="detail"
-      />
-    );
-  }
-
   const overviewEntry = overviewState.entries?.find(
     (entry) =>
       entry.automation.projectId === route.projectId &&
@@ -683,6 +675,7 @@ function DetailView({
       actionPending={actionPending}
       executionOptions={executionOptionsState.options}
       executionOptionsError={executionOptionsState.error}
+      editing={editing}
       onToggle={(checked) => runAction(checked ? "resume" : "pause")}
       onEdit={openEdit}
       onUpdateAgent={updateAgent}

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -18,6 +18,7 @@ import {
   ResourceDetailCollection,
   ResourceDetailPage,
   ResourceDetailPanel,
+  ResourcePromptPreview,
   ResourceDetailStack,
   ResourceMeta,
   ResourceOverflowMenu,
@@ -37,6 +38,7 @@ import {
   OptionDisplay,
   OPTION_BASE_CLASS_NAME,
   OPTION_INTERACTIVE_CLASS_NAME,
+  OPTION_MUTED_CLASS_NAME,
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
 import {
@@ -78,6 +80,7 @@ export interface AutomationDetailViewProps {
   actionPending: boolean;
   executionOptions: AutomationExecutionOptionsResponse | null;
   executionOptionsError: string | null;
+  editing: boolean;
   onToggle: (enabled: boolean) => void;
   onEdit: () => void;
   onUpdateAgent: (update: AgentExecutionUpdate) => Promise<void>;
@@ -341,6 +344,85 @@ function AutomationSelector({
   );
 }
 
+interface DisabledAutomationSelectorProps {
+  label: string;
+  value: string;
+  disabledReason: string;
+  accessibleValue?: string;
+  compactValue?: string;
+  leading?: ReactNode;
+  title?: string;
+  className?: string;
+}
+
+function DisabledAutomationSelector({
+  label,
+  value,
+  disabledReason,
+  accessibleValue,
+  compactValue,
+  leading,
+  title,
+  className,
+}: DisabledAutomationSelectorProps) {
+  const control = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-label={`${label}: ${accessibleValue ?? value}. Read only`}
+      disabled
+      data-disabled-automation-selector={label}
+      className={cn(
+        OPTION_BASE_CLASS_NAME,
+        OPTION_INTERACTIVE_CLASS_NAME,
+        OPTION_MUTED_CLASS_NAME,
+        "cursor-not-allowed disabled:cursor-not-allowed disabled:opacity-100",
+        className,
+      )}
+    >
+      <span
+        className={OPTION_TRIGGER_CONTENT_CLASS_NAME}
+        title={title ?? `${label}: ${value}`}
+      >
+        {leading}
+        <span className="min-w-0 truncate" data-promptbox-full-label="">
+          {value}
+        </span>
+        {compactValue ? (
+          <span className="min-w-0 truncate" data-promptbox-compact-label="">
+            {compactValue}
+          </span>
+        ) : null}
+      </span>
+      <Icon
+        name="ChevronDown"
+        className="size-3.5 shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+    </Button>
+  );
+
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex shrink-0 cursor-not-allowed rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            tabIndex={0}
+            aria-label={`${label}. ${disabledReason}`}
+          >
+            {control}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-64">
+          {disabledReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function automationEnvironmentLabel(execution: AutomationExecution): string {
   if (execution.mode !== "agent") return "Host";
   const environment = execution.environment;
@@ -398,6 +480,17 @@ function formatPermissionMode(
   if (permissionMode === "accept-edits") return "Accept Edits";
   if (permissionMode === "auto") return "Approve for me";
   return "Full Access";
+}
+
+function formatPermissionModeCompact(
+  permissionMode: Extract<
+    AutomationExecution,
+    { mode: "agent" }
+  >["permissionMode"],
+): string {
+  if (permissionMode === "accept-edits") return "Edits";
+  if (permissionMode === "auto") return "Auto";
+  return "Full";
 }
 
 function formatRunDuration(run: AutomationRunResponse): string | null {
@@ -571,82 +664,198 @@ function RunRow({
   );
 }
 
-function AgentAutomationEditor({
+function AgentAutomationDefinition({
   execution,
   options,
   optionsError,
+  editing,
+  personalProject,
+  projectContextLabel,
   pending,
   onUpdate,
 }: {
   execution: Extract<AutomationExecution, { mode: "agent" }>;
   options: AutomationExecutionOptionsResponse | null;
   optionsError: string | null;
+  editing: boolean;
+  personalProject: boolean;
+  projectContextLabel: string;
   pending: boolean;
   onUpdate: (update: AgentExecutionUpdate) => Promise<void>;
 }) {
   const [prompt, setPrompt] = useState(execution.prompt);
-  useEffect(() => setPrompt(execution.prompt), [execution.prompt]);
+  const [model, setModel] = useState(execution.model);
+  const [permissionMode, setPermissionMode] = useState(
+    execution.permissionMode,
+  );
+  useEffect(() => {
+    setPrompt(execution.prompt);
+    setModel(execution.model);
+    setPermissionMode(execution.permissionMode);
+  }, [execution.model, execution.permissionMode, execution.prompt]);
   const trimmedPrompt = prompt.trim();
-  const promptDirty = prompt !== execution.prompt;
+  const dirty =
+    prompt !== execution.prompt ||
+    model !== execution.model ||
+    permissionMode !== execution.permissionMode;
   const modelOptions = options?.models.map((model) => ({
     value: model.model,
-    label: model.displayName,
+    label: formatAutomationModelLabel(model.model, execution.providerId),
   })) ?? [
     {
       value: execution.model,
       label: formatAutomationModelLabel(execution.model, execution.providerId),
     },
   ];
-  if (!modelOptions.some((option) => option.value === execution.model)) {
+  if (!modelOptions.some((option) => option.value === model)) {
     modelOptions.unshift({
-      value: execution.model,
-      label: formatAutomationModelLabel(execution.model, execution.providerId),
+      value: model,
+      label: formatAutomationModelLabel(model, execution.providerId),
     });
   }
+  const permissionOptions = (options?.permissionModes ?? [permissionMode]).map(
+    (mode) => ({
+      value: mode,
+      label: formatPermissionMode(mode),
+    }),
+  );
+
+  const promptBox = editing ? (
+    <form
+      className="rounded-xl border border-border bg-background"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!dirty || trimmedPrompt.length === 0) return;
+        void onUpdate({
+          prompt: trimmedPrompt,
+          model,
+          permissionMode,
+        });
+      }}
+    >
+      <Textarea
+        value={prompt}
+        onChange={(event) => setPrompt(event.target.value)}
+        maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
+        aria-label="Automation prompt"
+        disabled={pending}
+        className="min-h-28 resize-y border-0 bg-transparent px-4 py-3 text-sm shadow-none focus-visible:ring-0"
+      />
+      <div className="flex min-w-0 items-center justify-between gap-2 border-t border-border px-2 py-1.5">
+        <AutomationSelector
+          label="Provider and model"
+          accessibleLabel={`Provider and model: ${formatAutomationProviderLabel(execution.providerId)}, ${modelOptions.find((option) => option.value === model)?.label ?? model}`}
+          value={model}
+          options={modelOptions}
+          disabled={pending || options === null}
+          onValueChange={setModel}
+          leading={<AutomationProviderIcon providerId={execution.providerId} />}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={pending || !dirty || trimmedPrompt.length === 0}
+        >
+          Save prompt
+        </Button>
+      </div>
+    </form>
+  ) : (
+    <ResourcePromptPreview
+      className="bg-background"
+      context={[
+        {
+          label: (
+            <DisabledAutomationSelector
+              label="Provider and model"
+              disabledReason="Select Edit via chat to change the provider and model."
+              value={formatAutomationModelLabel(
+                execution.model,
+                execution.providerId,
+              )}
+              accessibleValue={`${formatAutomationProviderLabel(execution.providerId)}, ${formatAutomationModelLabel(execution.model, execution.providerId)}`}
+              leading={
+                <AutomationProviderIcon providerId={execution.providerId} />
+              }
+              title={`${formatAutomationProviderLabel(execution.providerId)}: ${formatAutomationModelLabel(execution.model, execution.providerId)}`}
+            />
+          ),
+        },
+      ]}
+    >
+      {execution.prompt}
+    </ResourcePromptPreview>
+  );
+
   return (
     <div data-promptbox-shell="" className="min-w-0">
-      <form
-        className="rounded-xl border border-border bg-background"
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (!promptDirty || trimmedPrompt.length === 0) return;
-          void onUpdate({ prompt: trimmedPrompt });
-        }}
-      >
-        <Textarea
-          value={prompt}
-          onChange={(event) => setPrompt(event.target.value)}
-          maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
-          aria-label="Automation prompt"
-          disabled={pending}
-          className="min-h-28 resize-y border-0 bg-transparent px-4 py-3 text-sm shadow-none focus-visible:ring-0"
-        />
-        <div className="flex min-w-0 items-center justify-between gap-2 border-t border-border px-2 py-1.5">
-          <AutomationSelector
-            label="Provider and model"
-            accessibleLabel={`Provider and model: ${formatAutomationProviderLabel(execution.providerId)}, ${modelOptions.find((option) => option.value === execution.model)?.label ?? execution.model}`}
-            value={execution.model}
-            options={modelOptions}
-            disabled={pending || options === null}
-            onValueChange={(model) => void onUpdate({ model })}
-            leading={
-              <AutomationProviderIcon providerId={execution.providerId} />
-            }
-          />
-          <Button
-            type="submit"
-            size="sm"
-            disabled={pending || !promptDirty || trimmedPrompt.length === 0}
-          >
-            Save prompt
-          </Button>
-        </div>
-      </form>
+      {promptBox}
       {optionsError ? (
         <p className="mt-1 px-3.5 text-xs text-destructive">
           Couldn&apos;t load model options. {optionsError}
         </p>
       ) : null}
+      <div
+        data-automation-prompt-footer=""
+        className="mt-1 flex min-h-6 min-w-0 items-center justify-between gap-2 px-3.5 text-xs text-muted-foreground"
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+          {!personalProject ? (
+            <OptionDisplay
+              label="Project"
+              value={projectContextLabel}
+              compactValue={projectContextLabel}
+              leading={
+                <Icon name="Folder" className="size-3.5 shrink-0" aria-hidden />
+              }
+              className="shrink-0"
+              muted
+            />
+          ) : null}
+          <OptionDisplay
+            label="Environment"
+            value={
+              execution.targetThreadId !== undefined
+                ? "Existing thread"
+                : automationEnvironmentLabel(execution)
+            }
+            compactValue={automationEnvironmentCompactLabel(execution)}
+            leading={
+              <Icon
+                name={automationEnvironmentIcon(execution)}
+                className="size-3.5 shrink-0"
+                aria-hidden
+              />
+            }
+            muted
+          />
+        </div>
+        {editing ? (
+          <AutomationSelector
+            label="Permission mode"
+            value={permissionMode}
+            options={permissionOptions}
+            disabled={pending || options === null}
+            onValueChange={(value) => {
+              const next = options?.permissionModes.find(
+                (mode) => mode === value,
+              );
+              if (next !== undefined) setPermissionMode(next);
+            }}
+            className="h-6 shrink-0"
+          />
+        ) : (
+          <DisabledAutomationSelector
+            label="Permission mode"
+            disabledReason="Select Edit via chat to change permissions."
+            value={formatPermissionMode(execution.permissionMode)}
+            compactValue={formatPermissionModeCompact(
+              execution.permissionMode,
+            )}
+            className="h-6 shrink-0"
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -658,6 +867,7 @@ export function AutomationDetailView({
   actionPending,
   executionOptions,
   executionOptionsError,
+  editing,
   onToggle,
   onEdit,
   onUpdateAgent,
@@ -749,89 +959,29 @@ export function AutomationDetailView({
         <ResourceDefinitionSection
           label={bodyLabel}
           actions={
-            execution.mode === "script" ? (
-              <ResourceActionButton
-                label="Edit with chat"
-                tooltipLabel="Edit with chat"
-                icon="MessageCirclePlus"
-                onClick={onEdit}
-              />
-            ) : undefined
+            <ResourceActionButton
+              label={
+                execution.mode === "agent" ? "Edit via chat" : "Edit with chat"
+              }
+              tooltipLabel={
+                execution.mode === "agent" ? "Edit via chat" : "Edit with chat"
+              }
+              icon="MessageCirclePlus"
+              onClick={onEdit}
+            />
           }
         >
           {execution.mode === "agent" ? (
-            <div data-promptbox-shell="" className="min-w-0">
-              <AgentAutomationEditor
-                execution={execution}
-                options={executionOptions}
-                optionsError={executionOptionsError}
-                pending={actionPending}
-                onUpdate={onUpdateAgent}
-              />
-              <div
-                data-automation-prompt-footer=""
-                className="mt-1 flex min-h-6 min-w-0 items-center justify-between gap-2 px-3.5 text-xs text-muted-foreground"
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-                  {!personalProject ? (
-                    <OptionDisplay
-                      label="Project"
-                      value={projectContextLabel}
-                      compactValue={projectContextLabel}
-                      leading={
-                        <Icon
-                          name="Folder"
-                          className="size-3.5 shrink-0"
-                          aria-hidden
-                        />
-                      }
-                      className="shrink-0"
-                      muted
-                    />
-                  ) : null}
-                  <OptionDisplay
-                    label="Environment"
-                    value={
-                      execution.targetThreadId !== undefined
-                        ? "Existing thread"
-                        : automationEnvironmentLabel(execution)
-                    }
-                    compactValue={automationEnvironmentCompactLabel(execution)}
-                    leading={
-                      <Icon
-                        name={automationEnvironmentIcon(execution)}
-                        className="size-3.5 shrink-0"
-                        aria-hidden
-                      />
-                    }
-                    muted
-                  />
-                </div>
-                <AutomationSelector
-                  label="Permission mode"
-                  value={execution.permissionMode}
-                  options={(
-                    executionOptions?.permissionModes ?? [
-                      execution.permissionMode,
-                    ]
-                  ).map((mode) => ({
-                    value: mode,
-                    label: formatPermissionMode(mode),
-                  }))}
-                  disabled={actionPending || executionOptions === null}
-                  onValueChange={(value) => {
-                    const permissionMode =
-                      executionOptions?.permissionModes.find(
-                        (mode) => mode === value,
-                      );
-                    if (permissionMode !== undefined) {
-                      void onUpdateAgent({ permissionMode });
-                    }
-                  }}
-                  className="h-6 shrink-0"
-                />
-              </div>
-            </div>
+            <AgentAutomationDefinition
+              execution={execution}
+              options={executionOptions}
+              optionsError={executionOptionsError}
+              editing={editing}
+              pending={actionPending}
+              personalProject={personalProject}
+              projectContextLabel={projectContextLabel}
+              onUpdate={onUpdateAgent}
+            />
           ) : (
             <ResourceDetailPanel
               surface="flat"


### PR DESCRIPTION
Summary

- Restore the automation detail read-only prompt presentation and disabled setting controls.
- Enter inline editing from Edit via chat, with prompt-box styling and Save prompt in the bottom-right.
- Save prompt, model, and permission together through the existing automation update RPC.
- Keep configured model labels product-formatted in both read-only and editing states.

Verification

- Focused app detail recipe tests: 34 passed.
- Automations server harness: 14 passed.
- Turbo typecheck: @bb/app and bb-plugin-automations passed.
- Branch dev app: visually verified default, editing, save, persisted read-only, and restored fixture states.