### PR TITLE
Show configured provider logos in t3sidebar

### DIFF
--- a/examples/plugins/t3sidebar/README.md
+++ b/examples/plugins/t3sidebar/README.md
@@ -30,7 +30,8 @@ Three shelves:
 - **Inbox** — three-line cards: project and one fixed-width status slot on the
   first line; title on the second; then branch (or the machine, when a thread
   has no worktree), activity counts, the pull-request number, and the agent
-  glyph. Pinned threads sit above.
+  glyph. Configured provider logos are used when available, with built-in
+  Codex/Claude glyphs and a neutral dot as fallbacks. Pinned threads sit above.
 
   One slot, one marker, one width, so the whole column lines up. The slot
   shows the status glyph while a thread has something to say, and the age

--- a/examples/plugins/t3sidebar/src/ProviderGlyph.tsx
+++ b/examples/plugins/t3sidebar/src/ProviderGlyph.tsx
@@ -1,22 +1,47 @@
+import { useState } from "react";
 import { cn } from "./lib/utils";
 import { TRAILING_GLYPH_BOX_CLASS } from "./StatusSlot";
+
+export interface ProviderGlyphInfo {
+  displayName: string;
+  logoUrl: string | null;
+}
 
 /**
  * The agent a thread runs on, drawn by this plugin.
  *
  * Always rendered, so the card's third line has a fixed right edge even when
- * a thread has no branch. `providerId` is a free-form id, so an unknown
- * provider gets a neutral dot rather than nothing.
+ * a thread has no branch. A configured provider logo takes precedence over
+ * the built-in glyphs. `providerId` is a free-form id, so an unknown provider
+ * without a logo gets a neutral dot rather than nothing.
  */
 export function ProviderGlyph({
   providerId,
+  provider,
   className,
 }: {
   providerId: string;
+  provider?: ProviderGlyphInfo;
   className?: string;
 }) {
+  const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null);
   const shared = "size-3 text-muted-foreground/70";
   const box = cn(TRAILING_GLYPH_BOX_CLASS, className);
+  const logoUrl = provider?.logoUrl ?? null;
+  const displayName = provider?.displayName ?? providerId;
+
+  if (logoUrl !== null && logoUrl !== failedLogoUrl) {
+    return (
+      <span role="img" aria-label={displayName} className={box}>
+        <img
+          src={logoUrl}
+          alt=""
+          className="size-3 object-contain"
+          onError={() => setFailedLogoUrl(logoUrl)}
+        />
+      </span>
+    );
+  }
 
   if (providerId === "claude-code") {
     return (
@@ -52,7 +77,7 @@ export function ProviderGlyph({
   }
 
   return (
-    <span role="img" aria-label={providerId} className={box}>
+    <span role="img" aria-label={displayName} className={box}>
       <span className="size-2 rounded-full bg-muted-foreground/50" />
     </span>
   );

--- a/examples/plugins/t3sidebar/src/ThreadCard.tsx
+++ b/examples/plugins/t3sidebar/src/ThreadCard.tsx
@@ -7,7 +7,7 @@ import {
 import { Icon, type IconName } from "./components/Icon";
 import { cn } from "./lib/utils";
 import { RowContextMenu } from "./RowContextMenu";
-import { ProviderGlyph } from "./ProviderGlyph";
+import { ProviderGlyph, type ProviderGlyphInfo } from "./ProviderGlyph";
 import { STATUS_SLOT_CLASS, StatusOrTime } from "./StatusSlot";
 import { threadDisplayTitle } from "./inbox";
 import { resolveSnoozePresets } from "./lifecycle";
@@ -23,6 +23,7 @@ import { resolveSnoozePresets } from "./lifecycle";
  */
 export function ThreadCard({
   thread,
+  provider,
   projectName,
   isActive,
   canPark,
@@ -32,6 +33,7 @@ export function ThreadCard({
   now,
 }: {
   thread: PluginSidebarThread;
+  provider?: ProviderGlyphInfo;
   projectName: string | null;
   isActive: boolean;
   /** False while the thread is working or blocked on the user. */
@@ -168,7 +170,7 @@ export function ThreadCard({
               </a>
             ) : null}
             {/* Always drawn, so the line has a fixed right edge. */}
-            <ProviderGlyph providerId={thread.providerId} />
+            <ProviderGlyph providerId={thread.providerId} provider={provider} />
           </div>
         </div>
       </li>

--- a/examples/plugins/t3sidebar/src/ThreadInbox.test.tsx
+++ b/examples/plugins/t3sidebar/src/ThreadInbox.test.tsx
@@ -63,12 +63,20 @@ const listProps = {
 function render(
   threads: PluginSidebarThread[],
   projects = [{ id: "proj_1", name: "bb", isPersonal: false }],
+  providers: Array<{
+    id: string;
+    displayName: string;
+    logoUrl: string | null;
+  }> = [],
 ) {
   return renderSlot(inbox, listProps, {
     sidebarThreads: { status: "ready", threads, projects },
     // The lifecycle store is the plugin's own backend; an empty one means
     // every thread is active, which is what these list tests are about.
-    rpc: { listLifecycle: () => ({ rows: [] }) },
+    rpc: {
+      listLifecycle: () => ({ rows: [] }),
+      listProviders: () => ({ providers }),
+    },
   });
 }
 
@@ -363,6 +371,20 @@ describe("row context menu", () => {
 });
 
 describe("card metadata", () => {
+  it("uses a configured provider logo", async () => {
+    render([thread({ id: "thr_p", providerId: "acp-amp" })], undefined, [
+      {
+        id: "acp-amp",
+        displayName: "Amp",
+        logoUrl: "/api/v1/system/providers/acp-amp/logo",
+      },
+    ]);
+    const glyph = await screen.findByRole("img", { name: "Amp" });
+    expect(glyph.querySelector("img")?.getAttribute("src")).toBe(
+      "/api/v1/system/providers/acp-amp/logo",
+    );
+  });
+
   it("always shows the provider glyph, even without a branch", async () => {
     render([thread({ id: "thr_p", providerId: "claude-code" })]);
     expect(await screen.findByLabelText("Claude Code")).toBeDefined();

--- a/examples/plugins/t3sidebar/src/ThreadInbox.tsx
+++ b/examples/plugins/t3sidebar/src/ThreadInbox.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   experimental_useSidebarThreadActions as useSidebarThreadActions,
   experimental_useSidebarThreads as useSidebarThreads,
+  useRpc,
   type PluginSidebarThread,
   type PluginThreadListProps,
 } from "@bb/plugin-sdk/app";
@@ -15,7 +16,9 @@ import {
   SelectValue,
 } from "./components/Select";
 import { ThreadCard } from "./ThreadCard";
+import type { ProviderGlyphInfo } from "./ProviderGlyph";
 import { SlimRow } from "./SlimRow";
+import type { t3sidebarRpcContract } from "./server";
 import { useLifecycle } from "./useLifecycle";
 import { TRAILING_GLYPH_BOX_CLASS } from "./StatusSlot";
 import {
@@ -43,8 +46,36 @@ export function ThreadInbox({
 }: PluginThreadListProps) {
   const { status, threads, projects } = useSidebarThreads();
   const actions = useSidebarThreadActions();
+  const rpc = useRpc<typeof t3sidebarRpcContract>();
   const lifecycle = useLifecycle(threads);
+  const [providerInfoById, setProviderInfoById] = useState<
+    ReadonlyMap<string, ProviderGlyphInfo>
+  >(() => new Map());
   const [scope, setScope] = useState<string>(ALL_PROJECTS);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadProviderInfo = async () => {
+      try {
+        const result = await rpc.call("listProviders", {});
+        if (!cancelled) {
+          setProviderInfoById(
+            new Map(
+              result.providers.map((provider) => [provider.id, provider]),
+            ),
+          );
+        }
+      } catch {
+        // Provider metadata only improves the glyph. Keep the built-in and
+        // neutral fallbacks if the host cannot supply it.
+      }
+    };
+    void loadProviderInfo();
+    return () => {
+      cancelled = true;
+    };
+  }, [rpc]);
+
   // One clock for every card in a render, quantized to the minute so the
   // labels do not disagree and do not churn on unrelated re-renders.
   const [nowMinute, setNowMinute] = useState(() =>
@@ -159,6 +190,7 @@ export function ThreadInbox({
                   <ThreadCard
                     key={thread.id}
                     thread={thread}
+                    provider={providerInfoById.get(thread.providerId)}
                     projectName={projectNameById.get(thread.projectId) ?? null}
                     isActive={thread.id === activeThreadId}
                     canPark={lifecycle.canPark(thread)}
@@ -176,6 +208,7 @@ export function ThreadInbox({
                   <ThreadCard
                     key={thread.id}
                     thread={thread}
+                    provider={providerInfoById.get(thread.providerId)}
                     projectName={projectNameById.get(thread.projectId) ?? null}
                     isActive={thread.id === activeThreadId}
                     canPark={lifecycle.canPark(thread)}

--- a/examples/plugins/t3sidebar/src/server.ts
+++ b/examples/plugins/t3sidebar/src/server.ts
@@ -33,6 +33,18 @@ interface LifecycleDbRow {
 const threadIdSchema = z.object({ threadId: z.string().trim().min(1) });
 
 export const t3sidebarRpcContract = defineRpcContract({
+  listProviders: {
+    input: z.object({}),
+    output: z.object({
+      providers: z.array(
+        z.object({
+          id: z.string(),
+          displayName: z.string(),
+          logoUrl: z.string().nullable(),
+        }),
+      ),
+    }),
+  },
   listLifecycle: {
     input: z.object({}),
     output: z.object({
@@ -102,6 +114,16 @@ export default function plugin(bb: BbPluginApi) {
   };
 
   bb.rpc.register(t3sidebarRpcContract, {
+    async listProviders() {
+      const providers = await bb.sdk.providers.list();
+      return {
+        providers: providers.map(({ id, displayName, logoUrl }) => ({
+          id,
+          displayName,
+          logoUrl,
+        })),
+      };
+    },
     async listLifecycle() {
       return { rows: readAll() };
     },


### PR DESCRIPTION
## Summary

- load BB's provider metadata once through the t3sidebar backend
- render a provider's configured logo before the built-in Codex/Claude glyphs
- keep the neutral fallback when provider metadata or logo loading is unavailable
- cover the Amp ACP provider logo path in the sidebar test

## Why

Custom ACP providers already expose their configured `logoUrl`, but t3sidebar only recognized Codex and Claude. That left providers such as Amp as a neutral dot even though BB had their brand mark available.

## Validation

- `pnpm exec turbo run typecheck --filter=bb-plugin-t3sidebar`
- `pnpm exec turbo run test --filter=bb-plugin-t3sidebar --force` (81 tests)
- `pnpm exec prettier --check examples/plugins/t3sidebar/src/server.ts examples/plugins/t3sidebar/src/ProviderGlyph.tsx examples/plugins/t3sidebar/src/ThreadCard.tsx examples/plugins/t3sidebar/src/ThreadInbox.tsx examples/plugins/t3sidebar/src/ThreadInbox.test.tsx examples/plugins/t3sidebar/README.md`
- `pnpm run bb -- plugin build examples/plugins/t3sidebar`