### PR TITLE
Fix Cmd+W crash in About window

### DIFF
--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -140,6 +140,14 @@ export function buildApplicationMenuTemplate(
         {
           accelerator: args.accelerators.closeWindowOrSideTab,
           click(_menuItem, browserWindow) {
+            // Electron sends null here for native panels such as the About
+            // window. Its type defines only BaseWindow | undefined.
+            // These panels have no Electron BaseWindow, so use the native
+            // close action.
+            if (browserWindow === null) {
+              Menu.sendActionToFirstResponder("performClose:");
+              return;
+            }
             args.closeWindowOrSideTab(browserWindow);
           },
           label: CLOSE_WINDOW_MENU_LABEL,

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -52,6 +52,7 @@ function findServerSubmenu(
 
 describe("application menu", () => {
   it("closes a native panel when Electron omits its window", () => {
+    vi.mocked(Menu.sendActionToFirstResponder).mockClear();
     const closeWindowOrSideTab = vi.fn();
     const template = buildApplicationMenuTemplate(
       menuArgs(() => {}, { closeWindowOrSideTab }),
@@ -66,6 +67,22 @@ describe("application menu", () => {
       "performClose:",
     );
     expect(closeWindowOrSideTab).not.toHaveBeenCalled();
+  });
+
+  it("forwards an undefined window for detached DevTools", () => {
+    vi.mocked(Menu.sendActionToFirstResponder).mockClear();
+    const closeWindowOrSideTab = vi.fn();
+    const template = buildApplicationMenuTemplate(
+      menuArgs(() => {}, { closeWindowOrSideTab }),
+    );
+    const fileMenu = template.find((item) => item.label === "File");
+    const submenu = fileMenu?.submenu as MenuItemConstructorOptions[];
+    const closeWindow = submenu.find((item) => item.label === "Close Window");
+
+    closeWindow?.click?.({} as never, undefined, {} as never);
+
+    expect(closeWindowOrSideTab).toHaveBeenCalledWith(undefined);
+    expect(Menu.sendActionToFirstResponder).not.toHaveBeenCalled();
   });
 
   it("shows reload shortcuts without globally stealing browser commands", () => {

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -3,8 +3,10 @@ import type { BaseWindow, MenuItemConstructorOptions } from "electron";
 
 vi.mock("electron", () => ({
   app: { name: "bb" },
-  Menu: {},
+  Menu: { sendActionToFirstResponder: vi.fn() },
 }));
+
+import { Menu } from "electron";
 
 import {
   buildApplicationMenuTemplate,
@@ -49,6 +51,23 @@ function findServerSubmenu(
 }
 
 describe("application menu", () => {
+  it("closes a native panel when Electron omits its window", () => {
+    const closeWindowOrSideTab = vi.fn();
+    const template = buildApplicationMenuTemplate(
+      menuArgs(() => {}, { closeWindowOrSideTab }),
+    );
+    const fileMenu = template.find((item) => item.label === "File");
+    const submenu = fileMenu?.submenu as MenuItemConstructorOptions[];
+    const closeWindow = submenu.find((item) => item.label === "Close Window");
+
+    closeWindow?.click?.({} as never, null as never, {} as never);
+
+    expect(Menu.sendActionToFirstResponder).toHaveBeenCalledWith(
+      "performClose:",
+    );
+    expect(closeWindowOrSideTab).not.toHaveBeenCalled();
+  });
+
   it("shows reload shortcuts without globally stealing browser commands", () => {
     const reloadWindow = vi.fn();
     const template = buildApplicationMenuTemplate(menuArgs(reloadWindow));


### PR DESCRIPTION
Closes #1100.

## Summary
- handle the null window value that Electron sends for native panels
- send the native macOS close action for the About panel
- preserve the existing app-window and detached DevTools close paths
- add a regression test for the null window case

## Tests
- pnpm exec turbo run test typecheck --filter=@bb/desktop --force
- 230 desktop tests passed
- desktop type check passed