### PR TITLE
Fix mobile remote session lag caused by hidden thread outline refreshes

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -76,11 +76,13 @@ function userConversationRow(index = 1): TimelineRow {
 
 function TocHost({
   hasOlderTimelineRows = false,
+  hostWidth = 1_200,
   loadOlderTimelineRows = () => {},
   threadId = "thr_toc_test",
   timelineRows,
 }: {
   hasOlderTimelineRows?: boolean;
+  hostWidth?: number;
   loadOlderTimelineRows?: () => void | Promise<void>;
   threadId?: string;
   timelineRows: readonly TimelineRow[];
@@ -91,7 +93,7 @@ function TocHost({
         if (!node) return;
         Object.defineProperty(node, "clientWidth", {
           configurable: true,
-          value: 1_200,
+          value: hostWidth,
         });
       }}
       data-scroll-overlay=""
@@ -365,6 +367,15 @@ describe("ThreadTableOfContents", () => {
     expect(useThreadConversationOutline).toHaveBeenLastCalledWith(
       "thr_toc_test",
       { enabled: true },
+    );
+  });
+
+  it("does not request the hidden outline in a compact thread pane", () => {
+    render(<TocHost hostWidth={400} timelineRows={[userConversationRow(1)]} />);
+
+    expect(useThreadConversationOutline).toHaveBeenLastCalledWith(
+      "thr_toc_test",
+      { enabled: false },
     );
   });
 

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -76,12 +76,15 @@ function userConversationRow(index = 1): TimelineRow {
 
 function TocHost({
   hasOlderTimelineRows = false,
+  hostPaddingX = 0,
   hostWidth = 1_200,
   loadOlderTimelineRows = () => {},
   threadId = "thr_toc_test",
   timelineRows,
 }: {
   hasOlderTimelineRows?: boolean;
+  /** Horizontal padding on each side, as the real scroll overlay has. */
+  hostPaddingX?: number;
   hostWidth?: number;
   loadOlderTimelineRows?: () => void | Promise<void>;
   threadId?: string;
@@ -97,6 +100,10 @@ function TocHost({
         });
       }}
       data-scroll-overlay=""
+      style={{
+        paddingLeft: `${hostPaddingX}px`,
+        paddingRight: `${hostPaddingX}px`,
+      }}
     >
       <ThreadTableOfContents
         threadId={threadId}
@@ -376,6 +383,38 @@ describe("ThreadTableOfContents", () => {
     expect(useThreadConversationOutline).toHaveBeenLastCalledWith(
       "thr_toc_test",
       { enabled: false },
+    );
+  });
+
+  // The overlay pads itself, so `clientWidth` runs 24px ahead of the content
+  // box the `@container` rule measures. Both boundaries must agree with CSS.
+  it("does not request the outline when padding hides the TOC", () => {
+    render(
+      <TocHost
+        hostPaddingX={12}
+        hostWidth={900}
+        timelineRows={[userConversationRow(1)]}
+      />,
+    );
+
+    expect(useThreadConversationOutline).toHaveBeenLastCalledWith(
+      "thr_toc_test",
+      { enabled: false },
+    );
+  });
+
+  it("requests the outline once the padded content box reaches the breakpoint", () => {
+    render(
+      <TocHost
+        hostPaddingX={12}
+        hostWidth={920}
+        timelineRows={[userConversationRow(1)]}
+      />,
+    );
+
+    expect(useThreadConversationOutline).toHaveBeenLastCalledWith(
+      "thr_toc_test",
+      { enabled: true },
     );
   });
 

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -272,7 +272,7 @@ function useConversationTocItems({
   return outlineTocItems ?? timelineTocItems;
 }
 
-function useThreadTocVisible(rootElement: HTMLDivElement | null): boolean {
+function useThreadTocVisible(rootElement: HTMLElement | null): boolean {
   const [visible, setVisible] = useState(
     () => typeof ResizeObserver === "undefined",
   );
@@ -493,20 +493,19 @@ export function ThreadTableOfContents({
   loadOlderTimelineRows,
 }: ThreadTableOfContentsProps) {
   const bottomAnchor = useBottomAnchoredScroll();
-  // The outline is secondary to the latest timeline. Waiting for that first
-  // window prevents a long outline projection from occupying the synchronous
-  // server before the conversation can paint. Do not gate on `tocVisible`: the
-  // minimum-message early return can unmount the root before it is measured.
+  const [rootElement, setRootElement] = useState<HTMLElement | null>(null);
+  const tocVisible = useThreadTocVisible(rootElement);
+  // The full-thread outline exists only for the wide-layout TOC. Waiting for
+  // both its visible container and the first timeline window keeps compact
+  // clients from rebuilding an invisible outline on every appended-event batch.
   const outlineQuery = useThreadConversationOutline(threadId, {
-    enabled: timelineRows.length > 0,
+    enabled: tocVisible && timelineRows.length > 0,
   });
   const senderThreadMetadataById = useSenderThreadMetadataById();
   const { agentItems, userItems } = useConversationTocItems({
     outlineItems: outlineQuery.data?.items,
     timelineRows,
   });
-  const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
-  const tocVisible = useThreadTocVisible(rootElement);
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<TocTab>("user");
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
@@ -677,7 +676,9 @@ export function ThreadTableOfContents({
     [bottomAnchor],
   );
 
-  if (userItems.length < TOC_MIN_USER_MESSAGES) return null;
+  if (userItems.length < TOC_MIN_USER_MESSAGES) {
+    return <span ref={setRootElement} aria-hidden className="hidden" />;
+  }
 
   return (
     <div

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -40,6 +40,7 @@ interface ThreadTableOfContentsProps {
   loadOlderTimelineRows: () => void | Promise<void>;
 }
 
+// Matches `@container scroll-overlay (min-width: 56rem)` in app.css.
 const TOC_MIN_VISIBLE_WIDTH_PX = 56 * 16;
 const TOC_BOTTOM_ACTIVE_THRESHOLD_PX = 4;
 // Only worth showing once the conversation has enough user turns to navigate.
@@ -272,6 +273,21 @@ function useConversationTocItems({
   return outlineTocItems ?? timelineTocItems;
 }
 
+/**
+ * Returns the width a container query sees for `host`.
+ *
+ * An inline-size container query resolves against the content box, but
+ * `clientWidth` also counts horizontal padding. The scroll overlay pads itself,
+ * so the raw `clientWidth` would report the TOC as visible for a padding-wide
+ * band below the CSS breakpoint.
+ */
+function containerInlineSize(host: HTMLElement): number {
+  const style = window.getComputedStyle(host);
+  const paddingLeft = Number.parseFloat(style.paddingLeft) || 0;
+  const paddingRight = Number.parseFloat(style.paddingRight) || 0;
+  return host.clientWidth - paddingLeft - paddingRight;
+}
+
 function useThreadTocVisible(rootElement: HTMLElement | null): boolean {
   const [visible, setVisible] = useState(
     () => typeof ResizeObserver === "undefined",
@@ -292,7 +308,7 @@ function useThreadTocVisible(rootElement: HTMLElement | null): boolean {
     let frame: number | null = null;
     const measure = () => {
       frame = null;
-      setVisible(host.clientWidth >= TOC_MIN_VISIBLE_WIDTH_PX);
+      setVisible(containerInlineSize(host) >= TOC_MIN_VISIBLE_WIDTH_PX);
     };
     const scheduleMeasure = () => {
       if (frame !== null) return;


### PR DESCRIPTION
## Summary

- Only request the full-history conversation outline when the thread TOC is visible.
- Stop compact thread panes from refetching a hidden outline after every appended-event batch.
- Preserve delayed TOC visibility measurement and add compact-pane regression coverage.

## Root cause

The thread TOC is hidden below its 56rem container breakpoint, but its outline query was enabled whenever timeline rows existed. Because realtime `events-appended` notifications invalidate that query, mobile clients repeatedly fetched and rebuilt the full conversation outline even though they could not display it. Remote browser sessions paid both the server projection cost and tunnel latency for every request.

## Performance

I ran a controlled A/B test through the same phone and bb Connect tunnel using two fresh threads per variant. Every run used Claude Code's default model and the same prompt: 20 sequential tool calls followed by a fixed-length response. Both variants stored 110 events across the two runs.

| Metric | Upstream `main` | Patched | Change |
| --- | ---: | ---: | ---: |
| Stored events | 110 | 110 | Equal workload |
| Conversation-outline requests | 208 | 0 | **-100%** |
| Compressed outline traffic | 79,712 bytes | 0 | **-100%** |
| Aggregate outline request time | 3,073.7 ms | 0 | **-100%** |
| Outline request p95 | 24.2 ms | n/a | Eliminated |
| Normal timeline requests | 3 | 3 | Unchanged |

The individual upstream runs made 108 and 100 outline requests; both patched runs made zero. Run duration remained effectively equal because model generation dominates wall time.

During the original remote-session diagnosis, a 39.1-hour traffic capture contained 1,184 outline requests, 4.61 MB of compressed responses, and 62.26 seconds of aggregate origin request time, with a 198.9 ms p95. This change eliminates that request path whenever the TOC is hidden by the compact-pane breakpoint.

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force` — 324 files and 2,447 tests passed
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/thread/toc/ThreadTableOfContents.test.tsx` — 20 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors
- `pnpm exec turbo run build --filter=@bb/app`
- `git diff --check`

The new regression fails against the previous enablement condition (`enabled: true` at 400px) and passes with this change (`enabled: false`).
