### PR TITLE
Keep interactive plugin tools past the Connect timeout

### DIFF
--- a/apps/connect/src/tunnel-do.ts
+++ b/apps/connect/src/tunnel-do.ts
@@ -483,6 +483,24 @@ export class TunnelDO {
     }
   }
 
+  private cancelHttpStream(streamId: number, message: string): void {
+    const entry = this.pendingHttp.get(streamId);
+    if (!entry) return;
+    this.pendingHttp.delete(streamId);
+    clearTimeout(entry.timeout);
+    const tunnel = this.tunnelSocket();
+    if (!tunnel) return;
+    this.trySend(
+      tunnel,
+      encodeFrame({
+        type: "close-stream",
+        streamId,
+        code: 1000,
+        reason: message,
+      }),
+    );
+  }
+
   webSocketMessage(ws: WebSocket, message: ArrayBuffer | string): void {
     const tags = this.state.getTags(ws);
     if (tags.includes(TUNNEL_TAG)) {
@@ -558,6 +576,12 @@ export class TunnelDO {
           return;
         }
         entry.writer = writable.getWriter();
+        void entry.writer.closed.catch(() => {
+          this.cancelHttpStream(
+            frame.streamId,
+            "visitor canceled response body",
+          );
+        });
         entry.resolve(response);
         return;
       }

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -1364,6 +1364,44 @@ function openHttpStreamId(sent: Uint8Array[], index: number): number {
 }
 
 describe("TunnelDO response relay", () => {
+  it("closes the origin stream when the visitor cancels a response body", async () => {
+    const sent: Uint8Array[] = [];
+    const state = mockDoState({ protocolVersion: 1 });
+    const dob = new TunnelDO(state.api, makeDoEnv());
+    await state.restore;
+    const tunnel = fakeTunnelSocket(captureSent(sent));
+    state.addSocket(tunnel, ["tunnel"]);
+
+    const pending = dob.fetch(new Request("https://do.internal/slow"));
+    const streamId = openHttpStreamId(sent, 0);
+    dob.webSocketMessage(
+      tunnel,
+      frameBuffer({
+        type: "resp-head",
+        streamId,
+        status: 200,
+        headers: [["content-type", "text/plain"]],
+      }),
+    );
+    const response = await pending;
+
+    await response.body?.cancel("visitor left");
+    await vi.waitFor(() => {
+      const close = sent
+        .map(decodeFrame)
+        .find(
+          (frame) =>
+            frame.type === "close-stream" && frame.streamId === streamId,
+        );
+      expect(close).toMatchObject({
+        type: "close-stream",
+        streamId,
+        code: 1000,
+        reason: "visitor canceled response body",
+      });
+    });
+  });
+
   it("keeps a streamed response body open after the response-head timeout window", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -1364,6 +1364,49 @@ function openHttpStreamId(sent: Uint8Array[], index: number): number {
 }
 
 describe("TunnelDO response relay", () => {
+  it("keeps a streamed response body open after the response-head timeout window", async () => {
+    vi.useFakeTimers();
+    try {
+      const sent: Uint8Array[] = [];
+      const state = mockDoState({ protocolVersion: 1 });
+      const dob = new TunnelDO(state.api, makeDoEnv());
+      await state.restore;
+      const tunnel = fakeTunnelSocket(captureSent(sent));
+      state.addSocket(tunnel, ["tunnel"]);
+
+      const pending = dob.fetch(
+        new Request("https://do.internal/session/tool-call"),
+      );
+      const streamId = openHttpStreamId(sent, 0);
+      dob.webSocketMessage(
+        tunnel,
+        frameBuffer({
+          type: "resp-head",
+          streamId,
+          status: 200,
+          headers: [["content-type", "application/json"]],
+        }),
+      );
+      const response = await pending;
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      dob.webSocketMessage(
+        tunnel,
+        frameBuffer({
+          type: "body-chunk",
+          streamId,
+          data: new TextEncoder().encode('{"answer":"ready"}'),
+        }),
+      );
+      dob.webSocketMessage(tunnel, frameBuffer({ type: "body-end", streamId }));
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ answer: "ready" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("relays null-body statuses (304/204) bodiless instead of stranding the visitor", async () => {
     const sent: Uint8Array[] = [];
     const state = mockDoState({ protocolVersion: 1 });

--- a/apps/server/src/internal/tool-calls.ts
+++ b/apps/server/src/internal/tool-calls.ts
@@ -3,6 +3,7 @@ import {
   typedRoutes,
   type HostDaemonInternalSchema,
 } from "@bb/host-daemon-contract";
+import type { ToolCallResponse } from "@bb/domain";
 import type { Hono } from "hono";
 import type { AppDeps } from "../types.js";
 import { ApiError } from "../errors.js";
@@ -16,6 +17,34 @@ import {
   UPDATE_ENVIRONMENT_DIRECTORY_TOOL_NAME,
 } from "../services/threads/thread-environment-directory.js";
 import { requireAuthenticatedDaemonSession } from "./session-state.js";
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Return the response head before a plugin tool finishes. Interactive plugin
+ * tools can wait for user input for minutes, while bb Connect requires an
+ * origin response head within 30 seconds. The response body can stay open.
+ */
+function streamToolCallResponse(result: Promise<ToolCallResponse>): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      void result.then(
+        (response) => {
+          try {
+            controller.enqueue(textEncoder.encode(JSON.stringify(response)));
+            controller.close();
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+        (error) => controller.error(error),
+      );
+    },
+  });
+  return new Response(body, {
+    headers: { "content-type": "application/json; charset=UTF-8" },
+  });
+}
 
 export function registerInternalToolCallRoutes(app: Hono, deps: AppDeps): void {
   const { post } = typedRoutes<HostDaemonInternalSchema>(app, {
@@ -60,8 +89,8 @@ export function registerInternalToolCallRoutes(app: Hono, deps: AppDeps): void {
 
       const pluginTool = findPluginAgentTool(payload.tool);
       if (pluginTool) {
-        return context.json(
-          await invokePluginAgentTool(pluginTool, {
+        return streamToolCallResponse(
+          invokePluginAgentTool(pluginTool, {
             input: payload.arguments,
             ctx: {
               threadId: thread.id,

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -1,3 +1,4 @@
+import { once } from "node:events";
 import { setTimeout as sleep } from "node:timers/promises";
 import { eq } from "drizzle-orm";
 import {
@@ -9,12 +10,13 @@ import {
   listQueuedThreadMessages,
   threads,
 } from "@bb/db";
-import { threadScope, turnScope } from "@bb/domain";
+import { threadScope, turnScope, type ToolCallResponse } from "@bb/domain";
 import {
   groupHostDaemonEvents,
   type HostDaemonEventEnvelope,
 } from "@bb/host-daemon-contract";
 import { describe, expect, it, vi } from "vitest";
+import { serve } from "@hono/node-server";
 import {
   internalAuthHeaders,
   listQueuedThreadCommands,
@@ -81,6 +83,95 @@ async function flushDeferredChildThreadNotifications(): Promise<void> {
 }
 
 describe("internal event and tool-call routes", () => {
+  it("returns the response head before a plugin tool completes", async () => {
+    await withTestHarness(async (harness) => {
+      const record = {
+        name: "wait_for_user",
+      } as PluginAgentToolRecord;
+      let completeTool!: (value: ToolCallResponse) => void;
+      const toolResult = new Promise<ToolCallResponse>((resolve) => {
+        completeTool = resolve;
+      });
+      setPluginAgentContributions({
+        listSkillRootContributions: () => [],
+        listAgentTools: () => [],
+        listInstructionContributions: () => [],
+        findAgentTool: (name) =>
+          name === record.name ? { pluginId: "fixture", record } : undefined,
+        invokeAgentTool: () => toolResult,
+        resolveMention: async () => ({ ok: false, error: "unused" }),
+      });
+
+      try {
+        const { host, session } = seedHostSession(harness.deps, {
+          id: "host-streaming-tool-call",
+        });
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+        });
+        const environment = seedEnvironment(harness.deps, {
+          hostId: host.id,
+          projectId: project.id,
+        });
+        const thread = seedThread(harness.deps, {
+          projectId: project.id,
+          environmentId: environment.id,
+        });
+
+        const server = serve({
+          fetch: harness.app.fetch,
+          hostname: "127.0.0.1",
+          port: 0,
+        });
+        try {
+          if (!server.listening) await once(server, "listening");
+          const address = server.address();
+          if (address === null || typeof address === "string") {
+            throw new Error("Expected a TCP server address");
+          }
+          const responsePromise = fetch(
+            `http://127.0.0.1:${address.port}/internal/session/tool-call`,
+            {
+              method: "POST",
+              headers: internalAuthHeaders(harness),
+              body: JSON.stringify({
+                sessionId: session.id,
+                threadId: thread.id,
+                providerThreadId: "provider-tool-call",
+                turnId: "turn-tool-call",
+                callId: "call-tool-call",
+                tool: record.name,
+              }),
+            },
+          );
+          const earlyResponse = await Promise.race([
+            responsePromise,
+            sleep(1_000).then(() => null),
+          ]);
+
+          completeTool({
+            success: true,
+            contentItems: [{ type: "inputText", text: "answered" }],
+          });
+          const response = earlyResponse ?? (await responsePromise);
+
+          expect(earlyResponse).not.toBeNull();
+          expect(response.status).toBe(200);
+          await expect(readJson(response)).resolves.toEqual({
+            success: true,
+            contentItems: [{ type: "inputText", text: "answered" }],
+          });
+        } finally {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          });
+        }
+      } finally {
+        setPluginAgentContributions(undefined);
+      }
+    });
+  });
+
   it("snapshots native plugin status labels into tool-call events", async () => {
     await withTestHarness(async (harness) => {
       const statusLabels = {

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -981,6 +981,88 @@ describe("TunnelSession routing", () => {
     );
   });
 
+  it("aborts the origin request when the relay closes an HTTP stream", async () => {
+    let originStarted = false;
+    let originClosed = false;
+    const origin = await listen((request, response) => {
+      originStarted = true;
+      request.once("aborted", () => {
+        originClosed = true;
+      });
+      response.once("close", () => {
+        originClosed = true;
+      });
+    });
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => origin.server.close(() => resolve())),
+    );
+
+    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    await new Promise<void>((resolve) =>
+      wss.once("listening", () => resolve()),
+    );
+    const wssAddr = wss.address();
+    if (wssAddr === null || typeof wssAddr === "string") {
+      throw new Error("expected TCP address");
+    }
+    const relayReady = new Promise<NodeWebSocket>((resolve) => {
+      wss.on("connection", (socket) => resolve(socket));
+    });
+    const client = new NodeWebSocket(`ws://127.0.0.1:${wssAddr.port}`);
+    cleanups.push(async () => {
+      client.terminate();
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+    });
+    await waitForOpen(client);
+    const relay = await relayReady;
+
+    const session = new TunnelSession({
+      tunnel: client,
+      log: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      resolveOrigin: () => ({
+        kind: "ok",
+        resolved: {
+          origin: origin.origin,
+          publicOrigin: "https://sawyer.getbb.app",
+        },
+      }),
+    });
+    session.start();
+    cleanups.push(() => session.dispose());
+
+    relay.send(
+      Buffer.from(
+        encodeFrame({
+          type: "open-http",
+          streamId: 41,
+          method: "GET",
+          path: "/slow",
+          headers: [],
+          hasBody: false,
+        }),
+      ),
+    );
+    await waitFor(() => originStarted);
+
+    relay.send(
+      Buffer.from(
+        encodeFrame({
+          type: "close-stream",
+          streamId: 41,
+          code: 1000,
+          reason: "visitor canceled response body",
+        }),
+      ),
+    );
+    await waitFor(() => originClosed);
+  });
+
   it("preserves negotiated origin compression across the tunnel and relays 304 bodiless", async () => {
     const plainBody = "hello ".repeat(200);
     const gzippedBody = gzipSync(Buffer.from(plainBody));


### PR DESCRIPTION
## Summary

- send the internal plugin-tool response headers before the tool completes
- deliver the unchanged JSON result through the open response body
- add server and Connect regressions for responses delayed beyond 30 seconds

Fixes #1082

## Tests

- `pnpm exec turbo run test --filter=@bb/server -- --run test/internal/internal-events-tool-calls.test.ts test/services/plugins/plugin-agent-tools.test.ts test/services/pending-interactions.test.ts`
- `pnpm exec turbo run test --filter=bb-plugin-ask-user-question`
- `pnpm exec turbo run test typecheck --filter=@bb/connect`
- `pnpm exec turbo run build typecheck --filter=@bb/server`
- `pnpm exec prettier --check apps/server/src/internal/tool-calls.ts apps/server/test/internal/internal-events-tool-calls.test.ts apps/connect/src/worker.test.ts`

## Risk

The host-daemon JSON contract is unchanged. Existing daemons already read the full response body before they parse the result.