### PR TITLE
fix(app): accept unnamed Android IME image paste files

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -413,15 +413,21 @@ function pastePlainText(text: string) {
 }
 
 function pasteClipboard({
+  files = [],
   html = "",
   plainText = "",
 }: {
+  files?: File[];
   html?: string;
   plainText?: string;
 }) {
   fireEvent.paste(getPromptEditorElement(), {
     clipboardData: {
-      items: [],
+      items: files.map((file) => ({
+        getAsFile: () => file,
+        kind: "file",
+        type: file.type,
+      })),
       getData: (type: string) => {
         if (type === "text/html") return html;
         if (type === "text/plain") return plainText;
@@ -3046,6 +3052,34 @@ describe("PromptBoxInternal prompt actions", () => {
       coordsAtPosSpy.mockRestore();
       scrollRectSpy.mockRestore();
     }
+  });
+
+  it("names an unnamed Android IME image before attaching it", async () => {
+    const onAttachFiles = vi.fn<(files: File[]) => void>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          attachments: { onAttachFiles },
+          promptActions,
+        })}
+      />,
+    );
+    const image = new File([new Uint8Array([137, 80, 78, 71])], "", {
+      type: "image/png",
+      lastModified: 123,
+    });
+
+    pasteClipboard({ files: [image] });
+
+    await waitFor(() => expect(onAttachFiles).toHaveBeenCalledOnce());
+    const attachedFiles = onAttachFiles.mock.calls[0]?.[0];
+    expect(attachedFiles).toHaveLength(1);
+    expect(attachedFiles[0]).toMatchObject({
+      name: "pasted-image.png",
+      type: "image/png",
+      size: image.size,
+      lastModified: 123,
+    });
   });
 
   it("preserves blockquote structure when pasting copied blockquote html", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -168,6 +168,32 @@ const RICH_PASTE_IGNORED_TAGS = new Set([
   "TITLE",
 ]);
 
+const PASTED_IMAGE_EXTENSIONS: Readonly<Record<string, string>> = {
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/gif": "gif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+};
+
+function nameUnnamedPastedFile(file: File, index: number): File {
+  if (file.name.trim().length > 0) return file;
+
+  // Android IME media insertion provides valid image bytes without a filename.
+  const isImage = file.type.startsWith("image/");
+  const extension = isImage ? PASTED_IMAGE_EXTENSIONS[file.type] : undefined;
+  const sequence = index === 0 ? "" : `-${index + 1}`;
+  const extensionSuffix = extension ? `.${extension}` : "";
+  const name = `pasted-${isImage ? "image" : "file"}${sequence}${extensionSuffix}`;
+
+  return new File([file], name, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
+}
+
 function hasWhitespaceAfterPosition(
   doc: ProseMirrorNode,
   position: number,
@@ -1875,7 +1901,8 @@ export function PromptBoxInternal({
           const pastedFiles = clipboardItems
             .filter((item) => item.kind === "file")
             .map((item) => item.getAsFile())
-            .filter((file): file is File => file !== null);
+            .filter((file): file is File => file !== null)
+            .map(nameUnnamedPastedFile);
 
           if (attachFiles && pastedFiles.length > 0) {
             event.preventDefault();


### PR DESCRIPTION
## Summary

- give pasted files a safe filename when Android's IME supplies valid bytes with an empty `File.name`
- preserve MIME type, bytes, and `lastModified`, while leaving already-named files unchanged
- cover the exact Android/Gboard clipboard payload with a promptbox regression test

## Root cause

This was reproduced end to end in the installed bb WebAPK on an Oppo Pad Mini running Android 16 and Chrome 150.

There are two browser/application stages:

1. Chrome's **Enable IME media insertion** feature is currently disabled by default. In that state Android reports `contentMimeTypes=null`; Gboard stops before the page receives an event and displays “Chrome does not support image pasting here.” Web code cannot handle an event that Chrome does not emit.
2. With Chrome's feature enabled, Android reports `contentMimeTypes=[image/*]` and Gboard dispatches a normal `paste` event. Its clipboard payload contains one valid `image/png` file, but the filename is the empty string. `PromptBoxInternal` forwarded that file unchanged, and the SDK rejected it with `Project attachment filename must not be empty`.

This is not caused by the PWA manifest or standalone display mode. The WebAPK runs through Chrome's regular editor/input connection; the PWA simply exposed the same unnamed-file payload to bb's existing paste handler.

## Fix

Normalize only pasted files whose names are empty or whitespace. Images receive a stable `pasted-image` name and a MIME-derived extension (for example, `pasted-image.png`). Additional files receive numbered names. Existing filenames are preserved.

The live production upload path was also exercised with the equivalent normalization: Gboard's unnamed 11.7 KB PNG became `pasted-image.png`, uploaded successfully, and rendered in the composer.

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force` — 323 files / 2,431 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 0 errors (141 existing warnings)
- live Android WebAPK verification confirmed the unnamed-file failure and successful normalized upload

