### PR TITLE
Fix Codex project skill discovery

### DIFF
--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -870,6 +870,75 @@ describe("discoverProviderCommands (codex)", () => {
     });
   });
 
+  it("discovers .agents skills from the repository root through the cwd", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const serviceRoot = path.join(fixture.cwd, "services");
+    const cwd = path.join(serviceRoot, "api");
+    await mkdir(path.join(fixture.cwd, ".git"), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeFileEnsuringDir(
+      path.join(
+        fixture.cwd,
+        ".agents",
+        "skills",
+        "repository-skill",
+        "SKILL.md",
+      ),
+      "---\nname: repository-skill\ndescription: Repository skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(serviceRoot, ".agents", "skills", "service-skill", "SKILL.md"),
+      "---\nname: service-skill\ndescription: Service skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(cwd, ".agents", "skills", "cwd-skill", "SKILL.md"),
+      "---\nname: cwd-skill\ndescription: Cwd skill\n---\n",
+    );
+
+    const roots = await resolveProviderCommandScanRoots({
+      providerId: "codex",
+      cwd,
+      homeDir: fixture.homeDir,
+      codexHome: fixture.codexHome,
+    });
+    const agentsRootPaths = roots
+      .filter(
+        (root) =>
+          root.shape === "skill" &&
+          root.rootPath.includes(`${path.sep}.agents${path.sep}`),
+      )
+      .map((root) => ("rootPath" in root ? root.rootPath : null));
+    expect(agentsRootPaths).toEqual([
+      path.join(fixture.cwd, ".agents", "skills"),
+      path.join(serviceRoot, ".agents", "skills"),
+      path.join(cwd, ".agents", "skills"),
+    ]);
+
+    const commands = await discoverCodex(fixture, cwd);
+    expect(byName(commands, "repository-skill")?.origin).toBe("project");
+    expect(byName(commands, "service-skill")?.origin).toBe("project");
+    expect(byName(commands, "cwd-skill")?.origin).toBe("project");
+  });
+
+  it("does not search .agents skills above a cwd without a repository marker", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const cwd = path.join(fixture.cwd, "standalone");
+    await mkdir(cwd, { recursive: true });
+    await writeFileEnsuringDir(
+      path.join(fixture.cwd, ".agents", "skills", "parent-skill", "SKILL.md"),
+      "---\nname: parent-skill\ndescription: Parent skill\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(cwd, ".agents", "skills", "cwd-skill", "SKILL.md"),
+      "---\nname: cwd-skill\ndescription: Cwd skill\n---\n",
+    );
+
+    const commands = await discoverCodex(fixture, cwd);
+
+    expect(byName(commands, "parent-skill")).toBeUndefined();
+    expect(byName(commands, "cwd-skill")?.origin).toBe("project");
+  });
+
   it("follows user-origin symlinked skill directories and skill files", async () => {
     const fixture = await makeWorkspaceFixture();
     const skillsRoot = path.join(fixture.codexHome, "skills");
@@ -1054,6 +1123,10 @@ describe("discoverProviderCommands (codex)", () => {
     await writeFileEnsuringDir(
       path.join(fixture.cwd, ".codex", "skills", "proj", "SKILL.md"),
       "---\nname: proj\ndescription: project\n---\n",
+    );
+    await writeFileEnsuringDir(
+      path.join(fixture.cwd, ".agents", "skills", "agents", "SKILL.md"),
+      "---\nname: agents\ndescription: agents project\n---\n",
     );
     await writeFileEnsuringDir(
       path.join(fixture.codexHome, "skills", "home", "SKILL.md"),

--- a/apps/host-daemon/src/command-discovery.ts
+++ b/apps/host-daemon/src/command-discovery.ts
@@ -48,6 +48,8 @@ interface CommandScanRootBase {
   namePrefix: string;
   source: HostCommandSource;
   origin: HostCommandOrigin;
+  /** Stable root identity for native skill roots that share one root kind. */
+  skillIdentitySeed?: string;
 }
 
 export interface CommandScanDirectoryRoot extends CommandScanRootBase {

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -115,6 +115,7 @@ interface ResolvePluginSkillRootShapeArgs {
 const CODEX_PLUGIN_DIR_NAME = ".codex-plugin";
 const CODEX_PLUGIN_MANIFEST_FILE_NAME = "plugin.json";
 const CODEX_CONFIG_FILE_NAME = "config.toml";
+const AGENTS_DIR_NAME = ".agents";
 const CLAUDE_DIR_NAME = ".claude";
 const CLAUDE_PLUGIN_DIR_NAME = ".claude-plugin";
 const CLAUDE_PLUGIN_MANIFEST_FILE_NAME = "plugin.json";
@@ -1032,6 +1033,9 @@ export async function resolveProviderCommandScanRoots(
 ): Promise<CommandScanRoot[]> {
   const roots = resolveCommandScanRoots(resolution);
   if (resolution.providerId === "codex") {
+    if (resolution.cwd !== null) {
+      roots.push(...(await resolveCodexProjectSkillScanRoots(resolution.cwd)));
+    }
     roots.push(
       ...(await resolveCodexPluginCommandScanRoots({
         codexHome: resolution.codexHome,
@@ -1049,6 +1053,47 @@ export async function resolveProviderCommandScanRoots(
     })),
   );
   return roots;
+}
+
+async function hasProjectRootMarker(directoryPath: string): Promise<boolean> {
+  try {
+    await fs.lstat(path.join(directoryPath, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Match Codex's default repository skill search. The nearest ancestor with a
+ * `.git` entry is the repository root. Without that marker, Codex searches the
+ * cwd only. Roots run from the repository root to the cwd.
+ */
+async function resolveCodexProjectSkillScanRoots(
+  cwd: string,
+): Promise<CommandScanRoot[]> {
+  const directories: string[] = [];
+  let directoryPath = cwd;
+  while (true) {
+    directories.push(directoryPath);
+    if (await hasProjectRootMarker(directoryPath)) {
+      break;
+    }
+    const parentPath = path.dirname(directoryPath);
+    if (parentPath === directoryPath) {
+      directories.splice(1);
+      break;
+    }
+    directoryPath = parentPath;
+  }
+
+  return directories.reverse().map((projectDirectoryPath) => ({
+    rootPath: path.join(projectDirectoryPath, AGENTS_DIR_NAME, "skills"),
+    shape: "skill",
+    namePrefix: "",
+    source: "skill",
+    origin: "project",
+  }));
 }
 
 /**

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -1087,12 +1087,17 @@ async function resolveCodexProjectSkillScanRoots(
     directoryPath = parentPath;
   }
 
+  const projectRootPath = directories.at(-1) ?? cwd;
   return directories.reverse().map((projectDirectoryPath) => ({
     rootPath: path.join(projectDirectoryPath, AGENTS_DIR_NAME, "skills"),
     shape: "skill",
     namePrefix: "",
     source: "skill",
     origin: "project",
+    skillIdentitySeed: `codex:provider-project:.agents:${path
+      .relative(projectRootPath, projectDirectoryPath)
+      .split(path.sep)
+      .join("/")}`,
   }));
 }
 

--- a/apps/host-daemon/src/command-handlers/list-skills.test.ts
+++ b/apps/host-daemon/src/command-handlers/list-skills.test.ts
@@ -238,6 +238,28 @@ describe("resolveSkillScanRoots + discoverSkills (codex)", () => {
     expect(byName(skills, "nested-skill")?.rootKind).toBe("provider-project");
   });
 
+  it("gives same-named .agents skills in different roots distinct IDs", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const cwd = path.join(fixture.cwd, "packages", "app");
+    await mkdir(path.join(fixture.cwd, ".git"), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeSkill(
+      path.join(fixture.cwd, ".agents", "skills", "review", "SKILL.md"),
+      "review",
+    );
+    await writeSkill(
+      path.join(cwd, ".agents", "skills", "review", "SKILL.md"),
+      "review",
+    );
+
+    const skills = (await listSkills(fixture, "codex", cwd)).filter(
+      (skill) => skill.name === "review",
+    );
+
+    expect(skills).toHaveLength(2);
+    expect(new Set(skills.map((skill) => skill.id)).size).toBe(2);
+  });
+
   it("marks followed user skill directory and SKILL.md symlinks as linked", async () => {
     const fixture = await makeWorkspaceFixture();
     const skillsRoot = path.join(fixture.codexHome, "skills");

--- a/apps/host-daemon/src/command-handlers/list-skills.test.ts
+++ b/apps/host-daemon/src/command-handlers/list-skills.test.ts
@@ -210,6 +210,34 @@ describe("resolveSkillScanRoots + discoverSkills (codex)", () => {
     expect(byName(skills, "proj-bb")?.rootKind).toBe("bb-project");
   });
 
+  it("classifies repository and nested .agents roots as codex project skills", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const cwd = path.join(fixture.cwd, "packages", "app");
+    await mkdir(path.join(fixture.cwd, ".git"), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeSkill(
+      path.join(
+        fixture.cwd,
+        ".agents",
+        "skills",
+        "repository-skill",
+        "SKILL.md",
+      ),
+      "repository-skill",
+    );
+    await writeSkill(
+      path.join(cwd, ".agents", "skills", "nested-skill", "SKILL.md"),
+      "nested-skill",
+    );
+
+    const skills = await listSkills(fixture, "codex", cwd);
+
+    expect(byName(skills, "repository-skill")?.rootKind).toBe(
+      "provider-project",
+    );
+    expect(byName(skills, "nested-skill")?.rootKind).toBe("provider-project");
+  });
+
   it("marks followed user skill directory and SKILL.md symlinks as linked", async () => {
     const fixture = await makeWorkspaceFixture();
     const skillsRoot = path.join(fixture.codexHome, "skills");

--- a/apps/host-daemon/src/command-handlers/list-skills.ts
+++ b/apps/host-daemon/src/command-handlers/list-skills.ts
@@ -96,7 +96,11 @@ function classifySkillRoot(
   if (
     resolution.cwd !== null &&
     (rootPath === path.join(resolution.cwd, ".claude", "skills") ||
-      rootPath === path.join(resolution.cwd, ".codex", "skills"))
+      rootPath === path.join(resolution.cwd, ".codex", "skills") ||
+      (resolution.providerId === "codex" &&
+        root.origin === "project" &&
+        path.basename(rootPath) === "skills" &&
+        path.basename(path.dirname(rootPath)) === ".agents"))
   ) {
     return {
       identitySeed: `${resolution.providerId}:provider-project`,

--- a/apps/host-daemon/src/command-handlers/list-skills.ts
+++ b/apps/host-daemon/src/command-handlers/list-skills.ts
@@ -103,7 +103,8 @@ function classifySkillRoot(
         path.basename(path.dirname(rootPath)) === ".agents"))
   ) {
     return {
-      identitySeed: `${resolution.providerId}:provider-project`,
+      identitySeed:
+        root.skillIdentitySeed ?? `${resolution.providerId}:provider-project`,
       rootKind: "provider-project",
     };
   }

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 78 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 79 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1038,11 +1038,10 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 78 preserves version 77's workspace-aware Pi model discovery and
-  // adds byte-preserving terminal input plus bounded replay metadata. The bump
-  // updates enrolled daemons before they receive the new terminal wire contract.
-  it("uses protocol version 78 for reliable terminal transport", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(78);
+  // Version 79 adds canonical Codex repository skills to command and skill RPC
+  // results. The bump updates enrolled daemons before the server requests them.
+  it("uses protocol version 79 for canonical Codex repository skills", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(79);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
Closes #1105.

## Summary

- Scan `.agents/skills` from the Git repository root through the current directory.
- Keep the legacy `.codex/skills` path.
- Classify canonical roots as Codex project skills.
- Increase the host daemon protocol version to 79.

## Tests

- `pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/command-discovery.test.ts src/command-handlers/list-skills.test.ts`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract -- --run test/contract.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/host-daemon-contract`
- Prettier check
- `git diff --check`