### PR TITLE
Prepare bb-app 0.35.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bb/desktop",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "private": true,
   "description": "macOS Electron shell for bb",
   "main": "dist/main.js",

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-app",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "bb app launcher for npx",
   "keywords": [
     "bb",


### PR DESCRIPTION
Version bump only: `bb-app` and `@bb/desktop` to 0.35.1, kept in lockstep.

0.35.0 published to npm but its desktop build failed on the packaged smoke test (fixed in #987). This ships npm and desktop together from one commit so the two artifacts match.

`node .github/workflows/check-version-lockstep.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)