### PR TITLE
Keep the Pi model list alive when an extension is broken

### DIFF
--- a/packages/agent-runtime/src/pi/bridge/__tests__/configured-services.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/configured-services.test.ts
@@ -9,7 +9,10 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createConfiguredPiServices } from "../configured-services.js";
+import {
+  createConfiguredPiServices,
+  loadConfiguredPiServices,
+} from "../configured-services.js";
 
 const testRoots: string[] = [];
 
@@ -114,5 +117,35 @@ describe("configured Pi services", () => {
     await expect(createConfiguredPiServices({ agentDir, cwd })).rejects.toThrow(
       "Failed to load Pi extension",
     );
+  });
+
+  // The model picker lists whatever loaded. A broken extension must cost the
+  // user that one provider, not every model on the machine.
+  it("keeps the working services when one extension fails to load", async () => {
+    const { agentDir, cwd, markerPath } = await createTestDirs();
+    await writeFile(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ defaultProjectTrust: "always" }),
+    );
+    await writeFile(
+      join(cwd, ".pi", "settings.json"),
+      JSON.stringify({
+        extensions: ["./extensions/marker.ts", "./extensions/broken.ts"],
+      }),
+    );
+    await writeFile(
+      join(cwd, ".pi", "extensions", "broken.ts"),
+      "export default function extension( { this is invalid",
+    );
+
+    const { configErrors, services } = await loadConfiguredPiServices({
+      agentDir,
+      cwd,
+    });
+
+    expect(configErrors).toHaveLength(1);
+    expect(configErrors[0]).toContain("broken.ts");
+    expect(services.modelRuntime).toBeDefined();
+    expect(await markerWasWritten(markerPath)).toBe(true);
   });
 });

--- a/packages/agent-runtime/src/pi/bridge/__tests__/model-list.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/model-list.test.ts
@@ -82,6 +82,38 @@ describe("pi bridge model list", () => {
     expect(getAvailable).toHaveBeenCalledOnce();
   });
 
+  // An extension registers its models from plain JavaScript, so Pi's required
+  // `input` can be missing at runtime. Reading it blindly threw and dropped
+  // every other provider's models with it.
+  it("lists an extension model that omits its input types", async () => {
+    getAvailable.mockResolvedValue([
+      {
+        id: "deepseek-v4",
+        name: "DeepSeek V4",
+        provider: "commandcode",
+        reasoning: false,
+      },
+      {
+        id: "claude-sonnet-5",
+        input: ["text", "image"],
+        name: "Claude Sonnet 5",
+        provider: "anthropic",
+        reasoning: false,
+      },
+    ]);
+    getSupportedThinkingLevels.mockReturnValue(["off"]);
+
+    const result = await listPiBridgeModels(modelRuntime);
+
+    expect(result.models.map((model) => model.id)).toEqual([
+      "commandcode/deepseek-v4",
+      "anthropic/claude-sonnet-5",
+    ]);
+    expect(result.models[0]?.description).toBe(
+      "Commandcode non-reasoning model via Pi",
+    );
+  });
+
   it("preserves Pi's provider-verified thinking-level holes", async () => {
     getAvailable.mockResolvedValue([
       {

--- a/packages/agent-runtime/src/pi/bridge/__tests__/model-list.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/model-list.test.ts
@@ -114,6 +114,35 @@ describe("pi bridge model list", () => {
     );
   });
 
+  // `id` is equally extension-supplied. Without it the list builder called
+  // `id.endsWith()` and threw, which dropped every other provider's models.
+  it("skips a model without an id and keeps the rest", async () => {
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    getAvailable.mockResolvedValue([
+      { input: ["text"], name: "Nameless", provider: "commandcode" },
+      {
+        id: "claude-sonnet-5",
+        input: ["text"],
+        name: "Claude Sonnet 5",
+        provider: "anthropic",
+        reasoning: false,
+      },
+    ]);
+    getSupportedThinkingLevels.mockReturnValue(["off"]);
+
+    const result = await listPiBridgeModels(modelRuntime);
+
+    expect(result.models.map((model) => model.id)).toEqual([
+      "anthropic/claude-sonnet-5",
+    ]);
+    expect(write).toHaveBeenCalledWith(
+      'pi bridge: skipped an incomplete model from provider "commandcode"\n',
+    );
+    write.mockRestore();
+  });
+
   it("preserves Pi's provider-verified thinking-level holes", async () => {
     getAvailable.mockResolvedValue([
       {

--- a/packages/agent-runtime/src/pi/bridge/__tests__/model-runtime.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/model-runtime.test.ts
@@ -79,6 +79,34 @@ describe("Pi bridge model runtime", () => {
     write.mockRestore();
   });
 
+  // The bridge outlives the broken configuration, so a memoized partial
+  // runtime would hide the repaired extension until the process restarts.
+  it("reloads after a partial load so a repaired extension appears", async () => {
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    loadConfiguredPiServices.mockResolvedValueOnce({
+      configErrors: ['Failed to load Pi extension "broken.ts": boom'],
+      services: { modelRuntime: secondRuntime },
+    });
+
+    await expect(getPiModelRuntime("/tmp/project-one")).resolves.toBe(
+      secondRuntime,
+    );
+    await expect(getPiModelRuntime("/tmp/project-one")).resolves.toBe(
+      firstRuntime,
+    );
+    expect(loadConfiguredPiServices).toHaveBeenCalledTimes(2);
+    write.mockRestore();
+  });
+
+  it("keeps the memo when the configuration is clean", async () => {
+    await getPiModelRuntime("/tmp/project-one");
+    await getPiModelRuntime("/tmp/project-one");
+
+    expect(loadConfiguredPiServices).toHaveBeenCalledOnce();
+  });
+
   it("drops the memo when the services fail to build", async () => {
     loadConfiguredPiServices.mockRejectedValueOnce(new Error("no agent dir"));
 

--- a/packages/agent-runtime/src/pi/bridge/__tests__/model-runtime.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/model-runtime.test.ts
@@ -1,21 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createConfiguredPiServices, firstRuntime, secondRuntime } = vi.hoisted(
+const { loadConfiguredPiServices, firstRuntime, secondRuntime } = vi.hoisted(
   () => {
     const firstRuntime = { getModel: vi.fn() };
     const secondRuntime = { getModel: vi.fn() };
     return {
-      createConfiguredPiServices: vi.fn(async ({ cwd }: { cwd: string }) => ({
-        modelRuntime: cwd === "/tmp/project-one" ? firstRuntime : secondRuntime,
-      })),
       firstRuntime,
+      loadConfiguredPiServices: vi.fn(
+        async ({
+          cwd,
+        }: {
+          cwd: string;
+        }): Promise<{
+          configErrors: string[];
+          services: { modelRuntime: { getModel: unknown } };
+        }> => ({
+          configErrors: [],
+          services: {
+            modelRuntime:
+              cwd === "/tmp/project-one" ? firstRuntime : secondRuntime,
+          },
+        }),
+      ),
       secondRuntime,
     };
   },
 );
 
 vi.mock("../configured-services.js", () => ({
-  createConfiguredPiServices,
+  loadConfiguredPiServices,
 }));
 
 import {
@@ -37,12 +50,43 @@ describe("Pi bridge model runtime", () => {
     expect(first).toBe(firstRuntime);
     expect(firstAgain).toBe(firstRuntime);
     expect(second).toBe(secondRuntime);
-    expect(createConfiguredPiServices).toHaveBeenCalledTimes(2);
-    expect(createConfiguredPiServices).toHaveBeenNthCalledWith(1, {
+    expect(loadConfiguredPiServices).toHaveBeenCalledTimes(2);
+    expect(loadConfiguredPiServices).toHaveBeenNthCalledWith(1, {
       cwd: "/tmp/project-one",
     });
-    expect(createConfiguredPiServices).toHaveBeenNthCalledWith(2, {
+    expect(loadConfiguredPiServices).toHaveBeenNthCalledWith(2, {
       cwd: "/tmp/project-two",
     });
+  });
+
+  // A broken third-party extension used to reject here, so the picker lost
+  // every model instead of the one provider that failed to register.
+  it("still returns the runtime when the Pi configuration reports errors", async () => {
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    loadConfiguredPiServices.mockResolvedValueOnce({
+      configErrors: ['Failed to load Pi extension "broken.ts": boom'],
+      services: { modelRuntime: firstRuntime },
+    });
+
+    await expect(getPiModelRuntime("/tmp/project-one")).resolves.toBe(
+      firstRuntime,
+    );
+    expect(write).toHaveBeenCalledWith(
+      'pi bridge: Failed to load Pi extension "broken.ts": boom\n',
+    );
+    write.mockRestore();
+  });
+
+  it("drops the memo when the services fail to build", async () => {
+    loadConfiguredPiServices.mockRejectedValueOnce(new Error("no agent dir"));
+
+    await expect(getPiModelRuntime("/tmp/project-one")).rejects.toThrow(
+      "no agent dir",
+    );
+    await expect(getPiModelRuntime("/tmp/project-one")).resolves.toBe(
+      firstRuntime,
+    );
   });
 });

--- a/packages/agent-runtime/src/pi/bridge/configured-services.ts
+++ b/packages/agent-runtime/src/pi/bridge/configured-services.ts
@@ -84,9 +84,23 @@ function collectServiceErrors(services: AgentSessionServices): string[] {
   return [...new Set(errors)];
 }
 
-export async function createConfiguredPiServices(
+export interface LoadedPiServices {
+  /** Problems found in the user's Pi configuration. Empty when it is clean. */
+  configErrors: string[];
+  services: AgentSessionServices;
+}
+
+/**
+ * Build the Pi services and report configuration problems instead of throwing.
+ *
+ * Pi keeps every resource it did load when one extension, skill, prompt, or
+ * theme fails, so a caller that can work with a partial configuration should
+ * report the errors and continue. A caller that cannot must use
+ * {@link createConfiguredPiServices}.
+ */
+export async function loadConfiguredPiServices(
   options: CreateConfiguredPiServicesOptions,
-): Promise<AgentSessionServices> {
+): Promise<LoadedPiServices> {
   const cwd = resolve(options.cwd);
   const agentDir = resolve(options.agentDir ?? getAgentDir());
   const settingsManager = SettingsManager.create(cwd, agentDir, {
@@ -102,9 +116,16 @@ export async function createConfiguredPiServices(
     cwd,
     settingsManager,
   });
-  const errors = collectServiceErrors(services);
-  if (errors.length > 0) {
-    throw new Error(errors.join("\n"));
+  return { configErrors: collectServiceErrors(services), services };
+}
+
+/** Build the Pi services and fail on any configuration problem. */
+export async function createConfiguredPiServices(
+  options: CreateConfiguredPiServicesOptions,
+): Promise<AgentSessionServices> {
+  const { configErrors, services } = await loadConfiguredPiServices(options);
+  if (configErrors.length > 0) {
+    throw new Error(configErrors.join("\n"));
   }
   return services;
 }

--- a/packages/agent-runtime/src/pi/bridge/model-list.ts
+++ b/packages/agent-runtime/src/pi/bridge/model-list.ts
@@ -1,7 +1,7 @@
 import type { AvailableModel } from "@bb/domain";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
-import { buildPiAvailableModels } from "../model-list.js";
+import { buildPiAvailableModels, type PiCatalogModel } from "../model-list.js";
 
 const NETWORK_REFRESH_TIMEOUT_MS = 5_000;
 
@@ -99,6 +99,38 @@ async function ensureNetworkRefresh(modelRuntime: ModelRuntime): Promise<void> {
   }
 }
 
+type PiAvailableModel = Awaited<
+  ReturnType<ModelRuntime["getAvailable"]>
+>[number];
+
+/**
+ * Narrow one Pi model for the list builder, or drop it.
+ *
+ * Pi marks `id`, `name`, `provider`, and `input` as required, but an extension
+ * registers its models from plain JavaScript and Pi does not validate them. A
+ * missing field threw here or inside the builder, which failed the whole call
+ * and hid every other provider's models. Skip the bad model instead.
+ */
+function toPiCatalogModel(model: PiAvailableModel): PiCatalogModel | undefined {
+  if (
+    typeof model.id !== "string" ||
+    model.id.length === 0 ||
+    typeof model.name !== "string" ||
+    typeof model.provider !== "string" ||
+    model.provider.length === 0
+  ) {
+    return undefined;
+  }
+  return {
+    id: model.id,
+    input: Array.isArray(model.input) ? [...model.input] : [],
+    name: model.name,
+    provider: model.provider,
+    reasoning: model.reasoning === true,
+    supportedThinkingLevels: getSupportedThinkingLevels(model),
+  };
+}
+
 export async function listPiBridgeModels(modelRuntime: ModelRuntime): Promise<{
   models: AvailableModel[];
   selectedOnlyModels: AvailableModel[];
@@ -106,19 +138,19 @@ export async function listPiBridgeModels(modelRuntime: ModelRuntime): Promise<{
   await ensureNetworkRefresh(modelRuntime);
   const availableModels = await modelRuntime.getAvailable();
 
-  return buildPiAvailableModels({
-    models: availableModels.map((model) => ({
-      id: model.id,
-      // An extension registers its models from plain JavaScript, so Pi's
-      // required `input` can still be missing at runtime. Reading it blindly
-      // threw and failed the whole list, which hid every other provider too.
-      input: Array.isArray(model.input) ? [...model.input] : [],
-      name: model.name,
-      provider: model.provider,
-      reasoning: model.reasoning,
-      supportedThinkingLevels: getSupportedThinkingLevels(model),
-    })),
-  });
+  const models: PiCatalogModel[] = [];
+  for (const model of availableModels) {
+    const catalogModel = toPiCatalogModel(model);
+    if (catalogModel) {
+      models.push(catalogModel);
+      continue;
+    }
+    process.stderr.write(
+      `pi bridge: skipped an incomplete model from provider "${String(model.provider)}"\n`,
+    );
+  }
+
+  return buildPiAvailableModels({ models });
 }
 
 /** @internal Test seam: reset the per-process refresh latch. */

--- a/packages/agent-runtime/src/pi/bridge/model-list.ts
+++ b/packages/agent-runtime/src/pi/bridge/model-list.ts
@@ -109,7 +109,10 @@ export async function listPiBridgeModels(modelRuntime: ModelRuntime): Promise<{
   return buildPiAvailableModels({
     models: availableModels.map((model) => ({
       id: model.id,
-      input: [...model.input],
+      // An extension registers its models from plain JavaScript, so Pi's
+      // required `input` can still be missing at runtime. Reading it blindly
+      // threw and failed the whole list, which hid every other provider too.
+      input: Array.isArray(model.input) ? [...model.input] : [],
       name: model.name,
       provider: model.provider,
       reasoning: model.reasoning,

--- a/packages/agent-runtime/src/pi/bridge/model-runtime.ts
+++ b/packages/agent-runtime/src/pi/bridge/model-runtime.ts
@@ -20,8 +20,15 @@ export function getPiModelRuntime(cwd = process.cwd()): Promise<ModelRuntime> {
       // every provider it did load, so report the problem and list those
       // models. Thread start keeps failing on the same configuration, so the
       // user still learns about it before a run uses a partial setup.
-      for (const configError of configErrors) {
-        process.stderr.write(`pi bridge: ${configError}\n`);
+      if (configErrors.length > 0) {
+        for (const configError of configErrors) {
+          process.stderr.write(`pi bridge: ${configError}\n`);
+        }
+        // This runtime is missing whatever failed to load, so it must not
+        // outlive the broken configuration. Drop the memo and reload on the
+        // next call, which picks the repaired extension up without a restart
+        // of the long-lived bridge.
+        modelRuntimePromises.delete(resolvedCwd);
       }
       return services.modelRuntime;
     })

--- a/packages/agent-runtime/src/pi/bridge/model-runtime.ts
+++ b/packages/agent-runtime/src/pi/bridge/model-runtime.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
-import { createConfiguredPiServices } from "./configured-services.js";
+import { loadConfiguredPiServices } from "./configured-services.js";
 
 const modelRuntimePromises = new Map<string, Promise<ModelRuntime>>();
 
@@ -14,8 +14,17 @@ export function getPiModelRuntime(cwd = process.cwd()): Promise<ModelRuntime> {
   // Use the full service path here too. This adds models from configured Pi
   // extensions to BB's model picker. Cache each requested workspace separately
   // because project settings and extensions are bound to that workspace.
-  const modelRuntimePromise = createConfiguredPiServices({ cwd: resolvedCwd })
-    .then((services) => services.modelRuntime)
+  const modelRuntimePromise = loadConfiguredPiServices({ cwd: resolvedCwd })
+    .then(({ configErrors, services }) => {
+      // One broken extension must not empty the picker. Pi still registered
+      // every provider it did load, so report the problem and list those
+      // models. Thread start keeps failing on the same configuration, so the
+      // user still learns about it before a run uses a partial setup.
+      for (const configError of configErrors) {
+        process.stderr.write(`pi bridge: ${configError}\n`);
+      }
+      return services.modelRuntime;
+    })
     // Drop the memo if creation fails. A transient failure must not poison all
     // later model-list calls until the bridge restarts.
     .catch((error: unknown) => {


### PR DESCRIPTION
## Summary

- Verify that the `primeExtensions()` port asked for in #1086 already landed in #1080, end to end against the built bridge.
- Stop one broken Pi extension from emptying the whole model picker.
- Stop an extension model without `input` types from failing the whole model list.

## Why

#1086 asks to port `primeExtensions()` to the production Pi bridge so extension providers such as `commandcode` appear in the stock Pi provider.

That port already landed in #1080 (`8d7bf6124`). The bridge builds its model runtime through `createConfiguredPiServices()`, and Pi 0.84.0 flushes `pendingProviderRegistrations` inside `createAgentSessionServices()`. A disposable priming session is not necessary.

I confirmed this with the real extension from the issue, not a mock: `pi-commandcode-provider@0.5.0` installed from npm, driven by a real `model/list` JSON-RPC request to the built `dist/bb-pi-bridge.mjs`. It returns **51 CommandCode models**.

That test found two defects that still produce the exact symptom in the issue.

### 1. A broken extension emptied the whole picker

`collectServiceErrors()` throws on any extension load error, and `getPiModelRuntime()` passed that on, so `model/list` answered with a JSON-RPC error. The user lost every model on the machine, built-in providers included, because of one bad third-party extension.

Repro before this change, with a working extension and a broken one installed together:

```
Error: Failed to load Pi extension "/tmp/pi-broken/ext/broken.ts": Cannot find module '@not-installed/nope'
```

The fix splits the service builder. `loadConfiguredPiServices()` reports the problems, and `createConfiguredPiServices()` still throws. Model listing writes the problems to stderr and lists what loaded. Thread start still fails loudly, so a run never uses a partial configuration in silence.

After, through the shipped bundle:

```
pi bridge: Failed to load Pi extension "/tmp/pi-broken/ext/broken.ts": ...
TOTAL 2
  commandcode-fake: 2
```

### 2. An extension model without `input` crashed the list

`input: [...model.input]` threw `TypeError: model.input is not iterable`. Pi types `input` as required, but an extension registers its models from plain JavaScript and Pi does not validate them. One malformed model hid every other provider.

## Impact

A user with a broken or outdated Pi extension keeps a working model picker and gets the reason on stderr, instead of an empty picker with no explanation.

## Note on model counts

Extension models appear only when the provider has credentials. With `COMMANDCODE_API_KEY` unset, `getAvailable()` filters CommandCode out and the count returns to 0. That is correct Pi behavior, not a BB defect, but it may explain part of what the reporter saw.

`HOST_DAEMON_PROTOCOL_VERSION` is unchanged: this is internal to the bridge process and the `model/list` result shape is the same.

## Validation

- 823 `@bb/agent-runtime` tests, including 3 new regression tests
- 482 `@bb/host-daemon` tests
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon`
- ESLint on `packages/agent-runtime/src/pi`
- All three scenarios driven over JSON-RPC against the built `bb-pi-bridge.mjs`, not only against source

Fixes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)