### PR TITLE
Protect pending turns from runtime eviction

### DIFF
--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -278,11 +278,8 @@ function createFakeRuntime(): AgentRuntime {
     hasThread() {
       return false;
     },
-    getActiveThreadIds() {
+    getLiveThreadIds() {
       return [];
-    },
-    hasPendingTurnStart() {
-      return false;
     },
     hasOpenBackgroundWork() {
       return false;

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -281,6 +281,9 @@ function createFakeRuntime(): AgentRuntime {
     getActiveThreadIds() {
       return [];
     },
+    hasPendingTurnStart() {
+      return false;
+    },
     hasOpenBackgroundWork() {
       return false;
     },

--- a/apps/host-daemon/src/command-dispatch-support.test.ts
+++ b/apps/host-daemon/src/command-dispatch-support.test.ts
@@ -84,6 +84,9 @@ function makeRuntime(args: MakeRuntimeArgs): AgentRuntime {
     getActiveThreadIds() {
       return [];
     },
+    hasPendingTurnStart() {
+      return false;
+    },
     hasOpenBackgroundWork() {
       return false;
     },

--- a/apps/host-daemon/src/command-dispatch-support.test.ts
+++ b/apps/host-daemon/src/command-dispatch-support.test.ts
@@ -81,11 +81,8 @@ function makeRuntime(args: MakeRuntimeArgs): AgentRuntime {
     hasThread() {
       return false;
     },
-    getActiveThreadIds() {
+    getLiveThreadIds() {
       return [];
-    },
-    hasPendingTurnStart() {
-      return false;
     },
     hasOpenBackgroundWork() {
       return false;

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -205,8 +205,7 @@ function createRuntime(): FakeDispatchRuntime {
         : null,
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: (threadId) => hostedThreadIds.has(threadId),
-    getActiveThreadIds: () => [...activeTurnsByThreadId.keys()],
-    hasPendingTurnStart: () => false,
+    getLiveThreadIds: () => [...activeTurnsByThreadId.keys()],
     hasOpenBackgroundWork: () => false,
     shutdown: vi.fn(async () => undefined),
     setActiveTurn: (threadId, turnId) => {

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -206,6 +206,7 @@ function createRuntime(): FakeDispatchRuntime {
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: (threadId) => hostedThreadIds.has(threadId),
     getActiveThreadIds: () => [...activeTurnsByThreadId.keys()],
+    hasPendingTurnStart: () => false,
     hasOpenBackgroundWork: () => false,
     shutdown: vi.fn(async () => undefined),
     setActiveTurn: (threadId, turnId) => {

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -245,13 +245,13 @@ interface FakeAgentRuntime extends AgentRuntime {
   endActiveTurn: (threadId: string) => void;
   setActiveTurn: (threadId: string, turnId: string) => void;
   setOpenBackgroundWork: (hasOpenWork: boolean) => void;
-  setPendingTurnStart: (hasPending: boolean) => void;
+  setPendingTurnStart: (threadId: string, hasPending: boolean) => void;
 }
 
 function createFakeRuntime() {
   const activeTurnsByThreadId = new Map<string, string>();
   let openBackgroundWork = false;
-  let pendingTurnStart = false;
+  const pendingTurnStartThreadIds = new Set<string>();
   return {
     ensureProvider: vi.fn(async (_args: EnsureProviderArgs) => undefined),
     startThread: vi.fn(async (_args: StartThreadArgs) => ({
@@ -282,8 +282,12 @@ function createFakeRuntime() {
       async () => ({ reapedSessions: [] }),
     ),
     hasThread: (threadId) => activeTurnsByThreadId.has(threadId),
-    getActiveThreadIds: () => [...activeTurnsByThreadId.keys()],
-    hasPendingTurnStart: () => pendingTurnStart,
+    getLiveThreadIds: () => [
+      ...new Set([
+        ...activeTurnsByThreadId.keys(),
+        ...pendingTurnStartThreadIds,
+      ]),
+    ],
     hasOpenBackgroundWork: () => openBackgroundWork,
     shutdown: vi.fn(async () => undefined),
     endActiveTurn: (threadId) => {
@@ -295,8 +299,12 @@ function createFakeRuntime() {
     setOpenBackgroundWork: (hasOpenWork) => {
       openBackgroundWork = hasOpenWork;
     },
-    setPendingTurnStart: (hasPending) => {
-      pendingTurnStart = hasPending;
+    setPendingTurnStart: (threadId, hasPending) => {
+      if (hasPending) {
+        pendingTurnStartThreadIds.add(threadId);
+      } else {
+        pendingTurnStartThreadIds.delete(threadId);
+      }
     },
   } satisfies FakeAgentRuntime;
 }
@@ -1429,7 +1437,7 @@ describe("RuntimeManager", () => {
       environmentId: "env-1",
       workspacePath: "/tmp/env-1",
     });
-    runtime.setPendingTurnStart(true);
+    runtime.setPendingTurnStart("thread-1", true);
 
     await manager.replaceBaseShellEnv({
       PATH: "/tmp/fnm_multishells/second/bin:/usr/bin",
@@ -1438,7 +1446,7 @@ describe("RuntimeManager", () => {
     expect(manager.get("env-1")?.runtime).toBe(runtime);
     expect(runtime.shutdown).not.toHaveBeenCalled();
 
-    runtime.setPendingTurnStart(false);
+    runtime.setPendingTurnStart("thread-1", false);
     await manager.replaceBaseShellEnv({
       PATH: "/tmp/fnm_multishells/third/bin:/usr/bin",
     });
@@ -1597,7 +1605,7 @@ describe("RuntimeManager", () => {
     expect(hostWatcher.watchThreadStorageRoot).not.toHaveBeenCalled();
   });
 
-  it("lists the runtimes' active threads for session reconciliation", async () => {
+  it("lists live threads for session reconciliation before the first turn event", async () => {
     const runtime = createFakeRuntime();
     const manager = new RuntimeManager({
       provisionWorkspace: createProvisionWorkspaceMock("/tmp/env-1"),
@@ -1610,13 +1618,18 @@ describe("RuntimeManager", () => {
     });
 
     runtime.setActiveTurn("thread-1", "turn-1");
+    runtime.setPendingTurnStart("thread-2", true);
     expect(manager.listActiveThreads()).toEqual([
       {
         threadId: "thread-1",
       },
+      {
+        threadId: "thread-2",
+      },
     ]);
 
     runtime.endActiveTurn("thread-1");
+    runtime.setPendingTurnStart("thread-2", false);
     expect(manager.listActiveThreads()).toEqual([]);
   });
 

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -245,11 +245,13 @@ interface FakeAgentRuntime extends AgentRuntime {
   endActiveTurn: (threadId: string) => void;
   setActiveTurn: (threadId: string, turnId: string) => void;
   setOpenBackgroundWork: (hasOpenWork: boolean) => void;
+  setPendingTurnStart: (hasPending: boolean) => void;
 }
 
 function createFakeRuntime() {
   const activeTurnsByThreadId = new Map<string, string>();
   let openBackgroundWork = false;
+  let pendingTurnStart = false;
   return {
     ensureProvider: vi.fn(async (_args: EnsureProviderArgs) => undefined),
     startThread: vi.fn(async (_args: StartThreadArgs) => ({
@@ -281,6 +283,7 @@ function createFakeRuntime() {
     ),
     hasThread: (threadId) => activeTurnsByThreadId.has(threadId),
     getActiveThreadIds: () => [...activeTurnsByThreadId.keys()],
+    hasPendingTurnStart: () => pendingTurnStart,
     hasOpenBackgroundWork: () => openBackgroundWork,
     shutdown: vi.fn(async () => undefined),
     endActiveTurn: (threadId) => {
@@ -291,6 +294,9 @@ function createFakeRuntime() {
     },
     setOpenBackgroundWork: (hasOpenWork) => {
       openBackgroundWork = hasOpenWork;
+    },
+    setPendingTurnStart: (hasPending) => {
+      pendingTurnStart = hasPending;
     },
   } satisfies FakeAgentRuntime;
 }
@@ -1402,6 +1408,39 @@ describe("RuntimeManager", () => {
     release();
     await manager.replaceBaseShellEnv({
       PATH: "/newer/bin:/usr/bin",
+    });
+
+    expect(manager.get("env-1")).toBeUndefined();
+    expect(runtime.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an environment runtime while an accepted turn awaits its first event", async () => {
+    const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
+    const runtime = createFakeRuntime();
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      createRuntime: () => runtime,
+      shellEnv: {
+        PATH: "/tmp/fnm_multishells/first/bin:/usr/bin",
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+    runtime.setPendingTurnStart(true);
+
+    await manager.replaceBaseShellEnv({
+      PATH: "/tmp/fnm_multishells/second/bin:/usr/bin",
+    });
+
+    expect(manager.get("env-1")?.runtime).toBe(runtime);
+    expect(runtime.shutdown).not.toHaveBeenCalled();
+
+    runtime.setPendingTurnStart(false);
+    await manager.replaceBaseShellEnv({
+      PATH: "/tmp/fnm_multishells/third/bin:/usr/bin",
     });
 
     expect(manager.get("env-1")).toBeUndefined();

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -397,7 +397,7 @@ export class RuntimeManager {
   listActiveThreads(): HostDaemonActiveThread[] {
     const activeThreads: HostDaemonActiveThread[] = [];
     for (const entry of this.entries.values()) {
-      for (const threadId of entry.runtime.getActiveThreadIds()) {
+      for (const threadId of entry.runtime.getLiveThreadIds()) {
         activeThreads.push({
           threadId,
         });
@@ -485,8 +485,7 @@ export class RuntimeManager {
   private entryHasActiveRuntimeWork(entry: RuntimeEntry): boolean {
     return (
       entry.terminals.size > 0 ||
-      entry.runtime.getActiveThreadIds().length > 0 ||
-      entry.runtime.hasPendingTurnStart() ||
+      entry.runtime.getLiveThreadIds().length > 0 ||
       entry.runtime.hasOpenBackgroundWork()
     );
   }

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -486,6 +486,7 @@ export class RuntimeManager {
     return (
       entry.terminals.size > 0 ||
       entry.runtime.getActiveThreadIds().length > 0 ||
+      entry.runtime.hasPendingTurnStart() ||
       entry.runtime.hasOpenBackgroundWork()
     );
   }

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -229,8 +229,7 @@ function createFakeRuntime(): AgentRuntime {
     getProviderSession: vi.fn(() => null),
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: vi.fn(() => false),
-    getActiveThreadIds: vi.fn(() => []),
-    hasPendingTurnStart: vi.fn(() => false),
+    getLiveThreadIds: vi.fn(() => []),
     hasOpenBackgroundWork: vi.fn(() => false),
     shutdown: vi.fn(async () => undefined),
   };

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -230,6 +230,7 @@ function createFakeRuntime(): AgentRuntime {
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: vi.fn(() => false),
     getActiveThreadIds: vi.fn(() => []),
+    hasPendingTurnStart: vi.fn(() => false),
     hasOpenBackgroundWork: vi.fn(() => false),
     shutdown: vi.fn(async () => undefined),
   };

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -428,11 +428,8 @@ export function createFakeRuntime() {
     hasThread(threadId) {
       return providerSessionsByThreadId.has(threadId);
     },
-    getActiveThreadIds() {
+    getLiveThreadIds() {
       return [...activeTurnsByThreadId.keys()];
-    },
-    hasPendingTurnStart() {
-      return false;
     },
     hasOpenBackgroundWork() {
       return false;

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -431,6 +431,9 @@ export function createFakeRuntime() {
     getActiveThreadIds() {
       return [...activeTurnsByThreadId.keys()];
     },
+    hasPendingTurnStart() {
+      return false;
+    },
     hasOpenBackgroundWork() {
       return false;
     },

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -1087,7 +1087,76 @@ rl.on("line", (line) => {
       await expect(pendingTurnId).resolves.toBe("turn-1");
       expect(runtime.getActiveTurnId("t1")).toBe("turn-1");
       expect(runtime.getActiveThreadIds()).toEqual(["t1"]);
+      expect(runtime.hasPendingTurnStart()).toBe(false);
       await runtime.shutdown();
+    });
+
+    it("reports pending work before an accepted turn emits its first event", async () => {
+      const pendingTurnScriptPath = join(tmpDir, "pending-turn-provider.cjs");
+      writeFileSync(
+        pendingTurnScriptPath,
+        `
+const readline = require("node:readline");
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    return;
+  }
+
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { providerThreadId: "prov-pending-turn" },
+    });
+    return;
+  }
+
+  if (message.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+`,
+        "utf8",
+      );
+      const runtime = createAgentRuntimeWithAdapters({
+        workspacePath: tmpDir,
+        onEvent: () => {},
+        onToolCall: async () => ({
+          contentItems: [{ type: "inputText", text: "ok" }],
+          success: true,
+        }),
+        adapterFactory: () => createFakeAdapter(pendingTurnScriptPath),
+      });
+
+      try {
+        await runtime.startThread({
+          environmentId: "env-1",
+          threadId: "t1",
+          projectId: "p1",
+          providerId: "fake",
+          options: fullRuntimeOptions,
+        });
+        await runtime.runTurn({
+          clientRequestId: "creq_222222223u",
+          threadId: "t1",
+          input: [promptTextInput({ text: "wait for first event" })],
+          options: fullRuntimeOptions,
+        });
+
+        expect(runtime.getActiveTurnId("t1")).toBeNull();
+        expect(runtime.getActiveThreadIds()).toEqual([]);
+        expect(runtime.hasPendingTurnStart()).toBe(true);
+      } finally {
+        await runtime.shutdown();
+      }
     });
 
     it("resolves pending waitForActiveTurn waiters with null when the provider crashes", async () => {

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -1086,8 +1086,7 @@ rl.on("line", (line) => {
 
       await expect(pendingTurnId).resolves.toBe("turn-1");
       expect(runtime.getActiveTurnId("t1")).toBe("turn-1");
-      expect(runtime.getActiveThreadIds()).toEqual(["t1"]);
-      expect(runtime.hasPendingTurnStart()).toBe(false);
+      expect(runtime.getLiveThreadIds()).toEqual(["t1"]);
       await runtime.shutdown();
     });
 
@@ -1152,8 +1151,7 @@ rl.on("line", (line) => {
         });
 
         expect(runtime.getActiveTurnId("t1")).toBeNull();
-        expect(runtime.getActiveThreadIds()).toEqual([]);
-        expect(runtime.hasPendingTurnStart()).toBe(true);
+        expect(runtime.getLiveThreadIds()).toEqual(["t1"]);
       } finally {
         await runtime.shutdown();
       }

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1671,6 +1671,10 @@ function createAgentRuntimeInternal(
       return turnState.getActiveThreadIds();
     },
 
+    hasPendingTurnStart() {
+      return pendingTurnStartThreadIds.size > 0;
+    },
+
     hasOpenBackgroundWork() {
       return backgroundWorkState.hasOpenWork();
     },

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1667,12 +1667,13 @@ function createAgentRuntimeInternal(
       return threadIdentityRegistry.getProviderSession(threadId) !== null;
     },
 
-    getActiveThreadIds() {
-      return turnState.getActiveThreadIds();
-    },
-
-    hasPendingTurnStart() {
-      return pendingTurnStartThreadIds.size > 0;
+    getLiveThreadIds() {
+      return [
+        ...new Set([
+          ...turnState.getActiveThreadIds(),
+          ...pendingTurnStartThreadIds,
+        ]),
+      ];
     },
 
     hasOpenBackgroundWork() {

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -342,6 +342,9 @@ export interface AgentRuntime {
   /** Thread ids with an active turn. */
   getActiveThreadIds(): string[];
 
+  /** Whether a turn-start command was accepted but no first turn event arrived. */
+  hasPendingTurnStart(): boolean;
+
   /**
    * Whether any hosted thread still has an open background task (a workflow or
    * backgrounded command). These outlive their spawning turn, so a runtime with

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -339,11 +339,8 @@ export interface AgentRuntime {
   /** Whether the runtime currently hosts the thread (turns can run on it). */
   hasThread(threadId: string): boolean;
 
-  /** Thread ids with an active turn. */
-  getActiveThreadIds(): string[];
-
-  /** Whether a turn-start command was accepted but no first turn event arrived. */
-  hasPendingTurnStart(): boolean;
+  /** Thread ids with an active turn or an accepted turn awaiting its first event. */
+  getLiveThreadIds(): string[];
 
   /**
    * Whether any hosted thread still has an open background task (a workflow or

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 84 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 85 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,10 +1039,11 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 84 lets ACP model results contain no supported reasoning levels.
-  // The bump updates enrolled daemons before the server uses this result.
-  it("uses protocol version 84 for empty ACP reasoning support", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(84);
+  // Version 85 includes accepted turns that await their first event in the
+  // active-thread session report. The bump updates enrolled daemons before
+  // the server depends on the revised report meaning during reconciliation.
+  it("uses protocol version 85 for pending-turn session reports", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(85);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Reproduction

A focused provider test accepts `turn/start` without emitting `turn/started`. An FNM-shaped `PATH` refresh then exercises idle-runtime eviction during that gap.

## Root cause

The command retain ended after the provider accepted the queued prompt. The runtime had pending turn work, but neither the active-turn predicate nor the in-flight-command predicate reported it.

## Fix

Expose pending turn-start work from the agent runtime and count it as active environment work. Regression tests cover the event gap and FNM-shaped shell environment changes.

Fixes #1156