### PR TITLE
Rebrand the landing hero and lead with customization

### DIFF
--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -1985,10 +1985,6 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   padding: 0 12px;
 }
 
-.mock-customize-mobile .bar-actions {
-  display: none;
-}
-
 .customize-body {
   height: 438px;
   border-top: 0;

--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -482,17 +482,7 @@ code,
   max-width: 780px;
   margin: 0 auto;
   color: oklch(0.21 0 0);
-}
-
-.lde-star {
-  color: var(--accent);
-}
-
-.lde-expand {
-  margin: 9px auto 0;
-  font-size: 15px;
-  letter-spacing: 0.01em;
-  color: var(--subtle);
+  text-wrap: balance;
 }
 
 .hero .sub {

--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -1612,6 +1612,18 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   max-width: 32em;
 }
 
+/* Inline code in body copy, matching the chips in the thread mocks. The mono
+   face runs wide and tall next to 16px Inter, so it's set down to 0.86em and
+   given a recessed chip — otherwise it out-measures the sentence it sits in. */
+.band-copy code {
+  font-size: 0.86em;
+  background: var(--surface-recessed);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
 .band-cta {
   margin-top: 26px;
 }

--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -1949,71 +1949,73 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 
 /* ── Band 3 visual: mobile bb app mock ──────────────────────────── */
 
-.mockup-wrap-automation {
+.mockup-wrap-customize {
   width: min(100%, 360px);
   margin: 0;
 }
 
-.mock-automation-mobile {
+.mock-customize-mobile {
   width: 100%;
   border-radius: 22px;
 }
 
-.mock-automation-mobile .mock-bar {
+.mock-customize-mobile .mock-bar {
   height: 42px;
 }
 
-.mock-automation-mobile .bar-left {
+.mock-customize-mobile .bar-left {
   width: auto;
   gap: 10px;
   padding: 0 10px 0 14px;
 }
 
-.mock-automation-mobile .bar-main {
+.mock-customize-mobile .bar-main {
   padding: 0 12px;
 }
 
-.mock-automation-mobile .bar-actions {
+.mock-customize-mobile .bar-actions {
   display: none;
 }
 
-.automation-body {
+.customize-body {
   height: 438px;
   border-top: 0;
+  /* Clips the plugin panel while it waits offscreen below. */
+  overflow: hidden;
 }
 
-.automation-body.leaving {
-  animation: automation-leave 0.5s ease forwards;
+.customize-body.leaving {
+  animation: customize-leave 0.5s ease forwards;
 }
 
-.mock-automation-mobile .main {
+.mock-customize-mobile .main {
   min-height: 0;
 }
 
-.automation-feed {
+.customize-feed {
   padding: 18px 18px 16px;
   gap: 11px;
 }
 
-.automation-msg {
+.customize-msg {
   opacity: 0;
   transform: translateY(8px);
-  animation: automation-msg-in 0.44s ease forwards;
+  animation: customize-msg-in 0.44s ease forwards;
 }
 
-.automation-tool {
+.customize-tool {
   color: var(--accent);
 }
 
-.automation-composer {
+.customize-composer {
   padding: 12px;
 }
 
-.automation-composer-box {
+.customize-composer-box {
   padding: 11px 12px;
 }
 
-.automation-typeahead {
+.customize-typeahead {
   display: flex;
   align-items: center;
   gap: 2px;
@@ -2022,18 +2024,18 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   color: var(--ink);
 }
 
-.automation-type-text {
+.customize-type-text {
   display: inline-block;
   width: 0;
-  max-width: min(100%, var(--automation-prompt-width));
+  max-width: min(100%, var(--customize-prompt-width));
   overflow: hidden;
   white-space: nowrap;
   animation:
-    automation-type 1.45s steps(28, end) 0.25s forwards,
-    automation-clear 0.2s ease 2.95s forwards;
+    customize-type 1.45s steps(28, end) 0.25s forwards,
+    customize-clear 0.2s ease 2.95s forwards;
 }
 
-.automation-caret {
+.customize-caret {
   display: inline-block;
   width: 1px;
   height: 1em;
@@ -2041,57 +2043,167 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
   background: currentColor;
   color: var(--ink);
   animation:
-    automation-caret-blink 0.8s step-end infinite,
-    automation-clear 0.2s ease 2.95s forwards;
+    customize-caret-blink 0.8s step-end infinite,
+    customize-clear 0.2s ease 2.95s forwards;
 }
 
-.automation-send {
-  animation: automation-send-pulse 0.42s ease 2.7s both;
+.customize-send {
+  animation: customize-send-pulse 0.42s ease 2.7s both;
 }
 
-.automation-context {
+.customize-context {
   gap: 5px;
 }
 
-.automation-context .ctx {
+.customize-context .ctx {
   max-width: 100%;
 }
 
-@keyframes automation-type {
+@keyframes customize-type {
   to {
-    width: min(100%, var(--automation-prompt-width));
+    width: min(100%, var(--customize-prompt-width));
   }
 }
 
-@keyframes automation-clear {
+@keyframes customize-clear {
   to {
     opacity: 0;
   }
 }
 
-@keyframes automation-caret-blink {
+@keyframes customize-caret-blink {
   50% {
     opacity: 0;
   }
 }
 
-@keyframes automation-send-pulse {
+@keyframes customize-send-pulse {
   50% {
     transform: translateY(-1px) scale(1.04);
-    box-shadow: 0 8px 18px -12px color-mix(in oklab, var(--ink) 60%, transparent);
+    box-shadow: 0 8px 18px -12px
+      color-mix(in oklab, var(--ink) 60%, transparent);
   }
 }
 
-@keyframes automation-msg-in {
+@keyframes customize-msg-in {
   to {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
-@keyframes automation-leave {
+@keyframes customize-leave {
   to {
     opacity: 0;
+  }
+}
+
+/* The panel the agent just built, sliding up over the thread that built it.
+   Absolute inside .customize-body so the reveal never reflows the mock. */
+.plugin-panel {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  transform: translateY(100%);
+  animation: plugin-panel-up 0.62s cubic-bezier(0.16, 1, 0.3, 1) 7.9s forwards;
+}
+
+.plugin-panel-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 42px;
+  flex-shrink: 0;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--surface);
+}
+
+.plugin-panel-name {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.plugin-panel-badge {
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--accent);
+}
+
+.plugin-panel-rows {
+  padding: 6px 0;
+}
+
+/* Mirrors the Tasks plugin's list row: status dot, key, title, priority. */
+.plugin-task {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 14px;
+  height: 34px;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 13px;
+  opacity: 0;
+  animation: plugin-task-in 0.34s ease forwards;
+}
+
+.plugin-task-status {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1.5px solid var(--subtle);
+}
+
+.plugin-task-status.is-in_progress {
+  border-color: var(--spark);
+  background: linear-gradient(to right, var(--spark) 50%, transparent 50%);
+}
+
+.plugin-task-status.is-todo {
+  border-color: var(--accent);
+}
+
+.plugin-task-key {
+  width: 38px;
+  flex-shrink: 0;
+  font-size: 11.5px;
+  color: var(--subtle);
+  font-variant-numeric: tabular-nums;
+}
+
+.plugin-task-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.plugin-task-prio {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--subtle);
+}
+
+.plugin-task-prio.is-high {
+  color: var(--spark);
+}
+
+@keyframes plugin-panel-up {
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes plugin-task-in {
+  to {
+    opacity: 1;
   }
 }
 
@@ -2506,7 +2618,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
      card's drop shadow fades into the left gutter instead of being shaved off
      at the card's own edge. overflow-y stays visible so the bottom shadow and
      the scroll-in entrance still show. */
-  .mockup-wrap:not(.mockup-wrap-automation) {
+  .mockup-wrap:not(.mockup-wrap-customize) {
     margin-left: -28px;
     margin-right: -28px;
     padding-left: 28px;
@@ -2519,7 +2631,7 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
      (`--mock-visible-width`) fills the available width. Both vars are defined
      only here, so the mock is unscaled above this breakpoint; the fallback
      scale covers the pre-hydration/no-JS paint. */
-  .mockup-wrap:not(.mockup-wrap-automation) .mock {
+  .mockup-wrap:not(.mockup-wrap-customize) .mock {
     --mock-desktop-width: 980px;
     --mock-visible-width: 560px;
     width: var(--mock-desktop-width);
@@ -2592,26 +2704,41 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
     animation: none;
   }
 
-  .automation-body,
-  .automation-msg,
-  .automation-type-text,
-  .automation-caret,
-  .automation-send {
+  .customize-body,
+  .customize-msg,
+  .customize-type-text,
+  .customize-caret,
+  .customize-send {
     animation: none;
   }
 
-  .automation-msg {
+  .customize-msg {
     opacity: 1;
     transform: none;
   }
 
-  .automation-type-text {
+  .customize-type-text {
     clip-path: none;
     opacity: 0;
   }
 
-  .automation-caret {
+  .customize-caret {
     opacity: 0;
+  }
+
+  /* No slide: show the built panel already in place, which is the point of
+     the section. */
+  .plugin-panel,
+  .plugin-task {
+    animation: none;
+  }
+
+  .plugin-panel {
+    transform: none;
+  }
+
+  .plugin-task {
+    opacity: 1;
   }
 
   .tg-msg,

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1723,21 +1723,19 @@ function LandingPage() {
         </p>
       </Band>
 
-      <Band title="It can customize itself." visual={<CustomizeBuild />}>
+      <Band title="Fully customizable." visual={<CustomizeBuild />}>
         <p>
-          bb is extensible through plugins, and your agents write them. Ask for
-          a task tracker and one appears: a panel in your sidebar, a{" "}
+          Almost anything in bb can be changed in a single prompt. Ask for a
+          task tracker and one appears: a panel in your sidebar, a{" "}
           <code>bb tasks</code> command, and a skill that teaches every agent to
           use it.
         </p>
         <p>
-          Most of bb is already built this way. The doc editor is a plugin. So
-          is GitHub, the memory your agents keep, jobs that run on a schedule,
-          agent workflows, and even remote access. They all use the same API
-          your plugins get: panels, commands, tools, agent skills, and
-          background services.
+          Many of bb&rsquo;s own features are built with the same tools you
+          have. The doc editor, GitHub, agent memory, scheduled jobs, and even
+          remote access are all plugins.
         </p>
-        <p>Missing features stop being feature requests.</p>
+        <p>Nothing is stopping you from building your ideal workspace.</p>
       </Band>
 
       <Band title="The gang's all here" flip visual={<SpawnSidebar />}>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1732,7 +1732,7 @@ function LandingPage() {
         </p>
         <p>
           Many of bb&rsquo;s own features are built with the same tools you
-          have. The doc editor, GitHub, agent memory, scheduled jobs, and even
+          have. The GitHub integration, agent memory, scheduled jobs, and even
           remote access are all plugins.
         </p>
         <p>Nothing is stopping you from building your ideal workspace.</p>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1316,7 +1316,7 @@ function AgentChat() {
   );
 }
 
-/* ── Band 3 visual: bb builds itself a plugin ────────────────────── */
+/* ── Band visual: bb builds itself a plugin ───────────────────────── */
 
 type CustomizeMessage = {
   role: "user" | "agent" | "tool";
@@ -1556,7 +1556,7 @@ function CustomizeBuild() {
   );
 }
 
-/* ── Band 5 visual: one agent spawns and manages a thread per provider ── */
+/* ── Band visual: one agent spawns and manages a thread per provider ── */
 
 // A bb sidebar mock: a parent Claude thread with three worker threads nested
 // beneath it on a connector rail, one per provider. Each worker's status flips
@@ -1710,20 +1710,7 @@ function LandingPage() {
 
       <HeroAppMock />
 
-      <Band title="Anything can kick off work." flip visual={<AgentChat />}>
-        <p>
-          The same CLI your agents use is open to any program you write: a shell
-          script, a cron job, or your own Hermes Agent or OpenClaw bot in
-          Telegram, Signal, or Slack. Each can spawn a thread that&rsquo;s
-          waiting in your sidebar when you are.
-        </p>
-        <p>
-          It runs on your machine, and is waiting for you when you&rsquo;re
-          back.
-        </p>
-      </Band>
-
-      <Band title="Fully customizable." visual={<CustomizeBuild />}>
+      <Band title="Fully customizable." flip visual={<CustomizeBuild />}>
         <p>
           Almost anything in bb can be changed in a single prompt. Ask for a
           task tracker and one appears: a panel in your sidebar, a{" "}
@@ -1736,6 +1723,19 @@ function LandingPage() {
           remote access are all plugins.
         </p>
         <p>Nothing is stopping you from building your ideal workbench.</p>
+      </Band>
+
+      <Band title="Anything can kick off work." visual={<AgentChat />}>
+        <p>
+          The same CLI your agents use is open to any program you write: a shell
+          script, a cron job, or your own Hermes Agent or OpenClaw bot in
+          Telegram, Signal, or Slack. Each can spawn a thread that&rsquo;s
+          waiting in your sidebar when you are.
+        </p>
+        <p>
+          It runs on your machine, and is waiting for you when you&rsquo;re
+          back.
+        </p>
       </Band>
 
       <Band title="The gang's all here" flip visual={<SpawnSidebar />}>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1731,11 +1731,11 @@ function LandingPage() {
           use it.
         </p>
         <p>
-          Much of bb already works this way. A Markdown doc editor, GitHub
-          integration, cross-provider agent memory, cron jobs, cross-provider
-          agent workflows, and even remote access all ship as plugins, on the
-          same API yours get: panels, commands, tools, agent skills, and
-          background services.
+          Most of bb is built this way already. The doc editor is a plugin. So
+          is GitHub. So is the memory your agents keep, the jobs that run on a
+          timer, the workflows they follow, and even the way you reach bb from
+          far away. They all snap together from one set of parts, like Lego
+          bricks. Your plugins get the very same bricks.
         </p>
         <p>Missing features stop being feature requests.</p>
       </Band>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1731,11 +1731,11 @@ function LandingPage() {
           use it.
         </p>
         <p>
-          Much of bb already works this way. Tasks, GitHub issues and pull
-          requests, Markdown docs, durable agent memory, cron automations,
-          workflows, and remote access all ship as plugins, on the same API
-          yours get: panels, commands, tools, agent skills, and background
-          services.
+          Much of bb already works this way. A Markdown doc editor, GitHub
+          integration, cross-provider agent memory, cron jobs, cross-provider
+          agent workflows, and even remote access all ship as plugins, on the
+          same API yours get: panels, commands, tools, agent skills, and
+          background services.
         </p>
         <p>Missing features stop being feature requests.</p>
       </Band>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1432,11 +1432,6 @@ function CustomizeBuild() {
           </div>
           <div className="bar-main">
             <span className="bar-title">{run.title}</span>
-            <span className="bar-actions">
-              <span className="commit-btn" aria-hidden>
-                Automation
-              </span>
-            </span>
           </div>
         </div>
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1731,10 +1731,13 @@ function LandingPage() {
           use it.
         </p>
         <p>
-          Plugins reach the same API bb builds itself on — panels, commands,
-          tools, agent skills, and background services. Missing features stop
-          being feature requests.
+          Much of bb already works this way. Tasks, GitHub issues and pull
+          requests, Markdown docs, durable agent memory, cron automations,
+          workflows, and remote access all ship as plugins, on the same API
+          yours get: panels, commands, tools, agent skills, and background
+          services.
         </p>
+        <p>Missing features stop being feature requests.</p>
       </Band>
 
       <Band title="The gang's all here" flip visual={<SpawnSidebar />}>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1731,11 +1731,11 @@ function LandingPage() {
           use it.
         </p>
         <p>
-          Most of bb is built this way already. The doc editor is a plugin. So
-          is GitHub. So is the memory your agents keep, the jobs that run on a
-          timer, the workflows they follow, and even the way you reach bb from
-          far away. They all snap together from one set of parts, like Lego
-          bricks. Your plugins get the very same bricks.
+          Most of bb is already built this way. The doc editor is a plugin. So
+          is GitHub, the memory your agents keep, jobs that run on a schedule,
+          agent workflows, and even remote access. They all use the same API
+          your plugins get: panels, commands, tools, agent skills, and
+          background services.
         </p>
         <p>Missing features stop being feature requests.</p>
       </Band>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1646,10 +1646,7 @@ function LandingPage() {
           <span className="updates-title">{LATEST_RELEASE_META.headline}</span>
           <span aria-hidden="true">→</span>
         </a>
-        <h1>
-          The First LDE<span className="lde-star">*</span>
-        </h1>
-        <p className="lde-expand">(Loop Development Environment)</p>
+        <h1>The IDE that builds itself</h1>
         <p className="sub">
           bb can control, customize, and automate itself, laying the groundwork
           for your own software factory.

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1735,7 +1735,7 @@ function LandingPage() {
           have. The GitHub integration, agent memory, scheduled jobs, and even
           remote access are all plugins.
         </p>
-        <p>Nothing is stopping you from building your ideal workspace.</p>
+        <p>Nothing is stopping you from building your ideal workbench.</p>
       </Band>
 
       <Band title="The gang's all here" flip visual={<SpawnSidebar />}>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1346,7 +1346,9 @@ type CustomizeScenario = {
 const CUSTOMIZE_SCENARIO: CustomizeScenario = {
   title: "Build a tasks plugin",
   prompt: "Add a task management system",
-  promptWidth: "196px",
+  // Measured width of the prompt at the composer's 13.5px Inter, plus a few px
+  // of slack for the metric-adjusted fallback face. Too small clips the tail.
+  promptWidth: "210px",
   branch: "bb/tasks-plugin",
   messages: [
     { role: "user", text: "Add a task management system" },

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1316,94 +1316,111 @@ function AgentChat() {
   );
 }
 
-/* ── Band 3 visual: mobile automation thread ─────────────────────── */
+/* ── Band 3 visual: bb builds itself a plugin ────────────────────── */
 
-type AutomationMessage = {
+type CustomizeMessage = {
   role: "user" | "agent" | "tool";
   text: string;
 };
 
-type AutomationScenario = {
+type CustomizeTask = {
+  key: string;
+  title: string;
+  status: "in_progress" | "todo" | "backlog";
+  priority: "urgent" | "high" | "medium" | "low";
+};
+
+type CustomizeScenario = {
   title: string;
   prompt: string;
   promptWidth: string;
   branch: string;
-  messages: AutomationMessage[];
+  messages: CustomizeMessage[];
+  /** The panel the agent just built, revealed once the thread lands. */
+  panel: {
+    name: string;
+    tasks: CustomizeTask[];
+  };
 };
 
-const AUTOMATION_SCENARIOS: AutomationScenario[] = [
-  {
-    title: "Issue triage",
-    prompt: "triage every new issue",
-    promptWidth: "144px",
-    branch: "bb/issue-triage",
-    messages: [
-      { role: "user", text: "triage every new issue" },
+const CUSTOMIZE_SCENARIO: CustomizeScenario = {
+  title: "Build a tasks plugin",
+  prompt: "Add a task management system",
+  promptWidth: "196px",
+  branch: "bb/tasks-plugin",
+  messages: [
+    { role: "user", text: "Add a task management system" },
+    {
+      role: "agent",
+      text: "I'll build it as a bb plugin and mount it in your sidebar.",
+    },
+    { role: "tool", text: "wrote plugin: tasks" },
+    { role: "tool", text: "registered panel + bb tasks CLI" },
+    { role: "agent", text: "Done. Tasks is live, and your agents can use it." },
+  ],
+  panel: {
+    name: "Tasks",
+    tasks: [
       {
-        role: "agent",
-        text: "I'll set up an automation for every new issue.",
+        key: "BB-1",
+        title: "Ship task delegation",
+        status: "in_progress",
+        priority: "high",
       },
-      { role: "tool", text: "created trigger: on new issue" },
-      { role: "tool", text: "configured action: open triage thread" },
       {
-        role: "agent",
-        text: "Done. New issues will get a local bb thread and Slack summary.",
+        key: "BB-2",
+        title: "Wire up the tasks CLI",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        key: "BB-3",
+        title: "Add label filters",
+        status: "todo",
+        priority: "low",
+      },
+      {
+        key: "BB-4",
+        title: "Nightly changelog draft",
+        status: "in_progress",
+        priority: "medium",
+      },
+      {
+        key: "BB-5",
+        title: "Triage flaky integration tests",
+        status: "backlog",
+        priority: "high",
+      },
+      {
+        key: "BB-6",
+        title: "Port the settings panel",
+        status: "backlog",
+        priority: "low",
+      },
+      {
+        key: "BB-7",
+        title: "Document the plugin API",
+        status: "backlog",
+        priority: "medium",
       },
     ],
   },
-  {
-    title: "Nightly docs sync",
-    prompt: "run nightly docs sync",
-    promptWidth: "137px",
-    branch: "bb/sync-docs",
-    messages: [
-      { role: "user", text: "run nightly docs sync" },
-      {
-        role: "agent",
-        text: "I'll create a local 2am automation for the docs sync.",
-      },
-      { role: "tool", text: "created schedule: 0 2 * * *" },
-      { role: "tool", text: "configured action: run docs worker" },
-      {
-        role: "agent",
-        text: "Done. Each run will open a thread and prepare the PR.",
-      },
-    ],
-  },
-  {
-    title: "Watch failing jobs",
-    prompt: "watch failing jobs",
-    promptWidth: "112px",
-    branch: "bb/fix-ci",
-    messages: [
-      { role: "user", text: "watch failing jobs" },
-      {
-        role: "agent",
-        text: "I'll set up an automation that reacts to failed CI jobs.",
-      },
-      { role: "tool", text: "created trigger: on job failed" },
-      { role: "tool", text: "configured action: inspect logs and spawn fix" },
-      {
-        role: "agent",
-        text: "Done. Failures will start a worker thread automatically.",
-      },
-    ],
-  },
-];
+};
 
-// A phone-sized bb thread preview: a prompt types into the composer, sends, then
-// the matching automation transcript streams into the feed.
-function AutomationRun() {
-  const { cycle, leaving } = useCycle(7600, 500);
-  const run = AUTOMATION_SCENARIOS[cycle % AUTOMATION_SCENARIOS.length];
+// A phone-sized bb thread preview: the prompt types into the composer, sends,
+// the build transcript streams into the feed, and the panel the agent just
+// wrote slides up over the thread — bb extending itself, on screen.
+function CustomizeBuild() {
+  const { cycle, leaving } = useCycle(10600, 500);
+  const run = CUSTOMIZE_SCENARIO;
   const promptStyle = {
-    "--automation-prompt-width": run.promptWidth,
+    "--customize-prompt-width": run.promptWidth,
   } as CSSProperties;
   return (
-    <div className="mockup-wrap mockup-wrap-automation">
+    <div className="mockup-wrap mockup-wrap-customize">
       <div
-        className="mock mock-automation-mobile"
-        aria-label="Mobile bb preview showing an automation prompt and streamed thread messages"
+        className="mock mock-customize-mobile"
+        aria-label="Mobile bb preview: a prompt asks for a task management system, and the agent builds it as a plugin"
       >
         <div className="mock-bar">
           <div className="bar-left">
@@ -1424,19 +1441,19 @@ function AutomationRun() {
         <div
           className={
             leaving
-              ? "mock-body automation-body leaving"
-              : "mock-body automation-body"
+              ? "mock-body customize-body leaving"
+              : "mock-body customize-body"
           }
           key={cycle}
         >
           <div className="main">
-            <div className="feed feed-live automation-feed">
+            <div className="feed feed-live customize-feed">
               {run.messages.map((message, i) => {
                 const style = { animationDelay: `${3.2 + i * 0.68}s` };
                 if (message.role === "user") {
                   return (
                     <div
-                      className="msg-user automation-msg"
+                      className="msg-user customize-msg"
                       key={`${message.role}-${message.text}`}
                       style={style}
                     >
@@ -1447,7 +1464,7 @@ function AutomationRun() {
                 if (message.role === "tool") {
                   return (
                     <div
-                      className="msg-step automation-msg automation-tool"
+                      className="msg-step customize-msg customize-tool"
                       key={`${message.role}-${message.text}`}
                       style={style}
                     >
@@ -1458,7 +1475,7 @@ function AutomationRun() {
                 }
                 return (
                   <div
-                    className="msg-say automation-msg"
+                    className="msg-say customize-msg"
                     key={`${message.role}-${message.text}`}
                     style={style}
                   >
@@ -1468,14 +1485,14 @@ function AutomationRun() {
               })}
             </div>
 
-            <div className="composer automation-composer">
-              <div className="composer-box automation-composer-box">
+            <div className="composer customize-composer">
+              <div className="composer-box customize-composer-box">
                 <div className="composer-top">
-                  <span className="composer-input automation-typeahead">
-                    <span className="automation-type-text" style={promptStyle}>
+                  <span className="composer-input customize-typeahead">
+                    <span className="customize-type-text" style={promptStyle}>
                       {run.prompt}
                     </span>
-                    <span className="automation-caret" aria-hidden />
+                    <span className="customize-caret" aria-hidden />
                   </span>
                   <Maximize2 className="cb-expand" />
                 </div>
@@ -1487,19 +1504,48 @@ function AutomationRun() {
                   </span>
                   <span className="composer-actions" aria-hidden>
                     <Paperclip className="composer-clip" />
-                    <span className="send-btn automation-send">
+                    <span className="send-btn customize-send">
                       <SendIcon className="send-ic" />
                     </span>
                   </span>
                 </div>
               </div>
-              <div className="context-row automation-context">
+              <div className="context-row customize-context">
                 <span className="ctx">
                   <GitBranchIcon className="ctx-ic" />
                   <span className="ctx-branch">{run.branch}</span>
                 </span>
                 <Spinner className="ctx-spin" />
               </div>
+            </div>
+          </div>
+
+          {/* The panel the agent just wrote, sliding up over the thread it was
+              built in. Purely decorative — the transcript above already states
+              the outcome for assistive tech. */}
+          <div className="plugin-panel" aria-hidden>
+            <div className="plugin-panel-bar">
+              <span className="plugin-panel-name">{run.panel.name}</span>
+              <span className="plugin-panel-badge">Plugin</span>
+            </div>
+            <div className="plugin-panel-rows">
+              {run.panel.tasks.map((task, i) => (
+                <div
+                  className="plugin-task"
+                  key={task.key}
+                  style={{ animationDelay: `${8.3 + i * 0.14}s` }}
+                >
+                  <span
+                    className={`plugin-task-status is-${task.status}`}
+                    aria-hidden
+                  />
+                  <span className="plugin-task-key">{task.key}</span>
+                  <span className="plugin-task-title">{task.title}</span>
+                  <span className={`plugin-task-prio is-${task.priority}`}>
+                    {task.priority}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
         </div>
@@ -1675,12 +1721,17 @@ function LandingPage() {
         </p>
       </Band>
 
-      <Band title="It runs without you." visual={<AutomationRun />}>
+      <Band title="It can customize itself." visual={<CustomizeBuild />}>
         <p>
-          Schedule an automation to run an agent or a script on cron. Point one
-          at your tracker and it kicks off a thread for every new issue, or run
-          nightly docs, changelogs, error triage. All on your machine, not
-          someone else&rsquo;s cloud.
+          bb is extensible through plugins, and your agents write them. Ask for
+          a task tracker and one appears: a panel in your sidebar, a{" "}
+          <code>bb tasks</code> command, and a skill that teaches every agent to
+          use it.
+        </p>
+        <p>
+          Plugins reach the same API bb builds itself on — panels, commands,
+          tools, agent skills, and background services. Missing features stop
+          being feature requests.
         </p>
       </Band>
 


### PR DESCRIPTION
## Summary

Moves the landing page off the "The First LDE" branding and reframes it around customization.

- **Hero** — `The IDE that builds itself`, replacing `The First LDE*` and its `(Loop Development Environment)` decoder line. Adds `text-wrap: balance` to `.hero h1` so narrow widths split evenly instead of orphaning a word.
- **New lead band, "Fully customizable."** — replaces the old automation band. The visual types `Add a task management system` into the composer, streams the build transcript, then slides the Tasks panel the agent just wrote up over the thread. Rows mirror the real Tasks plugin list row (status dot, key, title, priority).
- **Copy** names features that already ship as plugins — the GitHub integration, agent memory, scheduled jobs, remote access — so the extensibility claim rests on shipped surface.
- **Band order** — customization now runs first, so the page argues the headline claim immediately. The `flip` prop moved with it to keep visuals alternating left/right/left.
- **Inline code in body copy** now gets the recessed chip the thread mocks already use. It previously inherited only `font-family`, so `bb tasks` rendered at full 16px in a wide fallback face.

The automation story is not lost: `automations` is itself a plugin, and now appears as evidence for extensibility rather than as its own band.

## Tests

- `turbo run test --filter=@bb/web` — 46 passed
- `turbo run typecheck --filter=@bb/web` — clean
- `turbo run build --filter=@bb/web` — clean
- Verified each animation phase in a headless browser against the dev server: composer typing, transcript streaming, and the panel reveal.

## Risks

Copy and CSS only on the marketing route. No behavior, contract, or daemon changes. The renamed `automation-*` classes are scoped to this band; the old names have no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
