### PR TITLE
Add Disable and Uninstall to plugin sidebar row menus

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -6,10 +6,15 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createStore, Provider } from "jotai";
-import { MemoryRouter } from "react-router-dom";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SidebarProvider } from "@/components/ui/sidebar.js";
+import { createTestQueryClient } from "@/test/queryClientTestHarness";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { listPanes } from "@/lib/split-layout";
+import type { SplitLayout } from "@/lib/split-layout";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -50,10 +55,100 @@ function registerPanel(pluginId: string, title: string) {
   );
 }
 
+function responseJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** An installed-plugin row as GET /api/v1/plugins reports it. */
+function installedPlugin(overrides: Record<string, unknown>) {
+  return {
+    id: "docs",
+    source: "builtin:docs",
+    rootDir: "/plugins/docs",
+    version: "0.1.0",
+    enabled: true,
+    status: "running",
+    statusDetail: null,
+    description: "Create and edit Markdown documents.",
+    name: "Docs",
+    icon: "FileText",
+    iconUrl: null,
+    logoUrl: null,
+    logoDarkUrl: null,
+    hasSettings: false,
+    provenance: "builtin",
+    isOrphanedBuiltin: false,
+    sourceDisplay: "builtin · docs",
+    updateState: {},
+    handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
+    services: [],
+    schedules: [],
+    cliCommand: null,
+    capabilities: [],
+    app: { hasApp: true, bundle: null },
+    ...overrides,
+  };
+}
+
+const DOCS_PLUGIN = installedPlugin({});
+// A catalog install is the removable case: bb owns the downloaded files.
+const GITHUB_PLUGIN = installedPlugin({
+  id: "github",
+  name: "GitHub",
+  source: "github-release:bb/github@^0.1.0",
+  rootDir: "/official-plugins/github",
+  provenance: "catalog",
+  sourceDisplay: "BB Official · GitHub",
+});
+
+function installFetch(plugins: readonly unknown[] = [DOCS_PLUGIN]) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const rawUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const url = new URL(rawUrl, "http://localhost");
+    if (url.pathname === "/api/v1/plugins") return responseJson({ plugins });
+    if (/^\/api\/v1\/plugins\/[^/]+\/(enable|disable)$/.test(url.pathname)) {
+      return responseJson({ ok: true, plugin: plugins[0] });
+    }
+    if (/^\/api\/v1\/plugins\/[^/]+$/.test(url.pathname)) {
+      return responseJson({ ok: true });
+    }
+    return responseJson({ error: "not found" }, 404);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function requestedPaths(fetchMock: ReturnType<typeof installFetch>): string[] {
+  return fetchMock.mock.calls.map((call) => {
+    const [input] = call;
+    const rawUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    return new URL(rawUrl, "http://localhost").pathname;
+  });
+}
+
+function LocationPath() {
+  return <span data-testid="location-path">{useLocation().pathname}</span>;
+}
+
 function renderSidebarItems(
   options: {
     toolsRoutePath?: string;
     storedOrder?: string[];
+    initialPath?: string;
+    splitLayout?: SplitLayout;
   } = {},
 ) {
   const store = createStore();
@@ -62,15 +157,38 @@ function renderSidebarItems(
   if (options.storedOrder) {
     store.set(pluginNavPanelOrderAtom, options.storedOrder);
   }
-  return render(
+  if (options.splitLayout) {
+    store.set(splitLayoutAtom, options.splitLayout);
+  }
+  const queryClient = createTestQueryClient();
+  render(
     <Provider store={store}>
-      <MemoryRouter initialEntries={["/"]}>
-        <SidebarProvider>
-          <PluginNavSidebarItems toolsRoutePath={options.toolsRoutePath} />
-        </SidebarProvider>
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[options.initialPath ?? "/"]}>
+          <SidebarProvider>
+            <PluginNavSidebarItems toolsRoutePath={options.toolsRoutePath} />
+          </SidebarProvider>
+          <LocationPath />
+        </MemoryRouter>
+      </QueryClientProvider>
     </Provider>,
   );
+  return store;
+}
+
+/** Labels of the items in the currently open menu, top to bottom. */
+function openMenuItemLabels(): string[] {
+  return screen
+    .getAllByRole("menuitem")
+    .map((item) => item.textContent?.trim() ?? "");
+}
+
+async function openRowMenu(rowTitle: string) {
+  fireEvent.pointerDown(
+    screen.getByRole("button", { name: `${rowTitle} panel options` }),
+    { button: 0 },
+  );
+  await screen.findByRole("menuitem", { name: "Hide from sidebar" });
 }
 
 const ROW_LABELS = new Set(["Extensions", "Docs", "GitHub"]);
@@ -84,12 +202,15 @@ function panelRowNames(): string[] {
 
 beforeEach(() => {
   window.localStorage.clear();
+  installFetch();
 });
 
 afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
   window.localStorage.clear();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("PluginNavSidebarItems", () => {
@@ -221,6 +342,229 @@ describe("PluginNavSidebarItems", () => {
     await waitFor(() => {
       expect(panelRowNames()).toEqual(["GitHub", "Extensions", "Docs"]);
     });
+  });
+
+  it("puts the lifecycle actions under the existing visibility item, destructive last", async () => {
+    installFetch([DOCS_PLUGIN, GITHUB_PLUGIN]);
+    registerPanel("docs", "Docs");
+    registerPanel("github", "GitHub");
+
+    renderSidebarItems();
+
+    // Wait for the installed list: the actions need real enabled/provenance
+    // state before they can label themselves.
+    await openRowMenu("GitHub");
+    await waitFor(() => {
+      expect(openMenuItemLabels()).toEqual([
+        "Hide from sidebar",
+        "Disable",
+        "Uninstall",
+      ]);
+    });
+    const uninstall = screen.getByRole("menuitem", { name: "Uninstall" });
+    expect(uninstall.className).toContain("text-destructive");
+    expect(uninstall.getAttribute("aria-disabled")).not.toEqual("true");
+  });
+
+  it("refuses to uninstall a plugin that ships with bb", async () => {
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems();
+
+    await openRowMenu("Docs");
+    await waitFor(() => {
+      expect(openMenuItemLabels()).toContain("Uninstall");
+    });
+    const uninstall = screen.getByRole("menuitem", { name: "Uninstall" });
+    expect(uninstall.getAttribute("aria-disabled")).toEqual("true");
+    // The reason has to stay reachable, so the item must not be natively
+    // disabled: both menu primitives pair that with pointer-events-none, which
+    // would swallow the hover that reveals it.
+    expect(uninstall.hasAttribute("data-disabled")).toBe(false);
+    fireEvent.focus(uninstall);
+    // findAll: the tooltip renders its reason twice, once visibly and once for
+    // screen readers.
+    expect(
+      await screen.findAllByText(
+        "Included with BB; disable this plugin instead.",
+      ),
+    ).not.toHaveLength(0);
+
+    // Still refused: hoverable must not mean selectable.
+    fireEvent.click(uninstall);
+    expect(screen.queryByText("Uninstall plugin?")).toBeNull();
+  });
+
+  it("disables a plugin through the same route the Extensions page calls", async () => {
+    const fetchMock = installFetch();
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems();
+
+    await openRowMenu("Docs");
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(requestedPaths(fetchMock)).toContain(
+        "/api/v1/plugins/docs/disable",
+      );
+    });
+  });
+
+  // Disabling unregisters the plugin's panels, so the route it opened dies with
+  // them. Staying would strand the window on a placeholder with the row that
+  // got there gone, and reload would return to it.
+  it("leaves the disabled plugin's panel route", async () => {
+    installFetch();
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems({ initialPath: "/plugins/docs/main" });
+
+    await openRowMenu("Docs");
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-path").textContent).toEqual("/");
+    });
+  });
+
+  it("stays put when disabling a plugin whose panel is not open", async () => {
+    installFetch();
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems({ initialPath: "/tools/plugins" });
+
+    await openRowMenu("Docs");
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-path").textContent).toEqual(
+        "/tools/plugins",
+      );
+    });
+  });
+
+  it("offers Enable, and enables, for a plugin that is already disabled", async () => {
+    const fetchMock = installFetch([
+      installedPlugin({ enabled: false, status: "disabled" }),
+    ]);
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems();
+
+    await openRowMenu("Docs");
+    await waitFor(() => {
+      expect(openMenuItemLabels()).toContain("Enable");
+    });
+    expect(openMenuItemLabels()).not.toContain("Disable");
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Enable" }));
+    await waitFor(() => {
+      expect(requestedPaths(fetchMock)).toContain(
+        "/api/v1/plugins/docs/enable",
+      );
+    });
+  });
+
+  it("confirms an uninstall, then leaves the removed plugin's panel route", async () => {
+    const fetchMock = installFetch([GITHUB_PLUGIN]);
+    registerPanel("github", "GitHub");
+
+    renderSidebarItems({ initialPath: "/plugins/github/main" });
+
+    await openRowMenu("GitHub");
+    await waitFor(() => {
+      expect(openMenuItemLabels()).toContain("Uninstall");
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Uninstall" }));
+
+    // Destructive actions never fire straight off the menu.
+    expect(await screen.findByText("Uninstall plugin?")).toBeTruthy();
+    expect(requestedPaths(fetchMock)).not.toContain("/api/v1/plugins/github");
+
+    fireEvent.click(screen.getByRole("button", { name: "Uninstall" }));
+
+    await waitFor(() => {
+      expect(requestedPaths(fetchMock)).toContain("/api/v1/plugins/github");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("location-path").textContent).toEqual("/");
+    });
+  });
+
+  it("closes the removed plugin's split pane instead of stranding a placeholder", async () => {
+    installFetch([GITHUB_PLUGIN]);
+    registerPanel("github", "GitHub");
+
+    // The window sits on the plugin route, so the pane is the focused one and
+    // a thread pane rides alongside it.
+    const store = renderSidebarItems({
+      initialPath: "/plugins/github/main",
+      splitLayout: {
+        root: {
+          type: "split",
+          dir: "row",
+          sizes: [0.5, 0.5],
+          children: [
+            {
+              type: "pane",
+              paneId: "pane-thread",
+              content: {
+                kind: "thread",
+                projectId: "proj_test",
+                threadId: "thr_test",
+              },
+            },
+            {
+              type: "pane",
+              paneId: "pane-plugin",
+              content: {
+                kind: "plugin-panel",
+                pluginId: "github",
+                panelPath: "main",
+                subPath: "",
+              },
+            },
+          ],
+        },
+        focusedPaneId: "pane-plugin",
+      },
+    });
+
+    await openRowMenu("GitHub");
+    await waitFor(() => {
+      expect(openMenuItemLabels()).toContain("Uninstall");
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Uninstall" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Uninstall" }));
+
+    await waitFor(() => {
+      expect(
+        listPanes(store.get(splitLayoutAtom)!.root).map((pane) => pane.content),
+      ).toEqual([
+        { kind: "thread", projectId: "proj_test", threadId: "thr_test" },
+      ]);
+    });
+    // The URL follows the pane that kept focus rather than resetting the
+    // window, so the surviving thread pane is not replaced by compose.
+    await waitFor(() => {
+      expect(screen.getByTestId("location-path").textContent).toEqual(
+        "/projects/proj_test/threads/thr_test",
+      );
+    });
+  });
+
+  it("keeps the Extensions row's menu to its visibility item", async () => {
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems({ toolsRoutePath: "/tools/plugins" });
+
+    await openRowMenu("Extensions");
+    // Give the installed list the same chance to land that a plugin row gets.
+    await waitFor(() => {
+      expect(screen.getByTestId("plugin-nav-sidebar-items")).toBeTruthy();
+    });
+    expect(openMenuItemLabels()).toEqual(["Hide from sidebar"]);
   });
 
   it("saves no Extensions key while the row is absent", async () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -16,7 +16,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { Button } from "@bb/shared-ui/button";
-import { Icon } from "@bb/shared-ui/icon";
+import { Icon, type IconName } from "@bb/shared-ui/icon";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -29,9 +29,24 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
+import {
+  ConfirmDeleteDialog,
+  ConfirmDeleteDialogContent,
+} from "@/components/dialogs/ConfirmDeleteDialog";
+import { CONTEXT_MENU_DESTRUCTIVE_ITEM_CLASS } from "@/components/ui/menu-item-tone";
+import {
+  usePluginList,
+  type PluginListItem,
+} from "@/hooks/queries/plugin-settings-queries";
 import { getPluginPanelRoutePath } from "@/lib/route-paths";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -48,6 +63,12 @@ import {
 import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
 import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
 import type { SidebarSortableDragBindings } from "@/components/sidebar/sortableMotion";
+import {
+  pluginRemovalBlockedReason,
+  pluginRemovalConfirmCopy,
+  pluginRemovalLabel,
+} from "./plugin-removal";
+import { usePluginLifecycle } from "./usePluginLifecycle";
 import {
   hiddenPluginNavPanelsAtom,
   pluginNavPanelOrderAtom,
@@ -162,6 +183,15 @@ function PluginNavSidebarItemList({
   const [storedOrder, setStoredOrder] = useAtom(pluginNavPanelOrderAtom);
   const [hiddenKeys, setHiddenKeys] = useAtom(hiddenPluginNavPanelsAtom);
   const [isOverflowOpen, setIsOverflowOpen] = useState(false);
+  // Only plugin rows carry lifecycle actions, so a sidebar showing nothing but
+  // the Extensions row never asks the server for the installed list.
+  const {
+    lifecycle,
+    removeTarget,
+    removePending,
+    confirmRemove,
+    cancelRemove,
+  } = usePluginNavRowLifecycle(rows.some((row) => row.kind === "plugin"));
 
   const { visible, hidden, normalizedOrder } = useMemo(() => {
     // Users who customized their plugin order before the Extensions row joined
@@ -231,6 +261,7 @@ function PluginNavSidebarItemList({
     onNavigate,
     pathname: location.pathname,
     splitEnabled,
+    lifecycle,
   };
 
   return (
@@ -277,6 +308,23 @@ function PluginNavSidebarItemList({
             : null}
         </>
       ) : null}
+      <ConfirmDeleteDialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !removePending) cancelRemove();
+        }}
+      >
+        {removeTarget ? (
+          <ConfirmDeleteDialogContent
+            title={pluginRemovalConfirmCopy(removeTarget).title}
+            description={pluginRemovalConfirmCopy(removeTarget).description}
+            confirmLabel={pluginRemovalLabel(removeTarget)}
+            pending={removePending}
+            onConfirm={confirmRemove}
+            onCancel={cancelRemove}
+          />
+        ) : null}
+      </ConfirmDeleteDialog>
     </div>
   );
 }
@@ -344,6 +392,7 @@ interface SidebarNavRowItemProps {
   pathname: string;
   onNavigate?: () => void;
   splitEnabled: boolean;
+  lifecycle: PluginNavRowLifecycle;
   /** Present for rows parked in the "More" disclosure. */
   isHidden?: boolean;
   onHide?: (key: string) => void;
@@ -356,16 +405,103 @@ interface SidebarNavRowItemProps {
 function SidebarNavRowItem({
   row,
   splitEnabled,
+  lifecycle,
   ...props
 }: SidebarNavRowItemProps) {
   return row.kind === "tools" ? (
+    // Extensions is host chrome, not a plugin: it has nothing to disable.
     <ToolsNavSidebarItem {...props} row={row} />
   ) : (
-    <PluginNavSidebarItem {...props} row={row} splitEnabled={splitEnabled} />
+    <PluginNavSidebarItem
+      {...props}
+      row={row}
+      splitEnabled={splitEnabled}
+      lifecycle={lifecycle}
+    />
   );
 }
 
 type PluginNavRowMenuSurface = "context" | "dropdown";
+
+/**
+ * One row action, rendered into whichever menu surface asked for it. The
+ * right-click and "…" menus carry the same items, so every action is written
+ * once and switches only its primitive.
+ */
+function PluginNavRowMenuItem({
+  children,
+  disabled = false,
+  disabledReason,
+  icon,
+  onSelect,
+  surface,
+  variant = "default",
+}: {
+  children: ReactNode;
+  disabled?: boolean;
+  /** Shown on hover while `disabled`, so a refused action explains itself. */
+  disabledReason?: string;
+  icon: IconName;
+  onSelect: () => void;
+  surface: PluginNavRowMenuSurface;
+  variant?: "default" | "destructive";
+}) {
+  const content = (
+    <>
+      <Icon name={icon} aria-hidden="true" />
+      {children}
+    </>
+  );
+  // An explained refusal cannot use the primitives' own `disabled`: both apply
+  // `data-[disabled]:pointer-events-none`, which swallows the hover that would
+  // reveal the reason. Mark it aria-disabled instead and refuse the select, the
+  // way ResourceOverflowMenu does for the same case.
+  const isExplained = disabled && disabledReason !== undefined;
+  const className = cn(
+    surface === "context" &&
+      variant === "destructive" &&
+      CONTEXT_MENU_DESTRUCTIVE_ITEM_CLASS,
+    disabled && "text-muted-foreground",
+    isExplained && "cursor-not-allowed focus:bg-transparent",
+  );
+  const handleSelect = (event: Event) => {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+    onSelect();
+  };
+  const item =
+    surface === "context" ? (
+      <ContextMenuItem
+        className={className}
+        disabled={disabled && !isExplained}
+        aria-disabled={disabled || undefined}
+        onSelect={handleSelect}
+      >
+        {content}
+      </ContextMenuItem>
+    ) : (
+      <DropdownMenuItem
+        className={className}
+        disabled={disabled && !isExplained}
+        aria-disabled={disabled || undefined}
+        variant={variant}
+        onSelect={handleSelect}
+      >
+        {content}
+      </DropdownMenuItem>
+    );
+  if (!isExplained) return item;
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>{item}</TooltipTrigger>
+        <TooltipContent side="left">{disabledReason}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 function PluginNavRowVisibilityMenuItem({
   isHidden,
@@ -376,17 +512,105 @@ function PluginNavRowVisibilityMenuItem({
   onSelect: () => void;
   surface: PluginNavRowMenuSurface;
 }) {
-  const content = (
-    <>
-      <Icon name={isHidden ? "Eye" : "EyeOff"} aria-hidden="true" />
+  return (
+    <PluginNavRowMenuItem
+      surface={surface}
+      icon={isHidden ? "Eye" : "EyeOff"}
+      onSelect={onSelect}
+    >
       {isHidden ? "Show in sidebar" : "Hide from sidebar"}
+    </PluginNavRowMenuItem>
+  );
+}
+
+/**
+ * Lifecycle actions for the plugin behind a row: the reversible enable toggle,
+ * then removal last as the destructive action. Both call the same admin routes
+ * the Extensions pages use, so the two surfaces cannot drift apart.
+ */
+function PluginNavRowLifecycleMenuItems({
+  lifecycle,
+  plugin,
+  surface,
+}: {
+  lifecycle: PluginNavRowLifecycle;
+  plugin: PluginListItem;
+  surface: PluginNavRowMenuSurface;
+}) {
+  const pending = lifecycle.pendingPluginId === plugin.id;
+  const blockedReason = pluginRemovalBlockedReason(plugin);
+  return (
+    <>
+      <PluginNavRowMenuItem
+        surface={surface}
+        icon={plugin.enabled ? "CircleX" : "CircleCheck"}
+        disabled={pending}
+        onSelect={() => lifecycle.onToggleEnabled(plugin)}
+      >
+        {plugin.enabled ? "Disable" : "Enable"}
+      </PluginNavRowMenuItem>
+      <PluginNavRowMenuItem
+        surface={surface}
+        icon="Trash2"
+        variant="destructive"
+        disabled={pending || blockedReason !== null}
+        disabledReason={blockedReason ?? undefined}
+        onSelect={() => lifecycle.onRequestRemove(plugin)}
+      >
+        {pluginRemovalLabel(plugin)}
+      </PluginNavRowMenuItem>
     </>
   );
-  return surface === "context" ? (
-    <ContextMenuItem onSelect={onSelect}>{content}</ContextMenuItem>
-  ) : (
-    <DropdownMenuItem onSelect={onSelect}>{content}</DropdownMenuItem>
-  );
+}
+
+/** Row-facing half of {@link usePluginNavRowLifecycle}. */
+interface PluginNavRowLifecycle {
+  /** The installed record for a row's plugin, or null until the list loads. */
+  pluginFor: (pluginId: string) => PluginListItem | null;
+  /** The plugin with a lifecycle request in flight, if any. */
+  pendingPluginId: string | null;
+  onToggleEnabled: (plugin: PluginListItem) => void;
+  onRequestRemove: (plugin: PluginListItem) => void;
+}
+
+interface PluginNavRowLifecycleState {
+  lifecycle: PluginNavRowLifecycle;
+  /** The plugin awaiting removal confirmation, if any. */
+  removeTarget: PluginListItem | null;
+  removePending: boolean;
+  confirmRemove: () => void;
+  cancelRemove: () => void;
+}
+
+/**
+ * Enable/disable and uninstall for plugin nav rows, over the shared lifecycle.
+ *
+ * The list owns this rather than the row: disabling or uninstalling
+ * unregisters the plugin's panels, so the row that started the request is gone
+ * before it settles — and with it any toast, navigation, or dialog it owned.
+ * Only the row-facing lookup is local; the mutations themselves are shared with
+ * the Extensions detail page so the two surfaces cannot drift apart again.
+ */
+function usePluginNavRowLifecycle(
+  enabled: boolean,
+): PluginNavRowLifecycleState {
+  const listQuery = usePluginList({ enabled });
+  const lifecycle = usePluginLifecycle();
+  const plugins = listQuery.data?.plugins;
+
+  return {
+    lifecycle: {
+      pluginFor: (pluginId) =>
+        plugins?.find((candidate) => candidate.id === pluginId) ?? null,
+      pendingPluginId: lifecycle.pendingPluginId,
+      onToggleEnabled: lifecycle.toggleEnabled,
+      onRequestRemove: lifecycle.requestRemove,
+    },
+    removeTarget: lifecycle.removeTarget,
+    removePending: lifecycle.removePending,
+    confirmRemove: lifecycle.confirmRemove,
+    cancelRemove: lifecycle.cancelRemove,
+  };
 }
 
 /**
@@ -398,7 +622,7 @@ function ToolsNavSidebarItem({
   pathname: _pathname,
   onNavigate,
   ...props
-}: Omit<SidebarNavRowItemProps, "row" | "splitEnabled"> & {
+}: Omit<SidebarNavRowItemProps, "row" | "splitEnabled" | "lifecycle"> & {
   row: Extract<SidebarNavRow, { kind: "tools" }>;
 }) {
   const navigate = useNavigate();
@@ -425,11 +649,13 @@ function PluginNavSidebarItem({
   pathname,
   onNavigate,
   splitEnabled,
+  lifecycle,
   ...props
 }: Omit<SidebarNavRowItemProps, "row"> & {
   row: Extract<SidebarNavRow, { kind: "plugin" }>;
 }) {
   const { panel } = row;
+  const plugin = lifecycle.pluginFor(panel.pluginId);
   const navigate = useNavigate();
   const path = getPluginPanelRoutePath({
     pluginId: panel.pluginId,
@@ -456,6 +682,19 @@ function PluginNavSidebarItem({
       icon={<PluginIcon pluginId={panel.pluginId} icon={panel.icon} />}
       isActive={pathname === path || pathname.startsWith(`${path}/`)}
       splitMiniMap={splitIndicator.miniMap}
+      // Omitted until the installed-plugin list resolves: a lifecycle action
+      // needs the plugin's real enabled state and provenance to label itself.
+      renderMenuItems={
+        plugin === null
+          ? undefined
+          : (surface) => (
+              <PluginNavRowLifecycleMenuItems
+                surface={surface}
+                plugin={plugin}
+                lifecycle={lifecycle}
+              />
+            )
+      }
       // Split-drag initiator; engages only when the pointer leaves the
       // sidebar, so it coexists with the dnd-kit reorder listeners.
       onPointerDown={onPointerDown}
@@ -485,6 +724,8 @@ interface SidebarNavRowChromeProps {
   dragBindings?: SidebarSortableDragBindings;
   rowRef?: (element: HTMLElement | null) => void;
   rowStyle?: CSSProperties;
+  /** Row-specific actions, appended below the shared visibility item. */
+  renderMenuItems?: (surface: PluginNavRowMenuSurface) => ReactNode;
 }
 
 /** Shared chrome for every sidebar nav row: button, hide menus, drag handle. */
@@ -502,6 +743,7 @@ function SidebarNavRowChrome({
   dragBindings,
   rowRef,
   rowStyle,
+  renderMenuItems,
 }: SidebarNavRowChromeProps) {
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   // dnd-kit's KeyboardSensor activates on Space/Enter and preventDefaults them.
@@ -584,6 +826,7 @@ function SidebarNavRowChrome({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 {visibilityItem("dropdown")}
+                {renderMenuItems?.("dropdown")}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
@@ -591,6 +834,7 @@ function SidebarNavRowChrome({
       </ContextMenuTrigger>
       <ContextMenuContent aria-label={`${title} panel options`}>
         {visibilityItem("context")}
+        {renderMenuItems?.("context")}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/apps/app/src/components/plugin/plugin-removal.ts
+++ b/apps/app/src/components/plugin/plugin-removal.ts
@@ -1,0 +1,73 @@
+import type { PluginListItem } from "@/hooks/queries/plugin-settings-queries";
+
+/**
+ * Removal policy and copy for an installed plugin, shared by every surface that
+ * offers it: the Extensions detail page and the sidebar panel-row menu. One
+ * home keeps the two menus from disagreeing about what "Uninstall" does to the
+ * files on disk.
+ */
+
+/** A `path:` install: bb registered a directory it does not own. */
+export function pluginIsLocalSource(plugin: PluginListItem): boolean {
+  return plugin.source.startsWith("path:");
+}
+
+export function pluginRemovalLabel(plugin: PluginListItem): string {
+  return pluginIsLocalSource(plugin) ? "Remove from bb" : "Uninstall";
+}
+
+/**
+ * Why removal is unavailable, or null while it is allowed. DELETE
+ * /plugins/:id answers 409 for a plugin that ships with bb, so the menus
+ * refuse it up front instead of surfacing a server error the user cannot act
+ * on.
+ */
+export function pluginRemovalBlockedReason(
+  plugin: PluginListItem,
+): string | null {
+  return plugin.provenance === "builtin"
+    ? "Included with BB; disable this plugin instead."
+    : null;
+}
+
+/**
+ * Whether removal actually deletes the plugin's files. Only a tree bb fetched
+ * itself is deleted: a `path:` source is the user's own directory, and a
+ * `builtin:` source — which an official catalog entry can also install from —
+ * is left in place behind a removal marker. Promising deletion for either
+ * would be a lie the server never carries out.
+ */
+export function pluginRemovalDeletesFiles(plugin: PluginListItem): boolean {
+  return (
+    !plugin.source.startsWith("path:") && !plugin.source.startsWith("builtin:")
+  );
+}
+
+export interface PluginRemovalConfirmCopy {
+  title: string;
+  description: string;
+}
+
+/** Confirmation wording, which turns on what removal does to the files. */
+export function pluginRemovalConfirmCopy(
+  plugin: PluginListItem,
+): PluginRemovalConfirmCopy {
+  if (pluginIsLocalSource(plugin)) {
+    return {
+      title: "Remove plugin from bb?",
+      description: `Remove "${plugin.id}" from bb and delete its settings? Its source files will stay on disk.`,
+    };
+  }
+  return {
+    title: "Uninstall plugin?",
+    description: pluginRemovalDeletesFiles(plugin)
+      ? `Uninstall "${plugin.id}" and delete its downloaded files and settings?`
+      : `Uninstall "${plugin.id}" and delete its settings? Its bundled files stay on disk.`,
+  };
+}
+
+export function pluginRemovalSuccessMessage(plugin: PluginListItem): string {
+  return pluginIsLocalSource(plugin)
+    ? "Plugin removed from bb"
+    : "Plugin uninstalled";
+}

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
-import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   act,
   cleanup,
@@ -10,10 +16,12 @@ import {
   screen,
 } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type { PluginComposerApi, PluginThreadPanelProps } from "@bb/plugin-sdk";
 import { createPluginPanelFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
+import { createTestQueryClient } from "@/test/queryClientTestHarness";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -1240,6 +1248,16 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
     return <div>board panel body</div>;
   }
 
+  // The rows' lifecycle menu reads the installed-plugin list, so every mount of
+  // the nav list needs a query client even when the test only looks at chrome.
+  function withQueryClient(children: ReactNode) {
+    return (
+      <QueryClientProvider client={createTestQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    );
+  }
+
   function registerAutomationsPanel() {
     setPluginSlotRegistrations(
       AUTOMATIONS_PLUGIN_ID,
@@ -1263,11 +1281,13 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
       registerAutomationsPanel();
 
       render(
-        <ToolsHubExperimentProvider enabled={enabled}>
-          <MemoryRouter>
-            <PluginNavSidebarItems />
-          </MemoryRouter>
-        </ToolsHubExperimentProvider>,
+        withQueryClient(
+          <ToolsHubExperimentProvider enabled={enabled}>
+            <MemoryRouter>
+              <PluginNavSidebarItems />
+            </MemoryRouter>
+          </ToolsHubExperimentProvider>,
+        ),
       );
 
       expect(screen.getByRole("button", { name: "Automations" })).toBeDefined();
@@ -1290,13 +1310,18 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
       }),
     );
     render(
-      <MemoryRouter initialEntries={["/"]}>
-        <PluginNavSidebarItems />
-        <Routes>
-          <Route path="/" element={<div>home</div>} />
-          <Route path={PLUGIN_PANEL_ROUTE_PATH} element={<PluginPanelView />} />
-        </Routes>
-      </MemoryRouter>,
+      withQueryClient(
+        <MemoryRouter initialEntries={["/"]}>
+          <PluginNavSidebarItems />
+          <Routes>
+            <Route path="/" element={<div>home</div>} />
+            <Route
+              path={PLUGIN_PANEL_ROUTE_PATH}
+              element={<PluginPanelView />}
+            />
+          </Routes>
+        </MemoryRouter>,
+      ),
     );
     fireEvent.click(screen.getByText("Demo board"));
     expect(screen.getByText("board panel body")).toBeDefined();
@@ -1349,11 +1374,13 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
     });
 
     render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <PluginNavSidebarItems splitEnabled />
-        </MemoryRouter>
-      </Provider>,
+      withQueryClient(
+        <Provider store={store}>
+          <MemoryRouter initialEntries={["/"]}>
+            <PluginNavSidebarItems splitEnabled />
+          </MemoryRouter>
+        </Provider>,
+      ),
     );
 
     const splitMap = screen.getByRole("img", {
@@ -1379,13 +1406,15 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
       }),
     );
     render(
-      <MemoryRouter
-        initialEntries={[
-          "/plugins/simple-notes/simple-notes/bb-plugin-marketplaces-and-compatible-updates.md",
-        ]}
-      >
-        <PluginNavSidebarItems />
-      </MemoryRouter>,
+      withQueryClient(
+        <MemoryRouter
+          initialEntries={[
+            "/plugins/simple-notes/simple-notes/bb-plugin-marketplaces-and-compatible-updates.md",
+          ]}
+        >
+          <PluginNavSidebarItems />
+        </MemoryRouter>,
+      ),
     );
 
     expect(

--- a/apps/app/src/components/plugin/usePluginLifecycle.ts
+++ b/apps/app/src/components/plugin/usePluginLifecycle.ts
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSetAtom } from "jotai";
+import { appToast } from "@/components/ui/app-toast";
+import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
+import {
+  removePlugin,
+  setPluginEnabled,
+  type PluginListItem,
+} from "@/hooks/queries/plugin-settings-queries";
+import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
+import { closePanesForPluginAtom } from "@/lib/split-layout/atoms";
+import { paneContentRoute } from "@/views/thread-detail/splitThreadNavigation";
+import {
+  getRootComposeRoutePath,
+  isPluginPanelRoutePath,
+} from "@/lib/route-paths";
+import { pluginRemovalSuccessMessage } from "./plugin-removal";
+
+/**
+ * Enable/disable and uninstall for an installed plugin, shared by every surface
+ * that offers them: the sidebar row's menu and the Extensions detail page.
+ *
+ * The surfaces used to own a mutation pair each, and they drifted — the detail
+ * page kept navigating away from a removed plugin while never dropping the
+ * split panes its panels left behind. What has to happen on every surface lives
+ * here; only where to go afterwards is the caller's business.
+ */
+export interface PluginLifecycleOptions {
+  /**
+   * Runs after a removal has settled, for a surface whose own page dies with
+   * the plugin. Leaving a dead *panel* route is handled here, since that is
+   * true everywhere.
+   */
+  onRemoved?: (plugin: PluginListItem) => void;
+}
+
+export interface PluginLifecycle {
+  /** The plugin with a lifecycle request in flight, if any. */
+  pendingPluginId: string | null;
+  toggleEnabled: (plugin: PluginListItem) => void;
+  requestRemove: (plugin: PluginListItem) => void;
+  /** The plugin awaiting removal confirmation, if any. */
+  removeTarget: PluginListItem | null;
+  removePending: boolean;
+  confirmRemove: () => void;
+  cancelRemove: () => void;
+}
+
+export function usePluginLifecycle(
+  options: PluginLifecycleOptions = {},
+): PluginLifecycle {
+  const { onRemoved } = options;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const closePanesForPlugin = useSetAtom(closePanesForPluginAtom);
+  const [removeTarget, setRemoveTarget] = useState<PluginListItem | null>(null);
+
+  const isOnPanelRouteFor = (plugin: PluginListItem) =>
+    isPluginPanelRoutePath({
+      pathname: location.pathname,
+      pluginId: plugin.id,
+    });
+
+  const toggleEnabled = useMutation({
+    mutationFn: (plugin: PluginListItem) =>
+      setPluginEnabled(fetch, plugin.id, !plugin.enabled),
+    onSuccess: (_result, plugin) => {
+      invalidatePluginList({ queryClient });
+      if (!plugin.enabled) return;
+      // Disabling unregisters the plugin's panels the same way uninstalling
+      // does, so staying would strand the window on a dead route with the row
+      // that opened it gone from the sidebar — and reload would return to it.
+      // The row's disappearance is the visible confirmation; the placeholder is
+      // not. Unlike an uninstall this leaves the split panes alone: disable is
+      // reversible, and re-enabling should restore the arrangement.
+      if (isOnPanelRouteFor(plugin)) void navigate(getRootComposeRoutePath());
+    },
+    onError: (error, plugin) => {
+      appToast.error(
+        `${plugin.enabled ? "Disabling" : "Enabling"} ${
+          plugin.name ?? plugin.id
+        } failed`,
+        { description: pluginAdminErrorMessage(error) },
+      );
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (plugin: PluginListItem) => removePlugin(fetch, plugin.id),
+    onSuccess: (_result, plugin) => {
+      setRemoveTarget(null);
+      invalidatePluginList({ queryClient });
+      appToast.success(pluginRemovalSuccessMessage(plugin));
+      // The plugin's panels are unregistered now, so every surface still
+      // pointing at one would render the "panel is not available" placeholder
+      // for a page nothing can restore — and the split layout is persisted, so
+      // reload would bring it back. Drop the panes first, then move the window
+      // off the dead route to whatever pane kept focus.
+      const closed = closePanesForPlugin(plugin.id);
+      if (isOnPanelRouteFor(plugin)) {
+        void navigate(
+          closed.focusedContent === null
+            ? getRootComposeRoutePath()
+            : paneContentRoute(closed.focusedContent),
+        );
+      }
+      onRemoved?.(plugin);
+    },
+    onError: (error, plugin) => {
+      appToast.error(`Removing ${plugin.name ?? plugin.id} failed`, {
+        description: pluginAdminErrorMessage(error),
+      });
+    },
+  });
+
+  const pendingPluginId = toggleEnabled.isPending
+    ? (toggleEnabled.variables?.id ?? null)
+    : remove.isPending
+      ? (remove.variables?.id ?? null)
+      : null;
+
+  return {
+    pendingPluginId,
+    toggleEnabled: (plugin) => toggleEnabled.mutate(plugin),
+    requestRemove: (plugin) => setRemoveTarget(plugin),
+    removeTarget,
+    removePending: remove.isPending,
+    confirmRemove: () => {
+      if (removeTarget !== null) remove.mutate(removeTarget);
+    },
+    cancelRemove: () => setRemoveTarget(null),
+  };
+}

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
+import { CONTEXT_MENU_DESTRUCTIVE_ITEM_CLASS } from "@/components/ui/menu-item-tone";
 import { usePathPickerHost } from "@/hooks/useLocalPathPicker";
 import { getProjectSettingsRoutePath } from "@/lib/route-paths";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -82,8 +83,7 @@ function ProjectActionMenuItem({
       <ContextMenuItem
         className={cn(
           className,
-          variant === "destructive" &&
-            "text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive",
+          variant === "destructive" && CONTEXT_MENU_DESTRUCTIVE_ITEM_CLASS,
         )}
         onSelect={onSelect}
       >

--- a/apps/app/src/components/secondary-panel/secondaryPanelTabState.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelTabState.ts
@@ -373,6 +373,23 @@ export function removeWorkspaceTabsForOtherEnvironments(
   return nextTabs.length === tabs.length ? tabs : nextTabs;
 }
 
+/**
+ * Drops panel tabs belonging to a plugin that is no longer installed. Keyed on
+ * the installed list rather than the registered slots: a plugin whose frontend
+ * has not loaded yet registers nothing, and its tabs have to survive that
+ * window — as do the tabs of a merely disabled plugin, which stays installed.
+ */
+export function pruneUninstalledPluginPanelTabs(
+  tabs: readonly FixedPanelTab[],
+  installedPluginIds: ReadonlySet<string>,
+): readonly FixedPanelTab[] {
+  const nextTabs = tabs.filter(
+    (tab) =>
+      tab.kind !== "plugin-panel" || installedPluginIds.has(tab.pluginId),
+  );
+  return nextTabs.length === tabs.length ? tabs : nextTabs;
+}
+
 export function pruneStorageTabs({
   knownPaths,
   tabs,

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -9,12 +9,14 @@ import {
   createBrowserFixedPanelTab,
   createEmptyFixedPanelTabsState,
   createHostFilePreviewFixedPanelTab,
+  createPluginPanelFixedPanelTab,
   createTerminalFixedPanelTab,
   createThreadStorageFilePreviewFixedPanelTab,
   getFixedPanelTabsStateStorageKey,
   serializeFixedPanelTabsState,
   FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
 } from "@/lib/fixed-panel-tabs-state";
+import { pluginListQueryKey } from "@/hooks/queries/plugin-settings-queries";
 import { useThreadFileTabs } from "./useThreadFileTabs";
 import {
   resetPluginSlotStoreForTest,
@@ -611,6 +613,80 @@ describe("useThreadFileTabs file opener diversion", () => {
       actionId: "file-opener:editor",
       title: "other.md",
     });
+  });
+});
+
+describe("useThreadFileTabs uninstalled plugin panel tabs", () => {
+  const KEPT_TAB = createPluginPanelFixedPanelTab({
+    actionId: "issue",
+    paramsJson: null,
+    pluginId: "docs",
+    title: "Docs",
+  });
+  const REMOVED_TAB = createPluginPanelFixedPanelTab({
+    actionId: "issue",
+    paramsJson: null,
+    pluginId: "ghost",
+    title: "Ghost",
+  });
+
+  /** A reload: both tabs already persisted, the removed plugin's one active. */
+  function seedPersistedTabs(threadId: string): void {
+    window.localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId }),
+      JSON.stringify({
+        version: FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
+        lastUsedAt: Date.now(),
+        secondary: {
+          activeTabId: REMOVED_TAB.id,
+          isOpen: true,
+          tabs: [KEPT_TAB, REMOVED_TAB],
+        },
+      }),
+    );
+  }
+
+  function renderTabs(threadId: string) {
+    return renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: threadId,
+        syncThreadId: threadId,
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+  }
+
+  it("drops persisted panel tabs of a plugin that is no longer installed", async () => {
+    const threadId = "uninstalled-plugin-panel";
+    seedPersistedTabs(threadId);
+    queryClient.setQueryData(pluginListQueryKey(true), {
+      plugins: [{ id: "docs" }],
+    });
+
+    const { result } = renderTabs(threadId);
+
+    await waitFor(() => {
+      expect(
+        result.current.orderedSecondaryFileTabs.map((tab) => tab.id),
+      ).toEqual([KEPT_TAB.id]);
+    });
+    // The removed tab was the active one, so the panel must not still resolve
+    // to it.
+    expect(result.current.activePluginPanelTab).toBeNull();
+  });
+
+  it("keeps the tabs while the installed list has not loaded", () => {
+    const threadId = "unloaded-plugin-list";
+    seedPersistedTabs(threadId);
+
+    const { result } = renderTabs(threadId);
+
+    // A pending or failed fetch must never look like "nothing is installed".
+    expect(
+      result.current.orderedSecondaryFileTabs.map((tab) => tab.id),
+    ).toEqual([KEPT_TAB.id, REMOVED_TAB.id]);
   });
 });
 

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -20,6 +20,7 @@ import {
   type WorkspaceFilePreviewFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
 import { usePluginSlots } from "@/lib/plugin-slots";
+import { usePluginList } from "@/hooks/queries/plugin-settings-queries";
 import { useFileOpenerPreferenceValue } from "@/lib/file-opener-preference";
 import {
   createFileOpenerTabForRequest,
@@ -47,6 +48,7 @@ import {
   isBrowserTab,
   openSecondaryPanelTabInState,
   pruneStorageTabs,
+  pruneUninstalledPluginPanelTabs,
   removeWorkspaceTabsForOtherEnvironments,
   replaceNewTabWithSecondaryPanelTabInState,
   reorderSecondaryPanelFileTabInState,
@@ -400,6 +402,54 @@ export function useThreadFileTabs({
     isPanelStateResolved,
     retainedTerminalId,
     terminalSessions,
+    updateFixedPanelTabsState,
+  ]);
+
+  const installedPluginsQuery = usePluginList({ enabled: true });
+  const installedPluginIds = useMemo(
+    () =>
+      installedPluginsQuery.data === undefined
+        ? undefined
+        : new Set(
+            installedPluginsQuery.data.plugins.map((plugin) => plugin.id),
+          ),
+    [installedPluginsQuery.data],
+  );
+
+  // Uninstalling a plugin leaves its panel tabs behind, and they are persisted:
+  // without this they come back as the "plugin tab is not available"
+  // placeholder on every reload, for a tab nothing can restore. Undefined while
+  // the list has not loaded, so a failed or pending fetch never prunes.
+  useEffect(() => {
+    if (!isPanelStateResolved || installedPluginIds === undefined) return;
+    updateFixedPanelTabsState((state) => {
+      const pruned = setPrunedSecondaryTabs({
+        activeTabId: state.secondary.activeTabId,
+        stateTabs: state.secondary.tabs,
+        tabs: pruneUninstalledPluginPanelTabs(
+          state.secondary.tabs,
+          installedPluginIds,
+        ),
+      });
+      return setSecondaryPanelTabsInState({
+        activeTabId: pruned.activeTabId,
+        isOpen: state.secondary.isOpen,
+        state,
+        tabs: pruned.tabs,
+      });
+    });
+    // The tab list is a dependency, not just an input: tabs arrive twice —
+    // synchronously from localStorage, then again when the server list
+    // hydrates and replaces it wholesale. Pruning only on the plugin list's
+    // identity would miss a dead tab that the server adds afterwards, and the
+    // plugin list is already warm at boot (the sidebar loads it), so that
+    // identity never changes again to catch it. Re-running is safe: the second
+    // pass finds nothing, returns the same reference, and the update
+    // short-circuits.
+  }, [
+    fixedPanelTabsState.secondary.tabs,
+    installedPluginIds,
+    isPanelStateResolved,
     updateFixedPanelTabsState,
   ]);
 

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -42,6 +42,11 @@ import {
 } from "@/components/tools/plugin-detail-table";
 import { PluginBannerBar } from "@/components/tools/plugin-detail-banner";
 import { ProvenancePill } from "@/components/tools/ProvenancePill";
+import {
+  pluginIsLocalSource,
+  pluginRemovalBlockedReason,
+  pluginRemovalLabel,
+} from "@/components/plugin/plugin-removal";
 import { appToast } from "@/components/ui/app-toast";
 import {
   usePluginSource,
@@ -64,14 +69,6 @@ function pluginSourceLabel(plugin: PluginListItem): string | null {
 export function PluginProvenancePill({ plugin }: { plugin: PluginListItem }) {
   const label = pluginSourceLabel(plugin);
   return label === null ? null : <ProvenancePill label={label} />;
-}
-
-export function pluginIsLocalSource(plugin: PluginListItem): boolean {
-  return plugin.source.startsWith("path:");
-}
-
-export function pluginRemovalLabel(plugin: PluginListItem): string {
-  return pluginIsLocalSource(plugin) ? "Remove from bb" : "Uninstall";
 }
 
 function PluginPath({ path }: { path: string }) {
@@ -322,6 +319,7 @@ export function PluginDetail({
       plugin.updateState.lastFailure !== null);
 
   const pluginName = plugin.name ?? plugin.id;
+  const removalBlockedReason = pluginRemovalBlockedReason(plugin);
   // Uninstall is destructive and irreversible-ish, so it belongs with the other
   // ownership actions rather than beside the reversible enable toggle.
   const overflowItems: ResourceOverflowMenuItem[] = [
@@ -348,11 +346,8 @@ export function PluginDetail({
       label: pluginRemovalLabel(plugin),
       icon: "Trash2" as const,
       tone: "destructive" as const,
-      disabled: pending || plugin.provenance === "builtin",
-      disabledReason:
-        plugin.provenance === "builtin"
-          ? "Included with BB; disable this plugin instead."
-          : undefined,
+      disabled: pending || removalBlockedReason !== null,
+      disabledReason: removalBlockedReason ?? undefined,
       onSelect: () => onDelete(plugin),
     },
   ];

--- a/apps/app/src/components/ui/menu-item-tone.ts
+++ b/apps/app/src/components/ui/menu-item-tone.ts
@@ -1,0 +1,8 @@
+/**
+ * Destructive tone for a `ContextMenuItem`. `DropdownMenuItem` ships
+ * `variant="destructive"`; its context-menu sibling takes no variant, so a menu
+ * that renders both surfaces applies this class on the context side to keep the
+ * two tones identical.
+ */
+export const CONTEXT_MENU_DESTRUCTIVE_ITEM_CLASS =
+  "text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive";

--- a/apps/app/src/lib/route-paths.ts
+++ b/apps/app/src/lib/route-paths.ts
@@ -233,6 +233,23 @@ export function getPluginPanelRoutePath({
   return encoded.length > 0 ? `${root}/${encoded}` : root;
 }
 
+export interface PluginPanelRouteMatchArgs {
+  pathname: string;
+  pluginId: string;
+}
+
+/**
+ * True while `pathname` sits on any nav panel belonging to `pluginId`. Callers
+ * that disable or uninstall a plugin use this to leave a route whose panel is
+ * about to stop existing.
+ */
+export function isPluginPanelRoutePath({
+  pathname,
+  pluginId,
+}: PluginPanelRouteMatchArgs): boolean {
+  return pathname.startsWith(`/plugins/${encodeURIComponent(pluginId)}/`);
+}
+
 export function getThreadRoutePath(args: ThreadRoutePathArgs): string {
   return isProjectlessProjectId(args.projectId)
     ? `/threads/${args.threadId}`

--- a/apps/app/src/lib/split-layout/atoms.test.ts
+++ b/apps/app/src/lib/split-layout/atoms.test.ts
@@ -3,14 +3,15 @@
 import { createStore } from "jotai";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  closePanesForPluginAtom,
   closePanesForThreadsAtom,
   maximizedPaneIdAtom,
   MAXIMIZED_PANE_STORAGE_KEY,
   splitLayoutAtom,
 } from "./atoms";
-import { countPanes, findPaneByThread, splitPane } from "./ops";
+import { countPanes, findPaneByThread, listPanes, splitPane } from "./ops";
 import { serializeSplitLayout, SPLIT_LAYOUT_STORAGE_KEY } from "./persistence";
-import type { SplitLayout } from "./types";
+import type { PaneContent, SplitLayout } from "./types";
 
 function singlePane(threadId: string): SplitLayout {
   return {
@@ -200,6 +201,123 @@ describe("closePanesForThreadsAtom", () => {
     expect(store.set(closePanesForThreadsAtom, [])).toEqual({
       removedAny: false,
       focusedRoute: null,
+    });
+    expect(countPanes(store.get(splitLayoutAtom)!.root)).toBe(2);
+  });
+});
+
+describe("closePanesForPluginAtom", () => {
+  const THREAD_CONTENT: PaneContent = {
+    kind: "thread",
+    projectId: "project-1",
+    threadId: "thread-1",
+  };
+
+  function panelContent(pluginId: string, panelPath: string): PaneContent {
+    return { kind: "plugin-panel", pluginId, panelPath, subPath: "" };
+  }
+
+  /** Panes left to right as `pane-1`…`pane-N`, with a chosen one focused. */
+  function rowLayout(
+    contents: readonly PaneContent[],
+    focusedIndex: number,
+  ): SplitLayout {
+    return {
+      root: {
+        type: "split",
+        dir: "row",
+        sizes: contents.map(() => 1 / contents.length),
+        children: contents.map((content, index) => ({
+          type: "pane",
+          paneId: `pane-${index + 1}`,
+          content,
+        })),
+      },
+      focusedPaneId: `pane-${focusedIndex + 1}`,
+    };
+  }
+
+  it("closes every pane of the removed plugin and reports the focused survivor", () => {
+    const store = createStore();
+    // Two panels from the same plugin: the loop has to clear both, not just
+    // the first one it finds.
+    store.set(
+      splitLayoutAtom,
+      rowLayout(
+        [
+          THREAD_CONTENT,
+          panelContent("github", "main"),
+          panelContent("github", "issues"),
+          panelContent("docs", "docs"),
+        ],
+        0,
+      ),
+    );
+
+    const result = store.set(closePanesForPluginAtom, "github");
+
+    expect(result.removedAny).toBe(true);
+    expect(
+      listPanes(store.get(splitLayoutAtom)!.root).map((pane) => pane.content),
+    ).toEqual([THREAD_CONTENT, panelContent("docs", "docs")]);
+    // The caller navigates here, so closing a background pane never drags the
+    // window off the page the user is actually looking at.
+    expect(result.focusedContent).toEqual(THREAD_CONTENT);
+  });
+
+  it("clears the layout when the removed plugin's own panel keeps focus", () => {
+    const store = createStore();
+    store.set(
+      splitLayoutAtom,
+      rowLayout(
+        [panelContent("github", "main"), panelContent("github", "issues")],
+        1,
+      ),
+    );
+    store.set(maximizedPaneIdAtom, "pane-2");
+
+    const result = store.set(closePanesForPluginAtom, "github");
+
+    // The last pane cannot be removed, so it would otherwise survive as a dead
+    // pane holding focus.
+    expect(result.removedAny).toBe(true);
+    expect(result.focusedContent).toBeNull();
+    expect(store.get(splitLayoutAtom)).toBeNull();
+    expect(store.get(maximizedPaneIdAtom)).toBeNull();
+  });
+
+  it("leaves a lone plugin pane for the caller's navigation to replace", () => {
+    const store = createStore();
+    const layout: SplitLayout = {
+      root: {
+        type: "pane",
+        paneId: "pane-1",
+        content: panelContent("github", "main"),
+      },
+      focusedPaneId: "pane-1",
+    };
+    store.set(splitLayoutAtom, layout);
+
+    const result = store.set(closePanesForPluginAtom, "github");
+
+    expect(result).toEqual({ removedAny: false, focusedContent: null });
+    expect(store.get(splitLayoutAtom)).toEqual(layout);
+  });
+
+  it("does nothing without a layout or a matching pane", () => {
+    const store = createStore();
+    expect(store.set(closePanesForPluginAtom, "github")).toEqual({
+      removedAny: false,
+      focusedContent: null,
+    });
+
+    store.set(
+      splitLayoutAtom,
+      rowLayout([THREAD_CONTENT, panelContent("docs", "docs")], 0),
+    );
+    expect(store.set(closePanesForPluginAtom, "github")).toEqual({
+      removedAny: false,
+      focusedContent: null,
     });
     expect(countPanes(store.get(splitLayoutAtom)!.root)).toBe(2);
   });

--- a/apps/app/src/lib/split-layout/atoms.ts
+++ b/apps/app/src/lib/split-layout/atoms.ts
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { createTabScopedStorage, type SyncStorage } from "@/lib/browser-storage";
+import {
+  createTabScopedStorage,
+  type SyncStorage,
+} from "@/lib/browser-storage";
 import type { ThreadRoutePathArgs } from "@/lib/route-paths";
 import { findPane, listPanes, removePane } from "./ops";
 import {
@@ -8,7 +11,7 @@ import {
   serializeSplitLayout,
   SPLIT_LAYOUT_STORAGE_KEY,
 } from "./persistence";
-import type { SplitLayout } from "./types";
+import type { PaneContent, SplitLayout } from "./types";
 
 function createSplitLayoutStorage(): SyncStorage<SplitLayout | null> {
   return createTabScopedStorage<SplitLayout | null>({
@@ -145,5 +148,82 @@ export const closePanesForThreadsAtom = atom(
     }
     set(splitLayoutAtom, layout);
     return { removedAny: true, focusedRoute: survivorRoute };
+  },
+);
+
+export interface ClosePanesForPluginResult {
+  /** True when at least one pane closed. */
+  removedAny: boolean;
+  /**
+   * Content of the focused pane that survived the close, or null when nothing
+   * closed or no valid pane survived. The caller navigates to this pane's own
+   * route, so removing a background pane never drags the window off the page
+   * the user is actually looking at; a null falls back to its navigate-away.
+   */
+  focusedContent: PaneContent | null;
+}
+
+/**
+ * Closes every pane showing a panel from `pluginId`, the split-layout sibling
+ * of {@link closePanesForThreadsAtom}. Uninstalling a plugin unregisters its
+ * panels, so a pane left behind renders the "panel is not available"
+ * placeholder for a page nothing can restore — and reload brings it back,
+ * because the layout is persisted.
+ *
+ * The layout never collapses below a single pane, so a lone plugin pane stays
+ * put: the caller's navigation replaces its content instead.
+ */
+export const closePanesForPluginAtom = atom(
+  null,
+  (get, set, pluginId: string): ClosePanesForPluginResult => {
+    const current = get(splitLayoutAtom);
+    if (current === null) {
+      return { removedAny: false, focusedContent: null };
+    }
+    const isRemovedPanel = (content: PaneContent): boolean =>
+      content.kind === "plugin-panel" && content.pluginId === pluginId;
+    let layout = current;
+    let removedAny = false;
+    for (;;) {
+      const pane = listPanes(layout.root).find((candidate) =>
+        isRemovedPanel(candidate.content),
+      );
+      if (pane === undefined) {
+        break;
+      }
+      const next = removePane(layout, pane.paneId);
+      if (next === layout) {
+        // removePane refuses to remove the last pane.
+        break;
+      }
+      layout = next;
+      removedAny = true;
+    }
+    if (!removedAny) {
+      return { removedAny: false, focusedContent: null };
+    }
+    const maximizedPaneId = get(maximizedPaneIdAtom);
+    if (
+      maximizedPaneId !== null &&
+      (listPanes(layout.root).length < 2 ||
+        findPane(layout.root, maximizedPaneId) === null)
+    ) {
+      set(maximizedPaneIdAtom, null);
+    }
+    // The pane that kept focus can still be the removed plugin's own panel,
+    // when its panels filled the layout. Treat that as "no valid survivor":
+    // clear the layout rather than leave a dead pane behind.
+    const focused = findPane(layout.root, layout.focusedPaneId);
+    const survivor =
+      focused !== null && !isRemovedPanel(focused.content)
+        ? focused.content
+        : null;
+    if (survivor === null) {
+      set(splitLayoutAtom, null);
+      set(maximizedPaneIdAtom, null);
+      return { removedAny: true, focusedContent: null };
+    }
+    set(splitLayoutAtom, layout);
+    return { removedAny: true, focusedContent: survivor };
   },
 );

--- a/apps/app/src/test/queryClientTestHarness.tsx
+++ b/apps/app/src/test/queryClientTestHarness.tsx
@@ -16,8 +16,12 @@ export interface QueryClientTestHarness {
   wrapper: QueryClientTestWrapper;
 }
 
-export function createQueryClientTestHarness(): QueryClientTestHarness {
-  const queryClient = createAppQueryClient({
+/**
+ * The app's query client with retries off, so a request a test never stubs
+ * fails once instead of being retried past the assertion's timeout.
+ */
+export function createTestQueryClient(): QueryClient {
+  return createAppQueryClient({
     defaultOptions: {
       mutations: {
         retry: false,
@@ -28,6 +32,10 @@ export function createQueryClientTestHarness(): QueryClientTestHarness {
       },
     },
   });
+}
+
+export function createQueryClientTestHarness(): QueryClientTestHarness {
+  const queryClient = createTestQueryClient();
 
   const wrapper: QueryClientTestWrapper = ({ children }) => (
     <JotaiProvider>

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -6,9 +6,7 @@ import {
   type ReactNode,
 } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { useMutation } from "@tanstack/react-query";
 import { buildPluginEditThreadPrompt } from "@bb/shared-ui/resource-edit-prompt";
-import { appToast } from "@/components/ui/app-toast";
 import { OverflowFade } from "@/components/ui/overflow-fade";
 import { useScrollOverflowState } from "@/components/thread/timeline/useScrollOverflowState";
 import {
@@ -22,21 +20,23 @@ import {
 } from "@bb/shared-ui/resource-list";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { PluginsOverview } from "@/components/plugin/PluginsOverview";
+import { usePluginLifecycle } from "@/components/plugin/usePluginLifecycle";
 import {
   CatalogPluginDetail,
   CatalogPluginDetailBanner,
   PluginDetail,
   PluginDetailBanners,
-  pluginIsLocalSource,
-  pluginRemovalLabel,
 } from "@/components/tools/PluginDetail";
+import {
+  pluginIsLocalSource,
+  pluginRemovalConfirmCopy,
+  pluginRemovalLabel,
+} from "@/components/plugin/plugin-removal";
 import {
   usePluginCatalogSearch,
   type PluginCatalogSearchEntry,
 } from "@/hooks/queries/plugin-catalog-queries";
 import {
-  removePlugin,
-  setPluginEnabled,
   usePluginList,
   type PluginListItem,
 } from "@/hooks/queries/plugin-settings-queries";
@@ -149,7 +149,6 @@ function PluginsToolView({ pluginId }: { pluginId: string | undefined }) {
 
 function PluginDetailToolView({ pluginId }: { pluginId: string }) {
   const navigate = useNavigate();
-  const [deleteTarget, setDeleteTarget] = useState<PluginListItem | null>(null);
   const [installTarget, setInstallTarget] =
     useState<PluginCatalogSearchEntry | null>(null);
   const listQuery = usePluginList({ enabled: true });
@@ -166,41 +165,11 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
       (plugin) => pluginIsLocalSource(plugin) && plugin.rootDir !== null,
     ),
   });
-  const pluginToggle = useMutation({
-    mutationFn: async (plugin: PluginListItem) => {
-      const action = plugin.enabled ? "disable" : "enable";
-      try {
-        await setPluginEnabled(fetch, plugin.id, !plugin.enabled);
-      } catch {
-        throw new Error(`Failed to ${action} plugin`);
-      }
-    },
-    onSuccess: () => listQuery.refetch(),
-    onError: (error) => {
-      appToast.error(error instanceof Error ? error.message : String(error));
-    },
-  });
-  const pluginDelete = useMutation({
-    mutationFn: async (plugin: PluginListItem) => {
-      try {
-        await removePlugin(fetch, plugin.id);
-      } catch {
-        throw new Error("Failed to delete plugin");
-      }
-    },
-    onSuccess: (_data, deletedPlugin) => {
-      appToast.success(
-        pluginIsLocalSource(deletedPlugin)
-          ? "Plugin removed from bb"
-          : "Plugin uninstalled",
-      );
-      setDeleteTarget(null);
-      navigate(getPluginsRoutePath());
-      return listQuery.refetch();
-    },
-    onError: (error) => {
-      appToast.error(error instanceof Error ? error.message : String(error));
-    },
+  // Same hook the sidebar row menu uses, so the two surfaces cannot disagree
+  // about what enabling or removing a plugin does. This surface additionally
+  // leaves the detail page, which dies with the plugin it describes.
+  const lifecycle = usePluginLifecycle({
+    onRemoved: () => navigate(getPluginsRoutePath()),
   });
   const isLoading = listQuery.isFetching && listQuery.data === undefined;
   const selectedPlugin =
@@ -214,11 +183,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
       null,
   );
   const pendingPluginId =
-    pluginToggle.isPending && pluginToggle.variables
-      ? pluginToggle.variables.id
-      : pluginDelete.isPending && pluginDelete.variables
-        ? pluginDelete.variables.id
-        : null;
+    lifecycle.pendingPluginId;
   const handleEditPlugin = useCallback(
     (plugin: PluginListItem) => {
       navigate(getRootComposeRoutePath(), {
@@ -272,10 +237,10 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
         plugin={selectedPlugin}
         pending={pendingPluginId === selectedPlugin.id}
         openSourceDisabled={!canOpenPreferredDirectoryTarget}
-        onToggle={(target) => pluginToggle.mutate(target)}
+        onToggle={lifecycle.toggleEnabled}
         onEdit={handleEditPlugin}
         onOpenSource={handleOpenPluginSource}
-        onDelete={setDeleteTarget}
+        onDelete={lifecycle.requestRemove}
       />
     );
   } else if (catalogQuery.isError) {
@@ -339,27 +304,19 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
         <ToolsScrollPage>
           {detailContent}
           <ConfirmDeleteDialog
-            open={deleteTarget !== null}
+            open={lifecycle.removeTarget !== null}
             onOpenChange={(open) => {
-              if (!open && !pluginDelete.isPending) setDeleteTarget(null);
+              if (!open && !lifecycle.removePending) lifecycle.cancelRemove();
             }}
           >
-            {deleteTarget ? (
+            {lifecycle.removeTarget ? (
               <ConfirmDeleteDialogContent
-                title={
-                  pluginIsLocalSource(deleteTarget)
-                    ? "Remove plugin from bb?"
-                    : "Uninstall plugin?"
-                }
-                description={
-                  pluginIsLocalSource(deleteTarget)
-                    ? `Remove "${deleteTarget.id}" from bb? Its source files will stay on disk.`
-                    : `Uninstall "${deleteTarget.id}" and delete its managed files and settings?`
-                }
-                confirmLabel={pluginRemovalLabel(deleteTarget)}
-                pending={pluginDelete.isPending}
-                onConfirm={() => pluginDelete.mutate(deleteTarget)}
-                onCancel={() => setDeleteTarget(null)}
+                title={pluginRemovalConfirmCopy(lifecycle.removeTarget).title}
+                description={pluginRemovalConfirmCopy(lifecycle.removeTarget).description}
+                confirmLabel={pluginRemovalLabel(lifecycle.removeTarget)}
+                pending={lifecycle.removePending}
+                onConfirm={lifecycle.confirmRemove}
+                onCancel={lifecycle.cancelRemove}
               />
             ) : null}
           </ConfirmDeleteDialog>


### PR DESCRIPTION
## What changed

A plugin's page row in the side panel offered one action — hide it from the sidebar — so turning a plugin off or removing it meant leaving for Extensions. The row now carries the plugin's lifecycle too:

| | Enabled | Disabled | Ships with bb |
|---|---|---|---|
| 1 | Hide from sidebar | Hide from sidebar | Hide from sidebar |
| 2 | **Disable** | **Enable** | Disable |
| 3 | **Uninstall** / *Remove from bb* (destructive) | same | Uninstall, greyed — *"Included with BB; disable this plugin instead."* |

Both call the plugin admin routes the Extensions pages already use — `setPluginEnabled` (POST `…/enable`|`…/disable`) and `removePlugin` (DELETE `/plugins/:id`). No new server or daemon surface.

Removal policy and copy move into `plugin-removal.ts`, shared with the Extensions detail page, so the two menus cannot drift. That is also where the builtin refusal lives, since `DELETE /plugins/:id` answers 409 for plugins that ship with bb.

## Two details worth reviewing

**The list owns the mutations and the confirmation dialog, not the row.** Uninstalling unregisters the plugin's panels, so the row that started the request unmounts before it settles — a row-owned toast, navigation, or dialog would be lost.

**Uninstall navigates away; disable does not.** After a successful removal, a panel sitting on that plugin's route goes to the app root instead of standing on the "panel is not available" placeholder. Disable deliberately stays put so the state change is visible.

Lifecycle items render only once the installed-plugin list resolves — an action needs real `enabled`/provenance state before it can label itself. The query is gated on the sidebar actually having plugin rows, so an Extensions-only sidebar never asks for it.

## Verification

Driven against the dev app with a `path:`-installed test plugin contributing a nav panel:

- Disable → server reported `enabled:false`, the row left the sidebar, the panel fell back to the placeholder, and Extensions → Plugins showed the plugin unchecked. Re-enabled from the detail page → row returned.
- Uninstall → confirmation dialog, confirm, route moved `/plugins/qa-panel/qa` → `/`, row gone; after a reload the plugin was absent from both the sidebar and `GET /api/v1/plugins`.

`turbo run typecheck --filter=@bb/app` clean · `PluginNavSidebarItems.test.tsx` 12/12 (6 new) · `ToolsView.plugin-detail` + `PluginsOverview` + `route-paths` + `ProjectActionsMenu` 55/55 · lint 0 errors in changed files.

## Known limitation

`Enable` is correct but effectively unreachable from this surface: a disabled plugin unregisters its nav panel, so its sidebar row disappears and there is no row left to open a menu on. The label logic is unit-tested; in practice re-enabling happens in Extensions → Plugins. Making disabled plugins keep a sidebar row would be a separate change to how rows are sourced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
