### PR TITLE
Relay DELETE request bodies through bb connect

### DIFF
--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from "./reconnect.js";
 export {
   isBareBbRealtimeWs,
+  requestOriginHttp,
   TunnelSession,
   type ResolvedStreamOrigin,
   type StreamOriginResult,

--- a/packages/tunnel-client/src/session.ts
+++ b/packages/tunnel-client/src/session.ts
@@ -37,12 +37,29 @@ interface OriginHttpRequestArgs {
   url: URL;
 }
 
-function requestOriginHttp(
+/**
+ * Restore the Content-Length that the relay strips.
+ *
+ * Node's HTTP client does not use chunked encoding by default for GET, HEAD,
+ * and DELETE. Without a Content-Length, it writes such a body with no framing
+ * at all. The origin then reads a body-less request and parses the leftover
+ * bytes as the next request on that connection, which answers an empty 400.
+ * An explicit Content-Length frames the body for every method.
+ */
+function frameBodyHeaders(
+  headers: Record<string, string>,
+  body: Buffer | undefined,
+): Record<string, string> {
+  if (body === undefined) return headers;
+  return { ...headers, "Content-Length": String(body.byteLength) };
+}
+
+export function requestOriginHttp(
   args: OriginHttpRequestArgs,
 ): Promise<IncomingMessage> {
   const request = args.url.protocol === "https:" ? httpsRequest : httpRequest;
   const options: RequestOptions = {
-    headers: args.headers,
+    headers: frameBodyHeaders(args.headers, args.body),
     method: args.method,
     signal: args.signal,
   };

--- a/packages/tunnel-client/test/origin-request.test.ts
+++ b/packages/tunnel-client/test/origin-request.test.ts
@@ -1,0 +1,90 @@
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { requestOriginHttp } from "../src/session.js";
+
+interface SeenRequest {
+  body: string;
+  contentLength: string | undefined;
+  method: string;
+}
+
+let server: Server;
+let origin: string;
+const seen: SeenRequest[] = [];
+
+async function readBody(response: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of response) {
+    chunks.push(chunk instanceof Buffer ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString();
+}
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      seen.push({
+        body: Buffer.concat(chunks).toString(),
+        contentLength: request.headers["content-length"],
+        method: request.method ?? "",
+      });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+    });
+  });
+  // A framing error answers an empty 400, which is the bug this guards.
+  server.on("clientError", (_error, socket) => {
+    socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test server has no port");
+  }
+  origin = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("requestOriginHttp", () => {
+  // The relay drops the visitor's Content-Length, so the client must restore
+  // it. Node skips chunked encoding for DELETE, GET, and HEAD.
+  it.each(["DELETE", "GET", "PATCH", "POST", "PUT"])(
+    "delivers a %s body to the origin",
+    async (method) => {
+      const body = Buffer.from(
+        JSON.stringify({ childThreadsConfirmed: false }),
+      );
+      const response = await requestOriginHttp({
+        body,
+        headers: { "Content-Type": "application/json" },
+        method,
+        signal: new AbortController().signal,
+        url: new URL(`${origin}/api/v1/threads/t1`),
+      });
+      expect(response.statusCode).toBe(200);
+      expect(await readBody(response)).toBe('{"ok":true}');
+      const last = seen.at(-1);
+      expect(last?.method).toBe(method);
+      expect(last?.body).toBe(body.toString());
+      expect(last?.contentLength).toBe(String(body.byteLength));
+    },
+  );
+
+  it("sends no Content-Length when there is no body", async () => {
+    const response = await requestOriginHttp({
+      body: undefined,
+      headers: {},
+      method: "DELETE",
+      signal: new AbortController().signal,
+      url: new URL(`${origin}/api/v1/threads/t1`),
+    });
+    expect(response.statusCode).toBe(200);
+    await readBody(response);
+    expect(seen.at(-1)?.contentLength).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #1055.

## The problem

A DELETE request with a JSON body returned an empty HTTP 400 through bb connect. The same request worked over loopback, and PATCH with a body relayed correctly. The mobile PWA could not delete a thread, because thread deletion needs a confirmation field in the body.

## The cause

The relay path is correct up to the last hop. `apps/connect` forwards the method and streams the body, and the tunnel client buffers the chunks. The tunnel client then drops the `content-length` header (`packages/tunnel-client/src/headers.ts`) and lets Node re-frame the body.

Node's HTTP client sets `useChunkedEncodingByDefault = false` for GET, HEAD, and DELETE. Without a Content-Length, Node writes the body with no framing at all. The bb server reads a body-less request, then parses the leftover body bytes as the start of the next request on that connection. That is a parse error, and Node answers an empty 400.

This reproduces with plain Node:

```
SERVER saw PATCH  cl=31        body="{...}"   PATCH  -> 200
CLIENT ERROR: HPE_INVALID_METHOD
SERVER saw DELETE cl=undefined body=""        DELETE -> 400 ""
```

## The fix

Set an explicit `Content-Length` in `requestOriginHttp` whenever a body is present. The body is already fully buffered before the loopback request starts, so the length is always known. This frames the body for every method.

## Tests

`packages/tunnel-client/test/origin-request.test.ts` drives `requestOriginHttp` against a real loopback server. It asserts the body and Content-Length for DELETE, GET, PATCH, POST, and PUT, and asserts no Content-Length when there is no body. The server answers an empty 400 on `clientError`, which is the exact symptom from the issue.

Without the fix, the DELETE and GET cases fail and the rest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
