### PR TITLE
fix(codex): respect CODEX_HOME when reading auth for usage

### DIFF
--- a/apps/host-daemon/src/codex-auth.test.ts
+++ b/apps/host-daemon/src/codex-auth.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { readCodexAuthCredentials } from "./codex-auth.js";
+
+const tempDirs: string[] = [];
+
+async function writeApiKeyAuth(
+  codexHome: string,
+  apiKey: string,
+): Promise<void> {
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(
+    path.join(codexHome, "auth.json"),
+    JSON.stringify({
+      auth_mode: "apikey",
+      OPENAI_API_KEY: apiKey,
+      tokens: null,
+    }),
+  );
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((tempDir) => fs.rm(tempDir, { force: true, recursive: true })),
+  );
+});
+
+it("reads auth.json from CODEX_HOME when configured", async () => {
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-codex-home-"));
+  tempDirs.push(homeDir);
+  const configuredCodexHome = path.join(homeDir, "custom-codex-home");
+  await writeApiKeyAuth(path.join(homeDir, ".codex"), "default-api-key");
+  await writeApiKeyAuth(configuredCodexHome, "configured-api-key");
+  vi.stubEnv("HOME", homeDir);
+  vi.stubEnv("CODEX_HOME", configuredCodexHome);
+
+  await expect(readCodexAuthCredentials()).resolves.toEqual({
+    type: "apiKey",
+    apiKey: "configured-api-key",
+  });
+});

--- a/apps/host-daemon/src/codex-auth.ts
+++ b/apps/host-daemon/src/codex-auth.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveCodexHome } from "@bb/config/codex-home";
 import { jsonValueSchema, type JsonObject, type JsonValue } from "@bb/domain";
 import { ExpectedCommandDispatchError } from "./command-dispatch-support.js";
 
-const CODEX_AUTH_RELATIVE_PATH = [".codex", "auth.json"] as const;
+const CODEX_AUTH_FILE_NAME = "auth.json";
 const CHATGPT_AUTH_CLAIM_PATH = "https://api.openai.com/auth";
 
 interface CodexAuthJson {
@@ -37,7 +38,7 @@ export type CodexAuthCredentials =
   | CodexOpenAiApiKeyCredentials;
 
 function codexAuthPath(): string {
-  return path.join(os.homedir(), ...CODEX_AUTH_RELATIVE_PATH);
+  return path.join(resolveCodexHome(os.homedir()), CODEX_AUTH_FILE_NAME);
 }
 
 function toJsonObject(value: JsonValue): JsonObject | null {

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -2,6 +2,7 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveCodexHome } from "@bb/config/codex-home";
 import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
 import type { ProviderNativeSkillRoots } from "@bb/domain";
 import { createConfiguredPiSettingsManager } from "@bb/agent-runtime";
@@ -239,10 +240,6 @@ const claudePluginManifestSchema = z
   })
   .passthrough();
 type ClaudePluginManifest = z.infer<typeof claudePluginManifestSchema>;
-
-export function resolveCodexHome(homeDir: string): string {
-  return process.env.CODEX_HOME?.trim() || path.join(homeDir, ".codex");
-}
 
 function resolveClaudeDir(homeDir: string): string {
   const configured = process.env.CLAUDE_CONFIG_DIR?.trim();

--- a/apps/host-daemon/src/command-handlers/list-skills.ts
+++ b/apps/host-daemon/src/command-handlers/list-skills.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveCodexHome } from "@bb/config/codex-home";
 import { resolveDataDirSkillsRootPath } from "@bb/config/skill-storage-paths";
 import type {
   HostDaemonOnlineRpcResult,
@@ -18,7 +19,6 @@ import {
 } from "../command-discovery.js";
 import {
   type CommandRootResolution,
-  resolveCodexHome,
   resolveProviderCommandScanRoots,
 } from "./list-commands.js";
 import { writeHostFile } from "./file-write.js";

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -118,6 +118,11 @@
       "types": "./src/skill-storage-paths.ts",
       "default": "./src/skill-storage-paths.ts"
     },
+    "./codex-home": {
+      "source": "./src/codex-home.ts",
+      "types": "./src/codex-home.ts",
+      "default": "./src/codex-home.ts"
+    },
     "./verified-process-stop": {
       "source": "./src/verified-process-stop.ts",
       "types": "./src/verified-process-stop.ts",

--- a/packages/config/src/codex-home.ts
+++ b/packages/config/src/codex-home.ts
@@ -1,0 +1,10 @@
+import { join } from "node:path";
+
+type CodexHomeEnvironment = Readonly<Record<string, string | undefined>>;
+
+export function resolveCodexHome(
+  homeDir: string,
+  env: CodexHomeEnvironment = process.env,
+): string {
+  return env.CODEX_HOME?.trim() || join(homeDir, ".codex");
+}

--- a/packages/config/test/codex-home.test.ts
+++ b/packages/config/test/codex-home.test.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveCodexHome } from "../src/codex-home.js";
+
+describe("resolveCodexHome", () => {
+  it("defaults to the .codex directory under the supplied home", () => {
+    expect(resolveCodexHome("/Users/tester", {})).toBe(
+      path.join("/Users/tester", ".codex"),
+    );
+  });
+
+  it("uses a nonblank CODEX_HOME value", () => {
+    expect(
+      resolveCodexHome("/Users/tester", {
+        CODEX_HOME: " /custom/codex-home ",
+      }),
+    ).toBe("/custom/codex-home");
+  });
+});

--- a/packages/scripts/src/commands/archive-codex-tmp-bb-sessions.ts
+++ b/packages/scripts/src/commands/archive-codex-tmp-bb-sessions.ts
@@ -6,6 +6,7 @@ import type { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import readline from "node:readline/promises";
 import type { ChildProcessByStdio } from "node:child_process";
+import { resolveCodexHome } from "@bb/config/codex-home";
 import { bold, cyan, dim, green, yellow, log } from "../lib/script-helpers.js";
 
 const DEFAULT_TMP_BB_PATTERNS: readonly string[] = [
@@ -124,18 +125,6 @@ function resolvePathOption(pathValue: string, homeDirectory: string): string {
   return resolve(expandHomePath(pathValue, homeDirectory));
 }
 
-function resolveDefaultCodexHome(
-  env: NodeJS.ProcessEnv,
-  homeDirectory: string,
-): string {
-  const configuredHome = env.CODEX_HOME?.trim();
-  if (configuredHome && configuredHome.length > 0) {
-    return resolvePathOption(configuredHome, homeDirectory);
-  }
-
-  return join(homeDirectory, ".codex");
-}
-
 function resolveDefaultCodexBin(
   env: NodeJS.ProcessEnv,
   homeDirectory: string,
@@ -237,7 +226,10 @@ export function parseArchiveTmpBbSessionsArgs(
 ): ParseArchiveTmpBbSessionsArgsResult {
   const options: ArchiveTmpBbSessionsOptions = {
     codexBin: resolveDefaultCodexBin(env, homeDirectory),
-    codexHome: resolveDefaultCodexHome(env, homeDirectory),
+    codexHome: resolvePathOption(
+      resolveCodexHome(homeDirectory, env),
+      homeDirectory,
+    ),
     concurrency: DEFAULT_ARCHIVE_CONCURRENCY,
     dryRun: false,
     patterns: [...DEFAULT_TMP_BB_PATTERNS],

--- a/packages/scripts/test/archive-codex-tmp-bb-sessions.test.ts
+++ b/packages/scripts/test/archive-codex-tmp-bb-sessions.test.ts
@@ -44,6 +44,18 @@ describe("archive-codex-tmp-bb-sessions", () => {
     });
   });
 
+  it("respects CODEX_HOME when choosing the default Codex state directory", () => {
+    const parsedArgs = parseArchiveTmpBbSessionsArgs(
+      [],
+      { CODEX_HOME: "~/custom-codex" },
+      "/Users/tester",
+    );
+
+    expect(parsedArgs.options.codexHome).toBe(
+      path.join("/Users/tester", "custom-codex"),
+    );
+  });
+
   it("parses explicit cleanup options", () => {
     const parsedArgs = parseArchiveTmpBbSessionsArgs(
       [


### PR DESCRIPTION
## Problem

Codex thread execution inherits `CODEX_HOME`, but the host-daemon auth reader used by Settings usage, structured inference, and voice transcription always read `~/.codex/auth.json`.

With a second Codex account under a custom `CODEX_HOME`, threads therefore used the configured account while usage and other host-daemon auth consumers used the default account.

## Fix

- resolve Codex home from `CODEX_HOME`, falling back to `<home>/.codex`
- keep one testable resolver in `@bb/config/codex-home` and reuse it from command/skill discovery and the archive script
- read the explicitly named `auth.json` file from that resolved home
- add a regression test with conflicting default and configured credentials, plus resolver and archive coverage

## Verification

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force` (533 tests)
- `pnpm exec turbo run typecheck test --filter=@bb/config --filter=@bb/scripts --force` (193 tests)

Fixes #1324