### PR TITLE
Give every app header the seam border

### DIFF
--- a/apps/app/src/components/layout/AppPageHeader.test.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppPageHeader } from "./AppPageHeader";
+
+vi.mock("@/components/ui/sidebar.js", () => ({
+  useIsSidebarShowing: () => true,
+}));
+
+vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
+  useIsCompactViewport: () => false,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AppPageHeader", () => {
+  it("separates every header from its body without a per-call-site opt-in", () => {
+    const { container } = render(<AppPageHeader center={<span>Docs</span>} />);
+
+    const header = container.querySelector("header");
+    expect(header?.classList).toContain("border-b");
+    expect(header?.classList).toContain("border-border-seam-vertical/60");
+  });
+
+  it("keeps the seam when a call site passes its own classes", () => {
+    const { container } = render(<AppPageHeader className="z-[21]" />);
+
+    const header = container.querySelector("header");
+    expect(header?.classList).toContain("border-b");
+    expect(header?.classList).toContain("z-[21]");
+  });
+});

--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -44,6 +44,13 @@ export const HEADER_REDUCED_GLYPH_ICON_BUTTON_CLASS =
 export const HEADER_PANE_ACTION_ICON_BUTTON_CLASS =
   HEADER_REDUCED_GLYPH_ICON_BUTTON_CLASS;
 
+/**
+ * Seam that separates a header row from the body below it. Every app header
+ * carries this seam, so it belongs to the shared chrome instead of to each
+ * call site. Panes without it read as if their title bar floats on the body.
+ */
+export const HEADER_SEAM_CLASS = "border-b border-border-seam-vertical/60";
+
 interface AppPageHeaderProps {
   center?: ReactNode;
   actions?: ReactNode;
@@ -86,6 +93,7 @@ export function AppPageHeader({
       ref={headerRef}
       className={cn(
         CHROME_ROW_HEIGHT_CLASS,
+        HEADER_SEAM_CLASS,
         "relative shrink-0 bg-surface-scrim px-4 backdrop-blur-sm",
         usesDesktopChrome && isWindowDragRegion && MACOS_WINDOW_DRAG_CLASS,
         className,

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -52,25 +52,8 @@ afterEach(() => {
 });
 
 describe("ThreadDetailHeader", () => {
-  it("keeps the thread header visually separated from the timeline", () => {
-    const { container } = render(
-      <PaneContext.Provider value={PANE_CONTEXT}>
-        <ThreadDetailHeader
-          actionsMenu={null}
-          childPillLabel={null}
-          isSecondaryPanelOpen={false}
-          onOpenThreadGitAction={vi.fn()}
-          onToggleSecondaryPanel={vi.fn()}
-          threadHeaderGitActions={[]}
-          threadTitle="Header separator"
-        />
-      </PaneContext.Provider>,
-    );
-
-    const header = container.querySelector("header");
-    expect(header?.classList).toContain("border-b");
-    expect(header?.classList).toContain("border-border-seam-vertical/60");
-  });
+  // The header seam now belongs to AppPageHeader, so AppPageHeader.test.tsx
+  // guards it for every header instead of this one call site.
 
   it("leaves the open right-panel collapse control to the panel header", () => {
     render(

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -299,10 +299,7 @@ export function ThreadDetailHeader({
       actions={actions}
       isWindowDragRegion={isTopRow}
       ownsWindowTopLeft={ownsWindowTopLeft}
-      className={cn(
-        "border-b border-border-seam-vertical/60",
-        beginPaneDrag && "z-[21]",
-      )}
+      className={beginPaneDrag ? "z-[21]" : undefined}
     />
   );
 }


### PR DESCRIPTION
## Summary

The bottom seam under a header was a per-call-site decoration, not part of the shared chrome. Only `ThreadDetailHeader` passed `border-b border-border-seam-vertical/60`. Plugin panel headers and the full-page `AppLayout` header passed no border, so their title bar sat flush against the body.

This moves the seam into `AppPageHeader` as a shared `HEADER_SEAM_CLASS` constant applied in the base class list, and removes the duplicate string from `ThreadDetailHeader`.

## Impact

`AppPageHeader` has three call sites. All three now carry the seam:

| Surface | Before | After |
|---|---|---|
| Split-pane plugin panels (Docs, Automations) | no seam | seam — the fix |
| Project, archived, settings, and tools routes | no seam | seam — new |
| Plugin panel routes with splits off | no seam | seam — new |
| Thread header | seam | seam — no change |
| Root and compose views | no header | no header |

The second row is a deliberate widening: those routes now match the thread header.

## Tests

- New `AppPageHeader.test.tsx` guards the seam for a header with no `className`, and for one that passes its own classes.
- Removed the old seam assertion from `ThreadDetailHeader.test.tsx`. It mocked `AppPageHeader`, so it could no longer see the real class.
- `turbo run typecheck --filter=@bb/app` passed.
- `turbo run test --filter=@bb/app` passed: 312 files, 2338 tests.
- `turbo run lint --filter=@bb/app`: 0 errors, no warnings in the changed files.

## QA

Checked in the dev app: the plugin panel and settings headers gained the seam, the thread header kept its single seam with no doubling, and the root view is unaffected.

## Risks

There is no opt-out prop. A future seamless header must pass `border-b-0` in `className`. I chose this over a `hideSeam` prop because no call site needs it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)