### PR TITLE
Fix duplicate React in Ladle workspace stories

### DIFF
--- a/apps/app/.ladle/vite.config.ts
+++ b/apps/app/.ladle/vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
   },
   resolve: {
     conditions: ["source"],
+    // Stories can live in linked workspace packages outside apps/app. Always
+    // resolve their React imports through Ladle's copy so the renderer and
+    // story hooks cannot end up on different module instances after Vite's
+    // dependency optimizer refreshes.
+    dedupe: ["react", "react-dom"],
     alias: {
       "@": path.resolve(__dirname, "../src"),
     },


### PR DESCRIPTION
## Summary

- deduplicate React and React DOM in the Ladle Vite resolver
- keep linked workspace stories on the same React module instance as the Ladle renderer
- prevent invalid hook calls when Vite refreshes its optimized dependency graph

## Verification

- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force (321 files, 2,402 tests)
- pnpm exec turbo run lint --filter=@bb/app (passes with existing warnings)
- confirmed the affected story, StoryRow, and renderer resolve through one optimized React graph