### PR TITLE
Fix mobile voice recording controls

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -905,6 +905,69 @@ describe("PromptBoxInternal controlled value sync", () => {
     }
   });
 
+  it("inserts text without reopening the editor on coarse pointers", async () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
+    try {
+      const onChange = vi.fn();
+      const promptBoxRef = createRef<PromptBoxHandle>();
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({ onChange, promptBoxRef })}
+        />,
+      );
+
+      await waitFor(() => expect(promptBoxRef.current).not.toBeNull());
+      const outsideTarget = document.createElement("button");
+      document.body.append(outsideTarget);
+      outsideTarget.focus();
+
+      act(() => promptBoxRef.current?.insertTextAtCursor("transcript"));
+
+      expect(onChange).toHaveBeenLastCalledWith("transcript", []);
+      expect(document.activeElement).toBe(outsideTarget);
+      outsideTarget.remove();
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
+  it("blurs the editor before starting voice input on coarse pointers", async () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
+    try {
+      const start = vi.fn();
+      const promptBoxRef = createRef<PromptBoxHandle>();
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            promptBoxRef,
+            voice: {
+              state: "idle",
+              isSupported: true,
+              stream: null,
+              start,
+              stop: vi.fn(),
+              cancel: vi.fn(),
+            },
+          })}
+        />,
+      );
+
+      await waitFor(() => expect(promptBoxRef.current).not.toBeNull());
+      const editor = getPromptEditorElement();
+      editor.focus();
+      expect(document.activeElement).toBe(editor);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Start voice input" }),
+      );
+
+      expect(start).toHaveBeenCalledOnce();
+      expect(document.activeElement).not.toBe(editor);
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
   it("refocuses when the history reset key changes on fine pointers", async () => {
     const restoreMatchMedia = mockPointerCoarse(false);
     try {
@@ -1696,6 +1759,29 @@ describe("PromptBoxInternal compact layout", () => {
 
     expect(submitGroup?.contains(submit)).toBe(true);
     expect(submitGroup?.contains(voice)).toBe(false);
+  });
+
+  it("keeps collapsed composer controls from covering voice controls", () => {
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          voice: {
+            state: "recording",
+            isSupported: true,
+            stream: null,
+            start: vi.fn(),
+            stop: vi.fn(),
+            cancel: vi.fn(),
+          },
+        })}
+      />,
+    );
+
+    const main = document.querySelector("[data-promptbox-main]");
+    expect(main?.classList.contains("pointer-events-none")).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Stop and transcribe recording" }),
+    ).toBeTruthy();
   });
 
   it("does not expose zen controls in the full mobile layout", () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1660,6 +1660,54 @@ describe("PromptBoxInternal compact layout", () => {
     ).toBe(true);
   });
 
+  it("uses voice as the primary action for an empty coarse-pointer prompt", () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
+    try {
+      const start = vi.fn();
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            compact: {
+              isCompact: true,
+              placeholder: "Ask a follow-up",
+            },
+            voice: {
+              state: "idle",
+              isSupported: true,
+              stream: null,
+              start,
+              stop: vi.fn(),
+              cancel: vi.fn(),
+            },
+          })}
+        />,
+      );
+
+      const voiceButton = screen.getByRole("button", {
+        name: "Start voice input",
+      });
+      const submitGroup = document.querySelector(
+        "[data-promptbox-submit-group]",
+      );
+      expect(submitGroup?.contains(voiceButton)).toBe(true);
+      expect(
+        screen.queryByRole("button", { name: "Submit (Enter)" }),
+      ).toBeNull();
+
+      expect(
+        fireEvent.pointerDown(voiceButton, {
+          button: 0,
+          pointerType: "touch",
+        }),
+      ).toBe(false);
+      fireEvent.click(voiceButton);
+
+      expect(start).toHaveBeenCalledOnce();
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
   it("keeps the editor focused through a pointer submit", async () => {
     const onSubmit = vi.fn();
     render(

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2291,6 +2291,18 @@ export function PromptBoxInternal({
   const showStop = Boolean(isRunning && onStop && !canSubmit && !isVoiceBusy);
   const canStartVoiceInput =
     voice !== undefined && voice.isSupported && !isSubmitting;
+  const showVoiceAsPrimaryAction =
+    isPointerCoarse && !hasSubmittableInput && canStartVoiceInput;
+  const handleVoicePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!isPointerCoarse || event.button !== 0) return;
+
+      // Keep mobile voice activation from focusing the button and expanding
+      // the follow-up composer before click can start recording.
+      event.preventDefault();
+    },
+    [isPointerCoarse],
+  );
   const startVoiceInput = useCallback(() => {
     if (isPointerCoarse) {
       const currentEditor = editorRef.current;
@@ -3009,7 +3021,9 @@ export function PromptBoxInternal({
                     {!suppressPluginComposerCustomizations ? (
                       <PluginComposerActions />
                     ) : null}
-                    {voice && !showVoiceActionGroup ? (
+                    {voice &&
+                    !showVoiceActionGroup &&
+                    !showVoiceAsPrimaryAction ? (
                       <Button
                         data-promptbox-expanded-only=""
                         type="button"
@@ -3021,6 +3035,7 @@ export function PromptBoxInternal({
                             : "Start voice input"
                         }
                         disabled={!canStartVoiceInput}
+                        onPointerDown={handleVoicePointerDown}
                         onClick={startVoiceInput}
                         className={
                           COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS
@@ -3053,6 +3068,24 @@ export function PromptBoxInternal({
                         name="Square"
                         className="size-3.5 fill-current [&_*]:stroke-0"
                       />
+                    </Button>
+                  ) : showVoiceAsPrimaryAction ? (
+                    <Button
+                      data-promptbox-submit-action=""
+                      type="button"
+                      size={showCompactLayout ? "icon" : "sm"}
+                      variant="default"
+                      aria-label="Start voice input"
+                      onPointerDown={handleVoicePointerDown}
+                      onClick={startVoiceInput}
+                      className={cn(
+                        showCompactLayout
+                          ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
+                          : ["ml-1", COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS],
+                        "transition-colors",
+                      )}
+                    >
+                      <Icon name="Mic" className="size-4" />
                     </Button>
                   ) : (
                     <Button

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -60,6 +60,7 @@ import {
   COARSE_POINTER_TEXT_BASE_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
+import { blurActiveKeyboardInputWithin } from "@bb/shared-ui/overlay-trigger";
 import { createJsonLocalStorage } from "@/lib/browser-storage";
 import {
   DEFAULT_PLUGIN_MENTION_TRIGGER,
@@ -2121,10 +2122,12 @@ export function PromptBoxInternal({
       const needsTrailingWhitespace = after.length > 0 && !/^\s/.test(after);
       const insertedText = `${needsLeadingWhitespace ? " " : ""}${normalizedText}${needsTrailingWhitespace ? " " : ""}`;
 
-      currentEditor.chain().focus().insertContent(insertedText).run();
-      scheduleRevealEditorSelection();
+      const insertion = currentEditor.chain();
+      if (!isPointerCoarse) insertion.focus();
+      insertion.insertContent(insertedText).run();
+      if (!isPointerCoarse) scheduleRevealEditorSelection();
     },
-    [scheduleRevealEditorSelection],
+    [isPointerCoarse, scheduleRevealEditorSelection],
   );
 
   const focusAfterPromptAction = useCallback(
@@ -2288,6 +2291,15 @@ export function PromptBoxInternal({
   const showStop = Boolean(isRunning && onStop && !canSubmit && !isVoiceBusy);
   const canStartVoiceInput =
     voice !== undefined && voice.isSupported && !isSubmitting;
+  const startVoiceInput = useCallback(() => {
+    if (isPointerCoarse) {
+      const currentEditor = editorRef.current;
+      if (currentEditor && !currentEditor.isDestroyed) {
+        blurActiveKeyboardInputWithin(currentEditor.view.dom);
+      }
+    }
+    void voice?.start();
+  }, [isPointerCoarse, voice]);
   const effectiveSubmitTitle = isZenMode
     ? submitTitle.replace(/^Submit\s+/, "")
     : submitTitle;
@@ -2763,7 +2775,7 @@ export function PromptBoxInternal({
             "min-h-0 overflow-hidden transition-opacity duration-[180ms] motion-reduce:transition-none",
             isZenMode && "flex flex-col",
             showCompactLayout && "relative h-12",
-            showVoiceActionGroup && "opacity-0",
+            showVoiceActionGroup && "pointer-events-none opacity-0",
           )}
         >
           {header && !showCompactLayout ? (
@@ -3009,7 +3021,7 @@ export function PromptBoxInternal({
                             : "Start voice input"
                         }
                         disabled={!canStartVoiceInput}
-                        onClick={voice.start}
+                        onClick={startVoiceInput}
                         className={
                           COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS
                         }


### PR DESCRIPTION
## Summary

- prevent the collapsed follow-up composer from intercepting taps on the voice confirmation control
- avoid reopening the soft keyboard when starting voice input or inserting a transcript on coarse-pointer devices
- use voice input as the primary action for an empty mobile prompt so recording starts in one tap

## Validation

- 99 prompt-box, follow-up, and new-thread tests passed
- app typecheck passed
- app lint passed with existing warnings only
- Prettier check passed
- voice confirmation manually verified on Android Chrome