### PR TITLE
Polish extensions browsing and details

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -201,14 +201,12 @@ describe("PluginsOverview", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
     expect(await screen.findByText("GitHub")).toBeTruthy();
-    expect(
-      screen.getByRole("radio", { name: "Developer tools" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Developer tools" })).toBeTruthy();
     expect(screen.queryByText("BB Official plugins")).toBeNull();
     expect(screen.getByRole("button", { name: "New plugin" })).toBeTruthy();
   });
 
-  it("filters installed plugins with the catalog categories", async () => {
+  it("shows category filters only in Browse", async () => {
     installFetch([
       AUTOMATIONS_PLUGIN,
       {
@@ -234,32 +232,36 @@ describe("PluginsOverview", () => {
     expect(await screen.findByText("Automations")).toBeTruthy();
     expect(screen.getByText("Docs")).toBeTruthy();
     expect(
-      screen.getByRole("radio", { name: "Developer tools" }),
-    ).toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("radio", { name: "Context & knowledge" }),
-    );
+      screen.queryByRole("radiogroup", {
+        name: "Filter plugins by category",
+      }),
+    ).toBeNull();
+    expect(screen.queryByText("Category")).toBeNull();
 
+    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
+    expect(
+      await screen.findByRole("radiogroup", {
+        name: "Filter plugins by category",
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Category")).toBeNull();
+    fireEvent.click(screen.getByRole("radio", { name: "Context & knowledge" }));
     expect(screen.getByText("Docs")).toBeTruthy();
     expect(screen.queryByText("Automations")).toBeNull();
-    fireEvent.click(
-      screen.getByRole("radio", { name: "Show all plugin categories" }),
-    );
-    expect(screen.getByText("Automations")).toBeTruthy();
   });
 
   it("keeps category pills visually secondary to the collection tabs", async () => {
     installFetch();
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=browse"]}>
         <QueryClientWrapper>
           <PluginsOverview />
         </QueryClientWrapper>
       </MemoryRouter>,
     );
 
-    await screen.findByText("Automations");
+    await screen.findByText("GitHub");
     const filters = screen.getByRole("radiogroup", {
       name: "Filter plugins by category",
     });
@@ -268,17 +270,11 @@ describe("PluginsOverview", () => {
     });
     expect(filters.className).toContain("py-2");
     expect(filters.className).toContain("gap-2");
-    expect(all.className).toContain("data-[state=on]:bg-secondary");
+    expect(all.className).toContain("data-[state=on]:bg-secondary/70");
     expect(all.className).not.toContain("data-[state=on]:bg-state-active");
-    expect(
-      screen.getByRole("tab", { name: "Installed, 1 plugin" }).className,
-    ).toContain("bg-accent");
-    expect(
-      screen.queryByRole("button", { name: "Automations actions" }),
-    ).toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Automations plugin details" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Browse" }).className).toContain(
+      "bg-accent",
+    );
   });
 
   it("opens installed resources on the canonical Tools detail route", async () => {

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -23,8 +23,6 @@ import {
 } from "@/components/plugin/management/AddPluginDialog";
 import { BrowsePluginsTab } from "@/components/plugin/management/BrowsePluginsTab";
 import { InstalledPluginsTab } from "@/components/plugin/management/InstalledPluginsTab";
-import { PluginCategoryFilterPills } from "@/components/plugin/management/PluginCategoryFilterPills";
-import { usePluginCatalogSearch } from "@/hooks/queries/plugin-catalog-queries";
 import { usePluginList } from "@/hooks/queries/plugin-settings-queries";
 import {
   getPluginDetailRoutePath,
@@ -48,13 +46,12 @@ export function PluginsOverview() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const listQuery = usePluginList({ enabled: true });
-  const catalogQuery = usePluginCatalogSearch("", { enabled: true });
-  const plugins = listQuery.data?.plugins ?? [];
+  const plugins = useMemo(
+    () => listQuery.data?.plugins ?? [],
+    [listQuery.data?.plugins],
+  );
   const activeMode = modeFromSearchParams(searchParams.get("view"));
   const [installedQuery, setInstalledQuery] = useState("");
-  const [installedCategory, setInstalledCategory] = useState<string | null>(
-    null,
-  );
   const [installedViewport, setInstalledViewport] =
     useState<HTMLDivElement | null>(null);
   const installedPageSize = useResourceViewportPageSize(installedViewport);
@@ -78,41 +75,10 @@ export function PluginsOverview() {
     { id: "browse" as const, label: "Browse" },
   ];
   const normalizedInstalledQuery = installedQuery.trim().toLowerCase();
-  const categoryByPluginId = useMemo(() => {
-    const categories = new Map<string, string>();
-    for (const entry of catalogQuery.data ?? []) {
-      categories.set(entry.entryId, entry.category);
-      categories.set(entry.pluginId, entry.category);
-    }
-    return categories;
-  }, [catalogQuery.data]);
-  const installedCategories = useMemo(() => {
-    const categories: string[] = [];
-    for (const entry of catalogQuery.data ?? []) {
-      if (!categories.includes(entry.category)) {
-        categories.push(entry.category);
-      }
-    }
-    if (
-      installedCategory !== null &&
-      !categories.includes(installedCategory)
-    ) {
-      categories.push(installedCategory);
-    }
-    return categories;
-  }, [catalogQuery.data, installedCategory]);
   const visiblePlugins = useMemo(
     () =>
       plugins
         .filter((plugin) => {
-          if (installedCategory !== null) {
-            const category =
-              (plugin.catalogEntryId === null
-                ? undefined
-                : categoryByPluginId.get(plugin.catalogEntryId)) ??
-              categoryByPluginId.get(plugin.id);
-            if (category !== installedCategory) return false;
-          }
           if (normalizedInstalledQuery.length === 0) return true;
           return [
             plugin.id,
@@ -145,21 +111,11 @@ export function PluginsOverview() {
           }
           return left.id.localeCompare(right.id);
         }),
-    [
-      categoryByPluginId,
-      installedCategory,
-      installedSortDirection,
-      normalizedInstalledQuery,
-      plugins,
-    ],
+    [installedSortDirection, normalizedInstalledQuery, plugins],
   );
   const installedPagination = useResourcePagination(visiblePlugins, {
     pageSize: installedPageSize,
-    resetKey: [
-      normalizedInstalledQuery,
-      installedCategory ?? "all",
-      installedSortDirection,
-    ].join("\u0000"),
+    resetKey: [normalizedInstalledQuery, installedSortDirection].join("\u0000"),
   });
   const hasInstalledPagination =
     !listQuery.isError &&
@@ -251,11 +207,6 @@ export function PluginsOverview() {
         }
         contentClassName="space-y-3"
       >
-        <PluginCategoryFilterPills
-          categories={installedCategories}
-          value={installedCategory}
-          onValueChange={setInstalledCategory}
-        />
         {listQuery.isError ? (
           <ResourceListState
             state="error"
@@ -267,11 +218,7 @@ export function PluginsOverview() {
         ) : plugins.length > 0 && visiblePlugins.length === 0 ? (
           <ResourceListState
             state="empty"
-            message={
-              installedCategory === null
-                ? `No plugins match "${installedQuery}"`
-                : `No installed plugins match ${installedCategory}.`
-            }
+            message={`No plugins match "${installedQuery}"`}
           />
         ) : (
           <InstalledPluginsTab plugins={installedPagination.items} />

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -1,11 +1,6 @@
 // @vitest-environment jsdom
 
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
@@ -90,6 +85,55 @@ afterEach(() => {
 });
 
 describe("BrowsePluginsTab", () => {
+  it("sorts by plugin name ascending by default and reverses direction", async () => {
+    const entries = [
+      { ...MEMORY_ENTRY, displayName: "Zulu" },
+      { ...GITHUB_ENTRY, displayName: "Alpha" },
+      { ...INCOMPATIBLE_ENTRY, displayName: "Middle" },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/v1/plugin-catalog") {
+          return jsonResponse({ catalog: CATALOG_STATUS });
+        }
+        if (url === "/api/v1/plugin-catalog/search?q=") {
+          return jsonResponse({ results: entries });
+        }
+        if (url === "/api/v1/plugins") {
+          return jsonResponse({ enabled: true, plugins: [] });
+        }
+        return jsonResponse({ error: "not found" }, 404);
+      }),
+    );
+
+    const { wrapper } = createQueryClientTestHarness();
+    render(<BrowsePluginsTab onInstall={() => {}} onOpenPlugin={() => {}} />, {
+      wrapper,
+    });
+
+    expect(await screen.findByText("Alpha")).toBeTruthy();
+    const cardOrder = () =>
+      [
+        ...document.querySelectorAll<HTMLButtonElement>(
+          'button[aria-label^="Open "][aria-label$=" details"]',
+        ),
+      ].map((button) => button.getAttribute("aria-label"));
+    expect(cardOrder()).toEqual([
+      "Open Alpha details",
+      "Open Middle details",
+      "Open Zulu details",
+    ]);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Sort" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Plugin name" }));
+    expect(cardOrder()).toEqual([
+      "Open Zulu details",
+      "Open Middle details",
+      "Open Alpha details",
+    ]);
+  });
+
   it("renders every catalog entry once and filters the grid with category pills", async () => {
     const entries = Array.from(
       { length: CATALOG_STATUS.pluginCount },
@@ -98,8 +142,7 @@ describe("BrowsePluginsTab", () => {
         entryId: `official-${index + 1}`,
         pluginId: `official-${index + 1}`,
         displayName: `Official ${index + 1}`,
-        category:
-          index % 2 === 0 ? "Context & knowledge" : "Developer tools",
+        category: index % 2 === 0 ? "Context & knowledge" : "Developer tools",
       }),
     );
     vi.stubGlobal(
@@ -133,9 +176,7 @@ describe("BrowsePluginsTab", () => {
     expect(
       screen.queryByRole("heading", { name: "Context & knowledge" }),
     ).toBeNull();
-    fireEvent.click(
-      screen.getByRole("radio", { name: "Developer tools" }),
-    );
+    fireEvent.click(screen.getByRole("radio", { name: "Developer tools" }));
     expect(
       screen.getAllByRole("button", { name: /^Open Official \d+ details$/ }),
     ).toHaveLength(6);
@@ -192,16 +233,18 @@ describe("BrowsePluginsTab", () => {
       .getByRole("button", { name: "Open GitHub details" })
       .closest('[class*="auto-fill"]');
     expect(githubGrid?.className).toContain("auto-fill");
+    expect(githubGrid?.className).toContain("18rem");
+    const githubCard = screen
+      .getByRole("button", { name: "Open GitHub details" })
+      .closest(".group");
+    expect(githubCard?.className).toContain("min-h-20");
+    expect(githubCard?.className).toContain("p-2.5");
     expect(
       screen.getByRole("radio", { name: "Context & knowledge" }),
     ).toBeTruthy();
-    expect(
-      screen.getByRole("radio", { name: "Developer tools" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Developer tools" })).toBeTruthy();
     expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Install Memory" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Install Memory" })).toBeTruthy();
     expect(screen.queryByText("BB Official plugins")).toBeNull();
 
     expect(screen.queryByText(MEMORY_ENTRY.source)).toBeNull();

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -8,6 +8,7 @@ import {
   ResourceInstallControl,
   ResourceInstalledControl,
   ResourceListState,
+  ResourceSortMenu,
   ResourceToolbar,
 } from "@bb/shared-ui/resource-list";
 import {
@@ -39,6 +40,7 @@ export function BrowsePluginsTab({
 }) {
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [debouncedQuery] = useDebounceValue(query.trim(), 300);
   const searchQuery = usePluginCatalogSearch(debouncedQuery, { enabled: true });
   const entries = searchQuery.data ?? [];
@@ -49,10 +51,17 @@ export function BrowsePluginsTab({
   if (category !== null && !categories.includes(category)) {
     categories.push(category);
   }
-  const visibleEntries =
+  const visibleEntries = (
     category === null
       ? entries
-      : entries.filter((entry) => entry.category === category);
+      : entries.filter((entry) => entry.category === category)
+  )
+    .slice()
+    .sort((left, right) => {
+      const result = left.displayName.localeCompare(right.displayName);
+      if (result !== 0) return sortDirection === "asc" ? result : -result;
+      return left.entryId.localeCompare(right.entryId);
+    });
 
   return (
     <ResourceCollectionViewport
@@ -63,6 +72,19 @@ export function BrowsePluginsTab({
           searchValue={query}
           searchPlaceholder="Search plugins"
           onSearchChange={setQuery}
+          containedControls
+          controls={
+            <ResourceSortMenu
+              value="alpha"
+              direction={sortDirection}
+              options={[{ id: "alpha", label: "Plugin name" }]}
+              onChange={() =>
+                setSortDirection((current) =>
+                  current === "asc" ? "desc" : "asc",
+                )
+              }
+            />
+          }
         />
       }
     >
@@ -103,7 +125,7 @@ export function BrowsePluginsTab({
               message="No plugins match this category."
             />
           ) : (
-            <ResourceBrowseGrid className="grid-cols-[repeat(auto-fill,minmax(min(100%,23rem),1fr))]">
+            <ResourceBrowseGrid className="grid-cols-[repeat(auto-fill,minmax(min(100%,18rem),1fr))] gap-2">
               {visibleEntries.map((entry) => (
                 <BrowseCard
                   key={entry.entryId}
@@ -194,6 +216,7 @@ function BrowseCard({
   return (
     <>
       <ResourceBrowseCard
+        className="min-h-20 gap-x-2 gap-y-1.5 p-2.5"
         leading={leading}
         title={entry.displayName}
         description={description}

--- a/apps/app/src/components/plugin/management/PluginCategoryFilterPills.tsx
+++ b/apps/app/src/components/plugin/management/PluginCategoryFilterPills.tsx
@@ -27,7 +27,7 @@ export function PluginCategoryFilterPills({
       <ToggleGroupItem
         value={ALL_CATEGORIES}
         aria-label="Show all plugin categories"
-        className="h-7 min-w-0 rounded-full border border-border bg-transparent px-3 text-xs text-muted-foreground shadow-none hover:bg-secondary/70 hover:text-foreground data-[state=on]:border-transparent data-[state=on]:bg-secondary data-[state=on]:text-secondary-foreground"
+        className="h-7 min-w-0 rounded-full border border-border bg-transparent px-3 text-xs text-muted-foreground shadow-none hover:bg-secondary/50 hover:text-foreground data-[state=on]:border-transparent data-[state=on]:bg-secondary/70 data-[state=on]:text-secondary-foreground"
       >
         All
       </ToggleGroupItem>
@@ -35,7 +35,7 @@ export function PluginCategoryFilterPills({
         <ToggleGroupItem
           key={category}
           value={category}
-          className="h-7 min-w-0 rounded-full border border-border bg-transparent px-3 text-xs text-muted-foreground shadow-none hover:bg-secondary/70 hover:text-foreground data-[state=on]:border-transparent data-[state=on]:bg-secondary data-[state=on]:text-secondary-foreground"
+          className="h-7 min-w-0 rounded-full border border-border bg-transparent px-3 text-xs text-muted-foreground shadow-none hover:bg-secondary/50 hover:text-foreground data-[state=on]:border-transparent data-[state=on]:bg-secondary/70 data-[state=on]:text-secondary-foreground"
         >
           {category}
         </ToggleGroupItem>

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -14,6 +14,7 @@ import {
   PluginDetailGlyph,
   PluginDetailRow,
   PluginDetailTable,
+  PLUGIN_DETAIL_HEADER_CELL_CLASS,
   PLUGIN_DETAIL_PRIMARY_COLUMN_CLASS,
 } from "@/components/tools/plugin-detail-table";
 import { formatAbsoluteDate } from "@/components/plugin/management/plugin-ui";
@@ -274,11 +275,7 @@ function pluginAppSurfaceItems(
   ];
 }
 
-export function PluginIncludes({
-  plugin,
-}: {
-  plugin: PluginListItem;
-}) {
+export function PluginIncludes({ plugin }: { plugin: PluginListItem }) {
   const slots = usePluginSlots();
   const appItems = pluginAppSurfaceItems(plugin.id, slots);
 
@@ -344,6 +341,8 @@ export function PluginIncludes({
     groupItems.map((item) => ({ ...item, icon, kind })),
   );
 
+  if (!plugin.enabled || items.length === 0) return null;
+
   // Commands, settings, agent tools, thread integrations and app surfaces are
   // only observable on a *running* plugin — not merely an enabled one. A
   // plugin that is enabled but failed to load, or is still loading, reports
@@ -357,11 +356,8 @@ export function PluginIncludes({
     plugin.status === "running" ||
     plugin.status === "degraded" ||
     plugin.status === "needs-configuration";
-  const liveCapabilitiesNote = plugin.enabled
-    ? "This plugin isn't running, so its commands, settings, agent tools, app surfaces, and thread integrations can't be listed."
-    : "Some capabilities are only listed while the plugin is enabled.";
-
-  if (items.length === 0) return null;
+  const liveCapabilitiesNote =
+    "This plugin isn't running, so its commands, settings, agent tools, app surfaces, and thread integrations can't be listed.";
 
   return (
     <ResourceDetailIncludesSection label="Capabilities">
@@ -506,14 +502,23 @@ export function PluginServices({ plugin }: { plugin: PluginListItem }) {
           <col className={PLUGIN_DETAIL_PRIMARY_COLUMN_CLASS} />
           <col />
         </colgroup>
-        <thead className="bg-surface-recessed/55 text-xs text-muted-foreground">
+        <thead className="text-xs text-muted-foreground">
           <tr className="border-b border-border">
-            <th scope="col" className="px-4 py-2 font-medium">
+            <th
+              scope="col"
+              className={cn(
+                PLUGIN_DETAIL_HEADER_CELL_CLASS,
+                "px-4 py-2 font-medium",
+              )}
+            >
               Status
             </th>
             <th
               scope="col"
-              className="border-l border-border px-4 py-2 font-medium"
+              className={cn(
+                PLUGIN_DETAIL_HEADER_CELL_CLASS,
+                "border-l border-border px-4 py-2 font-medium",
+              )}
             >
               Service
             </th>

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -17,6 +17,7 @@ import {
   ResourceRowDetailChevron,
   ResourceSortMenu,
   ResourceToolbar,
+  type ResourceOption,
 } from "@bb/shared-ui/resource-list";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { TOOLS_OWNED_COLLECTION_LABEL } from "@/components/tools/tools-navigation";
@@ -63,6 +64,12 @@ function providerFilterLabel(provider: ResourceProviderFilter): string {
   return provider === "bb" ? "bb" : providerLabel(provider);
 }
 
+function isResourceProviderFilter(
+  value: string,
+): value is ResourceProviderFilter {
+  return value === "bb" || value === "claude-code" || value === "codex";
+}
+
 function skillSourceFilterId(
   skill: SkillSummary,
 ): ResourceSkillSourceFilter | null {
@@ -72,7 +79,7 @@ function skillSourceFilterId(
 }
 
 function skillSourceFilterLabel(source: ResourceSkillSourceFilter): string {
-  return source === "bb-official" ? "BB official" : "Included";
+  return source === "bb-official" ? "bb official" : "Included in plugin";
 }
 
 function isResourceSkillSourceFilter(
@@ -111,6 +118,36 @@ function BbLogo({ className = "size-4" }: { className?: string }) {
   );
 }
 
+function ProviderFilterTooltip({
+  options,
+}: {
+  options: readonly ResourceOption[];
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span>Providers: </span>
+      {options.map((option) => {
+        if (!isResourceProviderFilter(option.id)) return null;
+        const provider = option.id;
+        return (
+          <span
+            key={option.id}
+            className="flex size-3.5 items-center justify-center"
+            data-provider-icon={provider}
+            aria-hidden="true"
+          >
+            {provider === "bb" ? (
+              <BbLogo className="size-3.5 brightness-0 invert" />
+            ) : (
+              <ProviderLogo providerId={provider} className="size-3.5" />
+            )}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
 export function SkillProvenanceTooltip({
   prefix,
   providerId,
@@ -129,10 +166,7 @@ export function SkillProvenanceTooltip({
         ) : (
           <ProviderLogo
             providerId={providerId}
-            className={cn(
-              "size-3.5",
-              providerId === "codex" && "text-white",
-            )}
+            className={cn("size-3.5", providerId === "codex" && "text-white")}
           />
         )}
       </span>
@@ -383,11 +417,11 @@ export function SkillsOverview({
     <ResourceListState
       state="empty"
       message={
-        normalizedQuery === "" && providerFilters.length === 0
-          ? "No skills in your library."
-          : normalizedQuery === ""
-            ? "No skills match these providers."
-            : `No skills match "${query}"`
+        normalizedQuery !== ""
+          ? `No skills match "${query}"`
+          : skills.length === 0
+            ? "No skills in your library."
+            : "No skills match these filters."
       }
     />
   ) : (
@@ -438,10 +472,12 @@ export function SkillsOverview({
               controls={
                 <>
                   <ResourceMultiSelectMenu
-                    label="Source"
+                    label="Type"
                     icon="PackageReceive"
                     selectedValues={sourceFilters}
                     options={sourceOptions}
+                    allOptionLabel="All"
+                    emptySelectionLabel="None"
                     selectedLabel={(options) =>
                       options.map((option) => option.label).join(", ")
                     }
@@ -459,6 +495,9 @@ export function SkillsOverview({
                     selectedLabel={(options) =>
                       options.map((option) => option.label).join(", ")
                     }
+                    selectedTooltip={(options) => (
+                      <ProviderFilterTooltip options={options} />
+                    )}
                     onChange={(values) =>
                       setProviderFilters(values as ResourceProviderFilter[])
                     }

--- a/apps/app/src/components/tools/automation-overview.test.tsx
+++ b/apps/app/src/components/tools/automation-overview.test.tsx
@@ -120,6 +120,66 @@ describe("AutomationOverviewView", () => {
     expect(screen.getByRole("button", { name: "New automation" })).toBeTruthy();
   });
 
+  it("labels the Projects filter and prefixes its tooltip summary", async () => {
+    render(
+      <AutomationOverviewView
+        entries={INSTALLED_AUTOMATIONS}
+        error={null}
+        onRetry={() => {}}
+        onOpenDetail={() => {}}
+        onEnabledChange={async () => {}}
+        onCreateViaChat={() => {}}
+        activeMode="installed"
+        onModeChange={() => {}}
+      />,
+    );
+
+    const projectsTrigger = screen.getByRole("button", { name: "Projects" });
+    fireEvent.focus(projectsTrigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Projects: All",
+    );
+    fireEvent.blur(projectsTrigger);
+    fireEvent.pointerDown(projectsTrigger);
+    expect(screen.getByText("Projects")).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "bb" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(
+      screen.getByRole("button", { name: "Projects: 1 selected" }),
+    ).toBeTruthy();
+  });
+
+  it("labels the Status filter and prefixes its tooltip summary", async () => {
+    render(
+      <AutomationOverviewView
+        entries={INSTALLED_AUTOMATIONS}
+        error={null}
+        onRetry={() => {}}
+        onOpenDetail={() => {}}
+        onEnabledChange={async () => {}}
+        onCreateViaChat={() => {}}
+        activeMode="installed"
+        onModeChange={() => {}}
+      />,
+    );
+
+    const statusTrigger = screen.getByRole("button", { name: "Status" });
+    fireEvent.focus(statusTrigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Status: All",
+    );
+    fireEvent.blur(statusTrigger);
+    fireEvent.pointerDown(statusTrigger);
+    expect(screen.getByText("Status")).toBeTruthy();
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Active" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Paused" }),
+    ).toBeTruthy();
+  });
+
   it("renders template actions as icon-only controls with specific labels", () => {
     const onCreateViaChat = vi.fn();
     const { container } = render(

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -133,6 +133,38 @@ describe("Plugin detail recipe", () => {
     ]);
   });
 
+  it("uses the Background services fill for both detail-table header orientations", () => {
+    renderPlugin({
+      ...PLUGIN,
+      capabilities: [
+        {
+          kind: "skill",
+          id: "review",
+          label: "Review issues",
+          detail: "Review repository issues.",
+        },
+      ],
+      services: [{ name: "sync", state: "running" }],
+    });
+
+    for (const name of ["Delivery", "Version"]) {
+      expect(screen.getByRole("rowheader", { name }).className).toContain(
+        "bg-surface-recessed/55",
+      );
+    }
+    expect(
+      screen.getByRole("rowheader", { name: /Review issues/ }).className,
+    ).toContain("bg-surface-recessed/55");
+
+    for (const header of screen.getAllByRole("columnheader")) {
+      expect(header.className).toContain("bg-surface-recessed/55");
+    }
+
+    expect(
+      screen.getByRole("rowheader", { name: "sync" }).className,
+    ).not.toContain("bg-surface-recessed/55");
+  });
+
   it("omits an activity section the plugin has no rows for", () => {
     const { container } = renderPlugin({
       ...PLUGIN,
@@ -276,11 +308,36 @@ describe("Plugin detail recipe", () => {
     expect(screen.queryByText("Frontend app")).toBeNull();
   });
 
-  it("keeps a disabled plugin's static capabilities and explains the missing live ones", () => {
+  it("hides the entire Capabilities section for a disabled plugin", () => {
     const { container } = renderPlugin({
       ...PLUGIN,
       enabled: false,
       status: "disabled",
+      capabilities: [
+        {
+          kind: "theme",
+          id: "github.dark",
+          label: "GitHub Dark",
+          detail: null,
+        },
+      ],
+    });
+
+    expect(renderedRecipe(container)).not.toContainEqual([
+      "includes",
+      "Capabilities",
+    ]);
+    expect(screen.queryByText("GitHub Dark")).toBeNull();
+    expect(
+      screen.queryByText(
+        "Some capabilities are only listed while the plugin is enabled.",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps the Capabilities section for an enabled plugin", () => {
+    const { container } = renderPlugin({
+      ...PLUGIN,
       capabilities: [
         {
           kind: "theme",
@@ -296,12 +353,6 @@ describe("Plugin detail recipe", () => {
       "Capabilities",
     ]);
     expect(screen.getByText("GitHub Dark")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Some capabilities are only listed while the plugin is enabled.",
-      ),
-    ).toBeTruthy();
-    expect(container.querySelector('[data-icon="Info"]')).toBeNull();
   });
 
   it("does not contradict a degraded plugin's still-running health banner", () => {
@@ -650,9 +701,7 @@ describe("Automation detail recipe", () => {
     ) as HTMLElement;
     expect(readOnlyPromptShell.className).toContain("rounded-xl");
     expect(readOnlyPromptShell.className).toContain("border-border");
-    expect(readOnlyPromptShell.className).toContain(
-      "bg-surface-recessed/55",
-    );
+    expect(readOnlyPromptShell.className).toContain("bg-surface-recessed/55");
     expect(readOnlyPromptShell.contains(savedPrompt)).toBe(true);
     expect(savedPrompt.textContent).toBe("Summarize yesterday's commits.");
     expect(screen.queryByRole("button", { name: "Save Prompt" })).toBeNull();
@@ -665,18 +714,16 @@ describe("Automation detail recipe", () => {
     expect(disabledModelSelector.disabled).toBe(true);
     expect(disabledPermissionSelector.disabled).toBe(true);
     expect(readOnlyPromptShell.contains(disabledModelSelector)).toBe(true);
-    expect(readOnlyPromptShell.contains(disabledPermissionSelector)).toBe(
-      true,
-    );
+    expect(readOnlyPromptShell.contains(disabledPermissionSelector)).toBe(true);
     expect(
       disabledModelSelector.querySelector(
         '[data-automation-selector-content=""]',
       )?.className,
     ).toContain("gap-1.5");
     expect(disabledModelSelector.getAttribute("data-state")).toBeNull();
-    expect(disabledModelSelector.parentElement?.getAttribute("data-state")).toBe(
-      null,
-    );
+    expect(
+      disabledModelSelector.parentElement?.getAttribute("data-state"),
+    ).toBe(null);
     const readOnlyPromptFooter = container.querySelector(
       '[data-automation-prompt-footer=""]',
     ) as HTMLElement;

--- a/apps/app/src/components/tools/plugin-detail-table.tsx
+++ b/apps/app/src/components/tools/plugin-detail-table.tsx
@@ -12,6 +12,9 @@ import { cn } from "@bb/shared-ui/lib/utils";
 /** Shared first-column width for conventional plugin detail tables. */
 export const PLUGIN_DETAIL_PRIMARY_COLUMN_CLASS = "w-40 md:w-48";
 
+/** Theme-aware fill shared by plugin detail table header cells. */
+export const PLUGIN_DETAIL_HEADER_CELL_CLASS = "bg-surface-recessed/55";
+
 const DETAIL_ROW_GRID =
   "grid grid-cols-[10rem_minmax(0,1fr)] md:grid-cols-[12rem_minmax(0,1fr)]";
 
@@ -59,6 +62,7 @@ export function PluginDetailFieldRow({
           scope="row"
           className={cn(
             CELL,
+            PLUGIN_DETAIL_HEADER_CELL_CLASS,
             "block w-full border-b border-border px-4 text-left text-xs font-normal text-muted-foreground sm:w-auto sm:border-b-0 sm:border-r sm:pl-4 sm:pr-2",
           )}
         >
@@ -77,6 +81,7 @@ export function PluginDetailFieldRow({
         scope="row"
         className={cn(
           CELL,
+          PLUGIN_DETAIL_HEADER_CELL_CLASS,
           "border-r border-border pl-4 pr-2 text-left text-xs font-normal text-muted-foreground",
         )}
       >
@@ -150,9 +155,12 @@ export function PluginDetailRow({
   const isLongDescription = typeof detail === "string" && detail.length > 180;
   return (
     <tr className={hasDetail ? DETAIL_ROW_GRID : "grid grid-cols-1"}>
-      <td
+      <th
+        scope="row"
         className={cn(
           CELL,
+          PLUGIN_DETAIL_HEADER_CELL_CLASS,
+          "text-left font-normal",
           hasDetail ? "border-r border-border pl-4 pr-2" : "px-4",
         )}
         colSpan={hasDetail ? undefined : 2}
@@ -173,7 +181,7 @@ export function PluginDetailRow({
             {name}
           </span>
         </span>
-      </td>
+      </th>
       {hasDetail ? (
         <td
           id={detailId}

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -270,7 +270,7 @@ describe("SkillsOverview", () => {
     );
   });
 
-  it("defaults to BB official on and Included off, then toggles Included independently", async () => {
+  it("labels the Type filter and preserves independent source toggles", async () => {
     renderDom(
       <SkillsOverview
         skills={[
@@ -303,18 +303,28 @@ describe("SkillsOverview", () => {
     expect(screen.getByText("official-skill")).toBeTruthy();
     expect(screen.getByText("user-skill")).toBeTruthy();
     expect(screen.queryByText("automations")).toBeNull();
-    fireEvent.pointerDown(screen.getByRole("button", { name: "BB official" }));
+    const typeTrigger = screen.getByRole("button", { name: "bb official" });
+    fireEvent.focus(typeTrigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Type: bb official",
+    );
+    fireEvent.blur(typeTrigger);
+    fireEvent.pointerDown(typeTrigger);
+    expect(screen.getByText("Type")).toBeTruthy();
+    expect(screen.getByRole("menuitemcheckbox", { name: "All" })).toBeTruthy();
     expect(
       screen
-        .getByRole("menuitemcheckbox", { name: "BB official" })
+        .getByRole("menuitemcheckbox", { name: "bb official" })
         .getAttribute("aria-checked"),
     ).toBe("true");
     expect(
       screen
-        .getByRole("menuitemcheckbox", { name: "Included" })
+        .getByRole("menuitemcheckbox", { name: "Included in plugin" })
         .getAttribute("aria-checked"),
     ).toBe("false");
-    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Included" }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: "Included in plugin" }),
+    );
 
     expect(await screen.findByText("automations")).toBeTruthy();
     expect(
@@ -322,7 +332,9 @@ describe("SkillsOverview", () => {
         "automations is included with Automations (bb plugin)",
       ).textContent,
     ).toBe("Included");
-    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Included" }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: "Included in plugin" }),
+    );
     expect(screen.queryByText("automations")).toBeNull();
     expect(screen.getByText("official-skill")).toBeTruthy();
   });
@@ -352,14 +364,45 @@ describe("SkillsOverview", () => {
       />,
     );
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "BB official" }));
-    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Included" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "bb official" }));
     fireEvent.click(
-      screen.getByRole("menuitemcheckbox", { name: "BB official" }),
+      screen.getByRole("menuitemcheckbox", { name: "Included in plugin" }),
+    );
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: "bb official" }),
     );
 
     expect(await screen.findByText("automations")).toBeTruthy();
     expect(screen.queryByText("official-skill")).toBeNull();
+  });
+
+  it("uses filter-neutral copy when a Type selection removes every skill", async () => {
+    renderDom(
+      <SkillsOverview
+        skills={[
+          makeSkill({
+            name: "official-skill",
+            provider: null,
+            scope: "bb-builtin",
+            manageable: false,
+          }),
+        ]}
+        isLoading={false}
+        hasError={false}
+        onCreateSkill={() => {}}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "bb official" }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: "bb official" }),
+    );
+
+    expect(
+      await screen.findByText("No skills match these filters."),
+    ).toBeTruthy();
+    expect(screen.queryByText("No skills match these providers.")).toBeNull();
   });
 
   it("renders browse content as the active full-page collection mode", () => {
@@ -433,6 +476,38 @@ describe("SkillsOverview", () => {
         .getByRole("menuitemcheckbox", { name: "bb" })
         .getAttribute("aria-disabled"),
     ).toBeNull();
+  });
+
+  it("labels the Provider filter and prefixes its logo tooltip", async () => {
+    renderDom(
+      <SkillsOverview
+        skills={[
+          makeSkill({
+            name: "bb-skill",
+            provider: null,
+            scope: "bb-user",
+          }),
+          makeSkill({ name: "claude-skill", provider: "claude-code" }),
+        ]}
+        isLoading={false}
+        hasError={false}
+        onCreateSkill={() => {}}
+        onSelectSkill={() => {}}
+      />,
+    );
+
+    const providerTrigger = screen.getByRole("button", { name: "bb" });
+    fireEvent.focus(providerTrigger);
+    const defaultTooltip = await screen.findByRole("tooltip");
+    expect(defaultTooltip.textContent?.trim()).toBe("Providers:");
+    expect(defaultTooltip.textContent).not.toContain("bb");
+    expect(
+      defaultTooltip.querySelector('[data-provider-icon="bb"] img'),
+    ).not.toBeNull();
+    fireEvent.blur(providerTrigger);
+
+    fireEvent.pointerDown(providerTrigger);
+    expect(screen.getByText("Provider")).toBeTruthy();
   });
 
   it("keeps the default BB filter selected when only provider skills exist", async () => {
@@ -880,8 +955,14 @@ describe("RegistrySkillsBrowsePage", () => {
     expect(screen.getByLabelText("10 installs")).toBeTruthy();
     expect(screen.getByLabelText("100 stars")).toBeTruthy();
     for (const byline of screen.getAllByText("by owner/repo")) {
-      expect(byline.className).toContain("text-xs");
+      expect(byline.className).toContain("truncate");
+      expect(byline.parentElement?.className).toContain("items-center");
+      expect(byline.parentElement?.className).toContain("text-xs");
     }
+    expect(
+      screen.getByLabelText("100 stars").parentElement?.parentElement
+        ?.className,
+    ).toContain("items-center");
     expect(
       screen.getByRole("button", {
         name: "Fork Alpha into a new bb skill",

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -1104,21 +1104,19 @@ describe("PluginDetail capability inventory", () => {
     // without absorbing the full-width table's spare space and visually
     // detaching names from descriptions.
     const firstRow = table?.querySelector("tr");
-    expect(firstRow?.className).toContain(
-      "grid-cols-[10rem_minmax(0,1fr)]",
-    );
-    expect(firstRow?.className).toContain(
-      "md:grid-cols-[12rem_minmax(0,1fr)]",
-    );
+    expect(firstRow?.className).toContain("grid-cols-[10rem_minmax(0,1fr)]");
+    expect(firstRow?.className).toContain("md:grid-cols-[12rem_minmax(0,1fr)]");
 
     // The cells own the content gutter so the row and column borders connect
     // directly to the table's outer edge.
-    const firstCell = table?.querySelector("td") as HTMLElement;
+    const firstCell = table?.querySelector('th[scope="row"]') as HTMLElement;
     expect(firstCell.className).toContain("border-r");
     expect(firstCell.className).toContain("border-border");
     expect(firstCell.className).toContain("pl-4");
     expect(firstCell.className).toContain("pr-2");
-    const secondCell = table?.querySelector("td + td") as HTMLElement;
+    const secondCell = table?.querySelector(
+      'th[scope="row"] + td',
+    ) as HTMLElement;
     expect(secondCell.className).toContain("pl-2");
     expect(secondCell.className).toContain("pr-4");
     expect(

--- a/packages/shared-ui/src/components/ui/resource/collection.tsx
+++ b/packages/shared-ui/src/components/ui/resource/collection.tsx
@@ -423,6 +423,7 @@ export function ResourceSourceItem({
 }
 
 type ResourceBrowseCardProps = {
+  className?: string;
   leading?: ReactNode;
   title: ReactNode;
   description?: ReactNode;
@@ -441,6 +442,7 @@ type ResourceBrowseCardProps = {
 );
 
 export function ResourceBrowseCard({
+  className,
   leading,
   title,
   description,
@@ -460,6 +462,7 @@ export function ResourceBrowseCard({
         "group relative grid min-h-28 w-full grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_1fr_auto] gap-2 rounded-lg border border-border bg-card p-3 text-left",
         onOpen &&
           "transition-[border-color,box-shadow] duration-150 hover:border-foreground/20 hover:shadow-xs",
+        className,
       )}
     >
       {onOpen ? (
@@ -504,12 +507,12 @@ export function ResourceBrowseCard({
         </span>
       ) : null}
       {byline ? (
-        <span className="pointer-events-none relative col-start-1 row-start-3 block truncate text-left text-xs text-subtle-foreground">
-          {byline}
+        <span className="pointer-events-none relative col-start-1 row-start-3 flex min-h-4 min-w-0 items-center text-left text-xs text-subtle-foreground">
+          <span className="block min-w-0 truncate">{byline}</span>
         </span>
       ) : null}
       {footerMeta ? (
-        <span className="pointer-events-none relative col-start-2 row-start-3 flex items-end justify-end text-right">
+        <span className="pointer-events-none relative col-start-2 row-start-3 flex min-h-4 items-center justify-end text-right">
           {footerMeta}
         </span>
       ) : null}

--- a/packages/shared-ui/src/components/ui/resource/toolbar.tsx
+++ b/packages/shared-ui/src/components/ui/resource/toolbar.tsx
@@ -114,10 +114,12 @@ function ResourceMenuTrigger({
   label,
   icon,
   active = false,
+  tooltip = label,
 }: {
   label: string;
   icon: IconName;
   active?: boolean;
+  tooltip?: ReactNode;
 }) {
   return (
     <TooltipProvider delayDuration={250}>
@@ -138,7 +140,7 @@ function ResourceMenuTrigger({
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
-        <TooltipContent side="bottom">{label}</TooltipContent>
+        <TooltipContent side="bottom">{tooltip}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );
@@ -200,6 +202,9 @@ export function ResourceMultiSelectMenu({
   options,
   onChange,
   selectedLabel,
+  selectedTooltip,
+  allOptionLabel,
+  emptySelectionLabel = "All",
 }: {
   label: string;
   icon: IconName;
@@ -207,17 +212,29 @@ export function ResourceMultiSelectMenu({
   options: readonly ResourceOption[];
   onChange: (values: string[]) => void;
   selectedLabel?: (options: readonly ResourceOption[]) => string;
+  selectedTooltip?: (options: readonly ResourceOption[]) => ReactNode;
+  allOptionLabel?: string;
+  emptySelectionLabel?: string;
 }) {
   const selected = new Set(selectedValues);
-  const activeOptions = options.filter(
-    (option) => !option.disabled && selected.has(option.id),
+  const enabledOptions = options.filter((option) => !option.disabled);
+  const activeOptions = enabledOptions.filter((option) =>
+    selected.has(option.id),
   );
   const activeSelectedCount = activeOptions.length;
+  const allSelected =
+    enabledOptions.length > 0 && activeSelectedCount === enabledOptions.length;
+  const selectionSummary =
+    activeSelectedCount === 0
+      ? emptySelectionLabel
+      : (selectedLabel?.(activeOptions) ?? `${activeSelectedCount} selected`);
   const triggerLabel =
     activeSelectedCount === 0
       ? label
       : (selectedLabel?.(activeOptions) ??
         `${label}: ${activeSelectedCount} selected`);
+  const triggerTooltip =
+    selectedTooltip?.(activeOptions) ?? `${label}: ${selectionSummary}`;
 
   function updateValue(option: ResourceOption, checked: boolean) {
     if (option.disabled) return;
@@ -239,11 +256,25 @@ export function ResourceMultiSelectMenu({
         label={triggerLabel}
         icon={icon}
         active={activeSelectedCount > 0}
+        tooltip={triggerTooltip}
       />
       <DropdownMenuContent align="end" mobileTitle={label} className="min-w-44">
         <DropdownMenuLabel className="text-xs font-normal text-subtle-foreground">
-          {triggerLabel}
+          {label}
         </DropdownMenuLabel>
+        {allOptionLabel ? (
+          <DropdownMenuCheckboxItem
+            checked={allSelected}
+            onSelect={(event) => event.preventDefault()}
+            onCheckedChange={(checked) =>
+              onChange(
+                checked === true ? enabledOptions.map(({ id }) => id) : [],
+              )
+            }
+          >
+            {allOptionLabel}
+          </DropdownMenuCheckboxItem>
+        ) : null}
         {options.map((option) => (
           <DropdownMenuCheckboxItem
             key={option.id}


### PR DESCRIPTION
## Summary
- standardize extension filter labels, tooltips, and Browse-only category controls
- compact plugin browse cards and align skills browse card metadata
- hide unavailable plugin capability sections and improve table header semantics/theme fills

## Verification
- 117 focused tests passed
- Turbo typecheck passed for @bb/app and @bb/shared-ui
- changed-file lint passed with two pre-existing SkillsCollection warnings
- visually verified plugin and skills Browse layouts at wide and narrow widths in the branch dev app

## Stack
- Base: #985