### PR TITLE
fix(pi): protect bridge JSON-RPC stdout

### DIFF
--- a/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
@@ -107,6 +107,10 @@ vi.mock("../model-runtime.js", () => ({
 }));
 
 import { handleLine } from "../bridge.js";
+import {
+  restorePiBridgeStdout,
+  takeOverPiBridgeStdout,
+} from "../output-guard.js";
 import { PI_BRIDGE_SESSION_DIR_ENV } from "../session-paths.js";
 import { createBridgeJsonRpcTestHarness } from "../../../test/bridge-json-rpc-test-helpers.js";
 
@@ -201,6 +205,44 @@ describe("pi bridge", () => {
       expect(mockGetPiModelRuntime).toHaveBeenCalledWith("/tmp/project-models");
     } finally {
       bridge.restore();
+    }
+  });
+
+  it("keeps extension stdout out of the JSON-RPC protocol channel", async () => {
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const piSession = createControlledPiAgentSession();
+    mockCreateAgentSession.mockResolvedValue({ session: piSession });
+    takeOverPiBridgeStdout();
+
+    try {
+      bridge.sendRequest(100, "thread/start", {
+        cwd: "/tmp/worktree",
+        threadId: "thread-extension-stdout",
+      });
+      await bridge.waitForResponse(100);
+
+      const terminalNotification = "\u001b]777;notify;π;done\u0007";
+      process.stdout.write(terminalNotification);
+      piSession.emit(createAgentEndEvent());
+      await bridge.flushWork();
+
+      expect(stderrWrite).toHaveBeenCalledWith(terminalNotification);
+      expect(bridge.messages).toContainEqual(
+        expect.objectContaining({
+          method: "sdk/message",
+          params: {
+            threadId: "thread-extension-stdout",
+            message: createAgentEndEvent(),
+          },
+        }),
+      );
+    } finally {
+      restorePiBridgeStdout();
+      bridge.restore();
+      stderrWrite.mockRestore();
     }
   });
 

--- a/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
@@ -246,6 +246,28 @@ describe("pi bridge", () => {
     }
   });
 
+  it("forwards redirected stderr backpressure through stdout", () => {
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => false);
+    const stdoutDrain = vi.fn();
+    process.stdout.once("drain", stdoutDrain);
+    takeOverPiBridgeStdout();
+
+    try {
+      expect(process.stdout.write("extension output")).toBe(false);
+      expect(stdoutDrain).not.toHaveBeenCalled();
+
+      process.stderr.emit("drain");
+
+      expect(stdoutDrain).toHaveBeenCalledOnce();
+    } finally {
+      restorePiBridgeStdout();
+      process.stdout.off("drain", stdoutDrain);
+      stderrWrite.mockRestore();
+    }
+  });
+
   afterEach(() => {
     if (originalPiBridgeSessionDir === undefined) {
       delete process.env[PI_BRIDGE_SESSION_DIR_ENV];

--- a/packages/agent-runtime/src/pi/bridge/bridge.ts
+++ b/packages/agent-runtime/src/pi/bridge/bridge.ts
@@ -42,6 +42,10 @@ import {
 } from "./tool-proxy.js";
 import { listPiBridgeModels } from "./model-list.js";
 import { getPiModelRuntime } from "./model-runtime.js";
+import {
+  takeOverPiBridgeStdout,
+  writePiBridgeProtocol,
+} from "./output-guard.js";
 
 // ---------------------------------------------------------------------------
 // Command schema — defines what JSON-RPC requests this bridge accepts
@@ -304,7 +308,7 @@ function send(
     | BridgeEventNotification
     | BridgeToolCallRequest,
 ): void {
-  process.stdout.write(JSON.stringify(msg) + "\n");
+  writePiBridgeProtocol(JSON.stringify(msg) + "\n");
 }
 
 function sendResult(id: string | number, result: unknown): void {
@@ -959,6 +963,7 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
+  takeOverPiBridgeStdout();
   const rl = createInterface({ input: process.stdin, terminal: false });
   rl.on("line", handleLine);
   rl.on("close", () => {

--- a/packages/agent-runtime/src/pi/bridge/output-guard.ts
+++ b/packages/agent-runtime/src/pi/bridge/output-guard.ts
@@ -1,0 +1,70 @@
+type ProcessWriteCallback = (error?: Error | null) => void;
+type RedirectedProcessWrite = (
+  chunk: string | Uint8Array,
+  encodingOrCallback?: BufferEncoding | ProcessWriteCallback,
+  callback?: ProcessWriteCallback,
+) => boolean;
+
+interface PiBridgeStdoutTakeoverState {
+  originalStdoutWrite: typeof process.stdout.write;
+  protocolStdoutWrite: (
+    chunk: string,
+    callback?: ProcessWriteCallback,
+  ) => boolean;
+}
+
+let stdoutTakeoverState: PiBridgeStdoutTakeoverState | undefined;
+
+export function takeOverPiBridgeStdout(): void {
+  if (stdoutTakeoverState) {
+    return;
+  }
+
+  const protocolStdoutWrite = process.stdout.write.bind(
+    process.stdout,
+  ) as PiBridgeStdoutTakeoverState["protocolStdoutWrite"];
+  const stderrWrite = process.stderr.write.bind(
+    process.stderr,
+  ) as RedirectedProcessWrite;
+  const originalStdoutWrite = process.stdout.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ProcessWriteCallback,
+    callback?: ProcessWriteCallback,
+  ): boolean => {
+    if (typeof encodingOrCallback === "function") {
+      return stderrWrite(chunk, encodingOrCallback);
+    }
+    if (encodingOrCallback !== undefined) {
+      return stderrWrite(chunk, encodingOrCallback, callback);
+    }
+    if (callback) {
+      return stderrWrite(chunk, callback);
+    }
+    return stderrWrite(chunk);
+  }) as typeof process.stdout.write;
+
+  stdoutTakeoverState = {
+    originalStdoutWrite,
+    protocolStdoutWrite,
+  };
+}
+
+export function restorePiBridgeStdout(): void {
+  if (!stdoutTakeoverState) {
+    return;
+  }
+
+  process.stdout.write = stdoutTakeoverState.originalStdoutWrite;
+  stdoutTakeoverState = undefined;
+}
+
+export function writePiBridgeProtocol(text: string): void {
+  const protocolStdoutWrite =
+    stdoutTakeoverState?.protocolStdoutWrite ??
+    (process.stdout.write.bind(
+      process.stdout,
+    ) as PiBridgeStdoutTakeoverState["protocolStdoutWrite"]);
+  protocolStdoutWrite(text);
+}

--- a/packages/agent-runtime/src/pi/bridge/output-guard.ts
+++ b/packages/agent-runtime/src/pi/bridge/output-guard.ts
@@ -6,6 +6,7 @@ type RedirectedProcessWrite = (
 ) => boolean;
 
 interface PiBridgeStdoutTakeoverState {
+  forwardStderrDrain: (() => void) | undefined;
   originalStdoutWrite: typeof process.stdout.write;
   protocolStdoutWrite: (
     chunk: string,
@@ -28,27 +29,42 @@ export function takeOverPiBridgeStdout(): void {
   ) as RedirectedProcessWrite;
   const originalStdoutWrite = process.stdout.write;
 
+  stdoutTakeoverState = {
+    forwardStderrDrain: undefined,
+    originalStdoutWrite,
+    protocolStdoutWrite,
+  };
+
   process.stdout.write = ((
     chunk: string | Uint8Array,
     encodingOrCallback?: BufferEncoding | ProcessWriteCallback,
     callback?: ProcessWriteCallback,
   ): boolean => {
-    if (typeof encodingOrCallback === "function") {
-      return stderrWrite(chunk, encodingOrCallback);
-    }
-    if (encodingOrCallback !== undefined) {
-      return stderrWrite(chunk, encodingOrCallback, callback);
-    }
-    if (callback) {
-      return stderrWrite(chunk, callback);
-    }
-    return stderrWrite(chunk);
-  }) as typeof process.stdout.write;
+    const accepted =
+      typeof encodingOrCallback === "function"
+        ? stderrWrite(chunk, encodingOrCallback)
+        : encodingOrCallback !== undefined
+          ? stderrWrite(chunk, encodingOrCallback, callback)
+          : callback
+            ? stderrWrite(chunk, callback)
+            : stderrWrite(chunk);
 
-  stdoutTakeoverState = {
-    originalStdoutWrite,
-    protocolStdoutWrite,
-  };
+    const takeoverState = stdoutTakeoverState;
+    if (!accepted && takeoverState && !takeoverState.forwardStderrDrain) {
+      const forwardStderrDrain = (): void => {
+        const state = stdoutTakeoverState;
+        if (!state || state.forwardStderrDrain !== forwardStderrDrain) {
+          return;
+        }
+        state.forwardStderrDrain = undefined;
+        process.stdout.emit("drain");
+      };
+      takeoverState.forwardStderrDrain = forwardStderrDrain;
+      process.stderr.once("drain", forwardStderrDrain);
+    }
+
+    return accepted;
+  }) as typeof process.stdout.write;
 }
 
 export function restorePiBridgeStdout(): void {
@@ -56,7 +72,11 @@ export function restorePiBridgeStdout(): void {
     return;
   }
 
-  process.stdout.write = stdoutTakeoverState.originalStdoutWrite;
+  const { forwardStderrDrain, originalStdoutWrite } = stdoutTakeoverState;
+  if (forwardStderrDrain) {
+    process.stderr.off("drain", forwardStderrDrain);
+  }
+  process.stdout.write = originalStdoutWrite;
   stdoutTakeoverState = undefined;
 }
 

--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -33,7 +33,8 @@ export interface RuntimeProviderProcess {
   pending: Map<string | number, PendingJsonRpcRequest>;
   processKey: string;
   providerId: string;
-  stderrChunks: string[];
+  stderrLineTail: Buffer;
+  stderrTail: Buffer;
 }
 
 export interface RuntimeProviderProcessLineArgs {
@@ -117,8 +118,10 @@ interface ProviderProcessExitStatus {
 interface ProviderProcessExitedErrorArgs {
   providerId: string;
   status: ProviderProcessExitStatus;
-  stderrChunks: readonly string[];
+  stderrTail: Buffer;
 }
+
+const PROVIDER_STDERR_TAIL_MAX_BYTES = 4_000;
 
 function createAdapterTurnIdPrefix(): string {
   const adapterId = randomUUID().replaceAll("-", "").slice(0, 16);
@@ -127,7 +130,7 @@ function createAdapterTurnIdPrefix(): string {
 
 export class ProviderProcessExitedError extends Error {
   constructor(args: ProviderProcessExitedErrorArgs) {
-    const stderr = formatProviderStderr(args.stderrChunks);
+    const stderr = formatProviderStderr(args.stderrTail);
     super(
       `Provider "${args.providerId}" exited unexpectedly (${formatProviderProcessExitStatus(args.status)})` +
         (stderr ? `\nstderr: ${stderr}` : ""),
@@ -165,7 +168,9 @@ export class RuntimeProviderProcessManager {
 
       try {
         if (hasChildProcessExited(providerProcess.child)) {
-          const stderr = providerProcess.stderrChunks.join("\n").slice(0, 500);
+          const stderr = formatProviderStderr(
+            providerProcess.stderrTail,
+          )?.slice(0, 500);
           throw new Error(
             `Provider "${args.providerId}" exited during startup with ${formatChildProcessExitStatus(providerProcess.child)}` +
               (stderr ? `\nstderr: ${stderr}` : ""),
@@ -358,7 +363,8 @@ export class RuntimeProviderProcessManager {
       pending: new Map(),
       processKey: args.processKey,
       providerId: args.providerId,
-      stderrChunks: [],
+      stderrLineTail: Buffer.alloc(0),
+      stderrTail: Buffer.alloc(0),
     };
 
     const stdout = createInterface({ input: child.stdout });
@@ -372,13 +378,22 @@ export class RuntimeProviderProcessManager {
       });
     });
 
-    const stderr = createInterface({ input: child.stderr });
-    stderr.on("line", (line) => {
+    child.stderr.on("data", (chunk: Buffer) => {
       if (this.shuttingDown) {
         return;
       }
-      providerProcess.stderrChunks.push(line);
-      this.args.onStderr?.(line);
+      consumeProviderStderrChunk({
+        chunk,
+        onLine: this.args.onStderr,
+        providerProcess,
+      });
+    });
+    child.stderr.on("end", () => {
+      if (this.shuttingDown || providerProcess.stderrLineTail.length === 0) {
+        return;
+      }
+      this.args.onStderr?.(decodeStderrLine(providerProcess.stderrLineTail));
+      providerProcess.stderrLineTail = Buffer.alloc(0);
     });
 
     child.on("error", (err) => {
@@ -496,7 +511,7 @@ export class RuntimeProviderProcessManager {
         new ProviderProcessExitedError({
           providerId: args.providerId,
           status: { code: args.code, signal: args.signal },
-          stderrChunks: args.providerProcess.stderrChunks,
+          stderrTail: args.providerProcess.stderrTail,
         }),
       );
     }
@@ -509,7 +524,7 @@ export class RuntimeProviderProcessManager {
       code: args.code,
       expected,
       signal: args.signal,
-      stderr: formatProviderStderr(args.providerProcess.stderrChunks),
+      stderr: formatProviderStderr(args.providerProcess.stderrTail),
     });
   }
 
@@ -554,12 +569,64 @@ function formatProviderProcessExitStatus(
   return "unknown status";
 }
 
-function formatProviderStderr(stderrChunks: readonly string[]): string | null {
-  const stderr = stderrChunks.join("\n").trim();
+function formatProviderStderr(stderrTail: Buffer): string | null {
+  const stderr = stderrTail.toString("utf8").trim();
   if (stderr.length === 0) {
     return null;
   }
-  return stderr.slice(-4000);
+  return stderr;
+}
+
+function appendBoundedStderrBytes(current: Buffer, chunk: Buffer): Buffer {
+  if (chunk.length >= PROVIDER_STDERR_TAIL_MAX_BYTES) {
+    return Buffer.from(
+      chunk.subarray(chunk.length - PROVIDER_STDERR_TAIL_MAX_BYTES),
+    );
+  }
+  const currentBytesToKeep = Math.min(
+    current.length,
+    PROVIDER_STDERR_TAIL_MAX_BYTES - chunk.length,
+  );
+  return Buffer.concat([
+    current.subarray(current.length - currentBytesToKeep),
+    chunk,
+  ]);
+}
+
+function decodeStderrLine(line: Buffer): string {
+  const end = line.at(-1) === 0x0d ? line.length - 1 : line.length;
+  return line.toString("utf8", 0, end);
+}
+
+function consumeProviderStderrChunk(args: {
+  chunk: Buffer;
+  onLine: AgentRuntimeOptions["onStderr"];
+  providerProcess: RuntimeProviderProcess;
+}): void {
+  args.providerProcess.stderrTail = appendBoundedStderrBytes(
+    args.providerProcess.stderrTail,
+    args.chunk,
+  );
+
+  let offset = 0;
+  let newline = args.chunk.indexOf(0x0a, offset);
+  while (newline !== -1) {
+    args.providerProcess.stderrLineTail = appendBoundedStderrBytes(
+      args.providerProcess.stderrLineTail,
+      args.chunk.subarray(offset, newline),
+    );
+    args.onLine?.(decodeStderrLine(args.providerProcess.stderrLineTail));
+    args.providerProcess.stderrLineTail = Buffer.alloc(0);
+    offset = newline + 1;
+    newline = args.chunk.indexOf(0x0a, offset);
+  }
+
+  if (offset < args.chunk.length) {
+    args.providerProcess.stderrLineTail = appendBoundedStderrBytes(
+      args.providerProcess.stderrLineTail,
+      args.chunk.subarray(offset),
+    );
+  }
 }
 
 function consumeExpectedProviderProcessShutdown(

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -434,6 +434,38 @@ rl.on("line", (line) => {
     await runtime.shutdown();
   });
 
+  it("bounds provider stderr while data arrives without a newline", async () => {
+    const exitInfo = vi.fn<NonNullable<AgentRuntimeOptions["onProcessExit"]>>();
+    const stderrLines: string[] = [];
+    const crashScript = join(tmpDir, "large-stderr-provider.cjs");
+    writeFileSync(
+      crashScript,
+      `process.stderr.write("a".repeat(100_000) + "stderr-tail");
+      process.exit(42);`,
+    );
+    const manager = createProviderProcessManager({
+      onProcessExit: exitInfo,
+      onStderr: (line) => stderrLines.push(line),
+      scriptPath: crashScript,
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    await waitForRuntimeState({
+      label: "bounded provider stderr exit callback",
+      predicate: () => exitInfo.mock.calls.length === 1,
+    });
+
+    const stderr = exitInfo.mock.calls[0]?.[0].stderr;
+    expect(Buffer.byteLength(stderr ?? "", "utf8")).toBeLessThanOrEqual(4_000);
+    expect(stderr?.endsWith("stderr-tail")).toBe(true);
+    expect(stderrLines).toHaveLength(1);
+    expect(Buffer.byteLength(stderrLines[0] ?? "", "utf8")).toBeLessThanOrEqual(
+      4_000,
+    );
+    await manager.shutdown();
+  });
+
   it("shutdown kills processes and rejects pending requests", async () => {
     const runtime = createAgentRuntimeWithAdapters({
       workspacePath: tmpDir,

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1390,15 +1390,19 @@ describe("events", () => {
     expect(rowsByThreadId.size).toBe(2);
   });
 
-  it("batches client turn request keys above the SQLite variable limit", () => {
-    const { db } = setup();
-    const keys = Array.from({ length: 16_383 }, (_, index) => ({
-      requestId: "creq_23456789ab",
-      threadId: `thr_missing_request_${index}`,
-    }));
+  it(
+    "batches client turn request keys above the SQLite variable limit",
+    () => {
+      const { db } = setup();
+      const keys = Array.from({ length: 16_383 }, (_, index) => ({
+        requestId: "creq_23456789ab",
+        threadId: `thr_missing_request_${index}`,
+      }));
 
-    expect(listStoredClientTurnRequestRowsByKeys(db, { keys })).toEqual([]);
-  });
+      expect(listStoredClientTurnRequestRowsByKeys(db, { keys })).toEqual([]);
+    },
+    15_000,
+  );
 
   it("lists client turn request ids in range with a storage predicate", () => {
     const { db, project, thread } = setup();

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 85 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 86 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,11 +1039,10 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 85 includes accepted turns that await their first event in the
-  // active-thread session report. The bump updates enrolled daemons before
-  // the server depends on the revised report meaning during reconciliation.
-  it("uses protocol version 85 for pending-turn session reports", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(85);
+  // Version 86 protects the Pi bridge JSON-RPC channel from stdout writes by
+  // user extensions, restoring terminal turn events for affected sessions.
+  it("uses protocol version 86 for guarded Pi bridge output", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(86);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
Reserve the Pi bridge stdout pipe for protocol frames and redirect extension output to stderr. Add regression coverage for OSC notification output.

Fixes #1180