### PR TITLE
Delay the pane arrangement menu on hover

### DIFF
--- a/apps/app/src/components/ui/hooks/use-hover-popover.ts
+++ b/apps/app/src/components/ui/hooks/use-hover-popover.ts
@@ -9,6 +9,7 @@ interface HoverPopoverHandlers {
 }
 
 interface UseHoverPopoverOptions {
+  openDelayMs?: number;
   closeDelayMs?: number;
   hoverableContent?: boolean;
 }
@@ -20,6 +21,7 @@ interface UseHoverPopoverResult {
   handleOpenChange: (nextOpen: boolean) => void;
 }
 
+const DEFAULT_OPEN_DELAY_MS = 0;
 const DEFAULT_CLOSE_DELAY_MS = 160;
 const noop = () => undefined;
 const preventAutoFocus = (event: Event) => {
@@ -40,6 +42,7 @@ const NON_HOVERABLE_CONTENT_PROPS: HoverPopoverHandlers = {
 };
 
 export function useHoverPopover({
+  openDelayMs = DEFAULT_OPEN_DELAY_MS,
   closeDelayMs = DEFAULT_CLOSE_DELAY_MS,
   hoverableContent = true,
 }: UseHoverPopoverOptions = {}): UseHoverPopoverResult {
@@ -47,57 +50,72 @@ export function useHoverPopover({
   const [open, setOpen] = useState(false);
   const [isPointerOverTrigger, setIsPointerOverTrigger] = useState(false);
   const [isPointerOverContent, setIsPointerOverContent] = useState(false);
-  const closeTimeoutRef = useRef<number | null>(null);
+  const toggleTimeoutRef = useRef<number | null>(null);
 
-  const clearCloseTimeout = useCallback(() => {
-    if (closeTimeoutRef.current === null) {
+  const clearToggleTimeout = useCallback(() => {
+    if (toggleTimeoutRef.current === null) {
       return;
     }
-    window.clearTimeout(closeTimeoutRef.current);
-    closeTimeoutRef.current = null;
+    window.clearTimeout(toggleTimeoutRef.current);
+    toggleTimeoutRef.current = null;
   }, []);
 
   useEffect(() => {
     // Touch pointers open via tap. Pointer-based hover state has no role.
     if (isPointerCoarse) return;
 
-    clearCloseTimeout();
+    clearToggleTimeout();
 
     if (isPointerOverTrigger || isPointerOverContent) {
-      setOpen(true);
-      return;
+      if (open) return;
+
+      if (openDelayMs <= 0) {
+        setOpen(true);
+        return;
+      }
+
+      toggleTimeoutRef.current = window.setTimeout(() => {
+        setOpen(true);
+        toggleTimeoutRef.current = null;
+      }, openDelayMs);
+
+      return clearToggleTimeout;
     }
 
-    closeTimeoutRef.current = window.setTimeout(() => {
+    if (!open) return;
+
+    toggleTimeoutRef.current = window.setTimeout(() => {
       setOpen(false);
-      closeTimeoutRef.current = null;
+      toggleTimeoutRef.current = null;
     }, closeDelayMs);
 
-    return clearCloseTimeout;
+    return clearToggleTimeout;
   }, [
-    clearCloseTimeout,
+    clearToggleTimeout,
     closeDelayMs,
     isPointerCoarse,
     isPointerOverContent,
     isPointerOverTrigger,
+    open,
+    openDelayMs,
   ]);
 
-  useEffect(() => clearCloseTimeout, [clearCloseTimeout]);
+  useEffect(() => clearToggleTimeout, [clearToggleTimeout]);
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (nextOpen) {
-        clearCloseTimeout();
+        clearToggleTimeout();
         setOpen(true);
         return;
       }
 
       setIsPointerOverTrigger(false);
       setIsPointerOverContent(false);
-      clearCloseTimeout();
+      clearToggleTimeout();
       setOpen(false);
     },
-    [clearCloseTimeout],
+    [clearToggleTimeout],
   );
 
   const triggerHoverProps = isPointerCoarse

--- a/apps/app/src/views/thread-detail/PaneMaximizeButton.test.tsx
+++ b/apps/app/src/views/thread-detail/PaneMaximizeButton.test.tsx
@@ -115,6 +115,17 @@ describe("PaneMaximizeButton", () => {
     expect(onMoveToSide).toHaveBeenCalledWith("left");
   });
 
+  it("keeps the menu closed while the pointer only passes over the button", async () => {
+    renderButton(false);
+    const button = screen.getByRole("button", { name: "Full Screen (⌘⇧E)" });
+
+    fireEvent.pointerEnter(button);
+    fireEvent.pointerLeave(button);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(screen.queryByRole("menu", { name: "Pane arrangement" })).toBeNull();
+  });
+
   it("uses the reduced-glyph header geometry so the arrows do not outsize the close/panel controls", () => {
     renderButton(false);
     const button = screen.getByRole("button", { name: "Full Screen (⌘⇧E)" });

--- a/apps/app/src/views/thread-detail/PaneMaximizeButton.tsx
+++ b/apps/app/src/views/thread-detail/PaneMaximizeButton.tsx
@@ -58,12 +58,14 @@ export function PaneMaximizeButton({
 }) {
   const { isMaximized, onToggleMaximize, onMoveToSide } = usePaneContext();
   const shortcut = useAppCommandShortcut("pane.maximize.toggle");
+  // The pointer crosses this button on the way to the close control, so the
+  // menu waits before it appears.
   const {
     open: hoverOpen,
     triggerHoverProps,
     contentHoverProps,
     handleOpenChange,
-  } = useHoverPopover({ closeDelayMs: 100 });
+  } = useHoverPopover({ openDelayMs: 400, closeDelayMs: 100 });
 
   if (onToggleMaximize === null) return null;
 


### PR DESCRIPTION
## Summary

The pointer crosses the pane full-screen button on the way to the close control, so the arrangement menu flashed open. The menu now waits before it appears.

- `use-hover-popover.ts`: new `openDelayMs` option, default `0`, so other callers keep their current behavior. One timer now drives both open and close.
- `PaneMaximizeButton.tsx`: the hover menu uses `openDelayMs: 400`. Click, keyboard focus, and the shortcut still act immediately.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- 17 related test files (145 tests) pass, including a new test that the menu stays closed after a quick pointer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)