### PR TITLE
fix: preserve provider sessions across environment switches

### DIFF
--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -207,20 +207,6 @@ function isMessageOnlyAcpAuthRequiredError(error: unknown): boolean {
   );
 }
 
-export async function requireExistingEnvironment(
-  environmentId: string,
-  runtimeManager: RuntimeManager,
-): Promise<RuntimeEntry> {
-  const entry = await runtimeManager.getOrAwait(environmentId);
-  if (!entry) {
-    throw new CommandDispatchError(
-      "unknown_environment",
-      `No runtime exists for environment ${environmentId}`,
-    );
-  }
-  return entry;
-}
-
 export async function requireWorkspaceEnvironment(
   args: {
     dataDir?: string;

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -537,6 +537,248 @@ describe("dispatchCommand", () => {
     );
   });
 
+  it("stops the old owner when the moved thread has no runtime yet", async () => {
+    const oldRuntime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => oldRuntime,
+      provisionWorkspace: async () => createWorkspace("/tmp/bb-stop-old"),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/bb-stop-old",
+    });
+    oldRuntime.setActiveTurn("thread-1", "turn-old");
+
+    // The thread already points at its new environment, which the daemon has
+    // never loaded. The stop must still reach the turn in the old runtime.
+    const command: CommandOf<"thread.stop"> = {
+      type: "thread.stop",
+      environmentId: "env-new",
+      threadId: "thread-1",
+    };
+    const flush = vi.fn(async () => undefined);
+
+    const result = await dispatchCommand(command, {
+      dataDir: "/tmp/bb-data",
+      eventSink: { emit: vi.fn(), flush },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    });
+
+    expect(result).toEqual({});
+    expect(oldRuntime.stopThread).toHaveBeenCalledWith({
+      threadId: "thread-1",
+    });
+    expect(flush).toHaveBeenCalledOnce();
+  });
+
+  it("rejects thread.stop when no runtime holds the thread", async () => {
+    const manager = new RuntimeManager({
+      createRuntime: () => createRuntime(),
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    const command: CommandOf<"thread.stop"> = {
+      type: "thread.stop",
+      environmentId: "env-missing-runtime",
+      threadId: "thread-1",
+    };
+
+    await expect(
+      dispatchCommand(command, {
+        dataDir: "/tmp/bb-data",
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      }),
+    ).rejects.toMatchObject({ code: "unknown_environment" });
+  });
+
+  it("cancels a plan in the environment the thread moved away from", async () => {
+    const oldRuntime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => oldRuntime,
+      provisionWorkspace: async () => createWorkspace("/tmp/bb-plan-old"),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/bb-plan-old",
+    });
+    oldRuntime.setActiveTurn("thread-1", "turn-old");
+
+    const command: CommandOf<"thread.plan.cancel"> = {
+      type: "thread.plan.cancel",
+      environmentId: "env-new",
+      threadId: "thread-1",
+      expectedTurnId: "turn-old",
+    };
+
+    const result = await dispatchCommand(command, {
+      dataDir: "/tmp/bb-data",
+      eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    });
+
+    expect(result).toEqual({ cancelled: true });
+    expect(oldRuntime.stopThread).toHaveBeenCalledWith({
+      threadId: "thread-1",
+    });
+  });
+
+  it("leaves a plan alone when no runtime runs the expected turn", async () => {
+    const oldRuntime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => oldRuntime,
+      provisionWorkspace: async () => createWorkspace("/tmp/bb-plan-old"),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/bb-plan-old",
+    });
+    oldRuntime.setActiveTurn("thread-1", "turn-other");
+
+    const command: CommandOf<"thread.plan.cancel"> = {
+      type: "thread.plan.cancel",
+      environmentId: "env-new",
+      threadId: "thread-1",
+      expectedTurnId: "turn-old",
+    };
+
+    const result = await dispatchCommand(command, {
+      dataDir: "/tmp/bb-data",
+      eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    });
+
+    expect(result).toEqual({ cancelled: false });
+    expect(oldRuntime.stopThread).not.toHaveBeenCalled();
+  });
+
+  it("keeps an old-environment turn alive through a rename", async () => {
+    const oldRuntime = createRuntime();
+    const newRuntime = createRuntime();
+    const createRuntimeSpy = vi
+      .fn<() => AgentRuntime>()
+      .mockReturnValueOnce(oldRuntime)
+      .mockReturnValueOnce(newRuntime);
+    const manager = new RuntimeManager({
+      createRuntime: createRuntimeSpy,
+      provisionWorkspace: async (args) =>
+        createWorkspace("path" in args ? args.path : args.targetPath),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/bb-rename-old",
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-new",
+      workspacePath: "/tmp/bb-rename-new",
+    });
+    // The switch moves the thread mid-turn, so the old runtime still runs it
+    // while the thread already points at the new environment.
+    oldRuntime.setActiveTurn("thread-1", "turn-old");
+
+    const command: CommandOf<"thread.rename"> = {
+      type: "thread.rename",
+      environmentId: "env-new",
+      threadId: "thread-1",
+      title: "Renamed",
+    };
+
+    const result = await dispatchCommand(command, {
+      dataDir: "/tmp/bb-data",
+      eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    });
+
+    expect(result).toEqual({});
+    expect(oldRuntime.stopThread).not.toHaveBeenCalled();
+    expect(oldRuntime.getActiveTurnId("thread-1")).toBe("turn-old");
+    expect(newRuntime.renameThread).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      title: "Renamed",
+    });
+  });
+
+  it("refuses a goal clear while the old environment still runs the turn", async () => {
+    const oldRuntime = createRuntime();
+    const newRuntime = createRuntime();
+    const createRuntimeSpy = vi
+      .fn<() => AgentRuntime>()
+      .mockReturnValueOnce(oldRuntime)
+      .mockReturnValueOnce(newRuntime);
+    const manager = new RuntimeManager({
+      createRuntime: createRuntimeSpy,
+      provisionWorkspace: async (args) =>
+        createWorkspace("path" in args ? args.path : args.targetPath),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/bb-goal-old",
+    });
+    oldRuntime.setActiveTurn("thread-1", "turn-old");
+
+    const command: CommandOf<"thread.goal.clear"> = {
+      type: "thread.goal.clear",
+      environmentId: "env-new",
+      threadId: "thread-1",
+      options: {
+        model: "gpt-5",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        workflowsEnabled: false,
+        permissionMode: "full",
+        permissionScope: "full",
+        approvalReviewer: null,
+        permissionEscalation: null,
+      },
+      resumeContext: {
+        workspaceContext: {
+          workspacePath: "/tmp/bb-goal-new",
+          workspaceProvisionType: "unmanaged",
+        },
+        projectId: "proj_1",
+        providerId: "codex",
+        providerThreadId: "provider-thread-1",
+        instructions: "Be concise.",
+        dynamicTools: [],
+        injectedSkillSources: [],
+        instructionMode: "append",
+      },
+    };
+
+    await expect(
+      dispatchCommand(command, {
+        dataDir: "/tmp/bb-data",
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      }),
+    ).rejects.toMatchObject({ code: "thread_busy_in_other_environment" });
+    expect(oldRuntime.stopThread).not.toHaveBeenCalled();
+    expect(newRuntime.clearThreadGoal).not.toHaveBeenCalled();
+  });
+
   it("treats thread.rename as best-effort when the runtime is not loaded", async () => {
     const runtime = createRuntime();
     const manager = new RuntimeManager({

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -134,9 +134,9 @@ async function unexpectedWorkspaceCall(): Promise<never> {
   throw new Error("Unexpected workspace call");
 }
 
-function createWorkspace(): HostWorkspace {
+function createWorkspace(workspacePath = WORKSPACE_PATH): HostWorkspace {
   return {
-    path: WORKSPACE_PATH,
+    path: workspacePath,
     managed: false,
     isGitRepo: false,
     isWorktree: false,
@@ -449,6 +449,92 @@ describe("dispatchCommand", () => {
       threadId: "thread-1",
     });
     expect(flush).toHaveBeenCalledOnce();
+  });
+
+  it("releases a moved thread from its old environment before resuming it", async () => {
+    const oldRuntime = createRuntime();
+    const newRuntime = createRuntime();
+    const createRuntimeSpy = vi
+      .fn<() => AgentRuntime>()
+      .mockReturnValueOnce(oldRuntime)
+      .mockReturnValueOnce(newRuntime);
+    const manager = new RuntimeManager({
+      createRuntime: createRuntimeSpy,
+      provisionWorkspace: async (args) =>
+        createWorkspace("path" in args ? args.path : args.targetPath),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/bb-command-dispatch-old",
+    });
+    oldRuntime.setIdle("thread-1");
+
+    const command: CommandOf<"turn.submit"> = {
+      type: "turn.submit",
+      environmentId: "env-new",
+      threadId: "thread-1",
+      requestId: "creq_moved_thread",
+      input: [{ type: "text", text: "follow up", mentions: [] }],
+      options: {
+        model: "gpt-5",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        workflowsEnabled: false,
+        permissionMode: "full",
+        permissionScope: "full",
+        approvalReviewer: null,
+        permissionEscalation: null,
+      },
+      resumeContext: {
+        workspaceContext: {
+          workspacePath: "/tmp/bb-command-dispatch-new",
+          workspaceProvisionType: "unmanaged",
+        },
+        projectId: "proj_1",
+        providerId: "codex",
+        providerThreadId: "provider-thread-1",
+        instructions: "Be concise.",
+        dynamicTools: [],
+        injectedSkillSources: [],
+        instructionMode: "append",
+      },
+      target: { mode: "start" },
+    };
+
+    const result = await dispatchCommand(command, {
+      dataDir: "/tmp/bb-data",
+      eventSink: {
+        emit: vi.fn(),
+        flush: vi.fn(async () => undefined),
+      },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    });
+
+    expect(result).toEqual({ appliedAs: "new-turn" });
+    expect(oldRuntime.stopThread).toHaveBeenCalledWith({
+      threadId: "thread-1",
+    });
+    expect(createRuntimeSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        workspacePath: "/tmp/bb-command-dispatch-new",
+      }),
+    );
+    expect(newRuntime.resumeThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerThreadId: "provider-thread-1",
+        threadId: "thread-1",
+      }),
+    );
+    expect(
+      (oldRuntime.stopThread as unknown as Mock).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      (newRuntime.resumeThread as unknown as Mock).mock.invocationCallOrder[0],
+    );
   });
 
   it("treats thread.rename as best-effort when the runtime is not loaded", async () => {

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -230,10 +230,11 @@ function shouldInvalidateProviderMaintenanceRuntimeAfterProviderCliInstall(args:
 
 const commandHandlers: CommandHandlerMap = {
   "thread.start": async (command, options) => {
-    const release = options.runtimeManager.retainEnvironmentForThreadCommand(
-      command.environmentId,
-      command.threadId,
-    );
+    const release =
+      await options.runtimeManager.retainEnvironmentForThreadCommand(
+        command.environmentId,
+        command.threadId,
+      );
     try {
       return await startThread(command, options);
     } finally {
@@ -241,10 +242,11 @@ const commandHandlers: CommandHandlerMap = {
     }
   },
   "turn.submit": async (command, options) => {
-    const release = options.runtimeManager.retainEnvironmentForThreadCommand(
-      command.environmentId,
-      command.threadId,
-    );
+    const release =
+      await options.runtimeManager.retainEnvironmentForThreadCommand(
+        command.environmentId,
+        command.threadId,
+      );
     try {
       const entry = await ensureThreadRuntime(command, options);
       return await submitTurn(command, entry, options);
@@ -257,6 +259,10 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
+    await options.runtimeManager.releaseThreadFromOtherEnvironments({
+      environmentId: command.environmentId,
+      threadId: command.threadId,
+    });
     if (entry.runtime.hasThread(command.threadId)) {
       // Stop can be dispatched while the start/submit RPC is still in flight
       // and the turn/started event has not been observed yet. Wait for the
@@ -286,6 +292,10 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
+    await options.runtimeManager.releaseThreadFromOtherEnvironments({
+      environmentId: command.environmentId,
+      threadId: command.threadId,
+    });
     if (!entry.runtime.hasThread(command.threadId)) {
       throw new ExpectedCommandDispatchError(
         "unknown_thread_runtime",
@@ -308,6 +318,10 @@ const commandHandlers: CommandHandlerMap = {
     if (!entry) {
       return {};
     }
+    await options.runtimeManager.releaseThreadFromOtherEnvironments({
+      environmentId: command.environmentId,
+      threadId: command.threadId,
+    });
     await entry.runtime.renameThread({
       threadId: command.threadId,
       title: command.title,
@@ -320,6 +334,10 @@ const commandHandlers: CommandHandlerMap = {
       environmentId: command.environmentId,
       runtimeManager: options.runtimeManager,
       workspaceContext: command.workspaceContext,
+    });
+    await options.runtimeManager.releaseThreadFromOtherEnvironments({
+      environmentId: command.environmentId,
+      threadId: command.threadId,
     });
     await entry.runtime.archiveThread({
       threadId: command.threadId,

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -230,6 +230,8 @@ function shouldInvalidateProviderMaintenanceRuntimeAfterProviderCliInstall(args:
 
 const commandHandlers: CommandHandlerMap = {
   "thread.start": async (command, options) => {
+    // Registration is ordered with handoffs; complete it before start work can
+    // be reaped or superseded by a directory switch.
     const release =
       await options.runtimeManager.retainEnvironmentForThreadCommand(
         command.environmentId,
@@ -242,6 +244,8 @@ const commandHandlers: CommandHandlerMap = {
     }
   },
   "turn.submit": async (command, options) => {
+    // A submit can be the first command after a directory switch, so it uses
+    // the same awaited ownership barrier as thread.start.
     const release =
       await options.runtimeManager.retainEnvironmentForThreadCommand(
         command.environmentId,
@@ -259,6 +263,8 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
+    // A moved thread may still be resident in another runtime. Make this
+    // environment the sole provider owner before lifecycle operations run.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,
@@ -292,6 +298,8 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
+    // Provider lifecycle operations must target the current environment too;
+    // cancel may otherwise stop a stale runtime owner.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,
@@ -318,6 +326,8 @@ const commandHandlers: CommandHandlerMap = {
     if (!entry) {
       return {};
     }
+    // Provider lifecycle operations must target the current environment too;
+    // rename may otherwise mutate a stale runtime owner.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,
@@ -335,6 +345,8 @@ const commandHandlers: CommandHandlerMap = {
       runtimeManager: options.runtimeManager,
       workspaceContext: command.workspaceContext,
     });
+    // Provider lifecycle operations must target the current environment too;
+    // archive may otherwise mutate a stale runtime owner.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -230,8 +230,6 @@ function shouldInvalidateProviderMaintenanceRuntimeAfterProviderCliInstall(args:
 
 const commandHandlers: CommandHandlerMap = {
   "thread.start": async (command, options) => {
-    // Registration is ordered with handoffs; complete it before start work can
-    // be reaped or superseded by a directory switch.
     const release =
       await options.runtimeManager.retainEnvironmentForThreadCommand(
         command.environmentId,
@@ -244,8 +242,6 @@ const commandHandlers: CommandHandlerMap = {
     }
   },
   "turn.submit": async (command, options) => {
-    // A submit can be the first command after a directory switch, so it uses
-    // the same awaited ownership barrier as thread.start.
     const release =
       await options.runtimeManager.retainEnvironmentForThreadCommand(
         command.environmentId,
@@ -263,8 +259,6 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
-    // A moved thread may still be resident in another runtime. Make this
-    // environment the sole provider owner before lifecycle operations run.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,
@@ -298,8 +292,6 @@ const commandHandlers: CommandHandlerMap = {
       command.environmentId,
       options.runtimeManager,
     );
-    // Provider lifecycle operations must target the current environment too;
-    // cancel may otherwise stop a stale runtime owner.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,
@@ -326,8 +318,6 @@ const commandHandlers: CommandHandlerMap = {
     if (!entry) {
       return {};
     }
-    // Provider lifecycle operations must target the current environment too;
-    // rename may otherwise mutate a stale runtime owner.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,
@@ -345,8 +335,6 @@ const commandHandlers: CommandHandlerMap = {
       runtimeManager: options.runtimeManager,
       workspaceContext: command.workspaceContext,
     });
-    // Provider lifecycle operations must target the current environment too;
-    // archive may otherwise mutate a stale runtime owner.
     await options.runtimeManager.releaseThreadFromOtherEnvironments({
       environmentId: command.environmentId,
       threadId: command.threadId,

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -9,10 +9,10 @@ import {
   HostDaemonSettledCommandType,
 } from "@bb/host-daemon-contract";
 import {
+  CommandDispatchError,
   defaultListModels,
   ExpectedCommandDispatchError,
   type CommandOf,
-  requireExistingEnvironment,
   type CommandDispatchOptions,
 } from "./command-dispatch-support.js";
 import {
@@ -255,14 +255,28 @@ const commandHandlers: CommandHandlerMap = {
     }
   },
   "thread.stop": async (command, options) => {
-    const entry = await requireExistingEnvironment(
+    // Release before the target runtime lookup. A moved thread often has no
+    // runtime in its new environment yet, and the old owner must still stop.
+    const released =
+      await options.runtimeManager.releaseThreadFromOtherEnvironments({
+        activeTurn: "interrupt",
+        environmentId: command.environmentId,
+        threadId: command.threadId,
+      });
+    const entry = await options.runtimeManager.getOrAwait(
       command.environmentId,
-      options.runtimeManager,
     );
-    await options.runtimeManager.releaseThreadFromOtherEnvironments({
-      environmentId: command.environmentId,
-      threadId: command.threadId,
-    });
+    if (!entry) {
+      if (released.releasedEnvironmentIds.length === 0) {
+        throw new CommandDispatchError(
+          "unknown_environment",
+          `No runtime exists for environment ${command.environmentId}`,
+        );
+      }
+      // The old owner stopped, so the stop reached the running turn.
+      await options.eventSink.flush();
+      return {};
+    }
     if (entry.runtime.hasThread(command.threadId)) {
       // Stop can be dispatched while the start/submit RPC is still in flight
       // and the turn/started event has not been observed yet. Wait for the
@@ -288,26 +302,26 @@ const commandHandlers: CommandHandlerMap = {
     return result;
   },
   "thread.plan.cancel": async (command, options) => {
-    const entry = await requireExistingEnvironment(
-      command.environmentId,
-      options.runtimeManager,
+    // A moved thread keeps its turn in the environment it left, and the new
+    // environment may hold no runtime yet. Cancel where the turn runs.
+    const owners = options.runtimeManager.listThreadOwnerEntries(
+      command.threadId,
     );
-    await options.runtimeManager.releaseThreadFromOtherEnvironments({
-      environmentId: command.environmentId,
-      threadId: command.threadId,
-    });
-    if (!entry.runtime.hasThread(command.threadId)) {
+    if (owners.length === 0) {
       throw new ExpectedCommandDispatchError(
         "unknown_thread_runtime",
         `No provider runtime available for thread ${command.threadId}`,
       );
     }
-    if (
-      entry.runtime.getActiveTurnId(command.threadId) !== command.expectedTurnId
-    ) {
+    const owner = owners.find(
+      (entry) =>
+        entry.runtime.getActiveTurnId(command.threadId) ===
+        command.expectedTurnId,
+    );
+    if (!owner) {
       return { cancelled: false };
     }
-    await entry.runtime.stopThread({ threadId: command.threadId });
+    await owner.runtime.stopThread({ threadId: command.threadId });
     await options.eventSink.flush();
     return { cancelled: true };
   },
@@ -318,10 +332,8 @@ const commandHandlers: CommandHandlerMap = {
     if (!entry) {
       return {};
     }
-    await options.runtimeManager.releaseThreadFromOtherEnvironments({
-      environmentId: command.environmentId,
-      threadId: command.threadId,
-    });
+    // Rename does not move the provider session, so it must not stop a turn
+    // that still runs in the environment the thread left.
     await entry.runtime.renameThread({
       threadId: command.threadId,
       title: command.title,
@@ -335,10 +347,8 @@ const commandHandlers: CommandHandlerMap = {
       runtimeManager: options.runtimeManager,
       workspaceContext: command.workspaceContext,
     });
-    await options.runtimeManager.releaseThreadFromOtherEnvironments({
-      environmentId: command.environmentId,
-      threadId: command.threadId,
-    });
+    // Archive works on stored provider state, not on the live session, so it
+    // must not stop a turn in the environment the thread left.
     await entry.runtime.archiveThread({
       threadId: command.threadId,
       providerId: command.providerId,

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -251,6 +251,8 @@ export async function ensureThreadRuntime(
     workspaceContext: resumeContext.workspaceContext,
   });
 
+  // Resolve the destination entry first, then transfer provider ownership
+  // before resuming the persisted session in that environment.
   await options.runtimeManager.releaseThreadFromOtherEnvironments({
     environmentId: command.environmentId,
     threadId: command.threadId,

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -251,8 +251,6 @@ export async function ensureThreadRuntime(
     workspaceContext: resumeContext.workspaceContext,
   });
 
-  // Resolve the destination entry first, then transfer provider ownership
-  // before resuming the persisted session in that environment.
   await options.runtimeManager.releaseThreadFromOtherEnvironments({
     environmentId: command.environmentId,
     threadId: command.threadId,

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -251,6 +251,10 @@ export async function ensureThreadRuntime(
     workspaceContext: resumeContext.workspaceContext,
   });
 
+  await options.runtimeManager.releaseThreadFromOtherEnvironments({
+    environmentId: command.environmentId,
+    threadId: command.threadId,
+  });
   await resumeThreadRuntimeIfMissing({ command, entry });
   return entry;
 }

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -251,10 +251,22 @@ export async function ensureThreadRuntime(
     workspaceContext: resumeContext.workspaceContext,
   });
 
-  await options.runtimeManager.releaseThreadFromOtherEnvironments({
-    environmentId: command.environmentId,
-    threadId: command.threadId,
-  });
+  // A new turn owns the provider session, so it interrupts an old turn that
+  // the thread left behind. A goal clear does not own it, so it waits for
+  // that turn instead of stopping it.
+  const released =
+    await options.runtimeManager.releaseThreadFromOtherEnvironments({
+      activeTurn: command.type === "turn.submit" ? "interrupt" : "keep",
+      environmentId: command.environmentId,
+      threadId: command.threadId,
+    });
+  const [busyEnvironmentId] = released.activeTurnEnvironmentIds;
+  if (busyEnvironmentId !== undefined) {
+    throw new ExpectedCommandDispatchError(
+      "thread_busy_in_other_environment",
+      `Thread ${command.threadId} still runs a turn in environment ${busyEnvironmentId}`,
+    );
+  }
   await resumeThreadRuntimeIfMissing({ command, entry });
   return entry;
 }

--- a/apps/host-daemon/src/command-router.ts
+++ b/apps/host-daemon/src/command-router.ts
@@ -138,9 +138,6 @@ export class CommandRouter {
   // while session lanes serialize commands for one provider thread/session.
   private readonly providerProcessLanes = new Map<string, ReadWriteLaneState>();
   private readonly providerSessionLaneTails = new Map<string, Promise<void>>();
-  // Environment ids change when a thread's working directory changes. Keep
-  // starts/submits on a thread-global lane as well, otherwise two environment
-  // lanes can each wait for the other's RuntimeManager handoff to finish.
   private readonly threadTurnLaneTails = new Map<string, Promise<void>>();
   private readonly inFlightThreadProviderLanes = new Map<
     string,
@@ -298,8 +295,6 @@ export class CommandRouter {
     if (command.type !== "thread.start" && command.type !== "turn.submit") {
       return work();
     }
-    // Keep the lane around the full dispatch body, including its finally
-    // release, so the next environment cannot retain ownership early.
     return this.runInSerialLane({
       key: command.threadId,
       lanes: this.threadTurnLaneTails,

--- a/apps/host-daemon/src/command-router.ts
+++ b/apps/host-daemon/src/command-router.ts
@@ -138,6 +138,10 @@ export class CommandRouter {
   // while session lanes serialize commands for one provider thread/session.
   private readonly providerProcessLanes = new Map<string, ReadWriteLaneState>();
   private readonly providerSessionLaneTails = new Map<string, Promise<void>>();
+  // Environment ids change when a thread's working directory changes. Keep
+  // starts/submits on a thread-global lane as well, otherwise two environment
+  // lanes can each wait for the other's RuntimeManager handoff to finish.
+  private readonly threadTurnLaneTails = new Map<string, Promise<void>>();
   private readonly inFlightThreadProviderLanes = new Map<
     string,
     InFlightThreadProviderLane
@@ -226,8 +230,13 @@ export class CommandRouter {
     const environmentLaneMode = this.getEnvironmentLaneMode(command);
     const providerLane = this.resolveProviderLane(command);
     const task = this.runAfterThreadUnarchiveBarrier(command, () =>
-      this.runInExecutionLanes(command, environmentLaneMode, providerLane, () =>
-        this.executeLiveDaemonCommandBody(command),
+      this.runInThreadTurnLane(command, () =>
+        this.runInExecutionLanes(
+          command,
+          environmentLaneMode,
+          providerLane,
+          () => this.executeLiveDaemonCommandBody(command),
+        ),
       ),
     );
     this.registerThreadUnarchiveBarrier(command, task);
@@ -280,6 +289,22 @@ export class CommandRouter {
       environmentLaneMode,
       providerWork,
     );
+  }
+
+  private runInThreadTurnLane<T>(
+    command: HostDaemonCommand,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    if (command.type !== "thread.start" && command.type !== "turn.submit") {
+      return work();
+    }
+    // Keep the lane around the full dispatch body, including its finally
+    // release, so the next environment cannot retain ownership early.
+    return this.runInSerialLane({
+      key: command.threadId,
+      lanes: this.threadTurnLaneTails,
+      work,
+    });
   }
 
   private runInProviderLane<T>(

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -1439,6 +1439,7 @@ describe("RuntimeManager", () => {
       "thread-1",
     );
     const handoff = manager.releaseThreadFromOtherEnvironments({
+      activeTurn: "interrupt",
       environmentId: "env-new",
       threadId: "thread-1",
     });
@@ -1452,6 +1453,76 @@ describe("RuntimeManager", () => {
     expect(oldRuntime.stopThread).toHaveBeenCalledWith({
       threadId: "thread-1",
     });
+  });
+
+  it("releases a moved thread while another environment control waits", async () => {
+    const oldRuntime = createFakeRuntime();
+    const manager = new RuntimeManager({
+      provisionWorkspace: createProvisionWorkspaceMock("/tmp/env-old"),
+      createRuntime: () => oldRuntime,
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/env-old",
+    });
+    // A turn command for the new environment holds its retain while a control
+    // command for the old environment waits for that retain. The waiting
+    // command must not hold the thread control lane against it.
+    const release = await manager.retainEnvironmentForThreadCommand(
+      "env-new",
+      "thread-1",
+    );
+    const oldEnvironmentControl = manager.releaseThreadFromOtherEnvironments({
+      activeTurn: "interrupt",
+      environmentId: "env-old",
+      threadId: "thread-1",
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    const turnHandoff = manager
+      .releaseThreadFromOtherEnvironments({
+        activeTurn: "interrupt",
+        environmentId: "env-new",
+        threadId: "thread-1",
+      })
+      .then(() => {
+        release();
+      });
+
+    await expect(
+      Promise.all([oldEnvironmentControl, turnHandoff]),
+    ).resolves.toBeDefined();
+    // A later turn on the same thread must still acquire the control lane.
+    await expect(
+      manager.retainEnvironmentForThreadCommand("env-new", "thread-1"),
+    ).resolves.toBeInstanceOf(Function);
+  });
+
+  it("keeps an old-environment turn when a control declines to interrupt it", async () => {
+    const oldRuntime = createFakeRuntime();
+    const manager = new RuntimeManager({
+      provisionWorkspace: createProvisionWorkspaceMock("/tmp/env-old"),
+      createRuntime: () => oldRuntime,
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/env-old",
+    });
+    oldRuntime.setActiveTurn("thread-1", "turn-old");
+
+    const result = await manager.releaseThreadFromOtherEnvironments({
+      activeTurn: "keep",
+      environmentId: "env-new",
+      threadId: "thread-1",
+    });
+
+    expect(oldRuntime.stopThread).not.toHaveBeenCalled();
+    expect(result.activeTurnEnvironmentIds).toEqual(["env-old"]);
+    expect(result.releasedEnvironmentIds).toEqual([]);
   });
 
   it("keeps an environment runtime while an accepted turn awaits its first event", async () => {

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -542,7 +542,7 @@ describe("RuntimeManager", () => {
       environmentId: "env-skills",
       workspacePath: "/tmp/env-1",
     });
-    const release = manager.retainEnvironmentForThreadCommand(
+    const release = await manager.retainEnvironmentForThreadCommand(
       "env-skills",
       "thread-1",
     );
@@ -1401,7 +1401,7 @@ describe("RuntimeManager", () => {
       environmentId: "env-1",
       workspacePath: "/tmp/env-1",
     });
-    const release = manager.retainEnvironmentForThreadCommand(
+    const release = await manager.retainEnvironmentForThreadCommand(
       "env-1",
       "thread-1",
     );
@@ -1420,6 +1420,38 @@ describe("RuntimeManager", () => {
 
     expect(manager.get("env-1")).toBeUndefined();
     expect(runtime.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an old-environment thread command before releasing a moved thread", async () => {
+    const oldRuntime = createFakeRuntime();
+    const manager = new RuntimeManager({
+      provisionWorkspace: createProvisionWorkspaceMock("/tmp/env-old"),
+      createRuntime: () => oldRuntime,
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-old",
+      workspacePath: "/tmp/env-old",
+    });
+    oldRuntime.setActiveTurn("thread-1", "turn-old");
+    const release = await manager.retainEnvironmentForThreadCommand(
+      "env-old",
+      "thread-1",
+    );
+    const handoff = manager.releaseThreadFromOtherEnvironments({
+      environmentId: "env-new",
+      threadId: "thread-1",
+    });
+
+    await Promise.resolve();
+    expect(oldRuntime.stopThread).not.toHaveBeenCalled();
+
+    release();
+    await handoff;
+
+    expect(oldRuntime.stopThread).toHaveBeenCalledWith({
+      threadId: "thread-1",
+    });
   });
 
   it("keeps an environment runtime while an accepted turn awaits its first event", async () => {

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -228,6 +228,19 @@ export interface RuntimeManagerReapIdleProviderSessionsResult {
   reapedSessions: RuntimeManagerReapedIdleProviderSession[];
 }
 
+/**
+ * `interrupt` stops an old runtime even while it runs a turn. `keep` leaves
+ * that turn alone and reports its environment to the caller.
+ */
+export type ReleaseThreadActiveTurnPolicy = "interrupt" | "keep";
+
+export interface ReleaseThreadFromOtherEnvironmentsResult {
+  /** Environments that still run a turn for the thread under `keep`. */
+  activeTurnEnvironmentIds: string[];
+  /** Environments whose runtime released the thread. */
+  releasedEnvironmentIds: string[];
+}
+
 interface RuntimeWorkspaceWriteRootsArgs {
   threadStorageRootPath: string | null | undefined;
   workspaceRoots: readonly string[];
@@ -369,12 +382,33 @@ export class RuntimeManager {
    * still resident in the old environment runtime. Release that old runtime
    * before the new environment resumes the persisted provider thread, so two
    * runtime processes never own the same provider session at once.
+   *
+   * `activeTurn` selects what happens when an old runtime still runs a turn.
+   * Turn dispatch and stop controls own the session, so they interrupt it.
+   * Other controls keep it and report the environment back to their caller.
    */
   async releaseThreadFromOtherEnvironments(args: {
+    activeTurn: ReleaseThreadActiveTurnPolicy;
+    environmentId: string;
+    threadId: string;
+  }): Promise<ReleaseThreadFromOtherEnvironmentsResult> {
+    // Wait outside the control lane. An in-flight thread command takes this
+    // same lane for its own release step, so a wait inside the lane can hold
+    // the lane against the command it waits for and deadlock the thread.
+    await this.waitForThreadCommandsInOtherEnvironments(args);
+    return this.enqueueThreadControl(args.threadId, () =>
+      this.releaseThreadFromOtherEnvironmentsOnce(args),
+    );
+  }
+
+  private async waitForThreadCommandsInOtherEnvironments(args: {
     environmentId: string;
     threadId: string;
   }): Promise<void> {
-    await this.enqueueThreadControl(args.threadId, async () => {
+    // A command can register while an earlier one settles, so drain until no
+    // other environment holds a thread command. Each pass awaits real command
+    // completions, so this cannot spin.
+    for (;;) {
       const inFlightOldCommands = [
         ...this.inFlightThreadCommandCompletionsByEnvironmentId.entries(),
       ].flatMap(([environmentId, commandsByThreadId]) =>
@@ -382,25 +416,55 @@ export class RuntimeManager {
           ? []
           : [...(commandsByThreadId.get(args.threadId) ?? [])],
       );
+      if (inFlightOldCommands.length === 0) {
+        return;
+      }
       await Promise.all(inFlightOldCommands);
-      await this.releaseThreadFromOtherEnvironmentsOnce(args);
-    });
+    }
   }
 
   private async releaseThreadFromOtherEnvironmentsOnce(args: {
+    activeTurn: ReleaseThreadActiveTurnPolicy;
     environmentId: string;
     threadId: string;
-  }): Promise<void> {
+  }): Promise<ReleaseThreadFromOtherEnvironmentsResult> {
     const staleEntries = [...this.entries.values()].filter(
       (entry) =>
         entry.environmentId !== args.environmentId &&
         entry.runtime.hasThread(args.threadId),
     );
+    const keptEntries =
+      args.activeTurn === "interrupt"
+        ? []
+        : staleEntries.filter(
+            (entry) => entry.runtime.getActiveTurnId(args.threadId) !== null,
+          );
+    const releasedEntries = staleEntries.filter(
+      (entry) => !keptEntries.includes(entry),
+    );
 
     await Promise.all(
-      staleEntries.map((entry) =>
+      releasedEntries.map((entry) =>
         entry.runtime.stopThread({ threadId: args.threadId }),
       ),
+    );
+    return {
+      activeTurnEnvironmentIds: keptEntries.map((entry) => entry.environmentId),
+      releasedEnvironmentIds: releasedEntries.map(
+        (entry) => entry.environmentId,
+      ),
+    };
+  }
+
+  /**
+   * Every loaded runtime that still holds the thread, in any environment. A
+   * moved thread can keep its provider session in the environment it left,
+   * so controls that act on the live session must look past the command's
+   * own environment.
+   */
+  listThreadOwnerEntries(threadId: string): RuntimeEntry[] {
+    return [...this.entries.values()].filter((entry) =>
+      entry.runtime.hasThread(threadId),
     );
   }
 

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -290,9 +290,6 @@ export class RuntimeManager {
     string,
     Promise<HostWorkspace>
   >();
-  // The count prevents environment reaping while a start/submit crosses the
-  // provider boundary. The completion promises below additionally let a
-  // cross-environment handoff wait for that command's finally block.
   private readonly inFlightThreadCommandsByEnvironmentId = new Map<
     string,
     Map<string, number>
@@ -301,8 +298,6 @@ export class RuntimeManager {
     string,
     Map<string, Set<Promise<void>>>
   >();
-  // Serialize ownership barriers per thread so retain/release cannot observe
-  // one another halfway through a handoff; resume waits on the release.
   private readonly threadControlTails = new Map<string, Promise<void>>();
   private providerMaintenanceRuntime: AgentRuntime | null = null;
   private pendingProviderMaintenanceRuntime: PendingProviderMaintenanceRuntime | null =
@@ -350,11 +345,6 @@ export class RuntimeManager {
     return undefined;
   }
 
-  /**
-   * Lifecycle operations are serialized per thread, while provider turns can
-   * continue independently. A settled tail deliberately swallows a previous
-   * cleanup failure so one failed handoff does not strand later commands.
-   */
   private enqueueThreadControl<T>(
     threadId: string,
     work: () => T | PromiseLike<T>,
@@ -379,8 +369,6 @@ export class RuntimeManager {
    * still resident in the old environment runtime. Release that old runtime
    * before the new environment resumes the persisted provider thread, so two
    * runtime processes never own the same provider session at once.
-   * Provider lifecycle commands use the same handoff before operating on a
-   * thread, because stop/cancel/rename/archive can otherwise hit a stale owner.
    */
   async releaseThreadFromOtherEnvironments(args: {
     environmentId: string;
@@ -394,9 +382,6 @@ export class RuntimeManager {
           ? []
           : [...(commandsByThreadId.get(args.threadId) ?? [])],
       );
-      // A command may have retained the old runtime before its provider turn
-      // became observable. Wait for its release callback, not just runtime
-      // state, so stopping the stale owner cannot race start/submit.
       await Promise.all(inFlightOldCommands);
       await this.releaseThreadFromOtherEnvironmentsOnce(args);
     });
@@ -450,8 +435,6 @@ export class RuntimeManager {
         commandsByThreadId,
       );
 
-      // The reaping count keeps the entry loaded; this separate promise lets
-      // a move wait until the command's finally block has actually released it.
       let resolveCompletion!: () => void;
       const completion = new Promise<void>((resolve) => {
         resolveCompletion = resolve;
@@ -504,8 +487,6 @@ export class RuntimeManager {
             environmentId,
           );
         }
-        // Remove both guards before waking a waiting handoff; it should see
-        // the old command as fully released when it resumes.
         resolveCompletion();
       };
     });

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -294,6 +294,11 @@ export class RuntimeManager {
     string,
     Map<string, number>
   >();
+  private readonly inFlightThreadCommandCompletionsByEnvironmentId = new Map<
+    string,
+    Map<string, Set<Promise<void>>>
+  >();
+  private readonly threadControlTails = new Map<string, Promise<void>>();
   private providerMaintenanceRuntime: AgentRuntime | null = null;
   private pendingProviderMaintenanceRuntime: PendingProviderMaintenanceRuntime | null =
     null;
@@ -340,6 +345,65 @@ export class RuntimeManager {
     return undefined;
   }
 
+  private enqueueThreadControl<T>(
+    threadId: string,
+    work: () => T | PromiseLike<T>,
+  ): Promise<T> {
+    const previous = this.threadControlTails.get(threadId) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(work);
+    const settled = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.threadControlTails.set(threadId, settled);
+    void settled.then(() => {
+      if (this.threadControlTails.get(threadId) === settled) {
+        this.threadControlTails.delete(threadId);
+      }
+    });
+    return next;
+  }
+
+  /**
+   * A thread can move between environments while its provider session is
+   * still resident in the old environment runtime. Release that old runtime
+   * before the new environment resumes the persisted provider thread, so two
+   * runtime processes never own the same provider session at once.
+   */
+  async releaseThreadFromOtherEnvironments(args: {
+    environmentId: string;
+    threadId: string;
+  }): Promise<void> {
+    await this.enqueueThreadControl(args.threadId, async () => {
+      const inFlightOldCommands = [
+        ...this.inFlightThreadCommandCompletionsByEnvironmentId.entries(),
+      ].flatMap(([environmentId, commandsByThreadId]) =>
+        environmentId === args.environmentId
+          ? []
+          : [...(commandsByThreadId.get(args.threadId) ?? [])],
+      );
+      await Promise.all(inFlightOldCommands);
+      await this.releaseThreadFromOtherEnvironmentsOnce(args);
+    });
+  }
+
+  private async releaseThreadFromOtherEnvironmentsOnce(args: {
+    environmentId: string;
+    threadId: string;
+  }): Promise<void> {
+    const staleEntries = [...this.entries.values()].filter(
+      (entry) =>
+        entry.environmentId !== args.environmentId &&
+        entry.runtime.hasThread(args.threadId),
+    );
+
+    await Promise.all(
+      staleEntries.map((entry) =>
+        entry.runtime.stopThread({ threadId: args.threadId }),
+      ),
+    );
+  }
+
   markTerminalActive(environmentId: string, terminalId: string): void {
     this.entries.get(environmentId)?.terminals.add(terminalId);
   }
@@ -354,44 +418,78 @@ export class RuntimeManager {
    * accepts the command, so it cannot by itself protect that short interval
    * from a concurrent shell-environment refresh.
    */
-  retainEnvironmentForThreadCommand(
+  async retainEnvironmentForThreadCommand(
     environmentId: string,
     threadId: string,
-  ): () => void {
-    const commandsByThreadId =
-      this.inFlightThreadCommandsByEnvironmentId.get(environmentId) ??
-      new Map<string, number>();
-    commandsByThreadId.set(
-      threadId,
-      (commandsByThreadId.get(threadId) ?? 0) + 1,
-    );
-    this.inFlightThreadCommandsByEnvironmentId.set(
-      environmentId,
-      commandsByThreadId,
-    );
+  ): Promise<() => void> {
+    return this.enqueueThreadControl(threadId, () => {
+      const commandsByThreadId =
+        this.inFlightThreadCommandsByEnvironmentId.get(environmentId) ??
+        new Map<string, number>();
+      commandsByThreadId.set(
+        threadId,
+        (commandsByThreadId.get(threadId) ?? 0) + 1,
+      );
+      this.inFlightThreadCommandsByEnvironmentId.set(
+        environmentId,
+        commandsByThreadId,
+      );
 
-    let released = false;
-    return () => {
-      if (released) {
-        return;
-      }
-      released = true;
+      let resolveCompletion!: () => void;
+      const completion = new Promise<void>((resolve) => {
+        resolveCompletion = resolve;
+      });
+      const completionsByThreadId =
+        this.inFlightThreadCommandCompletionsByEnvironmentId.get(
+          environmentId,
+        ) ?? new Map<string, Set<Promise<void>>>();
+      const completions =
+        completionsByThreadId.get(threadId) ?? new Set<Promise<void>>();
+      completions.add(completion);
+      completionsByThreadId.set(threadId, completions);
+      this.inFlightThreadCommandCompletionsByEnvironmentId.set(
+        environmentId,
+        completionsByThreadId,
+      );
 
-      const activeCommands =
-        this.inFlightThreadCommandsByEnvironmentId.get(environmentId);
-      if (!activeCommands) {
-        return;
-      }
-      const count = activeCommands.get(threadId) ?? 0;
-      if (count <= 1) {
-        activeCommands.delete(threadId);
-      } else {
-        activeCommands.set(threadId, count - 1);
-      }
-      if (activeCommands.size === 0) {
-        this.inFlightThreadCommandsByEnvironmentId.delete(environmentId);
-      }
-    };
+      let released = false;
+      return () => {
+        if (released) {
+          return;
+        }
+        released = true;
+
+        const activeCommands =
+          this.inFlightThreadCommandsByEnvironmentId.get(environmentId);
+        if (activeCommands) {
+          const count = activeCommands.get(threadId) ?? 0;
+          if (count <= 1) {
+            activeCommands.delete(threadId);
+          } else {
+            activeCommands.set(threadId, count - 1);
+          }
+          if (activeCommands.size === 0) {
+            this.inFlightThreadCommandsByEnvironmentId.delete(environmentId);
+          }
+        }
+
+        const activeCompletions =
+          this.inFlightThreadCommandCompletionsByEnvironmentId.get(
+            environmentId,
+          );
+        const threadCompletions = activeCompletions?.get(threadId);
+        threadCompletions?.delete(completion);
+        if (threadCompletions?.size === 0) {
+          activeCompletions?.delete(threadId);
+        }
+        if (activeCompletions?.size === 0) {
+          this.inFlightThreadCommandCompletionsByEnvironmentId.delete(
+            environmentId,
+          );
+        }
+        resolveCompletion();
+      };
+    });
   }
 
   listActiveThreads(): HostDaemonActiveThread[] {

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -290,6 +290,9 @@ export class RuntimeManager {
     string,
     Promise<HostWorkspace>
   >();
+  // The count prevents environment reaping while a start/submit crosses the
+  // provider boundary. The completion promises below additionally let a
+  // cross-environment handoff wait for that command's finally block.
   private readonly inFlightThreadCommandsByEnvironmentId = new Map<
     string,
     Map<string, number>
@@ -298,6 +301,8 @@ export class RuntimeManager {
     string,
     Map<string, Set<Promise<void>>>
   >();
+  // Serialize ownership barriers per thread so retain/release cannot observe
+  // one another halfway through a handoff; resume waits on the release.
   private readonly threadControlTails = new Map<string, Promise<void>>();
   private providerMaintenanceRuntime: AgentRuntime | null = null;
   private pendingProviderMaintenanceRuntime: PendingProviderMaintenanceRuntime | null =
@@ -345,6 +350,11 @@ export class RuntimeManager {
     return undefined;
   }
 
+  /**
+   * Lifecycle operations are serialized per thread, while provider turns can
+   * continue independently. A settled tail deliberately swallows a previous
+   * cleanup failure so one failed handoff does not strand later commands.
+   */
   private enqueueThreadControl<T>(
     threadId: string,
     work: () => T | PromiseLike<T>,
@@ -369,6 +379,8 @@ export class RuntimeManager {
    * still resident in the old environment runtime. Release that old runtime
    * before the new environment resumes the persisted provider thread, so two
    * runtime processes never own the same provider session at once.
+   * Provider lifecycle commands use the same handoff before operating on a
+   * thread, because stop/cancel/rename/archive can otherwise hit a stale owner.
    */
   async releaseThreadFromOtherEnvironments(args: {
     environmentId: string;
@@ -382,6 +394,9 @@ export class RuntimeManager {
           ? []
           : [...(commandsByThreadId.get(args.threadId) ?? [])],
       );
+      // A command may have retained the old runtime before its provider turn
+      // became observable. Wait for its release callback, not just runtime
+      // state, so stopping the stale owner cannot race start/submit.
       await Promise.all(inFlightOldCommands);
       await this.releaseThreadFromOtherEnvironmentsOnce(args);
     });
@@ -435,6 +450,8 @@ export class RuntimeManager {
         commandsByThreadId,
       );
 
+      // The reaping count keeps the entry loaded; this separate promise lets
+      // a move wait until the command's finally block has actually released it.
       let resolveCompletion!: () => void;
       const completion = new Promise<void>((resolve) => {
         resolveCompletion = resolve;
@@ -487,6 +504,8 @@ export class RuntimeManager {
             environmentId,
           );
         }
+        // Remove both guards before waking a waiting handoff; it should see
+        // the old command as fully released when it resumes.
         resolveCompletion();
       };
     });

--- a/apps/host-daemon/test/command/command-router.test.ts
+++ b/apps/host-daemon/test/command/command-router.test.ts
@@ -386,6 +386,10 @@ describe("CommandRouter", () => {
     const originalNewResumeThread = newRuntime.resumeThread.bind(newRuntime);
     const newResumeThread = vi.fn(originalNewResumeThread);
     newRuntime.resumeThread = newResumeThread;
+    const retainEnvironment = vi.spyOn(
+      runtimeManager,
+      "retainEnvironmentForThreadCommand",
+    );
 
     const router = createRouter(harness, { runtimeManager });
     const oldTask = runRouterCommand({
@@ -414,12 +418,21 @@ describe("CommandRouter", () => {
     });
     await flushAsyncWork();
 
+    // The environment lanes are intentionally distinct after a directory
+    // switch; the thread lane must keep the new retain from entering the
+    // handoff barrier until the old command has released its ownership.
+    expect(retainEnvironment).toHaveBeenCalledTimes(1);
     expect(newResumeThread).not.toHaveBeenCalled();
     releaseOldRun.resolve();
     const [oldResponse, newResponse] = await Promise.all([oldTask, newTask]);
 
     expect(oldResponse.ok).toBe(true);
     expect(newResponse.ok).toBe(true);
+    expect(retainEnvironment).toHaveBeenNthCalledWith(
+      2,
+      "env-router-new",
+      "thread-moved",
+    );
     expect(oldStopThread).toHaveBeenCalledWith({
       threadId: "thread-moved",
     });

--- a/apps/host-daemon/test/command/command-router.test.ts
+++ b/apps/host-daemon/test/command/command-router.test.ts
@@ -17,6 +17,8 @@ import {
 import { noopEventSink } from "../../src/command-dispatch-support.js";
 import {
   createHarness,
+  createFakeRuntime,
+  createFakeWorkspace,
   unexpectedProjectAttachmentFetch,
 } from "./dispatch-helpers.js";
 import { RuntimeManager } from "../../src/runtime-manager.js";
@@ -47,8 +49,10 @@ interface RunRouterCommandArgs {
 }
 
 interface CreateTurnSubmitCommandArgs {
+  environmentId?: string;
   providerId?: string;
   providerThreadId?: string;
+  workspacePath?: string;
   text?: string;
   threadId?: string;
 }
@@ -106,9 +110,10 @@ function createRouter(
 function createTurnSubmitCommand(
   args: CreateTurnSubmitCommandArgs = {},
 ): TurnSubmitCommand {
+  const workspacePath = args.workspacePath ?? "/tmp/env-router";
   return {
     type: "turn.submit",
-    environmentId: "env-router",
+    environmentId: args.environmentId ?? "env-router",
     threadId: args.threadId ?? "thread-router",
     requestId: createClientRequestId(),
     input: [textPromptInput(args.text ?? "after destroy")],
@@ -124,7 +129,7 @@ function createTurnSubmitCommand(
     },
     resumeContext: {
       workspaceContext: {
-        workspacePath: "/tmp/env-router",
+        workspacePath,
         workspaceProvisionType: "unmanaged",
       },
       projectId: "project-router",
@@ -334,6 +339,100 @@ describe("CommandRouter", () => {
     expect(stopResponse.ok).toBe(true);
     expect(harness.runtimeState.stoppedThreadId).toBe("thread-router-start");
     expect(harness.runtime.hasThread("thread-router-start")).toBe(false);
+  });
+
+  it("waits for an old-environment turn before resuming the moved thread", async () => {
+    const harness = createHarness({ workspacePath: "/tmp/env-router" });
+    const oldHarness = createFakeRuntime();
+    const newHarness = createFakeRuntime();
+    const oldRuntime = oldHarness.runtime;
+    const newRuntime = newHarness.runtime;
+    const runtimes = [oldRuntime, newRuntime];
+    const runtimeManager = new RuntimeManager({
+      createRuntime: () => {
+        const runtime = runtimes.shift();
+        if (!runtime) {
+          throw new Error("Unexpected runtime creation");
+        }
+        return runtime;
+      },
+      provisionWorkspace: async (options) =>
+        createFakeWorkspace(
+          "path" in options ? options.path : options.targetPath,
+        ).workspace,
+    });
+    await runtimeManager.ensureEnvironment({
+      environmentId: "env-router-old",
+      workspacePath: "/tmp/env-router-old",
+    });
+    // The old environment still owns the provider session while its in-flight
+    // turn settles, which is the handoff race this barrier protects.
+    oldHarness.threadControls.setProviderSession("thread-moved", {
+      providerId: "fake",
+      providerThreadId: "provider-moved",
+    });
+
+    const oldRunEntered = createDeferred<void>();
+    const releaseOldRun = createDeferred<void>();
+    const originalOldRunTurn = oldRuntime.runTurn.bind(oldRuntime);
+    oldRuntime.runTurn = async (args) => {
+      oldRunEntered.resolve();
+      await releaseOldRun.promise;
+      return originalOldRunTurn(args);
+    };
+    const originalOldStopThread = oldRuntime.stopThread.bind(oldRuntime);
+    const oldStopThread = vi.fn(originalOldStopThread);
+    oldRuntime.stopThread = oldStopThread;
+    const originalNewResumeThread = newRuntime.resumeThread.bind(newRuntime);
+    const newResumeThread = vi.fn(originalNewResumeThread);
+    newRuntime.resumeThread = newResumeThread;
+
+    const router = createRouter(harness, { runtimeManager });
+    const oldTask = runRouterCommand({
+      command: createTurnSubmitCommand({
+        environmentId: "env-router-old",
+        providerThreadId: "provider-moved",
+        threadId: "thread-moved",
+        workspacePath: "/tmp/env-router-old",
+        text: "old turn",
+      }),
+      requestId: "old-moved-turn",
+      router,
+    });
+    await oldRunEntered.promise;
+
+    const newTask = runRouterCommand({
+      command: createTurnSubmitCommand({
+        environmentId: "env-router-new",
+        providerThreadId: "provider-moved",
+        threadId: "thread-moved",
+        workspacePath: "/tmp/env-router-new",
+        text: "new turn",
+      }),
+      requestId: "new-moved-turn",
+      router,
+    });
+    await flushAsyncWork();
+
+    expect(newResumeThread).not.toHaveBeenCalled();
+    releaseOldRun.resolve();
+    const [oldResponse, newResponse] = await Promise.all([oldTask, newTask]);
+
+    expect(oldResponse.ok).toBe(true);
+    expect(newResponse.ok).toBe(true);
+    expect(oldStopThread).toHaveBeenCalledWith({
+      threadId: "thread-moved",
+    });
+    expect(newResumeThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerThreadId: "provider-moved",
+        threadId: "thread-moved",
+      }),
+    );
+    expect(oldStopThread.mock.invocationCallOrder[0]).toBeLessThan(
+      newResumeThread.mock.invocationCallOrder[0],
+    );
+    await runtimeManager.shutdownAll();
   });
 
   it("does not route separate codex threads through one provider process lane", async () => {

--- a/apps/host-daemon/test/command/command-router.test.ts
+++ b/apps/host-daemon/test/command/command-router.test.ts
@@ -418,9 +418,6 @@ describe("CommandRouter", () => {
     });
     await flushAsyncWork();
 
-    // The environment lanes are intentionally distinct after a directory
-    // switch; the thread lane must keep the new retain from entering the
-    // handoff barrier until the old command has released its ownership.
     expect(retainEnvironment).toHaveBeenCalledTimes(1);
     expect(newResumeThread).not.toHaveBeenCalled();
     releaseOldRun.resolve();

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -588,10 +588,7 @@ export async function createThreadFromRequest(
   options: {
     /** Provider-facing input when it differs from the persisted start seed. */
     providerInput?: ThreadCreateServiceRequestInput["input"];
-    /**
-     * Exact source environment selected by a fork route; this narrowly scopes
-     * the unmanaged personal-project reuse exception.
-     */
+    /** Source environment selected by the public fork route. */
     forkSourceEnvironmentId?: string;
   } = {},
 ) {
@@ -684,10 +681,6 @@ export async function createThreadFromRequest(
       "originKind requires a sourceThreadId",
     );
   }
-  // A switched personal directory is reusable only by a fork of that source.
-  // Carry the exact environment through both fork entry points so eligibility
-  // can reject a different unmanaged environment instead of broadening the
-  // personal-project reuse rule.
   const forkSourceEnvironmentId =
     options.forkSourceEnvironmentId ??
     (originKind === "fork" &&

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -588,6 +588,8 @@ export async function createThreadFromRequest(
   options: {
     /** Provider-facing input when it differs from the persisted start seed. */
     providerInput?: ThreadCreateServiceRequestInput["input"];
+    /** Source environment selected by the public fork route. */
+    forkSourceEnvironmentId?: string;
   } = {},
 ) {
   const project = requirePublicProjectForThreadCreate(
@@ -679,6 +681,15 @@ export async function createThreadFromRequest(
       "originKind requires a sourceThreadId",
     );
   }
+  const forkSourceEnvironmentId =
+    options.forkSourceEnvironmentId ??
+    (originKind === "fork" &&
+    sourceThread !== null &&
+    sourceThread.environmentId !== null &&
+    requestInput.environment.type === "reuse" &&
+    requestInput.environment.environmentId === sourceThread.environmentId
+      ? sourceThread.environmentId
+      : undefined);
   // Provenance coherence + anti-forgery. The validated source/parent thread
   // anchors senderThreadId so a caller cannot claim a start on behalf of an
   // arbitrary or cross-project thread.
@@ -744,7 +755,13 @@ export async function createThreadFromRequest(
       requestedVisibility: requestInput.visibility,
     }),
     environment: resolveCreateThreadEnvironment({
-      parentThread: sourceThread ?? parentThread,
+      // Source-derived forks already resolve their environment before this
+      // call. Applying ordinary child defaults here would turn an isolated
+      // personal fork back into source reuse.
+      parentThread:
+        forkSourceEnvironmentId !== undefined
+          ? null
+          : (sourceThread ?? parentThread),
       projectId: requestInput.projectId,
       requestedEnvironment: requestInput.environment,
     }),
@@ -756,6 +773,7 @@ export async function createThreadFromRequest(
     }),
   };
   const resolvedEnvironment = resolveStableThreadRequestEnvironment(deps, {
+    allowUnmanagedPersonalProjectReuseEnvironmentId: forkSourceEnvironmentId,
     environment: request.environment,
     projectId: request.projectId,
   });

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -588,7 +588,10 @@ export async function createThreadFromRequest(
   options: {
     /** Provider-facing input when it differs from the persisted start seed. */
     providerInput?: ThreadCreateServiceRequestInput["input"];
-    /** Source environment selected by the public fork route. */
+    /**
+     * Exact source environment selected by a fork route; this narrowly scopes
+     * the unmanaged personal-project reuse exception.
+     */
     forkSourceEnvironmentId?: string;
   } = {},
 ) {
@@ -681,6 +684,10 @@ export async function createThreadFromRequest(
       "originKind requires a sourceThreadId",
     );
   }
+  // A switched personal directory is reusable only by a fork of that source.
+  // Carry the exact environment through both fork entry points so eligibility
+  // can reject a different unmanaged environment instead of broadening the
+  // personal-project reuse rule.
   const forkSourceEnvironmentId =
     options.forkSourceEnvironmentId ??
     (originKind === "fork" &&

--- a/apps/server/src/services/threads/thread-fork.ts
+++ b/apps/server/src/services/threads/thread-fork.ts
@@ -71,9 +71,6 @@ function resolveForkEnvironment(
   if (args.workspace === "reuse") {
     return { type: "reuse", environmentId: sourceEnvironment.id };
   }
-  // An isolated personal fork needs a new personal workspace. Reusing the
-  // source's unmanaged path here would make the fork look like a new root
-  // thread while bypassing the personal-workspace boundary.
   if (
     args.projectId === PERSONAL_PROJECT_ID ||
     sourceEnvironment.workspaceProvisionType === "personal"
@@ -149,8 +146,6 @@ export async function createThreadForkFromRequest(
       visibility: request.visibility,
     },
     {
-      // Eligibility uses this exact id to allow only source-derived reuse of
-      // a switched unmanaged personal environment.
       forkSourceEnvironmentId: sourceEnvironment.id,
       ...(isSeedOnlyIdleFork ? { providerInput: [] } : {}),
     },

--- a/apps/server/src/services/threads/thread-fork.ts
+++ b/apps/server/src/services/threads/thread-fork.ts
@@ -1,5 +1,10 @@
 import { getEnvironment, getThread } from "@bb/db";
-import type { Environment, PromptInput, Thread } from "@bb/domain";
+import {
+  PERSONAL_PROJECT_ID,
+  type Environment,
+  type PromptInput,
+  type Thread,
+} from "@bb/domain";
 import { supportsNativeFork } from "@bb/agent-providers";
 import type { EnvironmentArgs, ForkThreadRequest } from "@bb/server-contract";
 import type { LoggedPendingInteractionWorkSessionDeps } from "../../types.js";
@@ -58,12 +63,18 @@ function requireSourceEnvironment(
 
 function resolveForkEnvironment(
   sourceEnvironment: Environment,
-  workspace: ForkThreadRequest["workspace"],
+  args: {
+    projectId: string;
+    workspace: ForkThreadRequest["workspace"];
+  },
 ): EnvironmentArgs {
-  if (workspace === "reuse") {
+  if (args.workspace === "reuse") {
     return { type: "reuse", environmentId: sourceEnvironment.id };
   }
-  if (sourceEnvironment.workspaceProvisionType === "personal") {
+  if (
+    args.projectId === PERSONAL_PROJECT_ID ||
+    sourceEnvironment.workspaceProvisionType === "personal"
+  ) {
     return {
       type: "host",
       hostId: sourceEnvironment.hostId,
@@ -102,7 +113,10 @@ export async function createThreadForkFromRequest(
   return createThreadFromRequest(
     deps,
     {
-      environment: resolveForkEnvironment(sourceEnvironment, request.workspace),
+      environment: resolveForkEnvironment(sourceEnvironment, {
+        projectId: sourceThread.projectId,
+        workspace: request.workspace,
+      }),
       input,
       origin: request.origin,
       ...(request.originPluginId === undefined
@@ -131,6 +145,9 @@ export async function createThreadForkFromRequest(
       ...(request.title === undefined ? {} : { title: request.title }),
       visibility: request.visibility,
     },
-    isSeedOnlyIdleFork ? { providerInput: [] } : {},
+    {
+      forkSourceEnvironmentId: sourceEnvironment.id,
+      ...(isSeedOnlyIdleFork ? { providerInput: [] } : {}),
+    },
   );
 }

--- a/apps/server/src/services/threads/thread-fork.ts
+++ b/apps/server/src/services/threads/thread-fork.ts
@@ -71,6 +71,9 @@ function resolveForkEnvironment(
   if (args.workspace === "reuse") {
     return { type: "reuse", environmentId: sourceEnvironment.id };
   }
+  // An isolated personal fork needs a new personal workspace. Reusing the
+  // source's unmanaged path here would make the fork look like a new root
+  // thread while bypassing the personal-workspace boundary.
   if (
     args.projectId === PERSONAL_PROJECT_ID ||
     sourceEnvironment.workspaceProvisionType === "personal"
@@ -146,6 +149,8 @@ export async function createThreadForkFromRequest(
       visibility: request.visibility,
     },
     {
+      // Eligibility uses this exact id to allow only source-derived reuse of
+      // a switched unmanaged personal environment.
       forkSourceEnvironmentId: sourceEnvironment.id,
       ...(isSeedOnlyIdleFork ? { providerInput: [] } : {}),
     },

--- a/apps/server/src/services/threads/thread-request-eligibility.ts
+++ b/apps/server/src/services/threads/thread-request-eligibility.ts
@@ -28,6 +28,12 @@ type ReuseThreadRequestEnvironment = Extract<
   { type: "reuse" }
 >;
 export interface ResolveStableThreadRequestEnvironmentArgs {
+  /**
+   * A directory switch can leave a personal-project source thread attached to
+   * an unmanaged environment. Source-derived forks may reuse that exact
+   * environment, but a new root thread must still use a personal workspace.
+   */
+  allowUnmanagedPersonalProjectReuseEnvironmentId?: string;
   environment: ThreadRequestEnvironment;
   projectId: string;
 }
@@ -81,11 +87,21 @@ function assertPersonalWorkspaceProjectCompatibility(projectId: string): void {
 function assertReuseWorkspaceProjectCompatibility(
   projectId: string,
   environment: Environment,
+  allowUnmanagedPersonalProjectReuseEnvironmentId: string | undefined,
 ): void {
   const projectIsPersonal = projectId === PERSONAL_PROJECT_ID;
   const environmentIsPersonal =
     environment.workspaceProvisionType === "personal";
-  if (projectIsPersonal && !environmentIsPersonal) {
+  const environmentIsUnmanaged =
+    environment.workspaceProvisionType === "unmanaged";
+  if (
+    projectIsPersonal &&
+    !environmentIsPersonal &&
+    !(
+      environmentIsUnmanaged &&
+      allowUnmanagedPersonalProjectReuseEnvironmentId === environment.id
+    )
+  ) {
     throw new ApiError(
       409,
       "invalid_request",
@@ -110,8 +126,7 @@ function resolveHostThreadRequestEnvironment(
   | ResolvedPersonalThreadRequestEnvironment {
   if (environment.workspace.type === "personal") {
     assertPersonalWorkspaceProjectCompatibility(projectId);
-    const hostId =
-      environment.hostId ?? requireConnectedPrimaryHostId(deps);
+    const hostId = environment.hostId ?? requireConnectedPrimaryHostId(deps);
     assertUsableHostId(deps, { hostId });
     return {
       hostId,
@@ -158,6 +173,7 @@ function resolveReuseThreadRequestEnvironment(
   deps: ThreadRequestEnvironmentDeps,
   environment: ReuseThreadRequestEnvironment,
   projectId: string,
+  allowUnmanagedPersonalProjectReuseEnvironmentId: string | undefined,
 ): ResolvedReuseThreadRequestEnvironment {
   const reusedEnvironment = requireEnvironment(
     deps.db,
@@ -170,7 +186,11 @@ function resolveReuseThreadRequestEnvironment(
       "Environment belongs to a different project",
     );
   }
-  assertReuseWorkspaceProjectCompatibility(projectId, reusedEnvironment);
+  assertReuseWorkspaceProjectCompatibility(
+    projectId,
+    reusedEnvironment,
+    allowUnmanagedPersonalProjectReuseEnvironmentId,
+  );
   assertUsableHostId(deps, { hostId: reusedEnvironment.hostId });
   return {
     environment: reusedEnvironment,
@@ -194,6 +214,7 @@ export function resolveStableThreadRequestEnvironment(
         deps,
         args.environment,
         args.projectId,
+        args.allowUnmanagedPersonalProjectReuseEnvironmentId,
       );
     default: {
       const exhaustiveCheck: never = args.environment;

--- a/apps/server/src/services/threads/thread-request-eligibility.ts
+++ b/apps/server/src/services/threads/thread-request-eligibility.ts
@@ -94,9 +94,6 @@ function assertReuseWorkspaceProjectCompatibility(
     environment.workspaceProvisionType === "personal";
   const environmentIsUnmanaged =
     environment.workspaceProvisionType === "unmanaged";
-  // The exception is intentionally identity-scoped: a personal fork may
-  // follow its source across a directory switch, but must not gain arbitrary
-  // access to another unmanaged personal environment.
   if (
     projectIsPersonal &&
     !environmentIsPersonal &&

--- a/apps/server/src/services/threads/thread-request-eligibility.ts
+++ b/apps/server/src/services/threads/thread-request-eligibility.ts
@@ -94,6 +94,9 @@ function assertReuseWorkspaceProjectCompatibility(
     environment.workspaceProvisionType === "personal";
   const environmentIsUnmanaged =
     environment.workspaceProvisionType === "unmanaged";
+  // The exception is intentionally identity-scoped: a personal fork may
+  // follow its source across a directory switch, but must not gain arbitrary
+  // access to another unmanaged personal environment.
   if (
     projectIsPersonal &&
     !environmentIsPersonal &&

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -1,8 +1,11 @@
-import { getThread, listEvents } from "@bb/db";
-import { turnRequestEventDataSchema } from "@bb/domain";
+import { ensurePersonalProject, getThread, listEvents } from "@bb/db";
+import { PERSONAL_PROJECT_ID, turnRequestEventDataSchema } from "@bb/domain";
 import { threadResponseSchema } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
-import { waitForQueuedCommand } from "../helpers/commands.js";
+import {
+  reportQueuedCommandSuccess,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
   seedEnvironment,
@@ -60,6 +63,35 @@ function seedForkSource(
   return { environment, host, project, sourceThread };
 }
 
+function seedPersonalDirectoryForkSource(harness: TestAppHarness) {
+  const { host } = seedHostSession(harness.deps);
+  ensurePersonalProject(harness.db);
+  const environment = seedEnvironment(harness.deps, {
+    hostId: host.id,
+    path: "/tmp/personal-switched-directory",
+    projectId: PERSONAL_PROJECT_ID,
+    workspaceProvisionType: "unmanaged",
+  });
+  const sourceThread = seedThread(harness.deps, {
+    environmentId: environment.id,
+    projectId: PERSONAL_PROJECT_ID,
+  });
+  seedThreadRuntimeState(harness.deps, {
+    environmentId: environment.id,
+    permissionMode: "full",
+    providerThreadId: "provider-personal-directory-source",
+    threadId: sourceThread.id,
+  });
+  seedTurnStarted(harness.deps, {
+    environmentId: environment.id,
+    providerThreadId: "provider-personal-directory-source",
+    sequence: 3,
+    threadId: sourceThread.id,
+    turnId: "turn-personal-directory-source",
+  });
+  return { environment, sourceThread };
+}
+
 async function postFork(
   harness: TestAppHarness,
   body: Record<string, unknown>,
@@ -72,6 +104,88 @@ async function postFork(
 }
 
 describe("public thread fork route", () => {
+  it("reuses a switched directory from a personal-project source", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, sourceThread } =
+        seedPersonalDirectoryForkSource(harness);
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      expect(getThread(harness.db, fork.id)?.environmentId).toBe(
+        environment.id,
+      );
+      const queued = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.start" && command.threadId === fork.id,
+      );
+      if (queued.command.type !== "thread.start") {
+        throw new Error("Expected thread.start");
+      }
+      expect(queued.command.fork).toEqual({
+        sourceProviderThreadId: "provider-personal-directory-source",
+      });
+    });
+  });
+
+  it("uses a personal workspace for an isolated fork after a directory switch", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, sourceThread } =
+        seedPersonalDirectoryForkSource(harness);
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        workspace: "isolated",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      expect(getThread(harness.db, fork.id)?.environmentId).not.toBe(
+        environment.id,
+      );
+      const personalEnvironment = getThread(harness.db, fork.id)?.environmentId;
+      expect(personalEnvironment).not.toBeNull();
+      const queued = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "environment.provision" &&
+          command.environmentId === personalEnvironment,
+      );
+      if (queued.command.type !== "environment.provision") {
+        throw new Error("Expected personal environment.provision");
+      }
+      expect(queued.command.workspaceProvisionType).toBe("personal");
+      if (queued.command.workspaceProvisionType !== "personal") {
+        throw new Error("Expected personal environment.provision");
+      }
+      await reportQueuedCommandSuccess(harness, queued, {
+        path: queued.command.targetPath,
+        branchName: "main",
+        defaultBranch: "main",
+        isGitRepo: false,
+        isWorktree: false,
+        transcript: [],
+      });
+
+      const start = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.start" && command.threadId === fork.id,
+      );
+      if (start.command.type !== "thread.start") {
+        throw new Error("Expected thread.start");
+      }
+      expect(start.command.fork).toEqual({
+        sourceProviderThreadId: "provider-personal-directory-source",
+      });
+    });
+  });
+
   it("creates an idle fork at the source tip with no first run", async () => {
     await withTestHarness(async (harness) => {
       const { sourceThread } = seedForkSource(harness);

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -66,8 +66,6 @@ function seedForkSource(
 function seedPersonalDirectoryForkSource(harness: TestAppHarness) {
   const { host } = seedHostSession(harness.deps);
   ensurePersonalProject(harness.db);
-  // This is the persisted state after update_environment_directory: the
-  // personal thread follows an unmanaged path rather than a personal workspace.
   const environment = seedEnvironment(harness.deps, {
     hostId: host.id,
     path: "/tmp/personal-switched-directory",
@@ -165,8 +163,6 @@ describe("public thread fork route", () => {
       if (queued.command.workspaceProvisionType !== "personal") {
         throw new Error("Expected personal environment.provision");
       }
-      // Complete provisioning so the test can inspect the subsequent
-      // thread.start handoff rather than stopping at the queued command.
       await reportQueuedCommandSuccess(harness, queued, {
         path: queued.command.targetPath,
         branchName: "main",

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -66,6 +66,8 @@ function seedForkSource(
 function seedPersonalDirectoryForkSource(harness: TestAppHarness) {
   const { host } = seedHostSession(harness.deps);
   ensurePersonalProject(harness.db);
+  // This is the persisted state after update_environment_directory: the
+  // personal thread follows an unmanaged path rather than a personal workspace.
   const environment = seedEnvironment(harness.deps, {
     hostId: host.id,
     path: "/tmp/personal-switched-directory",
@@ -163,6 +165,8 @@ describe("public thread fork route", () => {
       if (queued.command.workspaceProvisionType !== "personal") {
         throw new Error("Expected personal environment.provision");
       }
+      // Complete provisioning so the test can inspect the subsequent
+      // thread.start handoff rather than stopping at the queued command.
       await reportQueuedCommandSuccess(harness, queued, {
         path: queued.command.targetPath,
         branchName: "main",

--- a/apps/server/test/threads/thread-create-seed-without-run.test.ts
+++ b/apps/server/test/threads/thread-create-seed-without-run.test.ts
@@ -862,6 +862,8 @@ describe("thread creation child-thread boundary validation", () => {
         id: "host-personal-fork-source-environment",
       });
       ensurePersonalProject(harness.db);
+      // Model the environment left behind when a personal thread changes its
+      // working directory; this is the only unmanaged reuse exception.
       const sourceEnvironment = seedEnvironment(harness.deps, {
         hostId: host.id,
         path: "/tmp/personal-fork-source",

--- a/apps/server/test/threads/thread-create-seed-without-run.test.ts
+++ b/apps/server/test/threads/thread-create-seed-without-run.test.ts
@@ -856,6 +856,112 @@ describe("thread creation child-thread boundary validation", () => {
     });
   });
 
+  it("allows a personal fork to reuse its switched source environment", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-personal-fork-source-environment",
+      });
+      ensurePersonalProject(harness.db);
+      const sourceEnvironment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/personal-fork-source",
+        projectId: PERSONAL_PROJECT_ID,
+        workspaceProvisionType: "unmanaged",
+      });
+      const sourceThread = seedThread(harness.deps, {
+        environmentId: sourceEnvironment.id,
+        projectId: PERSONAL_PROJECT_ID,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: sourceEnvironment.id,
+        providerThreadId: "provider-personal-fork-source",
+        threadId: sourceThread.id,
+        turnId: "turn-personal-fork-source",
+      });
+
+      const fork = await createThreadFromRequest(harness.deps, {
+        environment: {
+          type: "reuse",
+          environmentId: sourceEnvironment.id,
+        },
+        input: textInput("Reuse the switched source environment"),
+        origin: "app",
+        originKind: "fork",
+        projectId: PERSONAL_PROJECT_ID,
+        providerId: "codex",
+        sourceThreadId: sourceThread.id,
+        startedOnBehalfOf: null,
+      });
+
+      expect(getThread(harness.db, fork.id)?.environmentId).toBe(
+        sourceEnvironment.id,
+      );
+      const queued = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.start" && command.threadId === fork.id,
+      );
+      if (queued.command.type !== "thread.start") {
+        throw new Error("Expected a thread.start command");
+      }
+      expect(queued.command.fork).toEqual({
+        sourceProviderThreadId: "provider-personal-fork-source",
+      });
+    });
+  });
+
+  it("rejects a personal fork that reuses a different unmanaged environment", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-personal-fork-different-environment",
+      });
+      ensurePersonalProject(harness.db);
+      const sourceEnvironment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/personal-fork-source",
+        projectId: PERSONAL_PROJECT_ID,
+        workspaceProvisionType: "unmanaged",
+      });
+      const otherEnvironment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/personal-fork-other",
+        projectId: PERSONAL_PROJECT_ID,
+        workspaceProvisionType: "unmanaged",
+      });
+      const sourceThread = seedThread(harness.deps, {
+        environmentId: sourceEnvironment.id,
+        projectId: PERSONAL_PROJECT_ID,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: sourceEnvironment.id,
+        providerThreadId: "provider-personal-fork-source",
+        threadId: sourceThread.id,
+        turnId: "turn-personal-fork-source",
+      });
+
+      await expect(
+        createThreadFromRequest(harness.deps, {
+          environment: {
+            type: "reuse",
+            environmentId: otherEnvironment.id,
+          },
+          input: textInput("Reuse only the source environment"),
+          origin: "app",
+          originKind: "fork",
+          projectId: PERSONAL_PROJECT_ID,
+          providerId: "codex",
+          sourceThreadId: sourceThread.id,
+          startedOnBehalfOf: null,
+        }),
+      ).rejects.toMatchObject({
+        body: {
+          message: "Personal project threads must reuse a personal workspace",
+        },
+        status: 409,
+      });
+    });
+  });
+
   it("auto-sends a queued first side-chat message after preload settles idle", async () => {
     await withChildBoundaryHarness(
       "empty-side-chat-preload-queued-message",

--- a/apps/server/test/threads/thread-create-seed-without-run.test.ts
+++ b/apps/server/test/threads/thread-create-seed-without-run.test.ts
@@ -862,8 +862,6 @@ describe("thread creation child-thread boundary validation", () => {
         id: "host-personal-fork-source-environment",
       });
       ensurePersonalProject(harness.db);
-      // Model the environment left behind when a personal thread changes its
-      // working directory; this is the only unmanaged reuse exception.
       const sourceEnvironment = seedEnvironment(harness.deps, {
         hostId: host.id,
         path: "/tmp/personal-fork-source",

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -313,8 +313,6 @@ describe("idle cold-start activation", () => {
         path: "/tmp/send-dispatch-switched",
         status: "ready",
       });
-      // Use the real directory-update handler so the regression covers the
-      // event and environment transition, not just a manually moved thread.
       seedTurnStarted(harness.deps, {
         environmentId: environment.id,
         providerThreadId: "provider-send-dispatch-4",

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -4,17 +4,12 @@ import {
   getThread,
   listQueuedThreadMessages,
   markThreadDeleted,
-  updateThread,
 } from "@bb/db";
-import {
-  threadScope,
-  turnScope,
-  type Environment,
-  type Thread,
-} from "@bb/domain";
+import { turnScope, type Environment, type Thread } from "@bb/domain";
 import { describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
+import { handleUpdateEnvironmentDirectoryToolCall } from "../../src/services/threads/thread-environment-directory.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
   listQueuedThreadCommands,
@@ -29,6 +24,7 @@ import {
   seedStoredEvent,
   seedThread,
   seedThreadRuntimeState,
+  seedTurnStarted,
 } from "../helpers/seed.js";
 import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 
@@ -305,7 +301,7 @@ describe("idle cold-start activation", () => {
     });
   });
 
-  it("cold-starts after an environment directory update resets provider continuity", async () => {
+  it("resumes provider continuity after an environment directory update", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedIdleProviderThreadFixture({
         harness,
@@ -317,33 +313,31 @@ describe("idle cold-start activation", () => {
         path: "/tmp/send-dispatch-switched",
         status: "ready",
       });
-      updateThread(harness.db, harness.hub, thread.id, {
-        environmentId: targetEnvironment.id,
-      });
-      seedStoredEvent(harness.deps, {
-        threadId: thread.id,
-        environmentId: targetEnvironment.id,
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-4",
         sequence: 3,
-        type: "system/operation",
-        scope: threadScope(),
-        data: {
-          operation: "environment_directory_update",
-          operationId: "evt_send_dispatch_switch",
-          status: "completed",
-          message: "Updated environment directory",
-          metadata: {
-            nextEnvironmentId: targetEnvironment.id,
-            nextPath: targetEnvironment.path,
-            previousEnvironmentId: environment.id,
-            previousPath: environment.path,
-          },
+        threadId: thread.id,
+        turnId: "turn_before_switch",
+      });
+      const updateResult = await handleUpdateEnvironmentDirectoryToolCall(
+        harness.deps,
+        {
+          currentEnvironment: environment,
+          input: { path: targetEnvironment.path },
+          thread,
+          turnId: "turn_before_switch",
         },
+      );
+      expect(updateResult).toMatchObject({ success: true });
+      expect(getThread(harness.db, thread.id)).toMatchObject({
+        environmentId: targetEnvironment.id,
       });
       seedStoredEvent(harness.deps, {
         threadId: thread.id,
         environmentId: targetEnvironment.id,
         providerThreadId: `provider-send-dispatch-4`,
-        sequence: 4,
+        sequence: 5,
         type: "turn/completed",
         scope: turnScope("turn_after_switch"),
         data: {
@@ -373,14 +367,27 @@ describe("idle cold-start activation", () => {
       await waitForQueuedCommand(
         harness,
         (queued) =>
-          queued.command.type === "thread.start" &&
+          queued.command.type === "turn.submit" &&
           queued.command.threadId === thread.id,
       );
+      const turnSubmitCommands = listQueuedThreadCommands(
+        harness,
+        "turn.submit",
+        thread.id,
+      );
+      expect(turnSubmitCommands).toHaveLength(1);
+      expect(turnSubmitCommands[0]).toMatchObject({
+        type: "turn.submit",
+        environmentId: targetEnvironment.id,
+        resumeContext: {
+          providerThreadId: "provider-send-dispatch-4",
+          workspaceContext: {
+            workspacePath: targetEnvironment.path,
+          },
+        },
+      });
       expect(
         listQueuedThreadCommands(harness, "thread.start", thread.id),
-      ).toHaveLength(1);
-      expect(
-        listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toHaveLength(0);
     });
   });

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -313,6 +313,8 @@ describe("idle cold-start activation", () => {
         path: "/tmp/send-dispatch-switched",
         status: "ready",
       });
+      // Use the real directory-update handler so the regression covers the
+      // event and environment transition, not just a manually moved thread.
       seedTurnStarted(harness.deps, {
         environmentId: environment.id,
         providerThreadId: "provider-send-dispatch-4",

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -2820,8 +2820,6 @@ export function getLastStoredProviderThreadId(
   db: DbQueryConnection,
   threadId: string,
 ): string | null {
-  // Directory switches are system operations, not provider identity changes;
-  // intentionally do not gate this on a newer thread/identity event.
   const latestProviderRow = db
     .select({ providerThreadId: events.providerThreadId })
     .from(events)

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -2820,6 +2820,8 @@ export function getLastStoredProviderThreadId(
   db: DbQueryConnection,
   threadId: string,
 ): string | null {
+  // Directory switches are system operations, not provider identity changes;
+  // intentionally do not gate this on a newer thread/identity event.
   const latestProviderRow = db
     .select({ providerThreadId: events.providerThreadId })
     .from(events)

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -97,7 +97,6 @@ const isNotNestedTurnUsageEvent = sql`NOT EXISTS (
     AND nested_turn_started.type = 'turn/started'
     AND COALESCE(json_extract(nested_turn_started.data, '$.parentToolCallId'), '') <> ''
 )`;
-const isEnvironmentDirectoryUpdateEventData = sql`json_extract(${events.data}, '$.operation') = 'environment_directory_update'`;
 
 export interface InsertEventInput {
   threadId: string;
@@ -2835,41 +2834,10 @@ export function getLastStoredProviderThreadId(
     return null;
   }
 
-  const latestIdentityRow = db
-    .select({ sequence: events.sequence })
-    .from(events)
-    .where(
-      and(
-        eq(events.threadId, threadId),
-        eq(events.type, "thread/identity"),
-        isNotNull(events.providerThreadId),
-      ),
-    )
-    .orderBy(desc(events.sequence))
-    .limit(1)
-    .get();
-  const latestEnvironmentDirectoryUpdateRow = db
-    .select({ sequence: events.sequence })
-    .from(events)
-    .where(
-      and(
-        eq(events.threadId, threadId),
-        eq(events.type, "system/operation"),
-        isEnvironmentDirectoryUpdateEventData,
-      ),
-    )
-    .orderBy(desc(events.sequence))
-    .limit(1)
-    .get();
-
-  if (
-    latestEnvironmentDirectoryUpdateRow &&
-    (!latestIdentityRow ||
-      latestIdentityRow.sequence < latestEnvironmentDirectoryUpdateRow.sequence)
-  ) {
-    return null;
-  }
-
+  // A directory switch changes the runtime cwd, not the provider thread's
+  // conversation identity. The host daemon releases the old runtime owner
+  // before the next turn is dispatched through `thread/resume` with the new
+  // workspace path, so keep the last provider id available across the switch.
   return latestProviderRow.providerThreadId;
 }
 

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1668,8 +1668,6 @@ describe("events", () => {
         },
       },
     });
-    // The directory update itself must not invalidate the provider session;
-    // this is the exact boundary that previously caused the transcript reset.
     expect(getLastStoredProviderThreadId(db, thread.id)).toBe("provider_old");
     appendStoredThreadEvent(db, noopNotifier, {
       threadId: thread.id,

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1668,6 +1668,9 @@ describe("events", () => {
         },
       },
     });
+    // The directory update itself must not invalidate the provider session;
+    // this is the exact boundary that previously caused the transcript reset.
+    expect(getLastStoredProviderThreadId(db, thread.id)).toBe("provider_old");
     appendStoredThreadEvent(db, noopNotifier, {
       threadId: thread.id,
       scope: turnScope("turn_1"),

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1637,7 +1637,7 @@ describe("events", () => {
     expect(getActiveStoredTurnId(db, thread.id)).toBeNull();
   });
 
-  it("resets the latest provider thread id after an environment directory update", () => {
+  it("preserves the latest provider thread id after an environment directory update", () => {
     const { db, thread } = setup();
 
     appendStoredThreadEvent(db, noopNotifier, {
@@ -1678,7 +1678,7 @@ describe("events", () => {
         status: "completed",
       },
     });
-    expect(getLastStoredProviderThreadId(db, thread.id)).toBeNull();
+    expect(getLastStoredProviderThreadId(db, thread.id)).toBe("provider_old");
 
     appendStoredThreadEvent(db, noopNotifier, {
       threadId: thread.id,

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -35,7 +35,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 86 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 87 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,10 +1039,13 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 86 protects the Pi bridge JSON-RPC channel from stdout writes by
-  // user extensions, restoring terminal turn events for affected sessions.
-  it("uses protocol version 86 for guarded Pi bridge output", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(86);
+  // Version 87 keeps the provider thread id across an environment directory
+  // switch. The server now sends `turn.submit` with that id where it sent
+  // `thread.start` before, and the daemon must release the old runtime owner
+  // first. A daemon without that release would own the same provider session
+  // twice, so an older daemon must update instead of connecting.
+  it("uses protocol version 87 for moved-thread session handoff", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(87);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
I hit this when the agent switched from my personal working directory to another directory with `update_environment_directory`.

The switch worked, but the session did not migrate with it. The transcript was still there; the next message started a new provider session.

The same state also broke forks: side chats returned HTTP 409, and Fork into new thread returned the same personal-workspace error.

## Repro

1. Start a thread in a personal workspace.
2. Switch it to another directory with `update_environment_directory`.
3. Ask a follow-up question.
4. Try Reply in side chat or Fork into new thread.
5. Before this change, the transcript context was lost and both fork actions failed.

## Fix

- Keep the provider thread ID when the environment changes.
- Release the old runtime before resuming in the new environment.
- Serialize starts and submits per thread across environment lanes so a move cannot deadlock the handoff.
- Let a source-derived fork reuse only its exact switched unmanaged environment.
- Give isolated forks from personal projects a personal workspace.
- Keep the existing project and host boundary checks.

## Verification

I ran the flow in the desktop app against both builds. The pre-fix build lost the transcript context and showed the 409 on both fork actions. The fixed build preserved the original opening message, the side chat replied `SIDE_CHAT_OK`, and the forked thread replied `FORK_OK`.

59 focused host-daemon tests, 37 focused server tests, and 76 DB event tests pass. The affected packages typecheck and build; formatting and diff checks pass. The PR contains no screenshot artifacts.