### PR TITLE
Fix the plugin catalog route test count

### DIFF
--- a/apps/server/test/services/plugin-catalog/plugin-catalog-routes.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-routes.test.ts
@@ -3,6 +3,11 @@ import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { registerPluginCatalogRoutes } from "../../../src/routes/plugin-catalog.js";
 import { createPluginCatalogService } from "../../../src/services/plugin-catalog/plugin-catalog-service.js";
+import {
+  BUILTIN_PLUGINS,
+  BUNDLED_PLUGINS,
+  OFFICIAL_PLUGINS,
+} from "../../../src/services/plugins/builtin-registry.js";
 
 describe("plugin catalog routes", () => {
   let db: DbConnection;
@@ -30,9 +35,9 @@ describe("plugin catalog routes", () => {
     const status = await app.request("/plugin-catalog");
     await expect(status.json()).resolves.toMatchObject({
       catalog: {
-        pluginCount: 13,
-        includedPluginCount: 8,
-        optionalPluginCount: 5,
+        pluginCount: BUNDLED_PLUGINS.length,
+        includedPluginCount: BUILTIN_PLUGINS.length,
+        optionalPluginCount: OFFICIAL_PLUGINS.length,
       },
     });
     const search = await app.request("/plugin-catalog/search?q=memory");


### PR DESCRIPTION
## Summary

- Derive `pluginCount`, `includedPluginCount`, and `optionalPluginCount` in `plugin-catalog-routes.test.ts` from the bundled plugin registry instead of hardcoding `13 / 8 / 5`.

## Why

CI is red on `main`. Commit f13c2d35f ("Move T3 sidebar plugin to examples", #1109) removed `t3sidebar` from `OFFICIAL_PLUGINS`, so the bundled catalog went from 13 plugins to 12. That PR updated `plugin-catalog-service.test.ts`, which derives its counts from the registry, but it missed the route test, which hardcoded the numbers.

```
AssertionError: expected { catalog: { pluginCount: 12, ... } }
                to match object { catalog: { pluginCount: 13, ... } }
```

#1109 landed without a green run: its own CI run (31186905645) was cancelled when #1108 pushed on top of it.

The route test now uses the same source of truth as the service test, so a future plugin add or remove will not break it again.

## Tests

- `pnpm exec turbo run test --filter=@bb/server -- plugin-catalog` — 7 passed.
- `pnpm exec turbo run test --filter=@bb/server` — 1336 passed. One unrelated local-only failure in `internal-skill-trees.test.ts`, which asserts file mode `0o644` but writes the file with no explicit `chmod`. It follows the umask, so it fails under umask `0002` and passes on CI runners under `0022`.
- `pnpm exec turbo run typecheck --filter=@bb/server` — pass.
- CI run 31187487485 on `main`: `Tests (server)` was the only failing job. All other jobs passed.

## Risk

Test-only change. No product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)