### PR TITLE
Polish automation inline prompt editing

### DIFF
--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -14,6 +14,7 @@ import { useState, type ComponentProps } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AgentExecutionUpdate,
   AutomationExecutionOptionsResponse,
   AutomationResponse,
   AutomationRunResponse,
@@ -563,7 +564,7 @@ const FAILED_SCRIPT_RUN: AutomationRunResponse = {
 
 describe("Automation detail recipe", () => {
   it("keeps Definition ahead of Runs, including with no runs yet", async () => {
-    const updateAgent = vi.fn(async () => {});
+    const updateAgent = vi.fn(async (_update: AgentExecutionUpdate) => {});
     function Harness() {
       const [editing, setEditing] = useState(false);
       return (
@@ -581,7 +582,10 @@ describe("Automation detail recipe", () => {
           }}
           actionPending={false}
           editing={editing}
-          onUpdateAgent={updateAgent}
+          onUpdateAgent={async (update) => {
+            await updateAgent(update);
+            setEditing(false);
+          }}
           onToggle={() => {}}
           onEdit={() => setEditing(true)}
           onRunNow={() => {}}
@@ -635,20 +639,37 @@ describe("Automation detail recipe", () => {
 
     const savedPrompt = screen.getByRole("textbox", { name: "Saved prompt" });
     expect(savedPrompt.getAttribute("aria-readonly")).toBe("true");
+    expect(savedPrompt.getAttribute("aria-disabled")).toBe("true");
+    expect(savedPrompt.className).toContain("text-muted-foreground");
+    expect(savedPrompt.parentElement?.className).toContain(
+      "bg-surface-recessed/55",
+    );
     expect(savedPrompt.textContent).toBe("Summarize yesterday's commits.");
-    expect(screen.queryByRole("button", { name: "Save prompt" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save Prompt" })).toBeNull();
+    const disabledModelSelector = container.querySelector(
+      '[data-disabled-automation-selector="Provider and model"]',
+    ) as HTMLButtonElement;
+    const disabledPermissionSelector = container.querySelector(
+      '[data-disabled-automation-selector="Permission mode"]',
+    ) as HTMLButtonElement;
+    expect(disabledModelSelector.disabled).toBe(true);
+    expect(disabledPermissionSelector.disabled).toBe(true);
     expect(
-      container.querySelector(
-        '[data-disabled-automation-selector="Provider and model"]',
-      ),
-    ).not.toBeNull();
-    expect(
-      container.querySelector(
-        '[data-disabled-automation-selector="Permission mode"]',
-      ),
-    ).not.toBeNull();
+      disabledModelSelector.querySelector(
+        '[data-automation-selector-content=""]',
+      )?.className,
+    ).toContain("gap-1.5");
+    expect(disabledModelSelector.getAttribute("data-state")).toBeNull();
+    expect(disabledModelSelector.parentElement?.getAttribute("data-state")).toBe(
+      null,
+    );
+    const editButton = screen.getByRole("button", { name: "Edit via chat" });
+    expect(editButton.querySelector('[data-icon="Edit"]')).not.toBeNull();
+    expect(editButton.className).toContain("size-7");
+    expect(editButton.className).toContain("bg-surface-raised");
+    expect(editButton.className).toContain("border-border");
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit via chat" }));
+    fireEvent.click(editButton);
 
     const promptContent = screen.getByRole("textbox", {
       name: "Automation prompt",
@@ -656,14 +677,22 @@ describe("Automation detail recipe", () => {
     const promptPanel = promptContent.closest("form") as HTMLElement;
     expect(promptPanel.className).toContain("bg-background");
     expect(promptPanel.className).toContain("rounded-xl");
+    expect(promptPanel.className).toContain("shadow-lift");
     expect(promptPanel.className).not.toContain("rounded-md");
-    expect(promptPanel.className).not.toContain("shadow-xs");
-    expect(promptPanel.className).not.toContain("shadow-sm");
     expect(promptContent.value).toBe("Summarize yesterday's commits.");
     expect(promptContent.readOnly).toBe(false);
     expect(promptContent.className).toContain("min-h-28");
+    expect(promptContent.className).toContain("resize-none");
+    expect(promptContent.className).not.toContain("resize-y");
     expect(promptContent.className).toContain("px-4");
-    expect(promptContent.className).toContain("py-3");
+    expect(promptContent.className).toContain("pt-3");
+    const promptActionRow = container.querySelector(
+      '[data-automation-prompt-action-row=""]',
+    ) as HTMLElement;
+    expect(promptPanel.contains(promptActionRow)).toBe(true);
+    expect(promptActionRow.className).toContain("pb-2");
+    expect(promptActionRow.className).toContain("pl-3.5");
+    expect(promptActionRow.className).not.toContain("border-t");
     const promptFooter = container.querySelector(
       '[data-automation-prompt-footer=""]',
     ) as HTMLElement;
@@ -697,12 +726,17 @@ describe("Automation detail recipe", () => {
       "Provider and model: Claude, Opus 5",
     );
     expect(
+      modelSelector.querySelector('[data-automation-selector-content=""]')
+        ?.className,
+    ).toContain("gap-1.5");
+    expect(
       modelSelector.querySelector('[data-icon="ChevronDown"]'),
     ).not.toBeNull();
     expect(
       container.querySelector('[data-automation-provider-icon="claude"] svg'),
     ).not.toBeNull();
-    const savePrompt = screen.getByRole("button", { name: "Save prompt" });
+    const savePrompt = screen.getByRole("button", { name: "Save Prompt" });
+    expect(promptPanel.contains(savePrompt)).toBe(true);
     expect((savePrompt as HTMLButtonElement).disabled).toBe(true);
     fireEvent.change(promptContent, {
       target: { value: "Summarize the last two days." },
@@ -718,6 +752,12 @@ describe("Automation detail recipe", () => {
       model: "claude-sonnet-5",
       permissionMode: "full",
     });
+    expect(
+      await screen.findByRole("textbox", { name: "Saved prompt" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("textbox", { name: "Automation prompt" }),
+    ).toBeNull();
   });
 
   it("uses the composer metadata treatment without inventing reasoning", () => {

--- a/packages/shared-ui/src/components/ui/resource/detail-shell.tsx
+++ b/packages/shared-ui/src/components/ui/resource/detail-shell.tsx
@@ -48,10 +48,12 @@ export function ResourcePromptPreview({
   children,
   className,
   context = [],
+  disabled = false,
 }: {
   children: ReactNode;
   className?: string;
   context?: readonly ResourcePromptContextItem[];
+  disabled?: boolean;
 }) {
   return (
     // Match the production follow-up composer's geometry while keeping this
@@ -60,6 +62,7 @@ export function ResourcePromptPreview({
     <div
       className={cn(
         "overflow-hidden rounded-xl border border-border bg-background",
+        disabled && "bg-surface-recessed/55",
         className,
       )}
     >
@@ -68,7 +71,11 @@ export function ResourcePromptPreview({
         role="textbox"
         aria-label="Saved prompt"
         aria-readonly="true"
-        className="min-h-[68px] min-w-0 whitespace-pre-wrap px-4 pb-1 pr-14 pt-3 text-sm leading-relaxed text-foreground"
+        aria-disabled={disabled || undefined}
+        className={cn(
+          "min-h-[68px] min-w-0 whitespace-pre-wrap px-4 pb-1 pr-14 pt-3 text-sm leading-relaxed text-foreground",
+          disabled && "text-muted-foreground",
+        )}
       >
         {children}
       </div>

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -37,9 +37,9 @@ import { Skeleton } from "@bb/shared-ui/skeleton";
 import {
   OptionDisplay,
   OPTION_BASE_CLASS_NAME,
+  OPTION_CONTENT_CLASS_NAME,
   OPTION_INTERACTIVE_CLASS_NAME,
   OPTION_MUTED_CLASS_NAME,
-  OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
 import {
   Tooltip,
@@ -324,7 +324,10 @@ function AutomationSelector({
           className,
         )}
       >
-        <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>
+        <span
+          data-automation-selector-content=""
+          className={OPTION_CONTENT_CLASS_NAME}
+        >
           {leading}
           <SelectValue />
         </span>
@@ -347,7 +350,6 @@ function AutomationSelector({
 interface DisabledAutomationSelectorProps {
   label: string;
   value: string;
-  disabledReason: string;
   accessibleValue?: string;
   compactValue?: string;
   leading?: ReactNode;
@@ -358,14 +360,13 @@ interface DisabledAutomationSelectorProps {
 function DisabledAutomationSelector({
   label,
   value,
-  disabledReason,
   accessibleValue,
   compactValue,
   leading,
   title,
   className,
 }: DisabledAutomationSelectorProps) {
-  const control = (
+  return (
     <Button
       type="button"
       variant="ghost"
@@ -382,7 +383,8 @@ function DisabledAutomationSelector({
       )}
     >
       <span
-        className={OPTION_TRIGGER_CONTENT_CLASS_NAME}
+        data-automation-selector-content=""
+        className={OPTION_CONTENT_CLASS_NAME}
         title={title ?? `${label}: ${value}`}
       >
         {leading}
@@ -401,25 +403,6 @@ function DisabledAutomationSelector({
         aria-hidden
       />
     </Button>
-  );
-
-  return (
-    <TooltipProvider delayDuration={250}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className="inline-flex shrink-0 cursor-not-allowed rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            tabIndex={0}
-            aria-label={`${label}. ${disabledReason}`}
-          >
-            {control}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-64">
-          {disabledReason}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
   );
 }
 
@@ -722,7 +705,7 @@ function AgentAutomationDefinition({
 
   const promptBox = editing ? (
     <form
-      className="rounded-xl border border-border bg-background"
+      className="rounded-xl border border-border bg-background shadow-lift"
       onSubmit={(event) => {
         event.preventDefault();
         if (!dirty || trimmedPrompt.length === 0) return;
@@ -739,36 +722,43 @@ function AgentAutomationDefinition({
         maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
         aria-label="Automation prompt"
         disabled={pending}
-        className="min-h-28 resize-y border-0 bg-transparent px-4 py-3 text-sm shadow-none focus-visible:ring-0"
+        className="min-h-28 resize-none border-0 bg-transparent px-4 pb-1 pr-14 pt-3 text-sm leading-relaxed shadow-none focus-visible:ring-0"
       />
-      <div className="flex min-w-0 items-center justify-between gap-2 border-t border-border px-2 py-1.5">
-        <AutomationSelector
-          label="Provider and model"
-          accessibleLabel={`Provider and model: ${formatAutomationProviderLabel(execution.providerId)}, ${modelOptions.find((option) => option.value === model)?.label ?? model}`}
-          value={model}
-          options={modelOptions}
-          disabled={pending || options === null}
-          onValueChange={setModel}
-          leading={<AutomationProviderIcon providerId={execution.providerId} />}
-        />
+      <div
+        data-automation-prompt-action-row=""
+        className="flex min-w-0 shrink-0 items-center gap-3 pb-2 pl-3.5 pr-2 pt-1.5"
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-1">
+          <AutomationSelector
+            label="Provider and model"
+            accessibleLabel={`Provider and model: ${formatAutomationProviderLabel(execution.providerId)}, ${modelOptions.find((option) => option.value === model)?.label ?? model}`}
+            value={model}
+            options={modelOptions}
+            disabled={pending || options === null}
+            onValueChange={setModel}
+            leading={
+              <AutomationProviderIcon providerId={execution.providerId} />
+            }
+          />
+        </div>
         <Button
           type="submit"
           size="sm"
+          className="ml-1 shrink-0"
           disabled={pending || !dirty || trimmedPrompt.length === 0}
         >
-          Save prompt
+          Save Prompt
         </Button>
       </div>
     </form>
   ) : (
     <ResourcePromptPreview
-      className="bg-background"
+      disabled
       context={[
         {
           label: (
             <DisabledAutomationSelector
               label="Provider and model"
-              disabledReason="Select Edit via chat to change the provider and model."
               value={formatAutomationModelLabel(
                 execution.model,
                 execution.providerId,
@@ -847,7 +837,6 @@ function AgentAutomationDefinition({
         ) : (
           <DisabledAutomationSelector
             label="Permission mode"
-            disabledReason="Select Edit via chat to change permissions."
             value={formatPermissionMode(execution.permissionMode)}
             compactValue={formatPermissionModeCompact(
               execution.permissionMode,
@@ -966,7 +955,8 @@ export function AutomationDetailView({
               tooltipLabel={
                 execution.mode === "agent" ? "Edit via chat" : "Edit with chat"
               }
-              icon="MessageCirclePlus"
+              icon="Edit"
+              className="size-7 border border-border bg-surface-raised text-foreground shadow-xs hover:bg-accent hover:text-foreground"
               onClick={onEdit}
             />
           }


### PR DESCRIPTION
## Summary

- visually distinguish the unavailable saved prompt without a tooltip
- use the standard pencil action and composer-like inline editor
- keep model and permission controls aligned and editable while editing
- save prompt, model, and permission together through the existing update path

## Verification

- 34 focused automation detail tests passed
- Turbo typecheck passed for @bb/app and @bb/shared-ui
- branch dev app verified saved, editing, save, exit, and persisted states

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>