### PR TITLE
Let the packaged desktop smoke attach without the prompt

### DIFF
--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -372,6 +372,10 @@ async function smokePackagedApp() {
   const childEnv = {
     ...process.env,
     BB_DATA_DIR: dataDir,
+    // The smoke server answers the bb probe, so a packaged build treats it as a
+    // foreign bb and asks before attaching. No one is here to click, so opt out
+    // and keep exercising the real attach path.
+    BB_DESKTOP_ATTACH_WITHOUT_PROMPT: "1",
     BB_DESKTOP_OPEN_DEVTOOLS: "0",
     BB_DESKTOP_VERSION_FEED_URL: `${serverUrl}/desktop-version.json`,
     BB_SERVER_PORT: String(smokeServer.port),

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1537,9 +1537,17 @@ interface InitializeRuntimeArgs {
  * Attaching to a bb this app did not start is invisible to the person using it,
  * so ask first. Local development stays silent, because attaching to a
  * `pnpm dev` server is the whole point there.
+ *
+ * `BB_DESKTOP_ATTACH_WITHOUT_PROMPT` exists for the packaged smoke test, which
+ * points a packaged build at a stub server and has no one to click the dialog.
+ * It is deliberately opt-in and never set by the app itself: the prompt is a
+ * safety boundary, so suppressing it must be an explicit act by the harness.
  */
 function shouldAskBeforeAttaching(): boolean {
   if (!app.isPackaged || existingServerDialogPreloadPath === null) {
+    return false;
+  }
+  if (process.env.BB_DESKTOP_ATTACH_WITHOUT_PROMPT === "1") {
     return false;
   }
   return (process.env.BB_DESKTOP_APP_URL ?? "").trim().length === 0;


### PR DESCRIPTION
## The failure

The 0.35.0 desktop release failed, and so did the 2026-08-04 nightly desktop build. Both died at `smoke:packaged`:

```
Error: Timed out waiting for the packaged Electron app to report ready.
```

The app started, checked for updates, and then went quiet until the 20s timeout.

## Cause

#942 (`f0bdce71c`) added a modal that asks before a packaged app attaches to a bb it did not start. `shouldAskBeforeAttaching()` fires when the app is packaged and `BB_DESKTOP_APP_URL` is empty.

The packaged smoke harness matches that gate exactly:

- `smoke-packaged-app.mjs` deletes `BB_DESKTOP_APP_URL`,
- its stub server answers `/health` and `/api/v1/system/config` with a `dataDir` — precisely the probe the gate reads,
- so the app treats the stub as a foreign bb and opens the dialog.

There is nobody on a CI runner to click it. The renderer never loads, the preload never POSTs `/smoke/preload-ready`, and the smoke times out.

#942 updated `apps/desktop/scripts/build.mjs` but not the smoke script.

## Why it merged green

`smoke:packaged` does not run on pull requests. It runs only in `build-desktop.yml` and the nightly path of `publish-bb-app.yml`, so the first signal was a failed nightly.

## The fix

`BB_DESKTOP_ATTACH_WITHOUT_PROMPT=1` suppresses the prompt. The harness sets it; the app never does. The prompt is a safety boundary, so opting out is an explicit act by the harness rather than an inference the app makes.

The smoke still deletes `BB_DESKTOP_APP_URL`, so it keeps exercising the real packaged attach path instead of routing around it.

## Tests

- `turbo typecheck --filter=@bb/desktop` — clean.
- `turbo lint --filter=@bb/desktop` — clean.
- `turbo test --filter=@bb/desktop` — 25 of 29 files, 189 tests pass. The 4 failing files fail with `Electron failed to install correctly` and fail identically on a stashed clean tree; this Linux host cannot load the darwin-only Electron binary.
- **`smoke:packaged` itself is macOS-only and was not run locally.** The real verification is this PR's macOS CI job, and the desktop release build that follows.

## Risk

A new env knob in product code can suppress a safety prompt. It is opt-in, requires the exact value `1`, is set nowhere in the app or in any shipped config, and only has any effect in a packaged build. No wire, schema, or protocol surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)