### PR TITLE
Resolve bare Pi models through sole authenticated provider

### DIFF
--- a/packages/agent-runtime/src/pi/bridge/__tests__/sdk-session.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/sdk-session.test.ts
@@ -449,6 +449,34 @@ describe("PiSdkSession", () => {
     );
   });
 
+  it("uses the sole authenticated provider for an ambiguous bare model id", async () => {
+    mockGetModel.mockReturnValue(undefined);
+    mockGetModels.mockReturnValue([
+      { id: "gpt-5.6-terra", provider: "azure-openai-responses" },
+      { id: "gpt-5.6-terra", provider: "openai" },
+      { id: "gpt-5.6-terra", provider: "openai-codex" },
+    ]);
+    mockHasConfiguredAuth.mockImplementation(
+      (provider: string) => provider === "openai-codex",
+    );
+    const session = new PiSdkSession(
+      {
+        cwd: "/tmp/project",
+        model: "gpt-5.6-terra",
+      },
+      vi.fn(),
+      vi.fn(),
+    );
+
+    await session.start();
+
+    expect(mockCreateAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: { id: "gpt-5.6-terra", provider: "openai-codex" },
+      }),
+    );
+  });
+
   it("refuses to guess when two providers serve one bare model id", async () => {
     mockGetModel.mockReturnValue(undefined);
     mockGetModels.mockReturnValue([

--- a/packages/agent-runtime/src/pi/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/pi/bridge/sdk-session.ts
@@ -622,8 +622,10 @@ type PiModel = NonNullable<ReturnType<ModelRuntime["getModel"]>>;
  * only when the first segment names no provider that serves the rest. CLI and
  * SDK callers type that form, and selections stored before bb applied the
  * provider prefix to aggregator models still use it. Two providers can list the
- * same id, and nothing in the string says which one was meant, so an ambiguous
- * match is an error rather than a guess.
+ * same id. When exactly one matching provider has configured credentials, that
+ * provider is the only usable match. Otherwise, nothing in the string says
+ * which provider was meant, so an ambiguous match is an error rather than a
+ * guess.
  */
 function resolveConfiguredModel(
   modelRuntime: ModelRuntime,
@@ -648,6 +650,12 @@ function resolveConfiguredModel(
     .getModels()
     .filter((candidate) => candidate.id === modelStr);
   if (bare.length > 1) {
+    const authenticated = bare.filter((candidate) =>
+      modelRuntime.hasConfiguredAuth(candidate.provider),
+    );
+    if (authenticated.length === 1) {
+      return authenticated[0];
+    }
     const providers = bare.map((candidate) => candidate.provider).join(", ");
     throw new Error(
       `Ambiguous Pi model "${modelStr}": served by ${providers}. Prefix it with the provider you want.`,

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 81 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 82 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1038,10 +1038,10 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 81 makes same-instance daemon session replacement reconnect-safe
-  // so enrolled daemons update before receiving the revised server behavior.
-  it("uses protocol version 81 for reconnect-safe session replacement", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(81);
+  // Version 82 changes how the Pi bridge resolves bare model ids. The bump
+  // updates enrolled daemons before they receive the revised model meaning.
+  it("uses protocol version 82 for authenticated Pi model resolution", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(82);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
Fixes #1123.

## Summary

- resolve an ambiguous bare Pi model through its sole authenticated provider
- keep explicit provider selections authoritative
- retain the ambiguity error when zero or multiple matching providers have authentication
- bump the host daemon protocol to update enrolled daemons before the model meaning changes

## Tests

- `pnpm exec turbo run test typecheck --filter=@bb/host-daemon-contract --filter=@bb/agent-runtime --force`
- 879 tests passed after rebasing on #1148
- both package typechecks passed

## Risk

The behavior changes only for bare model IDs with multiple catalog matches and exactly one authenticated provider. Explicit provider-prefixed IDs remain unchanged.