### PR TITLE
Improve right panel resize sensitivity

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -53,7 +53,7 @@ describe("ThreadSecondaryPanel resize handle", () => {
     });
     const hitTarget = handle.querySelector("[data-panel-resize-hit-target]");
 
-    expect(handle.className.split(/\s+/u)).toContain("z-[5]");
+    expect(handle.className.split(/\s+/u)).toContain("z-[25]");
     expect(hitTarget).not.toBeNull();
     expect(hitTarget?.className.split(/\s+/u)).toEqual(
       expect.arrayContaining([

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -41,6 +41,32 @@ function renderPanel(args: {
   );
 }
 
+describe("ThreadSecondaryPanel resize handle", () => {
+  it("uses a real 12px hit target centered over the resize seam", () => {
+    const view = renderPanel({
+      isConversationCollapsed: false,
+      onToggleConversationCollapse: noop,
+    });
+
+    const handle = view.getByRole("separator", {
+      name: "Resize thread and right panel",
+    });
+    const hitTarget = handle.querySelector("[data-panel-resize-hit-target]");
+
+    expect(handle.className.split(/\s+/u)).toContain("z-[5]");
+    expect(hitTarget).not.toBeNull();
+    expect(hitTarget?.className.split(/\s+/u)).toEqual(
+      expect.arrayContaining([
+        "left-1/2",
+        "z-10",
+        "w-3",
+        "-translate-x-1/2",
+        "cursor-col-resize",
+      ]),
+    );
+  });
+});
+
 // The full-screen control is the ONLY way back once the conversation is hidden
 // — there is no standalone rail to click. Pin both halves of the same-slot
 // expansion pair so a full-screen tab can always restore its prior layout.

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -25,6 +25,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import {
   PANEL_COLLAPSE_TRANSITION_CLASS,
   PANEL_RESIZE_HIT_AREA_MARGINS,
+  PANEL_RESIZE_HIT_TARGET_CLASS,
 } from "./panelTransitionTokens";
 import { SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS } from "./panelChromeClasses";
 import { resolveConversationCollapseControl } from "./panelToggleControlState";
@@ -997,15 +998,15 @@ function SecondaryPanelResizeHandle({
       onDragging={onDragging}
       hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
       className={cn(
-        "group relative shrink-0 overflow-visible transition-[width,opacity,background-color] before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
+        "group relative z-[5] shrink-0 overflow-visible transition-[width,opacity,background-color]",
         PANEL_COLLAPSE_TRANSITION_CLASS,
         isConversationCollapsed ? "cursor-default" : "cursor-col-resize",
         matchesSplitDividers
           ? [
               // Match SplitDivider: a one-pixel vertical seam that warms on
-              // hover/drag while the wide pseudo-element keeps it easy to
-              // grab. Collapses away with the panel.
-              "z-[5] bg-border-seam hover:bg-ring/40",
+              // hover/drag while the overlapping child keeps it easy to grab.
+              // Collapses away with the panel.
+              "bg-border-seam hover:bg-ring/40",
               isOpen && !isConversationCollapsed
                 ? "w-px opacity-100"
                 : "pointer-events-none w-0 opacity-0",
@@ -1027,6 +1028,11 @@ function SecondaryPanelResizeHandle({
       )}
       aria-label="Resize thread and right panel"
     >
+      <span
+        aria-hidden
+        data-panel-resize-hit-target=""
+        className={PANEL_RESIZE_HIT_TARGET_CLASS}
+      />
       {matchesSplitDividers ? null : (
         /*
           The panel's persistent left border lives on the content (aside

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -25,6 +25,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import {
   PANEL_COLLAPSE_TRANSITION_CLASS,
   PANEL_RESIZE_HIT_AREA_MARGINS,
+  PANEL_RESIZE_HANDLE_LAYER_CLASS,
   PANEL_RESIZE_HIT_TARGET_CLASS,
 } from "./panelTransitionTokens";
 import { SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS } from "./panelChromeClasses";
@@ -998,7 +999,8 @@ function SecondaryPanelResizeHandle({
       onDragging={onDragging}
       hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
       className={cn(
-        "group relative z-[5] shrink-0 overflow-visible transition-[width,opacity,background-color]",
+        "group relative shrink-0 overflow-visible transition-[width,opacity,background-color]",
+        PANEL_RESIZE_HANDLE_LAYER_CLASS,
         PANEL_COLLAPSE_TRANSITION_CLASS,
         isConversationCollapsed ? "cursor-default" : "cursor-col-resize",
         matchesSplitDividers

--- a/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
+++ b/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
@@ -10,23 +10,23 @@ export const PANEL_COLLAPSE_TRANSITION_CLASS =
 /**
  * Hit-area margins for the thread-detail `PanelResizeHandle`s.
  *
- * The handles render a 1px hairline and widen their *grab + cursor* region with
- * a `before:` pseudo-element that overhangs the hairline by `1.5` (6px) on each
- * side. react-resizable-panels does its own window-level hit detection against
- * the handle's bounding box (the 1px hairline) expanded by these margins — it
- * ignores the pseudo-element. Its default `fine` margin is only 5px, so the
- * outer ~1px of the pseudo-element showed the resize cursor while sitting
- * outside the library's hit area: the cursor promised a resize the drag never
- * delivered.
+ * The handles keep a zero/1px layout seam and render a real 12px-wide child as
+ * their pointer target. react-resizable-panels still calculates its hit area
+ * from the parent handle's bounding box, so these margins must fully envelop
+ * the child: unlike the old pseudo-element, the child then owns pointer hit
+ * testing while the library recognizes every point within it as a resize.
  *
- * The `fine` margin must therefore be at least as large as the 6px overhang.
- * We make it strictly larger (8px) rather than an exact 6px match so the
- * draggable region fully *envelops* the cursor region even at fractional pixel
- * boundaries (sub-pixel flex layout positions, HiDPI rounding) — an exact match
- * can still leave a ~1px sliver where the cursor shows but the drag has not yet
- * engaged. The library treats an edge-adjacent panel as non-overlapping
- * (strict intersection), so the wider margin genuinely extends the live drag
- * zone instead of being vetoed by the neighbouring panel. `coarse` (touch)
- * already exceeds the overhang, so it stays at the library default.
+ * `fine` stays slightly larger than the child's 6px overhang for fractional
+ * layout positions and HiDPI rounding. `coarse` keeps the library default.
  */
 export const PANEL_RESIZE_HIT_AREA_MARGINS = { coarse: 15, fine: 8 };
+
+/**
+ * A physical grab strip centered over a panel's zero/1px layout seam.
+ *
+ * Keep this on a real child rather than a pseudo-element: it must sit above the
+ * adjacent panel content and become the pointer target itself, matching the
+ * sidebar's dependable 12px-wide resize strip without consuming layout space.
+ */
+export const PANEL_RESIZE_HIT_TARGET_CLASS =
+  "absolute inset-y-0 left-1/2 z-10 w-3 -translate-x-1/2 touch-none cursor-col-resize bg-transparent";

--- a/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
+++ b/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
@@ -22,6 +22,14 @@ export const PANEL_COLLAPSE_TRANSITION_CLASS =
 export const PANEL_RESIZE_HIT_AREA_MARGINS = { coarse: 15, fine: 8 };
 
 /**
+ * Keep panel resize targets above bounded pane headers and focus scrims.
+ *
+ * This matches SplitDivider: a lower layer lets a pane header cover the half
+ * of the grab strip that overhangs into the main panel at the header row.
+ */
+export const PANEL_RESIZE_HANDLE_LAYER_CLASS = "z-[25]";
+
+/**
  * A physical grab strip centered over a panel's zero/1px layout seam.
  *
  * Keep this on a real child rather than a pseudo-element: it must sit above the

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -1319,10 +1319,11 @@ describe("SplitThreadArea", () => {
       "split-workspace-empty-panel-state",
     );
     expect(emptyState.textContent).toContain("This pane has no right panel.");
+    const panelResizeHandle = screen.getByTestId(
+      "workspace-panel-resize-handle",
+    );
     expect(
-      screen
-        .getByTestId("workspace-panel-resize-handle")
-        .querySelector("[data-panel-resize-hit-target]"),
+      panelResizeHandle.querySelector("[data-panel-resize-hit-target]"),
     ).not.toBeNull();
     const pluginToggle = screen
       .getByTestId("split-workspace-panel-toggle")
@@ -1349,6 +1350,38 @@ describe("SplitThreadArea", () => {
     expect(
       screen.queryByTestId("split-workspace-empty-panel-state"),
     ).toBeNull();
+  });
+
+  it("keeps the right-panel resize target above a bounded pane header", async () => {
+    const layout = pluginSplitLayout();
+    layout.focusedPaneId = "pane-1";
+    renderSplitArea({
+      path: threadPath("thr-a"),
+      layout,
+      routeAwareContent: true,
+    });
+
+    const pluginPane = document.querySelector('[data-split-pane-id="pane-2"]');
+    if (!(pluginPane instanceof HTMLElement)) {
+      throw new Error("Expected plugin split pane");
+    }
+
+    // Focusing a pane with no hosted panel exposes the empty right-panel
+    // handle beside that pane's bounded header. The handle must own the whole
+    // 12px grab strip at this row instead of losing its left overhang.
+    fireEvent.pointerDown(pluginPane);
+    await screen.findByTestId("split-workspace-empty-panel-state");
+
+    const panelResizeHandle = screen.getByTestId(
+      "workspace-panel-resize-handle",
+    );
+    const pluginPaneHeader = pluginPane.querySelector("header");
+    expect(pluginPaneHeader).toBeInstanceOf(HTMLElement);
+    if (pluginPaneHeader instanceof HTMLElement) {
+      expect(stackingLayer(pluginPaneHeader)).toBeLessThan(
+        stackingLayer(panelResizeHandle),
+      );
+    }
   });
 
   it("ignores the empty panel's initial collapse so a thread keeps its open panel", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -180,9 +180,11 @@ vi.mock("react-resizable-panels", async () => {
     );
   };
   const PanelResizeHandle = ({
+    children,
     className,
     id,
   }: {
+    children?: ReactNode;
     className?: string;
     id?: string;
   }) => (
@@ -190,7 +192,9 @@ vi.mock("react-resizable-panels", async () => {
       id={id}
       className={className}
       data-testid="workspace-panel-resize-handle"
-    />
+    >
+      {children}
+    </div>
   );
   return { Panel, PanelGroup, PanelResizeHandle };
 });
@@ -1315,6 +1319,11 @@ describe("SplitThreadArea", () => {
       "split-workspace-empty-panel-state",
     );
     expect(emptyState.textContent).toContain("This pane has no right panel.");
+    expect(
+      screen
+        .getByTestId("workspace-panel-resize-handle")
+        .querySelector("[data-panel-resize-hit-target]"),
+    ).not.toBeNull();
     const pluginToggle = screen
       .getByTestId("split-workspace-panel-toggle")
       .querySelector("button");

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -35,6 +35,7 @@ import {
 import {
   PANEL_COLLAPSE_TRANSITION_CLASS,
   PANEL_RESIZE_HIT_AREA_MARGINS,
+  PANEL_RESIZE_HIT_TARGET_CLASS,
 } from "@/components/secondary-panel/panelTransitionTokens";
 import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
 import { PluginComposerHostProvider } from "@/components/plugin/plugin-composer-host";
@@ -288,14 +289,20 @@ export function SplitWorkspaceSecondaryPanelHost({
                 onDragging={handleEmptyPanelDragging}
                 hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
                 className={cn(
-                  "relative z-[5] shrink-0 overflow-visible bg-border-seam transition-[width,opacity,background-color] before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-[''] hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
+                  "relative z-[5] shrink-0 overflow-visible bg-border-seam transition-[width,opacity,background-color] hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
                   PANEL_COLLAPSE_TRANSITION_CLASS,
                   isOpen
                     ? "w-px cursor-col-resize opacity-100"
                     : "pointer-events-none w-0 opacity-0",
                 )}
                 aria-label="Resize right panel"
-              />
+              >
+                <span
+                  aria-hidden
+                  data-panel-resize-hit-target=""
+                  className={PANEL_RESIZE_HIT_TARGET_CLASS}
+                />
+              </PanelResizeHandle>
               <Panel
                 id="split-workspace-empty-secondary-panel"
                 collapsible

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -35,6 +35,7 @@ import {
 import {
   PANEL_COLLAPSE_TRANSITION_CLASS,
   PANEL_RESIZE_HIT_AREA_MARGINS,
+  PANEL_RESIZE_HANDLE_LAYER_CLASS,
   PANEL_RESIZE_HIT_TARGET_CLASS,
 } from "@/components/secondary-panel/panelTransitionTokens";
 import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
@@ -289,7 +290,8 @@ export function SplitWorkspaceSecondaryPanelHost({
                 onDragging={handleEmptyPanelDragging}
                 hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
                 className={cn(
-                  "relative z-[5] shrink-0 overflow-visible bg-border-seam transition-[width,opacity,background-color] hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
+                  "relative shrink-0 overflow-visible bg-border-seam transition-[width,opacity,background-color] hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
+                  PANEL_RESIZE_HANDLE_LAYER_CLASS,
                   PANEL_COLLAPSE_TRANSITION_CLASS,
                   isOpen
                     ? "w-px cursor-col-resize opacity-100"


### PR DESCRIPTION
## Summary

- replace the pseudo-only right-panel grab zone with a real 12px pointer target
- keep the visible zero/1px seam and existing panel layout, constraints, animations, and keyboard behavior
- apply the same hit-target geometry to the split-workspace empty panel
- add regression coverage for both resize paths

## Why

The sidebar uses a physical 12px, high-stacking resize strip. The right panel instead relied on a zero/1px handle plus synthetic margins around a pseudo-element, making pointer acquisition less dependable around adjacent panel content. The new child element owns hit testing while the panel library still recognizes the full region.

## Testing

- pnpm exec turbo run test --filter=@bb/app -- src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
- pnpm exec turbo run test --filter=@bb/app -- src/views/thread-detail/SplitThreadArea.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (zero errors; existing warnings only)
- git diff --check