### PR TITLE
Polish inactive automation prompt controls

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -49,7 +49,10 @@ export function PluginsOverview() {
   const [searchParams, setSearchParams] = useSearchParams();
   const listQuery = usePluginList({ enabled: true });
   const catalogQuery = usePluginCatalogSearch("", { enabled: true });
-  const plugins = listQuery.data?.plugins ?? [];
+  const plugins = useMemo(
+    () => listQuery.data?.plugins ?? [],
+    [listQuery.data?.plugins],
+  );
   const activeMode = modeFromSearchParams(searchParams.get("view"));
   const [installedQuery, setInstalledQuery] = useState("");
   const [installedCategory, setInstalledCategory] = useState<string | null>(

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -645,9 +645,15 @@ describe("Automation detail recipe", () => {
     expect(savedPrompt.getAttribute("aria-readonly")).toBe("true");
     expect(savedPrompt.getAttribute("aria-disabled")).toBe("true");
     expect(savedPrompt.className).toContain("text-muted-foreground");
-    expect(savedPrompt.parentElement?.className).toContain(
+    const readOnlyPromptShell = container.querySelector(
+      '[data-automation-prompt-readonly-shell=""]',
+    ) as HTMLElement;
+    expect(readOnlyPromptShell.className).toContain("rounded-xl");
+    expect(readOnlyPromptShell.className).toContain("border-border");
+    expect(readOnlyPromptShell.className).toContain(
       "bg-surface-recessed/55",
     );
+    expect(readOnlyPromptShell.contains(savedPrompt)).toBe(true);
     expect(savedPrompt.textContent).toBe("Summarize yesterday's commits.");
     expect(screen.queryByRole("button", { name: "Save Prompt" })).toBeNull();
     const disabledModelSelector = container.querySelector(
@@ -658,6 +664,10 @@ describe("Automation detail recipe", () => {
     ) as HTMLButtonElement;
     expect(disabledModelSelector.disabled).toBe(true);
     expect(disabledPermissionSelector.disabled).toBe(true);
+    expect(readOnlyPromptShell.contains(disabledModelSelector)).toBe(true);
+    expect(readOnlyPromptShell.contains(disabledPermissionSelector)).toBe(
+      true,
+    );
     expect(
       disabledModelSelector.querySelector(
         '[data-automation-selector-content=""]',
@@ -667,11 +677,21 @@ describe("Automation detail recipe", () => {
     expect(disabledModelSelector.parentElement?.getAttribute("data-state")).toBe(
       null,
     );
-    const editButton = screen.getByRole("button", { name: "Edit via chat" });
+    const readOnlyPromptFooter = container.querySelector(
+      '[data-automation-prompt-footer=""]',
+    ) as HTMLElement;
+    expect(readOnlyPromptShell.contains(readOnlyPromptFooter)).toBe(true);
+    expect(readOnlyPromptFooter.className).toContain("border-t");
+    expect(readOnlyPromptFooter.className).not.toContain("mt-1");
+    const editButton = screen.getByRole("button", { name: "Edit prompt" });
     expect(editButton.querySelector('[data-icon="Edit"]')).not.toBeNull();
-    expect(editButton.className).toContain("size-7");
-    expect(editButton.className).toContain("bg-surface-raised");
-    expect(editButton.className).toContain("border-border");
+    expect(editButton.className).toContain("size-6");
+    expect(editButton.className).not.toContain("bg-surface-raised");
+    expect(editButton.className).not.toContain("border-border");
+    fireEvent.pointerMove(editButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Edit prompt",
+    );
 
     fireEvent.click(editButton);
 
@@ -679,6 +699,9 @@ describe("Automation detail recipe", () => {
       name: "Automation prompt",
     }) as HTMLTextAreaElement;
     const promptPanel = promptContent.closest("form") as HTMLElement;
+    expect(
+      container.querySelector('[data-automation-prompt-readonly-shell=""]'),
+    ).toBeNull();
     expect(promptPanel.className).toContain("bg-background");
     expect(promptPanel.className).toContain("rounded-xl");
     expect(promptPanel.className).toContain("shadow-lift");

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -754,6 +754,7 @@ function AgentAutomationDefinition({
   ) : (
     <ResourcePromptPreview
       disabled
+      className="rounded-none border-0 bg-transparent"
       context={[
         {
           label: (
@@ -777,74 +778,89 @@ function AgentAutomationDefinition({
     </ResourcePromptPreview>
   );
 
+  const promptFooter = (
+    <div
+      data-automation-prompt-footer=""
+      className={cn(
+        "flex min-h-6 min-w-0 items-center justify-between gap-2 px-3.5 text-xs text-muted-foreground",
+        editing ? "mt-1" : "border-t border-border/70 py-1.5",
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+        {!personalProject ? (
+          <OptionDisplay
+            label="Project"
+            value={projectContextLabel}
+            compactValue={projectContextLabel}
+            leading={
+              <Icon name="Folder" className="size-3.5 shrink-0" aria-hidden />
+            }
+            className="shrink-0"
+            muted
+          />
+        ) : null}
+        <OptionDisplay
+          label="Environment"
+          value={
+            execution.targetThreadId !== undefined
+              ? "Existing thread"
+              : automationEnvironmentLabel(execution)
+          }
+          compactValue={automationEnvironmentCompactLabel(execution)}
+          leading={
+            <Icon
+              name={automationEnvironmentIcon(execution)}
+              className="size-3.5 shrink-0"
+              aria-hidden
+            />
+          }
+          muted
+        />
+      </div>
+      {editing ? (
+        <AutomationSelector
+          label="Permission mode"
+          value={permissionMode}
+          options={permissionOptions}
+          disabled={pending || options === null}
+          onValueChange={(value) => {
+            const next = options?.permissionModes.find(
+              (mode) => mode === value,
+            );
+            if (next !== undefined) setPermissionMode(next);
+          }}
+          className="h-6 shrink-0"
+        />
+      ) : (
+        <DisabledAutomationSelector
+          label="Permission mode"
+          value={formatPermissionMode(execution.permissionMode)}
+          compactValue={formatPermissionModeCompact(execution.permissionMode)}
+          className="h-6 shrink-0"
+        />
+      )}
+    </div>
+  );
+
   return (
     <div data-promptbox-shell="" className="min-w-0">
-      {promptBox}
+      {editing ? (
+        promptBox
+      ) : (
+        <div
+          data-automation-prompt-readonly-shell=""
+          className="overflow-hidden rounded-xl border border-border bg-surface-recessed/55"
+        >
+          {promptBox}
+          {promptFooter}
+        </div>
+      )}
       {optionsError ? (
         <p className="mt-1 px-3.5 text-xs text-destructive">
           Couldn&apos;t load model options. {optionsError}
         </p>
       ) : null}
-      <div
-        data-automation-prompt-footer=""
-        className="mt-1 flex min-h-6 min-w-0 items-center justify-between gap-2 px-3.5 text-xs text-muted-foreground"
-      >
-        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-          {!personalProject ? (
-            <OptionDisplay
-              label="Project"
-              value={projectContextLabel}
-              compactValue={projectContextLabel}
-              leading={
-                <Icon name="Folder" className="size-3.5 shrink-0" aria-hidden />
-              }
-              className="shrink-0"
-              muted
-            />
-          ) : null}
-          <OptionDisplay
-            label="Environment"
-            value={
-              execution.targetThreadId !== undefined
-                ? "Existing thread"
-                : automationEnvironmentLabel(execution)
-            }
-            compactValue={automationEnvironmentCompactLabel(execution)}
-            leading={
-              <Icon
-                name={automationEnvironmentIcon(execution)}
-                className="size-3.5 shrink-0"
-                aria-hidden
-              />
-            }
-            muted
-          />
-        </div>
-        {editing ? (
-          <AutomationSelector
-            label="Permission mode"
-            value={permissionMode}
-            options={permissionOptions}
-            disabled={pending || options === null}
-            onValueChange={(value) => {
-              const next = options?.permissionModes.find(
-                (mode) => mode === value,
-              );
-              if (next !== undefined) setPermissionMode(next);
-            }}
-            className="h-6 shrink-0"
-          />
-        ) : (
-          <DisabledAutomationSelector
-            label="Permission mode"
-            value={formatPermissionMode(execution.permissionMode)}
-            compactValue={formatPermissionModeCompact(
-              execution.permissionMode,
-            )}
-            className="h-6 shrink-0"
-          />
-        )}
-      </div>
+      {editing ? promptFooter : null}
     </div>
   );
 }
@@ -950,13 +966,12 @@ export function AutomationDetailView({
           actions={
             <ResourceActionButton
               label={
-                execution.mode === "agent" ? "Edit via chat" : "Edit with chat"
+                execution.mode === "agent" ? "Edit prompt" : "Edit with chat"
               }
               tooltipLabel={
-                execution.mode === "agent" ? "Edit via chat" : "Edit with chat"
+                execution.mode === "agent" ? "Edit prompt" : "Edit with chat"
               }
               icon="Edit"
-              className="size-7 border border-border bg-surface-raised text-foreground shadow-xs hover:bg-accent hover:text-foreground"
               onClick={onEdit}
             />
           }


### PR DESCRIPTION
## Summary

- use the standard resource icon-button treatment for Edit prompt
- group the inactive prompt and its disabled model, project, environment, and permission controls into one cohesive surface
- preserve the existing active editing and save behavior

## Verification

- 34 focused automation detail recipe tests passed
- 55 automation plugin tests passed
- Turbo typecheck passed for @bb/app and bb-plugin-automations
- visually verified inactive and active editing states in the branch Electron app