### PR TITLE
docs(plugins): document the full bb.sdk area surface

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -291,6 +291,31 @@ portability.
 that need the singleton personal project use
 `bb.sdk.projects.list({ includePersonal: true })`.
 
+**Area map.** Every area below is reachable from `bb.sdk`. This lists the
+methods, not their arguments — read `types/bb-plugin-sdk.d.ts` for exact
+signatures.
+
+| Area | Methods |
+| --- | --- |
+| `threads` | `list` `get` `search` `spawn` `fork` `send` `update` `delete` `stop` `wait` `open` `output` `timeline` `conversationOutline` `promptHistory` `archive` `archiveAll` `unarchive` `pin` `unpin` `reorderPinned` `markRead` `markUnread` `childSummary` `paneAction` `timelineTurnSummaryDetails` `storageFiles` `storagePaths` `cancelPlan` `clearGoal` `continueAfterRateLimit` `rateLimitRecovery` `defaultExecutionOptions`; sub-areas `events` (`list` `wait`), `interactions` (`get` `list` `cancel` `resolve` `respond`), `queuedMessages` (`create` `list` `update` `delete` `send` `reorder` `setGroupBoundary`), `tabs` (`get` `update`) |
+| `threadSections` | `list` `create` `update` `delete` |
+| `projects` | `list` `get` `create` `update` `delete` `reorder` `paths` `files` `fileContent` `branches` `commands` `defaultExecutionOptions` `promptHistory`; sub-areas `attachments` (`upload` `read` `copy`), `sources` (`add` `update` `delete`) |
+| `environments` | `get` `update` `status` `paths` `commit` `archiveThreads` `diff` `diffFile` `diffFiles` `diffBranches` `diffPatch` `pullRequest` `markPullRequestDraft` `markPullRequestReady` `mergePullRequest` `squashMerge` |
+| `hosts` | `list` `get` `update` `delete` `directory` `pathsExist` `pickFolder` `cloneDefaultPath` `createJoinCode` `retryUpdate` `providerCliStatus` `installProviderCli` |
+| `files` | `read` `write` `list` `listPaths` `mkdir` `move` `remove` `createPreview` |
+| `terminals` | `list` `create` `get` `input` `output` `resize` `rename` `restart` `close` |
+| `providers` | `list` `models` |
+| `skills` | `list` `listFiles` `getContent` `update` `remove`; sub-area `registry` (`search` `get` `detail` `install` `repositoryStars`) |
+| `plugins` | `list` `install` `remove` `enable` `disable` `reload` `token` `callRpc` `getSource` `getSettings` `updateSettings` `checkUpdates` `listUpdateResults` `applyUpdate`; sub-area `catalog` (`search` `status` `install`) |
+| `theme` | `get` `catalog` `set` |
+| `status` | `get` |
+| `system` | `version` `config` `reloadConfig` `attention` `usageLimits` `executionOptions` `transcribeVoice` `updateGeneralSettings` `updateKeyboardSettings` `updateExperiments` `cliSkillsStatus` `installCliSkills` `onboardingAgents` `onboardingRepos` `onboardingEvent` |
+| `guide` | `render` (the `bb guide` text; local, no request) |
+
+Prefer your own `bb.settings` and `bb.storage` over `sdk.system` and
+`sdk.plugins` for your plugin's own configuration. The `system` and `plugins`
+areas write app-wide state that the user owns.
+
 ```ts
 const thread = await bb.sdk.threads.spawn({
   projectId,
@@ -306,6 +331,23 @@ inputs) — never both. Attribution is auto-filled: `origin: "plugin"` and
 `originPluginId: <your id>` unless you set them. `bb.sdk.threads.send({
 threadId, mode: "auto", input: [...] })` starts a turn on an idle thread or
 queues/steers a running one.
+
+Read and edit existing threads with the same area — you do not need a
+sidebar panel or a spawned thread to reach them:
+
+```ts
+const { threads } = await bb.sdk.threads.list({ projectId, limit: 50 });
+const thread = await bb.sdk.threads.get({ threadId });
+const timeline = await bb.sdk.threads.timeline({ threadId });
+await bb.sdk.threads.update({ threadId, title: "Fix the flaky test" });
+```
+
+`threads.list` filters on `projectId`, `parentThreadId`, `sourceThreadId`,
+`sectionId`, `originKind`, `originPluginId`, `archived`, `unsectioned`,
+`hasParent`, and `includeHidden`, and it pages with `limit` and `offset`.
+`threads.update` writes `title`, `sectionId`, `parentThreadId`, `model`,
+`reasoningLevel`, and `visibility`. Use `threads.timeline` (or
+`threads.output` for the last assistant text) to read a thread's messages.
 
 Use `visibility: "hidden"` for background workers. Hidden threads stay
 out of sidebar organization and do not contribute unread/pending favicon
@@ -402,6 +444,13 @@ and counted in the plugin's handler stats (`bb plugin list`).
 
 Lifecycle events are broadcast to all loaded plugins regardless of sidebar
 visibility.
+
+`thread.created` fires on row creation, so the first user message is not
+always in the timeline yet. To react to a thread's content, listen on
+`thread.active` or `thread.idle`, then read the messages with
+`bb.sdk.threads.timeline`. Because handlers are fire-and-forget, work you do
+in a handler — including `bb.sdk.threads.update({ threadId, title })` —
+cannot delay or interrupt the thread's turn.
 
 ### bb.http — HTTP routes
 

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -213,6 +213,19 @@ reimplementing it, and `indicatorLabel` carries the matching accessible string.
    a sidebar of many distinct worktrees does not stampede the git host; and
    returning `null` for "lookup failed" (rather than an error) is the right
    failure for a row that should simply show nothing.
+9. **`experimental_useSidebarThreadSplit`.** Gives a custom row the built-in
+   drag-to-split gesture: spread `splitProps` onto the row, gate any affordance
+   on `isAvailable`, and read `layout` to paint where the thread already sits.
+   The host owns every rule — the drag engages only after the pointer leaves the
+   sidebar, an edge drop splits, a center drop replaces, an open thread focuses
+   its pane, and the pane cap turns a split into a replace — so a plugin cannot
+   reach a layout the built-in sidebar cannot. Before stabilizing, confirm: a
+   list with its own pointer-drag (reorder, swipe) still composes with the
+   host's engage threshold; `splitProps` staying an open object is the right
+   forward-compatible shape, or it should narrow to a named handler; and
+   exposing the full `panes` array does not leak more layout state than a row
+   needs.
+
 ## `app.slots.experimental_threadHeaderAction` (`@bb/plugin-sdk/app`)
 
 **What it does.** Renders a plugin component in the thread header's action row.


### PR DESCRIPTION
Refs #1191.

## Why

Issue #1191 asks for `bb.sdk.threads.list()` and `bb.sdk.threads.update({ title })`. Both shipped on 2026-06-04, two months before the issue. The problem is discoverability: the plugin-authoring skill documents `threads.spawn`, `threads.send`, and `threads.get`, but never `list` or `update` — and it leaves nine `bb.sdk` areas out entirely. A plugin author who reads the skill concludes the APIs do not exist.

## What changed

**`SKILL.md` — an SDK area map.** The skill covered `threads`, `projects`, `files`, `terminals`, and `subscribe`. It never mentioned `hosts`, `providers`, `skills`, `plugins`, `theme`, `status`, `system`, `threadSections`, or `guide`. The new table lists all 14 areas, their 8 sub-areas, and every method name, with a pointer to `types/bb-plugin-sdk.d.ts` for exact signatures.

**`SKILL.md` — thread read/edit and event timing.** A worked example for `threads.list` / `get` / `timeline` / `update`, plus the third point the issue raised: `thread.created` fires on row creation, before the first user message lands, so a plugin should listen on `thread.active` and read messages with `threads.timeline`. Handlers dispatch fire-and-forget through `setImmediate` after the transition settles, so `threads.update` from a handler cannot delay or interrupt a turn.

**`api_to_audit.md` — one missing entry.** `AGENTS.md` requires every `experimental_` member to have an audit entry. `experimental_useSidebarThreadSplit` had none. The new entry lists three things to audit before the prefix drops.

## Verification

I swept four surfaces by script rather than by eye:

| Surface | Result |
| --- | --- |
| `bb.sdk` areas (15) | 9 undocumented → now covered |
| Backend `BbPluginApi` members (17) and their methods | already complete |
| Frontend slots (11) and hooks/components (17) | already complete |
| `experimental_` members vs `api_to_audit.md` | 1 missing → added |

The area map is checked against the 22 source interfaces: no invented method names, no missing ones. Documentation only — no code or wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)