### PR TITLE
Find Claude CLI in well-known locations and clarify the missing-CLI error

### DIFF
--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -263,7 +263,16 @@ function shellEnvEquals(
 function providerProcessEnvFromShellEnv(
   shellEnv: NonNullable<AgentRuntimeOptions["shellEnv"]>,
 ): Record<string, string> | null {
-  return shellEnv.PATH ? { PATH: shellEnv.PATH } : null;
+  const env: Record<string, string> = {};
+  if (shellEnv.PATH) {
+    env.PATH = shellEnv.PATH;
+  }
+  // The Claude bridge resolves the CLI from its own process env; forward the
+  // documented override past the BB_* spawn sanitization.
+  if (shellEnv.BB_CLAUDE_CODE_EXECUTABLE) {
+    env.BB_CLAUDE_CODE_EXECUTABLE = shellEnv.BB_CLAUDE_CODE_EXECUTABLE;
+  }
+  return Object.keys(env).length > 0 ? env : null;
 }
 
 export class RuntimeManager {

--- a/apps/host-daemon/src/runtime-shell-env.ts
+++ b/apps/host-daemon/src/runtime-shell-env.ts
@@ -391,6 +391,14 @@ export function prepareRuntimeShellEnv(
         ? undefined
         : String(options.hostDaemonPort),
   });
+  // Provider process spawning strips inherited BB_* variables, so the
+  // documented Claude CLI override must be forwarded explicitly for the
+  // bridge to see it.
+  assignIfDefined({
+    key: "BB_CLAUDE_CODE_EXECUTABLE",
+    target: shellEnv,
+    value: process.env.BB_CLAUDE_CODE_EXECUTABLE,
+  });
 
   return shellEnv;
 }

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -1,4 +1,10 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -726,6 +732,31 @@ describe("bridge", () => {
         permissionScope: "workspace",
       },
       { PATH: binDir },
+    );
+
+    expect(options.pathToClaudeCodeExecutable).toBe(executablePath);
+  });
+
+  it("falls back to well-known install locations when PATH discovery fails", () => {
+    const homeDir = mkdtempSync(join(tmpdir(), "bb-claude-home-"));
+    tempDirs.push(homeDir);
+    const localBinDir = join(homeDir, ".local", "bin");
+    mkdirSync(localBinDir, { recursive: true });
+    const executablePath = join(localBinDir, "claude");
+    writeFileSync(executablePath, "#!/bin/sh\nexit 0\n");
+    chmodSync(executablePath, 0o755);
+
+    const options = buildSessionOptions(
+      {
+        workflowsEnabled: false,
+        baseInstructions: "You are a coder.",
+        cwd: "/tmp/worktree",
+        instructionMode: "append",
+        permissionEscalation: "ask",
+        permissionMode: "default",
+        permissionScope: "workspace",
+      },
+      { HOME: homeDir, PATH: "/nonexistent-bb-test-dir" },
     );
 
     expect(options.pathToClaudeCodeExecutable).toBe(executablePath);

--- a/packages/agent-runtime/src/claude-code/bridge/missing-cli-error.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/missing-cli-error.ts
@@ -1,0 +1,22 @@
+// The Agent SDK throws this when it falls back to its bundled CLI binary and
+// cannot resolve the platform package. Packaged bb builds never ship that
+// package (the bridge bundle inlines the SDK), so the SDK's "reinstall"
+// guidance is wrong for bb users; point them at the real remedies instead.
+const MISSING_NATIVE_CLI_PATTERN = /Native CLI binary for .+ not found/;
+const MISSING_CLAUDE_CLI_GUIDANCE =
+  "bb could not find the Claude Code CLI on this machine. Install Claude Code (https://claude.com/claude-code), or set BB_CLAUDE_CODE_EXECUTABLE to the full path of the claude binary, then restart bb.";
+
+export function isMissingClaudeCliMessage(message: string): boolean {
+  return MISSING_NATIVE_CLI_PATTERN.test(message);
+}
+
+export function missingClaudeCliGuidance(): string {
+  return MISSING_CLAUDE_CLI_GUIDANCE;
+}
+
+export function translateMissingClaudeCliError(error: unknown): unknown {
+  if (error instanceof Error && isMissingClaudeCliMessage(error.message)) {
+    return new Error(MISSING_CLAUDE_CLI_GUIDANCE, { cause: error });
+  }
+  return error;
+}

--- a/packages/agent-runtime/src/claude-code/bridge/model-list.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/model-list.ts
@@ -1,6 +1,7 @@
 import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
 import type { AvailableModel } from "@bb/domain";
 import { buildClaudeCodeModels } from "../model-list.js";
+import { translateMissingClaudeCliError } from "./missing-cli-error.js";
 import { resolveClaudeCodeExecutable } from "./session-options.js";
 
 function buildModelProbeOptions(env: NodeJS.ProcessEnv): Options {
@@ -27,14 +28,21 @@ export async function listClaudeCodeBridgeModels(
   // reasoning policy, but only expose entries covered by a discovered value or
   // its canonical resolved model id. Probe failures intentionally propagate so
   // callers can distinguish temporary discovery failure from definite absence.
-  const session = query({
-    prompt: ".",
-    options: buildModelProbeOptions(env),
-  });
+  let session: ReturnType<typeof query>;
+  try {
+    session = query({
+      prompt: ".",
+      options: buildModelProbeOptions(env),
+    });
+  } catch (error) {
+    throw translateMissingClaudeCliError(error);
+  }
 
   try {
     const initialization = await session.initializationResult();
     return buildClaudeCodeModels(initialization.models);
+  } catch (error) {
+    throw translateMissingClaudeCliError(error);
   } finally {
     session.close();
   }

--- a/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
@@ -8,6 +8,11 @@ import {
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { ClaudePermissionMode } from "../interactive-contract.js";
+import {
+  isMissingClaudeCliMessage,
+  missingClaudeCliGuidance,
+  translateMissingClaudeCliError,
+} from "./missing-cli-error.js";
 
 export interface SdkSessionOptions {
   cwd: string;
@@ -74,25 +79,10 @@ function appendBoundedText(args: AppendBoundedTextArgs): string {
   return next.slice(next.length - SDK_STDERR_TAIL_MAX_CHARS);
 }
 
-// The Agent SDK throws this when it falls back to its bundled CLI binary and
-// cannot resolve the platform package. Packaged bb builds never ship that
-// package (the bridge bundle inlines the SDK), so the SDK's "reinstall"
-// guidance is wrong for bb users; point them at the real remedies instead.
-const MISSING_NATIVE_CLI_PATTERN = /Native CLI binary for .+ not found/;
-const MISSING_CLAUDE_CLI_GUIDANCE =
-  "bb could not find the Claude Code CLI on this machine. Install Claude Code (https://claude.com/claude-code), or set BB_CLAUDE_CODE_EXECUTABLE to the full path of the claude binary, then restart bb.";
-
-function translateMissingClaudeCliError(error: unknown): unknown {
-  if (error instanceof Error && MISSING_NATIVE_CLI_PATTERN.test(error.message)) {
-    return new Error(MISSING_CLAUDE_CLI_GUIDANCE, { cause: error });
-  }
-  return error;
-}
-
 function getErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return MISSING_NATIVE_CLI_PATTERN.test(message)
-    ? MISSING_CLAUDE_CLI_GUIDANCE
+  return isMissingClaudeCliMessage(message)
+    ? missingClaudeCliGuidance()
     : message;
 }
 

--- a/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
@@ -74,8 +74,26 @@ function appendBoundedText(args: AppendBoundedTextArgs): string {
   return next.slice(next.length - SDK_STDERR_TAIL_MAX_CHARS);
 }
 
+// The Agent SDK throws this when it falls back to its bundled CLI binary and
+// cannot resolve the platform package. Packaged bb builds never ship that
+// package (the bridge bundle inlines the SDK), so the SDK's "reinstall"
+// guidance is wrong for bb users; point them at the real remedies instead.
+const MISSING_NATIVE_CLI_PATTERN = /Native CLI binary for .+ not found/;
+const MISSING_CLAUDE_CLI_GUIDANCE =
+  "bb could not find the Claude Code CLI on this machine. Install Claude Code (https://claude.com/claude-code), or set BB_CLAUDE_CODE_EXECUTABLE to the full path of the claude binary, then restart bb.";
+
+function translateMissingClaudeCliError(error: unknown): unknown {
+  if (error instanceof Error && MISSING_NATIVE_CLI_PATTERN.test(error.message)) {
+    return new Error(MISSING_CLAUDE_CLI_GUIDANCE, { cause: error });
+  }
+  return error;
+}
+
 function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return MISSING_NATIVE_CLI_PATTERN.test(message)
+    ? MISSING_CLAUDE_CLI_GUIDANCE
+    : message;
 }
 
 function buildSdkDoneErrorMessage(args: BuildSdkDoneErrorMessageArgs): string {
@@ -202,10 +220,14 @@ export class SdkSession {
       ...(this.options.settings ? { settings: this.options.settings } : {}),
     };
 
-    this.query = query({
-      prompt: this.createInputIterable(),
-      options: sdkOptions,
-    });
+    try {
+      this.query = query({
+        prompt: this.createInputIterable(),
+        options: sdkOptions,
+      });
+    } catch (error) {
+      throw translateMissingClaudeCliError(error);
+    }
 
     void this.consumeStream();
   }

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import type { Options, Settings } from "@anthropic-ai/claude-agent-sdk";
 import type {
@@ -182,6 +182,17 @@ function buildWorkspaceWriteSandbox(
   };
 }
 
+// X_OK alone also passes for searchable directories, so require a regular
+// file (following symlinks) before treating a candidate as the Claude CLI.
+function isExecutableFile(candidatePath: string): boolean {
+  try {
+    accessSync(candidatePath, constants.X_OK);
+    return statSync(candidatePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
 function resolveExecutableOnPath(
   args: ResolveExecutableOnPathArgs,
 ): string | null {
@@ -194,11 +205,8 @@ function resolveExecutableOnPath(
       continue;
     }
     const candidate = join(searchDir, args.executableName);
-    try {
-      accessSync(candidate, constants.X_OK);
+    if (isExecutableFile(candidate)) {
       return candidate;
-    } catch {
-      continue;
     }
   }
 
@@ -210,6 +218,11 @@ function resolveExecutableOnPath(
 // install locations are checked before falling back to the SDK's bundled
 // binary, which packaged bb builds do not ship.
 function wellKnownClaudeExecutablePaths(env: NodeJS.ProcessEnv): string[] {
+  // Under elevated privileges a user-writable binary must never be picked up
+  // implicitly; root operators can still set BB_CLAUDE_CODE_EXECUTABLE.
+  if (process.getuid?.() === 0) {
+    return [];
+  }
   const candidatePaths: string[] = [];
   const home = env.HOME?.trim();
   if (home) {
@@ -249,11 +262,8 @@ export function resolveClaudeCodeExecutable(
   }
 
   for (const candidate of wellKnownClaudeExecutablePaths(args.env)) {
-    try {
-      accessSync(candidate, constants.X_OK);
+    if (isExecutableFile(candidate)) {
       return candidate;
-    } catch {
-      continue;
     }
   }
 

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -205,6 +205,23 @@ function resolveExecutableOnPath(
   return null;
 }
 
+// The login-shell PATH probe can miss user-level install directories (slow
+// shell startup, PATH exports the probe does not source), so common Claude
+// install locations are checked before falling back to the SDK's bundled
+// binary, which packaged bb builds do not ship.
+function wellKnownClaudeExecutablePaths(env: NodeJS.ProcessEnv): string[] {
+  const candidatePaths: string[] = [];
+  const home = env.HOME?.trim();
+  if (home) {
+    candidatePaths.push(
+      join(home, ".local", "bin", "claude"),
+      join(home, ".claude", "local", "claude"),
+    );
+  }
+  candidatePaths.push("/opt/homebrew/bin/claude", "/usr/local/bin/claude");
+  return candidatePaths;
+}
+
 export function resolveClaudeCodeExecutable(
   args: ResolveClaudeCodeExecutableArgs,
 ): string | null {
@@ -223,10 +240,24 @@ export function resolveClaudeCodeExecutable(
 
   // Bundled bridge files cannot rely on the SDK's package-relative CLI
   // resolution, so pass the host's Claude CLI path explicitly when available.
-  return resolveExecutableOnPath({
+  const executableOnPath = resolveExecutableOnPath({
     executableName: "claude",
     pathEnv: args.env.PATH,
   });
+  if (executableOnPath) {
+    return executableOnPath;
+  }
+
+  for (const candidate of wellKnownClaudeExecutablePaths(args.env)) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
 }
 
 export function buildSessionOptions(

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -385,7 +385,7 @@ async function smokeBridgeModelList({
     "error" in modelListResponse &&
     isRecord(modelListResponse.error) &&
     typeof modelListResponse.error.message === "string" &&
-    /(?:Native CLI binary|Claude Code executable).*not found/u.test(
+    /(?:Native CLI binary|Claude Code executable).*not found|could not find the Claude Code CLI/u.test(
       modelListResponse.error.message,
     );
   if (!allowUnavailableProvider || !unavailableProviderMessage) {


### PR DESCRIPTION
## Summary

A bb 0.35.1 user hit this error on every Claude turn:

> Native CLI binary for darwin-arm64 not found. Reinstall @anthropic-ai/claude-agent-sdk without --omit=optional, or set options.pathToClaudeCodeExecutable.

Packaged bb builds inline the Claude Agent SDK into the bridge bundle and do not ship the SDK's native platform package (217 MB per platform), so the SDK's bundled-binary fallback can never work in a shipped install. When the login-shell PATH probe also misses the user's claude install (theirs was at `~/.local/bin/claude`), the session fails with the raw SDK error above.

## Changes

- `resolveClaudeCodeExecutable` now checks well-known Claude install locations (`~/.local/bin/claude`, `~/.claude/local/claude`, `/opt/homebrew/bin/claude`, `/usr/local/bin/claude`) when PATH discovery finds nothing. This also benefits model listing, which shares the resolver.
- The bridge translates the SDK's "Native CLI binary ... not found" error into bb guidance: install Claude Code, or set `BB_CLAUDE_CODE_EXECUTABLE`, then restart bb. The old message told users to reinstall an npm package they do not own.

## Tests

- New test: falls back to well-known install locations when PATH discovery fails.
- `pnpm exec turbo run typecheck test --filter=@bb/agent-runtime`: 43 files, 831 tests pass.

## Risks

- The well-known-location scan runs only after PATH discovery fails, so existing setups keep their current resolution.
- A machine with a stale claude binary at a well-known location could now pick it up where the session previously failed outright; that is strictly better than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)