### PR TITLE
Fix flaky client request batching test

### DIFF
--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1390,19 +1390,30 @@ describe("events", () => {
     expect(rowsByThreadId.size).toBe(2);
   });
 
-  it(
-    "batches client turn request keys above the SQLite variable limit",
-    () => {
-      const { db } = setup();
-      const keys = Array.from({ length: 16_383 }, (_, index) => ({
-        requestId: "creq_23456789ab",
+  it("batches client turn request keys above the expression-depth limit", () => {
+    const { db, thread } = setup();
+    const requestId = "creq_23456789ab";
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "client/turn/requested",
+        ...threadEventFields,
+        data: clientTurnRequestData(requestId, "second batch"),
+      },
+    ]);
+    const keys = [
+      ...Array.from({ length: 995 }, (_, index) => ({
+        requestId,
         threadId: `thr_missing_request_${index}`,
-      }));
+      })),
+      { requestId, threadId: thread.id },
+    ];
 
-      expect(listStoredClientTurnRequestRowsByKeys(db, { keys })).toEqual([]);
-    },
-    15_000,
-  );
+    expect(listStoredClientTurnRequestRowsByKeys(db, { keys })).toEqual([
+      expect.objectContaining({ sequence: 1, threadId: thread.id }),
+    ]);
+  });
 
   it("lists client turn request ids in range with a storage predicate", () => {
     const { db, project, thread } = setup();


### PR DESCRIPTION
## Summary

- replace the 16,383-key timeout test with the real 996-key SQLite expression-depth boundary
- verify that a matching row from the second query batch is returned
- remove the custom 15-second timeout and its unnecessary query work

## Tests

- `pnpm exec turbo run test --filter=@bb/db --force` (six runs; 370 tests passed each run)
- `pnpm exec turbo run typecheck --filter=@bb/db`

## Risk

Low. This changes only regression test data and assertions.