### PR TITLE
Expand Extensions detail descriptions to full width

### DIFF
--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -150,7 +150,7 @@ export function CatalogPluginDetail({
     >
       <ResourceDetailStack>
         <ResourceDetailOverviewSection label="About">
-          <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
             {entry.description.length > 0
               ? entry.description
               : "This plugin does not describe itself."}
@@ -388,7 +388,7 @@ export function PluginDetail({
     >
       <ResourceDetailStack>
         <ResourceDetailOverviewSection label="About">
-          <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
             {plugin.description ?? "This plugin does not describe itself."}
           </p>
         </ResourceDetailOverviewSection>

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -190,9 +190,14 @@ describe("Plugin detail recipe", () => {
     expect(renderedRecipe(container).map(([kind]) => kind)).toContain(
       "overview",
     );
-    expect(
-      screen.getByText("This plugin does not describe itself."),
-    ).toBeTruthy();
+    const description = screen.getByText(
+      "This plugin does not describe itself.",
+    );
+    expect(description.className).not.toContain("max-w-prose");
+    expect(description.className).toContain("max-w-none");
+    expect(description.className).toContain("text-sm");
+    expect(description.className).toContain("leading-relaxed");
+    expect(description.className).toContain("text-muted-foreground");
   });
 
   it("lists declared capabilities without category chrome", () => {

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -124,9 +124,14 @@ describe("PluginDetail official catalog lifecycle", () => {
     expect(screen.getByRole("heading", { name: "GitHub" })).toBeTruthy();
     expect(screen.getByText("BB Official")).toBeTruthy();
     expect(screen.getByText("Developer tools")).toBeTruthy();
-    expect(
-      screen.getByText("Browse GitHub issues and pull requests in BB."),
-    ).toBeTruthy();
+    const description = screen.getByText(
+      "Browse GitHub issues and pull requests in BB.",
+    );
+    expect(description.className).not.toContain("max-w-prose");
+    expect(description.className).toContain("max-w-none");
+    expect(description.className).toContain("text-sm");
+    expect(description.className).toContain("leading-relaxed");
+    expect(description.className).toContain("text-muted-foreground");
     expect(screen.queryByText("Capabilities")).toBeNull();
     expect(container.querySelector('[data-icon="Github"]')).not.toBeNull();
 


### PR DESCRIPTION
## Summary

- remove the prose-width cap from installed and catalog plugin descriptions
- preserve the existing typography and spacing classes
- add regression assertions for both detail variants

## Verification

- `pnpm exec vitest run apps/app/src/views/ToolsView.plugin-detail.test.tsx apps/app/src/components/tools/detail-page-recipes.test.tsx` (70 passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings only)
- real-app visual QA at 1440×900 and 520×800 on installed and catalog plugin detail pages