### PR TITLE
Fix flaky git-source plugin install test timeout on CI

### DIFF
--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -279,7 +279,9 @@ describe("plugin install flows", () => {
     await rm(workDir, { recursive: true, force: true });
   });
 
-  describe.skipIf(!hasGit)("git sources", () => {
+  // Each test clones a repo and runs a full install (git subprocesses +
+  // esbuild build + plugin load); the 5s default flakes on loaded CI runners.
+  describe.skipIf(!hasGit)("git sources", { timeout: 30_000 }, () => {
     it("clones a pinned tag into its exact immutable cache dir and loads it", async () => {
       const repoDir = join(workDir, "repo");
       await writePluginFixture(repoDir, { name: "bb-plugin-gitty" });


### PR DESCRIPTION
## Why

Main CI failed on run [31284464089](https://github.com/get-bb/bb/actions/runs/31284464089). The test `plugin-install.test.ts > git sources > clones a pinned tag into its exact immutable cache dir and loads it` timed out at the 5s default.

Each test in the `git sources` block clones a repo and runs a full install. The install runs git subprocesses, an esbuild build, and a plugin load. The first test in the block also pays the warm-up cost. On a loaded CI runner, this work can take more than 5 seconds.

## Change

Raise the timeout for the `git sources` describe block to 30 seconds. The `npm sources` test in the same file already uses this pattern with a per-test timeout.

## Test

All 29 tests in the file pass locally in 8 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)