### PR TITLE
Document the GitHub stacked-PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,12 @@
 
 - Do not assume. Inspect logs, query the database, call server APIs, or use the CLI to observe real state.
 - See [docs/debugging-and-qa.md](docs/debugging-and-qa.md) for dev ports/data dirs, entity-ID lookups, and the `scripts/bb-dev-app` local dev QA launcher.
+
+## Pull Requests And Stacks
+
+- Stacked work uses GitHub's native stacked pull requests through the `gh stack` extension (`github/gh-stack`). PRs chained with `gh pr create --base` are not a stack: the stack is a server-side object, and only a real one gets the stack UI and atomic merge.
+- Add a layer with `gh stack link <stack-number> <new-pr-or-branch>`, and turn an existing chain into a stack with `gh stack link <bottom> … <top>` (bottom to top; each argument is a PR number, PR URL, or branch name). `link` keeps no local tracking state and never moves `HEAD`, so it is the only safe path in a worktree another session is working in.
+- `gh stack init`, `add`, `checkout`, `rebase`, and `sync` create or switch local branches. Do not run them in a shared worktree — check `git status` for edits you did not make before assuming a worktree is yours.
+- `gh stack view` reads local tracking state, so it reports "not part of a stack" after `link` even when the stack exists. Confirm server-side with `gh api repos/{owner}/{repo}/stacks/<stack-number>`.
+- Do not hand-write "Stacked on #N" in a PR body. The stack UI already renders the layers, and a hand-maintained pointer goes stale as soon as the stack is restructured.
+- Merge with `gh stack merge`. Every PR up to the one you choose merges in a single all-or-nothing operation, so a lower layer never lands without the layers built on it.


### PR DESCRIPTION
Nothing in `AGENTS.md` said how this repo stacks pull requests, so the reasonable-looking move — chaining PRs with `gh pr create --base` — produces something that reads like a stack but is not one. GitHub's stack is a server-side object; a `--base` chain gets neither the stack UI nor atomic merge.

Six bullets covering what an agent needs and cannot infer:

- Stacking goes through the `gh stack` extension (`github/gh-stack`), not `--base` chaining.
- `gh stack link` is the command to reach for: it keeps no local tracking state and never moves `HEAD`, which is what makes it usable in a worktree another session is working in. `gh stack init`/`add`/`checkout`/`rebase`/`sync` all create or switch local branches, so they are unsafe there.
- `gh stack view` reads local state and reports "not part of a stack" after `link` even when the stack exists — a confusing false negative worth calling out, with the server-side check that answers it.
- No hand-written "Stacked on #N" in PR bodies; the stack UI renders the layers and a manual pointer goes stale.
- `gh stack merge` is all-or-nothing up to the chosen PR, so a lower layer never lands without the layers built on it.

Every claim here was verified against `gh stack` v0.1.0 and the stacks API while assembling stack #1051, including the `gh stack view` false negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)