### PR TITLE
Fix app shortcuts and Escape in the chat input

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -112,6 +112,10 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
     new Map<AppCommandContextKey, Set<symbol>>(),
   );
   const sequenceRef = useRef(0);
+  // Key events already offered to the handlers, so a second delivery of the
+  // same event is a no-op. Weak so entries drop with the event.
+  const attemptedEventsRef = useRef(new WeakSet<KeyboardEvent>());
+  const clearShortcutHintHoldRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     if (!showKeyboardHints) return;
@@ -126,6 +130,9 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
       shortcutHintModifierHeldRef.current = false;
       setIsShortcutHintModifierHeld(false);
     };
+    // A widget that dispatches a chord itself stops the event before this
+    // listener sees it, so the dispatcher clears the hint through this ref.
+    clearShortcutHintHoldRef.current = clearModifierHold;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!isShortcutHintModifier(event.key)) {
         if (
@@ -166,6 +173,7 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
     window.addEventListener("blur", handleBlur);
     return () => {
       clearModifierHold();
+      clearShortcutHintHoldRef.current = () => {};
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("blur", handleBlur);
@@ -277,6 +285,11 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
       if (event.defaultPrevented || event.isComposing || event.repeat) {
         return false;
       }
+      // A widget that dispatched first leaves the event alone when every
+      // handler declines, so the same event still reaches the window listener.
+      // Without this, those handlers would run a second time.
+      if (attemptedEventsRef.current.has(event)) return false;
+      attemptedEventsRef.current.add(event);
       const bindings = keybindingsRef.current;
       let context: AppCommandContext | null = null;
       const isMac = isMacKeyboardPlatform(browserPlatform());
@@ -292,6 +305,7 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
         context ??= currentContext(event.target);
         if (!matchesAppCommandContext(binding, context)) continue;
         if (!dispatch(binding.command, event.target)) return false;
+        clearShortcutHintHoldRef.current();
         event.preventDefault();
         event.stopPropagation();
         return true;

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -45,6 +45,7 @@ interface AppCommandHandlerRegistration {
 interface AppCommandProviderValue {
   dispatch: (command: AppCommandId, target: EventTarget | null) => boolean;
   getShortcut: (command: AppCommandId) => AppShortcut | null;
+  handleKeyboardEvent: (event: KeyboardEvent) => boolean;
   registerContext: (
     key: AppCommandContextKey,
     source: symbol,
@@ -266,9 +267,16 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
     [isDesktop, keybindings],
   );
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.isComposing || event.repeat) return;
+  // Shared by the window listener below and by focused widgets that own their
+  // own key handling. A widget that consumes keys before they reach the window
+  // — the prompt editor's rich-text keymap is the one in the app — calls this
+  // first so an app chord still runs the app command instead of the widget's
+  // own binding for the same chord.
+  const handleKeyboardEvent = useCallback(
+    (event: KeyboardEvent): boolean => {
+      if (event.defaultPrevented || event.isComposing || event.repeat) {
+        return false;
+      }
       const bindings = keybindingsRef.current;
       let context: AppCommandContext | null = null;
       const isMac = isMacKeyboardPlatform(browserPlatform());
@@ -283,15 +291,23 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
         if (!matchesAppShortcut(event, binding.shortcut, isMac)) continue;
         context ??= currentContext(event.target);
         if (!matchesAppCommandContext(binding, context)) continue;
-        if (!dispatch(binding.command, event.target)) return;
+        if (!dispatch(binding.command, event.target)) return false;
         event.preventDefault();
         event.stopPropagation();
-        return;
+        return true;
       }
+      return false;
+    },
+    [currentContext, dispatch, isDesktop],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      handleKeyboardEvent(event);
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [currentContext, dispatch, isDesktop]);
+  }, [handleKeyboardEvent]);
 
   useEffect(() => {
     const desktop = getBbDesktopInfo();
@@ -308,10 +324,17 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
     () => ({
       dispatch,
       getShortcut,
+      handleKeyboardEvent,
       registerContext,
       registerHandler,
     }),
-    [dispatch, getShortcut, registerContext, registerHandler],
+    [
+      dispatch,
+      getShortcut,
+      handleKeyboardEvent,
+      registerContext,
+      registerHandler,
+    ],
   );
 
   return (
@@ -366,6 +389,22 @@ export function useIndexedAppCommandHandlers(
       unregister.forEach((dispose) => dispose());
     };
   }, [commands, priority, registerHandler]);
+}
+
+/**
+ * Run app keybindings for a key event a focused widget received before the
+ * event reaches the window listener. Returns true when an app command ran, so
+ * the caller can stop its own handling. The event is then marked handled, and
+ * the window listener skips it.
+ */
+export function useAppCommandKeyDispatch(): (event: KeyboardEvent) => boolean {
+  const handleKeyboardEvent = useContext(
+    AppCommandContextValue,
+  )?.handleKeyboardEvent;
+  return useCallback(
+    (event: KeyboardEvent) => handleKeyboardEvent?.(event) ?? false,
+    [handleKeyboardEvent],
+  );
 }
 
 export function useAppCommandContext(

--- a/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultAppSettings, type AppShortcut } from "@bb/domain";
+import {
+  AppCommandProvider,
+  useAppCommandHandler,
+} from "@/components/commands/AppCommandProvider";
+import {
+  INERT_TYPEAHEAD_COMMAND_CONFIG,
+  PromptBoxInternal,
+} from "./PromptBoxInternal";
+
+const testState = vi.hoisted(() => ({
+  calls: [] as string[],
+  // The sidebar chord under test. Overridden per test to cover both a chord the
+  // editor ignores and a chord the editor's own keymap claims.
+  sidebarShortcut: {
+    key: "\\",
+    mod: true,
+    meta: false,
+    control: false,
+    alt: false,
+    shift: false,
+  } as AppShortcut,
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: {
+      generalSettings: { ...defaultAppSettings },
+      keybindings: [
+        {
+          command: "sidebar.toggle" as const,
+          desktopOnly: false,
+          shortcut: testState.sidebarShortcut,
+          when: { all: ["mainSurface" as const], none: ["modalOpen" as const] },
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@/lib/bb-desktop", () => ({
+  getBbDesktopInfo: () => null,
+}));
+
+function SidebarToggleHandler() {
+  useAppCommandHandler("sidebar.toggle", () => {
+    testState.calls.push("sidebar.toggle");
+    return true;
+  });
+  return null;
+}
+
+function renderComposer() {
+  render(
+    <MemoryRouter>
+      <AppCommandProvider>
+        <SidebarToggleHandler />
+        <PromptBoxInternal
+          value=""
+          mentionRanges={[]}
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+          mentionMenuPlacement="bottom"
+          typeahead={{
+            mention: {
+              suggestions: [],
+              isLoading: false,
+              isError: false,
+              onQueryChange: vi.fn(),
+            },
+            command: INERT_TYPEAHEAD_COMMAND_CONFIG,
+          }}
+        />
+      </AppCommandProvider>
+    </MemoryRouter>,
+  );
+  const editor = document.querySelector<HTMLElement>('[contenteditable="true"]');
+  if (editor === null) throw new Error("prompt editor did not render");
+  editor.focus();
+  return editor;
+}
+
+function pressInEditor(
+  editor: HTMLElement,
+  init: KeyboardEventInit,
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  editor.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  cleanup();
+  testState.calls.length = 0;
+  testState.sidebarShortcut = {
+    key: "\\",
+    mod: true,
+    meta: false,
+    control: false,
+    alt: false,
+    shift: false,
+  };
+});
+
+describe("prompt editor app shortcuts", () => {
+  it("runs the sidebar shortcut while the composer has focus", () => {
+    const editor = renderComposer();
+
+    const event = pressInEditor(editor, { ctrlKey: true, key: "\\" });
+
+    expect(testState.calls).toEqual(["sidebar.toggle"]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("runs a sidebar shortcut whose chord the editor keymap also claims", () => {
+    // Mod+Shift+B toggles a blockquote in the editor. The editor cancels the
+    // event, which used to leave the app command unreachable from the composer.
+    testState.sidebarShortcut = {
+      key: "b",
+      mod: true,
+      meta: false,
+      control: false,
+      alt: false,
+      shift: true,
+    };
+    const editor = renderComposer();
+
+    pressInEditor(editor, {
+      code: "KeyB",
+      ctrlKey: true,
+      key: "B",
+      shiftKey: true,
+    });
+
+    expect(testState.calls).toEqual(["sidebar.toggle"]);
+  });
+
+  it("releases composer focus on Escape", () => {
+    const editor = renderComposer();
+    expect(document.activeElement).toBe(editor);
+
+    pressInEditor(editor, { key: "Escape" });
+
+    expect(document.activeElement).not.toBe(editor);
+  });
+
+  it("keeps typed text in the composer", () => {
+    const editor = renderComposer();
+
+    const event = pressInEditor(editor, { code: "KeyB", key: "b" });
+
+    expect(testState.calls).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultAppSettings, type AppShortcut } from "@bb/domain";
 import {
   AppCommandProvider,
   useAppCommandHandler,
+  useIsAppCommandModifierHeld,
 } from "@/components/commands/AppCommandProvider";
 import {
   INERT_TYPEAHEAD_COMMAND_CONFIG,
@@ -15,6 +16,8 @@ import {
 
 const testState = vi.hoisted(() => ({
   calls: [] as string[],
+  composerInputLocked: false,
+  sidebarHandlerResult: true,
   // The sidebar chord under test. Overridden per test to cover both a chord the
   // editor ignores and a chord the editor's own keymap claims.
   sidebarShortcut: {
@@ -47,19 +50,31 @@ vi.mock("@/lib/bb-desktop", () => ({
   getBbDesktopInfo: () => null,
 }));
 
+vi.mock("@/lib/plugin-sdk-hooks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/plugin-sdk-hooks")>()),
+  useComposerInputLock: () => testState.composerInputLocked,
+}));
+
 function SidebarToggleHandler() {
   useAppCommandHandler("sidebar.toggle", () => {
     testState.calls.push("sidebar.toggle");
-    return true;
+    return testState.sidebarHandlerResult;
   });
   return null;
 }
 
-function renderComposer() {
+function ShortcutHintState() {
+  return (
+    <span>{useIsAppCommandModifierHeld() ? "hint-held" : "hint-released"}</span>
+  );
+}
+
+function renderComposer(extra: React.ReactNode = null) {
   render(
     <MemoryRouter>
       <AppCommandProvider>
         <SidebarToggleHandler />
+        {extra}
         <PromptBoxInternal
           value=""
           mentionRanges={[]}
@@ -79,7 +94,9 @@ function renderComposer() {
       </AppCommandProvider>
     </MemoryRouter>,
   );
-  const editor = document.querySelector<HTMLElement>('[contenteditable="true"]');
+  const editor = document.querySelector<HTMLElement>(
+    "[data-promptbox-editor-content] [contenteditable]",
+  );
   if (editor === null) throw new Error("prompt editor did not render");
   editor.focus();
   return editor;
@@ -101,6 +118,8 @@ function pressInEditor(
 afterEach(() => {
   cleanup();
   testState.calls.length = 0;
+  testState.composerInputLocked = false;
+  testState.sidebarHandlerResult = true;
   testState.sidebarShortcut = {
     key: "\\",
     mod: true,
@@ -146,6 +165,51 @@ describe("prompt editor app shortcuts", () => {
 
   it("releases composer focus on Escape", () => {
     const editor = renderComposer();
+    expect(document.activeElement).toBe(editor);
+
+    pressInEditor(editor, { key: "Escape" });
+
+    expect(document.activeElement).not.toBe(editor);
+  });
+
+  it("offers a declined chord to the handlers only once", () => {
+    // The editor dispatches first and leaves a declined event alone, so the
+    // window listener receives the same event. The handlers must not run twice.
+    testState.sidebarHandlerResult = false;
+    const editor = renderComposer();
+
+    const event = pressInEditor(editor, { ctrlKey: true, key: "\\" });
+
+    expect(testState.calls).toEqual(["sidebar.toggle"]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("clears the keyboard hint when the composer runs a shortcut", () => {
+    vi.useFakeTimers();
+    try {
+      const editor = renderComposer(<ShortcutHintState />);
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Control", ctrlKey: true }),
+      );
+      act(() => vi.advanceTimersByTime(700));
+      expect(screen.getByText("hint-held")).toBeDefined();
+
+      act(() => {
+        pressInEditor(editor, { ctrlKey: true, key: "\\" });
+      });
+
+      expect(testState.calls).toEqual(["sidebar.toggle"]);
+      expect(screen.getByText("hint-released")).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases focus on Escape while a plugin locks the composer", () => {
+    testState.composerInputLocked = true;
+    const editor = renderComposer();
+    expect(editor.getAttribute("contenteditable")).toBe("false");
+    editor.focus();
     expect(document.activeElement).toBe(editor);
 
     pressInEditor(editor, { key: "Escape" });

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -35,7 +35,10 @@ import {
   type TypeaheadTrigger,
 } from "@/components/promptbox/mentions/types";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
-import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
+import {
+  useAppCommandKeyDispatch,
+  useAppCommandShortcut,
+} from "@/components/commands/AppCommandProvider";
 import { commandPillDismissedRangeEnd } from "@/components/promptbox/mentions/command-trigger";
 import { findActiveTrigger } from "@/components/promptbox/mentions/find-active-trigger";
 import { canLoadMoreCommandResults } from "@/components/promptbox/mentions/mention-menu-scroll";
@@ -1148,6 +1151,7 @@ export function PromptBoxInternal({
   const handleEditorKeyDownRef = useRef<(event: KeyboardEvent) => boolean>(
     () => false,
   );
+  const dispatchAppCommandKey = useAppCommandKeyDispatch();
   // The TipTap editor is created once; its `onUpdate`/`onSelectionUpdate`/click
   // handlers close over the first `syncTriggerState`. `syncTriggerState`
   // depends on the active trigger set, which changes when the thread's provider
@@ -2476,6 +2480,13 @@ export function PromptBoxInternal({
 
   const handleEditorKeyDown = useCallback(
     (event: KeyboardEvent): boolean => {
+      // App keybindings win over the editor's own keymap. TipTap cancels the
+      // chords it knows (Mod+Shift+B for a blockquote, Mod+B, Mod+Shift+7/8 for
+      // lists), and the window listener skips a canceled event — so without
+      // this an app chord silently did nothing while the composer had focus.
+      if (dispatchAppCommandKey(event)) {
+        return true;
+      }
       const currentEditor = editorRef.current;
       const selection = currentEditor?.state.selection;
       const hasCollapsedSelection = Boolean(selection?.empty);
@@ -2577,6 +2588,18 @@ export function PromptBoxInternal({
           onCommandQueryChange(null);
           return true;
         }
+      }
+
+      // Escape releases the composer so the keyboard can reach the rest of the
+      // app. Higher-priority Escape behavior still runs first: the typeahead
+      // menu above dismisses itself, and voice recording cancels from a window
+      // capture listener that stops the event before the editor sees it.
+      // TipTap's `blur` command defers to the next animation frame, so blur the
+      // editor DOM directly and drop the caret with it.
+      if (event.key === "Escape") {
+        currentEditor?.view.dom.blur();
+        window.getSelection()?.removeAllRanges();
+        return true;
       }
 
       if (history) {
@@ -2700,6 +2723,7 @@ export function PromptBoxInternal({
       commandError,
       commandHasMore,
       commandIsLoadingMore,
+      dispatchAppCommandKey,
       history,
       isZenMode,
       loadMoreCommands,

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1036,6 +1036,13 @@ export function suppressPromptEditorAnchorActivation(event: Event): boolean {
   return true;
 }
 
+// TipTap's `blur` command defers to the next animation frame, so blur the
+// editor DOM directly and drop the caret with it.
+function blurPromptEditor(editor: Editor | null | undefined): void {
+  editor?.view.dom.blur();
+  window.getSelection()?.removeAllRanges();
+}
+
 function focusEditorAtEnd(editor: Editor): void {
   const transaction = editor.state.tr
     .setSelection(TextSelection.atEnd(editor.state.doc))
@@ -2593,12 +2600,10 @@ export function PromptBoxInternal({
       // Escape releases the composer so the keyboard can reach the rest of the
       // app. Higher-priority Escape behavior still runs first: the typeahead
       // menu above dismisses itself, and voice recording cancels from a window
-      // capture listener that stops the event before the editor sees it.
-      // TipTap's `blur` command defers to the next animation frame, so blur the
-      // editor DOM directly and drop the caret with it.
+      // capture listener that stops the event before the editor sees it. A
+      // locked editor never reaches here — see the editor container below.
       if (event.key === "Escape") {
-        currentEditor?.view.dom.blur();
-        window.getSelection()?.removeAllRanges();
+        blurPromptEditor(currentEditor);
         return true;
       }
 
@@ -2926,6 +2931,16 @@ export function PromptBoxInternal({
               >
                 <EditorContent
                   editor={editor}
+                  // A plugin lock makes the editor non-editable, and
+                  // ProseMirror then skips its own key handlers — including the
+                  // Escape blur above. A lock applied to a focused composer
+                  // would otherwise strand focus there, so release it here.
+                  onKeyDown={(event) => {
+                    if (event.key !== "Escape") return;
+                    if (editor === null || editor.isEditable) return;
+                    event.preventDefault();
+                    blurPromptEditor(editor);
+                  }}
                   data-promptbox-editor-content=""
                   data-promptbox-compact-content={
                     showCompactLayout ? "" : undefined


### PR DESCRIPTION
Fixes #1162

## Root cause

The prompt editor consumes key events before the app command layer sees them.

1. `AppCommandProvider` listens on `window` in the bubble phase and skips any event whose default is already prevented (`AppCommandProvider.tsx:270`). TipTap's keymap cancels every chord it owns. Live check in the dev app, with the chat input focused: `Ctrl+Shift+B` (blockquote) and `Ctrl+B` reached the `window` listener with `defaultPrevented === true`. A sidebar shortcut bound to such a chord therefore did nothing while the chat input had focus.
2. ProseMirror cancels Escape unconditionally, but nothing released the editor. Live check: after Escape, `document.activeElement` was still the editor.

## User impact

- The sidebar shortcut, and any other app shortcut, silently did nothing while the chat input had focus, whenever its chord collided with the editor keymap. Users had to click the toggle.
- Escape did not release the chat input, so the keyboard could not reach the rest of the app.

## Implementation

- `AppCommandProvider.tsx`: the keybinding match and dispatch loop moves into `handleKeyboardEvent`, which reports whether a command ran. A new `useAppCommandKeyDispatch()` hook exposes it. The window listener keeps its current behavior.
- `PromptBoxInternal.tsx`: the editor keydown handler asks the app command layer first, so app keybindings win over the editor keymap. Escape blurs the editor DOM and drops the caret.

Escape priority stays intact. The typeahead menu claims Escape earlier in the same handler, so the first Escape dismisses the menu and the second releases focus. Voice recording cancels from a window capture listener that stops the event before the editor.

No server or daemon payload changed, so `HOST_DAEMON_PROTOCOL_VERSION` stays as it is.

## Validation

- New `PromptBoxAppShortcuts.test.tsx`: shortcut from a focused composer, shortcut on a chord the editor keymap also claims, Escape blur, and plain typing unaffected.
- `pnpm exec turbo run typecheck --filter=@bb/app` — pass.
- `pnpm exec vitest run --project @bb/app` — 322 files, 2418 tests, all pass.
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors, no warnings in the changed files.
- Live QA in the dev app, thread view and new-thread composer: the sidebar toggles from the focused chat input, the first Escape dismisses the mention menu and keeps focus, the second Escape blurs, and the draft text survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)