### PR TITLE
Surface error cause chain in CLI error messages

### DIFF
--- a/apps/cli/src/__tests__/get-error-message.test.ts
+++ b/apps/cli/src/__tests__/get-error-message.test.ts
@@ -12,6 +12,19 @@ describe("getErrorMessage", () => {
     );
   });
 
+  it("unwraps every connection error in an aggregate cause", () => {
+    const err = new TypeError("fetch failed", {
+      cause: new AggregateError([
+        new Error("connect EPERM ::1:38886"),
+        new Error("connect ECONNREFUSED 127.0.0.1:38886"),
+      ]),
+    });
+
+    expect(getErrorMessage(err)).toBe(
+      "fetch failed: connect EPERM ::1:38886: connect ECONNREFUSED 127.0.0.1:38886",
+    );
+  });
+
   it("returns the message unchanged without a cause", () => {
     expect(getErrorMessage(new Error("plain"))).toBe("plain");
   });

--- a/apps/cli/src/__tests__/get-error-message.test.ts
+++ b/apps/cli/src/__tests__/get-error-message.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage } from "../commands/helpers.js";
+
+describe("getErrorMessage", () => {
+  it("unwraps the cause chain so connect errors survive fetch failed", () => {
+    const err = new TypeError("fetch failed", {
+      cause: new Error("connect EPERM 127.0.0.1:38886"),
+    });
+
+    expect(getErrorMessage(err)).toBe(
+      "fetch failed: connect EPERM 127.0.0.1:38886",
+    );
+  });
+
+  it("returns the message unchanged without a cause", () => {
+    expect(getErrorMessage(new Error("plain"))).toBe("plain");
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(getErrorMessage("boom")).toBe("boom");
+  });
+
+  it("stops on a cyclic cause chain", () => {
+    const err = new Error("loop");
+    err.cause = err;
+
+    expect(getErrorMessage(err)).toBe("loop");
+  });
+});

--- a/apps/cli/src/commands/helpers.ts
+++ b/apps/cli/src/commands/helpers.ts
@@ -88,8 +88,20 @@ export async function confirmDestructiveAction(
 }
 
 export function getErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
+  if (!(err instanceof Error)) return String(err);
+  // Unwrap the cause chain: Node's fetch always says "fetch failed" and keeps
+  // the actionable error (e.g. connect EPERM/ECONNREFUSED) on `cause`.
+  const seen = new Set<Error>([err]);
+  const messages = [err.message];
+  for (
+    let cause = err.cause;
+    cause instanceof Error && !seen.has(cause);
+    cause = cause.cause
+  ) {
+    seen.add(cause);
+    messages.push(cause.message);
+  }
+  return messages.join(": ");
 }
 
 export function parseReasoningLevel(

--- a/apps/cli/src/commands/helpers.ts
+++ b/apps/cli/src/commands/helpers.ts
@@ -89,17 +89,36 @@ export async function confirmDestructiveAction(
 
 export function getErrorMessage(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
-  // Unwrap the cause chain: Node's fetch always says "fetch failed" and keeps
-  // the actionable error (e.g. connect EPERM/ECONNREFUSED) on `cause`.
-  const seen = new Set<Error>([err]);
-  const messages = [err.message];
-  for (
-    let cause = err.cause;
-    cause instanceof Error && !seen.has(cause);
-    cause = cause.cause
-  ) {
-    seen.add(cause);
-    messages.push(cause.message);
+  // Node's fetch says "fetch failed" and keeps the actionable socket errors
+  // under `cause`. Multi-address connections use an AggregateError, so walk
+  // both links while guarding against malformed cyclic error graphs.
+  const seen = new Set<Error>();
+  const messages: string[] = [];
+  const pending: Error[] = [err];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined || seen.has(current)) continue;
+    seen.add(current);
+
+    if (current.message.length > 0) {
+      messages.push(current.message);
+    }
+
+    const children: Error[] = [];
+    if (current.cause instanceof Error) {
+      children.push(current.cause);
+    }
+    if (current instanceof AggregateError) {
+      children.push(
+        ...current.errors.filter(
+          (nested): nested is Error => nested instanceof Error,
+        ),
+      );
+    }
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      pending.push(children[index]);
+    }
   }
   return messages.join(": ");
 }


### PR DESCRIPTION
## Summary
Fixes #1189. Node's fetch rejects with a generic `TypeError: fetch failed` and keeps the actionable socket error (for example, `connect EPERM 127.0.0.1:38886`) under `.cause`. For multi-address connections such as `localhost`, that cause can be an `AggregateError` whose `.errors` contain the per-address failures.

The CLI's `getErrorMessage` previously read only the outer `.message`, so distinct failures all printed the same uninformative `Error: fetch failed`.

Walk the error graph when formatting CLI errors:
- follow ordinary `.cause` chains;
- include every nested `AggregateError.errors` entry;
- skip empty wrapper messages; and
- stop safely on cyclic graphs.

A sandbox-blocked connection now prints the underlying `EPERM` detail, including when it is one attempt in a multi-address connection. The existing ECONNREFUSED mapping to "Cannot connect to BB server" is unchanged.

## Verification
- `pnpm exec turbo run typecheck --filter=@bb/cli --force`
- `pnpm exec turbo run test --filter=@bb/cli --force`
- `pnpm exec turbo run build --filter=@bb/cli --force`
- Prettier check for the changed files