### PR TITLE
Restore tab overflow controls

### DIFF
--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { createElement } from "react";
 import { afterEach, vi } from "vitest";
 import { describe, expect, it } from "vitest";
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 describe("secondary panel tab-strip edge fades", () => {
-  it("uses the themed edge fade without overlay scroll controls", () => {
+  it("uses the themed edge fade", () => {
     expect(SECONDARY_PANEL_TAB_STRIP_FADE_TONE).toBe("sidebar");
   });
 
@@ -70,10 +70,10 @@ describe("secondary panel tab-strip edge fades", () => {
     ).toBe(true);
     expect(
       container.querySelector('[aria-label="Scroll tabs left"]'),
-    ).toBeNull();
+    ).not.toBeNull();
     expect(
       container.querySelector('[aria-label="Scroll tabs right"]'),
-    ).toBeNull();
+    ).not.toBeNull();
 
     const rightFade = container.querySelector("[data-overflow-fade='right']");
     expect(rightFade?.classList.contains("opacity-0")).toBe(true);
@@ -86,5 +86,29 @@ describe("secondary panel tab-strip edge fades", () => {
       resizeCallback?.([], {} as ResizeObserver);
     });
     expect(rightFade?.classList.contains("opacity-100")).toBe(true);
+
+    const leftButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Scroll tabs left"]',
+    );
+    const rightButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Scroll tabs right"]',
+    );
+    expect(leftButton?.classList.contains("opacity-0")).toBe(true);
+    expect(leftButton?.tabIndex).toBe(-1);
+    expect(rightButton?.classList.contains("opacity-100")).toBe(true);
+    expect(rightButton?.tabIndex).toBe(0);
+    expect(rightButton?.classList.contains("bg-sidebar")).toBe(true);
+    expect(
+      rightButton?.classList.contains("hover:bg-surface-raised-solid"),
+    ).toBe(true);
+    expect(rightButton?.classList.contains("hover:bg-state-hover")).toBe(false);
+
+    const scrollBy = vi.fn();
+    Object.defineProperty(viewport!, "scrollBy", {
+      configurable: true,
+      value: scrollBy,
+    });
+    fireEvent.click(rightButton!);
+    expect(scrollBy).toHaveBeenCalledWith({ left: 140, behavior: "smooth" });
   });
 });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -22,6 +22,11 @@ describe("secondary panel tab-strip edge fades", () => {
   it("observes the intrinsic tab row so async title changes refresh overflow", () => {
     const observed: Element[] = [];
     let resizeCallback: ResizeObserverCallback | undefined;
+    let animationFrameCallback: FrameRequestCallback | undefined;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrameCallback = callback;
+      return 1;
+    });
     vi.stubGlobal(
       "ResizeObserver",
       class {
@@ -110,5 +115,14 @@ describe("secondary panel tab-strip edge fades", () => {
     });
     fireEvent.click(rightButton!);
     expect(scrollBy).toHaveBeenCalledWith({ left: 140, behavior: "smooth" });
+
+    rightButton?.focus();
+    expect(document.activeElement).toBe(rightButton);
+    viewport!.scrollLeft = 120;
+    fireEvent.scroll(viewport!);
+    act(() => animationFrameCallback?.(0));
+    expect(rightButton?.getAttribute("aria-hidden")).toBe("true");
+    expect(leftButton?.getAttribute("aria-hidden")).toBe("false");
+    expect(document.activeElement).toBe(leftButton);
   });
 });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -100,6 +100,8 @@ export function SecondaryPanelTabStrip({
   const viewportRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
+  const leftScrollButtonRef = useRef<HTMLButtonElement>(null);
+  const rightScrollButtonRef = useRef<HTMLButtonElement>(null);
   const [overflow, setOverflow] = useState<TabStripOverflowState>(
     INITIAL_OVERFLOW_STATE,
   );
@@ -223,6 +225,33 @@ export function SecondaryPanelTabStrip({
     }
     activeTabElement.scrollIntoView({ inline: "nearest", block: "nearest" });
   }, [activeTabId]);
+
+  // A scroll button can reach its edge while it has keyboard focus. Move focus
+  // before the button becomes an invisible, aria-hidden control.
+  useLayoutEffect(() => {
+    const focusedElement = document.activeElement;
+    const activeTabButton =
+      activeTabRef.current?.querySelector<HTMLButtonElement>("button") ?? null;
+    if (
+      !overflow.canScrollLeft &&
+      focusedElement === leftScrollButtonRef.current
+    ) {
+      (overflow.canScrollRight
+        ? rightScrollButtonRef.current
+        : activeTabButton
+      )?.focus();
+      return;
+    }
+    if (
+      !overflow.canScrollRight &&
+      focusedElement === rightScrollButtonRef.current
+    ) {
+      (overflow.canScrollLeft
+        ? leftScrollButtonRef.current
+        : activeTabButton
+      )?.focus();
+    }
+  }, [overflow.canScrollLeft, overflow.canScrollRight]);
 
   // A plain mouse wheel over the strip should move it sideways. React registers
   // its onWheel listener as passive, so a synthetic handler can't call
@@ -425,12 +454,14 @@ export function SecondaryPanelTabStrip({
         </div>
       </div>
       <TabStripScrollButton
+        buttonRef={leftScrollButtonRef}
         direction="left"
         canScroll={overflow.canScrollLeft}
         className={chevronNoDragClass}
         onClick={() => scrollByStep(-1)}
       />
       <TabStripScrollButton
+        buttonRef={rightScrollButtonRef}
         direction="right"
         canScroll={overflow.canScrollRight}
         className={chevronNoDragClass}
@@ -489,6 +520,7 @@ function SortableFileTab({
 }
 
 interface TabStripScrollButtonProps {
+  buttonRef: RefObject<HTMLButtonElement | null>;
   direction: "left" | "right";
   canScroll: boolean;
   className: string | null;
@@ -496,6 +528,7 @@ interface TabStripScrollButtonProps {
 }
 
 function TabStripScrollButton({
+  buttonRef,
   direction,
   canScroll,
   className,
@@ -505,6 +538,7 @@ function TabStripScrollButton({
     direction === "left" ? "Scroll tabs left" : "Scroll tabs right";
   return (
     <Button
+      ref={buttonRef}
       type="button"
       variant="ghost"
       size="sm"

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -27,6 +27,9 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@bb/shared-ui/button";
+import { COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { Icon } from "@bb/shared-ui/icon";
 import {
   OverflowFade,
   type OverflowFadeTone,
@@ -34,14 +37,20 @@ import {
 import { TabPill } from "@/components/ui/tab-pill";
 import { useDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { MACOS_WINDOW_NO_DRAG_CLASS } from "@/lib/bb-desktop";
+import {
+  MACOS_APP_REGION_NO_DRAG_CLASS,
+  MACOS_WINDOW_NO_DRAG_CLASS,
+} from "@/lib/bb-desktop";
 import type {
   SecondaryPanelFileTab,
   SecondaryPanelTabReorderHandler,
 } from "./secondaryPanelFileTab";
 export type { SecondaryPanelFileTab } from "./secondaryPanelFileTab";
 
-// Slack so sub-pixel scroll offsets don't leave a fade stuck on at a hard edge.
+// Roughly one wide tab, so one click reveals the next tab without overshooting.
+const CHEVRON_SCROLL_STEP_PX = 140;
+
+// Slack so sub-pixel scroll offsets don't leave an overflow cue at a hard edge.
 const EDGE_EPSILON_PX = 1;
 
 export const SECONDARY_PANEL_TAB_STRIP_FADE_TONE: OverflowFadeTone = "sidebar";
@@ -78,8 +87,8 @@ interface SortableFileTabProps {
  *
  * Only the file tabs scroll; the leading Info/Diff controls and trailing
  * new-tab/panel controls stay anchored outside this component. Edge
- * fades appear only on a side that has more tabs, and the active tab is
- * auto-scrolled into view on mount and whenever it changes
+ * fades and scroll buttons appear only on a side that has more tabs, and the
+ * active tab is auto-scrolled into view on mount and whenever it changes
  * (covering pointer, keyboard, and programmatic selection).
  */
 export function SecondaryPanelTabStrip({
@@ -263,6 +272,13 @@ export function SecondaryPanelTabStrip({
     };
   }, []);
 
+  const scrollByStep = useCallback((direction: -1 | 1) => {
+    viewportRef.current?.scrollBy({
+      left: direction * CHEVRON_SCROLL_STEP_PX,
+      behavior: "smooth",
+    });
+  }, []);
+
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
       setDraggingTabId(String(event.active.id));
@@ -302,9 +318,12 @@ export function SecondaryPanelTabStrip({
   );
 
   const noDragClass = usesDesktopChrome ? MACOS_WINDOW_NO_DRAG_CLASS : null;
+  const chevronNoDragClass = usesDesktopChrome
+    ? MACOS_APP_REGION_NO_DRAG_CLASS
+    : null;
   // Memoize the sortable tab tree so the overflow-flag state — which flips every
   // time you reach a scroll edge, i.e. constantly at narrow widths — re-renders
-  // only the edge fades, never the tabs. Without this, each edge
+  // only the edge controls, never the tabs. Without this, each edge
   // crossing reconciles the whole list and re-runs useSortable for every tab,
   // which is what kept narrow-width scrolling stuttery.
   const dndTabs = useMemo(
@@ -361,17 +380,16 @@ export function SecondaryPanelTabStrip({
 
   return (
     // Hugs its tabs (no `flex-1`) and shrinks (`min-w-0`) to scroll them under
-    // the edge fades when they overflow. The New Tab button follows this
+    // the edge controls when they overflow. The New Tab button follows this
     // viewport as an anchored sibling, so it stays visible at the trailing edge
     // while overflowing tabs scroll beneath the fades.
     <div
       data-testid="secondary-panel-tab-strip"
       className="group relative flex min-w-0 items-center"
     >
-      {/* Keep the overflow cue stationary. Overlay scroll buttons used to
-          animate above partially visible tabs, making the tab text and selected
-          fill look clipped while the strip moved. Native wheel, trackpad, and
-          active-tab scrolling already provide the interaction. */}
+      {/* Keep both overflow cues stationary while the tab content moves below
+          them. The buttons use the panel surface as a solid background, so tab
+          text cannot show through a button during a smooth scroll. */}
       <OverflowFade
         placement="left"
         tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
@@ -406,6 +424,18 @@ export function SecondaryPanelTabStrip({
           {dndTabs}
         </div>
       </div>
+      <TabStripScrollButton
+        direction="left"
+        canScroll={overflow.canScrollLeft}
+        className={chevronNoDragClass}
+        onClick={() => scrollByStep(-1)}
+      />
+      <TabStripScrollButton
+        direction="right"
+        canScroll={overflow.canScrollRight}
+        className={chevronNoDragClass}
+        onClick={() => scrollByStep(1)}
+      />
     </div>
   );
 }
@@ -455,6 +485,46 @@ function SortableFileTab({
     >
       <FileTab tab={tab} activeTreatment={activeTreatment} />
     </div>
+  );
+}
+
+interface TabStripScrollButtonProps {
+  direction: "left" | "right";
+  canScroll: boolean;
+  className: string | null;
+  onClick: () => void;
+}
+
+function TabStripScrollButton({
+  direction,
+  canScroll,
+  className,
+  onClick,
+}: TabStripScrollButtonProps) {
+  const label =
+    direction === "left" ? "Scroll tabs left" : "Scroll tabs right";
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      tabIndex={canScroll ? 0 : -1}
+      aria-hidden={!canScroll}
+      aria-label={label}
+      onClick={onClick}
+      className={cn(
+        "absolute z-20 shrink-0 bg-sidebar text-muted-foreground shadow-none hover:bg-surface-raised-solid hover:text-foreground focus-visible:bg-sidebar",
+        direction === "left" ? "left-0" : "right-0",
+        COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
+        "transition-opacity",
+        canScroll
+          ? "pointer-events-auto opacity-100"
+          : "pointer-events-none opacity-0",
+        className,
+      )}
+    >
+      <Icon name={direction === "left" ? "ChevronLeft" : "ChevronRight"} />
+    </Button>
   );
 }
 


### PR DESCRIPTION
## Summary

- Restore the left and right overflow buttons in the secondary panel tab strip.
- Show each button only when more tabs exist in its direction.
- Use an opaque hover surface so tab content does not show through.
- Keep mouse-wheel, trackpad, keyboard, and active-tab scroll behavior.

## Why

The tab strip removed its pointer controls during an overflow fade fix. Users without a trackpad then had no visible pointer control for tab overflow.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/secondary-panel/SecondaryPanelTabStrip.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`
- Manual verification in the development app.
