### PR TITLE
Finish extension detail and automation editing UX

### DIFF
--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -362,7 +362,17 @@ describe("BrowsePluginsTab", () => {
     expect(installed.querySelector('[data-icon="Check"]')).toBeNull();
     expect(installed.className).toContain("border-success/40");
     expect(installed.className).toContain("bg-success/15");
-    expect(installed.className).toContain("text-success-foreground");
+    expect(installed.className).toContain(
+      "text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]",
+    );
+    expect(installed.className).not.toContain("text-success-foreground");
+    expect(installed.className).toContain(
+      "hover:text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]",
+    );
+    expect(installed.className).toContain(
+      "focus-visible:text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]",
+    );
+    expect(installed.className).not.toContain("hover:text-foreground");
     expect(installed.className).toContain("hover:bg-success/25");
     expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
     fireEvent.click(installed);

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -197,7 +197,7 @@ function BrowseCard({
         pending={uninstall.isPending}
         presentation="icon"
         tooltip={`Uninstall ${entry.displayName}`}
-        className="border-success/40 bg-success/15 text-success-foreground hover:border-success/55 hover:bg-success/25 hover:text-success-foreground focus-visible:border-success/55 focus-visible:bg-success/25 focus-visible:text-success-foreground"
+        className="border-success/40 bg-success/15 text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))] hover:border-success/55 hover:bg-success/25 hover:text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))] focus-visible:border-success/55 focus-visible:bg-success/25 focus-visible:text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]"
         onAction={() => setConfirmingUninstall(true)}
       />
     ) : (

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -1,29 +1,73 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, vi } from "vitest";
 import { describe, expect, it } from "vitest";
 import {
-  getTabStripChevronEdgeClass,
-  getTabStripChevronVisibilityClass,
+  SecondaryPanelTabStrip,
   SECONDARY_PANEL_TAB_STRIP_FADE_TONE,
 } from "./SecondaryPanelTabStrip";
 
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
 describe("secondary panel tab-strip edge fades", () => {
-  it("uses one opaque themed edge fade and no second caret gradient", () => {
+  it("uses the themed edge fade without overlay scroll controls", () => {
     expect(SECONDARY_PANEL_TAB_STRIP_FADE_TONE).toBe("sidebar");
-    expect(getTabStripChevronEdgeClass("left")).toBe(
-      "left-0 justify-start",
-    );
-    expect(getTabStripChevronEdgeClass("right")).toBe(
-      "right-0 justify-end",
-    );
   });
 
-  it("keeps an available scroll control visible without requiring hover", () => {
-    const visibleClass = getTabStripChevronVisibilityClass(true);
-
-    expect(visibleClass).toContain("pointer-events-auto");
-    expect(visibleClass).toContain("opacity-100");
-    expect(visibleClass).not.toContain("hover:");
-    expect(getTabStripChevronVisibilityClass(false)).toBe(
-      "pointer-events-none opacity-0",
+  it("observes the intrinsic tab row so async title changes refresh overflow", () => {
+    const observed: Element[] = [];
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe(element: Element) {
+          observed.push(element);
+        }
+        disconnect() {}
+      },
     );
+
+    const { container } = render(
+      createElement(SecondaryPanelTabStrip, {
+        fileTabs: [
+          {
+            id: "browser",
+            filename: "Browser",
+            isActive: true,
+            isPinned: false,
+            leadingVisual: null,
+            statusLabel: null,
+            onSelect: vi.fn(),
+            onClose: vi.fn(),
+          },
+        ],
+        onReorderTab: vi.fn(),
+        usesDesktopChrome: false,
+      }),
+    );
+
+    const viewport = container.querySelector(".no-scrollbar");
+    const content = container.querySelector(
+      "[data-secondary-panel-tab-content]",
+    );
+    expect(content).not.toBeNull();
+    expect(observed).toContain(viewport);
+    expect(observed).toContain(content);
+    expect(container.querySelectorAll("[data-overflow-fade]")).toHaveLength(2);
+    expect(
+      container
+        .querySelector("[data-overflow-fade='left']")
+        ?.classList.contains("w-6"),
+    ).toBe(true);
+    expect(
+      container.querySelector('[aria-label="Scroll tabs left"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[aria-label="Scroll tabs right"]'),
+    ).toBeNull();
   });
 });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -27,9 +27,6 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Button } from "@bb/shared-ui/button";
-import { COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
-import { Icon } from "@bb/shared-ui/icon";
 import {
   OverflowFade,
   type OverflowFadeTone,
@@ -37,39 +34,17 @@ import {
 import { TabPill } from "@/components/ui/tab-pill";
 import { useDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import { cn } from "@bb/shared-ui/lib/utils";
-import {
-  MACOS_APP_REGION_NO_DRAG_CLASS,
-  MACOS_WINDOW_NO_DRAG_CLASS,
-} from "@/lib/bb-desktop";
+import { MACOS_WINDOW_NO_DRAG_CLASS } from "@/lib/bb-desktop";
 import type {
   SecondaryPanelFileTab,
   SecondaryPanelTabReorderHandler,
 } from "./secondaryPanelFileTab";
 export type { SecondaryPanelFileTab } from "./secondaryPanelFileTab";
 
-// How far a chevron click nudges the strip, in CSS pixels. Roughly one wide
-// file tab so a click reveals the next tab without overshooting.
-const CHEVRON_SCROLL_STEP_PX = 140;
-
-// Slack so sub-pixel scroll offsets don't leave a fade/chevron stuck on at a
-// hard edge.
+// Slack so sub-pixel scroll offsets don't leave a fade stuck on at a hard edge.
 const EDGE_EPSILON_PX = 1;
 
 export const SECONDARY_PANEL_TAB_STRIP_FADE_TONE: OverflowFadeTone = "sidebar";
-
-export function getTabStripChevronEdgeClass(
-  direction: "left" | "right",
-): string {
-  return direction === "left"
-    ? "left-0 justify-start"
-    : "right-0 justify-end";
-}
-
-export function getTabStripChevronVisibilityClass(canScroll: boolean): string {
-  return canScroll
-    ? "pointer-events-auto opacity-100"
-    : "pointer-events-none opacity-0";
-}
 
 interface TabStripOverflowState {
   /** Scrolled away from the left edge (content hidden to the left). */
@@ -103,8 +78,8 @@ interface SortableFileTabProps {
  *
  * Only the file tabs scroll; the leading Info/Diff controls and trailing
  * new-tab/panel controls stay anchored outside this component. Edge
- * fades and scroll chevrons appear only on a side that has more tabs, and the
- * active tab is auto-scrolled into view on mount and whenever it changes
+ * fades appear only on a side that has more tabs, and the active tab is
+ * auto-scrolled into view on mount and whenever it changes
  * (covering pointer, keyboard, and programmatic selection).
  */
 export function SecondaryPanelTabStrip({
@@ -114,6 +89,7 @@ export function SecondaryPanelTabStrip({
   activeTreatment = "fill",
 }: SecondaryPanelTabStripProps) {
   const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
   const [overflow, setOverflow] = useState<TabStripOverflowState>(
     INITIAL_OVERFLOW_STATE,
@@ -178,9 +154,9 @@ export function SecondaryPanelTabStrip({
     applyEdgeFlags();
   }, [applyEdgeFlags]);
 
-  // Track the viewport's own scrolling and resizing. The ResizeObserver fires
-  // once on observe (seeding the initial capacity + flags) and on every resize
-  // (including the panel's drag-resize, which changes clientWidth).
+  // Track the viewport's own scrolling and both dimensions that determine its
+  // capacity. The content row can change intrinsic width without the viewport
+  // resizing (for example, when an async browser title replaces "Browser").
   useEffect(() => {
     const viewport = viewportRef.current;
     if (viewport === null) {
@@ -200,6 +176,9 @@ export function SecondaryPanelTabStrip({
     viewport.addEventListener("scroll", handleScroll, { passive: true });
     const resizeObserver = new ResizeObserver(measureCapacity);
     resizeObserver.observe(viewport);
+    if (contentRef.current !== null) {
+      resizeObserver.observe(contentRef.current);
+    }
     return () => {
       viewport.removeEventListener("scroll", handleScroll);
       resizeObserver.disconnect();
@@ -284,12 +263,6 @@ export function SecondaryPanelTabStrip({
     };
   }, []);
 
-  const scrollByStep = (direction: -1 | 1) => {
-    viewportRef.current?.scrollBy({
-      left: direction * CHEVRON_SCROLL_STEP_PX,
-      behavior: "smooth",
-    });
-  };
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
       setDraggingTabId(String(event.active.id));
@@ -329,12 +302,9 @@ export function SecondaryPanelTabStrip({
   );
 
   const noDragClass = usesDesktopChrome ? MACOS_WINDOW_NO_DRAG_CLASS : null;
-  const chevronNoDragClass = usesDesktopChrome
-    ? MACOS_APP_REGION_NO_DRAG_CLASS
-    : null;
   // Memoize the sortable tab tree so the overflow-flag state — which flips every
   // time you reach a scroll edge, i.e. constantly at narrow widths — re-renders
-  // only the edge fades/chevrons, never the tabs. Without this, each edge
+  // only the edge fades, never the tabs. Without this, each edge
   // crossing reconciles the whole list and re-runs useSortable for every tab,
   // which is what kept narrow-width scrolling stuttery.
   const dndTabs = useMemo(
@@ -391,22 +361,22 @@ export function SecondaryPanelTabStrip({
 
   return (
     // Hugs its tabs (no `flex-1`) and shrinks (`min-w-0`) to scroll them under
-    // the edge fades/chevrons when they overflow. The New Tab button follows this
+    // the edge fades when they overflow. The New Tab button follows this
     // viewport as an anchored sibling, so it stays visible at the trailing edge
     // while overflowing tabs scroll beneath the fades.
     <div
       data-testid="secondary-panel-tab-strip"
       className="group relative flex min-w-0 items-center"
     >
-      {/* The single surface-colored fade stays opaque beneath the caret at the
-          outer edge while progressively obscuring only the tab content moving
-          behind it. The caret itself deliberately adds no second gradient: a
-          stacked gradient turns this transition into a mismatched solid tile. */}
+      {/* Keep the overflow cue stationary. Overlay scroll buttons used to
+          animate above partially visible tabs, making the tab text and selected
+          fill look clipped while the strip moved. Native wheel, trackpad, and
+          active-tab scrolling already provide the interaction. */}
       <OverflowFade
         placement="left"
         tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
         className={cn(
-          "z-10 transition-opacity",
+          "z-10",
           overflow.canScrollLeft ? "opacity-100" : "opacity-0",
         )}
       />
@@ -414,7 +384,7 @@ export function SecondaryPanelTabStrip({
         placement="right"
         tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
         className={cn(
-          "z-10 transition-opacity",
+          "z-10",
           overflow.canScrollRight ? "opacity-100" : "opacity-0",
         )}
       />
@@ -425,24 +395,17 @@ export function SecondaryPanelTabStrip({
         // (see the wheel handler), and CSS smooth-scroll would turn each wheel
         // notch into its own ~150ms animation — the strip advances, sits frozen
         // between notches, then jumps. Letting it track 1:1 matches native
-        // horizontal trackpad scrolling. The chevron buttons opt back into smooth
-        // per-call via `scrollBy({ behavior: "smooth" })`.
-        className="no-scrollbar flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden"
+        // horizontal trackpad scrolling.
+        className="no-scrollbar min-w-0 overflow-x-auto overflow-y-hidden"
       >
-        {dndTabs}
+        <div
+          ref={contentRef}
+          data-secondary-panel-tab-content
+          className="flex w-max items-center gap-1"
+        >
+          {dndTabs}
+        </div>
       </div>
-      <TabStripScrollChevron
-        direction="left"
-        canScroll={overflow.canScrollLeft}
-        className={chevronNoDragClass}
-        onClick={() => scrollByStep(-1)}
-      />
-      <TabStripScrollChevron
-        direction="right"
-        canScroll={overflow.canScrollRight}
-        className={chevronNoDragClass}
-        onClick={() => scrollByStep(1)}
-      />
     </div>
   );
 }
@@ -492,68 +455,6 @@ function SortableFileTab({
     >
       <FileTab tab={tab} activeTreatment={activeTreatment} />
     </div>
-  );
-}
-
-interface TabStripScrollChevronProps {
-  direction: "left" | "right";
-  canScroll: boolean;
-  className: string | null;
-  onClick: () => void;
-}
-
-function TabStripScrollChevron({
-  direction,
-  canScroll,
-  className,
-  onClick,
-}: TabStripScrollChevronProps) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      // Decorative scroll control: every tab is already reachable via Tab, so
-      // keep the chevron out of the tab order (tabIndex -1) to avoid duplicate
-      // stops. It stays mounted (so reaching an edge is an opacity toggle, not a
-      // DOM commit); when there's nothing to scroll, aria-hidden +
-      // pointer-events-none + opacity-0 (below) make it inert and invisible.
-      // Deliberately NOT the `disabled` attribute: Button carries
-      // `disabled:opacity-50`, which would beat the `opacity-0` hide and leave
-      // both chevrons painted at half opacity on every strip that doesn't
-      // overflow. aria-hidden already removes it from assistive tech, so
-      // `disabled` would add no a11y here anyway.
-      tabIndex={-1}
-      aria-hidden={!canScroll}
-      onClick={onClick}
-      aria-label={
-        direction === "left" ? "Scroll tabs left" : "Scroll tabs right"
-      }
-      className={cn(
-        // The chevron rides the edge fade instead of occluding the tab beneath
-        // it. Its own background stays transparent because the single
-        // OverflowFade already provides the opaque themed backing at the outer
-        // edge; adding another gradient here would double the opacity and make
-        // the selected tab look like a separate block.
-        // The arrow is edge-aligned (justify-start/end) so it hugs the opaque
-        // edge of the fade and clears the central tabs — rather than nudging the
-        // button itself outward, which a clipping ancestor would cut off.
-        "absolute z-50 shrink-0 text-muted-foreground hover:bg-transparent focus-visible:bg-transparent",
-        getTabStripChevronEdgeClass(direction),
-        COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
-        // Always mounted (so reaching an edge toggles opacity rather than
-        // committing/removing DOM mid-scroll) and always visible whenever there
-        // is more content in that direction. Keeping discovery independent of
-        // browser hover capability also makes the control reliable for pen and
-        // touch users. `pointer-events` follow visibility so an inert chevron
-        // never intercepts clicks meant for the tab beneath it.
-        "transition-opacity",
-        getTabStripChevronVisibilityClass(canScroll),
-        className,
-      )}
-    >
-      <Icon name={direction === "left" ? "ChevronLeft" : "ChevronRight"} />
-    </Button>
   );
 }
 

--- a/apps/app/src/components/tools/Automations.stories.tsx
+++ b/apps/app/src/components/tools/Automations.stories.tsx
@@ -522,9 +522,11 @@ function AutomationDetail({
       actionPending={false}
       editing={false}
       executionOptions={executionOptions}
+      permissionModes={["accept-edits", "auto", "full"]}
       executionOptionsError={null}
       onToggle={noop}
       onEdit={noop}
+      onCancelEdit={noop}
       onUpdateAgent={async () => {}}
       onRunNow={noop}
       onDelete={noop}

--- a/apps/app/src/components/tools/SkillDetailView.tsx
+++ b/apps/app/src/components/tools/SkillDetailView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { formatHomePathForDisplay } from "@bb/shared-ui/lib/utils";
@@ -129,6 +129,10 @@ function getSkillDirectoryPath(path: string): string {
   return path.replace(/[\\/]SKILL\.md$/i, "");
 }
 
+const SKILL_PAGE_WHEEL_THRESHOLD_PX = 40;
+const SKILL_PAGE_WHEEL_GESTURE_RESET_MS = 160;
+const WHEEL_LINE_HEIGHT_PX = 16;
+
 function SkillFileList({
   files,
   selectedPath,
@@ -173,6 +177,11 @@ function PagedSkillContent({
     pageHeight: 0,
     pageCount: 1,
   });
+  const pageRef = useRef(page);
+  const pageCountRef = useRef(measurement.pageCount);
+  const wheelDeltaRef = useRef(0);
+  const wheelPageChangedRef = useRef(false);
+  const wheelResetTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (viewport === null || pages === null) return;
@@ -209,6 +218,79 @@ function PagedSkillContent({
   }, [pages, viewport]);
 
   const safePage = Math.min(page, measurement.pageCount - 1);
+  pageRef.current = safePage;
+  pageCountRef.current = measurement.pageCount;
+
+  useEffect(() => {
+    if (viewport === null) return;
+    const viewportElement = viewport;
+
+    const resetWheelGesture = () => {
+      wheelDeltaRef.current = 0;
+      wheelPageChangedRef.current = false;
+      if (wheelResetTimeoutRef.current !== null) {
+        window.clearTimeout(wheelResetTimeoutRef.current);
+        wheelResetTimeoutRef.current = null;
+      }
+    };
+
+    const handleWheel = (event: WheelEvent) => {
+      if (
+        event.ctrlKey ||
+        event.deltaY === 0 ||
+        Math.abs(event.deltaX) >= Math.abs(event.deltaY)
+      ) {
+        return;
+      }
+
+      const direction = event.deltaY > 0 ? 1 : -1;
+      const currentPage = pageRef.current;
+      const pageCount = pageCountRef.current;
+      const nextPage = currentPage + direction;
+      if (nextPage < 0 || nextPage >= pageCount) {
+        resetWheelGesture();
+        return;
+      }
+
+      event.preventDefault();
+      if (wheelResetTimeoutRef.current !== null) {
+        window.clearTimeout(wheelResetTimeoutRef.current);
+      }
+      wheelResetTimeoutRef.current = window.setTimeout(
+        resetWheelGesture,
+        SKILL_PAGE_WHEEL_GESTURE_RESET_MS,
+      );
+
+      if (wheelPageChangedRef.current) return;
+      if (
+        wheelDeltaRef.current !== 0 &&
+        Math.sign(wheelDeltaRef.current) !== direction
+      ) {
+        wheelDeltaRef.current = 0;
+      }
+      const normalizedDelta =
+        event.deltaMode === 1
+          ? event.deltaY * WHEEL_LINE_HEIGHT_PX
+          : event.deltaMode === 2
+            ? event.deltaY * viewportElement.clientHeight
+            : event.deltaY;
+      wheelDeltaRef.current += normalizedDelta;
+      if (Math.abs(wheelDeltaRef.current) < SKILL_PAGE_WHEEL_THRESHOLD_PX) {
+        return;
+      }
+
+      wheelPageChangedRef.current = true;
+      wheelDeltaRef.current = 0;
+      pageRef.current = nextPage;
+      setPage(nextPage);
+    };
+
+    viewportElement.addEventListener("wheel", handleWheel, { passive: false });
+    return () => {
+      viewportElement.removeEventListener("wheel", handleWheel);
+      resetWheelGesture();
+    };
+  }, [viewport]);
 
   return (
     <div className="space-y-3">

--- a/apps/app/src/components/tools/SkillDetailView.tsx
+++ b/apps/app/src/components/tools/SkillDetailView.tsx
@@ -234,6 +234,16 @@ function PagedSkillContent({
       }
     };
 
+    const refreshWheelGestureReset = () => {
+      if (wheelResetTimeoutRef.current !== null) {
+        window.clearTimeout(wheelResetTimeoutRef.current);
+      }
+      wheelResetTimeoutRef.current = window.setTimeout(
+        resetWheelGesture,
+        SKILL_PAGE_WHEEL_GESTURE_RESET_MS,
+      );
+    };
+
     const handleWheel = (event: WheelEvent) => {
       if (
         event.ctrlKey ||
@@ -243,24 +253,19 @@ function PagedSkillContent({
         return;
       }
 
+      refreshWheelGestureReset();
       const direction = event.deltaY > 0 ? 1 : -1;
       const currentPage = pageRef.current;
       const pageCount = pageCountRef.current;
       const nextPage = currentPage + direction;
       if (nextPage < 0 || nextPage >= pageCount) {
-        resetWheelGesture();
+        if (!wheelPageChangedRef.current) {
+          wheelDeltaRef.current = 0;
+        }
         return;
       }
 
       event.preventDefault();
-      if (wheelResetTimeoutRef.current !== null) {
-        window.clearTimeout(wheelResetTimeoutRef.current);
-      }
-      wheelResetTimeoutRef.current = window.setTimeout(
-        resetWheelGesture,
-        SKILL_PAGE_WHEEL_GESTURE_RESET_MS,
-      );
-
       if (wheelPageChangedRef.current) return;
       if (
         wheelDeltaRef.current !== 0 &&

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -245,6 +245,7 @@ describe("Plugin detail recipe", () => {
       expect(screen.getByText(item).className).toContain("text-xs");
     }
     const skillName = screen.getByText("review");
+    expect(skillName.closest("th")?.className).toContain("items-center");
     expect(skillName.parentElement?.className).toContain("items-center");
     expect(skillName.previousElementSibling?.className).not.toContain("mt-px");
   });
@@ -269,15 +270,16 @@ describe("Plugin detail recipe", () => {
       name: "Show full description",
     });
     expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(disclosure.className).toContain("text-subtle-foreground");
 
     fireEvent.click(disclosure);
 
     expect(detail.className).not.toContain("line-clamp-3");
-    expect(
-      screen
-        .getByRole("button", { name: "Show less" })
-        .getAttribute("aria-expanded"),
-    ).toBe("true");
+    const collapseDisclosure = screen.getByRole("button", {
+      name: "Show less",
+    });
+    expect(collapseDisclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(collapseDisclosure.className).toContain("text-subtle-foreground");
     expect(container.textContent).toContain(description);
   });
 
@@ -616,6 +618,64 @@ describe("Skill detail recipe", () => {
     expect(content?.style.transform).toBe("translateY(-540px)");
     expect(next.getAttribute("disabled")).not.toBeNull();
   });
+
+  it("pages once per vertical wheel or trackpad gesture", () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = renderSkill(["/skills/writing-voice/SKILL.md"]);
+      const viewport = container.querySelector<HTMLElement>(
+        "[data-skill-content-viewport]",
+      );
+      const content = container.querySelector<HTMLElement>(
+        "[data-skill-content-pages]",
+      );
+      expect(viewport).not.toBeNull();
+      expect(content).not.toBeNull();
+
+      Object.defineProperty(viewport, "clientHeight", {
+        configurable: true,
+        value: 240,
+      });
+      Object.defineProperty(content, "scrollHeight", {
+        configurable: true,
+        value: 720,
+      });
+      act(() => window.dispatchEvent(new Event("resize")));
+
+      const pagination = screen.getByRole("navigation", {
+        name: "Skill content pagination",
+      });
+      fireEvent.wheel(viewport!, { deltaY: -100 });
+      expect(pagination.textContent).toContain("Page 1 of 3");
+
+      // Trackpads emit several small pixel deltas. Accumulate them, then move
+      // exactly one page for the gesture even if momentum events continue.
+      fireEvent.wheel(viewport!, { deltaY: 24 });
+      expect(pagination.textContent).toContain("Page 1 of 3");
+      fireEvent.wheel(viewport!, { deltaY: 24 });
+      expect(pagination.textContent).toContain("Page 2 of 3");
+      fireEvent.wheel(viewport!, { deltaY: 100 });
+      expect(pagination.textContent).toContain("Page 2 of 3");
+
+      act(() => {
+        vi.advanceTimersByTime(161);
+      });
+      // Line-mode wheel input is normalized to pixels and uses the same
+      // threshold and one-page-per-gesture behavior.
+      fireEvent.wheel(viewport!, { deltaY: 3, deltaMode: 1 });
+      expect(pagination.textContent).toContain("Page 3 of 3");
+
+      act(() => {
+        vi.advanceTimersByTime(161);
+      });
+      fireEvent.wheel(viewport!, { deltaY: 100 });
+      expect(pagination.textContent).toContain("Page 3 of 3");
+      fireEvent.wheel(viewport!, { deltaY: -40 });
+      expect(pagination.textContent).toContain("Page 2 of 3");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 const AUTOMATION: AutomationResponse = {
@@ -662,12 +722,22 @@ const AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptionsResponse = {
 
 type TestAutomationDetailProps = Omit<
   ComponentProps<typeof AutomationDetailViewBase>,
-  "editing" | "executionOptions" | "executionOptionsError" | "onUpdateAgent"
+  | "editing"
+  | "executionOptions"
+  | "executionOptionsError"
+  | "permissionModes"
+  | "onCancelEdit"
+  | "onUpdateAgent"
 > &
   Partial<
     Pick<
       ComponentProps<typeof AutomationDetailViewBase>,
-      "editing" | "executionOptions" | "executionOptionsError" | "onUpdateAgent"
+      | "editing"
+      | "executionOptions"
+      | "executionOptionsError"
+      | "permissionModes"
+      | "onCancelEdit"
+      | "onUpdateAgent"
     >
   >;
 
@@ -675,6 +745,8 @@ function AutomationDetailView({
   editing = false,
   executionOptions = AUTOMATION_EXECUTION_OPTIONS,
   executionOptionsError = null,
+  permissionModes = AUTOMATION_EXECUTION_OPTIONS.permissionModes,
+  onCancelEdit = () => {},
   onUpdateAgent = async () => {},
   ...props
 }: TestAutomationDetailProps) {
@@ -684,6 +756,8 @@ function AutomationDetailView({
       editing={editing}
       executionOptions={executionOptions}
       executionOptionsError={executionOptionsError}
+      permissionModes={permissionModes}
+      onCancelEdit={onCancelEdit}
       onUpdateAgent={onUpdateAgent}
     />
   );
@@ -731,6 +805,7 @@ describe("Automation detail recipe", () => {
           }}
           onToggle={() => {}}
           onEdit={() => setEditing(true)}
+          onCancelEdit={() => setEditing(false)}
           onRunNow={() => {}}
           onDelete={() => {}}
           onOpenThread={() => {}}
@@ -897,18 +972,53 @@ describe("Automation detail recipe", () => {
     expect(
       container.querySelector('[data-automation-provider-icon="claude"] svg'),
     ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[data-automation-provider-icon="claude"] svg.block',
+      ),
+    ).not.toBeNull();
     const savePrompt = screen.getByRole("button", { name: "Save Prompt" });
     expect(promptPanel.contains(savePrompt)).toBe(true);
+    expect(savePrompt.querySelector('[data-icon="Check"]')).not.toBeNull();
     expect((savePrompt as HTMLButtonElement).disabled).toBe(true);
-    fireEvent.change(promptContent, {
+    const cancelEditing = screen.getByRole("button", { name: "Cancel" });
+    expect((cancelEditing as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(cancelEditing);
+    expect(
+      await screen.findByRole("textbox", { name: "Saved prompt" }),
+    ).toBeTruthy();
+    expect(updateAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit prompt" }));
+    const reopenedPrompt = screen.getByRole("textbox", {
+      name: "Automation prompt",
+    }) as HTMLTextAreaElement;
+    const reopenedPanel = reopenedPrompt.closest("form") as HTMLElement;
+    const reopenedModelSelector = reopenedPanel.querySelector(
+      '[data-automation-selector="Provider and model"]',
+    ) as HTMLButtonElement;
+    const reopenedAccessSelector = container.querySelector(
+      '[data-automation-selector="Permission mode"]',
+    ) as HTMLButtonElement;
+    const reopenedSavePrompt = screen.getByRole("button", {
+      name: "Save Prompt",
+    });
+    fireEvent.change(reopenedPrompt, {
       target: { value: "Summarize the last two days." },
     });
-    fireEvent.keyDown(modelSelector, { key: "Enter" });
+    fireEvent.keyDown(reopenedModelSelector, { key: "Enter" });
+    const modelOptions = await screen.findByRole("listbox");
+    expect(modelOptions.className).toContain("w-max");
+    expect(modelOptions.className).toContain("min-w-0");
     fireEvent.click(await screen.findByRole("option", { name: "Sonnet 5" }));
-    fireEvent.keyDown(accessSelector, { key: "Enter" });
+    fireEvent.keyDown(reopenedAccessSelector, { key: "Enter" });
     fireEvent.click(await screen.findByRole("option", { name: "Full Access" }));
-    expect((savePrompt as HTMLButtonElement).disabled).toBe(false);
-    fireEvent.click(savePrompt);
+    expect((reopenedSavePrompt as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      (screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.click(reopenedSavePrompt);
     expect(updateAgent).toHaveBeenCalledWith({
       prompt: "Summarize the last two days.",
       model: "claude-sonnet-5",
@@ -920,6 +1030,44 @@ describe("Automation detail recipe", () => {
     expect(
       screen.queryByRole("textbox", { name: "Automation prompt" }),
     ).toBeNull();
+  });
+
+  it("does not make permission editing wait for model discovery", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AutomationDetailView
+          automation={AUTOMATION}
+          projectLabel="Local"
+          runsState={{
+            runs: [],
+            nextCursor: null,
+            loading: false,
+            loadingMore: false,
+            error: null,
+            loadMore: () => {},
+            retry: () => {},
+          }}
+          actionPending={false}
+          editing
+          executionOptions={null}
+          permissionModes={["accept-edits", "auto", "full"]}
+          onToggle={() => {}}
+          onEdit={() => {}}
+          onRunNow={() => {}}
+          onDelete={() => {}}
+          onOpenThread={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    const permissionSelector = container.querySelector(
+      '[data-automation-selector="Permission mode"]',
+    ) as HTMLButtonElement;
+    const modelSelector = container.querySelector(
+      '[data-automation-selector="Provider and model"]',
+    ) as HTMLButtonElement;
+    expect(permissionSelector.disabled).toBe(false);
+    expect(modelSelector.disabled).toBe(true);
   });
 
   it("uses the composer metadata treatment without inventing reasoning", () => {

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -665,11 +665,17 @@ describe("Skill detail recipe", () => {
       fireEvent.wheel(viewport!, { deltaY: 3, deltaMode: 1 });
       expect(pagination.textContent).toContain("Page 3 of 3");
 
+      // Momentum can keep moving toward the boundary, then briefly rebound in
+      // the opposite direction. Both events are still part of the gesture that
+      // moved from page 2 to page 3, so the rebound must not navigate back.
+      fireEvent.wheel(viewport!, { deltaY: 100 });
+      expect(pagination.textContent).toContain("Page 3 of 3");
+      fireEvent.wheel(viewport!, { deltaY: -40 });
+      expect(pagination.textContent).toContain("Page 3 of 3");
+
       act(() => {
         vi.advanceTimersByTime(161);
       });
-      fireEvent.wheel(viewport!, { deltaY: 100 });
-      expect(pagination.textContent).toContain("Page 3 of 3");
       fireEvent.wheel(viewport!, { deltaY: -40 });
       expect(pagination.textContent).toContain("Page 2 of 3");
     } finally {

--- a/apps/app/src/components/tools/plugin-detail-table.tsx
+++ b/apps/app/src/components/tools/plugin-detail-table.tsx
@@ -166,7 +166,7 @@ export function PluginDetailRow({
         className={cn(
           CELL,
           PLUGIN_DETAIL_HEADER_CELL_CLASS,
-          "text-left font-normal",
+          "flex items-center text-left font-normal",
           hasDetail ? "border-r border-border pl-4 pr-2" : "px-4",
         )}
         colSpan={hasDetail ? undefined : 2}
@@ -210,7 +210,7 @@ export function PluginDetailRow({
               type="button"
               aria-expanded={expanded}
               aria-controls={detailId}
-              className="mt-2 rounded-sm text-xs font-medium text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="mt-2 rounded-sm text-xs font-medium text-subtle-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               onClick={() => setExpanded((current) => !current)}
             >
               {expanded ? "Show less" : "Show full description"}

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -248,13 +248,14 @@ function useAutomation(route: DetailRoute): {
 function useAutomationExecutionOptions(
   route: DetailRoute,
   enabled: boolean,
+  executionKey: string,
 ): {
   options: AutomationExecutionOptionsResponse | null;
   error: string | null;
 } {
   const rpc = useRpc<typeof automationRpcContract>();
   const { projectId, automationId } = route;
-  const requestKey = `${projectId}:${automationId}`;
+  const requestKey = `${projectId}:${automationId}:${executionKey}`;
   const requestedKeyRef = useRef<string | null>(null);
   const [state, setState] = useState<{
     options: AutomationExecutionOptionsResponse | null;
@@ -293,6 +294,7 @@ function useAutomationExecutionOptions(
 function useAutomationPermissionOptions(
   route: DetailRoute,
   enabled: boolean,
+  executionKey: string,
 ): {
   options: AutomationPermissionOptionsResponse | null;
   error: string | null;
@@ -300,7 +302,7 @@ function useAutomationPermissionOptions(
 } {
   const rpc = useRpc<typeof automationRpcContract>();
   const { projectId, automationId } = route;
-  const requestKey = `${projectId}:${automationId}`;
+  const requestKey = `${projectId}:${automationId}:${executionKey}`;
   const requestedKeyRef = useRef<string | null>(null);
   const [attempt, setAttempt] = useState(0);
   const [state, setState] = useState<{
@@ -602,13 +604,22 @@ function DetailView({
   const navigate = useBbNavigate();
   const { automation, error, missing, refetch } = useAutomation(route);
   const [editingRequested, setEditingRequested] = useState(initialEditing);
+  const editingExecutionKey =
+    automation?.execution.mode === "agent"
+      ? JSON.stringify({
+          providerId: automation.execution.providerId,
+          environment: automation.execution.environment,
+        })
+      : "not-agent";
   const executionOptionsState = useAutomationExecutionOptions(
     route,
     editingRequested && automation?.execution.mode === "agent",
+    editingExecutionKey,
   );
   const permissionOptionsState = useAutomationPermissionOptions(
     route,
     editingRequested && automation?.execution.mode === "agent",
+    editingExecutionKey,
   );
   const editing = editingRequested && permissionOptionsState.options !== null;
   const overviewState = useOverview();

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import type {
   AutomationResponse,
   AutomationExecutionOptionsResponse,
+  AutomationPermissionOptionsResponse,
   AgentExecutionUpdate,
   AutomationRunListResponse,
   AutomationRunResponse,
@@ -256,28 +257,96 @@ function useAutomationExecutionOptions(
   const [state, setState] = useState<{
     options: AutomationExecutionOptionsResponse | null;
     error: string | null;
-  }>({ options: null, error: null });
+    requested: boolean;
+  }>({ options: null, error: null, requested: false });
+
+  useEffect(() => {
+    setState({ options: null, error: null, requested: false });
+  }, [automationId, projectId]);
 
   useEffect(() => {
     if (!enabled) {
-      setState({ options: null, error: null });
+      if (state.error !== null) {
+        setState({ options: null, error: null, requested: false });
+      }
       return;
     }
+    if (state.options !== null || state.requested) return;
     let active = true;
+    setState((current) => ({ ...current, requested: true }));
     rpc.call("automations_execution_options", { projectId, automationId }).then(
       (options) => {
-        if (active) setState({ options, error: null });
+        if (active) setState({ options, error: null, requested: true });
       },
       (error: unknown) => {
-        if (active) setState({ options: null, error: errorText(error) });
+        if (active) {
+          setState({
+            options: null,
+            error: errorText(error),
+            requested: true,
+          });
+        }
       },
     );
     return () => {
       active = false;
     };
-  }, [automationId, enabled, projectId, rpc]);
+  }, [automationId, enabled, projectId, rpc, state]);
 
-  return state;
+  return { options: state.options, error: state.error };
+}
+
+function useAutomationPermissionOptions(
+  route: DetailRoute,
+  enabled: boolean,
+): {
+  options: AutomationPermissionOptionsResponse | null;
+  error: string | null;
+} {
+  const rpc = useRpc<typeof automationRpcContract>();
+  const { projectId, automationId } = route;
+  const [state, setState] = useState<{
+    options: AutomationPermissionOptionsResponse | null;
+    error: string | null;
+    requested: boolean;
+  }>({ options: null, error: null, requested: false });
+
+  useEffect(() => {
+    setState({ options: null, error: null, requested: false });
+  }, [automationId, projectId]);
+
+  useEffect(() => {
+    if (!enabled) {
+      if (state.error !== null) {
+        setState({ options: null, error: null, requested: false });
+      }
+      return;
+    }
+    if (state.options !== null || state.requested) return;
+    let active = true;
+    setState((current) => ({ ...current, requested: true }));
+    rpc
+      .call("automations_permission_options", { projectId, automationId })
+      .then(
+        (options) => {
+          if (active) setState({ options, error: null, requested: true });
+        },
+        (error: unknown) => {
+          if (active) {
+            setState({
+              options: null,
+              error: errorText(error),
+              requested: true,
+            });
+          }
+        },
+      );
+    return () => {
+      active = false;
+    };
+  }, [automationId, enabled, projectId, rpc, state]);
+
+  return { options: state.options, error: state.error };
 }
 
 interface RunsState {
@@ -538,11 +607,16 @@ function DetailView({
 }) {
   const navigate = useBbNavigate();
   const { automation, error, missing, refetch } = useAutomation(route);
-  const [editing, setEditing] = useState(initialEditing);
+  const [editingRequested, setEditingRequested] = useState(initialEditing);
   const executionOptionsState = useAutomationExecutionOptions(
     route,
-    editing && automation?.execution.mode === "agent",
+    editingRequested && automation?.execution.mode === "agent",
   );
+  const permissionOptionsState = useAutomationPermissionOptions(
+    route,
+    editingRequested && automation?.execution.mode === "agent",
+  );
+  const editing = editingRequested && permissionOptionsState.options !== null;
   const overviewState = useOverview();
   const runsState = useRuns(route);
   const mutations = useMutations();
@@ -590,7 +664,7 @@ function DetailView({
   const openEdit = useCallback(() => {
     if (automation === null) return;
     if (automation.execution.mode === "agent") {
-      setEditing(true);
+      setEditingRequested(true);
       return;
     }
     editViaThread(automation);
@@ -602,7 +676,7 @@ function DetailView({
       try {
         await mutations.update(route, agent);
         toast.success("Automation updated");
-        setEditing(false);
+        setEditingRequested(false);
         refetch();
       } catch (rpcError: unknown) {
         toast.error(`Failed to update automation: ${errorText(rpcError)}`);
@@ -674,10 +748,14 @@ function DetailView({
       runsState={runsState}
       actionPending={actionPending}
       executionOptions={executionOptionsState.options}
-      executionOptionsError={executionOptionsState.error}
+      executionOptionsError={
+        executionOptionsState.error ?? permissionOptionsState.error
+      }
+      permissionModes={permissionOptionsState.options?.permissionModes ?? []}
       editing={editing}
       onToggle={(checked) => runAction(checked ? "resume" : "pause")}
       onEdit={openEdit}
+      onCancelEdit={() => setEditingRequested(false)}
       onUpdateAgent={updateAgent}
       onRunNow={() => runAction("run")}
       onDelete={() => setDeleteOpen(true)}

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -254,44 +254,38 @@ function useAutomationExecutionOptions(
 } {
   const rpc = useRpc<typeof automationRpcContract>();
   const { projectId, automationId } = route;
+  const requestKey = `${projectId}:${automationId}`;
+  const requestedKeyRef = useRef<string | null>(null);
   const [state, setState] = useState<{
     options: AutomationExecutionOptionsResponse | null;
     error: string | null;
-    requested: boolean;
-  }>({ options: null, error: null, requested: false });
+  }>({ options: null, error: null });
 
   useEffect(() => {
-    setState({ options: null, error: null, requested: false });
-  }, [automationId, projectId]);
+    requestedKeyRef.current = null;
+    setState({ options: null, error: null });
+  }, [requestKey]);
 
   useEffect(() => {
-    if (!enabled) {
-      if (state.error !== null) {
-        setState({ options: null, error: null, requested: false });
-      }
-      return;
-    }
-    if (state.options !== null || state.requested) return;
+    if (!enabled || requestedKeyRef.current === requestKey) return;
+    requestedKeyRef.current = requestKey;
     let active = true;
-    setState((current) => ({ ...current, requested: true }));
+    setState({ options: null, error: null });
     rpc.call("automations_execution_options", { projectId, automationId }).then(
       (options) => {
-        if (active) setState({ options, error: null, requested: true });
+        if (active) setState({ options, error: null });
       },
       (error: unknown) => {
         if (active) {
-          setState({
-            options: null,
-            error: errorText(error),
-            requested: true,
-          });
+          requestedKeyRef.current = null;
+          setState({ options: null, error: errorText(error) });
         }
       },
     );
     return () => {
       active = false;
     };
-  }, [automationId, enabled, projectId, rpc, state]);
+  }, [automationId, enabled, projectId, requestKey, rpc]);
 
   return { options: state.options, error: state.error };
 }
@@ -302,51 +296,51 @@ function useAutomationPermissionOptions(
 ): {
   options: AutomationPermissionOptionsResponse | null;
   error: string | null;
+  retry: () => void;
 } {
   const rpc = useRpc<typeof automationRpcContract>();
   const { projectId, automationId } = route;
+  const requestKey = `${projectId}:${automationId}`;
+  const requestedKeyRef = useRef<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
   const [state, setState] = useState<{
     options: AutomationPermissionOptionsResponse | null;
     error: string | null;
-    requested: boolean;
-  }>({ options: null, error: null, requested: false });
+  }>({ options: null, error: null });
 
   useEffect(() => {
-    setState({ options: null, error: null, requested: false });
-  }, [automationId, projectId]);
+    requestedKeyRef.current = null;
+    setState({ options: null, error: null });
+  }, [requestKey]);
 
   useEffect(() => {
-    if (!enabled) {
-      if (state.error !== null) {
-        setState({ options: null, error: null, requested: false });
-      }
-      return;
-    }
-    if (state.options !== null || state.requested) return;
+    if (!enabled || requestedKeyRef.current === requestKey) return;
+    requestedKeyRef.current = requestKey;
     let active = true;
-    setState((current) => ({ ...current, requested: true }));
+    setState({ options: null, error: null });
     rpc
       .call("automations_permission_options", { projectId, automationId })
       .then(
         (options) => {
-          if (active) setState({ options, error: null, requested: true });
+          if (active) setState({ options, error: null });
         },
         (error: unknown) => {
           if (active) {
-            setState({
-              options: null,
-              error: errorText(error),
-              requested: true,
-            });
+            requestedKeyRef.current = null;
+            setState({ options: null, error: errorText(error) });
           }
         },
       );
     return () => {
       active = false;
     };
-  }, [automationId, enabled, projectId, rpc, state]);
+  }, [attempt, automationId, enabled, projectId, requestKey, rpc]);
 
-  return { options: state.options, error: state.error };
+  const retry = useCallback(() => {
+    requestedKeyRef.current = null;
+    setAttempt((current) => current + 1);
+  }, []);
+  return { options: state.options, error: state.error, retry };
 }
 
 interface RunsState {
@@ -664,11 +658,14 @@ function DetailView({
   const openEdit = useCallback(() => {
     if (automation === null) return;
     if (automation.execution.mode === "agent") {
+      if (permissionOptionsState.error !== null) {
+        permissionOptionsState.retry();
+      }
       setEditingRequested(true);
       return;
     }
     editViaThread(automation);
-  }, [automation, editViaThread]);
+  }, [automation, editViaThread, permissionOptionsState]);
 
   const updateAgent = useCallback(
     async (agent: AgentExecutionUpdate) => {

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -7,6 +7,7 @@ import type {
   AutomationRunResponse,
   AutomationRunStatus,
   AgentExecutionUpdate,
+  PermissionMode,
 } from "./src/rpc-types";
 import { AUTOMATION_PROMPT_MAX_LENGTH } from "./src/rpc-types";
 import { Button } from "@bb/shared-ui/button";
@@ -80,9 +81,11 @@ export interface AutomationDetailViewProps {
   actionPending: boolean;
   executionOptions: AutomationExecutionOptionsResponse | null;
   executionOptionsError: string | null;
+  permissionModes: readonly PermissionMode[];
   editing: boolean;
   onToggle: (enabled: boolean) => void;
   onEdit: () => void;
+  onCancelEdit: () => void;
   onUpdateAgent: (update: AgentExecutionUpdate) => Promise<void>;
   onRunNow: () => void;
   onDelete: () => void;
@@ -329,10 +332,12 @@ function AutomationSelector({
           className={OPTION_CONTENT_CLASS_NAME}
         >
           {leading}
-          <SelectValue />
+          <span className="inline-flex min-w-0 items-center leading-none">
+            <SelectValue />
+          </span>
         </span>
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="w-max min-w-0">
         {options.map((option) => (
           <SelectItem
             key={option.value}
@@ -655,6 +660,8 @@ function AgentAutomationDefinition({
   personalProject,
   projectContextLabel,
   pending,
+  permissionModes,
+  onCancel,
   onUpdate,
 }: {
   execution: Extract<AutomationExecution, { mode: "agent" }>;
@@ -664,6 +671,8 @@ function AgentAutomationDefinition({
   personalProject: boolean;
   projectContextLabel: string;
   pending: boolean;
+  permissionModes: readonly PermissionMode[];
+  onCancel: () => void;
   onUpdate: (update: AgentExecutionUpdate) => Promise<void>;
 }) {
   const [prompt, setPrompt] = useState(execution.prompt);
@@ -696,12 +705,10 @@ function AgentAutomationDefinition({
       label: formatAutomationModelLabel(model, execution.providerId),
     });
   }
-  const permissionOptions = (options?.permissionModes ?? [permissionMode]).map(
-    (mode) => ({
-      value: mode,
-      label: formatPermissionMode(mode),
-    }),
-  );
+  const permissionOptions = permissionModes.map((mode) => ({
+    value: mode,
+    label: formatPermissionMode(mode),
+  }));
 
   const promptBox = editing ? (
     <form
@@ -742,11 +749,22 @@ function AgentAutomationDefinition({
           />
         </div>
         <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="ml-auto shrink-0"
+          disabled={pending || dirty}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
           type="submit"
           size="sm"
-          className="ml-1 shrink-0"
+          className="shrink-0"
           disabled={pending || !dirty || trimmedPrompt.length === 0}
         >
+          <Icon name="Check" className="size-3.5" aria-hidden />
           Save Prompt
         </Button>
       </div>
@@ -822,11 +840,9 @@ function AgentAutomationDefinition({
           label="Permission mode"
           value={permissionMode}
           options={permissionOptions}
-          disabled={pending || options === null}
+          disabled={pending}
           onValueChange={(value) => {
-            const next = options?.permissionModes.find(
-              (mode) => mode === value,
-            );
+            const next = permissionModes.find((mode) => mode === value);
             if (next !== undefined) setPermissionMode(next);
           }}
           className="h-6 shrink-0"
@@ -857,7 +873,7 @@ function AgentAutomationDefinition({
       )}
       {optionsError ? (
         <p className="mt-1 px-3.5 text-xs text-destructive">
-          Couldn&apos;t load model options. {optionsError}
+          Couldn&apos;t load editing options. {optionsError}
         </p>
       ) : null}
       {editing ? promptFooter : null}
@@ -872,9 +888,11 @@ export function AutomationDetailView({
   actionPending,
   executionOptions,
   executionOptionsError,
+  permissionModes,
   editing,
   onToggle,
   onEdit,
+  onCancelEdit,
   onUpdateAgent,
   onRunNow,
   onDelete,
@@ -983,8 +1001,10 @@ export function AutomationDetailView({
               optionsError={executionOptionsError}
               editing={editing}
               pending={actionPending}
+              permissionModes={permissionModes}
               personalProject={personalProject}
               projectContextLabel={projectContextLabel}
+              onCancel={onCancelEdit}
               onUpdate={onUpdateAgent}
             />
           ) : (

--- a/plugins/automations/lib/provider-icon.tsx
+++ b/plugins/automations/lib/provider-icon.tsx
@@ -110,7 +110,7 @@ export function AutomationProviderIcon({ providerId }: { providerId: string }) {
       aria-hidden="true"
       className="inline-flex size-3.5 shrink-0 items-center justify-center text-muted-foreground"
     >
-      <ProviderIcon className="size-full" />
+      <ProviderIcon className="block size-full" />
     </span>
   );
 }

--- a/plugins/automations/src/cli.ts
+++ b/plugins/automations/src/cli.ts
@@ -18,7 +18,10 @@ import type {
   ResolvedCreateAutomationInput,
   UpdateAutomationInput,
 } from "./rpc-types.js";
-import { resolvePermissionMode } from "./provider-permissions.js";
+import {
+  providerRoutingForEnvironment,
+  resolvePermissionMode,
+} from "./provider-permissions.js";
 import {
   AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS,
   automationScriptInterpreterSchema,
@@ -324,6 +327,7 @@ async function buildExecution(
       );
     }
     validateAgentTargetOptions(args);
+    const environment = await buildAgentEnvironment(bb, args);
     return {
       mode: "agent",
       prompt,
@@ -333,8 +337,9 @@ async function buildExecution(
         bb,
         provider,
         parsePermissionMode(flag(args, "permission-mode")),
+        providerRoutingForEnvironment(environment),
       ),
-      environment: await buildAgentEnvironment(bb, args),
+      environment,
       ...(flag(args, "target-thread")
         ? { targetThreadId: flag(args, "target-thread") }
         : {}),

--- a/plugins/automations/src/provider-permissions.ts
+++ b/plugins/automations/src/provider-permissions.ts
@@ -1,5 +1,5 @@
 import type { BbPluginApi } from "@bb/plugin-sdk";
-import type { PermissionMode } from "./rpc-types.js";
+import type { AgentEnvironment, PermissionMode } from "./rpc-types.js";
 
 type ProviderPermissionApi = {
   sdk: {
@@ -7,12 +7,29 @@ type ProviderPermissionApi = {
   };
 };
 
+type ProviderRouting = NonNullable<
+  Parameters<ProviderPermissionApi["sdk"]["providers"]["list"]>[0]
+>;
+
+export function providerRoutingForEnvironment(
+  environment: AgentEnvironment,
+): ProviderRouting {
+  if (environment.type === "reuse") {
+    return { environmentId: environment.environmentId };
+  }
+  if (environment.type === "host" && environment.hostId !== undefined) {
+    return { hostId: environment.hostId };
+  }
+  return {};
+}
+
 export async function resolvePermissionMode(
   bb: ProviderPermissionApi,
   providerId: string,
   requested: PermissionMode | undefined,
+  routing: ProviderRouting = {},
 ): Promise<PermissionMode> {
-  const providers = await bb.sdk.providers.list();
+  const providers = await bb.sdk.providers.list(routing);
   const provider = providers.find((candidate) => candidate.id === providerId);
   if (provider === undefined || provider.available === false) {
     throw new Error(`Provider ${providerId} is not available.`);

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -228,6 +228,15 @@ export type AutomationExecutionOptionsResponse = z.infer<
   typeof automationExecutionOptionsResponseSchema
 >;
 
+export const automationPermissionOptionsResponseSchema = z
+  .object({
+    permissionModes: z.array(permissionModeSchema),
+  })
+  .strict();
+export type AutomationPermissionOptionsResponse = z.infer<
+  typeof automationPermissionOptionsResponseSchema
+>;
+
 export const automationResponseSchema = z
   .object({
     id: z.string(),

--- a/plugins/automations/src/rpc.ts
+++ b/plugins/automations/src/rpc.ts
@@ -1,6 +1,7 @@
 import {
   automationListResponseSchema,
   automationExecutionOptionsResponseSchema,
+  automationPermissionOptionsResponseSchema,
   automationResponseSchema,
   automationRunListResponseSchema,
   automationRunRpcResponseSchema,
@@ -35,6 +36,10 @@ export const automationRpcContract = defineRpcContract({
   automations_execution_options: {
     input: projectAutomationInputSchema,
     output: automationExecutionOptionsResponseSchema,
+  },
+  automations_permission_options: {
+    input: projectAutomationInputSchema,
+    output: automationPermissionOptionsResponseSchema,
   },
   automations_create: {
     input: createAutomationInputSchema,
@@ -81,6 +86,11 @@ export function createRpcHandlers(service: AutomationService) {
       input: z.output<typeof projectAutomationInputSchema>,
     ) {
       return service.executionOptions(input);
+    },
+    automations_permission_options(
+      input: z.output<typeof projectAutomationInputSchema>,
+    ) {
+      return service.permissionOptions(input);
     },
     automations_create(input: z.output<typeof createAutomationInputSchema>) {
       return service.create(input);

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -45,6 +45,7 @@ async function bootAutomationsPlugin(
     "auto",
     "full",
   ],
+  routedPermissionModes?: Array<"accept-edits" | "auto" | "full">,
 ): Promise<FakePluginHost> {
   const host = createFakePluginHost({
     pluginId: "automations",
@@ -76,11 +77,16 @@ async function bootAutomationsPlugin(
         },
       },
       providers: {
-        async list() {
+        async list(routing) {
+          const permissionModes =
+            routing?.environmentId === "env_routed" &&
+            routedPermissionModes !== undefined
+              ? routedPermissionModes
+              : supportedPermissionModes;
           return [
             {
               id: "codex",
-              capabilities: { supportedPermissionModes },
+              capabilities: { supportedPermissionModes: permissionModes },
             },
           ] as never;
         },
@@ -737,6 +743,39 @@ describe("automations server plugin harness", () => {
     expect(unchanged.execution).toMatchObject({
       mode: "agent",
       permissionMode: "accept-edits",
+    });
+
+    await harness.dispose();
+  });
+
+  it("validates permission updates against the automation target environment", async () => {
+    const { harness } = await bootAutomationsPlugin(
+      ["accept-edits"],
+      ["full"],
+    );
+    const created = await createAgentAutomation(harness);
+
+    await expect(
+      harness.callRpc("automations_update", {
+        projectId: PROJECT_ID,
+        automationId: created.id,
+        agent: {
+          permissionMode: "full",
+          target: {
+            type: "environment",
+            environment: {
+              type: "reuse",
+              environmentId: "env_routed",
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      execution: {
+        mode: "agent",
+        permissionMode: "full",
+        environment: { type: "reuse", environmentId: "env_routed" },
+      },
     });
 
     await harness.dispose();

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -25,6 +25,7 @@ const rpcMethods = [
   "automations_list",
   "automations_get",
   "automations_execution_options",
+  "automations_permission_options",
   "automations_create",
   "automations_update",
   "automations_delete",
@@ -665,6 +666,14 @@ describe("automations server plugin harness", () => {
     });
     expect(options).toMatchObject({
       models: [{ model: "gpt-5.6-codex", displayName: "5.6 Sol" }],
+      permissionModes: ["accept-edits", "auto", "full"],
+    });
+    await expect(
+      harness.callRpc("automations_permission_options", {
+        projectId: PROJECT_ID,
+        automationId: created.id,
+      }),
+    ).resolves.toEqual({
       permissionModes: ["accept-edits", "auto", "full"],
     });
 

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -29,6 +29,7 @@ import {
   type AgentExecutionUpdate,
   type AutomationExecution,
   type AutomationExecutionOptionsResponse,
+  type AutomationPermissionOptionsResponse,
   type AutomationRunListResponse,
   type AutomationRunRpcResponse,
   type AutomationResponse,
@@ -72,6 +73,10 @@ export interface AutomationService {
     projectId: string;
     automationId: string;
   }): Promise<AutomationExecutionOptionsResponse>;
+  permissionOptions(input: {
+    projectId: string;
+    automationId: string;
+  }): Promise<AutomationPermissionOptionsResponse>;
   create(input: ResolvedCreateAutomationInput): Promise<AutomationResponse>;
   update(input: UpdateAutomationInput): Promise<AutomationResponse>;
   delete(input: {
@@ -436,6 +441,33 @@ export function createAutomationService(args: {
         .map(({ id, model, displayName }) => ({ id, model, displayName }));
       const permissionModes = provider.capabilities.supportedPermissionModes;
       return { models, permissionModes };
+    },
+
+    async permissionOptions(input) {
+      const automation = requireProjectAutomation(db, input);
+      const execution = parseAutomationExecution(automation.execution);
+      if (execution.mode !== "agent") {
+        throw new Error(
+          "Permission options are only available for agent automations",
+        );
+      }
+      const environment = execution.environment;
+      const routing =
+        environment.type === "reuse"
+          ? { environmentId: environment.environmentId }
+          : environment.type === "host" && environment.hostId !== undefined
+            ? { hostId: environment.hostId }
+            : {};
+      const providers = await bb.sdk.providers.list(routing);
+      const provider = providers.find(
+        (candidate) => candidate.id === execution.providerId,
+      );
+      if (provider === undefined || provider.available === false) {
+        throw new Error(`Provider ${execution.providerId} is not available.`);
+      }
+      return {
+        permissionModes: provider.capabilities.supportedPermissionModes,
+      };
     },
 
     async create(payload) {

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -20,7 +20,10 @@ import {
   type Db,
 } from "./data.js";
 import { createAutomationId } from "./ids.js";
-import { resolvePermissionMode } from "./provider-permissions.js";
+import {
+  providerRoutingForEnvironment,
+  resolvePermissionMode,
+} from "./provider-permissions.js";
 import { publishAutomationChange } from "./realtime.js";
 import {
   AUTOMATION_RUNS_LIMIT_MAX,
@@ -410,13 +413,7 @@ export function createAutomationService(args: {
           "Execution options are only available for agent automations",
         );
       }
-      const environment = execution.environment;
-      const routing =
-        environment.type === "reuse"
-          ? { environmentId: environment.environmentId }
-          : environment.type === "host" && environment.hostId !== undefined
-            ? { hostId: environment.hostId }
-            : {};
+      const routing = providerRoutingForEnvironment(execution.environment);
       const loadModels = bb.sdk.providers.models;
       if (loadModels === undefined) {
         throw new Error("Provider model discovery is unavailable.");
@@ -480,6 +477,7 @@ export function createAutomationService(args: {
           bb,
           payload.execution.providerId,
           payload.execution.permissionMode,
+          providerRoutingForEnvironment(payload.execution.environment),
         );
       }
       const automationId = createAutomationId();
@@ -543,6 +541,7 @@ export function createAutomationService(args: {
             bb,
             input.execution.providerId,
             input.execution.permissionMode,
+            providerRoutingForEnvironment(input.execution.environment),
           );
         }
         const stored = await resolveStoredExecution({
@@ -554,6 +553,10 @@ export function createAutomationService(args: {
         stagedScriptFile = stored.writtenScriptFile;
       }
       if (input.agent !== undefined) {
+        const updatedExecution = applyAgentExecutionUpdate(
+          currentExecution,
+          input.agent,
+        );
         if (input.agent.permissionMode !== undefined) {
           if (currentExecution.mode !== "agent") {
             throw new Error(
@@ -562,14 +565,12 @@ export function createAutomationService(args: {
           }
           await resolvePermissionMode(
             bb,
-            currentExecution.providerId,
+            updatedExecution.providerId,
             input.agent.permissionMode,
+            providerRoutingForEnvironment(updatedExecution.environment),
           );
         }
-        patch.execution = applyAgentExecutionUpdate(
-          currentExecution,
-          input.agent,
-        );
+        patch.execution = updatedExecution;
       }
       let updated: AutomationRow | null;
       try {


### PR DESCRIPTION
Completes the inherited skill pagination and wheel navigation, vertically centers shared plugin capability cells, subdues description disclosures, and finishes automation prompt editing with independently loaded permission modes, cached options, aligned provider icons, cancel/save behavior, and content-hugging selectors.\n\nFocused coverage: detail-page recipes (40 tests), automation server harness (14 tests), Turbo typechecks for @bb/app and bb-plugin-automations. Desktop QA artifacts cover the Tasks capability table, plugin action menu, and automation detail.