### PR TITLE
Defer instruction-only thread reconfigure while background tasks are open

### DIFF
--- a/packages/agent-runtime/src/runtime-background-work-state.ts
+++ b/packages/agent-runtime/src/runtime-background-work-state.ts
@@ -27,6 +27,10 @@ export class RuntimeBackgroundWorkState {
     return this.openTaskIdsByThreadId.size > 0;
   }
 
+  hasOpenWorkForThread(threadId: string): boolean {
+    return this.openTaskIdsByThreadId.has(threadId);
+  }
+
   observe(event: ThreadEvent): void {
     if (event.type === "item/started") {
       if (event.item.type === "backgroundTask") {

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -2,6 +2,7 @@ import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { threadScope } from "@bb/domain";
 import type { ThreadEvent } from "@bb/domain";
 import type {
   AdapterCommand,
@@ -495,6 +496,115 @@ rl.on("line", (line) => {
         BB_ENVIRONMENT_ID: "env-1",
       });
       expect(reconfigureCommand.cwd).toBe(tmpDir);
+
+      await runtime.shutdown();
+    });
+
+    it("defers an instruction-only reconfigure while background tasks are open", async () => {
+      const recordedCommands: AdapterCommand[] = [];
+      const pendingEvents: ThreadEvent[] = [];
+      const runtime = createAgentRuntimeWithAdapters({
+        workspacePath: tmpDir,
+        onEvent: () => undefined,
+        onToolCall: async () => ({
+          contentItems: [{ type: "inputText", text: "ok" }],
+          success: true,
+        }),
+        adapterFactory: () => {
+          const adapter = createRecordingAdapter({ recordedCommands, scriptPath });
+          return {
+            ...adapter,
+            translateAcceptedCommand(commandArgs) {
+              return [
+                ...adapter.translateAcceptedCommand(commandArgs),
+                ...pendingEvents.splice(0),
+              ];
+            },
+          };
+        },
+      });
+
+      const backgroundTaskItem = {
+        type: "backgroundTask" as const,
+        id: "task:bg1",
+        taskType: "local_bash",
+        description: "sleep 900",
+        status: "pending" as const,
+        taskStatus: "running" as const,
+        skipTranscript: false,
+      };
+      await runtime.startThread({
+        environmentId: "env-1",
+        threadId: "t1",
+        projectId: "p1",
+        providerId: "fake",
+        instructions: "Initial instructions",
+        options: fullRuntimeOptions,
+      });
+
+      pendingEvents.push({
+        type: "item/started",
+        threadId: "t1",
+        providerThreadId: "",
+        scope: threadScope(),
+        item: backgroundTaskItem,
+      });
+      await runtime.runTurn({
+        clientRequestId: "creq_2222222bg1",
+        threadId: "t1",
+        input: [promptTextInput({ text: "start background work" })],
+        instructions: "Initial instructions",
+        options: fullRuntimeOptions,
+      });
+
+      await runtime.runTurn({
+        clientRequestId: "creq_2222222bg2",
+        threadId: "t1",
+        input: [promptTextInput({ text: "is it still running?" })],
+        instructions: "Updated instructions",
+        options: fullRuntimeOptions,
+      });
+      expect(findLastRecordedCommand(recordedCommands, "thread/resume")).toBe(
+        undefined,
+      );
+
+      pendingEvents.push({
+        type: "item/backgroundTask/completed",
+        threadId: "t1",
+        providerThreadId: "",
+        scope: threadScope(),
+        item: {
+          ...backgroundTaskItem,
+          status: "completed",
+          taskStatus: "completed",
+        },
+      });
+      await runtime.runTurn({
+        clientRequestId: "creq_2222222bg3",
+        threadId: "t1",
+        input: [promptTextInput({ text: "done yet?" })],
+        instructions: "Updated instructions",
+        options: fullRuntimeOptions,
+      });
+      await runtime.runTurn({
+        clientRequestId: "creq_2222222bg4",
+        threadId: "t1",
+        input: [promptTextInput({ text: "follow up" })],
+        instructions: "Updated instructions",
+        options: fullRuntimeOptions,
+      });
+
+      const reconfigureCommand = findLastRecordedCommand(
+        recordedCommands,
+        "thread/resume",
+      );
+      expect(reconfigureCommand?.type).toBe("thread/resume");
+      if (!reconfigureCommand || reconfigureCommand.type !== "thread/resume") {
+        throw new Error("Expected thread/resume command");
+      }
+      expect(reconfigureCommand.options?.instructions).toBe(
+        "Updated instructions",
+      );
 
       await runtime.shutdown();
     });

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -752,13 +752,21 @@ function createAgentRuntimeInternal(
     const nextOptions = args.options;
     const nextInstructions = args.instructions ?? currentConfig.instructions;
 
-    if (
-      sameExecutionSettings({
-        left: currentConfig.options,
-        right: nextOptions,
-      }) &&
-      currentConfig.instructions === nextInstructions
-    ) {
+    const sameSettings = sameExecutionSettings({
+      left: currentConfig.options,
+      right: nextOptions,
+    });
+    if (sameSettings && currentConfig.instructions === nextInstructions) {
+      return;
+    }
+
+    // Applying new instructions replaces the provider session, which kills
+    // any background tasks still running inside it. Server-side instruction
+    // drift (plugin contributions, AGENTS.md edits) is not worth destroying
+    // live work over: defer the instruction-only reconfigure — the stored
+    // config stays stale, so it retries once the tasks settle. Explicit
+    // settings changes (e.g. a model switch) still apply immediately.
+    if (sameSettings && backgroundWorkState.hasOpenWorkForThread(args.threadId)) {
       return;
     }
 


### PR DESCRIPTION
Fixes #1217.

## Summary

When a turn arrives with instructions that differ from what the session was started with, `reconfigureThreadIfNeeded` issues `thread/resume`. For claude-code that replaces the live CLI session: every running background task is killed with it, and the adapter settles them as interrupted — in the same second as the user's message.

Instructions drift between turns without any user action: the Memory plugin renders the memory catalog into thread instructions, so any memory write armed the next message to silently kill all running background tasks; `AGENTS.md` edits and plugin dynamic instructions do the same.

An instruction-only change is now deferred while the thread has open background tasks: the stored runtime config stays stale, so the reconfigure retries on the first turn after the tasks settle. Explicit execution-setting changes (e.g. a model switch) still apply immediately.

The change is daemon-local (no wire shape change), so `HOST_DAEMON_PROTOCOL_VERSION` is untouched. The new regression test reproduces the kill without the fix: a turn with changed instructions and an open background task previously emitted `thread/resume`, now it does not, and the deferred instructions apply once the task completes.
