### PR TITLE
Prevent child thread names bleeding through sticky sidebar rows

### DIFF
--- a/apps/app/src/components/sidebar/sidebarRowClasses.test.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.test.ts
@@ -9,4 +9,10 @@ describe("sidebar selected thread styling", () => {
     );
     expect(CONTEXT_SELECTION_SURFACE_CLASS).toBe("bg-state-active");
   });
+
+  it("marks the row for an opaque backing surface when it becomes sticky", () => {
+    expect(SIDEBAR_ROW_SELECTED_STATE_CLASS).toContain(
+      "bb-sidebar-selected-row",
+    );
+  });
 });

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -70,7 +70,7 @@ export const SIDEBAR_ROW_STATIC_STATE_CLASS =
   "text-sidebar-foreground/85 dark:text-sidebar-foreground";
 
 export const SIDEBAR_ROW_SELECTED_STATE_CLASS =
-  `${CONTEXT_SELECTION_SURFACE_CLASS} text-sidebar-foreground`;
+  `${CONTEXT_SELECTION_SURFACE_CLASS} bb-sidebar-selected-row text-sidebar-foreground`;
 
 export const SIDEBAR_MORE_ACTION_TRIGGER_CLASS =
   "relative m-1 h-5 w-5 after:absolute after:left-1/2 after:top-1/2 after:h-7 after:w-7 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] max-md:pointer-coarse:m-0 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:after:hidden";

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -202,6 +202,16 @@
     height: var(--bb-sidebar-sticky-tier-shield-bottom-height, 0);
   }
 
+  /* The shared active-context surface is translucent so it can tint tabs and
+     other content surfaces. A sticky sidebar row needs an opaque sidebar layer
+     beneath that tint, or scrolled descendant text paints through the row. */
+  [data-sidebar-sticky-stack]
+    [data-sidebar-sticky-tier].bb-sidebar-selected-row {
+    background-image:
+      linear-gradient(var(--state-active), var(--state-active)),
+      linear-gradient(var(--sidebar), var(--sidebar));
+  }
+
   .bb-sidebar-hover-actions {
     pointer-events: none;
     opacity: 0;

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -133,6 +133,19 @@ function contrastRatio(foreground: OklchColor, background: OklchColor): number {
 }
 
 describe("theme.css neutral ramp", () => {
+  it("backs selected sticky sidebar rows with an opaque sidebar layer", () => {
+    const rule = css.match(
+      /\[data-sidebar-sticky-tier\]\.bb-sidebar-selected-row\s*\{([^}]*)\}/s,
+    )?.[1];
+
+    expect(rule).toContain(
+      "linear-gradient(var(--state-active), var(--state-active))",
+    );
+    expect(rule).toContain(
+      "linear-gradient(var(--sidebar), var(--sidebar))",
+    );
+  });
+
   for (const mode of MODES) {
     describe(mode, () => {
       const block = modeBlock(mode);


### PR DESCRIPTION
## Summary

- mark selected sidebar rows so sticky tiers can provide an opaque backing surface
- preserve the shared active-context tint above the sidebar background
- add regression coverage for the selected-row marker and two-layer sticky surface

Fixes #1161

## Test plan

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/sidebarRowClasses.test.ts src/components/ui/theme.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- verified the original scroll repro with dev-browser in light and dark themes