### PR TITLE
Make sandbox network permission prompts grantable

### DIFF
--- a/apps/server/src/services/interactions/pending-interaction-validation.ts
+++ b/apps/server/src/services/interactions/pending-interaction-validation.ts
@@ -204,7 +204,14 @@ function validateGrantedPermissions(
     );
   }
 
-  if (!hasGrantedPermissions(permissions)) {
+  // An empty grant is only wrong when the request had something to grant.
+  // A provider can ask about an action it cannot describe as a permission, and
+  // that prompt still reaches the user. Rejecting the empty grant there would
+  // leave the prompt unanswerable, so the approval stands on its own.
+  if (
+    !hasGrantedPermissions(permissions) &&
+    hasGrantedPermissions(requestedPermissions)
+  ) {
     throw new ApiError(
       400,
       "invalid_request",

--- a/apps/server/test/services/pending-interactions.test.ts
+++ b/apps/server/test/services/pending-interactions.test.ts
@@ -978,6 +978,70 @@ describe("pending interaction lifecycle", () => {
     });
   });
 
+  it("allows a permission grant whose request has nothing to grant", async () => {
+    // A provider can ask about an action it cannot describe as a permission.
+    // The prompt still reaches the user, so the user must still be able to
+    // answer it. Rejecting the empty grant here wedged the thread (#1041).
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-pending-interaction-no-grantable",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+      });
+
+      const created = registerPendingInteraction(
+        harness.deps,
+        harness.deps.pendingInteractions,
+        {
+          threadId: thread.id,
+          turnId: "turn-no-grantable",
+          providerId: "codex",
+          providerThreadId: "provider-thread-no-grantable",
+          providerRequestId: "request-no-grantable",
+          payload: createPermissionGrantApprovalPayload({
+            itemId: "item-no-grantable",
+            reason: "Needs approval",
+            toolName: "SomeOpaqueTool",
+            permissions: {
+              network: null,
+              fileSystem: null,
+            },
+          }),
+        },
+      );
+      if (created.outcome === "rejected") {
+        throw new Error(
+          `Expected interaction registration to succeed: ${created.reason}`,
+        );
+      }
+
+      harness.deps.pendingInteractions.resolvePendingInteraction({
+        threadId: thread.id,
+        interactionId: created.interaction.id,
+        resolution: createAllowOnceResolution({
+          network: null,
+          fileSystem: null,
+        }),
+      });
+
+      expect(
+        harness.deps.pendingInteractions.getThreadInteraction({
+          threadId: thread.id,
+          interactionId: created.interaction.id,
+        }).status,
+      ).not.toBe("pending");
+    });
+  });
+
   it("allows command approvals to grant explicit session permissions for session decisions", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1376,6 +1376,83 @@ describe("bridge", () => {
     }
   });
 
+  it("forwards a sandbox network ask with a grantable network permission", async () => {
+    // Claude suggests a "localSettings" rule for this prompt, not a "session"
+    // one. bb used to drop that suggestion, so the prompt reached the user with
+    // nothing to grant and the server rejected every allow. See issue #1041.
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-sandbox-network";
+      const toolUseID = "tool-sandbox-network";
+      await startBridgeThread({ bridge, threadId });
+
+      const resultPromise = getLastCanUseTool()(
+        "SandboxNetworkAccess",
+        { host: "registry.npmjs.org" },
+        {
+          description: "Allow network connection to registry.npmjs.org?",
+          signal: new AbortController().signal,
+          suggestions: [
+            {
+              type: "addRules",
+              rules: [
+                {
+                  toolName: "WebFetch",
+                  ruleContent: "domain:registry.npmjs.org",
+                },
+              ],
+              behavior: "allow",
+              destination: "localSettings",
+            },
+          ],
+          toolUseID,
+        },
+      );
+      await bridge.flushWork();
+
+      const permissionRequest = bridge.messages.find(
+        (message) =>
+          message.method === CLAUDE_PERMISSION_REQUEST_APPROVAL_METHOD,
+      );
+      if (permissionRequest?.id === undefined) {
+        throw new Error("Expected forwarded permission request");
+      }
+      expect(permissionRequest.params).toMatchObject({
+        itemId: toolUseID,
+        toolName: "SandboxNetworkAccess",
+        reason: "Allow network connection to registry.npmjs.org?",
+        permissions: { network: { enabled: true } },
+      });
+
+      handleLine(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: permissionRequest.id,
+          result: {
+            kind: "permission_request",
+            behavior: "allow",
+            decisionClassification: "user_temporary",
+          },
+        }),
+      );
+      await expect(resultPromise).resolves.toMatchObject({
+        behavior: "allow",
+        toolUseID,
+      });
+
+      await stopBridgeThread({ bridge, queries, threadId });
+    } finally {
+      bridge.restore();
+    }
+  });
+
   it("forwards AskUserQuestion through canUseTool and returns the answer payload", async () => {
     const bridge = createBridgeJsonRpcTestHarness(handleLine);
     const queries: ControlledClaudeQuery[] = [];

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -852,7 +852,7 @@ async function prepareSessionEnv(
   };
 }
 
-function parseClaudePermissionUpdates(
+function parseClaudeSuggestedPermissionUpdates(
   value: unknown,
 ): ClaudeSuggestedPermissionUpdate[] | undefined {
   if (!Array.isArray(value)) {
@@ -1105,7 +1105,9 @@ function createCanUseTool(threadIdRef: ThreadIdRef): CanUseTool {
       });
     }
 
-    const suggestions = parseClaudePermissionUpdates(options.suggestions);
+    const suggestions = parseClaudeSuggestedPermissionUpdates(
+      options.suggestions,
+    );
 
     const requestContext: ClaudeCanUseToolDecisionContext = {
       toolName,

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -73,14 +73,14 @@ import {
   type ClaudeInteractiveResponse,
   type ClaudePermissionMode,
   type ClaudePermissionRequestApprovalParams,
-  type ClaudePermissionUpdate,
+  type ClaudeSuggestedPermissionUpdate,
   type ClaudeUserQuestionInput,
   type ClaudeUserQuestionRequestParams,
   CLAUDE_PERMISSION_REQUEST_APPROVAL_METHOD,
   CLAUDE_USER_QUESTION_REQUEST_METHOD,
   CLAUDE_USER_QUESTION_TOOL_NAME,
   claudeInteractiveResponseSchema,
-  claudePermissionUpdateSchema,
+  claudeSuggestedPermissionUpdateSchema,
   claudeUserQuestionInputSchema,
   shouldRequestClaudePermissionApproval,
   toPendingInteractionPermissionProfile,
@@ -262,7 +262,7 @@ interface ClaudeCodeThreadStopResult {
 interface ClaudeCanUseToolDecisionContext {
   blockedPath: string | undefined;
   decisionReason: string | undefined;
-  suggestions: ClaudePermissionUpdate[] | undefined;
+  suggestions: ClaudeSuggestedPermissionUpdate[] | undefined;
   toolName: string;
 }
 
@@ -273,8 +273,9 @@ interface BuildInteractiveRequestParamsArgs {
   toolUseId: string;
   input: Record<string, unknown>;
   decisionReason: string | undefined;
+  promptText: string | undefined;
   blockedPath: string | undefined;
-  suggestions: ClaudePermissionUpdate[] | undefined;
+  suggestions: ClaudeSuggestedPermissionUpdate[] | undefined;
 }
 
 interface ForwardInteractiveRequestArgs extends BuildInteractiveRequestParamsArgs {
@@ -853,13 +854,13 @@ async function prepareSessionEnv(
 
 function parseClaudePermissionUpdates(
   value: unknown,
-): ClaudePermissionUpdate[] | undefined {
+): ClaudeSuggestedPermissionUpdate[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
 
   const parsedUpdates = value.flatMap((entry) => {
-    const parsed = claudePermissionUpdateSchema.safeParse(entry);
+    const parsed = claudeSuggestedPermissionUpdateSchema.safeParse(entry);
     return parsed.success ? [parsed.data] : [];
   });
 
@@ -876,7 +877,11 @@ function buildInteractiveRequestParams(
     itemId: args.toolUseId,
     toolName: args.toolName,
     input: args.input,
-    reason: args.decisionReason ?? null,
+    // Claude explains some prompts through decisionReason and others only
+    // through the prompt sentence it would have rendered itself. The sandbox
+    // network prompt uses the second: without it the banner names the tool but
+    // never the host, and the user cannot judge what they are granting.
+    reason: args.decisionReason ?? args.promptText ?? null,
     permissions: toPendingInteractionPermissionProfile({
       toolName: args.toolName,
       blockedPath: args.blockedPath,
@@ -1186,6 +1191,7 @@ function createCanUseTool(threadIdRef: ThreadIdRef): CanUseTool {
       toolUseId: options.toolUseID,
       input,
       decisionReason: options.decisionReason,
+      promptText: options.title ?? options.description,
       blockedPath: options.blockedPath,
       suggestions,
       signal: options.signal,

--- a/packages/agent-runtime/src/claude-code/interactive-contract.ts
+++ b/packages/agent-runtime/src/claude-code/interactive-contract.ts
@@ -42,6 +42,8 @@ const claudePermissionRuleValueSchema = z.object({
   ruleContent: z.string().optional(),
 });
 
+// Updates bb sends back to Claude. bb never writes a user's settings files, so
+// an outgoing update is always scoped to the session.
 export const claudePermissionUpdateSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("addRules"),
@@ -57,6 +59,40 @@ export const claudePermissionUpdateSchema = z.discriminatedUnion("type", [
 ]);
 export type ClaudePermissionUpdate = z.infer<
   typeof claudePermissionUpdateSchema
+>;
+
+// Suggestions Claude sends to bb. Claude picks the destination it would use for
+// its own prompt, and that is frequently not "session": the sandbox network
+// prompt suggests a "localSettings" rule. The destination describes where Claude
+// would persist the grant, not what the grant covers, so bb accepts every
+// destination here and re-scopes its answer to the session above. Dropping a
+// suggestion costs the prompt its grant and leaves the user unable to allow it.
+const claudePermissionUpdateDestinationSchema = z.enum([
+  "userSettings",
+  "projectSettings",
+  "localSettings",
+  "session",
+  "cliArg",
+]);
+
+export const claudeSuggestedPermissionUpdateSchema = z.discriminatedUnion(
+  "type",
+  [
+    z.object({
+      type: z.literal("addRules"),
+      rules: z.array(claudePermissionRuleValueSchema).min(1),
+      behavior: z.literal("allow"),
+      destination: claudePermissionUpdateDestinationSchema,
+    }),
+    z.object({
+      type: z.literal("addDirectories"),
+      directories: z.array(z.string()).min(1),
+      destination: claudePermissionUpdateDestinationSchema,
+    }),
+  ],
+);
+export type ClaudeSuggestedPermissionUpdate = z.infer<
+  typeof claudeSuggestedPermissionUpdateSchema
 >;
 
 const claudeNetworkPermissionsInputSchema = z.object({
@@ -81,7 +117,7 @@ const claudeRequestedPermissionProfileInputSchema = z
   );
 interface ClaudePermissionRequestProfileArgs {
   blockedPath: string | undefined;
-  suggestions: ClaudePermissionUpdate[] | undefined;
+  suggestions: ClaudeSuggestedPermissionUpdate[] | undefined;
   toolName: string;
 }
 
@@ -102,7 +138,16 @@ const CLAUDE_FILE_PERMISSION_KIND_BY_TOOL_NAME = new Map<
   ["Bash", "read_write"],
 ]);
 
-const CLAUDE_NETWORK_PERMISSION_TOOL_NAMES = new Set(["WebFetch", "WebSearch"]);
+// Claude asks with this pseudo tool when a sandboxed command opens an outbound
+// connection. It carries no file path, so the tool name is the only signal that
+// the prompt grants network access.
+export const CLAUDE_SANDBOX_NETWORK_TOOL_NAME = "SandboxNetworkAccess";
+
+const CLAUDE_NETWORK_PERMISSION_TOOL_NAMES = new Set([
+  "WebFetch",
+  "WebSearch",
+  CLAUDE_SANDBOX_NETWORK_TOOL_NAME,
+]);
 
 function getClaudeFilePermissionKind(
   toolName: string,
@@ -115,7 +160,7 @@ export function isClaudeConcreteFileChangeToolName(toolName: string): boolean {
 }
 
 function getSuggestedDirectories(
-  suggestions: ClaudePermissionUpdate[] | undefined,
+  suggestions: ClaudeSuggestedPermissionUpdate[] | undefined,
 ): string[] {
   return (suggestions ?? []).flatMap((suggestion) =>
     suggestion.type === "addDirectories" ? suggestion.directories : [],
@@ -173,7 +218,7 @@ export function toPendingInteractionPermissionProfile(
 interface ShouldRequestClaudePermissionApprovalArgs {
   blockedPath: string | undefined;
   decisionReason: string | undefined;
-  suggestions: ClaudePermissionUpdate[] | undefined;
+  suggestions: ClaudeSuggestedPermissionUpdate[] | undefined;
   toolName: string;
 }
 

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 74 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 75 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1036,13 +1036,13 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 74 prefixes the provider onto every Pi model id, so an aggregator
-  // model reads `openrouter/deepseek/deepseek-v4-flash` rather than
-  // `deepseek/deepseek-v4-flash`. A daemon on 73 answers `model.list` with the
-  // old unprefixed ids, which the server resolves to a different provider, so
-  // the bump forces an update before the server trusts either side.
-  it("uses protocol version 74 for provider-prefixed Pi model ids", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(74);
+  // Version 75 makes Claude's sandbox network prompt grantable. A daemon on 74
+  // drops the "localSettings" suggestion that carries the grant, so it sends a
+  // permission_grant subject with an empty profile and the user cannot allow
+  // the prompt. The fix lives in the daemon's Claude bridge, so the bump is
+  // what moves an enrolled machine onto it.
+  it("uses protocol version 75 for grantable sandbox network prompts", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(75);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
Fixes #1041.

## The problem

A first-run user could not get past a permission prompt. Allow and Deny both left the prompt on screen.

Claude asks with a `SandboxNetworkAccess` pseudo tool when a sandboxed command opens an outbound connection. It attaches exactly one suggestion:

```js
{ type: "addRules",
  rules: [{ toolName: "WebFetch", ruleContent: `domain:${host}` }],
  behavior: "allow",
  destination: "localSettings" }
```

bb's suggestion schema accepted only `destination: "session"`, so `parseClaudePermissionUpdates` dropped it. The prompt still opened, because the bridge falls back to the raw suggestion count, but it carried an empty permission profile. The client then sent an empty grant, and the server rejected it:

> Allowed permission resolutions must grant at least one permission

So Allow could never resolve the prompt. Deny did resolve it, but Claude asked again on the next connection, so it looked equally stuck.

## The fix

- **Accept every suggestion destination on the way in.** The destination says where Claude would persist the grant, not what the grant covers. A separate schema keeps bb's own answers scoped to `session`, so bb still never writes a user's settings files.
- **Treat `SandboxNetworkAccess` as a network tool.** The prompt stays grantable from the tool name alone if the suggestion shape changes again.
- **Carry Claude's prompt sentence into the banner title.** The banner named the tool but never the host. Nobody can judge a network grant without it.
- **Accept an empty grant when the request has nothing to grant.** A prompt that reaches the user must always be answerable. The rule still rejects an empty grant when the request did offer something.

The prompt now reads `Allow network connection to registry.npmjs.org?`, lists `Permission: Network access`, and offers Allow once / Allow for session / Deny.

## Protocol version

`HOST_DAEMON_PROTOCOL_VERSION` goes to 75. The bridge runs in the host daemon, so enrolled machines need the update to get the fix. Both mixed pairings stay compatible: an old daemon sends the empty profile that the new server now accepts, and a new daemon sends a network profile that an old server already understands.

## Tests

- `bridge.test.ts` — a sandbox network ask with a `localSettings` suggestion now forwards a grantable network permission and the host-bearing reason.
- `pending-interactions.test.ts` — an allow with an empty grant resolves a request that had nothing to grant. The existing rejection test still covers the case where the request did offer a permission.

`internal-skill-trees.test.ts` fails on this branch and on a clean `main` alike; it is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)