### PR TITLE
Fix pull request lookup for fork branches

### DIFF
--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -44,6 +44,11 @@ const GH_PR_VIEW_JSON_FIELDS = [
   "mergeable",
 ].join(",");
 
+interface GetPullRequestForBranchArgs {
+  cwd: string;
+  branch: string;
+}
+
 interface GetPullRequestForCurrentBranchArgs {
   cwd: string;
 }
@@ -54,6 +59,12 @@ export type GitHostPullRequestAction =
   | { operation: "ready" }
   | { operation: "draft" }
   | { operation: "merge"; method: GitHostPullRequestMergeMethod };
+
+interface RunPullRequestActionForBranchArgs {
+  cwd: string;
+  branch: string;
+  action: GitHostPullRequestAction;
+}
 
 interface RunPullRequestActionForCurrentBranchArgs {
   cwd: string;
@@ -287,15 +298,26 @@ function getMergeMethodFlag(method: GitHostPullRequestMergeMethod): string {
 
 function buildPullRequestActionArgs(
   action: GitHostPullRequestAction,
+  branch: string | null,
 ): string[] {
+  let args: string[];
   switch (action.operation) {
     case "ready":
-      return ["pr", "ready"];
+      args = ["pr", "ready"];
+      break;
     case "draft":
-      return ["pr", "ready", "--undo"];
+      args = ["pr", "ready", "--undo"];
+      break;
     case "merge":
-      return ["pr", "merge", getMergeMethodFlag(action.method)];
+      args = ["pr", "merge", getMergeMethodFlag(action.method)];
+      break;
   }
+  return branch === null ? args : [...args, "--", branch];
+}
+
+function buildPullRequestViewArgs(branch: string | null): string[] {
+  const args = ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS];
+  return branch === null ? args : [...args, "--", branch];
 }
 
 function getExecFileException(error: unknown): ExecFileException | undefined {
@@ -399,10 +421,8 @@ function classifyPullRequestViewError(
 }
 
 /**
- * Detect the open/most-relevant GitHub pull request for the branch checked out
- * in `cwd` by shelling out to the host `gh` CLI. The command deliberately has
- * no positional branch target: `gh` can then follow the branch's configured
- * upstream remote, which is required when the PR head belongs to a fork.
+ * Detect the open/most-relevant GitHub pull request either for an explicit
+ * branch or for the branch checked out in `cwd`.
  *
  * Never throws: a branch with no PR is `outcome: "none"`, while every lookup
  * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,
@@ -411,14 +431,15 @@ function classifyPullRequestViewError(
  * `PATH`/`HOME`/token vars so `gh` auth resolves the same way it would in the
  * user's shell.
  */
-export async function getPullRequestForCurrentBranch(
-  args: GetPullRequestForCurrentBranchArgs,
-): Promise<GitHostPullRequestLookup> {
+async function getPullRequest(args: {
+  cwd: string;
+  branch: string | null;
+}): Promise<GitHostPullRequestLookup> {
   let stdout: string;
   try {
     ({ stdout } = await execFileAsync(
       "gh",
-      ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS],
+      buildPullRequestViewArgs(args.branch),
       {
         cwd: args.cwd,
         encoding: "utf8",
@@ -441,15 +462,39 @@ export async function getPullRequestForCurrentBranch(
 }
 
 /**
- * Mutate the GitHub pull request for the branch checked out in `cwd`. Omitting
- * a positional target lets `gh` honor a fork branch's configured upstream.
- * Unlike pull-request detection, mutation failures are meaningful and are
- * surfaced to the caller.
+ * Detect the open/most-relevant GitHub pull request for an explicit branch.
+ * This preserves the original low-level helper contract for callers that need
+ * to target a branch other than the one checked out in `cwd`.
  */
-export async function runPullRequestActionForCurrentBranch(
-  args: RunPullRequestActionForCurrentBranchArgs,
-): Promise<void> {
-  const ghArgs = buildPullRequestActionArgs(args.action);
+export async function getPullRequestForBranch(
+  args: GetPullRequestForBranchArgs,
+): Promise<GitHostPullRequestLookup> {
+  return getPullRequest({ cwd: args.cwd, branch: args.branch });
+}
+
+/**
+ * Detect the open/most-relevant GitHub pull request for the branch checked out
+ * in `cwd`. Omitting a positional branch target lets `gh` follow the branch's
+ * configured upstream remote, which is required when the PR head belongs to a
+ * fork.
+ */
+export async function getPullRequestForCurrentBranch(
+  args: GetPullRequestForCurrentBranchArgs,
+): Promise<GitHostPullRequestLookup> {
+  return getPullRequest({ cwd: args.cwd, branch: null });
+}
+
+/**
+ * Mutate the GitHub pull request either for an explicit branch or for the
+ * branch checked out in `cwd`. Unlike pull-request detection, mutation
+ * failures are meaningful and are surfaced to the caller.
+ */
+async function runPullRequestAction(args: {
+  cwd: string;
+  branch: string | null;
+  action: GitHostPullRequestAction;
+}): Promise<void> {
+  const ghArgs = buildPullRequestActionArgs(args.action, args.branch);
   try {
     await execFileAsync("gh", ghArgs, {
       cwd: args.cwd,
@@ -461,4 +506,29 @@ export async function runPullRequestActionForCurrentBranch(
   } catch (error) {
     throw createGitHostCommandFailedError(ghArgs, error);
   }
+}
+
+/** Preserve the explicit-branch action helper's original command semantics. */
+export async function runPullRequestActionForBranch(
+  args: RunPullRequestActionForBranchArgs,
+): Promise<void> {
+  return runPullRequestAction({
+    cwd: args.cwd,
+    branch: args.branch,
+    action: args.action,
+  });
+}
+
+/**
+ * Mutate the pull request for the branch checked out in `cwd`. Omitting a
+ * positional target lets `gh` honor a fork branch's configured upstream.
+ */
+export async function runPullRequestActionForCurrentBranch(
+  args: RunPullRequestActionForCurrentBranchArgs,
+): Promise<void> {
+  return runPullRequestAction({
+    cwd: args.cwd,
+    branch: null,
+    action: args.action,
+  });
 }

--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -44,11 +44,6 @@ const GH_PR_VIEW_JSON_FIELDS = [
   "mergeable",
 ].join(",");
 
-interface GetPullRequestForBranchArgs {
-  cwd: string;
-  branch: string;
-}
-
 interface GetPullRequestForCurrentBranchArgs {
   cwd: string;
 }
@@ -59,12 +54,6 @@ export type GitHostPullRequestAction =
   | { operation: "ready" }
   | { operation: "draft" }
   | { operation: "merge"; method: GitHostPullRequestMergeMethod };
-
-interface RunPullRequestActionForBranchArgs {
-  cwd: string;
-  branch: string;
-  action: GitHostPullRequestAction;
-}
 
 interface RunPullRequestActionForCurrentBranchArgs {
   cwd: string;
@@ -298,26 +287,15 @@ function getMergeMethodFlag(method: GitHostPullRequestMergeMethod): string {
 
 function buildPullRequestActionArgs(
   action: GitHostPullRequestAction,
-  branch: string | null,
 ): string[] {
-  let args: string[];
   switch (action.operation) {
     case "ready":
-      args = ["pr", "ready"];
-      break;
+      return ["pr", "ready"];
     case "draft":
-      args = ["pr", "ready", "--undo"];
-      break;
+      return ["pr", "ready", "--undo"];
     case "merge":
-      args = ["pr", "merge", getMergeMethodFlag(action.method)];
-      break;
+      return ["pr", "merge", getMergeMethodFlag(action.method)];
   }
-  return branch === null ? args : [...args, "--", branch];
-}
-
-function buildPullRequestViewArgs(branch: string | null): string[] {
-  const args = ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS];
-  return branch === null ? args : [...args, "--", branch];
 }
 
 function getExecFileException(error: unknown): ExecFileException | undefined {
@@ -421,8 +399,10 @@ function classifyPullRequestViewError(
 }
 
 /**
- * Detect the open/most-relevant GitHub pull request either for an explicit
- * branch or for the branch checked out in `cwd`.
+ * Detect the open/most-relevant GitHub pull request for the branch checked out
+ * in `cwd` by shelling out to the host `gh` CLI. The command deliberately has
+ * no positional branch target: `gh` can then follow the branch's configured
+ * upstream remote, which is required when the PR head belongs to a fork.
  *
  * Never throws: a branch with no PR is `outcome: "none"`, while every lookup
  * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,
@@ -431,15 +411,14 @@ function classifyPullRequestViewError(
  * `PATH`/`HOME`/token vars so `gh` auth resolves the same way it would in the
  * user's shell.
  */
-async function getPullRequest(args: {
-  cwd: string;
-  branch: string | null;
-}): Promise<GitHostPullRequestLookup> {
+export async function getPullRequestForCurrentBranch(
+  args: GetPullRequestForCurrentBranchArgs,
+): Promise<GitHostPullRequestLookup> {
   let stdout: string;
   try {
     ({ stdout } = await execFileAsync(
       "gh",
-      buildPullRequestViewArgs(args.branch),
+      ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS],
       {
         cwd: args.cwd,
         encoding: "utf8",
@@ -462,39 +441,15 @@ async function getPullRequest(args: {
 }
 
 /**
- * Detect the open/most-relevant GitHub pull request for an explicit branch.
- * This preserves the original low-level helper contract for callers that need
- * to target a branch other than the one checked out in `cwd`.
+ * Mutate the GitHub pull request for the branch checked out in `cwd`. Omitting
+ * a positional target lets `gh` honor a fork branch's configured upstream.
+ * Unlike pull-request detection, mutation failures are meaningful and are
+ * surfaced to the caller.
  */
-export async function getPullRequestForBranch(
-  args: GetPullRequestForBranchArgs,
-): Promise<GitHostPullRequestLookup> {
-  return getPullRequest({ cwd: args.cwd, branch: args.branch });
-}
-
-/**
- * Detect the open/most-relevant GitHub pull request for the branch checked out
- * in `cwd`. Omitting a positional branch target lets `gh` follow the branch's
- * configured upstream remote, which is required when the PR head belongs to a
- * fork.
- */
-export async function getPullRequestForCurrentBranch(
-  args: GetPullRequestForCurrentBranchArgs,
-): Promise<GitHostPullRequestLookup> {
-  return getPullRequest({ cwd: args.cwd, branch: null });
-}
-
-/**
- * Mutate the GitHub pull request either for an explicit branch or for the
- * branch checked out in `cwd`. Unlike pull-request detection, mutation
- * failures are meaningful and are surfaced to the caller.
- */
-async function runPullRequestAction(args: {
-  cwd: string;
-  branch: string | null;
-  action: GitHostPullRequestAction;
-}): Promise<void> {
-  const ghArgs = buildPullRequestActionArgs(args.action, args.branch);
+export async function runPullRequestActionForCurrentBranch(
+  args: RunPullRequestActionForCurrentBranchArgs,
+): Promise<void> {
+  const ghArgs = buildPullRequestActionArgs(args.action);
   try {
     await execFileAsync("gh", ghArgs, {
       cwd: args.cwd,
@@ -506,29 +461,4 @@ async function runPullRequestAction(args: {
   } catch (error) {
     throw createGitHostCommandFailedError(ghArgs, error);
   }
-}
-
-/** Preserve the explicit-branch action helper's original command semantics. */
-export async function runPullRequestActionForBranch(
-  args: RunPullRequestActionForBranchArgs,
-): Promise<void> {
-  return runPullRequestAction({
-    cwd: args.cwd,
-    branch: args.branch,
-    action: args.action,
-  });
-}
-
-/**
- * Mutate the pull request for the branch checked out in `cwd`. Omitting a
- * positional target lets `gh` honor a fork branch's configured upstream.
- */
-export async function runPullRequestActionForCurrentBranch(
-  args: RunPullRequestActionForCurrentBranchArgs,
-): Promise<void> {
-  return runPullRequestAction({
-    cwd: args.cwd,
-    branch: null,
-    action: args.action,
-  });
 }

--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -44,9 +44,8 @@ const GH_PR_VIEW_JSON_FIELDS = [
   "mergeable",
 ].join(",");
 
-interface GetPullRequestForBranchArgs {
+interface GetPullRequestForCurrentBranchArgs {
   cwd: string;
-  branch: string;
 }
 
 export type GitHostPullRequestMergeMethod = "merge" | "squash" | "rebase";
@@ -56,9 +55,8 @@ export type GitHostPullRequestAction =
   | { operation: "draft" }
   | { operation: "merge"; method: GitHostPullRequestMergeMethod };
 
-interface RunPullRequestActionForBranchArgs {
+interface RunPullRequestActionForCurrentBranchArgs {
   cwd: string;
-  branch: string;
   action: GitHostPullRequestAction;
 }
 
@@ -289,15 +287,14 @@ function getMergeMethodFlag(method: GitHostPullRequestMergeMethod): string {
 
 function buildPullRequestActionArgs(
   action: GitHostPullRequestAction,
-  branch: string,
 ): string[] {
   switch (action.operation) {
     case "ready":
-      return ["pr", "ready", "--", branch];
+      return ["pr", "ready"];
     case "draft":
-      return ["pr", "ready", "--undo", "--", branch];
+      return ["pr", "ready", "--undo"];
     case "merge":
-      return ["pr", "merge", getMergeMethodFlag(action.method), "--", branch];
+      return ["pr", "merge", getMergeMethodFlag(action.method)];
   }
 }
 
@@ -402,24 +399,26 @@ function classifyPullRequestViewError(
 }
 
 /**
- * Detect the open/most-relevant GitHub pull request for `branch` by shelling
- * out to the host `gh` CLI in `cwd`. Never throws: a branch with no PR is
- * `outcome: "none"`, while every lookup failure (`gh` not installed, not
- * authenticated, no GitHub remote, a timeout, unparseable output) is
- * `outcome: "unavailable"` so callers can distinguish "no PR" from "could not
- * check". The inherited environment preserves `PATH`/`HOME`/token vars so
- * `gh` auth resolves the same way it would in the user's shell.
+ * Detect the open/most-relevant GitHub pull request for the branch checked out
+ * in `cwd` by shelling out to the host `gh` CLI. The command deliberately has
+ * no positional branch target: `gh` can then follow the branch's configured
+ * upstream remote, which is required when the PR head belongs to a fork.
+ *
+ * Never throws: a branch with no PR is `outcome: "none"`, while every lookup
+ * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,
+ * unparseable output) is `outcome: "unavailable"` so callers can distinguish
+ * "no PR" from "could not check". The inherited environment preserves
+ * `PATH`/`HOME`/token vars so `gh` auth resolves the same way it would in the
+ * user's shell.
  */
-export async function getPullRequestForBranch(
-  args: GetPullRequestForBranchArgs,
+export async function getPullRequestForCurrentBranch(
+  args: GetPullRequestForCurrentBranchArgs,
 ): Promise<GitHostPullRequestLookup> {
   let stdout: string;
   try {
     ({ stdout } = await execFileAsync(
       "gh",
-      // `--` ends option parsing so `branch` is always taken as the positional
-      // target, never mistaken for a flag.
-      ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS, "--", args.branch],
+      ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS],
       {
         cwd: args.cwd,
         encoding: "utf8",
@@ -442,13 +441,15 @@ export async function getPullRequestForBranch(
 }
 
 /**
- * Mutate the GitHub pull request for `branch`. Unlike pull-request detection,
- * mutation failures are meaningful and are surfaced to the caller.
+ * Mutate the GitHub pull request for the branch checked out in `cwd`. Omitting
+ * a positional target lets `gh` honor a fork branch's configured upstream.
+ * Unlike pull-request detection, mutation failures are meaningful and are
+ * surfaced to the caller.
  */
-export async function runPullRequestActionForBranch(
-  args: RunPullRequestActionForBranchArgs,
+export async function runPullRequestActionForCurrentBranch(
+  args: RunPullRequestActionForCurrentBranchArgs,
 ): Promise<void> {
-  const ghArgs = buildPullRequestActionArgs(args.action, args.branch);
+  const ghArgs = buildPullRequestActionArgs(args.action);
   try {
     await execFileAsync("gh", ghArgs, {
       cwd: args.cwd,

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -51,7 +51,6 @@ export type {
 } from "./git.js";
 
 export {
-  getPullRequestForBranch,
   getPullRequestForCurrentBranch,
   parseGitHostPullRequest,
   type GitHostPullRequestLookup,

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -51,7 +51,7 @@ export type {
 } from "./git.js";
 
 export {
-  getPullRequestForBranch,
+  getPullRequestForCurrentBranch,
   parseGitHostPullRequest,
   type GitHostPullRequestLookup,
 } from "./git-host.js";

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -51,6 +51,7 @@ export type {
 } from "./git.js";
 
 export {
+  getPullRequestForBranch,
   getPullRequestForCurrentBranch,
   parseGitHostPullRequest,
   type GitHostPullRequestLookup,

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -10,8 +10,8 @@ import type {
 import os from "node:os";
 import path from "node:path";
 import {
-  getPullRequestForBranch,
-  runPullRequestActionForBranch,
+  getPullRequestForCurrentBranch,
+  runPullRequestActionForCurrentBranch,
   type GitHostPullRequestAction,
   type GitHostPullRequestLookup,
 } from "./git-host.js";
@@ -688,7 +688,7 @@ export class Workspace {
    * Raw `gh` pull request lookup for the workspace's current branch. A
    * detached HEAD has no branch and therefore no PR ("none"); lookup failures
    * surface as "unavailable". Never throws — see
-   * {@link getPullRequestForBranch}.
+   * {@link getPullRequestForCurrentBranch}.
    */
   async getPullRequest(): Promise<GitHostPullRequestLookup> {
     // A vanished workspace (deleted worktree dir) means the lookup cannot
@@ -704,7 +704,7 @@ export class Workspace {
     if (!branch) {
       return { outcome: "none" };
     }
-    return getPullRequestForBranch({ cwd: this.path, branch });
+    return getPullRequestForCurrentBranch({ cwd: this.path });
   }
 
   async runPullRequestAction(
@@ -717,7 +717,7 @@ export class Workspace {
         "Cannot update pull request from a detached workspace",
       );
     }
-    return runPullRequestActionForBranch({ cwd: this.path, branch, action });
+    return runPullRequestActionForCurrentBranch({ cwd: this.path, action });
   }
 
   async getStatus(options: StatusOptions = {}): Promise<WorkspaceStatus> {

--- a/packages/host-workspace/test/git-host.test.ts
+++ b/packages/host-workspace/test/git-host.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  getPullRequestForBranch,
+  getPullRequestForCurrentBranch,
   parseGitHostPullRequest,
-  runPullRequestActionForBranch,
+  runPullRequestActionForCurrentBranch,
   type GitHostPullRequestAction,
 } from "../src/git-host.js";
 
@@ -179,7 +179,7 @@ describe("parseGitHostPullRequest", () => {
   });
 });
 
-describe("runPullRequestActionForBranch", () => {
+describe("runPullRequestActionForCurrentBranch", () => {
   function mockGhSuccess(): void {
     execFileMock.mockImplementation(
       (
@@ -194,56 +194,46 @@ describe("runPullRequestActionForBranch", () => {
   }
 
   it.each([
-    [
-      "ready",
-      { operation: "ready" },
-      ["pr", "ready", "--", "bb/pr-actions"],
-    ],
-    [
-      "draft",
-      { operation: "draft" },
-      ["pr", "ready", "--undo", "--", "bb/pr-actions"],
-    ],
+    ["ready", { operation: "ready" }, ["pr", "ready"]],
+    ["draft", { operation: "draft" }, ["pr", "ready", "--undo"]],
     [
       "merge",
       { operation: "merge", method: "merge" },
-      ["pr", "merge", "--merge", "--", "bb/pr-actions"],
+      ["pr", "merge", "--merge"],
     ],
     [
       "squash",
       { operation: "merge", method: "squash" },
-      ["pr", "merge", "--squash", "--", "bb/pr-actions"],
+      ["pr", "merge", "--squash"],
     ],
     [
       "rebase",
       { operation: "merge", method: "rebase" },
-      ["pr", "merge", "--rebase", "--", "bb/pr-actions"],
+      ["pr", "merge", "--rebase"],
     ],
-  ] satisfies readonly [
-    string,
-    GitHostPullRequestAction,
-    readonly string[],
-  ][])("runs gh pr %s for the branch", async (_label, action, expectedArgs) => {
-    mockGhSuccess();
+  ] satisfies readonly [string, GitHostPullRequestAction, readonly string[]][])(
+    "runs gh pr %s without a target so gh can honor a fork upstream",
+    async (_label, action, expectedArgs) => {
+      mockGhSuccess();
 
-    await runPullRequestActionForBranch({
-      cwd: "/tmp/workspace",
-      branch: "bb/pr-actions",
-      action,
-    });
-
-    expect(execFileMock).toHaveBeenCalledWith(
-      "gh",
-      expectedArgs,
-      expect.objectContaining({
+      await runPullRequestActionForCurrentBranch({
         cwd: "/tmp/workspace",
-        encoding: "utf8",
-        maxBuffer: 16 * 1024 * 1024,
-        timeout: 60_000,
-      }),
-      expect.any(Function),
-    );
-  });
+        action,
+      });
+
+      expect(execFileMock).toHaveBeenCalledWith(
+        "gh",
+        expectedArgs,
+        expect.objectContaining({
+          cwd: "/tmp/workspace",
+          encoding: "utf8",
+          maxBuffer: 16 * 1024 * 1024,
+          timeout: 60_000,
+        }),
+        expect.any(Function),
+      );
+    },
+  );
 
   it("maps a missing gh executable to a workspace error", async () => {
     const error = Object.assign(new Error("spawn gh ENOENT"), {
@@ -261,9 +251,8 @@ describe("runPullRequestActionForBranch", () => {
     );
 
     await expect(
-      runPullRequestActionForBranch({
+      runPullRequestActionForCurrentBranch({
         cwd: "/tmp/workspace",
-        branch: "bb/pr-actions",
         action: { operation: "ready" },
       }),
     ).rejects.toMatchObject({
@@ -273,7 +262,7 @@ describe("runPullRequestActionForBranch", () => {
   });
 });
 
-describe("getPullRequestForBranch", () => {
+describe("getPullRequestForCurrentBranch", () => {
   function mockGhStdout(stdout: string): void {
     execFileMock.mockImplementation(
       (
@@ -300,14 +289,22 @@ describe("getPullRequestForBranch", () => {
     );
   }
 
-  const lookupArgs = { cwd: "/tmp/workspace", branch: "bb/pr-lookup" };
+  const lookupArgs = { cwd: "/tmp/workspace" };
 
-  it("returns found for a well-formed PR", async () => {
+  it("lets gh resolve the current branch through its configured upstream", async () => {
     mockGhStdout(ghJson());
-    await expect(getPullRequestForBranch(lookupArgs)).resolves.toMatchObject({
+    await expect(
+      getPullRequestForCurrentBranch(lookupArgs),
+    ).resolves.toMatchObject({
       outcome: "found",
       pullRequest: { number: 42, state: "OPEN" },
     });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "view", "--json", expect.any(String)],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+      expect.any(Function),
+    );
   });
 
   it("returns none when gh reports the branch has no PR", async () => {
@@ -317,7 +314,7 @@ describe("getPullRequestForBranch", () => {
         stderr: 'no pull requests found for branch "bb/pr-lookup"',
       }),
     );
-    await expect(getPullRequestForBranch(lookupArgs)).resolves.toEqual({
+    await expect(getPullRequestForCurrentBranch(lookupArgs)).resolves.toEqual({
       outcome: "none",
     });
   });
@@ -326,7 +323,7 @@ describe("getPullRequestForBranch", () => {
     mockGhFailure(
       Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }),
     );
-    await expect(getPullRequestForBranch(lookupArgs)).resolves.toEqual({
+    await expect(getPullRequestForCurrentBranch(lookupArgs)).resolves.toEqual({
       outcome: "unavailable",
       message: "GitHub CLI is not available",
     });
@@ -340,7 +337,7 @@ describe("getPullRequestForBranch", () => {
           "gh: To get started with GitHub CLI, please run: gh auth login",
       }),
     );
-    const result = await getPullRequestForBranch(lookupArgs);
+    const result = await getPullRequestForCurrentBranch(lookupArgs);
     expect(result.outcome).toBe("unavailable");
     expect(result).toMatchObject({
       message: expect.stringContaining("gh auth login"),
@@ -351,7 +348,9 @@ describe("getPullRequestForBranch", () => {
     mockGhFailure(
       Object.assign(new Error("timed out"), { killed: true, code: null }),
     );
-    await expect(getPullRequestForBranch(lookupArgs)).resolves.toMatchObject({
+    await expect(
+      getPullRequestForCurrentBranch(lookupArgs),
+    ).resolves.toMatchObject({
       outcome: "unavailable",
       message: expect.stringContaining("timed out"),
     });
@@ -359,7 +358,7 @@ describe("getPullRequestForBranch", () => {
 
   it("returns unavailable for unparseable gh output", async () => {
     mockGhStdout("not json at all");
-    await expect(getPullRequestForBranch(lookupArgs)).resolves.toEqual({
+    await expect(getPullRequestForCurrentBranch(lookupArgs)).resolves.toEqual({
       outcome: "unavailable",
       message: "gh pr view returned unparseable output",
     });

--- a/packages/host-workspace/test/git-host.test.ts
+++ b/packages/host-workspace/test/git-host.test.ts
@@ -1,9 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  getPullRequestForBranch,
   getPullRequestForCurrentBranch,
   parseGitHostPullRequest,
-  runPullRequestActionForBranch,
   runPullRequestActionForCurrentBranch,
   type GitHostPullRequestAction,
 } from "../src/git-host.js";
@@ -234,19 +232,6 @@ describe("runPullRequestActionForCurrentBranch", () => {
         }),
         expect.any(Function),
       );
-
-      await runPullRequestActionForBranch({
-        cwd: "/tmp/workspace",
-        branch: "bb/pr-actions",
-        action,
-      });
-
-      expect(execFileMock).toHaveBeenLastCalledWith(
-        "gh",
-        [...expectedArgs, "--", "bb/pr-actions"],
-        expect.objectContaining({ cwd: "/tmp/workspace" }),
-        expect.any(Function),
-      );
     },
   );
 
@@ -317,32 +302,6 @@ describe("getPullRequestForCurrentBranch", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "gh",
       ["pr", "view", "--json", expect.any(String)],
-      expect.objectContaining({ cwd: "/tmp/workspace" }),
-      expect.any(Function),
-    );
-  });
-
-  it("preserves explicit branch lookup for existing callers", async () => {
-    mockGhStdout(ghJson());
-    await expect(
-      getPullRequestForBranch({
-        cwd: "/tmp/workspace",
-        branch: "bb/pr-lookup",
-      }),
-    ).resolves.toMatchObject({
-      outcome: "found",
-      pullRequest: { number: 42 },
-    });
-    expect(execFileMock).toHaveBeenCalledWith(
-      "gh",
-      [
-        "pr",
-        "view",
-        "--json",
-        expect.any(String),
-        "--",
-        "bb/pr-lookup",
-      ],
       expect.objectContaining({ cwd: "/tmp/workspace" }),
       expect.any(Function),
     );

--- a/packages/host-workspace/test/git-host.test.ts
+++ b/packages/host-workspace/test/git-host.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getPullRequestForBranch,
   getPullRequestForCurrentBranch,
   parseGitHostPullRequest,
+  runPullRequestActionForBranch,
   runPullRequestActionForCurrentBranch,
   type GitHostPullRequestAction,
 } from "../src/git-host.js";
@@ -232,6 +234,19 @@ describe("runPullRequestActionForCurrentBranch", () => {
         }),
         expect.any(Function),
       );
+
+      await runPullRequestActionForBranch({
+        cwd: "/tmp/workspace",
+        branch: "bb/pr-actions",
+        action,
+      });
+
+      expect(execFileMock).toHaveBeenLastCalledWith(
+        "gh",
+        [...expectedArgs, "--", "bb/pr-actions"],
+        expect.objectContaining({ cwd: "/tmp/workspace" }),
+        expect.any(Function),
+      );
     },
   );
 
@@ -302,6 +317,32 @@ describe("getPullRequestForCurrentBranch", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "gh",
       ["pr", "view", "--json", expect.any(String)],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+      expect.any(Function),
+    );
+  });
+
+  it("preserves explicit branch lookup for existing callers", async () => {
+    mockGhStdout(ghJson());
+    await expect(
+      getPullRequestForBranch({
+        cwd: "/tmp/workspace",
+        branch: "bb/pr-lookup",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "found",
+      pullRequest: { number: 42 },
+    });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "gh",
+      [
+        "pr",
+        "view",
+        "--json",
+        expect.any(String),
+        "--",
+        "bb/pr-lookup",
+      ],
       expect.objectContaining({ cwd: "/tmp/workspace" }),
       expect.any(Function),
     );

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -1164,16 +1164,6 @@ describe("Workspace", () => {
 });
 
 describe("getPullRequest", () => {
-  it("reports no pull request for a detached workspace", async () => {
-    const repoPath = await initRepo();
-    await runGit(["checkout", "--detach"], { cwd: repoPath });
-    const workspace = new Workspace(repoPath);
-
-    await expect(workspace.getPullRequest()).resolves.toEqual({
-      outcome: "none",
-    });
-  });
-
   it("reports a vanished workspace path as unavailable, not absent", async () => {
     const missingPath = path.join(
       os.tmpdir(),

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -1164,6 +1164,16 @@ describe("Workspace", () => {
 });
 
 describe("getPullRequest", () => {
+  it("reports no pull request for a detached workspace", async () => {
+    const repoPath = await initRepo();
+    await runGit(["checkout", "--detach"], { cwd: repoPath });
+    const workspace = new Workspace(repoPath);
+
+    await expect(workspace.getPullRequest()).resolves.toEqual({
+      outcome: "none",
+    });
+  });
+
   it("reports a vanished workspace path as unavailable, not absent", async () => {
     const missingPath = path.join(
       os.tmpdir(),


### PR DESCRIPTION
## Summary

- let GitHub CLI resolve pull requests from the checked-out branch and its configured upstream
- fix prompt-banner PR detection for branches tracking contributor forks
- apply the same tracking-aware resolution to ready, draft, and merge actions
- preserve detached-head and lookup-failure behavior

## Reproduction

PR #1076 checked out a branch that tracked Diffuzmetall/bb. Passing its bare branch name to gh pr view searched the base repository and returned no pull request. Running gh pr view from the worktree without a positional target followed the fork upstream and found the PR.

## Validation

- 185 host-workspace tests passed
- host-workspace and host-daemon typechecks passed
- verified the current-branch helper resolves same-repository and fork-backed pull requests and still reports no PR for main

## Commands

- pnpm exec turbo run test --filter=@bb/host-workspace --force
- pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-daemon