### PR TITLE
Hide empty plugin capability sections

### DIFF
--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@bb/shared-ui/button";
 import type { PluginCapability } from "@bb/server-contract";
-import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import {
+  ResourceDetailIncludesSection,
   ResourceStatus,
   type ResourceStatusTone,
 } from "@bb/shared-ui/resource-list";
@@ -281,13 +281,6 @@ export function PluginIncludes({
 }) {
   const slots = usePluginSlots();
   const appItems = pluginAppSurfaceItems(plugin.id, slots);
-  if (plugin.app.hasApp && appItems.length === 0) {
-    appItems.push({
-      key: "frontend-app",
-      label: "Frontend app",
-      detail: "Surface names are available while the plugin app is loaded",
-    });
-  }
 
   const declared = (kind: PluginCapability["kind"]): PluginCapabilityItem[] =>
     plugin.capabilities
@@ -368,45 +361,35 @@ export function PluginIncludes({
     ? "This plugin isn't running, so its commands, settings, agent tools, app surfaces, and thread integrations can't be listed."
     : "Some capabilities are only listed while the plugin is enabled.";
 
-  // Capabilities is a stable part of the plugin recipe, so it explains an empty
-  // result rather than disappearing.
-  if (items.length === 0) {
-    return (
-      <EmptyStatePanel className="py-6">
-        {live
-          ? "This plugin declares no user-facing capabilities."
-          : plugin.enabled
-            ? "This plugin isn't running yet, so what it adds can't be listed."
-            : "Enable this plugin to see what it adds to bb."}
-      </EmptyStatePanel>
-    );
-  }
+  if (items.length === 0) return null;
 
   return (
-    <div className="space-y-3">
-      <PluginDetailTable>
-        {items.map((item) => (
-          <PluginDetailRow
-            key={item.key}
-            glyph={
-              <PluginDetailGlyph
-                icon={item.icon}
-                label={item.kind}
-                className="text-muted-foreground"
-              />
-            }
-            name={item.label}
-            mono={item.mono}
-            detail={item.detail}
-          />
-        ))}
-      </PluginDetailTable>
-      {live ? null : (
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {liveCapabilitiesNote}
-        </p>
-      )}
-    </div>
+    <ResourceDetailIncludesSection label="Capabilities">
+      <div className="space-y-3">
+        <PluginDetailTable>
+          {items.map((item) => (
+            <PluginDetailRow
+              key={item.key}
+              glyph={
+                <PluginDetailGlyph
+                  icon={item.icon}
+                  label={item.kind}
+                  className="text-muted-foreground"
+                />
+              }
+              name={item.label}
+              mono={item.mono}
+              detail={item.detail}
+            />
+          ))}
+        </PluginDetailTable>
+        {live ? null : (
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {liveCapabilitiesNote}
+          </p>
+        )}
+      </div>
+    </ResourceDetailIncludesSection>
   );
 }
 

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -1,7 +1,6 @@
 import { useState, useSyncExternalStore } from "react";
 import {
   ResourceActivitySection,
-  ResourceDetailIncludesSection,
   ResourceDetailOverviewSection,
   ResourceDetailPage,
   ResourceDetailReleaseSection,
@@ -418,9 +417,7 @@ export function PluginDetail({
             ) : null}
           </PluginDetailTable>
         </ResourceDetailReleaseSection>
-        <ResourceDetailIncludesSection label="Capabilities">
-          <PluginIncludes plugin={plugin} />
-        </ResourceDetailIncludesSection>
+        <PluginIncludes plugin={plugin} />
         {/*
           Services and schedules are two different objects with two different
           status vocabularies, so they stay under their own names and use

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -99,13 +99,12 @@ function renderPlugin(plugin: PluginListItem) {
 }
 
 describe("Plugin detail recipe", () => {
-  it("places quiet release facts between About and Capabilities", () => {
+  it("omits Capabilities when the plugin has no capability rows", () => {
     const { container } = renderPlugin(PLUGIN);
 
     expect(renderedRecipe(container)).toEqual([
       ["overview", "About"],
       ["release", "Release"],
-      ["includes", "Capabilities"],
     ]);
   });
 
@@ -129,7 +128,6 @@ describe("Plugin detail recipe", () => {
     expect(renderedRecipe(container)).toEqual([
       ["overview", "About"],
       ["release", "Release"],
-      ["includes", "Capabilities"],
       ["activity", "Background services"],
       ["activity", "Scheduled jobs"],
     ]);
@@ -144,7 +142,6 @@ describe("Plugin detail recipe", () => {
     expect(renderedRecipe(container)).toEqual([
       ["overview", "About"],
       ["release", "Release"],
-      ["includes", "Capabilities"],
       ["activity", "Background services"],
     ]);
   });
@@ -266,16 +263,17 @@ describe("Plugin detail recipe", () => {
     expect(screen.getByText("Issues")).toBeTruthy();
   });
 
-  it("explains empty capabilities instead of dropping the section", () => {
-    const { container } = renderPlugin(PLUGIN);
+  it("does not preview an unloaded frontend app as a capability", () => {
+    const { container } = renderPlugin({
+      ...PLUGIN,
+      app: { hasApp: true, bundle: null },
+    });
 
-    expect(renderedRecipe(container)).toContainEqual([
+    expect(renderedRecipe(container)).not.toContainEqual([
       "includes",
       "Capabilities",
     ]);
-    expect(
-      screen.getByText("This plugin declares no user-facing capabilities."),
-    ).toBeTruthy();
+    expect(screen.queryByText("Frontend app")).toBeNull();
   });
 
   it("keeps a disabled plugin's static capabilities and explains the missing live ones", () => {
@@ -325,22 +323,28 @@ describe("Plugin detail recipe", () => {
     expect(screen.queryByText(/commands, settings, agent tools/)).toBeNull();
   });
 
-  it("says an enabled plugin is not running rather than claiming it declares nothing", () => {
-    renderPlugin({ ...PLUGIN, enabled: true, status: "error" });
+  it("omits Capabilities when an enabled plugin is not running and has no static rows", () => {
+    const { container } = renderPlugin({
+      ...PLUGIN,
+      enabled: true,
+      status: "error",
+    });
 
-    expect(
-      screen.getByText(
-        "This plugin isn't running yet, so what it adds can't be listed.",
-      ),
-    ).toBeTruthy();
+    expect(renderedRecipe(container).map(([, label]) => label)).not.toContain(
+      "Capabilities",
+    );
   });
 
-  it("keeps a disabled plugin with nothing static on the same explanation", () => {
-    renderPlugin({ ...PLUGIN, enabled: false, status: "disabled" });
+  it("omits Capabilities when a disabled plugin has no static rows", () => {
+    const { container } = renderPlugin({
+      ...PLUGIN,
+      enabled: false,
+      status: "disabled",
+    });
 
-    expect(
-      screen.getByText("Enable this plugin to see what it adds to bb."),
-    ).toBeTruthy();
+    expect(renderedRecipe(container).map(([, label]) => label)).not.toContain(
+      "Capabilities",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- render the plugin Capabilities section only when real capability rows are available
- remove the fabricated Frontend app preview for unloaded plugin surfaces
- preserve static and live capability rows, including the existing disabled-plugin context when rows exist

## Verification

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/tools/detail-page-recipes.test.tsx src/views/ToolsView.plugin-detail.test.tsx` — 63 passed
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed
- branch dev app: Ask User Question omits the empty section; Docs retains its populated capability table

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>