### PR TITLE
Skip the local bb server when the desktop targets a remote server

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@bb/connect-client": "workspace:*",
     "bb-app": "workspace:*",
     "electron-updater": "^6.8.3",
     "semver": "^7.7.0",

--- a/apps/desktop/src/connect-credential-cache.ts
+++ b/apps/desktop/src/connect-credential-cache.ts
@@ -27,6 +27,12 @@ export interface CreateConnectCredentialCacheArgs {
 }
 
 export interface ConnectCredentialCache {
+  /**
+   * Whether a written credential survives a restart. False means the OS gave
+   * Electron no encryption backend, so callers must not enroll: the credential
+   * would live in memory only, and every launch would enroll another machine.
+   */
+  canPersist(): boolean;
   clear(): Promise<void>;
   read(): Promise<ConnectCredential | null>;
   write(credential: ConnectCredential): Promise<void>;
@@ -58,6 +64,9 @@ export function createConnectCredentialCache(
   }
 
   return {
+    canPersist() {
+      return args.encryption.isEncryptionAvailable();
+    },
     clear,
     async read() {
       if (!args.encryption.isEncryptionAvailable()) {

--- a/apps/desktop/src/connect-credential-cache.ts
+++ b/apps/desktop/src/connect-credential-cache.ts
@@ -1,0 +1,105 @@
+import { rm, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  connectCredentialSchema,
+  type ConnectCredential,
+} from "@bb/connect-client";
+
+export const CONNECT_CREDENTIAL_FILE_NAME = "connect-credential.bin";
+
+/** Electron's `safeStorage`, narrowed to what the cache uses. */
+export interface ConnectCredentialEncryption {
+  decryptString(encrypted: Buffer): string;
+  encryptString(plainText: string): Buffer;
+  isEncryptionAvailable(): boolean;
+}
+
+export interface ConnectCredentialCacheFs {
+  readFile(path: string): Promise<Buffer>;
+  rm(path: string, options: { force: true }): Promise<void>;
+  writeFile(path: string, data: Buffer): Promise<void>;
+}
+
+export interface CreateConnectCredentialCacheArgs {
+  encryption: ConnectCredentialEncryption;
+  fs?: ConnectCredentialCacheFs;
+  userDataPath: string;
+}
+
+export interface ConnectCredentialCache {
+  clear(): Promise<void>;
+  read(): Promise<ConnectCredential | null>;
+  write(credential: ConnectCredential): Promise<void>;
+}
+
+const defaultFs: ConnectCredentialCacheFs = {
+  readFile,
+  rm,
+  writeFile,
+};
+
+/**
+ * The desktop app's own connect machine credential, encrypted at rest with the
+ * OS keychain through Electron `safeStorage`. It lets the app mint a Connect
+ * session cookie and list account servers with no local bb server running.
+ *
+ * When the OS offers no encryption backend the cache turns into a no-op rather
+ * than writing a durable secret in the clear; the app then falls back to the
+ * local server for those two calls.
+ */
+export function createConnectCredentialCache(
+  args: CreateConnectCredentialCacheArgs,
+): ConnectCredentialCache {
+  const fsImpl = args.fs ?? defaultFs;
+  const filePath = join(args.userDataPath, CONNECT_CREDENTIAL_FILE_NAME);
+
+  async function clear(): Promise<void> {
+    await fsImpl.rm(filePath, { force: true });
+  }
+
+  return {
+    clear,
+    async read() {
+      if (!args.encryption.isEncryptionAvailable()) {
+        return null;
+      }
+      let encrypted: Buffer;
+      try {
+        encrypted = await fsImpl.readFile(filePath);
+      } catch {
+        return null;
+      }
+      let plainText: string;
+      try {
+        plainText = args.encryption.decryptString(encrypted);
+      } catch {
+        // A keychain the OS can no longer unlock, or a file from another
+        // machine: the bytes are useless, so drop them and re-enroll.
+        await clear();
+        return null;
+      }
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(plainText);
+      } catch {
+        await clear();
+        return null;
+      }
+      const parsed = connectCredentialSchema.safeParse(parsedJson);
+      if (!parsed.success) {
+        await clear();
+        return null;
+      }
+      return parsed.data;
+    },
+    async write(credential) {
+      if (!args.encryption.isEncryptionAvailable()) {
+        return;
+      }
+      await fsImpl.writeFile(
+        filePath,
+        args.encryption.encryptString(JSON.stringify(credential)),
+      );
+    },
+  };
+}

--- a/apps/desktop/src/connect-desktop-session.ts
+++ b/apps/desktop/src/connect-desktop-session.ts
@@ -54,7 +54,8 @@ export type ConnectDesktopSessionFailureCode =
   | "unauthorized";
 
 export type ConnectDesktopSessionResult =
-  | { ok: true }
+  /** `expiresAt` is the cookie's epoch-ms expiry, so callers can renew it. */
+  | { expiresAt: number; ok: true }
   | {
       code: ConnectDesktopSessionFailureCode;
       detail: string;
@@ -198,5 +199,5 @@ export async function installConnectDesktopSession(args: {
       "Electron did not retain the desktop session cookie",
     );
   }
-  return { ok: true };
+  return { expiresAt: cookie.expiresAt, ok: true };
 }

--- a/apps/desktop/src/connect-desktop-session.ts
+++ b/apps/desktop/src/connect-desktop-session.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  ConnectListError,
+  fetchDesktopSession,
+  type ConnectCredential,
+} from "@bb/connect-client";
 
 const rpcSuccessSchema = z.object({
   ok: z.literal(true),
@@ -11,6 +16,13 @@ const rpcSuccessSchema = z.object({
     }),
   }),
 });
+
+export interface DesktopSessionCookie {
+  domain: string;
+  expiresAt: number;
+  name: string;
+  value: string;
+}
 
 export interface DesktopCookie {
   domain?: string;
@@ -38,7 +50,8 @@ export type ConnectDesktopSessionFailureCode =
   | "cookie_verification_failed"
   | "invalid_response"
   | "network"
-  | "request_rejected";
+  | "request_rejected"
+  | "unauthorized";
 
 export type ConnectDesktopSessionResult =
   | { ok: true }
@@ -48,10 +61,18 @@ export type ConnectDesktopSessionResult =
       ok: false;
     };
 
+export type MintDesktopSessionCookieResult =
+  | { cookie: DesktopSessionCookie; ok: true }
+  | { code: ConnectDesktopSessionFailureCode; detail: string; ok: false };
+
+/** Where a session cookie comes from: the local plugin, or the connect gate. */
+export type DesktopSessionCookieSource =
+  () => Promise<MintDesktopSessionCookieResult>;
+
 function failure(
   code: ConnectDesktopSessionFailureCode,
   detail: string,
-): ConnectDesktopSessionResult {
+): { code: ConnectDesktopSessionFailureCode; detail: string; ok: false } {
   return { code, detail, ok: false };
 }
 
@@ -59,43 +80,88 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export async function installConnectDesktopSession(args: {
-  cookieStore: DesktopCookieStore;
+/**
+ * Mint through the local bb server's connect plugin. The server holds the
+ * pairing secret and forwards the call to the gate.
+ */
+export function createLocalServerCookieSource(args: {
   fetchImpl?: typeof fetch;
   localServerUrl: string;
+}): DesktopSessionCookieSource {
+  return async () => {
+    const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+    const rpcUrl = new URL(
+      "/api/v1/plugins/connect/rpc/createDesktopSession",
+      args.localServerUrl,
+    );
+    let response: Response;
+    try {
+      response = await fetchImpl(rpcUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "null",
+      });
+    } catch (error) {
+      return failure("network", errorMessage(error));
+    }
+    if (!response.ok) {
+      return failure("request_rejected", `HTTP ${response.status}`);
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (error) {
+      return failure("invalid_response", errorMessage(error));
+    }
+    const parsed = rpcSuccessSchema.safeParse(body);
+    if (!parsed.success) {
+      return failure("invalid_response", "response did not match the contract");
+    }
+    return { cookie: parsed.data.result.cookie, ok: true };
+  };
+}
+
+/**
+ * Mint straight from the connect gate with the app's own cached machine
+ * credential — no local bb server involved.
+ */
+export function createCredentialCookieSource(args: {
+  credential: ConnectCredential;
+  fetchImpl?: typeof fetch;
+}): DesktopSessionCookieSource {
+  return async () => {
+    try {
+      const session = await fetchDesktopSession(
+        args.credential,
+        args.fetchImpl ?? globalThis.fetch,
+      );
+      return { cookie: session.cookie, ok: true };
+    } catch (error) {
+      if (error instanceof ConnectListError) {
+        // "not_paired" belongs to the plugin's own store, never to a call the
+        // app makes with a credential in hand.
+        return failure(
+          error.code === "not_paired" ? "invalid_response" : error.code,
+          error.message,
+        );
+      }
+      return failure("network", errorMessage(error));
+    }
+  };
+}
+
+export async function installConnectDesktopSession(args: {
+  cookieStore: DesktopCookieStore;
+  mintCookie: DesktopSessionCookieSource;
   remoteServerUrl: string;
 }): Promise<ConnectDesktopSessionResult> {
-  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
-  const rpcUrl = new URL(
-    "/api/v1/plugins/connect/rpc/createDesktopSession",
-    args.localServerUrl,
-  );
-  let response: Response;
-  try {
-    response = await fetchImpl(rpcUrl, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: "null",
-    });
-  } catch (error) {
-    return failure("network", errorMessage(error));
-  }
-  if (!response.ok) {
-    return failure("request_rejected", `HTTP ${response.status}`);
+  const minted = await args.mintCookie();
+  if (!minted.ok) {
+    return minted;
   }
 
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error) {
-    return failure("invalid_response", errorMessage(error));
-  }
-  const parsed = rpcSuccessSchema.safeParse(body);
-  if (!parsed.success) {
-    return failure("invalid_response", "response did not match the contract");
-  }
-
-  const { cookie } = parsed.data.result;
+  const { cookie } = minted;
   const remoteOrigin = new URL(args.remoteServerUrl).origin;
   try {
     await args.cookieStore.set({

--- a/apps/desktop/src/connect-machine-enrollment.ts
+++ b/apps/desktop/src/connect-machine-enrollment.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+import {
+  ConnectMachineRedeemError,
+  deriveConnectBaseUrl,
+  redeemMachineCredential,
+  type ConnectCredential,
+} from "@bb/connect-client";
+
+export const CREATE_MACHINE_CODE_RPC = "createMachineCode";
+
+const machineCodeRpcSchema = z
+  .object({
+    ok: z.literal(true),
+    result: z
+      .object({
+        code: z.string().min(1),
+        expiresAt: z.number(),
+        serverUrl: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const rpcFailureSchema = z
+  .object({ ok: z.literal(false), error: z.string().optional() })
+  .passthrough();
+
+export type EnrollDesktopMachineFailureCode =
+  | "machine_limit"
+  | "not_paired"
+  | "network"
+  | "invalid_response";
+
+export type EnrollDesktopMachineResult =
+  | { ok: true; credential: ConnectCredential }
+  | { code: EnrollDesktopMachineFailureCode; detail: string; ok: false };
+
+export interface EnrollDesktopMachineArgs {
+  fetchImpl?: typeof fetch;
+  /** Local builtin server origin, e.g. `http://127.0.0.1:38886`. */
+  localServerUrl: string;
+}
+
+function failure(
+  code: EnrollDesktopMachineFailureCode,
+  detail: string,
+): EnrollDesktopMachineResult {
+  return { code, detail, ok: false };
+}
+
+function redeemFailureCode(
+  error: ConnectMachineRedeemError,
+): EnrollDesktopMachineFailureCode {
+  if (error.code === "machine_limit") return "machine_limit";
+  if (error.code === "network") return "network";
+  return "invalid_response";
+}
+
+/**
+ * Give the desktop app its own connect machine credential.
+ *
+ * The local bb server mints a one-time machine code with its pairing secret,
+ * and the app redeems that code at the connect apex for a credential of its
+ * own. The app therefore never holds a copy of the server's pairing secret,
+ * and the account owner can revoke the desktop app on its own from the connect
+ * dashboard.
+ */
+export async function enrollDesktopMachine(
+  args: EnrollDesktopMachineArgs,
+): Promise<EnrollDesktopMachineResult> {
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  const base = args.localServerUrl.replace(/\/$/u, "");
+  const rpcUrl = `${base}/api/v1/plugins/connect/rpc/${CREATE_MACHINE_CODE_RPC}`;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "null",
+    });
+  } catch (error) {
+    return failure(
+      "network",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return failure("invalid_response", "machine code response was not JSON");
+  }
+
+  const minted = machineCodeRpcSchema.safeParse(body);
+  if (!minted.success) {
+    const rejected = rpcFailureSchema.safeParse(body);
+    const wireError = rejected.success ? (rejected.data.error ?? "") : "";
+    if (wireError === "not_paired") {
+      return failure("not_paired", "this bb is not paired with bb Connect");
+    }
+    if (wireError === "machine_limit") {
+      return failure("machine_limit", "the account is at its machine limit");
+    }
+    return failure(
+      "invalid_response",
+      wireError.length > 0
+        ? wireError
+        : "machine code response did not match the contract",
+    );
+  }
+
+  try {
+    const credential = await redeemMachineCredential(
+      {
+        apexUrl: deriveConnectBaseUrl(minted.data.result.serverUrl),
+        code: minted.data.result.code,
+      },
+      fetchImpl,
+    );
+    return { credential, ok: true };
+  } catch (error) {
+    if (error instanceof ConnectMachineRedeemError) {
+      return failure(redeemFailureCode(error), error.message);
+    }
+    return failure(
+      "network",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/apps/desktop/src/connect-machine-enrollment.ts
+++ b/apps/desktop/src/connect-machine-enrollment.ts
@@ -21,9 +21,13 @@ const machineCodeRpcSchema = z
   })
   .strict();
 
-const rpcFailureSchema = z
-  .object({ ok: z.literal(false), error: z.string().optional() })
-  .passthrough();
+// The plugin route wraps a throwing handler as
+// `{ ok: false, error: { code: "handler_error", message: <thrown message> } }`,
+// and the connect plugin throws its stable code as that message.
+const rpcFailureSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({ code: z.string(), message: z.string() }),
+});
 
 export type EnrollDesktopMachineFailureCode =
   | "machine_limit"
@@ -96,7 +100,7 @@ export async function enrollDesktopMachine(
   const minted = machineCodeRpcSchema.safeParse(body);
   if (!minted.success) {
     const rejected = rpcFailureSchema.safeParse(body);
-    const wireError = rejected.success ? (rejected.data.error ?? "") : "";
+    const wireError = rejected.success ? rejected.data.error.message : "";
     if (wireError === "not_paired") {
       return failure("not_paired", "this bb is not paired with bb Connect");
     }

--- a/apps/desktop/src/connect-server-sync.ts
+++ b/apps/desktop/src/connect-server-sync.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  ConnectListError,
+  listAccountServers,
+  type ConnectCredential,
+} from "@bb/connect-client";
 
 /** POST /api/v1/plugins/connect/rpc/listAccountServers result body. */
 export const connectAccountServerSchema = z
@@ -105,16 +110,27 @@ export async function fetchConnectAccountServers(
 export function selectTargetableConnectServers(
   result: ConnectListAccountServersResult,
 ): ConnectAccountServer[] {
-  return result.servers.filter(
-    (server) => server.handle !== result.selfHandle,
-  );
+  return result.servers.filter((server) => server.handle !== result.selfHandle);
 }
 
 export interface CreateConnectServerSyncArgs {
+  /**
+   * The app's own cached machine credential, or null when it has none. Used
+   * when no local runtime is up, so a remote target still lists servers.
+   */
+  getCredential: () => ConnectCredential | null;
   /** Builtin/local server URL when the runtime is up; null when not. */
   getLocalServerUrl: () => string | null;
   /** Fresh targetable server list after every successful sync. */
   onServers: (servers: ConnectAccountServer[]) => void;
+  /** The gate refused the cached credential — the caller must drop it. */
+  onUnauthorized: () => void;
+  /**
+   * Transport for the direct gate call. Separate from `fetchImpl` because the
+   * gate client needs a full `fetch`, while the local RPC needs only a slice
+   * of the response.
+   */
+  gateFetchImpl?: typeof fetch;
   fetchImpl?: ConnectServerSyncFetch;
   log?: ConnectServerSyncLog;
   now?: () => number;
@@ -135,7 +151,7 @@ export interface ConnectServerSync {
    * older than minIntervalMs (default 60s).
    */
   onListRequested(): void;
-  /** Exposed for tests. */
+  /** Sync once, now, coalescing with a sync already in flight. */
   syncNow(): Promise<void>;
 }
 
@@ -147,7 +163,8 @@ export function createConnectServerSync(
   args: CreateConnectServerSyncArgs,
 ): ConnectServerSync {
   const intervalMs = args.intervalMs ?? CONNECT_SERVER_SYNC_INTERVAL_MS;
-  const minIntervalMs = args.minIntervalMs ?? CONNECT_SERVER_SYNC_MIN_INTERVAL_MS;
+  const minIntervalMs =
+    args.minIntervalMs ?? CONNECT_SERVER_SYNC_MIN_INTERVAL_MS;
   const now = args.now ?? Date.now;
   const setIntervalFn =
     args.setIntervalFn ??
@@ -164,22 +181,41 @@ export function createConnectServerSync(
   let inFlight: Promise<void> | null = null;
   let loggedFailure = false;
 
+  /**
+   * Prefer the local server: it holds the pairing secret and always reflects
+   * whether the plugin is on. Fall back to the app's own credential so a
+   * remote target keeps a live server list with no local runtime.
+   */
+  async function fetchServers(): Promise<ConnectListAccountServersResult | null> {
+    const serverUrl = args.getLocalServerUrl();
+    if (serverUrl !== null) {
+      return fetchConnectAccountServers({
+        serverUrl,
+        fetchImpl: args.fetchImpl,
+      });
+    }
+    const credential = args.getCredential();
+    if (credential === null) {
+      return null;
+    }
+    try {
+      return await listAccountServers(credential, args.gateFetchImpl);
+    } catch (error) {
+      if (error instanceof ConnectListError && error.code === "unauthorized") {
+        args.onUnauthorized();
+      }
+      return null;
+    }
+  }
+
   async function runSync(): Promise<void> {
     lastSyncAttemptAt = now();
-    const serverUrl = args.getLocalServerUrl();
-    if (serverUrl === null) {
-      return;
-    }
-
-    const result = await fetchConnectAccountServers({
-      serverUrl,
-      fetchImpl: args.fetchImpl,
-    });
+    const result = await fetchServers();
     if (result === null) {
       if (!loggedFailure) {
         loggedFailure = true;
         log?.(
-          "connect server sync skipped (plugin disabled, not paired, or local server unavailable)",
+          "connect server sync skipped (plugin disabled, not paired, or no local server and no cached credential)",
         );
       }
       return;

--- a/apps/desktop/src/connect-session-renewal.ts
+++ b/apps/desktop/src/connect-session-renewal.ts
@@ -1,0 +1,156 @@
+export const CONNECT_SESSION_RENEWAL_LEAD_MS = 5 * 60 * 1000;
+export const CONNECT_SESSION_MIN_RENEWAL_DELAY_MS = 30 * 1000;
+
+export type ConnectSessionAuthenticateResult =
+  | { expiresAt: number; ok: true }
+  | { detail: string; ok: false };
+
+/**
+ * Mint and install a session cookie for `remoteServerUrl`.
+ *
+ * `isCurrent` reports whether that server is still the app's target. A slow
+ * authentication must consult it before any expensive fallback, because the
+ * user can switch targets while it runs.
+ */
+export type ConnectSessionAuthenticate = (
+  remoteServerUrl: string,
+  isCurrent: () => boolean,
+) => Promise<ConnectSessionAuthenticateResult>;
+
+export interface CreateConnectSessionRenewalArgs {
+  authenticate: ConnectSessionAuthenticate;
+  clearTimeoutFn?: (handle: unknown) => void;
+  leadMs?: number;
+  log?: (message: string) => void;
+  minDelayMs?: number;
+  now?: () => number;
+  setTimeoutFn?: (handler: () => void, timeout: number) => unknown;
+}
+
+export interface ConnectSessionRenewal {
+  /** Renew now when the session is spent or nearly spent. */
+  renewIfDue(): void;
+  /** Renew now, coalescing with a renewal already in flight. */
+  renewNow(): Promise<void>;
+  /** Track a fresh session for this server, and renew it before it expires. */
+  start(args: { expiresAt: number; remoteServerUrl: string }): void;
+  /** Forget the current session: a target switch, or quit. */
+  stop(): void;
+}
+
+/**
+ * Keep a Connect session cookie alive.
+ *
+ * The gate issues a one-hour cookie, and the app can hold one remote target far
+ * longer than that. So it re-mints ahead of expiry, and on demand when the app
+ * becomes active — a sleeping Mac holds timers, and waking must not land on a
+ * dead session.
+ *
+ * Every session gets a generation. `stop()` and `start()` both retire the
+ * current one, so a renewal that finishes after the user left its target
+ * neither reschedules itself nor revives that target.
+ */
+export function createConnectSessionRenewal(
+  args: CreateConnectSessionRenewalArgs,
+): ConnectSessionRenewal {
+  const leadMs = args.leadMs ?? CONNECT_SESSION_RENEWAL_LEAD_MS;
+  const minDelayMs = args.minDelayMs ?? CONNECT_SESSION_MIN_RENEWAL_DELAY_MS;
+  const now = args.now ?? Date.now;
+  const setTimeoutFn =
+    args.setTimeoutFn ??
+    ((handler: () => void, timeout: number) => {
+      const handle = setTimeout(handler, timeout);
+      handle.unref();
+      return handle;
+    });
+  const clearTimeoutFn =
+    args.clearTimeoutFn ??
+    ((handle: unknown) => {
+      clearTimeout(handle as ReturnType<typeof setTimeout>);
+    });
+
+  let generation = 0;
+  let expiresAt: number | null = null;
+  let serverUrl: string | null = null;
+  let timer: unknown = null;
+  let inFlight: Promise<void> | null = null;
+
+  function retire(): void {
+    generation += 1;
+    if (timer !== null) {
+      clearTimeoutFn(timer);
+      timer = null;
+    }
+    expiresAt = null;
+    serverUrl = null;
+  }
+
+  function start(session: {
+    expiresAt: number;
+    remoteServerUrl: string;
+  }): void {
+    retire();
+    const startedGeneration = generation;
+    expiresAt = session.expiresAt;
+    serverUrl = session.remoteServerUrl;
+    timer = setTimeoutFn(
+      () => {
+        if (generation !== startedGeneration) {
+          return;
+        }
+        timer = null;
+        void renewNow();
+      },
+      Math.max(minDelayMs, session.expiresAt - now() - leadMs),
+    );
+  }
+
+  async function runRenewal(
+    remoteServerUrl: string,
+    startedGeneration: number,
+  ): Promise<void> {
+    const isCurrent = (): boolean => generation === startedGeneration;
+    const result = await args.authenticate(remoteServerUrl, isCurrent);
+    if (!isCurrent()) {
+      // The user left this server while the call ran. Scheduling again here
+      // would resurrect a target they already dropped.
+      return;
+    }
+    if (result.ok) {
+      start({ expiresAt: result.expiresAt, remoteServerUrl });
+      return;
+    }
+    args.log?.(
+      `could not renew the bb Connect session: ${result.detail} — retrying`,
+    );
+    // Retry on the same cadence rather than giving up: the window still shows
+    // the remote server, and the next attempt may find the gate reachable.
+    start({ expiresAt: now() + leadMs, remoteServerUrl });
+  }
+
+  function renewNow(): Promise<void> {
+    const remoteServerUrl = serverUrl;
+    if (remoteServerUrl === null) {
+      return Promise.resolve();
+    }
+    if (inFlight !== null) {
+      return inFlight;
+    }
+    inFlight = runRenewal(remoteServerUrl, generation).finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  }
+
+  return {
+    renewIfDue(): void {
+      if (expiresAt === null || expiresAt - now() > leadMs) {
+        return;
+      }
+      void renewNow();
+    },
+    renewNow,
+    start,
+    stop: retire,
+  };
+}

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -457,11 +457,7 @@ export function createDesktopBrowserViewManager(
     const webContents = entry.view.webContents;
 
     webContents.on("before-input-event", (event, input) => {
-      if (
-        input.type !== "keyDown" ||
-        input.isAutoRepeat ||
-        input.isComposing
-      ) {
+      if (input.type !== "keyDown" || input.isAutoRepeat || input.isComposing) {
         return;
       }
       const command = args.resolveAppCommand({

--- a/apps/desktop/src/desktop-window-factory.ts
+++ b/apps/desktop/src/desktop-window-factory.ts
@@ -64,11 +64,7 @@ export interface DesktopBrowserWindow extends StatefulBrowserWindow {
   loadURL(url: string): Promise<void>;
   maximize(): void;
   on(
-    eventName:
-      | "close"
-      | "closed"
-      | "enter-full-screen"
-      | "leave-full-screen",
+    eventName: "close" | "closed" | "enter-full-screen" | "leave-full-screen",
     listener: () => void,
   ): void;
   once(eventName: "ready-to-show", listener: () => void): void;

--- a/apps/desktop/src/log-viewer-contract.ts
+++ b/apps/desktop/src/log-viewer-contract.ts
@@ -31,9 +31,7 @@ export interface LogViewerOpenLogsFolderResult {
 }
 
 export type LogViewerAppendHandler = (event: LogViewerAppendEvent) => void;
-export type LogViewerSnapshotHandler = (
-  event: LogViewerSnapshotEvent,
-) => void;
+export type LogViewerSnapshotHandler = (event: LogViewerSnapshotEvent) => void;
 export type LogViewerUnsubscribe = () => void;
 
 export interface LogViewerApi {

--- a/apps/desktop/src/log-viewer.ts
+++ b/apps/desktop/src/log-viewer.ts
@@ -144,9 +144,7 @@ export function createLogLineBuffer(
     args.onFlush(pendingLines);
   }
 
-  function scheduleBufferFlush(
-    scheduleArgs: ScheduleBufferFlushArgs,
-  ): void {
+  function scheduleBufferFlush(scheduleArgs: ScheduleBufferFlushArgs): void {
     if (scheduleArgs.buffer.flushTimer !== null) {
       return;
     }
@@ -164,10 +162,7 @@ export function createLogLineBuffer(
 
       state.visibleLines.push(...lines);
       if (state.visibleLines.length > args.maxLines) {
-        state.visibleLines.splice(
-          0,
-          state.visibleLines.length - args.maxLines,
-        );
+        state.visibleLines.splice(0, state.visibleLines.length - args.maxLines);
       }
 
       state.pendingLines.push(...lines);
@@ -193,7 +188,9 @@ export function createLogLineBuffer(
   };
 }
 
-export function createLogViewerViewUrl(args: CreateLogViewerViewUrlArgs): string {
+export function createLogViewerViewUrl(
+  args: CreateLogViewerViewUrlArgs,
+): string {
   const escapedLogDir = escapeHtmlText(args.logDir);
   const html = `<!doctype html>
 <html>
@@ -566,12 +563,7 @@ export function createLogTailer(args: CreateLogTailerArgs): LogTailer {
 
     const childProcess = spawn(
       "tail",
-      [
-        "-n",
-        String(LOG_VIEWER_INITIAL_TAIL_LINES),
-        "-F",
-        restartArgs.filePath,
-      ],
+      ["-n", String(LOG_VIEWER_INITIAL_TAIL_LINES), "-F", restartArgs.filePath],
       {
         stdio: ["ignore", "pipe", "pipe"],
       },
@@ -657,8 +649,7 @@ export function createLogTailer(args: CreateLogTailerArgs): LogTailer {
     refreshInProgress = true;
     void refreshTailProcesses()
       .catch((error) => {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         emitSystemLine({ text: `log refresh failed: ${message}` });
       })
       .finally(() => {
@@ -689,8 +680,7 @@ export function createLogTailer(args: CreateLogTailerArgs): LogTailer {
           handleDirectoryWatchError({ error, watcher });
         });
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         emitSystemLine({ text: `log directory watch failed: ${message}` });
       }
       pollTimer = setInterval(

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -93,6 +93,10 @@ import {
 } from "./connect-credential-cache.js";
 import { enrollDesktopMachine } from "./connect-machine-enrollment.js";
 import {
+  createConnectSessionRenewal,
+  type ConnectSessionRenewal,
+} from "./connect-session-renewal.js";
+import {
   createDesktopShutdownState,
   registerDesktopShutdownSignalHandlers,
 } from "./desktop-shutdown.js";
@@ -177,8 +181,6 @@ const OWNED_RUNTIME_KILL_TIMEOUT_MS = 1_000;
 const FOREIGN_RUNTIME_STOP_TIMEOUT_MS = 15_000;
 const FOREIGN_RUNTIME_KILL_TIMEOUT_MS = 3_000;
 const REMOTE_SYSTEM_CONFIG_POLL_INTERVAL_MS = 5 * 60 * 1000;
-const CONNECT_SESSION_RENEWAL_LEAD_MS = 5 * 60 * 1000;
-const CONNECT_SESSION_MIN_RENEWAL_DELAY_MS = 30 * 1000;
 
 interface DesktopRuntime {
   bbProcess: BbAppProcess | null;
@@ -308,10 +310,7 @@ let connectServerSync: ConnectServerSync | null = null;
 let connectCredentialCache: ConnectCredentialCache | null = null;
 let cachedConnectCredential: ConnectCredential | null = null;
 let enrollingDesktopMachine: Promise<void> | null = null;
-let connectSessionRenewalTimer: NodeJS.Timeout | null = null;
-let connectSessionExpiresAt: number | null = null;
-let connectSessionServerUrl: string | null = null;
-let renewingConnectSession: Promise<void> | null = null;
+let connectSessionRenewal: ConnectSessionRenewal | null = null;
 let connectAccountServers: ConnectAccountServer[] = [];
 let builtinServerUrl: string = DEFAULT_BB_SERVER_URL;
 let desktopBridgePath: string | null = null;
@@ -997,81 +996,6 @@ async function ensureBuiltinRuntimeAttached(): Promise<boolean> {
 }
 
 /**
- * Keep the Connect session cookie alive.
- *
- * The gate issues a one-hour cookie, and the app can sit on one remote target
- * far longer than that. So the app re-mints ahead of expiry, and also whenever
- * it becomes active — a sleeping Mac holds timers, and waking up must not land
- * on a dead session.
- */
-function scheduleConnectSessionRenewal(args: {
-  expiresAt: number;
-  remoteServerUrl: string;
-}): void {
-  stopConnectSessionRenewal();
-  connectSessionExpiresAt = args.expiresAt;
-  connectSessionServerUrl = args.remoteServerUrl;
-  const delayMs = Math.max(
-    CONNECT_SESSION_MIN_RENEWAL_DELAY_MS,
-    args.expiresAt - Date.now() - CONNECT_SESSION_RENEWAL_LEAD_MS,
-  );
-  connectSessionRenewalTimer = setTimeout(() => {
-    connectSessionRenewalTimer = null;
-    void renewConnectSession();
-  }, delayMs);
-  connectSessionRenewalTimer.unref();
-}
-
-function stopConnectSessionRenewal(): void {
-  if (connectSessionRenewalTimer !== null) {
-    clearTimeout(connectSessionRenewalTimer);
-    connectSessionRenewalTimer = null;
-  }
-  connectSessionExpiresAt = null;
-  connectSessionServerUrl = null;
-}
-
-async function renewConnectSession(): Promise<void> {
-  const remoteServerUrl = connectSessionServerUrl;
-  if (remoteServerUrl === null || renewingConnectSession !== null) {
-    return;
-  }
-  renewingConnectSession = (async () => {
-    const result = await authenticateConnectTarget(remoteServerUrl);
-    if (result.ok) {
-      scheduleConnectSessionRenewal({
-        expiresAt: result.expiresAt,
-        remoteServerUrl,
-      });
-      return;
-    }
-    createDesktopLogger().warn(
-      `[desktop] could not renew the bb Connect session (${result.code}): ${result.detail}`,
-    );
-    // Retry on the same cadence rather than giving up: the window still shows
-    // the remote server, and the next attempt may find the gate reachable.
-    scheduleConnectSessionRenewal({
-      expiresAt: Date.now() + CONNECT_SESSION_RENEWAL_LEAD_MS,
-      remoteServerUrl,
-    });
-  })().finally(() => {
-    renewingConnectSession = null;
-  });
-  await renewingConnectSession;
-}
-
-/** Renew now when the session is spent or nearly spent. */
-function renewConnectSessionIfDue(): void {
-  if (
-    connectSessionExpiresAt === null ||
-    connectSessionExpiresAt - Date.now() > CONNECT_SESSION_RENEWAL_LEAD_MS
-  ) {
-    return;
-  }
-  void renewConnectSession();
-}
-
-/**
  * Mint and install the Connect session cookie for a remote server.
  *
  * The app's own machine credential is the fast path: it needs no local bb
@@ -1081,6 +1005,7 @@ function renewConnectSessionIfDue(): void {
  */
 async function authenticateConnectTarget(
   remoteServerUrl: string,
+  isCurrent: () => boolean = () => true,
 ): Promise<ConnectDesktopSessionResult> {
   const cookieStore = session.defaultSession.cookies;
   let cachedFailure: ConnectDesktopSessionResult | null = null;
@@ -1108,6 +1033,17 @@ async function authenticateConnectTarget(
     cachedFailure = cachedResult;
   }
 
+  if (!isCurrent()) {
+    // The app left this server while the gate call ran. Starting the local
+    // server now would undo the switch the user just made.
+    return (
+      cachedFailure ?? {
+        code: "network",
+        detail: "the app no longer targets this server",
+        ok: false,
+      }
+    );
+  }
   const localRuntimeReady = await ensureBuiltinRuntimeAttached();
   if (!localRuntimeReady || currentRuntime === null) {
     return (
@@ -1195,7 +1131,7 @@ async function applyServerTarget(): Promise<void> {
       refreshApplicationMenu();
       return;
     }
-    stopConnectSessionRenewal();
+    connectSessionRenewal?.stop();
     const localServerUrl = currentRuntime?.serverUrl ?? builtinServerUrl;
     // Switching back from a remote target leaves that target's config poll
     // running, so re-pin the sync to the local server here.
@@ -1225,7 +1161,7 @@ async function applyServerTarget(): Promise<void> {
       refreshApplicationMenu();
       return;
     }
-    scheduleConnectSessionRenewal({
+    connectSessionRenewal?.start({
       expiresAt: result.expiresAt,
       remoteServerUrl: target.server.url,
     });
@@ -1234,7 +1170,7 @@ async function applyServerTarget(): Promise<void> {
     startRemoteSystemConfigSync(target.server.url);
   } else {
     // A custom server is a plain web load with no bb Connect involved.
-    stopConnectSessionRenewal();
+    connectSessionRenewal?.stop();
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.url });
     startRemoteSystemConfigSync(target.url);
@@ -1548,7 +1484,7 @@ function handleBeforeQuit(event: Event): void {
 
 async function finishQuit(): Promise<void> {
   stopSystemConfigSync();
-  stopConnectSessionRenewal();
+  connectSessionRenewal?.stop();
   desktopUpdateService?.stop();
   desktopAutoUpdateService?.stop();
   desktopBrowserViewManager?.destroyAll();
@@ -2006,7 +1942,7 @@ async function runDesktopApp(): Promise<void> {
     void desktopAutoUpdateService?.checkAfterActive();
     // A remote target has no realtime socket for config changes.
     refreshRemoteSystemConfig?.();
-    renewConnectSessionIfDue();
+    connectSessionRenewal?.renewIfDue();
   });
   app.on("browser-window-created", (_event, browserWindow) => {
     if (desktopBrowserViewManager === null) {
@@ -2131,6 +2067,20 @@ async function runDesktopApp(): Promise<void> {
     },
   });
   connectServerSync.start();
+  connectSessionRenewal = createConnectSessionRenewal({
+    async authenticate(remoteServerUrl, isCurrent) {
+      const result = await authenticateConnectTarget(
+        remoteServerUrl,
+        isCurrent,
+      );
+      return result.ok
+        ? result
+        : { detail: `${result.code}: ${result.detail}`, ok: false };
+    },
+    log: (message) => {
+      logger.warn(`[desktop] ${message}`);
+    },
+  });
 
   desktopUpdateService = createDesktopUpdateService({
     currentVersion: desktopVersion,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1119,6 +1119,10 @@ async function applyServerTarget(): Promise<void> {
     return;
   }
   const target = serverTargetStore.getTarget();
+  // Retire the outgoing session before any await below. A renewal already in
+  // flight would otherwise still read itself as current while this switch
+  // runs, and its local-server fallback would undo the switch.
+  connectSessionRenewal?.stop();
   if (target.kind === "builtin") {
     const attached = await ensureBuiltinRuntimeAttached();
     if (!attached) {
@@ -1131,7 +1135,6 @@ async function applyServerTarget(): Promise<void> {
       refreshApplicationMenu();
       return;
     }
-    connectSessionRenewal?.stop();
     const localServerUrl = currentRuntime?.serverUrl ?? builtinServerUrl;
     // Switching back from a remote target leaves that target's config poll
     // running, so re-pin the sync to the local server here.
@@ -1170,7 +1173,6 @@ async function applyServerTarget(): Promise<void> {
     startRemoteSystemConfigSync(target.server.url);
   } else {
     // A custom server is a plain web load with no bb Connect involved.
-    connectSessionRenewal?.stop();
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.url });
     startRemoteSystemConfigSync(target.url);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -8,6 +8,8 @@ import {
   ipcMain,
   nativeImage,
   nativeTheme,
+  net,
+  safeStorage,
   session,
   shell,
   type Event,
@@ -19,6 +21,7 @@ import {
   APP_SURFACE_DESKTOP,
   APP_SURFACE_ENV_NAME,
 } from "@bb/config/app-surface";
+import type { ConnectCredential } from "@bb/connect-client";
 import type { AppKeybindings } from "@bb/domain";
 import {
   bbDesktopThemeSchema,
@@ -78,7 +81,17 @@ import {
   type ConnectAccountServer,
   type ConnectServerSync,
 } from "./connect-server-sync.js";
-import { installConnectDesktopSession } from "./connect-desktop-session.js";
+import {
+  createCredentialCookieSource,
+  createLocalServerCookieSource,
+  installConnectDesktopSession,
+  type ConnectDesktopSessionResult,
+} from "./connect-desktop-session.js";
+import {
+  createConnectCredentialCache,
+  type ConnectCredentialCache,
+} from "./connect-credential-cache.js";
+import { enrollDesktopMachine } from "./connect-machine-enrollment.js";
 import {
   createDesktopShutdownState,
   registerDesktopShutdownSignalHandlers,
@@ -163,6 +176,7 @@ const OWNED_RUNTIME_STOP_TIMEOUT_MS = 6_000;
 const OWNED_RUNTIME_KILL_TIMEOUT_MS = 1_000;
 const FOREIGN_RUNTIME_STOP_TIMEOUT_MS = 15_000;
 const FOREIGN_RUNTIME_KILL_TIMEOUT_MS = 3_000;
+const REMOTE_SYSTEM_CONFIG_POLL_INTERVAL_MS = 5 * 60 * 1000;
 
 interface DesktopRuntime {
   bbProcess: BbAppProcess | null;
@@ -244,10 +258,16 @@ interface ResolveDesktopUpdateFeedUrlArgs {
 }
 
 interface FetchSystemConfigArgs {
+  /**
+   * Remote servers authenticate with the Electron session cookie, which only
+   * Electron's own network stack carries. Local ones use plain node fetch.
+   */
+  fetchImpl: typeof fetch;
   serverUrl: string;
 }
 
 interface RefreshSystemConfigArgs {
+  fetchImpl: typeof fetch;
   serverUrl: string;
 }
 
@@ -276,12 +296,16 @@ let logViewerTailer: LogTailer | null = null;
 let logViewerWindow: BrowserWindow | null = null;
 let systemConfigSync: SystemConfigSync | null = null;
 let systemConfigRefreshToken = 0;
+let refreshRemoteSystemConfig: (() => void) | null = null;
 const applicationWindowWebContentsIds = new Set<number>();
 let bbAppLoaded = false;
 let stoppingForQuit = false;
 let quitting = false;
 let serverTargetStore: ServerTargetStore | null = null;
 let connectServerSync: ConnectServerSync | null = null;
+let connectCredentialCache: ConnectCredentialCache | null = null;
+let cachedConnectCredential: ConnectCredential | null = null;
+let enrollingDesktopMachine: Promise<void> | null = null;
 let connectAccountServers: ConnectAccountServer[] = [];
 let builtinServerUrl: string = DEFAULT_BB_SERVER_URL;
 let desktopBridgePath: string | null = null;
@@ -743,7 +767,7 @@ function formatRealtimeUrl(serverUrl: string): string {
 }
 
 async function fetchSystemConfig(args: FetchSystemConfigArgs) {
-  const response = await fetch(formatApiUrl(args));
+  const response = await args.fetchImpl(formatApiUrl(args));
   if (!response.ok) {
     throw new Error(
       `System config request failed with HTTP ${response.status}`,
@@ -796,7 +820,7 @@ function createSystemConfigSync(serverUrl: string): SystemConfigSync {
         parsed.data.entity === "system" &&
         parsed.data.changes.includes("config-changed")
       ) {
-        void refreshSystemConfig({ serverUrl });
+        void refreshSystemConfig({ fetchImpl: fetch, serverUrl });
       }
     } catch {
       return;
@@ -810,7 +834,7 @@ function createSystemConfigSync(serverUrl: string): SystemConfigSync {
     socket = new WebSocket(realtimeUrl);
     socket.addEventListener("open", () => {
       socket?.send(JSON.stringify(subscribeMessage));
-      void refreshSystemConfig({ serverUrl });
+      void refreshSystemConfig({ fetchImpl: fetch, serverUrl });
     });
     socket.addEventListener("message", handleMessage);
     socket.addEventListener("close", scheduleReconnect);
@@ -837,7 +861,10 @@ async function refreshSystemConfig(
   const token = systemConfigRefreshToken + 1;
   systemConfigRefreshToken = token;
   try {
-    const config = await fetchSystemConfig({ serverUrl: args.serverUrl });
+    const config = await fetchSystemConfig({
+      fetchImpl: args.fetchImpl,
+      serverUrl: args.serverUrl,
+    });
     if (token !== systemConfigRefreshToken) {
       return;
     }
@@ -855,6 +882,40 @@ async function refreshSystemConfig(
   }
 }
 
+/**
+ * Poll a remote server for keybindings and theme.
+ *
+ * The realtime socket is not an option here: a remote server authenticates the
+ * desktop with the Electron session cookie, and only Electron's own network
+ * stack sends it. So the app re-reads the config on start, when it becomes
+ * active, and on a slow timer. A keybinding edit lands within a poll instead
+ * of instantly.
+ */
+function createRemoteSystemConfigSync(serverUrl: string): SystemConfigSync {
+  function refresh(): void {
+    void refreshSystemConfig({
+      fetchImpl: (input, init) =>
+        net.fetch(input as string | Request, {
+          ...init,
+          credentials: "include",
+        }),
+      serverUrl,
+    });
+  }
+
+  const timer = setInterval(refresh, REMOTE_SYSTEM_CONFIG_POLL_INTERVAL_MS);
+  timer.unref();
+  refreshRemoteSystemConfig = refresh;
+  refresh();
+
+  return {
+    stop(): void {
+      clearInterval(timer);
+      refreshRemoteSystemConfig = null;
+    },
+  };
+}
+
 function stopSystemConfigSync(): void {
   systemConfigSync?.stop();
   systemConfigSync = null;
@@ -863,7 +924,13 @@ function stopSystemConfigSync(): void {
 function startSystemConfigSync(serverUrl: string): void {
   systemConfigSync?.stop();
   systemConfigSync = createSystemConfigSync(serverUrl);
-  void refreshSystemConfig({ serverUrl });
+  void refreshSystemConfig({ fetchImpl: fetch, serverUrl });
+}
+
+/** System config for a connect or custom target, with no local server. */
+function startRemoteSystemConfigSync(serverUrl: string): void {
+  systemConfigSync?.stop();
+  systemConfigSync = createRemoteSystemConfigSync(serverUrl);
 }
 
 function registerApplicationWindow(browserWindow: DesktopBrowserWindow): void {
@@ -884,6 +951,10 @@ function registerApplicationWindow(browserWindow: DesktopBrowserWindow): void {
   });
 }
 
+/**
+ * Attach to a compatible bb server on this Mac, or start one. The caller pins
+ * the system config sync, because a remote target reads its config elsewhere.
+ */
 async function ensureBuiltinRuntimeAttached(): Promise<boolean> {
   if (currentRuntime !== null) {
     return true;
@@ -904,9 +975,6 @@ async function ensureBuiltinRuntimeAttached(): Promise<boolean> {
       serverUrl: existingProbe.serverUrl,
       userDataPath: null,
     });
-    // System config / updates stay pinned to the local runtime even when other
-    // windows display remote servers.
-    startSystemConfigSync(existingProbe.serverUrl);
     return true;
   }
 
@@ -919,11 +987,97 @@ async function ensureBuiltinRuntimeAttached(): Promise<boolean> {
     serverUrl: builtinServerUrl,
     userDataPath: desktopUserDataPath,
   });
-  if (runtime === null) {
-    return false;
+  return runtime !== null;
+}
+
+/**
+ * Mint and install the Connect session cookie for a remote server.
+ *
+ * The app's own machine credential is the fast path: it needs no local bb
+ * server. A credential the gate refuses (revoked machine, unpaired account) is
+ * dropped, and the local server mints the cookie instead — which is also the
+ * first-launch path, before the app has enrolled.
+ */
+async function authenticateConnectTarget(
+  remoteServerUrl: string,
+): Promise<ConnectDesktopSessionResult> {
+  const cookieStore = session.defaultSession.cookies;
+  if (cachedConnectCredential !== null) {
+    const cachedResult = await installConnectDesktopSession({
+      cookieStore,
+      mintCookie: createCredentialCookieSource({
+        credential: cachedConnectCredential,
+      }),
+      remoteServerUrl,
+    });
+    if (cachedResult.ok || cachedResult.code !== "unauthorized") {
+      return cachedResult;
+    }
+    createDesktopLogger().info(
+      "[desktop] bb Connect refused the cached machine credential — dropping it",
+    );
+    await clearCachedConnectCredential();
   }
-  startSystemConfigSync(runtime.serverUrl);
-  return true;
+
+  const localRuntimeReady = await ensureBuiltinRuntimeAttached();
+  if (!localRuntimeReady || currentRuntime === null) {
+    return {
+      code: "network",
+      detail:
+        "the local bb server is unavailable, and this app has no stored bb Connect credential",
+      ok: false,
+    };
+  }
+  const localResult = await installConnectDesktopSession({
+    cookieStore,
+    mintCookie: createLocalServerCookieSource({
+      localServerUrl: currentRuntime.serverUrl,
+    }),
+    remoteServerUrl,
+  });
+  if (localResult.ok) {
+    // Enroll for next launch, so this target needs no local server again.
+    void ensureDesktopMachineEnrolled();
+  }
+  return localResult;
+}
+
+async function clearCachedConnectCredential(): Promise<void> {
+  cachedConnectCredential = null;
+  await connectCredentialCache?.clear();
+}
+
+/**
+ * Give this app its own connect machine credential, using the local server's
+ * pairing secret once. Best effort: a failure only means the app keeps asking
+ * the local server for session cookies.
+ */
+function ensureDesktopMachineEnrolled(): void {
+  const cache = connectCredentialCache;
+  const localServerUrl = currentRuntime?.serverUrl;
+  if (
+    cache === null ||
+    cachedConnectCredential !== null ||
+    enrollingDesktopMachine !== null ||
+    localServerUrl === undefined
+  ) {
+    return;
+  }
+  const logger = createDesktopLogger();
+  enrollingDesktopMachine = (async () => {
+    const result = await enrollDesktopMachine({ localServerUrl });
+    if (!result.ok) {
+      logger.info(
+        `[desktop] could not enroll this app with bb Connect (${result.code}): ${result.detail}`,
+      );
+      return;
+    }
+    cachedConnectCredential = result.credential;
+    await cache.write(result.credential);
+    logger.info("[desktop] enrolled this app as a bb Connect machine");
+  })().finally(() => {
+    enrollingDesktopMachine = null;
+  });
 }
 
 async function applyServerTarget(): Promise<void> {
@@ -943,36 +1097,21 @@ async function applyServerTarget(): Promise<void> {
       refreshApplicationMenu();
       return;
     }
+    const localServerUrl = currentRuntime?.serverUrl ?? builtinServerUrl;
+    // Switching back from a remote target leaves that target's config poll
+    // running, so re-pin the sync to the local server here.
+    startSystemConfigSync(localServerUrl);
     await loadBbApp(
       resolveDesktopWindowUrl({
         env: process.env,
-        serverUrl: currentRuntime?.serverUrl ?? builtinServerUrl,
+        serverUrl: localServerUrl,
       }),
     );
   } else if (target.kind === "connect") {
-    // Connect servers authenticate through the local runtime's connect
-    // plugin, then load as plain web pages. System config and updates
-    // stay pinned to the local runtime.
-    const localRuntimeReady = await ensureBuiltinRuntimeAttached();
-    if (!localRuntimeReady || currentRuntime === null) {
-      const detail =
-        "The local bb server is unavailable, so the desktop app could not create a Connect session.";
-      createDesktopLogger().warn(
-        `[desktop] Connect authentication failed: ${detail}`,
-      );
-      await loadStartupError({
-        details: `${detail} Try switching servers again after the local server is running.`,
-        logs: "",
-        title: "Could not authenticate with bb Connect",
-      });
-      refreshApplicationMenu();
-      return;
-    }
-    const result = await installConnectDesktopSession({
-      cookieStore: session.defaultSession.cookies,
-      localServerUrl: currentRuntime.serverUrl,
-      remoteServerUrl: target.server.url,
-    });
+    // Connect servers load as plain web pages behind a session cookie. The
+    // cookie comes from the app's own machine credential when it has one, so
+    // no local bb server has to run.
+    const result = await authenticateConnectTarget(target.server.url);
     if (!result.ok) {
       createDesktopLogger().warn(
         `[desktop] Connect authentication failed (${result.code}): ${result.detail}`,
@@ -989,11 +1128,12 @@ async function applyServerTarget(): Promise<void> {
     }
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.server.url });
+    startRemoteSystemConfigSync(target.server.url);
   } else {
-    // A custom server is a plain web load. The owned local runtime keeps
-    // running, and system config and updates stay pinned to it.
+    // A custom server is a plain web load with no bb Connect involved.
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.url });
+    startRemoteSystemConfigSync(target.url);
   }
   refreshApplicationMenu();
 }
@@ -1759,6 +1899,8 @@ async function runDesktopApp(): Promise<void> {
   app.on("did-become-active", () => {
     void desktopUpdateService?.checkAfterActive();
     void desktopAutoUpdateService?.checkAfterActive();
+    // A remote target has no realtime socket for config changes.
+    refreshRemoteSystemConfig?.();
   });
   app.on("browser-window-created", (_event, browserWindow) => {
     if (desktopBrowserViewManager === null) {
@@ -1851,9 +1993,18 @@ async function runDesktopApp(): Promise<void> {
     storagePath: join(userDataPath, SERVER_TARGET_FILE_NAME),
   });
   await serverTargetStore.load();
+  connectCredentialCache = createConnectCredentialCache({
+    encryption: safeStorage,
+    userDataPath,
+  });
+  cachedConnectCredential = await connectCredentialCache.read();
   const logger = createDesktopLogger();
   connectServerSync = createConnectServerSync({
+    getCredential: () => cachedConnectCredential,
     getLocalServerUrl: () => currentRuntime?.serverUrl ?? null,
+    onUnauthorized() {
+      void clearCachedConnectCredential();
+    },
     onServers(servers) {
       connectAccountServers = servers;
       const selected = serverTargetStore?.getConnectServer() ?? null;
@@ -1967,11 +2118,15 @@ async function runDesktopApp(): Promise<void> {
   for (const browserWindow of restoredWindows) {
     registerApplicationWindow(browserWindow);
   }
-  await initializeRuntime({ bridgePath, serverUrl, userDataPath });
-  // The local runtime always starts (system config and updates stay
-  // pinned to it); a persisted remote target then replaces the window URL.
-  if (serverTargetStore.getTarget().kind !== "builtin") {
+  if (serverTargetStore.getTarget().kind === "builtin") {
+    await initializeRuntime({ bridgePath, serverUrl, userDataPath });
+  } else {
+    // A saved remote target needs no bb server on this Mac: the session cookie
+    // and the account server list both come from bb Connect. The local server
+    // starts only when the user switches back to "This Mac", or when this app
+    // has no credential of its own yet.
     await applyServerTarget();
+    connectServerSync.syncNow().catch(() => {});
   }
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -177,6 +177,8 @@ const OWNED_RUNTIME_KILL_TIMEOUT_MS = 1_000;
 const FOREIGN_RUNTIME_STOP_TIMEOUT_MS = 15_000;
 const FOREIGN_RUNTIME_KILL_TIMEOUT_MS = 3_000;
 const REMOTE_SYSTEM_CONFIG_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const CONNECT_SESSION_RENEWAL_LEAD_MS = 5 * 60 * 1000;
+const CONNECT_SESSION_MIN_RENEWAL_DELAY_MS = 30 * 1000;
 
 interface DesktopRuntime {
   bbProcess: BbAppProcess | null;
@@ -306,6 +308,10 @@ let connectServerSync: ConnectServerSync | null = null;
 let connectCredentialCache: ConnectCredentialCache | null = null;
 let cachedConnectCredential: ConnectCredential | null = null;
 let enrollingDesktopMachine: Promise<void> | null = null;
+let connectSessionRenewalTimer: NodeJS.Timeout | null = null;
+let connectSessionExpiresAt: number | null = null;
+let connectSessionServerUrl: string | null = null;
+let renewingConnectSession: Promise<void> | null = null;
 let connectAccountServers: ConnectAccountServer[] = [];
 let builtinServerUrl: string = DEFAULT_BB_SERVER_URL;
 let desktopBridgePath: string | null = null;
@@ -991,6 +997,81 @@ async function ensureBuiltinRuntimeAttached(): Promise<boolean> {
 }
 
 /**
+ * Keep the Connect session cookie alive.
+ *
+ * The gate issues a one-hour cookie, and the app can sit on one remote target
+ * far longer than that. So the app re-mints ahead of expiry, and also whenever
+ * it becomes active — a sleeping Mac holds timers, and waking up must not land
+ * on a dead session.
+ */
+function scheduleConnectSessionRenewal(args: {
+  expiresAt: number;
+  remoteServerUrl: string;
+}): void {
+  stopConnectSessionRenewal();
+  connectSessionExpiresAt = args.expiresAt;
+  connectSessionServerUrl = args.remoteServerUrl;
+  const delayMs = Math.max(
+    CONNECT_SESSION_MIN_RENEWAL_DELAY_MS,
+    args.expiresAt - Date.now() - CONNECT_SESSION_RENEWAL_LEAD_MS,
+  );
+  connectSessionRenewalTimer = setTimeout(() => {
+    connectSessionRenewalTimer = null;
+    void renewConnectSession();
+  }, delayMs);
+  connectSessionRenewalTimer.unref();
+}
+
+function stopConnectSessionRenewal(): void {
+  if (connectSessionRenewalTimer !== null) {
+    clearTimeout(connectSessionRenewalTimer);
+    connectSessionRenewalTimer = null;
+  }
+  connectSessionExpiresAt = null;
+  connectSessionServerUrl = null;
+}
+
+async function renewConnectSession(): Promise<void> {
+  const remoteServerUrl = connectSessionServerUrl;
+  if (remoteServerUrl === null || renewingConnectSession !== null) {
+    return;
+  }
+  renewingConnectSession = (async () => {
+    const result = await authenticateConnectTarget(remoteServerUrl);
+    if (result.ok) {
+      scheduleConnectSessionRenewal({
+        expiresAt: result.expiresAt,
+        remoteServerUrl,
+      });
+      return;
+    }
+    createDesktopLogger().warn(
+      `[desktop] could not renew the bb Connect session (${result.code}): ${result.detail}`,
+    );
+    // Retry on the same cadence rather than giving up: the window still shows
+    // the remote server, and the next attempt may find the gate reachable.
+    scheduleConnectSessionRenewal({
+      expiresAt: Date.now() + CONNECT_SESSION_RENEWAL_LEAD_MS,
+      remoteServerUrl,
+    });
+  })().finally(() => {
+    renewingConnectSession = null;
+  });
+  await renewingConnectSession;
+}
+
+/** Renew now when the session is spent or nearly spent. */
+function renewConnectSessionIfDue(): void {
+  if (
+    connectSessionExpiresAt === null ||
+    connectSessionExpiresAt - Date.now() > CONNECT_SESSION_RENEWAL_LEAD_MS
+  ) {
+    return;
+  }
+  void renewConnectSession();
+}
+
+/**
  * Mint and install the Connect session cookie for a remote server.
  *
  * The app's own machine credential is the fast path: it needs no local bb
@@ -1002,6 +1083,7 @@ async function authenticateConnectTarget(
   remoteServerUrl: string,
 ): Promise<ConnectDesktopSessionResult> {
   const cookieStore = session.defaultSession.cookies;
+  let cachedFailure: ConnectDesktopSessionResult | null = null;
   if (cachedConnectCredential !== null) {
     const cachedResult = await installConnectDesktopSession({
       cookieStore,
@@ -1010,23 +1092,32 @@ async function authenticateConnectTarget(
       }),
       remoteServerUrl,
     });
-    if (cachedResult.ok || cachedResult.code !== "unauthorized") {
+    if (cachedResult.ok) {
       return cachedResult;
     }
-    createDesktopLogger().info(
-      "[desktop] bb Connect refused the cached machine credential — dropping it",
-    );
-    await clearCachedConnectCredential();
+    if (cachedResult.code === "unauthorized") {
+      createDesktopLogger().info(
+        "[desktop] bb Connect refused the cached machine credential — dropping it",
+      );
+      await clearCachedConnectCredential();
+    } else if (cachedResult.code === "network") {
+      // The gate is unreachable. The local server would call the same gate, so
+      // starting one cannot help — and starting one is what this path avoids.
+      return cachedResult;
+    }
+    cachedFailure = cachedResult;
   }
 
   const localRuntimeReady = await ensureBuiltinRuntimeAttached();
   if (!localRuntimeReady || currentRuntime === null) {
-    return {
-      code: "network",
-      detail:
-        "the local bb server is unavailable, and this app has no stored bb Connect credential",
-      ok: false,
-    };
+    return (
+      cachedFailure ?? {
+        code: "network",
+        detail:
+          "the local bb server is unavailable, and this app has no stored bb Connect credential",
+        ok: false,
+      }
+    );
   }
   const localResult = await installConnectDesktopSession({
     cookieStore,
@@ -1063,6 +1154,13 @@ function ensureDesktopMachineEnrolled(): void {
   ) {
     return;
   }
+  if (!cache.canPersist()) {
+    // Enrolling now would burn an account machine slot on every launch.
+    createDesktopLogger().info(
+      "[desktop] no OS keychain available — keeping the local bb server for bb Connect sessions",
+    );
+    return;
+  }
   const logger = createDesktopLogger();
   enrollingDesktopMachine = (async () => {
     const result = await enrollDesktopMachine({ localServerUrl });
@@ -1097,6 +1195,7 @@ async function applyServerTarget(): Promise<void> {
       refreshApplicationMenu();
       return;
     }
+    stopConnectSessionRenewal();
     const localServerUrl = currentRuntime?.serverUrl ?? builtinServerUrl;
     // Switching back from a remote target leaves that target's config poll
     // running, so re-pin the sync to the local server here.
@@ -1126,11 +1225,16 @@ async function applyServerTarget(): Promise<void> {
       refreshApplicationMenu();
       return;
     }
+    scheduleConnectSessionRenewal({
+      expiresAt: result.expiresAt,
+      remoteServerUrl: target.server.url,
+    });
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.server.url });
     startRemoteSystemConfigSync(target.server.url);
   } else {
     // A custom server is a plain web load with no bb Connect involved.
+    stopConnectSessionRenewal();
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.url });
     startRemoteSystemConfigSync(target.url);
@@ -1444,6 +1548,7 @@ function handleBeforeQuit(event: Event): void {
 
 async function finishQuit(): Promise<void> {
   stopSystemConfigSync();
+  stopConnectSessionRenewal();
   desktopUpdateService?.stop();
   desktopAutoUpdateService?.stop();
   desktopBrowserViewManager?.destroyAll();
@@ -1901,6 +2006,7 @@ async function runDesktopApp(): Promise<void> {
     void desktopAutoUpdateService?.checkAfterActive();
     // A remote target has no realtime socket for config changes.
     refreshRemoteSystemConfig?.();
+    renewConnectSessionIfDue();
   });
   app.on("browser-window-created", (_event, browserWindow) => {
     if (desktopBrowserViewManager === null) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -311,6 +311,7 @@ let connectCredentialCache: ConnectCredentialCache | null = null;
 let cachedConnectCredential: ConnectCredential | null = null;
 let enrollingDesktopMachine: Promise<void> | null = null;
 let connectSessionRenewal: ConnectSessionRenewal | null = null;
+let serverTargetGeneration = 0;
 let connectAccountServers: ConnectAccountServer[] = [];
 let builtinServerUrl: string = DEFAULT_BB_SERVER_URL;
 let desktopBridgePath: string | null = null;
@@ -1005,7 +1006,7 @@ async function ensureBuiltinRuntimeAttached(): Promise<boolean> {
  */
 async function authenticateConnectTarget(
   remoteServerUrl: string,
-  isCurrent: () => boolean = () => true,
+  isCurrent: () => boolean,
 ): Promise<ConnectDesktopSessionResult> {
   const cookieStore = session.defaultSession.cookies;
   let cachedFailure: ConnectDesktopSessionResult | null = null;
@@ -1114,6 +1115,14 @@ function ensureDesktopMachineEnrolled(): void {
   });
 }
 
+/**
+ * Load the saved target and pin the session, config sync, and menu to it.
+ *
+ * The Server menu starts a switch without waiting, so two of these can overlap
+ * and a slow one can finish last. Each run therefore claims a generation and
+ * checks it after every wait: a run the user has already superseded stops
+ * quietly instead of loading its own server over the newer one.
+ */
 async function applyServerTarget(): Promise<void> {
   if (serverTargetStore === null) {
     return;
@@ -1123,8 +1132,15 @@ async function applyServerTarget(): Promise<void> {
   // flight would otherwise still read itself as current while this switch
   // runs, and its local-server fallback would undo the switch.
   connectSessionRenewal?.stop();
+  serverTargetGeneration += 1;
+  const generation = serverTargetGeneration;
+  const isCurrent = (): boolean => serverTargetGeneration === generation;
+
   if (target.kind === "builtin") {
     const attached = await ensureBuiltinRuntimeAttached();
+    if (!isCurrent()) {
+      return;
+    }
     if (!attached) {
       await loadStartupError({
         details:
@@ -1149,7 +1165,13 @@ async function applyServerTarget(): Promise<void> {
     // Connect servers load as plain web pages behind a session cookie. The
     // cookie comes from the app's own machine credential when it has one, so
     // no local bb server has to run.
-    const result = await authenticateConnectTarget(target.server.url);
+    const result = await authenticateConnectTarget(
+      target.server.url,
+      isCurrent,
+    );
+    if (!isCurrent()) {
+      return;
+    }
     if (!result.ok) {
       createDesktopLogger().warn(
         `[desktop] Connect authentication failed (${result.code}): ${result.detail}`,
@@ -1170,11 +1192,17 @@ async function applyServerTarget(): Promise<void> {
     });
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.server.url });
+    if (!isCurrent()) {
+      return;
+    }
     startRemoteSystemConfigSync(target.server.url);
   } else {
     // A custom server is a plain web load with no bb Connect involved.
     bbAppLoaded = true;
     await loadWindowUrl({ url: target.url });
+    if (!isCurrent()) {
+      return;
+    }
     startRemoteSystemConfigSync(target.url);
   }
   refreshApplicationMenu();

--- a/apps/desktop/test/bb-process.test.ts
+++ b/apps/desktop/test/bb-process.test.ts
@@ -27,7 +27,9 @@ interface CreateTempScriptArgs {
 const tempScripts: TempScript[] = [];
 const processes: BbAppProcess[] = [];
 
-async function createTempScript(args: CreateTempScriptArgs): Promise<TempScript> {
+async function createTempScript(
+  args: CreateTempScriptArgs,
+): Promise<TempScript> {
   const root = await mkdtemp(join(tmpdir(), "bb-desktop-process-"));
   const path = join(root, "child.mjs");
   await writeFile(path, args.contents, "utf8");

--- a/apps/desktop/test/connect-credential-cache.test.ts
+++ b/apps/desktop/test/connect-credential-cache.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createConnectCredentialCache,
+  type ConnectCredentialCacheFs,
+  type ConnectCredentialEncryption,
+} from "../src/connect-credential-cache.js";
+
+const CREDENTIAL = {
+  credential: "bbcm_desktop",
+  handle: "laptop",
+  serverUrl: "https://laptop.getbb.app",
+};
+
+/** Stand-in for the OS keychain: a reversible byte tag, never plain JSON. */
+function createEncryption(
+  available = true,
+): ConnectCredentialEncryption & { available: boolean } {
+  return {
+    available,
+    isEncryptionAvailable() {
+      return this.available;
+    },
+    encryptString(plainText) {
+      return Buffer.from(`sealed:${plainText}`);
+    },
+    decryptString(encrypted) {
+      const text = encrypted.toString();
+      if (!text.startsWith("sealed:")) {
+        throw new Error("cannot decrypt");
+      }
+      return text.slice("sealed:".length);
+    },
+  };
+}
+
+function createFs(seed: Buffer | null = null): ConnectCredentialCacheFs & {
+  file: Buffer | null;
+} {
+  return {
+    file: seed,
+    async readFile() {
+      if (this.file === null) {
+        throw new Error("ENOENT");
+      }
+      return this.file;
+    },
+    async rm() {
+      this.file = null;
+    },
+    async writeFile(_path, data) {
+      this.file = data;
+    },
+  };
+}
+
+describe("createConnectCredentialCache", () => {
+  it("round-trips a credential through the keychain", async () => {
+    const fs = createFs();
+    const cache = createConnectCredentialCache({
+      encryption: createEncryption(),
+      fs,
+      userDataPath: "/data",
+    });
+
+    await cache.write(CREDENTIAL);
+    // Only sealed bytes reach the disk; the cache never writes plain JSON.
+    expect(fs.file?.toString().startsWith("sealed:")).toBe(true);
+    await expect(cache.read()).resolves.toEqual(CREDENTIAL);
+
+    await cache.clear();
+    await expect(cache.read()).resolves.toBeNull();
+  });
+
+  it("never writes the secret when the OS offers no encryption", async () => {
+    const fs = createFs();
+    const encryption = createEncryption(false);
+    const encryptString = vi.spyOn(encryption, "encryptString");
+
+    const cache = createConnectCredentialCache({
+      encryption,
+      fs,
+      userDataPath: "/data",
+    });
+    await cache.write(CREDENTIAL);
+
+    expect(encryptString).not.toHaveBeenCalled();
+    expect(fs.file).toBeNull();
+    await expect(cache.read()).resolves.toBeNull();
+  });
+
+  it("drops bytes it cannot decrypt or parse", async () => {
+    const undecryptable = createFs(Buffer.from("from-another-machine"));
+    await expect(
+      createConnectCredentialCache({
+        encryption: createEncryption(),
+        fs: undecryptable,
+        userDataPath: "/data",
+      }).read(),
+    ).resolves.toBeNull();
+    expect(undecryptable.file).toBeNull();
+
+    const wrongShape = createFs(
+      Buffer.from(`sealed:${JSON.stringify({ handle: "laptop" })}`),
+    );
+    await expect(
+      createConnectCredentialCache({
+        encryption: createEncryption(),
+        fs: wrongShape,
+        userDataPath: "/data",
+      }).read(),
+    ).resolves.toBeNull();
+    expect(wrongShape.file).toBeNull();
+  });
+});

--- a/apps/desktop/test/connect-credential-cache.test.ts
+++ b/apps/desktop/test/connect-credential-cache.test.ts
@@ -83,6 +83,9 @@ describe("createConnectCredentialCache", () => {
     });
     await cache.write(CREDENTIAL);
 
+    // The caller checks this before enrolling, so a keychain-less machine
+    // never burns an account machine slot on every launch.
+    expect(cache.canPersist()).toBe(false);
     expect(encryptString).not.toHaveBeenCalled();
     expect(fs.file).toBeNull();
     await expect(cache.read()).resolves.toBeNull();

--- a/apps/desktop/test/connect-desktop-session.test.ts
+++ b/apps/desktop/test/connect-desktop-session.test.ts
@@ -55,7 +55,7 @@ describe("installConnectDesktopSession", () => {
         mintCookie: successfulSource(),
         remoteServerUrl: "https://laptop.getbb.app",
       }),
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual({ expiresAt: 1_800_000, ok: true });
     expect(set).toHaveBeenCalledWith({
       domain: ".getbb.app",
       expirationDate: 1800,

--- a/apps/desktop/test/connect-desktop-session.test.ts
+++ b/apps/desktop/test/connect-desktop-session.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  type DesktopCookieStore,
+  createCredentialCookieSource,
+  createLocalServerCookieSource,
   installConnectDesktopSession,
+  type DesktopCookieStore,
 } from "../src/connect-desktop-session.js";
+
+const CREDENTIAL = {
+  credential: "bbcm_desktop",
+  handle: "laptop",
+  serverUrl: "https://laptop.getbb.app",
+};
 
 function createCookieStore(): DesktopCookieStore {
   let installed: { name: string; value: string } | null = null;
@@ -16,43 +24,38 @@ function createCookieStore(): DesktopCookieStore {
   };
 }
 
-function successfulResponse(): Response {
-  return new Response(
-    JSON.stringify({
-      ok: true,
-      result: {
-        cookie: {
-          domain: ".getbb.app",
-          expiresAt: 1_800_000,
-          name: "__Secure-bb-connect.desktop_session",
-          value: "signed-session",
-        },
-      },
-    }),
-  );
+const COOKIE = {
+  domain: ".getbb.app",
+  expiresAt: 1_800_000,
+  name: "__Secure-bb-connect.desktop_session",
+  value: "signed-session",
+};
+
+function localRpcResponse(): Response {
+  return new Response(JSON.stringify({ ok: true, result: { cookie: COOKIE } }));
+}
+
+function gateResponse(): Response {
+  return new Response(JSON.stringify({ cookie: COOKIE }));
+}
+
+function successfulSource() {
+  return async () => ({ cookie: COOKIE, ok: true }) as const;
 }
 
 describe("installConnectDesktopSession", () => {
-  it("exchanges through the local plugin, installs, and verifies the cookie", async () => {
+  it("installs and verifies the cookie the source minted", async () => {
     const cookieStore = createCookieStore();
     const set = vi.spyOn(cookieStore, "set");
     const get = vi.spyOn(cookieStore, "get");
-    const fetchImpl = vi.fn(async () => successfulResponse());
 
     await expect(
       installConnectDesktopSession({
         cookieStore,
-        fetchImpl,
-        localServerUrl: "http://127.0.0.1:38886",
+        mintCookie: successfulSource(),
         remoteServerUrl: "https://laptop.getbb.app",
       }),
     ).resolves.toEqual({ ok: true });
-    expect(fetchImpl).toHaveBeenCalledWith(
-      new URL(
-        "http://127.0.0.1:38886/api/v1/plugins/connect/rpc/createDesktopSession",
-      ),
-      expect.objectContaining({ method: "POST" }),
-    );
     expect(set).toHaveBeenCalledWith({
       domain: ".getbb.app",
       expirationDate: 1800,
@@ -70,45 +73,18 @@ describe("installConnectDesktopSession", () => {
     });
   });
 
-  it("returns an actionable network failure when the local plugin is unavailable", async () => {
+  it("passes a mint failure through untouched", async () => {
     await expect(
       installConnectDesktopSession({
         cookieStore: createCookieStore(),
-        fetchImpl: async () => {
-          throw new Error("offline");
-        },
-        localServerUrl: "http://127.0.0.1:38886",
+        mintCookie: async () => ({
+          code: "unauthorized",
+          detail: "revoked",
+          ok: false,
+        }),
         remoteServerUrl: "https://laptop.getbb.app",
       }),
-    ).resolves.toEqual({ code: "network", detail: "offline", ok: false });
-  });
-
-  it("reports rejected and malformed RPC responses", async () => {
-    const args = {
-      cookieStore: createCookieStore(),
-      localServerUrl: "http://127.0.0.1:38886",
-      remoteServerUrl: "https://laptop.getbb.app",
-    };
-    await expect(
-      installConnectDesktopSession({
-        ...args,
-        fetchImpl: async () => new Response("no", { status: 503 }),
-      }),
-    ).resolves.toEqual({
-      code: "request_rejected",
-      detail: "HTTP 503",
-      ok: false,
-    });
-    await expect(
-      installConnectDesktopSession({
-        ...args,
-        fetchImpl: async () => new Response(JSON.stringify({ ok: true })),
-      }),
-    ).resolves.toEqual({
-      code: "invalid_response",
-      detail: "response did not match the contract",
-      ok: false,
-    });
+    ).resolves.toEqual({ code: "unauthorized", detail: "revoked", ok: false });
   });
 
   it("fails when Electron rejects or does not retain the cookie", async () => {
@@ -122,8 +98,7 @@ describe("installConnectDesktopSession", () => {
             throw new Error("cookie rejected");
           },
         },
-        fetchImpl: async () => successfulResponse(),
-        localServerUrl: "http://127.0.0.1:38886",
+        mintCookie: successfulSource(),
         remoteServerUrl: "https://laptop.getbb.app",
       }),
     ).resolves.toEqual({
@@ -140,8 +115,7 @@ describe("installConnectDesktopSession", () => {
           },
           async set() {},
         },
-        fetchImpl: async () => successfulResponse(),
-        localServerUrl: "http://127.0.0.1:38886",
+        mintCookie: successfulSource(),
         remoteServerUrl: "https://laptop.getbb.app",
       }),
     ).resolves.toEqual({
@@ -149,5 +123,81 @@ describe("installConnectDesktopSession", () => {
       detail: "Electron did not retain the desktop session cookie",
       ok: false,
     });
+  });
+});
+
+describe("createLocalServerCookieSource", () => {
+  it("exchanges through the local plugin RPC", async () => {
+    const fetchImpl = vi.fn(async () => localRpcResponse());
+    await expect(
+      createLocalServerCookieSource({
+        fetchImpl,
+        localServerUrl: "http://127.0.0.1:38886",
+      })(),
+    ).resolves.toEqual({ cookie: COOKIE, ok: true });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(
+        "http://127.0.0.1:38886/api/v1/plugins/connect/rpc/createDesktopSession",
+      ),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("reports unavailable, rejected, and malformed responses", async () => {
+    await expect(
+      createLocalServerCookieSource({
+        fetchImpl: async () => {
+          throw new Error("offline");
+        },
+        localServerUrl: "http://127.0.0.1:38886",
+      })(),
+    ).resolves.toEqual({ code: "network", detail: "offline", ok: false });
+
+    await expect(
+      createLocalServerCookieSource({
+        fetchImpl: async () => new Response("no", { status: 503 }),
+        localServerUrl: "http://127.0.0.1:38886",
+      })(),
+    ).resolves.toEqual({
+      code: "request_rejected",
+      detail: "HTTP 503",
+      ok: false,
+    });
+
+    await expect(
+      createLocalServerCookieSource({
+        fetchImpl: async () => new Response(JSON.stringify({ ok: true })),
+        localServerUrl: "http://127.0.0.1:38886",
+      })(),
+    ).resolves.toEqual({
+      code: "invalid_response",
+      detail: "response did not match the contract",
+      ok: false,
+    });
+  });
+});
+
+describe("createCredentialCookieSource", () => {
+  it("mints straight from the connect gate with the machine credential", async () => {
+    const fetchImpl = vi.fn(async () => gateResponse());
+    await expect(
+      createCredentialCookieSource({ credential: CREDENTIAL, fetchImpl })(),
+    ).resolves.toEqual({ cookie: COOKIE, ok: true });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://laptop.getbb.app/api/connect/desktop-session",
+      expect.objectContaining({
+        headers: { "x-bb-connect-machine": "bbcm_desktop" },
+        method: "POST",
+      }),
+    );
+  });
+
+  it("reports a refused credential as unauthorized so the caller can drop it", async () => {
+    await expect(
+      createCredentialCookieSource({
+        credential: CREDENTIAL,
+        fetchImpl: async () => new Response("no", { status: 403 }),
+      })(),
+    ).resolves.toMatchObject({ code: "unauthorized", ok: false });
   });
 });

--- a/apps/desktop/test/connect-machine-enrollment.test.ts
+++ b/apps/desktop/test/connect-machine-enrollment.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { enrollDesktopMachine } from "../src/connect-machine-enrollment.js";
+
+function machineCodeResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      result: {
+        code: "ABCD-1234",
+        expiresAt: 1_800_000,
+        serverUrl: "https://laptop.getbb.app",
+      },
+    }),
+  );
+}
+
+describe("enrollDesktopMachine", () => {
+  it("mints a code on the local server and redeems it at the connect apex", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/rpc/createMachineCode")) {
+        return machineCodeResponse();
+      }
+      expect(url).toBe("https://getbb.app/api/connect/redeem-machine");
+      return new Response(
+        JSON.stringify({
+          credential: "bbcm_desktop",
+          machineId: "machine-1",
+          handle: "laptop",
+          serverUrl: "https://laptop.getbb.app",
+        }),
+      );
+    });
+
+    await expect(
+      enrollDesktopMachine({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        localServerUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toEqual({
+      credential: {
+        credential: "bbcm_desktop",
+        handle: "laptop",
+        serverUrl: "https://laptop.getbb.app",
+      },
+      ok: true,
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      "http://127.0.0.1:38886/api/v1/plugins/connect/rpc/createMachineCode",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("falls back to the server URL for a code with no handle", async () => {
+    const fetchImpl = async (input: string | URL | Request) =>
+      String(input).endsWith("/rpc/createMachineCode")
+        ? machineCodeResponse()
+        : new Response(
+            JSON.stringify({
+              credential: "bbcm_desktop",
+              machineId: "machine-1",
+              handle: null,
+              serverUrl: "https://laptop.getbb.app",
+            }),
+          );
+
+    await expect(
+      enrollDesktopMachine({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        localServerUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toMatchObject({ credential: { handle: "laptop" }, ok: true });
+  });
+
+  it("reports an unpaired bb without calling the gate", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: false, error: "not_paired" }), {
+          status: 500,
+        }),
+    );
+
+    await expect(
+      enrollDesktopMachine({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        localServerUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toEqual({
+      code: "not_paired",
+      detail: "this bb is not paired with bb Connect",
+      ok: false,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the account machine limit from the gate", async () => {
+    const fetchImpl = async (input: string | URL | Request) =>
+      String(input).endsWith("/rpc/createMachineCode")
+        ? machineCodeResponse()
+        : new Response(JSON.stringify({ error: "machine-limit" }), {
+            status: 409,
+          });
+
+    await expect(
+      enrollDesktopMachine({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        localServerUrl: "http://127.0.0.1:38886",
+      }),
+    ).resolves.toMatchObject({ code: "machine_limit", ok: false });
+  });
+});

--- a/apps/desktop/test/connect-machine-enrollment.test.ts
+++ b/apps/desktop/test/connect-machine-enrollment.test.ts
@@ -52,7 +52,7 @@ describe("enrollDesktopMachine", () => {
     );
   });
 
-  it("falls back to the server URL for a code with no handle", async () => {
+  it("takes the label from the server URL, not the account handle", async () => {
     const fetchImpl = async (input: string | URL | Request) =>
       String(input).endsWith("/rpc/createMachineCode")
         ? machineCodeResponse()
@@ -60,7 +60,7 @@ describe("enrollDesktopMachine", () => {
             JSON.stringify({
               credential: "bbcm_desktop",
               machineId: "machine-1",
-              handle: null,
+              handle: "sawyer",
               serverUrl: "https://laptop.getbb.app",
             }),
           );
@@ -76,9 +76,13 @@ describe("enrollDesktopMachine", () => {
   it("reports an unpaired bb without calling the gate", async () => {
     const fetchImpl = vi.fn(
       async () =>
-        new Response(JSON.stringify({ ok: false, error: "not_paired" }), {
-          status: 500,
-        }),
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: { code: "handler_error", message: "not_paired" },
+          }),
+          { status: 500 },
+        ),
     );
 
     await expect(

--- a/apps/desktop/test/connect-server-sync.test.ts
+++ b/apps/desktop/test/connect-server-sync.test.ts
@@ -96,10 +96,7 @@ describe("selectTargetableConnectServers", () => {
         { handle: "phone", name: "Phone", live: false, url: "https://p.x" },
       ],
     });
-    expect(servers.map((server) => server.handle)).toEqual([
-      "laptop",
-      "phone",
-    ]);
+    expect(servers.map((server) => server.handle)).toEqual(["laptop", "phone"]);
   });
 });
 
@@ -128,10 +125,12 @@ describe("createConnectServerSync", () => {
     }));
 
     const sync = createConnectServerSync({
+      getCredential: () => null,
       getLocalServerUrl: () => "http://127.0.0.1:38886",
       onServers(servers) {
         received = servers;
       },
+      onUnauthorized: () => undefined,
       fetchImpl,
       now: () => now,
       minIntervalMs: 60_000,
@@ -188,10 +187,12 @@ describe("createConnectServerSync", () => {
     });
 
     const sync = createConnectServerSync({
+      getCredential: () => null,
       getLocalServerUrl: () => "http://127.0.0.1:38886",
       onServers() {
         onServersCalls += 1;
       },
+      onUnauthorized: () => undefined,
       fetchImpl,
       log: (message) => {
         logs.push(message);
@@ -211,5 +212,91 @@ describe("createConnectServerSync", () => {
     fail = true;
     await sync.syncNow();
     expect(logs).toHaveLength(2);
+  });
+});
+
+describe("createConnectServerSync without a local server", () => {
+  const credential = {
+    credential: "bbcm_desktop",
+    handle: "me",
+    serverUrl: "https://me.getbb.app",
+  };
+
+  it("lists servers straight from the gate with the cached credential", async () => {
+    let received: ConnectAccountServer[] | null = null;
+    const gateFetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            servers: [
+              { handle: "me", name: "This Mac", live: true },
+              { handle: "other", name: "Other", live: true },
+            ],
+          }),
+        ),
+    );
+
+    const sync = createConnectServerSync({
+      getCredential: () => credential,
+      getLocalServerUrl: () => null,
+      gateFetchImpl,
+      onServers(servers) {
+        received = servers;
+      },
+      onUnauthorized: () => undefined,
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => undefined,
+    });
+
+    await sync.syncNow();
+    expect(gateFetchImpl).toHaveBeenCalledWith(
+      "https://me.getbb.app/api/connect/servers",
+      expect.objectContaining({
+        headers: { "x-bb-connect-machine": "bbcm_desktop" },
+      }),
+    );
+    // selfHandle drops out: "This Mac" is its own menu entry.
+    expect(received).toEqual([
+      {
+        handle: "other",
+        name: "Other",
+        live: true,
+        url: "https://other.getbb.app",
+      },
+    ]);
+  });
+
+  it("reports a refused credential so the caller drops it", async () => {
+    let unauthorized = 0;
+    const sync = createConnectServerSync({
+      getCredential: () => credential,
+      getLocalServerUrl: () => null,
+      gateFetchImpl: async () => new Response("no", { status: 403 }),
+      onServers: () => undefined,
+      onUnauthorized() {
+        unauthorized += 1;
+      },
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => undefined,
+    });
+
+    await sync.syncNow();
+    expect(unauthorized).toBe(1);
+  });
+
+  it("stays quiet when the app has no credential", async () => {
+    const gateFetchImpl = vi.fn(async () => new Response("{}"));
+    const sync = createConnectServerSync({
+      getCredential: () => null,
+      getLocalServerUrl: () => null,
+      gateFetchImpl,
+      onServers: () => undefined,
+      onUnauthorized: () => undefined,
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => undefined,
+    });
+
+    await sync.syncNow();
+    expect(gateFetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/test/connect-session-renewal.test.ts
+++ b/apps/desktop/test/connect-session-renewal.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createConnectSessionRenewal,
+  type ConnectSessionAuthenticateResult,
+} from "../src/connect-session-renewal.js";
+
+const HOUR_MS = 60 * 60 * 1000;
+const LEAD_MS = 5 * 60 * 1000;
+
+/** A promise the test releases by hand, to hold a call open mid-flight. */
+function createGate(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+/** Manual clock plus timer queue, so the tests never wait on real time. */
+function createHarness(
+  authenticate: (
+    remoteServerUrl: string,
+    isCurrent: () => boolean,
+  ) => Promise<ConnectSessionAuthenticateResult>,
+) {
+  let now = 1_000_000;
+  let nextHandle = 1;
+  const timers = new Map<number, { at: number; handler: () => void }>();
+  const logs: string[] = [];
+
+  const renewal = createConnectSessionRenewal({
+    authenticate,
+    log: (message) => {
+      logs.push(message);
+    },
+    now: () => now,
+    setTimeoutFn(handler, timeout) {
+      const handle = nextHandle;
+      nextHandle += 1;
+      timers.set(handle, { at: now + timeout, handler });
+      return handle;
+    },
+    clearTimeoutFn(handle) {
+      timers.delete(handle as number);
+    },
+  });
+
+  return {
+    logs,
+    renewal,
+    get pendingDelays(): number[] {
+      return [...timers.values()].map((timer) => timer.at - now);
+    },
+    advanceTo(target: number): void {
+      now = target;
+    },
+    /** Fire every timer that is due, the way an event loop would. */
+    runDueTimers(): void {
+      for (const [handle, timer] of [...timers]) {
+        if (timer.at <= now) {
+          timers.delete(handle);
+          timer.handler();
+        }
+      }
+    },
+  };
+}
+
+describe("createConnectSessionRenewal", () => {
+  it("renews ahead of expiry and reschedules from the new cookie", async () => {
+    const authenticate = vi.fn(
+      async (): Promise<ConnectSessionAuthenticateResult> => ({
+        expiresAt: 1_000_000 + 2 * HOUR_MS,
+        ok: true,
+      }),
+    );
+    const harness = createHarness(authenticate);
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    expect(harness.pendingDelays).toEqual([HOUR_MS - LEAD_MS]);
+
+    harness.advanceTo(1_000_000 + HOUR_MS - LEAD_MS);
+    harness.runDueTimers();
+    await harness.renewal.renewNow();
+
+    expect(authenticate).toHaveBeenCalledWith(
+      "https://laptop.getbb.app",
+      expect.any(Function),
+    );
+    // The new cookie runs to now + 1h05m, so the next renewal waits an hour.
+    expect(harness.pendingDelays).toEqual([HOUR_MS]);
+  });
+
+  it("does not reschedule when the target changed during a successful renewal", async () => {
+    const gate = createGate();
+    const authenticate = vi.fn(
+      async (): Promise<ConnectSessionAuthenticateResult> => {
+        await gate.promise;
+        return { expiresAt: 1_000_000 + 2 * HOUR_MS, ok: true };
+      },
+    );
+    const harness = createHarness(authenticate);
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    const renewing = harness.renewal.renewNow();
+
+    // The user switches to a custom server while the gate call is open.
+    harness.renewal.stop();
+    gate.release();
+    await renewing;
+
+    expect(harness.pendingDelays).toEqual([]);
+  });
+
+  it("does not retry when the target changed during a failed renewal", async () => {
+    const gate = createGate();
+    const authenticate = vi.fn(
+      async (): Promise<ConnectSessionAuthenticateResult> => {
+        await gate.promise;
+        return { detail: "network: offline", ok: false };
+      },
+    );
+    const harness = createHarness(authenticate);
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    const renewing = harness.renewal.renewNow();
+
+    harness.renewal.stop();
+    gate.release();
+    await renewing;
+
+    expect(harness.pendingDelays).toEqual([]);
+    expect(harness.logs).toEqual([]);
+  });
+
+  it("tells the authenticate call when its target is gone", async () => {
+    const seen: boolean[] = [];
+    const gate = createGate();
+    const harness = createHarness(async (_serverUrl, isCurrent) => {
+      seen.push(isCurrent());
+      await gate.promise;
+      seen.push(isCurrent());
+      return { expiresAt: 1_000_000 + 2 * HOUR_MS, ok: true };
+    });
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    const renewing = harness.renewal.renewNow();
+    harness.renewal.stop();
+    gate.release();
+    await renewing;
+
+    // The local-server fallback reads this before it starts a bb server.
+    expect(seen).toEqual([true, false]);
+  });
+
+  it("retries on the lead interval after a failure", async () => {
+    const authenticate = vi.fn(
+      async (): Promise<ConnectSessionAuthenticateResult> => ({
+        detail: "network: offline",
+        ok: false,
+      }),
+    );
+    const harness = createHarness(authenticate);
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    await harness.renewal.renewNow();
+
+    expect(harness.pendingDelays).toEqual([30_000]);
+    expect(harness.logs).toHaveLength(1);
+  });
+
+  it("renews on demand only when the session is nearly spent", async () => {
+    const authenticate = vi.fn(
+      async (): Promise<ConnectSessionAuthenticateResult> => ({
+        expiresAt: 1_000_000 + 2 * HOUR_MS,
+        ok: true,
+      }),
+    );
+    const harness = createHarness(authenticate);
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    harness.renewal.renewIfDue();
+    expect(authenticate).not.toHaveBeenCalled();
+
+    // A Mac that slept past the timer wakes with the session almost gone.
+    harness.advanceTo(1_000_000 + HOUR_MS - 60_000);
+    harness.renewal.renewIfDue();
+    await harness.renewal.renewNow();
+    expect(authenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays idle after stop, and starts a new generation cleanly", async () => {
+    const authenticate = vi.fn(
+      async (): Promise<ConnectSessionAuthenticateResult> => ({
+        expiresAt: 1_000_000 + 2 * HOUR_MS,
+        ok: true,
+      }),
+    );
+    const harness = createHarness(authenticate);
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    harness.renewal.stop();
+    expect(harness.pendingDelays).toEqual([]);
+
+    harness.renewal.renewIfDue();
+    await harness.renewal.renewNow();
+    expect(authenticate).not.toHaveBeenCalled();
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://phone.getbb.app",
+    });
+    await harness.renewal.renewNow();
+    expect(authenticate).toHaveBeenCalledWith(
+      "https://phone.getbb.app",
+      expect.any(Function),
+    );
+  });
+});

--- a/apps/desktop/test/connect-session-renewal.test.ts
+++ b/apps/desktop/test/connect-session-renewal.test.ts
@@ -237,4 +237,31 @@ describe("createConnectSessionRenewal", () => {
       expect.any(Function),
     );
   });
+
+  it("retires an in-flight renewal when a new session starts", async () => {
+    const gate = createGate();
+    const harness = createHarness(async (_serverUrl, isCurrent) => {
+      await gate.promise;
+      expect(isCurrent()).toBe(false);
+      return { expiresAt: 1_000_000 + 2 * HOUR_MS, ok: true };
+    });
+
+    harness.renewal.start({
+      expiresAt: 1_000_000 + HOUR_MS,
+      remoteServerUrl: "https://laptop.getbb.app",
+    });
+    const renewing = harness.renewal.renewNow();
+
+    // The switch to another Connect server lands while the old renewal is
+    // still open, which is what applyServerTarget does before it authenticates.
+    harness.renewal.start({
+      expiresAt: 1_000_000 + 3 * HOUR_MS,
+      remoteServerUrl: "https://phone.getbb.app",
+    });
+    gate.release();
+    await renewing;
+
+    // Only the new session's timer survives; the old renewal added nothing.
+    expect(harness.pendingDelays).toEqual([3 * HOUR_MS - LEAD_MS]);
+  });
 });

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -360,7 +360,9 @@ const electronMock = vi.hoisted(() => {
       }
     }
 
-    emitBeforeInput(input: Partial<FakeInput> & Pick<FakeInput, "key">): boolean {
+    emitBeforeInput(
+      input: Partial<FakeInput> & Pick<FakeInput, "key">,
+    ): boolean {
       const event = new FakePreventableEventImpl();
       const resolvedInput: FakeInput = {
         alt: false,
@@ -699,8 +701,11 @@ describe("DesktopBrowserViewManager", () => {
   it("forwards resolved browser shortcuts and suppresses the untrusted page", () => {
     const dispatchAppCommand = vi.fn();
     const focusHostWebContents = vi.fn();
-    const resolveAppCommand = vi.fn((input: { key: string; metaKey: boolean }) =>
-      input.key === "l" && input.metaKey ? "browser.focusLocation" as const : null,
+    const resolveAppCommand = vi.fn(
+      (input: { key: string; metaKey: boolean }) =>
+        input.key === "l" && input.metaKey
+          ? ("browser.focusLocation" as const)
+          : null,
     );
     const manager = createDesktopBrowserViewManager({
       dispatchAppCommand,
@@ -846,9 +851,7 @@ describe("DesktopBrowserViewManager", () => {
         webContentsId: view.webContents.id,
       }),
     ).toBe(true);
-    expect(view.webContents.emitWillNavigate("http://192.168.1.1/")).toBe(
-      true,
-    );
+    expect(view.webContents.emitWillNavigate("http://192.168.1.1/")).toBe(true);
   });
 
   it("allows unattributed loopback main-frame requests with matching tabs", () => {
@@ -1409,9 +1412,11 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual({
-      action: "deny",
-    });
+    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual(
+      {
+        action: "deny",
+      },
+    );
     expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
     expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
       {

--- a/apps/desktop/test/desktop-shell-path.test.ts
+++ b/apps/desktop/test/desktop-shell-path.test.ts
@@ -29,9 +29,7 @@ interface WarningLogger {
   warnings: string[];
 }
 
-function createSpawnResult(
-  args: CreateSpawnResultArgs,
-): ShellPathSpawnResult {
+function createSpawnResult(args: CreateSpawnResultArgs): ShellPathSpawnResult {
   return {
     ...(args.error === undefined ? {} : { error: args.error }),
     signal: args.signal ?? null,

--- a/apps/desktop/test/desktop-window-factory.test.ts
+++ b/apps/desktop/test/desktop-window-factory.test.ts
@@ -196,11 +196,7 @@ class FakeDesktopWindow implements DesktopBrowserWindow {
   }
 
   on(
-    eventName:
-      | "close"
-      | "closed"
-      | "enter-full-screen"
-      | "leave-full-screen",
+    eventName: "close" | "closed" | "enter-full-screen" | "leave-full-screen",
     listener: () => void,
   ): void {
     if (eventName === "closed") {

--- a/docs/multiple-devices.md
+++ b/docs/multiple-devices.md
@@ -46,6 +46,23 @@ npx bb-app client ssh-target set <bb-server-origin> <ssh-target>
 
 Phones and tablets need no helper; editor-launch actions are simply unavailable.
 
+## Point the desktop app at another bb
+
+The desktop app's Server menu lists "This Mac", every bb connect server on the
+account, and a custom URL. When you select a remote server, the app stops
+starting a bb server on this Mac. It starts one again only when you select
+"This Mac".
+
+To reach bb connect without a local server, the app enrolls itself once as a
+connect machine. That step needs the local server, so the first switch to a
+remote server still starts it. The app keeps its own credential, encrypted with
+the OS keychain, and never holds the server's pairing secret. The app appears in
+the getbb.app dashboard machine list, where you can revoke it. After a revoke,
+the app drops the credential and asks the local server again.
+
+A remote server has no realtime link for keybindings and theme. The app re-reads
+them when it starts, when it becomes active, and every five minutes.
+
 ## Add an execution machine
 
 Open Settings → Machines and choose Add machine. Run the generated one-line

--- a/packages/connect-client/package.json
+++ b/packages/connect-client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bb/connect-client",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@bb/tsconfig": "workspace:*",
+    "@types/node": "^22.0.0",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "vitest": "^4.1.1"
+  }
+}

--- a/packages/connect-client/src/credential.ts
+++ b/packages/connect-client/src/credential.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+// The durable machine credential minted by pairing. On a bb server it lives in
+// the connect plugin's kv storage (bb.db); the desktop app caches a copy so it
+// can reach the connect gate without a local server.
+// `handle` is the paired server's routing label (subdomain), which may differ
+// from the account's primary handle when multiple bbs are connected.
+export const connectCredentialSchema = z.object({
+  serverUrl: z.string().min(1),
+  handle: z.string().min(1),
+  credential: z.string().min(1),
+});
+
+export type ConnectCredential = z.infer<typeof connectCredentialSchema>;
+
+/**
+ * Derive the connect cloud apex (`https://getbb.app`) from a server URL
+ * (`https://<handle>.getbb.app`) by dropping the handle label.
+ */
+export function deriveConnectBaseUrl(serverUrl: string): string {
+  return new URL(serverUrl).origin.replace(/\/\/[^.]+\./, "//");
+}
+
+/**
+ * `https://getbb.app` + routing label → `https://<label>.getbb.app`.
+ * `handle` is the redeemed server's subdomain (primary or additional).
+ */
+export function serverUrlForHandle(baseUrl: string, handle: string): string {
+  const url = new URL(baseUrl);
+  return `${url.protocol}//${handle}.${url.host}`;
+}

--- a/packages/connect-client/src/desktop-session.ts
+++ b/packages/connect-client/src/desktop-session.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { ConnectCredential } from "./credential.js";
-import { ConnectListError } from "./list-servers.js";
+import { ConnectListError } from "./errors.js";
 
 const desktopSessionResponseSchema = z.object({
   cookie: z.object({
@@ -13,13 +13,19 @@ const desktopSessionResponseSchema = z.object({
 
 export type DesktopSession = z.infer<typeof desktopSessionResponseSchema>;
 
+/**
+ * Exchange the durable machine credential for a short-lived browser session
+ * cookie at the connect gate. The cookie lasts one hour, so every caller mints
+ * a fresh one rather than storing it.
+ */
 export async function fetchDesktopSession(
   credential: ConnectCredential,
+  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<DesktopSession> {
   const url = `${credential.serverUrl.replace(/\/$/, "")}/api/connect/desktop-session`;
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await fetchImpl(url, {
       method: "POST",
       headers: { "x-bb-connect-machine": credential.credential },
     });

--- a/packages/connect-client/src/errors.ts
+++ b/packages/connect-client/src/errors.ts
@@ -1,0 +1,27 @@
+export type ConnectListErrorCode =
+  | "not_paired"
+  | "unauthorized"
+  | "network"
+  | "invalid_response";
+
+/**
+ * Typed gate-call failure. `code` is stable for RPC/CLI mapping; `message`
+ * carries detail for logs/stderr.
+ */
+export class ConnectListError extends Error {
+  constructor(
+    readonly code: ConnectListErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ConnectListError";
+  }
+}
+
+/**
+ * A credential the gate refuses is dead: the machine was revoked, or the
+ * account unpaired it. Callers that cache the credential must drop their copy.
+ */
+export function isRevokedCredentialError(error: unknown): boolean {
+  return error instanceof ConnectListError && error.code === "unauthorized";
+}

--- a/packages/connect-client/src/index.ts
+++ b/packages/connect-client/src/index.ts
@@ -1,0 +1,27 @@
+export {
+  connectCredentialSchema,
+  deriveConnectBaseUrl,
+  serverUrlForHandle,
+  type ConnectCredential,
+} from "./credential.js";
+export {
+  ConnectListError,
+  isRevokedCredentialError,
+  type ConnectListErrorCode,
+} from "./errors.js";
+export {
+  accountServerSchema,
+  accountServersResponseSchema,
+  fetchAccountServers,
+  listAccountServers,
+  withAccountServerUrls,
+  type AccountServer,
+  type AccountServerWithUrl,
+  type ListAccountServersResult,
+} from "./list-servers.js";
+export { fetchDesktopSession, type DesktopSession } from "./desktop-session.js";
+export {
+  ConnectMachineRedeemError,
+  redeemMachineCredential,
+  type ConnectMachineRedeemErrorCode,
+} from "./redeem-machine.js";

--- a/packages/connect-client/src/list-servers.ts
+++ b/packages/connect-client/src/list-servers.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import type { ConnectCredential } from "./credential.js";
-import { deriveConnectBaseUrl, serverUrlForHandle } from "./redeem.js";
+import {
+  deriveConnectBaseUrl,
+  serverUrlForHandle,
+  type ConnectCredential,
+} from "./credential.js";
+import { ConnectListError } from "./errors.js";
 
 /** One server row from `GET /api/connect/servers` (worker boundary). */
 export const accountServerSchema = z.object({
@@ -41,37 +45,18 @@ export function withAccountServerUrls(
   }));
 }
 
-export type ConnectListErrorCode =
-  | "not_paired"
-  | "unauthorized"
-  | "network"
-  | "invalid_response";
-
-/**
- * Typed list failure. `code` is stable for RPC/CLI mapping; `message` carries
- * detail for logs/stderr.
- */
-export class ConnectListError extends Error {
-  constructor(
-    readonly code: ConnectListErrorCode,
-    message: string,
-  ) {
-    super(message);
-    this.name = "ConnectListError";
-  }
-}
-
 /**
  * Call the connect gate `GET /api/connect/servers` with the stored pairing
  * credential. Zod-parses the worker response at the boundary.
  */
 export async function fetchAccountServers(
   credential: ConnectCredential,
+  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<AccountServer[]> {
   const url = `${credential.serverUrl.replace(/\/$/, "")}/api/connect/servers`;
   let res: Response;
   try {
-    res = await fetch(url, {
+    res = await fetchImpl(url, {
       method: "GET",
       headers: { "x-bb-connect-machine": credential.credential },
     });
@@ -97,7 +82,10 @@ export async function fetchAccountServers(
   try {
     raw = await res.json();
   } catch {
-    throw new ConnectListError("invalid_response", "List servers returned non-JSON");
+    throw new ConnectListError(
+      "invalid_response",
+      "List servers returned non-JSON",
+    );
   }
 
   const parsed = accountServersResponseSchema.safeParse(raw);
@@ -108,4 +96,19 @@ export async function fetchAccountServers(
     );
   }
   return parsed.data.servers;
+}
+
+/**
+ * The gate call plus the URL enrichment and self label, so a caller holding
+ * only a credential gets the same result as the plugin's RPC.
+ */
+export async function listAccountServers(
+  credential: ConnectCredential,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<ListAccountServersResult> {
+  const servers = withAccountServerUrls(
+    await fetchAccountServers(credential, fetchImpl),
+    credential,
+  );
+  return { servers, selfHandle: credential.handle };
 }

--- a/packages/connect-client/src/redeem-machine.ts
+++ b/packages/connect-client/src/redeem-machine.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import type { ConnectCredential } from "./credential.js";
 
+// `handle` also rides on this response, but it names the account's primary
+// handle, not the server the code targeted. Only `serverUrl` names that server,
+// so the routing label comes from there.
 const redeemMachineResponseSchema = z.object({
   credential: z.string().min(1),
   machineId: z.string().min(1),
-  handle: z.string().nullable(),
   serverUrl: z.string().nullable(),
 });
 
@@ -39,10 +41,28 @@ function codeForStatus(
   return "invalid_code";
 }
 
-/** `https://<label>.getbb.app` → `<label>`. */
-function handleFromServerUrl(serverUrl: string): string | null {
-  const [label] = new URL(serverUrl).hostname.split(".");
-  return label === undefined || label.length === 0 ? null : label;
+/**
+ * `https://<label>.getbb.app` → `<label>`, but only for a URL the apex we
+ * asked actually owns. The gate names the server it enrolled us on; a host
+ * outside that apex would point later gate calls at a stranger.
+ */
+function handleForApex(serverUrl: string, apexUrl: string): string | null {
+  let parsed: URL;
+  let apex: URL;
+  try {
+    parsed = new URL(serverUrl);
+    apex = new URL(apexUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== apex.protocol || parsed.port !== apex.port) {
+    return null;
+  }
+  const [label, ...rest] = parsed.hostname.split(".");
+  if (label === undefined || label.length === 0) {
+    return null;
+  }
+  return rest.join(".") === apex.hostname ? label : null;
 }
 
 /**
@@ -98,7 +118,7 @@ export async function redeemMachineCredential(
       "Machine redeem response failed schema validation",
     );
   }
-  const { credential, handle, serverUrl } = parsed.data;
+  const { credential, serverUrl } = parsed.data;
   // The gate echoes the server the code targeted. Without it there is nothing
   // to point a session at, so treat the row as unusable.
   if (serverUrl === null) {
@@ -107,12 +127,12 @@ export async function redeemMachineCredential(
       "Machine redeem returned no server URL",
     );
   }
-  const resolvedHandle = handle ?? handleFromServerUrl(serverUrl);
-  if (resolvedHandle === null) {
+  const handle = handleForApex(serverUrl, args.apexUrl);
+  if (handle === null) {
     throw new ConnectMachineRedeemError(
       "invalid_response",
-      "Machine redeem returned no routing handle",
+      `Machine redeem returned a server URL outside ${args.apexUrl}`,
     );
   }
-  return { credential, handle: resolvedHandle, serverUrl };
+  return { credential, handle, serverUrl };
 }

--- a/packages/connect-client/src/redeem-machine.ts
+++ b/packages/connect-client/src/redeem-machine.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import type { ConnectCredential } from "./credential.js";
+
+const redeemMachineResponseSchema = z.object({
+  credential: z.string().min(1),
+  machineId: z.string().min(1),
+  handle: z.string().nullable(),
+  serverUrl: z.string().nullable(),
+});
+
+const redeemMachineErrorSchema = z.object({ error: z.string() });
+
+export type ConnectMachineRedeemErrorCode =
+  | "already_used"
+  | "expired"
+  | "invalid_code"
+  | "machine_limit"
+  | "network"
+  | "invalid_response";
+
+export class ConnectMachineRedeemError extends Error {
+  constructor(
+    readonly code: ConnectMachineRedeemErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ConnectMachineRedeemError";
+  }
+}
+
+function codeForStatus(
+  status: number,
+  wireError: string,
+): ConnectMachineRedeemErrorCode {
+  if (wireError === "machine-limit") return "machine_limit";
+  if (wireError === "already-used" || status === 409) return "already_used";
+  if (wireError === "expired" || status === 410) return "expired";
+  if (status >= 500) return "network";
+  return "invalid_code";
+}
+
+/** `https://<label>.getbb.app` → `<label>`. */
+function handleFromServerUrl(serverUrl: string): string | null {
+  const [label] = new URL(serverUrl).hostname.split(".");
+  return label === undefined || label.length === 0 ? null : label;
+}
+
+/**
+ * Redeem a one-time machine code at the connect apex for this client's own
+ * durable machine credential (`POST /api/connect/redeem-machine`).
+ *
+ * A machine credential is a separate, individually revocable identity on the
+ * account. Clients that need to reach the gate without a bb server enroll this
+ * way instead of copying a server's pairing secret.
+ */
+export async function redeemMachineCredential(
+  args: { apexUrl: string; code: string },
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<ConnectCredential> {
+  const url = `${args.apexUrl.replace(/\/$/u, "")}/api/connect/redeem-machine`;
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: args.code }),
+    });
+  } catch (error) {
+    throw new ConnectMachineRedeemError(
+      "network",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new ConnectMachineRedeemError(
+      "invalid_response",
+      "Machine redeem returned non-JSON",
+    );
+  }
+
+  if (!response.ok) {
+    const parsedError = redeemMachineErrorSchema.safeParse(body);
+    const wireError = parsedError.success ? parsedError.data.error : "";
+    throw new ConnectMachineRedeemError(
+      codeForStatus(response.status, wireError),
+      `Machine redeem failed (${response.status})${wireError ? `: ${wireError}` : ""}`,
+    );
+  }
+
+  const parsed = redeemMachineResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new ConnectMachineRedeemError(
+      "invalid_response",
+      "Machine redeem response failed schema validation",
+    );
+  }
+  const { credential, handle, serverUrl } = parsed.data;
+  // The gate echoes the server the code targeted. Without it there is nothing
+  // to point a session at, so treat the row as unusable.
+  if (serverUrl === null) {
+    throw new ConnectMachineRedeemError(
+      "invalid_response",
+      "Machine redeem returned no server URL",
+    );
+  }
+  const resolvedHandle = handle ?? handleFromServerUrl(serverUrl);
+  if (resolvedHandle === null) {
+    throw new ConnectMachineRedeemError(
+      "invalid_response",
+      "Machine redeem returned no routing handle",
+    );
+  }
+  return { credential, handle: resolvedHandle, serverUrl };
+}

--- a/packages/connect-client/test/connect-client.test.ts
+++ b/packages/connect-client/test/connect-client.test.ts
@@ -78,14 +78,16 @@ describe("listAccountServers", () => {
 });
 
 describe("redeemMachineCredential", () => {
-  it("returns a credential for the server the code targeted", async () => {
+  it("labels the credential with the target server, not the account handle", async () => {
     const fetchImpl = vi.fn(
       async () =>
         new Response(
           JSON.stringify({
             credential: "bbcm_desktop",
             machineId: "machine-1",
-            handle: "laptop",
+            // The account's primary handle, which is not the server the code
+            // targeted. serverUrl names that server.
+            handle: "sawyer",
             serverUrl: "https://laptop.getbb.app",
           }),
         ),
@@ -134,11 +136,50 @@ describe("redeemMachineCredential", () => {
             JSON.stringify({
               credential: "bbcm_desktop",
               machineId: "machine-1",
-              handle: null,
               serverUrl: null,
             }),
           ),
       ),
     ).rejects.toBeInstanceOf(ConnectMachineRedeemError);
+  });
+
+  it("rejects a server URL the asked-for apex does not own", async () => {
+    const outsiders = [
+      "https://laptop.evil.app",
+      "https://laptop.getbb.app.evil.app",
+      "http://laptop.getbb.app",
+      "https://getbb.app",
+    ];
+    for (const serverUrl of outsiders) {
+      await expect(
+        redeemMachineCredential(
+          { apexUrl: "https://getbb.app", code: "ABCD-1234" },
+          async () =>
+            new Response(
+              JSON.stringify({
+                credential: "bbcm_desktop",
+                machineId: "machine-1",
+                serverUrl,
+              }),
+            ),
+        ),
+      ).rejects.toMatchObject({ code: "invalid_response" });
+    }
+  });
+
+  it("accepts a self-hosted apex", async () => {
+    await expect(
+      redeemMachineCredential(
+        { apexUrl: "https://bb.example", code: "ABCD-1234" },
+        async () =>
+          new Response(
+            JSON.stringify({
+              credential: "bbcm_desktop",
+              machineId: "machine-1",
+              serverUrl: "https://laptop.bb.example",
+            }),
+          ),
+      ),
+    ).resolves.toMatchObject({ handle: "laptop" });
   });
 });

--- a/packages/connect-client/test/connect-client.test.ts
+++ b/packages/connect-client/test/connect-client.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConnectListError,
+  ConnectMachineRedeemError,
+  deriveConnectBaseUrl,
+  listAccountServers,
+  redeemMachineCredential,
+  serverUrlForHandle,
+} from "../src/index.js";
+
+const CREDENTIAL = {
+  credential: "bbcm_desktop",
+  handle: "laptop",
+  serverUrl: "https://laptop.getbb.app",
+};
+
+describe("connect URL helpers", () => {
+  it("drops and re-adds the routing label", () => {
+    expect(deriveConnectBaseUrl("https://laptop.getbb.app")).toBe(
+      "https://getbb.app",
+    );
+    expect(serverUrlForHandle("https://getbb.app", "phone")).toBe(
+      "https://phone.getbb.app",
+    );
+    // Self-hosted apex, non-default port kept.
+    expect(deriveConnectBaseUrl("https://laptop.bb.example:8443")).toBe(
+      "https://bb.example:8443",
+    );
+  });
+});
+
+describe("listAccountServers", () => {
+  it("adds a public URL per handle and reports the self handle", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            servers: [
+              { handle: "laptop", name: "Laptop", live: true },
+              { handle: "phone", name: "Phone", live: false },
+            ],
+          }),
+        ),
+    );
+
+    await expect(listAccountServers(CREDENTIAL, fetchImpl)).resolves.toEqual({
+      selfHandle: "laptop",
+      servers: [
+        {
+          handle: "laptop",
+          name: "Laptop",
+          live: true,
+          url: "https://laptop.getbb.app",
+        },
+        {
+          handle: "phone",
+          name: "Phone",
+          live: false,
+          url: "https://phone.getbb.app",
+        },
+      ],
+    });
+  });
+
+  it("marks a refused credential unauthorized", async () => {
+    await expect(
+      listAccountServers(
+        CREDENTIAL,
+        async () => new Response("no", { status: 401 }),
+      ),
+    ).rejects.toMatchObject({ code: "unauthorized" });
+    await expect(
+      listAccountServers(CREDENTIAL, async () => {
+        throw new Error("offline");
+      }),
+    ).rejects.toBeInstanceOf(ConnectListError);
+  });
+});
+
+describe("redeemMachineCredential", () => {
+  it("returns a credential for the server the code targeted", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            credential: "bbcm_desktop",
+            machineId: "machine-1",
+            handle: "laptop",
+            serverUrl: "https://laptop.getbb.app",
+          }),
+        ),
+    );
+
+    await expect(
+      redeemMachineCredential(
+        { apexUrl: "https://getbb.app", code: "ABCD-1234" },
+        fetchImpl,
+      ),
+    ).resolves.toEqual(CREDENTIAL);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://getbb.app/api/connect/redeem-machine",
+      expect.objectContaining({
+        body: JSON.stringify({ code: "ABCD-1234" }),
+        method: "POST",
+      }),
+    );
+  });
+
+  it("maps the gate's rejections to stable codes", async () => {
+    const cases: Array<[number, string, string]> = [
+      [409, "already-used", "already_used"],
+      [409, "machine-limit", "machine_limit"],
+      [410, "expired", "expired"],
+      [404, "invalid-code", "invalid_code"],
+      [500, "boom", "network"],
+    ];
+    for (const [status, wireError, expected] of cases) {
+      await expect(
+        redeemMachineCredential(
+          { apexUrl: "https://getbb.app", code: "ABCD-1234" },
+          async () =>
+            new Response(JSON.stringify({ error: wireError }), { status }),
+        ),
+      ).rejects.toMatchObject({ code: expected });
+    }
+  });
+
+  it("rejects a response with no server to point at", async () => {
+    await expect(
+      redeemMachineCredential(
+        { apexUrl: "https://getbb.app", code: "ABCD-1234" },
+        async () =>
+          new Response(
+            JSON.stringify({
+              credential: "bbcm_desktop",
+              machineId: "machine-1",
+              handle: null,
+              serverUrl: null,
+            }),
+          ),
+      ),
+    ).rejects.toBeInstanceOf(ConnectMachineRedeemError);
+  });
+});

--- a/packages/connect-client/tsconfig.json
+++ b/packages/connect-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "@bb/tsconfig/base.json",
+    "@bb/tsconfig/typecheck-overrides.json"
+  ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/connect-client/vitest.config.ts
+++ b/packages/connect-client/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    name: "@bb/connect-client",
+    include: ["test/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/plugins/connect/package.json
+++ b/plugins/connect/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Remote access via getbb.app — this bb becomes reachable at https://<handle>.getbb.app. Disable to cut off all remote access.",
+  "description": "Remote access via getbb.app \u2014 this bb becomes reachable at https://<handle>.getbb.app. Disable to cut off all remote access.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Remote access",
-    "description": "Remote access via getbb.app — this bb becomes reachable at https://<handle>.getbb.app. Disable to cut off all remote access.",
+    "description": "Remote access via getbb.app \u2014 this bb becomes reachable at https://<handle>.getbb.app. Disable to cut off all remote access.",
     "branding": {
       "icon": "Smartphone"
     },
@@ -24,6 +24,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@bb/connect-client": "workspace:*",
     "@bb/shared-ui": "workspace:*",
     "@bb/tunnel-client": "workspace:*",
     "@bb/tunnel-contract": "workspace:*",

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -12,7 +12,7 @@ import {
   isBareBbRealtimeWs,
   TunnelSession,
 } from "@bb/tunnel-client";
-import { deriveConnectBaseUrl, serverUrlForHandle } from "./redeem.js";
+import { deriveConnectBaseUrl, serverUrlForHandle } from "@bb/connect-client";
 import {
   parseSharePort,
   SharePortError,

--- a/plugins/connect/src/credential.ts
+++ b/plugins/connect/src/credential.ts
@@ -1,16 +1,10 @@
-import { z } from "zod";
+import { connectCredentialSchema } from "@bb/connect-client";
+import type { ConnectCredential } from "@bb/connect-client";
 import type { PluginKvStorage } from "@bb/plugin-sdk";
 
-// The durable tunnel credential lives in the plugin's kv storage (bb.db).
-// `handle` is the paired server's routing label (subdomain), which may differ
-// from the account's primary handle when multiple bbs are connected.
-export const connectCredentialSchema = z.object({
-  serverUrl: z.string().min(1),
-  handle: z.string().min(1),
-  credential: z.string().min(1),
-});
-
-export type ConnectCredential = z.infer<typeof connectCredentialSchema>;
+// The durable tunnel credential lives in the plugin's kv storage (bb.db). Its
+// shape and the gate calls that use it live in @bb/connect-client, because the
+// desktop app reaches the same gate without a local server.
 
 export const CREDENTIAL_KV_KEY = "credential";
 

--- a/plugins/connect/src/machine-code.ts
+++ b/plugins/connect/src/machine-code.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
-import type { ConnectCredential } from "./credential.js";
-import { deriveConnectBaseUrl } from "./redeem.js";
+import {
+  deriveConnectBaseUrl,
+  type ConnectCredential,
+} from "@bb/connect-client";
 
 const machineCodeResponseSchema = z.object({
   code: z.string().min(1),

--- a/plugins/connect/src/redeem.ts
+++ b/plugins/connect/src/redeem.ts
@@ -63,23 +63,6 @@ export function asConnectPairError(error: unknown): ConnectPairError {
   return new ConnectPairError("network", message);
 }
 
-/**
- * Derive the connect cloud apex (`https://getbb.app`) from a server URL
- * (`https://<handle>.getbb.app`) by dropping the handle label.
- */
-export function deriveConnectBaseUrl(serverUrl: string): string {
-  return new URL(serverUrl).origin.replace(/\/\/[^.]+\./, "//");
-}
-
-/**
- * `https://getbb.app` + routing label → `https://<label>.getbb.app`.
- * `handle` is the redeemed server's subdomain (primary or additional).
- */
-export function serverUrlForHandle(baseUrl: string, handle: string): string {
-  const url = new URL(baseUrl);
-  return `${url.protocol}//${handle}.${url.host}`;
-}
-
 export async function redeemConnectCode(args: {
   code: string;
   baseUrl: string;

--- a/plugins/connect/src/revoke-machine.ts
+++ b/plugins/connect/src/revoke-machine.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
-import type { ConnectCredential } from "./credential.js";
-import { deriveConnectBaseUrl } from "./redeem.js";
+import {
+  deriveConnectBaseUrl,
+  type ConnectCredential,
+} from "@bb/connect-client";
 
 const revokeMachineResponseSchema = z.object({ ok: z.literal(true) });
 

--- a/plugins/connect/src/rpc.ts
+++ b/plugins/connect/src/rpc.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { defineRpcContract, type PluginRpcHandlers } from "@bb/plugin-sdk";
-import { ConnectListError } from "./list-servers.js";
+import {
+  ConnectListError,
+  type DesktopSession,
+  type ListAccountServersResult,
+} from "@bb/connect-client";
 import { ConnectPairError } from "./redeem.js";
 import type { ConnectTunnel } from "./tunnel.js";
 import type { ConnectStatus } from "./types.js";
-import type { ListAccountServersResult } from "./list-servers.js";
-import type { DesktopSession } from "./desktop-session.js";
 import { MachineCodeError, type MachineCode } from "./machine-code.js";
 import type { ShareHostResolver } from "./hosts.js";
 import type { ShareListing } from "./shares.js";

--- a/plugins/connect/src/shares.ts
+++ b/plugins/connect/src/shares.ts
@@ -6,13 +6,15 @@ import type {
   PluginKvStorage,
   PluginLogger,
 } from "@bb/plugin-sdk";
-import type { ConnectCredential } from "./credential.js";
 import {
   ShareHostNotFoundError,
   type ShareHost,
   type ShareHostResolver,
 } from "./hosts.js";
-import { deriveConnectBaseUrl } from "./redeem.js";
+import {
+  deriveConnectBaseUrl,
+  type ConnectCredential,
+} from "@bb/connect-client";
 
 export const SHARES_KV_KEY = "shares";
 

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -18,22 +18,23 @@ import {
   type StreamOriginResult,
 } from "@bb/tunnel-client";
 import type { PluginLogger } from "@bb/plugin-sdk";
-import type { ConnectCredential, CredentialStore } from "./credential.js";
-import { fetchMachineCode, MachineCodeError } from "./machine-code.js";
 import {
   ConnectListError,
-  fetchAccountServers,
-  withAccountServerUrls,
+  deriveConnectBaseUrl,
+  fetchDesktopSession,
+  listAccountServers,
+  serverUrlForHandle,
+  type ConnectCredential,
+  type DesktopSession,
   type ListAccountServersResult,
-} from "./list-servers.js";
+} from "@bb/connect-client";
+import type { CredentialStore } from "./credential.js";
+import { fetchMachineCode, MachineCodeError } from "./machine-code.js";
 import {
   asConnectPairError,
   DEFAULT_CONNECT_BASE_URL,
-  deriveConnectBaseUrl,
   redeemConnectCode,
-  serverUrlForHandle,
 } from "./redeem.js";
-import { fetchDesktopSession, type DesktopSession } from "./desktop-session.js";
 import { revokeMachine } from "./revoke-machine.js";
 import {
   ShareRegistry,
@@ -196,11 +197,7 @@ export class ConnectTunnel {
         "this bb is not connected to getbb.app — run `bb connect` for how to pair",
       );
     }
-    const servers = withAccountServerUrls(
-      await fetchAccountServers(credential),
-      credential,
-    );
-    return { servers, selfHandle: credential.handle };
+    return listAccountServers(credential);
   }
 
   async createDesktopSession(): Promise<DesktopSession> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@bb/connect-client':
+        specifier: workspace:*
+        version: link:../../packages/connect-client
       bb-app:
         specifier: workspace:*
         version: link:../../packages/bb-app
@@ -1555,6 +1558,28 @@ importers:
       typescript-7:
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
+
+  packages/connect-client:
+    dependencies:
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@bb/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/connect-db:
     dependencies:
@@ -2626,6 +2651,9 @@ importers:
 
   plugins/connect:
     dependencies:
+      '@bb/connect-client':
+        specifier: workspace:*
+        version: link:../../packages/connect-client
       '@bb/shared-ui':
         specifier: workspace:*
         version: link:../../packages/shared-ui


### PR DESCRIPTION
Closes BB-81.

## What changed

The desktop app no longer starts a bb server on this Mac when the saved target
is a bb Connect server or a custom URL. It starts one again when you select
"This Mac".

Three things kept the local server alive. Each one now has a remote path:

1. **The Connect session cookie.** The app enrolls itself once as a connect
   machine (mint a code on the local server, redeem it at the apex), then mints
   its own cookie at the gate. The credential lives in Electron `userData`,
   encrypted with the OS keychain through `safeStorage`. When the OS offers no
   encryption backend, the cache writes nothing and the app keeps asking the
   local server.
2. **The account server list.** The Server menu syncs from the gate with the
   same credential when no local server runs.
3. **System config.** A remote server cannot use the realtime socket, because
   only Electron's network stack carries the session cookie. A remote target
   polls `net.fetch` on start, on `did-become-active`, and every five minutes.

`packages/connect-client` now holds the gate client (credential shape, URL
helpers, server list, desktop session, machine redeem). The connect plugin and
the desktop app share it.

## On the credential

The task proposed caching the server's own pairing secret. This enrolls the app
as its own machine instead. Same file and same encryption, but the server's
secret never leaves `bb.db`, the app shows up in the dashboard machine list, and
revoking it there is enough. A gate `401`/`403` drops the cached copy, which
also closes the "bypasses the plugin gate" risk.

It costs one machine slot on the account, and only for users who select a remote
target.

## First launch

No cached credential means the local server mints the cookie, exactly as before,
and enrollment runs in the background for the next launch.

## Tests

New: credential cache (round trip, no-encryption no-op, undecryptable bytes),
machine enrollment (mint + redeem, missing handle, unpaired, machine limit),
both cookie sources, gate-backed server sync. `@bb/connect-client` covers the
URL helpers, the server list, and every redeem rejection code.

Whole-repo typecheck passes. Four `@bb/desktop` test files fail on Linux both
before and after this change; they need the Electron binary.

## Not covered

I could not run the packaged app: this worktree is Linux and the Electron binary
is macOS-only. The remote-target launch path wants a manual pass on a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)