### PR TITLE
Fix Git status for newly initialized repositories

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -459,6 +459,13 @@ export async function createHostDaemonApp(
         });
       }
     },
+    onWorkspaceMetadataChanged: ({ environmentId, workspace }) => {
+      sendServerMessage({
+        type: "environment-metadata-change",
+        environmentId,
+        workspace,
+      });
+    },
     onWorkspaceStatusWatchError: ({ error }) => {
       options.logger.warn(
         {

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -432,6 +432,8 @@ export async function createHostDaemonApp(
   watchManager = new WatchManager({
     dataDir: options.dataDir,
     hostWatcher: options.hostWatcher,
+    refreshWorkspace: (args) =>
+      runtimeManager.refreshEnvironmentWorkspace(args),
     threadStorageRootPath,
     onThreadStorageChanged: ({ environmentId }) => {
       sendServerMessage({

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -155,7 +155,7 @@ function getProvisionWorkspacePath(args: ProvisionWorkspaceArgs): string {
   }
 }
 
-function createFakeWorkspace(path: string) {
+function createFakeWorkspace(path: string, isGitRepo = true) {
   const status: GetStatusResult = makeWorkspaceStatus({
     mergeBase: makeWorkspaceMergeBase(),
   });
@@ -173,7 +173,7 @@ function createFakeWorkspace(path: string) {
   const workspace = {
     path,
     managed: false,
-    isGitRepo: true,
+    isGitRepo,
     isWorktree: false,
     getDefaultBranch: vi.fn(async () => "main"),
     getCurrentBranch: vi.fn(async (..._args: GetCurrentBranchArgs) => "main"),
@@ -318,6 +318,37 @@ describe("RuntimeManager", () => {
     expect(provisionWorkspace).toHaveBeenCalledTimes(1);
     expect(createRuntime).toHaveBeenCalledTimes(1);
     expect(entry.path).toBe("/tmp/env-1");
+  });
+
+  it("refreshes the workspace on the resident runtime entry", async () => {
+    const plainWorkspace = createFakeWorkspace("/tmp/env-refresh", false);
+    const gitWorkspace = createFakeWorkspace("/tmp/env-refresh");
+    const provisionWorkspace = vi
+      .fn<(options: ProvisionWorkspaceArgs) => Promise<HostWorkspace>>()
+      .mockResolvedValueOnce(plainWorkspace)
+      .mockResolvedValueOnce(gitWorkspace);
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      createRuntime: () => createFakeRuntime(),
+    });
+    const entry = await manager.ensureEnvironment({
+      environmentId: "env-refresh",
+      workspacePath: "/tmp/env-refresh",
+    });
+
+    const refreshed = await manager.refreshEnvironmentWorkspace({
+      environmentId: "env-refresh",
+      provision: {
+        workspaceProvisionType: "unmanaged",
+        path: "/tmp/env-refresh",
+      },
+      workspacePath: "/tmp/env-refresh",
+    });
+
+    expect(refreshed).toBe(gitWorkspace);
+    expect(entry.workspace).toBe(gitWorkspace);
+    expect(manager.get("env-refresh")?.workspace).toBe(gitWorkspace);
+    expect(provisionWorkspace).toHaveBeenCalledTimes(2);
   });
 
   it("reaps idle provider sessions from loaded runtimes", async () => {

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -179,6 +179,12 @@ export interface CancelEnvironmentProvisionResult {
   aborted: boolean;
 }
 
+export interface RefreshEnvironmentWorkspaceArgs {
+  environmentId: string;
+  provision: ProvisionWorkspaceArgs;
+  workspacePath: string;
+}
+
 export interface RuntimeManagerOptions {
   bridgeBundleDir?: AgentRuntimeOptions["bridgeBundleDir"];
   createRuntime?: (options: AgentRuntimeOptions) => AgentRuntime;
@@ -270,6 +276,10 @@ export class RuntimeManager {
   private readonly pendingEnvironmentProvisions = new Map<
     string,
     PendingEnvironmentProvision
+  >();
+  private readonly pendingWorkspaceRefreshes = new Map<
+    string,
+    Promise<HostWorkspace>
   >();
   private readonly inFlightThreadCommandsByEnvironmentId = new Map<
     string,
@@ -774,6 +784,45 @@ export class RuntimeManager {
     this.pendingEntries.set(args.environmentId, creation);
 
     return creation;
+  }
+
+  async refreshEnvironmentWorkspace(
+    args: RefreshEnvironmentWorkspaceArgs,
+  ): Promise<HostWorkspace> {
+    const pending = this.pendingWorkspaceRefreshes.get(args.environmentId);
+    if (pending) {
+      return pending;
+    }
+
+    const refresh = this.refreshEnvironmentWorkspaceOnce(args).finally(() => {
+      if (this.pendingWorkspaceRefreshes.get(args.environmentId) === refresh) {
+        this.pendingWorkspaceRefreshes.delete(args.environmentId);
+      }
+    });
+    this.pendingWorkspaceRefreshes.set(args.environmentId, refresh);
+    return refresh;
+  }
+
+  private async refreshEnvironmentWorkspaceOnce(
+    args: RefreshEnvironmentWorkspaceArgs,
+  ): Promise<HostWorkspace> {
+    const entry = await this.getOrAwait(args.environmentId);
+    if (entry && entry.path !== args.workspacePath) {
+      throw new Error(
+        `Cannot refresh environment ${args.environmentId} at ${args.workspacePath}; it is bound to ${entry.path}`,
+      );
+    }
+
+    const workspace = await this.provisionWorkspace(args.provision);
+    if (workspace.path !== args.workspacePath) {
+      throw new Error(
+        `Workspace refresh for ${args.environmentId} returned ${workspace.path}, not ${args.workspacePath}`,
+      );
+    }
+    if (entry) {
+      entry.workspace = workspace;
+    }
+    return workspace;
   }
 
   async cancelEnvironmentProvision(

--- a/apps/host-daemon/src/server-connection.ts
+++ b/apps/host-daemon/src/server-connection.ts
@@ -82,6 +82,8 @@ function recoverableMessageKey(
       return "connect-tunnel.identity";
     case "environment-change":
       return `environment-change\u0000${message.environmentId}\u0000${message.change}`;
+    case "environment-metadata-change":
+      return `environment-metadata-change\u0000${message.environmentId}`;
     default:
       return null;
   }

--- a/apps/host-daemon/src/watch-manager.test.ts
+++ b/apps/host-daemon/src/watch-manager.test.ts
@@ -7,7 +7,7 @@ import type {
 import type { HostWorkspace } from "@bb/host-workspace";
 import { makeWorkspaceMergeBase, makeWorkspaceStatus } from "@bb/test-helpers";
 import { describe, expect, it, vi } from "vitest";
-import { WatchManager } from "./watch-manager.js";
+import { WatchManager, type WatchManagerOptions } from "./watch-manager.js";
 
 type GetLocalStateFingerprintResult = Awaited<
   ReturnType<HostWorkspace["getLocalStateFingerprint"]>
@@ -37,7 +37,7 @@ function createDeferred<TValue>(): Deferred<TValue> {
   return { promise, resolve, reject };
 }
 
-function createFakeWorkspace(path: string) {
+function createFakeWorkspace(path: string, isGitRepo = true) {
   let localStateFingerprint: GetLocalStateFingerprintResult = `local:${path}:initial`;
   let localStateFingerprintError: Error | null = null;
   let sharedGitRefsFingerprint: GetSharedGitRefsFingerprintResult = `refs:${path}:initial`;
@@ -45,7 +45,7 @@ function createFakeWorkspace(path: string) {
   const workspace = {
     path,
     managed: false,
-    isGitRepo: true,
+    isGitRepo,
     isWorktree: false,
     getDefaultBranch: vi.fn(async () => "main"),
     getCurrentBranch: vi.fn(async () => "main"),
@@ -259,6 +259,68 @@ describe("WatchManager", () => {
       changeKinds: ["work-status-changed"],
       environmentId: "env-watch",
     });
+  });
+
+  it("refreshes workspace metadata when a plain workspace becomes a git repository", async () => {
+    let watchWorkspaceArgs: WatchWorkspaceArgs | undefined;
+    const plainWorkspace = createFakeWorkspace("/tmp/env-watch", false);
+    const gitWorkspace = createFakeWorkspace("/tmp/env-watch");
+    const provisionWorkspace = vi
+      .fn<NonNullable<WatchManagerOptions["provisionWorkspace"]>>()
+      .mockResolvedValueOnce(plainWorkspace)
+      .mockResolvedValueOnce(gitWorkspace);
+    const { hostWatcher } = createFakeHostWatcher({
+      watchWorkspaceImplementation: (args) => {
+        watchWorkspaceArgs = args;
+        return () => undefined;
+      },
+    });
+    const onWorkspaceMetadataChanged = vi.fn();
+    const onWorkspaceStatusChanged = vi.fn();
+    const manager = new WatchManager({
+      hostWatcher,
+      provisionWorkspace,
+      onWorkspaceMetadataChanged,
+      onWorkspaceStatusChanged,
+    });
+
+    await manager.replaceWatchSet({
+      generation: 1,
+      workspaceTargets: [
+        {
+          environmentId: "env-watch",
+          workspaceContext: {
+            workspacePath: "/tmp/env-watch",
+            workspaceProvisionType: "unmanaged",
+          },
+        },
+      ],
+      threadStorageTargets: [],
+    });
+    watchWorkspaceArgs?.onChange({
+      changedPaths: ["/tmp/env-watch/.git"],
+      changeKinds: ["workspace-content-changed"],
+      kind: "workspace-status-changed",
+      environmentId: "env-watch",
+    });
+
+    await vi.waitFor(() => {
+      expect(onWorkspaceMetadataChanged).toHaveBeenCalledWith({
+        environmentId: "env-watch",
+        workspace: {
+          path: "/tmp/env-watch",
+          isGitRepo: true,
+          isWorktree: false,
+          branchName: "main",
+          defaultBranch: "main",
+        },
+      });
+      expect(onWorkspaceStatusChanged).toHaveBeenCalledWith({
+        changeKinds: ["work-status-changed"],
+        environmentId: "env-watch",
+      });
+    });
+    expect(provisionWorkspace).toHaveBeenCalledTimes(2);
   });
 
   it("suppresses git metadata notifications when the local fingerprint is unchanged", async () => {

--- a/apps/host-daemon/src/watch-manager.test.ts
+++ b/apps/host-daemon/src/watch-manager.test.ts
@@ -267,8 +267,10 @@ describe("WatchManager", () => {
     const gitWorkspace = createFakeWorkspace("/tmp/env-watch");
     const provisionWorkspace = vi
       .fn<NonNullable<WatchManagerOptions["provisionWorkspace"]>>()
-      .mockResolvedValueOnce(plainWorkspace)
-      .mockResolvedValueOnce(gitWorkspace);
+      .mockResolvedValue(plainWorkspace);
+    const refreshWorkspace = vi
+      .fn<NonNullable<WatchManagerOptions["refreshWorkspace"]>>()
+      .mockResolvedValue(gitWorkspace);
     const { hostWatcher } = createFakeHostWatcher({
       watchWorkspaceImplementation: (args) => {
         watchWorkspaceArgs = args;
@@ -280,6 +282,7 @@ describe("WatchManager", () => {
     const manager = new WatchManager({
       hostWatcher,
       provisionWorkspace,
+      refreshWorkspace,
       onWorkspaceMetadataChanged,
       onWorkspaceStatusChanged,
     });
@@ -298,8 +301,28 @@ describe("WatchManager", () => {
       threadStorageTargets: [],
     });
     watchWorkspaceArgs?.onChange({
-      changedPaths: ["/tmp/env-watch/.git"],
+      changedPaths: ["/tmp/env-watch/file.txt"],
       changeKinds: ["workspace-content-changed"],
+      kind: "workspace-status-changed",
+      environmentId: "env-watch",
+    });
+    await vi.waitFor(() => {
+      expect(onWorkspaceStatusChanged).toHaveBeenCalledWith({
+        changeKinds: ["work-status-changed"],
+        environmentId: "env-watch",
+      });
+    });
+    expect(provisionWorkspace).toHaveBeenCalledTimes(1);
+    expect(refreshWorkspace).not.toHaveBeenCalled();
+    expect(onWorkspaceMetadataChanged).not.toHaveBeenCalled();
+    onWorkspaceStatusChanged.mockClear();
+
+    watchWorkspaceArgs?.onChange({
+      changedPaths: ["/tmp/env-watch/.git"],
+      changeKinds: [
+        "workspace-content-changed",
+        "workspace-git-repository-created",
+      ],
       kind: "workspace-status-changed",
       environmentId: "env-watch",
     });
@@ -320,7 +343,8 @@ describe("WatchManager", () => {
         environmentId: "env-watch",
       });
     });
-    expect(provisionWorkspace).toHaveBeenCalledTimes(2);
+    expect(provisionWorkspace).toHaveBeenCalledTimes(1);
+    expect(refreshWorkspace).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses git metadata notifications when the local fingerprint is unchanged", async () => {

--- a/apps/host-daemon/src/watch-manager.ts
+++ b/apps/host-daemon/src/watch-manager.ts
@@ -23,7 +23,11 @@ type StopWatching = () => void | Promise<void>;
 
 const STOP_WATCHING: StopWatching = () => undefined;
 const LOCAL_WORKSPACE_WATCH_CHANGE_KINDS: readonly WorkspaceStatusWatchChangeKind[] =
-  ["workspace-content-changed", "workspace-git-changed"];
+  [
+    "workspace-content-changed",
+    "workspace-git-changed",
+    "workspace-git-repository-created",
+  ];
 
 interface WorkspaceWatchState {
   lastLocalFingerprint: string | null;
@@ -39,12 +43,19 @@ interface WorkspaceWatchEntry {
   workspace: HostWorkspace;
 }
 
+interface RefreshWorkspaceArgs {
+  environmentId: string;
+  provision: ProvisionWorkspaceArgs;
+  workspacePath: string;
+}
+
 export interface WatchManagerOptions {
   dataDir?: string;
   hostWatcher?: HostWatcher;
   provisionWorkspace?: (
     options: ProvisionWorkspaceArgs,
   ) => Promise<HostWorkspace>;
+  refreshWorkspace?: (args: RefreshWorkspaceArgs) => Promise<HostWorkspace>;
   threadStorageRootPath?: string | null;
   onThreadStorageChanged?: (args: {
     environmentId: string;
@@ -100,6 +111,7 @@ function sameWorkspaceTarget(
 export class WatchManager {
   private readonly hostWatcher;
   private readonly provisionWorkspace;
+  private readonly refreshWorkspace;
   private readonly threadStorageTargets = new Map<
     string,
     HostDaemonWatchSetThreadStorageTarget
@@ -112,6 +124,10 @@ export class WatchManager {
   constructor(private readonly options: WatchManagerOptions = {}) {
     this.hostWatcher = options.hostWatcher;
     this.provisionWorkspace = options.provisionWorkspace ?? provisionWorkspace;
+    this.refreshWorkspace =
+      options.refreshWorkspace ??
+      ((args: RefreshWorkspaceArgs) =>
+        this.provisionWorkspace(args.provision));
   }
 
   async replaceWatchSet(watchSet: HostDaemonWatchSet): Promise<void> {
@@ -326,7 +342,10 @@ export class WatchManager {
     try {
       const changeKinds: HostDaemonEnvironmentChange[] = [];
       if (workspaceWatchKindsIncludeLocalState(pendingKinds)) {
-        if (!args.entry.workspace.isGitRepo) {
+        if (
+          pendingKinds.includes("workspace-git-repository-created") &&
+          !args.entry.workspace.isGitRepo
+        ) {
           await this.refreshGitWorkspaceMetadata(args.entry);
         }
         // A real workspace file event must reach live content consumers even
@@ -395,19 +414,22 @@ export class WatchManager {
     if (entry.workspace.isGitRepo) {
       return;
     }
-    const workspace = await this.provisionWorkspace(
-      reconnectProvisionArgsFromWorkspaceContext({
-        environmentId: entry.target.environmentId,
-        ...(this.options.dataDir
-          ? {
-              personalWorkspaceRoot: getPersonalWorkspaceRoot(
-                this.options.dataDir,
-              ),
-            }
-          : {}),
-        workspaceContext: entry.target.workspaceContext,
-      }),
-    );
+    const provision = reconnectProvisionArgsFromWorkspaceContext({
+      environmentId: entry.target.environmentId,
+      ...(this.options.dataDir
+        ? {
+            personalWorkspaceRoot: getPersonalWorkspaceRoot(
+              this.options.dataDir,
+            ),
+          }
+        : {}),
+      workspaceContext: entry.target.workspaceContext,
+    });
+    const workspace = await this.refreshWorkspace({
+      environmentId: entry.target.environmentId,
+      provision,
+      workspacePath: entry.target.workspaceContext.workspacePath,
+    });
     if (!workspace.isGitRepo) {
       return;
     }

--- a/apps/host-daemon/src/watch-manager.ts
+++ b/apps/host-daemon/src/watch-manager.ts
@@ -1,5 +1,6 @@
-import { getPersonalWorkspaceRoot } from "@bb/host-workspace";
+import type { DiscoveredWorkspaceProperties } from "@bb/domain";
 import {
+  getPersonalWorkspaceRoot,
   provisionWorkspace,
   type HostWorkspace,
   type ProvisionWorkspaceArgs,
@@ -55,6 +56,10 @@ export interface WatchManagerOptions {
   onWorkspaceStatusChanged?: (args: {
     changeKinds: HostDaemonEnvironmentChange[];
     environmentId: string;
+  }) => void;
+  onWorkspaceMetadataChanged?: (args: {
+    environmentId: string;
+    workspace: DiscoveredWorkspaceProperties;
   }) => void;
   onWorkspaceStatusWatchError?: (args: { error: WorkspaceWatchError }) => void;
 }
@@ -224,28 +229,26 @@ export class WatchManager {
         }),
       );
       const watchState = await this.createWorkspaceWatchState(workspace);
-      const stopWatchingStatus = this.hostWatcher.watchWorkspace({
+      const entry: WorkspaceWatchEntry = {
+        stopWatchingStatus: STOP_WATCHING,
+        target,
+        watchState,
+        workspace,
+      };
+      entry.stopWatchingStatus = this.hostWatcher.watchWorkspace({
         environmentId: target.environmentId,
         workspacePath: workspace.path,
         onChange: (event) => {
           this.queueWorkspaceWatchChange({
             changeKinds: event.changeKinds,
-            environmentId: target.environmentId,
-            workspace,
-            workspacePath: workspace.path,
-            workspaceWatchState: watchState,
+            entry,
           });
         },
         onWatchError: (error) => {
           this.options.onWorkspaceStatusWatchError?.({ error });
         },
       });
-      this.workspaceEntries.set(target.environmentId, {
-        stopWatchingStatus,
-        target,
-        watchState,
-        workspace,
-      });
+      this.workspaceEntries.set(target.environmentId, entry);
     } catch (error) {
       this.options.onWorkspaceStatusWatchError?.({
         error: {
@@ -289,51 +292,43 @@ export class WatchManager {
 
   private queueWorkspaceWatchChange(args: {
     changeKinds: readonly WorkspaceStatusWatchChangeKind[];
-    environmentId: string;
-    workspace: HostWorkspace;
-    workspacePath: string;
-    workspaceWatchState: WorkspaceWatchState;
+    entry: WorkspaceWatchEntry;
   }): void {
     for (const changeKind of args.changeKinds) {
-      args.workspaceWatchState.pendingKinds.add(changeKind);
+      args.entry.watchState.pendingKinds.add(changeKind);
     }
-    if (args.workspaceWatchState.processing) {
+    if (args.entry.watchState.processing) {
       return;
     }
     this.flushWorkspaceWatchChanges(args);
   }
 
   private flushWorkspaceWatchChanges(args: {
-    environmentId: string;
-    workspace: HostWorkspace;
-    workspacePath: string;
-    workspaceWatchState: WorkspaceWatchState;
+    entry: WorkspaceWatchEntry;
   }): void {
     const processing = this.processWorkspaceWatchChanges(args).finally(() => {
-      if (args.workspaceWatchState.processing === processing) {
-        args.workspaceWatchState.processing = null;
+      if (args.entry.watchState.processing === processing) {
+        args.entry.watchState.processing = null;
       }
-      if (args.workspaceWatchState.pendingKinds.size > 0) {
+      if (args.entry.watchState.pendingKinds.size > 0) {
         this.flushWorkspaceWatchChanges(args);
       }
     });
-    args.workspaceWatchState.processing = processing;
+    args.entry.watchState.processing = processing;
   }
 
   private async processWorkspaceWatchChanges(args: {
-    environmentId: string;
-    workspace: HostWorkspace;
-    workspacePath: string;
-    workspaceWatchState: WorkspaceWatchState;
+    entry: WorkspaceWatchEntry;
   }): Promise<void> {
-    const pendingKinds = Array.from(args.workspaceWatchState.pendingKinds);
-    args.workspaceWatchState.pendingKinds.clear();
+    const pendingKinds = Array.from(args.entry.watchState.pendingKinds);
+    args.entry.watchState.pendingKinds.clear();
 
     try {
       const changeKinds: HostDaemonEnvironmentChange[] = [];
       if (workspaceWatchKindsIncludeLocalState(pendingKinds)) {
-        const nextLocalFingerprint =
-          await args.workspace.getLocalStateFingerprint();
+        if (!args.entry.workspace.isGitRepo) {
+          await this.refreshGitWorkspaceMetadata(args.entry);
+        }
         // A real workspace file event must reach live content consumers even
         // when the git-status summary is unchanged. For example, replacing one
         // line with another repeatedly produces the same path/status/numstat
@@ -341,22 +336,33 @@ export class WatchManager {
         const workspaceContentChanged = pendingKinds.includes(
           "workspace-content-changed",
         );
-        if (
-          workspaceContentChanged ||
-          args.workspaceWatchState.lastLocalFingerprint !== nextLocalFingerprint
-        ) {
-          args.workspaceWatchState.lastLocalFingerprint = nextLocalFingerprint;
-          changeKinds.push("work-status-changed");
+        if (!args.entry.workspace.isGitRepo) {
+          if (workspaceContentChanged) {
+            changeKinds.push("work-status-changed");
+          }
+        } else {
+          const nextLocalFingerprint =
+            await args.entry.workspace.getLocalStateFingerprint();
+          if (
+            workspaceContentChanged ||
+            args.entry.watchState.lastLocalFingerprint !== nextLocalFingerprint
+          ) {
+            args.entry.watchState.lastLocalFingerprint = nextLocalFingerprint;
+            changeKinds.push("work-status-changed");
+          }
         }
       }
-      if (workspaceWatchKindsIncludeSharedRefs(pendingKinds)) {
+      if (
+        args.entry.workspace.isGitRepo &&
+        workspaceWatchKindsIncludeSharedRefs(pendingKinds)
+      ) {
         const nextSharedRefsFingerprint =
-          await args.workspace.getSharedGitRefsFingerprint();
+          await args.entry.workspace.getSharedGitRefsFingerprint();
         if (
-          args.workspaceWatchState.lastSharedRefsFingerprint !==
+          args.entry.watchState.lastSharedRefsFingerprint !==
           nextSharedRefsFingerprint
         ) {
-          args.workspaceWatchState.lastSharedRefsFingerprint =
+          args.entry.watchState.lastSharedRefsFingerprint =
             nextSharedRefsFingerprint;
           changeKinds.push("git-refs-changed");
         }
@@ -366,21 +372,64 @@ export class WatchManager {
       }
       this.options.onWorkspaceStatusChanged?.({
         changeKinds,
-        environmentId: args.environmentId,
+        environmentId: args.entry.target.environmentId,
       });
     } catch (error) {
       this.options.onWorkspaceStatusWatchError?.({
         error: {
-          environmentId: args.environmentId,
+          environmentId: args.entry.target.environmentId,
           kind: "workspace-watch-error",
           message:
             error instanceof Error
               ? toErrorMessage(error)
               : "Unknown workspace watch error",
-          rootPath: args.workspacePath,
+          rootPath: args.entry.target.workspaceContext.workspacePath,
         },
       });
     }
+  }
+
+  private async refreshGitWorkspaceMetadata(
+    entry: WorkspaceWatchEntry,
+  ): Promise<void> {
+    if (entry.workspace.isGitRepo) {
+      return;
+    }
+    const workspace = await this.provisionWorkspace(
+      reconnectProvisionArgsFromWorkspaceContext({
+        environmentId: entry.target.environmentId,
+        ...(this.options.dataDir
+          ? {
+              personalWorkspaceRoot: getPersonalWorkspaceRoot(
+                this.options.dataDir,
+              ),
+            }
+          : {}),
+        workspaceContext: entry.target.workspaceContext,
+      }),
+    );
+    if (!workspace.isGitRepo) {
+      return;
+    }
+
+    const [branchName, resolvedDefaultBranch, sharedRefsFingerprint] =
+      await Promise.all([
+        workspace.getCurrentBranch(),
+        workspace.getDefaultBranch(),
+        workspace.getSharedGitRefsFingerprint(),
+      ]);
+    entry.workspace = workspace;
+    entry.watchState.lastSharedRefsFingerprint = sharedRefsFingerprint;
+    this.options.onWorkspaceMetadataChanged?.({
+      environmentId: entry.target.environmentId,
+      workspace: {
+        path: workspace.path,
+        isGitRepo: true,
+        isWorktree: workspace.isWorktree,
+        branchName,
+        defaultBranch: resolvedDefaultBranch ?? branchName,
+      },
+    });
   }
 
   private async stopWorkspaceWatch(entry: WorkspaceWatchEntry): Promise<void> {

--- a/apps/host-daemon/src/workspace-resolution.ts
+++ b/apps/host-daemon/src/workspace-resolution.ts
@@ -5,7 +5,7 @@ import type {
   WorkspaceResolutionFailureCode,
 } from "@bb/host-daemon-contract";
 import { workspaceResolutionFailureCodeSchema } from "@bb/host-daemon-contract";
-import { WorkspaceError } from "@bb/host-workspace";
+import { detectGitRepo, WorkspaceError } from "@bb/host-workspace";
 import type { RuntimeEntry, RuntimeManager } from "./runtime-manager.js";
 import {
   CommandDispatchError,
@@ -143,7 +143,11 @@ export async function resolveWorkspaceForCommand(
       },
       args.runtimeManager,
     );
-    if (args.requireGit === true && !entry.workspace.isGitRepo) {
+    if (
+      args.requireGit === true &&
+      !entry.workspace.isGitRepo &&
+      !(await detectGitRepo(entry.workspace.path))
+    ) {
       return {
         ok: false,
         failure: buildWorkspaceResolutionFailure({

--- a/apps/host-daemon/src/workspace-resolution.ts
+++ b/apps/host-daemon/src/workspace-resolution.ts
@@ -5,13 +5,14 @@ import type {
   WorkspaceResolutionFailureCode,
 } from "@bb/host-daemon-contract";
 import { workspaceResolutionFailureCodeSchema } from "@bb/host-daemon-contract";
-import { detectGitRepo, WorkspaceError } from "@bb/host-workspace";
+import { getPersonalWorkspaceRoot, WorkspaceError } from "@bb/host-workspace";
 import type { RuntimeEntry, RuntimeManager } from "./runtime-manager.js";
 import {
   CommandDispatchError,
   ExpectedCommandDispatchError,
   requireWorkspaceEnvironment,
 } from "./command-dispatch-support.js";
+import { reconnectProvisionArgsFromWorkspaceContext } from "./workspace-provision-target.js";
 
 const WORKSPACE_RESOLUTION_FAILURE_CODES: readonly WorkspaceResolutionFailureCode[] =
   workspaceResolutionFailureCodeSchema.options;
@@ -143,19 +144,30 @@ export async function resolveWorkspaceForCommand(
       },
       args.runtimeManager,
     );
-    if (
-      args.requireGit === true &&
-      !entry.workspace.isGitRepo &&
-      !(await detectGitRepo(entry.workspace.path))
-    ) {
-      return {
-        ok: false,
-        failure: buildWorkspaceResolutionFailure({
-          code: "not_git_repo",
-          message: `Path is not a git repository: ${entry.workspace.path}`,
-          workspacePath: entry.workspace.path,
+    if (args.requireGit === true && !entry.workspace.isGitRepo) {
+      const workspace = await args.runtimeManager.refreshEnvironmentWorkspace({
+        environmentId: args.environmentId,
+        provision: reconnectProvisionArgsFromWorkspaceContext({
+          environmentId: args.environmentId,
+          ...(args.dataDir
+            ? {
+                personalWorkspaceRoot: getPersonalWorkspaceRoot(args.dataDir),
+              }
+            : {}),
+          workspaceContext: args.workspaceContext,
         }),
-      };
+        workspacePath: args.workspaceContext.workspacePath,
+      });
+      if (!workspace.isGitRepo) {
+        return {
+          ok: false,
+          failure: buildWorkspaceResolutionFailure({
+            code: "not_git_repo",
+            message: `Path is not a git repository: ${entry.workspace.path}`,
+            workspacePath: entry.workspace.path,
+          }),
+        };
+      }
     }
     if (
       args.requireManagedWorktree === true &&

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -466,6 +466,7 @@ export function createHarness(
   );
   workspace.getCurrentBranch = async () => args.currentBranch ?? "main";
   workspace.isWorktree = args.isWorktree ?? false;
+  let provisionedWorkspace: HostWorkspace = workspace;
   const { runtime, state: runtimeState, threadControls } = createFakeRuntime();
   const provisions: ProvisionWorkspaceArgs[] = [];
   const manager = new RuntimeManager({
@@ -474,7 +475,7 @@ export function createHarness(
       if ("path" in options && options.path !== workspace.path) {
         return createFakeWorkspace(options.path).workspace;
       }
-      return workspace;
+      return provisionedWorkspace;
     },
     createRuntime: () => runtime,
   });
@@ -487,6 +488,9 @@ export function createHarness(
     threadControls,
     workspaceState,
     workspace,
+    setProvisionedWorkspace(nextWorkspace: HostWorkspace): void {
+      provisionedWorkspace = nextWorkspace;
+    },
     /** Default dispatch options with threadStorageRootPath for tests. */
     dispatchOptions(
       overrides: { dataDir?: string; threadStorageRootPath?: string } = {},

--- a/apps/host-daemon/test/command/workspace-dispatch.test.ts
+++ b/apps/host-daemon/test/command/workspace-dispatch.test.ts
@@ -10,6 +10,7 @@ import {
   cleanupTempDirs,
   createHarness,
   makeTempDir,
+  runGitCommand,
 } from "./dispatch-helpers.js";
 
 afterEach(cleanupTempDirs);
@@ -94,6 +95,32 @@ describe("workspace command dispatch", () => {
     });
     expect(harness.workspaceState.statusReads).toBe(1);
     expect(harness.workspaceState.lastCommitMessage).toBe("Commit message");
+  });
+
+  it("uses a repository added after the runtime cached a plain workspace", async () => {
+    const workspacePath = await makeTempDir("bb-runtime-late-git-");
+    const harness = createHarness({ workspacePath });
+    harness.workspace.isGitRepo = false;
+    await harness.manager.ensureEnvironment({
+      environmentId: "env-late-git",
+      workspacePath,
+    });
+    await runGitCommand(["init", "-b", "main"], { cwd: workspacePath });
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "workspace.status",
+        environmentId: "env-late-git",
+        workspaceContext: {
+          workspacePath,
+          workspaceProvisionType: "unmanaged",
+        },
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.outcome).toBe("available");
+    expect(harness.workspaceState.statusReads).toBe(1);
   });
 
   it("covers workspace.pull_request", async () => {

--- a/apps/host-daemon/test/command/workspace-dispatch.test.ts
+++ b/apps/host-daemon/test/command/workspace-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../src/command-dispatch.js";
 import {
   cleanupTempDirs,
+  createFakeWorkspace,
   createHarness,
   makeTempDir,
   runGitCommand,
@@ -106,6 +107,8 @@ describe("workspace command dispatch", () => {
       workspacePath,
     });
     await runGitCommand(["init", "-b", "main"], { cwd: workspacePath });
+    const refreshed = createFakeWorkspace(workspacePath);
+    harness.setProvisionedWorkspace(refreshed.workspace);
 
     const result = await dispatchOnlineRpcCommand(
       {
@@ -120,7 +123,10 @@ describe("workspace command dispatch", () => {
     );
 
     expect(result.outcome).toBe("available");
-    expect(harness.workspaceState.statusReads).toBe(1);
+    expect(refreshed.state.statusReads).toBe(1);
+    expect(
+      harness.manager.get("env-late-git")?.workspace.isGitRepo,
+    ).toBe(true);
   });
 
   it("covers workspace.pull_request", async () => {

--- a/apps/server/src/internal/environment-changes.ts
+++ b/apps/server/src/internal/environment-changes.ts
@@ -1,5 +1,9 @@
-import type { HostDaemonEnvironmentChangePayload } from "@bb/host-daemon-contract";
+import type {
+  HostDaemonEnvironmentChangePayload,
+  HostDaemonEnvironmentMetadataChangePayload,
+} from "@bb/host-daemon-contract";
 import { getEnvironment, type DbNotifier } from "@bb/db";
+import { recordProvisionedEnvironmentWorkspace } from "@bb/db/internal-environment-lifecycle";
 import type { AppDeps } from "../types.js";
 
 interface EnvironmentChangeNotificationDeps {
@@ -7,6 +11,10 @@ interface EnvironmentChangeNotificationDeps {
 }
 
 interface NotifyDaemonEnvironmentChangeArgs extends HostDaemonEnvironmentChangePayload {
+  hostId: string;
+}
+
+interface RecordDaemonEnvironmentMetadataChangeArgs extends HostDaemonEnvironmentMetadataChangePayload {
   hostId: string;
 }
 
@@ -39,4 +47,26 @@ export function notifyDaemonEnvironmentChange(
   }
 
   deps.hub.notifyEnvironment(environment.id, [args.change]);
+}
+
+export function recordDaemonEnvironmentMetadataChange(
+  deps: Pick<AppDeps, "db" | "hub">,
+  args: RecordDaemonEnvironmentMetadataChangeArgs,
+): void {
+  const environment = getEnvironment(deps.db, args.environmentId);
+  if (
+    !environment ||
+    environment.hostId !== args.hostId ||
+    environment.status === "destroyed" ||
+    environment.path !== args.workspace.path
+  ) {
+    return;
+  }
+
+  recordProvisionedEnvironmentWorkspace(
+    deps.db,
+    deps.hub,
+    environment.id,
+    args.workspace,
+  );
 }

--- a/apps/server/src/ws/daemon-protocol.ts
+++ b/apps/server/src/ws/daemon-protocol.ts
@@ -13,7 +13,10 @@ import {
   requireAuthorizedOpenSession,
 } from "../internal/session-state.js";
 import { handleDaemonSocketClosed } from "../internal/session-owner-side-effects.js";
-import { notifyDaemonEnvironmentChange } from "../internal/environment-changes.js";
+import {
+  notifyDaemonEnvironmentChange,
+  recordDaemonEnvironmentMetadataChange,
+} from "../internal/environment-changes.js";
 import { decodeSocketPayload } from "./decode-payload.js";
 
 interface DaemonSocket {
@@ -131,6 +134,14 @@ export function onDaemonSocketMessage(
         hostId: args.hostId,
         environmentId: result.data.environmentId,
         change: result.data.change,
+      });
+      return;
+    }
+    if (result.data.type === "environment-metadata-change") {
+      recordDaemonEnvironmentMetadataChange(deps, {
+        hostId: args.hostId,
+        environmentId: result.data.environmentId,
+        workspace: result.data.workspace,
       });
       return;
     }

--- a/apps/server/test/internal/internal-environment-change.test.ts
+++ b/apps/server/test/internal/internal-environment-change.test.ts
@@ -165,6 +165,54 @@ describe("internal environment change websocket hints", () => {
     },
   );
 
+  it("records workspace metadata when a watched workspace becomes a repository", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-env-metadata-change",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/env-metadata-change",
+        status: "ready",
+        isGitRepo: false,
+      });
+      const notifyEnvironmentSpy = vi.spyOn(harness.hub, "notifyEnvironment");
+      const socket = createTestDaemonSocket();
+
+      onDaemonSocketMessage(harness.deps, {
+        hostId: host.id,
+        sessionId: session.id,
+        socket,
+        raw: JSON.stringify({
+          type: "environment-metadata-change",
+          environmentId: environment.id,
+          workspace: {
+            path: environment.path,
+            isGitRepo: true,
+            isWorktree: false,
+            branchName: "main",
+            defaultBranch: "main",
+          },
+        }),
+      });
+
+      expect(socket.close).not.toHaveBeenCalled();
+      expect(getEnvironment(harness.db, environment.id)).toMatchObject({
+        isGitRepo: true,
+        isWorktree: false,
+        branchName: "main",
+        defaultBranch: "main",
+      });
+      expect(notifyEnvironmentSpy).toHaveBeenCalledWith(environment.id, [
+        "metadata-changed",
+      ]);
+    });
+  });
+
   it("ignores hints for environments owned by a different host", async () => {
     await withTestHarness(async (harness) => {
       const hostA = seedHostSession(harness.deps, { id: "host-env-change-a" });

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 75 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 76 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono";
 import { hc } from "hono/client";
 import {
+  discoveredWorkspacePropertiesSchema,
   ENVIRONMENT_CHANGE_KINDS,
   hostTypeSchema,
   pendingInteractionCreateSchema,
@@ -314,6 +315,16 @@ export type HostDaemonEnvironmentChangePayload = z.infer<
   typeof hostDaemonEnvironmentChangePayloadSchema
 >;
 
+export const hostDaemonEnvironmentMetadataChangePayloadSchema = z
+  .object({
+    environmentId: z.string().min(1),
+    workspace: discoveredWorkspacePropertiesSchema,
+  })
+  .strict();
+export type HostDaemonEnvironmentMetadataChangePayload = z.infer<
+  typeof hostDaemonEnvironmentMetadataChangePayloadSchema
+>;
+
 export const hostDaemonSessionCloseReasonSchema = z.enum([
   "replaced",
   "expired",
@@ -590,6 +601,13 @@ const hostDaemonEnvironmentChangeMessageSchema =
     })
     .strict();
 
+const hostDaemonEnvironmentMetadataChangeMessageSchema =
+  hostDaemonEnvironmentMetadataChangePayloadSchema
+    .extend({
+      type: z.literal("environment-metadata-change"),
+    })
+    .strict();
+
 const hostDaemonConnectTunnelIdentityMessageSchema = z
   .object({
     type: z.literal("connect-tunnel.identity"),
@@ -653,6 +671,7 @@ const hostDaemonTerminalErrorMessageSchema = z
 export const hostDaemonDaemonWsMessageSchema = z.union([
   hostDaemonHeartbeatMessageSchema,
   hostDaemonEnvironmentChangeMessageSchema,
+  hostDaemonEnvironmentMetadataChangeMessageSchema,
   hostDaemonConnectTunnelIdentityMessageSchema,
   hostDaemonTerminalOpenedMessageSchema,
   hostDaemonTerminalOutputMessageSchema,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1036,13 +1036,10 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 75 makes Claude's sandbox network prompt grantable. A daemon on 74
-  // drops the "localSettings" suggestion that carries the grant, so it sends a
-  // permission_grant subject with an empty profile and the user cannot allow
-  // the prompt. The fix lives in the daemon's Claude bridge, so the bump is
-  // what moves an enrolled machine onto it.
-  it("uses protocol version 75 for grantable sandbox network prompts", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(75);
+  // Version 76 lets the daemon report a repository that appears after the
+  // server created the environment. Older daemons do not send that message.
+  it("uses protocol version 76 for live workspace metadata refresh", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(76);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {
@@ -3139,6 +3136,30 @@ describe("host-daemon session schemas", () => {
       type: "environment-change",
       environmentId: "env_123",
       change: "thread-storage-changed",
+    });
+
+    expect(
+      hostDaemonDaemonWsMessageSchema.parse({
+        type: "environment-metadata-change",
+        environmentId: "env_123",
+        workspace: {
+          path: "/tmp/workspace",
+          isGitRepo: true,
+          isWorktree: false,
+          branchName: "main",
+          defaultBranch: "main",
+        },
+      }),
+    ).toEqual({
+      type: "environment-metadata-change",
+      environmentId: "env_123",
+      workspace: {
+        path: "/tmp/workspace",
+        isGitRepo: true,
+        isWorktree: false,
+        branchName: "main",
+        defaultBranch: "main",
+      },
     });
 
     expect(

--- a/packages/host-watcher/src/watch-status-types.ts
+++ b/packages/host-watcher/src/watch-status-types.ts
@@ -1,6 +1,7 @@
 export const WORKSPACE_STATUS_WATCH_CHANGE_KINDS = [
   "workspace-content-changed",
   "workspace-git-changed",
+  "workspace-git-repository-created",
   "shared-git-refs-changed",
 ] as const;
 export type WorkspaceStatusWatchChangeKind =

--- a/packages/host-watcher/src/workspace-status-watcher.ts
+++ b/packages/host-watcher/src/workspace-status-watcher.ts
@@ -147,12 +147,19 @@ async function resolveWatchRootPath(rootPath: string): Promise<string> {
   }
 }
 
+function isPathInsideDotGit(cwd: string, candidatePath: string): boolean {
+  const relativePath = path.relative(cwd, candidatePath);
+  return relativePath === ".git" || relativePath.startsWith(`.git${path.sep}`);
+}
+
 export class WorkspaceStatusWatcher {
   private readonly changedPaths = new Set<string>();
   private readonly changeKinds = new Set<WorkspaceStatusWatchChangeKind>();
   private disposed = false;
+  private gitWorkspace = false;
   private metadataRetryAttempt = 0;
   private metadataStartRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private gitWorkspacePromotion: Promise<void> | null = null;
   private workspaceRootRetryAttempt = 0;
   private workspaceRootStartRetryTimer: ReturnType<typeof setTimeout> | null =
     null;
@@ -215,13 +222,20 @@ export class WorkspaceStatusWatcher {
   }
 
   private async startAsync(): Promise<void> {
-    if (!(await pathExists(path.join(this.args.cwd, ".git")))) {
-      return;
-    }
+    const rootPath = await resolveWatchRootPath(this.args.cwd);
     if (this.disposed) {
       return;
     }
-    const rootPath = await resolveWatchRootPath(this.args.cwd);
+    if (!(await pathExists(path.join(this.args.cwd, ".git")))) {
+      // A plain workspace can become a repository after `git init`. Watch the
+      // root without excluding `.git` until that marker appears.
+      this.startWatchSubscription({
+        kind: "workspace-root",
+        rootPath,
+      });
+      return;
+    }
+    this.gitWorkspace = true;
     this.startWorkspaceRootWatchSubscription(rootPath);
     this.startMetadataWatchSubscriptions();
   }
@@ -341,6 +355,48 @@ export class WorkspaceStatusWatcher {
       this.changeKinds.add(changeKind);
     }
     this.changeScheduler.schedule();
+    if (
+      spec.kind === "workspace-root" &&
+      spec.options?.ignore?.includes(".git") !== true &&
+      changeEvent.changedPaths.some((changedPath) =>
+        isPathInsideDotGit(this.args.cwd, changedPath),
+      )
+    ) {
+      this.promoteToGitWorkspace(spec.rootPath);
+    }
+  }
+
+  private promoteToGitWorkspace(rootPath: string): void {
+    if (
+      this.disposed ||
+      this.gitWorkspace ||
+      this.gitWorkspacePromotion !== null
+    ) {
+      return;
+    }
+    const promotion = this.promoteToGitWorkspaceAsync(rootPath).finally(() => {
+      if (this.gitWorkspacePromotion === promotion) {
+        this.gitWorkspacePromotion = null;
+      }
+    });
+    this.gitWorkspacePromotion = promotion;
+  }
+
+  private async promoteToGitWorkspaceAsync(rootPath: string): Promise<void> {
+    if (!(await pathExists(path.join(this.args.cwd, ".git")))) {
+      return;
+    }
+    const initialRootSubscription = this.subscriptions.get(rootPath);
+    if (initialRootSubscription) {
+      this.subscriptions.delete(rootPath);
+      await initialRootSubscription.dispose();
+    }
+    if (this.disposed) {
+      return;
+    }
+    this.gitWorkspace = true;
+    this.startWorkspaceRootWatchSubscription(rootPath);
+    this.startMetadataWatchSubscriptions();
   }
 
   private queueConservativeWorkspaceStatusChange(

--- a/packages/host-watcher/src/workspace-status-watcher.ts
+++ b/packages/host-watcher/src/workspace-status-watcher.ts
@@ -354,16 +354,17 @@ export class WorkspaceStatusWatcher {
     for (const changeKind of changeEvent.changeKinds) {
       this.changeKinds.add(changeKind);
     }
-    this.changeScheduler.schedule();
-    if (
+    const repositoryCreated =
       spec.kind === "workspace-root" &&
       spec.options?.ignore?.includes(".git") !== true &&
       changeEvent.changedPaths.some((changedPath) =>
-        isPathInsideDotGit(this.args.cwd, changedPath),
-      )
-    ) {
+        isPathInsideDotGit(spec.rootPath, changedPath),
+      );
+    if (repositoryCreated) {
+      this.changeKinds.add("workspace-git-repository-created");
       this.promoteToGitWorkspace(spec.rootPath);
     }
+    this.changeScheduler.schedule();
   }
 
   private promoteToGitWorkspace(rootPath: string): void {

--- a/packages/host-watcher/test/watch-status.test.ts
+++ b/packages/host-watcher/test/watch-status.test.ts
@@ -394,6 +394,58 @@ afterEach(async () => {
 
 // These tests mutate shared module spies, so keep them out of Vitest parallelism.
 describe.sequential("watchWorkspaceStatus", () => {
+  it("starts watching before git init and promotes the repository watch", async () => {
+    const workspacePath = await makeTempDir("bb-workspace-plain-");
+    const workspaceRootCallbacks: ParcelWatcherCallback[] = [];
+    const workspaceRootOptions: ParcelWatcherSubscribeOptions[] = [];
+    const ready = createDeferredPromise<void>();
+    vi.spyOn(parcelWatcher, "subscribe").mockImplementation(
+      async (...watchArgs: ParcelWatcherSubscribeArgs) => {
+        const [rootPath, callback, options] = watchArgs;
+        if (
+          normalizeWatchPath(rootPath) === normalizeWatchPath(workspacePath)
+        ) {
+          workspaceRootCallbacks.push(callback);
+          workspaceRootOptions.push(options);
+          ready.resolve(undefined);
+        }
+        return createMockWatcherSubscription();
+      },
+    );
+    const calls: WorkspaceStatusChangeEvent[] = [];
+    const stopWatching = watchWorkspaceStatusImpl(workspacePath, {
+      onChange: (event) => calls.push(event),
+      onWatchError: ignoreWatchError,
+    });
+
+    try {
+      await ready.promise;
+      expect(workspaceRootOptions[0]?.ignore).toBeUndefined();
+
+      await runGit({ args: ["init", "-b", "main"], cwd: workspacePath });
+      workspaceRootCallbacks[0]?.(null, [
+        {
+          path: path.join(workspacePath, ".git"),
+          type: "create",
+        },
+      ]);
+
+      await waitForCallCount(() => calls.length, 1, WATCH_TEST_TIMEOUT_MS);
+      await waitForCallCount(
+        () => workspaceRootCallbacks.length,
+        2,
+        WATCH_TEST_TIMEOUT_MS,
+      );
+      expect(calls[0]).toEqual({
+        changedPaths: [path.join(workspacePath, ".git")],
+        changeKinds: ["workspace-content-changed"],
+      });
+      expect(workspaceRootOptions[1]?.ignore).toContain(".git");
+    } finally {
+      await stopWatching();
+    }
+  });
+
   it("watches workspace status changes without duplicate callbacks for the same burst", async () => {
     const repoPath = await initRepo();
     const { emitWorkspaceRootEvents, ready, watchWorkspaceStatus } =

--- a/packages/host-watcher/test/watch-status.test.ts
+++ b/packages/host-watcher/test/watch-status.test.ts
@@ -423,9 +423,10 @@ describe.sequential("watchWorkspaceStatus", () => {
       expect(workspaceRootOptions[0]?.ignore).toBeUndefined();
 
       await runGit({ args: ["init", "-b", "main"], cwd: workspacePath });
+      const canonicalWorkspacePath = await fs.realpath(workspacePath);
       workspaceRootCallbacks[0]?.(null, [
         {
-          path: path.join(workspacePath, ".git"),
+          path: path.join(canonicalWorkspacePath, ".git"),
           type: "create",
         },
       ]);
@@ -437,8 +438,11 @@ describe.sequential("watchWorkspaceStatus", () => {
         WATCH_TEST_TIMEOUT_MS,
       );
       expect(calls[0]).toEqual({
-        changedPaths: [path.join(workspacePath, ".git")],
-        changeKinds: ["workspace-content-changed"],
+        changedPaths: [path.join(canonicalWorkspacePath, ".git")],
+        changeKinds: [
+          "workspace-content-changed",
+          "workspace-git-repository-created",
+        ],
       });
       expect(workspaceRootOptions[1]?.ignore).toContain(".git");
     } finally {
@@ -598,6 +602,7 @@ describe.sequential("watchWorkspaceStatus", () => {
         changeKinds: [
           "workspace-content-changed",
           "workspace-git-changed",
+          "workspace-git-repository-created",
           "shared-git-refs-changed",
         ],
       };

--- a/packages/host-workspace/src/provision.ts
+++ b/packages/host-workspace/src/provision.ts
@@ -718,11 +718,14 @@ async function provisionPersonalWorkspace(
     throw error;
   }
 
+  const isGitRepo = await detectGitRepo(targetPath);
+  const isWorktree = isGitRepo ? await detectWorktree(targetPath) : false;
+
   return new ProvisionedHostWorkspace({
     path: targetPath,
     managed: true,
-    isGitRepo: false,
-    isWorktree: false,
+    isGitRepo,
+    isWorktree,
     destroyFn: () => rm(targetPath, { recursive: true, force: true }),
   });
 }

--- a/packages/host-workspace/src/provision.ts
+++ b/packages/host-workspace/src/provision.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, realpath, rm } from "node:fs/promises";
 import path from "node:path";
 import type {
   ProvisioningTranscriptEntry,
@@ -28,7 +28,9 @@ import {
 import { createWorktree, removeWorktree } from "./provisioning.js";
 import {
   detectGitRepo,
+  getAbsoluteGitDir,
   getCheckoutRef,
+  getGitCommonDir,
   getWorkspaceGitOperation,
   hasUncommittedChanges,
   listBranches,
@@ -340,6 +342,32 @@ function isRelativeChildPath(relativePath: string): boolean {
     !relativePath.startsWith(`..${path.sep}`) &&
     relativePath !== ".." &&
     !path.isAbsolute(relativePath)
+  );
+}
+
+function isSamePathOrNestedUnder(
+  candidatePath: string,
+  rootPath: string,
+): boolean {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return relativePath === "" || isRelativeChildPath(relativePath);
+}
+
+async function hasContainedPersonalGitMetadata(
+  targetPath: string,
+): Promise<boolean> {
+  const [resolvedTargetPath, gitDir, commonGitDir] = await Promise.all([
+    realpath(targetPath),
+    getAbsoluteGitDir(targetPath),
+    getGitCommonDir(targetPath),
+  ]);
+  const [resolvedGitDir, resolvedCommonGitDir] = await Promise.all([
+    realpath(gitDir),
+    realpath(commonGitDir),
+  ]);
+  return (
+    isSamePathOrNestedUnder(resolvedGitDir, resolvedTargetPath) &&
+    isSamePathOrNestedUnder(resolvedCommonGitDir, resolvedTargetPath)
   );
 }
 
@@ -718,7 +746,12 @@ async function provisionPersonalWorkspace(
     throw error;
   }
 
-  const isGitRepo = await detectGitRepo(targetPath);
+  const detectedGitRepo = targetExisted
+    ? await detectGitRepo(targetPath)
+    : false;
+  const isGitRepo = detectedGitRepo
+    ? await hasContainedPersonalGitMetadata(targetPath)
+    : false;
   const isWorktree = isGitRepo ? await detectWorktree(targetPath) : false;
 
   return new ProvisionedHostWorkspace({

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -35,6 +35,7 @@ import {
   parsePatchId,
   revParse,
   runGit,
+  type GitCommandResult,
   type NumstatEntry,
   type RunGitOptions,
   runShellPipeline,
@@ -529,45 +530,21 @@ async function readHeadNumstat(
   workspacePath: string,
   timeoutMs?: number,
 ): Promise<string> {
-  const diffBase = await resolveUncommittedDiffBase(workspacePath, timeoutMs);
-  const result = await runGit(["diff", "--numstat", "-z", diffBase, "--"], {
-    cwd: workspacePath,
-    allowFailure: true,
+  const runUncommittedDiff = createUncommittedDiffRunner(
+    workspacePath,
     timeoutMs,
-  });
-  if (result.exitCode === 0) {
-    return result.stdout;
-  }
-  if (isMissingHeadRevisionError(result.stderr)) {
-    return "";
-  }
-  const detail = result.stderr.trim();
-  throw new WorkspaceError(
-    "git_command_failed",
-    `git diff --numstat -z HEAD -- failed${detail ? `: ${detail}` : ""}`,
   );
+  const result = await runUncommittedDiff(
+    (baseRef) => ["diff", "--numstat", "-z", baseRef, "--"],
+    { cwd: workspacePath, timeoutMs },
+  );
+  return result.stdout;
 }
 
-async function resolveUncommittedDiffBase(
+async function readEmptyTreeSha(
   workspacePath: string,
   timeoutMs?: number,
 ): Promise<string> {
-  const head = await runGit(["rev-parse", "--verify", "HEAD"], {
-    cwd: workspacePath,
-    allowFailure: true,
-    timeoutMs,
-  });
-  if (head.exitCode === 0) {
-    return "HEAD";
-  }
-  if (!isMissingHeadRevisionError(head.stderr)) {
-    const detail = head.stderr.trim();
-    throw new WorkspaceError(
-      "git_command_failed",
-      `git rev-parse --verify HEAD failed${detail ? `: ${detail}` : ""}`,
-    );
-  }
-
   // An unborn branch has no HEAD tree. Compare the index and working tree to
   // Git's empty tree so staged files remain visible before the first commit.
   const emptyTree = await runGit(["hash-object", "-t", "tree", os.devNull], {
@@ -582,6 +559,47 @@ async function resolveUncommittedDiffBase(
     );
   }
   return emptyTreeSha;
+}
+
+type UncommittedDiffRunner = (
+  buildArgs: (baseRef: string) => string[],
+  options: RunGitOptions,
+) => Promise<GitCommandResult>;
+
+function createUncommittedDiffRunner(
+  workspacePath: string,
+  defaultTimeoutMs?: number,
+): UncommittedDiffRunner {
+  let emptyTreeShaPromise: Promise<string> | null = null;
+
+  return async (buildArgs, options) => {
+    if (emptyTreeShaPromise !== null) {
+      return runGit(buildArgs(await emptyTreeShaPromise), options);
+    }
+
+    const headArgs = buildArgs("HEAD");
+    const headResult = await runGit(headArgs, {
+      ...options,
+      allowFailure: true,
+      timeoutMs: options.timeoutMs ?? defaultTimeoutMs,
+    });
+    if (headResult.exitCode === 0) {
+      return headResult;
+    }
+    if (!isMissingHeadRevisionError(headResult.stderr)) {
+      const detail = headResult.stderr.trim();
+      throw new WorkspaceError(
+        "git_command_failed",
+        `git ${headArgs.join(" ")} failed${detail ? `: ${detail}` : ""}`,
+      );
+    }
+
+    emptyTreeShaPromise ??= readEmptyTreeSha(
+      workspacePath,
+      options.timeoutMs ?? defaultTimeoutMs,
+    );
+    return runGit(buildArgs(await emptyTreeShaPromise), options);
+  };
 }
 
 async function readUntrackedNumstatEntries(
@@ -1369,7 +1387,7 @@ export class Workspace {
             "--count",
             `${mergeBaseBranch}...HEAD`,
           ],
-          { cwd: this.path, timeoutMs },
+          { cwd: this.path, allowFailure: true, timeoutMs },
         ),
         this.readPatchUniqueCommitSummaries(mergeBaseBranch, timeoutMs),
         runGit(
@@ -1393,6 +1411,26 @@ export class Workspace {
           { cwd: this.path, allowFailure: true, timeoutMs },
         ),
       ]);
+    if (aheadBehindCounts.exitCode !== 0) {
+      if (isMissingHeadRevisionError(aheadBehindCounts.stderr)) {
+        return {
+          mergeBaseBranch,
+          baseRef: null,
+          aheadCount: 0,
+          behindCount: 0,
+          hasCommittedUnmergedChanges: false,
+          commits: [],
+          files: [],
+          insertions: 0,
+          deletions: 0,
+        };
+      }
+      const detail = aheadBehindCounts.stderr.trim();
+      throw new WorkspaceError(
+        "git_command_failed",
+        `git rev-list ${mergeBaseBranch}...HEAD failed${detail ? `: ${detail}` : ""}`,
+      );
+    }
     const [behindCount, aheadCount] = aheadBehindCounts.stdout
       .trim()
       .split(/\s+/)
@@ -1542,8 +1580,7 @@ export class Workspace {
 
     switch (target.type) {
       case "uncommitted": {
-        const diffBase = await resolveUncommittedDiffBase(this.path);
-        const stats = await this.runDiffStatCommands([diffBase]);
+        const stats = await this.runUncommittedDiffStatCommands();
         return { ...stats, mergeBaseRef: null, untrackedPaths };
       }
       case "branch_committed": {
@@ -1623,6 +1660,47 @@ export class Workspace {
       runGit(["diff", "--no-ext-diff", "--shortstat", ...rangeArgs], {
         cwd: this.path,
       }),
+    ]);
+    return {
+      nameStatus: nameStatus.stdout,
+      numstat: numstat.stdout,
+      shortstat: shortstat.stdout,
+    };
+  }
+
+  private async runUncommittedDiffStatCommands(): Promise<{
+    nameStatus: string;
+    numstat: string;
+    shortstat: string;
+  }> {
+    const runUncommittedDiff = createUncommittedDiffRunner(this.path);
+    const [nameStatus, numstat, shortstat] = await Promise.all([
+      runUncommittedDiff(
+        (baseRef) => [
+          "diff",
+          "--no-ext-diff",
+          "--name-status",
+          "-M",
+          "-z",
+          baseRef,
+        ],
+        { cwd: this.path },
+      ),
+      runUncommittedDiff(
+        (baseRef) => [
+          "diff",
+          "--no-ext-diff",
+          "--numstat",
+          "-M",
+          "-z",
+          baseRef,
+        ],
+        { cwd: this.path },
+      ),
+      runUncommittedDiff(
+        (baseRef) => ["diff", "--no-ext-diff", "--shortstat", baseRef],
+        { cwd: this.path },
+      ),
     ]);
     return {
       nameStatus: nameStatus.stdout,
@@ -1781,8 +1859,23 @@ export class Workspace {
       return null;
     }
 
-    const fullNameStatus = await runGit(
-      [...range.baseArgs, "--name-status", "-z", "-M", ...range.rangeArgs],
+    const runUncommittedDiff = createUncommittedDiffRunner(this.path);
+    const runRangeGit = (
+      buildArgs: (rangeArgs: string[]) => string[],
+      options: RunGitOptions,
+    ): Promise<GitCommandResult> =>
+      range.usesUncommittedHead
+        ? runUncommittedDiff((baseRef) => buildArgs([baseRef]), options)
+        : runGit(buildArgs(range.rangeArgs), options);
+
+    const fullNameStatus = await runRangeGit(
+      (rangeArgs) => [
+        ...range.baseArgs,
+        "--name-status",
+        "-z",
+        "-M",
+        ...rangeArgs,
+      ],
       { cwd: this.path },
     );
     const requested = new Set(args.paths);
@@ -1796,18 +1889,20 @@ export class Workspace {
     const pagePathspec = [...args.paths, ...renameSources];
 
     const [nameStatus, patch] = await Promise.all([
-      runGit(
-        withDiffPathspec(
-          [...range.baseArgs, "--name-status", "-z", "-M", ...range.rangeArgs],
-          pagePathspec,
-        ),
+      runRangeGit(
+        (rangeArgs) =>
+          withDiffPathspec(
+            [...range.baseArgs, "--name-status", "-z", "-M", ...rangeArgs],
+            pagePathspec,
+          ),
         { cwd: this.path },
       ),
-      runGit(
-        withDiffPathspec(
-          [...range.baseArgs, "--binary", "-M", ...range.rangeArgs],
-          pagePathspec,
-        ),
+      runRangeGit(
+        (rangeArgs) =>
+          withDiffPathspec(
+            [...range.baseArgs, "--binary", "-M", ...rangeArgs],
+            pagePathspec,
+          ),
         buildDiffOutputGitOptions(
           this.path,
           combinedPageBufferBudget(pagePathspec.length, args.maxBytesPerFile),
@@ -1825,13 +1920,18 @@ export class Workspace {
    */
   private async resolveTrackedDiffRange(
     target: WorkspaceDiffTarget,
-  ): Promise<{ baseArgs: string[]; rangeArgs: string[] } | null> {
+  ): Promise<{
+    baseArgs: string[];
+    rangeArgs: string[];
+    usesUncommittedHead: boolean;
+  } | null> {
     const diffBase = ["diff", "--no-ext-diff"];
     switch (target.type) {
       case "uncommitted":
         return {
           baseArgs: diffBase,
-          rangeArgs: [await resolveUncommittedDiffBase(this.path)],
+          rangeArgs: ["HEAD"],
+          usesUncommittedHead: true,
         };
       case "branch_committed":
       case "all": {
@@ -1846,12 +1946,13 @@ export class Workspace {
           target.type === "branch_committed"
             ? [`${mergeBaseRef}..HEAD`]
             : [mergeBaseRef];
-        return { baseArgs: diffBase, rangeArgs };
+        return { baseArgs: diffBase, rangeArgs, usesUncommittedHead: false };
       }
       case "commit":
         return {
           baseArgs: ["show", "--format=", "--no-ext-diff"],
           rangeArgs: [target.sha],
+          usesUncommittedHead: false,
         };
       default: {
         const _exhaustive: never = target;
@@ -2152,11 +2253,38 @@ export class Workspace {
   private async readUncommittedDiffArtifacts(
     args: DiffOutputLimits & DiffPathSubset,
   ): Promise<[string, string, string]> {
-    const diffBase = await resolveUncommittedDiffBase(this.path);
-    return this.readDiffArtifactsIncludingUntracked({
-      diffArgs: [diffBase, "--"],
-      filesArgs: [diffBase, "--"],
-      numstatArgs: [diffBase, "--"],
+    const runUncommittedDiff = createUncommittedDiffRunner(this.path);
+    const [trackedDiff, trackedNumstat, trackedFiles] = await Promise.all([
+      runUncommittedDiff(
+        (baseRef) =>
+          withDiffPathspec(
+            ["diff", "--no-ext-diff", "--binary", baseRef],
+            args.paths,
+          ),
+        buildDiffOutputGitOptions(this.path, args.maxDiffBytes),
+      ),
+      runUncommittedDiff(
+        (baseRef) =>
+          withDiffPathspec(
+            ["diff", "--no-ext-diff", "--numstat", baseRef],
+            args.paths,
+          ),
+        { cwd: this.path },
+      ),
+      runUncommittedDiff(
+        (baseRef) =>
+          withDiffPathspec(
+            ["diff", "--no-ext-diff", "--name-status", baseRef],
+            args.paths,
+          ),
+        buildDiffOutputGitOptions(this.path, args.maxFileListBytes),
+      ),
+    ]);
+
+    return this.appendUntrackedDiffArtifacts({
+      diff: trackedDiff.stdout,
+      files: trackedFiles.stdout,
+      numstat: trackedNumstat.stdout,
       maxDiffBytes: args.maxDiffBytes,
       maxFileListBytes: args.maxFileListBytes,
       paths: args.paths,

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceFileStatusKind,
   WorkspaceStatus,
 } from "@bb/domain";
+import os from "node:os";
 import path from "node:path";
 import {
   getPullRequestForBranch,
@@ -528,7 +529,8 @@ async function readHeadNumstat(
   workspacePath: string,
   timeoutMs?: number,
 ): Promise<string> {
-  const result = await runGit(["diff", "--numstat", "-z", "HEAD", "--"], {
+  const diffBase = await resolveUncommittedDiffBase(workspacePath, timeoutMs);
+  const result = await runGit(["diff", "--numstat", "-z", diffBase, "--"], {
     cwd: workspacePath,
     allowFailure: true,
     timeoutMs,
@@ -544,6 +546,42 @@ async function readHeadNumstat(
     "git_command_failed",
     `git diff --numstat -z HEAD -- failed${detail ? `: ${detail}` : ""}`,
   );
+}
+
+async function resolveUncommittedDiffBase(
+  workspacePath: string,
+  timeoutMs?: number,
+): Promise<string> {
+  const head = await runGit(["rev-parse", "--verify", "HEAD"], {
+    cwd: workspacePath,
+    allowFailure: true,
+    timeoutMs,
+  });
+  if (head.exitCode === 0) {
+    return "HEAD";
+  }
+  if (!isMissingHeadRevisionError(head.stderr)) {
+    const detail = head.stderr.trim();
+    throw new WorkspaceError(
+      "git_command_failed",
+      `git rev-parse --verify HEAD failed${detail ? `: ${detail}` : ""}`,
+    );
+  }
+
+  // An unborn branch has no HEAD tree. Compare the index and working tree to
+  // Git's empty tree so staged files remain visible before the first commit.
+  const emptyTree = await runGit(["hash-object", "-t", "tree", os.devNull], {
+    cwd: workspacePath,
+    timeoutMs,
+  });
+  const emptyTreeSha = emptyTree.stdout.trim();
+  if (emptyTreeSha.length === 0) {
+    throw new WorkspaceError(
+      "git_command_failed",
+      "git hash-object returned no empty tree SHA",
+    );
+  }
+  return emptyTreeSha;
 }
 
 async function readUntrackedNumstatEntries(
@@ -1504,7 +1542,8 @@ export class Workspace {
 
     switch (target.type) {
       case "uncommitted": {
-        const stats = await this.runDiffStatCommands(["HEAD"]);
+        const diffBase = await resolveUncommittedDiffBase(this.path);
+        const stats = await this.runDiffStatCommands([diffBase]);
         return { ...stats, mergeBaseRef: null, untrackedPaths };
       }
       case "branch_committed": {
@@ -1790,7 +1829,10 @@ export class Workspace {
     const diffBase = ["diff", "--no-ext-diff"];
     switch (target.type) {
       case "uncommitted":
-        return { baseArgs: diffBase, rangeArgs: ["HEAD"] };
+        return {
+          baseArgs: diffBase,
+          rangeArgs: [await resolveUncommittedDiffBase(this.path)],
+        };
       case "branch_committed":
       case "all": {
         const mergeBaseRef = await readMergeBaseRef(
@@ -2110,10 +2152,11 @@ export class Workspace {
   private async readUncommittedDiffArtifacts(
     args: DiffOutputLimits & DiffPathSubset,
   ): Promise<[string, string, string]> {
+    const diffBase = await resolveUncommittedDiffBase(this.path);
     return this.readDiffArtifactsIncludingUntracked({
-      diffArgs: ["HEAD", "--"],
-      filesArgs: ["HEAD", "--"],
-      numstatArgs: ["HEAD", "--"],
+      diffArgs: [diffBase, "--"],
+      filesArgs: [diffBase, "--"],
+      numstatArgs: [diffBase, "--"],
       maxDiffBytes: args.maxDiffBytes,
       maxFileListBytes: args.maxFileListBytes,
       paths: args.paths,

--- a/packages/host-workspace/test/provision.test.ts
+++ b/packages/host-workspace/test/provision.test.ts
@@ -651,6 +651,32 @@ describe("provisionWorkspace", () => {
       await expect(fs.stat(targetPath)).rejects.toThrow();
     });
 
+    it("rediscovers git metadata in an existing personal workspace", async () => {
+      const parentDir = await makeTempDir("bb-personal-git-parent-");
+      const environmentId = "env_personal_git";
+      const personalWorkspaceRoot = path.join(parentDir, "personal-workspaces");
+      const targetPath = path.join(personalWorkspaceRoot, environmentId);
+      const initial = await provisionWorkspace({
+        workspaceProvisionType: "personal",
+        environmentId,
+        personalWorkspaceRoot,
+        targetPath,
+      });
+      expect(initial.isGitRepo).toBe(false);
+      await runGit(["init", "-b", "main"], { cwd: targetPath });
+
+      const refreshed = await provisionWorkspace({
+        workspaceProvisionType: "personal",
+        environmentId,
+        personalWorkspaceRoot,
+        targetPath,
+      });
+
+      expect(refreshed.isGitRepo).toBe(true);
+      expect(refreshed.isWorktree).toBe(false);
+      expect(await refreshed.getCurrentBranch()).toBe("main");
+    });
+
     it("rejects personal target paths outside the personal workspace root", async () => {
       const parentDir = await makeTempDir("bb-personal-parent-");
       const environmentId = "env_personal";

--- a/packages/host-workspace/test/provision.test.ts
+++ b/packages/host-workspace/test/provision.test.ts
@@ -677,6 +677,34 @@ describe("provisionWorkspace", () => {
       expect(await refreshed.getCurrentBranch()).toBe("main");
     });
 
+    it("does not accept external git metadata in a personal workspace", async () => {
+      const parentDir = await makeTempDir("bb-personal-external-git-parent-");
+      const environmentId = "env_personal_external_git";
+      const personalWorkspaceRoot = path.join(parentDir, "personal-workspaces");
+      const targetPath = path.join(personalWorkspaceRoot, environmentId);
+      const externalGitDir = path.join(parentDir, "external-git-dir");
+      await provisionWorkspace({
+        workspaceProvisionType: "personal",
+        environmentId,
+        personalWorkspaceRoot,
+        targetPath,
+      });
+      await runGit(
+        ["init", "-b", "main", "--separate-git-dir", externalGitDir],
+        { cwd: targetPath },
+      );
+
+      const refreshed = await provisionWorkspace({
+        workspaceProvisionType: "personal",
+        environmentId,
+        personalWorkspaceRoot,
+        targetPath,
+      });
+
+      expect(refreshed.isGitRepo).toBe(false);
+      expect(refreshed.isWorktree).toBe(false);
+    });
+
     it("rejects personal target paths outside the personal workspace root", async () => {
       const parentDir = await makeTempDir("bb-personal-parent-");
       const environmentId = "env_personal";

--- a/packages/host-workspace/test/workspace-diff.test.ts
+++ b/packages/host-workspace/test/workspace-diff.test.ts
@@ -120,6 +120,50 @@ afterEach(async () => {
 });
 
 describe("Workspace.diffFiles", () => {
+  it("reports staged and untracked files before the initial commit", async () => {
+    const repoPath = await initRepo();
+    await write(repoPath, "staged.txt", "staged pending\n");
+    await runGit(["add", "staged.txt"], { cwd: repoPath });
+    await write(repoPath, "untracked.txt", "untracked pending\n");
+    const workspace = new Workspace(repoPath);
+
+    const diff = await workspace.getDiff({ target: UNCOMMITTED });
+    const files = await workspace.diffFiles({ target: UNCOMMITTED });
+    const patches = await workspace.diffPatch({
+      target: UNCOMMITTED,
+      paths: ["staged.txt", "untracked.txt"],
+      maxBytesPerFile: 64 * 1024,
+    });
+
+    expect(diff.files).toContain("staged.txt");
+    expect(diff.files).toContain("untracked.txt");
+    expect(diff.shortstat).toContain("2 files changed");
+    expect(files.files).toEqual([
+      expect.objectContaining({
+        path: "staged.txt",
+        additions: 1,
+        origin: "tracked",
+        statusLetter: "A",
+      }),
+      expect.objectContaining({
+        path: "untracked.txt",
+        additions: 1,
+        origin: "untracked",
+        statusLetter: "A",
+      }),
+    ]);
+    expect(patches).toEqual([
+      expect.objectContaining({
+        path: "staged.txt",
+        patch: expect.stringContaining("staged pending"),
+      }),
+      expect.objectContaining({
+        path: "untracked.txt",
+        patch: expect.stringContaining("untracked pending"),
+      }),
+    ]);
+  });
+
   it("reports additions, modifications, and deletions with numstat counts", async () => {
     const repoPath = await initRepo();
     await write(repoPath, "keep.txt", "a\nb\nc\n");

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -516,7 +516,7 @@ describe("Workspace", () => {
     );
 
     const workspace = new Workspace(repoPath);
-    const status = await workspace.getStatus();
+    const status = await workspace.getStatus({ mergeBaseBranch: "main" });
 
     expect(status.workingTree.state).toBe("dirty_uncommitted");
     expect(status.branch.currentBranch).toBe("main");
@@ -537,6 +537,17 @@ describe("Workspace", () => {
     ]);
     expect(status.workingTree.insertions).toBe(2);
     expect(status.workingTree.deletions).toBe(0);
+    expect(status.mergeBase).toEqual({
+      mergeBaseBranch: "main",
+      baseRef: null,
+      aheadCount: 0,
+      behindCount: 0,
+      hasCommittedUnmergedChanges: false,
+      commits: [],
+      files: [],
+      insertions: 0,
+      deletions: 0,
+    });
   });
 
   it("returns diff content for each supported target", async () => {

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -504,6 +504,12 @@ describe("Workspace", () => {
     const repoPath = await makeTempDir("bb-workspace-unborn-repo-");
     await runGit(["init", "-b", "main"], { cwd: repoPath });
     await fs.writeFile(
+      path.join(repoPath, "staged.txt"),
+      "staged pending\n",
+      "utf8",
+    );
+    await runGit(["add", "staged.txt"], { cwd: repoPath });
+    await fs.writeFile(
       path.join(repoPath, "notes.txt"),
       "untracked pending\n",
       "utf8",
@@ -512,10 +518,16 @@ describe("Workspace", () => {
     const workspace = new Workspace(repoPath);
     const status = await workspace.getStatus();
 
-    expect(status.workingTree.state).toBe("untracked");
+    expect(status.workingTree.state).toBe("dirty_uncommitted");
     expect(status.branch.currentBranch).toBe("main");
     expect(status.checkout).toEqual({ kind: "unborn", branchName: "main" });
     expect(status.workingTree.files).toEqual([
+      {
+        path: "staged.txt",
+        status: "A",
+        insertions: 1,
+        deletions: 0,
+      },
       {
         path: "notes.txt",
         status: "??",
@@ -523,7 +535,7 @@ describe("Workspace", () => {
         deletions: 0,
       },
     ]);
-    expect(status.workingTree.insertions).toBe(1);
+    expect(status.workingTree.insertions).toBe(2);
     expect(status.workingTree.deletions).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- detect when a plain workspace becomes a Git repository after `git init`
- refresh the daemon, server, and cached runtime metadata for the repository
- support status and diff commands before the first commit exists
- increase the host daemon protocol version to 76

## Root cause

The workspace watcher stopped when `.git` did not exist. Static workspace metadata then kept Git support disabled after `git init`.

Some diff paths also used `HEAD` directly. A new repository has no valid `HEAD` commit.

## User impact

BB now enables Git status after a user adds Git to an existing workspace. BB also reports staged and untracked changes before the first commit.

## Validation

- `pnpm exec turbo run test --filter=@bb/host-workspace --filter=@bb/host-watcher --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --force`
- `pnpm exec turbo run test --filter=@bb/server --force -- test/internal/internal-environment-change.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-watcher --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server`
