### PR TITLE
Fix ACP plugin tools in packaged Electron builds

### DIFF
--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1036,6 +1036,59 @@ describe("acp bridge", () => {
     expect(agentMessageTexts()).toContain("electron-run-as-node:missing");
   });
 
+  it("preserves Electron Node mode for the dynamic-tool MCP process only", async () => {
+    vi.stubEnv("ELECTRON_RUN_AS_NODE", "1");
+    const { providerThreadId } = await startThread({
+      dynamicTools: [
+        {
+          name: "update_environment_directory",
+          description: "Move this thread to another environment directory.",
+          inputSchema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+        },
+      ],
+    });
+
+    sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "echo-mcp-server-config", mentions: [] }],
+    });
+    await waitForTurnCompleted();
+
+    const configPrefix = "mcp-server-config:";
+    const configText = agentMessageTexts().find((text) =>
+      text.startsWith(configPrefix),
+    );
+    if (!configText) {
+      throw new Error("Fake ACP agent did not report MCP server config");
+    }
+    const [mcpServerConfig] = JSON.parse(
+      configText.slice(configPrefix.length),
+    ) as { env: { name: string; value: string }[] }[];
+    expect(
+      mcpServerConfig?.env.find(
+        ({ name }) => name === "ELECTRON_RUN_AS_NODE",
+      )?.value,
+    ).toBe("1");
+
+    sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [
+        { type: "text", text: "echo-electron-run-as-node", mentions: [] },
+      ],
+    });
+    await waitFor(
+      () =>
+        agentMessageTexts().find(
+          (text) => text === "electron-run-as-node:missing",
+        ),
+      "agent environment report",
+    );
+  });
+
   it("warns and launches the family id when a reasoning variant is missing", async () => {
     chmodSync(FAKE_AGENT_PATH, 0o755);
     const listCommand = {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -225,6 +225,17 @@ function resolveBridgeProcessArgsForMcpServer(): string[] {
   return [...process.execArgv, entryPoint, "--mcp-stdio"];
 }
 
+function resolveBridgeProcessEnvForMcpServer(): AcpMcpServerConfig["env"] {
+  const electronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+  if (electronRunAsNode === undefined) {
+    return [];
+  }
+
+  // The ACP agent must not inherit Electron's Node mode, but this MCP process
+  // re-executes the packaged bridge and therefore needs it restored.
+  return [{ name: "ELECTRON_RUN_AS_NODE", value: electronRunAsNode }];
+}
+
 async function forwardDynamicToolCall(args: {
   arguments: Record<string, unknown>;
   callId: string;
@@ -338,6 +349,7 @@ async function buildSessionMcpServers(
       dynamicTools,
       host: bridge.host,
       port: bridge.port,
+      runtimeEnv: resolveBridgeProcessEnvForMcpServer(),
       threadId: params.threadId,
       token: bridge.token,
     }),

--- a/packages/agent-runtime/src/acp/bridge/tool-proxy-mcp.ts
+++ b/packages/agent-runtime/src/acp/bridge/tool-proxy-mcp.ts
@@ -24,6 +24,7 @@ export interface BuildAcpMcpServerConfigArgs {
   dynamicTools: readonly DynamicTool[];
   host: string;
   port: number;
+  runtimeEnv: { name: string; value: string }[];
   threadId: string;
   token: string;
 }
@@ -73,6 +74,7 @@ export function buildAcpMcpServerConfig(
     command: args.command,
     args: args.bridgeArgs,
     env: [
+      ...args.runtimeEnv,
       { name: ENV_HOST, value: args.host },
       { name: ENV_PORT, value: String(args.port) },
       { name: ENV_TOKEN, value: args.token },


### PR DESCRIPTION
## Summary

- restore `ELECTRON_RUN_AS_NODE` only for the ACP dynamic-tool MCP subprocess
- keep the variable stripped from the external ACP agent process
- add a regression covering the generated MCP config and agent environment

## Root cause

In packaged desktop builds, the ACP bridge runs through the Electron executable. Dynamic tools are exposed by asking the ACP agent to launch that executable again as a stdio MCP server. The bridge correctly stripped `ELECTRON_RUN_AS_NODE` before launching OpenCode/Grok, but the generated MCP configuration did not restore it for the nested bridge process. The MCP server therefore failed to start and the agent continued without the plugin-registered tools.

## Verification

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force` — 811 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run build --filter=@bb/host-daemon`
- packaged Electron ACP-to-MCP probe listed the registered tool
- real OpenCode ACP session under the Electron bridge called and completed the registered probe tool

## Related issue

Addresses the ACP plugin-tool availability portion of #1098. The fenced-JSON fallback and repair-settlement behavior are being handled separately.
