### PR TITLE
Make Browse the default Extensions tab

### DIFF
--- a/apps/app/src/App.legacy-skill-route.test.tsx
+++ b/apps/app/src/App.legacy-skill-route.test.tsx
@@ -3,16 +3,27 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { ExtensionsLandingRedirect, LegacySkillDetailRedirect } from "./App";
+import {
+  ExtensionsLandingRedirect,
+  LegacyPluginBrowseRedirect,
+  LegacySkillDetailRedirect,
+} from "./App";
 import {
   LEGACY_TOOLS_SKILL_DETAIL_ROUTE_PATH,
+  TOOLS_PLUGIN_BROWSE_ROUTE_PATH,
   TOOLS_PLUGINS_ROUTE_PATH,
   TOOLS_ROUTE_PATH,
   TOOLS_SKILL_DETAIL_ROUTE_PATH,
 } from "./lib/route-paths";
 
 function LocationPath() {
-  return <span>{useLocation().pathname}</span>;
+  const location = useLocation();
+  return (
+    <span>
+      {location.pathname}
+      {location.search}
+    </span>
+  );
 }
 
 describe("LegacySkillDetailRedirect", () => {
@@ -48,6 +59,26 @@ describe("ExtensionsLandingRedirect", () => {
           <Route
             path={TOOLS_ROUTE_PATH}
             element={<ExtensionsLandingRedirect />}
+          />
+          <Route path={TOOLS_PLUGINS_ROUTE_PATH} element={<LocationPath />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(TOOLS_PLUGINS_ROUTE_PATH)).toBeTruthy();
+  });
+});
+
+describe("LegacyPluginBrowseRedirect", () => {
+  afterEach(cleanup);
+
+  it("redirects the old Browse path to the canonical bare Plugins route", () => {
+    render(
+      <MemoryRouter initialEntries={[TOOLS_PLUGIN_BROWSE_ROUTE_PATH]}>
+        <Routes>
+          <Route
+            path={TOOLS_PLUGIN_BROWSE_ROUTE_PATH}
+            element={<LegacyPluginBrowseRedirect />}
           />
           <Route path={TOOLS_PLUGINS_ROUTE_PATH} element={<LocationPath />} />
         </Routes>

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -129,6 +129,10 @@ export function ExtensionsLandingRedirect() {
   return <Navigate to={TOOLS_PLUGINS_ROUTE_PATH} replace />;
 }
 
+export function LegacyPluginBrowseRedirect() {
+  return <Navigate to={TOOLS_PLUGINS_ROUTE_PATH} replace />;
+}
+
 function AppRoutes() {
   return (
     <AppLayout>
@@ -224,12 +228,7 @@ function AppRoutes() {
             <Route path={TOOLS_PLUGINS_ROUTE_PATH} element={<ToolsView />} />
             <Route
               path={TOOLS_PLUGIN_BROWSE_ROUTE_PATH}
-              element={
-                <Navigate
-                  to={`${TOOLS_PLUGINS_ROUTE_PATH}?view=browse`}
-                  replace
-                />
-              }
+              element={<LegacyPluginBrowseRedirect />}
             />
             <Route
               path={TOOLS_PLUGIN_DETAIL_ROUTE_PATH}

--- a/apps/app/src/components/layout/AppLayout.tools-breadcrumbs.test.ts
+++ b/apps/app/src/components/layout/AppLayout.tools-breadcrumbs.test.ts
@@ -28,13 +28,19 @@ describe("resolveToolsBreadcrumbs", () => {
   it("includes the selected collection tab", () => {
     expect(resolveToolsBreadcrumbs("/tools/skills")).toEqual([
       { label: "Skills", to: "/tools/skills" },
-      { label: "Library" },
-    ]);
-    expect(resolveToolsBreadcrumbs("/tools/skills", "?view=browse")).toEqual([
-      { label: "Skills", to: "/tools/skills" },
       { label: "Browse" },
     ]);
+    expect(resolveToolsBreadcrumbs("/tools/skills", "?view=library")).toEqual([
+      { label: "Skills", to: "/tools/skills" },
+      { label: "Library" },
+    ]);
     expect(resolveToolsBreadcrumbs("/tools/plugins")).toEqual([
+      { label: "Plugins", to: "/tools/plugins" },
+      { label: "Browse" },
+    ]);
+    expect(
+      resolveToolsBreadcrumbs("/tools/plugins", "?view=installed"),
+    ).toEqual([
       { label: "Plugins", to: "/tools/plugins" },
       { label: "Installed" },
     ]);
@@ -63,7 +69,7 @@ describe("resolveToolsBreadcrumbs", () => {
       ),
     ).toEqual([
       { label: "Skills", to: "/tools/skills" },
-      { label: "Library", to: "/tools/skills" },
+      { label: "Library", to: "/tools/skills?view=library" },
       { label: "Example Skill" },
     ]);
     expect(
@@ -77,14 +83,14 @@ describe("resolveToolsBreadcrumbs", () => {
     ]);
     expect(resolveToolsBreadcrumbs("/tools/plugins/ui-patterns")).toEqual([
       { label: "Plugins", to: "/tools/plugins" },
-      { label: "Installed", to: "/tools/plugins" },
+      { label: "Installed", to: "/tools/plugins?view=installed" },
       { label: "ui-patterns" },
     ]);
     expect(
       resolveToolsBreadcrumbs("/tools/plugins/ui-patterns", "", "UI Patterns"),
     ).toEqual([
       { label: "Plugins", to: "/tools/plugins" },
-      { label: "Installed", to: "/tools/plugins" },
+      { label: "Installed", to: "/tools/plugins?view=installed" },
       { label: "UI Patterns" },
     ]);
     expect(

--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -178,7 +178,7 @@ afterEach(() => {
 });
 
 describe("PluginsOverview", () => {
-  it("renders Installed and Browse as real collection projections", async () => {
+  it("opens on Browse and renders it before Installed", async () => {
     installFetch();
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
@@ -189,7 +189,15 @@ describe("PluginsOverview", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("Automations")).toBeTruthy();
+    expect(await screen.findByText("GitHub")).toBeTruthy();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toBe(screen.getByRole("tab", { name: "Browse" }));
+    expect(tabs[1]).toBe(
+      screen.getByRole("tab", { name: "Installed, 1 plugin" }),
+    );
+    expect(screen.getByRole("tab", { name: "Browse" }).className).toContain(
+      "bg-accent",
+    );
     const installedTab = screen.getByRole("tab", {
       name: "Installed, 1 plugin",
     });
@@ -201,11 +209,9 @@ describe("PluginsOverview", () => {
     ).toBeTruthy();
     expect(screen.queryByRole("tab", { name: /Marketplaces/ })).toBeNull();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
-    expect(await screen.findByText("GitHub")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Category" })).toBeTruthy();
-    expect(screen.queryByText("BB Official plugins")).toBeNull();
-    expect(screen.getByRole("button", { name: "New plugin" })).toBeTruthy();
+    fireEvent.click(installedTab);
+    expect(await screen.findByText("Automations")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Type" })).toBeTruthy();
   });
 
   it("shows category filters only in Browse", async () => {
@@ -231,15 +237,8 @@ describe("PluginsOverview", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("Automations")).toBeTruthy();
-    expect(screen.getByText("Docs")).toBeTruthy();
-    // Installed offers Type, not Category.
-    expect(screen.queryByRole("button", { name: "Category" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Type" })).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
+    expect(await screen.findByText("GitHub")).toBeTruthy();
     // Wait for the catalog so the Category menu has options to offer.
-    await screen.findByText("GitHub");
     const categoryTrigger = screen.getByRole("button", { name: "Category" });
     expect(screen.queryByRole("button", { name: "Type" })).toBeNull();
     fireEvent.pointerDown(categoryTrigger);
@@ -249,6 +248,10 @@ describe("PluginsOverview", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.getByText("Docs")).toBeTruthy();
     expect(screen.queryByText("GitHub")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Installed/ }));
+    expect(screen.queryByRole("button", { name: "Category" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Type" })).toBeTruthy();
   });
 
   it("keeps Browse filters in the toolbar rather than a separate pill band", async () => {
@@ -285,7 +288,7 @@ describe("PluginsOverview", () => {
     installFetch();
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
         <QueryClientWrapper>
           <Routes>
             <Route path="/tools/plugins" element={<PluginsOverview />} />
@@ -345,7 +348,7 @@ describe("PluginsOverview", () => {
     installFetch(plugins);
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
         <QueryClientWrapper>
           <PluginsOverview />
         </QueryClientWrapper>
@@ -437,7 +440,7 @@ describe("PluginsOverview", () => {
       installFetch(plugins);
       const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
       render(
-        <MemoryRouter initialEntries={["/tools/plugins"]}>
+        <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
           <QueryClientWrapper>
             <PluginsOverview />
           </QueryClientWrapper>
@@ -524,7 +527,7 @@ describe("PluginsOverview", () => {
     ]);
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
         <QueryClientWrapper>
           <PluginsOverview />
         </QueryClientWrapper>
@@ -612,7 +615,7 @@ describe("PluginsOverview", () => {
     ]);
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
         <QueryClientWrapper>
           <PluginsOverview />
         </QueryClientWrapper>
@@ -696,7 +699,7 @@ describe("PluginsOverview", () => {
     ]);
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
         <QueryClientWrapper>
           <PluginsOverview />
         </QueryClientWrapper>
@@ -730,7 +733,7 @@ describe("PluginsOverview", () => {
     ]);
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/tools/plugins"]}>
+      <MemoryRouter initialEntries={["/tools/plugins?view=installed"]}>
         <QueryClientWrapper>
           <PluginsOverview />
         </QueryClientWrapper>

--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -16,6 +16,7 @@ import {
   defaultExperiments,
 } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { focusManager } from "@tanstack/react-query";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { PluginsOverview } from "./PluginsOverview";
 
@@ -172,6 +173,7 @@ function LocationPath() {
 }
 
 afterEach(() => {
+  focusManager.setFocused(undefined);
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -209,9 +211,32 @@ describe("PluginsOverview", () => {
     ).toBeTruthy();
     expect(screen.queryByRole("tab", { name: /Marketplaces/ })).toBeNull();
 
+    const catalogRequests = () =>
+      vi.mocked(fetch).mock.calls.filter(([input]) => {
+        const rawUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        return (
+          new URL(rawUrl, "http://localhost").pathname ===
+          "/api/v1/plugin-catalog/search"
+        );
+      });
+    expect(catalogRequests()).toHaveLength(1);
+
+    act(() => focusManager.setFocused(false));
+    act(() => focusManager.setFocused(true));
+    await waitFor(() => expect(catalogRequests()).toHaveLength(1));
+
     fireEvent.click(installedTab);
     expect(await screen.findByText("Automations")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Type" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
+    expect(await screen.findByText("GitHub")).toBeTruthy();
+    expect(catalogRequests()).toHaveLength(1);
   });
 
   it("shows category filters only in Browse", async () => {

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -60,8 +60,8 @@ function isPluginTypeFilter(value: string): value is PluginTypeFilter {
 }
 
 function modeFromSearchParams(value: string | null): PluginsCollectionMode {
-  if (value === "browse") return value;
-  return "installed";
+  if (value === "installed") return value;
+  return "browse";
 }
 
 /**
@@ -94,6 +94,7 @@ export function PluginsOverview() {
   }>({ open: false, initial: null });
 
   const modes: readonly ResourceCollectionMode<PluginsCollectionMode>[] = [
+    { id: "browse" as const, label: "Browse" },
     {
       id: "installed",
       label: "Installed",
@@ -102,7 +103,6 @@ export function PluginsOverview() {
         plugins.length === 1 ? "plugin" : "plugins"
       }`,
     },
-    { id: "browse" as const, label: "Browse" },
   ];
   const normalizedInstalledQuery = installedQuery.trim().toLowerCase();
   const visiblePlugins = useMemo(
@@ -164,7 +164,7 @@ export function PluginsOverview() {
     setSearchParams(
       (current) => {
         const next = new URLSearchParams(current);
-        if (mode === "installed") next.delete("view");
+        if (mode === "browse") next.delete("view");
         else next.set("view", mode);
         return next;
       },

--- a/apps/app/src/components/settings/PluginSettingsCompatibilityRoute.test.tsx
+++ b/apps/app/src/components/settings/PluginSettingsCompatibilityRoute.test.tsx
@@ -2,9 +2,22 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { PluginSettingsCompatibilityRoute } from "./PluginSettingsCompatibilityRoute";
 import { ToolsHubExperimentProvider } from "@/components/tools/tools-experiment-context";
+
+function ToolsPluginsLocation() {
+  const location = useLocation();
+  return (
+    <div>
+      Tools plugins
+      <output data-testid="tools-plugins-location">
+        {location.pathname}
+        {location.search}
+      </output>
+    </div>
+  );
+}
 
 function renderRoute(path: string, toolsHubEnabled = false) {
   render(
@@ -27,7 +40,7 @@ function renderRoute(path: string, toolsHubEnabled = false) {
               </PluginSettingsCompatibilityRoute>
             }
           />
-          <Route path="/tools/plugins" element={<div>Tools plugins</div>} />
+          <Route path="/tools/plugins" element={<ToolsPluginsLocation />} />
           <Route
             path="/tools/plugins/:pluginId"
             element={<div>Tools plugin detail</div>}
@@ -59,6 +72,9 @@ describe("PluginSettingsCompatibilityRoute", () => {
     renderRoute("/settings/plugins", true);
 
     expect(screen.getByText("Tools plugins")).toBeTruthy();
+    expect(screen.getByTestId("tools-plugins-location").textContent).toBe(
+      "/tools/plugins?view=installed",
+    );
     expect(screen.queryByText("Settings plugin manager")).toBeNull();
   });
 });

--- a/apps/app/src/components/settings/PluginSettingsCompatibilityRoute.tsx
+++ b/apps/app/src/components/settings/PluginSettingsCompatibilityRoute.tsx
@@ -1,10 +1,8 @@
 import type { ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
+import { getToolsOwnedCollectionRoutePath } from "@/components/tools/tools-navigation";
 import { useToolsHubExperiment } from "@/components/tools/tools-experiment-context";
-import {
-  SETTINGS_PLUGINS_ROUTE_PATH,
-  TOOLS_PLUGINS_ROUTE_PATH,
-} from "@/lib/route-paths";
+import { SETTINGS_PLUGINS_ROUTE_PATH } from "@/lib/route-paths";
 
 /**
  * The Extensions collection replaces legacy plugin management while enabled.
@@ -18,7 +16,9 @@ export function PluginSettingsCompatibilityRoute({
   const location = useLocation();
   const toolsHubEnabled = useToolsHubExperiment();
   if (toolsHubEnabled && location.pathname === SETTINGS_PLUGINS_ROUTE_PATH) {
-    return <Navigate to={TOOLS_PLUGINS_ROUTE_PATH} replace />;
+    return (
+      <Navigate to={getToolsOwnedCollectionRoutePath("plugins")} replace />
+    );
   }
   return children;
 }

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -150,7 +150,7 @@ export function CatalogPluginDetail({
     >
       <ResourceDetailStack>
         <ResourceDetailOverviewSection label="About">
-          <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
             {entry.description.length > 0
               ? entry.description
               : "This plugin does not describe itself."}
@@ -388,7 +388,7 @@ export function PluginDetail({
     >
       <ResourceDetailStack>
         <ResourceDetailOverviewSection label="About">
-          <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
             {plugin.description ?? "This plugin does not describe itself."}
           </p>
         </ResourceDetailOverviewSection>

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -442,12 +442,12 @@ export function SkillsOverview({
       id="skills-collection"
       description="Create and manage agent skills. bb skills work across every agent you use in bb."
       modes={[
+        { id: "browse", label: "Browse" },
         {
           id: "library",
           label: TOOLS_OWNED_COLLECTION_LABEL.skills,
           count: skills.length,
         },
-        { id: "browse", label: "Browse" },
       ]}
       activeMode={activeMode}
       onModeChange={onModeChange}

--- a/apps/app/src/components/tools/SkillsLibrary.tsx
+++ b/apps/app/src/components/tools/SkillsLibrary.tsx
@@ -143,7 +143,8 @@ export function SkillsLibrary() {
     skillsQuery.isFetching && skillsQuery.data === undefined && !hasError;
   const isRegistryBrowseRoute =
     location.pathname === getRegistrySkillsRoutePath() ||
-    new URLSearchParams(location.search).get("view") === "browse";
+    (location.pathname === getSkillsRoutePath() &&
+      new URLSearchParams(location.search).get("view") !== "library");
   const registryRequestPage =
     isRegistryBrowseRoute || routeRegistrySkillId !== undefined
       ? registryPage
@@ -373,15 +374,15 @@ export function SkillsLibrary() {
     (mode: SkillsCollectionMode) => {
       if (mode === "browse") {
         setRegistryPage(0);
-        navigate(`${getSkillsRoutePath()}?view=browse`);
+        navigate(getSkillsRoutePath());
         return;
       }
-      navigate(getSkillsRoutePath());
+      navigate(`${getSkillsRoutePath()}?view=library`);
     },
     [navigate],
   );
   const closeSkillDetail = useCallback(() => {
-    navigate(getSkillsRoutePath());
+    navigate(`${getSkillsRoutePath()}?view=library`);
   }, [navigate]);
   // Create via prompt: open the composer seeded with the bb-skill prompt; the
   // spawned thread authors the SKILL.md.

--- a/apps/app/src/components/tools/SkillsLibrary.tsx
+++ b/apps/app/src/components/tools/SkillsLibrary.tsx
@@ -12,6 +12,7 @@ import {
   RegistrySkillDetailView,
   RegistrySkillsBrowsePage,
 } from "@/components/tools/SkillsBrowse";
+import { getToolsOwnedCollectionRoutePath } from "@/components/tools/tools-navigation";
 import {
   SkillDetailDialogView,
   SkillsOverview,
@@ -51,6 +52,7 @@ const EMPTY_REGISTRY_PAGINATION: RegistryPagination = {
   total: 0,
   hasMore: false,
 };
+const REGISTRY_LIST_STALE_TIME_MS = 30 * 60_000;
 
 type SkillsCollectionMode = "library" | "browse";
 
@@ -159,7 +161,8 @@ export function SkillsLibrary() {
         signal,
       }),
     enabled: isRegistryBrowseRoute,
-    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    staleTime: REGISTRY_LIST_STALE_TIME_MS,
   });
   const registryRepositorySources = useMemo(() => {
     const sources = new Map<string, string>();
@@ -377,12 +380,12 @@ export function SkillsLibrary() {
         navigate(getSkillsRoutePath());
         return;
       }
-      navigate(`${getSkillsRoutePath()}?view=library`);
+      navigate(getToolsOwnedCollectionRoutePath("skills"));
     },
     [navigate],
   );
   const closeSkillDetail = useCallback(() => {
-    navigate(`${getSkillsRoutePath()}?view=library`);
+    navigate(getToolsOwnedCollectionRoutePath("skills"));
   }, [navigate]);
   // Create via prompt: open the composer seeded with the bb-skill prompt; the
   // spawned thread authors the SKILL.md.

--- a/apps/app/src/components/tools/ToolsSidebar.test.tsx
+++ b/apps/app/src/components/tools/ToolsSidebar.test.tsx
@@ -51,7 +51,7 @@ describe("ToolsSidebar", () => {
 
     fireEvent.click(screen.getByRole("link", { name: "Plugins" }));
     expect(screen.getByLabelText("Current path").textContent).toBe(
-      "/tools/plugins/ui-patterns",
+      "/tools/plugins",
     );
   });
 

--- a/apps/app/src/components/tools/ToolsSidebar.test.tsx
+++ b/apps/app/src/components/tools/ToolsSidebar.test.tsx
@@ -8,7 +8,13 @@ import { ToolsSidebar } from "./ToolsSidebar";
 
 function CurrentPath() {
   const location = useLocation();
-  return <output aria-label="Current path">{location.pathname}</output>;
+  return (
+    <output aria-label="Current path">
+      {location.pathname}
+      {location.search}
+      {location.hash}
+    </output>
+  );
 }
 
 function renderToolsSidebar(path: string) {
@@ -42,6 +48,11 @@ describe("ToolsSidebar", () => {
       screen.getByRole("link", { name: "Skills" }).getAttribute("aria-current"),
     ).toBeNull();
     expect(screen.queryByRole("link", { name: "Automations" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("link", { name: "Plugins" }));
+    expect(screen.getByLabelText("Current path").textContent).toBe(
+      "/tools/plugins/ui-patterns",
+    );
   });
 
   it("contains only Plugins and Skills and navigates back to the app", () => {
@@ -63,6 +74,25 @@ describe("ToolsSidebar", () => {
     fireEvent.click(screen.getByRole("link", { name: "Back to app" }));
     expect(screen.getByLabelText("Current path").textContent).toBe(
       "/projects/proj_one/threads/thr_one",
+    );
+  });
+
+  it("preserves each section route while navigating within Extensions", () => {
+    renderToolsSidebar("/tools/plugins?view=installed#installed-list");
+
+    fireEvent.click(screen.getByRole("link", { name: "Skills" }));
+    expect(screen.getByLabelText("Current path").textContent).toBe(
+      "/tools/skills",
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Plugins" }));
+    expect(screen.getByLabelText("Current path").textContent).toBe(
+      "/tools/plugins?view=installed#installed-list",
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Skills" }));
+    expect(screen.getByLabelText("Current path").textContent).toBe(
+      "/tools/skills",
     );
   });
 });

--- a/apps/app/src/components/tools/ToolsSidebar.tsx
+++ b/apps/app/src/components/tools/ToolsSidebar.tsx
@@ -32,8 +32,7 @@ export function ToolsSidebar({
     plugins: TOOLS_SECTIONS.plugins.to,
     skills: TOOLS_SECTIONS.skills.to,
   });
-  const currentRoutePath =
-    `${location.pathname}${location.search}${location.hash}`;
+  const currentRoutePath = `${location.pathname}${location.search}${location.hash}`;
 
   return (
     <SectionSidebar
@@ -67,9 +66,7 @@ export function ToolsSidebar({
               }
               label={item.label}
               to={
-                item.id === activeSection
-                  ? currentRoutePath
-                  : sectionRoutePaths[item.id]
+                item.id === activeSection ? item.to : sectionRoutePaths[item.id]
               }
             >
               <SectionSidebarIcon name={item.icon} />

--- a/apps/app/src/components/tools/ToolsSidebar.tsx
+++ b/apps/app/src/components/tools/ToolsSidebar.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent as ReactMouseEvent } from "react";
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
 import { useLocation } from "react-router-dom";
 import {
   SectionSidebar,
@@ -6,7 +6,12 @@ import {
   SectionSidebarLabel,
   SectionSidebarRow,
 } from "@/components/sidebar/SectionSidebar";
-import { TOOLS_NAV_ITEMS, resolveToolsSection } from "./tools-navigation";
+import {
+  TOOLS_NAV_ITEMS,
+  TOOLS_SECTIONS,
+  resolveToolsSection,
+  type ToolsSectionId,
+} from "./tools-navigation";
 
 export function ToolsSidebar({
   appRoutePath,
@@ -21,6 +26,14 @@ export function ToolsSidebar({
 }) {
   const location = useLocation();
   const activeSection = resolveToolsSection(location.pathname);
+  const [sectionRoutePaths, setSectionRoutePaths] = useState<
+    Record<ToolsSectionId, string>
+  >({
+    plugins: TOOLS_SECTIONS.plugins.to,
+    skills: TOOLS_SECTIONS.skills.to,
+  });
+  const currentRoutePath =
+    `${location.pathname}${location.search}${location.hash}`;
 
   return (
     <SectionSidebar
@@ -34,19 +47,34 @@ export function ToolsSidebar({
       <SectionSidebarLabel>Extensions</SectionSidebarLabel>
       <div className="mt-1 space-y-0.5">
         {TOOLS_NAV_ITEMS.map((item) => (
-          <SectionSidebarRow
+          <div
             key={item.id}
-            active={activeSection === item.id}
-            current={
-              location.pathname === item.to && location.search === ""
-                ? "page"
-                : "location"
-            }
-            label={item.label}
-            to={item.to}
+            onClick={() => {
+              if (item.id === activeSection) return;
+              setSectionRoutePaths((current) =>
+                current[activeSection] === currentRoutePath
+                  ? current
+                  : { ...current, [activeSection]: currentRoutePath },
+              );
+            }}
           >
-            <SectionSidebarIcon name={item.icon} />
-          </SectionSidebarRow>
+            <SectionSidebarRow
+              active={activeSection === item.id}
+              current={
+                location.pathname === item.to && location.search === ""
+                  ? "page"
+                  : "location"
+              }
+              label={item.label}
+              to={
+                item.id === activeSection
+                  ? currentRoutePath
+                  : sectionRoutePaths[item.id]
+              }
+            >
+              <SectionSidebarIcon name={item.icon} />
+            </SectionSidebarRow>
+          </div>
         ))}
       </div>
     </SectionSidebar>

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -190,9 +190,14 @@ describe("Plugin detail recipe", () => {
     expect(renderedRecipe(container).map(([kind]) => kind)).toContain(
       "overview",
     );
-    expect(
-      screen.getByText("This plugin does not describe itself."),
-    ).toBeTruthy();
+    const description = screen.getByText(
+      "This plugin does not describe itself.",
+    );
+    expect(description.className).not.toContain("max-w-prose");
+    expect(description.className).toContain("max-w-none");
+    expect(description.className).toContain("text-sm");
+    expect(description.className).toContain("leading-relaxed");
+    expect(description.className).toContain("text-muted-foreground");
   });
 
   it("lists declared capabilities without category chrome", () => {

--- a/apps/app/src/components/tools/tools-navigation.ts
+++ b/apps/app/src/components/tools/tools-navigation.ts
@@ -116,7 +116,7 @@ function sectionCrumb(id: ToolsSectionId): ToolsBreadcrumbSegment {
 function collectionCrumb(
   id: ToolsSectionId,
   label: string = TOOLS_OWNED_COLLECTION_LABEL[id],
-  to = TOOLS_SECTIONS[id].to,
+  to = `${TOOLS_SECTIONS[id].to}?view=${id === "plugins" ? "installed" : "library"}`,
 ): ToolsBreadcrumbSegment {
   return { label, to };
 }
@@ -181,7 +181,8 @@ export function resolveToolsBreadcrumbs(
   for (const [section, browseRoute] of BROWSE_ROUTES) {
     if (
       pathname === browseRoute ||
-      (pathname === TOOLS_SECTIONS[section].to && view === "browse")
+      (pathname === TOOLS_SECTIONS[section].to &&
+        view !== (section === "plugins" ? "installed" : "library"))
     ) {
       return [sectionCrumb(section), { label: "Browse" }];
     }
@@ -206,6 +207,8 @@ export function resolveToolsBreadcrumbs(
       pathname === section.to ||
       ROOT_ROUTE_ALIASES[section.id].includes(pathname)
     ) {
+      const ownedView = section.id === "plugins" ? "installed" : "library";
+      if (pathname === section.to && view !== ownedView) continue;
       return [
         sectionCrumb(section.id),
         { label: TOOLS_OWNED_COLLECTION_LABEL[section.id] },

--- a/apps/app/src/components/tools/tools-navigation.ts
+++ b/apps/app/src/components/tools/tools-navigation.ts
@@ -50,6 +50,15 @@ export const TOOLS_OWNED_COLLECTION_LABEL = {
   plugins: "Installed",
 } as const satisfies Record<ToolsSectionId, string>;
 
+export const TOOLS_OWNED_COLLECTION_VIEW = {
+  skills: "library",
+  plugins: "installed",
+} as const satisfies Record<ToolsSectionId, string>;
+
+export function getToolsOwnedCollectionRoutePath(id: ToolsSectionId): string {
+  return `${TOOLS_SECTIONS[id].to}?view=${TOOLS_OWNED_COLLECTION_VIEW[id]}`;
+}
+
 export const TOOLS_NAV_ITEMS = [TOOLS_SECTIONS.plugins, TOOLS_SECTIONS.skills];
 
 export interface ToolsBreadcrumbSegment {
@@ -116,7 +125,7 @@ function sectionCrumb(id: ToolsSectionId): ToolsBreadcrumbSegment {
 function collectionCrumb(
   id: ToolsSectionId,
   label: string = TOOLS_OWNED_COLLECTION_LABEL[id],
-  to = `${TOOLS_SECTIONS[id].to}?view=${id === "plugins" ? "installed" : "library"}`,
+  to = getToolsOwnedCollectionRoutePath(id),
 ): ToolsBreadcrumbSegment {
   return { label, to };
 }
@@ -182,7 +191,7 @@ export function resolveToolsBreadcrumbs(
     if (
       pathname === browseRoute ||
       (pathname === TOOLS_SECTIONS[section].to &&
-        view !== (section === "plugins" ? "installed" : "library"))
+        view !== TOOLS_OWNED_COLLECTION_VIEW[section])
     ) {
       return [sectionCrumb(section), { label: "Browse" }];
     }
@@ -207,8 +216,12 @@ export function resolveToolsBreadcrumbs(
       pathname === section.to ||
       ROOT_ROUTE_ALIASES[section.id].includes(pathname)
     ) {
-      const ownedView = section.id === "plugins" ? "installed" : "library";
-      if (pathname === section.to && view !== ownedView) continue;
+      if (
+        pathname === section.to &&
+        view !== TOOLS_OWNED_COLLECTION_VIEW[section.id]
+      ) {
+        continue;
+      }
       return [
         sectionCrumb(section.id),
         { label: TOOLS_OWNED_COLLECTION_LABEL[section.id] },

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.ts
@@ -236,6 +236,8 @@ export function allPluginCatalogSearchQueryKeyPrefix(): QueryKey {
   return ["plugin-catalog-search"];
 }
 
+const PLUGIN_CATALOG_STALE_TIME_MS = 30 * 60_000;
+
 export function usePluginCatalogSearch(
   query: string,
   options: { enabled: boolean },
@@ -244,6 +246,7 @@ export function usePluginCatalogSearch(
     queryKey: pluginCatalogSearchQueryKey(query),
     queryFn: () => searchPluginCatalog(fetch, query),
     enabled: options.enabled,
-    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+    staleTime: PLUGIN_CATALOG_STALE_TIME_MS,
   });
 }

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
@@ -68,7 +68,7 @@ describe("useAppSettingsRouteMemory", () => {
     );
   });
 
-  it("keeps a Tools sub-route while Back to app returns to core app context", () => {
+  it("resets Extensions after Back to app returns to core app context", () => {
     render(
       <MemoryRouter
         initialEntries={[
@@ -93,15 +93,7 @@ describe("useAppSettingsRouteMemory", () => {
     );
 
     fireEvent.click(screen.getByRole("link", { name: "Tools" }));
-    expect(screen.getByTestId("location").textContent).toBe(
-      "/tools/plugins/ui-patterns?tab=settings#source",
-    );
-
-    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
-    fireEvent.click(screen.getByRole("link", { name: "App" }));
-    expect(screen.getByTestId("location").textContent).toBe(
-      "/tools/plugins/ui-patterns?tab=settings#source",
-    );
+    expect(screen.getByTestId("location").textContent).toBe("/tools/plugins");
   });
 
   it.each([
@@ -120,9 +112,7 @@ describe("useAppSettingsRouteMemory", () => {
       );
 
       fireEvent.click(screen.getByRole("link", { name: "Tools" }));
-      expect(screen.getByTestId("location").textContent).toBe(
-        "/tools/plugins",
-      );
+      expect(screen.getByTestId("location").textContent).toBe("/tools/plugins");
     },
   );
 });

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.ts
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.ts
@@ -27,9 +27,9 @@ function isGlobalSettingsRoute(pathname: string): boolean {
 }
 
 /**
- * Remembers the most recently visited core-app, Tools, and global Settings
- * routes while the app shell is mounted. Each focused sidebar can return to
- * the right parent context without resetting another surface to its root.
+ * Remembers the most recently visited core-app and global Settings routes
+ * while the app shell is mounted. Extensions route memory is intentionally
+ * scoped to its mounted sidebar; leaving Extensions resets its entry route.
  */
 export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
   const location = useLocation();
@@ -47,9 +47,6 @@ export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
   const lastSettingsRoutePathRef = useRef(
     isSettingsRoute ? currentRoutePath : SETTINGS_ROUTE_PATH,
   );
-  const lastToolsRoutePathRef = useRef(
-    isCurrentToolsRoute ? currentRoutePath : getPluginsRoutePath(),
-  );
 
   useEffect(() => {
     if (isSettingsRoute) {
@@ -58,7 +55,6 @@ export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
     }
     lastAppRoutePathRef.current = currentRoutePath;
     if (isCurrentToolsRoute) {
-      lastToolsRoutePathRef.current = currentRoutePath;
       return;
     }
     lastCoreAppRoutePathRef.current = currentRoutePath;
@@ -73,7 +69,7 @@ export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
       : lastSettingsRoutePathRef.current,
     toolsRoutePath: isCurrentToolsRoute
       ? currentRoutePath
-      : lastToolsRoutePathRef.current,
+      : getPluginsRoutePath(),
     toolsBackRoutePath: isCurrentToolsRoute
       ? lastCoreAppRoutePathRef.current
       : currentRoutePath,

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { focusManager } from "@tanstack/react-query";
 import type { SkillSummary } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
@@ -26,6 +27,7 @@ import {
 } from "./SkillsView";
 
 afterEach(() => {
+  focusManager.setFocused(undefined);
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -795,13 +797,29 @@ describe("SkillsLibrary registry detail lifecycle", () => {
       </MemoryRouter>,
     );
 
-    const forkButton = await screen.findByRole("button", {
+    let forkButton = await screen.findByRole("button", {
       name: "Fork Useful skill into a new bb skill",
     });
     const tabs = screen.getAllByRole("tab");
     expect(tabs[0]).toBe(screen.getByRole("tab", { name: "Browse" }));
     expect(tabs[1]).toBe(screen.getByRole("tab", { name: /Library/ }));
     expect(tabs[0]?.className).toContain("bg-accent");
+    const registryListRequests = () =>
+      fetchMock.mock.calls.filter(([input]) =>
+        requestPath(input).startsWith("/api/v1/skills-registry?"),
+      );
+    expect(registryListRequests()).toHaveLength(1);
+
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+    await waitFor(() => expect(registryListRequests()).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole("tab", { name: /Library/ }));
+    fireEvent.click(screen.getByRole("tab", { name: "Browse" }));
+    forkButton = await screen.findByRole("button", {
+      name: "Fork Useful skill into a new bb skill",
+    });
+    expect(registryListRequests()).toHaveLength(1);
 
     fireEvent.click(forkButton);
 

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -392,7 +392,9 @@ describe("SkillsOverview", () => {
 
     // Groups combine as AND: narrowing Provider to Claude Code drops the
     // codex-scoped skill while the User type selection still holds.
-    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Claude Code" }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: "Claude Code" }),
+    );
     expect(await screen.findByText("claude-authored")).toBeTruthy();
     expect(screen.queryByText("codex-authored")).toBeNull();
     expect(screen.queryByText("official-skill")).toBeNull();
@@ -777,13 +779,13 @@ describe("SkillsLibrary registry detail lifecycle", () => {
     ).toBeNull();
   });
 
-  it("opens the composer from a registry card with the reference prompt", async () => {
+  it("opens on Browse before Library and can start a skill from the registry", async () => {
     const registrySkill = makeRegistrySkill();
     vi.spyOn(sdk.skills, "list").mockResolvedValue({ skills: [] });
     const fetchMock = stubRegistryFetch(registrySkill, { list: true });
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     renderDom(
-      <MemoryRouter initialEntries={["/tools/skills?view=browse"]}>
+      <MemoryRouter initialEntries={["/tools/skills"]}>
         <QueryClientWrapper>
           <Routes>
             <Route path="/tools/skills" element={<SkillsLibrary />} />
@@ -793,11 +795,15 @@ describe("SkillsLibrary registry detail lifecycle", () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Fork Useful skill into a new bb skill",
-      }),
-    );
+    const forkButton = await screen.findByRole("button", {
+      name: "Fork Useful skill into a new bb skill",
+    });
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toBe(screen.getByRole("tab", { name: "Browse" }));
+    expect(tabs[1]).toBe(screen.getByRole("tab", { name: /Library/ }));
+    expect(tabs[0]?.className).toContain("bg-accent");
+
+    fireEvent.click(forkButton);
 
     const state = JSON.parse(
       (await screen.findByTestId("location-state")).textContent ?? "null",

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -124,9 +124,14 @@ describe("PluginDetail official catalog lifecycle", () => {
     expect(screen.getByRole("heading", { name: "GitHub" })).toBeTruthy();
     expect(screen.getByText("BB Official")).toBeTruthy();
     expect(screen.getByText("Developer tools")).toBeTruthy();
-    expect(
-      screen.getByText("Browse GitHub issues and pull requests in BB."),
-    ).toBeTruthy();
+    const description = screen.getByText(
+      "Browse GitHub issues and pull requests in BB.",
+    );
+    expect(description.className).not.toContain("max-w-prose");
+    expect(description.className).toContain("max-w-none");
+    expect(description.className).toContain("text-sm");
+    expect(description.className).toContain("leading-relaxed");
+    expect(description.className).toContain("text-muted-foreground");
     expect(screen.queryByText("Capabilities")).toBeNull();
     expect(container.querySelector('[data-icon="Github"]')).not.toBeNull();
 

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -195,7 +195,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
           : "Plugin uninstalled",
       );
       setDeleteTarget(null);
-      navigate(getPluginsRoutePath());
+      navigate(`${getPluginsRoutePath()}?view=installed`);
       return listQuery.refetch();
     },
     onError: (error) => {

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -44,10 +44,10 @@ import { useLocalOpenTargets } from "@/hooks/useLocalOpenTargets";
 import {
   TOOLS_REGISTRY_SKILLS_ROUTE_PATH,
   TOOLS_SKILLS_ROUTE_PATH,
-  getPluginsRoutePath,
   getRootComposeRoutePath,
 } from "@/lib/route-paths";
 import {
+  getToolsOwnedCollectionRoutePath,
   resolveToolsSection,
   type ToolsSectionId,
 } from "@/components/tools/tools-navigation";
@@ -195,7 +195,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
           : "Plugin uninstalled",
       );
       setDeleteTarget(null);
-      navigate(`${getPluginsRoutePath()}?view=installed`);
+      navigate(getToolsOwnedCollectionRoutePath("plugins"));
       return listQuery.refetch();
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary

- make Browse the default and first tab for Plugins and Skills
- preserve independent Plugins and Skills routes while navigating within Extensions
- reset Extensions navigation to Plugins → Browse after returning to the main app
- keep installed/library detail breadcrumbs pointed at their explicit collection routes

## Testing

- `pnpm exec vitest run --config vitest.config.ts src/hooks/useAppSettingsRouteMemory.test.tsx src/components/tools/ToolsSidebar.test.tsx src/components/plugin/PluginsOverview.test.tsx src/views/SkillsView.test.tsx src/components/layout/AppLayout.tools-breadcrumbs.test.ts src/App.legacy-skill-route.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- real desktop-app QA for default tabs, tab order, internal route preservation, and leave/reopen reset