### PR TITLE
Remove the redundant hide button from the right panel drawer

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -723,7 +723,11 @@ export function ThreadSecondaryPanel({
                 </TooltipContent>
               </Tooltip>
             ) : null}
-            {renderAsDrawer || inlinePanelToggle === "button" ? (
+            {/*
+              The drawer already closes with its own handle, a swipe, or a
+              backdrop tap, so it renders no hide button of its own.
+            */}
+            {!renderAsDrawer && inlinePanelToggle === "button" ? (
               <Button
                 type="button"
                 variant="ghost"


### PR DESCRIPTION
## Summary

On a compact viewport the right panel renders inside a drawer. The header showed a "Hide right panel" button there, but the drawer already closes with its grab handle, a swipe down, or a backdrop tap. The button was a redundant third way to do the same thing, and it sat in the top-right corner of an otherwise empty header.

The guard in `ThreadSecondaryPanel` changes from `renderAsDrawer || inlinePanelToggle === "button"` to `!renderAsDrawer && inlinePanelToggle === "button"`. Desktop and split-pane surfaces keep their button through the existing `inlinePanelToggle` prop.

This is not a revert of a recent break. The button has rendered in the drawer since the panel shipped; the drawer later gained the handle and swipe-to-dismiss, which made the button redundant.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/app` — passes.
- `pnpm exec vitest run src/components/secondary-panel src/views/RootComposeRightPanelToggle.test.tsx src/views/thread-detail/ThreadDetailHeader.test.tsx` — 22 files, 129 tests pass.

## Risks

Low. The change is one boolean condition on a purely visual control. The drawer keeps three other ways to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)