### PR TITLE
Move thread list reads off the event loop

### DIFF
--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   ThreadListEntry,
   ThreadWithRuntime,
@@ -38,7 +38,15 @@ import {
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { HttpError } from "@/lib/api";
 import { BbHttpError } from "@/lib/sdk";
-import { isTransientReadError, requireEnabledQueryArg } from "./query-helpers";
+import {
+  getTransientReadRetryDelay,
+  isTransientReadError,
+  requireEnabledQueryArg,
+  shouldRetryTransientReadQuery,
+  TRANSIENT_READ_MAX_ATTEMPTS,
+  TRANSIENT_READ_RETRY_BASE_DELAY_MS,
+  TRANSIENT_READ_RETRY_MAX_DELAY_MS,
+} from "./query-helpers";
 
 describe("requireEnabledQueryArg", () => {
   it("returns the value when present", () => {
@@ -73,10 +81,10 @@ describe("requireEnabledQueryArg", () => {
 });
 
 describe("isTransientReadError", () => {
-  it("matches browser transport failures but not HTTP responses", () => {
+  it("matches transport failures and retryable HTTP responses", () => {
     expect(isTransientReadError(new TypeError("Failed to fetch"))).toBe(true);
     expect(isTransientReadError(new TypeError("Load failed"))).toBe(true);
-    expect(isTransientReadError({ name: "AbortError" })).toBe(true);
+    expect(isTransientReadError({ name: "AbortError" })).toBe(false);
     expect(
       isTransientReadError(
         new HttpError({ status: 404, message: "Not found" }),
@@ -92,9 +100,66 @@ describe("isTransientReadError", () => {
         }),
       ),
     ).toBe(false);
+    expect(
+      isTransientReadError(
+        new HttpError({
+          status: 503,
+          message: "Queue full",
+          retryable: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientReadError(
+        new BbHttpError({
+          status: 503,
+          message: "Queue full",
+          body: { retryable: true },
+          code: "database_read_unavailable",
+          retryable: true,
+        }),
+      ),
+    ).toBe(true);
     expect(isTransientReadError(new Error("Unexpected parse error"))).toBe(
       false,
     );
+  });
+});
+
+describe("read query retry policy", () => {
+  it("stops after the maximum attempt count", () => {
+    const error = new HttpError({
+      status: 503,
+      message: "Queue full",
+      retryable: true,
+    });
+
+    expect(
+      shouldRetryTransientReadQuery(TRANSIENT_READ_MAX_ATTEMPTS - 2, error),
+    ).toBe(true);
+    expect(
+      shouldRetryTransientReadQuery(TRANSIENT_READ_MAX_ATTEMPTS - 1, error),
+    ).toBe(false);
+  });
+
+  it("adds jitter to capped exponential delays", () => {
+    const random = vi.spyOn(Math, "random");
+    random.mockReturnValue(0);
+    expect(getTransientReadRetryDelay(0)).toBe(
+      TRANSIENT_READ_RETRY_BASE_DELAY_MS / 2,
+    );
+    expect(getTransientReadRetryDelay(20)).toBe(
+      TRANSIENT_READ_RETRY_MAX_DELAY_MS / 2,
+    );
+
+    random.mockReturnValue(0.999);
+    expect(getTransientReadRetryDelay(0)).toBeGreaterThan(
+      TRANSIENT_READ_RETRY_BASE_DELAY_MS / 2,
+    );
+    expect(getTransientReadRetryDelay(20)).toBeLessThan(
+      TRANSIENT_READ_RETRY_MAX_DELAY_MS,
+    );
+    random.mockRestore();
   });
 });
 

--- a/apps/app/src/hooks/queries/query-helpers.ts
+++ b/apps/app/src/hooks/queries/query-helpers.ts
@@ -7,8 +7,9 @@ import { BbHttpError } from "@/lib/sdk";
  * project-scoped variants so they age out their cached suggestions together.
  */
 export const PROMPT_HISTORY_STALE_TIME_MS = 10_000;
-export const TRANSIENT_READ_RETRY_COUNT = 2;
-export const TRANSIENT_READ_RETRY_DELAY_MS = 250;
+export const TRANSIENT_READ_MAX_ATTEMPTS = 5;
+export const TRANSIENT_READ_RETRY_BASE_DELAY_MS = 250;
+export const TRANSIENT_READ_RETRY_MAX_DELAY_MS = 4_000;
 
 interface RequireEnabledQueryArgArgs<T> {
   value: T | null | undefined;
@@ -43,14 +44,14 @@ function normalizeErrorMessage(message: string): string {
 
 export function isTransientReadError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === "AbortError") {
-    return true;
+    return false;
   }
 
   if (toRecord(error)?.name === "AbortError") {
-    return true;
+    return false;
   }
   if (error instanceof HttpError || error instanceof BbHttpError) {
-    return false;
+    return error.retryable;
   }
 
   const record = toRecord(error);
@@ -70,9 +71,19 @@ export function shouldRetryTransientReadQuery(
   failureCount: number,
   error: unknown,
 ): boolean {
-  if (failureCount >= TRANSIENT_READ_RETRY_COUNT) {
+  if (failureCount >= TRANSIENT_READ_MAX_ATTEMPTS - 1) {
     return false;
   }
 
   return isTransientReadError(error);
+}
+
+export function getTransientReadRetryDelay(attemptIndex: number): number {
+  const boundedAttemptIndex = Math.max(0, attemptIndex);
+  const exponentialDelay = Math.min(
+    TRANSIENT_READ_RETRY_BASE_DELAY_MS * 2 ** boundedAttemptIndex,
+    TRANSIENT_READ_RETRY_MAX_DELAY_MS,
+  );
+  const jitterRange = exponentialDelay / 2;
+  return Math.floor(jitterRange + Math.random() * jitterRange);
 }

--- a/apps/app/src/hooks/queries/sidebar-navigation-retry.test.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-retry.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { QueryObserver } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { createAppQueryClient } from "@/lib/query-client";
+import { HttpError } from "@/lib/api";
+import {
+  fetchSidebarNavigation,
+  sidebarNavigationQueryKey,
+} from "./sidebar-navigation-query";
+
+const DATABASE_READ_QUEUE_CAPACITY = 32;
+
+function makeSidebarBootstrapResponse(): SidebarBootstrapResponse {
+  return {
+    sections: [],
+    projects: [],
+    personalProject: {
+      id: "proj_personal",
+      kind: "personal",
+      name: "Personal",
+      gitRemoteUrl: null,
+      createdAt: 1,
+      updatedAt: 1,
+      sources: [],
+      threads: [],
+      defaultExecutionOptions: null,
+    },
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("sidebar navigation retry", () => {
+  it("recovers after a full database read queue without a reload", async () => {
+    const sidebar = makeSidebarBootstrapResponse();
+    let pendingDatabaseReads = DATABASE_READ_QUEUE_CAPACITY;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      if (pendingDatabaseReads === DATABASE_READ_QUEUE_CAPACITY) {
+        pendingDatabaseReads--;
+        return jsonResponse(
+          {
+            code: "database_read_unavailable",
+            message: "The database read queue is full. Try again later.",
+            retryable: true,
+          },
+          { status: 503 },
+        );
+      }
+      return jsonResponse(sidebar, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { retryDelay: 0 } },
+      showMutationErrorToasts: false,
+    });
+    const queryKey = sidebarNavigationQueryKey();
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: ({ signal }) => fetchSidebarNavigation(signal),
+      staleTime: Infinity,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await vi.waitFor(() => {
+      expect(observer.getCurrentResult().isSuccess).toBe(true);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(observer.getCurrentResult().data).toEqual(sidebar);
+    expect(observer.getCurrentResult().isStale).toBe(false);
+    expect(queryClient.getQueryData(queryKey)).toEqual(sidebar);
+
+    unsubscribe();
+    queryClient.clear();
+  });
+
+  it.each([
+    {
+      name: "a non-retryable server error",
+      response: () =>
+        jsonResponse(
+          {
+            code: "database_read_unavailable",
+            message: "Database read failed.",
+            retryable: false,
+          },
+          { status: 503 },
+        ),
+      status: 503,
+    },
+    {
+      name: "a client-closed response",
+      response: () => new Response(null, { status: 499 }),
+      status: 499,
+    },
+  ])("does not retry $name", async ({ response, status }) => {
+    const fetchMock = vi.fn<typeof fetch>(async () => response());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { retryDelay: 0 } },
+      showMutationErrorToasts: false,
+    });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["sidebarNavigation", status],
+      queryFn: ({ signal }) => fetchSidebarNavigation(signal),
+      staleTime: Infinity,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await vi.waitFor(() => {
+      expect(observer.getCurrentResult().isError).toBe(true);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(observer.getCurrentResult().error).toBeInstanceOf(HttpError);
+    expect(observer.getCurrentResult().error).toMatchObject({
+      retryable: false,
+      status,
+    });
+
+    unsubscribe();
+    queryClient.clear();
+  });
+});

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -46,10 +46,10 @@ import {
   resolveThreadTimelinePlaceholder,
 } from "./query-placeholders";
 import {
+  getTransientReadRetryDelay,
   PROMPT_HISTORY_STALE_TIME_MS,
   requireEnabledQueryArg,
   shouldRetryTransientReadQuery,
-  TRANSIENT_READ_RETRY_DELAY_MS,
 } from "./query-helpers";
 import {
   REALTIME_OWNED_MOUNT_BASELINE_QUERY_POLICY,
@@ -528,7 +528,7 @@ export function useThread(id: string, options?: QueryOptions) {
     staleTime: THREAD_DETAIL_STALE_TIME_MS,
     refetchOnMount: options?.refetchOnMount ?? true,
     retry: shouldRetryTransientReadQuery,
-    retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
+    retryDelay: getTransientReadRetryDelay,
     placeholderData: (previousData, previousQuery) =>
       resolveThreadPlaceholder(previousData, previousQuery?.queryKey, id) ??
       liftThreadListPlaceholder(
@@ -594,7 +594,7 @@ export function useThreadDetailBootstrap(
     enabled,
     staleTime: Infinity,
     retry: shouldRetryTransientReadQuery,
-    retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
+    retryDelay: getTransientReadRetryDelay,
   });
 }
 
@@ -836,7 +836,7 @@ export function useThreadTimeline(
       ? {}
       : { staleTime: options.staleTime }),
     retry: shouldRetryTransientReadQuery,
-    retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
+    retryDelay: getTransientReadRetryDelay,
     placeholderData: (previousData, previousQuery) =>
       resolveThreadTimelinePlaceholder(
         previousData,

--- a/apps/app/src/lib/api.ts
+++ b/apps/app/src/lib/api.ts
@@ -31,18 +31,21 @@ export class HttpError extends Error {
   readonly status: number;
   readonly code?: string;
   readonly body?: unknown;
+  readonly retryable: boolean;
 
   constructor(args: {
     status: number;
     message: string;
     code?: string;
     body?: unknown;
+    retryable?: boolean;
   }) {
     super(`HTTP ${args.status}: ${args.message}`);
     this.name = "HttpError";
     this.status = args.status;
     this.code = args.code;
     this.body = args.body;
+    this.retryable = args.retryable ?? false;
   }
 }
 
@@ -115,6 +118,10 @@ function extractErrorCode(value: unknown): string | undefined {
     : undefined;
 }
 
+function extractRetryable(value: unknown): boolean {
+  return toRecord(value)?.retryable === true;
+}
+
 async function throwHttpError(res: Response): Promise<never> {
   const rawBody = await res.text().catch(() => "");
   const contentType = res.headers.get("content-type");
@@ -130,6 +137,7 @@ async function throwHttpError(res: Response): Promise<never> {
     message,
     code: extractErrorCode(body),
     body,
+    retryable: extractRetryable(body),
   });
 }
 

--- a/apps/app/src/lib/query-client.ts
+++ b/apps/app/src/lib/query-client.ts
@@ -11,8 +11,8 @@ import {
 import { invalidateActiveThreadBundleQueriesAfterBrowserResume } from "@/hooks/cache-owners/active-thread-lifecycle-cache-owner";
 import { cancelActiveQueryFetchesForBrowserSuspend } from "@/hooks/cache-owners/browser-lifecycle-cache-owner";
 import {
+  getTransientReadRetryDelay,
   shouldRetryTransientReadQuery,
-  TRANSIENT_READ_RETRY_DELAY_MS,
 } from "@/hooks/queries/query-helpers";
 
 export interface CreateAppQueryClientOptions {
@@ -146,7 +146,7 @@ export function createAppQueryClient(
         staleTime: 2000,
         refetchOnWindowFocus: true,
         retry: shouldRetryTransientReadQuery,
-        retryDelay: TRANSIENT_READ_RETRY_DELAY_MS,
+        retryDelay: getTransientReadRetryDelay,
         ...defaultOptions?.queries,
       },
     },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "node ../../packages/plugin-build/scripts/generate-runtime-export-manifest.mjs && node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --templates --external ./start-server.js --copy-dir ../../packages/db/drizzle dist/drizzle --copy-dir src/assets dist/assets && node --import tsx scripts/copy-builtin-skills.ts && node ../../scripts/build-node-entry.mjs src/start-server.ts dist/start-server.js && node ../../scripts/build-node-entry.mjs ../../packages/plugin-sdk/src/index.ts dist/plugin-sdk-runtime.js",
+    "build": "node ../../packages/plugin-build/scripts/generate-runtime-export-manifest.mjs && node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --templates --external ./start-server.js --copy-dir ../../packages/db/drizzle dist/drizzle --copy-dir src/assets dist/assets && node --import tsx scripts/copy-builtin-skills.ts && node ../../scripts/build-node-entry.mjs src/start-server.ts dist/start-server.js && node ../../scripts/build-node-entry.mjs src/services/database/database-read-worker-entry.ts dist/database-read-worker-entry.js && node ../../scripts/build-node-entry.mjs ../../packages/plugin-sdk/src/index.ts dist/plugin-sdk-runtime.js",
     "start": "node dist/index.js",
     "start:prod": "cross-env NODE_ENV=production node dist/index.js",
     "dev": "node --conditions=source --import tsx scripts/dev-supervisor.mjs",

--- a/apps/server/src/errors.ts
+++ b/apps/server/src/errors.ts
@@ -74,10 +74,15 @@ export class TurnStartGuardError extends ApiError {
   }
 }
 
+export class ClientClosedRequestError extends Error {}
+
 export function errorToResponse(
   error: unknown,
   logger: ServerLogger,
 ): Response {
+  if (error instanceof ClientClosedRequestError) {
+    return new Response(null, { status: 499 });
+  }
   if (error instanceof TurnStartGuardError) {
     logger.warn(
       { err: error, ...error.details },

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -194,21 +194,25 @@ function parseProjectListIncludes(
 async function buildProjectsWithThreadsResponse(
   deps: AppDeps,
   options: ProjectListOptions,
+  signal: AbortSignal,
 ): Promise<ProjectWithThreadsResponse[]> {
   return buildProjectsWithThreadsResponseFromRows(
     deps,
     listDiscoverableProjects(deps, options),
+    signal,
   );
 }
 
 async function buildProjectsWithThreadsResponseFromRows(
   deps: AppDeps,
   projectRows: ProjectResponseRow[],
+  signal: AbortSignal,
 ): Promise<ProjectWithThreadsResponse[]> {
   const projects = buildProjectResponsesFromRows(deps, projectRows);
   const projectIds = projects.map((project) => project.id);
   const threadResponses = await deps.databaseReads.listThreadEntriesForProjects(
     { archived: false, projectIds },
+    { signal },
   );
   const threadsByProjectId = new Map<
     string,
@@ -236,7 +240,10 @@ async function buildProjectsWithThreadsResponseFromRows(
   }));
 }
 
-async function buildSidebarBootstrapResponse(deps: AppDeps) {
+async function buildSidebarBootstrapResponse(
+  deps: AppDeps,
+  signal: AbortSignal,
+) {
   const personalProject = getPersonalProject(deps.db);
   if (!personalProject) {
     throw new ApiError(
@@ -246,8 +253,12 @@ async function buildSidebarBootstrapResponse(deps: AppDeps) {
     );
   }
   const [personalProjectResponses, projects] = await Promise.all([
-    buildProjectsWithThreadsResponseFromRows(deps, [personalProject]),
-    buildProjectsWithThreadsResponseFromRows(deps, listPublicProjects(deps.db)),
+    buildProjectsWithThreadsResponseFromRows(deps, [personalProject], signal),
+    buildProjectsWithThreadsResponseFromRows(
+      deps,
+      listPublicProjects(deps.db),
+      signal,
+    ),
   ]);
   const personalProjectResponse = personalProjectResponses[0];
   if (!personalProjectResponse) {
@@ -328,7 +339,11 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     };
     if (includes.has("threads")) {
       return context.json(
-        await buildProjectsWithThreadsResponse(deps, options),
+        await buildProjectsWithThreadsResponse(
+          deps,
+          options,
+          context.req.raw.signal,
+        ),
       );
     }
     return context.json(
@@ -340,7 +355,9 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
   });
 
   get(routes.sidebarBootstrap, async (context) =>
-    context.json(await buildSidebarBootstrapResponse(deps)),
+    context.json(
+      await buildSidebarBootstrapResponse(deps, context.req.raw.signal),
+    ),
   );
 
   post(routes.create, async (context, payload) => {

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -7,10 +7,8 @@ import {
   deleteProjectSource,
   getProjectSourceByHost,
   getProjectSourceForProject,
-  listProjectExecutionDefaultsByProjectIds,
   listPublicProjects,
   listProjectSourcesByProjectIds,
-  listThreadSections,
   reorderProject,
   updateProject,
   updateProjectSource,
@@ -44,7 +42,6 @@ import {
   requirePublicStandardProject,
 } from "../services/lib/entity-lookup.js";
 import { PROMPT_HISTORY_ENTRY_LIMIT } from "@bb/domain";
-import { resolveCreateThreadExecutionDefaults } from "../services/threads/thread-default-policy.js";
 import { resolveProjectCreateDefaultExecutionPlan } from "../services/threads/thread-execution-plan.js";
 import { callHostRetryableOnlineRpc } from "../services/hosts/online-rpc.js";
 import { runLiveHostCommand } from "../services/hosts/live-command.js";
@@ -196,80 +193,17 @@ async function buildProjectsWithThreadsResponse(
   options: ProjectListOptions,
   signal: AbortSignal,
 ): Promise<ProjectWithThreadsResponse[]> {
-  return buildProjectsWithThreadsResponseFromRows(
-    deps,
-    listDiscoverableProjects(deps, options),
-    signal,
-  );
-}
-
-async function buildProjectsWithThreadsResponseFromRows(
-  deps: AppDeps,
-  projectRows: ProjectResponseRow[],
-  signal: AbortSignal,
-): Promise<ProjectWithThreadsResponse[]> {
-  const projects = buildProjectResponsesFromRows(deps, projectRows);
-  const projectIds = projects.map((project) => project.id);
-  const threadResponses = await deps.databaseReads.listThreadEntriesForProjects(
-    { archived: false, projectIds },
+  return deps.databaseReads.listProjectsWithThreads(
+    { includePersonal: options.includePersonal },
     { signal },
   );
-  const threadsByProjectId = new Map<
-    string,
-    ProjectWithThreadsResponse["threads"]
-  >();
-  for (const thread of threadResponses) {
-    const projectThreads = threadsByProjectId.get(thread.projectId);
-    if (projectThreads) {
-      projectThreads.push(thread);
-      continue;
-    }
-    threadsByProjectId.set(thread.projectId, [thread]);
-  }
-  const defaultsByProjectId = listProjectExecutionDefaultsByProjectIds(
-    deps.db,
-    { projectIds },
-  );
-
-  return projects.map((project) => ({
-    ...project,
-    threads: threadsByProjectId.get(project.id) ?? [],
-    defaultExecutionOptions: resolveCreateThreadExecutionDefaults({
-      storedDefaults: defaultsByProjectId.get(project.id) ?? null,
-    }).executionDefaults,
-  }));
 }
 
 async function buildSidebarBootstrapResponse(
   deps: AppDeps,
   signal: AbortSignal,
 ) {
-  const personalProject = getPersonalProject(deps.db);
-  if (!personalProject) {
-    throw new ApiError(
-      500,
-      "internal_error",
-      "Personal project is not initialized",
-    );
-  }
-  const [personalProjectResponse, ...projects] =
-    await buildProjectsWithThreadsResponseFromRows(
-      deps,
-      [personalProject, ...listPublicProjects(deps.db)],
-      signal,
-    );
-  if (!personalProjectResponse) {
-    throw new ApiError(
-      500,
-      "internal_error",
-      "Personal project response was not built",
-    );
-  }
-  return {
-    sections: listThreadSections(deps.db),
-    projects,
-    personalProject: personalProjectResponse,
-  };
+  return deps.databaseReads.getSidebarBootstrap({ signal });
 }
 
 interface RequireProjectSourceArgs {

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -11,7 +11,6 @@ import {
   listPublicProjects,
   listProjectSourcesByProjectIds,
   listThreadSections,
-  listThreadsWithPendingInteractionStateForProjects,
   reorderProject,
   updateProject,
   updateProjectSource,
@@ -47,7 +46,6 @@ import {
 import { PROMPT_HISTORY_ENTRY_LIMIT } from "@bb/domain";
 import { resolveCreateThreadExecutionDefaults } from "../services/threads/thread-default-policy.js";
 import { resolveProjectCreateDefaultExecutionPlan } from "../services/threads/thread-execution-plan.js";
-import { toThreadListEntryResponses } from "../services/threads/thread-runtime-display.js";
 import { callHostRetryableOnlineRpc } from "../services/hosts/online-rpc.js";
 import { runLiveHostCommand } from "../services/hosts/live-command.js";
 import {
@@ -193,29 +191,25 @@ function parseProjectListIncludes(
   return includes;
 }
 
-function buildProjectsWithThreadsResponse(
+async function buildProjectsWithThreadsResponse(
   deps: AppDeps,
   options: ProjectListOptions,
-): ProjectWithThreadsResponse[] {
+): Promise<ProjectWithThreadsResponse[]> {
   return buildProjectsWithThreadsResponseFromRows(
     deps,
     listDiscoverableProjects(deps, options),
   );
 }
 
-function buildProjectsWithThreadsResponseFromRows(
+async function buildProjectsWithThreadsResponseFromRows(
   deps: AppDeps,
   projectRows: ProjectResponseRow[],
-): ProjectWithThreadsResponse[] {
+): Promise<ProjectWithThreadsResponse[]> {
   const projects = buildProjectResponsesFromRows(deps, projectRows);
   const projectIds = projects.map((project) => project.id);
-  const threadRows = listThreadsWithPendingInteractionStateForProjects(
-    deps.db,
+  const threadResponses = await deps.databaseReads.listThreadEntriesForProjects(
     { archived: false, projectIds },
   );
-  const threadResponses = toThreadListEntryResponses(deps, {
-    threads: threadRows,
-  });
   const threadsByProjectId = new Map<
     string,
     ProjectWithThreadsResponse["threads"]
@@ -242,7 +236,7 @@ function buildProjectsWithThreadsResponseFromRows(
   }));
 }
 
-function buildSidebarBootstrapResponse(deps: AppDeps) {
+async function buildSidebarBootstrapResponse(deps: AppDeps) {
   const personalProject = getPersonalProject(deps.db);
   if (!personalProject) {
     throw new ApiError(
@@ -251,10 +245,11 @@ function buildSidebarBootstrapResponse(deps: AppDeps) {
       "Personal project is not initialized",
     );
   }
-  const personalProjectResponse = buildProjectsWithThreadsResponseFromRows(
-    deps,
-    [personalProject],
-  )[0];
+  const [personalProjectResponses, projects] = await Promise.all([
+    buildProjectsWithThreadsResponseFromRows(deps, [personalProject]),
+    buildProjectsWithThreadsResponseFromRows(deps, listPublicProjects(deps.db)),
+  ]);
+  const personalProjectResponse = personalProjectResponses[0];
   if (!personalProjectResponse) {
     throw new ApiError(
       500,
@@ -264,10 +259,7 @@ function buildSidebarBootstrapResponse(deps: AppDeps) {
   }
   return {
     sections: listThreadSections(deps.db),
-    projects: buildProjectsWithThreadsResponseFromRows(
-      deps,
-      listPublicProjects(deps.db),
-    ),
+    projects,
     personalProject: personalProjectResponse,
   };
 }
@@ -327,7 +319,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
   });
   const routes = publicApiRoutes.projects;
 
-  get(routes.list, (context, query) => {
+  get(routes.list, async (context, query) => {
     const includes = parseProjectListIncludes(query);
     // Compatibility is resolved once at the HTTP boundary: ordinary projects
     // remain the default, and all internal list paths receive an explicit flag.
@@ -335,7 +327,9 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       includePersonal: query.includePersonal === "true",
     };
     if (includes.has("threads")) {
-      return context.json(buildProjectsWithThreadsResponse(deps, options));
+      return context.json(
+        await buildProjectsWithThreadsResponse(deps, options),
+      );
     }
     return context.json(
       buildProjectResponsesFromRows(
@@ -345,8 +339,8 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     );
   });
 
-  get(routes.sidebarBootstrap, (context) =>
-    context.json(buildSidebarBootstrapResponse(deps)),
+  get(routes.sidebarBootstrap, async (context) =>
+    context.json(await buildSidebarBootstrapResponse(deps)),
   );
 
   post(routes.create, async (context, payload) => {

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -252,15 +252,12 @@ async function buildSidebarBootstrapResponse(
       "Personal project is not initialized",
     );
   }
-  const [personalProjectResponses, projects] = await Promise.all([
-    buildProjectsWithThreadsResponseFromRows(deps, [personalProject], signal),
-    buildProjectsWithThreadsResponseFromRows(
+  const [personalProjectResponse, ...projects] =
+    await buildProjectsWithThreadsResponseFromRows(
       deps,
-      listPublicProjects(deps.db),
+      [personalProject, ...listPublicProjects(deps.db)],
       signal,
-    ),
-  ]);
-  const personalProjectResponse = personalProjectResponses[0];
+    );
   if (!personalProjectResponse) {
     throw new ApiError(
       500,

--- a/apps/server/src/routes/threads/base.ts
+++ b/apps/server/src/routes/threads/base.ts
@@ -4,7 +4,6 @@ import {
   countNonDeletedAssignedChildThreads,
   getEnvironment,
   getThreadSectionById,
-  listThreadsWithPendingInteractionState,
   markThreadDeleted,
   searchThreadsWithPendingInteractionState,
   updateThread,
@@ -195,7 +194,7 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
   });
   const routes = publicApiRoutes.threads;
 
-  get(routes.list, (context, query) => {
+  get(routes.list, async (context, query) => {
     const limit = parseOptionalInteger(query.limit, "limit");
     if (limit !== undefined && limit <= 0) {
       throw new ApiError(400, "invalid_request", "limit must be positive");
@@ -217,7 +216,7 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
     if (query.sectionId) {
       requireThreadSection(deps, query.sectionId);
     }
-    const threads = listThreadsWithPendingInteractionState(deps.db, {
+    const threadEntries = await deps.databaseReads.listThreadEntries({
       ...(query.projectId ? { projectId: query.projectId } : {}),
       ...(query.parentThreadId ? { parentThreadId: query.parentThreadId } : {}),
       ...(query.sourceThreadId ? { sourceThreadId: query.sourceThreadId } : {}),
@@ -234,9 +233,7 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
       ...(limit !== undefined ? { limit } : {}),
       ...(offset !== undefined ? { offset } : {}),
     });
-    return context.json(
-      toThreadListEntryResponses(deps, { threads }) satisfies ThreadListEntry[],
-    );
+    return context.json(threadEntries satisfies ThreadListEntry[]);
   });
 
   get(routes.search, (context, query) => {

--- a/apps/server/src/routes/threads/base.ts
+++ b/apps/server/src/routes/threads/base.ts
@@ -216,23 +216,34 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
     if (query.sectionId) {
       requireThreadSection(deps, query.sectionId);
     }
-    const threadEntries = await deps.databaseReads.listThreadEntries({
-      ...(query.projectId ? { projectId: query.projectId } : {}),
-      ...(query.parentThreadId ? { parentThreadId: query.parentThreadId } : {}),
-      ...(query.sourceThreadId ? { sourceThreadId: query.sourceThreadId } : {}),
-      ...(query.sectionId ? { sectionId: query.sectionId } : {}),
-      ...(query.unsectioned === "true" ? { unsectioned: true } : {}),
-      ...(query.originKind ? { originKind: query.originKind } : {}),
-      ...(query.originPluginId ? { originPluginId: query.originPluginId } : {}),
-      ...(query.childOrigin ? { childOrigin: query.childOrigin } : {}),
-      includeHidden: query.includeHidden === "true",
-      archived:
-        query.archived === undefined ? undefined : query.archived === "true",
-      hasParent:
-        query.hasParent === undefined ? undefined : query.hasParent === "true",
-      ...(limit !== undefined ? { limit } : {}),
-      ...(offset !== undefined ? { offset } : {}),
-    });
+    const threadEntries = await deps.databaseReads.listThreadEntries(
+      {
+        ...(query.projectId ? { projectId: query.projectId } : {}),
+        ...(query.parentThreadId
+          ? { parentThreadId: query.parentThreadId }
+          : {}),
+        ...(query.sourceThreadId
+          ? { sourceThreadId: query.sourceThreadId }
+          : {}),
+        ...(query.sectionId ? { sectionId: query.sectionId } : {}),
+        ...(query.unsectioned === "true" ? { unsectioned: true } : {}),
+        ...(query.originKind ? { originKind: query.originKind } : {}),
+        ...(query.originPluginId
+          ? { originPluginId: query.originPluginId }
+          : {}),
+        ...(query.childOrigin ? { childOrigin: query.childOrigin } : {}),
+        includeHidden: query.includeHidden === "true",
+        archived:
+          query.archived === undefined ? undefined : query.archived === "true",
+        hasParent:
+          query.hasParent === undefined
+            ? undefined
+            : query.hasParent === "true",
+        ...(limit !== undefined ? { limit } : {}),
+        ...(offset !== undefined ? { offset } : {}),
+      },
+      { signal: context.req.raw.signal },
+    );
     return context.json(threadEntries satisfies ThreadListEntry[]);
   });
 

--- a/apps/server/src/routes/threads/base.ts
+++ b/apps/server/src/routes/threads/base.ts
@@ -196,10 +196,24 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
 
   get(routes.list, async (context, query) => {
     const limit = parseOptionalInteger(query.limit, "limit");
+    if (limit !== undefined && !Number.isSafeInteger(limit)) {
+      throw new ApiError(
+        400,
+        "invalid_request",
+        "limit must be a safe integer",
+      );
+    }
     if (limit !== undefined && limit <= 0) {
       throw new ApiError(400, "invalid_request", "limit must be positive");
     }
     const offset = parseOptionalInteger(query.offset, "offset");
+    if (offset !== undefined && !Number.isSafeInteger(offset)) {
+      throw new ApiError(
+        400,
+        "invalid_request",
+        "offset must be a safe integer",
+      );
+    }
     if (offset !== undefined && offset < 0) {
       throw new ApiError(400, "invalid_request", "offset must be non-negative");
     }

--- a/apps/server/src/services/database/database-read-operations.ts
+++ b/apps/server/src/services/database/database-read-operations.ts
@@ -70,21 +70,14 @@ function toProjectResponses(
 
 function toThreadEntries(
   deps: DatabaseReadOperationDeps,
-  request: DatabaseReadWorkerRequest,
   threads: Parameters<typeof toThreadListEntryResponses>[1]["threads"],
 ): ThreadEntryResult {
-  const daemonSessionIdByHostId = new Map(
-    request.daemonSessions.map((session) => [
-      session.hostId,
-      session.sessionId,
-    ]),
-  );
   const rawEntries = toThreadListEntryResponses(
     {
       db: deps.db,
       hub: {
         getDaemonSessionIdForHost(hostId): string | null {
-          return daemonSessionIdByHostId.get(hostId) ?? null;
+          return null;
         },
       },
     },
@@ -99,14 +92,12 @@ function toThreadEntries(
 
 function toProjectsWithThreads(
   deps: DatabaseReadOperationDeps,
-  request: DatabaseReadWorkerRequest,
   projectRows: ProjectResponseRow[],
 ): ProjectsWithThreadsResult {
   const projects = toProjectResponses(deps.db, projectRows);
   const projectIds = projects.map((project) => project.id);
   const threadResult = toThreadEntries(
     deps,
-    request,
     listThreadsWithPendingInteractionStateForProjects(deps.db, {
       archived: false,
       projectIds,
@@ -159,7 +150,6 @@ export function executeDatabaseReadOperation(
           return {
             ...toThreadEntries(
               deps,
-              request,
               listThreadsWithPendingInteractionState(deps.db, request.options),
             ),
             operation: request.operation,
@@ -168,7 +158,6 @@ export function executeDatabaseReadOperation(
           return {
             ...toThreadEntries(
               deps,
-              request,
               listThreadsWithPendingInteractionStateForProjects(
                 deps.db,
                 request.options,
@@ -181,14 +170,14 @@ export function executeDatabaseReadOperation(
           if (request.options.includePersonal) {
             projectRows.unshift(requirePersonalProject(deps.db));
           }
-          const result = toProjectsWithThreads(deps, request, projectRows);
+          const result = toProjectsWithThreads(deps, projectRows);
           return {
             ...result,
             operation: request.operation,
           };
         }
         case "sidebarBootstrap": {
-          const result = toProjectsWithThreads(deps, request, [
+          const result = toProjectsWithThreads(deps, [
             requirePersonalProject(deps.db),
             ...listPublicProjects(deps.db),
           ]);

--- a/apps/server/src/services/database/database-read-operations.ts
+++ b/apps/server/src/services/database/database-read-operations.ts
@@ -1,0 +1,213 @@
+import {
+  getPersonalProject,
+  listProjectExecutionDefaultsByProjectIds,
+  listProjectSourcesByProjectIds,
+  listPublicProjects,
+  listThreadSections,
+  listThreadsWithPendingInteractionState,
+  listThreadsWithPendingInteractionStateForProjects,
+  type DbConnection,
+} from "@bb/db";
+import { threadListEntrySchema, type ThreadListEntry } from "@bb/domain";
+import type {
+  ProjectResponse,
+  ProjectWithThreadsResponse,
+  SidebarBootstrapResponse,
+} from "@bb/server-contract";
+import { resolveCreateThreadExecutionDefaults } from "../threads/thread-default-policy.js";
+import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
+import type {
+  DatabaseReadWorkerRequest,
+  DatabaseReadWorkerResult,
+} from "./database-read-worker-contract.js";
+
+interface DatabaseReadOperationDeps {
+  db: DbConnection;
+}
+
+type ProjectResponseRow = Omit<ProjectResponse, "sources">;
+
+interface ThreadEntryResult {
+  droppedEntryCount: number;
+  entries: ThreadListEntry[];
+}
+
+interface ProjectsWithThreadsResult {
+  droppedEntryCount: number;
+  projects: ProjectWithThreadsResponse[];
+}
+
+function isThreadListEntry(value: unknown): value is ThreadListEntry {
+  return threadListEntrySchema.safeParse(value).success;
+}
+
+function toProjectResponses(
+  db: DbConnection,
+  projects: ProjectResponseRow[],
+): ProjectResponse[] {
+  const sourcesByProjectId = new Map<string, ProjectResponse["sources"]>();
+  for (const source of listProjectSourcesByProjectIds(
+    db,
+    projects.map((project) => project.id),
+  )) {
+    const sources = sourcesByProjectId.get(source.projectId);
+    if (sources !== undefined) {
+      sources.push(source);
+    } else {
+      sourcesByProjectId.set(source.projectId, [source]);
+    }
+  }
+  return projects.map((project) => ({
+    id: project.id,
+    kind: project.kind,
+    name: project.name,
+    gitRemoteUrl: project.gitRemoteUrl,
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+    sources: sourcesByProjectId.get(project.id) ?? [],
+  }));
+}
+
+function toThreadEntries(
+  deps: DatabaseReadOperationDeps,
+  request: DatabaseReadWorkerRequest,
+  threads: Parameters<typeof toThreadListEntryResponses>[1]["threads"],
+): ThreadEntryResult {
+  const daemonSessionIdByHostId = new Map(
+    request.daemonSessions.map((session) => [
+      session.hostId,
+      session.sessionId,
+    ]),
+  );
+  const rawEntries = toThreadListEntryResponses(
+    {
+      db: deps.db,
+      hub: {
+        getDaemonSessionIdForHost(hostId): string | null {
+          return daemonSessionIdByHostId.get(hostId) ?? null;
+        },
+      },
+    },
+    { threads },
+  );
+  const entries = rawEntries.filter(isThreadListEntry);
+  return {
+    droppedEntryCount: rawEntries.length - entries.length,
+    entries,
+  };
+}
+
+function toProjectsWithThreads(
+  deps: DatabaseReadOperationDeps,
+  request: DatabaseReadWorkerRequest,
+  projectRows: ProjectResponseRow[],
+): ProjectsWithThreadsResult {
+  const projects = toProjectResponses(deps.db, projectRows);
+  const projectIds = projects.map((project) => project.id);
+  const threadResult = toThreadEntries(
+    deps,
+    request,
+    listThreadsWithPendingInteractionStateForProjects(deps.db, {
+      archived: false,
+      projectIds,
+    }),
+  );
+  const threadsByProjectId = new Map<
+    string,
+    ProjectWithThreadsResponse["threads"]
+  >();
+  for (const thread of threadResult.entries) {
+    const threads = threadsByProjectId.get(thread.projectId);
+    if (threads !== undefined) {
+      threads.push(thread);
+    } else {
+      threadsByProjectId.set(thread.projectId, [thread]);
+    }
+  }
+  const defaultsByProjectId = listProjectExecutionDefaultsByProjectIds(
+    deps.db,
+    { projectIds },
+  );
+  return {
+    droppedEntryCount: threadResult.droppedEntryCount,
+    projects: projects.map((project) => ({
+      ...project,
+      threads: threadsByProjectId.get(project.id) ?? [],
+      defaultExecutionOptions: resolveCreateThreadExecutionDefaults({
+        storedDefaults: defaultsByProjectId.get(project.id) ?? null,
+      }).executionDefaults,
+    })),
+  };
+}
+
+function requirePersonalProject(db: DbConnection): ProjectResponseRow {
+  const project = getPersonalProject(db);
+  if (project === null) {
+    throw new Error("Personal project is not initialized");
+  }
+  return project;
+}
+
+export function executeDatabaseReadOperation(
+  deps: DatabaseReadOperationDeps,
+  request: DatabaseReadWorkerRequest,
+): DatabaseReadWorkerResult {
+  return deps.db.$client
+    .transaction(() => {
+      switch (request.operation) {
+        case "listThreadEntries":
+          return {
+            ...toThreadEntries(
+              deps,
+              request,
+              listThreadsWithPendingInteractionState(deps.db, request.options),
+            ),
+            operation: request.operation,
+          };
+        case "listThreadEntriesForProjects":
+          return {
+            ...toThreadEntries(
+              deps,
+              request,
+              listThreadsWithPendingInteractionStateForProjects(
+                deps.db,
+                request.options,
+              ),
+            ),
+            operation: request.operation,
+          };
+        case "listProjectsWithThreads": {
+          const projectRows: ProjectResponseRow[] = listPublicProjects(deps.db);
+          if (request.options.includePersonal) {
+            projectRows.unshift(requirePersonalProject(deps.db));
+          }
+          const result = toProjectsWithThreads(deps, request, projectRows);
+          return {
+            ...result,
+            operation: request.operation,
+          };
+        }
+        case "sidebarBootstrap": {
+          const result = toProjectsWithThreads(deps, request, [
+            requirePersonalProject(deps.db),
+            ...listPublicProjects(deps.db),
+          ]);
+          const [personalProject, ...projects] = result.projects;
+          if (personalProject === undefined) {
+            throw new Error("Personal project response was not built");
+          }
+          const response: SidebarBootstrapResponse = {
+            sections: listThreadSections(deps.db),
+            projects,
+            personalProject,
+          };
+          return {
+            droppedEntryCount: result.droppedEntryCount,
+            operation: request.operation,
+            response,
+          };
+        }
+      }
+    })
+    .deferred();
+}

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -1,5 +1,12 @@
-import type { DbConnection, ListThreadsOptions } from "@bb/db";
-import { listThreadsWithPendingInteractionState } from "@bb/db";
+import type {
+  DbConnection,
+  ListThreadsForProjectsOptions,
+  ListThreadsOptions,
+} from "@bb/db";
+import {
+  listThreadsWithPendingInteractionState,
+  listThreadsWithPendingInteractionStateForProjects,
+} from "@bb/db";
 import type { ThreadListEntry } from "@bb/domain";
 import { Worker } from "node:worker_threads";
 import type { ServerLogger } from "../../types.js";
@@ -16,9 +23,21 @@ interface PendingDatabaseRead {
   resolve(entries: ThreadListEntry[]): void;
 }
 
+interface DatabaseReadWorkerState {
+  failed: boolean;
+  ready: Promise<void>;
+  rejectReady(error: Error): void;
+  resolveReady(): void;
+  wasReady: boolean;
+  worker: Worker;
+}
+
 export interface DatabaseReadService {
   close(): Promise<void>;
   listThreadEntries(options: ListThreadsOptions): Promise<ThreadListEntry[]>;
+  listThreadEntriesForProjects(
+    options: ListThreadsForProjectsOptions,
+  ): Promise<ThreadListEntry[]>;
 }
 
 interface CreateDirectDatabaseReadServiceArgs {
@@ -29,13 +48,27 @@ interface CreateDirectDatabaseReadServiceArgs {
 export function createDirectDatabaseReadService(
   args: CreateDirectDatabaseReadServiceArgs,
 ): DatabaseReadService {
+  function toEntries(
+    threads: Parameters<typeof toThreadListEntryResponses>[1]["threads"],
+  ) {
+    return toThreadListEntryResponses(args, { threads });
+  }
+
   return {
     async close(): Promise<void> {},
     async listThreadEntries(
       options: ListThreadsOptions,
     ): Promise<ThreadListEntry[]> {
-      const threads = listThreadsWithPendingInteractionState(args.db, options);
-      return toThreadListEntryResponses(args, { threads });
+      return toEntries(
+        listThreadsWithPendingInteractionState(args.db, options),
+      );
+    },
+    async listThreadEntriesForProjects(
+      options: ListThreadsForProjectsOptions,
+    ): Promise<ThreadListEntry[]> {
+      return toEntries(
+        listThreadsWithPendingInteractionStateForProjects(args.db, options),
+      );
     },
   };
 }
@@ -44,6 +77,7 @@ interface CreateWorkerDatabaseReadServiceArgs {
   databasePath: string;
   hub: NotificationHub;
   logger: ServerLogger;
+  onWorkerCreated?: (worker: Worker) => void;
 }
 
 function resolveWorkerEntryUrl(): URL {
@@ -56,23 +90,17 @@ function resolveWorkerEntryUrl(): URL {
   );
 }
 
-export function createWorkerDatabaseReadService(
+export async function createWorkerDatabaseReadService(
   args: CreateWorkerDatabaseReadServiceArgs,
-): DatabaseReadService {
+): Promise<DatabaseReadService> {
   const workerData: DatabaseReadWorkerData = {
     databasePath: args.databasePath,
   };
   const sourceFile = import.meta.url.endsWith(".ts");
-  const worker = new Worker(resolveWorkerEntryUrl(), {
-    ...(sourceFile
-      ? { execArgv: ["--conditions=source", "--import", "tsx"] }
-      : {}),
-    name: "bb-database-read-worker",
-    workerData,
-  });
   const pending = new Map<number, PendingDatabaseRead>();
+  const workers = new Set<Worker>();
+  let activeWorker: DatabaseReadWorkerState | null = null;
   let closed = false;
-  let failure: Error | null = null;
   let nextRequestId = 0;
 
   function rejectPending(error: Error): void {
@@ -82,79 +110,170 @@ export function createWorkerDatabaseReadService(
     pending.clear();
   }
 
-  function fail(error: Error): void {
-    if (failure !== null || closed) {
-      return;
-    }
-    failure = error;
-    rejectPending(error);
-  }
+  function startWorker(): DatabaseReadWorkerState {
+    const worker = new Worker(resolveWorkerEntryUrl(), {
+      ...(sourceFile
+        ? { execArgv: ["--conditions=source", "--import", "tsx"] }
+        : {}),
+      name: "bb-database-read-worker",
+      workerData,
+    });
+    let rejectReady!: (error: Error) => void;
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      rejectReady = reject;
+      resolveReady = resolve;
+    });
+    const state: DatabaseReadWorkerState = {
+      failed: false,
+      ready,
+      rejectReady,
+      resolveReady,
+      wasReady: false,
+      worker,
+    };
+    workers.add(worker);
+    args.onWorkerCreated?.(worker);
 
-  worker.on("message", (value: unknown) => {
-    const parsedMessage = databaseReadWorkerMessageSchema.safeParse(value);
-    if (!parsedMessage.success) {
-      fail(new Error("The database read worker sent an invalid message"));
-      return;
-    }
-    const message = parsedMessage.data;
-    if (message.kind === "log") {
-      args.logger.debug(message.fields, message.message);
-      return;
-    }
-
-    const read = pending.get(message.id);
-    if (read === undefined) {
-      return;
-    }
-    pending.delete(message.id);
-    if (message.kind === "error") {
-      const error = new Error(message.error.message);
-      error.stack = message.error.stack;
-      read.reject(error);
-      return;
-    }
-    read.resolve(message.entries);
-  });
-  worker.on("error", (error) => {
-    fail(error);
-  });
-  worker.on("exit", (code) => {
-    fail(new Error(`The database read worker stopped with exit code ${code}`));
-  });
-
-  return {
-    async close(): Promise<void> {
-      if (closed) {
+    function fail(error: Error): void {
+      if (state.failed || closed) {
         return;
       }
-      closed = true;
-      rejectPending(new Error("The database read service stopped"));
-      await worker.terminate();
-    },
+      state.failed = true;
+      args.logger.warn(
+        { err: error, workerWasReady: state.wasReady },
+        "Database read worker failed",
+      );
+      state.rejectReady(error);
+      rejectPending(error);
+      if (activeWorker !== state) {
+        return;
+      }
+      activeWorker = null;
+      if (state.wasReady) {
+        activeWorker = startWorker();
+        void activeWorker.ready.catch(() => {});
+      }
+    }
+
+    worker.on("message", (value: unknown) => {
+      const parsedMessage = databaseReadWorkerMessageSchema.safeParse(value);
+      if (!parsedMessage.success) {
+        fail(new Error("The database read worker sent an invalid message"));
+        void worker.terminate();
+        return;
+      }
+      const message = parsedMessage.data;
+      if (message.kind === "ready") {
+        state.wasReady = true;
+        state.resolveReady();
+        return;
+      }
+      if (message.kind === "log") {
+        args.logger.debug(message.fields, message.message);
+        return;
+      }
+
+      const read = pending.get(message.id);
+      if (read === undefined) {
+        return;
+      }
+      pending.delete(message.id);
+      if (message.kind === "error") {
+        const error = new Error(message.error.message);
+        error.stack = message.error.stack;
+        read.reject(error);
+        return;
+      }
+      read.resolve(message.entries);
+    });
+    worker.on("error", (error) => {
+      fail(error);
+    });
+    worker.on("exit", (code) => {
+      workers.delete(worker);
+      fail(
+        new Error(`The database read worker stopped with exit code ${code}`),
+      );
+    });
+
+    return state;
+  }
+
+  async function requireReadyWorker(): Promise<DatabaseReadWorkerState> {
+    if (closed) {
+      throw new Error("The database read service stopped");
+    }
+    const state = activeWorker ?? startWorker();
+    activeWorker = state;
+    await state.ready;
+    if (closed) {
+      throw new Error("The database read service stopped");
+    }
+    return state;
+  }
+
+  async function sendRequest(
+    createRequest: (id: number) => DatabaseReadWorkerRequest,
+  ): Promise<ThreadListEntry[]> {
+    const state = await requireReadyWorker();
+    const id = nextRequestId;
+    nextRequestId += 1;
+    return new Promise((resolve, reject) => {
+      if (state.failed) {
+        reject(new Error("The database read worker stopped"));
+        return;
+      }
+      pending.set(id, { reject, resolve });
+      try {
+        state.worker.postMessage(createRequest(id));
+      } catch (error) {
+        pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  async function close(): Promise<void> {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    activeWorker = null;
+    rejectPending(new Error("The database read service stopped"));
+    await Promise.all([...workers].map((worker) => worker.terminate()));
+  }
+
+  activeWorker = startWorker();
+  try {
+    await activeWorker.ready;
+  } catch (error) {
+    await close();
+    throw error;
+  }
+
+  return {
+    close,
     listThreadEntries(options: ListThreadsOptions): Promise<ThreadListEntry[]> {
-      if (closed) {
-        return Promise.reject(new Error("The database read service stopped"));
-      }
-      if (failure !== null) {
-        return Promise.reject(failure);
-      }
-      const id = nextRequestId;
-      nextRequestId += 1;
-      const request: DatabaseReadWorkerRequest = {
+      return sendRequest((id) => ({
         daemonSessions: args.hub.listDaemonSessions(),
         id,
         operation: "listThreadEntries",
         options,
-      };
-      return new Promise((resolve, reject) => {
-        pending.set(id, { reject, resolve });
-        try {
-          worker.postMessage(request);
-        } catch (error) {
-          pending.delete(id);
-          reject(error instanceof Error ? error : new Error(String(error)));
-        }
-      });
+      }));
+    },
+    listThreadEntriesForProjects(
+      options: ListThreadsForProjectsOptions,
+    ): Promise<ThreadListEntry[]> {
+      return sendRequest((id) => ({
+        daemonSessions: args.hub.listDaemonSessions(),
+        id,
+        operation: "listThreadEntriesForProjects",
+        options: {
+          ...options,
+          projectIds: [...options.projectIds],
+        },
+      }));
     },
   };
 }

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -7,7 +7,7 @@ import {
   listThreadsWithPendingInteractionState,
   listThreadsWithPendingInteractionStateForProjects,
 } from "@bb/db";
-import { threadListEntrySchema, type ThreadListEntry } from "@bb/domain";
+import type { ThreadListEntry } from "@bb/domain";
 import { Worker } from "node:worker_threads";
 import { ApiError, ClientClosedRequestError } from "../../errors.js";
 import type { ServerLogger } from "../../types.js";
@@ -51,10 +51,6 @@ export class DatabaseReadAbortedError extends ClientClosedRequestError {
     super("The database read request stopped");
     this.name = "DatabaseReadAbortedError";
   }
-}
-
-function isThreadListEntry(value: unknown): value is ThreadListEntry {
-  return threadListEntrySchema.safeParse(value).success;
 }
 
 export class DatabaseReadUnavailableError extends ApiError {
@@ -290,18 +286,16 @@ export async function createWorkerDatabaseReadService(
         error.stack = message.error.stack;
         rejectRead(read, error);
       } else {
-        const entries: ThreadListEntry[] = [];
-        for (const [entryIndex, entry] of message.entries.entries()) {
-          if (!isThreadListEntry(entry)) {
-            args.logger.warn(
-              { entryIndex, requestId: message.id },
-              "Dropped an invalid thread entry from a database read worker result",
-            );
-            continue;
-          }
-          entries.push(entry);
+        if (message.droppedEntryCount > 0) {
+          args.logger.warn(
+            {
+              droppedEntryCount: message.droppedEntryCount,
+              requestId: message.id,
+            },
+            "Dropped an invalid thread entry from a database read worker result",
+          );
         }
-        resolveRead(read, entries);
+        resolveRead(read, message.entries);
       }
       scheduleDispatch();
     });
@@ -411,13 +405,23 @@ export async function createWorkerDatabaseReadService(
         resolve,
         settled: false,
         timeout: setTimeout(() => {
+          const timedOutWhileActive = activeRead === read;
           removeQueuedRead(read);
-          rejectRead(
-            read,
-            new DatabaseReadUnavailableError(
-              "The database read timed out. Try again later.",
-            ),
+          if (timedOutWhileActive) {
+            activeRead = null;
+          }
+          const error = new DatabaseReadUnavailableError(
+            "The database read timed out. Try again later.",
           );
+          rejectRead(read, error);
+          if (timedOutWhileActive && activeWorker !== null) {
+            const timedOutWorker = activeWorker;
+            timedOutWorker.failed = true;
+            timedOutWorker.rejectReady(error);
+            activeWorker = startWorker();
+            void activeWorker.ready.catch(() => {});
+            void timedOutWorker.worker.terminate();
+          }
           scheduleDispatch();
         }, requestTimeoutMs),
       };

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -9,6 +9,7 @@ import {
 } from "@bb/db";
 import type { ThreadListEntry } from "@bb/domain";
 import { Worker } from "node:worker_threads";
+import { ApiError } from "../../errors.js";
 import type { ServerLogger } from "../../types.js";
 import type { NotificationHub } from "../../ws/hub.js";
 import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
@@ -18,9 +19,18 @@ import {
   type DatabaseReadWorkerRequest,
 } from "./database-read-worker-contract.js";
 
+const DEFAULT_MAX_PENDING_DATABASE_READS = 32;
+const DEFAULT_DATABASE_READ_TIMEOUT_MS = 30_000;
+
 interface PendingDatabaseRead {
+  abortHandler?: () => void;
+  createRequest(id: number): DatabaseReadWorkerRequest;
+  id: number;
   reject(error: Error): void;
   resolve(entries: ThreadListEntry[]): void;
+  settled: boolean;
+  signal?: AbortSignal;
+  timeout: NodeJS.Timeout;
 }
 
 interface DatabaseReadWorkerState {
@@ -32,11 +42,33 @@ interface DatabaseReadWorkerState {
   worker: Worker;
 }
 
+export interface DatabaseReadRequestContext {
+  signal?: AbortSignal;
+}
+
+export class DatabaseReadAbortedError extends Error {
+  constructor() {
+    super("The database read request stopped");
+    this.name = "DatabaseReadAbortedError";
+  }
+}
+
+export class DatabaseReadUnavailableError extends ApiError {
+  constructor(message: string) {
+    super(503, "database_read_unavailable", message, { retryable: true });
+    this.name = "DatabaseReadUnavailableError";
+  }
+}
+
 export interface DatabaseReadService {
   close(): Promise<void>;
-  listThreadEntries(options: ListThreadsOptions): Promise<ThreadListEntry[]>;
+  listThreadEntries(
+    options: ListThreadsOptions,
+    context?: DatabaseReadRequestContext,
+  ): Promise<ThreadListEntry[]>;
   listThreadEntriesForProjects(
     options: ListThreadsForProjectsOptions,
+    context?: DatabaseReadRequestContext,
   ): Promise<ThreadListEntry[]>;
 }
 
@@ -77,7 +109,9 @@ interface CreateWorkerDatabaseReadServiceArgs {
   databasePath: string;
   hub: NotificationHub;
   logger: ServerLogger;
+  maxPendingReads?: number;
   onWorkerCreated?: (worker: Worker) => void;
+  requestTimeoutMs?: number;
 }
 
 function resolveWorkerEntryUrl(): URL {
@@ -90,24 +124,92 @@ function resolveWorkerEntryUrl(): URL {
   );
 }
 
+function requireNonnegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a nonnegative integer`);
+  }
+  return value;
+}
+
 export async function createWorkerDatabaseReadService(
   args: CreateWorkerDatabaseReadServiceArgs,
 ): Promise<DatabaseReadService> {
   const workerData: DatabaseReadWorkerData = {
     databasePath: args.databasePath,
   };
+  const maxPendingReads = requireNonnegativeInteger(
+    args.maxPendingReads ?? DEFAULT_MAX_PENDING_DATABASE_READS,
+    "maxPendingReads",
+  );
+  const requestTimeoutMs = requireNonnegativeInteger(
+    args.requestTimeoutMs ?? DEFAULT_DATABASE_READ_TIMEOUT_MS,
+    "requestTimeoutMs",
+  );
   const sourceFile = import.meta.url.endsWith(".ts");
-  const pending = new Map<number, PendingDatabaseRead>();
+  const queue: PendingDatabaseRead[] = [];
   const workers = new Set<Worker>();
+  let activeRead: PendingDatabaseRead | null = null;
   let activeWorker: DatabaseReadWorkerState | null = null;
   let closed = false;
+  let dispatching = false;
   let nextRequestId = 0;
+  let preparingRead: PendingDatabaseRead | null = null;
 
-  function rejectPending(error: Error): void {
-    for (const read of pending.values()) {
-      read.reject(error);
+  function clearReadResources(read: PendingDatabaseRead): void {
+    clearTimeout(read.timeout);
+    if (read.abortHandler !== undefined) {
+      read.signal?.removeEventListener("abort", read.abortHandler);
     }
-    pending.clear();
+  }
+
+  function rejectRead(read: PendingDatabaseRead, error: Error): void {
+    if (read.settled) {
+      return;
+    }
+    read.settled = true;
+    clearReadResources(read);
+    read.reject(error);
+  }
+
+  function resolveRead(
+    read: PendingDatabaseRead,
+    entries: ThreadListEntry[],
+  ): void {
+    if (read.settled) {
+      return;
+    }
+    read.settled = true;
+    clearReadResources(read);
+    read.resolve(entries);
+  }
+
+  function removeQueuedRead(read: PendingDatabaseRead): void {
+    const index = queue.indexOf(read);
+    if (index !== -1) {
+      queue.splice(index, 1);
+    }
+  }
+
+  function rejectAllReads(error: Error): void {
+    if (preparingRead !== null) {
+      rejectRead(preparingRead, error);
+      preparingRead = null;
+    }
+    if (activeRead !== null) {
+      rejectRead(activeRead, error);
+      activeRead = null;
+    }
+    for (const read of queue.splice(0)) {
+      rejectRead(read, error);
+    }
+  }
+
+  function pendingReadCount(): number {
+    return (
+      queue.length +
+      (preparingRead === null ? 0 : 1) +
+      (activeRead === null ? 0 : 1)
+    );
   }
 
   function startWorker(): DatabaseReadWorkerState {
@@ -145,7 +247,7 @@ export async function createWorkerDatabaseReadService(
         "Database read worker failed",
       );
       state.rejectReady(error);
-      rejectPending(error);
+      rejectAllReads(error);
       if (activeWorker !== state) {
         return;
       }
@@ -173,19 +275,20 @@ export async function createWorkerDatabaseReadService(
         args.logger.debug(message.fields, message.message);
         return;
       }
-
-      const read = pending.get(message.id);
-      if (read === undefined) {
+      if (activeWorker !== state || activeRead?.id !== message.id) {
         return;
       }
-      pending.delete(message.id);
+
+      const read = activeRead;
+      activeRead = null;
       if (message.kind === "error") {
         const error = new Error(message.error.message);
         error.stack = message.error.stack;
-        read.reject(error);
-        return;
+        rejectRead(read, error);
+      } else {
+        resolveRead(read, message.entries);
       }
-      read.resolve(message.entries);
+      scheduleDispatch();
     });
     worker.on("error", (error) => {
       fail(error);
@@ -213,24 +316,109 @@ export async function createWorkerDatabaseReadService(
     return state;
   }
 
-  async function sendRequest(
+  function scheduleDispatch(): void {
+    if (closed || dispatching || activeRead !== null || queue.length === 0) {
+      return;
+    }
+    void dispatchNext();
+  }
+
+  async function dispatchNext(): Promise<void> {
+    if (dispatching || closed || activeRead !== null) {
+      return;
+    }
+    const read = queue.shift();
+    if (read === undefined) {
+      return;
+    }
+    if (read.settled) {
+      scheduleDispatch();
+      return;
+    }
+
+    dispatching = true;
+    preparingRead = read;
+    try {
+      const state = await requireReadyWorker();
+      if (read.settled || closed) {
+        return;
+      }
+      preparingRead = null;
+      activeRead = read;
+      try {
+        state.worker.postMessage(read.createRequest(read.id));
+      } catch (error) {
+        activeRead = null;
+        rejectRead(
+          read,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    } catch (error) {
+      rejectRead(
+        read,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    } finally {
+      if (preparingRead === read) {
+        preparingRead = null;
+      }
+      dispatching = false;
+      scheduleDispatch();
+    }
+  }
+
+  function sendRequest(
     createRequest: (id: number) => DatabaseReadWorkerRequest,
+    context: DatabaseReadRequestContext | undefined,
   ): Promise<ThreadListEntry[]> {
-    const state = await requireReadyWorker();
+    if (closed) {
+      return Promise.reject(new Error("The database read service stopped"));
+    }
+    if (context?.signal?.aborted === true) {
+      return Promise.reject(new DatabaseReadAbortedError());
+    }
+    if (pendingReadCount() >= maxPendingReads) {
+      return Promise.reject(
+        new DatabaseReadUnavailableError(
+          "The database read queue is full. Try again later.",
+        ),
+      );
+    }
+
     const id = nextRequestId;
     nextRequestId += 1;
     return new Promise((resolve, reject) => {
-      if (state.failed) {
-        reject(new Error("The database read worker stopped"));
-        return;
+      const read: PendingDatabaseRead = {
+        createRequest,
+        id,
+        reject,
+        resolve,
+        settled: false,
+        timeout: setTimeout(() => {
+          removeQueuedRead(read);
+          rejectRead(
+            read,
+            new DatabaseReadUnavailableError(
+              "The database read timed out. Try again later.",
+            ),
+          );
+          scheduleDispatch();
+        }, requestTimeoutMs),
+      };
+      if (context?.signal !== undefined) {
+        read.signal = context.signal;
+        read.abortHandler = (): void => {
+          removeQueuedRead(read);
+          rejectRead(read, new DatabaseReadAbortedError());
+          scheduleDispatch();
+        };
+        context.signal.addEventListener("abort", read.abortHandler, {
+          once: true,
+        });
       }
-      pending.set(id, { reject, resolve });
-      try {
-        state.worker.postMessage(createRequest(id));
-      } catch (error) {
-        pending.delete(id);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      }
+      queue.push(read);
+      scheduleDispatch();
     });
   }
 
@@ -238,9 +426,12 @@ export async function createWorkerDatabaseReadService(
     if (closed) {
       return;
     }
+    const error = new Error("The database read service stopped");
+    const workerState = activeWorker;
     closed = true;
     activeWorker = null;
-    rejectPending(new Error("The database read service stopped"));
+    workerState?.rejectReady(error);
+    rejectAllReads(error);
     await Promise.all([...workers].map((worker) => worker.terminate()));
   }
 
@@ -254,26 +445,36 @@ export async function createWorkerDatabaseReadService(
 
   return {
     close,
-    listThreadEntries(options: ListThreadsOptions): Promise<ThreadListEntry[]> {
-      return sendRequest((id) => ({
-        daemonSessions: args.hub.listDaemonSessions(),
-        id,
-        operation: "listThreadEntries",
-        options,
-      }));
+    listThreadEntries(
+      options: ListThreadsOptions,
+      context?: DatabaseReadRequestContext,
+    ): Promise<ThreadListEntry[]> {
+      return sendRequest(
+        (id) => ({
+          daemonSessions: args.hub.listDaemonSessions(),
+          id,
+          operation: "listThreadEntries",
+          options,
+        }),
+        context,
+      );
     },
     listThreadEntriesForProjects(
       options: ListThreadsForProjectsOptions,
+      context?: DatabaseReadRequestContext,
     ): Promise<ThreadListEntry[]> {
-      return sendRequest((id) => ({
-        daemonSessions: args.hub.listDaemonSessions(),
-        id,
-        operation: "listThreadEntriesForProjects",
-        options: {
-          ...options,
-          projectIds: [...options.projectIds],
-        },
-      }));
+      return sendRequest(
+        (id) => ({
+          daemonSessions: args.hub.listDaemonSessions(),
+          id,
+          operation: "listThreadEntriesForProjects",
+          options: {
+            ...options,
+            projectIds: [...options.projectIds],
+          },
+        }),
+        context,
+      );
     },
   };
 }

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -7,9 +7,9 @@ import {
   listThreadsWithPendingInteractionState,
   listThreadsWithPendingInteractionStateForProjects,
 } from "@bb/db";
-import type { ThreadListEntry } from "@bb/domain";
+import { threadListEntrySchema, type ThreadListEntry } from "@bb/domain";
 import { Worker } from "node:worker_threads";
-import { ApiError } from "../../errors.js";
+import { ApiError, ClientClosedRequestError } from "../../errors.js";
 import type { ServerLogger } from "../../types.js";
 import type { NotificationHub } from "../../ws/hub.js";
 import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
@@ -46,11 +46,15 @@ export interface DatabaseReadRequestContext {
   signal?: AbortSignal;
 }
 
-export class DatabaseReadAbortedError extends Error {
+export class DatabaseReadAbortedError extends ClientClosedRequestError {
   constructor() {
     super("The database read request stopped");
     this.name = "DatabaseReadAbortedError";
   }
+}
+
+function isThreadListEntry(value: unknown): value is ThreadListEntry {
+  return threadListEntrySchema.safeParse(value).success;
 }
 
 export class DatabaseReadUnavailableError extends ApiError {
@@ -286,7 +290,18 @@ export async function createWorkerDatabaseReadService(
         error.stack = message.error.stack;
         rejectRead(read, error);
       } else {
-        resolveRead(read, message.entries);
+        const entries: ThreadListEntry[] = [];
+        for (const [entryIndex, entry] of message.entries.entries()) {
+          if (!isThreadListEntry(entry)) {
+            args.logger.warn(
+              { entryIndex, requestId: message.id },
+              "Dropped an invalid thread entry from a database read worker result",
+            );
+            continue;
+          }
+          entries.push(entry);
+        }
+        resolveRead(read, entries);
       }
       scheduleDispatch();
     });

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -23,6 +23,7 @@ import {
 const DEFAULT_MAX_PENDING_DATABASE_READS = 32;
 const DEFAULT_DATABASE_READ_TIMEOUT_MS = 30_000;
 const DEFAULT_SLOW_DATABASE_READ_LOG_THRESHOLD_MS = 100;
+const DEFAULT_DATABASE_READ_WORKER_STARTUP_TIMEOUT_MS = 10_000;
 
 interface PendingDatabaseRead {
   abortHandler?: () => void;
@@ -36,6 +37,7 @@ interface PendingDatabaseRead {
 }
 
 interface DatabaseReadWorkerState {
+  clearReadyTimeout(): void;
   failed: boolean;
   ready: Promise<void>;
   rejectReady(error: Error): void;
@@ -93,6 +95,50 @@ export interface DatabaseReadService {
   ): Promise<SidebarBootstrapResponse>;
 }
 
+function applyLiveDaemonStateToEntry(
+  hub: NotificationHub,
+  entry: ThreadListEntry,
+): ThreadListEntry {
+  if (
+    entry.status !== "active" ||
+    entry.environmentHostId === null ||
+    hub.getDaemonSessionIdForHost(entry.environmentHostId) === null
+  ) {
+    return entry;
+  }
+  return {
+    ...entry,
+    runtime: {
+      displayStatus: "active",
+      hostReconnectGraceExpiresAt: null,
+    },
+  };
+}
+
+function applyLiveDaemonStateToEntries(
+  hub: NotificationHub,
+  entries: ThreadListEntry[],
+): ThreadListEntry[] {
+  return entries.map((entry) => applyLiveDaemonStateToEntry(hub, entry));
+}
+
+function applyLiveDaemonStateToProjects(
+  hub: NotificationHub,
+  projects: ProjectWithThreadsResponse[],
+): ProjectWithThreadsResponse[] {
+  return projects.map((project) => applyLiveDaemonStateToProject(hub, project));
+}
+
+function applyLiveDaemonStateToProject(
+  hub: NotificationHub,
+  project: ProjectWithThreadsResponse,
+): ProjectWithThreadsResponse {
+  return {
+    ...project,
+    threads: applyLiveDaemonStateToEntries(hub, project.threads),
+  };
+}
+
 interface CreateDirectDatabaseReadServiceArgs {
   db: DbConnection;
   hub: NotificationHub;
@@ -111,7 +157,6 @@ export function createDirectDatabaseReadService(
       options: ListThreadsOptions,
     ): Promise<ThreadListEntry[]> {
       const result = run({
-        daemonSessions: args.hub.listDaemonSessions(),
         id: 0,
         operation: "listThreadEntries",
         options,
@@ -119,13 +164,12 @@ export function createDirectDatabaseReadService(
       if (result.operation !== "listThreadEntries") {
         throw new Error("The direct database read returned an invalid result");
       }
-      return result.entries;
+      return applyLiveDaemonStateToEntries(args.hub, result.entries);
     },
     async listThreadEntriesForProjects(
       options: ListThreadsForProjectsOptions,
     ): Promise<ThreadListEntry[]> {
       const result = run({
-        daemonSessions: args.hub.listDaemonSessions(),
         id: 0,
         operation: "listThreadEntriesForProjects",
         options: { ...options, projectIds: [...options.projectIds] },
@@ -133,13 +177,12 @@ export function createDirectDatabaseReadService(
       if (result.operation !== "listThreadEntriesForProjects") {
         throw new Error("The direct database read returned an invalid result");
       }
-      return result.entries;
+      return applyLiveDaemonStateToEntries(args.hub, result.entries);
     },
     async listProjectsWithThreads(options: {
       includePersonal: boolean;
     }): Promise<ProjectWithThreadsResponse[]> {
       const result = run({
-        daemonSessions: args.hub.listDaemonSessions(),
         id: 0,
         operation: "listProjectsWithThreads",
         options,
@@ -147,18 +190,27 @@ export function createDirectDatabaseReadService(
       if (result.operation !== "listProjectsWithThreads") {
         throw new Error("The direct database read returned an invalid result");
       }
-      return result.projects;
+      return applyLiveDaemonStateToProjects(args.hub, result.projects);
     },
     async getSidebarBootstrap(): Promise<SidebarBootstrapResponse> {
       const result = run({
-        daemonSessions: args.hub.listDaemonSessions(),
         id: 0,
         operation: "sidebarBootstrap",
       });
       if (result.operation !== "sidebarBootstrap") {
         throw new Error("The direct database read returned an invalid result");
       }
-      return result.response;
+      return {
+        ...result.response,
+        projects: applyLiveDaemonStateToProjects(
+          args.hub,
+          result.response.projects,
+        ),
+        personalProject: applyLiveDaemonStateToProject(
+          args.hub,
+          result.response.personalProject,
+        ),
+      };
     },
   };
 }
@@ -171,6 +223,7 @@ interface CreateWorkerDatabaseReadServiceArgs {
   onWorkerCreated?: (worker: Worker) => void;
   requestTimeoutMs?: number;
   slowQueryThresholdMs?: number;
+  workerStartupTimeoutMs?: number;
 }
 
 function resolveWorkerEntryUrl(): URL {
@@ -204,6 +257,11 @@ export async function createWorkerDatabaseReadService(
   const slowQueryThresholdMs = requireNonnegativeInteger(
     args.slowQueryThresholdMs ?? DEFAULT_SLOW_DATABASE_READ_LOG_THRESHOLD_MS,
     "slowQueryThresholdMs",
+  );
+  const workerStartupTimeoutMs = requireNonnegativeInteger(
+    args.workerStartupTimeoutMs ??
+      DEFAULT_DATABASE_READ_WORKER_STARTUP_TIMEOUT_MS,
+    "workerStartupTimeoutMs",
   );
   const workerData: DatabaseReadWorkerData = {
     databasePath: args.databasePath,
@@ -305,7 +363,14 @@ export async function createWorkerDatabaseReadService(
       rejectReady = reject;
       resolveReady = resolve;
     });
+    let readyTimeout: NodeJS.Timeout | null = null;
     const state: DatabaseReadWorkerState = {
+      clearReadyTimeout(): void {
+        if (readyTimeout !== null) {
+          clearTimeout(readyTimeout);
+          readyTimeout = null;
+        }
+      },
       failed: false,
       ready,
       rejectReady,
@@ -321,6 +386,7 @@ export async function createWorkerDatabaseReadService(
         return;
       }
       state.failed = true;
+      state.clearReadyTimeout();
       args.logger.warn(
         { err: error, workerWasReady: state.wasReady },
         "Database read worker failed",
@@ -337,12 +403,14 @@ export async function createWorkerDatabaseReadService(
       }
       activeWorker = null;
       if (state.wasReady) {
-        activeWorker = startWorker();
-        void activeWorker.ready.catch(() => {});
+        activeWorker = startRecoveryWorker();
       }
     }
 
     worker.on("message", (value: unknown) => {
+      if (state.failed) {
+        return;
+      }
       const parsedMessage = databaseReadWorkerMessageSchema.safeParse(value);
       if (!parsedMessage.success) {
         fail(new Error("The database read worker sent an invalid message"));
@@ -351,6 +419,7 @@ export async function createWorkerDatabaseReadService(
       }
       const message = parsedMessage.data;
       if (message.kind === "ready") {
+        state.clearReadyTimeout();
         state.wasReady = true;
         hasReadyWorker = true;
         state.resolveReady();
@@ -394,7 +463,29 @@ export async function createWorkerDatabaseReadService(
       );
     });
 
+    readyTimeout = setTimeout(() => {
+      const error = new DatabaseReadUnavailableError(
+        "The database read worker did not start. Try again later.",
+      );
+      fail(error);
+      void worker.terminate();
+    }, workerStartupTimeoutMs);
+
     return state;
+  }
+
+  function startRecoveryWorker(): DatabaseReadWorkerState | null {
+    try {
+      const state = startWorker();
+      void state.ready.catch(() => {});
+      return state;
+    } catch (error) {
+      args.logger.warn(
+        { err: error },
+        "Database read worker replacement could not start",
+      );
+      return null;
+    }
   }
 
   function replaceWorker(error: Error): void {
@@ -403,9 +494,9 @@ export async function createWorkerDatabaseReadService(
     }
     const replacedWorker = activeWorker;
     replacedWorker.failed = true;
+    replacedWorker.clearReadyTimeout();
     replacedWorker.rejectReady(error);
-    activeWorker = startWorker();
-    void activeWorker.ready.catch(() => {});
+    activeWorker = startRecoveryWorker();
     void replacedWorker.worker.terminate();
   }
 
@@ -413,7 +504,20 @@ export async function createWorkerDatabaseReadService(
     if (closed) {
       throw new Error("The database read service stopped");
     }
-    const state = activeWorker ?? startWorker();
+    let state = activeWorker;
+    if (state === null) {
+      try {
+        state = startWorker();
+      } catch (error) {
+        args.logger.warn(
+          { err: error },
+          "Database read worker could not start",
+        );
+        throw new DatabaseReadUnavailableError(
+          "The database read worker could not start. Try again later.",
+        );
+      }
+    }
     activeWorker = state;
     await state.ready;
     if (closed) {
@@ -548,6 +652,7 @@ export async function createWorkerDatabaseReadService(
     closed = true;
     activeWorker = null;
     workerState?.rejectReady(error);
+    workerState?.clearReadyTimeout();
     rejectAllReads(error);
     await Promise.all([...workers].map((worker) => worker.terminate()));
   }
@@ -568,7 +673,6 @@ export async function createWorkerDatabaseReadService(
     ): Promise<ThreadListEntry[]> {
       return sendRequest(
         (id) => ({
-          daemonSessions: args.hub.listDaemonSessions(),
           id,
           operation: "listThreadEntries",
           options,
@@ -580,7 +684,7 @@ export async function createWorkerDatabaseReadService(
             "The database read worker returned an invalid result",
           );
         }
-        return result.entries;
+        return applyLiveDaemonStateToEntries(args.hub, result.entries);
       });
     },
     listThreadEntriesForProjects(
@@ -589,7 +693,6 @@ export async function createWorkerDatabaseReadService(
     ): Promise<ThreadListEntry[]> {
       return sendRequest(
         (id) => ({
-          daemonSessions: args.hub.listDaemonSessions(),
           id,
           operation: "listThreadEntriesForProjects",
           options: {
@@ -604,7 +707,7 @@ export async function createWorkerDatabaseReadService(
             "The database read worker returned an invalid result",
           );
         }
-        return result.entries;
+        return applyLiveDaemonStateToEntries(args.hub, result.entries);
       });
     },
     listProjectsWithThreads(
@@ -613,7 +716,6 @@ export async function createWorkerDatabaseReadService(
     ): Promise<ProjectWithThreadsResponse[]> {
       return sendRequest(
         (id) => ({
-          daemonSessions: args.hub.listDaemonSessions(),
           id,
           operation: "listProjectsWithThreads",
           options,
@@ -625,7 +727,7 @@ export async function createWorkerDatabaseReadService(
             "The database read worker returned an invalid result",
           );
         }
-        return result.projects;
+        return applyLiveDaemonStateToProjects(args.hub, result.projects);
       });
     },
     getSidebarBootstrap(
@@ -633,7 +735,6 @@ export async function createWorkerDatabaseReadService(
     ): Promise<SidebarBootstrapResponse> {
       return sendRequest(
         (id) => ({
-          daemonSessions: args.hub.listDaemonSessions(),
           id,
           operation: "sidebarBootstrap",
         }),
@@ -644,7 +745,18 @@ export async function createWorkerDatabaseReadService(
             "The database read worker returned an invalid result",
           );
         }
-        return result.response;
+        const projects = applyLiveDaemonStateToProjects(
+          args.hub,
+          result.response.projects,
+        );
+        return {
+          ...result.response,
+          projects,
+          personalProject: applyLiveDaemonStateToProject(
+            args.hub,
+            result.response.personalProject,
+          ),
+        };
       });
     },
   };

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -1,0 +1,160 @@
+import type { DbConnection, ListThreadsOptions } from "@bb/db";
+import { listThreadsWithPendingInteractionState } from "@bb/db";
+import type { ThreadListEntry } from "@bb/domain";
+import { Worker } from "node:worker_threads";
+import type { ServerLogger } from "../../types.js";
+import type { NotificationHub } from "../../ws/hub.js";
+import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
+import {
+  databaseReadWorkerMessageSchema,
+  type DatabaseReadWorkerData,
+  type DatabaseReadWorkerRequest,
+} from "./database-read-worker-contract.js";
+
+interface PendingDatabaseRead {
+  reject(error: Error): void;
+  resolve(entries: ThreadListEntry[]): void;
+}
+
+export interface DatabaseReadService {
+  close(): Promise<void>;
+  listThreadEntries(options: ListThreadsOptions): Promise<ThreadListEntry[]>;
+}
+
+interface CreateDirectDatabaseReadServiceArgs {
+  db: DbConnection;
+  hub: NotificationHub;
+}
+
+export function createDirectDatabaseReadService(
+  args: CreateDirectDatabaseReadServiceArgs,
+): DatabaseReadService {
+  return {
+    async close(): Promise<void> {},
+    async listThreadEntries(
+      options: ListThreadsOptions,
+    ): Promise<ThreadListEntry[]> {
+      const threads = listThreadsWithPendingInteractionState(args.db, options);
+      return toThreadListEntryResponses(args, { threads });
+    },
+  };
+}
+
+interface CreateWorkerDatabaseReadServiceArgs {
+  databasePath: string;
+  hub: NotificationHub;
+  logger: ServerLogger;
+}
+
+function resolveWorkerEntryUrl(): URL {
+  const sourceFile = import.meta.url.endsWith(".ts");
+  return new URL(
+    sourceFile
+      ? "./database-read-worker-entry.ts"
+      : "./database-read-worker-entry.js",
+    import.meta.url,
+  );
+}
+
+export function createWorkerDatabaseReadService(
+  args: CreateWorkerDatabaseReadServiceArgs,
+): DatabaseReadService {
+  const workerData: DatabaseReadWorkerData = {
+    databasePath: args.databasePath,
+  };
+  const sourceFile = import.meta.url.endsWith(".ts");
+  const worker = new Worker(resolveWorkerEntryUrl(), {
+    ...(sourceFile
+      ? { execArgv: ["--conditions=source", "--import", "tsx"] }
+      : {}),
+    name: "bb-database-read-worker",
+    workerData,
+  });
+  const pending = new Map<number, PendingDatabaseRead>();
+  let closed = false;
+  let failure: Error | null = null;
+  let nextRequestId = 0;
+
+  function rejectPending(error: Error): void {
+    for (const read of pending.values()) {
+      read.reject(error);
+    }
+    pending.clear();
+  }
+
+  function fail(error: Error): void {
+    if (failure !== null || closed) {
+      return;
+    }
+    failure = error;
+    rejectPending(error);
+  }
+
+  worker.on("message", (value: unknown) => {
+    const parsedMessage = databaseReadWorkerMessageSchema.safeParse(value);
+    if (!parsedMessage.success) {
+      fail(new Error("The database read worker sent an invalid message"));
+      return;
+    }
+    const message = parsedMessage.data;
+    if (message.kind === "log") {
+      args.logger.debug(message.fields, message.message);
+      return;
+    }
+
+    const read = pending.get(message.id);
+    if (read === undefined) {
+      return;
+    }
+    pending.delete(message.id);
+    if (message.kind === "error") {
+      const error = new Error(message.error.message);
+      error.stack = message.error.stack;
+      read.reject(error);
+      return;
+    }
+    read.resolve(message.entries);
+  });
+  worker.on("error", (error) => {
+    fail(error);
+  });
+  worker.on("exit", (code) => {
+    fail(new Error(`The database read worker stopped with exit code ${code}`));
+  });
+
+  return {
+    async close(): Promise<void> {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      rejectPending(new Error("The database read service stopped"));
+      await worker.terminate();
+    },
+    listThreadEntries(options: ListThreadsOptions): Promise<ThreadListEntry[]> {
+      if (closed) {
+        return Promise.reject(new Error("The database read service stopped"));
+      }
+      if (failure !== null) {
+        return Promise.reject(failure);
+      }
+      const id = nextRequestId;
+      nextRequestId += 1;
+      const request: DatabaseReadWorkerRequest = {
+        daemonSessions: args.hub.listDaemonSessions(),
+        id,
+        operation: "listThreadEntries",
+        options,
+      };
+      return new Promise((resolve, reject) => {
+        pending.set(id, { reject, resolve });
+        try {
+          worker.postMessage(request);
+        } catch (error) {
+          pending.delete(id);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+    },
+  };
+}

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -60,6 +60,18 @@ export class DatabaseReadUnavailableError extends ApiError {
   }
 }
 
+export class DatabaseReadTimeoutError extends ApiError {
+  constructor() {
+    super(
+      503,
+      "database_read_unavailable",
+      "The database read timed out. Try again later.",
+      { retryable: false },
+    );
+    this.name = "DatabaseReadTimeoutError";
+  }
+}
+
 export interface DatabaseReadService {
   close(): Promise<void>;
   listThreadEntries(
@@ -152,6 +164,7 @@ export async function createWorkerDatabaseReadService(
   let activeWorker: DatabaseReadWorkerState | null = null;
   let closed = false;
   let dispatching = false;
+  let hasReadyWorker = false;
   let nextRequestId = 0;
   let preparingRead: PendingDatabaseRead | null = null;
 
@@ -246,8 +259,13 @@ export async function createWorkerDatabaseReadService(
         { err: error, workerWasReady: state.wasReady },
         "Database read worker failed",
       );
-      state.rejectReady(error);
-      rejectAllReads(error);
+      const requestError = hasReadyWorker
+        ? new DatabaseReadUnavailableError(
+            "The database read worker stopped. Try again later.",
+          )
+        : error;
+      state.rejectReady(requestError);
+      rejectAllReads(requestError);
       if (activeWorker !== state) {
         return;
       }
@@ -268,6 +286,7 @@ export async function createWorkerDatabaseReadService(
       const message = parsedMessage.data;
       if (message.kind === "ready") {
         state.wasReady = true;
+        hasReadyWorker = true;
         state.resolveReady();
         return;
       }
@@ -310,6 +329,18 @@ export async function createWorkerDatabaseReadService(
     });
 
     return state;
+  }
+
+  function replaceWorker(error: Error): void {
+    if (activeWorker === null) {
+      return;
+    }
+    const replacedWorker = activeWorker;
+    replacedWorker.failed = true;
+    replacedWorker.rejectReady(error);
+    activeWorker = startWorker();
+    void activeWorker.ready.catch(() => {});
+    void replacedWorker.worker.terminate();
   }
 
   async function requireReadyWorker(): Promise<DatabaseReadWorkerState> {
@@ -410,17 +441,10 @@ export async function createWorkerDatabaseReadService(
           if (timedOutWhileActive) {
             activeRead = null;
           }
-          const error = new DatabaseReadUnavailableError(
-            "The database read timed out. Try again later.",
-          );
+          const error = new DatabaseReadTimeoutError();
           rejectRead(read, error);
-          if (timedOutWhileActive && activeWorker !== null) {
-            const timedOutWorker = activeWorker;
-            timedOutWorker.failed = true;
-            timedOutWorker.rejectReady(error);
-            activeWorker = startWorker();
-            void activeWorker.ready.catch(() => {});
-            void timedOutWorker.worker.terminate();
+          if (timedOutWhileActive) {
+            replaceWorker(error);
           }
           scheduleDispatch();
         }, requestTimeoutMs),
@@ -428,8 +452,16 @@ export async function createWorkerDatabaseReadService(
       if (context?.signal !== undefined) {
         read.signal = context.signal;
         read.abortHandler = (): void => {
+          const abortedWhileActive = activeRead === read;
           removeQueuedRead(read);
-          rejectRead(read, new DatabaseReadAbortedError());
+          if (abortedWhileActive) {
+            activeRead = null;
+          }
+          const error = new DatabaseReadAbortedError();
+          rejectRead(read, error);
+          if (abortedWhileActive) {
+            replaceWorker(error);
+          }
           scheduleDispatch();
         };
         context.signal.addEventListener("abort", read.abortHandler, {

--- a/apps/server/src/services/database/database-read-service.ts
+++ b/apps/server/src/services/database/database-read-service.ts
@@ -3,31 +3,33 @@ import type {
   ListThreadsForProjectsOptions,
   ListThreadsOptions,
 } from "@bb/db";
-import {
-  listThreadsWithPendingInteractionState,
-  listThreadsWithPendingInteractionStateForProjects,
-} from "@bb/db";
 import type { ThreadListEntry } from "@bb/domain";
+import type {
+  ProjectWithThreadsResponse,
+  SidebarBootstrapResponse,
+} from "@bb/server-contract";
 import { Worker } from "node:worker_threads";
 import { ApiError, ClientClosedRequestError } from "../../errors.js";
 import type { ServerLogger } from "../../types.js";
 import type { NotificationHub } from "../../ws/hub.js";
-import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
+import { executeDatabaseReadOperation } from "./database-read-operations.js";
 import {
   databaseReadWorkerMessageSchema,
   type DatabaseReadWorkerData,
   type DatabaseReadWorkerRequest,
+  type DatabaseReadWorkerResult,
 } from "./database-read-worker-contract.js";
 
 const DEFAULT_MAX_PENDING_DATABASE_READS = 32;
 const DEFAULT_DATABASE_READ_TIMEOUT_MS = 30_000;
+const DEFAULT_SLOW_DATABASE_READ_LOG_THRESHOLD_MS = 100;
 
 interface PendingDatabaseRead {
   abortHandler?: () => void;
   createRequest(id: number): DatabaseReadWorkerRequest;
   id: number;
   reject(error: Error): void;
-  resolve(entries: ThreadListEntry[]): void;
+  resolve(result: DatabaseReadWorkerResult): void;
   settled: boolean;
   signal?: AbortSignal;
   timeout: NodeJS.Timeout;
@@ -82,6 +84,13 @@ export interface DatabaseReadService {
     options: ListThreadsForProjectsOptions,
     context?: DatabaseReadRequestContext,
   ): Promise<ThreadListEntry[]>;
+  listProjectsWithThreads(
+    options: { includePersonal: boolean },
+    context?: DatabaseReadRequestContext,
+  ): Promise<ProjectWithThreadsResponse[]>;
+  getSidebarBootstrap(
+    context?: DatabaseReadRequestContext,
+  ): Promise<SidebarBootstrapResponse>;
 }
 
 interface CreateDirectDatabaseReadServiceArgs {
@@ -92,10 +101,8 @@ interface CreateDirectDatabaseReadServiceArgs {
 export function createDirectDatabaseReadService(
   args: CreateDirectDatabaseReadServiceArgs,
 ): DatabaseReadService {
-  function toEntries(
-    threads: Parameters<typeof toThreadListEntryResponses>[1]["threads"],
-  ) {
-    return toThreadListEntryResponses(args, { threads });
+  function run(request: DatabaseReadWorkerRequest): DatabaseReadWorkerResult {
+    return executeDatabaseReadOperation({ db: args.db }, request);
   }
 
   return {
@@ -103,16 +110,55 @@ export function createDirectDatabaseReadService(
     async listThreadEntries(
       options: ListThreadsOptions,
     ): Promise<ThreadListEntry[]> {
-      return toEntries(
-        listThreadsWithPendingInteractionState(args.db, options),
-      );
+      const result = run({
+        daemonSessions: args.hub.listDaemonSessions(),
+        id: 0,
+        operation: "listThreadEntries",
+        options,
+      });
+      if (result.operation !== "listThreadEntries") {
+        throw new Error("The direct database read returned an invalid result");
+      }
+      return result.entries;
     },
     async listThreadEntriesForProjects(
       options: ListThreadsForProjectsOptions,
     ): Promise<ThreadListEntry[]> {
-      return toEntries(
-        listThreadsWithPendingInteractionStateForProjects(args.db, options),
-      );
+      const result = run({
+        daemonSessions: args.hub.listDaemonSessions(),
+        id: 0,
+        operation: "listThreadEntriesForProjects",
+        options: { ...options, projectIds: [...options.projectIds] },
+      });
+      if (result.operation !== "listThreadEntriesForProjects") {
+        throw new Error("The direct database read returned an invalid result");
+      }
+      return result.entries;
+    },
+    async listProjectsWithThreads(options: {
+      includePersonal: boolean;
+    }): Promise<ProjectWithThreadsResponse[]> {
+      const result = run({
+        daemonSessions: args.hub.listDaemonSessions(),
+        id: 0,
+        operation: "listProjectsWithThreads",
+        options,
+      });
+      if (result.operation !== "listProjectsWithThreads") {
+        throw new Error("The direct database read returned an invalid result");
+      }
+      return result.projects;
+    },
+    async getSidebarBootstrap(): Promise<SidebarBootstrapResponse> {
+      const result = run({
+        daemonSessions: args.hub.listDaemonSessions(),
+        id: 0,
+        operation: "sidebarBootstrap",
+      });
+      if (result.operation !== "sidebarBootstrap") {
+        throw new Error("The direct database read returned an invalid result");
+      }
+      return result.response;
     },
   };
 }
@@ -124,6 +170,7 @@ interface CreateWorkerDatabaseReadServiceArgs {
   maxPendingReads?: number;
   onWorkerCreated?: (worker: Worker) => void;
   requestTimeoutMs?: number;
+  slowQueryThresholdMs?: number;
 }
 
 function resolveWorkerEntryUrl(): URL {
@@ -146,9 +193,6 @@ function requireNonnegativeInteger(value: number, name: string): number {
 export async function createWorkerDatabaseReadService(
   args: CreateWorkerDatabaseReadServiceArgs,
 ): Promise<DatabaseReadService> {
-  const workerData: DatabaseReadWorkerData = {
-    databasePath: args.databasePath,
-  };
   const maxPendingReads = requireNonnegativeInteger(
     args.maxPendingReads ?? DEFAULT_MAX_PENDING_DATABASE_READS,
     "maxPendingReads",
@@ -157,6 +201,14 @@ export async function createWorkerDatabaseReadService(
     args.requestTimeoutMs ?? DEFAULT_DATABASE_READ_TIMEOUT_MS,
     "requestTimeoutMs",
   );
+  const slowQueryThresholdMs = requireNonnegativeInteger(
+    args.slowQueryThresholdMs ?? DEFAULT_SLOW_DATABASE_READ_LOG_THRESHOLD_MS,
+    "slowQueryThresholdMs",
+  );
+  const workerData: DatabaseReadWorkerData = {
+    databasePath: args.databasePath,
+    slowQueryThresholdMs,
+  };
   const sourceFile = import.meta.url.endsWith(".ts");
   const queue: PendingDatabaseRead[] = [];
   const workers = new Set<Worker>();
@@ -176,24 +228,38 @@ export async function createWorkerDatabaseReadService(
   }
 
   function rejectRead(read: PendingDatabaseRead, error: Error): void {
+    clearReadResources(read);
     if (read.settled) {
       return;
     }
     read.settled = true;
-    clearReadResources(read);
     read.reject(error);
   }
 
   function resolveRead(
     read: PendingDatabaseRead,
-    entries: ThreadListEntry[],
+    result: DatabaseReadWorkerResult,
+  ): void {
+    clearReadResources(read);
+    if (read.settled) {
+      return;
+    }
+    read.settled = true;
+    read.resolve(result);
+  }
+
+  function rejectCallerWhileReadContinues(
+    read: PendingDatabaseRead,
+    error: Error,
   ): void {
     if (read.settled) {
       return;
     }
     read.settled = true;
-    clearReadResources(read);
-    read.resolve(entries);
+    if (read.abortHandler !== undefined) {
+      read.signal?.removeEventListener("abort", read.abortHandler);
+    }
+    read.reject(error);
   }
 
   function removeQueuedRead(read: PendingDatabaseRead): void {
@@ -305,16 +371,16 @@ export async function createWorkerDatabaseReadService(
         error.stack = message.error.stack;
         rejectRead(read, error);
       } else {
-        if (message.droppedEntryCount > 0) {
+        if (message.result.droppedEntryCount > 0) {
           args.logger.warn(
             {
-              droppedEntryCount: message.droppedEntryCount,
+              droppedEntryCount: message.result.droppedEntryCount,
               requestId: message.id,
             },
             "Dropped an invalid thread entry from a database read worker result",
           );
         }
-        resolveRead(read, message.entries);
+        resolveRead(read, message.result);
       }
       scheduleDispatch();
     });
@@ -411,7 +477,7 @@ export async function createWorkerDatabaseReadService(
   function sendRequest(
     createRequest: (id: number) => DatabaseReadWorkerRequest,
     context: DatabaseReadRequestContext | undefined,
-  ): Promise<ThreadListEntry[]> {
+  ): Promise<DatabaseReadWorkerResult> {
     if (closed) {
       return Promise.reject(new Error("The database read service stopped"));
     }
@@ -455,13 +521,13 @@ export async function createWorkerDatabaseReadService(
           const abortedWhileActive = activeRead === read;
           removeQueuedRead(read);
           if (abortedWhileActive) {
-            activeRead = null;
+            rejectCallerWhileReadContinues(
+              read,
+              new DatabaseReadAbortedError(),
+            );
+            return;
           }
-          const error = new DatabaseReadAbortedError();
-          rejectRead(read, error);
-          if (abortedWhileActive) {
-            replaceWorker(error);
-          }
+          rejectRead(read, new DatabaseReadAbortedError());
           scheduleDispatch();
         };
         context.signal.addEventListener("abort", read.abortHandler, {
@@ -508,7 +574,14 @@ export async function createWorkerDatabaseReadService(
           options,
         }),
         context,
-      );
+      ).then((result) => {
+        if (result.operation !== "listThreadEntries") {
+          throw new Error(
+            "The database read worker returned an invalid result",
+          );
+        }
+        return result.entries;
+      });
     },
     listThreadEntriesForProjects(
       options: ListThreadsForProjectsOptions,
@@ -525,7 +598,54 @@ export async function createWorkerDatabaseReadService(
           },
         }),
         context,
-      );
+      ).then((result) => {
+        if (result.operation !== "listThreadEntriesForProjects") {
+          throw new Error(
+            "The database read worker returned an invalid result",
+          );
+        }
+        return result.entries;
+      });
+    },
+    listProjectsWithThreads(
+      options: { includePersonal: boolean },
+      context?: DatabaseReadRequestContext,
+    ): Promise<ProjectWithThreadsResponse[]> {
+      return sendRequest(
+        (id) => ({
+          daemonSessions: args.hub.listDaemonSessions(),
+          id,
+          operation: "listProjectsWithThreads",
+          options,
+        }),
+        context,
+      ).then((result) => {
+        if (result.operation !== "listProjectsWithThreads") {
+          throw new Error(
+            "The database read worker returned an invalid result",
+          );
+        }
+        return result.projects;
+      });
+    },
+    getSidebarBootstrap(
+      context?: DatabaseReadRequestContext,
+    ): Promise<SidebarBootstrapResponse> {
+      return sendRequest(
+        (id) => ({
+          daemonSessions: args.hub.listDaemonSessions(),
+          id,
+          operation: "sidebarBootstrap",
+        }),
+        context,
+      ).then((result) => {
+        if (result.operation !== "sidebarBootstrap") {
+          throw new Error(
+            "The database read worker returned an invalid result",
+          );
+        }
+        return result.response;
+      });
     },
   };
 }

--- a/apps/server/src/services/database/database-read-worker-contract.ts
+++ b/apps/server/src/services/database/database-read-worker-contract.ts
@@ -7,29 +7,33 @@ import { threadChildOriginSchema, threadOriginKindSchema } from "@bb/domain";
 import type { ThreadListEntry } from "@bb/domain";
 import { z } from "zod";
 
+const listThreadsOptionsShape = {
+  archived: z.boolean().optional(),
+  childOrigin: threadChildOriginSchema.optional(),
+  hasParent: z.boolean().optional(),
+  includeHidden: z.boolean().optional(),
+  limit: z.number().int().nonnegative().optional(),
+  offset: z.number().int().nonnegative().optional(),
+  originKind: threadOriginKindSchema.optional(),
+  originPluginId: z.string().optional(),
+  parentThreadId: z.string().optional(),
+  projectId: z.string().optional(),
+  sectionId: z.string().optional(),
+  sourceThreadId: z.string().optional(),
+  unsectioned: z.boolean().optional(),
+} satisfies Record<keyof ListThreadsOptions, z.ZodType>;
+
 const listThreadsOptionsSchema = z
-  .object({
-    archived: z.boolean().optional(),
-    childOrigin: threadChildOriginSchema.optional(),
-    hasParent: z.boolean().optional(),
-    includeHidden: z.boolean().optional(),
-    limit: z.number().int().nonnegative().optional(),
-    offset: z.number().int().nonnegative().optional(),
-    originKind: threadOriginKindSchema.optional(),
-    originPluginId: z.string().optional(),
-    parentThreadId: z.string().optional(),
-    projectId: z.string().optional(),
-    sectionId: z.string().optional(),
-    sourceThreadId: z.string().optional(),
-    unsectioned: z.boolean().optional(),
-  })
+  .object(listThreadsOptionsShape)
   .strict() satisfies z.ZodType<ListThreadsOptions>;
 
+const listThreadsForProjectsOptionsShape = {
+  archived: z.boolean().optional(),
+  projectIds: z.array(z.string()),
+} satisfies Record<keyof ListThreadsForProjectsOptions, z.ZodType>;
+
 const listThreadsForProjectsOptionsSchema = z
-  .object({
-    archived: z.boolean().optional(),
-    projectIds: z.array(z.string()),
-  })
+  .object(listThreadsForProjectsOptionsShape)
   .strict() satisfies z.ZodType<ListThreadsForProjectsOptions>;
 
 const slowDbQueryLogFieldsSchema = z.object({
@@ -90,6 +94,12 @@ export type DatabaseReadWorkerRequest = z.infer<
   typeof databaseReadWorkerRequestSchema
 >;
 
+export const databaseReadWorkerRequestIdSchema = z
+  .object({
+    id: z.number().int().nonnegative(),
+  })
+  .passthrough();
+
 const workerErrorSchema = z
   .object({
     message: z.string(),
@@ -119,21 +129,14 @@ export const databaseReadWorkerMessageSchema = z.discriminatedUnion("kind", [
     .strict(),
   z
     .object({
+      droppedEntryCount: z.number().int().nonnegative(),
       id: z.number().int().nonnegative(),
       kind: z.literal("result"),
-      entries: z.array(z.unknown()),
+      entries: z.custom<ThreadListEntry[]>(Array.isArray),
     })
     .strict(),
 ]);
 
-type DatabaseReadWorkerMessageEnvelope = z.infer<
+export type DatabaseReadWorkerMessage = z.infer<
   typeof databaseReadWorkerMessageSchema
 >;
-
-export type DatabaseReadWorkerMessage =
-  | Exclude<DatabaseReadWorkerMessageEnvelope, { kind: "result" }>
-  | {
-      entries: ThreadListEntry[];
-      id: number;
-      kind: "result";
-    };

--- a/apps/server/src/services/database/database-read-worker-contract.ts
+++ b/apps/server/src/services/database/database-read-worker-contract.ts
@@ -5,6 +5,10 @@ import type {
 } from "@bb/db";
 import { threadChildOriginSchema, threadOriginKindSchema } from "@bb/domain";
 import type { ThreadListEntry } from "@bb/domain";
+import type {
+  ProjectWithThreadsResponse,
+  SidebarBootstrapResponse,
+} from "@bb/server-contract";
 import { z } from "zod";
 
 const listThreadsOptionsShape = {
@@ -47,6 +51,7 @@ const slowDbQueryLogFieldsSchema = z.object({
 export const databaseReadWorkerDataSchema = z
   .object({
     databasePath: z.string().min(1),
+    slowQueryThresholdMs: z.number().nonnegative(),
   })
   .strict();
 
@@ -87,6 +92,39 @@ export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
         options: listThreadsForProjectsOptionsSchema,
       })
       .strict(),
+    z
+      .object({
+        id: z.number().int().nonnegative(),
+        daemonSessions: z.array(
+          z
+            .object({
+              hostId: z.string(),
+              sessionId: z.string(),
+            })
+            .strict(),
+        ),
+        operation: z.literal("listProjectsWithThreads"),
+        options: z
+          .object({
+            includePersonal: z.boolean(),
+          })
+          .strict(),
+      })
+      .strict(),
+    z
+      .object({
+        id: z.number().int().nonnegative(),
+        daemonSessions: z.array(
+          z
+            .object({
+              hostId: z.string(),
+              sessionId: z.string(),
+            })
+            .strict(),
+        ),
+        operation: z.literal("sidebarBootstrap"),
+      })
+      .strict(),
   ],
 );
 
@@ -106,6 +144,49 @@ const workerErrorSchema = z
     stack: z.string().optional(),
   })
   .strict();
+
+const databaseReadWorkerResultSchema = z.discriminatedUnion("operation", [
+  z
+    .object({
+      droppedEntryCount: z.number().int().nonnegative(),
+      entries: z.custom<ThreadListEntry[]>(
+        (value): value is ThreadListEntry[] => Array.isArray(value),
+      ),
+      operation: z.literal("listThreadEntries"),
+    })
+    .strict(),
+  z
+    .object({
+      droppedEntryCount: z.number().int().nonnegative(),
+      entries: z.custom<ThreadListEntry[]>(
+        (value): value is ThreadListEntry[] => Array.isArray(value),
+      ),
+      operation: z.literal("listThreadEntriesForProjects"),
+    })
+    .strict(),
+  z
+    .object({
+      droppedEntryCount: z.number().int().nonnegative(),
+      operation: z.literal("listProjectsWithThreads"),
+      projects: z.custom<ProjectWithThreadsResponse[]>(
+        (value): value is ProjectWithThreadsResponse[] => Array.isArray(value),
+      ),
+    })
+    .strict(),
+  z
+    .object({
+      droppedEntryCount: z.number().int().nonnegative(),
+      operation: z.literal("sidebarBootstrap"),
+      response: z.custom<SidebarBootstrapResponse>(
+        (value) => typeof value === "object" && value !== null,
+      ),
+    })
+    .strict(),
+]);
+
+export type DatabaseReadWorkerResult = z.infer<
+  typeof databaseReadWorkerResultSchema
+>;
 
 export const databaseReadWorkerMessageSchema = z.discriminatedUnion("kind", [
   z
@@ -129,10 +210,9 @@ export const databaseReadWorkerMessageSchema = z.discriminatedUnion("kind", [
     .strict(),
   z
     .object({
-      droppedEntryCount: z.number().int().nonnegative(),
       id: z.number().int().nonnegative(),
       kind: z.literal("result"),
-      entries: z.custom<ThreadListEntry[]>(Array.isArray),
+      result: databaseReadWorkerResultSchema,
     })
     .strict(),
 ]);

--- a/apps/server/src/services/database/database-read-worker-contract.ts
+++ b/apps/server/src/services/database/database-read-worker-contract.ts
@@ -1,0 +1,103 @@
+import type { ListThreadsOptions, SlowDbQueryLogFields } from "@bb/db";
+import {
+  threadListEntrySchema,
+  threadChildOriginSchema,
+  threadOriginKindSchema,
+} from "@bb/domain";
+import { z } from "zod";
+
+const listThreadsOptionsSchema = z
+  .object({
+    archived: z.boolean().optional(),
+    childOrigin: threadChildOriginSchema.optional(),
+    hasParent: z.boolean().optional(),
+    includeHidden: z.boolean().optional(),
+    limit: z.number().int().nonnegative().optional(),
+    offset: z.number().int().nonnegative().optional(),
+    originKind: threadOriginKindSchema.optional(),
+    originPluginId: z.string().optional(),
+    parentThreadId: z.string().optional(),
+    projectId: z.string().optional(),
+    sectionId: z.string().optional(),
+    sourceThreadId: z.string().optional(),
+    unsectioned: z.boolean().optional(),
+  })
+  .strict() satisfies z.ZodType<ListThreadsOptions>;
+
+const slowDbQueryLogFieldsSchema = z.object({
+  bindingArgumentCount: z.number().int().nonnegative(),
+  durationMs: z.number().nonnegative(),
+  operation: z.enum(["all", "get", "run"]),
+  sql: z.string(),
+  thresholdMs: z.number().nonnegative(),
+}) satisfies z.ZodType<SlowDbQueryLogFields>;
+
+export const databaseReadWorkerDataSchema = z
+  .object({
+    databasePath: z.string().min(1),
+  })
+  .strict();
+
+export type DatabaseReadWorkerData = z.infer<
+  typeof databaseReadWorkerDataSchema
+>;
+
+export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
+  "operation",
+  [
+    z
+      .object({
+        id: z.number().int().nonnegative(),
+        daemonSessions: z.array(
+          z
+            .object({
+              hostId: z.string(),
+              sessionId: z.string(),
+            })
+            .strict(),
+        ),
+        operation: z.literal("listThreadEntries"),
+        options: listThreadsOptionsSchema,
+      })
+      .strict(),
+  ],
+);
+
+export type DatabaseReadWorkerRequest = z.infer<
+  typeof databaseReadWorkerRequestSchema
+>;
+
+const workerErrorSchema = z
+  .object({
+    message: z.string(),
+    stack: z.string().optional(),
+  })
+  .strict();
+
+export const databaseReadWorkerMessageSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      fields: slowDbQueryLogFieldsSchema,
+      kind: z.literal("log"),
+      message: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      error: workerErrorSchema,
+      id: z.number().int().nonnegative(),
+      kind: z.literal("error"),
+    })
+    .strict(),
+  z
+    .object({
+      id: z.number().int().nonnegative(),
+      kind: z.literal("result"),
+      entries: z.array(threadListEntrySchema),
+    })
+    .strict(),
+]);
+
+export type DatabaseReadWorkerMessage = z.infer<
+  typeof databaseReadWorkerMessageSchema
+>;

--- a/apps/server/src/services/database/database-read-worker-contract.ts
+++ b/apps/server/src/services/database/database-read-worker-contract.ts
@@ -1,4 +1,8 @@
-import type { ListThreadsOptions, SlowDbQueryLogFields } from "@bb/db";
+import type {
+  ListThreadsForProjectsOptions,
+  ListThreadsOptions,
+  SlowDbQueryLogFields,
+} from "@bb/db";
 import {
   threadListEntrySchema,
   threadChildOriginSchema,
@@ -23,6 +27,13 @@ const listThreadsOptionsSchema = z
     unsectioned: z.boolean().optional(),
   })
   .strict() satisfies z.ZodType<ListThreadsOptions>;
+
+const listThreadsForProjectsOptionsSchema = z
+  .object({
+    archived: z.boolean().optional(),
+    projectIds: z.array(z.string()),
+  })
+  .strict() satisfies z.ZodType<ListThreadsForProjectsOptions>;
 
 const slowDbQueryLogFieldsSchema = z.object({
   bindingArgumentCount: z.number().int().nonnegative(),
@@ -60,6 +71,21 @@ export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
         options: listThreadsOptionsSchema,
       })
       .strict(),
+    z
+      .object({
+        id: z.number().int().nonnegative(),
+        daemonSessions: z.array(
+          z
+            .object({
+              hostId: z.string(),
+              sessionId: z.string(),
+            })
+            .strict(),
+        ),
+        operation: z.literal("listThreadEntriesForProjects"),
+        options: listThreadsForProjectsOptionsSchema,
+      })
+      .strict(),
   ],
 );
 
@@ -75,6 +101,11 @@ const workerErrorSchema = z
   .strict();
 
 export const databaseReadWorkerMessageSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("ready"),
+    })
+    .strict(),
   z
     .object({
       fields: slowDbQueryLogFieldsSchema,

--- a/apps/server/src/services/database/database-read-worker-contract.ts
+++ b/apps/server/src/services/database/database-read-worker-contract.ts
@@ -65,14 +65,6 @@ export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
     z
       .object({
         id: z.number().int().nonnegative(),
-        daemonSessions: z.array(
-          z
-            .object({
-              hostId: z.string(),
-              sessionId: z.string(),
-            })
-            .strict(),
-        ),
         operation: z.literal("listThreadEntries"),
         options: listThreadsOptionsSchema,
       })
@@ -80,14 +72,6 @@ export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
     z
       .object({
         id: z.number().int().nonnegative(),
-        daemonSessions: z.array(
-          z
-            .object({
-              hostId: z.string(),
-              sessionId: z.string(),
-            })
-            .strict(),
-        ),
         operation: z.literal("listThreadEntriesForProjects"),
         options: listThreadsForProjectsOptionsSchema,
       })
@@ -95,14 +79,6 @@ export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
     z
       .object({
         id: z.number().int().nonnegative(),
-        daemonSessions: z.array(
-          z
-            .object({
-              hostId: z.string(),
-              sessionId: z.string(),
-            })
-            .strict(),
-        ),
         operation: z.literal("listProjectsWithThreads"),
         options: z
           .object({
@@ -114,14 +90,6 @@ export const databaseReadWorkerRequestSchema = z.discriminatedUnion(
     z
       .object({
         id: z.number().int().nonnegative(),
-        daemonSessions: z.array(
-          z
-            .object({
-              hostId: z.string(),
-              sessionId: z.string(),
-            })
-            .strict(),
-        ),
         operation: z.literal("sidebarBootstrap"),
       })
       .strict(),

--- a/apps/server/src/services/database/database-read-worker-contract.ts
+++ b/apps/server/src/services/database/database-read-worker-contract.ts
@@ -3,11 +3,8 @@ import type {
   ListThreadsOptions,
   SlowDbQueryLogFields,
 } from "@bb/db";
-import {
-  threadListEntrySchema,
-  threadChildOriginSchema,
-  threadOriginKindSchema,
-} from "@bb/domain";
+import { threadChildOriginSchema, threadOriginKindSchema } from "@bb/domain";
+import type { ThreadListEntry } from "@bb/domain";
 import { z } from "zod";
 
 const listThreadsOptionsSchema = z
@@ -124,11 +121,19 @@ export const databaseReadWorkerMessageSchema = z.discriminatedUnion("kind", [
     .object({
       id: z.number().int().nonnegative(),
       kind: z.literal("result"),
-      entries: z.array(threadListEntrySchema),
+      entries: z.array(z.unknown()),
     })
     .strict(),
 ]);
 
-export type DatabaseReadWorkerMessage = z.infer<
+type DatabaseReadWorkerMessageEnvelope = z.infer<
   typeof databaseReadWorkerMessageSchema
 >;
+
+export type DatabaseReadWorkerMessage =
+  | Exclude<DatabaseReadWorkerMessageEnvelope, { kind: "result" }>
+  | {
+      entries: ThreadListEntry[];
+      id: number;
+      kind: "result";
+    };

--- a/apps/server/src/services/database/database-read-worker-entry.ts
+++ b/apps/server/src/services/database/database-read-worker-entry.ts
@@ -1,18 +1,12 @@
-import {
-  createReadOnlyConnection,
-  listThreadsWithPendingInteractionState,
-  listThreadsWithPendingInteractionStateForProjects,
-  type SlowDbQueryLogger,
-} from "@bb/db";
+import { createReadOnlyConnection, type SlowDbQueryLogger } from "@bb/db";
 import { parentPort, workerData } from "node:worker_threads";
-import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
-import { threadListEntrySchema, type ThreadListEntry } from "@bb/domain";
 import {
   databaseReadWorkerDataSchema,
   databaseReadWorkerRequestIdSchema,
   databaseReadWorkerRequestSchema,
   type DatabaseReadWorkerMessage,
 } from "./database-read-worker-contract.js";
+import { executeDatabaseReadOperation } from "./database-read-operations.js";
 
 if (parentPort === null) {
   throw new Error("The database read worker requires a parent port");
@@ -31,6 +25,7 @@ const slowQueryLogger: SlowDbQueryLogger = {
 };
 const db = createReadOnlyConnection(config.databasePath, {
   slowQueryLogger,
+  slowQueryThresholdMs: config.slowQueryThresholdMs,
 });
 
 function serializeError(error: unknown): { message: string; stack?: string } {
@@ -43,10 +38,6 @@ function serializeError(error: unknown): { message: string; stack?: string } {
   return { message: String(error) };
 }
 
-function isThreadListEntry(value: unknown): value is ThreadListEntry {
-  return threadListEntrySchema.safeParse(value).success;
-}
-
 port.on("message", (value: unknown) => {
   const requestIdResult = databaseReadWorkerRequestIdSchema.safeParse(value);
   if (!requestIdResult.success) {
@@ -55,36 +46,11 @@ port.on("message", (value: unknown) => {
   const requestId = requestIdResult.data.id;
   try {
     const request = databaseReadWorkerRequestSchema.parse(value);
-    const threads =
-      request.operation === "listThreadEntries"
-        ? listThreadsWithPendingInteractionState(db, request.options)
-        : listThreadsWithPendingInteractionStateForProjects(
-            db,
-            request.options,
-          );
-    const daemonSessionIdByHostId = new Map(
-      request.daemonSessions.map((session) => [
-        session.hostId,
-        session.sessionId,
-      ]),
-    );
-    const rawEntries = toThreadListEntryResponses(
-      {
-        db,
-        hub: {
-          getDaemonSessionIdForHost(hostId): string | null {
-            return daemonSessionIdByHostId.get(hostId) ?? null;
-          },
-        },
-      },
-      { threads },
-    );
-    const entries = rawEntries.filter(isThreadListEntry);
+    const result = executeDatabaseReadOperation({ db }, request);
     port.postMessage({
-      droppedEntryCount: rawEntries.length - entries.length,
-      entries,
       id: request.id,
       kind: "result",
+      result,
     } satisfies DatabaseReadWorkerMessage);
   } catch (error) {
     port.postMessage({

--- a/apps/server/src/services/database/database-read-worker-entry.ts
+++ b/apps/server/src/services/database/database-read-worker-entry.ts
@@ -1,6 +1,7 @@
 import {
   createReadOnlyConnection,
   listThreadsWithPendingInteractionState,
+  listThreadsWithPendingInteractionStateForProjects,
   type SlowDbQueryLogger,
 } from "@bb/db";
 import { parentPort, workerData } from "node:worker_threads";
@@ -44,7 +45,13 @@ port.on("message", (value: unknown) => {
   let request;
   try {
     request = databaseReadWorkerRequestSchema.parse(value);
-    const threads = listThreadsWithPendingInteractionState(db, request.options);
+    const threads =
+      request.operation === "listThreadEntries"
+        ? listThreadsWithPendingInteractionState(db, request.options)
+        : listThreadsWithPendingInteractionStateForProjects(
+            db,
+            request.options,
+          );
     const daemonSessionIdByHostId = new Map(
       request.daemonSessions.map((session) => [
         session.hostId,
@@ -79,3 +86,5 @@ port.on("message", (value: unknown) => {
     } satisfies DatabaseReadWorkerMessage);
   }
 });
+
+port.postMessage({ kind: "ready" } satisfies DatabaseReadWorkerMessage);

--- a/apps/server/src/services/database/database-read-worker-entry.ts
+++ b/apps/server/src/services/database/database-read-worker-entry.ts
@@ -6,8 +6,10 @@ import {
 } from "@bb/db";
 import { parentPort, workerData } from "node:worker_threads";
 import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
+import { threadListEntrySchema, type ThreadListEntry } from "@bb/domain";
 import {
   databaseReadWorkerDataSchema,
+  databaseReadWorkerRequestIdSchema,
   databaseReadWorkerRequestSchema,
   type DatabaseReadWorkerMessage,
 } from "./database-read-worker-contract.js";
@@ -41,10 +43,18 @@ function serializeError(error: unknown): { message: string; stack?: string } {
   return { message: String(error) };
 }
 
+function isThreadListEntry(value: unknown): value is ThreadListEntry {
+  return threadListEntrySchema.safeParse(value).success;
+}
+
 port.on("message", (value: unknown) => {
-  let request;
+  const requestIdResult = databaseReadWorkerRequestIdSchema.safeParse(value);
+  if (!requestIdResult.success) {
+    throw new Error("The database read worker received an invalid request ID");
+  }
+  const requestId = requestIdResult.data.id;
   try {
-    request = databaseReadWorkerRequestSchema.parse(value);
+    const request = databaseReadWorkerRequestSchema.parse(value);
     const threads =
       request.operation === "listThreadEntries"
         ? listThreadsWithPendingInteractionState(db, request.options)
@@ -58,7 +68,7 @@ port.on("message", (value: unknown) => {
         session.sessionId,
       ]),
     );
-    const entries = toThreadListEntryResponses(
+    const rawEntries = toThreadListEntryResponses(
       {
         db,
         hub: {
@@ -69,16 +79,14 @@ port.on("message", (value: unknown) => {
       },
       { threads },
     );
+    const entries = rawEntries.filter(isThreadListEntry);
     port.postMessage({
+      droppedEntryCount: rawEntries.length - entries.length,
       entries,
       id: request.id,
       kind: "result",
     } satisfies DatabaseReadWorkerMessage);
   } catch (error) {
-    const requestId = request?.id;
-    if (requestId === undefined) {
-      throw error;
-    }
     port.postMessage({
       error: serializeError(error),
       id: requestId,

--- a/apps/server/src/services/database/database-read-worker-entry.ts
+++ b/apps/server/src/services/database/database-read-worker-entry.ts
@@ -1,0 +1,81 @@
+import {
+  createReadOnlyConnection,
+  listThreadsWithPendingInteractionState,
+  type SlowDbQueryLogger,
+} from "@bb/db";
+import { parentPort, workerData } from "node:worker_threads";
+import { toThreadListEntryResponses } from "../threads/thread-runtime-display.js";
+import {
+  databaseReadWorkerDataSchema,
+  databaseReadWorkerRequestSchema,
+  type DatabaseReadWorkerMessage,
+} from "./database-read-worker-contract.js";
+
+if (parentPort === null) {
+  throw new Error("The database read worker requires a parent port");
+}
+
+const port = parentPort;
+const config = databaseReadWorkerDataSchema.parse(workerData);
+const slowQueryLogger: SlowDbQueryLogger = {
+  debug(fields, message): void {
+    port.postMessage({
+      fields,
+      kind: "log",
+      message,
+    } satisfies DatabaseReadWorkerMessage);
+  },
+};
+const db = createReadOnlyConnection(config.databasePath, {
+  slowQueryLogger,
+});
+
+function serializeError(error: unknown): { message: string; stack?: string } {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      ...(error.stack === undefined ? {} : { stack: error.stack }),
+    };
+  }
+  return { message: String(error) };
+}
+
+port.on("message", (value: unknown) => {
+  let request;
+  try {
+    request = databaseReadWorkerRequestSchema.parse(value);
+    const threads = listThreadsWithPendingInteractionState(db, request.options);
+    const daemonSessionIdByHostId = new Map(
+      request.daemonSessions.map((session) => [
+        session.hostId,
+        session.sessionId,
+      ]),
+    );
+    const entries = toThreadListEntryResponses(
+      {
+        db,
+        hub: {
+          getDaemonSessionIdForHost(hostId): string | null {
+            return daemonSessionIdByHostId.get(hostId) ?? null;
+          },
+        },
+      },
+      { threads },
+    );
+    port.postMessage({
+      entries,
+      id: request.id,
+      kind: "result",
+    } satisfies DatabaseReadWorkerMessage);
+  } catch (error) {
+    const requestId = request?.id;
+    if (requestId === undefined) {
+      throw error;
+    }
+    port.postMessage({
+      error: serializeError(error),
+      id: requestId,
+      kind: "error",
+    } satisfies DatabaseReadWorkerMessage);
+  }
+});

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -9,6 +9,7 @@ import { createLogger } from "@bb/logger";
 import { initDb } from "./db.js";
 import { createApp } from "./server.js";
 import { PendingInteractionLifecycle } from "./services/interactions/pending-interactions.js";
+import { createWorkerDatabaseReadService } from "./services/database/database-read-service.js";
 import { createMachineAuthService } from "./services/machine-auth.js";
 import { resolveBuiltinSkillsRootPath } from "./services/skills/builtin-skills-copy.js";
 import { SkillTreeRegistry } from "./services/skills/injected-skills.js";
@@ -51,6 +52,11 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
     logger,
   });
   const hub = new NotificationHub();
+  const databaseReads = createWorkerDatabaseReadService({
+    databasePath: serverConfig.databasePath,
+    hub,
+    logger,
+  });
   const watchInterests = new WatchInterestCoordinator({ db, hub });
   const sharedPorts = new HostSharedPortCoordinator({ db, hub });
   const lifecycleDedupers = createLifecycleDedupers();
@@ -141,6 +147,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       appVersion,
       bbAppManagedConfig,
       config: runtimeConfig,
+      databaseReads,
       db,
       hub,
       lifecycleDedupers,
@@ -224,6 +231,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       await pluginService.stop().catch((error: unknown) => {
         logger.warn({ err: error }, "Plugin shutdown failed");
       });
+      await databaseReads.close();
       const closeServer = new Promise<void>((resolve, reject) => {
         server.close((error) => {
           if (error) {

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -9,7 +9,10 @@ import { createLogger } from "@bb/logger";
 import { initDb } from "./db.js";
 import { createApp } from "./server.js";
 import { PendingInteractionLifecycle } from "./services/interactions/pending-interactions.js";
-import { createWorkerDatabaseReadService } from "./services/database/database-read-service.js";
+import {
+  createWorkerDatabaseReadService,
+  type DatabaseReadService,
+} from "./services/database/database-read-service.js";
 import { createMachineAuthService } from "./services/machine-auth.js";
 import { resolveBuiltinSkillsRootPath } from "./services/skills/builtin-skills-copy.js";
 import { SkillTreeRegistry } from "./services/skills/injected-skills.js";
@@ -42,6 +45,18 @@ export function startHttpListener(args: StartHttpListenerArgs) {
   });
 }
 
+export async function runStartupWithDatabaseReads(
+  databaseReads: DatabaseReadService,
+  start: () => Promise<void>,
+): Promise<void> {
+  try {
+    await start();
+  } catch (error) {
+    await databaseReads.close();
+    throw error;
+  }
+}
+
 export async function runServer(serverConfig: ServerConfig): Promise<void> {
   const logger = createLogger({
     component: "server",
@@ -52,102 +67,121 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
     logger,
   });
   const hub = new NotificationHub();
-  const databaseReads = createWorkerDatabaseReadService({
+  const databaseReads = await createWorkerDatabaseReadService({
     databasePath: serverConfig.databasePath,
     hub,
     logger,
   });
-  const watchInterests = new WatchInterestCoordinator({ db, hub });
-  const sharedPorts = new HostSharedPortCoordinator({ db, hub });
-  const lifecycleDedupers = createLifecycleDedupers();
-  const appUrl = toOptionalString(serverConfig.BB_APP_URL);
-  const threadStorageRootPath = resolveThreadStorageRootPath({
-    dataDir: serverConfig.BB_DATA_DIR,
-  });
+  await runStartupWithDatabaseReads(databaseReads, async () => {
+    const watchInterests = new WatchInterestCoordinator({ db, hub });
+    const sharedPorts = new HostSharedPortCoordinator({ db, hub });
+    const lifecycleDedupers = createLifecycleDedupers();
+    const appUrl = toOptionalString(serverConfig.BB_APP_URL);
+    const threadStorageRootPath = resolveThreadStorageRootPath({
+      dataDir: serverConfig.BB_DATA_DIR,
+    });
 
-  const selfDir = dirname(fileURLToPath(import.meta.url));
-  const appDir = resolve(selfDir, "../../app");
-  const appDistDir = join(appDir, "dist");
-  const isProduction = process.env.NODE_ENV === "production";
-  const staticDir =
-    isProduction && existsSync(appDistDir) ? appDistDir : undefined;
-  const runtimeConfig: ServerRuntimeConfig = {
-    appSurface: serverConfig.BB_APP_SURFACE,
-    appVersion: serverConfig.BB_APP_VERSION,
-    builtinSkillsRootPath: resolveBuiltinSkillsRootPath(),
-    customAcpAgents: [],
-    customModels: [],
-    dataDir: serverConfig.BB_DATA_DIR,
-    featureFlags: serverConfig.featureFlags,
-    hostDaemonPort: serverConfig.BB_HOST_DAEMON_PORT,
-    inheritedSkillsRootPaths: serverConfig.BB_INHERITED_SKILLS_ROOTS,
-    inferenceModel: serverConfig.BB_INFERENCE,
-    isDevelopment: !isProduction,
-    openAiApiKey: serverConfig.OPENAI_API_KEY,
-    serverPort: serverConfig.BB_SERVER_PORT,
-    threadStorageRootPath,
-    transcriptionModel: serverConfig.BB_TRANSCRIPTION,
-  };
+    const selfDir = dirname(fileURLToPath(import.meta.url));
+    const appDir = resolve(selfDir, "../../app");
+    const appDistDir = join(appDir, "dist");
+    const isProduction = process.env.NODE_ENV === "production";
+    const staticDir =
+      isProduction && existsSync(appDistDir) ? appDistDir : undefined;
+    const runtimeConfig: ServerRuntimeConfig = {
+      appSurface: serverConfig.BB_APP_SURFACE,
+      appVersion: serverConfig.BB_APP_VERSION,
+      builtinSkillsRootPath: resolveBuiltinSkillsRootPath(),
+      customAcpAgents: [],
+      customModels: [],
+      dataDir: serverConfig.BB_DATA_DIR,
+      featureFlags: serverConfig.featureFlags,
+      hostDaemonPort: serverConfig.BB_HOST_DAEMON_PORT,
+      inheritedSkillsRootPaths: serverConfig.BB_INHERITED_SKILLS_ROOTS,
+      inferenceModel: serverConfig.BB_INFERENCE,
+      isDevelopment: !isProduction,
+      openAiApiKey: serverConfig.OPENAI_API_KEY,
+      serverPort: serverConfig.BB_SERVER_PORT,
+      threadStorageRootPath,
+      transcriptionModel: serverConfig.BB_TRANSCRIPTION,
+    };
 
-  if (appUrl !== undefined) {
-    runtimeConfig.appUrl = appUrl;
-  }
-  if (serverConfig.BB_DEV_APP_PORT !== undefined) {
-    runtimeConfig.devAppPort = serverConfig.BB_DEV_APP_PORT;
-  }
-  const terminalSessions = new TerminalSessionLifecycle({
-    config: runtimeConfig,
-    db,
-    hub,
-    logger,
-  });
-  const bbAppManagedConfig = await createBbAppManagedConfigReloader({
-    config: runtimeConfig,
-    hub,
-    logger,
-  });
-
-  // Telemetry only operates in production runs (the bb-app launcher and the
-  // desktop app both set NODE_ENV=production); dev/source runs never send.
-  const telemetry = await createTelemetryService({
-    apiKey: serverConfig.BB_POSTHOG_API_KEY,
-    appSurface: serverConfig.BB_APP_SURFACE,
-    appVersion: serverConfig.BB_APP_VERSION,
-    dataDir: serverConfig.BB_DATA_DIR,
-    enabled: serverConfig.BB_TELEMETRY && isProduction,
-    logger,
-  });
-
-  const machineAuth = await createMachineAuthService({
-    dataDir: serverConfig.BB_DATA_DIR,
-    db,
-    logger,
-  });
-  await machineAuth.ensureReady();
-  const skillTreeRegistry = new SkillTreeRegistry();
-  const pendingInteractions = new PendingInteractionLifecycle({
-    config: runtimeConfig,
-    db,
-    hub,
-    lifecycleDedupers,
-    logger,
-    machineAuth,
-    skillTreeRegistry,
-    telemetry,
-    terminalSessions,
-  });
-  pendingInteractions.start();
-
-  const appVersion = createAppVersionService({
-    config: runtimeConfig,
-    logger,
-  });
-  const { app, closeWebSockets, injectWebSocket, pluginService } = createApp(
-    {
-      appVersion,
-      bbAppManagedConfig,
+    if (appUrl !== undefined) {
+      runtimeConfig.appUrl = appUrl;
+    }
+    if (serverConfig.BB_DEV_APP_PORT !== undefined) {
+      runtimeConfig.devAppPort = serverConfig.BB_DEV_APP_PORT;
+    }
+    const terminalSessions = new TerminalSessionLifecycle({
       config: runtimeConfig,
-      databaseReads,
+      db,
+      hub,
+      logger,
+    });
+    const bbAppManagedConfig = await createBbAppManagedConfigReloader({
+      config: runtimeConfig,
+      hub,
+      logger,
+    });
+
+    // Telemetry only operates in production runs (the bb-app launcher and the
+    // desktop app both set NODE_ENV=production); dev/source runs never send.
+    const telemetry = await createTelemetryService({
+      apiKey: serverConfig.BB_POSTHOG_API_KEY,
+      appSurface: serverConfig.BB_APP_SURFACE,
+      appVersion: serverConfig.BB_APP_VERSION,
+      dataDir: serverConfig.BB_DATA_DIR,
+      enabled: serverConfig.BB_TELEMETRY && isProduction,
+      logger,
+    });
+
+    const machineAuth = await createMachineAuthService({
+      dataDir: serverConfig.BB_DATA_DIR,
+      db,
+      logger,
+    });
+    await machineAuth.ensureReady();
+    const skillTreeRegistry = new SkillTreeRegistry();
+    const pendingInteractions = new PendingInteractionLifecycle({
+      config: runtimeConfig,
+      db,
+      hub,
+      lifecycleDedupers,
+      logger,
+      machineAuth,
+      skillTreeRegistry,
+      telemetry,
+      terminalSessions,
+    });
+    pendingInteractions.start();
+
+    const appVersion = createAppVersionService({
+      config: runtimeConfig,
+      logger,
+    });
+    const { app, closeWebSockets, injectWebSocket, pluginService } = createApp(
+      {
+        appVersion,
+        bbAppManagedConfig,
+        config: runtimeConfig,
+        databaseReads,
+        db,
+        hub,
+        lifecycleDedupers,
+        logger,
+        machineAuth,
+        pendingInteractions,
+        skillTreeRegistry,
+        telemetry,
+        terminalSessions,
+        watchInterests,
+        sharedPorts,
+      },
+      { staticDir },
+    );
+    const eventLoopStallMonitor = startEventLoopStallMonitor({ logger });
+
+    const sweepDeps = {
+      config: runtimeConfig,
       db,
       hub,
       lifecycleDedupers,
@@ -155,102 +189,85 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       machineAuth,
       pendingInteractions,
       skillTreeRegistry,
+      pluginSchedules: pluginService,
+      pluginService,
       telemetry,
       terminalSessions,
-      watchInterests,
-      sharedPorts,
-    },
-    { staticDir },
-  );
-  const eventLoopStallMonitor = startEventLoopStallMonitor({ logger });
+    };
+    await runStartupRecoverySweep(sweepDeps).catch((error) => {
+      logger.error({ err: error }, "Startup recovery sweep failed");
+    });
 
-  const sweepDeps = {
-    config: runtimeConfig,
-    db,
-    hub,
-    lifecycleDedupers,
-    logger,
-    machineAuth,
-    pendingInteractions,
-    skillTreeRegistry,
-    pluginSchedules: pluginService,
-    pluginService,
-    telemetry,
-    terminalSessions,
-  };
-  await runStartupRecoverySweep(sweepDeps).catch((error) => {
-    logger.error({ err: error }, "Startup recovery sweep failed");
-  });
-
-  if (!isLoopbackHostname(serverConfig.BB_SERVER_BIND_HOST)) {
-    logger.warn(
-      { bindHost: serverConfig.BB_SERVER_BIND_HOST },
-      "SECURITY WARNING: The public API is unauthenticated and permits command execution and file reads. Wildcard server binding must only be used behind a trusted network boundary.",
-    );
-  }
-
-  const server = startHttpListener({
-    fetch: app.fetch,
-    serverConfig,
-  });
-  injectWebSocket(server);
-
-  logger.info(
-    {
-      bindHost: serverConfig.BB_SERVER_BIND_HOST,
-      port: serverConfig.BB_SERVER_PORT,
-      dataDir: serverConfig.BB_DATA_DIR,
-    },
-    "Server listening",
-  );
-  telemetry.capture({ name: "app_started" });
-
-  // Plugins load after the listener is up: they are additive, and a slow
-  // plugin must not delay serving. Bind the loopback SDK first so bb.sdk is
-  // usable from the moment factories run.
-  pluginService.bindSdk({
-    baseUrl: `http://127.0.0.1:${serverConfig.BB_SERVER_PORT}`,
-  });
-  void pluginService.start().catch((error: unknown) => {
-    logger.error({ err: error }, "Plugin startup failed");
-  });
-
-  const sweepInterval = setInterval(() => {
-    void runPeriodicSweeps(sweepDeps);
-  }, 10_000);
-  sweepInterval.unref();
-
-  let shutdownPromise: Promise<void> | null = null;
-  const runShutdown = (): Promise<void> => {
-    if (shutdownPromise) {
-      return shutdownPromise;
+    if (!isLoopbackHostname(serverConfig.BB_SERVER_BIND_HOST)) {
+      logger.warn(
+        { bindHost: serverConfig.BB_SERVER_BIND_HOST },
+        "SECURITY WARNING: The public API is unauthenticated and permits command execution and file reads. Wildcard server binding must only be used behind a trusted network boundary.",
+      );
     }
-    shutdownPromise = (async () => {
-      eventLoopStallMonitor.stop();
-      clearInterval(sweepInterval);
-      await pluginService.stop().catch((error: unknown) => {
-        logger.warn({ err: error }, "Plugin shutdown failed");
-      });
-      await databaseReads.close();
-      const closeServer = new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-      await closeWebSockets();
-      await closeServer;
-    })();
-    return shutdownPromise;
-  };
 
-  process.once("SIGINT", () => {
-    void runShutdown().finally(() => process.exit(0));
-  });
-  process.once("SIGTERM", () => {
-    void runShutdown().finally(() => process.exit(0));
+    const server = startHttpListener({
+      fetch: app.fetch,
+      serverConfig,
+    });
+    injectWebSocket(server);
+
+    logger.info(
+      {
+        bindHost: serverConfig.BB_SERVER_BIND_HOST,
+        port: serverConfig.BB_SERVER_PORT,
+        dataDir: serverConfig.BB_DATA_DIR,
+      },
+      "Server listening",
+    );
+    telemetry.capture({ name: "app_started" });
+
+    // Plugins load after the listener is up: they are additive, and a slow
+    // plugin must not delay serving. Bind the loopback SDK first so bb.sdk is
+    // usable from the moment factories run.
+    pluginService.bindSdk({
+      baseUrl: `http://127.0.0.1:${serverConfig.BB_SERVER_PORT}`,
+    });
+    void pluginService.start().catch((error: unknown) => {
+      logger.error({ err: error }, "Plugin startup failed");
+    });
+
+    const sweepInterval = setInterval(() => {
+      void runPeriodicSweeps(sweepDeps);
+    }, 10_000);
+    sweepInterval.unref();
+
+    let shutdownPromise: Promise<void> | null = null;
+    const runShutdown = (): Promise<void> => {
+      if (shutdownPromise) {
+        return shutdownPromise;
+      }
+      shutdownPromise = (async () => {
+        eventLoopStallMonitor.stop();
+        clearInterval(sweepInterval);
+        await pluginService.stop().catch((error: unknown) => {
+          logger.warn({ err: error }, "Plugin shutdown failed");
+        });
+        await databaseReads.close();
+        const closeServer = new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+        await closeWebSockets();
+        await closeServer;
+      })();
+      return shutdownPromise;
+    };
+
+    process.once("SIGINT", () => {
+      void runShutdown().finally(() => process.exit(0));
+    });
+    process.once("SIGTERM", () => {
+      void runShutdown().finally(() => process.exit(0));
+    });
   });
 }

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -17,6 +17,7 @@ import type { NotificationHub } from "./ws/hub.js";
 import type { WatchInterestCoordinator } from "./ws/watch-interests.js";
 import type { HostSharedPortCoordinator } from "./ws/host-shared-ports.js";
 import type { SkillTreeRegistry } from "./services/skills/injected-skills.js";
+import type { DatabaseReadService } from "./services/database/database-read-service.js";
 
 export type ServerLogger = Pick<Logger, "debug" | "error" | "info" | "warn">;
 
@@ -42,6 +43,7 @@ export interface ServerRuntimeConfig {
 
 export interface AppDeps {
   config: ServerRuntimeConfig;
+  databaseReads: DatabaseReadService;
   db: DbConnection;
   hub: NotificationHub;
   lifecycleDedupers: LifecycleDedupers;

--- a/apps/server/src/ws/hub.ts
+++ b/apps/server/src/ws/hub.ts
@@ -501,6 +501,13 @@ export class NotificationHub implements DbNotifier {
     return sessionId;
   }
 
+  listDaemonSessions(): Array<{ hostId: string; sessionId: string }> {
+    return [...this.daemonSessionIdsByHost.entries()].flatMap(
+      ([hostId, sessionId]) =>
+        this.daemonSessions.has(sessionId) ? [{ hostId, sessionId }] : [],
+    );
+  }
+
   getDaemonPlatformForHost(hostId: string): HostPlatform | null {
     const sessionId = this.daemonSessionIdsByHost.get(hostId);
     if (!sessionId) {

--- a/apps/server/test/app/startup-diagnostics.test.ts
+++ b/apps/server/test/app/startup-diagnostics.test.ts
@@ -1,7 +1,9 @@
+import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { readFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { loadServerConfig } from "@bb/config/server";
 import { describe, expect, it } from "vitest";
 import { startHttpListener } from "../../src/start-server.js";
@@ -14,6 +16,36 @@ async function readServerEntrypoint(): Promise<string> {
 
 async function readServerPackageJson(): Promise<string> {
   return readFile(resolve(testDir, "../../package.json"), "utf8");
+}
+
+async function waitForChildExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<number | null> {
+  let timeout: NodeJS.Timeout | null = null;
+  const result = await Promise.race([
+    once(child, "exit").then(
+      ([code]): { code: number | null; kind: "exit" } => ({
+        code: typeof code === "number" ? code : null,
+        kind: "exit",
+      }),
+    ),
+    new Promise<{ kind: "timeout" }>((resolveTimeout) => {
+      timeout = setTimeout(
+        () => resolveTimeout({ kind: "timeout" }),
+        timeoutMs,
+      );
+    }),
+  ]);
+  if (timeout !== null) {
+    clearTimeout(timeout);
+  }
+  if (result.kind === "timeout") {
+    child.kill("SIGKILL");
+    await once(child, "exit");
+    throw new Error("The server startup failure kept the child process alive");
+  }
+  return result.code;
 }
 
 describe("server startup diagnostics", () => {
@@ -34,6 +66,64 @@ describe("server startup diagnostics", () => {
 
     expect(packageJson).toContain("--external ./start-server.js");
     expect(packageJson).toContain("src/start-server.ts dist/start-server.js");
+  });
+
+  it("closes the database worker after a later startup failure", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "bb-startup-failure-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    const startServerUrl = pathToFileURL(
+      resolve(testDir, "../../src/start-server.ts"),
+    ).href;
+    const databaseReadServiceUrl = pathToFileURL(
+      resolve(testDir, "../../src/services/database/database-read-service.ts"),
+    ).href;
+    const databaseUrl = pathToFileURL(resolve(testDir, "../../src/db.ts")).href;
+    const hubUrl = pathToFileURL(resolve(testDir, "../../src/ws/hub.ts")).href;
+    const source = `
+      import { initDb } from ${JSON.stringify(databaseUrl)};
+      import { createWorkerDatabaseReadService } from ${JSON.stringify(databaseReadServiceUrl)};
+      import { runStartupWithDatabaseReads } from ${JSON.stringify(startServerUrl)};
+      import { NotificationHub } from ${JSON.stringify(hubUrl)};
+      const databasePath = process.env.BB_STARTUP_FAILURE_TEST_DATABASE_PATH;
+      if (databasePath === undefined) throw new Error("The test database path is missing");
+      const db = initDb(databasePath);
+      db.$client.close();
+      const logger = { debug() {}, error() {}, info() {}, warn() {} };
+      const databaseReads = await createWorkerDatabaseReadService({
+        databasePath,
+        hub: new NotificationHub(),
+        logger,
+      });
+      await runStartupWithDatabaseReads(databaseReads, async () => {
+        throw new Error("Test startup failure");
+      });
+    `;
+
+    try {
+      const child = spawn(
+        process.execPath,
+        [
+          "--conditions=source",
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "-e",
+          source,
+        ],
+        {
+          cwd: resolve(testDir, "../../../.."),
+          env: {
+            ...process.env,
+            BB_STARTUP_FAILURE_TEST_DATABASE_PATH: databasePath,
+          },
+          stdio: "ignore",
+        },
+      );
+
+      await expect(waitForChildExit(child, 10_000)).resolves.toBe(1);
+    } finally {
+      await rm(dataDir, { force: true, recursive: true });
+    }
   });
 
   it("binds the default server listener to IPv4 loopback", async () => {

--- a/apps/server/test/app/startup-diagnostics.test.ts
+++ b/apps/server/test/app/startup-diagnostics.test.ts
@@ -18,18 +18,17 @@ async function readServerPackageJson(): Promise<string> {
   return readFile(resolve(testDir, "../../package.json"), "utf8");
 }
 
-async function waitForChildExit(
-  child: ReturnType<typeof spawn>,
+async function waitWithTimeout<T>(
+  promise: Promise<T>,
   timeoutMs: number,
-): Promise<number | null> {
+  message: string,
+): Promise<T> {
   let timeout: NodeJS.Timeout | null = null;
   const result = await Promise.race([
-    once(child, "exit").then(
-      ([code]): { code: number | null; kind: "exit" } => ({
-        code: typeof code === "number" ? code : null,
-        kind: "exit",
-      }),
-    ),
+    promise.then((value): { kind: "result"; value: T } => ({
+      kind: "result",
+      value,
+    })),
     new Promise<{ kind: "timeout" }>((resolveTimeout) => {
       timeout = setTimeout(
         () => resolveTimeout({ kind: "timeout" }),
@@ -41,11 +40,17 @@ async function waitForChildExit(
     clearTimeout(timeout);
   }
   if (result.kind === "timeout") {
-    child.kill("SIGKILL");
-    await once(child, "exit");
-    throw new Error("The server startup failure kept the child process alive");
+    throw new Error(message);
   }
-  return result.code;
+  return result.value;
+}
+
+function waitForChildClose(
+  child: ReturnType<typeof spawn>,
+): Promise<number | null> {
+  return once(child, "close").then(([code]) =>
+    typeof code === "number" ? code : null,
+  );
 }
 
 describe("server startup diagnostics", () => {
@@ -94,13 +99,15 @@ describe("server startup diagnostics", () => {
         hub: new NotificationHub(),
         logger,
       });
+      process.stdout.write("worker-ready\\n");
       await runStartupWithDatabaseReads(databaseReads, async () => {
         throw new Error("Test startup failure");
       });
       `;
 
+    let child: ReturnType<typeof spawn> | null = null;
     try {
-      const child = spawn(
+      child = spawn(
         process.execPath,
         [
           "--conditions=source",
@@ -116,15 +123,46 @@ describe("server startup diagnostics", () => {
             ...process.env,
             BB_STARTUP_FAILURE_TEST_DATABASE_PATH: databasePath,
           },
-          stdio: "ignore",
+          stdio: ["ignore", "pipe", "ignore"],
         },
       );
+      if (child.stdout === null) {
+        throw new Error("The child process output is not available");
+      }
+      const childClose = waitForChildClose(child);
+      const workerReady = new Promise<void>((resolveReady) => {
+        child?.stdout?.on("data", (chunk: Buffer) => {
+          if (chunk.includes("worker-ready\n")) {
+            resolveReady();
+          }
+        });
+      });
 
-      await expect(waitForChildExit(child, 10_000)).resolves.toBe(1);
+      await waitWithTimeout(
+        workerReady,
+        25_000,
+        "The database worker did not become ready",
+      );
+      await expect(
+        waitWithTimeout(
+          childClose,
+          5_000,
+          "The server startup failure kept the child process alive",
+        ),
+      ).resolves.toBe(1);
     } finally {
+      if (
+        child !== null &&
+        child.exitCode === null &&
+        child.signalCode === null
+      ) {
+        const childClose = once(child, "close");
+        child.kill("SIGKILL");
+        await childClose;
+      }
       await rm(dataDir, { force: true, recursive: true });
     }
-  }, 15_000);
+  }, 35_000);
 
   it("binds the default server listener to IPv4 loopback", async () => {
     const serverConfig = loadServerConfig({

--- a/apps/server/test/app/startup-diagnostics.test.ts
+++ b/apps/server/test/app/startup-diagnostics.test.ts
@@ -97,7 +97,7 @@ describe("server startup diagnostics", () => {
       await runStartupWithDatabaseReads(databaseReads, async () => {
         throw new Error("Test startup failure");
       });
-    `;
+      `;
 
     try {
       const child = spawn(
@@ -124,7 +124,7 @@ describe("server startup diagnostics", () => {
     } finally {
       await rm(dataDir, { force: true, recursive: true });
     }
-  });
+  }, 15_000);
 
   it("binds the default server listener to IPv4 loopback", async () => {
     const serverConfig = loadServerConfig({

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -8,6 +8,7 @@ import { defaultFeatureFlags, type HostType } from "@bb/domain";
 import { initDb } from "../../src/db.js";
 import { createApp } from "../../src/server.js";
 import { PendingInteractionLifecycle } from "../../src/services/interactions/pending-interactions.js";
+import { createDirectDatabaseReadService } from "../../src/services/database/database-read-service.js";
 import { createMachineAuthService } from "../../src/services/machine-auth.js";
 import { SkillTreeRegistry } from "../../src/services/skills/injected-skills.js";
 import {
@@ -98,6 +99,7 @@ export async function createTestAppHarness(
   const dataDir = await mkdtemp(join(tmpdir(), "bb-server-test-"));
   const db = initDb(":memory:");
   const hub = new NotificationHubImpl();
+  const databaseReads = createDirectDatabaseReadService({ db, hub });
   const watchInterests = new WatchInterestCoordinator({ db, hub });
   const sharedPorts = new HostSharedPortCoordinator({ db, hub });
   const lifecycleDedupers = createLifecycleDedupers();
@@ -179,6 +181,7 @@ export async function createTestAppHarness(
     appVersion,
     bbAppManagedConfig,
     config,
+    databaseReads,
     db,
     hub,
     lifecycleDedupers,

--- a/apps/server/test/public/public-project-thread-reads.test.ts
+++ b/apps/server/test/public/public-project-thread-reads.test.ts
@@ -18,15 +18,32 @@ describe("project thread reads", () => {
           finishRead = resolve;
         });
         let requestSignal: AbortSignal | undefined;
-        harness.deps.databaseReads.listThreadEntriesForProjects = async (
-          _options,
-          context,
-        ) => {
-          requestSignal = context?.signal;
-          markReadStarted();
-          await readFinished;
-          return [];
-        };
+        if (path.includes("sidebar-bootstrap")) {
+          const getSidebarBootstrap =
+            harness.deps.databaseReads.getSidebarBootstrap.bind(
+              harness.deps.databaseReads,
+            );
+          harness.deps.databaseReads.getSidebarBootstrap = async (context) => {
+            requestSignal = context?.signal;
+            markReadStarted();
+            await readFinished;
+            return getSidebarBootstrap(context);
+          };
+        } else {
+          const listProjectsWithThreads =
+            harness.deps.databaseReads.listProjectsWithThreads.bind(
+              harness.deps.databaseReads,
+            );
+          harness.deps.databaseReads.listProjectsWithThreads = async (
+            options,
+            context,
+          ) => {
+            requestSignal = context?.signal;
+            markReadStarted();
+            await readFinished;
+            return listProjectsWithThreads(options, context);
+          };
+        }
 
         const projectRead = harness.app.request(path);
         await readStarted;
@@ -43,7 +60,7 @@ describe("project thread reads", () => {
 
   it("returns a retryable unavailable response when the read queue is full", async () => {
     await withTestHarness(async (harness) => {
-      harness.deps.databaseReads.listThreadEntriesForProjects = async () => {
+      harness.deps.databaseReads.listProjectsWithThreads = async () => {
         throw new DatabaseReadUnavailableError(
           "The database read queue is full. Try again later.",
         );
@@ -64,22 +81,18 @@ describe("project thread reads", () => {
 
   it("uses one database read for the sidebar bootstrap", async () => {
     await withTestHarness(async (harness) => {
-      const listThreadEntriesForProjects = vi.spyOn(
+      const getSidebarBootstrap = vi.spyOn(
         harness.deps.databaseReads,
-        "listThreadEntriesForProjects",
+        "getSidebarBootstrap",
       );
 
       const response = await harness.app.request("/api/v1/sidebar-bootstrap");
 
       expect(response.status).toBe(200);
-      expect(listThreadEntriesForProjects).toHaveBeenCalledOnce();
-      expect(listThreadEntriesForProjects).toHaveBeenCalledWith(
-        {
-          archived: false,
-          projectIds: expect.arrayContaining(["proj_personal"]),
-        },
-        { signal: expect.any(AbortSignal) },
-      );
+      expect(getSidebarBootstrap).toHaveBeenCalledOnce();
+      expect(getSidebarBootstrap).toHaveBeenCalledWith({
+        signal: expect.any(AbortSignal),
+      });
     });
   });
 });

--- a/apps/server/test/public/public-project-thread-reads.test.ts
+++ b/apps/server/test/public/public-project-thread-reads.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DatabaseReadUnavailableError } from "../../src/services/database/database-read-service.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
@@ -59,6 +59,27 @@ describe("project thread reads", () => {
         message: "The database read queue is full. Try again later.",
         retryable: true,
       });
+    });
+  });
+
+  it("uses one database read for the sidebar bootstrap", async () => {
+    await withTestHarness(async (harness) => {
+      const listThreadEntriesForProjects = vi.spyOn(
+        harness.deps.databaseReads,
+        "listThreadEntriesForProjects",
+      );
+
+      const response = await harness.app.request("/api/v1/sidebar-bootstrap");
+
+      expect(response.status).toBe(200);
+      expect(listThreadEntriesForProjects).toHaveBeenCalledOnce();
+      expect(listThreadEntriesForProjects).toHaveBeenCalledWith(
+        {
+          archived: false,
+          projectIds: expect.arrayContaining(["proj_personal"]),
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
   });
 });

--- a/apps/server/test/public/public-project-thread-reads.test.ts
+++ b/apps/server/test/public/public-project-thread-reads.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { withTestHarness } from "../helpers/test-app.js";
+
+describe("project thread reads", () => {
+  for (const path of [
+    "/api/v1/projects?include=threads",
+    "/api/v1/sidebar-bootstrap",
+  ]) {
+    it(`serves health checks while ${path} waits for thread data`, async () => {
+      await withTestHarness(async (harness) => {
+        let finishRead!: () => void;
+        let markReadStarted!: () => void;
+        const readStarted = new Promise<void>((resolve) => {
+          markReadStarted = resolve;
+        });
+        const readFinished = new Promise<void>((resolve) => {
+          finishRead = resolve;
+        });
+        harness.deps.databaseReads.listThreadEntriesForProjects = async () => {
+          markReadStarted();
+          await readFinished;
+          return [];
+        };
+
+        const projectRead = harness.app.request(path);
+        await readStarted;
+        const healthResponse = await harness.app.request("/health");
+
+        expect(healthResponse.status).toBe(200);
+        await expect(healthResponse.json()).resolves.toEqual({ ok: true });
+        finishRead();
+        await expect(projectRead).resolves.toMatchObject({ status: 200 });
+      });
+    });
+  }
+});

--- a/apps/server/test/public/public-project-thread-reads.test.ts
+++ b/apps/server/test/public/public-project-thread-reads.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DatabaseReadUnavailableError } from "../../src/services/database/database-read-service.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("project thread reads", () => {
@@ -16,7 +17,12 @@ describe("project thread reads", () => {
         const readFinished = new Promise<void>((resolve) => {
           finishRead = resolve;
         });
-        harness.deps.databaseReads.listThreadEntriesForProjects = async () => {
+        let requestSignal: AbortSignal | undefined;
+        harness.deps.databaseReads.listThreadEntriesForProjects = async (
+          _options,
+          context,
+        ) => {
+          requestSignal = context?.signal;
           markReadStarted();
           await readFinished;
           return [];
@@ -26,6 +32,7 @@ describe("project thread reads", () => {
         await readStarted;
         const healthResponse = await harness.app.request("/health");
 
+        expect(requestSignal).toBeInstanceOf(AbortSignal);
         expect(healthResponse.status).toBe(200);
         await expect(healthResponse.json()).resolves.toEqual({ ok: true });
         finishRead();
@@ -33,4 +40,25 @@ describe("project thread reads", () => {
       });
     });
   }
+
+  it("returns a retryable unavailable response when the read queue is full", async () => {
+    await withTestHarness(async (harness) => {
+      harness.deps.databaseReads.listThreadEntriesForProjects = async () => {
+        throw new DatabaseReadUnavailableError(
+          "The database read queue is full. Try again later.",
+        );
+      };
+
+      const response = await harness.app.request(
+        "/api/v1/projects?include=threads",
+      );
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        code: "database_read_unavailable",
+        message: "The database read queue is full. Try again later.",
+        retryable: true,
+      });
+    });
+  });
 });

--- a/apps/server/test/public/public-thread-list-worker.test.ts
+++ b/apps/server/test/public/public-thread-list-worker.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { initDb } from "../../src/db.js";
+import {
+  createDirectDatabaseReadService,
+  createWorkerDatabaseReadService,
+} from "../../src/services/database/database-read-service.js";
+import { testLogger, withTestHarness } from "../helpers/test-app.js";
+
+describe("public thread list worker", () => {
+  it("returns the same response bytes as the direct database path", async () => {
+    await withTestHarness(async (harness) => {
+      const dataDir = await mkdtemp(join(tmpdir(), "bb-thread-list-worker-"));
+      const databasePath = join(dataDir, "bb.db");
+      const db = initDb(databasePath);
+      db.$client.exec(`
+        INSERT INTO threads (
+          id,
+          project_id,
+          provider_id,
+          status,
+          latest_attention_at,
+          created_at,
+          updated_at,
+          visibility
+        ) VALUES (
+          'thr_worker_route',
+          'proj_personal',
+          'codex',
+          'idle',
+          1,
+          1,
+          1,
+          'visible'
+        )
+      `);
+      const directReads = createDirectDatabaseReadService({
+        db,
+        hub: harness.hub,
+      });
+      const workerReads = await createWorkerDatabaseReadService({
+        databasePath,
+        hub: harness.hub,
+        logger: testLogger,
+      });
+      harness.deps.databaseReads = workerReads;
+
+      try {
+        const directEntries = await directReads.listThreadEntries({});
+        const response = await harness.app.request("/api/v1/threads");
+
+        expect(response.status).toBe(200);
+        await expect(response.text()).resolves.toBe(
+          JSON.stringify(directEntries),
+        );
+      } finally {
+        await workerReads.close();
+        db.$client.close();
+        await rm(dataDir, { force: true, recursive: true });
+      }
+    });
+  }, 15_000);
+
+  it("rejects unsafe list bounds at the HTTP boundary", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request(
+        `/api/v1/threads?limit=${String(Number.MAX_SAFE_INTEGER + 1)}`,
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        code: "invalid_request",
+      });
+    });
+  });
+});

--- a/apps/server/test/public/public-thread-list-worker.test.ts
+++ b/apps/server/test/public/public-thread-list-worker.test.ts
@@ -63,6 +63,38 @@ describe("public thread list worker", () => {
     });
   }, 15_000);
 
+  it("keeps sidebar response bytes equal to the direct database path", async () => {
+    await withTestHarness(async (harness) => {
+      const dataDir = await mkdtemp(join(tmpdir(), "bb-sidebar-worker-"));
+      const databasePath = join(dataDir, "bb.db");
+      const db = initDb(databasePath);
+      const directReads = createDirectDatabaseReadService({
+        db,
+        hub: harness.hub,
+      });
+      const workerReads = await createWorkerDatabaseReadService({
+        databasePath,
+        hub: harness.hub,
+        logger: testLogger,
+      });
+      harness.deps.databaseReads = workerReads;
+
+      try {
+        const directResponse = await directReads.getSidebarBootstrap();
+        const response = await harness.app.request("/api/v1/sidebar-bootstrap");
+
+        expect(response.status).toBe(200);
+        await expect(response.text()).resolves.toBe(
+          JSON.stringify(directResponse),
+        );
+      } finally {
+        await workerReads.close();
+        db.$client.close();
+        await rm(dataDir, { force: true, recursive: true });
+      }
+    });
+  }, 15_000);
+
   it("rejects unsafe list bounds at the HTTP boundary", async () => {
     await withTestHarness(async (harness) => {
       const response = await harness.app.request(

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -374,12 +374,19 @@ describe("worker database reads", () => {
       FROM thread_numbers
     `);
     const workers: Worker[] = [];
+    let markReplacementReady!: () => void;
+    const replacementReady = new Promise<void>((resolve) => {
+      markReplacementReady = resolve;
+    });
     databaseReads = await createWorkerDatabaseReadService({
       databasePath,
       hub: new NotificationHub(),
       logger: testLogger,
       onWorkerCreated(worker): void {
         workers.push(worker);
+        if (workers.length === 2) {
+          worker.once("message", markReplacementReady);
+        }
       },
       requestTimeoutMs: 1_000,
     });
@@ -387,6 +394,7 @@ describe("worker database reads", () => {
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_personal" }),
     ).rejects.toBeInstanceOf(DatabaseReadTimeoutError);
+    await replacementReady;
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_missing" }),
     ).resolves.toEqual([]);

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -119,6 +119,90 @@ describe("worker database reads", () => {
     expect(JSON.stringify(workerResponse)).toBe(JSON.stringify(directResponse));
   }, 15_000);
 
+  it("keeps a sidebar response in one database snapshot", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    db.$client.exec(`
+      WITH RECURSIVE project_numbers(value) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT value + 1
+        FROM project_numbers
+        WHERE value < 10000
+      )
+      INSERT INTO projects (
+        id,
+        kind,
+        name,
+        sort_key,
+        created_at,
+        updated_at
+      )
+      SELECT
+        printf('proj_snapshot_%05d', value),
+        'standard',
+        printf('Snapshot %05d', value),
+        printf('%05d', value),
+        value,
+        value
+      FROM project_numbers;
+
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      ) VALUES (
+        'thr_snapshot',
+        'proj_snapshot_05000',
+        'codex',
+        'idle',
+        1,
+        1,
+        1,
+        'visible'
+      );
+    `);
+    let markProjectDeleted!: () => void;
+    const projectDeleted = new Promise<void>((resolve) => {
+      markProjectDeleted = resolve;
+    });
+    let deleted = false;
+    const logger = {
+      ...testLogger,
+      debug(fields: { sql?: string }): void {
+        if (deleted || !fields.sql?.includes('from "projects"')) {
+          return;
+        }
+        deleted = true;
+        db?.$client
+          .prepare("DELETE FROM projects WHERE id = ?")
+          .run("proj_snapshot_05000");
+        markProjectDeleted();
+      },
+    };
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger,
+      slowQueryThresholdMs: 0,
+    });
+
+    const response = await databaseReads.getSidebarBootstrap();
+    await projectDeleted;
+
+    expect(
+      response.projects.find((project) => project.id === "proj_snapshot_05000"),
+    ).toMatchObject({
+      threads: [{ id: "thr_snapshot" }],
+    });
+  }, 15_000);
+
   it("maps an aborted read to a silent client-closed response", async () => {
     const logger = { ...testLogger, error: vi.fn() };
 
@@ -401,7 +485,7 @@ describe("worker database reads", () => {
     expect(workers).toHaveLength(2);
   }, 15_000);
 
-  it("replaces the worker when an active read is aborted", async () => {
+  it("keeps the worker active until an aborted read finishes", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
     const databasePath = join(dataDir, "bb.db");
     db = initDb(databasePath);
@@ -456,7 +540,7 @@ describe("worker database reads", () => {
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_missing" }),
     ).resolves.toEqual([]);
-    expect(workers).toHaveLength(2);
+    expect(workers).toHaveLength(1);
   }, 15_000);
 
   it("keeps the event loop available during a slow thread-list query", async () => {

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -69,7 +69,7 @@ describe("worker database reads", () => {
       }),
     ).resolves.toEqual([]);
     expect(workers).toHaveLength(2);
-  });
+  }, 15_000);
 
   it("keeps the event loop available during a slow thread-list query", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
@@ -124,5 +124,5 @@ describe("worker database reads", () => {
     await expect(read).resolves.toMatchObject([
       { id: `thr_worker_${String(BULK_THREAD_COUNT).padStart(7, "0")}` },
     ]);
-  });
+  }, 15_000);
 });

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DbConnection } from "@bb/db";
+import { initDb } from "../../../src/db.js";
+import { createWorkerDatabaseReadService } from "../../../src/services/database/database-read-service.js";
+import type { DatabaseReadService } from "../../../src/services/database/database-read-service.js";
+import { testLogger } from "../../helpers/test-app.js";
+import { NotificationHub } from "../../../src/ws/hub.js";
+
+const BULK_THREAD_COUNT = 250_000;
+
+let dataDir: string | null = null;
+let databaseReads: DatabaseReadService | null = null;
+let db: DbConnection | null = null;
+
+afterEach(async () => {
+  await databaseReads?.close();
+  db?.$client.close();
+  if (dataDir !== null) {
+    await rm(dataDir, { force: true, recursive: true });
+  }
+  dataDir = null;
+  databaseReads = null;
+  db = null;
+});
+
+describe("worker database reads", () => {
+  it("keeps the event loop available during a slow thread-list query", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    db.$client.exec(`
+      WITH RECURSIVE thread_numbers(value) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT value + 1
+        FROM thread_numbers
+        WHERE value < ${BULK_THREAD_COUNT}
+      )
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      )
+      SELECT
+        printf('thr_worker_%07d', value),
+        'proj_personal',
+        'codex',
+        'idle',
+        0,
+        value,
+        value,
+        'visible'
+      FROM thread_numbers
+    `);
+    databaseReads = createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+    });
+
+    const timer = new Promise<"timer">((resolve) => {
+      setTimeout(() => resolve("timer"), 0);
+    });
+    const read = databaseReads.listThreadEntries({
+      limit: 1,
+      projectId: "proj_personal",
+    });
+
+    expect(await Promise.race([timer, read.then(() => "read" as const)])).toBe(
+      "timer",
+    );
+    await expect(read).resolves.toMatchObject([
+      { id: `thr_worker_${String(BULK_THREAD_COUNT).padStart(7, "0")}` },
+    ]);
+  });
+});

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -170,6 +170,29 @@ describe("worker database reads", () => {
     expect(workers).toHaveLength(2);
   }, 15_000);
 
+  it("rejects invalid options without restarting the worker", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    const workers: Worker[] = [];
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+      },
+    });
+
+    await expect(
+      databaseReads.listThreadEntries({
+        limit: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ).rejects.toThrow();
+    await expect(databaseReads.listThreadEntries({})).resolves.toEqual([]);
+    expect(workers).toHaveLength(1);
+  }, 15_000);
+
   it("rejects a read that waits for a replacement when the service closes", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
     const databasePath = join(dataDir, "bb.db");
@@ -277,6 +300,59 @@ describe("worker database reads", () => {
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_personal" }),
     ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
+  }, 15_000);
+
+  it("replaces the worker when an active read exceeds its deadline", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    db.$client.exec(`
+      WITH RECURSIVE thread_numbers(value) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT value + 1
+        FROM thread_numbers
+        WHERE value < ${BULK_THREAD_COUNT}
+      )
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      )
+      SELECT
+        printf('thr_timeout_%07d', value),
+        'proj_personal',
+        'codex',
+        'idle',
+        0,
+        value,
+        value,
+        'visible'
+      FROM thread_numbers
+    `);
+    const workers: Worker[] = [];
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+      },
+      requestTimeoutMs: 1_000,
+    });
+
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_personal" }),
+    ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_missing" }),
+    ).resolves.toEqual([]);
+    expect(workers).toHaveLength(2);
   }, 15_000);
 
   it("keeps the event loop available during a slow thread-list query", async () => {

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -4,7 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DbConnection } from "@bb/db";
+import {
+  createEnvironment,
+  createProject,
+  createThread,
+  noopNotifier,
+  upsertHost,
+  type DbConnection,
+} from "@bb/db";
 import { initDb } from "../../../src/db.js";
 import {
   createDirectDatabaseReadService,
@@ -119,6 +126,90 @@ describe("worker database reads", () => {
     expect(JSON.stringify(workerResponse)).toBe(JSON.stringify(directResponse));
   }, 15_000);
 
+  it("applies current daemon state after a worker read", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    const host = upsertHost(db, noopNotifier, {
+      id: "host_live_state",
+      name: "Live State Host",
+      type: "persistent",
+    });
+    const { project } = createProject(db, noopNotifier, {
+      name: "Live State Project",
+      source: {
+        type: "local_path",
+        hostId: host.id,
+        path: "/tmp/live-state-project",
+      },
+    });
+    const environment = createEnvironment(db, noopNotifier, {
+      hostId: host.id,
+      path: "/tmp/live-state-environment",
+      projectId: project.id,
+      status: "ready",
+      workspaceProvisionType: "unmanaged",
+    });
+    const thread = createThread(db, noopNotifier, {
+      environmentId: environment.id,
+      projectId: project.id,
+      providerId: "codex",
+      status: "active",
+    });
+    db.$client.exec(`
+      WITH RECURSIVE thread_numbers(value) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT value + 1
+        FROM thread_numbers
+        WHERE value < 10000
+      )
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      )
+      SELECT
+        printf('thr_live_state_%06d', value),
+        '${project.id}',
+        'codex',
+        'idle',
+        0,
+        value,
+        value,
+        'visible'
+      FROM thread_numbers
+    `);
+    const hub = new NotificationHub();
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub,
+      logger: testLogger,
+    });
+
+    const read = databaseReads.listThreadEntries({ projectId: project.id });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    hub.registerDaemon("session_live_state", host.id, {
+      close() {},
+      send() {},
+    });
+
+    await expect(read).resolves.toContainEqual(
+      expect.objectContaining({
+        id: thread.id,
+        runtime: {
+          displayStatus: "active",
+          hostReconnectGraceExpiresAt: null,
+        },
+      }),
+    );
+  }, 15_000);
+
   it("keeps a sidebar response in one database snapshot", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
     const databasePath = join(dataDir, "bb.db");
@@ -223,6 +314,21 @@ describe("worker database reads", () => {
         logger: testLogger,
       }),
     ).rejects.toThrow();
+  });
+
+  it("reports a controlled error when worker startup exceeds its deadline", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+
+    await expect(
+      createWorkerDatabaseReadService({
+        databasePath,
+        hub: new NotificationHub(),
+        logger: testLogger,
+        workerStartupTimeoutMs: 0,
+      }),
+    ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
   });
 
   it("restarts the worker after an unexpected exit", async () => {

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -10,6 +10,7 @@ import {
   createDirectDatabaseReadService,
   createWorkerDatabaseReadService,
   DatabaseReadAbortedError,
+  DatabaseReadTimeoutError,
   DatabaseReadUnavailableError,
 } from "../../../src/services/database/database-read-service.js";
 import type { DatabaseReadService } from "../../../src/services/database/database-read-service.js";
@@ -170,6 +171,39 @@ describe("worker database reads", () => {
     expect(workers).toHaveLength(2);
   }, 15_000);
 
+  it("returns a retryable error when a worker exits during a read", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    const workers: Worker[] = [];
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+      },
+    });
+    const firstWorker = workers[0];
+    if (firstWorker === undefined) {
+      throw new Error("The database read worker was not created");
+    }
+
+    const read = databaseReads.listThreadEntries({
+      projectId: "proj_personal",
+    });
+    void firstWorker.terminate();
+
+    await expect(read).rejects.toMatchObject({
+      body: { retryable: true },
+      status: 503,
+    });
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_personal" }),
+    ).resolves.toEqual([]);
+    expect(workers).toHaveLength(2);
+  }, 15_000);
+
   it("rejects invalid options without restarting the worker", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
     const databasePath = join(dataDir, "bb.db");
@@ -299,7 +333,11 @@ describe("worker database reads", () => {
 
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_personal" }),
-    ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
+    ).rejects.toMatchObject({
+      body: { retryable: false },
+      name: "DatabaseReadTimeoutError",
+      status: 503,
+    });
   }, 15_000);
 
   it("replaces the worker when an active read exceeds its deadline", async () => {
@@ -348,7 +386,65 @@ describe("worker database reads", () => {
 
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_personal" }),
-    ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
+    ).rejects.toBeInstanceOf(DatabaseReadTimeoutError);
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_missing" }),
+    ).resolves.toEqual([]);
+    expect(workers).toHaveLength(2);
+  }, 15_000);
+
+  it("replaces the worker when an active read is aborted", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    db.$client.exec(`
+      WITH RECURSIVE thread_numbers(value) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT value + 1
+        FROM thread_numbers
+        WHERE value < ${BULK_THREAD_COUNT}
+      )
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      )
+      SELECT
+        printf('thr_abort_%07d', value),
+        'proj_personal',
+        'codex',
+        'idle',
+        0,
+        value,
+        value,
+        'visible'
+      FROM thread_numbers
+    `);
+    const workers: Worker[] = [];
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+      },
+    });
+    const abortController = new AbortController();
+    const read = databaseReads.listThreadEntries(
+      { projectId: "proj_personal" },
+      { signal: abortController.signal },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    abortController.abort();
+
+    await expect(read).rejects.toBeInstanceOf(DatabaseReadAbortedError);
     await expect(
       databaseReads.listThreadEntries({ projectId: "proj_missing" }),
     ).resolves.toEqual([]);

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -6,7 +6,11 @@ import type { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it } from "vitest";
 import type { DbConnection } from "@bb/db";
 import { initDb } from "../../../src/db.js";
-import { createWorkerDatabaseReadService } from "../../../src/services/database/database-read-service.js";
+import {
+  createWorkerDatabaseReadService,
+  DatabaseReadAbortedError,
+  DatabaseReadUnavailableError,
+} from "../../../src/services/database/database-read-service.js";
 import type { DatabaseReadService } from "../../../src/services/database/database-read-service.js";
 import { testLogger } from "../../helpers/test-app.js";
 import { NotificationHub } from "../../../src/ws/hub.js";
@@ -69,6 +73,115 @@ describe("worker database reads", () => {
       }),
     ).resolves.toEqual([]);
     expect(workers).toHaveLength(2);
+  }, 15_000);
+
+  it("rejects a read that waits for a replacement when the service closes", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    const workers: Worker[] = [];
+    let replacementReady = false;
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+        if (workers.length === 2) {
+          worker.once("message", () => {
+            replacementReady = true;
+          });
+        }
+      },
+    });
+    const firstWorker = workers[0];
+    if (firstWorker === undefined) {
+      throw new Error("The database read worker was not created");
+    }
+
+    const exit = once(firstWorker, "exit");
+    void firstWorker.terminate();
+    await exit;
+    expect(workers).toHaveLength(2);
+    expect(replacementReady).toBe(false);
+
+    const read = databaseReads.listThreadEntries({
+      projectId: "proj_personal",
+    });
+    const readResult = expect(read).rejects.toThrow(
+      "The database read service stopped",
+    );
+    await databaseReads.close();
+
+    await readResult;
+  }, 15_000);
+
+  it("rejects reads above the pending request limit", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      maxPendingReads: 1,
+    });
+
+    const firstRead = databaseReads.listThreadEntries({
+      projectId: "proj_personal",
+    });
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_personal" }),
+    ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
+    await expect(firstRead).resolves.toEqual([]);
+  }, 15_000);
+
+  it("removes an aborted read from the pending queue", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      maxPendingReads: 2,
+    });
+    const abortController = new AbortController();
+
+    const firstRead = databaseReads.listThreadEntries({
+      projectId: "proj_personal",
+    });
+    const abortedRead = databaseReads.listThreadEntries(
+      { projectId: "proj_personal" },
+      { signal: abortController.signal },
+    );
+    const abortedResult = expect(abortedRead).rejects.toBeInstanceOf(
+      DatabaseReadAbortedError,
+    );
+    abortController.abort();
+    const replacementRead = databaseReads.listThreadEntries({
+      projectId: "proj_personal",
+    });
+
+    await abortedResult;
+    await expect(firstRead).resolves.toEqual([]);
+    await expect(replacementRead).resolves.toEqual([]);
+  }, 15_000);
+
+  it("rejects a read after its deadline", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      requestTimeoutMs: 0,
+    });
+
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_personal" }),
+    ).rejects.toBeInstanceOf(DatabaseReadUnavailableError);
   }, 15_000);
 
   it("keeps the event loop available during a slow thread-list query", async () => {

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -3,15 +3,17 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Worker } from "node:worker_threads";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DbConnection } from "@bb/db";
 import { initDb } from "../../../src/db.js";
 import {
+  createDirectDatabaseReadService,
   createWorkerDatabaseReadService,
   DatabaseReadAbortedError,
   DatabaseReadUnavailableError,
 } from "../../../src/services/database/database-read-service.js";
 import type { DatabaseReadService } from "../../../src/services/database/database-read-service.js";
+import { errorToResponse } from "../../../src/errors.js";
 import { testLogger } from "../../helpers/test-app.js";
 import { NotificationHub } from "../../../src/ws/hub.js";
 
@@ -33,6 +35,99 @@ afterEach(async () => {
 });
 
 describe("worker database reads", () => {
+  it("returns valid entries without restarting for an invalid database row", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    db.$client.exec(`
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        origin_kind,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      ) VALUES
+        ('thr_valid', 'proj_personal', 'codex', 'idle', NULL, 1, 1, 1, 'visible'),
+        ('thr_invalid', 'proj_personal', 'codex', 'idle', 'future', 2, 2, 2, 'visible')
+    `);
+    const workers: Worker[] = [];
+    const logger = { ...testLogger, warn: vi.fn() };
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+      },
+    });
+
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_personal" }),
+    ).resolves.toMatchObject([{ id: "thr_valid" }]);
+    await expect(
+      databaseReads.listThreadEntries({ projectId: "proj_personal" }),
+    ).resolves.toMatchObject([{ id: "thr_valid" }]);
+    expect(workers).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: expect.any(Number) }),
+      "Dropped an invalid thread entry from a database read worker result",
+    );
+  }, 15_000);
+
+  it("keeps worker response bytes equal to direct response bytes", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    db.$client.exec(`
+      INSERT INTO threads (
+        id,
+        project_id,
+        provider_id,
+        status,
+        latest_attention_at,
+        created_at,
+        updated_at,
+        visibility
+      ) VALUES (
+        'thr_response_order',
+        'proj_personal',
+        'codex',
+        'idle',
+        1,
+        1,
+        1,
+        'visible'
+      )
+    `);
+    const hub = new NotificationHub();
+    const directReads = createDirectDatabaseReadService({ db, hub });
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub,
+      logger: testLogger,
+    });
+    const options = { projectId: "proj_personal" };
+
+    const directResponse = await directReads.listThreadEntries(options);
+    const workerResponse = await databaseReads.listThreadEntries(options);
+
+    expect(JSON.stringify(workerResponse)).toBe(JSON.stringify(directResponse));
+  }, 15_000);
+
+  it("maps an aborted read to a silent client-closed response", async () => {
+    const logger = { ...testLogger, error: vi.fn() };
+
+    const response = errorToResponse(new DatabaseReadAbortedError(), logger);
+
+    expect(response.status).toBe(499);
+    await expect(response.text()).resolves.toBe("");
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
   it("reports an initialization failure before the service becomes ready", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
 

--- a/apps/server/test/services/database/database-read-service.test.ts
+++ b/apps/server/test/services/database/database-read-service.test.ts
@@ -1,6 +1,8 @@
+import { once } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it } from "vitest";
 import type { DbConnection } from "@bb/db";
 import { initDb } from "../../../src/db.js";
@@ -27,6 +29,48 @@ afterEach(async () => {
 });
 
 describe("worker database reads", () => {
+  it("reports an initialization failure before the service becomes ready", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+
+    await expect(
+      createWorkerDatabaseReadService({
+        databasePath: join(dataDir, "missing", "bb.db"),
+        hub: new NotificationHub(),
+        logger: testLogger,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("restarts the worker after an unexpected exit", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
+    const databasePath = join(dataDir, "bb.db");
+    db = initDb(databasePath);
+    const workers: Worker[] = [];
+    databaseReads = await createWorkerDatabaseReadService({
+      databasePath,
+      hub: new NotificationHub(),
+      logger: testLogger,
+      onWorkerCreated(worker): void {
+        workers.push(worker);
+      },
+    });
+    const firstWorker = workers[0];
+    if (firstWorker === undefined) {
+      throw new Error("The database read worker was not created");
+    }
+
+    const exit = once(firstWorker, "exit");
+    void firstWorker.terminate();
+    await exit;
+
+    await expect(
+      databaseReads.listThreadEntriesForProjects({
+        projectIds: ["proj_personal"],
+      }),
+    ).resolves.toEqual([]);
+    expect(workers).toHaveLength(2);
+  });
+
   it("keeps the event loop available during a slow thread-list query", async () => {
     dataDir = await mkdtemp(join(tmpdir(), "bb-database-read-worker-test-"));
     const databasePath = join(dataDir, "bb.db");
@@ -60,7 +104,7 @@ describe("worker database reads", () => {
         'visible'
       FROM thread_numbers
     `);
-    databaseReads = createWorkerDatabaseReadService({
+    databaseReads = await createWorkerDatabaseReadService({
       databasePath,
       hub: new NotificationHub(),
       logger: testLogger,

--- a/packages/db/src/connection.ts
+++ b/packages/db/src/connection.ts
@@ -175,3 +175,19 @@ export function createConnection(
 
   return db;
 }
+
+export function createReadOnlyConnection(
+  dbPath: string,
+  options: CreateConnectionOptions = {},
+): DbConnection {
+  const sqlite = new Database(dbPath, {
+    fileMustExist: true,
+    readonly: true,
+  });
+
+  sqlite.pragma("foreign_keys = ON");
+  sqlite.pragma("query_only = ON");
+  instrumentSqliteClient(sqlite, options);
+
+  return drizzle({ client: sqlite, schema });
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-export { createConnection } from "./connection.js";
+export { createConnection, createReadOnlyConnection } from "./connection.js";
 export type {
   CreateConnectionOptions,
   DbConnection,

--- a/packages/db/test/connection.test.ts
+++ b/packages/db/test/connection.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createConnection,
+  createReadOnlyConnection,
   type SlowDbQueryLogger,
   type SlowDbQueryLogFields,
 } from "../src/connection.js";
@@ -123,5 +127,24 @@ describe("createConnection", () => {
     expect(debugLog.fields.sql.endsWith("...")).toBe(true);
 
     db.$client.close();
+  });
+});
+
+describe("createReadOnlyConnection", () => {
+  it("opens an existing database without write access", () => {
+    const dataDir = mkdtempSync(
+      join(tmpdir(), "bb-read-only-connection-test-"),
+    );
+    const databasePath = join(dataDir, "bb.db");
+    const writer = createConnection(databasePath);
+    migrate(writer);
+    writer.$client.close();
+
+    const reader = createReadOnlyConnection(databasePath);
+    expect(() =>
+      reader.$client.prepare("CREATE TABLE forbidden (id TEXT)").run(),
+    ).toThrow(/readonly/u);
+    reader.$client.close();
+    rmSync(dataDir, { force: true, recursive: true });
   });
 });

--- a/packages/sdk/src/response.ts
+++ b/packages/sdk/src/response.ts
@@ -71,6 +71,7 @@ export interface BbHttpErrorArgs {
   body: unknown;
   code: string | null;
   message: string;
+  retryable?: boolean;
   status: number;
 }
 
@@ -80,11 +81,13 @@ export interface BbHttpErrorArgs {
  * the error body provides one, so callers can branch on the failure kind
  * instead of parsing the message. `body` is the parsed JSON error payload
  * (null when the body was empty or not JSON) for callers that need
- * structured error details beyond `code`.
+ * structured error details beyond `code`. `retryable` carries the server's
+ * explicit retry policy and defaults to false when the response omits it.
  */
 export class BbHttpError extends Error {
   readonly body: unknown;
   readonly code: string | null;
+  readonly retryable: boolean;
   readonly status: number;
 
   constructor(args: BbHttpErrorArgs) {
@@ -92,6 +95,7 @@ export class BbHttpError extends Error {
     this.name = "BbHttpError";
     this.body = args.body;
     this.code = args.code;
+    this.retryable = args.retryable ?? false;
     this.status = args.status;
   }
 }
@@ -152,8 +156,15 @@ export async function resolveResponse<TResponse extends Response>(
     throw error;
   }
   if (!response.ok) {
-    const { body, code, message } = await readHttpErrorInfo(response);
-    throw new BbHttpError({ body, code, message, status: response.status });
+    const { body, code, message, retryable } =
+      await readHttpErrorInfo(response);
+    throw new BbHttpError({
+      body,
+      code,
+      message,
+      retryable,
+      status: response.status,
+    });
   }
   return response;
 }
@@ -292,6 +303,7 @@ interface HttpErrorInfo {
   body: unknown;
   code: string | null;
   message: string;
+  retryable: boolean;
 }
 
 function readHttpErrorCode(parsed: unknown): string | null {
@@ -303,6 +315,13 @@ function readHttpErrorCode(parsed: unknown): string | null {
   }
   const { code } = parsed;
   return typeof code === "string" ? code : null;
+}
+
+function readHttpErrorRetryable(parsed: unknown): boolean {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return false;
+  }
+  return "retryable" in parsed && parsed.retryable === true;
 }
 
 async function readHttpErrorInfo(response: Response): Promise<HttpErrorInfo> {
@@ -317,7 +336,12 @@ async function readHttpErrorInfo(response: Response): Promise<HttpErrorInfo> {
   }
   const normalized = rawBody.replace(/\s+/g, " ").trim();
   if (normalized.length === 0) {
-    return { body: null, code: null, message: response.statusText };
+    return {
+      body: null,
+      code: null,
+      message: response.statusText,
+      retryable: false,
+    };
   }
 
   const contentType = response.headers.get("content-type");
@@ -331,7 +355,7 @@ async function readHttpErrorInfo(response: Response): Promise<HttpErrorInfo> {
     const message = normalized.startsWith("<")
       ? response.statusText || `Request failed with status ${response.status}`
       : normalized;
-    return { body: null, code: null, message };
+    return { body: null, code: null, message, retryable: false };
   }
 
   try {
@@ -340,8 +364,14 @@ async function readHttpErrorInfo(response: Response): Promise<HttpErrorInfo> {
       body: parsed,
       code: readHttpErrorCode(parsed),
       message: extractErrorMessage(parsed, ERROR_EXTRACT_OPTS) ?? normalized,
+      retryable: readHttpErrorRetryable(parsed),
     };
   } catch {
-    return { body: null, code: null, message: normalized };
+    return {
+      body: null,
+      code: null,
+      message: normalized,
+      retryable: false,
+    };
   }
 }

--- a/packages/sdk/test/response.test.ts
+++ b/packages/sdk/test/response.test.ts
@@ -201,6 +201,7 @@ describe("readJsonResponse()", () => {
         code: "thread_not_found",
         message: "Thread thread-1 not found",
         error: "Thread thread-1 not found",
+        retryable: true,
       }),
       {
         status: 404,
@@ -223,6 +224,7 @@ describe("readJsonResponse()", () => {
     expect(error.message).toBe("HTTP 404: Thread thread-1 not found");
     expect(error.status).toBe(404);
     expect(error.code).toBe("thread_not_found");
+    expect(error.retryable).toBe(true);
   });
 
   it("reports a null code when the error body has none", async () => {
@@ -235,6 +237,7 @@ describe("readJsonResponse()", () => {
       code: null,
       message: "HTTP 502: plain failure",
       name: "BbHttpError",
+      retryable: false,
       status: 502,
     });
   });

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -24,6 +24,7 @@ import { initDb } from "../../../apps/server/src/db.js";
 import { createLifecycleDedupers } from "../../../apps/server/src/lifecycle-dedupers.js";
 import { createApp } from "../../../apps/server/src/server.js";
 import { PendingInteractionLifecycle } from "../../../apps/server/src/services/interactions/pending-interactions.js";
+import { createDirectDatabaseReadService } from "../../../apps/server/src/services/database/database-read-service.js";
 import { createMachineAuthService } from "../../../apps/server/src/services/machine-auth.js";
 import {
   copyBuiltinSkills,
@@ -275,10 +276,12 @@ async function startIntegrationServer(
     config,
     logger: testLogger,
   });
+  const databaseReads = createDirectDatabaseReadService({ db, hub });
   const { app, injectWebSocket } = createApp({
     appVersion,
     bbAppManagedConfig,
     config,
+    databaseReads,
     db,
     hub,
     lifecycleDedupers,


### PR DESCRIPTION
## Reproduction

A cold thread-list query on a 2.0 GB test database took 1.150 seconds. A concurrent health request took 1.098 seconds, and the server logged a 1.166-second event-loop stall.

## Root cause

The thread-list handler ran synchronous better-sqlite3 reads on the server event loop. SQLite used temporary B-trees for the list query, so every client waited for the read to finish.

## Fix

Move the complete thread-list read phase to a worker thread with a read-only database connection. Each worker operation uses one deferred read transaction.

The worker derives database-backed disconnected state. After the worker returns, the main thread applies current live daemon session state from the notification hub. This prevents stale host status during a slow read.

The same cold query now leaves the health route responsive at 1.2 ms. Slow-query logs return to the server logger, worker messages use validated contracts, and shutdown terminates the worker.

Fixes #1131