### PR TITLE
Preserve background tasks across daemon reconnects

### DIFF
--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -87,10 +87,19 @@ export async function handleHostSessionOpened(
     args.previousSession &&
     args.previousSession.id !== args.openedSession.id
   ) {
+    const sameDaemonInstance =
+      args.previousSession.instanceId === args.openedSession.instanceId;
     deps.hub.cancelPendingDaemonDisconnect(args.previousSession.id);
 
     if (args.previousSession.status === "active") {
-      deps.hub.closeDaemonSession(args.previousSession.id, "replaced");
+      if (sameDaemonInstance) {
+        // A reconnect opens the replacement session before its new WebSocket.
+        // Close only the superseded socket: sending session-close would make
+        // this same daemon shut down every resident provider runtime.
+        deps.hub.closeDaemonSessionSocket(args.previousSession.id, "replaced");
+      } else {
+        deps.hub.closeDaemonSession(args.previousSession.id, "replaced");
+      }
       deps.terminalSessions.handleDaemonSessionClosed({
         sessionId: args.previousSession.id,
       });
@@ -98,13 +107,12 @@ export async function handleHostSessionOpened(
 
     interruptPendingInteractionsForHostThreads(deps, {
       hostId: args.hostId,
-      reason:
-        args.previousSession.instanceId === args.openedSession.instanceId
-          ? DAEMON_DISCONNECTED_PENDING_INTERACTION_REASON
-          : DAEMON_RESTARTED_PENDING_INTERACTION_REASON,
+      reason: sameDaemonInstance
+        ? DAEMON_DISCONNECTED_PENDING_INTERACTION_REASON
+        : DAEMON_RESTARTED_PENDING_INTERACTION_REASON,
     });
 
-    if (args.previousSession.instanceId !== args.openedSession.instanceId) {
+    if (!sameDaemonInstance) {
       interruptActiveThreadsForHost(deps, {
         hostId: args.hostId,
         reason: "host-daemon-restarted",

--- a/apps/server/src/ws/hub.ts
+++ b/apps/server/src/ws/hub.ts
@@ -537,12 +537,22 @@ export class NotificationHub implements DbNotifier {
     sessionId: string,
     reason: HostDaemonSessionCloseReason,
   ): void {
+    const entry = this.daemonSessions.get(sessionId);
+    if (entry) {
+      entry.socket.send(JSON.stringify({ type: "session-close", reason }));
+    }
+    this.closeDaemonSessionSocket(sessionId, reason);
+  }
+
+  closeDaemonSessionSocket(
+    sessionId: string,
+    reason: HostDaemonSessionCloseReason,
+  ): void {
     this.cancelPendingDaemonDisconnect(sessionId);
     const entry = this.daemonSessions.get(sessionId);
     if (!entry) {
       return;
     }
-    entry.socket.send(JSON.stringify({ type: "session-close", reason }));
     entry.socket.close(1000, reason);
     this.unregisterDaemon(sessionId);
   }

--- a/apps/server/test/internal/background-task-reconciliation.test.ts
+++ b/apps/server/test/internal/background-task-reconciliation.test.ts
@@ -18,6 +18,7 @@ import {
   seedThreadFixture,
   seedTurnStarted,
 } from "../helpers/seed.js";
+import { createMockHubSocket } from "../helpers/mock-hub-socket.js";
 import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 
 function backgroundTaskItemData(args: {
@@ -364,6 +365,78 @@ describe("background-task lifecycle reconciliation triggers", () => {
 
       expect(response.status).toBe(201);
       expect(listSettledBackgroundTaskItems(harness, thread.id)).toEqual([]);
+    });
+  });
+
+  it("does not tell a live daemon to shut down when that same instance reconnects", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session, thread } = seedOpenBackgroundTaskThread(harness);
+      const previousSocket = createMockHubSocket();
+      harness.deps.hub.registerDaemon(session.id, host.id, previousSocket);
+
+      const response = await harness.app.request("/internal/session/open", {
+        method: "POST",
+        headers: internalAuthHeaders(harness, {
+          hostId: host.id,
+          hostType: host.type,
+        }),
+        body: JSON.stringify({
+          hostId: host.id,
+          instanceId: session.instanceId,
+          hostName: host.name,
+          hostType: host.type,
+          hasMachineCredential: false,
+          platform: "darwin",
+          dataDir: "/tmp/host-daemon-task-live-same-instance",
+          protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+          activeThreads: [],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(previousSocket.messages).toEqual([]);
+      expect(previousSocket.closed).toEqual([
+        { code: 1000, reason: "replaced" },
+      ]);
+      expect(listSettledBackgroundTaskItems(harness, thread.id)).toEqual([]);
+    });
+  });
+
+  it("still tells a superseded daemon instance to shut down", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session, thread } = seedOpenBackgroundTaskThread(harness);
+      const previousSocket = createMockHubSocket();
+      harness.deps.hub.registerDaemon(session.id, host.id, previousSocket);
+
+      const response = await harness.app.request("/internal/session/open", {
+        method: "POST",
+        headers: internalAuthHeaders(harness, {
+          hostId: host.id,
+          hostType: host.type,
+        }),
+        body: JSON.stringify({
+          hostId: host.id,
+          instanceId: "instance-restarted",
+          hostName: host.name,
+          hostType: host.type,
+          hasMachineCredential: false,
+          platform: "darwin",
+          dataDir: "/tmp/host-daemon-task-live-restarted",
+          protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+          activeThreads: [],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(previousSocket.messages).toEqual([
+        JSON.stringify({ type: "session-close", reason: "replaced" }),
+      ]);
+      expect(previousSocket.closed).toEqual([
+        { code: 1000, reason: "replaced" },
+      ]);
+      expect(listSettledBackgroundTaskItems(harness, thread.id)).toEqual([
+        { status: "interrupted", taskStatus: "stopped" },
+      ]);
     });
   });
 

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 80 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 81 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1038,12 +1038,10 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 80 adds structured provider account rate-limit events in runtime
-  // session messages on top of version 79's canonical Codex repository skills.
-  // The bump updates enrolled daemons before they receive the combined wire
-  // contract.
-  it("uses protocol version 80 for provider rate-limit events", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(80);
+  // Version 81 makes same-instance daemon session replacement reconnect-safe
+  // so enrolled daemons update before receiving the revised server behavior.
+  it("uses protocol version 81 for reconnect-safe session replacement", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(81);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {

--- a/tests/integration/real/provider-background-survival.test.ts
+++ b/tests/integration/real/provider-background-survival.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createRealThread,
+  pathExists,
+  REAL_POLL_INTERVAL_MS,
+  sendAndWaitForIdle,
+  TEST_TIMEOUT_MS,
+} from "./provider-smoke-harness.js";
+
+const PROVIDER_ID = "claude-code";
+
+async function waitForCondition(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt <= timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, REAL_POLL_INTERVAL_MS));
+  }
+  throw new Error(message);
+}
+
+describe("real Claude background process integration", () => {
+  it(
+    "survives a same-daemon session reconnect and follow-up",
+    async () => {
+      const { environment, harness, thread } = await createRealThread({
+        providerId: PROVIDER_ID,
+        workspace: { path: null, type: "unmanaged" },
+      });
+
+      try {
+        if (!environment.path) {
+          throw new Error("Expected an unmanaged workspace path");
+        }
+        const markerPath = path.join(
+          environment.path,
+          "background-survived-reconnect.txt",
+        );
+
+        await sendAndWaitForIdle({
+          harness,
+          providerId: PROVIDER_ID,
+          threadId: thread.id,
+          text: `Use the Bash tool exactly once to execute this exact command: sleep 40; printf survived > ${JSON.stringify(markerPath)}. Set Bash's run_in_background parameter to true. As soon as Bash accepts it, reply exactly STARTED. Do not poll it, wait for it, or use another tool.`,
+        });
+        expect(await pathExists(markerPath)).toBe(false);
+
+        // Cross the host daemon's 10-second shell-environment refresh TTL so
+        // the follow-up exercises the same idle-gap maintenance path as the
+        // report, while the background command remains live.
+        await new Promise((resolve) => setTimeout(resolve, 12_000));
+        expect(await pathExists(markerPath)).toBe(false);
+
+        const runtimeBeforeReconnect = harness.daemonApp.runtimeManager.get(
+          environment.id,
+        )?.runtime;
+        const previousSessionId = harness.daemonApp.connection.sessionId;
+        if (!runtimeBeforeReconnect || !previousSessionId) {
+          throw new Error("Expected a live runtime and daemon session");
+        }
+
+        harness.daemonApp.connection.handleSessionInvalidated({
+          code: "inactive_session",
+          observedSessionId: previousSessionId,
+          source: "postEvents",
+        });
+        await waitForCondition(
+          () => {
+            const sessionId = harness.daemonApp.connection.sessionId;
+            return sessionId !== null && sessionId !== previousSessionId;
+          },
+          10_000,
+          "Daemon did not establish a replacement session",
+        );
+
+        expect(
+          harness.daemonApp.runtimeManager.get(environment.id)?.runtime,
+        ).toBe(runtimeBeforeReconnect);
+
+        await sendAndWaitForIdle({
+          harness,
+          providerId: PROVIDER_ID,
+          threadId: thread.id,
+          text: "Reply exactly FOLLOWUP. Do not use any tools.",
+        });
+        await waitForCondition(
+          () => pathExists(markerPath),
+          45_000,
+          "Background command did not write its marker after reconnect",
+        );
+
+        expect(await fs.readFile(markerPath, "utf8")).toBe("survived");
+      } finally {
+        await harness.cleanup();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/tests/integration/real/provider-background-survival.test.ts
+++ b/tests/integration/real/provider-background-survival.test.ts
@@ -1,15 +1,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { scaleTimeoutMs } from "../helpers/time.js";
 import {
   createRealThread,
   pathExists,
   REAL_POLL_INTERVAL_MS,
   sendAndWaitForIdle,
-  TEST_TIMEOUT_MS,
 } from "./provider-smoke-harness.js";
 
 const PROVIDER_ID = "claude-code";
+const BACKGROUND_SURVIVAL_TEST_TIMEOUT_MS = scaleTimeoutMs(240_000);
 
 async function waitForCondition(
   predicate: () => boolean | Promise<boolean>,
@@ -74,10 +75,15 @@ describe("real Claude background process integration", () => {
         await waitForCondition(
           () => {
             const sessionId = harness.daemonApp.connection.sessionId;
-            return sessionId !== null && sessionId !== previousSessionId;
+            return (
+              sessionId !== null &&
+              sessionId !== previousSessionId &&
+              harness.hub.getDaemonSessionIdForHost(harness.hostId) ===
+                sessionId
+            );
           },
           10_000,
-          "Daemon did not establish a replacement session",
+          "Daemon did not register the replacement session socket",
         );
 
         expect(
@@ -101,6 +107,6 @@ describe("real Claude background process integration", () => {
         await harness.cleanup();
       }
     },
-    TEST_TIMEOUT_MS,
+    BACKGROUND_SURVIVAL_TEST_TIMEOUT_MS,
   );
 });


### PR DESCRIPTION
## Summary

- distinguish a reconnect from a genuinely new host-daemon instance when replacing a server session
- close only the superseded WebSocket for same-instance reconnects, preserving resident provider runtimes and their background processes
- retain the fatal `session-close` and task reconciliation behavior when a different daemon instance takes over
- bump the host-daemon protocol version and add unit plus real-provider regression coverage

## Root cause

Opening a replacement server session always sent `session-close:replaced` to the previous socket. On an ordinary reconnect, that socket belonged to the same live daemon instance. The daemon treated the message as terminal and shut down every environment runtime, which killed background commands before its supervisor restarted it.

The server already has both session instance IDs, so it can tell these cases apart. A same-instance replacement now closes only the stale transport. A different-instance replacement still shuts down the superseded daemon and settles its work.

## Reproduction

I reproduced this with standalone dev servers and the `bb` CLI against both the v0.35.1 tag and this branch:

- v0.35.1: replacing the live session with the same daemon instance immediately killed the background shell and sleep PIDs, recorded the task as stopped/interrupted, and logged `session-close:replaced` daemon shutdown
- patched branch: the daemon reconnected with the same instance ID, the same background PIDs remained alive across a CLI follow-up, and the task completed and wrote its marker normally
- control: an unchanged CLI follow-up without a reconnect preserved the background PIDs, confirming the reported failure is specifically the reconnect path

## Tests

- `@bb/server` lifecycle and hub regression tests: 32 passed
- `@bb/host-daemon-contract` tests: 49 passed
- sanitized install-machine regression suite: 10 passed
- typechecks for `@bb/server`, `@bb/host-daemon-contract`, and `@bb/integration-tests`
- real Claude end-to-end reconnect/background-process regression: passed
- full server suite: 1,357 passed; the one environment-dependent install-script failure passed when rerun with the expected sanitized `PATH`

Closes #1127
