### PR TITLE
Fix workflows structured fallback and repair settlement

### DIFF
--- a/plugins/workflows/src/server-harness.test.ts
+++ b/plugins/workflows/src/server-harness.test.ts
@@ -619,10 +619,12 @@ describe("workflows plugin", () => {
           ).length,
       ).toBeGreaterThanOrEqual(1);
     });
-    await expect(
-      workflowStatus(harness, idleOnly.runId),
-    ).resolves.toMatchObject({
-      status: "failed",
+    await eventually(async () => {
+      await expect(
+        workflowStatus(harness, idleOnly.runId),
+      ).resolves.toMatchObject({
+        status: "failed",
+      });
     });
 
     const nullSource = `export const meta = {

--- a/plugins/workflows/src/service-policy.test.ts
+++ b/plugins/workflows/src/service-policy.test.ts
@@ -574,6 +574,210 @@ describe("workflow service policy integration", () => {
     await worker;
   });
 
+  it.each([
+    ["JSON-labelled", '```json\r\n{"answer":42}\r\n```'],
+    ["unlabelled", '```\n{"answer":42}\n```'],
+  ])(
+    "accepts %s whole-output fences in the structured text fallback",
+    async (_label, output) => {
+      const test = setup();
+      harnesses.push(test.harness);
+      const run = await test.start(
+        source(`return await agent("structured", {
+          outputSchema: {
+            type: "object",
+            required: ["answer"],
+            properties: { answer: { type: "number" } }
+          }
+        });`),
+      );
+      const controller = new AbortController();
+      const worker = test.service.runWorker(controller.signal);
+      try {
+        await eventually(() => expect(test.childCount()).toBe(1));
+
+        test.service.onThreadIdle("child-1", output);
+
+        await eventually(() => {
+          expect(getRunRequired(test.db, run.id)).toMatchObject({
+            status: "succeeded",
+            resultJson: '{"answer":42}',
+          });
+          expect(getCall(test.db, run.id, 0)).toMatchObject({
+            status: "succeeded",
+            repairAttempts: 0,
+            error: null,
+          });
+        });
+      } finally {
+        controller.abort();
+        await worker;
+      }
+    },
+  );
+
+  it.each([
+    ["an unterminated fence", '```json\n{"answer":42}'],
+    [
+      "a fence with surrounding prose",
+      'Result follows:\n```json\n{"answer":42}\n```',
+    ],
+  ])("does not normalize %s", async (_label, output) => {
+    const test = setup();
+    harnesses.push(test.harness);
+    const run = await test.start(
+      source(`return await agent("strict-structured", {
+        outputSchema: {
+          type: "object",
+          required: ["answer"],
+          properties: { answer: { type: "number" } }
+        }
+      });`),
+    );
+    const controller = new AbortController();
+    const worker = test.service.runWorker(controller.signal);
+    try {
+      await eventually(() => expect(test.childCount()).toBe(1));
+
+      test.service.onThreadIdle("child-1", output);
+
+      await eventually(() => {
+        expect(
+          test.harness.sdk
+            .callsTo("threads.send")
+            .filter(
+              ([input]) =>
+                (input as { threadId: string }).threadId === "child-1",
+            ),
+        ).toHaveLength(1);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getRunRequired(test.db, run.id).status).toBe("running");
+      expect(getCall(test.db, run.id, 0)).toMatchObject({
+        status: "running",
+        repairAttempts: 1,
+        resultJson: null,
+        error: null,
+      });
+
+      await expect(test.service.stop(run.id)).resolves.toBe(true);
+      expect(getRunRequired(test.db, run.id)).toMatchObject({
+        status: "cancelled",
+        error: "Cancelled",
+      });
+      expect(getCall(test.db, run.id, 0)).toMatchObject({
+        status: "cancelled",
+        error: "Cancelled",
+      });
+    } finally {
+      controller.abort();
+      await worker;
+    }
+  });
+
+  it("keeps an awaited corrective turn alive until its valid retry completes", async () => {
+    const test = setup();
+    harnesses.push(test.harness);
+    const run = await test.start(
+      source(`return await agent("repair-structured", {
+        outputSchema: {
+          type: "object",
+          required: ["answer"],
+          properties: { answer: { type: "number" } }
+        }
+      });`),
+    );
+    const controller = new AbortController();
+    const worker = test.service.runWorker(controller.signal);
+    try {
+      await eventually(() => expect(test.childCount()).toBe(1));
+
+      test.service.onThreadIdle(
+        "child-1",
+        '```json\n{"answer":"not-a-number"}\n```',
+      );
+
+      await eventually(() => {
+        expect(
+          test.harness.sdk
+            .callsTo("threads.send")
+            .filter(
+              ([input]) =>
+                (input as { threadId: string }).threadId === "child-1",
+            ),
+        ).toHaveLength(1);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getRunRequired(test.db, run.id).status).toBe("running");
+      expect(getCall(test.db, run.id, 0)).toMatchObject({
+        status: "running",
+        repairAttempts: 1,
+        error: null,
+      });
+
+      test.service.onThreadIdle("child-1", '{"answer":42}');
+
+      await eventually(() => {
+        expect(getRunRequired(test.db, run.id)).toMatchObject({
+          status: "succeeded",
+          resultJson: '{"answer":42}',
+        });
+        expect(getCall(test.db, run.id, 0)).toMatchObject({
+          status: "succeeded",
+          repairAttempts: 1,
+          error: null,
+        });
+      });
+    } finally {
+      controller.abort();
+      await worker;
+    }
+  });
+
+  it("still cancels a genuinely detached call when its parent succeeds", async () => {
+    const test = setup();
+    harnesses.push(test.harness);
+    const run = await test.start(
+      source(`
+        agent("detached");
+        const result = await agent("awaited");
+        return result;
+      `),
+    );
+    const controller = new AbortController();
+    const worker = test.service.runWorker(controller.signal);
+    try {
+      await eventually(() => expect(test.childCount()).toBe(2));
+
+      test.service.onThreadIdle("child-2", "done");
+
+      await eventually(() => {
+        expect(getRunRequired(test.db, run.id)).toMatchObject({
+          status: "succeeded",
+          resultJson: '"done"',
+        });
+        expect(getCall(test.db, run.id, 0)).toMatchObject({
+          status: "cancelled",
+          error: "Parent workflow finished before this call",
+        });
+        expect(getCall(test.db, run.id, 1)).toMatchObject({
+          status: "succeeded",
+          error: null,
+        });
+      });
+      expect(
+        test.harness.sdk
+          .callsTo("threads.stop")
+          .some(
+            ([input]) => (input as { threadId: string }).threadId === "child-1",
+          ),
+      ).toBe(true);
+    } finally {
+      controller.abort();
+      await worker;
+    }
+  });
+
   it("rejects child schema failures and recursive grandchildren", async () => {
     const test = setup();
     harnesses.push(test.harness);
@@ -902,9 +1106,7 @@ describe("workflow service policy integration", () => {
   it("keeps quiet workers alive until the total run timeout", async () => {
     const test = setup();
     harnesses.push(test.harness);
-    const run = await test.start(
-      source(`return await agent("quiet");`),
-    );
+    const run = await test.start(source(`return await agent("quiet");`));
     const controller = new AbortController();
     const worker = test.service.runWorker(controller.signal);
     await eventually(() => expect(test.childCount()).toBe(1));

--- a/plugins/workflows/src/service.ts
+++ b/plugins/workflows/src/service.ts
@@ -179,6 +179,12 @@ function parseJson(text: string, path: string): JsonValue {
   }
 }
 
+function normalizeWholeOutputJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const fenced = /^```(?:json)?[\t ]*\r?\n([\s\S]*)\r?\n```$/i.exec(trimmed);
+  return fenced?.[1] ?? trimmed;
+}
+
 function assertBoundedJson(
   value: unknown,
   path: string,
@@ -925,7 +931,10 @@ export function createWorkflowService(
       };
       if (output !== null) {
         try {
-          const value = parseJson(output, "worker JSON response");
+          const value = parseJson(
+            normalizeWholeOutputJsonFence(output),
+            "worker JSON response",
+          );
           const resolved = resolveStructuredValue(options.outputSchema, value);
           fallback = {
             parsed: true,
@@ -980,6 +989,9 @@ export function createWorkflowService(
             },
           ],
         });
+        // The corrective turn is still part of this call. A later idle event
+        // or result-tool submission settles it and wakes the existing waiter.
+        return;
       } catch (error) {
         const correctionError = `Could not request structured-output correction: ${message(error)}`;
         settleCall(db, {


### PR DESCRIPTION
## Summary

- accept JSON values wrapped in an exact whole-output `json` or plain Markdown fence in the structured-output text fallback
- keep an awaited structured-output call pending after a corrective turn is sent, allowing a later idle event or result-tool submission to settle it
- preserve strict parsing/schema validation and the existing cancellation behavior for explicit run cancellation and genuinely detached calls

## Root cause

The text fallback passed the worker's full output directly to `JSON.parse`, so otherwise-valid fenced JSON was rejected.

Separately, after successfully sending a corrective structured-output turn, the idle handler fell through to an unconditional waiter wake. Because the call was deliberately still running, that wake rejected the awaiting workflow promise. The parent then settled and normal outstanding-call cleanup cancelled the repair with `Parent workflow finished before this call`.

## Regression coverage

- JSON-labelled whole-output fence, including CRLF
- plain whole-output fence
- unterminated and non-whole-output fences remain invalid and enter repair
- schema-invalid fenced JSON still enters repair
- successful corrective retry reaches a terminal result
- explicit cancellation during repair still cancels the run/call
- detached calls are still cancelled when their parent succeeds

## Verification

- focused lifecycle harnesses: 42 tests passed
- `pnpm exec turbo run test --filter=bb-plugin-workflows --force`: 219 tests passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-workflows`: passed

## Scope

This is the provider-independent workflows change and does not include the packaged Electron ACP tool-availability work handled separately by #1102.

Addresses the workflows fallback and repair-timing portions of #1098.
