### PR TITLE
Replay migrations skipped behind newer applied ledger rows

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1368,6 +1368,39 @@ function repairBranchLocalThreadTabsBeforePendingInteractionsMigration(
   applyMigrationStatements(db, pendingInteractionsMigration);
 }
 
+// Drizzle only applies journal entries whose timestamp is newer than the
+// ledger's max created_at, so a single branch-local migration row with a newer
+// timestamp makes it skip every pending published migration and startup then
+// fails validation. Replay the journal migrations that follow the newest
+// applied journal entry; gaps older than that are left for
+// validateAppliedMigrationHistory to report.
+function replayMigrationsSkippedByNewerAppliedRows(
+  db: DbConnection,
+  migrationsFolder: string,
+): void {
+  if (!tableExists(db, "__drizzle_migrations")) {
+    return;
+  }
+
+  const expectedMigrations = readExpectedAppliedMigrations(migrationsFolder);
+  const appliedCreatedAts = readAppliedMigrationCreatedAts(db);
+  const latestAppliedJournalCreatedAt = Math.max(
+    ...expectedMigrations
+      .filter((migration) => appliedCreatedAts.has(migration.createdAt))
+      .map((migration) => migration.createdAt),
+  );
+  for (const migration of expectedMigrations) {
+    if (
+      appliedCreatedAts.has(migration.createdAt) ||
+      migration.createdAt < latestAppliedJournalCreatedAt
+    ) {
+      continue;
+    }
+
+    applyMigrationStatements(db, migration);
+  }
+}
+
 function warnAboutFutureAppliedMigrations(
   db: DbConnection,
   options: MigrateOptions,
@@ -1503,6 +1536,7 @@ export function migrate(db: DbConnection, options: MigrateOptions = {}): void {
       if (stagedConnectMachineId) restoreStagedConnectMachineIdColumn(db);
     }
     applyReorderedCleanupMigrations(db, migrationsFolder);
+    replayMigrationsSkippedByNewerAppliedRows(db, migrationsFolder);
     applyQueuedMessageGroupingSchema(db);
   } finally {
     sqlite.pragma("foreign_keys = ON");

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -508,6 +508,9 @@ function dropSteerActiveThreadOnEnterColumn(db: DbConnection): void {
 // Journal `when` for 0085, used to rewind exactly that migration.
 const onboardingMigrationWhen = 1785947206119;
 
+// Journal `when` for 0087, used to rewind exactly that migration.
+const newOnboardingMigrationWhen = 1786043536668;
+
 // Migration 0085 adds the onboarding completion timestamp. Rewind scenarios
 // that clear its migration row must drop the column before replay, for the same
 // reason as the preference column above: ALTER TABLE ADD is not re-appliable.
@@ -3830,6 +3833,43 @@ describe("migrate", () => {
       expect(readLatestAppliedMigrationCreatedAt(db)).toBe(latestMigrationWhen);
       expect(readTableNames(db)).not.toContain("event_large_values");
       expectEventLargeValuesInline(db, values);
+    } finally {
+      closeConnection(db);
+    }
+  });
+
+  it("replays published migrations skipped behind a newer branch-local migration row", () => {
+    const db = createConnection(":memory:");
+
+    try {
+      migrate(db);
+      dropNewOnboardingExperimentColumn(db);
+      db.$client
+        .prepare<DeleteMigrationParameters>(
+          `
+            DELETE FROM __drizzle_migrations
+            WHERE created_at = ?
+          `,
+        )
+        .run(newOnboardingMigrationWhen);
+      db.$client
+        .prepare<InsertMigrationParameters>(
+          `
+            INSERT INTO __drizzle_migrations (hash, created_at)
+            VALUES (?, ?)
+          `,
+        )
+        .run("branch-local-hash", newOnboardingMigrationWhen + 60_000);
+
+      expect(() => migrate(db)).not.toThrow();
+      expect(readAppliedMigrationCreatedAts(db)).toContain(
+        newOnboardingMigrationWhen,
+      );
+      const experimentColumns = db.$client
+        .prepare<[], TableInfoRow>("PRAGMA table_info(system_experiments)")
+        .all()
+        .map((column) => column.name);
+      expect(experimentColumns).toContain("new_onboarding");
     } finally {
       closeConnection(db);
     }


### PR DESCRIPTION
## Summary
Fixes #1186. Drizzle's sqlite migrator only applies journal entries whose timestamp is newer than the ledger's max `created_at`. A single branch-local migration row with a newer timestamp (e.g. from running a dev build) therefore makes it skip every later published migration, and `validateAppliedMigrationHistory` then fails startup with "Database migration history is incomplete after migration".

After the Drizzle pass, replay journal migrations that are missing from the ledger and newer than the newest applied journal entry. Gaps older than that are still reported by validation as before. This generalizes the existing one-off repairs for skipped migrations (e.g. the branch-local thread-tabs repair), whose timestamps can't be enumerated upstream.

Verified locally. Able to start the app after the fix.