### PR TITLE
Keep right-panel collapse in panel header

### DIFF
--- a/apps/app/src/views/RootComposeRightPanelToggle.test.tsx
+++ b/apps/app/src/views/RootComposeRightPanelToggle.test.tsx
@@ -22,7 +22,7 @@ describe("RootComposeRightPanelToggle", () => {
     ).toEqual({ inlinePanelToggle: "button", showPinnedToggle: false });
     expect(
       resolveRootComposePanelTogglePlacement({ isHosted: true, isOpen: true }),
-    ).toEqual({ inlinePanelToggle: "reserved", showPinnedToggle: false });
+    ).toEqual({ inlinePanelToggle: "button", showPinnedToggle: false });
   });
 
   it("uses a disclosure state without painting the whole click target as selected", () => {

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -454,7 +454,7 @@ export function resolveRootComposePanelTogglePlacement(args: {
   showPinnedToggle: boolean;
 } {
   if (args.isHosted) {
-    return { inlinePanelToggle: "reserved", showPinnedToggle: false };
+    return { inlinePanelToggle: "button", showPinnedToggle: false };
   }
   return {
     inlinePanelToggle: "button",

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -72,7 +72,7 @@ describe("ThreadDetailHeader", () => {
     expect(header?.classList).toContain("border-border-seam-vertical/60");
   });
 
-  it("uses a neutral disclosure state for the right-panel toggle", () => {
+  it("leaves the open right-panel collapse control to the panel header", () => {
     render(
       <PaneContext.Provider value={PANE_CONTEXT}>
         <ThreadDetailHeader
@@ -87,9 +87,37 @@ describe("ThreadDetailHeader", () => {
       </PaneContext.Provider>,
     );
 
-    const toggle = screen.getByRole("button", { name: "Hide right panel" });
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    expect(toggle.hasAttribute("aria-pressed")).toBe(false);
+    expect(
+      screen.queryByRole("button", { name: "Hide right panel" }),
+    ).toBeNull();
+  });
+
+  it("keeps thread Full Screen in a split header while its panel is open", () => {
+    render(
+      <PaneContext.Provider
+        value={{
+          ...PANE_CONTEXT,
+          isSplitPane: true,
+          secondaryPanelHost: { clear: vi.fn(), publish: vi.fn() },
+          onToggleMaximize: vi.fn(),
+        }}
+      >
+        <ThreadDetailHeader
+          actionsMenu={null}
+          childPillLabel={null}
+          isSecondaryPanelOpen
+          onOpenThreadGitAction={vi.fn()}
+          onToggleSecondaryPanel={vi.fn()}
+          threadHeaderGitActions={[]}
+          threadTitle="Split panel state"
+        />
+      </PaneContext.Provider>,
+    );
+
+    expect(screen.getByRole("button", { name: /Full Screen/ })).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Hide right panel" }),
+    ).toBeNull();
   });
 
   it("moves secondary controls into overflow for narrow split panes", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -134,12 +134,11 @@ export function ThreadDetailHeader({
     ? "Hide right panel"
     : "Show right panel";
   const rightPanelIconName = renderAsDrawer ? "PanelBottom" : "PanelRight";
-  // Standalone thread pages keep their header toggle mounted across open/close
-  // on wide layouts. Split panes publish to the one workspace-level toggle, so
-  // no pane header renders its own copy. The drawer still hides the standalone
-  // toggle while open because the drawer carries its own close affordance.
+  // The thread header owns only the show control. Once the panel opens, its
+  // toolbar owns collapse so pane actions (including Full Screen) keep their
+  // stable positions in the thread header.
   const showRightPanelToggle =
-    secondaryPanelHost === null && (!renderAsDrawer || !isSecondaryPanelOpen);
+    secondaryPanelHost === null && !isSecondaryPanelOpen;
 
   const center = (
     <>

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -465,6 +465,21 @@ beforeEach(() => {
 });
 
 describe("ThreadDetailSecondaryContent compact drawer settling", () => {
+  it("keeps the standalone panel hide control in the panel toolbar", () => {
+    renderThreadDetail({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: true,
+      renderBrowserDeck: createBrowserDeckRenderer(),
+      threadId: "thread-1",
+    });
+
+    expect(
+      screen
+        .getByTestId("inline-secondary-panel")
+        .getAttribute("data-inline-panel-toggle"),
+    ).toBe("button");
+  });
+
   it("places the hosted panel hide control at the outer edge of its own toolbar", () => {
     renderThreadDetail({
       isCompactViewport: false,

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -287,13 +287,9 @@ function ThreadDetailSecondaryContentBody({
           renderAsDrawer={false}
           isConversationCollapsed={isConversationCollapsedActive}
           onToggleConversationCollapse={onToggleConversationCollapse}
-          // The split-workspace host owns the show control while the panel is
-          // closed. Once open, the panel owns its hide control so the two
-          // trailing actions read in their natural order: Full Screen, then
-          // Hide right panel at the outer edge.
-          inlinePanelToggle={
-            secondaryPanelHost === null ? "hidden" : "button"
-          }
+          // The owning thread or workspace header shows a closed panel. Once
+          // open, collapse belongs at the outer edge of the panel toolbar.
+          inlinePanelToggle="button"
           // In the split-workspace host, panes' panels share one PanelGroup, so
           // each pane's Panel needs its own layout identity (see the prop doc).
           resizablePanelId={


### PR DESCRIPTION
## Summary

- keep the thread header focused on thread pane actions while an open right panel owns its collapse control
- render the collapse control in both standalone thread panels and hosted New Thread panels
- preserve thread Full Screen controls in split headers while the right panel is open

## Verification

- 4 focused Vitest files: 24 tests passed
- pnpm exec turbo run typecheck --filter=@bb/app
- branch dev app visual QA: opened a real two-pane split, opened the right panel, and confirmed both thread headers retain Full Screen while the panel header shows Full Screen then Hide right panel
- collapsed and reopened the right panel and confirmed the control remains available in the panel header
- git diff --check