### PR TITLE
Document visual verification against the desktop shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@
 ## Debugging And QA
 
 - Do not assume. Inspect logs, query the database, call server APIs, or use the CLI to observe real state.
-- See [docs/debugging-and-qa.md](docs/debugging-and-qa.md) for dev ports/data dirs, entity-ID lookups, and the `scripts/bb-dev-app` local dev QA launcher.
+- Verify UI work by launching the app and screenshotting it. Window chrome (traffic lights, title-bar geometry, full-screen layout) exists only in the desktop shell, so it must be checked there — a renderer screenshot cannot show it.
+- See [docs/debugging-and-qa.md](docs/debugging-and-qa.md) for dev ports/data dirs, entity-ID lookups, the `scripts/bb-dev-app` local dev QA launcher, and visual verification.
 
 ## Pull Requests And Stacks
 

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -30,3 +30,31 @@ Test agents with:
 eval "$(scripts/bb-dev-app env)"
 pnpm bb:dev thread spawn --project proj_personal --provider codex --permission-mode accept-edits --title "Smoke test" --prompt "Reply only with ok." --json
 ```
+
+## Visual Verification
+
+Launch the app, drive it, and screenshot the result. Do not settle for reading
+the markup and reasoning about what it renders.
+
+- `scripts/bb-dev-app current --desktop` runs the Electron shell against this
+  checkout. Prefer it whenever the change touches window chrome — traffic
+  lights, title-bar geometry, window insets, full-screen layout — because only
+  the desktop build has any of that.
+- Capture the desktop window with `screencapture`. A DevTools screenshot cannot
+  show native chrome: CDP captures the renderer's web contents, and macOS draws
+  the window frame outside it. `screencapture: could not create image from
+  display` means the process hosting the agent lacks Screen Recording
+  permission (System Settings → Privacy & Security → Screen Recording) — it does
+  not mean the command is wrong, so ask for the grant instead of debugging the
+  invocation.
+- For in-page changes the dev web app is faster. `scripts/bb-dev-app current`
+  prints the URL; capture one state with a headless screenshot, or drive Chrome
+  for Testing over CDP when the check needs interaction — open a menu, confirm a
+  dialog, screenshot each state — by keeping a single attached session and
+  scripting `Page.navigate` / `Input.dispatchMouseEvent` /
+  `Page.captureScreenshot`.
+- Do not fake `window.bbDesktop` to coax macOS chrome out of the web build. The
+  desktop path expects the whole `BbDesktopApi`: a partial stub throws during
+  render and silently blanks the page (subscribe methods must *return* an
+  unsubscribe function, not be one), and even a complete stub only proves what
+  the renderer does, never what the native frame does.


### PR DESCRIPTION
Verifying UI work meant reading markup and reasoning about what it renders, because nothing in the repo said to launch the app and look at it. Adds a **Visual Verification** section to `docs/debugging-and-qa.md` with the actual recipe, plus a pointer from `AGENTS.md`.

The substance is two findings that each cost real time in the session that prompted this:

- **A DevTools screenshot can never show traffic lights.** CDP captures the renderer's web contents; macOS draws the window frame outside it. So `screencapture` against the desktop shell is the only way to verify anything about window chrome — and its `could not create image from display` failure means the host process lacks Screen Recording permission, not that the command is malformed. Worth stating plainly, because the message reads like a bug in the invocation.
- **Faking `window.bbDesktop` to coax macOS chrome out of the web build does not work.** The desktop path expects the whole `BbDesktopApi`; a partial stub throws mid-render and silently blanks the page (the specific trap: subscribe methods must *return* an unsubscribe function, not be one). Even a complete stub only proves what the renderer does, never what the native frame does.

The section also records the cheaper path for in-page changes — the dev web app, with a static headless capture or a single long-lived CDP session when the check needs interaction across several states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)