### PR TITLE
Document the better-sqlite3 bindings failure in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,40 @@ See [System overview](docs/system-overview.md) for runtime architecture, data mo
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+## Troubleshooting
+
+### `Could not locate the bindings file`
+
+bb uses native add-ons, for example `better-sqlite3` and `@parcel/watcher`. npm
+downloads or builds those binaries in a package install script. If npm does not
+run install scripts, the binaries are absent. bb then stops at startup with this
+error:
+
+```
+Error: Could not locate the bindings file. Tried:
+ → .../node_modules/better-sqlite3/build/better_sqlite3.node
+```
+
+The usual cause is `ignore-scripts=true` in your `~/.npmrc`. Set the
+`npm_config_ignore_scripts` environment variable to let this one command run its
+install scripts:
+
+```bash
+npm_config_ignore_scripts=false npx bb-app@latest
+```
+
+For a permanent install with the same setting, use:
+
+```bash
+npm_config_ignore_scripts=false npm install -g bb-app
+bb-app
+```
+
+The environment variable applies to that one command only. Keep
+`ignore-scripts=true` in your `~/.npmrc` if you want it for security.
+
+The same error has other causes. A Node.js major-version change after the
+install causes it. A copy of `node_modules` from a different operating system,
+CPU architecture, or libc variant also causes it. To recover, install the
+package again, or run `npm rebuild better-sqlite3`.


### PR DESCRIPTION
## Summary

`npx bb-app@latest` fails at startup with `Error: Could not locate the bindings file` on machines that set `ignore-scripts=true` in `~/.npmrc`. npm then skips the install script that fetches the `better-sqlite3` native binary. There is no bb-side fix, so this documents the cause and the workaround.

Adds a `## Troubleshooting` section at the bottom of the root `README.md`:

- explains why the native add-ons need install scripts
- gives the one-off `npm_config_ignore_scripts=false npx bb-app@latest` command
- gives a permanent global-install variant
- notes that the variable applies to one command only, so the `~/.npmrc` setting can stay
- lists the other causes of the same error (Node major-version change, copied `node_modules`) and `npm rebuild better-sqlite3`

## Tests

Documentation only. No code changed.

Fixes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)