### PR TITLE
Keep disabled plugins installed

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -553,7 +553,7 @@ describe("PluginsOverview", () => {
     ]);
   });
 
-  it("omits disabled auto-included builtins from the installed projection", async () => {
+  it("keeps disabled plugins installed regardless of provenance", async () => {
     installFetch([
       AUTOMATIONS_PLUGIN,
       {
@@ -592,9 +592,12 @@ describe("PluginsOverview", () => {
 
     expect(await screen.findByText("Automations")).toBeTruthy();
     expect(
-      screen.getByRole("tab", { name: "Installed, 3 plugins" }),
+      screen.getByRole("tab", { name: "Installed, 4 plugins" }),
     ).toBeTruthy();
-    expect(screen.queryByText("Inactive Builtin")).toBeNull();
+    expect(screen.getByText("Inactive Builtin")).toBeTruthy();
+    expect(
+      screen.getByRole("switch", { name: "Enable inactive-builtin" }),
+    ).toBeTruthy();
     expect(screen.getByText("Inactive Catalog Plugin")).toBeTruthy();
     expect(screen.getByText("Inactive Local Plugin")).toBeTruthy();
   });

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -49,13 +49,7 @@ export function PluginsOverview() {
   const [searchParams, setSearchParams] = useSearchParams();
   const listQuery = usePluginList({ enabled: true });
   const catalogQuery = usePluginCatalogSearch("", { enabled: true });
-  const plugins = useMemo(
-    () =>
-      (listQuery.data?.plugins ?? []).filter(
-        (plugin) => plugin.provenance !== "builtin" || plugin.enabled,
-      ),
-    [listQuery.data],
-  );
+  const plugins = listQuery.data?.plugins ?? [];
   const activeMode = modeFromSearchParams(searchParams.get("view"));
   const [installedQuery, setInstalledQuery] = useState("");
   const [installedCategory, setInstalledCategory] = useState<string | null>(


### PR DESCRIPTION
## Summary

- keep disabled plugins in the Installed Plugins projection regardless of provenance
- preserve the existing enabled-first ordering and disabled toggle state
- retain uninstall as a separate detail-page lifecycle action

## Root cause

The Installed view filtered disabled `builtin` records out of the plugin list even though the server keeps disable (`enabled = false`) distinct from uninstall (`removedAt` set). Removing that presentation-only filter makes the UI follow the persisted lifecycle contract.

## Verification

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/PluginsOverview.test.tsx src/views/ToolsView.plugin-detail.test.tsx` — 38 passed
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed
- branch dev app: disabled Inline visualizations; row and Installed count remained; toggle changed to Enable; restored afterward
- branch dev app: verified Docs keeps Disable as the reversible control and Uninstall in its separate actions menu

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>