### PR TITLE
Report progress while a plugin installs

### DIFF
--- a/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
@@ -126,6 +126,39 @@ describe("AddPluginDialog", () => {
     });
   });
 
+  it("reports progress while an install is in flight", async () => {
+    // A first install on a machine also downloads the build toolchain, so this
+    // window can run ~17s. The server does that behind one blocking request, so
+    // the client can only say that work is happening — not how far along it is.
+    let release: (() => void) | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = () => resolve(jsonResponse(INSTALLED_PLUGIN_RESPONSE));
+        }),
+    );
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Plugin source"), {
+      target: { value: "./plugins/linear" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /install plugin/i }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /installing plugin/i }),
+      ).toBeTruthy();
+    });
+    // The trust warning has served its purpose by now; the bar replaces it.
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+    expect(screen.queryByTestId("full-trust-warning")).toBeNull();
+
+    release?.();
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("progressbar")).toBeNull();
+    });
+  });
+
   it("installs official catalog entries through the catalog endpoint", async () => {
     const requests = stubFetch();
     renderDialog({

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -164,7 +164,17 @@ function AddPluginDialogContent({
           </div>
         )}
 
-        <FullTrustWarning />
+        {install.isPending ? (
+          <div
+            className="h-0.5 overflow-hidden rounded-full bg-border"
+            role="progressbar"
+            aria-label="Installing plugin"
+          >
+            <div className="h-full w-1/3 animate-plugin-install-progress rounded-full bg-muted-foreground" />
+          </div>
+        ) : (
+          <FullTrustWarning />
+        )}
       </div>
       <DialogFooter>
         <Button
@@ -185,7 +195,9 @@ function AddPluginDialogContent({
           {install.isPending ? (
             <Icon name="Spinner" className="animate-spin" />
           ) : null}
-          Install {initial?.displayName ?? "plugin"}
+          {install.isPending
+            ? `Installing ${initial?.displayName ?? "plugin"}…`
+            : `Install ${initial?.displayName ?? "plugin"}`}
         </Button>
       </DialogFooter>
     </>

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -879,9 +879,25 @@ body.sidebar-resizing [data-sidebar="panel"] {
     background-color: var(--foreground);
   }
 
+  /*
+   * Indeterminate progress sweep. Used while a plugin installs: the server does
+   * the work behind one blocking request, so the client can say that work is
+   * happening but not how far along it is. A first install on a machine also
+   * downloads the build toolchain, which is why this window can run ~17s.
+   */
+  .animate-plugin-install-progress {
+    animation: plugin-install-progress 1.5s ease-in-out infinite;
+  }
+
   /* Reduced motion: drop the shimmer sweep and render the active cue as plain
      full-strength foreground text/glyph instead of a frozen gradient/mask. */
   @media (prefers-reduced-motion: reduce) {
+    /* A static half-width fill still reads as "busy" without the sweep. */
+    .animate-plugin-install-progress {
+      animation: none;
+      width: 50%;
+    }
+
     .animate-shine {
       animation: none;
       background: none;
@@ -902,6 +918,15 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
   100% {
     background-position: -200% 0%;
+  }
+}
+
+@keyframes plugin-install-progress {
+  0% {
+    margin-inline-start: -35%;
+  }
+  100% {
+    margin-inline-start: 100%;
   }
 }
 

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -25,6 +25,7 @@ import {
   buildPluginApp,
   buildPluginServer,
   createPluginDevLoop,
+  PLUGIN_TOOLCHAIN_PINS,
   resolvePluginBuildToolchain,
   type PluginBuildToolchain,
 } from "@bb/plugin-build";
@@ -53,9 +54,16 @@ function toolchainBaseDir(): string {
 async function cliBuildToolchain(): Promise<PluginBuildToolchain> {
   return resolvePluginBuildToolchain(toolchainBaseDir(), {
     onFetchStart: () => {
-      console.log(
-        "Downloading the plugin build toolchain (first plugin build on this machine)…",
-      );
+      const pins = Object.entries(PLUGIN_TOOLCHAIN_PINS)
+        .map(([name, version]) => `${name}@${version}`)
+        .join(", ");
+      console.log("Downloading the plugin build toolchain (one time)…");
+      console.log(`  ${pins}`);
+    },
+    // Without this the command sits silent for the whole download — measured at
+    // 17s on a cold macOS cache against 1.6s once cached.
+    onFetchDone: (elapsedMs) => {
+      console.log(`Toolchain ready (${(elapsedMs / 1000).toFixed(1)}s)`);
     },
   });
 }

--- a/apps/server/src/services/plugins/build-toolchain.ts
+++ b/apps/server/src/services/plugins/build-toolchain.ts
@@ -33,6 +33,11 @@ export async function getPluginBuildToolchain(
         "downloading the plugin build toolchain (first plugin build on this machine)",
       );
     },
+    onFetchDone: (elapsedMs) => {
+      args.logger.info(
+        `plugin build toolchain ready in ${Math.round(elapsedMs / 100) / 10}s`,
+      );
+    },
   });
   byDataDir.set(args.dataDir, pending);
   try {

--- a/packages/plugin-build/src/toolchain.test.ts
+++ b/packages/plugin-build/src/toolchain.test.ts
@@ -72,9 +72,17 @@ describe("plugin build toolchain", () => {
     it.runIf(process.env.BB_TEST_TOOLCHAIN_FETCH === "1")(
       "builds a plugin frontend with nothing resolvable locally",
       async () => {
+        const fetchEvents: string[] = [];
         const toolchain = await resolvePluginBuildToolchain(baseDir, {
           ignoreLocal: true,
+          onFetchStart: () => fetchEvents.push("start"),
+          onFetchDone: (ms) => fetchEvents.push(`done:${ms > 0}`),
         });
+
+        // Both ends are reported: without the completion callback the caller
+        // has no way to say the download finished, which is what left the CLI
+        // silent for the whole fetch.
+        expect(fetchEvents).toEqual(["start", "done:true"]);
 
         expect(toolchain.esbuild).toContain("toolchain-");
         expect(toolchain.tailwindCssDir).toContain("toolchain-");

--- a/packages/plugin-build/src/toolchain.ts
+++ b/packages/plugin-build/src/toolchain.ts
@@ -179,7 +179,12 @@ async function isInstalled(dir: string): Promise<boolean> {
  */
 export async function resolvePluginBuildToolchain(
   baseDir: string,
-  options?: { onFetchStart?: () => void; ignoreLocal?: boolean },
+  options?: {
+    onFetchStart?: () => void;
+    /** Called once the toolchain is on disk and verified, with elapsed ms. */
+    onFetchDone?: (elapsedMs: number) => void;
+    ignoreLocal?: boolean;
+  },
 ): Promise<PluginBuildToolchain> {
   if (options?.ignoreLocal !== true) {
     const local = resolveLocalToolchain();
@@ -193,6 +198,7 @@ export async function resolvePluginBuildToolchain(
   }
 
   options?.onFetchStart?.();
+  const startedAt = Date.now();
   const staging = `${dir}.staging-${randomUUID()}`;
   try {
     await mkdir(staging, { recursive: true });
@@ -242,6 +248,7 @@ export async function resolvePluginBuildToolchain(
 
   const promoted = toolchainFrom(createRequire(join(dir, "noop.js")));
   if (promoted === null) throw new Error(errorPromoting(dir));
+  options?.onFetchDone?.(Date.now() - startedAt);
   return promoted;
 }
 


### PR DESCRIPTION
**Layer 4 of 4.** Depends on #1006. Addresses the one P2 from macOS QA.

A first install sat silent for **17.22 s** (vs **1.64 s** cached), because the first plugin build on a machine downloads the toolchain. Measured on macOS by `thr_3wmkakaaix`.

## Dialog

`Installing plugin…` plus an indeterminate bar, replacing the full-trust warning — which has served its purpose by the time you've clicked install.

It deliberately **does not name the phase.** The server does the work behind one blocking `POST`, so the client cannot know whether it's downloading tools, resolving dependencies, or bundling. Saying so would mean either guessing, or adding a realtime phase contract maintained forever for a window that happens once per machine.

Reduced motion gets a static half-width fill rather than a frozen sweep.

## CLI

`resolvePluginBuildToolchain` gains `onFetchDone(elapsedMs)`. `bb plugin build` and `bb plugin dev` resolve the toolchain in-process, so they now print the pinned versions on start and the elapsed time on completion.

`bb plugin install` is **unchanged** — the server fetches on its behalf, so the CLI has no more visibility than the browser does. The server logs the duration instead.

## Verification

- New `AddPluginDialog` test asserts the label, the bar, and the warning being replaced. Confirmed to **fail** with the label change reverted.
- The gated fetch test now asserts both `onFetchStart` and `onFetchDone` fire on a real download.
- Observed in the running app with the install response held open — label, `role="progressbar"`, and no trust warning.
- Full-repo `turbo run typecheck --force`: 57/57, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)