### PR TITLE
Fix bold rendering on changelog

### DIFF
--- a/apps/web/src/landing/changelog-inline.test.ts
+++ b/apps/web/src/landing/changelog-inline.test.ts
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ChangelogInline } from "./changelog-inline";
+
+function render(text: string): string {
+  return renderToStaticMarkup(createElement(ChangelogInline, { text }));
+}
+
+describe("ChangelogInline", () => {
+  it("renders bold Markdown and inline code", () => {
+    expect(
+      render(
+        "**Node.js 22.19 is now the minimum.** Use `max`; keep `**literal**` as code.",
+      ),
+    ).toBe(
+      "<strong>Node.js 22.19 is now the minimum.</strong> Use <code>max</code>; keep <code>**literal**</code> as code.",
+    );
+  });
+
+  it("renders inline code inside bold text", () => {
+    expect(render("**Run `bb plugin install` now.**")).toBe(
+      "<strong>Run <code>bb plugin install</code> now.</strong>",
+    );
+  });
+
+  it("preserves unmatched Markdown delimiters as text", () => {
+    expect(render("Keep **this and `that readable")).toBe(
+      "Keep **this and `that readable",
+    );
+  });
+});

--- a/apps/web/src/landing/changelog-inline.tsx
+++ b/apps/web/src/landing/changelog-inline.tsx
@@ -1,0 +1,82 @@
+import { Fragment } from "react";
+import type { ReactNode } from "react";
+
+type InlineToken =
+  | { kind: "text"; text: string }
+  | { kind: "code"; text: string }
+  | { kind: "strong"; children: InlineToken[] };
+
+function appendText(tokens: InlineToken[], text: string): void {
+  if (!text) {
+    return;
+  }
+  const previous = tokens.at(-1);
+  if (previous?.kind === "text") {
+    previous.text += text;
+    return;
+  }
+  tokens.push({ kind: "text", text });
+}
+
+function parseInline(text: string, allowStrong: boolean): InlineToken[] {
+  const tokens: InlineToken[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const codeStart = text.indexOf("`", cursor);
+    const strongStart = allowStrong ? text.indexOf("**", cursor) : -1;
+    const tokenStart =
+      codeStart === -1
+        ? strongStart
+        : strongStart === -1
+          ? codeStart
+          : Math.min(codeStart, strongStart);
+
+    if (tokenStart === -1) {
+      appendText(tokens, text.slice(cursor));
+      break;
+    }
+
+    appendText(tokens, text.slice(cursor, tokenStart));
+    const isCode = tokenStart === codeStart;
+    const delimiter = isCode ? "`" : "**";
+    const contentStart = tokenStart + delimiter.length;
+    const tokenEnd = text.indexOf(delimiter, contentStart);
+
+    if (tokenEnd === -1) {
+      appendText(tokens, delimiter);
+      cursor = contentStart;
+      continue;
+    }
+
+    const content = text.slice(contentStart, tokenEnd);
+    if (isCode) {
+      tokens.push({ kind: "code", text: content });
+    } else {
+      tokens.push({
+        kind: "strong",
+        children: parseInline(content, false),
+      });
+    }
+    cursor = tokenEnd + delimiter.length;
+  }
+
+  return tokens;
+}
+
+function renderTokens(tokens: InlineToken[]): ReactNode {
+  return tokens.map((token, index) => {
+    switch (token.kind) {
+      case "code":
+        return <code key={index}>{token.text}</code>;
+      case "strong":
+        return <strong key={index}>{renderTokens(token.children)}</strong>;
+      case "text":
+        return <Fragment key={index}>{token.text}</Fragment>;
+    }
+  });
+}
+
+export function ChangelogInline({ text }: { text: string }): ReactNode {
+  return renderTokens(parseInline(text, true));
+}

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -9,6 +9,7 @@ import bbIcon from "../assets/bb-icon.png";
 import { initAnalytics } from "../landing/analytics";
 import type { Release, ReleaseBlock } from "../landing/changelog";
 import { RELEASE_META, parseChangelog } from "../landing/changelog";
+import { ChangelogInline } from "../landing/changelog-inline";
 import { DownloadLink, EmailSignup, GitHubLink } from "../landing/cta";
 import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
@@ -56,17 +57,6 @@ const RELEASES = parseChangelog(changelogMd);
 /** "0.0.30" → "0-0-30", a fragment id that survives URL parsing. */
 function anchorId(version: string): string {
   return version.replaceAll(".", "-");
-}
-
-/** Render a changelog line, turning `backtick` spans into <code>. */
-function inline(text: string): ReactNode {
-  const parts = text.split("`");
-  if (parts.length === 1) {
-    return text;
-  }
-  return parts.map((part, index) =>
-    index % 2 === 1 ? <code key={index}>{part}</code> : <Fragment key={index}>{part}</Fragment>,
-  );
 }
 
 /* ── Release media ────────────────────────────────────────────────────
@@ -135,11 +125,15 @@ function Blocks({ blocks }: { blocks: ReleaseBlock[] }) {
         block.kind === "list" ? (
           <ul key={index}>
             {block.items.map((item) => (
-              <li key={item}>{inline(item)}</li>
+              <li key={item}>
+                <ChangelogInline text={item} />
+              </li>
             ))}
           </ul>
         ) : (
-          <p key={index}>{inline(block.text)}</p>
+          <p key={index}>
+            <ChangelogInline text={block.text} />
+          </p>
         ),
       )}
     </>
@@ -164,7 +158,7 @@ function ReleaseEntry({ release }: { release: Release }) {
         {release.lede.map((block, index) =>
           block.kind === "paragraph" ? (
             <p key={index} className="lede">
-              {inline(block.text)}
+              <ChangelogInline text={block.text} />
             </p>
           ) : null,
         )}


### PR DESCRIPTION
## Summary

- render `**bold**` changelog spans as semantic `<strong>` elements
- preserve inline code, including code nested inside bold text
- keep unmatched Markdown delimiters readable
- add regression coverage for the failure visible on the deployed changelog

## Verification

- `pnpm exec turbo run test --filter=@bb/web --force` (46 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/web`
- `pnpm exec turbo run build --filter=@bb/web`
- verified the local `/changelog` SSR output contains `<strong>` elements for all bold release-note spans