### PR TITLE
Fix file links in sidechat timelines

### DIFF
--- a/apps/app/src/components/plugin/PluginThreadChat.test.tsx
+++ b/apps/app/src/components/plugin/PluginThreadChat.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { pluginSdkAppImplementation } from "@/lib/plugin-sdk-app-impl";
+import { ThreadTimelineNavigationProvider } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { PluginSlotMount } from "./PluginSlotMount";
 
 const mocks = vi.hoisted(() => ({
@@ -167,6 +168,61 @@ describe("PluginThreadChat", () => {
     expect(mocks.embeddedChatProps.at(-1)!.composer).toEqual(
       expect.objectContaining({ permissionPolicy: "editable" }),
     );
+  });
+
+  it("uses the surrounding thread detail navigation for timeline links", async () => {
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+    const onOpenLink = vi.fn(() => true);
+    const onOpenLocalFileLink = vi.fn(() => true);
+    const workspaceMentionHandler = vi.fn();
+    const resolveMentionLink = vi.fn(() => workspaceMentionHandler);
+
+    render(
+      <Wrapper>
+        <MemoryRouter>
+          <ThreadTimelineNavigationProvider
+            environmentId={null}
+            onOpenLink={onOpenLink}
+            onOpenLocalFileLink={onOpenLocalFileLink}
+            resolveMentionLink={resolveMentionLink}
+            workspaceRootPath="/workspace"
+          >
+            <DemoPluginPage threadId="thr_demo" />
+          </ThreadTimelineNavigationProvider>
+        </MemoryRouter>
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("embedded-thread-chat")).toBeTruthy(),
+    );
+    const props = mocks.embeddedChatProps.at(-1)!;
+    expect(props).toEqual(
+      expect.objectContaining({
+        onOpenLink,
+        onOpenLocalFileLink,
+        workspaceRootPath: "/workspace",
+      }),
+    );
+
+    const embeddedResolveMentionLink = props.resolveMentionLink as (resource: {
+      kind: "path";
+      source: "workspace";
+      entryKind: "file";
+      path: string;
+      label: string;
+    }) => (() => void) | null;
+    const workspaceMention = {
+      kind: "path" as const,
+      source: "workspace" as const,
+      entryKind: "file" as const,
+      path: "README.md",
+      label: "README.md",
+    };
+    expect(embeddedResolveMentionLink(workspaceMention)).toBe(
+      workspaceMentionHandler,
+    );
+    expect(resolveMentionLink).toHaveBeenCalledWith(workspaceMention);
   });
 
   it("maps variant timeline to a composer-less transcript", async () => {

--- a/apps/app/src/components/plugin/PluginThreadChat.tsx
+++ b/apps/app/src/components/plugin/PluginThreadChat.tsx
@@ -15,6 +15,7 @@ import {
   ThreadTimelinePanelContent,
   type ThreadTimelineConsumerMessageAction,
 } from "@/components/thread/timeline";
+import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { PluginContext } from "@/components/plugin/plugin-context";
 import { useEnvironment } from "@/hooks/queries/environment-queries";
 import { useThread } from "@/hooks/queries/thread-queries";
@@ -91,6 +92,22 @@ function PluginThreadChatBody({
   const { isLocalDaemonHost } = useHostDaemon();
   const environmentQuery = useEnvironment(thread?.environmentId ?? null);
   const environment = environmentQuery.data ?? null;
+  const timelineNavigation = useThreadTimelineNavigation();
+  const canUseHostFileNavigation =
+    thread !== undefined &&
+    thread.environmentId === timelineNavigation?.environmentId;
+  const onOpenLink = timelineNavigation?.onOpenLink;
+  const onOpenLocalFileLink = canUseHostFileNavigation
+    ? timelineNavigation.onOpenLocalFileLink
+    : undefined;
+  const resolveHostMentionLink = canUseHostFileNavigation
+    ? timelineNavigation.resolveMentionLink
+    : undefined;
+  const workspaceRootPath =
+    environment?.path ??
+    (canUseHostFileNavigation
+      ? timelineNavigation.workspaceRootPath
+      : undefined);
   // Null outside a plugin slot mount (host-internal usages, tests): actions
   // then render their icon hint instead of the plugin's branding icon.
   const pluginId = useContext(PluginContext);
@@ -113,8 +130,9 @@ function PluginThreadChatBody({
     [messageActions, pluginId],
   );
 
-  // Threads and projects stay navigable from a plugin surface; file mentions
-  // have no file viewer here, so their pills render as plain text.
+  // Threads and projects always stay navigable. A hosted thread panel can also
+  // open workspace-file mentions through its owning detail surface; standalone
+  // plugin surfaces and thread-storage mentions have no unambiguous file tab.
   const resolveMentionLink = useCallback<PromptMentionLinkResolver>(
     (resource) => {
       if (resource.kind === "thread") {
@@ -131,9 +149,16 @@ function PluginThreadChatBody({
       if (resource.kind === "project") {
         return () => navigate(getProjectComposeRoutePath(resource.projectId));
       }
+      if (
+        resource.kind === "path" &&
+        resource.entryKind === "file" &&
+        resource.source === "workspace"
+      ) {
+        return resolveHostMentionLink?.(resource) ?? null;
+      }
       return null;
     },
-    [navigate, thread?.projectId],
+    [navigate, resolveHostMentionLink, thread?.projectId],
   );
 
   const environmentSummary = useMemo(() => {
@@ -173,7 +198,8 @@ function PluginThreadChatBody({
   }, [environment, isLocalDaemonHost]);
 
   const isThreadMissing =
-    threadQuery.error instanceof BbHttpError && threadQuery.error.status === 404;
+    threadQuery.error instanceof BbHttpError &&
+    threadQuery.error.status === 404;
   if (isThreadMissing) {
     return (
       <EmptyStatePanel className="m-2 rounded-lg">
@@ -196,12 +222,14 @@ function PluginThreadChatBody({
       <ThreadTimelinePanelContent
         leadingContent={leadingContent}
         consumerMessageActions={consumerMessageActions}
-      includePluginMessageActions={false}
+        includePluginMessageActions={false}
+        onOpenLink={onOpenLink}
+        onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={thread.projectId}
         resolveMentionLink={resolveMentionLink}
         surfaceKey={`plugin-thread-chat:${threadId}`}
         threadId={threadId}
-        workspaceRootPath={environment?.path ?? undefined}
+        workspaceRootPath={workspaceRootPath}
       />
     );
     return layout === "contained" ? (
@@ -227,6 +255,9 @@ function PluginThreadChatBody({
       leadingContent={leadingContent}
       consumerMessageActions={consumerMessageActions}
       includePluginMessageActions={false}
+      onOpenLink={onOpenLink}
+      onOpenLocalFileLink={onOpenLocalFileLink}
+      workspaceRootPath={workspaceRootPath}
       composer={{
         draftScope: {
           kind: "thread",

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -9,6 +9,8 @@ import { EmbeddedThreadChat } from "./EmbeddedThreadChat";
 const mocks = vi.hoisted(() => ({
   createQueuedMessageMutateAsync: vi.fn(),
   markThreadReadMutate: vi.fn(),
+  onOpenLink: vi.fn(),
+  onOpenLocalFileLink: vi.fn(),
   pendingInteractions: [] as Array<{
     id: string;
     createdAt: number;
@@ -22,7 +24,9 @@ const mocks = vi.hoisted(() => ({
   // while the component is unmounted must appear after a remount.
   timelineRows: [] as Array<{ text: string }>,
   injectedTimelineProps: [] as Array<unknown>,
+  timelinePanelProps: [] as Array<Record<string, unknown>>,
   timelineProjectIds: [] as Array<string | undefined>,
+  resolveMentionLink: vi.fn(),
 }));
 
 vi.mock("@/components/promptbox/FollowUpPromptBox", () => ({
@@ -90,12 +94,10 @@ vi.mock("@/components/ui/overflow-fade", () => ({
 
 vi.mock("@/components/thread/timeline", () => ({
   isRunningThreadRuntimeDisplayStatus: (status: string) => status === "active",
-  ThreadTimelinePanelContent: (props: {
-    timeline?: unknown;
-    projectId?: string;
-  }) => {
+  ThreadTimelinePanelContent: (props: Record<string, unknown>) => {
+    mocks.timelinePanelProps.push(props);
     mocks.injectedTimelineProps.push(props.timeline);
-    mocks.timelineProjectIds.push(props.projectId);
+    mocks.timelineProjectIds.push(props.projectId as string | undefined);
     return (
       <div>
         {mocks.timelineRows.map((row, index) => (
@@ -289,7 +291,10 @@ function renderEmbeddedChat({
       providerId="provider-1"
       promptContextEnvironmentId={null}
       isActive={isActive}
-      resolveMentionLink={() => null}
+      onOpenLink={mocks.onOpenLink}
+      onOpenLocalFileLink={mocks.onOpenLocalFileLink}
+      resolveMentionLink={mocks.resolveMentionLink}
+      workspaceRootPath="/workspace"
       composer={{
         draftScope: {
           kind: "thread",
@@ -311,13 +316,17 @@ describe("EmbeddedThreadChat", () => {
     mocks.createQueuedMessageMutateAsync.mockReset().mockResolvedValue({});
     mocks.sendThreadMessageMutateAsync.mockReset().mockResolvedValue({});
     mocks.markThreadReadMutate.mockReset();
+    mocks.onOpenLink.mockReset();
+    mocks.onOpenLocalFileLink.mockReset();
     mocks.pendingInteractions = [];
     mocks.queuedMessages = [];
     mocks.readTrackingThreads = [];
     mocks.threadRuntimeDisplayStatus = "idle";
     mocks.timelineRows = [];
     mocks.injectedTimelineProps = [];
+    mocks.timelinePanelProps = [];
     mocks.timelineProjectIds = [];
+    mocks.resolveMentionLink.mockReset();
   });
 
   it("applies the requested surface tone to the timeline and footer", () => {
@@ -347,6 +356,19 @@ describe("EmbeddedThreadChat", () => {
     // resolves them against the current route (e.g. /plugins/<id>/...).
     renderEmbeddedChat();
     expect(mocks.timelineProjectIds.at(-1)).toBe("proj-1");
+  });
+
+  it("forwards host navigation to the embedded timeline", () => {
+    renderEmbeddedChat();
+
+    expect(mocks.timelinePanelProps.at(-1)).toEqual(
+      expect.objectContaining({
+        onOpenLink: mocks.onOpenLink,
+        onOpenLocalFileLink: mocks.onOpenLocalFileLink,
+        resolveMentionLink: mocks.resolveMentionLink,
+        workspaceRootPath: "/workspace",
+      }),
+    );
   });
 
   it("restores the draft and a stream that advanced while unmounted on remount", () => {

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -44,6 +44,8 @@ import {
   ThreadTimelineSurface,
   type ThreadTimelineAddToChatHandler,
   type ThreadTimelineConsumerMessageAction,
+  type ThreadTimelineLinkHandler,
+  type ThreadTimelineLocalFileLinkHandler,
   type ThreadTimelineRowFilter,
   type ThreadTimelineSendToMainMessageHandler,
   type ThreadTimelineSurfaceProps,
@@ -203,7 +205,11 @@ interface EmbeddedThreadChatSharedProps {
   draftModeTimelineRows?: readonly TimelineRow[];
   labels?: Partial<EmbeddedThreadChatLabels>;
   showLoadOlderRows?: boolean;
+  onOpenLink?: ThreadTimelineLinkHandler;
+  onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   onSendToMainMessage?: ThreadTimelineSendToMainMessageHandler;
+  /** Workspace root used to resolve relative links in timeline Markdown. */
+  workspaceRootPath?: string;
   /**
    * "contained" (default) fills and scrolls inside a bounded parent;
    * "document" grows with its content and defers scrolling to the page (no
@@ -301,7 +307,10 @@ function EmbeddedThreadChatWithComposer({
   draftModeTimelineRows,
   labels: labelOverrides,
   showLoadOlderRows = true,
+  onOpenLink,
+  onOpenLocalFileLink,
   onSendToMainMessage,
+  workspaceRootPath,
   layout = "contained",
   measure = "panel",
   surfaceTone = "background",
@@ -1333,16 +1342,20 @@ function EmbeddedThreadChatWithComposer({
         consumerMessageActions={consumerMessageActions}
         includePluginMessageActions={includePluginMessageActions}
         missingThreadLabel={labels.missingThread}
+        onOpenLink={onOpenLink}
+        onOpenLocalFileLink={onOpenLocalFileLink}
         onSendToMainMessage={onSendToMainMessage}
         onMessageAddToChat={handleAddToChat}
         onSelectionAddToChat={handleAddToChat}
         projectId={projectId}
         provisioningLabel={labels.provisioning}
+        resolveMentionLink={resolveMentionLink}
         rowFilter={rowFilter}
         showLoadOlderRows={showLoadOlderRows}
         threadId={threadId}
         timeline={timeline}
         timelineErrorLabel={labels.timelineError}
+        workspaceRootPath={workspaceRootPath}
       />
     ) : (
       <ThreadTimelineSurface
@@ -1352,10 +1365,13 @@ function EmbeddedThreadChatWithComposer({
         timelineError={false}
         showOngoingIndicator={isTurnSubmitting}
         ongoingIndicatorLabel={labels.draftSubmitting}
+        onOpenLink={onOpenLink}
+        onOpenLocalFileLink={onOpenLocalFileLink}
+        resolveMentionLink={resolveMentionLink}
         timelineRows={draftModeTimelineRows ? [...draftModeTimelineRows] : []}
         threadId={surfaceKey}
         threadRuntimeDisplayStatus="starting"
-        workspaceRootPath={undefined}
+        workspaceRootPath={workspaceRootPath}
       />
     );
 

--- a/apps/app/src/components/thread/timeline/ThreadTimelineNavigationContext.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineNavigationContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
+import type {
+  ThreadTimelineLinkHandler,
+  ThreadTimelineLocalFileLinkHandler,
+} from "./types.js";
+
+export interface ThreadTimelineNavigation {
+  environmentId: string | null;
+  onOpenLink: ThreadTimelineLinkHandler;
+  onOpenLocalFileLink: ThreadTimelineLocalFileLinkHandler;
+  resolveMentionLink: PromptMentionLinkResolver;
+  workspaceRootPath: string | undefined;
+}
+
+const ThreadTimelineNavigationContext =
+  createContext<ThreadTimelineNavigation | null>(null);
+
+export function ThreadTimelineNavigationProvider({
+  children,
+  environmentId,
+  onOpenLink,
+  onOpenLocalFileLink,
+  resolveMentionLink,
+  workspaceRootPath,
+}: ThreadTimelineNavigation & { children: ReactNode }) {
+  const navigation = useMemo<ThreadTimelineNavigation>(
+    () => ({
+      environmentId,
+      onOpenLink,
+      onOpenLocalFileLink,
+      resolveMentionLink,
+      workspaceRootPath,
+    }),
+    [
+      environmentId,
+      onOpenLink,
+      onOpenLocalFileLink,
+      resolveMentionLink,
+      workspaceRootPath,
+    ],
+  );
+
+  return (
+    <ThreadTimelineNavigationContext.Provider value={navigation}>
+      {children}
+    </ThreadTimelineNavigationContext.Provider>
+  );
+}
+
+/**
+ * Navigation owned by the surrounding thread detail surface. Hosted plugin
+ * panels consume it without adding file-viewer controls to the public plugin
+ * SDK contract. Null means the plugin component is mounted outside a thread
+ * detail surface and must leave host-local links inert.
+ */
+export function useThreadTimelineNavigation(): ThreadTimelineNavigation | null {
+  return useContext(ThreadTimelineNavigationContext);
+}

--- a/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadTimelineNavigationProvider } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
+import { pluginSdkAppImplementation } from "./plugin-sdk-app-impl";
+
+afterEach(cleanup);
+
+describe("plugin SDK Markdown", () => {
+  it("uses the surrounding thread detail navigation for file and web links", () => {
+    const onOpenLink = vi.fn(() => true);
+    const onOpenLocalFileLink = vi.fn(() => true);
+    const Markdown = pluginSdkAppImplementation.Markdown;
+
+    render(
+      <ThreadTimelineNavigationProvider
+        environmentId={null}
+        onOpenLink={onOpenLink}
+        onOpenLocalFileLink={onOpenLocalFileLink}
+        resolveMentionLink={() => null}
+        workspaceRootPath="/workspace"
+      >
+        <Markdown content="Open [README](README.md) or [the docs](https://example.com/docs)." />
+      </ThreadTimelineNavigationProvider>,
+    );
+
+    const fileLink = screen.getByRole("link", { name: "README" });
+    expect(fileLink.getAttribute("href")).toBe("file:///workspace/README.md");
+    fireEvent.click(fileLink);
+    expect(onOpenLocalFileLink).toHaveBeenCalledWith({
+      lineRange: null,
+      path: "/workspace/README.md",
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: "the docs" }));
+    expect(onOpenLink).toHaveBeenCalledWith({
+      href: "https://example.com/docs",
+    });
+  });
+});

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -1,7 +1,13 @@
+import { useMemo } from "react";
 import type { MarkdownProps, PluginSdkApp } from "@bb/plugin-sdk";
 import { PluginNewThreadComposer } from "@/components/plugin/PluginNewThreadComposer";
 import { PluginThreadChat } from "@/components/plugin/PluginThreadChat";
 import { MarkdownPreview } from "@/components/ui/markdown-preview";
+import type {
+  MarkdownLinkRouting,
+  MarkdownLocalFileLinkRouting,
+} from "@/components/ui/markdown-link-routing";
+import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { definePluginApp } from "./plugin-app-definition";
 import {
   useBbContext,
@@ -66,5 +72,32 @@ export const pluginSdkAppImplementation = {
  * (lightbox, link routing, thread mentions) stay host-internal.
  */
 function PluginMarkdown({ content, className }: MarkdownProps) {
-  return <MarkdownPreview content={content} className={className} />;
+  const timelineNavigation = useThreadTimelineNavigation();
+  const onOpenLink = timelineNavigation?.onOpenLink;
+  const onOpenLocalFileLink = timelineNavigation?.onOpenLocalFileLink;
+  const workspaceRootPath = timelineNavigation?.workspaceRootPath;
+  const linkRouting = useMemo<MarkdownLinkRouting | undefined>(() => {
+    if (onOpenLink === undefined || onOpenLocalFileLink === undefined) {
+      return undefined;
+    }
+    const localFile: MarkdownLocalFileLinkRouting = {
+      absoluteLinks: { kind: "trusted-host" },
+      onOpenLink: onOpenLocalFileLink,
+    };
+    if (workspaceRootPath !== undefined) {
+      localFile.relativeLinks = {
+        baseDir: workspaceRootPath,
+        rootPath: workspaceRootPath,
+      };
+    }
+    return { localFile, onOpenLink };
+  }, [onOpenLink, onOpenLocalFileLink, workspaceRootPath]);
+
+  return (
+    <MarkdownPreview
+      content={content}
+      className={className}
+      linkRouting={linkRouting}
+    />
+  );
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -145,6 +145,7 @@ import {
   usePluginPanelActions,
 } from "@/components/plugin/PluginPanelActions";
 import { PluginThreadPanelNavigationProvider } from "@/components/plugin/plugin-thread-panel-navigation";
+import { ThreadTimelineNavigationProvider } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { getFileExtension } from "@/lib/file-opener-preference";
 import { Icon } from "@bb/shared-ui/icon";
@@ -2442,7 +2443,15 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       threadId={thread.id}
     />
   ) : activePluginPanelTab ? (
-    <PluginPanelTabContent tab={activePluginPanelTab} threadId={thread.id} />
+    <ThreadTimelineNavigationProvider
+      environmentId={thread.environmentId}
+      onOpenLink={handleOpenTimelineLink}
+      onOpenLocalFileLink={handleOpenTimelineLocalFileLink}
+      resolveMentionLink={resolveMentionLink}
+      workspaceRootPath={environment?.path ?? undefined}
+    >
+      <PluginPanelTabContent tab={activePluginPanelTab} threadId={thread.id} />
+    </ThreadTimelineNavigationProvider>
   ) : undefined;
   const isBrowserTabActive = activeBrowserTab !== null;
   const threadDetailContent = (


### PR DESCRIPTION
## Summary

- provide active plugin panels with host-scoped timeline navigation without changing the public plugin SDK
- forward file, URL, workspace-root, and mention routing through `PluginThreadChat` and `EmbeddedThreadChat`
- make plugin Markdown, including the sidechat reply header, use the owning thread file viewer and URL preferences
- guard host-local file navigation by environment so generic embedded thread chats cannot use the wrong workspace

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/plugin/PluginThreadChat.test.tsx src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx src/lib/plugin-sdk-app-impl.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing unrelated warnings)
- Prettier check on all changed files