### PR TITLE
Clear the traffic lights when a panel tab goes full screen

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
@@ -81,12 +81,17 @@ describe("resolveCollapsedPanelTrafficLightReserveClassName", () => {
   const base = {
     isConversationCollapsed: true,
     renderAsDrawer: false,
-    isInSplitHost: true,
     isSidebarShowing: false as boolean | null,
     reserveMacosTrafficLights: true,
   };
 
-  it("reserves the safe area for the panel full-screen split-host case", () => {
+  // Covers both thread surfaces. Collapsing takes the conversation column to
+  // zero width and the thread header with it, on the split host and on inline
+  // thread detail alike, leaving the panel alone on the title-bar row. The
+  // reserve used to additionally require the split host, which is what left
+  // inline detail's tab strip sitting under the traffic lights; with that gate
+  // gone the surfaces are indistinguishable here, so one case covers them.
+  it("reserves the safe area for the panel full-screen case", () => {
     expect(resolveCollapsedPanelTrafficLightReserveClassName(base)).toBe(
       MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS,
     );
@@ -97,15 +102,6 @@ describe("resolveCollapsedPanelTrafficLightReserveClassName", () => {
       resolveCollapsedPanelTrafficLightReserveClassName({
         ...base,
         isSidebarShowing: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("does not reserve inline (non-host) thread detail, which keeps a header on the lights' row", () => {
-    expect(
-      resolveCollapsedPanelTrafficLightReserveClassName({
-        ...base,
-        isInSplitHost: false,
       }),
     ).toBe(false);
   });

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -149,13 +149,6 @@ interface CollapsedPanelTrafficLightReserveArgs {
   /** The compact drawer layout (never the window's top-left surface). */
   renderAsDrawer: boolean;
   /**
-   * True inside the split-workspace host — the only surface where the panel
-   * itself owns the window's flush top-left corner while the conversation is
-   * collapsed. Inline (non-split) thread detail keeps a full-width header on the
-   * traffic-light row above the panel, so it needs no reserve here.
-   */
-  isInSplitHost: boolean;
-  /**
    * Whether the main app sidebar is showing. `null` when the sidebar context is
    * absent (e.g. tests) — treated as showing, so no reserve is applied. The
    * sidebar hosts the traffic lights in its own top strip while open.
@@ -172,23 +165,31 @@ interface CollapsedPanelTrafficLightReserveArgs {
 /**
  * Left-padding class that clears the macOS traffic-light safe area for the
  * secondary panel's leading top-chrome toolbar, or `false` when no reserve is
- * needed. The reserve applies only when the panel is the window's flush
- * top-left surface (split host, conversation collapsed) while the main sidebar
- * is collapsed and the lights are visible — the collapsed-left / expanded-right
- * case from BB-46. See {@link MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS}
+ * needed. The reserve applies when the panel is the window's flush top-left
+ * surface — the conversation is collapsed — while the main sidebar is collapsed
+ * and the lights are visible: the collapsed-left / expanded-right case from
+ * BB-46. It lands the leading controls on the same x = 120px as
+ * AppPageHeader's own reserve. See {@link MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS}
  * for the geometry.
+ *
+ * Collapsing hands the panel the top-left on BOTH thread surfaces, so this does
+ * not test for the split host. Either way the conversation column collapses to
+ * zero width — the split host sets its layout to [0, panel], inline thread
+ * detail sizes the timeline panel to 0 — and the thread header rides inside
+ * that column, so nothing is left on the title-bar row but this toolbar. The
+ * split host reserved correctly because it satisfied the host gate; inline
+ * thread detail, identical in layout, did not, which left its tab strip
+ * sitting under the traffic lights.
  */
 export function resolveCollapsedPanelTrafficLightReserveClassName({
   isConversationCollapsed,
   renderAsDrawer,
-  isInSplitHost,
   isSidebarShowing,
   reserveMacosTrafficLights,
 }: CollapsedPanelTrafficLightReserveArgs): string | false {
   const reserves =
     isConversationCollapsed &&
     !renderAsDrawer &&
-    isInSplitHost &&
     isSidebarShowing === false &&
     reserveMacosTrafficLights;
   return reserves && MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS;
@@ -513,14 +514,13 @@ export function ThreadSecondaryPanel({
   const desktopWindowState = useDesktopWindowState();
   const isSidebarShowing = useOptionalIsSidebarShowing();
   // The panel reserves the traffic-light safe area only when it is the window's
-  // flush top-left surface (split-workspace host, conversation collapsed) with
-  // the main sidebar collapsed and the lights visible. See
+  // flush top-left surface (conversation collapsed) with the main sidebar
+  // collapsed and the lights visible. See
   // resolveCollapsedPanelTrafficLightReserveClassName.
   const collapsedPanelTrafficLightReserveClassName =
     resolveCollapsedPanelTrafficLightReserveClassName({
       isConversationCollapsed,
       renderAsDrawer,
-      isInSplitHost: hostLayout !== null,
       isSidebarShowing,
       reserveMacosTrafficLights: shouldReserveMacosTrafficLights({
         desktopInfo,
@@ -627,8 +627,9 @@ export function ThreadSecondaryPanel({
           <div
             className={cn(
               "flex min-w-0 flex-1 items-center gap-1",
-              // When this panel owns the window's top-left (split host, sidebar
-              // collapsed, conversation collapsed), reserve the traffic-light
+              // When this panel owns the window's top-left (conversation
+              // collapsed, on either thread surface, with the sidebar
+              // collapsed), reserve the traffic-light
               // safe area so the leading controls clear the lights and the
               // pinned sidebar trigger. The padding must animate on the SAME
               // timing/easing as the panel's collapse slide

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -20,11 +20,13 @@ import type {
 // it can transition in lockstep with the sidebar slide instead of snapping
 // on/off while the inset animates. The two surfaces are:
 //  - the page header content row.
-//  - the split-workspace secondary panel's top chrome, while the conversation
-//    is collapsed and the panel is flush at the window top-left. (This is the
-//    only surface where the panel itself owns the top-left — inline non-split
-//    thread detail keeps a full-width header on the lights' row above the
-//    panel, and root compose keeps the panel on the right of the main content.)
+//  - the secondary panel's top chrome, while the conversation is collapsed and
+//    the panel is flush at the window top-left. That happens on both thread
+//    surfaces, not just the split-workspace host: collapsing takes the
+//    conversation column to zero width and the thread header rides inside it,
+//    so inline thread detail hands over the top-left too. Assuming otherwise is
+//    what once left its tab strip sitting under the lights. Root compose is
+//    genuinely exempt — it keeps the panel to the right of the main content.
 export const MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS = "left-[84px]";
 export const MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS = "pl-[104px]";
 


### PR DESCRIPTION
Full-screening a tab leaves the tab strip sitting under the macOS traffic lights — but only on a thread that is **not** in a split. In a split, the same action clears the lights correctly.

## Root cause

Collapsing the conversation produces the same layout on both thread surfaces:

- **Split host** sets its group layout to `[0, MAIN_PANEL_OPEN_SIZE_PERCENT]` (`SplitWorkspaceSecondaryPanelHost.tsx:129`).
- **Inline thread detail** sizes the timeline panel to `COLLAPSED_TIMELINE_PANEL_SIZE_PERCENT = 0`.

Either way the conversation column goes to zero width, and the thread header rides inside that column, so the panel's toolbar is left alone on the title-bar row on both surfaces.

Only the reserve differed. `resolveCollapsedPanelTrafficLightReserveClassName` gated it on `isInSplitHost`, justified in its own doc comment: inline thread detail "keeps a full-width header on the traffic-light row above the panel, so it needs no reserve here." That is not true once the conversation is collapsed — inline renders `{header}` inside the wrapper that collapsing makes `opacity-0` and `inert` (`ThreadDetailSecondaryContent.tsx:400`), and the comment there says as much: "`inert` removes the hidden conversation (header, timeline, composer)".

So the split host cleared the lights because it passed the host gate, and inline thread detail — laid out identically — did not. That asymmetry is exactly the reported symptom.

## Fix

Drop `isInSplitHost`. The reserve is about the collapse, not the host. The parameter is removed rather than left accepted-and-ignored.

## Verification

Measured the working reference — `AppPageHeader`'s reserve — in the running app under real macOS chrome, driving Chrome for Testing over CDP:

```
sidebar hidden, panel docked right:
  header:        left 16,   padding-left 104px,  content at 120   <- reference
  panel toolbar: left 1517, padding-left 0px                      <- correct while docked
```

120px is the shared target: `px-4` (16) + `MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS` (104), which clears the lights and the pinned sidebar trigger. After this change the panel lands its leading controls on that same 120px when it owns the top-left, on both surfaces.

`turbo run typecheck --filter=@bb/app` clean; `ThreadSecondaryPanel.test.ts` (13) + `AppPageHeader.test.tsx` + `bb-desktop.test.ts` — 17 passed. The test that encoded the wrong premise now asserts the opposite, with the reason recorded.

**Verification gap, stated plainly:** I could not drive BB's own Full Screen toggle headlessly — it does not flip `isConversationCollapsed` under a stubbed desktop API — so the collapsed state is verified by code reading, the split/non-split asymmetry reported from the real app, and unit tests, rather than by a screenshot of the fixed window. Capturing the real lights needs OS-level screen capture, which is not permitted for the host process here. Worth an eyeball on a desktop build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
