### PR TITLE
Refresh pull request status when turns complete

### DIFF
--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -264,6 +264,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
       dirtyThreadListQueriesForBackgroundActivity, // Sidebar rows render active workflow/background task state.
       dirtyThreadSearchQueries, // Indexed conversation content may now match a search query.
       dirtyThreadTimelineQueries, // Timeline rows are built from appended events.
+      dirtyThreadPullRequestQueryForCompletedTurn, // A turn may create a remote PR without changing the workspace.
       dirtyThreadPromptHistoryQueriesForTurnRequests, // Follow-up recall is built from client turn requests.
     ],
   },
@@ -685,6 +686,22 @@ function dirtyThreadPromptHistoryQueriesForTurnRequests({
     return [];
   }
   return getThreadPromptHistoryInvalidationQueryKeys({ threadId });
+}
+
+function dirtyThreadPullRequestQueryForCompletedTurn({
+  eventTypes,
+  queryClient,
+  threadId,
+}: ThreadRealtimeDirtyContext): QueryKey[] {
+  if (!threadId || !eventTypes?.includes("turn/completed")) {
+    return [];
+  }
+  const environmentId = queryClient.getQueryData<ThreadWithRuntime>(
+    threadQueryKey(threadId),
+  )?.environmentId;
+  return environmentId
+    ? [environmentPullRequestQueryKey(environmentId)]
+    : [];
 }
 
 function dirtyThreadPendingInteractionQueries({

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -49,6 +49,7 @@ import {
   getCachedProjectThreadListInvalidationQueryKeys,
   getCachedRootOrderThreadListInvalidationQueryKeys,
   getCachedSidebarNavigationThreads,
+  getCachedThreadListPlaceholder,
   getEnvironmentBranchListInvalidationQueryKeys,
   getEnvironmentRecordInvalidationQueryKeys,
   getEnvironmentWorkspaceStateInvalidationQueryKeys,
@@ -696,12 +697,14 @@ function dirtyThreadPullRequestQueryForCompletedTurn({
   if (!threadId || !eventTypes?.includes("turn/completed")) {
     return [];
   }
-  const environmentId = queryClient.getQueryData<ThreadWithRuntime>(
-    threadQueryKey(threadId),
-  )?.environmentId;
-  return environmentId
-    ? [environmentPullRequestQueryKey(environmentId)]
-    : [];
+  const cachedThread =
+    queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId)) ??
+    getCachedThreadListPlaceholder(queryClient, threadId) ??
+    getCachedSidebarNavigationThreads(queryClient).find(
+      (thread) => thread.id === threadId,
+    );
+  const environmentId = cachedThread?.environmentId;
+  return environmentId ? [environmentPullRequestQueryKey(environmentId)] : [];
 }
 
 function dirtyThreadPendingInteractionQueries({

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -413,42 +413,56 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("refetches the active environment pull request when a turn completes", async () => {
-    vi.useFakeTimers();
-    const { effects, queryClient } = createRealtimeEffectsTestContext();
-    const pullRequestKey = environmentPullRequestQueryKey("env-1");
-    const nextPullRequest = {
-      outcome: "available",
-      pullRequest: { number: 42 },
-    };
-    const pullRequestQueryFn = vi.fn(async () => nextPullRequest);
-    queryClient.setQueryData(threadQueryKey("thr_1"), {
-      environmentId: "env-1",
-      id: "thr_1",
-    });
-    queryClient.setQueryData(pullRequestKey, { outcome: "absent" });
-    const pullRequestObserver = new QueryObserver(queryClient, {
-      queryFn: pullRequestQueryFn,
-      queryKey: pullRequestKey,
-      staleTime: Infinity,
-    });
-    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+  it.each(["thread detail", "sidebar navigation"] as const)(
+    "refetches the active environment pull request from %s when a turn completes",
+    async (cacheSource) => {
+      vi.useFakeTimers();
+      const { effects, queryClient } = createRealtimeEffectsTestContext();
+      const pullRequestKey = environmentPullRequestQueryKey("env-1");
+      const nextPullRequest = {
+        outcome: "available",
+        pullRequest: { number: 42 },
+      };
+      const pullRequestQueryFn = vi.fn(async () => nextPullRequest);
+      if (cacheSource === "thread detail") {
+        queryClient.setQueryData(threadQueryKey("thr_1"), {
+          environmentId: "env-1",
+          id: "thr_1",
+        });
+      } else {
+        queryClient.setQueryData(sidebarNavigationQueryKey(), {
+          personalProject: { threads: [] },
+          projects: [
+            {
+              threads: [{ environmentId: "env-1", id: "thr_1" }],
+            },
+          ],
+        });
+      }
+      queryClient.setQueryData(pullRequestKey, { outcome: "absent" });
+      const pullRequestObserver = new QueryObserver(queryClient, {
+        queryFn: pullRequestQueryFn,
+        queryKey: pullRequestKey,
+        staleTime: Infinity,
+      });
+      const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
 
-    effects.handleChanged({
-      type: "changed",
-      entity: "thread",
-      id: "thr_1",
-      metadata: { eventTypes: ["turn/completed"] },
-      changes: ["events-appended"],
-    });
-    await vi.advanceTimersByTimeAsync(50);
+      effects.handleChanged({
+        type: "changed",
+        entity: "thread",
+        id: "thr_1",
+        metadata: { eventTypes: ["turn/completed"] },
+        changes: ["events-appended"],
+      });
+      await vi.advanceTimersByTimeAsync(50);
 
-    expect(pullRequestQueryFn).toHaveBeenCalledTimes(1);
-    expect(queryClient.getQueryData(pullRequestKey)).toEqual(nextPullRequest);
+      expect(pullRequestQueryFn).toHaveBeenCalledTimes(1);
+      expect(queryClient.getQueryData(pullRequestKey)).toEqual(nextPullRequest);
 
-    unsubscribePullRequest();
-    effects.dispose();
-  });
+      unsubscribePullRequest();
+      effects.dispose();
+    },
+  );
 
   it("invalidates cached thread search results when environment metadata changes", () => {
     vi.useFakeTimers();

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -12,6 +12,7 @@ import {
   archivedThreadsListQueryKey,
   environmentDiffFilesQueryKey,
   environmentDiffPatchQueryKey,
+  environmentPullRequestQueryKey,
   environmentWorkStatusQueryKey,
   hostPathExistenceQueryKey,
   projectPathsQueryKey,
@@ -409,6 +410,43 @@ describe("createRealtimeCacheEffects", () => {
       true,
     );
 
+    effects.dispose();
+  });
+
+  it("refetches the active environment pull request when a turn completes", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
+    const nextPullRequest = {
+      outcome: "available",
+      pullRequest: { number: 42 },
+    };
+    const pullRequestQueryFn = vi.fn(async () => nextPullRequest);
+    queryClient.setQueryData(threadQueryKey("thr_1"), {
+      environmentId: "env-1",
+      id: "thr_1",
+    });
+    queryClient.setQueryData(pullRequestKey, { outcome: "absent" });
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryFn: pullRequestQueryFn,
+      queryKey: pullRequestKey,
+      staleTime: Infinity,
+    });
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { eventTypes: ["turn/completed"] },
+      changes: ["events-appended"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(pullRequestQueryFn).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(pullRequestKey)).toEqual(nextPullRequest);
+
+    unsubscribePullRequest();
     effects.dispose();
   });
 


### PR DESCRIPTION
## Summary

- invalidate the active environment pull request query when a thread turn completes
- catch PRs created remotely by an agent even when no local workspace change follows `gh pr create`
- add a regression test covering an actively observed PR query changing from absent to available without navigation

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force` (312 files, 2,346 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`