### PR TITLE
Stabilize recurring CI flakes

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -38,4 +38,14 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile --prefer-offline
+      run: |
+        for attempt in 1 2 3; do
+          if pnpm install --frozen-lockfile --prefer-offline; then
+            exit 0
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            exit 1
+          fi
+          echo "::warning::pnpm install failed on attempt $attempt; retrying"
+          sleep $((attempt * 5))
+        done

--- a/apps/host-daemon/src/partysocket.test.ts
+++ b/apps/host-daemon/src/partysocket.test.ts
@@ -11,6 +11,7 @@ describe("PartySocket", () => {
       import PartySocket from "partysocket/ws";
 
       let closeCount = 0;
+      let failureDeadline;
 
       class ConnectingWebSocket extends EventEmitter {
         readyState = 0;
@@ -31,9 +32,18 @@ describe("PartySocket", () => {
               "error",
               new Error("WebSocket was closed before the connection was established"),
             );
+            clearTimeout(failureDeadline);
+            if (closeCount !== 1) {
+              throw new Error(\`Expected one timed-out connection, received \${closeCount}\`);
+            }
+            process.stdout.write("survived late WebSocket error");
           });
         }
       }
+
+      failureDeadline = setTimeout(() => {
+        throw new Error("Timed out waiting for PartySocket to close the connection");
+      }, 5_000);
 
       new PartySocket("ws://unreachable.test", [], {
         WebSocket: ConnectingWebSocket,
@@ -41,13 +51,6 @@ describe("PartySocket", () => {
         maxRetries: 0,
         minReconnectionDelay: 0,
       });
-
-      setTimeout(() => {
-        if (closeCount !== 1) {
-          throw new Error(\`Expected one timed-out connection, received \${closeCount}\`);
-        }
-        process.stdout.write("survived late WebSocket error");
-      }, 25);
     `;
 
     const result = await execFileAsync(

--- a/official-plugins/docs/vitest.config.ts
+++ b/official-plugins/docs/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineWorkspaceTestConfig({
   test: {
     silent: "passed-only",
     name: "bb-plugin-simple-notes",
+    // The full jsdom app suite runs alongside the other package tests in CI.
+    // Give CPU-heavy UI tests the same budget as the main app suite.
+    testTimeout: 15_000,
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules/**"],
   },

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -115,7 +115,7 @@ function spawnManagedProcess({ args, command, env = {}, label }) {
   };
 }
 
-function getFreePort() {
+function reserveFreePort() {
   return new Promise((resolvePromise, reject) => {
     const server = createServer();
     server.once("error", reject);
@@ -126,16 +126,36 @@ function getFreePort() {
         reject(new Error("Expected TCP server address with a port"));
         return;
       }
-      const { port } = address;
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolvePromise(port);
-      });
+      resolvePromise({ port: address.port, server });
     });
   });
+}
+
+async function getFreePorts(count) {
+  const reservations = [];
+  try {
+    // Keep every listener open until the whole set is allocated. Closing each
+    // one immediately lets the OS hand the same port to the next request.
+    for (let index = 0; index < count; index += 1) {
+      reservations.push(await reserveFreePort());
+    }
+    return reservations.map(({ port }) => port);
+  } finally {
+    await Promise.all(
+      reservations.map(
+        ({ server }) =>
+          new Promise((resolvePromise, reject) => {
+            server.close((error) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+              resolvePromise();
+            });
+          }),
+      ),
+    );
+  }
 }
 
 async function waitForHttp({ label, processRef, url }) {
@@ -565,8 +585,7 @@ async function smokeBuiltinPluginsRunning({ cliEnv, tarballPath }) {
 
 async function smokeFullStack(tarballPath, sdkDir) {
   const dataDir = join(tempRoot, "full-stack-data");
-  const serverPort = await getFreePort();
-  const daemonPort = await getFreePort();
+  const [serverPort, daemonPort] = await getFreePorts(2);
   const serverUrl = `http://127.0.0.1:${serverPort}`;
   const stack = spawnManagedProcess({
     args: createNpxArgs(tarballPath, "bb-app", [
@@ -632,10 +651,9 @@ async function smokeFullStack(tarballPath, sdkDir) {
 async function smokeDaemonJoin(tarballPath) {
   const serverDataDir = join(tempRoot, "join-server-data");
   const daemonDataDir = join(tempRoot, "join-daemon-data");
-  const serverPort = await getFreePort();
-  const daemonPort = await getFreePort();
+  const [serverPort, daemonPort, staleEnvPort] = await getFreePorts(3);
   const serverUrl = `http://127.0.0.1:${serverPort}`;
-  const staleEnvServerUrl = `http://127.0.0.1:${await getFreePort()}`;
+  const staleEnvServerUrl = `http://127.0.0.1:${staleEnvPort}`;
   const server = spawnManagedProcess({
     args: createNpxArgs(tarballPath, "bb-server", [
       "--data-dir",

--- a/packages/plugin-build/src/runtime-export-manifest.test.ts
+++ b/packages/plugin-build/src/runtime-export-manifest.test.ts
@@ -3,14 +3,17 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const GENERATOR_TIMEOUT_MS = 30_000;
 
 describe("runtime export manifest generator", () => {
-  it("runs when Node does not provide a global Navigator", async () => {
-    const scriptUrl = new URL(
-      "../scripts/generate-runtime-export-manifest.mjs",
-      import.meta.url,
-    ).href;
-    const source = `
+  it(
+    "runs when Node does not provide a global Navigator",
+    async () => {
+      const scriptUrl = new URL(
+        "../scripts/generate-runtime-export-manifest.mjs",
+        import.meta.url,
+      ).href;
+      const source = `
       delete globalThis.navigator;
       if (typeof globalThis.navigator !== "undefined") {
         throw new Error("test could not remove globalThis.navigator");
@@ -19,12 +22,14 @@ describe("runtime export manifest generator", () => {
       await import(${JSON.stringify(scriptUrl)});
     `;
 
-    const result = await execFileAsync(
-      process.execPath,
-      ["--input-type=module", "--eval", source],
-      { timeout: 30_000 },
-    );
+      const result = await execFileAsync(
+        process.execPath,
+        ["--input-type=module", "--eval", source],
+        { timeout: GENERATOR_TIMEOUT_MS },
+      );
 
-    expect(result.stdout).toContain("runtime-export-manifest.ts");
-  });
+      expect(result.stdout).toContain("runtime-export-manifest.ts");
+    },
+    GENERATOR_TIMEOUT_MS,
+  );
 });

--- a/plugins/connect/src/tunnel-lifecycle.test.ts
+++ b/plugins/connect/src/tunnel-lifecycle.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFakePluginHost } from "@bb/plugin-sdk/testing";
+import { ShareHostResolver } from "./hosts.js";
+import { ShareRegistry } from "./shares.js";
+
+interface FakeTunnelSocket {
+  emit(eventName: string, ...args: unknown[]): boolean;
+}
+
+const fakeWebSockets = vi.hoisted(() => ({
+  instances: [] as FakeTunnelSocket[],
+}));
+
+vi.mock("ws", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ws")>();
+  const { EventEmitter } = await import("node:events");
+
+  class FakeWebSocket extends EventEmitter {
+    readyState = 0;
+
+    constructor() {
+      super();
+      fakeWebSockets.instances.push(this);
+    }
+
+    terminate(): void {
+      this.readyState = 3;
+    }
+  }
+
+  return { ...actual, WebSocket: FakeWebSocket };
+});
+
+import { ConnectTunnel } from "./tunnel.js";
+
+function createTunnelFixture() {
+  const fakeHost = createFakePluginHost({
+    pluginId: "connect",
+    sdk: {
+      system: {
+        config: async () => ({ primaryHostId: "host-server" }) as never,
+      },
+    },
+  });
+  const pluginBb = fakeHost.bb;
+  const credential = {
+    serverUrl: "https://sawyer.getbb.app",
+    handle: "sawyer",
+    credential: "bbcred_x",
+  };
+  const clearCredential = vi.fn(async () => {});
+  const onStatusChange = vi.fn();
+  const shares = new ShareRegistry({
+    kv: {
+      get: async () => undefined,
+      set: async () => {},
+      delete: async () => {},
+    },
+    hosts: pluginBb.hosts,
+    hostResolver: new ShareHostResolver(() => pluginBb.sdk),
+    getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+    getCredential: () => credential,
+    log: pluginBb.log,
+  });
+  const tunnel = new ConnectTunnel({
+    store: {
+      read: async () => credential,
+      write: async () => {},
+      clear: clearCredential,
+    },
+    shares,
+    getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+    log: pluginBb.log,
+    onStatusChange,
+  });
+  return {
+    clearCredential,
+    credential,
+    fakeHost,
+    onStatusChange,
+    tunnel,
+  };
+}
+
+describe("ConnectTunnel socket lifecycle", () => {
+  afterEach(() => {
+    fakeWebSockets.instances.length = 0;
+  });
+
+  it("ignores events from a socket after the tunnel stops", async () => {
+    const { clearCredential, credential, fakeHost, onStatusChange, tunnel } =
+      createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      await vi.waitFor(() => {
+        expect(onStatusChange).toHaveBeenCalledTimes(2);
+      });
+      expect(fakeWebSockets.instances).toHaveLength(1);
+
+      tunnel.stop();
+      onStatusChange.mockClear();
+      const socket = fakeWebSockets.instances[0]!;
+      socket.emit("open");
+      socket.emit("unexpected-response", {}, { statusCode: 401 });
+      socket.emit("error", new Error("late socket error"));
+      socket.emit("close", 1006, Buffer.from("late close"));
+
+      expect(clearCredential).not.toHaveBeenCalled();
+      expect(onStatusChange).not.toHaveBeenCalled();
+      expect(tunnel.getCredential()).toEqual(credential);
+      expect(tunnel.status().lastError).toBeNull();
+    } finally {
+      tunnel.stop();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("does not let a replaced socket close the current session", async () => {
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      expect(fakeWebSockets.instances).toHaveLength(1);
+      const replacedSocket = fakeWebSockets.instances[0]!;
+
+      tunnel.stop();
+      await tunnel.start();
+      expect(fakeWebSockets.instances).toHaveLength(2);
+      const currentSocket = fakeWebSockets.instances[1]!;
+      currentSocket.emit("open");
+      expect(tunnel.status().state).toBe("connected");
+
+      replacedSocket.emit("close", 1006, Buffer.from("late close"));
+
+      expect(tunnel.status().state).toBe("connected");
+    } finally {
+      tunnel.stop();
+      await fakeHost.harness.dispose();
+    }
+  });
+});

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -433,6 +433,7 @@ export class ConnectTunnel {
     let connectedAt = 0;
 
     tunnel.on("open", () => {
+      if (this.stopped || this.tunnel !== tunnel) return;
       connectedAt = Date.now();
       this.connected = true;
       this.lastError = null;
@@ -454,6 +455,7 @@ export class ConnectTunnel {
       this.publish();
     });
     tunnel.on("unexpected-response", (_req, res) => {
+      if (this.stopped || this.tunnel !== tunnel) return;
       const statusCode = res.statusCode ?? 0;
       if (statusCode === 401 || statusCode === 403) {
         this.credentialRejected(statusCode);
@@ -463,6 +465,7 @@ export class ConnectTunnel {
       this.options.log.warn(this.lastError);
     });
     tunnel.on("error", (e: Error) => {
+      if (this.stopped || this.tunnel !== tunnel) return;
       // Humanize transport failures for the reconnecting card; the raw
       // message still rides the log via the close handler below.
       this.lastError = humanizeTransportError(
@@ -471,11 +474,11 @@ export class ConnectTunnel {
       );
     });
     tunnel.on("close", (code: number, reason: Buffer) => {
+      if (this.stopped || this.tunnel !== tunnel) return;
       this.connected = false;
       this.session?.dispose();
       this.session = undefined;
       this.remoteClients = 0;
-      if (this.stopped || this.tunnel !== tunnel) return;
       const stable = connectedAt ? Date.now() - connectedAt : 0;
       const delay = this.backoff.nextDelayAfterClose(stable);
       // A clean close with no prior socket error still leaves the card empty;


### PR DESCRIPTION
## Summary

- raise the Docs jsdom suite timeout from the Vitest default to 15 seconds
- ignore late events from stopped or replaced Connect WebSockets before they mutate state or publish through a disposed plugin host
- make the PartySocket late-error test complete from the event under test instead of a fixed 25 ms timer
- reserve package-smoke ports as a set so server, daemon, and stale-env ports cannot collide
- align the runtime export manifest Vitest timeout with its 30-second child-process timeout
- retry dependency installation up to three times for transient registry and Electron download failures

## Seven-day CI audit

I inspected 451 CI workflow runs created since July 29, downloaded and classified all 61 concluded-failure logs, inspected every rerun attempt, and statically reviewed test timers, subprocess timeouts, listener ports, and async cleanup paths.

Five genuine fail-then-pass reruns reduced to four mechanisms:

- Connect stale WebSocket callbacks: [run 30500141108](https://github.com/get-bb/bb/actions/runs/30500141108) and [run 30957459063](https://github.com/get-bb/bb/actions/runs/30957459063)
- PartySocket fixed-timer assertion: [run 30856640681](https://github.com/get-bb/bb/actions/runs/30856640681)
- package-smoke port collision: [run 30864816916](https://github.com/get-bb/bb/actions/runs/30864816916)
- Docs test crossing the 5-second default: [run 31026715226](https://github.com/get-bb/bb/actions/runs/31026715226)

The only concluded failure on `main` in the window was an Electron postinstall `ECONNRESET`, now covered by the bounded install retry: [run 30416020989](https://github.com/get-bb/bb/actions/runs/30416020989).

The other concluded failures were deterministic branch failures such as lint/type errors, stale generated output, missing migrations, and assertion changes. The 70 cancellations match the workflow concurrency policy. The static sweep found no tests binding hard-coded listener ports; most short timers are polling intervals, deliberate negative windows, or simulated child behavior. One successful runtime-manifest test reached 4.76 seconds against a 5-second Vitest limit, so its test budget now matches its existing child timeout.

## Verification

- `pnpm exec turbo run test typecheck --filter=bb-plugin-connect --force` (67 tests)
- `pnpm exec turbo run test typecheck --filter=@bb/host-daemon --force` (470 tests)
- PartySocket regression repeated 10 times through Turbo (10/10)
- `pnpm exec turbo run test typecheck --filter=@bb/plugin-build --force`
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force`
- Docs tests and typecheck through Turbo
- Prettier check, YAML parse, and `git diff --check`

The first CI pass for this PR was green on every required job, including package smoke on Ubuntu and macOS. The audit commit triggers the same full matrix again.