### PR TITLE
Remove deprecated work-host routes from the daemon local API

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -133,7 +133,6 @@ export interface CreateHostDaemonAppOptions {
   threadStorageRootPath?: string;
   hostWatcher?: HostWatcher;
   onToolCall?: (request: ToolCallRequest) => Promise<ToolCallResponse>;
-  pickFolder?: () => Promise<string | null>;
   fetchFn?: FetchFn;
   createWebSocket?: CreateReconnectingWebSocket;
   closeMachineAuthProxy?: () => Promise<void>;
@@ -207,12 +206,6 @@ export function startIdleProviderSessionReaper(
       timer.clear();
     },
   };
-}
-
-function providerCliEnvFromShellEnv(
-  shellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]>,
-): NodeJS.ProcessEnv {
-  return shellEnv.PATH ? { ...process.env, PATH: shellEnv.PATH } : process.env;
 }
 
 interface SessionRequestArgs<TResult> {
@@ -703,9 +696,6 @@ export async function createHostDaemonApp(
       throw error;
     }
   };
-  const getProviderCliEnv = async () =>
-    providerCliEnvFromShellEnv(runtimeManager.getShellEnv());
-
   const idleProviderSessionReaper = startIdleProviderSessionReaper({
     logger: options.logger,
     nowMs: Date.now,
@@ -866,9 +856,7 @@ export async function createHostDaemonApp(
         serverPort: Number(new URL(options.serverUrl).port) || 0,
         devAppPort: options.devAppPort,
         appUrl: options.appUrl,
-        getProviderCliEnv,
         getConnected: () => connection.sessionId != null,
-        pickFolder: options.pickFolder,
       })
     : null;
   const eventLoopStallMonitor = startEventLoopStallMonitor({

--- a/apps/host-daemon/src/local-api.test.ts
+++ b/apps/host-daemon/src/local-api.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -8,7 +8,6 @@ import {
   type WorkspaceOpenTarget,
 } from "@bb/host-daemon-contract";
 import {
-  resolveNativeFolderPicker,
   startLocalApiServer,
   type LocalApiServer,
 } from "./local-api.js";
@@ -37,27 +36,6 @@ describe("local API server", () => {
     server = null;
   });
 
-  it("resolves native folder picker support from one shared helper", () => {
-    const providedPicker = async () => "/tmp/project";
-
-    expect(
-      resolveNativeFolderPicker({
-        pickFolder: providedPicker,
-        platform: "linux",
-      }),
-    ).toBe(providedPicker);
-    expect(
-      resolveNativeFolderPicker({
-        platform: "darwin",
-      }),
-    ).not.toBeNull();
-    expect(
-      resolveNativeFolderPicker({
-        platform: "linux",
-      }),
-    ).toBeNull();
-  });
-
   it("serves host identity and status over localhost", async () => {
     server = await startLocalApiServer({
       hostId: "host-1",
@@ -78,128 +56,11 @@ describe("local API server", () => {
       connected: true,
       protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
       serverUrl: "http://server.test",
-      supportsNativeFolderPicker:
-        resolveNativeFolderPicker({
-          platform: process.platform,
-        }) !== null,
+      supportsNativeFolderPicker: process.platform === "darwin",
       platform: resolveHostPlatform(),
     });
     const healthResponse = await client.health.$get();
     expect(await healthResponse.text()).toBe("ok");
-  });
-
-  it("reports path existence by stat'ing each requested path", async () => {
-    const dir = await mkdtemp(path.join(tmpdir(), "bb-path-exists-"));
-    const existingDir = path.join(dir, "repo");
-    const existingFile = path.join(dir, "file.txt");
-    const missing = path.join(dir, "nope");
-    await mkdir(existingDir);
-    await writeFile(existingFile, "hi");
-
-    try {
-      server = await startLocalApiServer({
-        hostId: "host-1",
-        localApiConfig: createLocalApiConfig(),
-        serverUrl: "http://server.test",
-        serverPort: 3334,
-        devAppPort: 5173,
-        getConnected: () => true,
-      });
-      const client = createHostDaemonLocalClient(
-        `http://localhost:${server.port}`,
-      );
-
-      const response = await client.paths.exist.$post({
-        json: { paths: [existingDir, existingFile, missing] },
-      });
-
-      expect(await response.json()).toEqual({
-        existence: {
-          [existingDir]: true,
-          [existingFile]: true,
-          [missing]: false,
-        },
-      });
-    } finally {
-      await rm(dir, { force: true, recursive: true });
-    }
-  });
-
-  it("treats permission-denied paths as existing rather than failing the batch", async () => {
-    if (process.platform === "win32" || process.getuid?.() === 0) {
-      return;
-    }
-    const dir = await mkdtemp(path.join(tmpdir(), "bb-path-exists-eacces-"));
-    const lockedParent = path.join(dir, "locked");
-    const inaccessible = path.join(lockedParent, "child");
-    const reachable = path.join(dir, "reachable");
-    await mkdir(lockedParent);
-    await mkdir(reachable);
-    await chmod(lockedParent, 0o000);
-
-    try {
-      server = await startLocalApiServer({
-        hostId: "host-1",
-        localApiConfig: createLocalApiConfig(),
-        serverUrl: "http://server.test",
-        serverPort: 3334,
-        devAppPort: 5173,
-        getConnected: () => true,
-      });
-      const client = createHostDaemonLocalClient(
-        `http://localhost:${server.port}`,
-      );
-
-      const response = await client.paths.exist.$post({
-        json: { paths: [inaccessible, reachable] },
-      });
-
-      expect(response.ok).toBe(true);
-      expect(await response.json()).toEqual({
-        existence: {
-          [inaccessible]: true,
-          [reachable]: true,
-        },
-      });
-    } finally {
-      await chmod(lockedParent, 0o700);
-      await rm(dir, { force: true, recursive: true });
-    }
-  });
-
-  it("dedupes repeated paths in /paths/exist and rejects oversized batches", async () => {
-    server = await startLocalApiServer({
-      hostId: "host-1",
-      localApiConfig: createLocalApiConfig(),
-      serverUrl: "http://server.test",
-      serverPort: 3334,
-      devAppPort: 5173,
-      getConnected: () => true,
-    });
-    const client = createHostDaemonLocalClient(
-      `http://localhost:${server.port}`,
-    );
-
-    const dir = await mkdtemp(path.join(tmpdir(), "bb-path-exists-dedup-"));
-    try {
-      const dedupeResponse = await client.paths.exist.$post({
-        json: { paths: [dir, dir, dir] },
-      });
-      expect(await dedupeResponse.json()).toEqual({
-        existence: { [dir]: true },
-      });
-
-      const oversizedPaths = Array.from(
-        { length: 201 },
-        (_, i) => `${dir}/p${i}`,
-      );
-      const oversizedResponse = await client.paths.exist.$post({
-        json: { paths: oversizedPaths },
-      });
-      expect(oversizedResponse.ok).toBe(false);
-    } finally {
-      await rm(dir, { force: true, recursive: true });
-    }
   });
 
   it("lists workspace open targets and delegates target-aware open requests", async () => {
@@ -434,31 +295,6 @@ describe("local API server", () => {
       path: "/tmp/workspace",
       targetId: "vscode",
     });
-  });
-
-  it("returns 501 for folder picking when native picker support is unavailable", async () => {
-    if (process.platform === "darwin") {
-      return;
-    }
-
-    server = await startLocalApiServer({
-      hostId: "host-1",
-      localApiConfig: createLocalApiConfig(),
-      serverUrl: "http://server.test",
-      serverPort: 3334,
-      devAppPort: 5173,
-      getConnected: () => true,
-    });
-    const client = createHostDaemonLocalClient(
-      `http://localhost:${server.port}`,
-    );
-
-    const statusResponse = await client.status.$get();
-    const status = await statusResponse.json();
-    expect(status.supportsNativeFolderPicker).toBe(false);
-
-    const pickFolderResponse = await client["pick-folder"].$post({});
-    expect(pickFolderResponse.status).toBe(501);
   });
 
   it("supports health-only mode", async () => {

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -1,6 +1,4 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
-import { promisify } from "node:util";
 import { serve } from "@hono/node-server";
 import {
   buildLocalAppOrigins,
@@ -18,9 +16,6 @@ import {
   healthResponseSchema,
   HOST_DAEMON_PROTOCOL_VERSION,
   openInTargetRequestSchema,
-  pathsExistRequestSchema,
-  providerCliInstallRequestSchema,
-  providerCliStatusResponseSchema,
   typedRoutes,
   workspaceOpenTargetsQuerySchema,
   type HostDaemonLocalSchema,
@@ -34,19 +29,12 @@ import {
   type OpenPathInTargetArgs,
   WorkspaceOpenTargetError,
 } from "@bb/local-open-targets";
-import { sanitizeInheritedChildProcessEnv } from "@bb/process-utils";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import type { HostDaemonLocalApiConfig } from "./local-api-config.js";
-import {
-  getProviderCliStatus,
-  ProviderCliInstallInProgressError,
-  streamProviderCliInstall,
-} from "./provider-cli-health.js";
 import { resolveHostPlatform } from "./host-platform.js";
 
-const execFileAsync = promisify(execFile);
 export type WorkspaceOpenTargetListHandler = (
   query: WorkspaceOpenTargetsQuery,
 ) => Promise<WorkspaceOpenTarget[]>;
@@ -77,24 +65,15 @@ export interface StartLocalApiServerOptions {
   /** Optional public app origin (e.g. `https://app.example.com`); allowed
    * origin for CORS when the frontend is served from a non-localhost domain. */
   appUrl?: string;
-  getProviderCliEnv?: () => Promise<NodeJS.ProcessEnv>;
   getConnected: () => boolean;
   listWorkspaceOpenTargets?: WorkspaceOpenTargetListHandler;
   openInTarget?: OpenInTargetHandler;
-  pickFolder?: () => Promise<string | null>;
 }
 
 export interface LocalApiServer {
   bindHost: string;
   port: number;
   close(): Promise<void>;
-}
-
-export type FolderPickerHandler = () => Promise<string | null>;
-
-export interface ResolveNativeFolderPickerOptions {
-  pickFolder?: FolderPickerHandler;
-  platform?: NodeJS.Platform;
 }
 
 interface ClientConfigLoader {
@@ -209,18 +188,6 @@ async function resolveOpenPathInTargetArgs({
   };
 }
 
-export function resolveNativeFolderPicker(
-  options: ResolveNativeFolderPickerOptions,
-): FolderPickerHandler | null {
-  if (options.pickFolder) {
-    return options.pickFolder;
-  }
-
-  return (options.platform ?? process.platform) === "darwin"
-    ? pickLocalFolder
-    : null;
-}
-
 export async function startLocalApiServer(
   options: StartLocalApiServerOptions,
 ): Promise<LocalApiServer> {
@@ -268,9 +235,6 @@ export async function startLocalApiServer(
   });
 
   const { get, post } = typedRoutes<HostDaemonLocalSchema>(app);
-  const nativeFolderPicker = resolveNativeFolderPicker({
-    pickFolder: options.pickFolder,
-  });
   const platform = resolveHostPlatform();
 
   get("/status", (c) =>
@@ -279,64 +243,10 @@ export async function startLocalApiServer(
       connected: options.getConnected(),
       protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
       serverUrl: options.serverUrl,
-      supportsNativeFolderPicker: nativeFolderPicker !== null,
+      supportsNativeFolderPicker: platform === "darwin",
       platform,
     }),
   );
-
-  get("/provider-clis/status", async (c) => {
-    const env = await options.getProviderCliEnv?.();
-    return c.json(
-      providerCliStatusResponseSchema.parse(
-        await getProviderCliStatus(env ? { env } : {}),
-      ),
-    );
-  });
-
-  app.post("/provider-clis/install", async (c) => {
-    const parsed = providerCliInstallRequestSchema.safeParse(
-      await c.req.json().catch(() => null),
-    );
-    if (!parsed.success) {
-      const issue = parsed.error.issues[0];
-      throw new HTTPException(400, {
-        message: issue?.message ?? "Invalid provider CLI install request",
-      });
-    }
-
-    try {
-      const env = await options.getProviderCliEnv?.();
-      return new Response(
-        streamProviderCliInstall({
-          provider: parsed.data.provider,
-          actionKind: parsed.data.actionKind,
-          ...(env ? { env } : {}),
-        }),
-        {
-          headers: {
-            "content-type": "application/x-ndjson; charset=utf-8",
-            "cache-control": "no-store",
-          },
-        },
-      );
-    } catch (error) {
-      if (error instanceof ProviderCliInstallInProgressError) {
-        throw new HTTPException(409, {
-          message: error.message,
-        });
-      }
-      throw error;
-    }
-  });
-
-  post("/paths/exist", pathsExistRequestSchema, async (c, payload) => {
-    const entries = await Promise.all(
-      payload.paths.map(
-        async (path) => [path, await pathExists(path)] as const,
-      ),
-    );
-    return c.json({ existence: Object.fromEntries(entries) });
-  });
 
   get(
     "/workspace-open-targets",
@@ -365,16 +275,6 @@ export async function startLocalApiServer(
     }
 
     return c.json({});
-  });
-
-  post("/pick-folder", async (c) => {
-    if (!nativeFolderPicker) {
-      throw new HTTPException(501, {
-        message: "Folder picker is only supported on macOS",
-      });
-    }
-    const path = await nativeFolderPicker();
-    return c.json({ path });
   });
 
   const { server, port: boundPort } = await new Promise<{
@@ -407,48 +307,4 @@ export async function startLocalApiServer(
       });
     },
   };
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await fs.stat(path);
-    return true;
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      (error.code === "ENOENT" || error.code === "ENOTDIR")
-    ) {
-      return false;
-    }
-    // Permission denied / loops / etc. — we can't tell, but the entry exists
-    // enough to error on, so don't claim it's missing.
-    return true;
-  }
-}
-
-async function pickLocalFolder(): Promise<string | null> {
-  let stdout: string;
-  try {
-    const result = await execFileAsync(
-      "osascript",
-      [
-        "-e",
-        'try\nPOSIX path of (choose folder with prompt "Choose a project folder")\non error number -128\nreturn ""\nend try',
-      ],
-      {
-        env: sanitizeInheritedChildProcessEnv({ env: process.env }),
-      },
-    );
-    stdout = result.stdout;
-  } catch (error) {
-    throw new HTTPException(500, {
-      message: `Folder picker failed: ${error instanceof Error ? error.message : String(error)}`,
-    });
-  }
-  const selectedPath = stdout.trim();
-  if (selectedPath === "") {
-    return null;
-  }
-  return selectedPath.replace(/\/$/, "");
 }

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -61,7 +61,6 @@ export interface StartHostDaemonOptions {
   createRuntime?: CreateHostDaemonAppOptions["createRuntime"];
   hostWatcher?: HostWatcher;
   onToolCall?: (request: ToolCallRequest) => Promise<ToolCallResponse>;
-  pickFolder?: () => Promise<string | null>;
   fetchFn?: typeof fetch;
   createWebSocket?: CreateReconnectingWebSocket;
 }
@@ -273,7 +272,6 @@ export async function startHostDaemon(
       resolveRuntimeShellEnv,
       hostWatcher,
       onToolCall: options.onToolCall,
-      pickFolder: options.pickFolder,
       fetchFn: options.fetchFn,
       createWebSocket: options.createWebSocket,
       closeMachineAuthProxy: machineAuthProxy?.close,

--- a/packages/host-daemon-contract/src/local.ts
+++ b/packages/host-daemon-contract/src/local.ts
@@ -294,16 +294,10 @@ export type ProviderCliInstallEvent = z.infer<
 /**
  * Local daemon HTTP API.
  *
- * This API predates remote-client support and currently mixes two ownership
- * classes:
- *
- * - client-machine-local routes: actions about the machine showing the UI, such as
- *   local editor discovery and launch
- * - work-host routes: actions about the machine running bb work, such as path
- *   checks and provider CLI health
- *
- * Keep the ownership comments below accurate while the API is split or routed
- * through server-backed work-host commands.
+ * This API is limited to client-machine-local helper actions about the machine
+ * showing the UI, plus daemon status and health. Work-host operations are
+ * exposed through server routes and forwarded to the connected daemon over
+ * WebSocket RPC.
  */
 export type HostDaemonLocalSchema = {
   [DEFAULT_HOST_DAEMON_LOCAL_HEALTH_PATH]: {
@@ -320,38 +314,9 @@ export type HostDaemonLocalSchema = {
   "/open-in-target": {
     $post: Endpoint<{ json: OpenInTargetRequest }, Record<string, never>>;
   };
-  /**
-   * work-host, same-machine only; deprecated for direct app/browser callers.
-   * The canonical app path should be a server route that gates same-machine
-   * access before asking the work host daemon to show a native folder picker.
-   */
-  "/pick-folder": {
-    $post: Endpoint<EmptyInput, PickFolderResponse>;
-  };
-  /** work-host; deprecated for direct app/browser callers. */
-  "/paths/exist": {
-    $post: Endpoint<{ json: PathsExistRequest }, PathsExistResponse>;
-  };
   /** mixed: helper reachability plus connected work-host/session identity. */
   "/status": {
     $get: Endpoint<EmptyInput, StatusResponse>;
-  };
-  /** work-host; deprecated for direct app/browser callers. */
-  "/provider-clis/status": {
-    $get: Endpoint<EmptyInput, ProviderCliStatusResponse>;
-  };
-  /**
-   * work-host; deprecated for direct app/browser callers.
-   * Installs or updates provider CLIs on the machine that runs agents.
-   */
-  "/provider-clis/install": {
-    /** Streams `npm install -g <provider package>@latest` progress as newline-delimited JSON events. */
-    $post: Endpoint<
-      { json: ProviderCliInstallRequest },
-      ProviderCliInstallEvent,
-      200,
-      "text"
-    >;
   };
 };
 


### PR DESCRIPTION
## Summary

- remove the deprecated local HTTP routes for folder picking, path existence, and provider CLI status/install
- keep the daemon local API focused on client-machine-local helpers plus health/status
- remove the now-dead local handler tests and folder-picker/provider-environment plumbing
- preserve the shared request/response schemas used by the WebSocket RPC and server contracts

## Audit evidence

A repo-wide search for `/pick-folder`, `/paths/exist`, `/provider-clis/status`, and `/provider-clis/install` found no live consumer of the daemon-local versions, including app/desktop code, the SDK, CLI code, scripts, and tests. Before removal, the only local-path occurrences were the route definitions and their local-api tests. The remaining occurrences are the canonical `/hosts/:id/...` server routes and the SDK call through that server API.

## Motivation

These deprecated endpoints were unmaintained second doors around work-host product behavior owned by the WebSocket RPC handlers. In particular, the local provider CLI install path bypassed the provider-maintenance-runtime invalidation on the RPC path, which could leave the Codex model catalog stale after an update.

## Protocol version

No `HOST_DAEMON_PROTOCOL_VERSION` bump: the server-daemon WebSocket commands, results, schemas, defaults, and meanings are unchanged. This removes only routes from the daemon's loopback HTTP API.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/host-daemon-contract`
- `pnpm exec turbo run typecheck --filter=@bb/sdk --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force` (44 files, 468 tests passed)
