### PR TITLE
Mark stable desktop releases as GitHub Latest

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -208,7 +208,7 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "bb desktop ${VERSION}" \
             --notes "bb desktop ${VERSION}" \
-            --latest=false
+            --latest
 
           git tag -f "$LATEST_TAG" "$GITHUB_SHA"
           git push --force origin "refs/tags/${LATEST_TAG}"

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -206,6 +206,9 @@ gh workflow run build-desktop.yml \
   publishes `desktop-version.json` only and withholds the unsigned `.dmg`/`.zip`.
 - The `desktop-v<version>` release is immutable: if it already exists the
   workflow fails. Bump to a new version rather than re-running the same one.
+- The immutable `desktop-v<version>` release owns GitHub's repository-wide
+  **Latest** designation. The moving `desktop-latest` release remains opted out;
+  it exists only to provide stable download and auto-update URLs.
 
 If the `npm-release`-style environment or branch protection gates the run, tell
 the user and let the human approval be the release control point.
@@ -217,11 +220,14 @@ After the desktop workflow succeeds, confirm the published version and feed:
 ```bash
 gh release view desktop-latest --json tagName,assets \
   -q '{tag:.tagName,assets:[.assets[].name]}'
+gh release list --limit 10 --json tagName,isLatest \
+  -q '.[] | select(.isLatest) | .tagName'
 curl -fsSL https://github.com/get-bb/bb/releases/download/desktop-latest/desktop-version.json
 ```
 
 Confirm `desktop-version.json` reports the released version and that the
-`desktop-v<version>` release exists with the expected `.dmg`/`.zip` assets.
+`desktop-v<version>` release exists with the expected `.dmg`/`.zip` assets and
+is the release reported as GitHub's **Latest**.
 
 Add to the report from "Verify The Release":
 


### PR DESCRIPTION
## Summary

- mark each immutable `desktop-v<version>` release as GitHub's repository-wide Latest release
- keep the moving `desktop-latest` download and auto-update feed opted out
- document the ownership policy and add an explicit release verification command

## Why

Stable desktop releases currently pass `--latest=false`, which leaves an old official-plugin release carrying GitHub's Latest badge even after newer desktop versions ship. The website download and desktop updater already use the explicit `desktop-latest` tag, so the human-facing immutable desktop release can own the repository-wide designation without changing update behavior.

## Testing

- `pnpm exec prettier --check .github/workflows/build-desktop.yml docs/bb-release-process.md`
- `git diff --check`

## Existing release follow-up

Merging this PR fixes future stable releases. Correct the current badge separately with:

```bash
gh release edit desktop-v0.35.1 --repo get-bb/bb --latest
```
