### PR TITLE
Clarify plugin browse categories

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -171,7 +171,10 @@ describe("PluginsOverview", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
     expect(await screen.findByText("GitHub")).toBeTruthy();
-    expect(screen.getByText("BB Official plugins")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Developer tools" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("BB Official plugins")).toBeNull();
     expect(screen.getByRole("button", { name: "New plugin" })).toBeTruthy();
   });
 

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -5,7 +5,6 @@ import {
   fireEvent,
   render,
   screen,
-  within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
@@ -25,7 +24,7 @@ const MEMORY_ENTRY: PluginCatalogSearchEntry = {
   displayName: "Memory",
   description: "Provider-independent durable memory for agents.",
   icon: "Brain",
-  category: "Productivity",
+  category: "Context & knowledge",
   source: "builtin:memory",
   installed: false,
   compatible: true,
@@ -91,7 +90,7 @@ afterEach(() => {
 });
 
 describe("BrowsePluginsTab", () => {
-  it("renders every official catalog card represented by the catalog count", async () => {
+  it("renders every returned catalog entry exactly once in direct categories", async () => {
     const entries = Array.from(
       { length: CATALOG_STATUS.pluginCount },
       (_, index) => ({
@@ -99,7 +98,8 @@ describe("BrowsePluginsTab", () => {
         entryId: `official-${index + 1}`,
         pluginId: `official-${index + 1}`,
         displayName: `Official ${index + 1}`,
-        category: index % 2 === 0 ? "Productivity" : "Developer tools",
+        category:
+          index % 2 === 0 ? "Context & knowledge" : "Developer tools",
       }),
     );
     vi.stubGlobal(
@@ -123,15 +123,11 @@ describe("BrowsePluginsTab", () => {
       wrapper,
     });
 
-    expect(
-      await screen.findByText("13 plugins · 9 included with BB, 4 optional"),
-    ).toBeTruthy();
+    expect(await screen.findByText("Official 1")).toBeTruthy();
     expect(
       screen.getAllByRole("button", { name: /^Open Official \d+ details$/ }),
     ).toHaveLength(CATALOG_STATUS.pluginCount);
-    expect(
-      screen.queryByRole("heading", { name: "Included with BB" }),
-    ).toBeNull();
+    expect(screen.queryByText("BB Official plugins")).toBeNull();
   });
 
   it("shows the official plugins and entries", async () => {
@@ -161,12 +157,7 @@ describe("BrowsePluginsTab", () => {
       { wrapper },
     );
 
-    expect(
-      await screen.findByText("13 plugins · 9 included with BB, 4 optional"),
-    ).toBeTruthy();
-    const officialCatalog = screen.getByRole("region", {
-      name: "BB Official plugins",
-    });
+    expect(await screen.findByText("Memory")).toBeTruthy();
     const memoryCard = (await screen.findByText("Memory")).closest("div");
     expect(memoryCard).not.toBeNull();
     // Scoped to the card on purpose: INCOMPATIBLE_ENTRY spreads MEMORY_ENTRY
@@ -183,16 +174,15 @@ describe("BrowsePluginsTab", () => {
       .closest('[class*="auto-fill"]');
     expect(githubGrid?.className).toContain("auto-fill");
     expect(
-      within(officialCatalog).getByRole("heading", { name: "Productivity" }),
+      screen.getByRole("heading", { name: "Context & knowledge" }),
     ).toBeTruthy();
     expect(
-      within(officialCatalog).getByRole("heading", {
-        name: "Developer tools",
-      }),
+      screen.getByRole("heading", { name: "Developer tools" }),
     ).toBeTruthy();
     expect(
-      within(officialCatalog).getByRole("button", { name: "Install Memory" }),
+      screen.getByRole("button", { name: "Install Memory" }),
     ).toBeTruthy();
+    expect(screen.queryByText("BB Official plugins")).toBeNull();
 
     expect(screen.queryByText(MEMORY_ENTRY.source)).toBeNull();
     expect(screen.getByText("Requires a newer BB version")).toBeTruthy();

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/hooks/cache-owners/plugin-cache-owner";
 import {
   usePluginCatalogSearch,
-  usePluginCatalogStatus,
   type PluginCatalogSearchEntry,
 } from "@/hooks/queries/plugin-catalog-queries";
 import { removePlugin } from "@/hooks/queries/plugin-settings-queries";
@@ -39,9 +38,7 @@ export function BrowsePluginsTab({
 }) {
   const [query, setQuery] = useState("");
   const [debouncedQuery] = useDebounceValue(query.trim(), 300);
-  const statusQuery = usePluginCatalogStatus({ enabled: true });
   const searchQuery = usePluginCatalogSearch(debouncedQuery, { enabled: true });
-  const status = statusQuery.data;
   const entries = searchQuery.data ?? [];
   const byCategory = new Map<string, PluginCatalogSearchEntry[]>();
   for (const entry of entries) {
@@ -62,89 +59,52 @@ export function BrowsePluginsTab({
         />
       }
     >
-      <section
-        aria-labelledby="bb-official-plugins-heading"
-        className="space-y-4 rounded-lg border border-border bg-card px-3.5 py-3"
-      >
-        <div>
-          <h2
-            id="bb-official-plugins-heading"
-            className="text-sm font-medium text-foreground"
-          >
-            BB Official plugins
-          </h2>
-          {status === undefined ? (
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {statusQuery.isPending
-                ? "Loading plugins…"
-                : "Plugin list unavailable."}
-            </p>
-          ) : (
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {status.pluginCount} plugin
-              {status.pluginCount === 1 ? "" : "s"} ·{" "}
-              {status.includedPluginCount}
-              {" included with BB, "}
-              {status.optionalPluginCount} optional
-            </p>
-          )}
+      {searchQuery.isError && entries.length > 0 ? (
+        <p className="text-xs text-warning-text" role="status">
+          Showing cached catalog results because the latest search failed.
+        </p>
+      ) : null}
+
+      {searchQuery.isPending ? (
+        <ResourceListState state="loading" message="Loading plugins" />
+      ) : entries.length === 0 ? (
+        <ResourceListState
+          state={searchQuery.isError ? "error" : "empty"}
+          message={
+            searchQuery.isError
+              ? "BB's official plugins are unavailable."
+              : "No plugins match this search."
+          }
+          onRetry={
+            searchQuery.isError
+              ? () => {
+                  void searchQuery.refetch();
+                }
+              : undefined
+          }
+        />
+      ) : (
+        <div className="space-y-5">
+          {[...byCategory.entries()].map(([category, categoryEntries]) => (
+            <section key={category} aria-label={category}>
+              <h2 className="mb-2 text-sm font-semibold text-foreground">
+                {category}
+              </h2>
+              <ResourceBrowseGrid className="grid-cols-[repeat(auto-fill,minmax(min(100%,23rem),1fr))]">
+                {categoryEntries.map((entry) => (
+                  <BrowseCard
+                    key={entry.entryId}
+                    entry={entry}
+                    installedPluginId={entry.installed ? entry.pluginId : null}
+                    onInstall={onInstall}
+                    onOpenPlugin={onOpenPlugin}
+                  />
+                ))}
+              </ResourceBrowseGrid>
+            </section>
+          ))}
         </div>
-
-        {searchQuery.isError && entries.length > 0 ? (
-          <p className="text-xs text-warning-text" role="status">
-            Showing cached catalog results because the latest search failed.
-          </p>
-        ) : null}
-
-        {searchQuery.isPending ? (
-          <ResourceListState state="loading" message="Loading plugins" />
-        ) : entries.length === 0 ? (
-          <ResourceListState
-            state={searchQuery.isError ? "error" : "empty"}
-            message={
-              searchQuery.isError
-                ? "BB's official plugins are unavailable."
-                : "No plugins match this search."
-            }
-            onRetry={
-              searchQuery.isError
-                ? () => {
-                    void searchQuery.refetch();
-                  }
-                : undefined
-            }
-          />
-        ) : (
-          <div className="space-y-4">
-            {[...byCategory.entries()].map(([category, categoryEntries]) => (
-              <section
-                key={category}
-                aria-labelledby={`plugin-category-${category}`}
-              >
-                <h3
-                  id={`plugin-category-${category}`}
-                  className="mb-2 text-sm font-semibold text-foreground"
-                >
-                  {category}
-                </h3>
-                <ResourceBrowseGrid className="grid-cols-[repeat(auto-fill,minmax(min(100%,23rem),1fr))]">
-                  {categoryEntries.map((entry) => (
-                    <BrowseCard
-                      key={entry.entryId}
-                      entry={entry}
-                      installedPluginId={
-                        entry.installed ? entry.pluginId : null
-                      }
-                      onInstall={onInstall}
-                      onOpenPlugin={onOpenPlugin}
-                    />
-                  ))}
-                </ResourceBrowseGrid>
-              </section>
-            ))}
-          </div>
-        )}
-      </section>
+      )}
     </ResourceCollectionViewport>
   );
 }

--- a/apps/app/src/components/settings/plugins/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/settings/plugins/BrowsePluginsTab.test.tsx
@@ -19,7 +19,7 @@ const MEMORY_ENTRY: PluginCatalogSearchEntry = {
   displayName: "Memory",
   description: "Provider-independent durable memory for agents.",
   icon: "Brain",
-  category: "Productivity",
+  category: "Context & knowledge",
   source: "builtin:memory",
   installed: false,
   compatible: true,
@@ -59,7 +59,10 @@ describe("BrowsePluginsTab", () => {
     const { wrapper } = createQueryClientTestHarness();
     render(<BrowsePluginsTab onInstall={onInstall} />, { wrapper });
 
-    expect(await screen.findByText("BB Official plugins")).toBeTruthy();
+    expect(
+      await screen.findByRole("heading", { name: "Context & knowledge" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("BB Official plugins")).toBeNull();
     const card = await screen.findByTestId("browse-card-memory");
     expect(card.querySelector('[data-icon="Brain"]')).not.toBeNull();
 

--- a/apps/app/src/components/settings/plugins/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/settings/plugins/BrowsePluginsTab.tsx
@@ -7,7 +7,6 @@ import { Input } from "@bb/shared-ui/input";
 import { pluginIconName } from "@/components/plugin/PluginIcon";
 import {
   usePluginCatalogSearch,
-  usePluginCatalogStatus,
   type PluginCatalogSearchEntry,
 } from "@/hooks/queries/plugin-catalog-queries";
 import type { AddPluginInitial } from "@/components/plugin/management/AddPluginDialog";
@@ -25,9 +24,7 @@ export function BrowsePluginsTab({
 }) {
   const [query, setQuery] = useState("");
   const [debouncedQuery] = useDebounceValue(query.trim(), 300);
-  const statusQuery = usePluginCatalogStatus({ enabled: true });
   const searchQuery = usePluginCatalogSearch(debouncedQuery, { enabled: true });
-  const status = statusQuery.data;
   const entries = searchQuery.data ?? [];
 
   const byCategory = new Map<string, PluginCatalogSearchEntry[]>();
@@ -39,26 +36,6 @@ export function BrowsePluginsTab({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-border bg-card px-3.5 py-3">
-        <p className="text-sm font-medium text-foreground">
-          BB Official plugins
-        </p>
-        {status === undefined ? (
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {statusQuery.isPending
-              ? "Loading plugins…"
-              : "Plugin list unavailable."}
-          </p>
-        ) : (
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {status.pluginCount} plugin
-            {status.pluginCount === 1 ? "" : "s"} · {status.includedPluginCount}
-            {" included with BB, "}
-            {status.optionalPluginCount} optional
-          </p>
-        )}
-      </div>
-
       <div className="relative min-w-48">
         <Icon
           name="Search"

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -7,6 +7,7 @@ import type {
 import {
   builtinPluginSource,
   listBundledPluginRegistrations,
+  PLUGIN_CATALOG_CATEGORIES,
   type BundledPluginRegistration,
 } from "../plugins/builtin-registry.js";
 import {
@@ -40,6 +41,9 @@ export function createPluginCatalogService(deps: {
     ...plugin,
     category: plugin.category ?? "Other",
   }));
+  const categoryOrder = new Map<string, number>(
+    PLUGIN_CATALOG_CATEGORIES.map((category, index) => [category, index]),
+  );
 
   // Manifests are read per search so a dev checkout editing a bundled
   // plugin's package.json sees fresh store metadata; this small local catalog
@@ -126,9 +130,15 @@ export function createPluginCatalogService(deps: {
               .includes(query),
         )
         .map(({ result }) => result)
-        .sort((left, right) =>
-          left.displayName.localeCompare(right.displayName),
-        );
+        .sort((left, right) => {
+          const categoryDifference =
+            (categoryOrder.get(left.category) ?? categoryOrder.size) -
+            (categoryOrder.get(right.category) ?? categoryOrder.size);
+          return (
+            categoryDifference ||
+            left.displayName.localeCompare(right.displayName)
+          );
+        });
     },
 
     async install(entryId) {

--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -31,36 +31,46 @@ interface ResolveBuiltinPluginRootPathArgs {
 }
 
 export const BUILTIN_PLUGINS_DIRECTORY_NAME = "builtin-plugins";
+
+export const PLUGIN_CATALOG_CATEGORIES = [
+  "Workflow management",
+  "Agent interaction",
+  "Context & knowledge",
+  "Developer tools",
+  "Host access",
+  "Interface",
+] as const;
+
 export const BUILTIN_PLUGINS = [
   {
     name: "ask-user-question",
     pluginId: "ask-user-question",
     defaultEnabled: false,
-    category: "Productivity",
+    category: "Agent interaction",
   },
   {
     name: "automations",
     pluginId: "automations",
     defaultEnabled: true,
-    category: "Productivity",
+    category: "Workflow management",
   },
   {
     name: "connect",
     pluginId: "connect",
     defaultEnabled: true,
-    category: "Developer tools",
+    category: "Host access",
   },
   {
     name: "custom-instructions",
     pluginId: "custom-instructions",
     defaultEnabled: true,
-    category: "Productivity",
+    category: "Context & knowledge",
   },
   {
     name: "inline-vis",
     pluginId: "inline-vis",
     defaultEnabled: true,
-    category: "Developer tools",
+    category: "Interface",
   },
   {
     name: "secrets",
@@ -72,13 +82,13 @@ export const BUILTIN_PLUGINS = [
     name: "side-chat",
     pluginId: "side-chat",
     defaultEnabled: true,
-    category: "Productivity",
+    category: "Agent interaction",
   },
   {
     name: "workflows",
     pluginId: "workflows",
     defaultEnabled: false,
-    category: "Productivity",
+    category: "Workflow management",
   },
   // Ships with the app but stays off: it replaces the sidebar, which is a
   // choice the user makes in Settings, never something an install does.
@@ -86,7 +96,7 @@ export const BUILTIN_PLUGINS = [
     name: "t3sidebar",
     pluginId: "t3sidebar",
     defaultEnabled: false,
-    category: "Productivity",
+    category: "Interface",
   },
 ].map(
   (plugin): BundledPluginDefinition => ({
@@ -111,19 +121,19 @@ export const OFFICIAL_PLUGINS = [
     name: "docs",
     pluginId: "simple-notes",
     defaultEnabled: true,
-    category: "Productivity",
+    category: "Context & knowledge",
   },
   {
     name: "memory",
     pluginId: "memory",
     defaultEnabled: true,
-    category: "Productivity",
+    category: "Context & knowledge",
   },
   {
     name: "tasks",
     pluginId: "tasks",
     defaultEnabled: true,
-    category: "Productivity",
+    category: "Workflow management",
   },
 ].map(
   (plugin): BundledPluginDefinition => ({

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -14,6 +14,7 @@ import {
   BUILTIN_PLUGINS,
   BUNDLED_PLUGINS,
   OFFICIAL_PLUGINS,
+  PLUGIN_CATALOG_CATEGORIES,
   listBundledPluginRegistrations,
 } from "../../../src/services/plugins/builtin-registry.js";
 
@@ -90,25 +91,28 @@ describe("bundled plugin catalog service", () => {
     expect(results.some((entry) => entry.category === "Included with BB")).toBe(
       false,
     );
-    expect(new Set(results.map((entry) => entry.category))).toEqual(
-      new Set(["Developer tools", "Productivity"]),
+    expect([...new Set(results.map((entry) => entry.category))]).toEqual(
+      PLUGIN_CATALOG_CATEGORIES,
     );
     const docs = results.find((entry) => entry.entryId === "docs");
     expect(docs).toMatchObject({
       pluginId: "simple-notes",
       displayName: "Docs",
       icon: "FileText",
-      category: "Productivity",
+      category: "Context & knowledge",
       source: "builtin:docs",
       installed: false,
       compatible: true,
       incompatibleReason: null,
     });
-    expect(results.map((entry) => entry.displayName)).toEqual(
-      [...results.map((entry) => entry.displayName)].sort((a, b) =>
-        a.localeCompare(b),
-      ),
-    );
+    for (const category of PLUGIN_CATALOG_CATEGORIES) {
+      const categoryNames = results
+        .filter((entry) => entry.category === category)
+        .map((entry) => entry.displayName);
+      expect(categoryNames).toEqual(
+        [...categoryNames].sort((a, b) => a.localeCompare(b)),
+      );
+    }
   });
 
   it("matches queries against entry id, plugin id, and manifest text", async () => {

--- a/apps/server/test/services/plugins/official-plugins.test.ts
+++ b/apps/server/test/services/plugins/official-plugins.test.ts
@@ -16,7 +16,8 @@ import {
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import {
-  OFFICIAL_PLUGINS,
+  BUNDLED_PLUGINS,
+  PLUGIN_CATALOG_CATEGORIES,
   listBundledPluginRegistrations,
   type BundledPluginRegistration,
 } from "../../../src/services/plugins/builtin-registry.js";
@@ -84,10 +85,37 @@ describe("official plugin registry invariants", () => {
     }
   });
 
-  it("gives every official plugin a store category", () => {
-    for (const plugin of OFFICIAL_PLUGINS) {
-      expect(plugin.category, plugin.name).toBeTruthy();
-    }
+  it("assigns every bundled plugin to one curated store category", () => {
+    const expectedCategories = {
+      "ask-user-question": "Agent interaction",
+      automations: "Workflow management",
+      connect: "Host access",
+      "custom-instructions": "Context & knowledge",
+      docs: "Context & knowledge",
+      github: "Developer tools",
+      "inline-vis": "Interface",
+      memory: "Context & knowledge",
+      secrets: "Developer tools",
+      "side-chat": "Agent interaction",
+      t3sidebar: "Interface",
+      tasks: "Workflow management",
+      workflows: "Workflow management",
+    };
+
+    expect(new Set(BUNDLED_PLUGINS.map((plugin) => plugin.name)).size).toBe(
+      BUNDLED_PLUGINS.length,
+    );
+    expect(
+      Object.fromEntries(
+        BUNDLED_PLUGINS.map((plugin) => [plugin.name, plugin.category]),
+      ),
+    ).toEqual(expectedCategories);
+    const validCategories = new Set<string>(PLUGIN_CATALOG_CATEGORIES);
+    expect(
+      BUNDLED_PLUGINS.every((plugin) =>
+        validCategories.has(plugin.category ?? ""),
+      ),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- remove the redundant BB Official catalog container so categories render directly
- define one authoritative curated category order for all 13 bundled plugins
- preserve existing cards, install state, detail navigation, loading, error, empty, and search behavior
- keep the legacy Settings browse projection consistent without changing extension experiment behavior

## Category structure

- **Workflow management:** Automations, Tasks, Workflows
- **Agent interaction:** Ask User Question, Side chat
- **Context & knowledge:** Custom instructions, Docs, Memory
- **Developer tools:** GitHub, Secrets
- **Host access:** Remote access
- **Interface:** Inline visualizations, t3sidebar

## Verification

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/management/BrowsePluginsTab.test.tsx src/components/plugin/PluginsOverview.test.tsx src/components/settings/plugins/BrowsePluginsTab.test.tsx` — 15 passed
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/plugin-catalog/plugin-catalog-service.test.ts test/services/plugins/official-plugins.test.ts` — 13 passed
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server` — passed
- branch dev app visually verified at the top and bottom of the catalog plus a Memory-filtered result; all 13 cards render exactly once in category order
- `git diff --check` — passed

Stacked on #976. Not merged.