### PR TITLE
Stabilize structured workflow harness test

### DIFF
--- a/plugins/workflows/src/server-harness.test.ts
+++ b/plugins/workflows/src/server-harness.test.ts
@@ -20,6 +20,8 @@ async function eventually(
   }
 }
 
+const STRUCTURED_WORKFLOW_TEST_TIMEOUT_MS = 30_000;
+
 async function workflowStatus(
   harness: ReturnType<typeof createFakePluginHost>["harness"],
   runId: string,
@@ -712,7 +714,7 @@ describe("workflows plugin", () => {
 
     worker.controller.abort();
     await worker.done;
-  });
+  }, STRUCTURED_WORKFLOW_TEST_TIMEOUT_MS);
 
   it("rejects cyclic and unsafe host values before persistence", async () => {
     const { bb, harness } = createFakePluginHost({ pluginId: "workflows" });


### PR DESCRIPTION
## Summary

- give the structured workflow harness test a test-local 30-second timeout
- keep the 15-second default timeout for the rest of the workflows suite

## Why

The packages check on #1027 timed this test out after 15.815 seconds. The same test took 8.065 seconds and 10.852 seconds in the two preceding successful runs, while it takes about 0.9 seconds locally. The test runs several complete workflow lifecycles and validates multi-megabyte payloads, so its runtime is unusually sensitive to shared-runner contention.

## Testing

- pnpm exec turbo run test --filter=bb-plugin-workflows --force (5 consecutive runs)
- pnpm exec turbo run typecheck --filter=bb-plugin-workflows