### PR TITLE
Accept null for optional ACP model and config-option strings

### DIFF
--- a/packages/agent-runtime/src/acp/wire.test.ts
+++ b/packages/agent-runtime/src/acp/wire.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { acpSessionNewResultSchema } from "./wire.js";
+
+describe("acpSessionNewResultSchema", () => {
+  // pi-acp serializes absent optional strings as explicit `null` instead of
+  // omitting them. Before this was accepted, every pi-acp thread failed to
+  // start with "ACP agent returned an unexpected session/new result".
+  it("accepts explicit null for optional model and config-option strings", () => {
+    const parsed = acpSessionNewResultSchema.safeParse({
+      sessionId: "session-1",
+      models: {
+        currentModelId: "openai-codex/gpt-5.5",
+        availableModels: [
+          {
+            modelId: "openai-codex/gpt-5.5",
+            name: "openai-codex/GPT-5.5",
+            description: null,
+          },
+        ],
+      },
+      configOptions: [
+        {
+          type: "select",
+          id: "model",
+          category: "model",
+          name: "Model",
+          description: "Select the model for this session",
+          currentValue: "openai-codex/gpt-5.5",
+          options: [
+            {
+              value: "openai-codex/gpt-5.5",
+              name: "openai-codex/GPT-5.5",
+              description: null,
+            },
+          ],
+        },
+        {
+          type: "select",
+          id: "thought_level",
+          category: null,
+          name: "Thinking",
+          currentValue: "medium",
+          options: [{ value: "medium", name: null }],
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    expect(parsed.data.models?.availableModels?.[0].description).toBeUndefined();
+    expect(parsed.data.configOptions?.[0].options?.[0].name).toBe(
+      "openai-codex/GPT-5.5",
+    );
+    expect(parsed.data.configOptions?.[1].category).toBeUndefined();
+    expect(parsed.data.configOptions?.[1].options?.[0].name).toBeUndefined();
+  });
+});

--- a/packages/agent-runtime/src/acp/wire.ts
+++ b/packages/agent-runtime/src/acp/wire.ts
@@ -205,10 +205,21 @@ export const acpInitializeResultSchema = z
   .passthrough();
 export type AcpInitializeResult = z.infer<typeof acpInitializeResultSchema>;
 
+/**
+ * Some ACP agents serialize an absent optional string as an explicit `null`
+ * instead of omitting the key — pi-acp does this for every model and
+ * config-option `description`. Accept both forms and normalize to `undefined`
+ * so downstream code sees a single shape.
+ */
+const acpOptionalString = z
+  .union([z.string(), z.null()])
+  .transform((value) => value ?? undefined)
+  .optional();
+
 export const acpConfigOptionSelectOptionSchema = z
   .object({
     value: z.string(),
-    name: z.string().optional(),
+    name: acpOptionalString,
   })
   .passthrough();
 export type AcpConfigOptionSelectOption = z.infer<
@@ -218,10 +229,10 @@ export type AcpConfigOptionSelectOption = z.infer<
 export const acpConfigOptionSchema = z
   .object({
     id: z.string(),
-    name: z.string().optional(),
-    category: z.string().optional(),
+    name: acpOptionalString,
+    category: acpOptionalString,
     type: z.string(),
-    currentValue: z.string().optional(),
+    currentValue: acpOptionalString,
     options: z.array(acpConfigOptionSelectOptionSchema).optional(),
   })
   .passthrough();
@@ -230,15 +241,15 @@ export type AcpConfigOption = z.infer<typeof acpConfigOptionSchema>;
 export const acpSessionModelSchema = z
   .object({
     modelId: z.string(),
-    name: z.string().optional(),
-    description: z.string().optional(),
+    name: acpOptionalString,
+    description: acpOptionalString,
   })
   .passthrough();
 export type AcpSessionModel = z.infer<typeof acpSessionModelSchema>;
 
 export const acpSessionModelsSchema = z
   .object({
-    currentModelId: z.string().optional(),
+    currentModelId: acpOptionalString,
     availableModels: z.array(acpSessionModelSchema).optional(),
   })
   .passthrough();
@@ -248,7 +259,7 @@ const acpLooseConfigOptionSchema = z
   .object({
     id: z.string().optional(),
     name: z.unknown().optional(),
-    category: z.string().optional(),
+    category: acpOptionalString,
     type: z.unknown().optional(),
     currentValue: z.unknown().optional(),
     options: z.unknown().optional(),


### PR DESCRIPTION
## Problem

Threads on a custom ACP provider backed by `pi-acp` never started. Every `thread.start` failed:

```
ACP agent returned an unexpected session/new result:
  path: ["models","availableModels",0,"description"]
  "Invalid input: expected string, received null"      (x7 models)
```

`pi-acp` serializes an absent optional string as an explicit `null` instead of omitting the key. Its `session/new` result looks like this:

```json
{
  "models": {
    "currentModelId": "openai-codex/gpt-5.5",
    "availableModels": [
      { "modelId": "openai-codex/gpt-5.5", "name": "openai-codex/GPT-5.5", "description": null }
    ]
  }
}
```

Our schema accepted only a string or an omitted key. The same `null` appears in the `model` and `thought_level` config options, so model discovery failed too and fell back to the single `acp-default` entry. The picker looked empty.

## Fix

Add an `acpOptionalString` helper that accepts `null` and normalizes it to `undefined`. Apply it to `name`, `description`, `category`, `currentValue`, and `currentModelId` in the model and config-option schemas. Downstream code still sees `string | undefined`, so no call sites change.

The file already used `.nullable().optional()` for `oldText` and `line`, so this follows the existing convention.

## Protocol version

No `HOST_DAEMON_PROTOCOL_VERSION` bump. This only changes how the daemon parses traffic from the ACP agent. The server/daemon wire shape is unchanged.

## Testing

New `packages/agent-runtime/src/acp/wire.test.ts` covers the real pi-acp payload shape. Typecheck passes and all 119 ACP tests pass.

Verified end to end on a dev instance with a real `pi-acp` provider:

| Check | Before | After |
| --- | --- | --- |
| `bb provider models acp-pi-acp` | only the `acp-default` fallback | all 7 models, `gpt-5.5` default |
| Thread spawn | failed on `session/new` | `turn/completed`, message streamed |
| `unexpected session/new` in daemon log | 7 errors per start | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)