### PR TITLE
Separate automation run transport status from domain outcome

### DIFF
--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -63,6 +63,10 @@ import {
 } from "./lib/model-label";
 import { AutomationProviderIcon } from "./lib/provider-icon";
 import { AutomationMetadataItem } from "./metadata";
+import {
+  formatRunDomainLabel,
+  formatRunTransportLabel,
+} from "./src/run-summary";
 
 export interface AutomationRunsViewState {
   runs: readonly AutomationRunResponse[];
@@ -505,17 +509,17 @@ export const AUTOMATION_RUN_STATUS_VISUALS: Record<
   }
 > = {
   running: {
-    label: "Running",
+    label: "transport=running",
     icon: "Loading",
     className: "animate-spin text-muted-foreground",
   },
   failed: {
-    label: "Failed",
+    label: "transport=failed",
     icon: "CircleX",
     className: "text-destructive",
   },
   skipped: {
-    label: "Skipped",
+    label: "transport=skipped",
     // Not CircleDashed: icon.tsx aliases it to the same DashedLineCircleIcon as
     // Spinner, so a skipped run rendered an identical shape to a running one.
     // ArrowTurnForward is the only glyph in the map that reads as "passed
@@ -524,7 +528,7 @@ export const AUTOMATION_RUN_STATUS_VISUALS: Record<
     className: "text-subtle-foreground",
   },
   succeeded: {
-    label: "Succeeded",
+    label: "transport=succeeded",
     icon: "CircleCheck",
     className: "text-success",
   },
@@ -567,6 +571,8 @@ function RunRow({
     run.runMode === "script" &&
     (run.output !== null || run.error !== null || silent);
   const visual = AUTOMATION_RUN_STATUS_VISUALS[run.status];
+  const transportLabel = formatRunTransportLabel(run.status);
+  const domainLabel = formatRunDomainLabel(run.terminalToken);
   const running = run.status === "running";
   const openable = run.runMode === "agent" && run.threadId !== null;
   // The whole row is the affordance when there is a thread, so the destination
@@ -619,9 +625,18 @@ function RunRow({
             : "text-subtle-foreground",
         )}
       >
-        {running ? `${visual.label}\u2026` : (duration ?? "")}
-        {run.skipReason ? `${duration ? " · " : ""}${run.skipReason}` : ""}
+        {running ? `${transportLabel}\u2026` : transportLabel}
+        {duration ? ` · ${duration}` : ""}
+        {run.skipReason ? ` · ${run.skipReason}` : ""}
       </span>
+      {domainLabel ? (
+        <span
+          aria-label={domainLabel}
+          className="max-w-40 shrink-0 truncate rounded-full bg-surface-recessed/70 px-2 py-0.5 font-mono text-xs text-muted-foreground"
+        >
+          {domainLabel}
+        </span>
+      ) : null}
       {openable ? (
         <Icon
           name="ChevronRight"

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -37,9 +37,9 @@ import { sweepDueAutomations } from "./sweep.js";
 import { createAutomationService } from "./service.js";
 import { automationScriptDir } from "./script-files.js";
 
-function createTestDb(): Db {
+function createTestDb(includeRunMigration = true): Db {
   const db = new Database(":memory:");
-  db.exec(migrations[0] ?? "");
+  db.exec(includeRunMigration ? migrations.join("\n") : (migrations[0] ?? ""));
   return db;
 }
 
@@ -152,7 +152,7 @@ function createAutomationServiceBb() {
 
 describe("data migrations", () => {
   it("migrates stored agent automations to current permission modes", () => {
-    const db = createTestDb();
+    const db = createTestDb(false);
     const insert = db.prepare(
       `INSERT INTO automations (
          id, project_id, name, enabled, trigger_type, trigger_config,

--- a/plugins/automations/src/cli.ts
+++ b/plugins/automations/src/cli.ts
@@ -26,6 +26,10 @@ import {
   AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS,
   automationScriptInterpreterSchema,
 } from "./rpc-types.js";
+import {
+  formatRunDomainLabel,
+  formatRunTransportLabel,
+} from "./run-summary.js";
 
 const DURATION_PATTERN =
   /^(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$/iu;
@@ -523,10 +527,11 @@ function printAutomationTable(automations: AutomationResponse[]): string {
 
 function printRunTable(runs: AutomationRunResponse[]): string {
   return table(
-    ["ID", "Status", "Started", "Thread/Exit", "Detail"],
+    ["ID", "Transport", "Domain", "Started", "Thread/Exit", "Detail"],
     runs.map((run) => [
       run.id,
-      run.status,
+      formatRunTransportLabel(run.status),
+      formatRunDomainLabel(run.terminalToken) ?? "-",
       formatTimestamp(run.startedAt),
       run.threadId ?? (run.exitCode === null ? "-" : `exit ${run.exitCode}`),
       run.skipReason ?? run.error ?? "-",

--- a/plugins/automations/src/data.ts
+++ b/plugins/automations/src/data.ts
@@ -50,14 +50,14 @@ export interface AutomationRunRow {
   error: string | null;
   output: string | null;
   exitCode: number | null;
+  terminalToken: string | null;
   idempotencyKey: string | null;
   scheduledFor: number;
   startedAt: number;
   finishedAt: number | null;
 }
 
-interface RawAutomationRow
-  extends Omit<AutomationRow, "enabled"> {
+interface RawAutomationRow extends Omit<AutomationRow, "enabled"> {
   enabled: 0 | 1;
 }
 
@@ -163,7 +163,16 @@ export const migrations = [
        'workspace-write',
        'readonly'
      );`,
+  `ALTER TABLE automation_runs ADD COLUMN terminal_token TEXT;`,
 ];
+
+const automationRunSelectColumns = `
+  id, automation_id AS automationId, run_mode AS runMode,
+  thread_id AS threadId, status, trigger, skip_reason AS skipReason,
+  error, output, exit_code AS exitCode, terminal_token AS terminalToken,
+  idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
+  started_at AS startedAt, finished_at AS finishedAt
+`;
 
 export interface CreateAutomationInput {
   id?: string;
@@ -194,11 +203,15 @@ function serializeExecution(execution: AutomationExecution): string {
   return JSON.stringify(execution);
 }
 
-export function parseAutomationTrigger(triggerConfig: string): AutomationTrigger {
+export function parseAutomationTrigger(
+  triggerConfig: string,
+): AutomationTrigger {
   return automationTriggerSchema.parse(JSON.parse(triggerConfig));
 }
 
-export function parseAutomationExecution(execution: string): AutomationExecution {
+export function parseAutomationExecution(
+  execution: string,
+): AutomationExecution {
   return automationExecutionSchema.parse(JSON.parse(execution));
 }
 
@@ -239,13 +252,17 @@ export function toAutomationRunResponse(
     error: row.error,
     output: row.output,
     exitCode: row.exitCode,
+    terminalToken: row.terminalToken,
     scheduledFor: row.scheduledFor,
     startedAt: row.startedAt,
     finishedAt: row.finishedAt,
   });
 }
 
-export function createAutomation(db: Db, input: CreateAutomationInput): AutomationRow {
+export function createAutomation(
+  db: Db,
+  input: CreateAutomationInput,
+): AutomationRow {
   const now = Date.now();
   const id = input.id ?? createAutomationId();
   db.prepare(
@@ -353,11 +370,16 @@ export function listAllAutomations(db: Db): AutomationRow[] {
 
 export function updateAutomation(
   db: Db,
-  args: { projectId: string; automationId: string; patch: UpdateAutomationInput },
+  args: {
+    projectId: string;
+    automationId: string;
+    patch: UpdateAutomationInput;
+  },
 ): AutomationRow | null {
   const existing = getAutomationForProject(db, args);
   if (!existing) return null;
-  const nextTrigger = args.patch.trigger ?? parseAutomationTrigger(existing.triggerConfig);
+  const nextTrigger =
+    args.patch.trigger ?? parseAutomationTrigger(existing.triggerConfig);
   const nextExecution =
     args.patch.execution ?? parseAutomationExecution(existing.execution);
   const now = Date.now();
@@ -387,7 +409,9 @@ export function updateAutomation(
           ? (nextExecution.targetThreadId ?? null)
           : null,
     nextRunAt:
-      args.patch.nextRunAt !== undefined ? args.patch.nextRunAt : existing.nextRunAt,
+      args.patch.nextRunAt !== undefined
+        ? args.patch.nextRunAt
+        : existing.nextRunAt,
     now,
   });
   return getAutomationForProject(db, args);
@@ -526,11 +550,11 @@ export function claimAutomationScheduledRun(
     db.prepare(
       `INSERT INTO automation_runs (
          id, automation_id, run_mode, thread_id, status, trigger, skip_reason,
-         error, output, exit_code, idempotency_key, scheduled_for, started_at,
-         finished_at
+         error, output, exit_code, terminal_token, idempotency_key,
+         scheduled_for, started_at, finished_at
        ) VALUES (
          @id, @automationId, @runMode, NULL, @status, 'schedule', @skipReason,
-         NULL, NULL, NULL, NULL, @scheduledFor, @startedAt, @finishedAt
+         NULL, NULL, NULL, NULL, NULL, @scheduledFor, @startedAt, @finishedAt
        )`,
     ).run({
       id: runId,
@@ -601,7 +625,8 @@ export function restoreAutomationAfterFailedRun(
     }
     db.prepare(
       `UPDATE automation_runs
-       SET status = 'failed', error = @error, finished_at = @now
+       SET status = 'failed', error = @error, terminal_token = NULL,
+           finished_at = @now
        WHERE id = @runId`,
     ).run({ runId: args.runId, error: args.error, now: args.now });
   })();
@@ -617,33 +642,43 @@ export function closeAutomationRun(
     output?: string | null;
     exitCode?: number | null;
     threadId?: string | null;
+    terminalToken?: string | null;
     now: number;
   },
 ): { run: AutomationRunRow; automationId: string } | null {
   return db.transaction(() => {
     const existing = getAutomationRun(db, args.runId);
     if (!existing) return null;
-    db.prepare(
-       `UPDATE automation_runs SET
-         status = @status,
-         skip_reason = @skipReason,
-         error = @error,
-         output = @output,
-         exit_code = @exitCode,
-         thread_id = CASE WHEN @hasThreadId THEN @threadId ELSE thread_id END,
-         finished_at = @now
-       WHERE id = @runId`,
-    ).run({
-      runId: args.runId,
-      status: args.status,
-      skipReason: args.skipReason ?? null,
-      error: args.error ?? null,
-      output: args.output ?? null,
-      exitCode: args.exitCode ?? null,
-      hasThreadId: args.threadId === undefined ? 0 : 1,
-      threadId: args.threadId ?? null,
-      now: args.now,
-    });
+    const run = optionalRunRow(
+      db
+        .prepare(
+          `UPDATE automation_runs SET
+             status = @status,
+             skip_reason = @skipReason,
+             error = @error,
+             output = @output,
+             exit_code = @exitCode,
+             terminal_token = @terminalToken,
+             thread_id = CASE WHEN @hasThreadId THEN @threadId ELSE thread_id END,
+             finished_at = @now
+           WHERE id = @runId AND status = 'running'
+           RETURNING ${automationRunSelectColumns}`,
+        )
+        .get({
+          runId: args.runId,
+          status: args.status,
+          skipReason: args.skipReason ?? null,
+          error: args.error ?? null,
+          output: args.output ?? null,
+          exitCode: args.exitCode ?? null,
+          terminalToken:
+            args.status === "succeeded" ? (args.terminalToken ?? null) : null,
+          hasThreadId: args.threadId === undefined ? 0 : 1,
+          threadId: args.threadId ?? null,
+          now: args.now,
+        }),
+    );
+    if (!run) return { run: existing, automationId: existing.automationId };
     db.prepare(
       `UPDATE automations SET
          last_run_status = @status,
@@ -661,8 +696,6 @@ export function closeAutomationRun(
       error: args.error ?? null,
       now: args.now,
     });
-    const run = getAutomationRun(db, args.runId);
-    if (!run) return null;
     return { run, automationId: run.automationId };
   })();
 }
@@ -682,11 +715,7 @@ export function createManualRun(
         db
           .prepare(
             `SELECT
-               id, automation_id AS automationId, run_mode AS runMode,
-               thread_id AS threadId, status, trigger, skip_reason AS skipReason,
-               error, output, exit_code AS exitCode,
-               idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
-               started_at AS startedAt, finished_at AS finishedAt
+               ${automationRunSelectColumns}
              FROM automation_runs
              WHERE automation_id = ? AND idempotency_key = ?`,
           )
@@ -698,11 +727,11 @@ export function createManualRun(
     db.prepare(
       `INSERT INTO automation_runs (
          id, automation_id, run_mode, thread_id, status, trigger, skip_reason,
-         error, output, exit_code, idempotency_key, scheduled_for, started_at,
-         finished_at
+         error, output, exit_code, terminal_token, idempotency_key,
+         scheduled_for, started_at, finished_at
        ) VALUES (
          @id, @automationId, @runMode, NULL, 'running', 'manual', NULL,
-         NULL, NULL, NULL, @idempotencyKey, @now, @now, NULL
+         NULL, NULL, NULL, NULL, @idempotencyKey, @now, @now, NULL
        )`,
     ).run({
       id: runId,
@@ -722,11 +751,7 @@ export function getAutomationRun(db: Db, id: string): AutomationRunRow | null {
     db
       .prepare(
         `SELECT
-           id, automation_id AS automationId, run_mode AS runMode,
-           thread_id AS threadId, status, trigger, skip_reason AS skipReason,
-           error, output, exit_code AS exitCode,
-           idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
-           started_at AS startedAt, finished_at AS finishedAt
+           ${automationRunSelectColumns}
          FROM automation_runs WHERE id = ?`,
       )
       .get(id),
@@ -763,9 +788,7 @@ export function isAutomationSpawnedThread(db: Db, threadId: string): boolean {
       )
       .get(threadId) !== undefined ||
     db
-      .prepare(
-        `SELECT id FROM automation_runs WHERE thread_id = ? LIMIT 1`,
-      )
+      .prepare(`SELECT id FROM automation_runs WHERE thread_id = ? LIMIT 1`)
       .get(threadId) !== undefined
   );
 }
@@ -778,11 +801,7 @@ export function getRunningAutomationRunByThread(
     db
       .prepare(
         `SELECT
-           id, automation_id AS automationId, run_mode AS runMode,
-           thread_id AS threadId, status, trigger, skip_reason AS skipReason,
-           error, output, exit_code AS exitCode,
-           idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
-           started_at AS startedAt, finished_at AS finishedAt
+           ${automationRunSelectColumns}
          FROM automation_runs
          WHERE thread_id = ? AND status = 'running'
          ORDER BY started_at DESC
@@ -804,11 +823,7 @@ export function listAutomationRuns(
     ? db
         .prepare(
           `SELECT
-             id, automation_id AS automationId, run_mode AS runMode,
-             thread_id AS threadId, status, trigger, skip_reason AS skipReason,
-             error, output, exit_code AS exitCode,
-             idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
-             started_at AS startedAt, finished_at AS finishedAt
+             ${automationRunSelectColumns}
            FROM automation_runs
            WHERE automation_id = ?
              AND (started_at < ? OR (started_at = ? AND id < ?))
@@ -825,11 +840,7 @@ export function listAutomationRuns(
     : db
         .prepare(
           `SELECT
-             id, automation_id AS automationId, run_mode AS runMode,
-             thread_id AS threadId, status, trigger, skip_reason AS skipReason,
-             error, output, exit_code AS exitCode,
-             idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
-             started_at AS startedAt, finished_at AS finishedAt
+             ${automationRunSelectColumns}
            FROM automation_runs
            WHERE automation_id = ?
            ORDER BY started_at DESC, id DESC

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -271,6 +271,7 @@ export const automationRunResponseSchema = z
     error: z.string().nullable(),
     output: z.string().nullable(),
     exitCode: z.number().int().nullable(),
+    terminalToken: z.string().nullable(),
     scheduledFor: z.number(),
     startedAt: z.number(),
     finishedAt: z.number().nullable(),

--- a/plugins/automations/src/run-status-ui.test.tsx
+++ b/plugins/automations/src/run-status-ui.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { AutomationDetailView } from "../detail-view.js";
+import type { AutomationResponse, AutomationRunResponse } from "./rpc-types.js";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(cleanup);
+
+const automation: AutomationResponse = {
+  id: "auto_status",
+  projectId: "proj_test",
+  name: "Status check",
+  enabled: true,
+  trigger: {
+    triggerType: "schedule",
+    cron: "* * * * *",
+    timezone: "UTC",
+  },
+  execution: {
+    mode: "agent",
+    prompt: "Run",
+    providerId: "codex",
+    model: "gpt-5",
+    permissionMode: "auto",
+    environment: { type: "project-default" },
+  },
+  origin: "human",
+  createdByThreadId: null,
+  nextRunAt: 2_000,
+  lastRunAt: 1_000,
+  runCount: 2,
+  lastRunStatus: "succeeded",
+  lastRunThreadId: "thr_status",
+  lastError: null,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+function run(id: string, terminalToken: string | null): AutomationRunResponse {
+  return {
+    id,
+    automationId: automation.id,
+    runMode: "agent",
+    threadId: `thr_${id}`,
+    status: "succeeded",
+    trigger: "schedule",
+    skipReason: null,
+    error: null,
+    output: null,
+    exitCode: null,
+    terminalToken,
+    scheduledFor: 1_000,
+    startedAt: 1_000,
+    finishedAt: 2_000,
+  };
+}
+
+describe("automation run transport and domain labels", () => {
+  it("renders explicit accessible labels and omits absent domains", () => {
+    render(
+      <AutomationDetailView
+        automation={automation}
+        projectLabel="Test"
+        runsState={{
+          runs: [run("domain", "TASK_COMPLETE"), run("legacy", null)],
+          nextCursor: null,
+          loading: false,
+          loadingMore: false,
+          error: null,
+          loadMore: vi.fn(),
+          retry: vi.fn(),
+        }}
+        actionPending={false}
+        executionOptions={null}
+        executionOptionsError={null}
+        permissionModes={["auto"]}
+        editing={false}
+        onToggle={vi.fn()}
+        onEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onUpdateAgent={vi.fn()}
+        onRunNow={vi.fn()}
+        onDelete={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText(/^transport=succeeded/u)).toHaveLength(2);
+    expect(screen.getByText("domain=TASK_COMPLETE")).toBeTruthy();
+    expect(
+      screen.getAllByRole("img", { name: "transport=succeeded" }),
+    ).toHaveLength(2);
+    expect(screen.queryAllByText(/^domain=/u)).toHaveLength(1);
+  });
+});

--- a/plugins/automations/src/run-summary.ts
+++ b/plugins/automations/src/run-summary.ts
@@ -1,0 +1,11 @@
+import type { AutomationRunStatus } from "./rpc-types.js";
+
+export function formatRunTransportLabel(status: AutomationRunStatus): string {
+  return `transport=${status}`;
+}
+
+export function formatRunDomainLabel(
+  terminalToken: string | null,
+): string | null {
+  return terminalToken === null ? null : `domain=${terminalToken}`;
+}

--- a/plugins/automations/src/run.ts
+++ b/plugins/automations/src/run.ts
@@ -280,6 +280,7 @@ export async function executeScriptRun(
       output: mapped.output,
       exitCode: mapped.exitCode,
       error: mapped.error,
+      terminalToken: mapped.terminalToken,
       now: Date.now(),
     });
   } catch (error) {
@@ -298,14 +299,21 @@ export async function executeScriptRun(
 export function closeAutomationRunForSettledThread(
   bb: Pick<BbPluginApi, "realtime">,
   db: Db,
-  args: { threadId: string; status: "idle" | "failed"; error?: string | null },
+  args: {
+    threadId: string;
+    status: "succeeded" | "failed";
+    error?: string | null;
+    terminalToken?: string | null;
+  },
 ): void {
   const run = getRunningAutomationRunByThread(db, args.threadId);
   if (!run) return;
   const closed = closeAutomationRun(db, {
     runId: run.id,
-    status: args.status === "idle" ? "succeeded" : "failed",
-    error: args.status === "idle" ? null : (args.error ?? "Turn failed"),
+    status: args.status,
+    error: args.status === "succeeded" ? null : (args.error ?? "Turn failed"),
+    terminalToken:
+      args.status === "succeeded" ? (args.terminalToken ?? null) : null,
     threadId: args.threadId,
     now: Date.now(),
   });

--- a/plugins/automations/src/script-runner.ts
+++ b/plugins/automations/src/script-runner.ts
@@ -6,6 +6,7 @@ import {
   AUTOMATION_SCRIPT_TIMEOUT_MAX_MS,
   type AutomationScriptInterpreter,
 } from "./rpc-types.js";
+import { extractTerminalToken } from "./terminal-token.js";
 import {
   resolveAutomationScriptPath,
   resolveDefaultInterpreter,
@@ -71,6 +72,7 @@ export interface ScriptRunOutcome {
   exitCode: number | null;
   error: string | null;
   skipReason: string | null;
+  terminalToken: string | null;
 }
 
 export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome {
@@ -81,6 +83,7 @@ export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome 
       exitCode: null,
       error: "Script timed out",
       skipReason: null,
+      terminalToken: null,
     };
   }
   if (result.exitCode !== 0) {
@@ -90,6 +93,7 @@ export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome 
       exitCode: result.exitCode,
       error: `Script exited with code ${result.exitCode}`,
       skipReason: null,
+      terminalToken: null,
     };
   }
   if (result.output.trim().length === 0) {
@@ -99,6 +103,7 @@ export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome 
       exitCode: 0,
       error: null,
       skipReason: "empty output",
+      terminalToken: null,
     };
   }
   if (isWakeAgentSuppressed(result.output)) {
@@ -108,6 +113,7 @@ export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome 
       exitCode: 0,
       error: null,
       skipReason: "wakeAgent false",
+      terminalToken: null,
     };
   }
   return {
@@ -116,6 +122,7 @@ export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome 
     exitCode: 0,
     error: null,
     skipReason: null,
+    terminalToken: extractTerminalToken(result.output),
   };
 }
 

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -850,7 +850,7 @@ describe("automations server plugin harness", () => {
 
     await harness.emitThreadEvent("thread.idle", {
       thread: makeThreadResponse({ id: "thr_spawned", projectId: PROJECT_ID }),
-      lastAssistantText: null,
+      lastAssistantText: "work complete\nTASK_COMPLETE\n",
     });
     const closedRuns = automationRunListResponseSchema.parse(
       await harness.callRpc("automations_runs", {
@@ -861,7 +861,19 @@ describe("automations server plugin harness", () => {
     expect(closedRuns[0]).toMatchObject({
       status: "succeeded",
       threadId: "thr_spawned",
+      terminalToken: "TASK_COMPLETE",
     });
+    const cliRuns = await harness.runCli([
+      "runs",
+      automation.id,
+      "--project",
+      PROJECT_ID,
+    ]);
+    expect(cliRuns.exitCode).toBe(0);
+    expect(cliRuns.stdout).toContain("Transport");
+    expect(cliRuns.stdout).toContain("Domain");
+    expect(cliRuns.stdout).toContain("transport=succeeded");
+    expect(cliRuns.stdout).toContain("domain=TASK_COMPLETE");
     expect(signalKinds(host)).toEqual(
       expect.arrayContaining([
         "automations-changed",

--- a/plugins/automations/src/server.ts
+++ b/plugins/automations/src/server.ts
@@ -10,6 +10,7 @@ import {
 import { registerAutomationCli } from "./cli.js";
 import { createAutomationService } from "./service.js";
 import { sleep, sweepDueAutomations, SWEEP_INTERVAL_MS } from "./sweep.js";
+import { extractTerminalToken } from "./terminal-token.js";
 
 function resolveServerUrl(): string {
   return process.env.BB_SERVER_URL?.trim() || "http://127.0.0.1:38886";
@@ -31,10 +32,11 @@ export default async function plugin(bb: BbPluginApi) {
   bb.rpc.register(automationRpcContract, createRpcHandlers(service));
   registerAutomationCli({ bb, service });
 
-  bb.events.on("thread.idle", ({ thread }) => {
+  bb.events.on("thread.idle", ({ thread, lastAssistantText }) => {
     closeAutomationRunForSettledThread(bb, db, {
       threadId: thread.id,
-      status: "idle",
+      status: "succeeded",
+      terminalToken: extractTerminalToken(lastAssistantText),
     });
   });
   bb.events.on("thread.failed", ({ thread, error }) => {

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -671,6 +671,7 @@ export function createAutomationService(args: {
             runId: run.id,
             status: "failed",
             error: error instanceof Error ? error.message : String(error),
+            terminalToken: null,
             now: Date.now(),
           });
         };

--- a/plugins/automations/src/terminal-token.test.ts
+++ b/plugins/automations/src/terminal-token.test.ts
@@ -1,0 +1,189 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import {
+  closeAutomationRun,
+  createAutomation,
+  createManualRun,
+  listAutomationRuns,
+  migrations,
+  type Db,
+} from "./data.js";
+import { mapScriptResultToRun } from "./script-runner.js";
+import { extractTerminalToken } from "./terminal-token.js";
+
+function migrateByIndex(db: Db, statements: readonly string[]): void {
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)",
+  );
+  const applied = new Set(
+    db
+      .prepare<[], { id: number }>("SELECT id FROM _bb_migrations")
+      .all()
+      .map((row) => row.id),
+  );
+  const record = db.prepare(
+    "INSERT INTO _bb_migrations (id, applied_at) VALUES (?, ?)",
+  );
+  db.transaction(() => {
+    statements.forEach((statement, index) => {
+      if (applied.has(index)) return;
+      db.exec(statement);
+      record.run(index, 1);
+    });
+  })();
+}
+
+function createMigratedDb(): Db {
+  const db = new Database(":memory:");
+  migrateByIndex(db, migrations);
+  return db;
+}
+
+function createAgentAutomation(db: Db): void {
+  createAutomation(db, {
+    id: "auto_status",
+    projectId: "proj_test",
+    name: "Status",
+    enabled: true,
+    trigger: {
+      triggerType: "schedule",
+      cron: "* * * * *",
+      timezone: "UTC",
+    },
+    runMode: "agent",
+    execution: {
+      mode: "agent",
+      prompt: "Run",
+      providerId: "codex",
+      model: "gpt-5",
+      permissionMode: "auto",
+      environment: { type: "project-default" },
+    },
+    origin: "human",
+    createdByThreadId: null,
+    nextRunAt: 1_000,
+  });
+}
+
+describe("terminal token extraction", () => {
+  it("extracts only a generic strict final non-empty line", () => {
+    expect(extractTerminalToken("work\nTASK_COMPLETE\n\n")).toBe(
+      "TASK_COMPLETE",
+    );
+    expect(extractTerminalToken("work\r\nDOMAIN_42\r\n  \r\n")).toBe(
+      "DOMAIN_42",
+    );
+    expect(extractTerminalToken("TASK_COMPLETE\nmore output")).toBeNull();
+    expect(extractTerminalToken("work\ntask_complete")).toBeNull();
+    expect(extractTerminalToken("work\nTASK-COMPLETE")).toBeNull();
+    expect(extractTerminalToken(`work\n${"A".repeat(129)}`)).toBeNull();
+    expect(extractTerminalToken(null)).toBeNull();
+  });
+
+  it("stores a token only for successful script transport", () => {
+    expect(
+      mapScriptResultToRun({
+        exitCode: 0,
+        output: "detail\nTASK_COMPLETE\n",
+        timedOut: false,
+      }),
+    ).toMatchObject({ status: "succeeded", terminalToken: "TASK_COMPLETE" });
+    expect(
+      mapScriptResultToRun({
+        exitCode: 2,
+        output: "detail\nTASK_COMPLETE\n",
+        timedOut: false,
+      }),
+    ).toMatchObject({ status: "failed", terminalToken: null });
+    expect(
+      mapScriptResultToRun({
+        exitCode: 0,
+        output: "detail\nTASK_COMPLETE\n",
+        timedOut: true,
+      }),
+    ).toMatchObject({ status: "failed", terminalToken: null });
+    expect(
+      mapScriptResultToRun({
+        exitCode: 0,
+        output: 'detail\n{"wakeAgent": false}\n',
+        timedOut: false,
+      }),
+    ).toMatchObject({ status: "skipped", terminalToken: null });
+  });
+});
+
+describe("terminal token storage", () => {
+  it("suppresses non-success tokens and keeps running and legacy values null", () => {
+    const db = createMigratedDb();
+    createAgentAutomation(db);
+    const running = createManualRun(db, {
+      automationId: "auto_status",
+      runMode: "agent",
+      now: 1,
+    }).run;
+    const failed = createManualRun(db, {
+      automationId: "auto_status",
+      runMode: "agent",
+      now: 2,
+    }).run;
+    const skipped = createManualRun(db, {
+      automationId: "auto_status",
+      runMode: "agent",
+      now: 3,
+    }).run;
+
+    closeAutomationRun(db, {
+      runId: failed.id,
+      status: "failed",
+      terminalToken: "TASK_COMPLETE",
+      now: 4,
+    });
+    closeAutomationRun(db, {
+      runId: skipped.id,
+      status: "skipped",
+      terminalToken: "TASK_COMPLETE",
+      now: 5,
+    });
+
+    expect(
+      listAutomationRuns(db, { automationId: "auto_status", limit: 10 }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: running.id, terminalToken: null }),
+        expect.objectContaining({ id: failed.id, terminalToken: null }),
+        expect.objectContaining({ id: skipped.id, terminalToken: null }),
+      ]),
+    );
+  });
+
+  it("makes close idempotent and preserves the first final state", () => {
+    const db = createMigratedDb();
+    createAgentAutomation(db);
+    const run = createManualRun(db, {
+      automationId: "auto_status",
+      runMode: "agent",
+      now: 1,
+    }).run;
+
+    const first = closeAutomationRun(db, {
+      runId: run.id,
+      status: "succeeded",
+      terminalToken: "TASK_COMPLETE",
+      now: 2,
+    });
+    const duplicate = closeAutomationRun(db, {
+      runId: run.id,
+      status: "failed",
+      error: "late failure",
+      terminalToken: "LATE_FAILURE",
+      now: 3,
+    });
+
+    expect(first?.run).toMatchObject({
+      status: "succeeded",
+      terminalToken: "TASK_COMPLETE",
+      finishedAt: 2,
+    });
+    expect(duplicate?.run).toEqual(first?.run);
+  });
+});

--- a/plugins/automations/src/terminal-token.ts
+++ b/plugins/automations/src/terminal-token.ts
@@ -1,0 +1,21 @@
+const TERMINAL_TOKEN_MAX_LENGTH = 128;
+const BARE_TERMINAL_TOKEN = /^[A-Z][A-Z0-9_]*$/u;
+
+export function extractTerminalToken(
+  text: string | null | undefined,
+): string | null {
+  if (text === null || text === undefined) return null;
+  const lines = text.replace(/\r\n?|\n/gu, "\n").split("\n");
+  let index = lines.length - 1;
+  while (index >= 0 && lines[index]?.trim().length === 0) index -= 1;
+  const line = lines[index]?.trim();
+  if (
+    line === undefined ||
+    line.length === 0 ||
+    line.length > TERMINAL_TOKEN_MAX_LENGTH ||
+    !BARE_TERMINAL_TOKEN.test(line)
+  ) {
+    return null;
+  }
+  return line;
+}


### PR DESCRIPTION
<!--
For the repo owner to run (not the agent):

gh pr create --repo ymichael/bb --base main --head amadad:automation-domain-status \
  --title "Separate automation run transport status from domain outcome" \
  --body-file /tmp/claude-1000/-home-deploy/8d3befd4-b34b-4be8-8001-6297bf81ad08/scratchpad/bb-pr-body.md
-->

## Problem

`closeAutomationRunForSettledThread` in `plugins/automations/src/run.ts` collapses every settled agent thread into a single `automation_runs.status` column: `thread.idle` always maps to `"succeeded"`, `thread.failed` always maps to `"failed"`. That status only tells you the *transport* outcome — did the thread reach a terminal state without crashing — not the *domain* outcome the automation's prompt was actually trying to report.

Concretely, `thread.idle` fires whenever the provider turn settles, regardless of whether the agent's own instructions succeeded. The event carries `lastAssistantText`, which can contain a terminal token the automation's prompt was told to emit (e.g. `TASK_COMPLETE`, or a failure sentinel like `REFRESH_FAILED`) — but the run-closing code discards it. Today the only way to learn a script-mode run's actual outcome is via `output`/`skipReason`; agent-mode runs have no equivalent, so downstream consumers (dashboards, other automations chaining off a run) are forced to scrape thread logs or guess from `"succeeded"` even when the agent's own prompt reported a domain failure. The `workflows` plugin already sidesteps this by having its own `bb_workflow_result` convention; automations had no equivalent.

## Fix

Separate the two concerns instead of conflating them:

- **Transport status** (`automation_runs.status`: `running` / `succeeded` / `failed` / `skipped`) keeps meaning exactly what it means today — did the run mechanism itself complete.
- **Domain status** (new `terminal_token` column) captures the last non-empty line of the run's output when it is a bare `[A-Z][A-Z0-9_]*` token (`extractTerminalToken` in `plugins/automations/src/terminal-token.ts`), so an automation's prompt can report its own outcome without the platform inventing a taxonomy for it.

Changes:
- `terminal-token.ts` (new): strict single-line token extractor, capped at 128 chars, only accepted from a successful transport close.
- `run-summary.ts` (new): `formatRunTransportLabel` / `formatRunDomainLabel` — shared `transport=…` / `domain=…` formatting for CLI and UI.
- `run.ts`: `closeAutomationRunForSettledThread` now takes the caller-determined transport `status` directly (`"succeeded" | "failed"`) plus an optional `terminalToken`, instead of remapping `"idle" | "failed"` internally.
- `server.ts`: the `thread.idle` handler extracts the terminal token from `lastAssistantText` and passes it through; `thread.failed` explicitly nulls it (a transport failure has no trustworthy domain signal).
- `script-runner.ts`: `mapScriptResultToRun` extracts a terminal token from script stdout on successful runs (timeouts, non-zero exit, empty output, and `wakeAgent:false` skips all stay null).
- `data.ts`: adds the `terminal_token` column via the plugin's standard sequential migration (`bb.storage.migrate`, same pattern every other migration in this file uses), threads it through the run row/select/insert/close paths, and nulls it whenever a run is reopened or closes non-successfully. `closeAutomationRun` now does its update+read as a single `UPDATE … WHERE status = 'running' RETURNING …` instead of an unconditional update followed by a separate read, so calling it twice on an already-closed run is a no-op that returns the first final state instead of silently overwriting it.
- `service.ts`: the manual-run failure path explicitly sets `terminalToken: null`.
- `rpc-types.ts` / `cli.ts` / `detail-view.tsx`: `terminalToken` flows through the RPC response schema; the CLI run table and the run detail view both render `transport=…` and `domain=…` labels (domain omitted when null).

## What's intentionally left out of this PR

The commit this is drawn from also included a ~600-line preflight schema-reconciliation pass (`reconcileTerminalTokenMigrationPreflight`) that ran before `bb.storage.migrate` on every plugin startup, plus ~350 lines of tests exercising it. That code defends against a specific migration-history drift this deployment's automations DB had accumulated during its own dev/rebase history — it is not something a normal install of this plugin can get into via `bb.storage.migrate`'s existing sequential apply-by-index mechanism (see `apps/server/src/services/plugins/plugin-api.ts`), and its schema/index/foreign-key introspection would actively throw on any database shape it doesn't recognize. It's excluded here as operationally-specific scar tissue, not a generalizable fix. The plain `ALTER TABLE automation_runs ADD COLUMN terminal_token TEXT;` migration entry is the only schema change upstream needs, consistent with how every other migration in this file is written.

## Test coverage

- `plugins/automations/src/terminal-token.test.ts` (new, trimmed from the larger test file above): token-extraction edge cases (strict format, trailing whitespace/CRLF, length cap, wrong-case rejection) and `mapScriptResultToRun`'s success/timeout/non-zero-exit/skip branches; plus `closeAutomationRun` storage behavior — non-success statuses always null out the token, and closing an already-closed run is idempotent and preserves the first terminal state.
- `plugins/automations/src/server-harness.test.ts`: end-to-end `thread.idle` → closed run assertion that `terminalToken` is populated from `lastAssistantText`, plus a CLI-table assertion (`Transport`/`Domain` columns, `transport=succeeded`, `domain=TASK_COMPLETE`).
- `plugins/automations/src/run-status-ui.test.tsx` (new): renders `AutomationDetailView` with a token-bearing and a legacy (null-token) run, asserts accessible `transport=…`/`domain=…` labels and that the domain badge is omitted when there's no token.

Ran locally: `pnpm exec turbo run test --filter=bb-plugin-automations` — 8 test files, 63/63 passing. `pnpm exec turbo run typecheck --filter=bb-plugin-automations` — clean.

## Production note

This fix (in its full form, including the deployment-specific migration-reconciliation code excluded from this PR) is running in production on the author's own bb deployment.
