### PR TITLE
Tasks: show child tickets in task overviews

### DIFF
--- a/plugins/tasks/views/list/data.ts
+++ b/plugins/tasks/views/list/data.ts
@@ -18,10 +18,7 @@ export interface ListTaskFilters {
   labelIds: readonly string[] | null;
 }
 
-/**
- * Server-side filtered task list. Subtasks are excluded (parentTaskId: null),
- * matching the design mock — they surface on their parent's detail page.
- */
+/** Server-side filtered task list, including matching parent and child tasks. */
 export function useListTasks(
   projectId: string | null,
   activeOnly: boolean,
@@ -41,7 +38,6 @@ export function useListTasks(
           ? { labelIds: [...filters.labelIds] }
           : {}),
         activeOnly,
-        parentTaskId: null,
       }),
     ["tasks:changed", "threads:changed"],
     [

--- a/plugins/tasks/views/list/hierarchy.test.tsx
+++ b/plugins/tasks/views/list/hierarchy.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import { cleanup, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import type { Task } from "../../shared/contract.js";
+import { LIST_PREFERENCE_STORAGE_KEY } from "./list-preference.js";
+
+window.matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+window.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView ??= () => {};
+
+const app = await loadPluginApp(() => import("../../app"));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+const PROJECT_A = "01HZZZZZZZZZZZZZZZZZZZZZP1";
+const PROJECT_B = "01HZZZZZZZZZZZZZZZZZZZZZP2";
+
+const projectA = {
+  id: PROJECT_A,
+  name: "Alpha",
+  prefix: "ALP",
+  nextTaskNumber: 20,
+  color: "blue",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-08-08T00:00:00.000Z",
+};
+
+const projectB = {
+  id: PROJECT_B,
+  name: "Beta",
+  prefix: "BET",
+  nextTaskNumber: 20,
+  color: "green",
+  folderId: null,
+  linkedBbProjectId: null,
+  createdAt: "2026-08-08T00:00:00.000Z",
+};
+
+function task(
+  projectId: string,
+  number: number,
+  overrides: Partial<Task> = {},
+): Task {
+  const prefix = projectId === PROJECT_A ? "ALP" : "BET";
+  return {
+    id: `${projectId.slice(0, -2)}T${projectId.slice(-1)}${number}`,
+    projectId,
+    number,
+    key: `${prefix}-${number}`,
+    title: `${prefix} task ${number}`,
+    description: "",
+    status: "todo",
+    priority: "none",
+    dueDate: null,
+    parentTaskId: null,
+    position: number,
+    createdAt: "2026-08-08T00:00:00.000Z",
+    updatedAt: "2026-08-08T00:00:00.000Z",
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+interface ListTasksInput {
+  projectId?: string;
+  statuses?: Task["status"][];
+  priorities?: Task["priority"][];
+  parentTaskId?: string | null;
+}
+
+function taskRpc(allTasks: readonly Task[]) {
+  const listTasksCalls: ListTasksInput[] = [];
+  const rpc = {
+    listProjects: () => ({ projects: [projectA, projectB] }),
+    listFolders: () => ({ folders: [] }),
+    listPresets: () => ({ presets: [] }),
+    sidebarSummary: () => ({ projects: [] }),
+    listLabels: () => ({ labels: [] }),
+    listTasks: (input: ListTasksInput) => {
+      listTasksCalls.push(input);
+      let tasks = [...allTasks];
+      if (input.projectId !== undefined) {
+        tasks = tasks.filter((entry) => entry.projectId === input.projectId);
+      }
+      if (input.statuses !== undefined) {
+        const statuses = new Set(input.statuses);
+        tasks = tasks.filter((entry) => statuses.has(entry.status));
+      }
+      if (input.priorities !== undefined) {
+        const priorities = new Set(input.priorities);
+        tasks = tasks.filter((entry) => priorities.has(entry.priority));
+      }
+      if (input.parentTaskId !== undefined) {
+        tasks = tasks.filter(
+          (entry) => entry.parentTaskId === input.parentTaskId,
+        );
+      }
+      return { tasks, nextCursor: null };
+    },
+    listTaskThreads: () => ({ taskThreads: [] }),
+    listComments: () => ({ comments: [] }),
+    listAttachments: () => ({ attachments: [] }),
+  };
+  return Object.assign(rpc, { listTasksCalls });
+}
+
+function renderList(subPath: string, tasks: readonly Task[]) {
+  const rpc = taskRpc(tasks);
+  const slot = renderSlot(app.navPanels[0]!, { subPath }, { rpc });
+  return { rpc, slot };
+}
+
+async function renderedKeys(slot: ReturnType<typeof renderSlot>) {
+  await waitFor(() =>
+    expect(slot.container.querySelector("[data-task-key]")).not.toBeNull(),
+  );
+  return Array.from(
+    slot.container.querySelectorAll<HTMLElement>("[data-task-key]"),
+  ).map((row) => row.dataset.taskKey);
+}
+
+function row(slot: ReturnType<typeof renderSlot>, key: string): HTMLElement {
+  const result = slot.container.querySelector<HTMLElement>(
+    `[data-task-key="${key}"]`,
+  );
+  if (result === null) throw new Error(`Missing task row ${key}`);
+  return result;
+}
+
+function storePreference(
+  scope: string,
+  preference: {
+    statuses?: Task["status"][];
+    priorities?: Task["priority"][];
+    sort: "manual" | "priority" | "due";
+  },
+) {
+  window.localStorage.setItem(
+    LIST_PREFERENCE_STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      scopes: {
+        [scope]: {
+          filters: {
+            statuses: preference.statuses ?? [],
+            priorities: preference.priorities ?? [],
+            labelNames: [],
+          },
+          sort: preference.sort,
+        },
+      },
+    }),
+  );
+}
+
+describe("task list hierarchy", () => {
+  it("renders project children directly beneath their parent", async () => {
+    const parent = task(PROJECT_A, 1);
+    const child = task(PROJECT_A, 2, {
+      status: "done",
+      parentTaskId: parent.id,
+    });
+    const doneRoot = task(PROJECT_A, 3, { status: "done" });
+    const { rpc, slot } = renderList(PROJECT_A, [parent, child, doneRoot]);
+
+    expect(await renderedKeys(slot)).toEqual(["ALP-1", "ALP-2", "ALP-3"]);
+    expect(row(slot, "ALP-1").dataset.taskDepth).toBe("0");
+    expect(row(slot, "ALP-2").dataset.taskDepth).toBe("1");
+    expect(
+      row(slot, "ALP-2").querySelector('[data-icon="CornerDownRight"]'),
+    ).not.toBeNull();
+    expect(rpc.listTasksCalls.some((input) => "parentTaskId" in input)).toBe(
+      false,
+    );
+
+    const todoSection = slot.container
+      .querySelector('[data-status-group-header="todo"]')
+      ?.closest("section");
+    expect(
+      Array.from(todoSection?.querySelectorAll("[data-task-key]") ?? []).map(
+        (entry) => entry.getAttribute("data-task-key"),
+      ),
+    ).toEqual(["ALP-1", "ALP-2"]);
+  });
+
+  it("sorts roots and child siblings while keeping each child attached", async () => {
+    storePreference(`project:${PROJECT_A}`, { sort: "priority" });
+    const parent = task(PROJECT_A, 1);
+    const lowChild = task(PROJECT_A, 2, {
+      priority: "low",
+      parentTaskId: parent.id,
+    });
+    const urgentChild = task(PROJECT_A, 3, {
+      priority: "urgent",
+      parentTaskId: parent.id,
+    });
+    const highRoot = task(PROJECT_A, 4, { priority: "high" });
+    const { slot } = renderList(PROJECT_A, [
+      parent,
+      lowChild,
+      urgentChild,
+      highRoot,
+    ]);
+
+    expect(await renderedKeys(slot)).toEqual([
+      "ALP-4",
+      "ALP-1",
+      "ALP-3",
+      "ALP-2",
+    ]);
+    expect(row(slot, "ALP-3").dataset.taskDepth).toBe("1");
+    expect(row(slot, "ALP-2").dataset.taskDepth).toBe("1");
+  });
+
+  it("keeps a filtered child visible as a root when its parent is absent", async () => {
+    storePreference(`project:${PROJECT_A}`, {
+      statuses: ["done"],
+      sort: "manual",
+    });
+    const parent = task(PROJECT_A, 1, { status: "todo" });
+    const child = task(PROJECT_A, 2, {
+      status: "done",
+      parentTaskId: parent.id,
+    });
+    const { slot } = renderList(PROJECT_A, [parent, child]);
+
+    expect(await renderedKeys(slot)).toEqual(["ALP-2"]);
+    expect(row(slot, "ALP-2").dataset.taskDepth).toBe("0");
+    expect(
+      row(slot, "ALP-2").querySelector('[data-icon="CornerDownRight"]'),
+    ).toBeNull();
+  });
+
+  it("nests children for each project in the All Tasks overview", async () => {
+    const parentA = task(PROJECT_A, 1);
+    const childA = task(PROJECT_A, 2, { parentTaskId: parentA.id });
+    const parentB = task(PROJECT_B, 1);
+    const childB = task(PROJECT_B, 2, { parentTaskId: parentB.id });
+    const { rpc, slot } = renderList("all", [parentA, childA, parentB, childB]);
+
+    expect(await renderedKeys(slot)).toEqual([
+      "ALP-1",
+      "ALP-2",
+      "BET-1",
+      "BET-2",
+    ]);
+    expect(row(slot, "ALP-2").dataset.taskDepth).toBe("1");
+    expect(row(slot, "BET-2").dataset.taskDepth).toBe("1");
+    expect(rpc.listTasksCalls[0]?.projectId).toBeUndefined();
+    expect(rpc.listTasksCalls.some((input) => "parentTaskId" in input)).toBe(
+      false,
+    );
+  });
+});

--- a/plugins/tasks/views/list/index.tsx
+++ b/plugins/tasks/views/list/index.tsx
@@ -27,7 +27,7 @@ import {
   useListScrollRestoration,
 } from "./scroll-restoration.js";
 import {
-  groupTasksByStatus,
+  groupTaskHierarchyByStatus,
   labelFilterOptions,
   selectedLabelIds,
   STATUS_LABELS,
@@ -193,7 +193,7 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
     labelIds,
   ]);
   const groups = useMemo(
-    () => groupTasksByStatus(sortTasks(displayTasks ?? [], sort)),
+    () => groupTaskHierarchyByStatus(sortTasks(displayTasks ?? [], sort)),
     [displayTasks, sort],
   );
 
@@ -294,13 +294,14 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
           <StatusIcon status={group.status} />
           {STATUS_LABELS[group.status]}
           <span className="text-xs font-normal tabular-nums text-subtle-foreground">
-            {group.tasks.length}
+            {group.entries.length}
           </span>
         </div>
-        {group.tasks.map((task) => (
+        {group.entries.map(({ task, depth }) => (
           <TaskRow
             key={task.id}
             task={task}
+            depth={depth}
             meta={meta.data?.get(task.id)}
             project={projectsById.get(task.projectId)}
             showProject={showProject}

--- a/plugins/tasks/views/list/lib.ts
+++ b/plugins/tasks/views/list/lib.ts
@@ -35,6 +35,16 @@ export interface StatusGroup {
   tasks: Task[];
 }
 
+export interface HierarchicalTask {
+  task: Task;
+  depth: 0 | 1;
+}
+
+export interface HierarchicalStatusGroup {
+  status: TaskStatus;
+  entries: HierarchicalTask[];
+}
+
 /**
  * Buckets tasks into canonical status order, dropping empty groups. Within a
  * group the incoming order is preserved, so callers control ordering by
@@ -50,6 +60,50 @@ export function groupTasksByStatus(tasks: readonly Task[]): StatusGroup[] {
   return TASK_STATUSES.flatMap((status) => {
     const bucket = byStatus.get(status);
     return bucket ? [{ status, tasks: bucket }] : [];
+  });
+}
+
+/**
+ * Builds the list presentation from an already-sorted task set. Roots keep
+ * their incoming order, while matching children move directly beneath their
+ * parent and keep their incoming sibling order. A child whose parent is not
+ * in the filtered result remains a root, so filtering never hides a match.
+ *
+ * Children inherit their parent's presentation group even when their own
+ * status differs; the row still renders the child's status editor. This keeps
+ * the parent/child relationship intact while preserving canonical root status
+ * groups and the caller's selected sort.
+ */
+export function groupTaskHierarchyByStatus(
+  tasks: readonly Task[],
+): HierarchicalStatusGroup[] {
+  const taskIds = new Set(tasks.map((task) => task.id));
+  const childrenByParentId = new Map<string, Task[]>();
+  const roots: Task[] = [];
+
+  for (const task of tasks) {
+    if (task.parentTaskId !== null && taskIds.has(task.parentTaskId)) {
+      const children = childrenByParentId.get(task.parentTaskId);
+      if (children) children.push(task);
+      else childrenByParentId.set(task.parentTaskId, [task]);
+    } else {
+      roots.push(task);
+    }
+  }
+
+  const byStatus = new Map<TaskStatus, HierarchicalTask[]>();
+  for (const root of roots) {
+    const entries = byStatus.get(root.status) ?? [];
+    entries.push({ task: root, depth: 0 });
+    for (const child of childrenByParentId.get(root.id) ?? []) {
+      entries.push({ task: child, depth: 1 });
+    }
+    byStatus.set(root.status, entries);
+  }
+
+  return TASK_STATUSES.flatMap((status) => {
+    const entries = byStatus.get(status);
+    return entries ? [{ status, entries }] : [];
   });
 }
 
@@ -97,9 +151,7 @@ export function formatDueDate(dueDate: string, today = new Date()): string {
   return date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
-    ...(date.getFullYear() === today.getFullYear()
-      ? {}
-      : { year: "numeric" }),
+    ...(date.getFullYear() === today.getFullYear() ? {} : { year: "numeric" }),
   });
 }
 

--- a/plugins/tasks/views/list/row.tsx
+++ b/plugins/tasks/views/list/row.tsx
@@ -112,6 +112,8 @@ function LabelChips({
 export interface TaskRowProps {
   /** Task with any pending optimistic edit already applied. */
   task: Task;
+  /** Zero for a root result; one for a child rendered beneath its parent. */
+  depth: 0 | 1;
   meta: TaskRowMeta | undefined;
   project: Project | undefined;
   showProject: boolean;
@@ -134,6 +136,7 @@ export interface TaskRowProps {
  */
 export function TaskRow({
   task,
+  depth,
   meta,
   project,
   showProject,
@@ -149,6 +152,7 @@ export function TaskRow({
     <TaskContextMenu task={task} onEdit={onEdit} projectLabels={projectLabels}>
       <div
         data-task-key={task.key}
+        data-task-depth={depth}
         aria-busy={pending || undefined}
         className={cn(
           // Narrow containers get a two-line hierarchy: status + full-width
@@ -158,9 +162,17 @@ export function TaskRow({
           // keeps its exact 34px rows.
           "relative grid w-full grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-x-2 gap-y-1 border-b border-border-hairline px-3.5 py-1.5 text-left transition-opacity hover:bg-state-hover",
           "@md:flex @md:h-[34px] @md:py-0",
+          depth === 1 && "pl-8",
           pending && "opacity-70",
         )}
       >
+        {depth === 1 ? (
+          <Icon
+            name="CornerDownRight"
+            aria-hidden
+            className="pointer-events-none absolute left-3.5 top-2 size-3 text-subtle-foreground @md:top-1/2 @md:-translate-y-1/2"
+          />
+        ) : null}
         <button
           type="button"
           aria-label={`Open ${task.key}: ${task.title}`}


### PR DESCRIPTION
## Summary

- include matching child tickets in the task overview query
- preserve canonical status grouping and existing sort semantics while placing children directly beneath their parent
- render a compact indented child treatment in both project-scoped and All Tasks views
- keep a matching child visible at root depth when filtering excludes its parent

## Validation

- `pnpm exec turbo run test --filter=bb-plugin-tasks --force` — 35 files, 331 tests passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-tasks`
- `pnpm exec turbo run build --filter=bb-plugin-tasks`
- `pnpm exec prettier --check plugins/tasks/views/list/data.ts plugins/tasks/views/list/index.tsx plugins/tasks/views/list/lib.ts plugins/tasks/views/list/row.tsx plugins/tasks/views/list/hierarchy.test.tsx`
- `git diff --check`
- live light/dark visual QA with project-scoped and All Tasks demo hierarchy