### PR TITLE
Preserve host-daemon startup error causes

### DIFF
--- a/packages/process-utils/src/index.ts
+++ b/packages/process-utils/src/index.ts
@@ -63,6 +63,7 @@ export interface WriteSafeProcessDiagnosticReportArgs
 }
 
 const MAX_DIAGNOSTIC_ERROR_CAUSE_DEPTH = 8;
+const MAX_DIAGNOSTIC_AGGREGATE_ERRORS = 8;
 
 interface SafeProcessDiagnosticError {
   name: string;
@@ -70,6 +71,8 @@ interface SafeProcessDiagnosticError {
   stack?: string;
   code?: string;
   cause?: SafeProcessDiagnosticError;
+  errors?: SafeProcessDiagnosticError[];
+  errorsTruncated?: number;
   truncationReason?: "cycle" | "depth";
 }
 
@@ -241,6 +244,20 @@ function serializeDiagnosticError(
         depth + 1,
       );
     }
+    if (error instanceof AggregateError) {
+      const aggregateErrors = error.errors.slice(
+        0,
+        MAX_DIAGNOSTIC_AGGREGATE_ERRORS,
+      );
+      serialized.errors = aggregateErrors.map((aggregateError) =>
+        serializeDiagnosticError(aggregateError, seenErrors, depth + 1),
+      );
+      const errorsTruncated = error.errors.length - aggregateErrors.length;
+      if (errorsTruncated > 0) {
+        serialized.errorsTruncated = errorsTruncated;
+      }
+    }
+    seenErrors.delete(error);
     return serialized;
   }
 

--- a/packages/process-utils/src/index.ts
+++ b/packages/process-utils/src/index.ts
@@ -62,10 +62,15 @@ export interface WriteSafeProcessDiagnosticReportArgs
   createReportId?: () => string;
 }
 
+const MAX_DIAGNOSTIC_ERROR_CAUSE_DEPTH = 8;
+
 interface SafeProcessDiagnosticError {
   name: string;
   message: string;
   stack?: string;
+  code?: string;
+  cause?: SafeProcessDiagnosticError;
+  truncationReason?: "cycle" | "depth";
 }
 
 interface SafeProcessDiagnosticReport {
@@ -192,16 +197,49 @@ function formatDiagnosticTimestamp(date: Date): string {
   return date.toISOString().replace(/[:.]/g, "-");
 }
 
+function createTruncatedDiagnosticError(
+  truncationReason: "cycle" | "depth",
+): SafeProcessDiagnosticError {
+  return {
+    name: "TruncatedErrorCause",
+    message:
+      truncationReason === "cycle"
+        ? "Error cause serialization stopped because the cause chain contains a cycle"
+        : `Error cause serialization stopped at the maximum depth of ${MAX_DIAGNOSTIC_ERROR_CAUSE_DEPTH}`,
+    truncationReason,
+  };
+}
+
 function serializeDiagnosticError(
   error: unknown,
+  seenErrors: Set<Error> = new Set(),
+  depth = 0,
 ): SafeProcessDiagnosticError {
   if (error instanceof Error) {
+    if (seenErrors.has(error)) {
+      return createTruncatedDiagnosticError("cycle");
+    }
+    if (depth >= MAX_DIAGNOSTIC_ERROR_CAUSE_DEPTH) {
+      return createTruncatedDiagnosticError("depth");
+    }
+    seenErrors.add(error);
+
     const serialized: SafeProcessDiagnosticError = {
       name: error.name,
       message: error.message,
     };
     if (error.stack !== undefined) {
       serialized.stack = error.stack;
+    }
+    if ("code" in error && typeof error.code === "string") {
+      serialized.code = error.code;
+    }
+    if (error.cause !== undefined) {
+      serialized.cause = serializeDiagnosticError(
+        error.cause,
+        seenErrors,
+        depth + 1,
+      );
     }
     return serialized;
   }

--- a/packages/process-utils/test/index.test.ts
+++ b/packages/process-utils/test/index.test.ts
@@ -108,6 +108,100 @@ describe("process utils", () => {
     }
   });
 
+  it("writes nested error causes", () => {
+    const logsDir = join(
+      mkdtempSync(join(tmpdir(), "bb-process-utils-report-")),
+      "logs",
+    );
+    const connectionError = new Error(
+      "connect ECONNREFUSED 127.0.0.1:38886",
+    );
+    Object.defineProperty(connectionError, "code", {
+      value: "ECONNREFUSED",
+    });
+    const reportPath = writeSafeProcessDiagnosticReport({
+      kind: "startupFailure",
+      logsDir,
+      processName: "host-daemon",
+      error: new TypeError("fetch failed", { cause: connectionError }),
+      now: () => new Date("2026-06-01T12:00:00.000Z"),
+      createReportId: () => "report-id",
+    });
+
+    expect(JSON.parse(readFileSync(reportPath, "utf8"))).toMatchObject({
+      error: {
+        name: "TypeError",
+        message: "fetch failed",
+        cause: {
+          name: "Error",
+          message: "connect ECONNREFUSED 127.0.0.1:38886",
+          code: "ECONNREFUSED",
+        },
+      },
+    });
+  });
+
+  it("truncates cyclic error causes", () => {
+    const logsDir = join(
+      mkdtempSync(join(tmpdir(), "bb-process-utils-report-")),
+      "logs",
+    );
+    const firstError = new Error("first");
+    const secondError = new Error("second");
+    firstError.cause = secondError;
+    secondError.cause = firstError;
+
+    const reportPath = writeSafeProcessDiagnosticReport({
+      kind: "startupFailure",
+      logsDir,
+      processName: "host-daemon",
+      error: firstError,
+      now: () => new Date("2026-06-01T12:00:00.000Z"),
+      createReportId: () => "report-id",
+    });
+
+    expect(JSON.parse(readFileSync(reportPath, "utf8"))).toMatchObject({
+      error: {
+        message: "first",
+        cause: {
+          message: "second",
+          cause: {
+            name: "TruncatedErrorCause",
+            truncationReason: "cycle",
+          },
+        },
+      },
+    });
+  });
+
+  it("truncates error causes that exceed the depth limit", () => {
+    const logsDir = join(
+      mkdtempSync(join(tmpdir(), "bb-process-utils-report-")),
+      "logs",
+    );
+    const rootError = new Error("cause-0");
+    let currentError = rootError;
+    for (let index = 1; index < 32; index += 1) {
+      const cause = new Error(`cause-${index}`);
+      currentError.cause = cause;
+      currentError = cause;
+    }
+
+    const reportPath = writeSafeProcessDiagnosticReport({
+      kind: "startupFailure",
+      logsDir,
+      processName: "host-daemon",
+      error: rootError,
+      now: () => new Date("2026-06-01T12:00:00.000Z"),
+      createReportId: () => "report-id",
+    });
+    const reportText = readFileSync(reportPath, "utf8");
+
+    expect(reportText).toContain('"name": "TruncatedErrorCause"');
+    expect(reportText).toContain('"truncationReason": "depth"');
+    expect(reportText).not.toContain("cause-31");
+  });
+
   it("spawns a process with piped stdio", async () => {
     await expect(readProcessOutput()).resolves.toEqual({
       exitCode: 0,

--- a/packages/process-utils/test/index.test.ts
+++ b/packages/process-utils/test/index.test.ts
@@ -202,6 +202,33 @@ describe("process utils", () => {
     expect(reportText).not.toContain("cause-31");
   });
 
+  it("writes bounded AggregateError details", () => {
+    const logsDir = join(
+      mkdtempSync(join(tmpdir(), "bb-process-utils-report-")),
+      "logs",
+    );
+    const connectionErrors = Array.from({ length: 10 }, (_, index) => {
+      const error = new Error(`connect ECONNREFUSED address-${index}`);
+      Object.defineProperty(error, "code", { value: "ECONNREFUSED" });
+      return error;
+    });
+    const reportPath = writeSafeProcessDiagnosticReport({
+      kind: "startupFailure",
+      logsDir,
+      processName: "host-daemon",
+      error: new AggregateError(connectionErrors, "fetch failed"),
+      now: () => new Date("2026-06-01T12:00:00.000Z"),
+      createReportId: () => "report-id",
+    });
+    const reportText = readFileSync(reportPath, "utf8");
+
+    expect(reportText).toContain('"errors"');
+    expect(reportText).toContain('"code": "ECONNREFUSED"');
+    expect(reportText).toContain("connect ECONNREFUSED address-7");
+    expect(reportText).toContain('"errorsTruncated": 2');
+    expect(reportText).not.toContain("connect ECONNREFUSED address-8");
+  });
+
   it("spawns a process with piped stdio", async () => {
     await expect(readProcessOutput()).resolves.toEqual({
       exitCode: 0,


### PR DESCRIPTION
## Reproduction

Starting the host daemon against a closed server port produced TypeError: fetch failed. The startup report omitted the nested ECONNREFUSED cause.

## Root cause

The safe diagnostic writer copied only the outer error name, message, and stack.

## Fix

Serialize nested error causes and system error codes. Stop cyclic or deep cause chains with explicit truncation markers. Add regression tests for each case.

Fixes #1119