### PR TITLE
Name Docs capabilities by their function

### DIFF
--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -1232,4 +1232,69 @@ describe("PluginDetail capability inventory", () => {
         ),
     ).toBe(true);
   });
+
+  it("names repeated product-titled surfaces by their actual capability", () => {
+    const EmptySlot = () => null;
+    setPluginSlotRegistrations("simple-notes", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [
+        {
+          id: "docs",
+          title: "Docs",
+          icon: "FileText",
+          path: "docs",
+          component: EmptySlot,
+        },
+      ],
+      threadPanelActions: [
+        {
+          id: "document",
+          title: "Document",
+          icon: "FileText",
+          component: EmptySlot,
+        },
+      ],
+      composerCustomizations: [],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [
+        {
+          id: "docs",
+          title: "Markdown",
+          extensions: ["md", "mdx", "markdown"],
+          component: EmptySlot,
+        },
+      ],
+      messageDirectives: [{ id: "docs", component: EmptySlot }],
+      messageActions: [],
+    });
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginDetail
+            isLoading={false}
+            plugin={{
+              ...GITHUB_PLUGIN,
+              id: "simple-notes",
+              name: "Docs",
+              capabilities: [],
+            }}
+            pending={false}
+            openSourceDisabled
+            onToggle={() => {}}
+            onEdit={() => {}}
+            onOpenSource={() => {}}
+            onDelete={() => {}}
+          />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText("Docs")).toHaveLength(2);
+    for (const label of ["Document", "Markdown", "::docs"]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
 });

--- a/apps/cli/src/__tests__/docs-official-plugin-bundle.test.ts
+++ b/apps/cli/src/__tests__/docs-official-plugin-bundle.test.ts
@@ -135,7 +135,7 @@ describe("Docs official plugin frontend bundle", () => {
     expect(registered.homepageSection).toHaveLength(0);
     expect(registered.threadPanelAction[0]).toMatchObject({
       id: "document",
-      title: "Docs",
+      title: "Document",
     });
     expect(typeof registered.threadPanelAction[0]?.component).toBe("function");
     expect(registered.messageDirective[0]).toMatchObject({ id: "docs" });
@@ -143,7 +143,7 @@ describe("Docs official plugin frontend bundle", () => {
     expect(registered.sidebarFooterAction).toHaveLength(0);
     expect(registered.fileOpener[0]).toMatchObject({
       id: "docs",
-      title: "Docs",
+      title: "Markdown",
       extensions: ["md", "mdx", "markdown"],
     });
     expect(typeof registered.fileOpener[0]?.component).toBe("function");

--- a/official-plugins/docs/app.test.tsx
+++ b/official-plugins/docs/app.test.tsx
@@ -92,11 +92,11 @@ describe("Docs nav panel", () => {
     expect(app.messageDirectives[0]?.id).toBe("docs");
     expect(app.threadPanelActions[0]).toMatchObject({
       id: "document",
-      title: "Docs",
+      title: "Document",
     });
     expect(app.fileOpeners[0]).toMatchObject({
       id: "docs",
-      title: "Docs",
+      title: "Markdown",
       extensions: ["md", "mdx", "markdown"],
     });
   });

--- a/official-plugins/docs/app.tsx
+++ b/official-plugins/docs/app.tsx
@@ -2275,13 +2275,13 @@ export default definePluginApp((app) => {
   });
   app.slots.threadPanelAction({
     id: "document",
-    title: "Docs",
+    title: "Document",
     icon: "FileText",
     component: DocumentPanel,
   });
   app.slots.fileOpener({
     id: "docs",
-    title: "Docs",
+    title: "Markdown",
     extensions: ["md", "mdx", "markdown"],
     component: DocsFileOpener,
   });


### PR DESCRIPTION
## Summary

- rename the BB-owned Docs thread-panel registration to Document
- rename the BB-owned Docs file-opener registration to Markdown
- verify plugin details render the real registered capability names without Docs-specific presentation logic

## Verification

- 30 focused plugin-detail tests passed
- 57 Docs plugin tests passed
- 368 CLI tests passed
- Turbo typecheck passed for @bb/app, @bb/cli, and bb-plugin-simple-notes
- visually verified the enabled Docs detail page in the branch Electron app